### PR TITLE
fix(runtime): harden lifecycle cleanup and verification boundaries

### DIFF
--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -330,18 +330,25 @@ class TenantRuntimeRouter:
     def _close_runtime_entries(
         self, runtimes: tuple[tuple[str, _TenantRuntimeEntry], ...]
     ) -> None:
-        failures: list[Exception] = []
+        failures: list[BaseException] = []
         for tenant_key, entry in runtimes:
             try:
                 entry.runtime.close()
-            except Exception as exc:
+            except BaseException as exc:
                 failures.append(exc)
             else:
                 with self._condition:
                     self._runtimes.pop(tenant_key, None)
                     self._quarantined.pop(tenant_key, None)
         if failures:
-            raise ExceptionGroup(
+            exception_failures = [
+                failure for failure in failures if isinstance(failure, Exception)
+            ]
+            if len(exception_failures) == len(failures):
+                raise ExceptionGroup(
+                    "one or more tenant runtimes failed to close", exception_failures
+                )
+            raise BaseExceptionGroup(
                 "one or more tenant runtimes failed to close", failures
             )
 

--- a/src/jacobian/eval/trajectory_score.py
+++ b/src/jacobian/eval/trajectory_score.py
@@ -123,65 +123,97 @@ class TrajectoryScoreReplay(ContractModel):
     assurance_authority: Literal[False] = False
 
     @model_validator(mode="after")
-    def require_bound_ordered_replay(self) -> Self:  # noqa: C901
+    def require_bound_ordered_replay(self) -> Self:
         _require_terminal_pair(
             self.eventual_terminal_result, self.eventual_terminal_reward
         )
-        if self.states[0].boundary is not StateBoundary.PLAN:
-            raise ValueError("replay must begin at a PLAN observation")
-        if any(state.trajectory_id != self.trajectory_id for state in self.states):
-            raise ValueError("replay state trajectory identity mismatch")
-        if any(state.task_group != self.task_group for state in self.states):
-            raise ValueError("replay state task-group mismatch")
-        if any(state.estimator is not self.estimator for state in self.states):
-            raise ValueError("replay state estimator mismatch")
-        if tuple(state.state_index for state in self.states) != tuple(
-            sorted(state.state_index for state in self.states)
-        ):
-            raise ValueError("replay states must be ordered by source state index")
-        if len({state.state_index for state in self.states}) != len(self.states):
-            raise ValueError("replay state indices must be unique")
-        if any(
-            state.eventual_terminal_reward != self.eventual_terminal_reward
-            or state.eventual_terminal_result is not self.eventual_terminal_result
-            for state in self.states
-        ):
-            raise ValueError("replay states must share the bound terminal result")
-        if self.total_milestone_credit != self.states[-1].cumulative_milestone_credit:
-            raise ValueError("total credit must equal the last cumulative credit")
-        running_cumulative = 0.0
-        previous_id: str | None = None
-        previous_value: float | None = None
-        for index, state in enumerate(self.states):
-            if index == 0:
-                if state.previous_observation_id is not None:
-                    raise ValueError(
-                        "initial replay state must not reference a previous observation"
-                    )
-            else:
-                if state.previous_observation_id != previous_id:
-                    raise ValueError(
-                        "replay state previous observation must chain to its predecessor"
-                    )
-                if previous_value is None:
-                    raise ValueError(
-                        "non-initial replay state requires a previous estimated value"
-                    )
-                expected_delta = _round_value(state.estimated_value - previous_value)
-                if state.value_delta is None or state.value_delta != expected_delta:
-                    raise ValueError(
-                        "replay value delta must equal the adjacent estimated value difference"
-                    )
-            running_cumulative = _round_value(
-                running_cumulative + state.transition_credit
-            )
-            if state.cumulative_milestone_credit != running_cumulative:
-                raise ValueError(
-                    "replay cumulative credit must equal the running total of transition credits"
-                )
-            previous_id = state.observation_id
-            previous_value = state.estimated_value
+        _require_replay_header(self)
+        _require_replay_indices(self.states)
+        _require_replay_terminal_binding(
+            self.states,
+            self.eventual_terminal_result,
+            self.eventual_terminal_reward,
+        )
+        _require_replay_credit_chain(self.states, self.total_milestone_credit)
         return self
+
+
+def _require_replay_header(replay: TrajectoryScoreReplay) -> None:
+    """Require every state to belong to its declared replay identity."""
+
+    if replay.states[0].boundary is not StateBoundary.PLAN:
+        raise ValueError("replay must begin at a PLAN observation")
+    if any(state.trajectory_id != replay.trajectory_id for state in replay.states):
+        raise ValueError("replay state trajectory identity mismatch")
+    if any(state.task_group != replay.task_group for state in replay.states):
+        raise ValueError("replay state task-group mismatch")
+    if any(state.estimator is not replay.estimator for state in replay.states):
+        raise ValueError("replay state estimator mismatch")
+
+
+def _require_replay_indices(states: tuple[ScoredTrajectoryState, ...]) -> None:
+    """Require source ordering without silently normalizing a replay."""
+
+    if tuple(state.state_index for state in states) != tuple(
+        sorted(state.state_index for state in states)
+    ):
+        raise ValueError("replay states must be ordered by source state index")
+    if len({state.state_index for state in states}) != len(states):
+        raise ValueError("replay state indices must be unique")
+
+
+def _require_replay_terminal_binding(
+    states: tuple[ScoredTrajectoryState, ...],
+    terminal_result: TerminalResult,
+    terminal_reward: Literal[0, 1],
+) -> None:
+    """Bind each state to the replay's one eventual terminal outcome."""
+
+    if any(
+        state.eventual_terminal_reward != terminal_reward
+        or state.eventual_terminal_result is not terminal_result
+        for state in states
+    ):
+        raise ValueError("replay states must share the bound terminal result")
+
+
+def _require_replay_credit_chain(
+    states: tuple[ScoredTrajectoryState, ...], total_milestone_credit: float
+) -> None:
+    """Require adjacency and cumulative credit invariants across replay states."""
+
+    if total_milestone_credit != states[-1].cumulative_milestone_credit:
+        raise ValueError("total credit must equal the last cumulative credit")
+    running_cumulative = 0.0
+    previous_id: str | None = None
+    previous_value: float | None = None
+    for index, state in enumerate(states):
+        if index == 0:
+            if state.previous_observation_id is not None:
+                raise ValueError(
+                    "initial replay state must not reference a previous observation"
+                )
+        else:
+            if state.previous_observation_id != previous_id:
+                raise ValueError(
+                    "replay state previous observation must chain to its predecessor"
+                )
+            if previous_value is None:
+                raise ValueError(
+                    "non-initial replay state requires a previous estimated value"
+                )
+            expected_delta = _round_value(state.estimated_value - previous_value)
+            if state.value_delta is None or state.value_delta != expected_delta:
+                raise ValueError(
+                    "replay value delta must equal the adjacent estimated value difference"
+                )
+        running_cumulative = _round_value(running_cumulative + state.transition_credit)
+        if state.cumulative_milestone_credit != running_cumulative:
+            raise ValueError(
+                "replay cumulative credit must equal the running total of transition credits"
+            )
+        previous_id = state.observation_id
+        previous_value = state.estimated_value
 
 
 def _round_value(value: float) -> float:

--- a/src/jacobian/experiments/service.py
+++ b/src/jacobian/experiments/service.py
@@ -54,7 +54,10 @@ from jacobian.experiments.errors import (
 from jacobian.lifecycle import (
     LifecycleTimeoutError,
     ServiceLifecycleState,
+    WorkerLaunchStatus,
+    launch_worker,
     wait_for_worker_quiescence,
+    wait_for_worker_settlement,
 )
 from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
 from jacobian.plugin_execution import PluginExecutor
@@ -402,26 +405,19 @@ class ExperimentService:
         *,
         lifecycle_reserved: bool = False,
     ) -> None:
-        with self._thread_lock:
-            if self._lifecycle_state is ServiceLifecycleState.CLOSED or (
-                self._lifecycle_state is ServiceLifecycleState.CLOSING
-                and not lifecycle_reserved
-            ):
-                raise ExperimentError("experiment service is closing")
-            current = self._threads.get(experiment_uri)
-            if current is not None and current.is_alive():
-                return
-            thread = threading.Thread(
-                target=self._run_enumeration,
-                args=(experiment_uri,),
-                name=(
-                    "jacobian-enumeration-"
-                    f"{experiment_uri.removeprefix('experiment://')}"
-                ),
-                daemon=True,
-            )
-            self._threads[experiment_uri] = thread
-            thread.start()
+        status = launch_worker(
+            lock=self._thread_lock,
+            lifecycle_state=lambda: self._lifecycle_state,
+            workers=self._threads,
+            worker_id=experiment_uri,
+            target=self._run_enumeration,
+            name=(
+                f"jacobian-enumeration-{experiment_uri.removeprefix('experiment://')}"
+            ),
+            lifecycle_reserved=lifecycle_reserved,
+        )
+        if status is WorkerLaunchStatus.SERVICE_CLOSING:
+            raise ExperimentError("experiment service is closing")
 
     def inspect(self, experiment_uri: str) -> ExperimentSnapshot:
         """Read the latest durable experiment snapshot."""
@@ -465,23 +461,18 @@ class ExperimentService:
     ) -> ExperimentSnapshot:
         """Wait locally for a terminal state, then return its snapshot."""
 
-        deadline = time.monotonic() + timeout_seconds
-        while True:
-            snapshot = self.inspect(experiment_uri)
-            if snapshot.state in _TERMINAL_STATES:
-                return snapshot
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    "The experiment is still running. Inspect it or wait again with "
-                    "a larger timeout."
-                )
-            with self._thread_lock:
-                thread = self._threads.get(experiment_uri)
-            if thread is not None:
-                thread.join(timeout=min(remaining, 0.05))
-            else:
-                time.sleep(min(remaining, 0.05))
+        return wait_for_worker_settlement(
+            lock=self._thread_lock,
+            workers=self._threads,
+            worker_id=experiment_uri,
+            inspect=self.inspect,
+            is_settled=lambda snapshot: snapshot.state in _TERMINAL_STATES,
+            timeout_seconds=timeout_seconds,
+            timeout_message=(
+                "The experiment is still running. Inspect it or wait again with a "
+                "larger timeout."
+            ),
+        )
 
     def cancel(self, experiment_uri: str) -> ExperimentCancelResult:
         """Request cooperative cancellation without deleting committed artifacts."""

--- a/src/jacobian/lean_frontend/repl.py
+++ b/src/jacobian/lean_frontend/repl.py
@@ -316,17 +316,26 @@ class LeanExplorationReplRuntime:
                 return
             self._closing = True
             sessions = tuple(self._sessions.items())
-        failures: list[Exception] = []
+        failures: list[BaseException] = []
         for environment, session in sessions:
             try:
                 session.close()
-            except Exception as exc:
+            except BaseException as exc:
                 failures.append(exc)
             else:
                 with self._lock:
                     self._sessions.pop(environment, None)
         if failures:
-            raise ExceptionGroup("Lean exploration sessions failed to close", failures)
+            exception_failures = [
+                failure for failure in failures if isinstance(failure, Exception)
+            ]
+            if len(exception_failures) == len(failures):
+                raise ExceptionGroup(
+                    "Lean exploration sessions failed to close", exception_failures
+                )
+            raise BaseExceptionGroup(
+                "Lean exploration sessions failed to close", failures
+            )
         with self._lock:
             self._finalizer.detach()
             self._closed = True

--- a/src/jacobian/lifecycle.py
+++ b/src/jacobian/lifecycle.py
@@ -20,6 +20,14 @@ class ServiceLifecycleState(StrEnum):
     CLOSED = "CLOSED"
 
 
+class WorkerLaunchStatus(StrEnum):
+    """Outcome of attempting to start one runtime-owned worker."""
+
+    STARTED = "STARTED"
+    ALREADY_RUNNING = "ALREADY_RUNNING"
+    SERVICE_CLOSING = "SERVICE_CLOSING"
+
+
 def wait_for_worker_quiescence(
     *,
     lock: threading.Lock,
@@ -51,8 +59,71 @@ def wait_for_worker_quiescence(
             thread.join(timeout=min(remaining, 0.05))
 
 
+def launch_worker(
+    *,
+    lock: threading.Lock,
+    lifecycle_state: Callable[[], ServiceLifecycleState],
+    workers: dict[str, threading.Thread],
+    worker_id: str,
+    target: Callable[[str], None],
+    name: str,
+    lifecycle_reserved: bool,
+) -> WorkerLaunchStatus:
+    """Start one worker unless its service is closing or it is already active."""
+
+    with lock:
+        state = lifecycle_state()
+        if state is ServiceLifecycleState.CLOSED or (
+            state is ServiceLifecycleState.CLOSING and not lifecycle_reserved
+        ):
+            return WorkerLaunchStatus.SERVICE_CLOSING
+        current = workers.get(worker_id)
+        if current is not None and current.is_alive():
+            return WorkerLaunchStatus.ALREADY_RUNNING
+        worker = threading.Thread(
+            target=target,
+            args=(worker_id,),
+            name=name,
+            daemon=True,
+        )
+        workers[worker_id] = worker
+        worker.start()
+    return WorkerLaunchStatus.STARTED
+
+
+def wait_for_worker_settlement[SnapshotT](
+    *,
+    lock: threading.Lock,
+    workers: Mapping[str, threading.Thread],
+    worker_id: str,
+    inspect: Callable[[str], SnapshotT],
+    is_settled: Callable[[SnapshotT], bool],
+    timeout_seconds: float,
+    timeout_message: str,
+) -> SnapshotT:
+    """Poll one durable snapshot while joining its local worker when present."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        snapshot = inspect(worker_id)
+        if is_settled(snapshot):
+            return snapshot
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(timeout_message)
+        with lock:
+            worker = workers.get(worker_id)
+        if worker is not None:
+            worker.join(timeout=min(remaining, 0.05))
+        else:
+            time.sleep(min(remaining, 0.05))
+
+
 __all__ = [
     "LifecycleTimeoutError",
     "ServiceLifecycleState",
+    "WorkerLaunchStatus",
+    "launch_worker",
     "wait_for_worker_quiescence",
+    "wait_for_worker_settlement",
 ]

--- a/src/jacobian/persistence/database.py
+++ b/src/jacobian/persistence/database.py
@@ -319,9 +319,12 @@ class StateDatabase:
                 close_error = exc
             self._state.connection = None
         if checkpoint_error is not None:
-            raise StateDatabaseError(
-                "could not checkpoint state database"
-            ) from checkpoint_error
+            error = StateDatabaseError("could not checkpoint state database")
+            if close_error is not None:
+                error.add_note(
+                    f"state database handle cleanup also failed: {close_error}"
+                )
+            raise error from checkpoint_error
         if close_error is not None:
             raise close_error
 

--- a/src/jacobian/polynomial_expression_capabilities.py
+++ b/src/jacobian/polynomial_expression_capabilities.py
@@ -200,7 +200,17 @@ class PolynomialExpressionNormalizationVerificationAdapter:
             ) from exc
 
         checker_id = self.installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="POLYNOMIAL_EXPRESSION_CHECKER_UNAVAILABLE",
+                    stage="normalization_verification",
+                    message=(
+                        "The independent polynomial-expression checker is not installed "
+                        "in this runtime."
+                    ),
+                )
+            )
         bindings = EvidenceBindings(
             claim_digest=resolved.expression_artifact.manifest.object_digest,
             semantics_digest=semantics.manifest.object_digest,

--- a/src/jacobian/polynomial_system_capabilities.py
+++ b/src/jacobian/polynomial_system_capabilities.py
@@ -158,7 +158,10 @@ class PolynomialSystemSolutionAdapter:
     def __init__(self, resources: PolynomialSystemResources) -> None:
         self.resources = resources
         checker_id = resources.installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise RuntimeError(
+                "polynomial system solution adapter requires an authorized checker"
+            )
         self._descriptor = CapabilityDescriptor(
             capability_id="polynomial.system.solution.verify",
             version="1",
@@ -207,7 +210,17 @@ class PolynomialSystemSolutionAdapter:
             ) from exc
         installation = self.resources.installation
         checker_id = installation.checker_id
-        assert checker_id is not None
+        if checker_id is None:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="POLYNOMIAL_SYSTEM_CHECKER_UNAVAILABLE",
+                    stage="solution_verification",
+                    message=(
+                        "The independent polynomial-system checker is not installed "
+                        "in this runtime."
+                    ),
+                )
+            )
         equation_residuals, inequation_values = _evaluate_request(validated)
         system = self.resources.artifacts.put(
             schema_uri=installation.system_schema_uri,

--- a/src/jacobian/polynomials/collision.py
+++ b/src/jacobian/polynomials/collision.py
@@ -63,6 +63,38 @@ from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import model_schema
 
 
+def _require_found_evaluation(
+    first: str | None,
+    second: str | None,
+) -> tuple[str, str]:
+    """Return both evaluation URIs or fail closed for an impossible result."""
+
+    if first is None:
+        raise RuntimeError("first evaluation result is unexpectedly None")
+    if second is None:
+        raise RuntimeError("second evaluation result is unexpectedly None")
+    return first, second
+
+
+def _require_found_result(
+    first_evaluation_result: str | None,
+    second_evaluation_result: str | None,
+    claim_uri: str | None,
+    witness_uri: str | None,
+) -> tuple[str, str, str, str]:
+    """Return every collision result URI or fail closed for an impossible result."""
+
+    first_evaluation_result, second_evaluation_result = _require_found_evaluation(
+        first_evaluation_result,
+        second_evaluation_result,
+    )
+    if claim_uri is None:
+        raise RuntimeError("claim URI is unexpectedly None")
+    if witness_uri is None:
+        raise RuntimeError("witness URI is unexpectedly None")
+    return first_evaluation_result, second_evaluation_result, claim_uri, witness_uri
+
+
 class PolynomialCollisionAdapter:
     """Compare exact evaluation artifacts and materialize collision evidence."""
 
@@ -96,32 +128,6 @@ class PolynomialCollisionAdapter:
     @property
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
-
-    @staticmethod
-    def _require_found_evaluation(
-        first: str | None,
-        second: str | None,
-    ) -> None:
-        if first is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-
-    @staticmethod
-    def _require_found_result(
-        first_evaluation_result: str | None,
-        second_evaluation_result: str | None,
-        claim_uri: str | None,
-        witness_uri: str | None,
-    ) -> None:
-        if first_evaluation_result is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second_evaluation_result is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-        if claim_uri is None:
-            raise RuntimeError("claim URI is unexpectedly None")
-        if witness_uri is None:
-            raise RuntimeError("witness URI is unexpectedly None")
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         validated = _validate_request(
@@ -331,32 +337,6 @@ class PolynomialCollisionSearchAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    @staticmethod
-    def _require_found_evaluation(
-        first: str | None,
-        second: str | None,
-    ) -> None:
-        if first is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-
-    @staticmethod
-    def _require_found_result(
-        first_evaluation_result: str | None,
-        second_evaluation_result: str | None,
-        claim_uri: str | None,
-        witness_uri: str | None,
-    ) -> None:
-        if first_evaluation_result is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second_evaluation_result is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-        if claim_uri is None:
-            raise RuntimeError("claim URI is unexpectedly None")
-        if witness_uri is None:
-            raise RuntimeError("witness URI is unexpectedly None")
-
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         validated = _validate_request(
             PolynomialCollisionSearchRequest,
@@ -437,8 +417,10 @@ class PolynomialCollisionSearchAdapter:
                 first_evaluation_result,
                 second_evaluation_result,
             ) = found
-            self._require_found_evaluation(
-                first_evaluation_result, second_evaluation_result
+            first_evaluation_result, second_evaluation_result = (
+                _require_found_evaluation(
+                    first_evaluation_result, second_evaluation_result
+                )
             )
             candidate = self.resources.store.get(map_uri)
             claim = self.resources.artifacts.put(
@@ -516,17 +498,16 @@ class PolynomialCollisionSearchAdapter:
                 )
             )
         if found is not None:
-            self._require_found_result(
+            (
                 first_evaluation_result,
                 second_evaluation_result,
                 claim_uri,
                 witness_uri,
-            )
-            assert (
-                first_evaluation_result is not None
-                and second_evaluation_result is not None
-                and claim_uri is not None
-                and witness_uri is not None
+            ) = _require_found_result(
+                first_evaluation_result,
+                second_evaluation_result,
+                claim_uri,
+                witness_uri,
             )
             artifacts.extend(
                 [
@@ -659,32 +640,6 @@ class PolynomialCollisionVerifyAdapter:
     @property
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
-
-    @staticmethod
-    def _require_found_evaluation(
-        first: str | None,
-        second: str | None,
-    ) -> None:
-        if first is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-
-    @staticmethod
-    def _require_found_result(
-        first_evaluation_result: str | None,
-        second_evaluation_result: str | None,
-        claim_uri: str | None,
-        witness_uri: str | None,
-    ) -> None:
-        if first_evaluation_result is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second_evaluation_result is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-        if claim_uri is None:
-            raise RuntimeError("claim URI is unexpectedly None")
-        if witness_uri is None:
-            raise RuntimeError("witness URI is unexpectedly None")
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         validated = _validate_request(
@@ -838,32 +793,6 @@ class PolynomialMapInverseCollisionVerifyAdapter:
     @property
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
-
-    @staticmethod
-    def _require_found_evaluation(
-        first: str | None,
-        second: str | None,
-    ) -> None:
-        if first is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-
-    @staticmethod
-    def _require_found_result(
-        first_evaluation_result: str | None,
-        second_evaluation_result: str | None,
-        claim_uri: str | None,
-        witness_uri: str | None,
-    ) -> None:
-        if first_evaluation_result is None:
-            raise RuntimeError("first evaluation result is unexpectedly None")
-        if second_evaluation_result is None:
-            raise RuntimeError("second evaluation result is unexpectedly None")
-        if claim_uri is None:
-            raise RuntimeError("claim URI is unexpectedly None")
-        if witness_uri is None:
-            raise RuntimeError("witness URI is unexpectedly None")
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         validated = _validate_request(

--- a/src/jacobian/portfolio/result.py
+++ b/src/jacobian/portfolio/result.py
@@ -263,7 +263,7 @@ class PortfolioInstallation:
 
         if self._closed:
             return
-        failures: list[Exception] = []
+        failures: list[BaseException] = []
         resources = (
             self.lean_declarations,
             self.lean_exploration.repl if self.lean_exploration is not None else None,
@@ -274,10 +274,17 @@ class PortfolioInstallation:
                 continue
             try:
                 resource.close()
-            except Exception as exc:
+            except BaseException as exc:
                 failures.append(exc)
         if failures:
-            raise ExceptionGroup("portfolio resources failed to close", failures)
+            exception_failures = [
+                failure for failure in failures if isinstance(failure, Exception)
+            ]
+            if len(exception_failures) == len(failures):
+                raise ExceptionGroup(
+                    "portfolio resources failed to close", exception_failures
+                )
+            raise BaseExceptionGroup("portfolio resources failed to close", failures)
         self._closed = True
 
     def installed_bundle(self, domain_id: str) -> InstalledDomainBundle | None:

--- a/src/jacobian/runtime/model.py
+++ b/src/jacobian/runtime/model.py
@@ -60,7 +60,7 @@ class JacobianRuntime:
 
         if self._closed:
             return
-        failures: list[Exception] = []
+        failures: list[BaseException] = []
         for close in (
             self.services.close,
             self.portfolio.close,
@@ -68,10 +68,17 @@ class JacobianRuntime:
         ):
             try:
                 close()
-            except Exception as exc:
+            except BaseException as exc:
                 failures.append(exc)
         if failures:
-            raise ExceptionGroup("runtime resources failed to close", failures)
+            exception_failures = [
+                failure for failure in failures if isinstance(failure, Exception)
+            ]
+            if len(exception_failures) == len(failures):
+                raise ExceptionGroup(
+                    "runtime resources failed to close", exception_failures
+                )
+            raise BaseExceptionGroup("runtime resources failed to close", failures)
         self._closed = True
 
     def __enter__(self) -> JacobianRuntime:

--- a/src/jacobian/runtime/services.py
+++ b/src/jacobian/runtime/services.py
@@ -80,14 +80,21 @@ class ApplicationServices:
     def close(self) -> None:
         """Quiesce application-owned workers before foundational teardown."""
 
-        failures: list[Exception] = []
+        failures: list[BaseException] = []
         for close in (self.search.close, self.experiments.close):
             try:
                 close()
-            except Exception as exc:
+            except BaseException as exc:
                 failures.append(exc)
         if failures:
-            raise ExceptionGroup("application services did not quiesce", failures)
+            exception_failures = [
+                failure for failure in failures if isinstance(failure, Exception)
+            ]
+            if len(exception_failures) == len(failures):
+                raise ExceptionGroup(
+                    "application services did not quiesce", exception_failures
+                )
+            raise BaseExceptionGroup("application services did not quiesce", failures)
 
 
 def build_application_services(core: CoreServices) -> ApplicationServices:

--- a/src/jacobian/search/service.py
+++ b/src/jacobian/search/service.py
@@ -42,7 +42,10 @@ from jacobian.experiment_identity import new_experiment_uri
 from jacobian.lifecycle import (
     LifecycleTimeoutError,
     ServiceLifecycleState,
+    WorkerLaunchStatus,
+    launch_worker,
     wait_for_worker_quiescence,
+    wait_for_worker_settlement,
 )
 from jacobian.persistence import PersistenceCorruptionError, decode_persisted_model
 from jacobian.persistence.recovery import (
@@ -572,23 +575,18 @@ class SearchService:
     ) -> SearchExperimentSnapshot:
         """Wait until the search is paused or terminal."""
 
-        deadline = time.monotonic() + timeout_seconds
-        while True:
-            snapshot = self.inspect(experiment_uri)
-            if snapshot.state in _SETTLED_STATES:
-                return snapshot
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    "The search is still running. Inspect the experiment or wait "
-                    "again with a larger timeout."
-                )
-            with self._thread_lock:
-                thread = self._threads.get(experiment_uri)
-            if thread is not None:
-                thread.join(timeout=min(remaining, 0.05))
-            else:
-                time.sleep(min(remaining, 0.05))
+        return wait_for_worker_settlement(
+            lock=self._thread_lock,
+            workers=self._threads,
+            worker_id=experiment_uri,
+            inspect=self.inspect,
+            is_settled=lambda snapshot: snapshot.state in _SETTLED_STATES,
+            timeout_seconds=timeout_seconds,
+            timeout_message=(
+                "The search is still running. Inspect the experiment or wait again "
+                "with a larger timeout."
+            ),
+        )
 
     def pause(self, experiment_uri: str) -> ExperimentControlResult:
         """Request a pause at the next committed checkpoint boundary."""
@@ -750,25 +748,17 @@ class SearchService:
         *,
         lifecycle_reserved: bool = False,
     ) -> None:
-        with self._thread_lock:
-            if self._lifecycle_state is ServiceLifecycleState.CLOSED or (
-                self._lifecycle_state is ServiceLifecycleState.CLOSING
-                and not lifecycle_reserved
-            ):
-                raise SearchError("search service is closing")
-            current = self._threads.get(experiment_uri)
-            if current is not None and current.is_alive():
-                return
-            thread = threading.Thread(
-                target=self._run,
-                args=(experiment_uri,),
-                name=(
-                    f"jacobian-search-{experiment_uri.removeprefix('experiment://')}"
-                ),
-                daemon=True,
-            )
-            self._threads[experiment_uri] = thread
-            thread.start()
+        status = launch_worker(
+            lock=self._thread_lock,
+            lifecycle_state=lambda: self._lifecycle_state,
+            workers=self._threads,
+            worker_id=experiment_uri,
+            target=self._run,
+            name=f"jacobian-search-{experiment_uri.removeprefix('experiment://')}",
+            lifecycle_reserved=lifecycle_reserved,
+        )
+        if status is WorkerLaunchStatus.SERVICE_CLOSING:
+            raise SearchError("search service is closing")
 
     def _budget_exhausted(
         self,

--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -89,6 +89,20 @@ class CheckerExecutionCancelledError(CheckerExecutionError):
     """An authorized checker was cancelled by its caller."""
 
 
+_RECOVERABLE_VERIFICATION_ERRORS: tuple[type[Exception], ...] = (
+    TimeoutError,
+    CheckerExecutionCancelledError,
+    CheckerExecutableChangedError,
+    CheckerRegistryError,
+    SchemaRegistryError,
+    ValueError,
+    ValidationError,
+    ArtifactNotFoundError,
+    StorageError,
+    CheckerExecutionError,
+)
+
+
 class VerificationService:
     """The only application service allowed to persist verified records."""
 
@@ -289,13 +303,21 @@ class VerificationService:
                 timeout_seconds=timeout_seconds,
             )
             runtime_ms = int((time.monotonic() - started) * 1000)
-            if not decision.accepted:
+            if not decision.accepted or decision.coverage is Coverage.BOUNDED:
+                detail = (
+                    decision.detail
+                    if not decision.accepted
+                    else (
+                        "Inline exact verification cannot bind a bounded scope; the "
+                        "checker must report exhaustive or not-applicable coverage."
+                    )
+                )
                 return ResultEnvelope(
                     execution=Execution(
                         status=ExecutionStatus.COMPLETED, runtime_ms=runtime_ms
                     ),
                     input=InputValidation(
-                        status=InputStatus.REJECTED, errors=(decision.detail,)
+                        status=InputStatus.REJECTED, errors=(detail,)
                     ),
                     conclusion=Conclusion.UNKNOWN,
                     assurance=Assurance(
@@ -360,18 +382,7 @@ class VerificationService:
                 evidence_uris=(record_artifact.artifact_uri,),
                 verification_record_uri=record_artifact.artifact_uri,
             )
-        except (
-            TimeoutError,
-            CheckerExecutionCancelledError,
-            CheckerExecutableChangedError,
-            CheckerRegistryError,
-            SchemaRegistryError,
-            ValueError,
-            ValidationError,
-            ArtifactNotFoundError,
-            StorageError,
-            CheckerExecutionError,
-        ) as exc:
+        except _RECOVERABLE_VERIFICATION_ERRORS as exc:
             return self._verification_failure_result(exc, started)
 
     def _validate_checker_response(
@@ -509,18 +520,7 @@ class VerificationService:
                 summary="authorized witness verification",
                 execution_detail=decision.detail,
             )
-        except (
-            TimeoutError,
-            CheckerExecutionCancelledError,
-            CheckerExecutableChangedError,
-            CheckerRegistryError,
-            SchemaRegistryError,
-            ValueError,
-            ValidationError,
-            ArtifactNotFoundError,
-            StorageError,
-            CheckerExecutionError,
-        ) as exc:
+        except _RECOVERABLE_VERIFICATION_ERRORS as exc:
             return self._verification_failure_result(exc, started)
 
     def verify_certificate(
@@ -623,18 +623,7 @@ class VerificationService:
                 summary="authorized certificate verification",
                 execution_detail=decision.detail,
             )
-        except (
-            TimeoutError,
-            CheckerExecutionCancelledError,
-            CheckerExecutableChangedError,
-            CheckerRegistryError,
-            SchemaRegistryError,
-            ValueError,
-            ValidationError,
-            ArtifactNotFoundError,
-            StorageError,
-            CheckerExecutionError,
-        ) as exc:
+        except _RECOVERABLE_VERIFICATION_ERRORS as exc:
             return self._verification_failure_result(exc, started)
 
     def verify_transformation(
@@ -757,18 +746,7 @@ class VerificationService:
                 ),
                 summary="authorized transformation verification",
             )
-        except (
-            TimeoutError,
-            CheckerExecutionCancelledError,
-            CheckerExecutableChangedError,
-            CheckerRegistryError,
-            SchemaRegistryError,
-            ValueError,
-            ValidationError,
-            ArtifactNotFoundError,
-            StorageError,
-            CheckerExecutionError,
-        ) as exc:
+        except _RECOVERABLE_VERIFICATION_ERRORS as exc:
             return self._verification_failure_result(exc, started)
 
     def verify_preservation(
@@ -868,18 +846,7 @@ class VerificationService:
                 parents=(*parent_uris, evidence_artifact.artifact_uri),
                 summary="authorized reduction preservation verification",
             )
-        except (
-            TimeoutError,
-            CheckerExecutionCancelledError,
-            CheckerExecutableChangedError,
-            CheckerRegistryError,
-            SchemaRegistryError,
-            ValueError,
-            ValidationError,
-            ArtifactNotFoundError,
-            StorageError,
-            CheckerExecutionError,
-        ) as exc:
+        except _RECOVERABLE_VERIFICATION_ERRORS as exc:
             return self._verification_failure_result(exc, started)
 
     def _validate_artifacts(self, artifacts: tuple[StoredArtifact, ...]) -> None:

--- a/tests/boundary/mcp/test_remote_mcp_tenants.py
+++ b/tests/boundary/mcp/test_remote_mcp_tenants.py
@@ -307,7 +307,7 @@ def test_tenant_router_shutdown_is_retryable_after_base_exception(
     )
     router.runtime_for("alpha")
 
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(BaseExceptionGroup, match="tenant runtimes failed to close"):
         router.close()
 
     with pytest.raises(TenantRuntimeRouterClosedError, match="closing"):
@@ -318,6 +318,36 @@ def test_tenant_router_shutdown_is_retryable_after_base_exception(
     assert runtime.close_calls == 2
     with pytest.raises(TenantRuntimeRouterClosedError, match="closing"):
         router.lease_for("alpha")
+
+
+def test_tenant_router_closes_remaining_runtimes_after_base_exception(
+    tmp_path: Path,
+) -> None:
+    class InterruptOnceRuntime(_FakeRuntime):
+        def close(self) -> None:
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise KeyboardInterrupt("interrupt first runtime close")
+
+    first = InterruptOnceRuntime(tmp_path / "first")
+    second = _FakeRuntime(tmp_path / "second")
+    created = iter((first, second))
+    router = TenantRuntimeRouter(
+        tmp_path,
+        max_tenant_runtimes=2,
+        runtime_factory=lambda _path, **_kwargs: next(created),  # type: ignore[arg-type]
+    )
+    router.runtime_for("alpha")
+    router.runtime_for("beta")
+
+    with pytest.raises(BaseExceptionGroup, match="tenant runtimes failed to close"):
+        router.close()
+
+    assert [first.close_calls, second.close_calls] == [1, 1]
+
+    router.close()
+
+    assert [first.close_calls, second.close_calls] == [2, 1]
 
 
 def test_tenant_router_releases_shutdown_claim_when_condition_exit_is_interrupted(

--- a/tests/boundary/providers/lean/test_lean_repl_runtime.py
+++ b/tests/boundary/providers/lean/test_lean_repl_runtime.py
@@ -334,3 +334,56 @@ def test_runtime_close_retries_failed_sessions_and_rejects_new_execution(
             tactic="skip",
             environment=LeanEnvironment.CORE,
         )
+
+
+def test_runtime_close_continues_after_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = LeanExplorationReplRuntime(tmp_path, {})
+
+    class FakeSession:
+        def __init__(self, *, interrupt: bool) -> None:
+            self.interrupt = interrupt
+            self.close_calls = 0
+
+        def execute(
+            self,
+            *,
+            command: str,
+            tactic: str,
+            pickle_path: Path | None = None,
+        ) -> tuple[dict[str, object], dict[str, object]]:
+            return {}, {}
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if self.interrupt:
+                raise KeyboardInterrupt("injected session close interrupt")
+
+    sessions = [FakeSession(interrupt=True), FakeSession(interrupt=False)]
+    monkeypatch.setattr(
+        runtime, "_create_session", lambda _environment: sessions.pop(0)
+    )
+    runtime.execute(command="first", tactic="skip", environment=LeanEnvironment.CORE)
+    runtime.execute(
+        command="second", tactic="skip", environment=LeanEnvironment.MATHLIB
+    )
+    interrupted, closed = tuple(
+        runtime._sessions[environment]
+        for environment in (LeanEnvironment.CORE, LeanEnvironment.MATHLIB)
+    )
+
+    with pytest.raises(
+        BaseExceptionGroup, match="Lean exploration sessions failed to close"
+    ) as exc:
+        runtime.close()
+
+    assert interrupted.close_calls == 1
+    assert closed.close_calls == 1
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "injected session close interrupt",
+    ]
+
+    interrupted.interrupt = False
+    runtime.close()

--- a/tests/boundary/storage/transactions/test_state_database_migrations.py
+++ b/tests/boundary/storage/transactions/test_state_database_migrations.py
@@ -583,6 +583,34 @@ def test_close_cannot_race_connection_configuration_and_registration(
     assert connect_errors == []
 
 
+def test_close_preserves_handle_cleanup_failure_after_checkpoint_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = StateDatabase(tmp_path / "state.sqlite3", synchronous="FULL")
+    checkpoint_failure = sqlite3.OperationalError("injected checkpoint failure")
+    close_failure = StateDatabaseError("injected handle close failure")
+
+    monkeypatch.setattr(
+        database,
+        "_checkpoint_for_close",
+        lambda: checkpoint_failure,
+    )
+
+    def fail_close_all_connections() -> None:
+        raise close_failure
+
+    monkeypatch.setattr(database, "_close_all_connections", fail_close_all_connections)
+
+    with pytest.raises(StateDatabaseError, match="could not checkpoint") as exc:
+        database.close(checkpoint=True)
+
+    assert exc.value.__cause__ is checkpoint_failure
+    assert exc.value.__notes__ == [
+        "state database handle cleanup also failed: injected handle close failure"
+    ]
+
+
 def test_two_processes_can_race_to_migrate_empty_state(tmp_path: Path) -> None:
     ready = tmp_path / "start"
     script = """

--- a/tests/composition/runtime/exact_verification/test_inline_exact_verification.py
+++ b/tests/composition/runtime/exact_verification/test_inline_exact_verification.py
@@ -5,7 +5,9 @@ from typing import Any
 import pytest
 
 from jacobian.contracts.capabilities import CapabilityMode, CapabilityRequest
+from jacobian.contracts.checkers import CheckerDecision
 from jacobian.contracts.exact_domain_verification import InlineExactVerificationRecord
+from jacobian.contracts.results import Arithmetic, Conclusion, Coverage, Method
 from jacobian.runtime.model import JacobianRuntime
 
 
@@ -71,3 +73,48 @@ def test_inline_exact_replay_persists_only_its_bound_record(
     assert parsed.operation_id == verified.scope.parameters["operation_id"]
     assert parsed.checker_id == verified.scope.parameters["checker_id"]
     assert parsed.witness_format == verified.scope.parameters["witness_format"]
+
+
+def test_inline_exact_rejects_bounded_accepted_checker_decisions(
+    authorized_complete_runtime: JacobianRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline values have no scope artifact for a bounded verified assurance."""
+
+    runtime = authorized_complete_runtime
+
+    def accept_with_bounded_coverage(**_kwargs: object) -> CheckerDecision:
+        return CheckerDecision(
+            accepted=True,
+            conclusion=Conclusion.TRUE,
+            arithmetic=Arithmetic.EXACT_RATIONAL,
+            method=Method.BOUNDED_SEARCH,
+            coverage=Coverage.BOUNDED,
+        )
+
+    monkeypatch.setattr(
+        runtime.services.verification,
+        "_run_checker",
+        accept_with_bounded_coverage,
+    )
+
+    computed = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.compute", input={"matrix": _matrix()}
+        )
+    )
+    checked = runtime.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "input": {"matrix": _matrix()},
+                "candidate": computed.output["result"],
+            },
+        )
+    )
+
+    assert checked.execution.status == "COMPLETED"
+    assert checked.output["status"] == "REJECTED"
+    assert checked.output["verification_record_uri"] is None
+    assert "cannot bind a bounded scope" in checked.output["detail"]

--- a/tests/composition/runtime/test_polynomial_system_capabilities.py
+++ b/tests/composition/runtime/test_polynomial_system_capabilities.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import sqlite3
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -169,3 +171,45 @@ def test_solution_capability_is_only_available_with_checker(
     }
 
     assert "polynomial.system.solution.verify" not in ids
+
+
+def test_solution_adapter_rejects_missing_checker_under_optimized_python() -> None:
+    """An optimized interpreter must not erase checker-authorization guards."""
+
+    script = """
+from jacobian.polynomial_system_capabilities import (
+    PolynomialSystemInstallation,
+    PolynomialSystemResources,
+    PolynomialSystemSolutionAdapter,
+)
+
+installation = PolynomialSystemInstallation(
+    semantics_uri="semantics://test",
+    system_schema_uri="schema://system",
+    assignment_schema_uri="schema://assignment",
+    claim_schema_uri="schema://claim",
+    certificate_schema_uri="schema://certificate",
+    checker_id=None,
+)
+resources = PolynomialSystemResources(
+    store=None,
+    artifacts=None,
+    verification=None,
+    installation=installation,
+)
+try:
+    PolynomialSystemSolutionAdapter(resources)
+except RuntimeError as exc:
+    if "authorized checker" not in str(exc):
+        raise
+else:
+    raise SystemExit("missing checker did not prevent adapter construction")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/composition/runtime/test_runtime_lifecycle.py
+++ b/tests/composition/runtime/test_runtime_lifecycle.py
@@ -591,3 +591,79 @@ def test_close_attempts_every_owner_before_raising_failures(
     monkeypatch.undo()
     runtime.close()
     runtime.close()
+
+
+def test_close_attempts_every_owner_after_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interrupting one owner must not skip shutdown of the remaining owners."""
+
+    runtime = create_runtime(tmp_path)
+    store = runtime.core.store
+    close_order: list[str] = []
+    services_close = ApplicationServices.close
+    portfolio_close = PortfolioInstallation.close
+    core_close = CoreServices.close
+
+    def interrupt_after_services_close(self: ApplicationServices) -> None:
+        close_order.append("services")
+        services_close(self)
+        raise KeyboardInterrupt("services close interrupted")
+
+    def record_portfolio_close(self: PortfolioInstallation) -> None:
+        close_order.append("portfolio")
+        portfolio_close(self)
+
+    def record_core_close(self: CoreServices) -> None:
+        close_order.append("core")
+        core_close(self)
+
+    monkeypatch.setattr(ApplicationServices, "close", interrupt_after_services_close)
+    monkeypatch.setattr(PortfolioInstallation, "close", record_portfolio_close)
+    monkeypatch.setattr(CoreServices, "close", record_core_close)
+
+    with pytest.raises(
+        BaseExceptionGroup, match="runtime resources failed to close"
+    ) as exc:
+        runtime.close()
+
+    assert close_order == ["services", "portfolio", "core"]
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "services close interrupted",
+    ]
+    with pytest.raises(StorageClosedError), store.connection():
+        pass
+
+
+def test_application_services_close_continues_after_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An interrupt from search must not leave experiment workers running."""
+
+    runtime = create_runtime(tmp_path)
+    close_order: list[str] = []
+
+    def interrupt_search_close(self: SearchService) -> None:
+        close_order.append("search")
+        raise KeyboardInterrupt("search close interrupted")
+
+    def record_experiment_close(self: ExperimentService) -> None:
+        close_order.append("experiments")
+
+    monkeypatch.setattr(SearchService, "close", interrupt_search_close)
+    monkeypatch.setattr(ExperimentService, "close", record_experiment_close)
+
+    with pytest.raises(
+        BaseExceptionGroup, match="application services did not quiesce"
+    ) as exc:
+        runtime.services.close()
+
+    assert close_order == ["search", "experiments"]
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "search close interrupted",
+    ]
+
+    monkeypatch.undo()
+    runtime.close()

--- a/tests/unit/portfolio/test_portfolio_installation_phases.py
+++ b/tests/unit/portfolio/test_portfolio_installation_phases.py
@@ -144,3 +144,37 @@ def test_portfolio_close_releases_every_owned_lean_resource_once() -> None:
     result.close()
 
     assert closed == ["declarations", "exploration", "verification"]
+
+
+def test_portfolio_close_continues_after_keyboard_interrupt() -> None:
+    closed: list[str] = []
+
+    class InterruptingResource:
+        def close(self) -> None:
+            closed.append("declarations")
+            raise KeyboardInterrupt("declarations close interrupted")
+
+    class Resource:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def close(self) -> None:
+            closed.append(self.name)
+
+    result = PortfolioInstallation()
+    result.lean_declarations = cast(Any, InterruptingResource())
+    result.lean_exploration = cast(
+        Any,
+        SimpleNamespace(repl=Resource("exploration")),
+    )
+    result.lean = cast(Any, Resource("verification"))
+
+    with pytest.raises(
+        BaseExceptionGroup, match="portfolio resources failed to close"
+    ) as exc:
+        result.close()
+
+    assert closed == ["declarations", "exploration", "verification"]
+    assert [str(failure) for failure in exc.value.exceptions] == [
+        "declarations close interrupted",
+    ]

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -1,11 +1,5 @@
 {
   "version": 1,
   "max_complexity": 10,
-  "violations": [
-    {
-      "path": "src/jacobian/eval/trajectory_score.py",
-      "symbol": "require_bound_ordered_replay",
-      "complexity": 16
-    }
-  ]
+  "violations": []
 }

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -144,6 +144,11 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath("tests/domain/analysis/test_real_analysis.py"),
         # SAT assignment composition test invokes the SAT checker directly.
         PurePosixPath("tests/composition/runtime/test_sat_assignment_verification.py"),
+        # Polynomial-system composition test exercises checker authorization
+        # under an optimized Python interpreter.
+        PurePosixPath(
+            "tests/composition/runtime/test_polynomial_system_capabilities.py"
+        ),
         # Untrusted plugin entrypoints manage their own process lifecycle.
         PurePosixPath("tests/support/process_entrypoints.py"),
         # Architecture policy test uses subprocess in a synthetic import probe.
@@ -197,6 +202,10 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath(
             "benchmarks/validation/conjecture_probes_v1/"
             "test_yang_mills_gauge_invariance_certificate.py"
+        ),
+        PurePosixPath(
+            "benchmarks/validation/conjecture_probes_v1/"
+            "test_zarankiewicz_projective_plane_certificate.py"
         ),
         # Repository-command integration tests deliberately invoke CLI entrypoints.
         PurePosixPath("benchmarks/validation/test_benchmark_plan_validation.py"),


### PR DESCRIPTION
## Summary

Tightens the cleanup and verification boundaries identified in the repository hotspot audit.

- preserve every runtime, MCP tenant, portfolio, Lean-session, and SQLite-close failure while continuing sibling teardown
- reject missing polynomial checkers at the capability boundary and keep bounded inline checker outcomes unverified
- move common worker launch and settlement mechanics into the lifecycle owner
- split trajectory replay validation into named invariants and remove the final C901 baseline exception

## Why

Several nested resource owners previously stopped on `KeyboardInterrupt` or discarded a secondary close failure. That could leave sibling resources running or hide useful shutdown diagnostics. Polynomial capability construction and inline verification also had paths where checker availability or bounded coverage did not produce the clearest fail-closed result.

## Validation

- `make test-unit` — 869 passed
- `make test-process` — 235 passed
- `make test-composition` — 481 passed
- `make lint typecheck` — passed; C901 baseline now has 0 violations
- `make check-static` — passed
- `make security-audit` — no known vulnerabilities
- `make duplicate-code` — 0 clones

## Suggested review order

1. Runtime/MCP/SQLite teardown behavior and regressions
2. Polynomial checker and inline-verification safeguards
3. Shared lifecycle extraction
4. Trajectory replay validation refactor