### PR TITLE
feat(math): expose P-recursive evaluation under sequence domains

### DIFF
--- a/src/jacobian/domains/combinatorics/recurrence.py
+++ b/src/jacobian/domains/combinatorics/recurrence.py
@@ -137,6 +137,8 @@ RECURRENCE_CAPABILITIES = (
         evaluate_polynomial_coefficient_recurrence,
         "combinatorics",
         "recurrence",
+        "sequence",
+        "polynomial",
         "p-recursive",
         "polynomial-coefficients",
         "exact-rational",

--- a/tests/domain/combinatorics/test_recurrence_series_capabilities.py
+++ b/tests/domain/combinatorics/test_recurrence_series_capabilities.py
@@ -184,6 +184,27 @@ def test_polynomial_coefficient_recurrence_exposes_exact_terms_and_residuals(
     }
 
 
+@pytest.mark.parametrize("domain", ("sequence", "polynomial"))
+def test_polynomial_coefficient_recurrence_is_discoverable_by_intuitive_domain(
+    combinatorics_services,
+    domain: str,
+) -> None:
+    discovered = combinatorics_services.core.capabilities.discover(
+        CapabilityDiscoveryRequest(
+            query=(
+                "exactly compute terms of a sequence and residuals of a "
+                "variable-coefficient polynomial recurrence"
+            ),
+            domain=domain,
+            limit=5,
+        )
+    )
+
+    assert "combinatorics.recurrence.p_recursive.evaluate" in {
+        match.capability_id for match in discovered.matches
+    }
+
+
 def test_polynomial_coefficient_recurrence_rejects_singular_required_step(
     combinatorics_services,
 ) -> None:


### PR DESCRIPTION
## What changed

- Tag the exact polynomial-coefficient recurrence evaluator with the intuitive `sequence` and `polynomial` domain aliases.
- Add discovery regressions proving that variable-coefficient recurrence queries under either domain route to `combinatorics.recurrence.p_recursive.evaluate` first.

## Why

A frozen weak-model replay of Tong Niu's 2026 proof of Mathar's OEIS A176677 recurrence searched Jacobian twice using natural domain filters:

1. `domain="polynomial"` with a variable-coefficient recurrence query;
2. `domain="sequence"` with an exact finite recurrence-residual query.

Both filters were recognized, but both excluded the newly merged P-recursive evaluator because its descriptor only advertised the `combinatorics` domain. The model therefore fell back to hand arithmetic even though the exact operation was installed. This is a routing/discoverability defect, not a computation defect.

The capability remains owned by the combinatorics bundle; these tags only expose two mathematically accurate entry vocabularies already used by nearby installed operations and agents.

## Validation

- `uv run --locked pytest -q tests/composition/runtime/test_recurrence_series_capabilities.py` — 19 passed
- `make test-mcp` — 47 passed

## Scope

No recurrence arithmetic, schemas, assurance, checker behavior, or capability identifiers change.