### PR TITLE
docs(agents): improve Jacobian adoption in Harbor evaluations

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -59,12 +59,12 @@ Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
 Model-authored calculations or programs are not independent evidence. Use
-installed `VERIFY` when requested. A writable path or schema alone is not
+installed `VERIFY` when requested; a writable path or schema alone is not
 authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
 exact record bytes, and that required task authorization and bindings are preserved;
 the visible contract must authorize the checker identity, digest, or Jacobian
 record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
-`COMPUTED`), even if Jacobian returned `VERIFIED`. Never reconstruct or
+`COMPUTED`), even if Jacobian returned `VERIFIED`; never reconstruct or
 paraphrase such a record from tool fields or transfer verification between
 claims or artifacts.
 For locally constructed inline input, check payload fields against the intended

--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -31,6 +31,8 @@ Call `math.run` directly for these stable contracts, preserving JSON types:
 - `polynomial.compute.gcd` in `EXPLORE` mode: payload keys are `left` and
   `right`; each value has shape
   `{"polynomial_schema_version":"1","domain":"QQ","variables":["x"],"polynomial":{"terms":[{"coefficient":{"num":"1","den":"1"},"exponents":[2]}]}}`.
+- For expression normalization, inspect the known
+  `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` in `VERIFY` mode for an independent check:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
 
@@ -56,15 +58,15 @@ artifact refs, including verification record URIs.
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
-When independent checking is requested, model-authored calculations or programs
-are not independent evidence. Use installed `VERIFY` when available. An artifact
-URI or checker summary is not a task-local verification-record file: never
-reconstruct or paraphrase such a record from returned fields. Claim `VERIFIED`
-only when the result has assurance level `VERIFIED`, exact record bytes, and
-required task authorization and bindings are preserved; otherwise use lower
-task-permitted assurance. Verification is bound to the exact checked claim: do
-not transfer `VERIFIED` from an input, premise, factorization, or related
-artifact to a model-derived conclusion, which needs its own checker-bound record.
+Model-authored calculations or programs are not independent evidence. Use
+installed `VERIFY` when requested. A writable path or schema alone is not
+authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
+exact record bytes, and that required task authorization and bindings are preserved;
+the visible contract must authorize the checker identity, digest, or Jacobian
+record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
+`COMPUTED`), even if Jacobian returned `VERIFIED`. Never reconstruct or
+paraphrase such a record from tool fields or transfer verification between
+claims or artifacts.
 For locally constructed inline input, check payload fields against the intended
 object. When output echoes scope or a bound digest/URI, compare it with the
 submitted input; do not use mismatched output. This catches routing and

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation-proxy.json
@@ -37,6 +37,9 @@
   "agents": [
     {
       "name": "codex",
+      "skills": [
+        ".agents/skills/jacobian-math"
+      ],
       "kwargs": {
         "web_search": "disabled"
       }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/jobs/jacobian-observation.json
@@ -35,6 +35,9 @@
   "agents": [
     {
       "name": "codex",
+      "skills": [
+        ".agents/skills/jacobian-math"
+      ],
       "kwargs": {
         "web_search": "disabled"
       }

--- a/benchmarks/schemas/harbor-job.schema.json
+++ b/benchmarks/schemas/harbor-job.schema.json
@@ -79,6 +79,11 @@
         "properties": {
           "name": {"type": "string", "minLength": 1},
           "model_name": {"type": "string", "minLength": 1},
+          "skills": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
           "kwargs": {
             "type": "object",
             "additionalProperties": false,

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -213,6 +213,23 @@ def _validate_task(suite: Suite, task_dir: Path) -> list[str]:
     return failures
 
 
+def _remove_jacobian_skill(agents: Any) -> None:
+    if not isinstance(agents, list):
+        return
+    for agent in agents:
+        if not isinstance(agent, dict) or not isinstance(agent.get("skills"), list):
+            continue
+        remaining = [
+            skill
+            for skill in agent["skills"]
+            if skill != ".agents/skills/jacobian-math"
+        ]
+        if remaining:
+            agent["skills"] = remaining
+        else:
+            agent.pop("skills", None)
+
+
 def _observation_pair_failures() -> list[str]:
     treatment_path = (
         BENCHMARKS
@@ -246,12 +263,14 @@ def _observation_pair_failures() -> list[str]:
                     for item in compose
                     if "jacobian-observation.compose.yaml" not in item
                 ]
+        _remove_jacobian_skill(copy.get("agents"))
         return copy
 
     if normalized(treatment) != normalized(control):
         return [
             "agent workflow control/treatment jobs differ outside the allowed "
-            "jobs_dir, Jacobian sidecar composition, and sidecar telemetry artifact"
+            "jobs_dir, Jacobian skill, sidecar composition, and sidecar telemetry "
+            "artifact"
         ]
     return []
 

--- a/benchmarks/tooling/codex_tool_context.py
+++ b/benchmarks/tooling/codex_tool_context.py
@@ -64,14 +64,15 @@ def _visible_results(step: dict[str, Any]) -> dict[str, int]:
     return visible_by_call
 
 
-def _analyze_step(step: object) -> tuple[int, int, int, int, int, int]:
+def _analyze_step(step: object) -> tuple[int, int, int, int, int, int, int]:
     if not isinstance(step, dict):
-        return (0, 0, 0, 0, 0, 0)
+        return (0, 0, 0, 0, 0, 0, 0)
     visible_by_call = _visible_results(step)
     tool_calls = step.get("tool_calls", [])
     if not isinstance(tool_calls, list):
-        return (0, 0, 0, 0, 0, 0)
+        return (0, 0, 0, 0, 0, 0, 0)
     scan_count = scan_bytes = unbound_scan_count = tool_output_bytes = 0
+    jacobian_output_bytes = 0
     direct_find_references = direct_run_references = 0
     for call in tool_calls:
         if not isinstance(call, dict):
@@ -83,8 +84,12 @@ def _analyze_step(step: object) -> tuple[int, int, int, int, int, int]:
         source = arguments.get("input") if isinstance(arguments, dict) else None
         if call.get("function_name") != "exec" or not isinstance(source, str):
             continue
-        direct_find_references += source.count(_JACOBIAN_FIND)
-        direct_run_references += source.count(_JACOBIAN_RUN)
+        find_references = source.count(_JACOBIAN_FIND)
+        run_references = source.count(_JACOBIAN_RUN)
+        direct_find_references += find_references
+        direct_run_references += run_references
+        if find_references or run_references:
+            jacobian_output_bytes += visible
         if "ALL_TOOLS" in source:
             scan_count += 1
             scan_bytes += visible
@@ -95,6 +100,7 @@ def _analyze_step(step: object) -> tuple[int, int, int, int, int, int]:
         scan_bytes,
         unbound_scan_count,
         tool_output_bytes,
+        jacobian_output_bytes,
         direct_find_references,
         direct_run_references,
     )
@@ -108,6 +114,7 @@ def analyze_trajectory(path: Path) -> dict[str, Any]:
     scan_bytes = 0
     unbound_scan_count = 0
     tool_output_bytes = 0
+    jacobian_output_bytes = 0
     direct_find_references = 0
     direct_run_references = 0
 
@@ -117,8 +124,9 @@ def analyze_trajectory(path: Path) -> dict[str, Any]:
         scan_bytes += step_counts[1]
         unbound_scan_count += step_counts[2]
         tool_output_bytes += step_counts[3]
-        direct_find_references += step_counts[4]
-        direct_run_references += step_counts[5]
+        jacobian_output_bytes += step_counts[4]
+        direct_find_references += step_counts[5]
+        direct_run_references += step_counts[6]
 
     metrics = trajectory.get("final_metrics")
     metrics = metrics if isinstance(metrics, dict) else {}
@@ -137,6 +145,7 @@ def analyze_trajectory(path: Path) -> dict[str, Any]:
         "all_tools_model_visible_bytes": scan_bytes,
         "all_tools_unbound_observation_count": unbound_scan_count,
         "tool_model_visible_bytes": tool_output_bytes,
+        "direct_jacobian_find_run_model_visible_bytes": jacobian_output_bytes,
         "direct_jacobian_find_references": direct_find_references,
         "direct_jacobian_run_references": direct_run_references,
         "prompt_tokens": prompt_tokens,
@@ -165,6 +174,33 @@ def build_report(paths: list[Path], *, label: str) -> dict[str, Any]:
         "label": label,
         "trial_count": len(trials),
         "summary": {
+            "jacobian_invocation_trials": sum(
+                int(
+                    trial["direct_jacobian_find_references"] > 0
+                    or trial["direct_jacobian_run_references"] > 0
+                )
+                for trial in trials
+            ),
+            "jacobian_execution_trials": sum(
+                int(trial["direct_jacobian_run_references"] > 0) for trial in trials
+            ),
+            "jacobian_unused_trials": sum(
+                int(
+                    trial["direct_jacobian_find_references"] == 0
+                    and trial["direct_jacobian_run_references"] == 0
+                )
+                for trial in trials
+            ),
+            "direct_jacobian_find_references": sum(
+                int(trial["direct_jacobian_find_references"]) for trial in trials
+            ),
+            "direct_jacobian_run_references": sum(
+                int(trial["direct_jacobian_run_references"]) for trial in trials
+            ),
+            "direct_jacobian_find_run_model_visible_bytes": sum(
+                int(trial["direct_jacobian_find_run_model_visible_bytes"])
+                for trial in trials
+            ),
             "all_tools_scan_trials": sum(
                 int(trial["all_tools_scan_count"] > 0) for trial in trials
             ),

--- a/benchmarks/tooling/observation_results.py
+++ b/benchmarks/tooling/observation_results.py
@@ -192,6 +192,15 @@ def _comparison_job(job: dict[str, Any]) -> dict[str, Any]:
             ]
     for agent in normalized.get("agents", []):
         if isinstance(agent, dict):
+            skills = agent.get("skills")
+            if isinstance(skills, list):
+                remaining_skills = [
+                    skill for skill in skills if skill != ".agents/skills/jacobian-math"
+                ]
+                if remaining_skills:
+                    agent["skills"] = remaining_skills
+                else:
+                    agent.pop("skills", None)
             servers = agent.get("mcp_servers")
             if isinstance(servers, list):
                 remaining = [

--- a/benchmarks/validation/conftest.py
+++ b/benchmarks/validation/conftest.py
@@ -5,6 +5,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_task_verifier_imports():
+    """Prevent one task's top-level verifier_support import leaking to another."""
+
+    original_path = list(sys.path)
+    sys.modules.pop("verifier_support", None)
+    try:
+        yield
+    finally:
+        sys.modules.pop("verifier_support", None)
+        sys.path[:] = original_path

--- a/benchmarks/validation/test_observation_comparison.py
+++ b/benchmarks/validation/test_observation_comparison.py
@@ -199,6 +199,7 @@ def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> N
         "agents": [
             {
                 "name": "codex",
+                "skills": [".agents/skills/jacobian-math"],
                 "mcp_servers": [
                     {
                         "name": "jacobian",
@@ -216,6 +217,10 @@ def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> N
     assert _comparison_job(control) != _comparison_job(treatment)
     treatment["artifacts"].pop()
 
+    treatment["agents"][0]["skills"].append("unexpected-skill")
+    assert _comparison_job(control) != _comparison_job(treatment)
+    treatment["agents"][0]["skills"].pop()
+
     heldout_treatment = {
         "artifacts": ["/logs/agent/trajectory.json"],
         "environment": {
@@ -227,6 +232,7 @@ def test_comparison_normalization_allows_only_frozen_jacobian_differences() -> N
         "agents": [
             {
                 "name": "codex",
+                "skills": [".agents/skills/jacobian-math"],
                 "mcp_servers": [
                     {
                         "name": "jacobian",

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -150,7 +150,12 @@ make agent-eval DATASET=mathematical-benchmarks-v1 \
 ```
 
 Use `TASKS=graph-counterexample` for a small smoke run. The treatment run uses
-`benchmarks/config/jacobian.mcp.json`; task TOMLs remain agent-agnostic.
+`benchmarks/config/jacobian.mcp.json` and installs the repository's
+`.agents/skills/jacobian-math` skill. `agent-eval` passes both explicitly
+because its agent/model CLI overrides replace the agent block from the job
+JSON. Set `JACOBIAN_EVAL_SKILL` only for a deliberate development comparison;
+normalized evidence requires a matching job declaration. Task TOMLs remain
+agent-agnostic.
 
 ### Evaluate tool adoption and task design
 
@@ -217,8 +222,9 @@ task's structured submission contract. Otherwise a control answer can reuse
 `VERIFIED` as an ordinary English synonym and make the assurance comparison
 misleading.
 
-`JACOBIAN_ENABLED=1` selects the treatment job and passes
-Harbor's `--mcp-config` option. `JACOBIAN_EVAL_PROXY=1` selects matching
+`JACOBIAN_ENABLED=1` selects the treatment job and passes Harbor's
+`--mcp-config` and `--skill` options. `JACOBIAN_ENABLED=0` clears both
+interventions. `JACOBIAN_EVAL_PROXY=1` selects matching
 proxy-enabled control/treatment job configs and requires at least one proxy
 URL variable. The Makefile also passes Harbor's
 `web_search=disabled` agent kwarg explicitly, because the `-a codex` and
@@ -305,6 +311,11 @@ before invoking Make:
 ```sh
 export JACOBIAN_MODEL='your-model'
 ```
+
+When `OPENAI_API_KEY` is empty and `~/.codex/auth.json` exists, `agent-eval`
+sets `CODEX_FORCE_AUTH_JSON=1` for Harbor automatically. An explicitly set
+`CODEX_FORCE_AUTH_JSON` still wins. This avoids Harbor 0.20 selecting an empty
+API-key credential instead of an existing ChatGPT login.
 
 If the run stalls at `starting environment`, Docker may be building the task
 image or waiting on package installation. Check the Docker build output and

--- a/make/evaluations.mk
+++ b/make/evaluations.mk
@@ -35,7 +35,9 @@ else
 EVAL_CONFIG ?= benchmarks/config/mathematical-benchmarks-v1-control.json
 endif
 override MCP_CONFIG :=
+override JACOBIAN_EVAL_SKILL :=
 else
+JACOBIAN_EVAL_SKILL ?= .agents/skills/jacobian-math
 ifeq ($(JACOBIAN_EVAL_PROXY),1)
 EVAL_CONFIG ?= benchmarks/datasets/$(or $(DATASET),mathematical-benchmarks-v1)/jobs/jacobian-observation-proxy.json
 MCP_CONFIG ?= benchmarks/config/jacobian-loopback.mcp.json
@@ -62,9 +64,13 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 			$(UV_RUN) python -m benchmarks.tooling.harbor_proxy \
 			--output "$(JACOBIAN_EVAL_GOST_CONFIG)"; \
 	fi; \
+	if [ -z "$${OPENAI_API_KEY:-}" ] && [ -z "$${CODEX_FORCE_AUTH_JSON+x}" ] && [ -s "$${HOME}/.codex/auth.json" ]; then \
+		export CODEX_FORCE_AUTH_JSON=1; \
+	fi; \
 	if [ "$(JACOBIAN_ENABLED)" = "1" ]; then \
 		test -n "$${JACOBIAN_IMAGE:-}" || { echo "JACOBIAN_IMAGE must be exported" >&2; exit 2; }; \
 		test -n "$(RUNTIME_SNAPSHOT)" || { echo "RUNTIME_SNAPSHOT is required for a Jacobian-enabled run" >&2; exit 2; }; \
+		test -f "$(JACOBIAN_EVAL_SKILL)/SKILL.md" || { echo "JACOBIAN_EVAL_SKILL must contain SKILL.md: $(JACOBIAN_EVAL_SKILL)" >&2; exit 2; }; \
 		$(UV_RUN) python -m tools.manage_jacobian_image bind-runtime \
 			--image "$${JACOBIAN_IMAGE}" --runtime-snapshot "$(RUNTIME_SNAPSHOT)"; \
 	fi; \
@@ -80,6 +86,7 @@ agent-eval: ## Run a Harbor evaluation (JACOBIAN_ENABLED=0|1, JACOBIAN_EVAL_PROX
 		-m "$${JACOBIAN_MODEL}" \
 		--ak "web_search=$(CODEX_WEB_SEARCH)" \
 		$(if $(MCP_CONFIG),--mcp-config "$(MCP_CONFIG)",) \
+		$(if $(JACOBIAN_EVAL_SKILL),--skill "$(JACOBIAN_EVAL_SKILL)",) \
 		$(if $(TASKS),-p "benchmarks/datasets/$(or $(DATASET),mathematical-benchmarks-v1)" $(foreach task,$(TASKS),--include-task-name "$(task)"),) \
 		$(EVAL_ARGS)
 

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -59,12 +59,12 @@ Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
 Model-authored calculations or programs are not independent evidence. Use
-installed `VERIFY` when requested. A writable path or schema alone is not
+installed `VERIFY` when requested; a writable path or schema alone is not
 authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
 exact record bytes, and that required task authorization and bindings are preserved;
 the visible contract must authorize the checker identity, digest, or Jacobian
 record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
-`COMPUTED`), even if Jacobian returned `VERIFIED`. Never reconstruct or
+`COMPUTED`), even if Jacobian returned `VERIFIED`; never reconstruct or
 paraphrase such a record from tool fields or transfer verification between
 claims or artifacts.
 For locally constructed inline input, check payload fields against the intended

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -31,6 +31,8 @@ Call `math.run` directly for these stable contracts, preserving JSON types:
 - `polynomial.compute.gcd` in `EXPLORE` mode: payload keys are `left` and
   `right`; each value has shape
   `{"polynomial_schema_version":"1","domain":"QQ","variables":["x"],"polynomial":{"terms":[{"coefficient":{"num":"1","den":"1"},"exponents":[2]}]}}`.
+- For expression normalization, inspect the known
+  `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` in `VERIFY` mode for an independent check:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
 
@@ -56,15 +58,15 @@ artifact refs, including verification record URIs.
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
-When independent checking is requested, model-authored calculations or programs
-are not independent evidence. Use installed `VERIFY` when available. An artifact
-URI or checker summary is not a task-local verification-record file: never
-reconstruct or paraphrase such a record from returned fields. Claim `VERIFIED`
-only when the result has assurance level `VERIFIED`, exact record bytes, and
-required task authorization and bindings are preserved; otherwise use lower
-task-permitted assurance. Verification is bound to the exact checked claim: do
-not transfer `VERIFIED` from an input, premise, factorization, or related
-artifact to a model-derived conclusion, which needs its own checker-bound record.
+Model-authored calculations or programs are not independent evidence. Use
+installed `VERIFY` when requested. A writable path or schema alone is not
+authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
+exact record bytes, and that required task authorization and bindings are preserved;
+the visible contract must authorize the checker identity, digest, or Jacobian
+record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
+`COMPUTED`), even if Jacobian returned `VERIFIED`. Never reconstruct or
+paraphrase such a record from tool fields or transfer verification between
+claims or artifacts.
 For locally constructed inline input, check payload fields against the intended
 object. When output echoes scope or a bound digest/URI, compare it with the
 submitted input; do not use mismatched output. This catches routing and

--- a/tests/unit/tooling/test_codex_tool_context.py
+++ b/tests/unit/tooling/test_codex_tool_context.py
@@ -65,6 +65,7 @@ def test_analyze_trajectory_measures_all_tools_projection(tmp_path: Path) -> Non
     assert result["all_tools_model_visible_bytes"] == len(b"catalog output")
     assert result["all_tools_unbound_observation_count"] == 0
     assert result["tool_model_visible_bytes"] == len(b"catalog output")
+    assert result["direct_jacobian_find_run_model_visible_bytes"] == 0
     assert result["direct_jacobian_find_references"] == 0
     assert result["uncached_prompt_tokens"] == 40
 
@@ -89,6 +90,9 @@ def test_analyze_trajectory_counts_direct_nested_calls_without_scan(
     assert result["all_tools_model_visible_bytes"] == 0
     assert result["direct_jacobian_find_references"] == 1
     assert result["direct_jacobian_run_references"] == 1
+    assert result["direct_jacobian_find_run_model_visible_bytes"] == len(
+        json.dumps({"kind": "result"}, separators=(",", ":"), sort_keys=True).encode()
+    )
 
 
 def test_build_report_aggregates_trials_with_medians(tmp_path: Path) -> None:
@@ -104,6 +108,12 @@ def test_build_report_aggregates_trials_with_medians(tmp_path: Path) -> None:
     assert report["label"] == "paired-control"
     assert report["trial_count"] == 2
     assert report["summary"] == {
+        "jacobian_invocation_trials": 0,
+        "jacobian_execution_trials": 0,
+        "jacobian_unused_trials": 2,
+        "direct_jacobian_find_references": 0,
+        "direct_jacobian_run_references": 0,
+        "direct_jacobian_find_run_model_visible_bytes": 0,
         "all_tools_scan_trials": 1,
         "all_tools_scan_count": 1,
         "all_tools_model_visible_bytes": 3,

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -160,6 +160,7 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
         "matrix.determinant.compute",
         "matrix.rank.compute",
         "polynomial.compute.gcd",
+        "polynomial.expression.normalize",
         "matrix.determinant.verify",
     ):
         assert f"`{capability_id}`" in skill
@@ -199,6 +200,9 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     assert "`matrix.determinant.verify` in `VERIFY` mode" in skill_flat
     assert "never reconstruct or paraphrase such a record" in skill_flat
     assert "required task authorization and bindings are preserved" in skill_flat
+    assert "a writable path or schema alone is not authorization" in skill_flat
+    assert "claim the highest lower permitted assurance" in skill_flat
+    assert "even if Jacobian returned `VERIFIED`" in skill_flat
     for guidance in (
         "Keep decomposition and routing decisions agent-owned",
         "composing already-known supporting operations remains allowed",

--- a/tests/unit/tooling/test_harbor_egress.py
+++ b/tests/unit/tooling/test_harbor_egress.py
@@ -50,7 +50,13 @@ def _read_json(path: Path) -> dict[str, object]:
 def test_observation_job_keeps_the_minimal_jacobian_treatment() -> None:
     job = _read_json(JOB)
 
-    assert job["agents"] == [{"name": "codex", "kwargs": {"web_search": "disabled"}}]
+    assert job["agents"] == [
+        {
+            "name": "codex",
+            "skills": [".agents/skills/jacobian-math"],
+            "kwargs": {"web_search": "disabled"},
+        }
+    ]
     assert job["environment"]["extra_docker_compose"] == [
         "benchmarks/datasets/mathematical-benchmarks-v1/jacobian-observation.compose.yaml",
     ]
@@ -76,12 +82,15 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
     assert "JACOBIAN_EVAL_CODEX_BINARY" in evaluations
     assert "benchmarks.tooling.codex_binary" in evaluations
     assert "JACOBIAN_EVAL_UPSTREAM_PROXY" in evaluations
+    assert "export CODEX_FORCE_AUTH_JSON=1" in evaluations
     assert "benchmarks.tooling.harbor_proxy" in evaluations
     assert 'if [ "$(JACOBIAN_EVAL_PROXY)" = "1" ]; then' in evaluations
     assert 'JACOBIAN_EVAL_NO_PROXY="$(JACOBIAN_EVAL_NO_PROXY)"' in evaluations
     assert "mathematical-benchmarks-v1-control-proxy.json" in evaluations
     assert "jacobian-observation-proxy.json" in evaluations
     assert "jacobian-loopback.mcp.json" in evaluations
+    assert "JACOBIAN_EVAL_SKILL ?= .agents/skills/jacobian-math" in evaluations
+    assert '--skill "$(JACOBIAN_EVAL_SKILL)"' in evaluations
     validate_recipe = evaluations.split("agent-eval-validate:", maxsplit=1)[1].split(
         "\n\n", maxsplit=1
     )[0]

--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -36,7 +36,13 @@ def test_observation_job_uses_harbor_dataset_selection() -> None:
             "task_names": ["graph-counterexample"],
         }
     ]
-    assert job["agents"] == [{"name": "codex", "kwargs": {"web_search": "disabled"}}]
+    assert job["agents"] == [
+        {
+            "name": "codex",
+            "skills": [".agents/skills/jacobian-math"],
+            "kwargs": {"web_search": "disabled"},
+        }
+    ]
 
 
 @pytest.mark.timeout(30)


### PR DESCRIPTION
## Summary

- make the repository Jacobian skill the default frozen intervention for Harbor treatment runs while keeping control runs free of both MCP and skill interventions
- record trial-level Jacobian adoption, execution, direct tool references, and model-visible tool bytes so visibility and token cost can be compared without relying on `ALL_TOOLS`
- isolate task-local `verifier_support` imports during host validation and make Codex auth selection work with an existing `auth.json`
- tighten direct contract and task-level assurance guidance while keeping the packaged skill byte-identical and below 4 KiB

## Why

MCP metadata alone did not reliably cause Codex to select Jacobian in held-out Harbor tasks. The evaluation path also lacked compact adoption/cost counters, and full host validation could reuse a different task's top-level `verifier_support` module. These changes make the skill intervention explicit and reproducible, preserve a clean control, and fail closed across task-local verifier imports.

## Evaluation

- MCP-only baseline: 0/3 trials adopted Jacobian
- skill treatment baseline: 3/3 trials adopted Jacobian, with no `ALL_TOOLS` enumeration
- default treatment on `matrix-square-zero-counterexample`: reward 1.0, one `math.find`, one `math.run`, zero `ALL_TOOLS`, and 1,597 direct model-visible tool bytes
- exact polynomial routing reduced discovery/execution calls from 4/3 to 3/2 and prompt tokens from 908,588 to 380,782; its task-local checker authorization remains a separate benchmark-contract limitation

## Validation

- `make test-plan BASE=origin/main`
- `make harbor-plan BASE=origin/main`
- `make check` (852 unit tests)
- `make harbor-check` (900/899/899/899 host tests)
- `make npm-test` (59 tests plus package dry-run)
- `make docs-linkcheck`

The planner defers benchmark Oracle execution to the merge queue.
