### PR TITLE
fix(benchmarks): harden Jacobian evaluation evidence

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jacobian-math
-description: Use Jacobian for exact mathematics, matrix determinants, symbolic computation, structural analysis, counterexamples, bounded search, and independent verification. Trigger on relevant math tasks even when the user does not name Jacobian.
+description: Use Jacobian for exact math, matrix determinants, symbolic work, counterexamples, search, and independent verification, even when unnamed.
 ---
 
 # Jacobian Math
@@ -10,19 +10,20 @@ description: Use Jacobian for exact mathematics, matrix determinants, symbolic c
 In Code Mode, call
 `tools.mcp__jacobian__math_find(...)` and
 `tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
-print `ALL_TOOLS`. Return the typed projection when available:
+print `ALL_TOOLS`. Return the typed projection:
 
 ```js
 const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
-Use Jacobian for each requested exact mathematical outcome, even when small.
+Use Jacobian for each requested exact outcome, even when small.
 Keep decomposition and routing decisions agent-owned; composing already-known
 supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-Call `math.run` directly for these stable contracts, preserving JSON types:
+No discovery for stable producers: `{"capability_id":"<id>","mode":"EXPLORE","payload":<JSON>}`
+(not `COMPUTE`/`input`). Payloads:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or `integer.compute.extended_gcd`:
   `{"left":"84","right":"30"}`.
@@ -35,38 +36,38 @@ Call `math.run` directly for these stable contracts, preserving JSON types:
   `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` in `VERIFY` mode for an independent check:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
+- `combinatorics.cyclic_difference_set.extension.decide`:
+  `{"base_elements":["1","2","4","8","13"],"target_order":7}`.
+  `combinatorics.cyclic_difference_set.extension.verify` uses
+  `{"input":<same payload>,"candidate":<producer output.result>}` in `VERIFY` mode.
 
-For other outcomes, use `math.find` with a specific plain-language outcome;
-no capability ID is required.
-Use low `limit` values. For a selected operation's schema, call
+For other outcomes, query `math.find` by plain-language outcome; no ID is
+required. Use low `limit` only for query search, never with `capability_id`. For
+a selected operation's schema, call
 `math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never send
 `mode: "CONTRACT"` to `math.run` or put `CONTRACT` in a query. A card's
 `invocation_example`, or required top-level fields, may be enough.
 
-Do not add a discovery domain filter unless its exact installed spelling is
-known. Follow exposed recovery paths such as removing unknown filters or
-reformulating the query before
-treating absence as final. After invalid input, correct the reported constraint
-and retry within the task resource bounds. If
-one provider is unavailable, continue with other installed routes that can
-produce the outcome. Treat timeouts, cancellations, errors, incomplete searches,
-and missing witnesses as non-conclusions. Accept only a completed
-result whose scope covers the input, and carry forward the smallest decisive
-value, witness, status, assurance, completeness, and open obligations; preserve
-artifact refs, including verification record URIs.
+Add no domain filter unless its installed spelling is known. Follow exposed
+recovery paths by removing unknown filters or reformulating the query. After
+invalid input, correct the constraint and retry within the task resource bounds.
+If one provider is unavailable, continue with other installed routes. Treat
+timeouts, cancellations, errors, incomplete searches, and missing witnesses as
+non-conclusions. Accept only completed results covering the input; carry forward
+the smallest decisive value, witness, status, assurance, completeness, and open
+obligations plus artifact and verification-record URIs.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
-Model-authored calculations or programs are not independent evidence. Use
-installed `VERIFY` when requested; a writable path or schema alone is not
-authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
-exact record bytes, and that required task authorization and bindings are preserved;
-the visible contract must authorize the checker identity, digest, or Jacobian
-record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
-`COMPUTED`), even if Jacobian returned `VERIFIED`; never reconstruct or
-paraphrase such a record from tool fields or transfer verification between
-claims or artifacts.
+Model-authored work is not independent evidence. Use installed `VERIFY` when
+requested; a writable path or schema alone is not authorization. Task-level
+`VERIFIED` requires exact record bytes, result assurance `VERIFIED`, required
+task authorization and bindings are preserved, and a contract-authorized
+checker identity, digest, or Jacobian record type. Otherwise claim the highest
+lower permitted assurance (`CHECKED` or `COMPUTED`), even if Jacobian returned
+`VERIFIED`; never
+reconstruct or paraphrase such a record or transfer it between claims.
 For locally constructed inline input, check payload fields against the intended
 object. When output echoes scope or a bound digest/URI, compare it with the
 submitted input; do not use mismatched output. This catches routing and

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -310,7 +310,7 @@ jobs:
           name: benchmark-oracle-${{ matrix.dataset }}-${{ matrix.shard }}
           path: |
             benchmarks/results/${{ matrix.dataset }}-oracle
-            benchmarks/results/${{ matrix.dataset }}-oracle/jacobian-augmented-task-digests.json
+            benchmarks/results/${{ matrix.dataset }}-oracle/jacobian-augmented-task-digests.*.json
             benchmarks/results/${{ matrix.dataset }}-oracle/**/oracle-evidence.json
           if-no-files-found: ignore
           retention-days: ${{ github.event_name == 'pull_request' && 14 || 90 }}

--- a/benchmarks/config/codex-visibility-v2.json
+++ b/benchmarks/config/codex-visibility-v2.json
@@ -57,6 +57,15 @@
       "require_verified": false
     },
     {
+      "case_id": "latent-fixed-order-difference-set-extension",
+      "cue_level": "LATENT",
+      "prompt": "For the integer set {1,2,4,8,13}, decide exactly whether its reduced residues are contained in a cyclic perfect difference set of order 7, and report the exact candidate-space size covered by the decision.",
+      "expected_capability_ids": [
+        "combinatorics.cyclic_difference_set.extension.decide"
+      ],
+      "require_verified": false
+    },
+    {
       "case_id": "latent-independent-verification",
       "cue_level": "LATENT",
       "prompt": "Compute and independently verify the exact determinant of [[31, -7, 12, 5], [4, 19, -3, 8], [11, 6, 23, -9], [-5, 14, 2, 17]]. State the determinant and the assurance level supported by the evidence.",

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/environment/submission_schema.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/environment/submission_schema.json
@@ -47,14 +47,19 @@
           "minLength": 1
         },
         "key_facts": {
-          "additionalProperties": {
-            "type": "string",
-            "minLength": 1
+          "additionalProperties": false,
+          "properties": {
+            "identity_holds": {
+              "const": "true"
+            },
+            "index_order": {
+              "const": "a<a+1<2a<2a+2<c<c+1"
+            }
           },
-          "minProperties": 1,
-          "propertyNames": {
-            "pattern": "^[a-z][a-z0-9_]*$"
-          },
+          "required": [
+            "identity_holds",
+            "index_order"
+          ],
           "type": "object"
         }
       }

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/instruction.md
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/instruction.md
@@ -8,9 +8,9 @@ report the capability boundary honestly. The portfolio does not currently own a 
 
 Write `submission.json` to the exact agent-visible `submission_schema.json`, record your
 reasoning in `evidence/answer.txt`, and include that file's SHA-256 digest in the evidence
-list. In `result.key_facts`, use a nonempty object with lower-snake-case fact
-names and nonempty string values; do not rely on prose or numeric/boolean
-coercion. You may claim `UNVERIFIED` or `COMPUTED`; only `COMPUTED`
+list. In `result.key_facts`, reproduce the exact public facts declared by
+`submission_schema.json`; do not rename the fields or coerce their string
+values to booleans. You may claim `UNVERIFIED` or `COMPUTED`; only `COMPUTED`
 receives full aggregate credit. Do not claim `VERIFIED`. Treat timeout,
 error, or incomplete search as a non-conclusion, not as evidence for or
 against the claim.

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/task.toml
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.4"
 artifacts = ["/app/submission.json", "/app/evidence"]
 [task]
 name = "jacobian/jcb-postdoc-013"
-version = "1.0.0"
+version = "1.1.0"
 description = "Research diagnostic: Erdős Problem 397: a parametric family of central-binomial collisions"
 keywords = ["research", "diagnostic", "mathematical-sciences", "enumerative combinatorics", "number theory", "symbolic identities"]
 [metadata]

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/public_contract.json
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-013/tests/public_contract.json
@@ -65,14 +65,19 @@
             ]
           },
           "key_facts": {
-            "additionalProperties": {
-              "minLength": 1,
-              "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "identity_holds": {
+                "const": "true"
+              },
+              "index_order": {
+                "const": "a<a+1<2a<2a+2<c<c+1"
+              }
             },
-            "minProperties": 1,
-            "propertyNames": {
-              "pattern": "^[a-z][a-z0-9_]*$"
-            },
+            "required": [
+              "identity_holds",
+              "index_order"
+            ],
             "type": "object"
           }
         },

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/instruction.md
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/instruction.md
@@ -15,9 +15,10 @@ checkable finite core:
 - the exact number of candidate supersets examined for each fixed order.
 
 Write that evidence to `evidence/finite-core.json` and bind its SHA-256 digest
-in `submission.json`. Follow the exact schemas in `input.json` and
-`submission_schema.json`. The fixed-order checks must cover every candidate,
-not a sample. The public universal result may be reported, but this task does
+in `submission.json`. Follow `submission_schema.json` for the submission and
+the separate agent-visible `/app/evidence_schema.json` for the complete
+`evidence/finite-core.json` body. The fixed-order checks must cover every
+candidate, not a sample. The public universal result may be reported, but this task does
 not supply its projective-geometric or formal obstruction certificate: set
 `universal_obstruction_replayed` to `false` and do not claim that the three
 finite searches prove the universal statement.

--- a/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/task.toml
+++ b/benchmarks/datasets/research-diagnostics-v1/jcb-postdoc-015/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.4"
 artifacts = ["/app/submission.json", "/app/evidence"]
 [task]
 name = "jacobian/jcb-postdoc-015"
-version = "2.0.0"
+version = "2.1.0"
 description = "Research diagnostic: Erdős Problem 707 finite Sidon and fixed-order extension evidence"
 keywords = ["research", "diagnostic", "mathematical-sciences", "additive combinatorics", "finite geometry", "modular arithmetic"]
 [metadata]

--- a/benchmarks/tooling/validate_harbor_results.py
+++ b/benchmarks/tooling/validate_harbor_results.py
@@ -9,6 +9,8 @@ import importlib.metadata
 import json
 import math
 import re
+import secrets
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -16,7 +18,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
-_AUGMENTED_DIGEST_MANIFEST = "jacobian-augmented-task-digests.json"
+_AUGMENTED_DIGEST_MANIFEST = "jacobian-augmented-task-digests"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
@@ -45,13 +47,66 @@ def _prefixed_digest(value: str) -> str:
     return value if value.startswith("sha256:") else f"sha256:{value}"
 
 
-def _augmented_job_name(*, dataset: str, digests: dict[str, str]) -> str:
+def _augmented_job_identity(
+    *,
+    dataset: str,
+    digests: dict[str, str],
+    job_config_digest: str,
+    harbor_version: str,
+    execution_args: tuple[str, ...],
+    docker_build_mode: str,
+    docker_server_version: str,
+    docker_compose_version: str,
+) -> str:
     identity = json.dumps(
-        {"dataset": dataset, "tasks": sorted(digests.items())},
+        {
+            "dataset": dataset,
+            "docker_build_mode": docker_build_mode,
+            "docker_compose_version": docker_compose_version,
+            "docker_server_version": docker_server_version,
+            "execution_args": execution_args,
+            "harbor_version": harbor_version,
+            "job_config_digest": job_config_digest,
+            "tasks": sorted(digests.items()),
+        },
         separators=(",", ":"),
         sort_keys=True,
     ).encode()
-    return f"jacobian-oracle-{hashlib.sha256(identity).hexdigest()}"
+    return f"sha256:{hashlib.sha256(identity).hexdigest()}"
+
+
+def _augmented_job_name(*, job_identity: str, attempt_id: str) -> str:
+    digest = job_identity.removeprefix("sha256:")
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise HarborSuiteError("invalid augmented Oracle job identity")
+    if re.fullmatch(r"[0-9a-f]{16}", attempt_id) is None:
+        raise HarborSuiteError("invalid augmented Oracle attempt identity")
+    return f"jacobian-oracle-{digest[:32]}-{attempt_id}"
+
+
+def _augmented_digest_manifest_path(jobs_dir: Path, job_name: str) -> Path:
+    return jobs_dir / f"{_AUGMENTED_DIGEST_MANIFEST}.{job_name}.json"
+
+
+def _job_config_digest(path: Path) -> str:
+    try:
+        return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+    except OSError as exc:
+        raise HarborSuiteError(
+            f"unable to read Harbor job config {path}: {exc}"
+        ) from exc
+
+
+def _execution_args(value: str) -> tuple[str, ...]:
+    try:
+        normalized = tuple(shlex.split(value))
+    except ValueError as exc:
+        raise HarborSuiteError(
+            f"unable to parse Harbor execution arguments: {exc}"
+        ) from exc
+    if any(arg == "--job-name" or arg.startswith("--job-name=") for arg in normalized):
+        raise HarborSuiteError("EVAL_ARGS must not override the bound Oracle job name")
+    return normalized
 
 
 def _is_nonnegative_integer(value: Any) -> bool:
@@ -251,7 +306,15 @@ def _load_trial_results(result_path: Path) -> tuple[list[Any], list[Path], list[
 
 
 def _prepare_augmented_digest_manifest(
-    *, dataset: str, tasks: tuple[str, ...] | None, jobs_dir: Path
+    *,
+    dataset: str,
+    tasks: tuple[str, ...] | None,
+    jobs_dir: Path,
+    job_config: Path,
+    execution_args: str,
+    docker_build_mode: str,
+    docker_server_version: str,
+    docker_compose_version: str,
 ) -> Path:
     """Record the augmented task identity before Harbor starts an Oracle run."""
 
@@ -262,19 +325,42 @@ def _prepare_augmented_digest_manifest(
     if unknown:
         raise HarborSuiteError(f"unknown task(s) for {dataset}: {', '.join(unknown)}")
     jobs_dir.mkdir(parents=True, exist_ok=True)
-    manifest = jobs_dir / _AUGMENTED_DIGEST_MANIFEST
     augmented_digests = {
         task_id: _prefixed_digest(task_digest(known[task_id].path))
         for task_id in sorted(requested)
     }
+    prepared_at_ns = time.time_ns()
+    attempt_id = secrets.token_hex(8)
+    harbor_version = importlib.metadata.version("harbor")
+    job_config_digest = _job_config_digest(job_config)
+    normalized_execution_args = _execution_args(execution_args)
+    job_identity = _augmented_job_identity(
+        dataset=suite.id,
+        digests=augmented_digests,
+        job_config_digest=job_config_digest,
+        harbor_version=harbor_version,
+        execution_args=normalized_execution_args,
+        docker_build_mode=docker_build_mode,
+        docker_server_version=docker_server_version,
+        docker_compose_version=docker_compose_version,
+    )
+    job_name = _augmented_job_name(job_identity=job_identity, attempt_id=attempt_id)
+    manifest = _augmented_digest_manifest_path(jobs_dir, job_name)
     manifest.write_text(
         json.dumps(
             {
+                "schema_version": "2",
                 "dataset": suite.id,
-                "job_name": _augmented_job_name(
-                    dataset=suite.id, digests=augmented_digests
-                ),
-                "prepared_at_ns": time.time_ns(),
+                "job_identity": job_identity,
+                "job_name": job_name,
+                "attempt_id": attempt_id,
+                "prepared_at_ns": prepared_at_ns,
+                "harbor_version": harbor_version,
+                "job_config_digest": job_config_digest,
+                "execution_args": normalized_execution_args,
+                "docker_build_mode": docker_build_mode,
+                "docker_server_version": docker_server_version,
+                "docker_compose_version": docker_compose_version,
                 "tasks": [
                     {
                         "task": task_id,
@@ -309,23 +395,70 @@ def _validate_augmented_manifest_metadata(
     manifest: dict[str, Any],
     result_path: Path,
     dataset: str,
-    expected_job_name: str,
+    expected_job_identity: str,
 ) -> list[str]:
+    if manifest.get("schema_version") != "2":
+        return ["augmented task digest manifest has the wrong schema version"]
     if manifest.get("dataset") != dataset:
         return ["augmented task digest manifest has the wrong dataset"]
-    if manifest.get("job_name") != expected_job_name:
+    if manifest.get("job_identity") != expected_job_identity:
         return ["augmented task digest manifest has the wrong job identity"]
+    attempt_id = manifest.get("attempt_id")
+    if not isinstance(attempt_id, str):
+        return ["augmented task digest manifest has no attempt identity"]
+    try:
+        expected_job_name = _augmented_job_name(
+            job_identity=expected_job_identity, attempt_id=attempt_id
+        )
+    except HarborSuiteError:
+        return ["augmented task digest manifest has an invalid attempt identity"]
+    if manifest.get("job_name") != expected_job_name:
+        return ["augmented task digest manifest has the wrong attempt name"]
     if result_path.parent.name != expected_job_name:
-        return ["Harbor result is not bound to its augmented task identity"]
+        return ["Harbor result is not bound to its augmented task attempt"]
+    return []
+
+
+def _validate_execution_identity_fields(
+    *,
+    manifest: dict[str, Any],
+    expected_harbor_version: str,
+    expected_job_config_digest: str,
+    expected_execution_args: tuple[str, ...],
+    expected_docker_build_mode: str,
+    expected_docker_server_version: str,
+    expected_docker_compose_version: str,
+) -> list[str]:
+    expected = {
+        "harbor_version": expected_harbor_version,
+        "job_config_digest": expected_job_config_digest,
+        "execution_args": list(expected_execution_args),
+        "docker_build_mode": expected_docker_build_mode,
+        "docker_server_version": expected_docker_server_version,
+        "docker_compose_version": expected_docker_compose_version,
+    }
+    return [
+        f"augmented task digest manifest has the wrong {key}"
+        for key, value in expected.items()
+        if manifest.get(key) != value
+    ]
+
+
+def _validate_attempt_freshness(
+    *, manifest: dict[str, Any], result_path: Path, trial_paths: list[Path]
+) -> list[str]:
     prepared_at_ns = manifest.get("prepared_at_ns")
     if not isinstance(prepared_at_ns, int) or isinstance(prepared_at_ns, bool):
         return ["augmented task digest manifest has no preparation timestamp"]
     try:
-        result_mtime_ns = result_path.stat().st_mtime_ns
+        result_paths = [result_path, *trial_paths]
+        stale = [
+            path for path in result_paths if path.stat().st_mtime_ns < prepared_at_ns
+        ]
     except OSError as exc:
         return [f"unable to stat Harbor result: {exc}"]
-    if result_mtime_ns < prepared_at_ns:
-        return ["Harbor result predates its augmented task digest manifest"]
+    if stale:
+        return ["Harbor result predates its augmented task attempt"]
     return []
 
 
@@ -357,6 +490,14 @@ def _validate_augmented_digest_manifest(
     result_path: Path,
     dataset: str,
     expected_digests: dict[str, str],
+    expected_job_identity: str,
+    expected_harbor_version: str,
+    expected_job_config_digest: str,
+    expected_execution_args: tuple[str, ...],
+    expected_docker_build_mode: str,
+    expected_docker_server_version: str,
+    expected_docker_compose_version: str,
+    trial_paths: list[Path] | None = None,
 ) -> list[str]:
     """Require the result to be newer than and bound to its pre-run identity."""
 
@@ -367,13 +508,28 @@ def _validate_augmented_digest_manifest(
         manifest=manifest,
         result_path=result_path,
         dataset=dataset,
-        expected_job_name=_augmented_job_name(
-            dataset=dataset, digests=expected_digests
-        ),
+        expected_job_identity=expected_job_identity,
     )
     if failures:
         return failures
-    return _validate_augmented_task_entries(manifest.get("tasks"), expected_digests)
+    failures = _validate_execution_identity_fields(
+        manifest=manifest,
+        expected_harbor_version=expected_harbor_version,
+        expected_job_config_digest=expected_job_config_digest,
+        expected_execution_args=expected_execution_args,
+        expected_docker_build_mode=expected_docker_build_mode,
+        expected_docker_server_version=expected_docker_server_version,
+        expected_docker_compose_version=expected_docker_compose_version,
+    )
+    failures.extend(
+        _validate_attempt_freshness(
+            manifest=manifest, result_path=result_path, trial_paths=trial_paths or []
+        )
+    )
+    failures.extend(
+        _validate_augmented_task_entries(manifest.get("tasks"), expected_digests)
+    )
+    return failures
 
 
 def validate(
@@ -381,6 +537,11 @@ def validate(
     dataset: str,
     tasks: tuple[str, ...] | None,
     jobs_dir: Path,
+    job_config: Path,
+    execution_args: str,
+    docker_build_mode: str,
+    docker_server_version: str,
+    docker_compose_version: str,
     result_path: Path | None = None,
 ) -> Path:
     jobs_dir = jobs_dir.resolve()
@@ -407,12 +568,34 @@ def validate(
         for task_id, ref in known.items()
         if task_id in requested
     }
+    harbor_version = importlib.metadata.version("harbor")
+    job_config_digest = _job_config_digest(job_config)
+    normalized_execution_args = _execution_args(execution_args)
+    expected_job_identity = _augmented_job_identity(
+        dataset=suite.id,
+        digests=augmented_digests,
+        job_config_digest=job_config_digest,
+        harbor_version=harbor_version,
+        execution_args=normalized_execution_args,
+        docker_build_mode=docker_build_mode,
+        docker_server_version=docker_server_version,
+        docker_compose_version=docker_compose_version,
+    )
     trial_results, trial_paths, trial_digests = _load_trial_results(result_path)
+    manifest_path = _augmented_digest_manifest_path(jobs_dir, result_path.parent.name)
     failures = _validate_augmented_digest_manifest(
-        manifest_path=jobs_dir / _AUGMENTED_DIGEST_MANIFEST,
+        manifest_path=manifest_path,
         result_path=result_path,
         dataset=suite.id,
         expected_digests=augmented_digests,
+        expected_job_identity=expected_job_identity,
+        expected_harbor_version=harbor_version,
+        expected_job_config_digest=job_config_digest,
+        expected_execution_args=normalized_execution_args,
+        expected_docker_build_mode=docker_build_mode,
+        expected_docker_server_version=docker_server_version,
+        expected_docker_compose_version=docker_compose_version,
+        trial_paths=trial_paths,
     )
     failures.extend(
         _validate_payload(
@@ -430,7 +613,17 @@ def validate(
         json.dumps(
             {
                 "source_sha": _git_sha(),
-                "harbor_version": importlib.metadata.version("harbor"),
+                "harbor_version": harbor_version,
+                "job_identity": expected_job_identity,
+                "job_config_digest": job_config_digest,
+                "execution_args": normalized_execution_args,
+                "docker_build_mode": docker_build_mode,
+                "docker_server_version": docker_server_version,
+                "docker_compose_version": docker_compose_version,
+                "manifest": {
+                    "path": manifest_path.relative_to(ROOT).as_posix(),
+                    "sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+                },
                 "dataset": suite.id,
                 "tasks": [
                     {
@@ -468,6 +661,13 @@ def main() -> int:
     parser.add_argument("--dataset", required=True)
     parser.add_argument("--tasks", nargs="*")
     parser.add_argument("--jobs-dir", type=Path, required=True)
+    parser.add_argument("--job-config", type=Path, required=True)
+    parser.add_argument("--execution-args", default="")
+    parser.add_argument(
+        "--docker-build-mode", choices=("legacy", "buildkit"), required=True
+    )
+    parser.add_argument("--docker-server-version", required=True)
+    parser.add_argument("--docker-compose-version", required=True)
     parser.add_argument("--result", type=Path)
     parser.add_argument("--prepare", action="store_true")
     args = parser.parse_args()
@@ -478,6 +678,11 @@ def main() -> int:
                 dataset=args.dataset,
                 tasks=task_selection,
                 jobs_dir=args.jobs_dir,
+                job_config=args.job_config,
+                execution_args=args.execution_args,
+                docker_build_mode=args.docker_build_mode,
+                docker_server_version=args.docker_server_version,
+                docker_compose_version=args.docker_compose_version,
             )
             manifest = json.loads(evidence.read_text(encoding="utf-8"))
             evidence = manifest["job_name"]
@@ -486,6 +691,11 @@ def main() -> int:
                 dataset=args.dataset,
                 tasks=task_selection,
                 jobs_dir=args.jobs_dir,
+                job_config=args.job_config,
+                execution_args=args.execution_args,
+                docker_build_mode=args.docker_build_mode,
+                docker_server_version=args.docker_server_version,
+                docker_compose_version=args.docker_compose_version,
                 result_path=args.result,
             )
     except HarborSuiteError as exc:

--- a/benchmarks/validation/research_diagnostics_v1/test_jcb_postdoc_013.py
+++ b/benchmarks/validation/research_diagnostics_v1/test_jcb_postdoc_013.py
@@ -1,0 +1,47 @@
+"""Public-contract regressions for the answer-visible Problem 397 task."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+from benchmarks.validation.research_diagnostics_v1 import support
+from jsonschema import Draft202012Validator, ValidationError
+
+TASK = support.DATASET / "jcb-postdoc-013"
+
+
+def test_required_key_facts_are_fully_agent_visible() -> None:
+    schema = json.loads(
+        (TASK / "environment" / "submission_schema.json").read_text(encoding="utf-8")
+    )
+    facts = schema["properties"]["result"]["properties"]["key_facts"]
+
+    assert facts == {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["identity_holds", "index_order"],
+        "properties": {
+            "identity_holds": {"const": "true"},
+            "index_order": {"const": "a<a+1<2a<2a+2<c<c+1"},
+        },
+    }
+
+
+def test_public_schema_rejects_renamed_hidden_lexical_keys() -> None:
+    schema = json.loads(
+        (TASK / "environment" / "submission_schema.json").read_text(encoding="utf-8")
+    )
+    submission = json.loads(
+        (TASK / "solution" / "submission.json").read_text(encoding="utf-8")
+    )
+    renamed = copy.deepcopy(submission)
+    renamed["result"]["key_facts"] = {
+        "exact_identity": "true",
+        "strict_index_order": "a<a+1<2a<2a+2<c<c+1",
+    }
+
+    Draft202012Validator(schema).validate(submission)
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(renamed)

--- a/benchmarks/validation/research_diagnostics_v1/test_jcb_postdoc_015.py
+++ b/benchmarks/validation/research_diagnostics_v1/test_jcb_postdoc_015.py
@@ -1,0 +1,17 @@
+"""Agent-visible evidence-contract regressions for Problem 707."""
+
+from __future__ import annotations
+
+from benchmarks.validation.research_diagnostics_v1 import support
+
+TASK = support.DATASET / "jcb-postdoc-015"
+
+
+def test_evidence_schema_is_named_and_copied_into_the_agent_environment() -> None:
+    instruction = (TASK / "instruction.md").read_text(encoding="utf-8")
+    dockerfile = (TASK / "environment" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "/app/evidence_schema.json" in instruction
+    assert "COPY input.json submission_schema.json evidence_schema.json /app/" in (
+        dockerfile
+    )

--- a/benchmarks/validation/research_diagnostics_v1/test_legacy_key_facts_contract.py
+++ b/benchmarks/validation/research_diagnostics_v1/test_legacy_key_facts_contract.py
@@ -19,7 +19,6 @@ TASKS = (
     "jcb-postdoc-010",
     "jcb-postdoc-011",
     "jcb-postdoc-012",
-    "jcb-postdoc-013",
     "jcb-postdoc-017",
 )
 

--- a/benchmarks/validation/test_harbor_result_validation.py
+++ b/benchmarks/validation/test_harbor_result_validation.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from benchmarks.tooling.validate_harbor_results import (
     _AUGMENTED_DIGEST_MANIFEST,
+    _augmented_digest_manifest_path,
+    _augmented_job_identity,
     _augmented_job_name,
     _validate_augmented_digest_manifest,
     _validate_payload,
@@ -14,6 +17,49 @@ from benchmarks.tooling.validate_harbor_results import (
 
 _DIGEST = "a" * 64
 _DURABLE_DIGEST = f"sha256:{_DIGEST}"
+_JOB_CONFIG_DIGEST = f"sha256:{'c' * 64}"
+_HARBOR_VERSION = "0.20.0"
+_ATTEMPT_ID = "1" * 16
+_DOCKER_BUILD_MODE = "buildkit"
+_DOCKER_SERVER_VERSION = "27.5.1"
+_DOCKER_COMPOSE_VERSION = "2.32.4"
+
+
+def _identity(dataset: str, digests: dict[str, str]) -> str:
+    return _augmented_job_identity(
+        dataset=dataset,
+        digests=digests,
+        job_config_digest=_JOB_CONFIG_DIGEST,
+        harbor_version=_HARBOR_VERSION,
+        execution_args=(),
+        docker_build_mode=_DOCKER_BUILD_MODE,
+        docker_server_version=_DOCKER_SERVER_VERSION,
+        docker_compose_version=_DOCKER_COMPOSE_VERSION,
+    )
+
+
+def _manifest(
+    *,
+    dataset: str,
+    job_identity: str,
+    job_name: str,
+    tasks: list[dict[str, str]],
+) -> dict[str, object]:
+    return {
+        "schema_version": "2",
+        "dataset": dataset,
+        "job_identity": job_identity,
+        "job_name": job_name,
+        "attempt_id": _ATTEMPT_ID,
+        "prepared_at_ns": 0,
+        "harbor_version": _HARBOR_VERSION,
+        "job_config_digest": _JOB_CONFIG_DIGEST,
+        "execution_args": [],
+        "docker_build_mode": _DOCKER_BUILD_MODE,
+        "docker_server_version": _DOCKER_SERVER_VERSION,
+        "docker_compose_version": _DOCKER_COMPOSE_VERSION,
+        "tasks": tasks,
+    }
 
 
 def _trial(*, reward: object = 1.0, **trial_overrides: object) -> dict:
@@ -198,22 +244,22 @@ def test_changed_augmented_task_digest_rejects_old_trial() -> None:
 def test_augmented_manifest_rejects_context_change(tmp_path) -> None:
     dataset = "provider-feasibility-v1"
     current_digest = f"sha256:{'b' * 64}"
-    job_name = _augmented_job_name(
-        dataset=dataset, digests={"example-task": current_digest}
-    )
+    current_digests = {"example-task": current_digest}
+    job_identity = _identity(dataset, current_digests)
+    job_name = _augmented_job_name(job_identity=job_identity, attempt_id=_ATTEMPT_ID)
     result = tmp_path / job_name / "result.json"
     result.parent.mkdir()
     result.write_text("{}", encoding="utf-8")
     assert not _AUGMENTED_DIGEST_MANIFEST.startswith(".")
-    manifest = tmp_path / _AUGMENTED_DIGEST_MANIFEST
+    manifest = _augmented_digest_manifest_path(tmp_path, job_name)
     manifest.write_text(
         json.dumps(
-            {
-                "dataset": dataset,
-                "job_name": job_name,
-                "prepared_at_ns": 0,
-                "tasks": [{"task": "example-task", "digest": f"sha256:{'a' * 64}"}],
-            }
+            _manifest(
+                dataset=dataset,
+                job_identity=job_identity,
+                job_name=job_name,
+                tasks=[{"task": "example-task", "digest": f"sha256:{'a' * 64}"}],
+            )
         ),
         encoding="utf-8",
     )
@@ -222,7 +268,14 @@ def test_augmented_manifest_rejects_context_change(tmp_path) -> None:
         manifest_path=manifest,
         result_path=result,
         dataset=dataset,
-        expected_digests={"example-task": current_digest},
+        expected_digests=current_digests,
+        expected_job_identity=job_identity,
+        expected_harbor_version=_HARBOR_VERSION,
+        expected_job_config_digest=_JOB_CONFIG_DIGEST,
+        expected_execution_args=(),
+        expected_docker_build_mode=_DOCKER_BUILD_MODE,
+        expected_docker_server_version=_DOCKER_SERVER_VERSION,
+        expected_docker_compose_version=_DOCKER_COMPOSE_VERSION,
     )
 
     assert failures == ["augmented task digest mismatch for example-task"]
@@ -233,22 +286,26 @@ def test_changed_augmented_digest_cannot_resume_stale_job(tmp_path) -> None:
     old_digest = f"sha256:{'a' * 64}"
     current_digest = f"sha256:{'b' * 64}"
     current_digests = {"example-task": current_digest}
-    current_job_name = _augmented_job_name(dataset=dataset, digests=current_digests)
+    current_identity = _identity(dataset, current_digests)
+    current_job_name = _augmented_job_name(
+        job_identity=current_identity, attempt_id=_ATTEMPT_ID
+    )
+    stale_identity = _identity(dataset, {"example-task": old_digest})
     stale_job_name = _augmented_job_name(
-        dataset=dataset, digests={"example-task": old_digest}
+        job_identity=stale_identity, attempt_id=_ATTEMPT_ID
     )
     result = tmp_path / stale_job_name / "result.json"
     result.parent.mkdir()
     result.write_text("{}", encoding="utf-8")
-    manifest = tmp_path / _AUGMENTED_DIGEST_MANIFEST
+    manifest = _augmented_digest_manifest_path(tmp_path, current_job_name)
     manifest.write_text(
         json.dumps(
-            {
-                "dataset": dataset,
-                "job_name": current_job_name,
-                "prepared_at_ns": 0,
-                "tasks": [{"task": "example-task", "digest": current_digest}],
-            }
+            _manifest(
+                dataset=dataset,
+                job_identity=current_identity,
+                job_name=current_job_name,
+                tasks=[{"task": "example-task", "digest": current_digest}],
+            )
         ),
         encoding="utf-8",
     )
@@ -258,6 +315,47 @@ def test_changed_augmented_digest_cannot_resume_stale_job(tmp_path) -> None:
         result_path=result,
         dataset=dataset,
         expected_digests=current_digests,
+        expected_job_identity=current_identity,
+        expected_harbor_version=_HARBOR_VERSION,
+        expected_job_config_digest=_JOB_CONFIG_DIGEST,
+        expected_execution_args=(),
+        expected_docker_build_mode=_DOCKER_BUILD_MODE,
+        expected_docker_server_version=_DOCKER_SERVER_VERSION,
+        expected_docker_compose_version=_DOCKER_COMPOSE_VERSION,
     )
 
-    assert failures == ["Harbor result is not bound to its augmented task identity"]
+    assert failures == ["Harbor result is not bound to its augmented task attempt"]
+
+
+def test_same_experiment_identity_uses_distinct_attempt_names() -> None:
+    identity = _identity(
+        "provider-feasibility-v1", {"example-task": f"sha256:{'a' * 64}"}
+    )
+
+    first = _augmented_job_name(job_identity=identity, attempt_id="1" * 16)
+    second = _augmented_job_name(job_identity=identity, attempt_id="2" * 16)
+
+    assert first != second
+    assert first.startswith(f"jacobian-oracle-{identity.removeprefix('sha256:')[:32]}-")
+    jobs_dir = Path("jobs")
+    assert _augmented_digest_manifest_path(
+        jobs_dir, first
+    ) != _augmented_digest_manifest_path(jobs_dir, second)
+
+
+def test_execution_configuration_changes_experiment_identity() -> None:
+    digests = {"example-task": f"sha256:{'a' * 64}"}
+    baseline = _identity("provider-feasibility-v1", digests)
+
+    changed = _augmented_job_identity(
+        dataset="provider-feasibility-v1",
+        digests=digests,
+        job_config_digest=_JOB_CONFIG_DIGEST,
+        harbor_version=_HARBOR_VERSION,
+        execution_args=("--n-concurrent", "2"),
+        docker_build_mode=_DOCKER_BUILD_MODE,
+        docker_server_version=_DOCKER_SERVER_VERSION,
+        docker_compose_version=_DOCKER_COMPOSE_VERSION,
+    )
+
+    assert changed != baseline

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -41,6 +41,15 @@ paths only for shared Harbor tooling, schemas, registry, suite policy, or
 other control-plane changes. Pass `TASKS="..."` for a bounded dataset Oracle;
 pass `FULL=1` only when a complete dataset sweep is intentional.
 
+Oracle attempts are serialized on a shared Docker host and receive a unique
+job name plus a content-bound preparation receipt. The receipt includes task
+digests, Harbor and Docker runtime versions, the Oracle job digest, and
+normalized execution arguments. On Docker Engine versions older than 23, the
+Make target selects the classic builder because the bundled legacy BuildKit
+can reuse a same-named Dockerfile from another task through Compose Bake. Set
+`HARBOR_ORACLE_DOCKER_BUILD_MODE` only for an explicit compatibility test; the
+resolved mode remains part of the recorded experiment identity.
+
 For changes limited to Harbor job JSON, MCP configuration, job-level Compose
 overlays, or their execution helpers, use the focused local handoff instead:
 
@@ -230,6 +239,14 @@ URL variable. The Makefile also passes Harbor's
 `web_search=disabled` agent kwarg explicitly, because the `-a codex` and
 `-m <model>` command-line overrides replace the agent block from the job JSON.
 The default treatment job does not include the proxy overlay.
+
+The pinned Harbor Codex adapter creates a fresh temporary `CODEX_HOME` for
+each trial and copies only the job-declared configuration and skills into it.
+Therefore a direct host `codex exec`, even with user configuration partially
+disabled, is not a valid control for this protocol: installed host apps or
+plugins may still be visible. For first-party evidence, inspect each trial's
+`lock.json`: control must have empty `skills` and `mcp_servers`, while
+treatment must contain exactly the declared Jacobian skill and MCP server.
 
 ## Docker and Daytona
 

--- a/make/harbor.mk
+++ b/make/harbor.mk
@@ -6,6 +6,27 @@ HARBOR_PROJECT_PYTHON ?= uv run --locked --with harbor==$(HARBOR_VERSION) --with
 # worker-local. Oracle/adapter Make targets remain serial.
 HARBOR_VALIDATION_WORKERS ?= 2
 HARBOR_VALIDATION_TOTAL_WORKERS ?= 4
+HARBOR_ORACLE_LOCK ?= benchmarks/results/.harbor-oracle.lock
+HARBOR_ORACLE_DOCKER_BUILD_MODE ?= auto
+
+# Compose Bake can reuse the wrong same-named Dockerfile with the BuildKit
+# bundled by pre-23 Docker engines. Keep modern BuildKit, but fail over to the
+# classic builder on older daemons and bind the resolved runtime into evidence.
+define _resolve_harbor_oracle_docker_build_mode
+docker_server_version="$$(docker version --format '{{.Server.Version}}')"; \
+docker_compose_version="$$(docker compose version --short)"; \
+docker_build_mode="$(HARBOR_ORACLE_DOCKER_BUILD_MODE)"; \
+if [ "$$docker_build_mode" = "auto" ]; then \
+	docker_server_major="$${docker_server_version%%.*}"; \
+	case "$$docker_server_major" in ''|*[!0-9]*) echo "unable to parse Docker server version: $$docker_server_version" >&2; exit 2;; esac; \
+	if [ "$$docker_server_major" -lt 23 ]; then docker_build_mode="legacy"; else docker_build_mode="buildkit"; fi; \
+fi; \
+case "$$docker_build_mode" in \
+	legacy) export DOCKER_BUILDKIT=0 COMPOSE_BAKE=false;; \
+	buildkit) export DOCKER_BUILDKIT=1 COMPOSE_BAKE=true;; \
+	*) echo "HARBOR_ORACLE_DOCKER_BUILD_MODE must be auto, legacy, or buildkit" >&2; exit 2;; \
+esac;
+endef
 
 .PHONY: harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke
 
@@ -141,9 +162,17 @@ harbor-oracle: ## Check contracts, then run an explicitly scoped dataset Oracle.
 
 harbor-oracle-task: harbor-check-task ## Check selected leaf tasks, then run their exact Oracle.
 	@test -f "benchmarks/datasets/$(DATASET)/jobs/oracle.json" || { echo "unknown dataset or missing Oracle job: $(DATASET)" >&2; exit 2; }
+	@mkdir -p "$(dir $(HARBOR_ORACLE_LOCK))"
+	@exec 9>"$(HARBOR_ORACLE_LOCK)"; flock 9; \
+	$(_resolve_harbor_oracle_docker_build_mode) \
 	job_name="$$( $(HARBOR_PYTHON) benchmarks/tooling/validate_harbor_results.py \
 		--prepare --dataset "$(DATASET)" \
 		--jobs-dir "benchmarks/results/$(DATASET)-oracle" \
+		--job-config "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
+		--execution-args="$(EVAL_ARGS)" \
+		--docker-build-mode "$$docker_build_mode" \
+		--docker-server-version "$$docker_server_version" \
+		--docker-compose-version "$$docker_compose_version" \
 		--tasks $(TASKS) )" && \
 	$(HARBOR_RUNNER) run \
 		-c "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
@@ -154,6 +183,11 @@ harbor-oracle-task: harbor-check-task ## Check selected leaf tasks, then run the
 	$(HARBOR_PYTHON) benchmarks/tooling/validate_harbor_results.py \
 		--dataset "$(DATASET)" \
 		--jobs-dir "benchmarks/results/$(DATASET)-oracle" \
+		--job-config "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
+		--execution-args="$(EVAL_ARGS)" \
+		--docker-build-mode "$$docker_build_mode" \
+		--docker-server-version "$$docker_server_version" \
+		--docker-compose-version "$$docker_compose_version" \
 		--result "benchmarks/results/$(DATASET)-oracle/$$job_name/result.json" \
 		--tasks $(TASKS)
 
@@ -161,9 +195,17 @@ harbor-oracle-run: ## Run a dataset Oracle after an already-successful contract 
 	@test -n "$(DATASET)" || { echo "DATASET is required" >&2; exit 2; }
 	@test -n "$(TASKS)" -o "$(FULL)" = "1" || { echo "TASKS is required; use FULL=1 only for an intentional full-dataset Oracle" >&2; exit 2; }
 	@test -f "benchmarks/datasets/$(DATASET)/jobs/oracle.json" || { echo "unknown dataset or missing Oracle job: $(DATASET)" >&2; exit 2; }
+	@mkdir -p "$(dir $(HARBOR_ORACLE_LOCK))"
+	@exec 9>"$(HARBOR_ORACLE_LOCK)"; flock 9; \
+	$(_resolve_harbor_oracle_docker_build_mode) \
 	job_name="$$( $(HARBOR_PYTHON) benchmarks/tooling/validate_harbor_results.py \
 		--prepare --dataset "$(DATASET)" \
 		--jobs-dir "benchmarks/results/$(DATASET)-oracle" \
+		--job-config "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
+		--execution-args="$(EVAL_ARGS)" \
+		--docker-build-mode "$$docker_build_mode" \
+		--docker-server-version "$$docker_server_version" \
+		--docker-compose-version "$$docker_compose_version" \
 		$(if $(TASKS),--tasks $(TASKS),) )" && \
 	$(HARBOR_RUNNER) run \
 		-c "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
@@ -174,6 +216,11 @@ harbor-oracle-run: ## Run a dataset Oracle after an already-successful contract 
 	$(HARBOR_PYTHON) benchmarks/tooling/validate_harbor_results.py \
 		--dataset "$(DATASET)" \
 		--jobs-dir "benchmarks/results/$(DATASET)-oracle" \
+		--job-config "benchmarks/datasets/$(DATASET)/jobs/oracle.json" \
+		--execution-args="$(EVAL_ARGS)" \
+		--docker-build-mode "$$docker_build_mode" \
+		--docker-server-version "$$docker_server_version" \
+		--docker-compose-version "$$docker_compose_version" \
 		--result "benchmarks/results/$(DATASET)-oracle/$$job_name/result.json" \
 		$(if $(TASKS),--tasks $(TASKS),)
 

--- a/npm/cli-e2e.test.mjs
+++ b/npm/cli-e2e.test.mjs
@@ -144,10 +144,9 @@ test("npx jacobian setup manages the Codex visibility skill safely", async () =>
     assert.equal(setupReport.results[0].visibilitySkill.status, "create");
     const managedSkill = await readFile(skillPath, "utf8");
     assert.match(managedSkill, /name: jacobian-math/);
-    assert.match(managedSkill, /matrix determinants/);
     assert.match(
       managedSkill,
-      /Trigger on relevant math tasks even when the user does not name Jacobian/,
+      /description: .*matrix determinants.*even when unnamed\./,
     );
 
     const remove = await runNpx(

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jacobian-math
-description: Use Jacobian for exact mathematics, matrix determinants, symbolic computation, structural analysis, counterexamples, bounded search, and independent verification. Trigger on relevant math tasks even when the user does not name Jacobian.
+description: Use Jacobian for exact math, matrix determinants, symbolic work, counterexamples, search, and independent verification, even when unnamed.
 ---
 
 # Jacobian Math
@@ -10,19 +10,20 @@ description: Use Jacobian for exact mathematics, matrix determinants, symbolic c
 In Code Mode, call
 `tools.mcp__jacobian__math_find(...)` and
 `tools.mcp__jacobian__math_run(...)` directly. Do not enumerate, filter, or
-print `ALL_TOOLS`. Return the typed projection when available:
+print `ALL_TOOLS`. Return the typed projection:
 
 ```js
 const r = await tools.mcp__jacobian__math_find({query: "...", limit: 3});
 text(r.structuredContent ?? r);
 ```
 
-Use Jacobian for each requested exact mathematical outcome, even when small.
+Use Jacobian for each requested exact outcome, even when small.
 Keep decomposition and routing decisions agent-owned; composing already-known
 supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-Call `math.run` directly for these stable contracts, preserving JSON types:
+No discovery for stable producers: `{"capability_id":"<id>","mode":"EXPLORE","payload":<JSON>}`
+(not `COMPUTE`/`input`). Payloads:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or `integer.compute.extended_gcd`:
   `{"left":"84","right":"30"}`.
@@ -35,38 +36,38 @@ Call `math.run` directly for these stable contracts, preserving JSON types:
   `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` in `VERIFY` mode for an independent check:
   `{"determinant_uri":"<determinant_uri from compute output>"}`.
+- `combinatorics.cyclic_difference_set.extension.decide`:
+  `{"base_elements":["1","2","4","8","13"],"target_order":7}`.
+  `combinatorics.cyclic_difference_set.extension.verify` uses
+  `{"input":<same payload>,"candidate":<producer output.result>}` in `VERIFY` mode.
 
-For other outcomes, use `math.find` with a specific plain-language outcome;
-no capability ID is required.
-Use low `limit` values. For a selected operation's schema, call
+For other outcomes, query `math.find` by plain-language outcome; no ID is
+required. Use low `limit` only for query search, never with `capability_id`. For
+a selected operation's schema, call
 `math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never send
 `mode: "CONTRACT"` to `math.run` or put `CONTRACT` in a query. A card's
 `invocation_example`, or required top-level fields, may be enough.
 
-Do not add a discovery domain filter unless its exact installed spelling is
-known. Follow exposed recovery paths such as removing unknown filters or
-reformulating the query before
-treating absence as final. After invalid input, correct the reported constraint
-and retry within the task resource bounds. If
-one provider is unavailable, continue with other installed routes that can
-produce the outcome. Treat timeouts, cancellations, errors, incomplete searches,
-and missing witnesses as non-conclusions. Accept only a completed
-result whose scope covers the input, and carry forward the smallest decisive
-value, witness, status, assurance, completeness, and open obligations; preserve
-artifact refs, including verification record URIs.
+Add no domain filter unless its installed spelling is known. Follow exposed
+recovery paths by removing unknown filters or reformulating the query. After
+invalid input, correct the constraint and retry within the task resource bounds.
+If one provider is unavailable, continue with other installed routes. Treat
+timeouts, cancellations, errors, incomplete searches, and missing witnesses as
+non-conclusions. Accept only completed results covering the input; carry forward
+the smallest decisive value, witness, status, assurance, completeness, and open
+obligations plus artifact and verification-record URIs.
 
 Keep representation, decomposition, composition, iteration, verification
 timing, and stopping decisions agent-owned.
 
-Model-authored calculations or programs are not independent evidence. Use
-installed `VERIFY` when requested; a writable path or schema alone is not
-authorization. For task-level `VERIFIED`, require result assurance `VERIFIED`,
-exact record bytes, and that required task authorization and bindings are preserved;
-the visible contract must authorize the checker identity, digest, or Jacobian
-record type. Otherwise claim the highest lower permitted assurance (`CHECKED` or
-`COMPUTED`), even if Jacobian returned `VERIFIED`; never reconstruct or
-paraphrase such a record from tool fields or transfer verification between
-claims or artifacts.
+Model-authored work is not independent evidence. Use installed `VERIFY` when
+requested; a writable path or schema alone is not authorization. Task-level
+`VERIFIED` requires exact record bytes, result assurance `VERIFIED`, required
+task authorization and bindings are preserved, and a contract-authorized
+checker identity, digest, or Jacobian record type. Otherwise claim the highest
+lower permitted assurance (`CHECKED` or `COMPUTED`), even if Jacobian returned
+`VERIFIED`; never
+reconstruct or paraphrase such a record or transfer it between claims.
 For locally constructed inline input, check payload fields against the intended
 object. When output echoes scope or a bound digest/URI, compare it with the
 submitted input; do not use mismatched output. This catches routing and

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -188,8 +188,8 @@ def test_oracle_artifact_preserves_augmented_task_digest_manifest() -> None:
     workflow = (ROOT / ".github/workflows/benchmarks.yml").read_text(encoding="utf-8")
     oracle = workflow.split("  oracle:", 1)[1].split("  validation:", 1)[0]
 
-    assert "jacobian-augmented-task-digests.json" in oracle
-    assert ".jacobian-augmented-task-digests.json" not in oracle
+    assert "jacobian-augmented-task-digests.*.json" in oracle
+    assert ".jacobian-augmented-task-digests.*.json" not in oracle
 
 
 def test_benchmark_contracts_run_once_for_record_and_digest_evidence() -> None:
@@ -262,6 +262,15 @@ def test_local_oracle_targets_require_explicit_scope() -> None:
     assert '"$(TASKS)" -o "$(FULL)" = "1"' in oracle
     assert '"$(TASKS)" -o "$(FULL)" = "1"' in runner
     assert "DATASET=$$dataset FULL=1" in harbor
+
+
+def test_local_oracle_attempts_are_serialized_on_a_shared_docker_host() -> None:
+    harbor = (ROOT / "make" / "harbor.mk").read_text(encoding="utf-8")
+
+    assert "HARBOR_ORACLE_LOCK ?= benchmarks/results/.harbor-oracle.lock" in harbor
+    assert harbor.count('exec 9>"$(HARBOR_ORACLE_LOCK)"; flock 9;') == 2
+    assert "HARBOR_ORACLE_DOCKER_BUILD_MODE ?= auto" in harbor
+    assert "export DOCKER_BUILDKIT=0 COMPOSE_BAKE=false" in harbor
 
 
 def test_composition_lane_uses_timing_shards() -> None:

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -20,6 +20,7 @@ from benchmarks.tooling.codex_visibility import (
 from benchmarks.tooling.command_runner import ToolCommandResult, ToolCommandStatus
 from pydantic import ValidationError
 
+from jacobian.contracts.combinatorics import CyclicDifferenceSetExtensionRequest
 from jacobian.contracts.matrix_operations import MatrixDeterminantRequest
 from jacobian.contracts.number_theory import IntegerPairRequest
 from jacobian.contracts.polynomial_operations import PolynomialGcdRequest
@@ -162,6 +163,8 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
         "polynomial.compute.gcd",
         "polynomial.expression.normalize",
         "matrix.determinant.verify",
+        "combinatorics.cyclic_difference_set.extension.decide",
+        "combinatorics.cyclic_difference_set.extension.verify",
     ):
         assert f"`{capability_id}`" in skill
     integer_payload = '{"left":"84","right":"30"}'
@@ -174,12 +177,20 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     assert integer_payload in skill
     assert matrix_payload in skill
     assert polynomial in skill
+    extension_payload = '{"base_elements":["1","2","4","8","13"],"target_order":7}'
+    assert extension_payload in skill
+    assert '"mode":"EXPLORE","payload":<JSON>' in skill
+    assert "(not `COMPUTE`/`input`)" in skill
+    assert "No discovery for stable producers" in skill
+    assert "never with `capability_id`" in skill
+    assert '"candidate":<producer output.result>' in skill
     IntegerPairRequest.model_validate_json(integer_payload)
     MatrixDeterminantRequest.model_validate_json(matrix_payload)
     polynomial_value = json.loads(polynomial)
     PolynomialGcdRequest.model_validate(
         {"left": polynomial_value, "right": polynomial_value}
     )
+    CyclicDifferenceSetExtensionRequest.model_validate_json(extension_payload)
     assert len(skill.encode("utf-8")) <= 4 * 1024
 
 

--- a/tests/unit/tooling/test_harbor_egress.py
+++ b/tests/unit/tooling/test_harbor_egress.py
@@ -99,6 +99,16 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
     )
 
 
+def test_agent_eval_docs_exclude_host_codex_from_the_control_protocol() -> None:
+    guide = (ROOT / "docs" / "how-to" / "run-agent-evaluations.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "fresh temporary `CODEX_HOME`" in guide
+    assert "direct host `codex exec`" in guide
+    assert "control must have empty `skills` and `mcp_servers`" in guide
+
+
 def test_proxy_observation_job_is_opt_in_and_preserves_local_mcp_access() -> None:
     proxy_job = _read_json(OBSERVATION_PROXY_JOB)
     proxy_control = _read_json(CONTROL_PROXY_JOB)


### PR DESCRIPTION
## Problem

The evaluation audit found two agent-hidden task requirements, repeat Oracle runs that could reuse prior Harbor jobs, old Compose/BuildKit cross-task Dockerfile reuse, and an avoidable discovery/token penalty for a stable combinatorics capability.

## Changes

- make the Problem 397 key facts and Problem 707 evidence schema fully agent-visible
- assign every Oracle run a unique attempt while binding its stable experiment identity, task digests, job config, execution args, runtime versions, and result freshness into a sidecar receipt
- serialize local Oracle builds and automatically use the classic builder on pre-23 Docker engines where Compose Bake can cross-load same-named Dockerfiles
- add a bounded, installation-safe direct-run contract and latent visibility case for fixed-order difference-set extension
- document the fresh `CODEX_HOME` control/treatment boundary

Task versions 013 and 015 advance to 1.1.0 and 2.1.0. Oracle result directory names are now attempt-specific, and old Docker engines resolve to the evidence-bound legacy builder mode.

## Validation

- `make harbor-host-validation`: 3,601 passed across four shards
- `make check`: Ruff, formatting, complexity, mypy, 854 unit tests passed
- focused visibility/Harbor unit lane: 55 passed
- `make npm-test`: 59 passed and package dry-run succeeded
- `make docs-linkcheck`
- scoped 013/015 Harbor contract validation
- exact 013 and 015 Oracle runs: 1/1 trial and reward 1.0 each
- four Codex visibility experiments; final fixed-order case used 2 direct `math.run` calls, 0 discovery calls, and 0 tool/parameter errors
