### PR TITLE
chore(devex): make check-changed the fast local developer handoff

### DIFF
--- a/.github/local-test-ownership.json
+++ b/.github/local-test-ownership.json
@@ -5,6 +5,10 @@
       "tests/boundary/process/tooling/test_ci_classification.py",
       "tests/unit/tooling/test_ci_execution_policy.py"
     ],
+    ".github/local-test-ownership.json": [
+      "tests/unit/tooling/test_plan_local_tests.py",
+      "tests/unit/tooling/test_ci_planner_catalog.py"
+    ],
     ".github/scripts/classify-ci-paths": [
       "tests/boundary/process/tooling/test_ci_classification.py",
       "tests/unit/tooling/test_ci_execution_policy.py"
@@ -28,6 +32,28 @@
     ],
     ".github/scripts/validate-benchmark-plan": [
       "tests/boundary/process/tooling/test_benchmark_classification.py"
+    ],
+    "Makefile": [
+      "tests/boundary/process/tooling/test_make_help.py",
+      "tests/unit/tooling/test_plan_local_tests.py"
+    ],
+    "make/development.mk": [
+      "tests/boundary/process/tooling/test_make_help.py",
+      "tests/boundary/process/tooling/test_source_agent_bootstrap.py"
+    ],
+    "scripts/setup-agent": [
+      "tests/boundary/process/tooling/test_source_agent_bootstrap.py"
+    ],
+    "tools/check_architecture.py": [
+      "tests/unit/tooling/test_architecture_policy.py",
+      "tests/unit/tooling/test_architecture_process_policies.py"
+    ],
+    "tools/development_profiles.py": [
+      "tests/unit/tooling/test_development_profiles.py",
+      "tests/boundary/process/tooling/test_source_agent_bootstrap.py"
+    ],
+    "tools/source_agent_doctor.py": [
+      "tests/boundary/process/tooling/test_source_agent_bootstrap.py"
     ],
     "tools/test_topology.py": [
       "tests/boundary/process/tooling/test_topology_runner.py",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,14 +7,26 @@
 ## Testing
 <!-- How was this change tested? List the exact commands and any manual verification. -->
 
+Contributor quick path:
+
 ```sh
-make setup
-make check
+make setup PROFILE=core
+make check-changed BASE=origin/main
 ```
+
+If this change crosses a named boundary, add the explicitly relevant specialist
+lane(s) and list them below. Specialist lanes are troubleshooting/boundary
+work, not a routine gate; CI owns the full Lean/provider, coverage,
+compatibility, packaging, security, and exhaustive-matrix surface. See
+[CONTRIBUTING.md](../CONTRIBUTING.md) and the
+[testing strategy](../docs/reference/testing-strategy.md) for lane ownership.
+
+- Specialist validation run (if any): <!-- e.g. make test-lean TESTS=..., make harbor-validate-task DATASET=... TASKS="..." -->
 
 ## Trust & Compatibility Impact
 <!-- Does this change affect the verification kernel, checker registry, artifact format, or public API? -->
 
 ## Checklist
-- [ ] Routine local validation passes (`make check`)
-- [ ] Relevant focused tests are listed above
+- [ ] `make check-changed BASE=origin/main` passes
+- [ ] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
+- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)

--- a/.github/scripts/plan-local-tests
+++ b/.github/scripts/plan-local-tests
@@ -11,6 +11,7 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -82,6 +83,53 @@ TOPOLOGY_LANES = (
     "e2e",
 )
 
+# Independent local gates. Security, duplicate-code, compatibility, coverage,
+# and platform matrices remain hosted-CI evidence.
+GATE_LANES = ("static", "npm", "docs")
+
+LINT_TYPECHECK_COMMAND = "make lint typecheck"
+
+# Repository paths whose impact is structural rather than ordinary Python
+# behavior.  Such changes route to ``make check-static`` (which already includes
+# lint-full, typecheck, architecture, and a package build) instead of the
+# lighter ``make lint typecheck`` handoff.
+INFRASTRUCTURE_PREFIXES = (
+    ".github/",
+    "Makefile",
+    "make/",
+    "pyproject.toml",
+    "uv.lock",
+    "tools/",
+    ".pre-commit-config.yaml",
+    ".jscpd.json",
+    "tests/topology.toml",
+)
+
+
+def is_infrastructure_path(path: str) -> bool:
+    """Return whether a changed path is structural infrastructure."""
+
+    return any(
+        path == prefix.rstrip("/") or path.startswith(prefix)
+        for prefix in INFRASTRUCTURE_PREFIXES
+    )
+
+
+def is_ordinary_python_path(path: str) -> bool:
+    """Return whether a changed path is ordinary Python source or tests."""
+
+    return path.endswith(".py") and path.startswith(("src/", "tests/"))
+
+
+def is_documentation_path(path: str) -> bool:
+    """Return whether a path has no pytest ownership of its own."""
+
+    return (
+        path.startswith("docs/")
+        or path in {"README.md", "README.zh-CN.md", "CONTRIBUTING.md", "AGENTS.md"}
+        or path == ".github/pull_request_template.md"
+    )
+
 
 def local_command_lanes(lanes: list[str]) -> list[str]:
     """Remove lanes whose local command is already owned by a selected gate."""
@@ -94,6 +142,7 @@ def local_command_lanes(lanes: list[str]) -> list[str]:
         if str(subsumed_lane) in selected
     }
     return [lane for lane in lanes if lane not in subsumed]
+
 
 HIGH_IMPACT_PATHS = {
     "src/jacobian/__init__.py",
@@ -268,6 +317,8 @@ def exact_tests(entries: list[Change]) -> tuple[list[str], str | None]:
 
     for entry in entries:
         path = entry.path
+        if is_documentation_path(path):
+            continue
         if entry.status not in {"A", "M"}:
             return [], f"{path}: {entry.status} changes are not exact"
         override_nodes = {
@@ -403,21 +454,157 @@ def _lane_for_path(path: str) -> str | None:
     return matches[0] if len(matches) == 1 else None
 
 
+def planned_commands(
+    entries: list[Change],
+    plan: dict[str, str],
+    tests: list[str],
+    fallback: str | None,
+    deployment: bool,
+) -> list[str]:
+    """Build the ordered, affected-handoff command list.
+
+    Independent gates (docs, npm, check-static for infrastructure, lint/typecheck
+    once for ordinary Python, and the deployment gate) run regardless of whether
+    exact test selectors are available, so focused selection never suppresses an
+    independent check.  The pytest portion uses focused selectors when exact
+    ownership is available and falls back to the selected topology lane commands
+    otherwise.
+    """
+
+    lanes = [suite for suite in COMMANDS if plan.get(f"run-{suite}") == "true"]
+    command_lanes = local_command_lanes(lanes)
+    gate_lanes = [lane for lane in command_lanes if lane in GATE_LANES]
+    pytest_lanes = [lane for lane in command_lanes if lane in TOPOLOGY_LANES]
+
+    has_infrastructure = any(is_infrastructure_path(entry.path) for entry in entries)
+    has_ordinary_python = any(is_ordinary_python_path(entry.path) for entry in entries)
+    has_npm = any(entry.path.startswith("npm/") for entry in entries)
+    run_python = plan.get("run-python") == "true"
+
+    commands: list[str] = []
+    # ``make check-static`` already includes lint-full and typecheck, so the
+    # lighter lint/typecheck handoff is only added when ordinary Python is
+    # affected and the infrastructure gate is not.  Infrastructure-leaning
+    # changes (including static-only changes with no ordinary Python) route to
+    # check-static.
+    use_check_static = "static" in gate_lanes and (
+        has_infrastructure or not has_ordinary_python
+    )
+    use_lint_typecheck = not use_check_static and run_python and has_ordinary_python
+    if use_check_static:
+        commands.append(COMMANDS["static"][0])
+    elif use_lint_typecheck:
+        commands.append(LINT_TYPECHECK_COMMAND)
+
+    for lane in GATE_LANES:
+        if lane == "static":
+            continue
+        if lane == "npm" and not has_npm:
+            continue
+        if lane in gate_lanes:
+            commands.append(COMMANDS[lane][0])
+
+    if tests:
+        commands.extend(focused_commands(tests))
+    elif fallback:
+        commands.extend(COMMANDS[lane][0] for lane in pytest_lanes)
+
+    if deployment:
+        commands.append(DEPLOY_COMMAND)
+
+    return commands
+
+
 def _command_arguments(command: str) -> list[str]:
     """Convert a displayed make command into an executable argv."""
 
     return shlex.split(command)
 
 
-def execute_commands(commands: list[str]) -> int:
-    """Execute planner output in fresh make invocations and retain failures."""
+def _git_revision(revision: str) -> str:
+    """Resolve a revision to an immutable commit, or return ``(unknown)``."""
 
-    status = 0
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", f"{revision}^{{commit}}"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return "(unknown)"
+    return result.stdout.strip() or "(unknown)"
+
+
+def _git_dirty() -> bool:
+    """Return whether the working tree has uncommitted or untracked changes."""
+
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return False
+    return bool(result.stdout.strip())
+
+
+def execute_commands(commands: list[str], *, base: str = "(explicit paths)") -> int:
+    """Execute planner output sequentially and print a complete summary.
+
+    Every command runs in order regardless of prior failures so the summary
+    reports the full affected-handoff result.  The return value is nonzero if
+    any command failed and zero only if every command succeeded (or there were
+    no commands to run).
+    """
+
+    results: list[tuple[str, int, float]] = []
     for command in commands:
+        start = time.monotonic()
         completed = subprocess.run(_command_arguments(command), cwd=ROOT, check=False)
-        if completed.returncode and status == 0:
-            status = completed.returncode
-    return status
+        duration = time.monotonic() - start
+        results.append((command, completed.returncode, duration))
+
+    return print_execution_summary(results, base=base)
+
+
+def print_execution_summary(
+    results: list[tuple[str, int, float]],
+    *,
+    base: str,
+    planning_failure: str | None = None,
+) -> int:
+    """Print one terminal summary for execution or planning failure."""
+
+    passed = sum(1 for _, returncode, _ in results if returncode == 0)
+    failed = len(results) - passed + (planning_failure is not None)
+    head = _git_revision("HEAD")
+    resolved_base = base if base == "(explicit paths)" else _git_revision(base)
+    dirty = _git_dirty()
+    print("summary:")
+    print(f"  base: {resolved_base}")
+    print(f"  head: {head}")
+    print(f"  dirty: {str(dirty).lower()}")
+    print(f"  total: {len(results) + (planning_failure is not None)}")
+    print(f"  passed: {passed}")
+    print(f"  failed: {failed}")
+    print(f"  result: {'pass' if failed == 0 else 'fail'}")
+    print("  commands:")
+    print("    status  seconds  command")
+    for command, returncode, duration in results:
+        status = "pass" if returncode == 0 else "fail"
+        print(f"    [{status}] {duration:.2f}s {command}")
+    if planning_failure is not None:
+        print(f"    [fail] 0.00s planner: {planning_failure}")
+    elif not results:
+        print("    [no-op] 0.00s (no commands selected)")
+    if planning_failure is not None:
+        return 2
+    return next((returncode for _, returncode, _ in results if returncode), 0)
 
 
 def classify(paths: list[str]) -> dict[str, str]:
@@ -480,13 +667,14 @@ def main() -> None:
     paths = sorted({entry.path for entry in entries})
     plan = classify(paths)
     lanes = [suite for suite in COMMANDS if plan.get(f"run-{suite}") == "true"]
-    command_lanes = local_command_lanes(lanes)
     tests, fallback = exact_tests(entries)
     # The classifier already owns deployment routing (run-deploy); re-deriving
     # it here would duplicate the deployment rule and could drift from it.
     deployment = plan.get("run-deploy") == "true"
+    commands = planned_commands(entries, plan, tests, fallback, deployment)
+    base_label = args.base or "(explicit paths)"
 
-    print(f"base: {args.base or '(explicit paths)'}")
+    print(f"base: {base_label}")
     print(f"classification: {plan['classification']}")
     print("paths:")
     for path in paths:
@@ -501,41 +689,35 @@ def main() -> None:
             print(f"  {test}")
     elif fallback and any(lane in TOPOLOGY_LANES for lane in lanes):
         print(f"  suite fallback ({fallback})")
-    elif fallback:
+    elif not any(lane in TOPOLOGY_LANES for lane in lanes):
         print("  not applicable (no pytest lane selected)")
     else:
         print("  none")
     print("commands:")
-    if tests:
-        print("  focused selectors:")
-        for command in focused_commands(tests):
-            print(f"    {command}")
-    else:
-        print("  planned lanes:")
-        for lane in command_lanes:
-            for command in COMMANDS[lane]:
-                print(f"    {command}")
-    if deployment:
-        print(f"  deployment gate: {DEPLOY_COMMAND}")
+    for command in commands:
+        print(f"  {command}")
+    if any("test-lean" in command for command in commands):
+        print("recovery: make setup PROFILE=lean")
+    if any("test-provider" in command for command in commands):
+        provider_profile = (
+            "external-proof"
+            if any("external_sat" in test for test in tests)
+            else "full-python"
+        )
+        print(f"recovery: make setup PROFILE={provider_profile}")
 
     if args.execute:
-        if tests:
-            commands = focused_commands(tests)
-            if not commands:
-                print(
-                    "cannot execute: selected tests have no unique topology lane",
-                    file=sys.stderr,
-                )
-                raise SystemExit(2)
-        elif fallback:
-            commands = [
-                command for lane in command_lanes for command in COMMANDS[lane]
-            ]
-        else:
-            commands = []
-        if deployment:
-            commands.append(DEPLOY_COMMAND)
-        raise SystemExit(execute_commands(commands))
+        sys.stdout.flush()
+        # Focused selection that cannot be narrowed to a unique topology lane is
+        # unsafe to execute; fail closed rather than silently dropping the pytest
+        # portion of the handoff.
+        if tests and not focused_commands(tests):
+            message = "selected tests have no unique topology lane"
+            print(f"cannot execute: {message}", file=sys.stderr)
+            raise SystemExit(
+                print_execution_summary([], base=base_label, planning_failure=message)
+            )
+        raise SystemExit(execute_commands(commands, base=base_label))
 
 
 if __name__ == "__main__":

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,165 +14,100 @@ Read the [documentation home](docs/index.md), the
 Use the installed catalog and current reference documents for present
 capability membership.
 
-## Validation at a glance
+## Contributor quick path
 
-| Change | Start here | Oracle requirement |
-| --- | --- | --- |
-| Documentation, benchmark README, or `benchmarks/validation/` | `make docs-linkcheck` | None |
-| Focused Python behavior | `make test-plan BASE=<revision>`, the selected lane, then `make check` | None |
-| Harbor job JSON, MCP config, job-level Compose overlay, or execution helper | `make harbor-execution-check` | None |
-| Benchmark task input or verifier | `make harbor-prepare-task DATASET=... TASKS="..."`, then `make harbor-validate-task DATASET=... TASKS="..."` | Exact selected-task Oracle |
-| Deployment entrypoint | `make deploy-check` | None |
-| CI, dependencies, or unknown paths | `make check-static` plus affected tests | As required by the selected plan |
+Most changes need only a light environment and the changed-path gate:
 
-The four primary test profiles are the cheapest useful starting points:
-`unit` covers pure contracts and models; `component` exercises one real service
-or adapter; `domain` loads explicitly selected mathematical bundles; and
-`composition` checks complete runtime wiring. Use the named boundary profiles
-(`storage`, `process`, `mcp`, `provider`, `lean`, and `e2e`) when the change
-crosses one of those boundaries. The [testing strategy](docs/reference/testing-strategy.md)
-defines the ownership and escalation rules.
+```sh
+make setup PROFILE=core
+make check-changed BASE=origin/main
+```
+
+Then open a pull request. `make setup PROFILE=core` installs the locked
+development environment and requires only the core provider surface (NetworkX,
+SymPy, and Z3). `make check-changed BASE=origin/main`
+runs format, type-checking, and the exact tests selected from your changed
+paths against that base ref. Open the PR once it is green, and add any
+explicitly relevant specialist validation called out below.
+
+CI owns the expensive correctness surface so the local loop stays fast. The
+hosted pipeline owns the supported Python and OS matrices, the full Lean and
+optional-provider environments, coverage enforcement, the compatibility smoke
+suite, packaging, the security audit, duplicate-code detection, and the
+exhaustive semantic-lane matrix. You do not need to reproduce those locally for
+a routine change.
+
+Specialist lanes (`make test-lean`, `make test-provider`, `make test-storage`,
+`make test-process`, `make test-mcp`, `make test-e2e`, `make test-domain`, and
+`make test-composition`) are troubleshooting and boundary work, not a routine
+confidence gate. Run one only when your change crosses that boundary or you are
+reproducing an environment-specific failure. The
+[testing strategy](docs/reference/testing-strategy.md) is the authoritative
+source for the change matrix, lane ownership, planning entry points, CI
+classification, and the escalation rules.
+
+### When the quick path is not enough
+
+- **Documentation only:** `make docs-linkcheck` is the dedicated lane; CI runs
+  it too. See [Documentation](#documentation).
+- **Broad or unknown impact** (CI, dependencies, shared infrastructure): run
+  `make check-static` plus the affected tests, and let CI own the fail-closed
+  functional lanes.
+- **Exhaustive local reproduction:** `make test-all-ci` is an explicit exception
+  path, not a routine gate. Before it, verify that no other pytest or
+  delegated-agent validation is running on the host, and never assign it to a
+  parallel agent sharing the checkout. The manually dispatched Python Debug and
+  Lean Debug workflows reproduce one pytest file or node in a prepared remote
+  environment when the relevant local runtime is impractical.
+
+Preview the exact local test selectors with `make test-plan BASE=origin/main`
+and the hosted CI lane decision with `make ci-plan BASE=origin/main`. The two
+reports answer different questions: the local plan may run exact importing
+tests, while the hosted plan owns required semantic lanes and fail-closed
+infrastructure coverage and emits a provenance-bound plan receipt. The full
+command inventory, narrowing examples, diagnostic-duration overrides, and CI
+classification detail live in the
+[testing strategy](docs/reference/testing-strategy.md).
 
 ## Development environment
 
-Jacobian uses Python 3.12, the uv release pinned in `.uv-version`, and a small
-`Makefile` that keeps local commands aligned:
+Jacobian uses Python 3.12 and the uv release pinned in [`.uv-version`](.uv-version).
 
 ```sh
-make setup
-make test-unit
-make test-component
+make setup PROFILE=core          # locked dev environment; core readiness
+make setup PROFILE=full-python    # also require every maintained Python extra
 ```
 
-The suite is split into semantic lanes. Use the narrowest lane that proves the
-behavior: `unit` for pure contracts and models, `component` for one real
-service, `domain` for explicitly installed mathematical bundles,
-`composition` for complete runtime wiring, and the `storage`, `process`,
-`mcp`, `provider`, `lean`, and `e2e` lanes for their named boundaries. Each
-semantic lane target accepts a pytest file or node through
-`TESTS=<file-or-node>` and extra pytest options through `PYTEST_ARGS`.
-`make check` runs Ruff, mypy, and the
-unit lane; it is a useful local handoff, but the pre-push hook intentionally
-runs only `make lint typecheck` so it stays below the interactive feedback
-budget. CI owns path-planned correctness lanes and optional environments.
-
-`make check-changed` combines the static edit-loop checks with exact changed
-test selection. `make check-static` adds dependency/dead-code checks and a
-package build when a focused change needs them. `make test-all-ci` is the explicit exceptional local
-reproduction of every semantic lane. Run `make help` for the complete command
-index of common commands; use `make help-all` for lifecycle and diagnostic
-plumbing. Lane ownership and local commands are documented in
-[testing strategy](docs/reference/testing-strategy.md).
-
-Use `make test-plan BASE=origin/main` for exact local test selectors and
-`make ci-plan BASE=origin/main` for the broader hosted-CI lane decision plus a
-provenance-bound plan receipt. The two reports intentionally answer different
-questions: the local plan may run exact importing tests, while the hosted plan
-owns required semantic lanes and fail-closed infrastructure coverage. Use
-`make harbor-plan BASE=origin/main`
-for benchmark contracts and Oracle scope; run it through Make because the
-planner requires the pinned Harbor runtime to compute task digests.
-The plan also selects host-side verifier regressions: task- or dataset-owned
-modules for focused changes, the changed validation file itself, and the full
-`benchmarks/validation` suite, sharded in hosted CI, for shared or unclassified
-infrastructure. To reproduce one selected host check locally, run
-`make harbor-validation-tests TESTS=<pytest-file-or-directory>`.
-
-For task authoring, `make harbor-prepare-task DATASET=... TASKS="..."` is the
-explicitly mutating preparation step. It formats only Python owned by the
-selected task and its dedicated validation leaf, runs scoped public-contract
-and verifier-checksum synchronization, and reports every generated file that
-changed. Follow it with `make harbor-validate-task DATASET=... TASKS="..."` for
-the complete source-read-only leaf gate. That command resolves membership and
-planner selectors once, fails fast through static quality and contracts, runs
-the selected host tests serially in a worktree-local temporary pytest directory,
-then runs each exact Oracle serially. Its summary includes per-stage timings and
-the resulting task digest and Oracle evidence path.
-
-Tests can be narrowed without learning another wrapper:
-
-```sh
-make test-component TESTS=tests/component/capabilities/test_atomic_capabilities.py
-make test-component TESTS=tests/component/capabilities/test_atomic_capabilities.py PYTEST_ARGS="-k schema -n 0"
-make test-unit TESTS=tests/unit/contracts/test_result_envelope.py
-make test-process TESTS=tests/boundary/process/search/test_shrinking.py
-make test-mcp PYTEST_ARGS="-k authentication"
-make test-storage TESTS=tests/boundary/storage/transactions/test_state_database_migrations.py
-make test-lean TESTS=tests/boundary/providers/lean/test_lean_repl_runtime.py PYTEST_ARGS="-k induction"
-```
-
-All Makefile pytest targets print their ten slowest tests by default. Set
-`PYTEST_DIAGNOSTIC_ARGS=--durations=0` to suppress that report, or use a larger
-value such as `PYTEST_DIAGNOSTIC_ARGS=--durations=25` while investigating a
-regression.
+`make check` runs Ruff, mypy, and the unit lane; it is a useful local handoff.
+The pre-push hook intentionally runs only `make lint typecheck` so it stays
+below the interactive feedback budget. `make check-changed` combines the static
+edit-loop checks with exact changed-path test selection; `make check-static`
+adds dependency/dead-code checks and a package build when a focused change needs
+them. Run `make help` for the common command index and `make help-all` for
+lifecycle and diagnostic plumbing.
 
 Run `make hooks` once to install commit-time formatting, syntax, secret,
-large-file, dead-code, and actionlint hooks plus the static `make lint typecheck`
-pre-push gate. Use `make check` when you also want the unit lane locally. Hooks
-remain bypassable for exceptional cases with Git's standard `--no-verify`
-option.
-`make fix` applies Ruff's safe lint fixes followed by formatting. `make
-precommit` applies those fixes and then runs the routine handoff checks.
+large-file, dead-code, and actionlint hooks plus the static
+`make lint typecheck` pre-push gate. `make fix` applies Ruff's safe lint fixes
+followed by formatting; `make precommit` applies those fixes and then runs the
+routine handoff checks. Hooks remain bypassable for exceptional cases with Git's
+standard `--no-verify` option.
 
 On macOS, read the
-[Z3 installation guide](docs/how-to/troubleshoot-z3-macos.md) before troubleshooting a
-source-build failure from `uv sync --dev`.
+[Z3 installation guide](docs/how-to/troubleshoot-z3-macos.md) before
+troubleshooting a source-build failure from `uv sync --dev`.
 
-Use focused tests while implementing. Run `make check` (or the affected
-semantic target) and wait for green CI checks before merge. Run broad local
-validation only when changing CI itself, debugging an environment-specific
-failure, or when CI is unavailable. `make test-all-ci` is an explicit exception
-path, not a routine confidence gate. Before it, verify that no other pytest or
-delegated-agent validation is running on the host. Never assign an exhaustive
-suite to a parallel agent sharing the checkout. Report only checks that
-actually ran. The manually
-dispatched Python Debug and Lean Debug workflows reproduce one pytest file or
-node in a prepared remote environment when the relevant local runtime is
-impractical.
+Every `make test-*` target accepts `TESTS=<file-or-node>` and extra pytest
+options through `PYTEST_ARGS`, and prints its ten slowest tests by default
+(override with `PYTEST_DIAGNOSTIC_ARGS=--durations=0`). Use
+`uv run --locked pytest --lf` after a failure and `uv run --locked pytest -n 0`
+while debugging. Do not use unfiltered `uv run pytest` as the complete-suite
+command: it mixes Lean into the general xdist pool, and pytest rejects that
+unsafe combination with the corresponding `make` targets in its error message.
+See the [testing strategy](docs/reference/testing-strategy.md) for the canonical
+lane commands and narrowing examples.
 
-CI classifies pull requests through the tested source-to-suite impact
-manifest in `.github/ci-impact.json`. Documentation-only changes skip
-Python, npm, Lean, static, package, security, and duplicate-code lanes, but
-run the dedicated `make docs-linkcheck` lane.
-Documentation plus npm or npm-only changes run npm packaging without the
-Python and Lean lanes. Unknown paths fail closed to all functional lanes.
-Required status contexts still complete after checking the plan when their
-expensive validation is intentionally omitted.
-Maintainers can add the `ci:full` label to force every lane or `ci:lean` to
-add real-Lean validation to an otherwise isolated plan. Label changes re-trigger
-CI so the override applies without an extra push. These overrides only add work;
-labels cannot reduce the fail-closed path classification.
-Pull requests run the canonical Python version. Merge-queue groups and pushes
-to `main` additionally run supported-version compatibility and combined
-coverage as exhaustive gates. Successful `main` runs publish fresh integration
-shard timings. Timing history is not committed, and missing or invalid history
-falls back to equal-weight sharding.
-
-Use `make test-plan BASE=<revision>` to preview the same changed-path routing
-before validation. For an added or modified leaf Python module, the planner
-selects test files that directly import that module when no production module
-imports it. Changes to test files select those files directly. Maintained
-non-Python mappings may be declared in `.github/local-test-ownership.json`;
-selectors there may be pytest files or nodes. This narrowing is deliberately
-conservative: deletes, renames, untracked files, transitive production imports,
-shared infrastructure, unknown paths, invalid manifests, and import parse
-failures retain the owning suite commands. The focused selection is an edit-loop
-aid; `make check` and CI remain the handoff gates.
-
-| Change | Local handoff | CI adds |
-| --- | --- | --- |
-| Docs only | `make docs-linkcheck` | Documentation |
-| Focused Python | affected target, then `make check` | Planned Python/static/package lanes |
-| Benchmark task or verifier | `make harbor-prepare-task DATASET=... TASKS="..."`, then `make harbor-validate-task DATASET=... TASKS="..."` | Exact task contract, planner-selected host tests, and Oracle |
-| Benchmark README or validation regression | focused Harbor checks | Contract checks; no Oracle |
-| Lean runtime | focused `make test-lean`, then `make check` | Lean plus affected lanes |
-| CI, dependencies, or unknown paths | `make check-static` plus affected tests | Fail-closed functional lanes |
-
-Before final validation, use `make test-plan BASE=<revision>` to preview the
-changed-path selection and run the selected checks on the final tree. If the
-tree changes during validation, rerun checks whose evidence was invalidated by
-that change; do not describe results from an earlier tree as final-tree
-validation.
+### Parallel agents sharing a checkout
 
 Parallel agents sharing one checkout must divide path ownership before editing.
 They must not switch branches, stage, commit, clean, or rewrite shared files
@@ -180,28 +115,49 @@ while another agent is working. Integrate their edits first, then run the
 planned checks on the final tree. Use isolated worktrees only when the workflow
 explicitly assigns them.
 
-Keep the local edit loop on directory-owned Make targets rather than inventing
-marker filters:
+Before final validation, use `make test-plan BASE=<revision>` to preview the
+changed-path selection and run the selected checks on the final tree. If the
+tree changes during validation, rerun checks whose evidence was invalidated by
+that change; do not describe results from an earlier tree as final-tree
+validation. `make check-changed` is the normal local handoff; CI owns the
+exhaustive evidence described above.
 
-```sh
-make test-unit
-make test-component TESTS=tests/component/capabilities/test_atomic_capabilities.py
-make test-domain TESTS=tests/domain/graph/test_graph_invariant_domain.py
-```
+## Harbor and Oracle validation
 
-Ownership is by test directory. Lean tests live in the serial `lean` boundary
-lane; keep them out of the normal xdist pools because Mathlib processes can
-retain several gigabytes. CI installs the pinned Lean toolchain and Mathlib
-cache in a dedicated runner.
-Use `uv run --locked pytest --lf` after a failure, `uv run --locked pytest -n 0`
-while debugging, and `make check` before handoff. Use
-`make test-lean TESTS=tests/boundary/providers/lean/test_lean_repl_runtime.py` for
-a deliberately focused local Lean reproduction, or dispatch the remote Lean
-debug workflow from GitHub Actions when local Lean is impractical. Use
-`make test-lean PYTEST_ARGS=--lf` to rerun a failed Lean-runtime test.
-Do not use unfiltered `uv run pytest` as the normal complete-suite command
-because it mixes Lean into the general xdist pool; pytest rejects that unsafe
-combination with the corresponding `make` targets in its error message.
+Benchmark validation is decomposed into evidence roles even though CI shares
+one checkout for the deterministic contract gate. A task README is documentation;
+a task instruction, environment, manifest, or member record is executable
+evaluation input. Shared environment profiles and execution-control changes may
+escalate to merge-queue portfolio evidence.
+
+For task authoring, `make harbor-prepare-task DATASET=... TASKS="..."` is the
+explicitly mutating preparation step: it formats only Python owned by the
+selected task and its dedicated validation leaf, runs scoped public-contract
+and verifier-checksum synchronization, and reports every generated file that
+changed. Follow it with
+`make harbor-validate-task DATASET=... TASKS="..."` for the complete
+source-read-only leaf gate, which resolves membership and planner selectors
+once, fails fast through static quality and contracts, runs the selected host
+tests serially, then runs each exact Oracle serially. Neither command starts an
+Oracle or model.
+
+`make harbor-execution-check` validates repository-wide Harbor contracts (job
+JSON, MCP config, job-level Compose overlays, execution helpers) and the unit
+tests that own them; it deliberately excludes the task-specific verifier
+regressions under `benchmarks/validation/`, where `make harbor-check` retains
+the full integration role. Task `environment/docker-compose.yaml` files are
+executable benchmark input, not job overlays, and remain gated by
+`make harbor-check-task` and `make harbor-oracle-task`. Use
+`make harbor-plan BASE=origin/main` for benchmark contracts and Oracle scope;
+run it through Make because the planner requires the pinned Harbor runtime to
+compute task digests.
+
+For the exact task authoring workflow and verifier changes, use the
+[`harbor-benchmarks`](.agents/skills/harbor-benchmarks/SKILL.md) skill. The
+[testing strategy](docs/reference/testing-strategy.md) and
+[benchmark contracts](docs/reference/evaluations/benchmark-contracts.md) define
+the full ownership, host-validation sharding, and Oracle semantics.
+
 ## Verification rules
 
 - Do not turn a timeout, cancellation, error, incomplete enumeration, or
@@ -282,18 +238,17 @@ Test directories define semantic ownership: `tests/unit`, `tests/component`,
 matching `make test-*` target as the canonical entry point. Markers are retained
 only when they alter execution: `requires_provider(name)`, `performance`,
 `property`, and `destructive_process`. They do not replace directory ownership.
-Reproduce the scheduled validation lanes locally with `make test-stress` and
-`make test-ordering ORDERING_LANE=domain PYTEST_ARGS=--randomly-seed=17`
-(`ORDERING_LANE` selects the semantic lane to reseed; `domain` and
-`composition` are the sharded lanes whose scheduled seed matters most).
-Locked `pytest-repeat` and `pytest-randomly` are part of the dev environment.
 
 Tests may reuse concept-specific helpers under `tests/support`, but must not
 import helpers from a sibling semantic lane. Keep fixtures in the narrowest
 directory or module that needs them, and keep support modules to ordinary data
 builders or one stable test concept rather than hidden setup.
 
-CI change impact is declared in `.github/ci-impact.json`. Its matching rules are
+The [testing strategy](docs/reference/testing-strategy.md) is the authoritative
+source for the change matrix, the canonical lane commands, planning entry
+points, CI classification, shard scheduling, marker policy, and the
+specialist-lane escalation rules. CI change impact is declared in
+[`.github/ci-impact.json`](.github/ci-impact.json); its matching rules are
 additive, so a path may require several suites. Integration timing history is a
 scheduling hint produced by successful `main` runs; it is not committed state,
 and missing or invalid history falls back to equal-weight sharding.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 TOPOLOGY_RUNNER := $(UV_RUN) python tools/test_topology.py
 PYTEST_RUNNER := $(UV_RUN) python tools/pytest_lifecycle.py
-PUBLIC_COMMANDS := help setup check check-changed ci-plan test-plan test-changed test-unit test-component test-domain test-composition test-storage test-process test-mcp test-provider test-lean test-e2e docs-command-check docs-linkcheck harbor-plan harbor-prepare-task harbor-validate-task harbor-execution-check harbor-check-task harbor-oracle-task npm-test test-all-ci check-static deploy-check
+PUBLIC_COMMANDS := setup doctor fix check-changed check ci-plan
 
 ifneq ($(strip $(PATHS)),)
 PATHS_FILE := $(shell mktemp)
@@ -27,12 +27,12 @@ include make/evaluations.mk
 # provider lanes run risky work in killable children and set their own deadline.
 .PHONY: help help-all
 
-help: ## Show available developer commands.
-	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian common developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / && ($$1 in wanted) {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+help: ## Show the primary developer workflow.
+	@awk -v public="$(PUBLIC_COMMANDS)" 'BEGIN {FS = ":.*## "; n = split(public, names, " "); for (i = 1; i <= n; i++) wanted[names[i]] = 1; printf "Jacobian primary developer commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / && ($$1 in wanted) {description[$$1] = $$2} END {for (i = 1; i <= n; i++) printf "  %-18s %s\n", names[i], description[names[i]]}' $(MAKEFILE_LIST)
 	@printf '\nAdvanced lifecycle and diagnostic commands are hidden from the daily index. Use `make help-all` to list them.\n'
 
 help-all: ## Show every low-level and lifecycle developer command.
-	@awk 'BEGIN {FS = ":.*## "; printf "All Jacobian developer commands:\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-26s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*## "; printf "All Jacobian developer commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-26s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 
 test-plan: ## Print local validation selected for BASE..HEAD or explicit PATHS.
@@ -93,8 +93,7 @@ test-changed: ## Run changed-path tests, defaulting BASE to origin/main.
 		$(UV_RUN) python .github/scripts/plan-local-tests --base "$(or $(BASE),origin/main)" --execute; \
 	fi
 
-check-changed: ## Run format, types, and exact changed-path tests.
-	$(MAKE) lint typecheck
+check-changed: ## Plan and run the affected local handoff (BASE=origin/main).
 	$(MAKE) test-changed BASE="$(or $(BASE),origin/main)"
 
 define run_topology_lane

--- a/docs/how-to/install-optional-backends.md
+++ b/docs/how-to/install-optional-backends.md
@@ -25,6 +25,15 @@ and checker runtimes. The
 [source setup profiles](setup-agent-from-source.md#profiles) provide maintained
 installation paths for `full-python`, `lean`, and `external-proof` checkouts.
 
+For ordinary contributor work, `make setup PROFILE=core` installs the locked
+development environment and diagnoses only the core provider surface
+(NetworkX, SymPy, and Z3); that is the contributor quick path described in
+[CONTRIBUTING.md](../../CONTRIBUTING.md). Use
+`make setup PROFILE=full-python` when the change requires every maintained
+Python extra. CI owns the full Lean and optional-provider environments, so you
+do not need to prepare them locally unless you are reproducing a
+boundary-specific failure.
+
 ## Lean certificates
 
 The `lean.check` capability binds an exact proposition and proof body to its

--- a/docs/how-to/setup-agent-from-source.md
+++ b/docs/how-to/setup-agent-from-source.md
@@ -70,6 +70,15 @@ is absent or has the wrong identity, doctor fails before client configuration.
 The `lean` profile likewise uses the repository's pinned toolchain and manifest
 instead of a floating Lean installation.
 
+These profiles configure an agent client against a source checkout. For
+ordinary contributor work that only needs to run the test suite, the
+`make setup PROFILE=core` quick path installs the same locked base surface
+(NetworkX, SymPy, and Z3) without writing client configuration; see
+[CONTRIBUTING.md](../../CONTRIBUTING.md). `make setup PROFILE=full-python`
+additionally requires every maintained Python extra. Optional backend
+installation is described in
+[Install optional backends](install-optional-backends.md).
+
 Add `--dev` when the clone also needs the locked development group. Use
 `--dry-run` to inspect every sync, init, configuration, and doctor command
 without changing the environment, state directory, or client files. Repeating

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -67,6 +67,27 @@ digest, configuration digests, and canonical plan digest. `make harbor-plan`
 uses the pinned Harbor runtime because task digests are part of the plan
 contract.
 
+### Local development and CI ownership
+
+The contributor quick path is `make setup PROFILE=core` followed by
+`make check-changed BASE=origin/main` (see
+[CONTRIBUTING.md](../../CONTRIBUTING.md)). It keeps the local loop on the
+changed-path gate. CI owns the exhaustive correctness surface that the local
+loop intentionally skips: the supported Python and OS matrices, the full Lean
+and optional-provider environments, coverage enforcement, the compatibility
+smoke suite, packaging, the security audit, duplicate-code detection, and the
+complete semantic-lane matrix. You do not need to reproduce those locally for a
+routine change.
+
+Specialist lanes (`storage`, `process`, `mcp`, `provider`, `lean`, and `e2e`)
+own their named boundaries, but for routine contributor work they are
+troubleshooting and boundary-crossing work rather than a required local gate.
+Run one when a change crosses that boundary or when reproducing an
+environment-specific failure; CI runs the full matrix. The command inventory
+below is the authoritative reference for lane commands, narrowing, planning
+entry points, and CI classification, and is linked from
+[CONTRIBUTING.md](../../CONTRIBUTING.md) instead of being duplicated there.
+
 ## Purpose
 
 Jacobian is a mathematical capability toolbox with a fail-closed verification

--- a/make/development.mk
+++ b/make/development.mk
@@ -1,10 +1,15 @@
-.PHONY: uv-version-check setup setup-agent container-image eval-image eval-image-pull eval-image-bind deploy-check hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture docs-command-check docs-linkcheck
+.PHONY: uv-version-check setup doctor setup-agent container-image eval-image eval-image-pull eval-image-bind deploy-check hooks fix lint complexity-check lint-full security-audit typecheck test-architecture architecture docs-command-check docs-linkcheck
+
+PROFILE ?= core
 
 uv-version-check: ## Require the repository-pinned uv release.
 	@test "$$(uv --version | awk '{print $$2}')" = "$$(tr -d '[:space:]' < .uv-version)" || { echo "install uv $$(tr -d '[:space:]' < .uv-version) before using this checkout" >&2; exit 2; }
 
-setup: uv-version-check ## Install the locked development environment.
-	uv sync --locked --dev
+setup: ## Install and diagnose a locked development profile (PROFILE=core).
+	python3 tools/development_profiles.py setup --profile "$(PROFILE)" --repo .
+
+doctor: ## Diagnose a development profile without changing it (PROFILE=core).
+	uv run --locked --no-sync python tools/development_profiles.py doctor --profile "$(PROFILE)" --repo .
 
 setup-agent: ## Configure an agent against this source checkout (ARGS="--client codex --profile full-python").
 	./scripts/setup-agent $(ARGS)

--- a/scripts/setup-agent
+++ b/scripts/setup-agent
@@ -55,10 +55,7 @@ while (($#)); do
   esac
 done
 
-case "$PROFILE" in
-  core|full-python|lean|external-proof) ;;
-  *) echo "unknown profile: $PROFILE" >&2; exit 2 ;;
-esac
+python3 "$REPO_ROOT/tools/development_profiles.py" validate --profile "$PROFILE" || exit $?
 if ((!ALL && ${#CLIENTS[@]} == 0)); then
   echo "select at least one --client or use --all" >&2
   exit 2
@@ -152,16 +149,12 @@ STATE_DIR=$("$PYTHON_PATH" -c 'from pathlib import Path; import sys; print(Path(
 require_checkout_path_ignored "the Jacobian state directory" "$STATE_DIR"
 UV_BIN=$(command -v uv)
 
-SYNC=(uv sync --project "$REPO_ROOT" --python "$PYTHON_PATH" --locked --no-dev)
-case "$PROFILE" in
-  full-python|lean|external-proof) SYNC+=(--all-extras) ;;
-esac
-if ((DEV)); then
-  SYNC=(uv sync --project "$REPO_ROOT" --python "$PYTHON_PATH" --locked --dev)
-  case "$PROFILE" in
-    full-python|lean|external-proof) SYNC+=(--all-extras) ;;
-  esac
-fi
+PROFILE_SYNC_ARGS=()
+SYNC_FLAG_ARGS=(sync-flags --profile "$PROFILE" --no-dev)
+((DEV)) && SYNC_FLAG_ARGS=(sync-flags --profile "$PROFILE")
+mapfile -t PROFILE_SYNC_ARGS < <("$PYTHON_PATH" "$REPO_ROOT/tools/development_profiles.py" "${SYNC_FLAG_ARGS[@]}")
+SYNC=(uv "${PROFILE_SYNC_ARGS[@]}" --project "$REPO_ROOT" --python "$PYTHON_PATH")
+PREPARE=("$PYTHON_PATH" "$REPO_ROOT/tools/development_profiles.py" prepare --profile "$PROFILE" --repo "$REPO_ROOT")
 INIT=(uv run --project "$REPO_ROOT" --locked --no-sync jacobian --state-dir "$STATE_DIR" init)
 CONFIG=(node "$REPO_ROOT/npm/bin/jacobian.cjs" setup --source "$REPO_ROOT" --state-dir "$STATE_DIR" --uv-bin "$UV_BIN" --profile "$PROFILE" --provider-path "$PATH")
 test -z "${UV_PROJECT_ENVIRONMENT:-}" || CONFIG+=(--project-environment "$UV_PROJECT_ENVIRONMENT")
@@ -185,6 +178,7 @@ test -z "${JACOBIAN_LEAN_RUNTIME:-}" || echo "  Lean dir: $JACOBIAN_LEAN_RUNTIME
 
 if ((DRY_RUN)); then
   printf '  sync:     '; printf '%q ' "${SYNC[@]}"; printf '\n'
+  printf '  prepare:  '; printf '%q ' "${PREPARE[@]}"; printf '\n'
   printf '  init:     '; printf '%q ' "${INIT[@]}"; printf '\n'
   printf '  doctor:   '; printf '%q ' "${DOCTOR[@]}"; printf '\n'
   "${CONFIG[@]}"
@@ -192,13 +186,7 @@ if ((DRY_RUN)); then
 fi
 
 "${SYNC[@]}"
-if test "$PROFILE" = lean; then
-  command -v lake >/dev/null || {
-    echo "the lean profile requires elan/lake and the pinned toolchain in lean/lean-toolchain" >&2
-    exit 2
-  }
-  (cd "$REPO_ROOT/lean" && lake build repl jacobian_lean_proof_state)
-fi
+"${PREPARE[@]}"
 mkdir -p -- "$STATE_DIR"
 "${INIT[@]}"
 "${DOCTOR[@]}"

--- a/tests/boundary/process/tooling/test_make_help.py
+++ b/tests/boundary/process/tooling/test_make_help.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[4]
+PRIMARY_COMMANDS = {
+    "setup",
+    "doctor",
+    "fix",
+    "check-changed",
+    "check",
+    "ci-plan",
+}
+PRIMARY_COMMAND_ORDER = [
+    "setup",
+    "doctor",
+    "fix",
+    "check-changed",
+    "check",
+    "ci-plan",
+]
+
+
+def _listed_command_order(target: str) -> list[str]:
+    completed = subprocess.run(
+        ["make", "--no-print-directory", target],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line.split()[0]
+        for line in completed.stdout.splitlines()
+        if line.startswith("  ") and line.split()
+    ]
+
+
+def test_help_lists_only_the_primary_developer_workflow() -> None:
+    assert _listed_command_order("help") == PRIMARY_COMMAND_ORDER
+
+
+def test_help_all_retains_specialist_and_compatibility_commands() -> None:
+    commands = set(_listed_command_order("help-all"))
+
+    assert commands >= PRIMARY_COMMANDS
+    assert commands >= {
+        "test-plan",
+        "test-changed",
+        "test-unit",
+        "test-component",
+        "test-domain",
+        "test-composition",
+        "test-storage",
+        "test-process",
+        "test-mcp",
+        "test-provider",
+        "test-lean",
+        "test-e2e",
+        "harbor-plan",
+        "harbor-prepare-task",
+        "harbor-validate-task",
+        "deploy-check",
+        "npm-test",
+        "test-all-ci",
+    }

--- a/tests/boundary/process/tooling/test_source_agent_bootstrap.py
+++ b/tests/boundary/process/tooling/test_source_agent_bootstrap.py
@@ -27,8 +27,13 @@ def _load_tool(name: str) -> ModuleType:
 def _bootstrap_checkout(tmp_path: Path) -> tuple[Path, dict[str, str]]:
     checkout = tmp_path / "checkout"
     (checkout / "scripts").mkdir(parents=True)
+    (checkout / "tools").mkdir(parents=True)
     (checkout / "npm" / "bin").mkdir(parents=True)
     shutil.copy2(ROOT / "scripts" / "setup-agent", checkout / "scripts" / "setup-agent")
+    shutil.copy2(
+        ROOT / "tools" / "development_profiles.py",
+        checkout / "tools" / "development_profiles.py",
+    )
     (checkout / "pyproject.toml").write_text("[project]\nname = 'fixture'\n")
     (checkout / "uv.lock").touch()
     (checkout / ".uv-version").write_text("0.0.0\n")
@@ -157,6 +162,15 @@ def test_every_bootstrap_profile_audits_z3_and_networkx() -> None:
     for providers in doctor._PROFILE_PROVIDERS.values():
         assert "z3" in providers
         assert "networkx" in providers
+
+
+def test_source_bootstrap_delegates_profile_setup_to_shared_definitions() -> None:
+    script = (ROOT / "scripts" / "setup-agent").read_text(encoding="utf-8")
+
+    assert "tools/development_profiles.py" in script
+    assert 'prepare --profile "$PROFILE"' in script
+    assert "lake update" not in script
+    assert "lake build" not in script
 
 
 def test_bootstrap_dry_run_forwards_resolved_environment_without_downloads(

--- a/tests/unit/tooling/test_development_profiles.py
+++ b/tests/unit/tooling/test_development_profiles.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parents[3]
+
+
+def _load_profiles() -> ModuleType:
+    path = ROOT / "tools" / "development_profiles.py"
+    spec = importlib.util.spec_from_file_location("development_profiles", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_profiles_share_locked_sync_contracts() -> None:
+    profiles = _load_profiles()
+
+    assert profiles.PROFILE_NAMES == (
+        "core",
+        "full-python",
+        "lean",
+        "external-proof",
+    )
+    assert profiles.sync_arguments("core") == ("sync", "--locked", "--dev")
+    for name in ("full-python", "lean", "external-proof"):
+        assert profiles.sync_arguments(name) == (
+            "sync",
+            "--locked",
+            "--dev",
+            "--all-extras",
+        )
+
+
+def test_invalid_profile_reports_all_supported_choices() -> None:
+    profiles = _load_profiles()
+
+    with pytest.raises(ValueError, match="core, full-python, lean, external-proof"):
+        profiles.profile("everything")
+
+
+def test_lean_setup_installs_pin_then_gets_cache_and_builds_without_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profiles = _load_profiles()
+    repo = tmp_path / "repo"
+    (repo / "lean").mkdir(parents=True)
+    (repo / "lean" / "lean-toolchain").write_text(
+        "leanprover/lean4:v4.31.0\n", encoding="utf-8"
+    )
+    commands: list[tuple[tuple[str, ...], Path]] = []
+    monkeypatch.setattr(profiles, "_tool_path", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(
+        profiles,
+        "_uv_diagnostic",
+        lambda _repo: profiles.Diagnostic(
+            "uv", "available", "0.11.28", "0.11.28", "", ""
+        ),
+    )
+
+    def record(arguments: object, cwd: Path) -> int:
+        commands.append((tuple(arguments), cwd))
+        return 0
+
+    profiles.setup_profile(repo, "lean", run=record)
+
+    assert commands[:4] == [
+        (("uv", "sync", "--locked", "--dev", "--all-extras"), repo),
+        (
+            ("elan", "toolchain", "install", "leanprover/lean4:v4.31.0"),
+            repo,
+        ),
+        (("lake", "exe", "cache", "get"), repo / "lean"),
+        (
+            ("lake", "build", "repl", "jacobian_lean_proof_state"),
+            repo / "lean",
+        ),
+    ]
+    assert all("update" not in command for command, _cwd in commands)
+    assert commands[-1][0][:6] == (
+        "uv",
+        "run",
+        "--locked",
+        "--no-sync",
+        "python",
+        str(repo / "tools" / "development_profiles.py"),
+    )
+
+
+def test_external_proof_setup_never_downloads_executables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profiles = _load_profiles()
+    repo = tmp_path / "repo"
+    commands: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        profiles,
+        "_uv_diagnostic",
+        lambda _repo: profiles.Diagnostic(
+            "uv", "available", "0.11.28", "0.11.28", "", ""
+        ),
+    )
+
+    def record(arguments: object, _cwd: Path) -> int:
+        commands.append(tuple(arguments))
+        return 0
+
+    profiles.setup_profile(repo, "external-proof", run=record)
+    first_run = list(commands)
+    profiles.setup_profile(repo, "external-proof", run=record)
+
+    assert first_run[0] == (
+        "uv",
+        "sync",
+        "--locked",
+        "--dev",
+        "--all-extras",
+    )
+    assert commands == [*first_run, *first_run]
+    assert all(command[0] == "uv" for command in commands)
+
+
+def test_doctor_distinguishes_available_unavailable_and_incompatible_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profiles = _load_profiles()
+
+    monkeypatch.setattr(profiles.importlib.metadata, "version", lambda _name: "1.3.4")
+    available = profiles._distribution_diagnostic(
+        requirement="cvc5",
+        distribution="cvc5",
+        expected="==1.3.4",
+        profile_name="full-python",
+    )
+    monkeypatch.setattr(profiles.importlib.metadata, "version", lambda _name: "1.2.0")
+    incompatible = profiles._distribution_diagnostic(
+        requirement="cvc5",
+        distribution="cvc5",
+        expected="==1.3.4",
+        profile_name="full-python",
+    )
+
+    def missing(_name: str) -> str:
+        raise profiles.importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(profiles.importlib.metadata, "version", missing)
+    unavailable = profiles._distribution_diagnostic(
+        requirement="cvc5",
+        distribution="cvc5",
+        expected="==1.3.4",
+        profile_name="full-python",
+    )
+
+    assert [available.status, incompatible.status, unavailable.status] == [
+        "available",
+        "incompatible",
+        "unavailable",
+    ]
+    assert unavailable.recovery == "Run `make setup PROFILE=full-python`"
+    assert unavailable.documentation == profiles.OPTIONAL_BACKEND_DOCUMENTATION

--- a/tests/unit/tooling/test_plan_local_tests.py
+++ b/tests/unit/tooling/test_plan_local_tests.py
@@ -125,6 +125,13 @@ def test_explicit_paths_report_missing_files_as_deletes(
             "tools/check_doc_commands.py",
             {"tests/unit/tooling/test_doc_commands.py"},
         ),
+        (
+            "tools/development_profiles.py",
+            {
+                "tests/unit/tooling/test_development_profiles.py",
+                "tests/boundary/process/tooling/test_source_agent_bootstrap.py",
+            },
+        ),
     ],
 )
 def test_new_tooling_changes_use_narrow_owned_tests(
@@ -150,6 +157,23 @@ def test_deleted_ci_tooling_change_cannot_use_owned_process_override() -> None:
 
     assert selected == []
     assert fallback == ".github/scripts/emit-plan-receipt: D changes are not exact"
+
+
+def test_documentation_does_not_erase_exact_tooling_ownership() -> None:
+    planner = _load_script_module("plan_local_tests_docs_mixed", "plan-local-tests")
+
+    selected, fallback = planner.exact_tests(
+        [
+            planner.Change("M", "CONTRIBUTING.md"),
+            planner.Change("M", "tools/development_profiles.py"),
+        ]
+    )
+
+    assert fallback is None
+    assert selected == [
+        "tests/boundary/process/tooling/test_source_agent_bootstrap.py",
+        "tests/unit/tooling/test_development_profiles.py",
+    ]
 
 
 def test_plan_preserves_both_sides_of_rename(monkeypatch) -> None:
@@ -465,7 +489,7 @@ def test_plan_fails_closed_for_unknown_path_and_invalid_manifest(
     assert fallback == ".github/local-test-ownership.json: invalid manifest"
 
 
-def test_plan_labels_focused_commands_without_printing_lane_fallbacks(
+def test_plan_focused_tests_keep_independent_gates(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -476,7 +500,356 @@ def test_plan_labels_focused_commands_without_printing_lane_fallbacks(
     planner.main()
     output = capsys.readouterr().out
 
-    assert "focused selectors:" in output
+    # Focused selectors are still present...
     assert "make test-unit TESTS=tests/unit/tooling/test_doc_commands.py" in output
+    # ...but focused selection no longer suppresses the independent gates that
+    # the classification selected for this infrastructure tool path.
+    assert "make check-static" in output
+    assert "make docs-linkcheck" in output
+    # Broad pytest lane fallbacks are not printed for a focused selection.
+    assert "make test-process" not in output
     assert "make test-component" not in output
-    assert "make check-static" not in output
+
+
+def _plan(**selected: bool) -> dict[str, str]:
+    plan = {
+        "classification": "selective",
+        "run-python": "false",
+        "run-deploy": "false",
+    }
+    plan.update(
+        {
+            f"run-{name.replace('_', '-')}": str(value).lower()
+            for name, value in selected.items()
+        }
+    )
+    return plan
+
+
+def test_planned_commands_selects_docs_linkcheck_for_docs_paths() -> None:
+    planner = _load_script_module("plan_local_tests_docs_gate", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [planner.Change("M", "docs/explanation/goals.md")],
+        _plan(docs=True),
+        [],
+        None,
+        False,
+    )
+
+    assert commands == ["make docs-linkcheck"]
+
+
+def test_planned_commands_selects_npm_test_for_npm_paths() -> None:
+    planner = _load_script_module("plan_local_tests_npm_gate", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [planner.Change("M", "npm/index.js")],
+        _plan(npm=True),
+        [],
+        None,
+        False,
+    )
+
+    assert commands == ["make npm-test"]
+
+
+def test_planned_commands_uses_check_static_for_makefile() -> None:
+    planner = _load_script_module("plan_local_tests_makefile_gate", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [planner.Change("M", "Makefile")],
+        _plan(static=True),
+        [],
+        None,
+        False,
+    )
+
+    assert commands == ["make check-static"]
+    assert "make lint typecheck" not in commands
+
+
+def test_planned_commands_uses_lint_typecheck_once_for_ordinary_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = _load_script_module("plan_local_tests_lint_gate", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "focused_commands",
+        lambda tests: ["make test-unit TESTS=tests/unit/test_leaf.py"],
+    )
+
+    commands = planner.planned_commands(
+        [planner.Change("M", "src/jacobian/leaf.py")],
+        _plan(unit=True, component=True, static=True, python=True),
+        ["tests/unit/test_leaf.py"],
+        None,
+        False,
+    )
+
+    # Ordinary Python routes to the light lint/typecheck handoff once, even
+    # though the classifier also selected the heavier static lane.
+    assert commands[0] == "make lint typecheck"
+    assert commands.count("make lint typecheck") == 1
+    assert "make check-static" not in commands
+    # Focused selectors are preserved alongside the gate.
+    assert "make test-unit TESTS=tests/unit/test_leaf.py" in commands
+
+
+def test_planned_commands_uses_check_static_for_infrastructure_with_focused_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = _load_script_module("plan_local_tests_ci_tool_gate", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "focused_commands",
+        lambda tests: ["make test-unit TESTS=tests/unit/test_plan_local_tests.py"],
+    )
+
+    commands = planner.planned_commands(
+        [planner.Change("M", ".github/scripts/plan-local-tests")],
+        _plan(
+            unit=True,
+            process=True,
+            static=True,
+            npm=True,
+            security=True,
+            duplicate=True,
+            python=True,
+        ),
+        ["tests/unit/tooling/test_plan_local_tests.py"],
+        None,
+        False,
+    )
+
+    # Infrastructure routes to check-static (which already covers lint and
+    # typecheck), so the separate lint/typecheck handoff is not added.
+    assert commands[0] == "make check-static"
+    assert "make lint typecheck" not in commands
+    assert "make test-unit TESTS=tests/unit/test_plan_local_tests.py" in commands
+    assert all("security" not in command for command in commands)
+    assert all("duplicate" not in command for command in commands)
+    assert all("npm-test" not in command for command in commands)
+
+
+def test_planned_commands_mixed_infra_and_python_uses_check_static(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = _load_script_module("plan_local_tests_mixed", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "focused_commands",
+        lambda tests: ["make test-unit TESTS=tests/unit/test_leaf.py"],
+    )
+
+    commands = planner.planned_commands(
+        [
+            planner.Change("M", "src/jacobian/leaf.py"),
+            planner.Change("M", ".github/workflows/ci.yml"),
+        ],
+        _plan(unit=True, static=True, python=True),
+        ["tests/unit/test_leaf.py"],
+        None,
+        False,
+    )
+
+    assert commands[0] == "make check-static"
+    assert "make lint typecheck" not in commands
+    assert "make test-unit TESTS=tests/unit/test_leaf.py" in commands
+
+
+def test_planned_commands_adds_docs_gate_alongside_ordinary_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = _load_script_module("plan_local_tests_docs_py", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "focused_commands",
+        lambda tests: ["make test-unit TESTS=tests/unit/test_leaf.py"],
+    )
+
+    commands = planner.planned_commands(
+        [
+            planner.Change("M", "docs/explanation/goals.md"),
+            planner.Change("M", "src/jacobian/leaf.py"),
+        ],
+        _plan(unit=True, static=True, docs=True, python=True),
+        ["tests/unit/test_leaf.py"],
+        None,
+        False,
+    )
+
+    assert "make lint typecheck" in commands
+    assert "make docs-linkcheck" in commands
+    assert "make check-static" not in commands
+    assert "make test-unit TESTS=tests/unit/test_leaf.py" in commands
+
+
+def test_planned_commands_appends_deploy_gate_last() -> None:
+    planner = _load_script_module("plan_local_tests_deploy_gate", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [planner.Change("M", "deploy/install.sh")],
+        _plan(process=True),
+        [],
+        "deploy/install.sh: no exact Python ownership evidence",
+        True,
+    )
+
+    assert commands[-1] == "make deploy-check"
+    assert "make test-process" in commands
+
+
+def test_planned_commands_falls_back_to_pytest_lanes_with_lint_gate() -> None:
+    planner = _load_script_module("plan_local_tests_fallback_lanes", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [planner.Change("D", "src/jacobian/leaf.py")],
+        _plan(unit=True, component=True, static=True, python=True),
+        [],
+        "src/jacobian/leaf.py: D changes are not exact",
+        False,
+    )
+
+    # Delete -> fallback. Ordinary Python with no focused tests still gets the
+    # lint/typecheck handoff once, plus the selected pytest lanes (static is not
+    # re-run as a separate gate because ordinary Python routes to lint/typecheck).
+    assert commands[0] == "make lint typecheck"
+    assert "make test-unit" in commands
+    assert "make test-component" in commands
+    assert "make check-static" not in commands
+
+
+def test_planned_commands_clean_tree_selects_no_commands() -> None:
+    planner = _load_script_module("plan_local_tests_clean_cmds", "plan-local-tests")
+
+    commands = planner.planned_commands(
+        [],
+        {"classification": "clean", "run-python": "false", "run-deploy": "false"},
+        [],
+        None,
+        False,
+    )
+
+    assert commands == []
+
+
+def test_execute_commands_runs_all_and_summarizes_nonzero_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    planner = _load_script_module("plan_local_tests_exec_fail", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "_git_revision",
+        lambda revision: "deadbeef" if revision == "HEAD" else "basebeef",
+    )
+    monkeypatch.setattr(planner, "_git_dirty", lambda: True)
+    calls: list[list[str]] = []
+
+    def fake_run(argv, cwd, check):  # type: ignore[no-untyped-def]
+        calls.append(list(argv))
+        returncode = 1 if "boom" in argv[-1] else 0
+        return planner.subprocess.CompletedProcess(argv, returncode)
+
+    monkeypatch.setattr(planner.subprocess, "run", fake_run)
+
+    returncode = planner.execute_commands(
+        ["make lint typecheck", "make boom"], base="origin/main"
+    )
+    output = capsys.readouterr().out
+
+    assert returncode != 0
+    # Every command runs even after a failure so the summary is complete.
+    assert len(calls) == 2
+    assert "summary:" in output
+    assert "base: basebeef" in output
+    assert "head: deadbeef" in output
+    assert "dirty: true" in output
+    assert "total: 2" in output
+    assert "passed: 1" in output
+    assert "failed: 1" in output
+    assert "result: fail" in output
+    assert "[pass]" in output
+    assert "[fail]" in output
+    assert "make lint typecheck" in output
+    assert "make boom" in output
+
+
+def test_execute_commands_returns_zero_when_all_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    planner = _load_script_module("plan_local_tests_exec_pass", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "_git_revision",
+        lambda revision: "abc123" if revision == "HEAD" else "base123",
+    )
+    monkeypatch.setattr(planner, "_git_dirty", lambda: False)
+    monkeypatch.setattr(
+        planner.subprocess,
+        "run",
+        lambda argv, cwd, check: planner.subprocess.CompletedProcess(argv, 0),
+    )
+
+    returncode = planner.execute_commands(
+        ["make lint typecheck", "make docs-linkcheck"], base="origin/main"
+    )
+    output = capsys.readouterr().out
+
+    assert returncode == 0
+    assert "result: pass" in output
+    assert "total: 2" in output
+    assert "failed: 0" in output
+    assert "passed: 2" in output
+
+
+def test_execute_commands_handles_empty_command_list(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    planner = _load_script_module("plan_local_tests_exec_empty", "plan-local-tests")
+    monkeypatch.setattr(
+        planner,
+        "_git_revision",
+        lambda revision: "abc123" if revision == "HEAD" else "base123",
+    )
+    monkeypatch.setattr(planner, "_git_dirty", lambda: False)
+
+    returncode = planner.execute_commands([], base="origin/main")
+    output = capsys.readouterr().out
+
+    assert returncode == 0
+    assert "total: 0" in output
+    assert "result: pass" in output
+    assert "passed: 0" in output
+    assert "failed: 0" in output
+
+
+def test_plan_discovery_preserves_deleted_renamed_and_untracked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planner = _load_script_module("plan_local_tests_discovery_all", "plan-local-tests")
+    responses = {
+        ("diff", "--name-status", "base..HEAD"): [planner.Change("D", "src/gone.py")],
+        ("diff", "--name-status"): [
+            planner.Change("R", "src/old.py"),
+            planner.Change("R", "src/new.py"),
+        ],
+        ("diff", "--cached", "--name-status"): [],
+    }
+    monkeypatch.setattr(planner, "ROOT", tmp_path)
+    monkeypatch.setattr(planner, "git_changes", lambda *args: responses[args])
+    monkeypatch.setattr(planner, "git_paths", lambda *args: ["untracked.py"])
+    monkeypatch.setattr(planner.subprocess, "run", lambda *args, **kwargs: None)
+
+    entries = [
+        (change.status, change.path) for change in planner.changed_entries("base")
+    ]
+
+    assert ("D", "src/gone.py") in entries
+    assert ("R", "src/old.py") in entries
+    assert ("R", "src/new.py") in entries
+    assert ("?", "untracked.py") in entries

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -106,6 +106,7 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath("tests/boundary/process/tooling/test_topology_runner.py"),
         PurePosixPath("tests/boundary/process/tooling/test_cli_import_surface.py"),
         PurePosixPath("tests/boundary/process/tooling/test_source_agent_bootstrap.py"),
+        PurePosixPath("tests/boundary/process/tooling/test_make_help.py"),
         # MCP transport boundary tests spawn server processes.
         PurePosixPath("tests/boundary/mcp/test_mcp_operations.py"),
         PurePosixPath("tests/boundary/mcp/test_remote_mcp_auth.py"),

--- a/tools/development_profiles.py
+++ b/tools/development_profiles.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Authoritative local development setup profiles and diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import re
+import sys
+import tomllib
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+PROFILE_DOCUMENTATION = "docs/how-to/setup-agent-from-source.md#profiles"
+OPTIONAL_BACKEND_DOCUMENTATION = "docs/how-to/install-optional-backends.md"
+
+
+@dataclass(frozen=True, slots=True)
+class DevelopmentProfile:
+    """One supported, deterministic development environment."""
+
+    name: str
+    all_extras: bool
+    providers: tuple[str, ...]
+
+
+PROFILES = {
+    "core": DevelopmentProfile("core", False, ("networkx", "sympy", "z3")),
+    "full-python": DevelopmentProfile(
+        "full-python",
+        True,
+        ("networkx", "sympy", "z3", "python-flint", "python-flint-hnf", "cvc5"),
+    ),
+    "lean": DevelopmentProfile(
+        "lean",
+        True,
+        (
+            "networkx",
+            "sympy",
+            "z3",
+            "python-flint",
+            "python-flint-hnf",
+            "cvc5",
+            "lean",
+        ),
+    ),
+    "external-proof": DevelopmentProfile(
+        "external-proof",
+        True,
+        (
+            "networkx",
+            "sympy",
+            "z3",
+            "python-flint",
+            "python-flint-hnf",
+            "cvc5",
+            "cadical",
+            "drat-trim",
+            "carcara",
+        ),
+    ),
+}
+PROFILE_NAMES = tuple(PROFILES)
+
+
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    """One read-only profile readiness observation."""
+
+    requirement: str
+    status: str
+    expected: str
+    found: str | None
+    recovery: str
+    documentation: str
+
+
+CommandRunner = Callable[[Sequence[str], Path], int]
+
+
+def profile(name: str) -> DevelopmentProfile:
+    """Return a supported profile or fail with the complete choice list."""
+
+    try:
+        return PROFILES[name]
+    except KeyError as exc:
+        choices = ", ".join(PROFILE_NAMES)
+        raise ValueError(f"unknown profile: {name}; choose one of: {choices}") from exc
+
+
+def sync_arguments(name: str, *, development: bool = True) -> tuple[str, ...]:
+    """Return locked uv sync arguments for a profile."""
+
+    selected = profile(name)
+    arguments = ["sync", "--locked", "--dev" if development else "--no-dev"]
+    if selected.all_extras:
+        arguments.append("--all-extras")
+    return tuple(arguments)
+
+
+def _run(arguments: Sequence[str], cwd: Path) -> int:
+    from benchmarks.tooling.command_runner import (
+        ToolCommandStatus,
+        run_operator_command,
+    )
+
+    result = run_operator_command(
+        arguments[0],
+        arguments[1:],
+        cwd=cwd,
+        timeout_seconds=3600.0,
+        stdout_limit_bytes=8 * 1024 * 1024,
+        stderr_limit_bytes=8 * 1024 * 1024,
+        environment=dict(os.environ),
+    )
+    if result.stdout:
+        sys.stdout.buffer.write(result.stdout)
+    if result.stderr:
+        sys.stderr.buffer.write(result.stderr)
+    return result.exit_code if result.status is ToolCommandStatus.EXITED else 2
+
+
+def _tool_path(name: str) -> str | None:
+    from benchmarks.tooling.command_runner import ToolResolver
+
+    return ToolResolver(search_path=os.environ.get("PATH")).resolve(name)
+
+
+def _run_required(arguments: Sequence[str], *, cwd: Path, run: CommandRunner) -> None:
+    status = run(arguments, cwd)
+    if status:
+        raise RuntimeError(f"command failed ({status}): {' '.join(arguments)}")
+
+
+def setup_profile(repo: Path, name: str, *, run: CommandRunner = _run) -> None:
+    """Install one profile without updating dependency manifests."""
+
+    selected = profile(name)
+    repo = repo.resolve()
+    uv_diagnostic = _uv_diagnostic(repo)
+    if uv_diagnostic.status != "available":
+        _print_diagnostics((uv_diagnostic,))
+        raise RuntimeError(
+            f"uv {uv_diagnostic.expected} is required before profile setup"
+        )
+    _run_required(("uv", *sync_arguments(name)), cwd=repo, run=run)
+    prepare_profile(repo, name, run=run)
+    # The doctor runs inside the newly synced environment. In particular, the
+    # external-proof profile only probes operator-installed binaries; it never
+    # downloads provenance-sensitive executables.
+    _run_required(
+        (
+            "uv",
+            "run",
+            "--locked",
+            "--no-sync",
+            "python",
+            str(repo / "tools" / "development_profiles.py"),
+            "doctor",
+            "--profile",
+            selected.name,
+            "--repo",
+            str(repo),
+        ),
+        cwd=repo,
+        run=run,
+    )
+
+
+def prepare_profile(repo: Path, name: str, *, run: CommandRunner = _run) -> None:
+    """Perform profile-specific setup after a locked sync."""
+
+    profile(name)
+    repo = repo.resolve()
+    if name == "lean":
+        if _tool_path("elan") is None:
+            raise RuntimeError(
+                "the lean profile requires elan; install it, then rerun "
+                "`make setup PROFILE=lean`"
+            )
+        toolchain = (
+            (repo / "lean" / "lean-toolchain").read_text(encoding="utf-8").strip()
+        )
+        _run_required(("elan", "toolchain", "install", toolchain), cwd=repo, run=run)
+        _run_required(("lake", "exe", "cache", "get"), cwd=repo / "lean", run=run)
+        _run_required(
+            ("lake", "build", "repl", "jacobian_lean_proof_state"),
+            cwd=repo / "lean",
+            run=run,
+        )
+
+
+def _requirements(repo: Path) -> dict[str, str]:
+    with (repo / "pyproject.toml").open("rb") as stream:
+        pyproject = tomllib.load(stream)
+    values = list(pyproject["project"]["dependencies"])
+    for extra in pyproject["project"].get("optional-dependencies", {}).values():
+        values.extend(extra)
+    requirements: dict[str, str] = {}
+    for value in values:
+        match = re.match(r"([A-Za-z0-9_-]+)\s*(.*)", value)
+        if match:
+            requirements[match.group(1).lower()] = match.group(2)
+    return requirements
+
+
+def _version_parts(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", version))
+
+
+def _matches_spec(version: str, spec: str) -> bool:
+    if not spec:
+        return True
+    actual = _version_parts(version)
+    for clause in spec.split(","):
+        clause = clause.strip()
+        match = re.fullmatch(r"(==|>=|<=|>|<)(.+)", clause)
+        if match is None:
+            continue
+        operator, expected_text = match.groups()
+        expected = _version_parts(expected_text)
+        comparisons = {
+            "==": actual == expected,
+            ">=": actual >= expected,
+            "<=": actual <= expected,
+            ">": actual > expected,
+            "<": actual < expected,
+        }
+        if not comparisons[operator]:
+            return False
+    return True
+
+
+def _distribution_diagnostic(
+    *,
+    requirement: str,
+    distribution: str,
+    expected: str,
+    profile_name: str,
+) -> Diagnostic:
+    try:
+        found = importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        found = None
+    status = (
+        "unavailable"
+        if found is None
+        else "available"
+        if _matches_spec(found, expected)
+        else "incompatible"
+    )
+    return Diagnostic(
+        requirement=requirement,
+        status=status,
+        expected=expected or "installed distribution",
+        found=found,
+        recovery=f"Run `make setup PROFILE={profile_name}`",
+        documentation=(
+            OPTIONAL_BACKEND_DOCUMENTATION
+            if profile_name != "core"
+            else PROFILE_DOCUMENTATION
+        ),
+    )
+
+
+def _uv_diagnostic(repo: Path) -> Diagnostic:
+    from benchmarks.tooling.command_runner import (
+        ToolCommandStatus,
+        run_operator_command,
+    )
+
+    expected = (repo / ".uv-version").read_text(encoding="utf-8").strip()
+    found: str | None = None
+    executable = _tool_path("uv")
+    if executable is not None:
+        completed = run_operator_command(
+            "uv",
+            ("--version",),
+            cwd=repo,
+            timeout_seconds=30.0,
+        )
+        if completed.status is ToolCommandStatus.EXITED and completed.exit_code == 0:
+            parts = completed.stdout.decode(errors="replace").strip().split()
+            found = parts[1] if len(parts) >= 2 else None
+    status = (
+        "available"
+        if found == expected
+        else "unavailable"
+        if found is None
+        else "incompatible"
+    )
+    return Diagnostic(
+        requirement="uv",
+        status=status,
+        expected=expected,
+        found=found,
+        recovery=f"Install uv {expected}: https://docs.astral.sh/uv/",
+        documentation=PROFILE_DOCUMENTATION,
+    )
+
+
+def _lean_diagnostics(repo: Path) -> list[Diagnostic]:
+    from benchmarks.tooling.command_runner import (
+        ToolCommandStatus,
+        run_operator_command,
+    )
+
+    expected = (repo / "lean" / "lean-toolchain").read_text(encoding="utf-8").strip()
+    elan = _tool_path("elan")
+    lake = _tool_path("lake")
+    installed = False
+    found: str | None = None
+    if elan is not None:
+        completed = run_operator_command(
+            "elan",
+            ("toolchain", "list"),
+            cwd=repo,
+            timeout_seconds=30.0,
+        )
+        if completed.status is ToolCommandStatus.EXITED and completed.exit_code == 0:
+            toolchains = [
+                line.split(maxsplit=1)[0]
+                for line in completed.stdout.decode(errors="replace").splitlines()
+                if line.strip()
+            ]
+            installed = expected in toolchains
+            found = expected if installed else ", ".join(toolchains) or None
+    return [
+        Diagnostic(
+            "elan",
+            "available" if elan else "unavailable",
+            "installed executable",
+            elan,
+            "Install elan, then run `make setup PROFILE=lean`",
+            PROFILE_DOCUMENTATION,
+        ),
+        Diagnostic(
+            "Lean toolchain",
+            "available"
+            if installed and lake
+            else "incompatible"
+            if elan and lake
+            else "unavailable",
+            expected,
+            found,
+            "Run `make setup PROFILE=lean`",
+            PROFILE_DOCUMENTATION,
+        ),
+    ]
+
+
+def _external_proof_diagnostics() -> list[Diagnostic]:
+    from jacobian.providers.external_solver_runtime import (
+        CADICAL_VERSION,
+        CARCARA_VERSION,
+        DRAT_TRIM_RELEASE_TAG,
+        cadical_provider_runtime,
+        carcara_provider_runtime,
+        drat_trim_provider_runtime,
+    )
+
+    diagnostics: list[Diagnostic] = []
+    recovery = (
+        "Install the pinned, operator-provenanced runtime; no download is automatic"
+    )
+    for executable, name, expected, resolve in (
+        ("cadical", "CaDiCaL", CADICAL_VERSION, cadical_provider_runtime),
+        ("drat-trim", "DRAT-trim", DRAT_TRIM_RELEASE_TAG, drat_trim_provider_runtime),
+        ("carcara", "Carcara", CARCARA_VERSION, carcara_provider_runtime),
+    ):
+        runtime = resolve()
+        available = runtime.availability.value == "AVAILABLE"
+        diagnostics.append(
+            Diagnostic(
+                name,
+                "available"
+                if available
+                else "incompatible"
+                if _tool_path(executable)
+                else "unavailable",
+                expected,
+                runtime.version,
+                recovery,
+                OPTIONAL_BACKEND_DOCUMENTATION,
+            )
+        )
+    return diagnostics
+
+
+def inspect_profile(repo: Path, name: str) -> list[Diagnostic]:
+    """Inspect one profile without writing the checkout or environment."""
+
+    selected = profile(name)
+    repo = repo.resolve()
+    requirements = _requirements(repo)
+    diagnostics = [_uv_diagnostic(repo)]
+    for provider, distribution in (
+        ("networkx", "networkx"),
+        ("sympy", "sympy"),
+        ("z3", "z3-solver"),
+        ("python-flint", "python-flint"),
+        ("python-flint-hnf", "python-flint"),
+        ("cvc5", "cvc5"),
+    ):
+        if provider not in selected.providers:
+            continue
+        diagnostics.append(
+            _distribution_diagnostic(
+                requirement=provider,
+                distribution=distribution,
+                expected=requirements.get(distribution, ""),
+                profile_name=name,
+            )
+        )
+    if name == "lean":
+        diagnostics.extend(_lean_diagnostics(repo))
+    if name == "external-proof":
+        diagnostics.extend(_external_proof_diagnostics())
+    return diagnostics
+
+
+def _print_diagnostics(
+    diagnostics: Sequence[Diagnostic], *, json_output: bool = False
+) -> None:
+    if json_output:
+        print(json.dumps([asdict(item) for item in diagnostics], indent=2))
+        return
+    for item in diagnostics:
+        print(
+            f"{item.status:12} {item.requirement}: expected {item.expected}; "
+            f"found {item.found or 'not found'}"
+        )
+        if item.status != "available":
+            print(f"  recovery: {item.recovery}")
+            print(f"  docs: {item.documentation}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "action", choices=("validate", "sync-flags", "prepare", "setup", "doctor")
+    )
+    parser.add_argument("--profile", default="core")
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--no-dev", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        profile(args.profile)
+        if args.action == "validate":
+            return 0
+        if args.action == "sync-flags":
+            print("\n".join(sync_arguments(args.profile, development=not args.no_dev)))
+            return 0
+        if args.action == "setup":
+            setup_profile(args.repo, args.profile)
+            return 0
+        if args.action == "prepare":
+            prepare_profile(args.repo, args.profile)
+            return 0
+        diagnostics = inspect_profile(args.repo, args.profile)
+        _print_diagnostics(diagnostics, json_output=args.json)
+        return 0 if all(item.status == "available" for item in diagnostics) else 1
+    except (OSError, RuntimeError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/source_agent_doctor.py
+++ b/tools/source_agent_doctor.py
@@ -40,39 +40,9 @@ from jacobian.providers.flint_runtime import (  # noqa: E402
     python_flint_provider_runtime,
 )
 from jacobian.runtime import CheckerAuthorityMode, create_runtime  # noqa: E402
+from tools.development_profiles import PROFILE_NAMES, PROFILES  # noqa: E402
 
-PROFILES = ("core", "full-python", "lean", "external-proof")
-_PROFILE_PROVIDERS = {
-    "core": ("networkx", "sympy", "z3"),
-    "full-python": (
-        "networkx",
-        "sympy",
-        "z3",
-        "python-flint",
-        "python-flint-hnf",
-        "cvc5",
-    ),
-    "lean": (
-        "networkx",
-        "sympy",
-        "z3",
-        "python-flint",
-        "python-flint-hnf",
-        "cvc5",
-        "lean",
-    ),
-    "external-proof": (
-        "networkx",
-        "sympy",
-        "z3",
-        "python-flint",
-        "python-flint-hnf",
-        "cvc5",
-        "cadical",
-        "drat-trim",
-        "carcara",
-    ),
-}
+_PROFILE_PROVIDERS = {name: selected.providers for name, selected in PROFILES.items()}
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -354,7 +324,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", type=Path, required=True)
     parser.add_argument("--state-dir", type=Path, required=True)
-    parser.add_argument("--profile", choices=PROFILES, required=True)
+    parser.add_argument("--profile", choices=PROFILE_NAMES, required=True)
     parser.add_argument("--expected-revision", required=True)
     parser.add_argument("--provider-path", required=True)
     parser.add_argument("--project-environment", default="")


### PR DESCRIPTION
## Problem

The routine local handoff ran Ruff and mypy before it knew whether a change
needed Python validation. Clean trees and documentation-only edits therefore
paid for unrelated work, while setup profiles were duplicated across Make,
`setup-agent`, and source diagnostics. The daily help output also mixed the
common workflow with specialist commands.

## Solution

- make `make check-changed BASE=origin/main` plan and execute the affected
  handoff in one sequential invocation, preserving exact test ownership and
  fail-closed fallbacks while keeping independent docs, npm, deployment, Lean,
  and provider checks
- print the plan before execution and finish with command status, duration,
  resolved revisions, dirty state, and an aggregate result; clean trees now
  report a successful no-op
- centralize the `core`, `full-python`, `lean`, and `external-proof` setup and
  doctor contracts in one import-light module shared by Make and source setup
- reduce `make help` to the six daily commands, retain specialist targets in
  `make help-all`, and rewrite the contributor path around
  `setup -> check-changed -> PR`

Hosted CI remains responsible for the supported Python and operating-system
matrices, full Lean/provider environments, coverage, compatibility, packaging,
security, and exhaustive semantic lanes. This PR does not change CI scheduling
or product behavior.

### Local handoff timing

Illustrative wall-clock timings were collected on the same Linux host with warm
dependency caches using `/usr/bin/time`:

| Scenario | `origin/main` | This branch | Structural result |
| --- | ---: | ---: | --- |
| Clean tree | 0.80 s | 0.11 s | no Ruff, mypy, or pytest command |
| Documentation only | 3.18 s | 2.51 s | documentation checks only; no Python static gate |

The command-selection assertions are the acceptance contract; the timings are
included as local evidence rather than performance thresholds.

## Testing

- `make check-changed BASE=origin/main` — passed `make check-static`,
  `make docs-linkcheck`, 107 focused unit tests, and 29 focused process tests;
  all four commands appeared in the final summary
- `make check-changed BASE=HEAD` — passed as a clean no-op with zero commands
- explicit docs-only and ordinary-Python planner executions — passed; docs did
  not select Ruff or mypy, and Python selected lint/typecheck once plus its exact
  test
- profile diagnostics and setup contract tests — passed for pinned Lean order,
  invalid profiles, deterministic repeat setup, and the external-proof
  no-download policy

- Specialist validation run: none; this change is confined to local tooling
  and its owned unit/process tests.

## Trust & Compatibility Impact

No verification-kernel, checker-registry, artifact-format, public API, Harbor,
Oracle, release, deployment, or hosted-CI matrix behavior changes.

## Suggested review order

1. `.github/scripts/plan-local-tests` and its planner tests
2. `tools/development_profiles.py` and the Make/source-bootstrap integration
3. the help contract, ownership map, and contributor documentation

## Checklist

- [x] `make check-changed BASE=origin/main` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier validation is not applicable
