### PR TITLE
fix(polynomials): correct Groebner result variable bound

### DIFF
--- a/src/jacobian/contracts/polynomial_operations.py
+++ b/src/jacobian/contracts/polynomial_operations.py
@@ -13,6 +13,7 @@ from jacobian.contracts.exact import (
 )
 from jacobian.contracts.polynomials import (
     MAX_POLYNOMIAL_TERMS,
+    MAX_POLYNOMIAL_VARIABLES,
     PolynomialVariable,
     RationalPolynomial,
     require_polynomial_budget,
@@ -219,7 +220,10 @@ class PolynomialGroebnerBasisRequest(ContractModel):
 
 
 class PolynomialGroebnerBasisResult(ContractModel):
-    variables: tuple[PolynomialVariable, ...] = Field(min_length=1, max_length=4)
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+    )
     monomial_order: Literal["lex", "grlex", "grevlex"]
     basis: tuple[RationalPolynomial, ...] = Field(max_length=64)
     completion: Literal["COMPLETE"] = "COMPLETE"

--- a/tests/composition/portfolio/test_polynomial_operation_bundle.py
+++ b/tests/composition/portfolio/test_polynomial_operation_bundle.py
@@ -276,6 +276,36 @@ def test_polynomial_bundle_installs_and_computes_exact_invariants(
     assert timeout_result.artifact_uris == ()
 
 
+def test_groebner_result_preserves_advertised_input_variable_bound(
+    attached_complete_runtime,
+) -> None:
+    variables = ["a", "b", "c", "d", "e"]
+    result = _invoke(
+        attached_complete_runtime,
+        "polynomial.groebner_basis.compute",
+        {
+            "generators": [
+                _polynomial(variables, [((0, 0, 0, 0, 0), 1, 1)]),
+            ],
+            "monomial_order": "lex",
+            "resource_budget": {
+                "wall_seconds": 10,
+                "maximum_basis_polynomials": 64,
+                "maximum_output_terms": 1024,
+            },
+        },
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output == {
+        "variables": variables,
+        "monomial_order": "lex",
+        "basis": [_polynomial(variables, [((0, 0, 0, 0, 0), 1, 1)])],
+        "completion": "COMPLETE",
+        "normalization": "REDUCED_MONIC",
+    }
+
+
 def test_polynomial_output_budget_failure_is_explicit_and_writes_no_artifacts(
     attached_complete_runtime,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- align the bounded Gröbner result contract with the shared eight-variable polynomial input bound
- add a five-variable unit-ideal regression that previously failed after successful input validation

## Root cause

`PolynomialGroebnerBasisRequest` uses the shared sparse-polynomial contract, which accepts up to eight ordered variables. `PolynomialGroebnerBasisResult.variables` independently capped outputs at four. Consequently, a valid five-variable request reached the isolated worker but failed during result construction and surfaced as `POLYNOMIAL_GROEBNER_WORKER_FAILED`.

This patch uses the existing `MAX_POLYNOMIAL_VARIABLES` constant for the result contract. It does not expand the advertised input budget, alter the worker resource limits, or change assurance.

## Validation

- focused regression: passed
- full lint, format, complexity, and mypy: passed
- `make test-plan BASE=origin/main`: selected unit, component, domain, composition, storage, process, MCP, and end-to-end lanes
- change-aware results:
  - 864 unit passed
  - 765 component passed, 3 platform skips
  - 185 domain passed
  - 494 composition passed, 2 Lean-runtime skips
  - 126 storage passed
  - 243 process passed, 1 platform skip, 1 unrelated macOS failure
  - 52 MCP passed
  - 7 end-to-end passed, 1 Lean-runtime skip

The sole failure is pre-existing and unrelated: `scripts/setup-agent` invokes Bash `mapfile`, which is unavailable in macOS system Bash, in `test_bootstrap_dry_run_forwards_resolved_environment_without_downloads`.

## Scope boundary

The evaluation that exposed this mismatch used a ten-variable Toeplitz-factor ideal. Supporting more than the existing eight-variable input bound is deliberately not part of this localized fix; that requires separate maintainer judgment about resource and schema budgets.