### PR TITLE
test(polynomials): align polynomial point bounds with map dimension

### DIFF
--- a/src/jacobian/contracts/polynomials.py
+++ b/src/jacobian/contracts/polynomials.py
@@ -701,9 +701,15 @@ class PolynomialCollisionSearchStopReason(StrEnum):
 
 class PolynomialCollisionVerifyRequest(ContractModel):
     map: RationalPolynomialMap
-    first_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
-    second_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
-    claimed_image: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
+    first_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    second_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    claimed_image: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
 
     @model_validator(mode="after")
     def require_collision_dimensions_and_distinct_points(self) -> Self:
@@ -725,11 +731,15 @@ class PolynomialMapInverseCollisionVerifyRequest(ContractModel):
     """Use one exact collision to refute a two-sided polynomial inverse."""
 
     map: RationalPolynomialMap
-    first_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
-    second_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
+    first_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    second_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
     claimed_image: tuple[CanonicalRational, ...] = Field(
         min_length=1,
-        max_length=4,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
     )
 
     @model_validator(mode="after")
@@ -752,7 +762,9 @@ class PolynomialMapEvaluation(ContractModel):
     evaluation_schema_version: Literal["1"] = "1"
     map_uri: ArtifactUri
     point: RationalPolynomialPoint
-    image: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
+    image: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
     backend: Literal["sympy"] = "sympy"
     backend_version: str = Field(min_length=1, max_length=64)
 
@@ -920,9 +932,15 @@ class PolynomialKellerConditionReplayPayload(ContractModel):
 
 
 class PolynomialCollisionPayload(ContractModel):
-    first_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
-    second_point: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
-    image: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
+    first_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    second_point: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
+    image: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
 
     @model_validator(mode="after")
     def require_matching_point_dimensions(self) -> Self:

--- a/tests/unit/contracts/test_polynomial_contracts.py
+++ b/tests/unit/contracts/test_polynomial_contracts.py
@@ -13,9 +13,11 @@ from jacobian.contracts.polynomials import (
     PolynomialCollisionPayload,
     PolynomialCollisionRequest,
     PolynomialCollisionSearchRequest,
+    PolynomialCollisionVerifyRequest,
     PolynomialEvaluationRequest,
     PolynomialJacobianRequest,
     PolynomialMapEvaluation,
+    PolynomialMapInverseCollisionVerifyRequest,
     RationalFunctionArtifact,
     RationalFunctionIdentityRequest,
     RationalPolynomialMap,
@@ -90,6 +92,55 @@ def test_evaluation_artifact_accepts_rectangular_map_image() -> None:
 
     assert len(evaluation.point.values) == 1
     assert len(evaluation.image) == 2
+
+
+def test_polynomial_map_point_contracts_accept_five_dimensions() -> None:
+    point = [_rational()] * 5
+    second_point = [_rational(1), *([_rational()] * 4)]
+    image = [_rational()] * 5
+    polynomial_map = _identity_map(5)
+
+    request = PolynomialEvaluationRequest.model_validate(
+        {"map": polynomial_map, "point": point}
+    )
+    evaluation = PolynomialMapEvaluation.model_validate(
+        {
+            "map_uri": "artifact://sha256/" + "a" * 64,
+            "point": {"values": point},
+            "image": image,
+            "backend": "sympy",
+            "backend_version": "1.14.0",
+        }
+    )
+    collision = PolynomialCollisionVerifyRequest.model_validate(
+        {
+            "map": polynomial_map,
+            "first_point": point,
+            "second_point": second_point,
+            "claimed_image": image,
+        }
+    )
+    inverse_collision = PolynomialMapInverseCollisionVerifyRequest.model_validate(
+        {
+            "map": polynomial_map,
+            "first_point": point,
+            "second_point": second_point,
+            "claimed_image": image,
+        }
+    )
+    payload = PolynomialCollisionPayload.model_validate(
+        {
+            "first_point": point,
+            "second_point": second_point,
+            "image": image,
+        }
+    )
+
+    assert len(request.point) == 5
+    assert len(evaluation.image) == 5
+    assert len(collision.claimed_image) == 5
+    assert len(inverse_collision.claimed_image) == 5
+    assert len(payload.image) == 5
 
 
 def test_collision_payload_enforces_all_dimensions() -> None:


### PR DESCRIPTION
## What changed

- align polynomial evaluation images, collision witnesses, inverse-collision witnesses, and replay payloads with the existing eight-variable `RationalPolynomialMap` limit
- add a regression covering five-dimensional requests and artifacts across those dependent contracts

## Why

`RationalPolynomialMap`, `RationalPolynomialPoint`, and `PolynomialEvaluationRequest` support up to eight variables, but several dependent point/image fields still retained the former four-item limit. Valid five- through eight-variable evaluation and collision workflows could therefore fail during request or result validation.

The change only replaces those stale dependent bounds with `MAX_POLYNOMIAL_VARIABLES`; unrelated operations that intentionally remain four-variable are unchanged. Verification authority, artifact binding, and assurance semantics are unchanged.

## Validation

- regression confirmed failing before the implementation change
- `tests/unit/contracts/test_polynomial_contracts.py`: 20 passed
- complete unit suite: 865 passed
- Ruff format/check: passed
- mypy for `src/jacobian/contracts/polynomials.py`: passed
- change-aware planner: broad suite fallback because this shared contract is imported transitively; hosted CI owns the remaining semantic lanes