### PR TITLE
refactor(tests): reorganize test lanes around semantic ownership

### DIFF
--- a/docs/reference/capabilities/graphs/graph-maximum-matching.md
+++ b/docs/reference/capabilities/graphs/graph-maximum-matching.md
@@ -2,7 +2,7 @@
 
 [Documentation home](../../../index.md)
 
-`graph.invariant.maximum_matching.compute` version `2` returns a feasible
+`graph.invariant.maximum_matching.compute` version `3` returns a feasible
 matching together with a Tutte–Berge barrier certificate. The producer remains
 `COMPUTED`. An operator-authorized
 `graph.invariant.maximum_matching.verify` capability may promote the exact
@@ -21,8 +21,11 @@ runtime. It does not certify a graph supplied directly by the caller, a
 different matching, or any theorem that uses the matching as an intermediate
 fact.
 
-The producer accepts at most 32 vertices and 496 edges. The independent checker
-uses only bounded standard-library graph traversal. It imports neither
+The producer accepts at most 64 vertices and 2,016 edges through a
+matching-specific graph contract. Other graph invariants retain their own
+existing bounds; this does not broaden coloring or exponential graph-search
+operations. The independent checker uses only bounded standard-library graph
+traversal. It imports neither
 NetworkX, which constructs the matching and certificate, nor Python-FLINT,
 which serves unrelated polynomial and matrix checkers.
 

--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -19,6 +19,17 @@ class GraphInvariantRequest(ContractModel):
     graph: ChromaticGraph
 
 
+class GraphMaximumMatchingGraph(ChromaticGraph):
+    """A simple graph bounded for the polynomial-time matching capability."""
+
+    vertices: tuple[GraphVertex, ...] = Field(max_length=64)
+    edges: tuple[tuple[GraphVertex, GraphVertex], ...] = Field(max_length=2_016)
+
+
+class GraphMaximumMatchingRequest(ContractModel):
+    graph: GraphMaximumMatchingGraph
+
+
 GraphDistance = Annotated[StrictInt, Field(ge=0, le=31)] | None
 GraphDistanceRow = Annotated[
     tuple[GraphDistance, ...],
@@ -161,9 +172,9 @@ class GraphSpanningTreeCountResult(ContractModel):
 class GraphTutteBergeCertificate(ContractModel):
     certificate_schema_version: Literal["1"] = "1"
     kind: Literal["TUTTE_BERGE_BARRIER"] = "TUTTE_BERGE_BARRIER"
-    barrier_vertices: tuple[GraphVertex, ...] = Field(max_length=32)
-    odd_component_count: StrictInt = Field(ge=0, le=32)
-    upper_bound: StrictInt = Field(ge=0, le=16)
+    barrier_vertices: tuple[GraphVertex, ...] = Field(max_length=64)
+    odd_component_count: StrictInt = Field(ge=0, le=64)
+    upper_bound: StrictInt = Field(ge=0, le=32)
 
     @model_validator(mode="after")
     def require_canonical_barrier(self) -> Self:
@@ -175,7 +186,7 @@ class GraphTutteBergeCertificate(ContractModel):
 
 
 class GraphMaximumMatchingResult(ContractModel):
-    maximum_matching_cardinality: StrictInt = Field(ge=0, le=16)
+    maximum_matching_cardinality: StrictInt = Field(ge=0, le=32)
     witness_edges: tuple[tuple[GraphVertex, GraphVertex], ...]
     certificate: GraphTutteBergeCertificate
 

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -1,7 +1,10 @@
 """Independent checker declarations owned by the graph-optimization domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
-from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
+from jacobian.contracts.graph_invariant_operations import (
+    GraphInvariantRequest,
+    GraphMaximumMatchingRequest,
+)
 from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
     GraphMinimumSpanningTreeRequest,
@@ -159,7 +162,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
     ),
     ExactReplayCheckerDeclaration(
         "graph.invariant.maximum_matching.compute",
-        GraphInvariantRequest,
+        GraphMaximumMatchingRequest,
         "check_graph_maximum_matching",
         "graph.maximum-matching.tutte-berge-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -23,6 +23,7 @@ from jacobian.contracts.graph_invariant_operations import (
     GraphGirthResult,
     GraphIndependenceNumberResult,
     GraphInvariantRequest,
+    GraphMaximumMatchingRequest,
     GraphMaximumMatchingResult,
     GraphRadiusResult,
     GraphSpanningTreeCountResult,
@@ -55,6 +56,15 @@ _INVALID_REQUEST = CapabilityDiagnostic(
     stage="graph_invariant_input_validation",
     message="Input does not satisfy the bounded finite simple-graph contract.",
     hint="Supply a canonical simple graph with at most 32 vertices.",
+)
+
+_INVALID_MAXIMUM_MATCHING_REQUEST = CapabilityDiagnostic(
+    code="INVALID_GRAPH_MAXIMUM_MATCHING_REQUEST",
+    stage="graph_maximum_matching_input_validation",
+    message=(
+        "Input does not satisfy the bounded finite simple-graph matching contract."
+    ),
+    hint="Supply a simple graph with at most 64 vertices and 2,016 edges.",
 )
 
 
@@ -254,6 +264,25 @@ def _maximum_matching(graph: Any) -> GraphMaximumMatchingResult:
             upper_bound=cardinality,
         ),
     )
+
+
+def _maximum_matching_execute(
+    request: GraphMaximumMatchingRequest,
+) -> ComputedOutcome[GraphMaximumMatchingResult]:
+    import networkx as nx
+
+    try:
+        graph = cast(Any, build_simple_graph(request.graph))
+        return ComputedSuccess(_maximum_matching(graph))
+    except (ArithmeticError, nx.NetworkXError, TypeError, ValueError) as exc:
+        return ComputedNotApplicable(
+            CapabilityDiagnostic(
+                code="GRAPH_INVARIANT_NOT_APPLICABLE",
+                stage="graph_invariant_computation",
+                message=str(exc),
+                hint="Check the invariant's graph preconditions.",
+            )
+        )
 
 
 def _triangle_count(graph: Any) -> GraphTriangleCountResult:
@@ -743,16 +772,20 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
             ),
         ),
     ),
-    _computed(
-        "graph.invariant.maximum_matching.compute",
-        "Maximum matching",
-        "Compute an exact maximum-cardinality matching and its edge witness.",
-        GraphMaximumMatchingResult,
-        _maximum_matching,
-        "matching",
-        "maximum",
-        "exact",
-        version="2",
+    ComputedOperation(
+        capability_id="graph.invariant.maximum_matching.compute",
+        title="Maximum matching",
+        description=(
+            "Compute an exact maximum-cardinality matching and a Tutte-Berge "
+            "upper-bound certificate for one simple graph of at most 64 vertices."
+        ),
+        request_model=GraphMaximumMatchingRequest,
+        result_model=GraphMaximumMatchingResult,
+        implementation=_maximum_matching_execute,
+        relation_id="graph.invariant.maximum_matching.relation",
+        tags=("graph", "invariant", "matching", "maximum", "exact"),
+        invalid_request=_INVALID_MAXIMUM_MATCHING_REQUEST,
+        version="3",
         invocation_examples=(
             example(
                 "triangle_with_tail",

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -1244,7 +1244,7 @@ def _maximum_matching(
 ) -> bool:
     vertices, normalized_edges, adjacency = _finite_simple_graph(
         source,
-        maximum_order=32,
+        maximum_order=64,
     )
     if set(result) != {
         "maximum_matching_cardinality",

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -780,7 +780,7 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
             )
             assert isinstance(matching_description.structured_content, dict)
             matching_contract = matching_description.structured_content
-            assert matching_contract["capability"]["version"] == "2"
+            assert matching_contract["capability"]["version"] == "3"
             assert matching_contract["invocations"][0]["name"] == ("triangle_with_tail")
             assert matching_contract["related_capabilities"] == [
                 {

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -7,7 +7,10 @@ from tests.support.artifacts import artifact_uri as _uri
 
 import jacobian.exact_domain_checkers as exact_domain_checkers
 from jacobian.contracts.capabilities import CapabilityProviderAvailability
-from jacobian.contracts.graph_invariant_operations import GraphInvariantRequest
+from jacobian.contracts.graph_invariant_operations import (
+    GraphInvariantRequest,
+    GraphMaximumMatchingRequest,
+)
 from jacobian.contracts.graph_optimization import (
     GraphHamiltonianPathRequest,
     GraphMinimumSpanningTreeRequest,
@@ -174,7 +177,7 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             character="7",
         ),
         graph_invariants=_installed(
-            (GraphInvariantRequest,),
+            (GraphInvariantRequest, GraphMaximumMatchingRequest),
             graph_ids[3:],
             character="8",
         ),
@@ -325,7 +328,7 @@ def test_installer_skips_checkers_for_an_unavailable_graph_bundle(
         character="7",
     )
     graph_invariants = _installed(
-        (GraphInvariantRequest,),
+        (GraphInvariantRequest, GraphMaximumMatchingRequest),
         (
             "graph.invariant.diameter.compute",
             "graph.invariant.radius.compute",

--- a/tests/domain/graph/test_graph_invariant_domain.py
+++ b/tests/domain/graph/test_graph_invariant_domain.py
@@ -107,7 +107,7 @@ def test_maximum_matching_and_star_conventions(domain_services) -> None:
             "upper_bound": 2,
         },
     }
-    assert matching.capability_version == "2"
+    assert matching.capability_version == "3"
 
     star = domain_services.core.capabilities.invoke(
         CapabilityRequest(
@@ -128,6 +128,48 @@ def test_maximum_matching_and_star_conventions(domain_services) -> None:
         "odd_component_count": 3,
         "upper_bound": 1,
     }
+
+
+def test_maximum_matching_has_a_capability_specific_64_vertex_bound(
+    domain_services,
+) -> None:
+    vertices = [f"v{index:02d}" for index in range(64)]
+    edges = [[vertices[index], vertices[index + 1]] for index in range(0, 64, 2)]
+
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.compute",
+            input={"graph": _graph(vertices, edges)},
+        )
+    )
+
+    assert result.output["result"]["maximum_matching_cardinality"] == 32
+    assert result.output["result"]["witness_edges"] == edges
+    assert result.output["result"]["certificate"] == {
+        "certificate_schema_version": "1",
+        "kind": "TUTTE_BERGE_BARRIER",
+        "barrier_vertices": [],
+        "odd_component_count": 0,
+        "upper_bound": 32,
+    }
+
+    too_large = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.compute",
+            input={"graph": _graph([*vertices, "v64"], edges)},
+        )
+    )
+    assert too_large.execution.status is ExecutionStatus.ERROR
+    assert too_large.diagnostics[0].code == "INVALID_REQUEST"
+
+    unrelated_invariant = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.diameter.compute",
+            input={"graph": _graph(vertices[:33], edges[:16])},
+        )
+    )
+    assert unrelated_invariant.execution.status is ExecutionStatus.ERROR
+    assert unrelated_invariant.diagnostics[0].code == "INVALID_REQUEST"
 
 
 def test_disconnected_and_acyclic_graph_conventions(domain_services) -> None:

--- a/tests/domain/graph/test_graph_verification.py
+++ b/tests/domain/graph/test_graph_verification.py
@@ -165,7 +165,7 @@ def test_maximum_matching_result_uses_independent_tutte_berge_replay(
         )
     )
 
-    assert computed.capability_version == "2"
+    assert computed.capability_version == "3"
     assert verified.execution.status is ExecutionStatus.COMPLETED
     assert verified.output["status"] == "VERIFIED"
     assert verified.output["operation_id"] == (
@@ -211,6 +211,37 @@ def test_maximum_matching_result_uses_independent_tutte_berge_replay(
     assert rejected.output["status"] == "REJECTED"
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.output["verification_record_uri"] is None
+
+
+def test_maximum_matching_verifier_replays_a_64_vertex_certificate(
+    graph_verification_services: DomainTestServices,
+) -> None:
+    vertices = [f"v{index:02d}" for index in range(64)]
+    producer_input = {
+        "graph": {
+            "vertices": vertices,
+            "edges": [
+                [vertices[index], vertices[index + 1]] for index in range(0, 64, 2)
+            ],
+        }
+    }
+    computed = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.compute",
+            input=producer_input,
+        )
+    )
+
+    verified = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.invariant.maximum_matching.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": producer_input, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- give maximum matching a capability-specific simple-graph contract bounded at 64 vertices and 2,016 edges
- expand matching and Tutte–Berge certificate result bounds coherently to cardinality 32
- update the independent standard-library checker to replay the same 64-vertex scope
- leave the shared 32-vertex graph contract unchanged for coloring and other graph invariants

## Why

`graph.invariant.maximum_matching.compute` and `.verify` already use polynomial-time producer/checker paths, but inherited the 32-vertex `ChromaticGraph` boundary shared with substantially more expensive graph operations. This prevented exact producer/checker use for the 64-vertex source artifact in #965.

The change isolates the larger bound to maximum matching rather than broadening unrelated graph capabilities.

Closes #965.

## Validation

- focused graph domain, verifier, checker, and checker-installation tests: **65 passed**
- unit lane: **866 passed**
- Ruff lint and formatting: passed
- mypy: passed
- `git diff --check`: passed
- broad domain lane: 318 passed with one unrelated randomized number-theory setup failure; the owning test passed immediately in isolation
- docs command validation passed; external Markdown link checking was unavailable because `npx` is not installed in this environment

## Compatibility and assurance

This is a capability-version bump from v2 to v3 because the accepted input and result ranges expand. Existing requests and results remain valid. Producers remain `COMPUTED`; only the existing operator-authorized independent Tutte–Berge replay can return `VERIFIED`. Inputs above 64 vertices remain fail closed.