### PR TITLE
feat(geometry): add exact rational-weight convex-polygon triangulation

### DIFF
--- a/src/jacobian/contracts/geometry.py
+++ b/src/jacobian/contracts/geometry.py
@@ -347,3 +347,78 @@ class GeometryConvexHullResult(ContractModel):
 class GeometryCircleResult(ContractModel):
     center: RationalPoint2D
     radius_squared: CanonicalRational
+
+
+class WeightedPolygonDiagonal(ContractModel):
+    first: StrictInt = Field(ge=0, le=31)
+    second: StrictInt = Field(ge=0, le=31)
+    weight: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_canonical_positive_pair(self) -> Self:
+        if self.first >= self.second:
+            raise ValueError("weighted diagonal endpoints must be strictly increasing")
+        if self.weight.as_fraction() < 0:
+            raise ValueError("weighted diagonal cost must be nonnegative")
+        return self
+
+
+class ConvexPolygonTriangulationRequest(ContractModel):
+    polygon: PolygonRequest
+    diagonal_weights: tuple[WeightedPolygonDiagonal, ...] = Field(
+        min_length=1, max_length=464
+    )
+    objective: Literal["NON_HULL_DIAGONAL_WEIGHT_SUM"] = "NON_HULL_DIAGONAL_WEIGHT_SUM"
+
+    @model_validator(mode="after")
+    def require_strict_convexity_and_complete_weights(self) -> Self:
+        points = tuple(_point_key(point) for point in self.polygon.points)
+        if not 4 <= len(points) <= 32:
+            raise ValueError("weighted triangulation supports 4 to 32 vertices")
+        turns = tuple(
+            _cross(
+                _subtract(points[(index + 1) % len(points)], points[index]),
+                _subtract(points[(index + 2) % len(points)], points[index]),
+            )
+            for index in range(len(points))
+        )
+        if any(turn <= 0 for turn in turns):
+            raise ValueError("weighted triangulation requires strict CCW convexity")
+        expected = {
+            (first, second)
+            for first in range(len(points))
+            for second in range(first + 1, len(points))
+            if second != first + 1 and (first, second) != (0, len(points) - 1)
+        }
+        actual = {(item.first, item.second) for item in self.diagonal_weights}
+        if len(actual) != len(self.diagonal_weights) or actual != expected:
+            raise ValueError("diagonal weights must cover every non-hull pair exactly")
+        pairs = tuple((item.first, item.second) for item in self.diagonal_weights)
+        if pairs != tuple(sorted(pairs)):
+            raise ValueError("diagonal weights must use lexicographic pair order")
+        return self
+
+
+class PolygonTriangle(ContractModel):
+    vertices: tuple[StrictInt, StrictInt, StrictInt]
+
+
+class TriangulationSplitEntry(ContractModel):
+    start: StrictInt = Field(ge=0, le=31)
+    end: StrictInt = Field(ge=0, le=31)
+    split: StrictInt = Field(ge=0, le=31)
+    optimum: CanonicalRational
+
+
+class ConvexPolygonTriangulationResult(ContractModel):
+    vertex_count: StrictInt = Field(ge=4, le=32)
+    diagonals: tuple[WeightedPolygonDiagonal, ...] = Field(min_length=1, max_length=29)
+    triangles: tuple[PolygonTriangle, ...] = Field(min_length=2, max_length=30)
+    split_table: tuple[TriangulationSplitEntry, ...] = Field(
+        min_length=3, max_length=496
+    )
+    optimum: CanonicalRational
+    objective: Literal["NON_HULL_DIAGONAL_WEIGHT_SUM"] = "NON_HULL_DIAGONAL_WEIGHT_SUM"
+    tie_break: Literal["LOWEST_SPLIT_INDEX"] = "LOWEST_SPLIT_INDEX"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+    verification: Literal["UNVERIFIED"] = "UNVERIFIED"

--- a/src/jacobian/domains/geometry/bundle.py
+++ b/src/jacobian/domains/geometry/bundle.py
@@ -24,9 +24,12 @@ def build_geometry_bundle() -> DomainBundle:
         schema_namespace="jacobian.geometry",
         semantics=DomainSemantics(
             name="jacobian.exact-rational-plane-geometry",
-            version="2",
+            version="3",
             definition={
-                "description": "Euclidean plane geometry over exact rational coordinates",
+                "description": (
+                    "Euclidean plane geometry over exact rational coordinates, "
+                    "including bounded exact rational-weight convex triangulation"
+                ),
                 "degeneracy": "operation-specific and fail-closed",
                 "assurance": (
                     "computed producers; selected results admit separately "

--- a/src/jacobian/domains/geometry/checkers.py
+++ b/src/jacobian/domains/geometry/checkers.py
@@ -2,6 +2,7 @@
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
 from jacobian.contracts.geometry import (
+    ConvexPolygonTriangulationRequest,
     PointPairRequest,
     PointSetRequest,
     PointTripleRequest,
@@ -12,6 +13,10 @@ from jacobian.contracts.geometry import (
 
 _ENTRYPOINT = "jacobian_checkers.exact_geometry"
 _OPERATIONS = (
+    (
+        "geometry.polygon.triangulation.minimum_weight.compute",
+        ConvexPolygonTriangulationRequest,
+    ),
     ("geometry.points.compute.convex_hull", PointSetRequest),
     ("geometry.points.compute.squared_distance", PointPairRequest),
     ("geometry.segment.compute.midpoint", PointPairRequest),

--- a/src/jacobian/domains/geometry/polygons.py
+++ b/src/jacobian/domains/geometry/polygons.py
@@ -1,6 +1,8 @@
 """Polygon-owned exact geometry capabilities."""
 
 from jacobian.contracts.geometry import (
+    ConvexPolygonTriangulationRequest,
+    ConvexPolygonTriangulationResult,
     GeometryRationalResult,
     PolygonPointClassificationResult,
     PolygonRequest,
@@ -14,6 +16,7 @@ from jacobian.domains.geometry.operations import (
     signed_area,
     simple_polygon,
 )
+from jacobian.domains.geometry.triangulation import minimum_weight_triangulation
 
 _UNIT_SQUARE = [
     {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
@@ -23,6 +26,23 @@ _UNIT_SQUARE = [
 ]
 
 POLYGON_CAPABILITIES = (
+    geometry_operation(
+        "geometry.polygon.triangulation.minimum_weight.compute",
+        "Compute an exact minimum-weight convex-polygon triangulation",
+        (
+            "Compute the deterministic minimum triangulation of a strict CCW "
+            "convex rational polygon under a complete exact rational weight for "
+            "each non-hull diagonal, charging every selected diagonal once."
+        ),
+        ConvexPolygonTriangulationRequest,
+        ConvexPolygonTriangulationResult,
+        minimum_weight_triangulation,
+        "geometry",
+        "polygon",
+        "triangulation",
+        "optimization",
+        relation_id="geometry.polygon.triangulation.minimum_weight.relation",
+    ),
     geometry_operation(
         "geometry.polygon.compute.signed_area",
         "Compute polygon signed area",

--- a/src/jacobian/domains/geometry/triangulation.py
+++ b/src/jacobian/domains/geometry/triangulation.py
@@ -1,0 +1,101 @@
+"""Exact bounded rational-weight triangulation of strict convex polygons."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.geometry import (
+    ConvexPolygonTriangulationRequest,
+    ConvexPolygonTriangulationResult,
+    PolygonTriangle,
+    TriangulationSplitEntry,
+    WeightedPolygonDiagonal,
+)
+
+
+def _wire(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
+
+
+def minimum_weight_triangulation(
+    request: ConvexPolygonTriangulationRequest,
+) -> ConvexPolygonTriangulationResult:
+    count = len(request.polygon.points)
+    weights = {
+        (item.first, item.second): item.weight.as_fraction()
+        for item in request.diagonal_weights
+    }
+
+    def edge_weight(first: int, second: int) -> Fraction:
+        pair = (first, second) if first < second else (second, first)
+        if second == first + 1 or pair == (0, count - 1):
+            return Fraction()
+        return weights[pair]
+
+    optimum: dict[tuple[int, int], Fraction] = {
+        (index, index + 1): Fraction() for index in range(count - 1)
+    }
+    split: dict[tuple[int, int], int] = {}
+    ledger: list[TriangulationSplitEntry] = []
+    for span in range(2, count):
+        for start in range(count - span):
+            end = start + span
+            candidates = [
+                (
+                    optimum[start, pivot]
+                    + optimum[pivot, end]
+                    + edge_weight(start, pivot)
+                    + edge_weight(pivot, end),
+                    pivot,
+                )
+                for pivot in range(start + 1, end)
+            ]
+            value, pivot = min(candidates)
+            optimum[start, end] = value
+            split[start, end] = pivot
+            ledger.append(
+                TriangulationSplitEntry(
+                    start=start,
+                    end=end,
+                    split=pivot,
+                    optimum=_wire(value),
+                )
+            )
+
+    triangles: list[PolygonTriangle] = []
+    diagonals: set[tuple[int, int]] = set()
+
+    def reconstruct(start: int, end: int) -> None:
+        if end == start + 1:
+            return
+        pivot = split[start, end]
+        triangles.append(PolygonTriangle(vertices=(start, pivot, end)))
+        for pair in ((start, pivot), (pivot, end)):
+            ordered = pair if pair[0] < pair[1] else (pair[1], pair[0])
+            if pair[1] != pair[0] + 1 and ordered != (0, count - 1):
+                diagonals.add(ordered)
+        reconstruct(start, pivot)
+        reconstruct(pivot, end)
+
+    reconstruct(0, count - 1)
+    return ConvexPolygonTriangulationResult(
+        vertex_count=count,
+        diagonals=tuple(
+            WeightedPolygonDiagonal(
+                first=first, second=second, weight=_wire(weights[pair])
+            )
+            for pair in sorted(diagonals)
+            for first, second in (pair,)
+        ),
+        triangles=tuple(sorted(triangles, key=lambda item: item.vertices)),
+        split_table=tuple(ledger),
+        optimum=_wire(optimum[0, count - 1]),
+    )
+
+
+__all__ = ["minimum_weight_triangulation"]

--- a/src/jacobian_checkers/exact_geometry.py
+++ b/src/jacobian_checkers/exact_geometry.py
@@ -30,6 +30,7 @@ _ARTIFACT_KEYS = {
     "payload",
 }
 _OPERATIONS = {
+    "geometry.polygon.triangulation.minimum_weight.compute",
     "geometry.points.compute.squared_distance",
     "geometry.points.compute.convex_hull",
     "geometry.segment.compute.midpoint",
@@ -39,6 +40,172 @@ _OPERATIONS = {
     "geometry.triangle.compute.orientation",
     "geometry.triangle.compute.centroid",
 }
+
+
+def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: C901
+    if not isinstance(claim, dict) or set(claim) != {
+        "polygon",
+        "diagonal_weights",
+        "objective",
+    }:
+        raise ValueError("triangulation source has an invalid shape")
+    if claim["objective"] != "NON_HULL_DIAGONAL_WEIGHT_SUM":
+        raise ValueError("triangulation objective is unsupported")
+    points = _points(claim["polygon"])
+    count = len(points)
+    if not 4 <= count <= 32:
+        raise ValueError("triangulation vertex count is unsupported")
+    turns = [
+        _cross(
+            _subtract(points[(index + 1) % count], points[index]),
+            _subtract(points[(index + 2) % count], points[index]),
+        )
+        for index in range(count)
+    ]
+    if any(turn <= 0 for turn in turns):
+        raise ValueError("triangulation polygon is not strict CCW convex")
+    raw_weights = claim["diagonal_weights"]
+    if not isinstance(raw_weights, list):
+        raise ValueError("triangulation weights are malformed")
+    weights: dict[tuple[int, int], Fraction] = {}
+    for item in raw_weights:
+        if not isinstance(item, dict) or set(item) != {"first", "second", "weight"}:
+            raise ValueError("triangulation weight entry is malformed")
+        first, second = item["first"], item["second"]
+        if (
+            type(first) is not int
+            or type(second) is not int
+            or not 0 <= first < second < count
+        ):
+            raise ValueError("triangulation weight endpoints are malformed")
+        pair = (first, second)
+        if pair in weights:
+            raise ValueError("triangulation weight pair is duplicated")
+        weight = _rational(item["weight"])
+        if weight < 0:
+            raise ValueError("triangulation weight is negative")
+        weights[pair] = weight
+    expected_pairs = {
+        (first, second)
+        for first in range(count)
+        for second in range(first + 1, count)
+        if second != first + 1 and (first, second) != (0, count - 1)
+    }
+    if set(weights) != expected_pairs or list(weights) != sorted(weights):
+        raise ValueError("triangulation weights are incomplete or noncanonical")
+
+    def edge_weight(first: int, second: int) -> Fraction:
+        pair = (first, second) if first < second else (second, first)
+        return (
+            Fraction()
+            if second == first + 1 or pair == (0, count - 1)
+            else weights[pair]
+        )
+
+    optimum = {(index, index + 1): Fraction() for index in range(count - 1)}
+    splits: dict[tuple[int, int], int] = {}
+    ledger: list[dict[str, object]] = []
+    for span in range(2, count):
+        for start in range(count - span):
+            end = start + span
+            value, pivot = min(
+                (
+                    optimum[start, candidate]
+                    + optimum[candidate, end]
+                    + edge_weight(start, candidate)
+                    + edge_weight(candidate, end),
+                    candidate,
+                )
+                for candidate in range(start + 1, end)
+            )
+            optimum[start, end] = value
+            splits[start, end] = pivot
+            ledger.append(
+                {"start": start, "end": end, "split": pivot, "optimum": value}
+            )
+    triangles: list[tuple[int, int, int]] = []
+    diagonals: set[tuple[int, int]] = set()
+
+    def reconstruct(start: int, end: int) -> None:
+        if end == start + 1:
+            return
+        pivot = splits[start, end]
+        triangles.append((start, pivot, end))
+        for pair in ((start, pivot), (pivot, end)):
+            ordered = pair if pair[0] < pair[1] else (pair[1], pair[0])
+            if pair[1] != pair[0] + 1 and ordered != (0, count - 1):
+                diagonals.add(ordered)
+        reconstruct(start, pivot)
+        reconstruct(pivot, end)
+
+    reconstruct(0, count - 1)
+    return {
+        "vertex_count": count,
+        "diagonals": [
+            {"first": first, "second": second, "weight": weights[first, second]}
+            for first, second in sorted(diagonals)
+        ],
+        "triangles": [{"vertices": item} for item in sorted(triangles)],
+        "split_table": ledger,
+        "optimum": optimum[0, count - 1],
+        "objective": "NON_HULL_DIAGONAL_WEIGHT_SUM",
+        "tie_break": "LOWEST_SPLIT_INDEX",
+        "exactness": "EXACT_RATIONAL",
+        "verification": "UNVERIFIED",
+    }
+
+
+def _triangulation_candidate(payload: dict[str, object]) -> dict[str, object]:
+    if set(payload) != {
+        "vertex_count",
+        "diagonals",
+        "triangles",
+        "split_table",
+        "optimum",
+        "objective",
+        "tie_break",
+        "exactness",
+        "verification",
+    }:
+        raise ValueError("triangulation candidate has an invalid shape")
+    result = dict(payload)
+    result["optimum"] = _rational(payload["optimum"])
+    diagonals = payload["diagonals"]
+    if not isinstance(diagonals, list):
+        raise ValueError("triangulation diagonals are malformed")
+    result["diagonals"] = [
+        {
+            "first": item["first"],
+            "second": item["second"],
+            "weight": _rational(item["weight"]),
+        }
+        for item in diagonals
+        if isinstance(item, dict) and set(item) == {"first", "second", "weight"}
+    ]
+    triangles = payload["triangles"]
+    if not isinstance(triangles, list):
+        raise ValueError("triangulation triangles are malformed")
+    result["triangles"] = [
+        {"vertices": tuple(item["vertices"])}
+        for item in triangles
+        if isinstance(item, dict)
+        and set(item) == {"vertices"}
+        and isinstance(item["vertices"], list)
+    ]
+    ledger = payload["split_table"]
+    if not isinstance(ledger, list):
+        raise ValueError("triangulation split table is malformed")
+    result["split_table"] = [
+        {
+            "start": item["start"],
+            "end": item["end"],
+            "split": item["split"],
+            "optimum": _rational(item["optimum"]),
+        }
+        for item in ledger
+        if isinstance(item, dict) and set(item) == {"start", "end", "split", "optimum"}
+    ]
+    return result
 
 
 def _reject(detail: str) -> dict[str, Any]:
@@ -400,7 +567,9 @@ def _point_classification(
     }
 
 
-def _expected(operation: str, claim: object) -> dict[str, object]:
+def _expected(operation: str, claim: object) -> dict[str, object]:  # noqa: C901
+    if operation == "geometry.polygon.triangulation.minimum_weight.compute":
+        return _minimum_weight_triangulation(claim)
     if operation == "geometry.points.compute.squared_distance":
         first, second = _pair(claim)
         value = (first[0] - second[0]) ** 2 + (first[1] - second[1]) ** 2
@@ -567,6 +736,8 @@ def _candidate(payload: object, operation: str) -> dict[str, object]:
         return _simple_polygon_candidate(payload)
     if operation == "geometry.polygon.point.classify":
         return _point_classification_candidate(payload)
+    if operation == "geometry.polygon.triangulation.minimum_weight.compute":
+        return _triangulation_candidate(payload)
     return _orientation_candidate(payload)
 
 

--- a/src/jacobian_checkers/exact_geometry.py
+++ b/src/jacobian_checkers/exact_geometry.py
@@ -42,7 +42,9 @@ _OPERATIONS = {
 }
 
 
-def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: C901
+def _triangulation_source(
+    claim: object,
+) -> tuple[list[tuple[Fraction, Fraction]], object]:
     if not isinstance(claim, dict) or set(claim) != {
         "polygon",
         "diagonal_weights",
@@ -64,7 +66,13 @@ def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: 
     ]
     if any(turn <= 0 for turn in turns):
         raise ValueError("triangulation polygon is not strict CCW convex")
-    raw_weights = claim["diagonal_weights"]
+    return points, claim["diagonal_weights"]
+
+
+def _triangulation_weights(
+    raw_weights: object,
+    count: int,
+) -> dict[tuple[int, int], Fraction]:
     if not isinstance(raw_weights, list):
         raise ValueError("triangulation weights are malformed")
     weights: dict[tuple[int, int], Fraction] = {}
@@ -93,6 +101,15 @@ def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: 
     }
     if set(weights) != expected_pairs or list(weights) != sorted(weights):
         raise ValueError("triangulation weights are incomplete or noncanonical")
+    return weights
+
+
+def _triangulation_dynamic_program(
+    count: int,
+    weights: dict[tuple[int, int], Fraction],
+) -> tuple[
+    dict[tuple[int, int], Fraction], dict[tuple[int, int], int], list[dict[str, object]]
+]:
 
     def edge_weight(first: int, second: int) -> Fraction:
         pair = (first, second) if first < second else (second, first)
@@ -123,6 +140,13 @@ def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: 
             ledger.append(
                 {"start": start, "end": end, "split": pivot, "optimum": value}
             )
+    return optimum, splits, ledger
+
+
+def _triangulation_reconstruct(
+    count: int,
+    splits: dict[tuple[int, int], int],
+) -> tuple[list[tuple[int, int, int]], set[tuple[int, int]]]:
     triangles: list[tuple[int, int, int]] = []
     diagonals: set[tuple[int, int]] = set()
 
@@ -139,6 +163,15 @@ def _minimum_weight_triangulation(claim: object) -> dict[str, object]:  # noqa: 
         reconstruct(pivot, end)
 
     reconstruct(0, count - 1)
+    return triangles, diagonals
+
+
+def _minimum_weight_triangulation(claim: object) -> dict[str, object]:
+    points, raw_weights = _triangulation_source(claim)
+    count = len(points)
+    weights = _triangulation_weights(raw_weights, count)
+    optimum, _splits, ledger = _triangulation_dynamic_program(count, weights)
+    triangles, diagonals = _triangulation_reconstruct(count, _splits)
     return {
         "vertex_count": count,
         "diagonals": [
@@ -567,7 +600,33 @@ def _point_classification(
     }
 
 
-def _expected(operation: str, claim: object) -> dict[str, object]:  # noqa: C901
+def _polygon_classification_expected(claim: object) -> dict[str, object]:
+    if not isinstance(claim, dict) or set(claim) != {"polygon", "point"}:
+        raise ValueError("polygon classification source has an invalid shape")
+    return _point_classification(
+        _points(claim["polygon"]),
+        _point(claim["point"]),
+    )
+
+
+def _triangle_expected(operation: str, claim: object) -> dict[str, object]:
+    first, second, third = _triple(claim)
+    if operation == "geometry.triangle.compute.orientation":
+        determinant = (second[0] - first[0]) * (third[1] - first[1]) - (
+            second[1] - first[1]
+        ) * (third[0] - first[0])
+        return {"orientation": (determinant > 0) - (determinant < 0)}
+    if operation == "geometry.triangle.compute.centroid":
+        return {
+            "point": (
+                (first[0] + second[0] + third[0]) / 3,
+                (first[1] + second[1] + third[1]) / 3,
+            )
+        }
+    raise ValueError("unsupported exact geometry operation")
+
+
+def _expected(operation: str, claim: object) -> dict[str, object]:
     if operation == "geometry.polygon.triangulation.minimum_weight.compute":
         return _minimum_weight_triangulation(claim)
     if operation == "geometry.points.compute.squared_distance":
@@ -589,26 +648,8 @@ def _expected(operation: str, claim: object) -> dict[str, object]:  # noqa: C901
     if operation == "geometry.polygon.simple.decide":
         return _polygon_decision(_points(claim))
     if operation == "geometry.polygon.point.classify":
-        if not isinstance(claim, dict) or set(claim) != {"polygon", "point"}:
-            raise ValueError("polygon classification source has an invalid shape")
-        return _point_classification(
-            _points(claim["polygon"]),
-            _point(claim["point"]),
-        )
-    first, second, third = _triple(claim)
-    if operation == "geometry.triangle.compute.orientation":
-        determinant = (second[0] - first[0]) * (third[1] - first[1]) - (
-            second[1] - first[1]
-        ) * (third[0] - first[0])
-        return {"orientation": (determinant > 0) - (determinant < 0)}
-    if operation == "geometry.triangle.compute.centroid":
-        return {
-            "point": (
-                (first[0] + second[0] + third[0]) / 3,
-                (first[1] + second[1] + third[1]) / 3,
-            )
-        }
-    raise ValueError("unsupported exact geometry operation")
+        return _polygon_classification_expected(claim)
+    return _triangle_expected(operation, claim)
 
 
 def _squared_distance_candidate(payload: dict[str, object]) -> dict[str, object]:

--- a/tests/domain/geometry/test_geometry_verification.py
+++ b/tests/domain/geometry/test_geometry_verification.py
@@ -78,6 +78,73 @@ def test_geometry_checker_availability_does_not_grant_authority(
         )
 
 
+def _weighted_square() -> dict[str, object]:
+    return {
+        "polygon": {"points": [P0, PX, PXY, PY]},
+        "diagonal_weights": [
+            {"first": 0, "second": 2, "weight": ONE},
+            {"first": 1, "second": 3, "weight": TWO},
+        ],
+        "objective": "NON_HULL_DIAGONAL_WEIGHT_SUM",
+    }
+
+
+def test_minimum_weight_triangulation_charges_one_diagonal_once(
+    geometry_services: DomainTestServices,
+) -> None:
+    payload = _weighted_square()
+    computed = geometry_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.triangulation.minimum_weight.compute",
+            input=payload,
+        )
+    )
+
+    assert computed.output["result"]["optimum"] == ONE
+    assert computed.output["result"]["diagonals"] == [
+        {"first": 0, "second": 2, "weight": ONE}
+    ]
+    assert computed.output["result"]["triangles"] == [
+        {"vertices": [0, 1, 2]},
+        {"vertices": [0, 2, 3]},
+    ]
+
+    verified = geometry_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.triangulation.minimum_weight.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": computed.output["result"]},
+        )
+    )
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_triangulation_checker_rejects_double_counted_cost(
+    geometry_services: DomainTestServices,
+) -> None:
+    payload = _weighted_square()
+    computed = geometry_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.triangulation.minimum_weight.compute",
+            input=payload,
+        )
+    )
+    forged = dict(computed.output["result"])
+    forged["optimum"] = TWO
+
+    rejected = geometry_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.polygon.triangulation.minimum_weight.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": forged},
+        )
+    )
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+
+
 _GEOMETRY_CASES = (
     (
         "geometry.points.compute.squared_distance",


### PR DESCRIPTION
## Summary
- add `geometry.polygon.triangulation.minimum_weight.compute` for 4–32 vertex strict CCW convex rational polygons with a complete canonical rational weight for every non-hull diagonal
- materialize the optimum, selected diagonals, triangle list, and complete deterministic split table
- charge each selected diagonal exactly once, with lowest-split-index tie breaking
- add independent standard-library rational replay through `geometry.polygon.triangulation.minimum_weight.verify`

## Scope boundary
This is the smallest exact first slice related to #945. It intentionally uses caller-supplied exact rational diagonal weights. It does **not** approximate Euclidean square-root sums, report runner-up interval gaps, or claim to solve the paper's 28-vertex Euclidean instance. Those require the algebraic/interval comparison contract still under design in #945.

The producer remains `COMPUTED`; only the operator-authorized independent checker returns `VERIFIED`.

## Validation
- focused geometry producer/verifier suite: 27 passed
- regression fixture distinguishes one-charge accounting from a double-counted cost
- Ruff lint and format: passed
- mypy on affected source: passed
- `git diff --check`: passed
- hosted CI will run broad lanes selected for the shared geometry contract/checker

Related to #945; does not close it.