### PR TITLE
Add a passive external reasoning observer

### DIFF
--- a/benchmarks/config/external-reasoning-observer-v1.json
+++ b/benchmarks/config/external-reasoning-observer-v1.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "1",
+  "study_id": "external-reasoning-observer-v1",
+  "status": "FROZEN_BEFORE_IMPLEMENTATION",
+  "evidence_class": "EXPLORATORY_PAIRED_POST_RUN_OBSERVATION",
+  "causal_claim_authorized": false,
+  "frozen_against": {
+    "git_sha": "9653dd991a47c1be3cf8ad478450b69c8be01482",
+    "git_ref": "origin/main"
+  },
+  "research_question": "Can a passive harness-side observer retain useful server-observed Jacobian events and optional explicit agent progress summaries without changing capability discovery, invocation, or mathematical outcomes?",
+  "decision_hypothesis": "Keep the observer only if it leaves the model-facing MCP surface and every paired trajectory outcome unchanged, fails observation closed without affecting mathematics, and records all parseable math.find/math.run server events.",
+  "intervention": {
+    "baseline": "The completed agent trajectory and Jacobian runtime log without observer output.",
+    "treatment": "Run the observer only after the agent process and verifier have completed, over immutable copies of the same trajectory and runtime log.",
+    "model_visible_change": "NONE",
+    "production_mcp_change": "NONE",
+    "prompt_change": "NONE",
+    "observer_effect": "Post-run CPU time and one additional derived artifact only. The observer cannot affect the paired agent or verifier execution."
+  },
+  "runtime": {
+    "agent": "codex",
+    "agent_authentication": "locally authenticated ChatGPT session",
+    "model": "gpt-5.4-mini",
+    "reasoning_effort": "medium",
+    "web_search": "disabled",
+    "repetitions_per_task": 1,
+    "task_timeout_seconds": 900,
+    "sampling_seed": null,
+    "sampling_deterministic": false
+  },
+  "tasks": [
+    "jacobian/graph-counterexample",
+    "jacobian/finite-field-irreducibility-repair",
+    "jacobian/symbolic-block-determinant-decomposition"
+  ],
+  "primary_safety_outcomes": [
+    "canonical MCP tool names and input schemas are identical before and after the implementation",
+    "paired math.find count is unchanged",
+    "paired math.run count is unchanged",
+    "paired tool-error and parameter-error counts are unchanged",
+    "paired verifier result and false-certification classification are unchanged",
+    "missing or malformed observer input does not change or block any agent, verifier, or mathematical result"
+  ],
+  "secondary_observation_outcomes": [
+    "server event coverage",
+    "explicit user-visible agent-message coverage",
+    "observer status and diagnostics",
+    "observer wall time",
+    "derived artifact bytes",
+    "agent prompt, cached, and completion tokens",
+    "agent wall time and tool-call count"
+  ],
+  "interpretation": {
+    "success": "All primary safety outcomes pass and the observer preserves every parseable server event. Partial or zero explicit-summary coverage is acceptable and must be reported.",
+    "failure": "Any product-surface delta, changed paired outcome, false certification, or observer error that affects agent, verifier, discovery, invocation, assurance, or mathematical execution.",
+    "limitations": [
+      "The small non-deterministic sample estimates usability, not a general performance effect.",
+      "The post-run paired design establishes non-interference structurally; it does not estimate the effect of prompting a model to write summaries.",
+      "Only explicit agent messages are eligible summaries. Hidden chain-of-thought and ATIF reasoning_content are excluded."
+    ]
+  }
+}

--- a/benchmarks/tooling/external_reasoning_observer.py
+++ b/benchmarks/tooling/external_reasoning_observer.py
@@ -57,6 +57,10 @@ _REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(?i)\bBearer\s+[^\s,;]+"), "[REDACTED_BEARER]"),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), "[REDACTED_API_KEY]"),
     (re.compile(r"/(?:Users|home)/[^/\s]+"), "[REDACTED_HOME]"),
+    (
+        re.compile(r"/(?:private/)?tmp/[^\s)\]]+|/var/folders/[^\s)\]]+"),
+        "[REDACTED_TEMP_PATH]",
+    ),
 )
 
 
@@ -82,6 +86,7 @@ class ObserverDiagnostic(_Contract):
         "MISSING_SERVER_LOG",
         "UNREADABLE_SERVER_LOG",
         "MALFORMED_SERVER_EVENT",
+        "SOURCE_OUTSIDE_TRIAL_ROOT",
     ]
     source_kind: Literal["AGENT_TRACE", "JACOBIAN_MCP_LOG"]
     source_position: int | None = Field(default=None, ge=1)
@@ -249,6 +254,47 @@ def _read_source(
             byte_count=len(content),
         ),
         None,
+    )
+
+
+def _source_is_within_trial_root(path: Path, trial_root: Path) -> bool:
+    try:
+        relative = path.relative_to(trial_root)
+    except ValueError:
+        return False
+    if not relative.parts:
+        return False
+    current = trial_root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            return False
+    try:
+        path.resolve().relative_to(trial_root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _outside_trial_binding(
+    path: Path,
+    *,
+    kind: Literal["AGENT_TRACE", "JACOBIAN_MCP_LOG"],
+    source_format: Literal["CODEX_JSONL", "ATIF_JSON", "JACOBIAN_MCP_LOG"],
+) -> tuple[None, SourceBinding, ObserverDiagnostic]:
+    return (
+        None,
+        SourceBinding(
+            source_kind=kind,
+            source_name=path.name or "outside-trial-root",
+            source_format=source_format,
+            status="INCOMPLETE",
+            byte_count=0,
+        ),
+        ObserverDiagnostic(
+            code="SOURCE_OUTSIDE_TRIAL_ROOT",
+            source_kind=kind,
+        ),
     )
 
 
@@ -518,6 +564,7 @@ def _parse_server_events(
 def observe_external_reasoning(
     *,
     trial_id: str,
+    trial_root: Path,
     agent_trace: Path,
     server_log: Path,
 ) -> ExternalReasoningObservation:
@@ -526,15 +573,31 @@ def observe_external_reasoning(
     trace_format: Literal["CODEX_JSONL", "ATIF_JSON"] = (
         "CODEX_JSONL" if agent_trace.suffix == ".jsonl" else "ATIF_JSON"
     )
-    trace_bytes, trace_binding, trace_read_diagnostic = _read_source(
-        agent_trace,
-        kind="AGENT_TRACE",
-        source_format=trace_format,
+    trace_bytes, trace_binding, trace_read_diagnostic = (
+        _read_source(
+            agent_trace,
+            kind="AGENT_TRACE",
+            source_format=trace_format,
+        )
+        if _source_is_within_trial_root(agent_trace, trial_root)
+        else _outside_trial_binding(
+            agent_trace,
+            kind="AGENT_TRACE",
+            source_format=trace_format,
+        )
     )
-    server_bytes, server_binding, server_read_diagnostic = _read_source(
-        server_log,
-        kind="JACOBIAN_MCP_LOG",
-        source_format="JACOBIAN_MCP_LOG",
+    server_bytes, server_binding, server_read_diagnostic = (
+        _read_source(
+            server_log,
+            kind="JACOBIAN_MCP_LOG",
+            source_format="JACOBIAN_MCP_LOG",
+        )
+        if _source_is_within_trial_root(server_log, trial_root)
+        else _outside_trial_binding(
+            server_log,
+            kind="JACOBIAN_MCP_LOG",
+            source_format="JACOBIAN_MCP_LOG",
+        )
     )
     diagnostics = [
         item
@@ -607,6 +670,7 @@ def observe_external_reasoning(
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--trial-id", required=True)
+    parser.add_argument("--trial-root", type=Path, required=True)
     parser.add_argument("--agent-trace", type=Path, required=True)
     parser.add_argument("--server-log", type=Path, required=True)
     parser.add_argument("--output", type=Path)
@@ -617,6 +681,7 @@ def main() -> int:
     args = _parser().parse_args()
     report = observe_external_reasoning(
         trial_id=args.trial_id,
+        trial_root=args.trial_root,
         agent_trace=args.agent_trace,
         server_log=args.server_log,
     )

--- a/benchmarks/tooling/external_reasoning_observer.py
+++ b/benchmarks/tooling/external_reasoning_observer.py
@@ -1,0 +1,646 @@
+"""Build a passive external record from agent messages and Jacobian telemetry.
+
+The observer runs after an agent and verifier finish.  It never participates in
+MCP dispatch, and it deliberately excludes prompts, tool arguments, tool
+results, and ``reasoning_content``.  Server telemetry remains authoritative for
+mathematical calls; agent messages are optional self-reports only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_DIGEST_16_PATTERN = r"^(?:[0-9a-f]{16}|none)$"
+_TRACE_DIGEST_PATTERN = r"^(?:[0-9a-f]{8}|none)$"
+_SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
+_TRIAL_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+_DECIMAL_PATTERN = r"^[0-9]+(?:\.[0-9]+)?$"
+_SUMMARY_MAX_BYTES = 512
+
+_SERVER_EVENT_START = re.compile(r"\bMCP (?:tool call|capability attempt)\b")
+_TOOL_CALL = re.compile(
+    r"\bMCP tool call tool=(math\.(?:find|run))\b"
+    r".{0,512}?\bstatus=(success|error)\b"
+    r".{0,512}?\brequest_digest=([0-9a-f]{16}|none)\b"
+    r".{0,512}?\btrace_digest=([0-9a-f]{8}|none)\b"
+    r".{0,512}?\btrace_source=([^\s]+)\b"
+    r".{0,512}?\bduration_ms=([0-9]+(?:\.[0-9]+)?)\b"
+    r".{0,512}?\bresponse_bytes=([0-9]+)\b"
+    r".{0,512}?\bargument_digest=(sha256:(?:[0-9a-f]\s*){64})",
+    re.DOTALL,
+)
+_CAPABILITY_ATTEMPT = re.compile(
+    r"\bMCP capability attempt request_digest=([0-9a-f]{16}|none)\b"
+    r".{0,512}?\btrace_digest=([0-9a-f]{8}|none)\b"
+    r".{0,512}?\btrace_source=([^\s]+)\b"
+    r".{0,512}?\bcapability_id=([^\s]+)\b"
+    r".{0,512}?\bcapability_version=([^\s]+)\b"
+    r".{0,512}?\bmode=([^\s]+)\b"
+    r".{0,512}?\bexecution_status=([A-Z_]+)\b"
+    r".{0,512}?\bassurance=([^\s]+)\b"
+    r".{0,512}?\bdiagnostic_codes=([^\s]+)\b"
+    r".{0,512}?\battempt_duration_ms=([0-9]+(?:\.[0-9]+)?)\b"
+    r".{0,512}?\boperation_runtime_ms=([^\s]+)\b"
+    r".{0,512}?\bresponse_bytes=([0-9]+)\b"
+    r".{0,512}?\bargument_digest=(sha256:(?:[0-9a-f]\s*){64})",
+    re.DOTALL,
+)
+
+_REDACTIONS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)\bBearer\s+[^\s,;]+"), "[REDACTED_BEARER]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"), "[REDACTED_API_KEY]"),
+    (re.compile(r"/(?:Users|home)/[^/\s]+"), "[REDACTED_HOME]"),
+)
+
+
+class _Contract(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class SourceBinding(_Contract):
+    source_kind: Literal["AGENT_TRACE", "JACOBIAN_MCP_LOG"]
+    source_name: str = Field(min_length=1, max_length=255)
+    source_format: Literal["CODEX_JSONL", "ATIF_JSON", "JACOBIAN_MCP_LOG"]
+    status: Literal["COMPLETE", "INCOMPLETE", "MISSING"]
+    sha256: str | None = Field(default=None, pattern=_SHA256_PATTERN)
+    byte_count: int = Field(ge=0)
+
+
+class ObserverDiagnostic(_Contract):
+    code: Literal[
+        "MISSING_AGENT_TRACE",
+        "UNREADABLE_AGENT_TRACE",
+        "MALFORMED_AGENT_TRACE",
+        "MALFORMED_AGENT_TRACE_ENTRY",
+        "MISSING_SERVER_LOG",
+        "UNREADABLE_SERVER_LOG",
+        "MALFORMED_SERVER_EVENT",
+    ]
+    source_kind: Literal["AGENT_TRACE", "JACOBIAN_MCP_LOG"]
+    source_position: int | None = Field(default=None, ge=1)
+
+
+class PrivacyPolicy(_Contract):
+    summary_source: Literal["EXPLICIT_AGENT_MESSAGE_ONLY"] = (
+        "EXPLICIT_AGENT_MESSAGE_ONLY"
+    )
+    summary_max_utf8_bytes: Literal[512] = _SUMMARY_MAX_BYTES
+    excluded_fields: tuple[
+        Literal[
+            "PROMPTS",
+            "REASONING_CONTENT",
+            "TOOL_ARGUMENTS",
+            "TOOL_RESULTS",
+            "HIDDEN_CHAIN_OF_THOUGHT",
+        ],
+        ...,
+    ] = (
+        "PROMPTS",
+        "REASONING_CONTENT",
+        "TOOL_ARGUMENTS",
+        "TOOL_RESULTS",
+        "HIDDEN_CHAIN_OF_THOUGHT",
+    )
+    retention: Literal["OPERATOR_CONTROLLED_DERIVED_ARTIFACT"] = (
+        "OPERATOR_CONTROLLED_DERIVED_ARTIFACT"
+    )
+
+
+class ExplicitSummary(_Contract):
+    sequence: int = Field(ge=1)
+    trial_id: str = Field(pattern=_TRIAL_ID_PATTERN)
+    source_format: Literal["CODEX_JSONL", "ATIF_JSON"]
+    source_position: int = Field(ge=1)
+    text: str = Field(min_length=1)
+    original_utf8_bytes: int = Field(ge=1)
+    truncated: bool
+    redaction_count: int = Field(ge=0)
+    evidence_semantics: Literal["OPTIONAL_SELF_REPORT"] = "OPTIONAL_SELF_REPORT"
+
+
+class ToolCallEvent(_Contract):
+    kind: Literal["TOOL_CALL"] = "TOOL_CALL"
+    sequence: int = Field(ge=1)
+    trial_id: str = Field(pattern=_TRIAL_ID_PATTERN)
+    tool: Literal["math.find", "math.run"]
+    status: Literal["success", "error"]
+    request_digest: str = Field(pattern=_DIGEST_16_PATTERN)
+    trace_digest: str = Field(pattern=_TRACE_DIGEST_PATTERN)
+    trace_source: str = Field(min_length=1)
+    duration_ms: str = Field(pattern=_DECIMAL_PATTERN)
+    response_bytes: int = Field(ge=0)
+    argument_digest: str = Field(pattern=_SHA256_PATTERN)
+    correlation: Literal["SERVER_REQUEST_DIGEST", "UNAVAILABLE"]
+
+
+class CapabilityAttemptEvent(_Contract):
+    kind: Literal["CAPABILITY_ATTEMPT"] = "CAPABILITY_ATTEMPT"
+    sequence: int = Field(ge=1)
+    trial_id: str = Field(pattern=_TRIAL_ID_PATTERN)
+    request_digest: str = Field(pattern=_DIGEST_16_PATTERN)
+    trace_digest: str = Field(pattern=_TRACE_DIGEST_PATTERN)
+    trace_source: str = Field(min_length=1)
+    capability_id: str = Field(min_length=1)
+    capability_version: str = Field(min_length=1)
+    mode: str = Field(min_length=1)
+    execution_status: str = Field(min_length=1)
+    assurance: str = Field(min_length=1)
+    diagnostic_codes: tuple[str, ...]
+    attempt_duration_ms: str = Field(pattern=_DECIMAL_PATTERN)
+    operation_runtime_ms: str | None
+    response_bytes: int = Field(ge=0)
+    argument_digest: str = Field(pattern=_SHA256_PATTERN)
+    correlation: Literal["SERVER_REQUEST_DIGEST", "UNAVAILABLE"]
+
+
+ServerEvent = Annotated[
+    ToolCallEvent | CapabilityAttemptEvent,
+    Field(discriminator="kind"),
+]
+
+
+class ObserverMetrics(_Contract):
+    server_event_candidates: int = Field(ge=0)
+    server_events_recorded: int = Field(ge=0)
+    server_event_coverage: float = Field(ge=0.0, le=1.0)
+    tool_calls_recorded: int = Field(ge=0)
+    capability_attempts_recorded: int = Field(ge=0)
+    explicit_summaries_recorded: int = Field(ge=0)
+
+
+class ExternalReasoningObservation(_Contract):
+    schema_version: Literal["1"] = "1"
+    observer_id: Literal["jacobian.external-reasoning-observer"] = (
+        "jacobian.external-reasoning-observer"
+    )
+    status: Literal["COMPLETE", "INCOMPLETE"]
+    trial_id: str = Field(pattern=_TRIAL_ID_PATTERN)
+    evidence_class: Literal["SERVER_OBSERVATION_WITH_OPTIONAL_SELF_REPORT"] = (
+        "SERVER_OBSERVATION_WITH_OPTIONAL_SELF_REPORT"
+    )
+    causal_claim_authorized: Literal[False] = False
+    affects_mathematical_assurance: Literal[False] = False
+    sources: tuple[SourceBinding, SourceBinding]
+    privacy: PrivacyPolicy
+    explicit_summaries: tuple[ExplicitSummary, ...]
+    server_events: tuple[ServerEvent, ...]
+    metrics: ObserverMetrics
+    diagnostics: tuple[ObserverDiagnostic, ...]
+
+
+def _sha256(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _read_source(
+    path: Path,
+    *,
+    kind: Literal["AGENT_TRACE", "JACOBIAN_MCP_LOG"],
+    source_format: Literal["CODEX_JSONL", "ATIF_JSON", "JACOBIAN_MCP_LOG"],
+) -> tuple[bytes | None, SourceBinding, ObserverDiagnostic | None]:
+    missing_code = (
+        "MISSING_AGENT_TRACE" if kind == "AGENT_TRACE" else "MISSING_SERVER_LOG"
+    )
+    unreadable_code = (
+        "UNREADABLE_AGENT_TRACE" if kind == "AGENT_TRACE" else "UNREADABLE_SERVER_LOG"
+    )
+    if not path.is_file():
+        return (
+            None,
+            SourceBinding(
+                source_kind=kind,
+                source_name=path.name or "missing",
+                source_format=source_format,
+                status="MISSING",
+                byte_count=0,
+            ),
+            ObserverDiagnostic(code=missing_code, source_kind=kind),
+        )
+    try:
+        content = path.read_bytes()
+        content.decode("utf-8")
+    except (OSError, UnicodeError):
+        return (
+            None,
+            SourceBinding(
+                source_kind=kind,
+                source_name=path.name,
+                source_format=source_format,
+                status="INCOMPLETE",
+                byte_count=0,
+            ),
+            ObserverDiagnostic(code=unreadable_code, source_kind=kind),
+        )
+    return (
+        content,
+        SourceBinding(
+            source_kind=kind,
+            source_name=path.name,
+            source_format=source_format,
+            status="COMPLETE",
+            sha256=_sha256(content),
+            byte_count=len(content),
+        ),
+        None,
+    )
+
+
+def _bounded_summary(text: str) -> tuple[str, int, bool, int]:
+    redaction_count = 0
+    redacted = text.strip()
+    for pattern, replacement in _REDACTIONS:
+        redacted, count = pattern.subn(replacement, redacted)
+        redaction_count += count
+    encoded = redacted.encode("utf-8")
+    original_bytes = len(encoded)
+    if original_bytes <= _SUMMARY_MAX_BYTES:
+        return redacted, original_bytes, False, redaction_count
+    bounded = encoded[:_SUMMARY_MAX_BYTES].decode("utf-8", errors="ignore")
+    return bounded, original_bytes, True, redaction_count
+
+
+def _summary(
+    *,
+    sequence: int,
+    trial_id: str,
+    source_format: Literal["CODEX_JSONL", "ATIF_JSON"],
+    source_position: int,
+    text: str,
+) -> ExplicitSummary | None:
+    if not text.strip():
+        return None
+    bounded, original_bytes, truncated, redactions = _bounded_summary(text)
+    if not bounded:
+        return None
+    return ExplicitSummary(
+        sequence=sequence,
+        trial_id=trial_id,
+        source_format=source_format,
+        source_position=source_position,
+        text=bounded,
+        original_utf8_bytes=original_bytes,
+        truncated=truncated,
+        redaction_count=redactions,
+    )
+
+
+def _parse_codex_jsonl(
+    text: str,
+    *,
+    trial_id: str,
+) -> tuple[list[ExplicitSummary], list[ObserverDiagnostic]]:
+    summaries: list[ExplicitSummary] = []
+    diagnostics: list[ObserverDiagnostic] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            diagnostics.append(
+                ObserverDiagnostic(
+                    code="MALFORMED_AGENT_TRACE_ENTRY",
+                    source_kind="AGENT_TRACE",
+                    source_position=line_number,
+                )
+            )
+            continue
+        item = event.get("item") if isinstance(event, dict) else None
+        if not (
+            isinstance(event, dict)
+            and event.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "agent_message"
+            and isinstance(item.get("text"), str)
+        ):
+            continue
+        value = _summary(
+            sequence=len(summaries) + 1,
+            trial_id=trial_id,
+            source_format="CODEX_JSONL",
+            source_position=line_number,
+            text=item["text"],
+        )
+        if value is not None:
+            summaries.append(value)
+    return summaries, diagnostics
+
+
+def _atif_message_text(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        return None
+    parts = [
+        item["text"]
+        for item in value
+        if isinstance(item, dict)
+        and item.get("type") == "text"
+        and isinstance(item.get("text"), str)
+    ]
+    return "\n".join(parts)
+
+
+def _parse_atif(
+    text: str,
+    *,
+    trial_id: str,
+) -> tuple[list[ExplicitSummary], list[ObserverDiagnostic]]:
+    try:
+        trajectory = json.loads(text)
+    except json.JSONDecodeError:
+        return [], [
+            ObserverDiagnostic(
+                code="MALFORMED_AGENT_TRACE",
+                source_kind="AGENT_TRACE",
+            )
+        ]
+    if not isinstance(trajectory, dict) or not isinstance(
+        trajectory.get("steps"), list
+    ):
+        return [], [
+            ObserverDiagnostic(
+                code="MALFORMED_AGENT_TRACE",
+                source_kind="AGENT_TRACE",
+            )
+        ]
+    summaries: list[ExplicitSummary] = []
+    for position, step in enumerate(trajectory["steps"], start=1):
+        if not (
+            isinstance(step, dict)
+            and step.get("source") == "agent"
+            and step.get("is_copied_context") is not True
+        ):
+            continue
+        text_value = _atif_message_text(step.get("message"))
+        if text_value is None:
+            continue
+        step_id = step.get("step_id")
+        source_position = (
+            step_id
+            if isinstance(step_id, int)
+            and not isinstance(step_id, bool)
+            and step_id > 0
+            else position
+        )
+        value = _summary(
+            sequence=len(summaries) + 1,
+            trial_id=trial_id,
+            source_format="ATIF_JSON",
+            source_position=source_position,
+            text=text_value,
+        )
+        if value is not None:
+            summaries.append(value)
+    return summaries, []
+
+
+def _correlation(
+    request_digest: str,
+) -> Literal["SERVER_REQUEST_DIGEST", "UNAVAILABLE"]:
+    return "UNAVAILABLE" if request_digest == "none" else "SERVER_REQUEST_DIGEST"
+
+
+def _tool_call_event(
+    match: re.Match[str],
+    *,
+    sequence: int,
+    trial_id: str,
+) -> ToolCallEvent:
+    (
+        tool,
+        status,
+        request_digest,
+        trace_digest,
+        trace_source,
+        duration_ms,
+        response_bytes,
+        argument_digest,
+    ) = match.groups()
+    return ToolCallEvent(
+        sequence=sequence,
+        trial_id=trial_id,
+        tool=tool,
+        status=status,
+        request_digest=request_digest,
+        trace_digest=trace_digest,
+        trace_source=trace_source,
+        duration_ms=duration_ms,
+        response_bytes=int(response_bytes),
+        argument_digest=re.sub(r"\s", "", argument_digest),
+        correlation=_correlation(request_digest),
+    )
+
+
+def _capability_attempt_event(
+    match: re.Match[str],
+    *,
+    sequence: int,
+    trial_id: str,
+) -> CapabilityAttemptEvent:
+    (
+        request_digest,
+        trace_digest,
+        trace_source,
+        capability_id,
+        capability_version,
+        mode,
+        execution_status,
+        assurance,
+        diagnostic_codes,
+        attempt_duration_ms,
+        operation_runtime_ms,
+        response_bytes,
+        argument_digest,
+    ) = match.groups()
+    return CapabilityAttemptEvent(
+        sequence=sequence,
+        trial_id=trial_id,
+        request_digest=request_digest,
+        trace_digest=trace_digest,
+        trace_source=trace_source,
+        capability_id=capability_id,
+        capability_version=capability_version,
+        mode=mode,
+        execution_status=execution_status,
+        assurance=assurance,
+        diagnostic_codes=(
+            () if diagnostic_codes == "none" else tuple(diagnostic_codes.split(","))
+        ),
+        attempt_duration_ms=attempt_duration_ms,
+        operation_runtime_ms=(
+            None if operation_runtime_ms == "none" else operation_runtime_ms
+        ),
+        response_bytes=int(response_bytes),
+        argument_digest=re.sub(r"\s", "", argument_digest),
+        correlation=_correlation(request_digest),
+    )
+
+
+def _parse_server_events(
+    text: str,
+    *,
+    trial_id: str,
+) -> tuple[list[ToolCallEvent | CapabilityAttemptEvent], int]:
+    starts = list(_SERVER_EVENT_START.finditer(text))
+    events: list[ToolCallEvent | CapabilityAttemptEvent] = []
+    for index, start in enumerate(starts):
+        end = starts[index + 1].start() if index + 1 < len(starts) else len(text)
+        segment = text[start.start() : end]
+        tool_match = _TOOL_CALL.search(segment)
+        attempt_match = _CAPABILITY_ATTEMPT.search(segment)
+        if tool_match is not None:
+            events.append(
+                _tool_call_event(
+                    tool_match,
+                    sequence=len(events) + 1,
+                    trial_id=trial_id,
+                )
+            )
+        elif attempt_match is not None:
+            events.append(
+                _capability_attempt_event(
+                    attempt_match,
+                    sequence=len(events) + 1,
+                    trial_id=trial_id,
+                )
+            )
+    return events, len(starts)
+
+
+def observe_external_reasoning(
+    *,
+    trial_id: str,
+    agent_trace: Path,
+    server_log: Path,
+) -> ExternalReasoningObservation:
+    """Return a fail-closed post-run observation without changing the run."""
+
+    trace_format: Literal["CODEX_JSONL", "ATIF_JSON"] = (
+        "CODEX_JSONL" if agent_trace.suffix == ".jsonl" else "ATIF_JSON"
+    )
+    trace_bytes, trace_binding, trace_read_diagnostic = _read_source(
+        agent_trace,
+        kind="AGENT_TRACE",
+        source_format=trace_format,
+    )
+    server_bytes, server_binding, server_read_diagnostic = _read_source(
+        server_log,
+        kind="JACOBIAN_MCP_LOG",
+        source_format="JACOBIAN_MCP_LOG",
+    )
+    diagnostics = [
+        item
+        for item in (trace_read_diagnostic, server_read_diagnostic)
+        if item is not None
+    ]
+
+    summaries: list[ExplicitSummary] = []
+    if trace_bytes is not None:
+        trace_text = trace_bytes.decode("utf-8")
+        summaries, trace_diagnostics = (
+            _parse_codex_jsonl(trace_text, trial_id=trial_id)
+            if trace_format == "CODEX_JSONL"
+            else _parse_atif(trace_text, trial_id=trial_id)
+        )
+        diagnostics.extend(trace_diagnostics)
+
+    server_events: list[ToolCallEvent | CapabilityAttemptEvent] = []
+    candidate_count = 0
+    if server_bytes is not None:
+        server_events, candidate_count = _parse_server_events(
+            server_bytes.decode("utf-8"),
+            trial_id=trial_id,
+        )
+        if len(server_events) != candidate_count:
+            diagnostics.append(
+                ObserverDiagnostic(
+                    code="MALFORMED_SERVER_EVENT",
+                    source_kind="JACOBIAN_MCP_LOG",
+                )
+            )
+
+    trace_status = (
+        "INCOMPLETE"
+        if any(item.source_kind == "AGENT_TRACE" for item in diagnostics)
+        else trace_binding.status
+    )
+    server_status = (
+        "INCOMPLETE"
+        if any(item.source_kind == "JACOBIAN_MCP_LOG" for item in diagnostics)
+        else server_binding.status
+    )
+    trace_binding = trace_binding.model_copy(update={"status": trace_status})
+    server_binding = server_binding.model_copy(update={"status": server_status})
+    recorded = len(server_events)
+    coverage = 1.0 if candidate_count == 0 else recorded / candidate_count
+    return ExternalReasoningObservation(
+        status="INCOMPLETE" if diagnostics else "COMPLETE",
+        trial_id=trial_id,
+        sources=(trace_binding, server_binding),
+        privacy=PrivacyPolicy(),
+        explicit_summaries=tuple(summaries),
+        server_events=tuple(server_events),
+        metrics=ObserverMetrics(
+            server_event_candidates=candidate_count,
+            server_events_recorded=recorded,
+            server_event_coverage=coverage,
+            tool_calls_recorded=sum(
+                isinstance(item, ToolCallEvent) for item in server_events
+            ),
+            capability_attempts_recorded=sum(
+                isinstance(item, CapabilityAttemptEvent) for item in server_events
+            ),
+            explicit_summaries_recorded=len(summaries),
+        ),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trial-id", required=True)
+    parser.add_argument("--agent-trace", type=Path, required=True)
+    parser.add_argument("--server-log", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    report = observe_external_reasoning(
+        trial_id=args.trial_id,
+        agent_trace=args.agent_trace,
+        server_log=args.server_log,
+    )
+    rendered = json.dumps(report.model_dump(mode="json"), indent=2, sort_keys=True)
+    if args.output is None:
+        print(rendered)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if report.status == "COMPLETE" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CapabilityAttemptEvent",
+    "ExplicitSummary",
+    "ExternalReasoningObservation",
+    "ObserverDiagnostic",
+    "ObserverMetrics",
+    "PrivacyPolicy",
+    "SourceBinding",
+    "ToolCallEvent",
+    "observe_external_reasoning",
+]

--- a/docs/reference/evaluations/evaluation-methods.md
+++ b/docs/reference/evaluations/evaluation-methods.md
@@ -101,6 +101,11 @@ flow, repeated calls, shell activity, tokens, time, and completion. This is
 workflow evidence, not a causal comparison: the public suite has no held-out
 performance claim.
 
+Use the [external reasoning observer](external-reasoning-observer.md) when an
+evaluation needs a bounded, derived record of server-observed Jacobian calls
+and optional explicit agent progress messages. The observer is post-run and
+does not alter the MCP surface, prompt, agent execution, verifier, or assurance.
+
 ## Performance benchmarks
 
 ### Purpose

--- a/docs/reference/evaluations/external-reasoning-observer-pilot.md
+++ b/docs/reference/evaluations/external-reasoning-observer-pilot.md
@@ -1,0 +1,174 @@
+# External reasoning observer pilot
+
+[External reasoning observer](external-reasoning-observer.md) · [Evaluation references](index.md)
+
+- Status: completed exploratory pilot
+- Date: 2026-08-09 (America/Los_Angeles)
+- Frozen study: `external-reasoning-observer-v1`
+- Evidence class: paired post-run workflow observation
+- Causal claim authorized: no
+
+## Decision
+
+Keep the passive observer for evaluation use. Do not restore a production
+reasoning tool, runtime mode, required phase protocol, or model-supplied
+correlation IDs.
+
+The observer preserved every parseable server event and every explicit agent
+message in this pilot. It added no model calls, prompt tokens, tool parameters,
+or production source changes. Missing and malformed inputs remain observation
+failures only. These results support the observer's usability boundary; they do
+not establish a general model-performance improvement.
+
+## Frozen boundary
+
+The study contract was committed before implementation at `877aa3b3` and has
+SHA-256 digest
+`dddd0c9d93c2eba2b94c3ab3984404b66845a506153dcf1d189e6f15034c6a78`.
+It was frozen against upstream commit
+`9653dd991a47c1be3cf8ad478450b69c8be01482`.
+
+Baseline and treatment are the same immutable completed trajectory. Baseline
+has no derived observer artifact; treatment runs the observer after the agent
+and verifier finish. Therefore solution, verifier, tool-call, error, token, and
+latency outcomes are paired invariants. The only treatment cost is local
+post-processing and a derived JSON file.
+
+The model-visible prompt was identical for all three tasks:
+
+> Read instruction.md, input.json, and submission_schema.json. Solve the task
+> completely. Use the available Jacobian mathematical tools when useful. Write
+> submission.json and every required evidence file in this workspace. Do not
+> use the network or inspect files outside this workspace.
+
+## Runtime identity
+
+- Agent: Codex CLI `0.147.0`, authenticated through the local ChatGPT session
+- Model: `gpt-5.4-mini`, reasoning effort `medium`
+- Jacobian package and MCP server: `0.10.0`
+- Catalog digest:
+  `sha256:36577b0c299cf47bc19964131cc5427d142f34013a872364841140e1669ae43c`
+- Policy digest:
+  `sha256:870a92b83d3e522e4015b6bb1cabda33086906f9de1c3c36e466251ea7ed1957`
+- Dataset snapshot:
+  `sha256:26e558abcfda80f944ff1659f73b3c89b22ed4ddd2700d8340c067dc4ed7b323`
+- Sampling seed: unavailable; sampling was non-deterministic
+- Network search: disabled
+- Agent sandbox: isolated writable task workspace
+- MCP server: one fresh anonymous loopback runtime per task
+
+Docker and Podman were unavailable on the host. The paid model runs therefore
+used the maintained local Codex/MCP boundary, and verifier functions were
+replayed over path-adapted task workspaces. This is not a Harbor container-run
+claim. The same task contracts, mathematical checks, evidence bindings, scope,
+assurance, and false-certification logic were used.
+
+## Results
+
+`run error` below means the Codex client reported a cancelled MCP call before
+the Jacobian server observed a capability attempt. Server counts therefore
+remain lower than agent-trace counts by two, correctly preserving the trust
+boundary.
+
+| Task | Agent seconds | `math.find` | `math.run` (errors) | Server tool events | Explicit summaries (truncated) | Input / cached / output tokens | Verifier | False certification |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| `graph-counterexample` | 78 | 3 | 1 (1) | 3 | 8 (1) | 226353 / 204288 / 3761 | pass | false |
+| `finite-field-irreducibility-repair` | 161 | 2 | 0 (0) | 2 | 9 (0) | 353300 / 313600 / 9129 | pass | false |
+| `symbolic-block-determinant-decomposition` | 116 | 1 | 1 (1) | 1 | 8 (1) | 200311 / 183424 / 6276 | pass | false |
+| **Total** | **355** | **6** | **2 (2)** | **6** | **25 (2)** | **779964 / 701312 / 19166** | **3/3 pass** | **0/3** |
+
+Additional totals:
+
+- parameter errors: 0;
+- total agent-side MCP calls: 8;
+- successful server-observed discovery calls: 6;
+- server-observed capability attempts: 0;
+- uncached input tokens: 78,652;
+- reasoning output tokens: 9,249;
+- observer server-event coverage: 6/6, or 100%;
+- explicit-message retention: 25/25, or 100%;
+- redactions: 10, primarily repeated temporary paths in link labels and targets;
+- derived observation size: 21,404 bytes across three trials;
+- observer wall time: 0.07 to 0.09 seconds per trial, including `uv run`
+  startup;
+- treatment changes to `src/`: none relative to the frozen upstream commit.
+
+Because treatment is downstream of the completed runs, baseline and treatment
+both have a 3/3 verifier pass rate, zero false certifications, six
+server-observed calls, two client-side tool errors, and the same tokens and
+agent latency. The observer adds 25 bounded summaries and six typed server
+events without changing those outcomes.
+
+## Manual trajectory review
+
+The graph trajectory found a suitable exact graph-construction capability,
+inspected its contract, and attempted it. When the client cancelled the run,
+the model explicitly reported the fallback and produced a correct six-vertex
+witness locally. The log makes both the intended capability and the failed
+execution boundary visible without treating the attempt as a server result.
+
+The finite-field trajectory used two discovery searches, then computed the
+certificate locally. Its explicit messages exposed a suspicious first
+brute-force result, the decision to debug it, and recovery to the valid repair
+prime 11. This is useful progress evidence that required no logging prompt.
+
+The symbolic trajectory discovered a matrix route and attempted
+`matrix.inverse.compute`. After the client-side cancellation it reported the
+fallback, derived the rational basis locally, and produced a verifier-passing
+symbolic decomposition. Again, the server log contains only the successful
+search, while the self-report explains the later choice.
+
+All three final answers were useful and fully bound to evidence. Two long final
+messages were truncated at the declared 512-byte boundary; earlier progress
+messages retained the important decisions. No hidden reasoning or ATIF
+`reasoning_content` was collected.
+
+## Upstream canary and historical diagnosis
+
+Before implementing the observer, an authenticated four-case upstream canary
+ran at preregistration commit `877aa3b3`. It recorded 10 agent-side MCP calls,
+three invocation attempts, two discovered workflows, one correct abstention,
+zero completed or verified capability results, and 220.66 seconds of agent
+time. Several `math.run` calls were cancelled client-side. The canary's weak
+completion rate is not attributed to logging: no observer existed and the
+production surface was current upstream.
+
+Historical inspection of PR #956 and its parent confirmed why the retired
+design interfered. It added `reasoning.write`, changed `math.run` schemas by
+mode, required model-managed run and call IDs, and encouraged a
+PLAN/BEFORE_TOOL/AFTER_TOOL/FINAL state machine. A preserved historical trace
+spent four of nine MCP calls on `reasoning.write`, including a failed call.
+The passive observer spends zero model calls on logging and leaves
+`math.find`/`math.run` unchanged.
+
+## Evidence bindings
+
+Host-local raw evidence is under
+`/tmp/jacobian-external-observer-baseline.GspjDA/`. It is intentionally not
+checked in. The relevant immutable digests are:
+
+| Task | Codex JSONL SHA-256 | MCP log SHA-256 | Observation SHA-256 |
+| --- | --- | --- | --- |
+| graph | `78464f1ed10401437a12495f5e2b1201ddbe33cfc11ba1e54c9b39c70d3e588a` | `f9f5d5b9dd1bcf01eb1a3c66d847d607b03cd56e39e3ad551892ad29ef8ff3b6` | `ca018aaaae67f4f297cdc3b314fcc55adefc1edce56a279566c0f3ed200aeab1` |
+| finite field | `05b42f89b9b9a74d6df38f28728cce7eb830a7ac5e3e59c9f0629f1dfe714b06` | `47931c1cb129f238eec5dcfa60c4fbb4de6797601e4cc929f289b16b0dbb0012` | `d657d89821e189b91453c02fd6b088c9d15af27d1df8206742ae4c2425028eb3` |
+| symbolic block | `604087b2eb0cf523caa9b35c8a4ed05db0f7b2ec31c7ecba535c703a66e7215e` | `6196bb845cca5587d131e770cdec214c0b59ea37002758392ec41f455be20192` | `ad585412beb23b971f7503bf263bb6c7172cb28d2c9326d84001c09dcd7df1a5` |
+
+The model submission SHA-256 digests are
+`0eafc262481ae97cb6281f5271dd8a17b4ca6634c9e2f52b6ad4b9d82785b657`,
+`9697d830c5c0518f648c543e708c56a59bec86847743e1ca9fa45738c6bdddbd`,
+and `c9426bdecd0469e2fd8e217334762464b9ad0368b8de5f5216c6cd54a5a70c03`
+for graph, finite-field, and symbolic tasks respectively. Their evidence files
+are bound by the submitted full digests and were independently replayed.
+
+## Limitations and next action
+
+This pilot is small, public, non-deterministic, answer-visible to repository
+maintainers, and host-run. It cannot support a causal performance claim or
+generalize solution quality. A future operator may repeat the frozen design in
+Harbor when a container runtime is available. That follow-up must keep the
+observer downstream and must not tune prompts, tool schemas, or task selection
+to improve the result.
+
+For this change, the next action is normal pull-request review of the typed
+observer, privacy bounds, fail-closed tests, documentation, and the invariant
+two-tool production surface.

--- a/docs/reference/evaluations/external-reasoning-observer.md
+++ b/docs/reference/evaluations/external-reasoning-observer.md
@@ -1,0 +1,89 @@
+# External reasoning observer
+
+[Evaluation references](index.md) · [Capability surface](../tools.md)
+
+The external reasoning observer is a post-run evaluation adapter. It derives a
+bounded audit record from two already-completed artifacts:
+
+- a Codex JSONL or Harbor ATIF agent trajectory; and
+- the Jacobian MCP runtime log.
+
+It is not an MCP tool, runtime mode, prompt, persistence service, or source of
+mathematical evidence. It runs only after the agent and verifier have exited.
+Consequently it cannot gate `math.find`, add fields to `math.run`, require a
+phase sequence, authorize a checker, or change assurance.
+
+The typed contract is
+`benchmarks.tooling.external_reasoning_observer.ExternalReasoningObservation`.
+Its `causal_claim_authorized` and `affects_mathematical_assurance` fields are
+always `false`.
+
+## Recorded evidence
+
+The runtime log is authoritative for automatic events. The observer preserves
+the server-emitted tool name, status, request and trace digests, trace source,
+duration, response size, argument digest, and capability-attempt fields. It
+normalizes only terminal line wrapping inside SHA-256 digests. It does not
+reconstruct tool calls from prose or copy tool arguments or results from the
+agent trace.
+
+Each server event receives an operator-supplied trial ID and a sequence within
+the runtime log. A non-`none` server request digest is the only cross-event
+correlation key. The observer does not ask the model to mint run or call IDs,
+and it does not infer chronology between the independently ordered agent and
+server artifacts.
+
+Agent summaries are optional self-reports. Only explicit, user-visible agent
+messages are eligible:
+
+- Codex `item.completed` events whose item type is `agent_message`; or
+- non-copied ATIF steps whose source is `agent` and whose `message` is text.
+
+The observer excludes prompts, ATIF `reasoning_content`, hidden
+chain-of-thought, tool arguments, and tool results. A valid trace with no agent
+messages is a complete observation with zero summaries.
+
+## Privacy, retention, and bounds
+
+Each retained message is redacted for bearer tokens, OpenAI-style API keys,
+and user home-directory prefixes, then bounded to 512 UTF-8 bytes. The record
+states the original post-redaction byte count, whether truncation occurred,
+and the redaction count. Source bindings retain only a basename, byte count,
+and SHA-256 digest; they do not copy source paths.
+
+The derived JSON is an operator-controlled evaluation artifact. Do not publish
+raw traces or derived summaries without the evaluation's retention and review
+policy. The observer contract is not consent to retain model or user content.
+
+## Failure semantics
+
+Missing, unreadable, or malformed sources produce an `INCOMPLETE` observation
+and bounded diagnostic codes. Valid events parsed before or after a malformed
+entry remain visible. Observer failure never changes the completed agent,
+verifier, mathematical result, artifact, or assurance level.
+
+The server event coverage metric is the fraction of log entries carrying a
+Jacobian event marker that parsed into typed records. Zero explicit summaries
+does not reduce server coverage and is not an error.
+
+## Usage
+
+Run the observer over immutable copies of one trial's artifacts:
+
+```sh
+uv run python -m benchmarks.tooling.external_reasoning_observer \
+  --trial-id graph-counterexample-r01 \
+  --agent-trace results/attempt-0/artifacts/logs/agent/trajectory.json \
+  --server-log results/attempt-0/artifacts/logs/jacobian/mcp.log \
+  --output results/attempt-0/external-reasoning-observation.json
+```
+
+The command exits zero only for a `COMPLETE` record. It still writes a partial
+record before returning nonzero for an `INCOMPLETE` observation.
+
+The frozen exploratory study contract is
+[`external-reasoning-observer-v1.json`](../../../benchmarks/config/external-reasoning-observer-v1.json).
+Its baseline and treatment use the same completed trajectory: treatment is the
+post-run derivation only. Agent behavior, tool calls, tokens, verifier results,
+and false-certification classification are therefore paired invariants rather
+than outcomes the observer is allowed to influence.

--- a/docs/reference/evaluations/external-reasoning-observer.md
+++ b/docs/reference/evaluations/external-reasoning-observer.md
@@ -31,7 +31,8 @@ Each server event receives an operator-supplied trial ID and a sequence within
 the runtime log. A non-`none` server request digest is the only cross-event
 correlation key. The observer does not ask the model to mint run or call IDs,
 and it does not infer chronology between the independently ordered agent and
-server artifacts.
+server artifacts. Both sources must resolve beneath the operator-bound trial
+root without crossing a symlink; a source from another trial is rejected.
 
 Agent summaries are optional self-reports. Only explicit, user-visible agent
 messages are eligible:
@@ -46,7 +47,8 @@ messages is a complete observation with zero summaries.
 ## Privacy, retention, and bounds
 
 Each retained message is redacted for bearer tokens, OpenAI-style API keys,
-and user home-directory prefixes, then bounded to 512 UTF-8 bytes. The record
+user home-directory prefixes, and common temporary-workspace paths, then
+bounded to 512 UTF-8 bytes. The record
 states the original post-redaction byte count, whether truncation occurred,
 and the redaction count. Source bindings retain only a basename, byte count,
 and SHA-256 digest; they do not copy source paths.
@@ -73,6 +75,7 @@ Run the observer over immutable copies of one trial's artifacts:
 ```sh
 uv run python -m benchmarks.tooling.external_reasoning_observer \
   --trial-id graph-counterexample-r01 \
+  --trial-root results/attempt-0 \
   --agent-trace results/attempt-0/artifacts/logs/agent/trajectory.json \
   --server-log results/attempt-0/artifacts/logs/jacobian/mcp.log \
   --output results/attempt-0/external-reasoning-observation.json

--- a/docs/reference/evaluations/external-reasoning-observer.md
+++ b/docs/reference/evaluations/external-reasoning-observer.md
@@ -90,3 +90,7 @@ Its baseline and treatment use the same completed trajectory: treatment is the
 post-run derivation only. Agent behavior, tool calls, tokens, verifier results,
 and false-certification classification are therefore paired invariants rather
 than outcomes the observer is allowed to influence.
+
+See the [completed pilot report](external-reasoning-observer-pilot.md) for the
+authenticated weak-model observations, evidence digests, limitations, and keep
+decision.

--- a/docs/reference/evaluations/index.md
+++ b/docs/reference/evaluations/index.md
@@ -4,3 +4,4 @@
 
 - [Benchmark contracts](benchmark-contracts.md) — Harbor task contracts, dataset inventory, registry/suite/members, snapshot locks, task and verifier validation
 - [Evaluation methods](evaluation-methods.md) — workflow observation modes, metrics and interpretation, performance benchmark method, corpus design, runtime groups, regression policy
+- [External reasoning observer](external-reasoning-observer.md) — passive post-run server events and optional explicit agent summaries

--- a/docs/reference/evaluations/index.md
+++ b/docs/reference/evaluations/index.md
@@ -5,3 +5,4 @@
 - [Benchmark contracts](benchmark-contracts.md) — Harbor task contracts, dataset inventory, registry/suite/members, snapshot locks, task and verifier validation
 - [Evaluation methods](evaluation-methods.md) — workflow observation modes, metrics and interpretation, performance benchmark method, corpus design, runtime groups, regression policy
 - [External reasoning observer](external-reasoning-observer.md) — passive post-run server events and optional explicit agent summaries
+- [External reasoning observer pilot](external-reasoning-observer-pilot.md) — frozen authenticated weak-model study, evidence, limitations, and decision

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -26,7 +26,10 @@ equivalent top-level tools. Adding a capability does not add a new MCP tool.
 The `math.run` input schema is invariant across local, remote, and evaluation
 deployments. Evaluation observation belongs outside the production tool
 contract and cannot change mathematical behavior, assurance, or checker
-authority.
+authority. The optional
+[external reasoning observer](evaluations/external-reasoning-observer.md)
+derives bounded evaluation records after a run has completed; it does not add a
+model-facing logging protocol.
 
 Because `math.run` dispatches the installed portfolio, its MCP annotation is
 conservatively `destructiveHint: true`: some installed operations can change

--- a/tests/unit/tooling/test_external_reasoning_observer.py
+++ b/tests/unit/tooling/test_external_reasoning_observer.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmarks.tooling.external_reasoning_observer import observe_external_reasoning
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _server_log() -> str:
+    first_argument_digest = "sha256:" + "1" * 64
+    second_argument_digest = "sha256:" + "2" * 64
+    return "\n".join(
+        [
+            "INFO MCP tool call tool=math.find status=success "
+            "request_digest=aaaaaaaaaaaaaaaa trace_digest=none "
+            "trace_source=none duration_ms=12.375 response_bytes=321 "
+            f"argument_digest={first_argument_digest}",
+            "INFO MCP capability attempt request_digest=bbbbbbbbbbbbbbbb "
+            "trace_digest=none trace_source=none "
+            "capability_id=matrix.determinant.compute capability_version=1.0.0 "
+            "mode=EXPLORE execution_status=COMPLETED assurance=COMPUTED "
+            "diagnostic_codes=none attempt_duration_ms=8.250 "
+            "operation_runtime_ms=1.5 response_bytes=456 "
+            f"argument_digest={second_argument_digest}",
+            "INFO MCP tool call tool=math.run status=success "
+            "request_digest=bbbbbbbbbbbbbbbb trace_digest=none "
+            "trace_source=none duration_ms=9.500 response_bytes=456 "
+            f"argument_digest={second_argument_digest}",
+        ]
+    )
+
+
+def test_observer_preserves_server_facts_and_only_explicit_messages(
+    tmp_path: Path,
+) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "agent_message",
+                            "text": (
+                                "I will inspect /Users/alice/private and use "
+                                "Bearer top-secret-token before computing."
+                            ),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "reasoning",
+                            "text": "hidden reasoning must not be retained",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "mcp_tool_call",
+                            "arguments": {"secret": "never retain tool arguments"},
+                            "result": {"secret": "never retain tool results"},
+                        },
+                    }
+                ),
+            ]
+        ),
+    )
+    server_log = _write(tmp_path / "mcp.log", _server_log())
+
+    report = observe_external_reasoning(
+        trial_id="trial-01",
+        agent_trace=trace,
+        server_log=server_log,
+    ).model_dump(mode="json")
+
+    assert report["status"] == "COMPLETE"
+    assert report["causal_claim_authorized"] is False
+    assert report["affects_mathematical_assurance"] is False
+    assert len(report["explicit_summaries"]) == 1
+    summary = report["explicit_summaries"][0]
+    assert summary["text"] == (
+        "I will inspect [REDACTED_HOME]/private and use "
+        "[REDACTED_BEARER] before computing."
+    )
+    assert summary["redaction_count"] == 2
+    rendered = json.dumps(report)
+    assert "hidden reasoning" not in rendered
+    assert "never retain tool arguments" not in rendered
+    assert "never retain tool results" not in rendered
+
+    assert [event["kind"] for event in report["server_events"]] == [
+        "TOOL_CALL",
+        "CAPABILITY_ATTEMPT",
+        "TOOL_CALL",
+    ]
+    assert report["server_events"][0] == {
+        "kind": "TOOL_CALL",
+        "sequence": 1,
+        "trial_id": "trial-01",
+        "tool": "math.find",
+        "status": "success",
+        "request_digest": "aaaaaaaaaaaaaaaa",
+        "trace_digest": "none",
+        "trace_source": "none",
+        "duration_ms": "12.375",
+        "response_bytes": 321,
+        "argument_digest": "sha256:" + "1" * 64,
+        "correlation": "SERVER_REQUEST_DIGEST",
+    }
+    attempt = report["server_events"][1]
+    assert attempt["capability_id"] == "matrix.determinant.compute"
+    assert attempt["execution_status"] == "COMPLETED"
+    assert attempt["assurance"] == "COMPUTED"
+    assert attempt["diagnostic_codes"] == []
+    assert report["metrics"] == {
+        "server_event_candidates": 3,
+        "server_events_recorded": 3,
+        "server_event_coverage": 1.0,
+        "tool_calls_recorded": 2,
+        "capability_attempts_recorded": 1,
+        "explicit_summaries_recorded": 1,
+    }
+
+
+def test_atif_uses_agent_message_but_excludes_reasoning_content(tmp_path: Path) -> None:
+    trace = _write(
+        tmp_path / "trajectory.json",
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "agent": {"name": "codex", "version": "0.147.0"},
+                "steps": [
+                    {"step_id": 1, "source": "user", "message": "Solve it."},
+                    {
+                        "step_id": 2,
+                        "source": "agent",
+                        "message": "I found a relevant exact determinant capability.",
+                        "reasoning_content": "private derivation",
+                    },
+                    {
+                        "step_id": 3,
+                        "source": "agent",
+                        "message": "copied summary",
+                        "is_copied_context": True,
+                    },
+                ],
+            }
+        ),
+    )
+    server_log = _write(tmp_path / "mcp.log", _server_log())
+
+    report = observe_external_reasoning(
+        trial_id="atif-trial",
+        agent_trace=trace,
+        server_log=server_log,
+    ).model_dump(mode="json")
+
+    assert report["status"] == "COMPLETE"
+    assert [item["text"] for item in report["explicit_summaries"]] == [
+        "I found a relevant exact determinant capability."
+    ]
+    assert "private derivation" not in json.dumps(report)
+    assert "copied summary" not in json.dumps(report)
+
+
+def test_no_explicit_messages_is_complete_and_does_not_gate_server_log(
+    tmp_path: Path,
+) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10}}),
+    )
+    server_log = _write(tmp_path / "mcp.log", _server_log())
+
+    report = observe_external_reasoning(
+        trial_id="no-summary",
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    assert report.status == "COMPLETE"
+    assert report.explicit_summaries == ()
+    assert len(report.server_events) == 3
+
+
+def test_malformed_inputs_fail_observation_closed_but_retain_valid_events(
+    tmp_path: Path,
+) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        "\n".join(
+            [
+                "{not-json",
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "Still visible."},
+                    }
+                ),
+            ]
+        ),
+    )
+    server_log = _write(
+        tmp_path / "mcp.log",
+        "INFO MCP tool call tool=math.find status=success request_digest=broken\n"
+        + _server_log(),
+    )
+
+    report = observe_external_reasoning(
+        trial_id="partial",
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    assert report.status == "INCOMPLETE"
+    assert len(report.server_events) == 3
+    assert [item.text for item in report.explicit_summaries] == ["Still visible."]
+    assert {diagnostic.code for diagnostic in report.diagnostics} == {
+        "MALFORMED_AGENT_TRACE_ENTRY",
+        "MALFORMED_SERVER_EVENT",
+    }
+    assert report.metrics.server_event_candidates == 4
+    assert report.metrics.server_events_recorded == 3
+    assert report.metrics.server_event_coverage == 0.75
+
+
+def test_summary_is_bounded_by_utf8_bytes_after_redaction(tmp_path: Path) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "é" * 400},
+            }
+        ),
+    )
+    server_log = _write(tmp_path / "mcp.log", _server_log())
+
+    report = observe_external_reasoning(
+        trial_id="bounded",
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    summary = report.explicit_summaries[0]
+    assert summary.truncated is True
+    assert len(summary.text.encode("utf-8")) <= 512
+    assert summary.original_utf8_bytes == 800
+
+
+def test_rich_wrapped_runtime_log_is_normalized_without_losing_digest(
+    tmp_path: Path,
+) -> None:
+    trace = _write(tmp_path / "codex.jsonl", "")
+    digest = "815b1d6727e4a612ca3166cd88af142b05de72964f9575af923f471c402d0233"
+    server_log = _write(
+        tmp_path / "mcp.log",
+        "\n".join(
+            [
+                "INFO MCP tool call tool=math.find          server.py:286",
+                "     status=success",
+                "     request_digest=d4735e3a265e16ee",
+                "     trace_digest=d4735e3a",
+                "     trace_source=request_id",
+                "     duration_ms=162.258",
+                "     response_bytes=12492",
+                "     argument_digest=sha256:815b1d6727e4a6",
+                "     12ca3166cd88af142b05de72964f9575af923",
+                "     f471c402d0233",
+            ]
+        ),
+    )
+
+    report = observe_external_reasoning(
+        trial_id="wrapped",
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    assert report.status == "COMPLETE"
+    event = report.server_events[0]
+    assert event.trace_digest == "d4735e3a"
+    assert event.argument_digest == "sha256:" + digest

--- a/tests/unit/tooling/test_external_reasoning_observer.py
+++ b/tests/unit/tooling/test_external_reasoning_observer.py
@@ -80,6 +80,7 @@ def test_observer_preserves_server_facts_and_only_explicit_messages(
 
     report = observe_external_reasoning(
         trial_id="trial-01",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     ).model_dump(mode="json")
@@ -162,6 +163,7 @@ def test_atif_uses_agent_message_but_excludes_reasoning_content(tmp_path: Path) 
 
     report = observe_external_reasoning(
         trial_id="atif-trial",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     ).model_dump(mode="json")
@@ -185,6 +187,7 @@ def test_no_explicit_messages_is_complete_and_does_not_gate_server_log(
 
     report = observe_external_reasoning(
         trial_id="no-summary",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     )
@@ -219,6 +222,7 @@ def test_malformed_inputs_fail_observation_closed_but_retain_valid_events(
 
     report = observe_external_reasoning(
         trial_id="partial",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     )
@@ -249,6 +253,7 @@ def test_summary_is_bounded_by_utf8_bytes_after_redaction(tmp_path: Path) -> Non
 
     report = observe_external_reasoning(
         trial_id="bounded",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     )
@@ -284,6 +289,7 @@ def test_rich_wrapped_runtime_log_is_normalized_without_losing_digest(
 
     report = observe_external_reasoning(
         trial_id="wrapped",
+        trial_root=tmp_path,
         agent_trace=trace,
         server_log=server_log,
     )
@@ -292,3 +298,79 @@ def test_rich_wrapped_runtime_log_is_normalized_without_losing_digest(
     event = report.server_events[0]
     assert event.trace_digest == "d4735e3a"
     assert event.argument_digest == "sha256:" + digest
+
+
+def test_sources_cannot_cross_the_operator_bound_trial_root(tmp_path: Path) -> None:
+    trial_a = tmp_path / "trial-a"
+    trial_b = tmp_path / "trial-b"
+    trial_a.mkdir()
+    trial_b.mkdir()
+    trace = _write(trial_a / "codex.jsonl", "")
+    server_log = _write(trial_b / "mcp.log", _server_log())
+
+    report = observe_external_reasoning(
+        trial_id="trial-a",
+        trial_root=trial_a,
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    assert report.status == "INCOMPLETE"
+    assert report.server_events == ()
+    assert report.diagnostics[0].code == "SOURCE_OUTSIDE_TRIAL_ROOT"
+    assert report.diagnostics[0].source_kind == "JACOBIAN_MCP_LOG"
+
+
+def test_missing_log_returns_partial_self_reports_without_gating(
+    tmp_path: Path,
+) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "Visible fallback."},
+            }
+        ),
+    )
+
+    report = observe_external_reasoning(
+        trial_id="missing-log",
+        trial_root=tmp_path,
+        agent_trace=trace,
+        server_log=tmp_path / "missing.log",
+    )
+
+    assert report.status == "INCOMPLETE"
+    assert [summary.text for summary in report.explicit_summaries] == [
+        "Visible fallback."
+    ]
+    assert report.server_events == ()
+    assert report.diagnostics[0].code == "MISSING_SERVER_LOG"
+
+
+def test_temporary_workspace_paths_are_redacted(tmp_path: Path) -> None:
+    trace = _write(
+        tmp_path / "codex.jsonl",
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "text": "Wrote [result](/tmp/private-run/submission.json).",
+                },
+            }
+        ),
+    )
+    server_log = _write(tmp_path / "mcp.log", "")
+
+    report = observe_external_reasoning(
+        trial_id="temp-redaction",
+        trial_root=tmp_path,
+        agent_trace=trace,
+        server_log=server_log,
+    )
+
+    assert report.explicit_summaries[0].text == (
+        "Wrote [result]([REDACTED_TEMP_PATH])."
+    )


### PR DESCRIPTION
## Summary

- add a passive, harness-side observer for Codex JSONL or Harbor ATIF agent messages plus Jacobian MCP runtime telemetry
- retain only bounded explicit agent messages and exact server-emitted event fields; exclude prompts, hidden reasoning, tool arguments, and tool results
- fail observation closed on missing, malformed, cross-trial, or symlink-escaping sources without affecting mathematical execution or assurance
- freeze and run an authenticated weak-model pilot, with typed tests and operator documentation

## Why

The retired production reasoning workflow interfered with ordinary tool use: it added `reasoning.write`, changed `math.run` schemas by mode, required model-managed IDs, and encouraged a PLAN/BEFORE_TOOL/AFTER_TOOL/FINAL state machine. That made logging compete with mathematical discovery and invocation.

This change puts observation after the agent and verifier have exited. It makes no changes under `src/`, adds no MCP tool or CLI runtime mode, and leaves `math.find` and `math.run` untouched.

Closes #955.

## User and developer impact

Operators can derive a schema-versioned JSON record with:

- server-observed `math.find` / `math.run` metadata and capability-attempt outcomes;
- optional user-visible agent progress messages;
- source digests, trial-root binding, redaction/truncation metadata, coverage, and fail-closed diagnostics.

The record is observational only. It cannot authorize a checker, promote assurance, gate discovery, or block a capability invocation.

## Pilot evidence

The frozen post-run paired pilot used authenticated Codex CLI `0.147.0`, `gpt-5.4-mini`, medium reasoning, three public workflow tasks, and one fresh local MCP runtime per task.

- verifier outcomes: 3/3 pass in both baseline and post-run treatment
- false certifications: 0/3
- server event coverage: 6/6
- explicit agent messages retained: 25/25, with two bounded truncations
- agent-side calls: six `math.find`, two client-cancelled `math.run`, zero parameter errors
- production source delta: none
- observer wall time: 0.07-0.09 seconds per trial including `uv run` startup

Docker and Podman were unavailable, so the pilot is explicitly documented as a host-run exploratory workflow observation, not a Harbor container or causal-performance claim. Raw traces remain host-local; checked-in documentation binds their digests.

## Validation

- `make test-plan BASE=origin/main`
- `make lint typecheck`
- `make docs-linkcheck`
- `make test-unit` — 875 passed
- focused observer tests — 9 passed
- authenticated weak-model pilot — 3/3 path-adapted independent verifier replays passed, zero false certifications
