### PR TITLE
Bind graph distance-matrix entries to vertex labels

### DIFF
--- a/docs/reference/capabilities/graphs/graph-distance-matrix.md
+++ b/docs/reference/capabilities/graphs/graph-distance-matrix.md
@@ -10,11 +10,15 @@ so inputs retain the established limit of 32 vertices and 496 edges.
 ## Result semantics
 
 The result is bound to
-`unweighted-shortest-path-distance-matrix.v1` and makes its representation
+`unweighted-shortest-path-distance-matrix.v3` and makes its representation
 choices explicit:
 
-- `vertices` is the complete input vertex set in lexicographic ascending order;
-- `distances[i][j]` covers every ordered pair of vertices in that order;
+- `target_vertices` is the complete input vertex set in lexicographic ascending
+  order and labels every distance-vector position;
+- `rows` is in the same canonical order, and every row carries its own
+  `source_vertex` label next to a `distances_by_target` mapping;
+- every distance is therefore bound directly to both its source and target
+  labels rather than relying on a detached pair of positional indices;
 - a finite entry is the number of edges in a shortest path;
 - an unreachable pair is represented by JSON `null`, never a numeric sentinel;
 - the diagonal is zero, finite off-diagonal entries are positive, and the
@@ -22,8 +26,9 @@ choices explicit:
 - `connected` is true exactly when the graph is nonempty and every matrix
   entry is finite.
 
-The empty graph returns an empty matrix with `connected = false`. A singleton
-returns `[[0]]` with `connected = true`.
+The empty graph returns empty targets and rows with `connected = false`. A
+singleton returns one labelled row mapping itself to zero with
+`connected = true`.
 
 The result model rejects inconsistent ordering, shape, diagonal, symmetry,
 component closure, triangle inequality, or connectedness before an artifact is

--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -31,26 +31,41 @@ class GraphMaximumMatchingRequest(ContractModel):
 
 
 GraphDistance = Annotated[StrictInt, Field(ge=0, le=31)] | None
-GraphDistanceRow = Annotated[
-    tuple[GraphDistance, ...],
-    Field(max_length=32),
-]
+
+
+class GraphDistanceMatrixRow(ContractModel):
+    """One source-labelled row over the result's declared target vertices."""
+
+    source_vertex: GraphVertex
+    distances_by_target: Annotated[
+        dict[GraphVertex, GraphDistance],
+        Field(max_length=32),
+    ]
 
 
 def _validate_distance_matrix_shape(
-    vertices: tuple[GraphVertex, ...],
-    distances: tuple[GraphDistanceRow, ...],
+    target_vertices: tuple[GraphVertex, ...],
+    rows: tuple[GraphDistanceMatrixRow, ...],
 ) -> int:
-    order = len(vertices)
-    if tuple(sorted(vertices)) != vertices or len(set(vertices)) != order:
-        raise ValueError("distance-matrix vertices must be unique and sorted")
-    if len(distances) != order or any(len(row) != order for row in distances):
-        raise ValueError("distance matrix must be square on the declared vertices")
+    order = len(target_vertices)
+    if (
+        tuple(sorted(target_vertices)) != target_vertices
+        or len(set(target_vertices)) != order
+    ):
+        raise ValueError("distance-matrix target vertices must be unique and sorted")
+    if tuple(row.source_vertex for row in rows) != target_vertices:
+        raise ValueError(
+            "distance-matrix rows must bind every source vertex in target order"
+        )
+    if any(tuple(row.distances_by_target) != target_vertices for row in rows):
+        raise ValueError(
+            "every distance-matrix row must bind all targets in target order"
+        )
     return order
 
 
 def _validate_distance_matrix_diagonal_and_symmetry(
-    distances: tuple[GraphDistanceRow, ...],
+    distances: tuple[tuple[GraphDistance, ...], ...],
     order: int,
 ) -> None:
     for source in range(order):
@@ -66,7 +81,7 @@ def _validate_distance_matrix_diagonal_and_symmetry(
 
 
 def _validate_distance_matrix_triangle_inequality(
-    distances: tuple[GraphDistanceRow, ...],
+    distances: tuple[tuple[GraphDistance, ...], ...],
     order: int,
 ) -> None:
     for source in range(order):
@@ -87,23 +102,28 @@ def _validate_distance_matrix_triangle_inequality(
 
 
 class GraphDistanceMatrixResult(ContractModel):
-    """All exact unweighted shortest-path distances in canonical vertex order."""
+    """All exact distances with every positional row bound to its source label."""
 
-    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v1"]
-    vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
+    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v3"]
+    row_ordering: Literal["SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING"]
+    target_ordering: Literal["TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING"]
     pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
     unreachable_representation: Literal["JSON_NULL"]
-    vertices: tuple[GraphVertex, ...] = Field(max_length=32)
-    distances: tuple[GraphDistanceRow, ...] = Field(max_length=32)
+    target_vertices: tuple[GraphVertex, ...] = Field(max_length=32)
+    rows: tuple[GraphDistanceMatrixRow, ...] = Field(max_length=32)
     connected: StrictBool
 
     @model_validator(mode="after")
     def bind_complete_metric(self) -> Self:
-        order = _validate_distance_matrix_shape(self.vertices, self.distances)
-        _validate_distance_matrix_diagonal_and_symmetry(self.distances, order)
-        _validate_distance_matrix_triangle_inequality(self.distances, order)
+        order = _validate_distance_matrix_shape(self.target_vertices, self.rows)
+        distances = tuple(
+            tuple(row.distances_by_target[target] for target in self.target_vertices)
+            for row in self.rows
+        )
+        _validate_distance_matrix_diagonal_and_symmetry(distances, order)
+        _validate_distance_matrix_triangle_inequality(distances, order)
         expected_connected = order > 0 and all(
-            distance is not None for row in self.distances for distance in row
+            distance is not None for row in distances for distance in row
         )
         if self.connected != expected_connected:
             raise ValueError("connected must match all-pairs finite reachability")

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -138,7 +138,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "graph.distance_matrix.compute",
         GraphInvariantRequest,
         "check_graph_distance_matrix",
-        "graph.distance-matrix.all-sources-bfs-v1",
+        "graph.distance-matrix.all-sources-bfs-v3",
         entrypoint_module=_GRAPH_ENTRYPOINT,
         replay_method="all-sources breadth-first distance-matrix replay",
         reason=(

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -18,6 +18,7 @@ from jacobian.contracts.graph_invariant_operations import (
     GraphCoreResult,
     GraphDiameterResult,
     GraphDistanceMatrixResult,
+    GraphDistanceMatrixRow,
     GraphEdgeConnectivityResult,
     GraphEulerianResult,
     GraphGirthResult,
@@ -129,20 +130,28 @@ def _distance_matrix(graph: Any) -> GraphDistanceMatrixResult:
         source: nx.single_source_shortest_path_length(graph, source)
         for source in vertices
     }
-    distances = tuple(
-        tuple(shortest_paths[source].get(target) for target in vertices)
+    rows = tuple(
+        GraphDistanceMatrixRow(
+            source_vertex=source,
+            distances_by_target={
+                target: shortest_paths[source].get(target) for target in vertices
+            },
+        )
         for source in vertices
     )
     connected = bool(vertices) and all(
-        distance is not None for row in distances for distance in row
+        distance is not None
+        for row in rows
+        for distance in row.distances_by_target.values()
     )
     return GraphDistanceMatrixResult(
-        semantics_version="unweighted-shortest-path-distance-matrix.v1",
-        vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+        semantics_version="unweighted-shortest-path-distance-matrix.v3",
+        row_ordering="SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING",
+        target_ordering="TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING",
         pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
         unreachable_representation="JSON_NULL",
-        vertices=vertices,
-        distances=distances,
+        target_vertices=vertices,
+        rows=rows,
         connected=connected,
     )
 
@@ -562,6 +571,7 @@ EXACT_GRAPH_INVARIANT_CAPABILITIES = (
         "distance",
         "matrix",
         "exact",
+        version="3",
         invocation_examples=(
             example(
                 "path_three_distance_matrix",

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -868,20 +868,42 @@ def _validate_distance_matrix_header(
         set(result)
         != {
             "semantics_version",
-            "vertex_ordering",
+            "row_ordering",
+            "target_ordering",
             "pair_coverage",
             "unreachable_representation",
-            "vertices",
-            "distances",
+            "target_vertices",
+            "rows",
             "connected",
         }
-        or result["semantics_version"] != "unweighted-shortest-path-distance-matrix.v1"
-        or result["vertex_ordering"] != "LEXICOGRAPHIC_ASCENDING"
+        or result["semantics_version"] != "unweighted-shortest-path-distance-matrix.v3"
+        or result["row_ordering"] != "SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING"
+        or result["target_ordering"] != "TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING"
         or result["pair_coverage"] != "ALL_ORDERED_VERTEX_PAIRS"
         or result["unreachable_representation"] != "JSON_NULL"
-        or result["vertices"] != list(vertices)
+        or result["target_vertices"] != list(vertices)
         or type(result["connected"]) is not bool
     )
+
+
+def _distance_matrix_rows(
+    value: object,
+    vertices: tuple[str, ...],
+) -> list[list[int | None]] | None:
+    if not isinstance(value, list) or len(value) != len(vertices):
+        return None
+    matrix: list[list[int | None]] = []
+    for source_vertex, row in zip(vertices, value, strict=True):
+        if (
+            not isinstance(row, dict)
+            or set(row) != {"source_vertex", "distances_by_target"}
+            or row["source_vertex"] != source_vertex
+            or not isinstance(row["distances_by_target"], dict)
+            or list(row["distances_by_target"]) != list(vertices)
+        ):
+            return None
+        matrix.append([row["distances_by_target"][target] for target in vertices])
+    return matrix
 
 
 def _validate_distance_matrix_entries(
@@ -938,7 +960,9 @@ def _distance_matrix(source: dict[str, Any], result: dict[str, Any]) -> bool:
     if not _validate_distance_matrix_header(result, vertices):
         return False
 
-    matrix = result["distances"]
+    matrix = _distance_matrix_rows(result["rows"], vertices)
+    if matrix is None:
+        return False
     order = len(vertices)
     if not _validate_distance_matrix_entries(matrix, order):
         return False
@@ -965,7 +989,7 @@ def check_graph_distance_matrix(request: dict[str, Any]) -> dict[str, Any]:
     return _run(
         request,
         operation_id="graph.distance_matrix.compute",
-        witness_format="graph.distance-matrix.all-sources-bfs-v1",
+        witness_format="graph.distance-matrix.all-sources-bfs-v3",
         replay=_distance_matrix,
         replay_method="all-sources breadth-first distance-matrix replay",
         exhaustive=True,

--- a/tests/component/checkers/exact_domain_checker_support.py
+++ b/tests/component/checkers/exact_domain_checker_support.py
@@ -525,7 +525,7 @@ _GRAPH_CASES: tuple[
         check_graph_distance_matrix,
         _request(
             "graph.distance_matrix.compute",
-            "graph.distance-matrix.all-sources-bfs-v1",
+            "graph.distance-matrix.all-sources-bfs-v3",
             {
                 "graph": {
                     "graph_schema_version": "1",
@@ -534,12 +534,26 @@ _GRAPH_CASES: tuple[
                 }
             },
             {
-                "semantics_version": ("unweighted-shortest-path-distance-matrix.v1"),
-                "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+                "semantics_version": ("unweighted-shortest-path-distance-matrix.v3"),
+                "row_ordering": "SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING",
+                "target_ordering": "TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING",
                 "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
                 "unreachable_representation": "JSON_NULL",
-                "vertices": ["a", "b", "c"],
-                "distances": [[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+                "target_vertices": ["a", "b", "c"],
+                "rows": [
+                    {
+                        "source_vertex": "a",
+                        "distances_by_target": {"a": 0, "b": 1, "c": 2},
+                    },
+                    {
+                        "source_vertex": "b",
+                        "distances_by_target": {"a": 1, "b": 0, "c": 1},
+                    },
+                    {
+                        "source_vertex": "c",
+                        "distances_by_target": {"a": 2, "b": 1, "c": 0},
+                    },
+                ],
                 "connected": True,
             },
         ),

--- a/tests/component/checkers/test_exact_graph_checkers.py
+++ b/tests/component/checkers/test_exact_graph_checkers.py
@@ -41,7 +41,7 @@ def _distance_matrix_checker_request(
 ) -> dict[str, Any]:
     return _request(
         "graph.distance_matrix.compute",
-        "graph.distance-matrix.all-sources-bfs-v1",
+        "graph.distance-matrix.all-sources-bfs-v3",
         {
             "graph": {
                 "graph_schema_version": "1",
@@ -50,12 +50,19 @@ def _distance_matrix_checker_request(
             }
         },
         {
-            "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
-            "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+            "semantics_version": "unweighted-shortest-path-distance-matrix.v3",
+            "row_ordering": "SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING",
+            "target_ordering": "TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING",
             "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
             "unreachable_representation": "JSON_NULL",
-            "vertices": result_vertices,
-            "distances": distances,
+            "target_vertices": result_vertices,
+            "rows": [
+                {
+                    "source_vertex": vertex,
+                    "distances_by_target": dict(zip(result_vertices, row, strict=True)),
+                }
+                for vertex, row in zip(result_vertices, distances, strict=True)
+            ],
             "connected": connected,
         },
     )
@@ -281,26 +288,43 @@ def test_distance_matrix_checker_accepts_exact_boundary_claims(
 @pytest.mark.parametrize(
     "mutate",
     (
-        lambda result: result.update(vertices=["b", "a", "c"]),
+        lambda result: result.update(target_vertices=["b", "a", "c"]),
+        lambda result: result.update(rows=result["rows"][:2]),
+        lambda result: result["rows"][0].update(source_vertex="b"),
+        lambda result: result["rows"][0].update(extra="forged"),
+        lambda result: result["rows"][0]["distances_by_target"].pop("c"),
+        lambda result: result["rows"][0]["distances_by_target"].__setitem__("a", 1),
+        lambda result: result["rows"][0]["distances_by_target"].__setitem__("b", 0),
+        lambda result: result["rows"][0]["distances_by_target"].__setitem__("c", 1),
+        lambda result: result["rows"][2]["distances_by_target"].__setitem__("a", 1),
         lambda result: result.update(
-            distances=[[0, 1], [1, 0]],
-        ),
-        lambda result: result["distances"][0].__setitem__(0, 1),
-        lambda result: result["distances"][0].__setitem__(1, 0),
-        lambda result: result["distances"][0].__setitem__(2, 1),
-        lambda result: result["distances"][2].__setitem__(0, 1),
-        lambda result: result.update(
-            distances=[[0, 1, 1], [1, 0, 1], [1, 1, 0]],
+            rows=[
+                {
+                    "source_vertex": "a",
+                    "distances_by_target": {"a": 0, "b": 1, "c": 1},
+                },
+                {
+                    "source_vertex": "b",
+                    "distances_by_target": {"a": 1, "b": 0, "c": 1},
+                },
+                {
+                    "source_vertex": "c",
+                    "distances_by_target": {"a": 1, "b": 1, "c": 0},
+                },
+            ],
         ),
         lambda result: result.update(connected=False),
         lambda result: result.update(
-            semantics_version="unweighted-shortest-path-distance-matrix.v2"
+            semantics_version="unweighted-shortest-path-distance-matrix.v1"
         ),
         lambda result: result.update(extra="forged"),
-        lambda result: result["distances"][0].__setitem__(1, True),
+        lambda result: result["rows"][0]["distances_by_target"].__setitem__("b", True),
     ),
     ids=(
         "wrong-order",
+        "missing-row",
+        "wrong-source-label",
+        "extra-row-field",
         "wrong-shape",
         "diagonal",
         "off-diagonal-zero",

--- a/tests/domain/graph/test_graph_distance_matrix.py
+++ b/tests/domain/graph/test_graph_distance_matrix.py
@@ -33,14 +33,31 @@ def _invoke(domain_services, vertices: list[str], edges: list[list[str]]):
     )
 
 
+def _row(
+    source_vertex: str,
+    distances: tuple[int | None, ...] | list[int | None],
+    *,
+    targets: tuple[str, ...] = ("a", "b", "c"),
+) -> dict[str, object]:
+    return {
+        "source_vertex": source_vertex,
+        "distances_by_target": dict(zip(targets, distances, strict=True)),
+    }
+
+
 def _result(**changes: object) -> GraphDistanceMatrixResult:
     values: dict[str, object] = {
-        "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
-        "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+        "semantics_version": "unweighted-shortest-path-distance-matrix.v3",
+        "row_ordering": "SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING",
+        "target_ordering": "TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING",
         "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
         "unreachable_representation": "JSON_NULL",
-        "vertices": ("a", "b", "c"),
-        "distances": ((0, 1, 2), (1, 0, 1), (2, 1, 0)),
+        "target_vertices": ("a", "b", "c"),
+        "rows": (
+            _row("a", (0, 1, 2)),
+            _row("b", (1, 0, 1)),
+            _row("c", (2, 1, 0)),
+        ),
         "connected": True,
     }
     values.update(changes)
@@ -59,16 +76,39 @@ def test_distance_matrix_is_complete_canonical_and_lineage_bound(
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.output["result"] == {
-        "semantics_version": "unweighted-shortest-path-distance-matrix.v1",
-        "vertex_ordering": "LEXICOGRAPHIC_ASCENDING",
+        "semantics_version": "unweighted-shortest-path-distance-matrix.v3",
+        "row_ordering": "SOURCE_VERTEX_LEXICOGRAPHIC_ASCENDING",
+        "target_ordering": "TARGET_VERTEX_LEXICOGRAPHIC_ASCENDING",
         "pair_coverage": "ALL_ORDERED_VERTEX_PAIRS",
         "unreachable_representation": "JSON_NULL",
-        "vertices": ["a", "b", "c"],
-        "distances": [[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+        "target_vertices": ["a", "b", "c"],
+        "rows": [
+            _row("a", [0, 1, 2]),
+            _row("b", [1, 0, 1]),
+            _row("c", [2, 1, 0]),
+        ],
         "connected": True,
     }
     assert result.artifact_uris == ()
     assert result.relationships == ()
+
+
+def test_distance_matrix_rows_bind_numeric_looking_vertex_labels(
+    domain_services,
+) -> None:
+    result = _invoke(
+        domain_services,
+        ["0", "2", "10"],
+        [["0", "2"], ["2", "10"]],
+    )
+
+    assert "distances" not in result.output["result"]
+    assert result.output["result"]["target_vertices"] == ["0", "10", "2"]
+    assert result.output["result"]["rows"] == [
+        _row("0", [0, 2, 1], targets=("0", "10", "2")),
+        _row("10", [2, 0, 1], targets=("0", "10", "2")),
+        _row("2", [1, 1, 0], targets=("0", "10", "2")),
+    ]
 
 
 def test_distance_matrix_represents_disconnected_pairs_with_null(
@@ -77,11 +117,11 @@ def test_distance_matrix_represents_disconnected_pairs_with_null(
     result = _invoke(domain_services, ["c", "a", "b"], [["a", "b"]])
 
     assert result.execution.status is ExecutionStatus.COMPLETED
-    assert result.output["result"]["vertices"] == ["a", "b", "c"]
-    assert result.output["result"]["distances"] == [
-        [0, 1, None],
-        [1, 0, None],
-        [None, None, 0],
+    assert result.output["result"]["target_vertices"] == ["a", "b", "c"]
+    assert result.output["result"]["rows"] == [
+        _row("a", [0, 1, None]),
+        _row("b", [1, 0, None]),
+        _row("c", [None, None, 0]),
     ]
     assert result.output["result"]["connected"] is False
 
@@ -90,11 +130,11 @@ def test_distance_matrix_empty_and_singleton_conventions(domain_services) -> Non
     empty = _invoke(domain_services, [], [])
     singleton = _invoke(domain_services, ["only"], [])
 
-    assert empty.output["result"]["vertices"] == []
-    assert empty.output["result"]["distances"] == []
+    assert empty.output["result"]["target_vertices"] == []
+    assert empty.output["result"]["rows"] == []
     assert empty.output["result"]["connected"] is False
-    assert singleton.output["result"]["vertices"] == ["only"]
-    assert singleton.output["result"]["distances"] == [[0]]
+    assert singleton.output["result"]["target_vertices"] == ["only"]
+    assert singleton.output["result"]["rows"] == [_row("only", [0], targets=("only",))]
     assert singleton.output["result"]["connected"] is True
 
 
@@ -111,26 +151,74 @@ def test_distance_matrix_rejects_graph_above_existing_order_bound(
 @pytest.mark.parametrize(
     ("changes", "message"),
     (
-        ({"vertices": ("b", "a", "c")}, "unique and sorted"),
-        ({"distances": ((0, 1), (1, 0))}, "square"),
+        ({"target_vertices": ("b", "a", "c")}, "unique and sorted"),
         (
-            {"distances": ((1, 1, 2), (1, 0, 1), (2, 1, 0))},
+            {
+                "rows": (
+                    _row("b", (0, 1, 2)),
+                    _row("a", (1, 0, 1)),
+                    _row("c", (2, 1, 0)),
+                )
+            },
+            "bind every source vertex",
+        ),
+        (
+            {
+                "rows": (
+                    _row("a", (0, 1, 2)),
+                    _row("b", (1, 0, 1)),
+                )
+            },
+            "bind every source vertex",
+        ),
+        (
+            {
+                "rows": (
+                    _row("a", (1, 1, 2)),
+                    _row("b", (1, 0, 1)),
+                    _row("c", (2, 1, 0)),
+                )
+            },
             "diagonal",
         ),
         (
-            {"distances": ((0, 0, 2), (0, 0, 1), (2, 1, 0))},
+            {
+                "rows": (
+                    _row("a", (0, 0, 2)),
+                    _row("b", (0, 0, 1)),
+                    _row("c", (2, 1, 0)),
+                )
+            },
             "off-diagonal",
         ),
         (
-            {"distances": ((0, 1, 2), (2, 0, 1), (2, 1, 0))},
+            {
+                "rows": (
+                    _row("a", (0, 1, 2)),
+                    _row("b", (2, 0, 1)),
+                    _row("c", (2, 1, 0)),
+                )
+            },
             "symmetric",
         ),
         (
-            {"distances": ((0, 1, 3), (1, 0, 1), (3, 1, 0))},
+            {
+                "rows": (
+                    _row("a", (0, 1, 3)),
+                    _row("b", (1, 0, 1)),
+                    _row("c", (3, 1, 0)),
+                )
+            },
             "triangle inequality",
         ),
         (
-            {"distances": ((0, 1, None), (1, 0, 1), (None, 1, 0))},
+            {
+                "rows": (
+                    _row("a", (0, 1, None)),
+                    _row("b", (1, 0, 1)),
+                    _row("c", (None, 1, 0)),
+                )
+            },
             "component closure",
         ),
         ({"connected": False}, "connected"),
@@ -152,12 +240,13 @@ def test_distance_matrix_public_postdoc_graph(domain_services) -> None:
     )
 
     assert result.execution.status is ExecutionStatus.COMPLETED
-    assert result.output["result"]["distances"] == [
-        [0, 2, 2, 1, 1, 2],
-        [2, 0, 2, 2, 1, 3],
-        [2, 2, 0, 2, 1, 3],
-        [1, 2, 2, 0, 1, 1],
-        [1, 1, 1, 1, 0, 2],
-        [2, 3, 3, 1, 2, 0],
+    targets = ("0", "1", "2", "3", "4", "5")
+    assert result.output["result"]["rows"] == [
+        _row("0", [0, 2, 2, 1, 1, 2], targets=targets),
+        _row("1", [2, 0, 2, 2, 1, 3], targets=targets),
+        _row("2", [2, 2, 0, 2, 1, 3], targets=targets),
+        _row("3", [1, 2, 2, 0, 1, 1], targets=targets),
+        _row("4", [1, 1, 1, 1, 0, 2], targets=targets),
+        _row("5", [2, 3, 3, 1, 2, 0], targets=targets),
     ]
     assert result.output["result"]["connected"] is True

--- a/tests/domain/graph/test_graph_verification.py
+++ b/tests/domain/graph/test_graph_verification.py
@@ -358,7 +358,10 @@ def test_distance_matrix_result_uses_independent_all_sources_bfs_replay(
     assert verified.output["verification_record_uri"] in verified.artifact_uris
     assert len(verified.artifact_uris) == 2
 
-    matrix = computed.output["result"]["distances"]
+    matrix = [
+        list(row["distances_by_target"].values())
+        for row in computed.output["result"]["rows"]
+    ]
     degree = dict.fromkeys(graph["vertices"], 0)
     for left, right in graph["edges"]:
         degree[left] += 1
@@ -367,7 +370,7 @@ def test_distance_matrix_result_uses_independent_all_sources_bfs_replay(
     maximum_degree_vertices = sorted(
         vertex for vertex, value in degree.items() if value == maximum_degree
     )
-    matrix_vertices = computed.output["result"]["vertices"]
+    matrix_vertices = computed.output["result"]["target_vertices"]
     designated_indices = [
         matrix_vertices.index(vertex) for vertex in maximum_degree_vertices
     ]
@@ -391,10 +394,17 @@ def test_distance_matrix_result_uses_independent_all_sources_bfs_replay(
     assert maximizing_vertices == ["5"]
 
     false_candidate = deepcopy(computed.output["result"])
-    order = len(false_candidate["vertices"])
-    false_candidate["distances"] = [
-        [0 if source == target else 1 for target in range(order)]
-        for source in range(order)
+    false_candidate["rows"] = [
+        {
+            "source_vertex": vertex,
+            "distances_by_target": {
+                target_vertex: 0 if source == target else 1
+                for target, target_vertex in enumerate(
+                    false_candidate["target_vertices"]
+                )
+            },
+        }
+        for source, vertex in enumerate(false_candidate["target_vertices"])
     ]
     rejected = graph_verification_services.core.capabilities.invoke(
         CapabilityRequest(


### PR DESCRIPTION
## Summary

- replace the detached positional `vertices` / `distances` result of `graph.distance_matrix.compute` with v3 source-labelled rows and `distances_by_target` mappings;
- bind every entry directly to its source and target vertex labels while retaining canonical lexicographic serialization;
- advance the independent all-sources BFS witness format to v3 and fail closed on missing, reordered, mislabeled, extra, malformed, or mathematically false rows; and
- document the pre-stable contract change and add focused producer, checker, verification, numeric-label, and adversarial regressions.

This does not add a new capability or workflow policy. The existing atomic distance-matrix producer remains `COMPUTED`, and only the operator-authorized stdlib BFS replay can return `VERIFIED`.

Closes #930.

## Why

The public reproduction is the finite graph used in Zhi-Wei Sun's conjecture inside Tang's 2026 proof of the Sárközy conjecture ([arXiv:2603.29992](https://arxiv.org/abs/2603.29992)). For `p = 17`, the vertices are numeric-looking string labels `"0"` through `"16"`, while Jacobian v1 serialized the matrix in lexicographic order (`"0", "1", "10", ...`).

The v1 artifact declared that order and was mathematically correct, but its row and column labels were detached from the matrix entries. In the frozen weak-model reproduction, the agent declared natural numeric output order and copied the lexicographic matrix as if it already used that order. Jacobian's independent checker correctly verified the stored artifact; the clean-room task verifier correctly rejected the relabeled final answer. This is a representation/handoff defect rather than an error in NetworkX shortest paths or the independent BFS replay.

## Contract and checker boundary

`graph.distance_matrix.compute` version 3 now returns:

- `target_vertices` with explicit target ordering metadata;
- one row per canonical source, each carrying `source_vertex`; and
- `distances_by_target`, an exact mapping covering every declared target.

The Pydantic result boundary validates exact source/target coverage, diagonal, positivity, symmetry, component closure, triangle inequality, and connectedness before publication. The separate `jacobian_checkers` replay requires the exact v3 fields and witness format, reconstructs the matrix from both labels, and exhaustively recomputes every source's distances using its own stdlib BFS implementation. Generic verification still binds the exact input, candidate, semantics, scope, checker identity, and verification record.

The old v1 result shape is intentionally not accepted. Jacobian is pre-stable, and the capability version, semantics version, and witness format all move together to v3.

## Frozen public reproduction

Evaluation class: source-backed public reproduction with answers visible during design. It is not held out and supports no general performance or causal claim.

- baseline git tree: `9653dd991a47c1be3cf8ad478450b69c8be01482`
- rebased PR tree: `eef9dd39c67c7c0ad870102fb39e85bcadd5a200`
- package: non-editable `jacobian==0.10.0` installs
- model: authenticated Codex user, `gpt-5.4-mini`, low reasoning, ephemeral sessions
- policy: `COMPUTE_VERIFY_NO_RETRIEVAL`; digest `sha256:0749b72e4263a380432feb9973b0fda9d5ed2b04d29417a1262bfc45134c71c6`
- task SHA-256: `ce945bc27888d23afafc7b1cf473d92ba7dec323fcdb8d5990a48cdc6e7def32`
- output-schema SHA-256: `e5521b1466cac9b30957513807a6d2b4fa6f9374e176db07011e1ab4ad9078a3`
- exact task scope: the `p = 17` graph's natural-order distance matrix and components, plus one independently checkable size-8 independent set avoiding the three looped vertices

The prompt and output schema were frozen before any production edit. Each arm used a fresh state directory and real `math.find` / `math.run` trajectories. Results below include every evidence-bearing run, not only the successful sample.

| Arm | Contract/catalog | MCP calls | Runtime | Input / output tokens | Jacobian distance verification | Clean-room whole-answer oracle |
| --- | --- | ---: | ---: | ---: | --- | --- |
| baseline | v1 / `c0b9d1dd...` | 6 | 119 s | 169,074 / 6,127 | `VERIFIED`, record `790ac5eb...` | fail: matrix bound to wrong declared order |
| first tweak | v2 source labels, positional targets / `e9a1cd67...` | 9 | 127 s | 374,466 / 6,002 | `VERIFIED` | fail: target order remained ambiguous in the handoff |
| v3 sample 1 | explicit source + target labels / `5827a1b9...` | 13 | 106 s | 462,309 / 5,256 | not completed by the agent trajectory | fail: strategy drift and missing verification |
| v3 sample 2 | same frozen v3 tree / `5827a1b9...` | 10 | 117 s | 223,421 / 6,089 | `VERIFIED` | fail: isolated final-answer transcription errors |
| v3 sample 3 | same frozen v3 tree / `5827a1b9...` | 11 | 109 s | 229,434 / 5,485 | `VERIFIED`, record `2c0f82d...` | **pass** |
| rebased v3 sample | final PR tree / `9730c15d...` | 9 | 148 s | 384,554 / 7,705 | `VERIFIED`, record `805bfdd9...` | fail: 11 final-answer transcription errors |

The baseline and the fully passing v3 sample demonstrate the requested failure-to-success path under the same frozen task. The rebased-tree sample separately confirms that the final published producer/checker boundary succeeds after the latest upstream graph changes. The mixed v3 whole-answer results are important: direct target labels remove the v1 semantic ambiguity and enabled an exact sample, but an agent can still make manual transcription mistakes after receiving a verified artifact.

No false certification was observed. The independent checker rejected adversarial source-label, target-coverage, field, shape, diagonal, off-diagonal-zero, symmetry, path-length, connectedness, semantics, and boolean mutations in focused tests.

## Validation

Final rebased tree:

- `64 passed` across `test_graph_distance_matrix.py`, `test_exact_graph_checkers.py`, and `test_graph_verification.py`
- `make lint typecheck`
- `make docs-linkcheck`
- `git diff --check origin/main...HEAD`

`make test-plan BASE=origin/main` selected the suite fallback because the shared graph contract has ambiguous transitive impact. The pre-rebase `make check-changed BASE=origin/main` run passed 8 of 10 selected commands: static/type, docs, unit, domain, composition, storage, MCP, and e2e. Its two failures reproduce alone in untouched host-sensitive tests:

- the Carcara timeout fixture does not create its marker before the one-second timeout on this macOS host; and
- the source bootstrap fixture invokes `mapfile`, which is absent from macOS system Bash 3.2.

Neither failure touches a changed path. The directly owning graph tests, lint, typecheck, formatting, complexity check, and documentation checks were rerun after rebasing onto the latest `origin/main`.

## Evidence and handoff

Raw local evaluation evidence is intentionally ignored rather than committed as a benchmark or dataset:

- frozen task and oracle: `tmp/grace-tool-tweak/frozen-task.md`, `frozen-output.schema.json`, `verify_frozen_output.py`
- baseline trace: `tmp/grace-tool-tweak/baseline-main-9653dd99-3/`
- first-tweak trace: `tmp/grace-tool-tweak/treatment-labelled-rows-1/`
- v3 traces: `tmp/grace-tool-tweak/treatment-target-labelled-{1,2,3}/`
- final rebased trace: `tmp/grace-tool-tweak/treatment-rebased-eef9dd39-1/`
- selected-gate log: `tmp/grace-tool-tweak/check-changed-final.log`

Provider/runtime state was NetworkX 3.6.1 and SymPy 1.14.0 on macOS arm64. The pinned Lean runtime and optional python-flint/external proof executables were unavailable, as expected for this install; affected capabilities were omitted without affecting the graph producer or authorized checker. The temporary user-level evaluation MCP registration was removed after the runs.

Unresolved obligation: reviewers should treat this as a bounded representation fix supported by a public reproduction and focused adversarial tests, not as evidence of general agent-performance improvement. Exact downstream rendering remains agent-owned.
