### PR TITLE
Expose proof-critical projective flat previews

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -240,7 +240,10 @@ summaries are not substitutes for the stored system or certificate.
 `geometry.projective_line_arrangement.flats.materialize` is a complete finite
 materializer rather than a theorem prover. It normalizes labelled rational
 projective lines, groups every pair intersection, recovers all incidences, and
-reports multiplicity and pair accounting at `COMPUTED` assurance. When the
+reports multiplicity and pair accounting at `COMPUTED` assurance. Its typed
+inline preview includes at most 32 higher-multiplicity flats, whether that
+projection is complete, and the complete multiplicity histogram and line-pair
+count. The complete flat lattice remains in the result artifact. When the
 operator authorizes it,
 `geometry.projective_line_arrangement.flats.verify` independently replays all
 of those finite incidence obligations and returns the bound verification

--- a/src/jacobian/contracts/projective_geometry.py
+++ b/src/jacobian/contracts/projective_geometry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from math import comb, gcd, lcm
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StrictBool, StringConstraints, model_validator
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
@@ -136,6 +136,47 @@ class ProjectiveMultiplicityCount(ContractModel):
     flat_count: int = Field(ge=1, le=2016, strict=True)
 
 
+class ProjectiveLineArrangementPreview(ContractModel):
+    """Bounded inline projection of proof-critical higher flats and accounting."""
+
+    preview_schema_version: Literal["1"] = "1"
+    line_count: int = Field(ge=2, le=64, strict=True)
+    non_double_flat_count: int = Field(ge=0, le=2016, strict=True)
+    non_double_flats: tuple[ProjectiveArrangementFlat, ...] = Field(max_length=32)
+    non_double_flats_complete: StrictBool
+    multiplicity_histogram: tuple[ProjectiveMultiplicityCount, ...]
+    pair_count_total: int = Field(ge=1, le=2016, strict=True)
+    artifact_completion: Literal["COMPLETE"] = "COMPLETE"
+    arithmetic: Literal["EXACT_INTEGER"] = "EXACT_INTEGER"
+
+    @model_validator(mode="after")
+    def bind_bounded_projection(self) -> Self:
+        if any(flat.multiplicity <= 2 for flat in self.non_double_flats):
+            raise ValueError(
+                "preview non-double flats must have multiplicity above two"
+            )
+        if self.non_double_flat_count < len(self.non_double_flats):
+            raise ValueError(
+                "preview cannot contain more flats than the reported count"
+            )
+        if self.non_double_flats_complete != (
+            self.non_double_flat_count == len(self.non_double_flats)
+        ):
+            raise ValueError(
+                "preview completeness must match its bounded flat projection"
+            )
+        supplied_histogram = tuple(
+            (item.multiplicity, item.flat_count) for item in self.multiplicity_histogram
+        )
+        if supplied_histogram != tuple(sorted(set(supplied_histogram))):
+            raise ValueError("preview multiplicity histogram must be unique and sorted")
+        if self.pair_count_total != comb(self.line_count, 2):
+            raise ValueError(
+                "preview pair_count_total must account for every line pair"
+            )
+        return self
+
+
 class ProjectiveLineArrangementResult(ContractModel):
     """Complete exact flat lattice at rank two for one labelled arrangement."""
 
@@ -197,6 +238,7 @@ __all__ = [
     "NormalizedProjectiveLine",
     "PrimitiveProjectiveTriple",
     "ProjectiveArrangementFlat",
+    "ProjectiveLineArrangementPreview",
     "ProjectiveLineArrangementRequest",
     "ProjectiveLineArrangementResult",
     "ProjectiveMultiplicityCount",

--- a/src/jacobian/domains/projective_geometry/arrangements.py
+++ b/src/jacobian/domains/projective_geometry/arrangements.py
@@ -11,6 +11,7 @@ from jacobian.contracts.projective_geometry import (
     NormalizedProjectiveLine,
     PrimitiveProjectiveTriple,
     ProjectiveArrangementFlat,
+    ProjectiveLineArrangementPreview,
     ProjectiveLineArrangementRequest,
     ProjectiveLineArrangementResult,
     ProjectiveMultiplicityCount,
@@ -19,10 +20,14 @@ from jacobian.contracts.results import ContractModel
 from jacobian.domains._examples import example
 from jacobian.math.arithmetic import primitive_integer_vector
 from jacobian.operations import (
+    ComputedNotApplicable,
+    ComputedOutcome,
+    ComputedSuccess,
     MaterializedOperation,
-    MaterializedOperationFactory,
     OperationFailure,
 )
+
+_PREVIEW_FLAT_LIMIT = 32
 
 
 def _primitive(values: tuple[Fraction, Fraction, Fraction]) -> tuple[int, int, int]:
@@ -134,45 +139,71 @@ def materialize_projective_line_flats(
     )
 
 
-_FACTORY = MaterializedOperationFactory(
-    OperationFailure(
-        code="PROJECTIVE_ARRANGEMENT_NOT_APPLICABLE",
-        stage="projective_arrangement_computation",
-        hint=(
-            "Supply distinct labelled nonzero rational homogeneous line coefficients."
-        ),
-        exceptions=(ArithmeticError, RuntimeError, TypeError, ValueError),
-    )
+_FAILURE = OperationFailure(
+    code="PROJECTIVE_ARRANGEMENT_NOT_APPLICABLE",
+    stage="projective_arrangement_computation",
+    hint=("Supply distinct labelled nonzero rational homogeneous line coefficients."),
+    exceptions=(ArithmeticError, RuntimeError, TypeError, ValueError),
 )
+
+
+def _materialize_projective_line_flats(
+    request: ProjectiveLineArrangementRequest,
+) -> ComputedOutcome[ProjectiveLineArrangementResult]:
+    try:
+        return ComputedSuccess(materialize_projective_line_flats(request))
+    except _FAILURE.exceptions as exc:
+        return ComputedNotApplicable(_FAILURE.diagnostic(exc))
+
+
+def _projective_line_arrangement_preview(
+    result: ProjectiveLineArrangementResult,
+) -> ProjectiveLineArrangementPreview:
+    non_double_flats = tuple(flat for flat in result.flats if flat.multiplicity > 2)
+    projected_flats = non_double_flats[:_PREVIEW_FLAT_LIMIT]
+    return ProjectiveLineArrangementPreview(
+        line_count=result.line_count,
+        non_double_flat_count=len(non_double_flats),
+        non_double_flats=projected_flats,
+        non_double_flats_complete=len(projected_flats) == len(non_double_flats),
+        multiplicity_histogram=result.multiplicity_histogram,
+        pair_count_total=result.pair_count_total,
+    )
+
 
 PROJECTIVE_LINE_ARRANGEMENT_CAPABILITY: MaterializedOperation[
     ProjectiveLineArrangementRequest,
     ProjectiveLineArrangementResult,
-    ProjectiveLineArrangementResult,
+    ProjectiveLineArrangementPreview,
     ContractModel,
-] = _FACTORY(
-    "geometry.projective_line_arrangement.flats.materialize",
-    "Materialize projective line-arrangement flats",
-    (
+] = MaterializedOperation(
+    capability_id="geometry.projective_line_arrangement.flats.materialize",
+    title="Materialize projective line-arrangement flats",
+    description=(
         "Normalize labelled rational projective lines and exactly materialize "
         "every rank-two flat, full incidence set, multiplicity, non-double flat, "
         "and line-pair accounting identity."
     ),
-    ProjectiveLineArrangementRequest,
-    ProjectiveLineArrangementResult,
-    materialize_projective_line_flats,
-    "geometry",
-    "projective",
-    "line-arrangement",
-    "incidence",
-    "flats",
-    "exact",
+    request_model=ProjectiveLineArrangementRequest,
+    result_model=ProjectiveLineArrangementResult,
+    implementation=_materialize_projective_line_flats,
+    tags=(
+        "geometry",
+        "projective",
+        "line-arrangement",
+        "incidence",
+        "flats",
+        "exact",
+    ),
     relation_id="geometry.projective_line_arrangement.flats.relation",
     resource_reason=(
         "the complete labelled flat lattice is retained for durable projective "
         "incidence provenance and downstream certificate binding"
     ),
-    version="3",
+    preview_model=ProjectiveLineArrangementPreview,
+    preview=_projective_line_arrangement_preview,
+    preview_complete=False,
+    version="4",
     invocation_examples=(
         example(
             "two_coordinate_lines",

--- a/tests/composition/runtime/test_frontier_capabilities.py
+++ b/tests/composition/runtime/test_frontier_capabilities.py
@@ -86,6 +86,105 @@ def _result_payload(
     return computed.output["result"]
 
 
+def test_projective_arrangement_exposes_proof_critical_flat_preview(
+    frontier_services: DomainTestServices,
+) -> None:
+    lines = {
+        "x0": (1, 0, 0),
+        "x1": (1, 0, -1),
+        "y0": (0, 1, 0),
+        "y1": (0, 1, -1),
+        "diag_main": (1, -1, 0),
+        "diag_anti": (1, 1, -1),
+    }
+    result = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.projective_line_arrangement.flats.materialize",
+            input={
+                "lines": [
+                    {
+                        "label": label,
+                        "coefficients": [_q(value) for value in coefficients],
+                    }
+                    for label, coefficients in lines.items()
+                ]
+            },
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["preview_complete"] is False
+    assert result.output["preview"] == {
+        "preview_schema_version": "1",
+        "line_count": 6,
+        "non_double_flat_count": 4,
+        "non_double_flats": [
+            {
+                "point": {"coordinates": ["0", "0", "1"]},
+                "incident_labels": ["diag_main", "x0", "y0"],
+                "multiplicity": 3,
+                "pair_count": 3,
+            },
+            {
+                "point": {"coordinates": ["0", "1", "1"]},
+                "incident_labels": ["diag_anti", "x0", "y1"],
+                "multiplicity": 3,
+                "pair_count": 3,
+            },
+            {
+                "point": {"coordinates": ["1", "0", "1"]},
+                "incident_labels": ["diag_anti", "x1", "y0"],
+                "multiplicity": 3,
+                "pair_count": 3,
+            },
+            {
+                "point": {"coordinates": ["1", "1", "1"]},
+                "incident_labels": ["diag_main", "x1", "y1"],
+                "multiplicity": 3,
+                "pair_count": 3,
+            },
+        ],
+        "non_double_flats_complete": True,
+        "multiplicity_histogram": [
+            {"multiplicity": 2, "flat_count": 3},
+            {"multiplicity": 3, "flat_count": 4},
+        ],
+        "pair_count_total": 15,
+        "artifact_completion": "COMPLETE",
+        "arithmetic": "EXACT_INTEGER",
+    }
+
+
+def test_projective_arrangement_bounds_large_flat_preview(
+    frontier_services: DomainTestServices,
+) -> None:
+    lines = [(f"x_{value}", (1, 0, -value)) for value in range(21)]
+    lines.extend((f"y_{value}", (0, 1, -value)) for value in range(21))
+    lines.extend((f"s_{value}", (1, 1, -value)) for value in range(22))
+
+    result = frontier_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="geometry.projective_line_arrangement.flats.materialize",
+            input={
+                "lines": [
+                    {
+                        "label": label,
+                        "coefficients": [_q(value) for value in coefficients],
+                    }
+                    for label, coefficients in lines
+                ]
+            },
+        )
+    )
+
+    preview = result.output["preview"]
+    assert result.output["preview_complete"] is False
+    assert preview["non_double_flat_count"] > 32
+    assert len(preview["non_double_flats"]) == 32
+    assert preview["non_double_flats_complete"] is False
+    assert preview["pair_count_total"] == 2016
+
+
 def test_projective_arrangement_materializes_the_nine_line_flat_lattice(
     frontier_services: DomainTestServices,
 ) -> None:


### PR DESCRIPTION
## What changed

- add a bounded typed preview for `geometry.projective_line_arrangement.flats.materialize`
- expose up to 32 higher-multiplicity flats with exact points and incident labels
- expose the complete multiplicity histogram, pair count, and projection completeness
- retain the complete arrangement in the durable result artifact and leave the independent checker unchanged
- bump the producer contract from v3 to v4 and document the preview boundary

## Why

Solymosi's 2024 proof of Gruenbaum's conjecture uses a proof-critical six-line arrangement in the third case of Theorem 2. Main computed and independently verified the complete flat lattice, but `math.run` returned only an artifact URI with `preview: null`. Because MCP exposes no artifact-read tool, the model manually reconstructed every requested flat; the producer contributed no agent-visible mathematical value even though its hidden artifact was correct.

Primary source: https://arxiv.org/abs/2408.09370

## Frozen model-in-the-loop reproduction

- base: `c9dd6310a03571fb9816a3fee9acab47d9ff9bec`
- model: `gpt-5.4-mini`, reasoning `low`, fresh ephemeral authenticated Codex CLI
- policy: `COMPUTE_VERIFY_NO_RETRIEVAL`, digest `sha256:0749b72e4263a380432feb9973b0fda9d5ed2b04d29417a1262bfc45134c71c6`
- task/schema/oracle SHA-256: `f673608b...`, `3a763912...`, `d23688ee...`
- baseline catalog digest: `sha256:397ea62ff06069896ff0b0f89d1d9c26c19907e9accbe27c8e5fdf6d6b6bade3`
- treatment catalog digest: `sha256:b3e0a22d8c81efd96d6c2b928b74da0ded349e69714cc1bfda6b30204f8893ae`

Baseline completed the producer and verifier, but the producer output was `preview: null`; the final flats were an unaided reconstruction. Treatment returned all four triple points, histogram `{2: 3, 3: 4}`, and pair count `15` directly in the v4 preview. The unchanged operator-authorized checker returned `VERIFIED`, record `artifact://sha256/e9cf8044e116239a7ec7b06d4daa7398cf45adfabd91ce622ddbb06f7c9b3e49`. The identical external oracle passed both mathematical answers; the treatment changes the provenance of the proof-critical values from manual derivation to inspectable Jacobian output. Wall time fell from about 65 s to 50 s and reasoning output from 1,061 to 537 tokens; this is one run per arm, not a performance claim.

The result remains scoped to the supplied six-line arrangement. The producer remains `COMPUTED`; only the independent checker grants `VERIFIED`.

## Validation

- red regression on main: `preview is None`
- `make test-composition TESTS=tests/composition/runtime/test_frontier_capabilities.py` (17 passed), including a 64-line truncation case
- `uv run mypy src/jacobian/contracts/projective_geometry.py src/jacobian/domains/projective_geometry/arrangements.py`
- `make test-plan BASE=origin/main`
- selected final-tree lanes: lint/typecheck, docs linkcheck, unit, domain, composition, storage, MCP, and e2e; the full component lane passed before the disjoint upstream rebase
- post-rebase component lane: 788 passed and 3 skipped; its one-second fake-DRAT marker did not appear before timeout on this host (the affected paths do not differ from main)
- process lane: 243 passed, 1 skipped, with one unchanged-main macOS host failure because Bash 3.2 lacks `mapfile`; the owning test reproduces alone and neither its test nor `scripts/setup-agent` differs from main

## Proof obligations

- the inline projection is intentionally incomplete with respect to the full artifact (`preview_complete=false`)
- `non_double_flats_complete` states whether all higher-multiplicity flats fit within the 32-flat bound
- the full exact flat lattice and verification binding remain artifact-backed
