### PR TITLE
Add independently verified real-quadratic order

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -155,10 +155,11 @@ checks fraction-field equality by independent polynomial cross multiplication;
 pointwise denominator-definedness remains outside its scope. See
 [Rational-function identities](capabilities/polynomial/rational-function-identities.md).
 
-Some polynomial, matrix, graph, geometry, probability, topology, poset, and
-combinatorics results have a separate verification capability. The producer
-first returns a result artifact in `EXPLORE` mode. A verification request then
-supplies that exact `result_uri` to the matching `VERIFY` capability.
+Some arithmetic, polynomial, matrix, graph, geometry, probability, topology,
+poset, and combinatorics results have a separate verification capability. The
+producer first returns an exact result in `EXPLORE` mode. A verification request
+then supplies that result, inline or by artifact URI as declared by the
+contract, to the matching `VERIFY` capability.
 
 Domain-owned `ExactReplayCheckerDeclaration` values name the request model,
 certificate format, and checker function, but they carry no authority.
@@ -188,6 +189,13 @@ installed runtime.
 
 Bounded portfolio examples show the intended boundary:
 
+- `arithmetic.real_quadratic.order.compute` compares two bounded canonical
+  values `a+b*sqrt(d)` with one shared positive square-free radicand. It returns
+  the exact difference, order, and squared rational/radical magnitudes without
+  claiming general number-field arithmetic or matrix spectral computation.
+  `arithmetic.real_quadratic.order.verify` independently replays the comparison
+  with standard-library fractions and integer squares, without importing the
+  SymPy producer.
 - `graph.hamiltonian_path.decide` returns either a complete spanning path
   witness or a negative decision after exhausting its order-18 state space.
   `graph.hamiltonian_path.verify` checks a positive witness directly and

--- a/src/jacobian/contracts/arithmetic.py
+++ b/src/jacobian/contracts/arithmetic.py
@@ -8,11 +8,17 @@ integer predicates) live in ``contracts/number_theory.py``.
 
 from __future__ import annotations
 
+from fractions import Fraction
+from math import isqrt
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StringConstraints, model_validator
+from pydantic import Field, StrictInt, StringConstraints, model_validator
 
-from jacobian.contracts.exact import CanonicalInteger
+from jacobian.contracts.exact import (
+    CanonicalInteger,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian.contracts.results import ContractModel
 
 # ---------------------------------------------------------------------------
@@ -22,6 +28,8 @@ from jacobian.contracts.results import ContractModel
 _MAX_BASE = 10_000
 _MAX_NONNEGATIVE = 1_000
 MAX_BASE_DIGITS = 1_024
+MAX_REAL_QUADRATIC_RADICAND = 1_000_000
+MAX_REAL_QUADRATIC_DIGITS = 256
 
 # A positional digit is a small non-negative canonical integer string.  The
 # max length of 4 comfortably covers every base up to ``_MAX_BASE`` (10_000).
@@ -75,6 +83,88 @@ class IntegerNthRootRequest(ContractModel):
 
 
 # ---------------------------------------------------------------------------
+# Requests — real quadratic order
+# ---------------------------------------------------------------------------
+
+
+def _is_square_free(value: int) -> bool:
+    for divisor in range(2, isqrt(value) + 1):
+        if value % (divisor * divisor) == 0:
+            return False
+    return True
+
+
+def _fraction_order(left: Fraction, right: Fraction) -> Literal["LT", "EQ", "GT"]:
+    if left < right:
+        return "LT"
+    if left > right:
+        return "GT"
+    return "EQ"
+
+
+def _quadratic_sign(
+    rational_part: Fraction,
+    radical_coefficient: Fraction,
+    radicand: int,
+) -> Literal[-1, 0, 1]:
+    if radical_coefficient == 0:
+        if rational_part < 0:
+            return -1
+        if rational_part > 0:
+            return 1
+        return 0
+    if rational_part == 0:
+        return -1 if radical_coefficient < 0 else 1
+    if (rational_part > 0) == (radical_coefficient > 0):
+        return -1 if rational_part < 0 else 1
+    rational_square = rational_part * rational_part
+    radical_square = radical_coefficient * radical_coefficient * radicand
+    if rational_square == radical_square:
+        raise ValueError("square-free quadratic magnitudes cannot tie")
+    dominant = (
+        radical_coefficient if radical_square > rational_square else rational_part
+    )
+    return -1 if dominant < 0 else 1
+
+
+class RealQuadraticValue(ContractModel):
+    """One canonical real value ``a + b*sqrt(d)`` with square-free ``d``."""
+
+    rational_part: CanonicalRational
+    radical_coefficient: CanonicalRational
+    radicand: StrictInt = Field(ge=2, le=MAX_REAL_QUADRATIC_RADICAND)
+
+    @model_validator(mode="after")
+    def require_bounded_canonical_quadratic(self) -> Self:
+        require_bounded_rational(
+            self.rational_part,
+            max_digits=MAX_REAL_QUADRATIC_DIGITS,
+            label="real-quadratic rational part",
+        )
+        require_bounded_rational(
+            self.radical_coefficient,
+            max_digits=MAX_REAL_QUADRATIC_DIGITS,
+            label="real-quadratic radical coefficient",
+        )
+        if not _is_square_free(self.radicand):
+            raise ValueError("real-quadratic radicand must be square-free")
+        return self
+
+
+class RealQuadraticOrderRequest(ContractModel):
+    """Two values in one explicitly shared real quadratic field."""
+
+    left: RealQuadraticValue
+    right: RealQuadraticValue
+
+    @model_validator(mode="after")
+    def require_shared_radicand(self) -> Self:
+        if self.left.radicand != self.right.radicand:
+            raise ValueError("real-quadratic comparison requires one shared radicand")
+        return self
+
+
+# ---------------------------------------------------------------------------
 # Structured results — integer
 # ---------------------------------------------------------------------------
 
@@ -113,4 +203,77 @@ class IntegerBaseDigitsResult(ContractModel):
             raise ValueError("zero sign requires the canonical zero digit")
         if self.sign != 0 and self.digits[0] == "0":
             raise ValueError("nonzero positional digits cannot have a leading zero")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Structured results — real quadratic order
+# ---------------------------------------------------------------------------
+
+
+class RealQuadraticSignCertificate(ContractModel):
+    rational_part_squared: CanonicalRational
+    radical_part_squared: CanonicalRational
+    magnitude_order: Literal["LT", "EQ", "GT"]
+
+
+class RealQuadraticOrderResult(ContractModel):
+    """Exact order and inspectable sign data for two real quadratic values."""
+
+    result_schema_version: Literal["1"] = "1"
+    left: RealQuadraticValue
+    right: RealQuadraticValue
+    difference: RealQuadraticValue
+    order: Literal["LT", "EQ", "GT"]
+    sign_basis: Literal[
+        "RATIONAL_ONLY",
+        "RADICAL_ONLY",
+        "SAME_SIGN",
+        "OPPOSING_SIGNS_SQUARED_MAGNITUDES",
+    ]
+    sign_certificate: RealQuadraticSignCertificate
+    arithmetic: Literal["EXACT_REAL_QUADRATIC"] = "EXACT_REAL_QUADRATIC"
+
+    @model_validator(mode="after")
+    def bind_exact_order(self) -> Self:
+        if not (self.left.radicand == self.right.radicand == self.difference.radicand):
+            raise ValueError("result values must share one radicand")
+        left_a = self.left.rational_part.as_fraction()
+        left_b = self.left.radical_coefficient.as_fraction()
+        right_a = self.right.rational_part.as_fraction()
+        right_b = self.right.radical_coefficient.as_fraction()
+        difference_a = left_a - right_a
+        difference_b = left_b - right_b
+        if (
+            self.difference.rational_part.as_fraction() != difference_a
+            or self.difference.radical_coefficient.as_fraction() != difference_b
+        ):
+            raise ValueError("result difference must equal left minus right")
+        sign = _quadratic_sign(difference_a, difference_b, self.difference.radicand)
+        expected_order: Literal["LT", "EQ", "GT"] = (
+            "LT" if sign < 0 else "GT" if sign > 0 else "EQ"
+        )
+        if self.order != expected_order:
+            raise ValueError("result order must match the exact quadratic difference")
+        expected_basis = (
+            "RATIONAL_ONLY"
+            if difference_b == 0
+            else "RADICAL_ONLY"
+            if difference_a == 0
+            else "SAME_SIGN"
+            if (difference_a > 0) == (difference_b > 0)
+            else "OPPOSING_SIGNS_SQUARED_MAGNITUDES"
+        )
+        if self.sign_basis != expected_basis:
+            raise ValueError("sign basis must match the exact difference structure")
+        rational_square = difference_a * difference_a
+        radical_square = difference_b * difference_b * self.difference.radicand
+        if (
+            self.sign_certificate.rational_part_squared.as_fraction() != rational_square
+            or self.sign_certificate.radical_part_squared.as_fraction()
+            != radical_square
+            or self.sign_certificate.magnitude_order
+            != _fraction_order(rational_square, radical_square)
+        ):
+            raise ValueError("sign certificate must contain exact squared magnitudes")
         return self

--- a/src/jacobian/domains/arithmetic/bundle.py
+++ b/src/jacobian/domains/arithmetic/bundle.py
@@ -11,8 +11,14 @@ from __future__ import annotations
 
 import platform
 
+from jacobian.contracts.arithmetic import (
+    MAX_REAL_QUADRATIC_DIGITS,
+    MAX_REAL_QUADRATIC_RADICAND,
+)
 from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.domains.arithmetic.checkers import ARITHMETIC_EXACT_REPLAY_CHECKERS
 from jacobian.domains.arithmetic.integers import INTEGER_CAPABILITIES
+from jacobian.domains.arithmetic.quadratic import REAL_QUADRATIC_CAPABILITIES
 from jacobian.domains.arithmetic.rationals import RATIONAL_CAPABILITIES
 from jacobian.operations import (
     DomainBundle,
@@ -29,28 +35,43 @@ def build_arithmetic_bundle() -> DomainBundle:
         schema_namespace="jacobian.arithmetic",
         semantics=DomainSemantics(
             name="jacobian.exact-arithmetic",
-            version="1",
+            version="2",
             definition={
                 "description": (
                     "exact integer absolute value, sign, decimal digit sum/count, "
-                    "base expansion, integer nth root, and rational arithmetic/order "
-                    "over canonical integer and rational strings"
+                    "base expansion, integer nth root, rational arithmetic/order, "
+                    "and bounded same-radicand real-quadratic order"
                 ),
                 "integer_encoding": "canonical decimal string",
                 "rational_encoding": "canonical reduced num/den with positive denominator",
+                "real_quadratic_encoding": (
+                    "a+b*sqrt(d), with shared positive square-free d"
+                ),
                 "arithmetic": "exact via stdlib and maintained SymPy APIs",
-                "assurance": "computed; no independent checker",
+                "assurance": (
+                    "computed; real-quadratic order supports operator-authorized "
+                    "independent standard-library replay"
+                ),
             },
         ),
         provider_runtime=known_provider_runtime(
             "jacobian.sympy",
-            features=("exact-integer-arithmetic", "exact-rational-arithmetic"),
-            configuration={"sympy_version": SYMPY_VERSION},
+            features=(
+                "exact-integer-arithmetic",
+                "exact-rational-arithmetic",
+                "exact-real-quadratic-order",
+            ),
+            configuration={
+                "sympy_version": SYMPY_VERSION,
+                "real_quadratic_max_digits": MAX_REAL_QUADRATIC_DIGITS,
+                "real_quadratic_max_radicand": MAX_REAL_QUADRATIC_RADICAND,
+            },
         ),
         backend_version=f"python-{platform.python_version()};sympy-{SYMPY_VERSION}",
         capabilities=(
             *INTEGER_CAPABILITIES,
             *RATIONAL_CAPABILITIES,
+            *REAL_QUADRATIC_CAPABILITIES,
         ),
         diagnostics=DomainDiagnostics(
             invalid_request=CapabilityDiagnostic(
@@ -70,6 +91,8 @@ def build_arithmetic_bundle() -> DomainBundle:
         ),
         assurance_basis=(
             "deterministic exact arithmetic from the pinned stdlib/SymPy runtime; "
-            "no independent checker invoked"
+            "independent verification requires an explicit domain-owned verifier "
+            "invocation where declared"
         ),
+        checker_declarations=ARITHMETIC_EXACT_REPLAY_CHECKERS,
     )

--- a/src/jacobian/domains/arithmetic/checkers.py
+++ b/src/jacobian/domains/arithmetic/checkers.py
@@ -1,0 +1,22 @@
+"""Independent checker declarations owned by exact arithmetic."""
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.arithmetic import RealQuadraticOrderRequest
+
+ARITHMETIC_EXACT_REPLAY_CHECKERS = (
+    ExactReplayCheckerDeclaration(
+        "arithmetic.real_quadratic.order.compute",
+        RealQuadraticOrderRequest,
+        "check_real_quadratic_order",
+        "arithmetic.real-quadratic-order.fraction-square-replay",
+        entrypoint_module="jacobian_checkers.real_quadratic",
+        replay_method="standard-library Fraction and integer-square replay",
+        reason=(
+            "operator-authorized standard-library checker independently compares "
+            "opposing real-quadratic terms without importing SymPy or producer code"
+        ),
+    ),
+)
+
+
+__all__ = ["ARITHMETIC_EXACT_REPLAY_CHECKERS"]

--- a/src/jacobian/domains/arithmetic/quadratic.py
+++ b/src/jacobian/domains/arithmetic/quadratic.py
@@ -1,0 +1,134 @@
+"""Exact order for bounded values in one real quadratic field."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Literal
+
+from sympy import Rational, sign, sqrt
+
+from jacobian.contracts.arithmetic import (
+    RealQuadraticOrderRequest,
+    RealQuadraticOrderResult,
+    RealQuadraticSignCertificate,
+    RealQuadraticValue,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.domains._examples import example
+from jacobian.domains.arithmetic._support import arithmetic_operation
+
+
+def _wire_rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(value)
+
+
+def _wire_value(
+    rational_part: Fraction,
+    radical_coefficient: Fraction,
+    radicand: int,
+) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=_wire_rational(rational_part),
+        radical_coefficient=_wire_rational(radical_coefficient),
+        radicand=radicand,
+    )
+
+
+def _magnitude_order(left: Fraction, right: Fraction) -> Literal["LT", "EQ", "GT"]:
+    if left < right:
+        return "LT"
+    if left > right:
+        return "GT"
+    return "EQ"
+
+
+def compute_real_quadratic_order(
+    request: RealQuadraticOrderRequest,
+) -> RealQuadraticOrderResult:
+    """Compare two ``a + b*sqrt(d)`` values using exact SymPy ordering."""
+
+    left_a = request.left.rational_part.as_fraction()
+    left_b = request.left.radical_coefficient.as_fraction()
+    right_a = request.right.rational_part.as_fraction()
+    right_b = request.right.radical_coefficient.as_fraction()
+    difference_a = left_a - right_a
+    difference_b = left_b - right_b
+    radicand = request.left.radicand
+    expression = Rational(difference_a.numerator, difference_a.denominator) + Rational(
+        difference_b.numerator, difference_b.denominator
+    ) * sqrt(radicand)
+    exact_sign = int(sign(expression))
+    if exact_sign not in {-1, 0, 1}:
+        raise ValueError("SymPy did not determine the exact real-quadratic sign")
+    order: Literal["LT", "EQ", "GT"] = (
+        "LT" if exact_sign < 0 else "GT" if exact_sign > 0 else "EQ"
+    )
+    sign_basis: Literal[
+        "RATIONAL_ONLY",
+        "RADICAL_ONLY",
+        "SAME_SIGN",
+        "OPPOSING_SIGNS_SQUARED_MAGNITUDES",
+    ] = (
+        "RATIONAL_ONLY"
+        if difference_b == 0
+        else "RADICAL_ONLY"
+        if difference_a == 0
+        else "SAME_SIGN"
+        if (difference_a > 0) == (difference_b > 0)
+        else "OPPOSING_SIGNS_SQUARED_MAGNITUDES"
+    )
+    rational_square = difference_a * difference_a
+    radical_square = difference_b * difference_b * radicand
+    return RealQuadraticOrderResult(
+        left=request.left,
+        right=request.right,
+        difference=_wire_value(difference_a, difference_b, radicand),
+        order=order,
+        sign_basis=sign_basis,
+        sign_certificate=RealQuadraticSignCertificate(
+            rational_part_squared=_wire_rational(rational_square),
+            radical_part_squared=_wire_rational(radical_square),
+            magnitude_order=_magnitude_order(rational_square, radical_square),
+        ),
+    )
+
+
+REAL_QUADRATIC_CAPABILITIES = (
+    arithmetic_operation(
+        "arithmetic.real_quadratic.order.compute",
+        "Compare exact real quadratic values",
+        (
+            "Compute the exact order of two bounded canonical values a+b*sqrt(d) "
+            "with one shared positive square-free radicand, retaining their exact "
+            "difference and squared-magnitude sign certificate."
+        ),
+        RealQuadraticOrderRequest,
+        RealQuadraticOrderResult,
+        compute_real_quadratic_order,
+        "arithmetic",
+        "real-quadratic",
+        "quadratic-surd",
+        "exact-order",
+        invocation_examples=(
+            example(
+                "pang_m4_matrix_young_gap",
+                "Compare 3*sqrt(3)/8 with 1/2+sqrt(3)/20 exactly.",
+                {
+                    "left": {
+                        "rational_part": {"num": "0", "den": "1"},
+                        "radical_coefficient": {"num": "3", "den": "8"},
+                        "radicand": 3,
+                    },
+                    "right": {
+                        "rational_part": {"num": "1", "den": "2"},
+                        "radical_coefficient": {"num": "1", "den": "20"},
+                        "radicand": 3,
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["REAL_QUADRATIC_CAPABILITIES", "compute_real_quadratic_order"]

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -84,6 +84,7 @@ _ENTRYPOINT_PROVIDER_RUNTIME_KEYS = {
     "jacobian_checkers.additive_combinatorics": "combinatorics",
     "jacobian_checkers.jacobian_syzygy": "graded-syzygy",
     "jacobian_checkers.projective_arrangements": "projective-arrangement",
+    "jacobian_checkers.real_quadratic": "arithmetic",
     "jacobian_checkers.simplicial_topology": "topology",
     "jacobian_checkers.certified_snf": "certified-snf",
     "jacobian_checkers.finite_posets": "poset",
@@ -153,6 +154,18 @@ def install_exact_domain_checkers(
             install_tier=CapabilityInstallTier.T1,
             license_id="MIT",
             features=("standard-library-rational-replay", "clean-process-checker"),
+        ),
+        "arithmetic": source_provider_runtime(
+            "jacobian.real-quadratic-checker",
+            version="1",
+            entrypoint="jacobian_checkers.real_quadratic:check_real_quadratic_order",
+            install_tier=CapabilityInstallTier.T1,
+            license_id="MIT",
+            features=(
+                "standard-library-rational-replay",
+                "integer-square-sign-replay",
+                "clean-process-checker",
+            ),
         ),
         "matrix-hnf": source_provider_runtime(
             "jacobian.matrix-hnf-checker",
@@ -296,6 +309,21 @@ def install_exact_domain_checkers(
                     "clean-process-checker",
                 ),
                 checker_ids=authorized_ids["geometry"],
+            ),
+            "arithmetic": source_provider_runtime(
+                "jacobian.real-quadratic-checker",
+                version="1",
+                entrypoint=(
+                    "jacobian_checkers.real_quadratic:check_real_quadratic_order"
+                ),
+                install_tier=CapabilityInstallTier.T1,
+                license_id="MIT",
+                features=(
+                    "standard-library-rational-replay",
+                    "integer-square-sign-replay",
+                    "clean-process-checker",
+                ),
+                checker_ids=authorized_ids["arithmetic"],
             ),
             "matrix-hnf": source_provider_runtime(
                 "jacobian.matrix-hnf-checker",

--- a/src/jacobian_checkers/real_quadratic.py
+++ b/src/jacobian_checkers/real_quadratic.py
@@ -1,0 +1,180 @@
+"""Independent real-quadratic order replay using only the standard library.
+
+This module imports neither SymPy nor the arithmetic producer and accepts only
+passive artifact-bound JSON from the exact replay protocol.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from fractions import Fraction
+from typing import Any, Literal
+
+from jacobian_checkers.bound_artifacts import bound_request
+
+_INTEGER = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+_MAX_DIGITS = 256
+_MAX_RADICAND = 1_000_000
+_OPERATION_ID = "arithmetic.real_quadratic.order.compute"
+_WITNESS_FORMAT = "arithmetic.real-quadratic-order.fraction-square-replay"
+
+
+def _reject(detail: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "conclusion": "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _accept() -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "conclusion": "TRUE",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": "independent exact real-quadratic order replay accepted the result",
+    }
+
+
+def _rational(value: object) -> Fraction:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational is malformed")
+    numerator = value["num"]
+    denominator = value["den"]
+    if (
+        not isinstance(numerator, str)
+        or not isinstance(denominator, str)
+        or len(numerator.lstrip("-")) > _MAX_DIGITS
+        or len(denominator.lstrip("-")) > _MAX_DIGITS
+        or _INTEGER.fullmatch(numerator) is None
+        or _INTEGER.fullmatch(denominator) is None
+    ):
+        raise ValueError("rational is outside checker bounds")
+    parsed = Fraction(int(numerator), int(denominator))
+    if str(parsed.numerator) != numerator or str(parsed.denominator) != denominator:
+        raise ValueError("rational is not canonical")
+    return parsed
+
+
+def _square_free(value: int) -> bool:
+    return all(
+        value % (divisor * divisor) for divisor in range(2, math.isqrt(value) + 1)
+    )
+
+
+def _value(value: object) -> tuple[Fraction, Fraction, int]:
+    if not isinstance(value, dict) or set(value) != {
+        "rational_part",
+        "radical_coefficient",
+        "radicand",
+    }:
+        raise ValueError("real-quadratic value is malformed")
+    radicand = value["radicand"]
+    if (
+        type(radicand) is not int
+        or not 2 <= radicand <= _MAX_RADICAND
+        or not _square_free(radicand)
+    ):
+        raise ValueError("real-quadratic radicand is outside checker scope")
+    return (
+        _rational(value["rational_part"]),
+        _rational(value["radical_coefficient"]),
+        radicand,
+    )
+
+
+def _wire_rational(value: Fraction) -> dict[str, str]:
+    return {"num": str(value.numerator), "den": str(value.denominator)}
+
+
+def _wire_value(a: Fraction, b: Fraction, d: int) -> dict[str, object]:
+    return {
+        "rational_part": _wire_rational(a),
+        "radical_coefficient": _wire_rational(b),
+        "radicand": d,
+    }
+
+
+def _order(left: Fraction, right: Fraction) -> Literal["LT", "EQ", "GT"]:
+    if left < right:
+        return "LT"
+    if left > right:
+        return "GT"
+    return "EQ"
+
+
+def _sign(a: Fraction, b: Fraction, d: int) -> int:
+    if b == 0:
+        return -1 if a < 0 else 1 if a > 0 else 0
+    if a == 0:
+        return -1 if b < 0 else 1
+    if (a > 0) == (b > 0):
+        return -1 if a < 0 else 1
+    rational_square = a * a
+    radical_square = b * b * d
+    if rational_square == radical_square:
+        raise ValueError("square-free quadratic magnitudes cannot tie")
+    dominant = b if radical_square > rational_square else a
+    return -1 if dominant < 0 else 1
+
+
+def _expected(source: dict[str, Any]) -> dict[str, Any]:
+    if set(source) != {"left", "right"}:
+        raise ValueError("real-quadratic request is malformed")
+    left_a, left_b, left_d = _value(source["left"])
+    right_a, right_b, right_d = _value(source["right"])
+    if left_d != right_d:
+        raise ValueError("comparison values do not share a radicand")
+    difference_a = left_a - right_a
+    difference_b = left_b - right_b
+    sign = _sign(difference_a, difference_b, left_d)
+    rational_square = difference_a * difference_a
+    radical_square = difference_b * difference_b * left_d
+    basis = (
+        "RATIONAL_ONLY"
+        if difference_b == 0
+        else "RADICAL_ONLY"
+        if difference_a == 0
+        else "SAME_SIGN"
+        if (difference_a > 0) == (difference_b > 0)
+        else "OPPOSING_SIGNS_SQUARED_MAGNITUDES"
+    )
+    return {
+        "result_schema_version": "1",
+        "left": source["left"],
+        "right": source["right"],
+        "difference": _wire_value(difference_a, difference_b, left_d),
+        "order": "LT" if sign < 0 else "GT" if sign > 0 else "EQ",
+        "sign_basis": basis,
+        "sign_certificate": {
+            "rational_part_squared": _wire_rational(rational_square),
+            "radical_part_squared": _wire_rational(radical_square),
+            "magnitude_order": _order(rational_square, radical_square),
+        },
+        "arithmetic": "EXACT_REAL_QUADRATIC",
+    }
+
+
+def check_real_quadratic_order(request: object) -> dict[str, Any]:
+    try:
+        source, candidate = bound_request(
+            request,
+            operation_id=_OPERATION_ID,
+            witness_format=_WITNESS_FORMAT,
+        )
+        if candidate != _expected(source):
+            return _reject(
+                "declared order does not match independent real-quadratic replay"
+            )
+        return _accept()
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _reject("malformed, unsupported, or mismatched checker request")
+
+
+__all__ = ["check_real_quadratic_order"]

--- a/tests/boundary/mcp/test_mcp_adapter.py
+++ b/tests/boundary/mcp/test_mcp_adapter.py
@@ -623,7 +623,7 @@ def test_mcp_exposes_only_math_tools_with_read_only_resources(
                 "math.find",
                 {
                     "query": "compute exact event probability",
-                    "domain": "arithmetic",
+                    "domain": "quuxonium",
                 },
             )
             assert isinstance(unknown_domain_result.structured_content, dict)
@@ -641,7 +641,7 @@ def test_mcp_exposes_only_math_tools_with_read_only_resources(
             assert {
                 "action": "remove_unknown_domain_filter",
                 "tool": "math.find",
-                "rejected_domain": "arithmetic",
+                "rejected_domain": "quuxonium",
                 "change": "Retry without the unrecognized domain filter.",
             } in unknown_domain["available_recovery_paths"]
             assert {
@@ -652,7 +652,7 @@ def test_mcp_exposes_only_math_tools_with_read_only_resources(
 
             browse_unknown_result = await client.call_tool(
                 "math.find",
-                {"domain": "arithmetic"},
+                {"domain": "quuxonium"},
             )
             assert isinstance(browse_unknown_result.structured_content, dict)
             browse_unknown = browse_unknown_result.structured_content
@@ -663,7 +663,7 @@ def test_mcp_exposes_only_math_tools_with_read_only_resources(
             assert {
                 "action": "remove_unknown_domain_filter",
                 "tool": "math.find",
-                "rejected_domain": "arithmetic",
+                "rejected_domain": "quuxonium",
                 "change": "Retry without the unrecognized domain filter.",
             } in browse_unknown["available_recovery_paths"]
             assert all(

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -6,6 +6,7 @@ import pytest
 from tests.support.artifacts import artifact_uri as _uri
 
 import jacobian.exact_domain_checkers as exact_domain_checkers
+from jacobian.contracts.arithmetic import RealQuadraticOrderRequest
 from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.contracts.graph_invariant_operations import (
     GraphInvariantRequest,
@@ -36,6 +37,7 @@ from jacobian.contracts.polynomial_operations import (
 )
 from jacobian.contracts.projective_geometry import ProjectiveLineArrangementRequest
 from jacobian.contracts.results import ContractModel
+from jacobian.domains.arithmetic.bundle import build_arithmetic_bundle
 from jacobian.domains.graph_optimization.bundle import (
     build_graph_optimization_bundle,
 )
@@ -96,6 +98,7 @@ def install_exact_domain_checkers(
         "graph_optimization": build_graph_optimization_bundle,
         "graph_invariants": build_graph_invariant_bundle,
         "graph_symmetry": build_graph_symmetry_bundle,
+        "arithmetic": build_arithmetic_bundle,
         "matrix": build_matrix_bundle,
         "number_theory": build_number_theory_bundle,
         "polynomial": build_polynomial_bundle,
@@ -114,6 +117,7 @@ def install_exact_domain_checkers(
 
 
 def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
+    arithmetic_ids = ("arithmetic.real_quadratic.order.compute",)
     polynomial_ids = (
         "polynomial.jacobian_syzygy.minimum_degree.compute",
         "polynomial.compute.gcd",
@@ -146,6 +150,11 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
 
     installation = install_exact_domain_checkers(
         registry,
+        arithmetic=_installed(
+            (RealQuadraticOrderRequest,),
+            arithmetic_ids,
+            character="5",
+        ),
         polynomial=_installed(
             (
                 GradedJacobianSyzygyRequest,
@@ -199,22 +208,31 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     )
 
     assert set(installation.checker_ids) == set(
-        polynomial_ids + matrix_ids + graph_ids + number_theory_ids + projective_ids
+        arithmetic_ids
+        + polynomial_ids
+        + matrix_ids
+        + graph_ids
+        + number_theory_ids
+        + projective_ids
     )
     assert all(installation.checker_ids.values())
     for capability_id, checker_id in installation.checker_ids.items():
         assert checker_id is not None
         registration = registry.require_active(checker_id)
         expected_module = (
-            "jacobian_checkers.graph_exact_operations:"
-            if capability_id.startswith("graph.")
+            "jacobian_checkers.real_quadratic:"
+            if capability_id.startswith("arithmetic.real_quadratic.")
             else (
-                "jacobian_checkers.projective_arrangements:"
-                if capability_id.startswith("geometry.projective_")
+                "jacobian_checkers.graph_exact_operations:"
+                if capability_id.startswith("graph.")
                 else (
-                    "jacobian_checkers.jacobian_syzygy:"
-                    if "jacobian_syzygy" in capability_id
-                    else "jacobian_checkers.exact_domain_operations:"
+                    "jacobian_checkers.projective_arrangements:"
+                    if capability_id.startswith("geometry.projective_")
+                    else (
+                        "jacobian_checkers.jacobian_syzygy:"
+                        if "jacobian_syzygy" in capability_id
+                        else "jacobian_checkers.exact_domain_operations:"
+                    )
                 )
             )
         )
@@ -232,6 +250,8 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
     } == {"jacobian.graded-syzygy-checker-source"}
     projective_runtime = installation.provider_runtimes["projective-arrangement"]
     assert projective_runtime.provider == "jacobian.projective-arrangement-checkers"
+    arithmetic_runtime = installation.provider_runtimes["arithmetic"]
+    assert arithmetic_runtime.provider == "jacobian.real-quadratic-checker"
 
 
 def test_installer_preserves_operator_control(tmp_path: Path) -> None:

--- a/tests/composition/portfolio/test_domain_bundles.py
+++ b/tests/composition/portfolio/test_domain_bundles.py
@@ -12,6 +12,7 @@ from jacobian.capability_service import CapabilityService
 from jacobian.contracts.arithmetic import (
     IntegerBaseDigitsRequest,
     IntegerNthRootRequest,
+    RealQuadraticOrderRequest,
 )
 from jacobian.contracts.arithmetic import (
     IntegerValueRequest as ArithIntegerValueRequest,
@@ -97,6 +98,21 @@ _REPR: list[tuple[type[ContractModel], dict[str, object]]] = [
     (ArithIntegerValueRequest, {"value": "12"}),
     (IntegerBaseDigitsRequest, {"value": "12", "base": 2}),
     (IntegerNthRootRequest, {"value": 8, "degree": 3}),
+    (
+        RealQuadraticOrderRequest,
+        {
+            "left": {
+                "rational_part": {"num": "0", "den": "1"},
+                "radical_coefficient": {"num": "1", "den": "1"},
+                "radicand": 2,
+            },
+            "right": {
+                "rational_part": {"num": "1", "den": "1"},
+                "radical_coefficient": {"num": "0", "den": "1"},
+                "radicand": 2,
+            },
+        },
+    ),
     (CombNonnegIntRequest, {"n": 5}),
     (FibonacciPairRequest, {"n": 5}),
     (CombNonnegPairRequest, {"n": 5, "k": 2}),

--- a/tests/domain/arithmetic/test_real_quadratic_verification.py
+++ b/tests/domain/arithmetic/test_real_quadratic_verification.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from tests.support.services import DomainTestServices, open_domain_services
+
+from jacobian.contracts.capabilities import (
+    CapabilityAssuranceLevel,
+    CapabilityMode,
+    CapabilityRequest,
+)
+from jacobian.contracts.results import ExecutionStatus
+from jacobian.domains.arithmetic import build_arithmetic_bundle
+from jacobian.exact_domain_checkers import install_exact_domain_verification
+from jacobian.portfolio.domain_installation import DomainBundleInstaller
+from jacobian.portfolio.model import PortfolioPlan
+from jacobian.runtime.config import CheckerAuthorityMode
+
+
+@pytest.fixture
+def arithmetic_services(tmp_path: Path) -> Iterator[DomainTestServices]:
+    bundle = build_arithmetic_bundle()
+    with open_domain_services(
+        tmp_path / "state",
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        installed = DomainBundleInstaller(services.installation).install(
+            PortfolioPlan(domain_bundles=(bundle,))
+        )
+        adapters, _ = install_exact_domain_verification(
+            services.core.store,
+            services.core.schemas,
+            services.core.artifacts,
+            services.application.verification,
+            services.core.checkers,
+            bundles={"arithmetic": (bundle, installed.installed["arithmetic"])},
+            authorize=services.installation.authorizes_bundled_checkers,
+        )
+        for adapter in adapters:
+            services.installation.register_capability(adapter)
+        yield services
+
+
+def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(numerator), "den": str(denominator)}
+
+
+def _value(
+    rational_numerator: int,
+    radical_numerator: int,
+    *,
+    rational_denominator: int = 1,
+    radical_denominator: int = 1,
+) -> dict[str, object]:
+    return {
+        "rational_part": _q(rational_numerator, rational_denominator),
+        "radical_coefficient": _q(radical_numerator, radical_denominator),
+        "radicand": 3,
+    }
+
+
+def test_pang_m4_quadratic_order_is_independently_verified(
+    arithmetic_services: DomainTestServices,
+) -> None:
+    payload = {
+        "left": _value(0, 3, radical_denominator=8),
+        "right": _value(
+            1,
+            1,
+            rational_denominator=2,
+            radical_denominator=20,
+        ),
+    }
+    computed = arithmetic_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="arithmetic.real_quadratic.order.compute",
+            input=payload,
+        )
+    )
+    verified = arithmetic_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="arithmetic.real_quadratic.order.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert computed.output["result"] == {
+        "result_schema_version": "1",
+        "left": _value(0, 3, radical_denominator=8),
+        "right": _value(
+            1,
+            1,
+            rational_denominator=2,
+            radical_denominator=20,
+        ),
+        "difference": _value(
+            -1,
+            13,
+            rational_denominator=2,
+            radical_denominator=40,
+        ),
+        "order": "GT",
+        "sign_basis": "OPPOSING_SIGNS_SQUARED_MAGNITUDES",
+        "sign_certificate": {
+            "rational_part_squared": _q(1, 4),
+            "radical_part_squared": _q(507, 1600),
+            "magnitude_order": "LT",
+        },
+        "arithmetic": "EXACT_REAL_QUADRATIC",
+    }
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_real_quadratic_checker_rejects_a_result_for_different_input(
+    arithmetic_services: DomainTestServices,
+) -> None:
+    payload = {"left": _value(0, 1), "right": _value(0, -1)}
+    different = arithmetic_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="arithmetic.real_quadratic.order.compute",
+            input={"left": payload["right"], "right": payload["left"]},
+        )
+    )
+
+    rejected = arithmetic_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="arithmetic.real_quadratic.order.verify",
+            mode=CapabilityMode.VERIFY,
+            input={"input": payload, "candidate": different.output["result"]},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+    assert rejected.assurance.level is CapabilityAssuranceLevel.COMPUTED

--- a/tests/unit/contracts/test_real_quadratic_contracts.py
+++ b/tests/unit/contracts/test_real_quadratic_contracts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.arithmetic import (
+    RealQuadraticOrderRequest,
+    RealQuadraticValue,
+)
+
+
+def _value(radicand: int, *, digits: int = 1) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part={"num": "1" * digits, "den": "1"},
+        radical_coefficient={"num": "1", "den": "2"},
+        radicand=radicand,
+    )
+
+
+def test_real_quadratic_value_rejects_a_non_square_free_radicand() -> None:
+    with pytest.raises(ValidationError, match="radicand must be square-free"):
+        _value(12)
+
+
+def test_real_quadratic_request_requires_one_shared_radicand() -> None:
+    with pytest.raises(ValidationError, match="one shared radicand"):
+        RealQuadraticOrderRequest(left=_value(2), right=_value(3))
+
+
+def test_real_quadratic_value_enforces_its_operation_digit_bound() -> None:
+    with pytest.raises(ValidationError, match="exceeds the 256-digit bound"):
+        _value(3, digits=257)

--- a/tests/unit/domains/test_real_quadratic_order.py
+++ b/tests/unit/domains/test_real_quadratic_order.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.arithmetic import RealQuadraticOrderRequest
+from jacobian.domains.arithmetic.quadratic import compute_real_quadratic_order
+
+
+def _value(a: int, b: int) -> dict[str, object]:
+    return {
+        "rational_part": {"num": str(a), "den": "1"},
+        "radical_coefficient": {"num": str(b), "den": "1"},
+        "radicand": 2,
+    }
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "order", "basis"),
+    (
+        (_value(1, 0), _value(2, 0), "LT", "RATIONAL_ONLY"),
+        (_value(1, 1), _value(0, 0), "GT", "SAME_SIGN"),
+        (_value(1, -1), _value(1, -1), "EQ", "RATIONAL_ONLY"),
+    ),
+)
+def test_real_quadratic_order_covers_exact_sign_structures(
+    left: dict[str, object],
+    right: dict[str, object],
+    order: str,
+    basis: str,
+) -> None:
+    result = compute_real_quadratic_order(
+        RealQuadraticOrderRequest(left=left, right=right)
+    )
+
+    assert result.order == order
+    assert result.sign_basis == basis


### PR DESCRIPTION
## Summary

- add `arithmetic.real_quadratic.order.compute` for two bounded canonical values `a+b*sqrt(d)` with one shared positive square-free radicand
- retain the exact difference, order, sign basis, and squared-magnitude certificate in a typed result
- add operator-authorized `arithmetic.real_quadratic.order.verify`, replayed in a clean process with standard-library `Fraction` and integer squares and no SymPy or producer import
- keep the scope deliberately below general algebraic-field arithmetic and matrix spectral computation

## Grace-style reproduction

Primary source: Zhekai Pang, *Counterexamples to a multivariable matrix Young conjecture*, arXiv:2607.11866v1 (2026), Theorem 1, `m=4`: https://arxiv.org/abs/2607.11866

Frozen proof-critical scalar subproblem:

`L = 3*sqrt(3)/8`, `R = 1/2 + sqrt(3)/20`, so
`L-R = -1/2 + 13*sqrt(3)/40 > 0`, certified by
`1/4 < 507/1600`.

The authenticated Codex CLI arms used `gpt-5.4-mini`, low reasoning, one run per arm, the same task/schema/oracle, and isolated non-editable installs.

| Arm | Result |
| --- | --- |
| installed `main` at `6df30e45` | mathematics passed, evidence failed; 7 `math.find` calls, 0 `math.run` calls, and all producer/verifier fields were absent |
| this branch | mathematics and evidence passed; direct discovery of the new operation, one producer run (`COMPUTED`), one independent verifier run (`VERIFIED`), record `artifact://sha256/dd0a28b19009e1bc4608c588ecc2797e8d4b7f0ffb19232ef7c645ea070530a4` |

Frozen input hashes:

- task: `9a7931639f7d30c29b14498c9cc47f1a413e21465fdc386ce0035aea7063d6e5`
- output schema: `5f3de7ef08dfc9620b99c3d8deabb33d558980529a004e460116ace5b135e9d4`
- independent oracle: `8ac04cd7a184a362cf183da3d8ed02122d136bd3ae5ebd888d16ea8fe0fcfb29`
- policy: `COMPUTE_VERIFY_NO_RETRIEVAL`, digest `sha256:0749b72e4263a380432feb9973b0fda9d5ed2b04d29417a1262bfc45134c71c6`
- baseline catalog: `sha256:98488060424b44551f7e0d920f6c59a2e76890315a7c34ef5076f1644fd6c23f`
- treatment catalog: `sha256:81e61b33f46e7ebce8dd68a0203389850609393565829588136bb42b7c9b1fa5`

The treatment verifies only the supplied scalar comparison, not Pang's general theorem. This is a bounded slice motivated by #939 and does not claim the general simple-algebraic-field surface discussed in #916.

## Validation

Planner: `make test-plan BASE=origin/main`.

Passed on the final tree:

- `make lint typecheck`
- `make docs-linkcheck`
- `make test-unit` (872 passed)
- `make test-domain` (324 passed)
- `make test-composition` (319 passed, 2 skipped)
- `make test-storage` (126 passed)
- `make test-mcp` (52 passed; rerun after replacing a now-recognized `arithmetic` unknown-domain sentinel)
- `make test-e2e` (7 passed, 1 Lean-runtime skip)
- focused producer/verifier, contract-bound, checker-installation, and portfolio tests

Two unrelated host-specific selected-lane cases remain for hosted CI to adjudicate:

- `make test-component`: 788 passed, 3 skipped; the existing macOS one-second DRAT timeout-marker race failed when the marker file was not created before process termination
- `make test-process`: 243 passed, 1 skipped; macOS Bash 3.2 lacks `mapfile`

Hosted CI is expected to run these lanes in the supported Linux environment.
