### PR TITLE
test(composition): switch non-verification tests from authorized to attached runtime

### DIFF
--- a/tests/composition/runtime/test_capability_discovery.py
+++ b/tests/composition/runtime/test_capability_discovery.py
@@ -142,9 +142,9 @@ def test_discovery_distinguishes_unknown_domain_from_lexical_absence(
 
 
 def test_discovery_recognizes_hidden_installed_domains_without_returning_them(
-    authorized_complete_runtime: JacobianRuntime,
+    attached_complete_runtime: JacobianRuntime,
 ) -> None:
-    discovered = authorized_complete_runtime.core.capabilities.discover(
+    discovered = attached_complete_runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(domain="artifact")
     )
 
@@ -156,9 +156,9 @@ def test_discovery_recognizes_hidden_installed_domains_without_returning_them(
 
 
 def test_storage_primitive_is_catalogued_but_not_discovered(
-    authorized_complete_runtime: JacobianRuntime,
+    attached_complete_runtime: JacobianRuntime,
 ) -> None:
-    capabilities = authorized_complete_runtime.core.capabilities
+    capabilities = attached_complete_runtime.core.capabilities
     catalog_ids = {
         descriptor.capability_id for descriptor in capabilities.catalog().capabilities
     }
@@ -172,12 +172,12 @@ def test_storage_primitive_is_catalogued_but_not_discovered(
 
 
 def test_bounded_search_producers_advertise_produced_artifact_types(
-    authorized_complete_runtime: JacobianRuntime,
+    attached_complete_runtime: JacobianRuntime,
 ) -> None:
     descriptors = {
         descriptor.capability_id: descriptor
         for descriptor in (
-            authorized_complete_runtime.core.capabilities.catalog().capabilities
+            attached_complete_runtime.core.capabilities.catalog().capabilities
         )
     }
     induced_tree = descriptors["graph.induced_tree.maximum.compute"]
@@ -187,12 +187,12 @@ def test_bounded_search_producers_advertise_produced_artifact_types(
 
 
 def test_materialize_to_width_produced_types_are_symmetric_and_discoverable(
-    authorized_complete_runtime: JacobianRuntime,
+    attached_complete_runtime: JacobianRuntime,
 ) -> None:
     descriptors = {
         descriptor.capability_id: descriptor
         for descriptor in (
-            authorized_complete_runtime.core.capabilities.catalog().capabilities
+            attached_complete_runtime.core.capabilities.catalog().capabilities
         )
     }
     assert descriptors["poset.finite.compute"].produced_artifact_types == ()
@@ -200,9 +200,9 @@ def test_materialize_to_width_produced_types_are_symmetric_and_discoverable(
 
 
 def test_discovery_distinguishes_strong_weak_and_absent_lexical_fit(
-    authorized_complete_runtime: JacobianRuntime,
+    attached_complete_runtime: JacobianRuntime,
 ) -> None:
-    runtime = authorized_complete_runtime
+    runtime = attached_complete_runtime
 
     strong = runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(

--- a/tests/composition/runtime/test_finite_coverage_capability.py
+++ b/tests/composition/runtime/test_finite_coverage_capability.py
@@ -146,10 +146,10 @@ def test_finite_coverage_rejects_nfc_collisions_in_scope(
 
 
 def test_finite_coverage_is_unavailable_without_authorized_checker(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         _request(["alpha"], [["alpha"]])
     )
 

--- a/tests/composition/runtime/test_finite_partition_capability.py
+++ b/tests/composition/runtime/test_finite_partition_capability.py
@@ -35,10 +35,10 @@ def _request(
 
 
 def test_finite_partition_explore_keeps_coverage_obligation_open(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         _request(CapabilityMode.EXPLORE)
     )
 
@@ -159,12 +159,12 @@ def test_verification_rejects_checker_obligation_outside_request(
 
 
 def test_finite_partition_duplicate_case_ids_cannot_report_complete(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
     request = _request(CapabilityMode.EXPLORE)
     request.input["cases"][1]["case_id"] = "even"
 
-    result = fresh_complete_runtime.core.capabilities.invoke(request)
+    result = attached_complete_runtime.core.capabilities.invoke(request)
 
     assert result.output["duplicate_case_ids"] == ["even"]
     assert result.completeness.status.value == "PARTIAL"

--- a/tests/composition/runtime/test_graph_capabilities.py
+++ b/tests/composition/runtime/test_graph_capabilities.py
@@ -14,9 +14,9 @@ from jacobian.contracts.results import ExecutionStatus
 
 
 def test_generic_graph_artifacts_use_the_authoritative_bounded_model(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    runtime = authorized_complete_runtime
+    runtime = attached_complete_runtime
     installation = runtime.portfolio.graph
     vertices = [f"v{index:03d}" for index in range(256)]
 
@@ -69,10 +69,10 @@ def test_generic_graph_artifacts_use_the_authoritative_bounded_model(
     ],
 )
 def test_generic_graph_artifacts_reject_noncanonical_simple_graphs(
-    authorized_complete_runtime,
+    attached_complete_runtime,
     payload: dict[str, object],
 ) -> None:
-    runtime = authorized_complete_runtime
+    runtime = attached_complete_runtime
     installation = runtime.portfolio.graph
 
     with pytest.raises(ArtifactValidationError, match="does not match its schema"):
@@ -84,9 +84,9 @@ def test_generic_graph_artifacts_reject_noncanonical_simple_graphs(
 
 
 def test_graph_consumers_reject_forged_malformed_payloads(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    runtime = authorized_complete_runtime
+    runtime = attached_complete_runtime
     installation = runtime.portfolio.graph
     forged = runtime.core.store.put(
         schema_uri=installation.graph_schema_uri,
@@ -111,10 +111,10 @@ def test_graph_consumers_reject_forged_malformed_payloads(
 
 
 def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    constructed = authorized_complete_runtime.core.capabilities.invoke(
+    constructed = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.construct.explicit",
             input={
@@ -131,19 +131,19 @@ def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
         "edges": [["a", "b"], ["b", "c"]],
     }
     graph_uri = constructed.output["graph_uri"]
-    stored = authorized_complete_runtime.core.store.get(graph_uri)
+    stored = attached_complete_runtime.core.store.get(graph_uri)
     assert stored.payload == constructed.output["graph"]
     assert (
         stored.manifest.schema_uri
-        == authorized_complete_runtime.portfolio.graph.graph_schema_uri
+        == attached_complete_runtime.portfolio.graph.graph_schema_uri
     )
     assert (
         stored.manifest.semantics_uri
-        == authorized_complete_runtime.portfolio.graph.semantics_uri
+        == attached_complete_runtime.portfolio.graph.semantics_uri
     )
     assert stored.manifest.object_digest == constructed.output["graph_object_digest"]
 
-    properties = authorized_complete_runtime.core.capabilities.invoke(
+    properties = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.compute.properties",
             input={"graph_uri": graph_uri, "properties": ["order", "tree"]},
@@ -164,11 +164,11 @@ def test_explicit_graph_construction_canonicalizes_and_feeds_graph_capabilities(
     ],
 )
 def test_explicit_graph_construction_fails_before_artifact_writes(
-    authorized_complete_runtime,
+    attached_complete_runtime,
     input_payload: dict[str, object],
 ) -> None:
 
-    result = authorized_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.construct.explicit",
             input=input_payload,
@@ -182,10 +182,10 @@ def test_explicit_graph_construction_fails_before_artifact_writes(
 
 
 def test_graph_atlas_search_is_bounded_complete_and_replayable(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = authorized_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -213,7 +213,7 @@ def test_graph_atlas_search_is_bounded_complete_and_replayable(
 
     for candidate in result.output["candidates"]:
         graph_uri = candidate["graph_uri"]
-        graph = authorized_complete_runtime.core.store.get(graph_uri)
+        graph = attached_complete_runtime.core.store.get(graph_uri)
         assert candidate["graph"] == graph.payload
         assert graph.payload["graph_schema_version"] == "1"
         assert len(graph.payload["vertices"]) == 5
@@ -221,17 +221,17 @@ def test_graph_atlas_search_is_bounded_complete_and_replayable(
         assert candidate["properties"]["triangle_count"] == 0
         assert candidate["properties"]["independence_number"] == 3
 
-    scope = authorized_complete_runtime.core.store.get(result.scope.artifact_uri)
+    scope = attached_complete_runtime.core.store.get(result.scope.artifact_uri)
     assert scope.payload["source"] == "networkx.graph_atlas_g"
     assert scope.payload["order"] == 5
     assert scope.payload["enumerated_count"] > 0
 
 
 def test_graph_atlas_search_reports_no_match_without_a_truth_claim(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = authorized_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -253,10 +253,10 @@ def test_graph_atlas_search_reports_no_match_without_a_truth_claim(
 
 
 def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    invalid_range = authorized_complete_runtime.core.capabilities.invoke(
+    invalid_range = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -272,7 +272,7 @@ def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
     assert invalid_range.diagnostics[0].code == "INVALID_CONSTRAINT_RANGE"
     assert invalid_range.diagnostics[0].path == "constraints/minimum_edges"
 
-    missing_graph = authorized_complete_runtime.core.capabilities.invoke(
+    missing_graph = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.compute.properties",
             input={
@@ -286,9 +286,9 @@ def test_graph_capabilities_return_actionable_parameter_and_artifact_errors(
 
 
 def test_graph_property_batch_materializes_exact_computed_artifact(
-    authorized_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    searched = authorized_complete_runtime.core.capabilities.invoke(
+    searched = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -300,7 +300,7 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
     )
     graph_uri = searched.output["candidates"][0]["graph_uri"]
 
-    result = authorized_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.compute.properties",
             mode=CapabilityMode.EXPLORE,
@@ -369,7 +369,7 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
     assert set(relationship.target_artifact_uris[1:]) == {
         binding["artifact_uri"] for binding in result.output["results"]
     }
-    property_artifact = authorized_complete_runtime.core.store.get(
+    property_artifact = attached_complete_runtime.core.store.get(
         result.output["property_artifact_uri"]
     )
     assert set(property_artifact.manifest.parents) == {
@@ -387,7 +387,7 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
         "triangle_count",
     ]
     for binding in result.output["results"]:
-        invariant_artifact = authorized_complete_runtime.core.store.get(
+        invariant_artifact = attached_complete_runtime.core.store.get(
             binding["artifact_uri"]
         )
         assert invariant_artifact.manifest.parents == (graph_uri,)
@@ -399,11 +399,11 @@ def test_graph_property_batch_materializes_exact_computed_artifact(
     [(24, "COMPUTED"), (25, "NOT_COMPUTED")],
 )
 def test_exact_independence_number_stops_at_the_order_boundary(
-    authorized_complete_runtime,
+    attached_complete_runtime,
     order: int,
     expected_status: str,
 ) -> None:
-    runtime = authorized_complete_runtime
+    runtime = attached_complete_runtime
     installation = runtime.portfolio.graph
     graph = runtime.core.artifacts.put(
         schema_uri=installation.graph_schema_uri,
@@ -437,9 +437,9 @@ def test_exact_independence_number_stops_at_the_order_boundary(
 
 
 def test_graph_counterexample_invariant_batch_reproduces_path_five(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    searched = fresh_complete_runtime.core.capabilities.invoke(
+    searched = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -451,7 +451,7 @@ def test_graph_counterexample_invariant_batch_reproduces_path_five(
     )
     graph_uri = searched.output["candidates"][0]["graph_uri"]
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.compute.properties",
             input={
@@ -490,9 +490,9 @@ def test_graph_counterexample_invariant_batch_reproduces_path_five(
 
 
 def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    searched = fresh_complete_runtime.core.capabilities.invoke(
+    searched = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.search.atlas",
             input={
@@ -503,7 +503,7 @@ def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
         )
     )
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.compute.properties",
             input={
@@ -564,11 +564,11 @@ def test_graph_invariant_batch_preserves_unsupported_and_not_applicable_results(
 
 
 def test_graph_invariant_registry_is_fixed_and_discoverable(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
     descriptor = next(
         item
-        for item in fresh_complete_runtime.core.capabilities.catalog().capabilities
+        for item in attached_complete_runtime.core.capabilities.catalog().capabilities
         if item.capability_id == "graph.compute.properties"
     )
 

--- a/tests/composition/runtime/test_graph_installation_contract.py
+++ b/tests/composition/runtime/test_graph_installation_contract.py
@@ -34,14 +34,14 @@ def test_graph_installation_preserves_public_identity_and_adapter_order(
 
 
 def test_graph_installation_omits_unauthorized_checker_ids(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    installation = fresh_complete_runtime.portfolio.graph
+    installation = attached_complete_runtime.portfolio.graph
     assert isinstance(installation, GraphInstallation)
     assert installation.degree_sequence_checker_id is None
     assert installation.neighborhood_checker_id is None
 
-    descriptors = fresh_complete_runtime.core.capabilities.catalog().capabilities
+    descriptors = attached_complete_runtime.core.capabilities.catalog().capabilities
     for capability_id in (
         "graph.realize.degree_sequence",
         "graph.compute.neighborhood_independence",

--- a/tests/composition/runtime/test_poset_discovery.py
+++ b/tests/composition/runtime/test_poset_discovery.py
@@ -10,13 +10,13 @@ from jacobian.contracts.results import ExecutionStatus
 
 
 def test_poset_width_intents_discover_the_domain_owned_operation(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
     for query in (
         "maximum antichain and minimum chain decomposition of a finite poset",
         "compute the width of a finite partially ordered set",
     ):
-        discovered = fresh_complete_runtime.core.capabilities.discover(
+        discovered = attached_complete_runtime.core.capabilities.discover(
             CapabilityDiscoveryRequest(query=query, limit=5)
         )
 
@@ -25,22 +25,22 @@ def test_poset_width_intents_discover_the_domain_owned_operation(
 
 
 def test_artifact_put_is_hidden_from_discovery_but_remains_dispatchable(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
     catalog_ids = {
         descriptor.capability_id
-        for descriptor in fresh_complete_runtime.core.capabilities.catalog().capabilities
+        for descriptor in attached_complete_runtime.core.capabilities.catalog().capabilities
     }
     assert "artifact.put" in catalog_ids
 
-    discovered = fresh_complete_runtime.core.capabilities.discover(
+    discovered = attached_complete_runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(query="store artifact", limit=20)
     )
     assert not any(
         match.capability_id == "artifact.put" for match in discovered.matches
     )
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="artifact.put",
             input={

--- a/tests/composition/runtime/test_topology_discovery.py
+++ b/tests/composition/runtime/test_topology_discovery.py
@@ -6,9 +6,9 @@ from jacobian.contracts.capabilities import CapabilityDiscoveryRequest
 
 
 def test_homology_intent_discovers_the_domain_owned_operation(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
-    discovered = fresh_complete_runtime.core.capabilities.discover(
+    discovered = attached_complete_runtime.core.capabilities.discover(
         CapabilityDiscoveryRequest(
             query="homology of a finite simplicial complex over F_2",
             limit=5,

--- a/tests/composition/runtime/test_universal_algebra_capabilities.py
+++ b/tests/composition/runtime/test_universal_algebra_capabilities.py
@@ -194,22 +194,22 @@ def test_evaluate_laws_returns_exact_truth_and_counterexample(
 
 
 def test_complete_request_validation_precedes_artifact_writes(
-    fresh_complete_runtime,
+    attached_complete_runtime,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     problem = _left_projection_problem()
     problem["structure"]["table"] = [[0, 0]]
     artifact_put_calls = 0
-    original_put = fresh_complete_runtime.core.artifacts.put
+    original_put = attached_complete_runtime.core.artifacts.put
 
     def recording_put(*args: Any, **kwargs: Any) -> Any:
         nonlocal artifact_put_calls
         artifact_put_calls += 1
         return original_put(*args, **kwargs)
 
-    monkeypatch.setattr(fresh_complete_runtime.core.artifacts, "put", recording_put)
+    monkeypatch.setattr(attached_complete_runtime.core.artifacts, "put", recording_put)
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="universal_algebra.evaluate_laws",
             input={"problem": problem},
@@ -271,11 +271,11 @@ def test_countermodel_search_composes_with_independent_law_replay(
 
 
 def test_countermodel_search_reports_fixed_order_no_witness_without_conclusion(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
     laws = _left_projection_problem()["laws"]
 
-    search = fresh_complete_runtime.core.capabilities.invoke(
+    search = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="universal_algebra.search.countermodel",
             input={
@@ -294,23 +294,23 @@ def test_countermodel_search_reports_fixed_order_no_witness_without_conclusion(
 
 
 def test_countermodel_request_validation_precedes_artifact_writes(
-    fresh_complete_runtime,
+    attached_complete_runtime,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     laws = _left_projection_problem()["laws"]
     duplicate_target = dict(laws[1])
     duplicate_target["law_id"] = laws[0]["law_id"]
     artifact_put_calls = 0
-    original_put = fresh_complete_runtime.core.artifacts.put
+    original_put = attached_complete_runtime.core.artifacts.put
 
     def recording_put(*args: Any, **kwargs: Any) -> Any:
         nonlocal artifact_put_calls
         artifact_put_calls += 1
         return original_put(*args, **kwargs)
 
-    monkeypatch.setattr(fresh_complete_runtime.core.artifacts, "put", recording_put)
+    monkeypatch.setattr(attached_complete_runtime.core.artifacts, "put", recording_put)
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="universal_algebra.search.countermodel",
             input={
@@ -327,10 +327,10 @@ def test_countermodel_request_validation_precedes_artifact_writes(
 
 
 def test_finite_magma_table_enumeration_is_exact_and_canonical(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="finite_magma.table.enumerate",
             input={"order": 2},
@@ -344,13 +344,13 @@ def test_finite_magma_table_enumeration_is_exact_and_canonical(
     assert result.assurance.level is CapabilityAssuranceLevel.COMPUTED
     assert result.completeness.status is CapabilityCompletenessStatus.COMPLETE
     table_payloads = [
-        fresh_complete_runtime.core.store.get(uri).payload
+        attached_complete_runtime.core.store.get(uri).payload
         for uri in result.output["table_uris"]
     ]
     assert table_payloads[0]["table"] == [[0, 0], [0, 0]]
     assert table_payloads[-1]["table"] == [[1, 1], [1, 1]]
     assert len({str(payload["table"]) for payload in table_payloads}) == 16
-    enumeration = fresh_complete_runtime.core.store.get(
+    enumeration = attached_complete_runtime.core.store.get(
         result.output["enumeration_uri"]
     )
     assert enumeration.payload["table_uris"] == result.output["table_uris"]
@@ -358,10 +358,10 @@ def test_finite_magma_table_enumeration_is_exact_and_canonical(
 
 
 def test_finite_magma_table_enumeration_handles_order_one(
-    fresh_complete_runtime,
+    attached_complete_runtime,
 ) -> None:
 
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="finite_magma.table.enumerate",
             input={"order": 1},
@@ -369,24 +369,24 @@ def test_finite_magma_table_enumeration_handles_order_one(
     )
 
     assert result.output["enumerated_count"] == 1
-    table = fresh_complete_runtime.core.store.get(result.output["table_uris"][0])
+    table = attached_complete_runtime.core.store.get(result.output["table_uris"][0])
     assert table.payload["table"] == [[0]]
 
 
 def test_finite_magma_table_enumeration_rejects_unsupported_order_before_writes(
-    fresh_complete_runtime,
+    attached_complete_runtime,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     artifact_put_calls = 0
-    original_put = fresh_complete_runtime.core.artifacts.put
+    original_put = attached_complete_runtime.core.artifacts.put
 
     def recording_put(*args: Any, **kwargs: Any) -> Any:
         nonlocal artifact_put_calls
         artifact_put_calls += 1
         return original_put(*args, **kwargs)
 
-    monkeypatch.setattr(fresh_complete_runtime.core.artifacts, "put", recording_put)
-    result = fresh_complete_runtime.core.capabilities.invoke(
+    monkeypatch.setattr(attached_complete_runtime.core.artifacts, "put", recording_put)
+    result = attached_complete_runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="finite_magma.table.enumerate",
             input={"order": 3},


### PR DESCRIPTION
## Summary

Reduces excessive `authorized_complete_runtime` construction in the composition test lane by switching tests that exercise compute/explore/discovery modes (but never invoke verification) to the lighter `attached_complete_runtime` fixture. Also switches `fresh_complete_runtime` to `attached_complete_runtime` where a clean portfolio state suffices but full rebuild is unnecessary.

## Changes

| File | Before | After | Count |
|------|--------|-------|-------|
| `test_graph_capabilities.py` | `authorized` / `fresh` | `attached` | 41 |
| `test_capability_discovery.py` | `authorized` | `attached` | 5 |
| `test_poset_discovery.py` | `fresh` | `attached` | 6 |
| `test_graph_installation_contract.py` | `fresh` | `attached` | 1 |
| `test_finite_partition_capability.py` | `fresh` | `attached` | 2 |
| `test_finite_coverage_capability.py` | `fresh` | `attached` | 1 |
| `test_topology_discovery.py` | `fresh` | `attached` | 1 |
| `test_universal_algebra_capabilities.py` | `fresh` | `attached` | 4 |

**Total: 61 fixture replacements**

## Rationale

- `authorized_complete_runtime` copies a ~6 MiB template, creates ~1,050 files, then rebuilds the entire portfolio and checker setup.
- `attached_complete_runtime` copies the same template but skips checker hydration, which is unnecessary for tests that only catalog, discover, compute, or explore.
- `fresh_complete_runtime` builds the portfolio from scratch for each test; `attached_complete_runtime` reuses a session-scoped template.

## Verification

- `python tools/check_test_architecture.py` — passes
- All 8 affected test files pass individually:
  - `test_graph_capabilities.py` — 20 passed
  - `test_capability_discovery.py` — 12 passed
  - `test_poset_discovery.py` — 2 passed
  - `test_graph_installation_contract.py` — 2 passed
  - `test_finite_partition_capability.py` — 7 passed
  - `test_finite_coverage_capability.py` — 7 passed
  - `test_topology_discovery.py` — 1 passed
  - `test_universal_algebra_capabilities.py` — 11 passed

## Intentionally Unchanged

Tests that use `CapabilityMode.VERIFY`, `portfolio.references[...]`, or `portfolio.*_checker.checker_id` remain on `authorized_complete_runtime` because they genuinely need checker authority or reference installation.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/morluto/jacobian/pull/994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->