### PR TITLE
Extend exact determinant bound to order 64

### DIFF
--- a/docs/reference/capabilities/matrix/matrix-rational-determinant.md
+++ b/docs/reference/capabilities/matrix/matrix-rational-determinant.md
@@ -7,17 +7,19 @@ separate trust boundaries.
 
 ## Input and result contracts
 
-The producer accepts one [`RationalMatrix`](../index.md#shared-matrix-values)
-from `jacobian.contracts.matrices`: a nonempty square matrix with at most 32
-rows and columns. Every entry is a canonical reduced rational:
+The producer accepts one determinant-owned exact rational matrix: a nonempty
+square matrix with at most 64 rows and columns. This operation-specific bound
+does not widen the shared 32-row and 32-column [`RationalMatrix`](../index.md#shared-matrix-values)
+used by rank, RREF, multiplication, and other matrix operations. Every entry is
+a canonical reduced rational:
 
 ```json
 {"num": "-3", "den": "7"}
 ```
 
-The shared `RationalMatrix` model permits up to 32,768 canonical digits per
-scalar component; the determinant request model tightens this to 256 decimal
-digits via its own `require_matrix_scalar_digits` validator.
+The determinant input value has the same canonical `QQ` matrix semantics. The
+determinant request model limits every scalar component to 256 decimal digits
+via its own `require_matrix_scalar_digits` validator.
 
 `matrix.determinant.compute` uses SymPy's exact matrix determinant API with the
 fraction-free Bareiss method. It returns the bounded canonical determinant

--- a/src/jacobian/contracts/matrix_operations.py
+++ b/src/jacobian/contracts/matrix_operations.py
@@ -19,6 +19,7 @@ from jacobian.contracts.matrices import (
 from jacobian.contracts.results import ContractModel
 
 MAX_INPUT_SCALAR_DIGITS = 256
+MAX_DETERMINANT_MATRIX_DIMENSION = 64
 
 
 def _check_integer_digits(
@@ -74,10 +75,32 @@ class SquareRationalMatrixRequest(ContractModel):
         return self
 
 
-class MatrixDeterminantRequest(ContractModel):
-    """One bounded square matrix whose exact determinant is requested."""
+class DeterminantRationalMatrix(ContractModel):
+    """One determinant-owned exact rational matrix bounded independently."""
 
-    matrix: RationalMatrix
+    matrix_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ"] = "QQ"
+    entries: tuple[tuple[CanonicalRational, ...], ...] = Field(
+        min_length=1,
+        max_length=MAX_DETERMINANT_MATRIX_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_rectangular_nonempty_rows(self) -> Self:
+        column_count = len(self.entries[0])
+        if not 1 <= column_count <= MAX_DETERMINANT_MATRIX_DIMENSION:
+            raise ValueError(
+                "determinant matrix rows must contain between 1 and 64 entries"
+            )
+        if any(len(row) != column_count for row in self.entries):
+            raise ValueError("determinant matrix rows must all have the same length")
+        return self
+
+
+class MatrixDeterminantRequest(ContractModel):
+    """One square matrix of order at most 64 whose determinant is requested."""
+
+    matrix: DeterminantRationalMatrix
 
     @model_validator(mode="after")
     def require_square(self) -> Self:

--- a/src/jacobian/domains/matrix_lattice/capabilities.py
+++ b/src/jacobian/domains/matrix_lattice/capabilities.py
@@ -115,7 +115,10 @@ MATRIX_CAPABILITIES = (
     matrix_operation(
         "matrix.determinant.compute",
         "Compute an exact rational matrix determinant",
-        "Compute the determinant of one square matrix over QQ with SymPy's exact Bareiss algorithm.",
+        (
+            "Compute the determinant of one square matrix over QQ through order 64 "
+            "with SymPy's exact Bareiss algorithm."
+        ),
         MatrixDeterminantRequest,
         MatrixDeterminantResult,
         compute_determinant,
@@ -143,7 +146,7 @@ MATRIX_CAPABILITIES = (
                 },
             ),
         ),
-        version="2",
+        version="3",
     ),
     matrix_operation(
         "matrix.rank.compute",

--- a/src/jacobian/domains/matrix_lattice/conversions.py
+++ b/src/jacobian/domains/matrix_lattice/conversions.py
@@ -7,6 +7,7 @@ from typing import Any
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.matrices import IntegerMatrix, RationalMatrix
+from jacobian.contracts.matrix_operations import DeterminantRationalMatrix
 
 __all__ = [
     "integer_matrix_from_sympy",
@@ -30,7 +31,9 @@ def rational_from_sympy(value: Any) -> CanonicalRational:
     )
 
 
-def rational_matrix_to_sympy(matrix: RationalMatrix) -> Any:
+def rational_matrix_to_sympy(
+    matrix: RationalMatrix | DeterminantRationalMatrix,
+) -> Any:
     import sympy
 
     return sympy.Matrix(

--- a/src/jacobian/domains/matrix_lattice/kernels.py
+++ b/src/jacobian/domains/matrix_lattice/kernels.py
@@ -22,11 +22,22 @@ __all__ = [
 ]
 
 
-def _exact_matrix(value: MatrixBase) -> MatrixBase:
+_DEFAULT_MAX_MATRIX_DIMENSION = 32
+_DETERMINANT_MAX_MATRIX_DIMENSION = 64
+
+
+def _exact_matrix(
+    value: MatrixBase,
+    *,
+    maximum_dimension: int = _DEFAULT_MAX_MATRIX_DIMENSION,
+) -> MatrixBase:
     if not isinstance(value, MatrixBase):
         raise TypeError("matrix must be a SymPy MatrixBase")
-    if not 1 <= value.rows <= 32 or not 1 <= value.cols <= 32:
-        raise ValueError("matrix dimensions must be between 1 and 32")
+    if (
+        not 1 <= value.rows <= maximum_dimension
+        or not 1 <= value.cols <= maximum_dimension
+    ):
+        raise ValueError(f"matrix dimensions must be between 1 and {maximum_dimension}")
     if any(not entry.is_number or entry.is_finite is not True for entry in value):
         raise ValueError("matrix entries must be finite exact numbers")
     if any(entry.has(sympy.Float) for entry in value):
@@ -67,7 +78,10 @@ def characteristic_polynomial(matrix: MatrixBase, variable: str) -> Any:
 
 
 def determinant(matrix: MatrixBase) -> Any:
-    source = _exact_matrix(matrix)
+    source = _exact_matrix(
+        matrix,
+        maximum_dimension=_DETERMINANT_MAX_MATRIX_DIMENSION,
+    )
     if source.rows != source.cols:
         raise ValueError("determinant requires a square matrix")
     return source.det(method="bareiss")

--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -27,6 +27,7 @@ _MAX_RESIDUE_EXPONENT = 32
 _MAX_RESIDUE_ASSIGNMENTS = 4_096
 _MAX_RESIDUE_MODULUS = 1_000_000
 _MAX_MATRIX_DIMENSION = 32
+_MAX_DETERMINANT_MATRIX_DIMENSION = 64
 _MAX_MATRIX_INPUT_DIGITS = 256
 _MAX_MATRIX_OUTPUT_DIGITS = 32_768
 
@@ -213,15 +214,32 @@ def _integer_matrix(value: object) -> fmpz_mat:
     return fmpz_mat([[_integer(item) for item in row] for row in entries])
 
 
-def _bounded_rational_matrix(value: object, *, maximum_digits: int) -> fmpq_mat:
+def _bounded_q(value: object, *, maximum_digits: int) -> fmpq:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational is malformed")
+    for component in (value["num"], value["den"]):
+        if (
+            not isinstance(component, str)
+            or len(component.lstrip("-")) > maximum_digits
+        ):
+            raise ValueError("rational scalar exceeds the checker bound")
+    return _q(value)
+
+
+def _bounded_rational_matrix(
+    value: object,
+    *,
+    maximum_digits: int,
+    maximum_dimension: int = _MAX_MATRIX_DIMENSION,
+) -> fmpq_mat:
     if not isinstance(value, dict):
         raise ValueError("rational matrix is malformed")
     entries = value.get("entries")
     if (
         not isinstance(entries, list)
-        or not 1 <= len(entries) <= _MAX_MATRIX_DIMENSION
+        or not 1 <= len(entries) <= maximum_dimension
         or not isinstance(entries[0], list)
-        or not 1 <= len(entries[0]) <= _MAX_MATRIX_DIMENSION
+        or not 1 <= len(entries[0]) <= maximum_dimension
     ):
         raise ValueError("rational matrix exceeds the checker dimension bound")
     for row in entries:
@@ -950,10 +968,19 @@ def _matrix_determinant(source: dict[str, Any], result: dict[str, Any]) -> bool:
         "FRACTION_FREE_BAREISS"
     ):
         return False
-    matrix = _matrix_source(source)
+    if set(source) != {"matrix"}:
+        return False
+    matrix = _bounded_rational_matrix(
+        source["matrix"],
+        maximum_digits=_MAX_MATRIX_INPUT_DIGITS,
+        maximum_dimension=_MAX_DETERMINANT_MATRIX_DIMENSION,
+    )
     if matrix.nrows() != matrix.ncols():
         return False
-    return bool(_q(result["determinant"]) == matrix.det())
+    declared = _bounded_q(
+        result["determinant"], maximum_digits=_MAX_MATRIX_OUTPUT_DIGITS
+    )
+    return bool(declared == matrix.det())
 
 
 def check_matrix_determinant(request: dict[str, Any]) -> dict[str, Any]:

--- a/tests/component/checkers/test_exact_domain_checker_attacks.py
+++ b/tests/component/checkers/test_exact_domain_checker_attacks.py
@@ -32,7 +32,7 @@ def test_exact_domain_checker_accepts_independent_replay(
     assert checker(checker_request)["accepted"] is True
 
 
-def test_matrix_determinant_checker_accepts_supported_large_canonical_result() -> None:
+def test_matrix_determinant_checker_accepts_order_64_large_canonical_result() -> None:
     diagonal_entry = "1" + "0" * 255
     zero = {"num": "0", "den": "1"}
     source = {
@@ -42,9 +42,9 @@ def test_matrix_determinant_checker_accepts_supported_large_canonical_result() -
             "entries": [
                 [
                     ({"num": diagonal_entry, "den": "1"} if row == column else zero)
-                    for column in range(32)
+                    for column in range(64)
                 ]
-                for row in range(32)
+                for row in range(64)
             ],
         }
     }
@@ -53,12 +53,41 @@ def test_matrix_determinant_checker_accepts_supported_large_canonical_result() -
         "matrix.determinant.flint-replay",
         source,
         {
-            "determinant": {"num": "1" + "0" * (255 * 32), "den": "1"},
+            "determinant": {"num": "1" + "0" * (255 * 64), "den": "1"},
             "method": "FRACTION_FREE_BAREISS",
         },
     )
 
     assert check_matrix_determinant(request)["accepted"] is True
+
+
+def test_matrix_determinant_checker_rejects_order_above_64() -> None:
+    zero = {"num": "0", "den": "1"}
+    one = {"num": "1", "den": "1"}
+    source = {
+        "matrix": {
+            "matrix_schema_version": "1",
+            "domain": "QQ",
+            "entries": [
+                [one if row == column else zero for column in range(65)]
+                for row in range(65)
+            ],
+        }
+    }
+    request = _request(
+        "matrix.determinant.compute",
+        "matrix.determinant.flint-replay",
+        source,
+        {
+            "determinant": one,
+            "method": "FRACTION_FREE_BAREISS",
+        },
+    )
+
+    decision = check_matrix_determinant(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
 
 
 @pytest.mark.parametrize(("checker", "checker_request"), _CASES)

--- a/tests/component/providers/matrix/test_matrix_capabilities.py
+++ b/tests/component/providers/matrix/test_matrix_capabilities.py
@@ -43,6 +43,23 @@ def _matrix(rows: list[list[int | Fraction]]) -> dict[str, Any]:
     }
 
 
+def _truncated_legendre_matrix(prime: int) -> dict[str, Any]:
+    order = (prime - 5) // 2
+
+    def entry(row: int, column: int) -> int:
+        residue = (row - column) % prime
+        character = (
+            0
+            if residue == 0
+            else (1 if pow(residue, (prime - 1) // 2, prime) == 1 else -1)
+        )
+        return 1 + character
+
+    return _matrix(
+        [[entry(row, column) for column in range(order)] for row in range(order)]
+    )
+
+
 def _reference_determinant(rows: list[list[Fraction]]) -> Fraction:
     total = Fraction(0)
     for permutation in permutations(range(len(rows))):
@@ -181,6 +198,55 @@ def test_matrix_determinant_verify_independently_recomputes_exact_value(
     assert verified.output["conclusion"] == "TRUE"
     assert verified.output["verification_record_uri"].startswith("artifact://sha256/")
     assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_matrix_determinant_computes_and_verifies_order_33_sun_conjecture_case(
+    matrix_checker_services: _MatrixRuntime,
+) -> None:
+    """Reproduce Yang--Yang--Zhang, arXiv:2606.22548, Theorem 1.1 at p=71."""
+
+    matrix = _truncated_legendre_matrix(71)
+    computed = matrix_checker_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.compute",
+            input={"matrix": matrix},
+        )
+    )
+    verified = matrix_checker_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.verify",
+            mode=CapabilityMode.VERIFY,
+            input={
+                "input": {"matrix": matrix},
+                "candidate": computed.output["result"],
+            },
+        )
+    )
+
+    assert computed.output["result"]["determinant"] == _rational(529)
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+
+
+def test_matrix_determinant_rejects_order_above_64(
+    matrix_services: _MatrixRuntime,
+) -> None:
+    matrix = _matrix(
+        [[1 if row == column else 0 for column in range(65)] for row in range(65)]
+    )
+
+    result = matrix_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.determinant.compute",
+            input={"matrix": matrix},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
 
 
 def test_matrix_determinant_verify_rejects_wrong_bound_value(


### PR DESCRIPTION
## What changed

- give `matrix.determinant.compute` a determinant-owned exact `QQ` matrix input capped at order 64 while leaving the shared matrix contract at 32
- apply the same order-64 and 256-digit source bounds in the independent Python-FLINT replay, plus the existing 32,768-digit candidate bound
- bump the experimental determinant producer to version 3 and document the operation-specific scope
- add the p=71 truncated Legendre-symbol determinant (`33 x 33`, determinant `529`) as a compute-and-verify regression, with order-65 fail-closed producer/checker cases

## Why

Yang, Yang, and Zhang's arXiv:2606.22548v1, Theorem 1.1 gives a proof-critical exact order-33 determinant. The existing producer and checker use exact polynomial-time backends, but the producer inherited the shared order-32 matrix boundary used by heavier rank, RREF, and multiplication operations. A fresh control agent found the correct producer/verifier and received `INVALID_REQUEST` at `matrix/entries` with `maxItems=32`.

Local timings were about 0.055 s (SymPy Bareiss) and 0.0016 s (Python-FLINT) for the order-33 source. A seeded order-64 small-integer matrix took about 0.505 s and 0.0014 s, with exact agreement.

## Evaluation caveat

This is an experimental capability-scope fix, not evidence of autonomous-agent improvement. In a frozen `gpt-5.4-mini`, low-reasoning, MCP-only pilot, treatment made producer version 3 discoverable but completed 0/3 attempts: one model timeout before invocation, one ragged matrix request, and one 81-row request. Jacobian failed closed each time and produced no false conclusion or verification record. The direct runtime regression did compute `529` and the independently authorized Python-FLINT replay returned `VERIFIED`.

## Validation

- focused matrix producer/checker tests: `127 passed`
- `make test-plan BASE=origin/main`
- `make check-changed BASE=origin/main`: 8/10 commands passed on the rebased
  tree. The selected component lane had two unrelated one-second SAT/SMT
  timeout failures (the SMT node passed serially; the DRAT marker still missed
  its startup window), and the process lane's source-bootstrap test requires
  Bash `mapfile` while this macOS host only provides Bash 3.2. The immediately
  preceding selected run passed the complete component lane; the Bash failure
  reproduced unchanged.

The broader selected gate was rerun after rebasing onto the then-current upstream `main`.
