### PR TITLE
fix(release): synchronize npm lockfile and guard release surface drift

### DIFF
--- a/.github/scripts/check-release-consistency
+++ b/.github/scripts/check-release-consistency
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Assert all version-bearing release surfaces agree on one package version.
+
+This is the release-consistency check requested in issue #1014. Release Please
+bumps manifests (`pyproject.toml`, `npm/package.json`, `server.json`,
+`.release-please-manifest.json`) but repository-specific lockfile synchronization
+happens separately. Without this check, a release PR can be mergeable while
+`npm/package-lock.json` or `uv.lock` still reports the previous version.
+
+Surfaces verified (all must equal one expected version):
+
+- `.release-please-manifest.json` (``["."]``)
+- `pyproject.toml` (``project.version``)
+- `uv.lock` (the editable ``jacobian`` package row)
+- `npm/package.json` (``version``)
+- `npm/package-lock.json` (top-level ``version`` and ``packages[""].version``)
+- `server.json` (``version``)
+
+The expected version is derived from `npm/package.json` (the surface Release
+Please bumps first via ``extra-files``) and every other surface must agree.
+
+Exit code is non-zero on any drift. Designed to be cheap enough for ordinary CI
+and release PRs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+SURFACE_NAMES = (
+    ".release-please-manifest.json",
+    "pyproject.toml",
+    "uv.lock",
+    "npm/package.json",
+    "npm/package-lock.json",
+    "server.json",
+)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _npm_package_version(root: Path) -> str | None:
+    text = _read_text(root / "npm" / "package.json")
+    if not text:
+        return None
+    data: dict[str, Any] = json.loads(text)
+    version = data.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _release_please_manifest_version(root: Path) -> str | None:
+    text = _read_text(root / ".release-please-manifest.json")
+    if not text:
+        return None
+    data: dict[str, Any] = json.loads(text)
+    version = data.get(".")
+    return version if isinstance(version, str) else None
+
+
+def _pyproject_version(root: Path) -> str | None:
+    text = _read_text(root / "pyproject.toml")
+    if not text:
+        return None
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _uv_lock_version(root: Path) -> str | None:
+    text = _read_text(root / "uv.lock")
+    if not text:
+        return None
+    # The editable jacobian row is a `[[package]]` block whose `name = "jacobian"`.
+    for block in re.finditer(
+        r'\[\[package\]\]\n(?:(?!\[\[package\]\]).)*?name\s*=\s*"jacobian"\n(?:(?!\[\[package\]\]).)*?version\s*=\s*"([^"]+)"',
+        text,
+        re.DOTALL,
+    ):
+        return block.group(1)
+    # Fall back to the first version field following the jacobian name match.
+    name_match = re.search(r'name\s*=\s*"jacobian"', text)
+    if not name_match:
+        return None
+    version_match = re.search(r'version\s*=\s*"([^"]+)"', text[name_match.end():])
+    return version_match.group(1) if version_match else None
+
+
+def _npm_lock_top_version(root: Path) -> str | None:
+    text = _read_text(root / "npm" / "package-lock.json")
+    if not text:
+        return None
+    data: dict[str, Any] = json.loads(text)
+    version = data.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _npm_lock_root_package_version(root: Path) -> str | None:
+    text = _read_text(root / "npm" / "package-lock.json")
+    if not text:
+        return None
+    data: dict[str, Any] = json.loads(text)
+    packages = data.get("packages", {})
+    if not isinstance(packages, dict):
+        return None
+    root_entry = packages.get("", {})
+    if not isinstance(root_entry, dict):
+        return None
+    version = root_entry.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _server_json_version(root: Path) -> str | None:
+    text = _read_text(root / "server.json")
+    if not text:
+        return None
+    data: dict[str, Any] = json.loads(text)
+    version = data.get("version")
+    return version if isinstance(version, str) else None
+
+
+def collect_versions(root: Path) -> dict[str, str | None]:
+    return {
+        "npm/package.json": _npm_package_version(root),
+        ".release-please-manifest.json": _release_please_manifest_version(root),
+        "pyproject.toml": _pyproject_version(root),
+        "uv.lock": _uv_lock_version(root),
+        "npm/package-lock.json (top-level)": _npm_lock_top_version(root),
+        'npm/package-lock.json (packages[""])': _npm_lock_root_package_version(root),
+        "server.json": _server_json_version(root),
+    }
+
+
+def _format_table(versions: dict[str, str | None], expected: str | None) -> str:
+    width = max(len(name) for name in versions)
+    lines = [f"  {name:<{width}}  {value!s:<20}  {'OK' if value == expected else 'DRIFT'}"
+             for name, value in versions.items()]
+    return "\n".join(lines)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (default: autodetect from script location).",
+    )
+    parser.add_argument(
+        "--expected",
+        help="Expected version. If omitted, derived from npm/package.json.",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root.resolve()
+    versions = collect_versions(root)
+
+    expected: str | None = args.expected or versions["npm/package.json"]
+    if expected is None:
+        print("error: could not derive expected version from npm/package.json", file=sys.stderr)
+        return 2
+
+    # Missing surfaces (None) are reported separately from drift: a surface
+    # that does not exist cannot disagree, and the expected-version source
+    # (npm/package.json) is always required.
+    missing = [name for name, value in versions.items() if value is None]
+    drift = {
+        name: value
+        for name, value in versions.items()
+        if value is not None and value != expected
+    }
+
+    print(f"Expected release version: {expected}")
+    print(_format_table(versions, expected))
+
+    if drift:
+        print("\nRelease surface drift detected:", file=sys.stderr)
+        for name, value in drift.items():
+            print(f"  {name}: {value!s} (expected {expected})", file=sys.stderr)
+        return 1
+
+    if missing:
+        print("\nMissing release surfaces (not drift, but noted):", file=sys.stderr)
+        for name in missing:
+            print(f"  {name}", file=sys.stderr)
+
+    print("\nAll present release surfaces agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-release-consistency
+++ b/.github/scripts/check-release-consistency
@@ -93,7 +93,7 @@ def _uv_lock_version(root: Path) -> str | None:
     name_match = re.search(r'name\s*=\s*"jacobian"', text)
     if not name_match:
         return None
-    version_match = re.search(r'version\s*=\s*"([^"]+)"', text[name_match.end():])
+    version_match = re.search(r'version\s*=\s*"([^"]+)"', text[name_match.end() :])
     return version_match.group(1) if version_match else None
 
 
@@ -144,8 +144,10 @@ def collect_versions(root: Path) -> dict[str, str | None]:
 
 def _format_table(versions: dict[str, str | None], expected: str | None) -> str:
     width = max(len(name) for name in versions)
-    lines = [f"  {name:<{width}}  {value!s:<20}  {'OK' if value == expected else 'DRIFT'}"
-             for name, value in versions.items()]
+    lines = [
+        f"  {name:<{width}}  {value!s:<20}  {'OK' if value == expected else 'DRIFT'}"
+        for name, value in versions.items()
+    ]
     return "\n".join(lines)
 
 
@@ -168,7 +170,10 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     expected: str | None = args.expected or versions["npm/package.json"]
     if expected is None:
-        print("error: could not derive expected version from npm/package.json", file=sys.stderr)
+        print(
+            "error: could not derive expected version from npm/package.json",
+            file=sys.stderr,
+        )
         return 2
 
     # Missing surfaces (None) are reported separately from drift: a surface

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,9 @@ jobs:
           node-version: ${{ needs.plan.outputs.node-version-npm }}
           package-manager-cache: false
       - if: needs.plan.outputs.run-npm == 'true'
+        name: Assert release surfaces agree
+        run: python .github/scripts/check-release-consistency
+      - if: needs.plan.outputs.run-npm == 'true'
         run: npm test
         working-directory: npm
       - if: needs.plan.outputs.run-npm == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,27 +61,52 @@ jobs:
         with:
           version: "0.11.28"
           enable-cache: false
+      - id: node
+        name: Load npm Node version
+        if: steps.validated-head.outputs.current == 'true' && steps.release.outputs.prs_created == 'true'
+        run: echo "node-version=$(.github/scripts/manage-test-timings node-version npm)" >> "$GITHUB_OUTPUT"
       - if: steps.validated-head.outputs.current == 'true' && steps.release.outputs.prs_created == 'true'
-        name: Synchronize release lockfile
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ steps.node.outputs.node-version }}
+          package-manager-cache: false
+      - if: steps.validated-head.outputs.current == 'true' && steps.release.outputs.prs_created == 'true'
+        name: Synchronize release lockfiles
         env:
           RELEASE_BRANCH: release-please--branches--main--components--jacobian
         run: |
+          set -euo pipefail
+
+          # Regenerate uv.lock against the bumped pyproject.toml.
           uv lock
-          unexpected_files="$(git diff --name-only | grep -v '^uv\.lock$' || true)"
+
+          # Regenerate npm/package-lock.json against the bumped npm/package.json.
+          # --package-lock-only rewrites the lockfile without touching node_modules;
+          # --ignore-scripts and --no-fund/--no-audit keep it offline and quiet.
+          npm install --package-lock-only --ignore-scripts --no-audit --no-fund \
+            --prefix npm
+
+          unexpected_files="$(git diff --name-only | grep -vE '^(uv\.lock|npm/package-lock\.json)$' || true)"
           if [[ -n "$unexpected_files" ]]; then
-            echo "uv lock changed unexpected files:" >&2
+            echo "lockfile sync changed unexpected files:" >&2
             echo "$unexpected_files" >&2
             git diff >&2
             exit 1
           fi
-          if git diff --quiet -- uv.lock; then
-            echo "uv.lock is already synchronized"
+
+          # Fail rather than committing a drifted release tree. This is the
+          # release-side guard for issue #1014: the CI-side guard lives in
+          # .github/scripts/check-release-consistency.
+          python .github/scripts/check-release-consistency
+
+          if git diff --quiet -- uv.lock npm/package-lock.json; then
+            echo "uv.lock and npm/package-lock.json are already synchronized"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add uv.lock
-          git commit -m "chore(release): synchronize uv lock"
+          git add uv.lock npm/package-lock.json
+          git commit -m "chore(release): synchronize uv and npm lockfiles"
           git push origin "HEAD:$RELEASE_BRANCH"
       - name: Dispatch release candidate CI
         if: steps.validated-head.outputs.current == 'true' && steps.release.outputs.prs_created == 'true'

--- a/tests/boundary/process/tooling/test_release_consistency.py
+++ b/tests/boundary/process/tooling/test_release_consistency.py
@@ -1,0 +1,110 @@
+"""Tests for the release-surface consistency check (issue #1014)."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from tests.boundary.process.tooling.ci import run_ci_script
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_release_consistency_passes_on_clean_tree() -> None:
+    """The checked-in tree must agree across all version-bearing surfaces."""
+
+    result = run_ci_script("check-release-consistency", check=True)
+    assert "All present release surfaces agree." in result.stdout
+
+
+def test_release_consistency_detects_npm_lockfile_drift(tmp_path: Path) -> None:
+    """Reproduce the #904 defect: package.json bumped, lockfile not."""
+
+    npm_dir = tmp_path / "npm"
+    npm_dir.mkdir()
+    (npm_dir / "package.json").write_text(
+        json.dumps({"name": "jacobian", "version": "0.11.0"}), encoding="utf-8"
+    )
+    (npm_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "jacobian",
+                "version": "0.10.0",
+                "lockfileVersion": 3,
+                "packages": {"": {"name": "jacobian", "version": "0.10.0"}},
+            }
+        ),
+        encoding="utf-8"
+    )
+
+    result = run_ci_script(
+        "check-release-consistency", "--root", tmp_path, check=False
+    )
+    assert result.returncode == 1
+    assert "npm/package-lock.json (top-level)" in result.stderr
+    assert "0.10.0 (expected 0.11.0)" in result.stderr
+
+
+def test_release_consistency_detects_pyproject_drift(tmp_path: Path) -> None:
+    """A pyproject.toml version mismatch is also caught."""
+
+    npm_dir = tmp_path / "npm"
+    npm_dir.mkdir()
+    (npm_dir / "package.json").write_text(
+        json.dumps({"name": "jacobian", "version": "0.11.0"}), encoding="utf-8"
+    )
+    (npm_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "jacobian",
+                "version": "0.11.0",
+                "lockfileVersion": 3,
+                "packages": {"": {"name": "jacobian", "version": "0.11.0"}},
+            }
+        ),
+        encoding="utf-8"
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            '''
+            [project]
+            name = "jacobian"
+            version = "0.10.0"
+            '''
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    result = run_ci_script(
+        "check-release-consistency", "--root", tmp_path, check=False
+    )
+    assert result.returncode == 1
+    assert "pyproject.toml" in result.stderr
+
+
+def test_release_consistency_accepts_explicit_expected(tmp_path: Path) -> None:
+    """--expected overrides the npm/package.json derivation."""
+
+    npm_dir = tmp_path / "npm"
+    npm_dir.mkdir()
+    (npm_dir / "package.json").write_text(
+        json.dumps({"name": "jacobian", "version": "0.10.0"}), encoding="utf-8"
+    )
+    (npm_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "name": "jacobian",
+                "version": "0.10.0",
+                "lockfileVersion": 3,
+                "packages": {"": {"name": "jacobian", "version": "0.10.0"}},
+            }
+        ),
+        encoding="utf-8"
+    )
+
+    result = run_ci_script(
+        "check-release-consistency", "--root", tmp_path, "--expected", "0.10.0",
+        check=True,
+    )
+    assert "All present release surfaces agree." in result.stdout

--- a/tests/boundary/process/tooling/test_release_consistency.py
+++ b/tests/boundary/process/tooling/test_release_consistency.py
@@ -35,12 +35,10 @@ def test_release_consistency_detects_npm_lockfile_drift(tmp_path: Path) -> None:
                 "packages": {"": {"name": "jacobian", "version": "0.10.0"}},
             }
         ),
-        encoding="utf-8"
+        encoding="utf-8",
     )
 
-    result = run_ci_script(
-        "check-release-consistency", "--root", tmp_path, check=False
-    )
+    result = run_ci_script("check-release-consistency", "--root", tmp_path, check=False)
     assert result.returncode == 1
     assert "npm/package-lock.json (top-level)" in result.stderr
     assert "0.10.0 (expected 0.11.0)" in result.stderr
@@ -63,22 +61,20 @@ def test_release_consistency_detects_pyproject_drift(tmp_path: Path) -> None:
                 "packages": {"": {"name": "jacobian", "version": "0.11.0"}},
             }
         ),
-        encoding="utf-8"
+        encoding="utf-8",
     )
     (tmp_path / "pyproject.toml").write_text(
         textwrap.dedent(
-            '''
+            """
             [project]
             name = "jacobian"
             version = "0.10.0"
-            '''
+            """
         ).strip(),
         encoding="utf-8",
     )
 
-    result = run_ci_script(
-        "check-release-consistency", "--root", tmp_path, check=False
-    )
+    result = run_ci_script("check-release-consistency", "--root", tmp_path, check=False)
     assert result.returncode == 1
     assert "pyproject.toml" in result.stderr
 
@@ -100,11 +96,15 @@ def test_release_consistency_accepts_explicit_expected(tmp_path: Path) -> None:
                 "packages": {"": {"name": "jacobian", "version": "0.10.0"}},
             }
         ),
-        encoding="utf-8"
+        encoding="utf-8",
     )
 
     result = run_ci_script(
-        "check-release-consistency", "--root", tmp_path, "--expected", "0.10.0",
+        "check-release-consistency",
+        "--root",
+        tmp_path,
+        "--expected",
+        "0.10.0",
         check=True,
     )
     assert "All present release surfaces agree." in result.stdout


### PR DESCRIPTION
## Summary

- Fix the root cause of release PR #904's lockfile drift: Release Please bumps `npm/package.json` via `extra-files` but the release workflow only synchronized `uv.lock` afterward, leaving `npm/package-lock.json` at the previous version.
- Add `npm install --package-lock-only` to the release-please workflow so both `uv.lock` and `npm/package-lock.json` are regenerated and committed in one step before the release candidate CI is dispatched.
- Add `.github/scripts/check-release-consistency` (issue #1014) — a cheap check that asserts all version-bearing surfaces agree: `npm/package.json`, `.release-please-manifest.json`, `pyproject.toml`, `uv.lock`, `npm/package-lock.json` (top-level + `packages[""]`), and `server.json`.
- Wire the consistency check into the CI `npm-package` lane so release PRs and ordinary PRs touching `npm/` fail on drift.
- Add focused tests reproducing the #904 defect (npm lockfile drift), a pyproject drift case, the clean-tree pass, and the `--expected` override.

## Root cause

`release-please-config.json` declares `npm/package.json` as an `extra-files` target, so Release Please bumps it. But `release-please.yml` only ran `uv lock` after the bump — there was no equivalent `npm install --package-lock-only` step, so `npm/package-lock.json` kept the old version at both the top level and `packages[""]`.

## Validation

- `python .github/scripts/check-release-consistency` — passes on `main` (all surfaces at 0.10.0)
- Reproduced the #904 defect against the release-please branch: check correctly reports `npm/package-lock.json (top-level): 0.10.0 (expected 0.11.0)` and `packages[""]: 0.10.0 (expected 0.11.0)`, exit 1
- Verified `npm install --package-lock-only --prefix npm` regenerates the lockfile to the bumped version (tested against the release-please branch tree)
- `uv run pytest tests/boundary/process/tooling/test_release_consistency.py -q` — 4 passed
- `uv run pytest tests/boundary/process/tooling/ -q` — 142 passed (no regressions)
- `make test-architecture` — OK (437 files checked)
- `make architecture` — OK (1724 files checked)
- `uv run ruff check` + `uv run mypy` on the new script — clean

#### Test plan

- [ ] CI `npm-package` lane runs `check-release-consistency` and passes on this PR
- [ ] CI `process` lane runs the new `test_release_consistency.py` tests
- [ ] Next Release Please run regenerates `npm/package-lock.json` alongside `uv.lock` and the release PR is mergeable with all surfaces agreeing

Closes #1014.

Generated with [Devin](https://devin.ai)