### PR TITLE
Allow reviewed approvals in Codex visibility evaluations

### DIFF
--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -340,8 +340,7 @@ def _codex_arguments(
     tool_mode: ToolMode,
 ) -> tuple[str, ...]:
     arguments = [
-        "-a",
-        "never",
+        "--approve-for-me",
         "exec",
         "--ephemeral",
         "--skip-git-repo-check",

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -135,6 +135,8 @@ def test_unified_exec_mode_is_opt_in(tmp_path: Path) -> None:
     direct = _codex_arguments(**common, tool_mode=ToolMode.DIRECT)
     unified = _codex_arguments(**common, tool_mode=ToolMode.UNIFIED_EXEC)
 
+    assert "--approve-for-me" in direct
+    assert "never" not in direct
     assert "unified_exec" not in direct
     assert unified[-3:-1] == ("--enable", "unified_exec")
     assert 'mcp_servers.jacobian.default_tools_approval_mode="approve"' in unified


### PR DESCRIPTION
## What changed

- run Codex visibility evaluations with `--approve-for-me`
- remove the hard-coded `-a never` policy
- assert the approval configuration in the visibility tooling unit test

## Why

`math.run` is intentionally annotated as potentially destructive because some capabilities may create artifacts. The visibility harness hard-coded `-a never`, so Codex automatically returned `user cancelled MCP tool call` for every execution attempt. This prevented the evaluation from measuring successful Jacobian adoption or task completion.

The harness already executes Codex in an isolated temporary workspace with a read-only sandbox. Reviewed automatic approval preserves that isolation while allowing the evaluation's required MCP calls to proceed.

## Impact

Model evaluations can now distinguish genuine Jacobian execution behavior from approval-policy cancellation. This makes task-success, call-count, token, and latency comparisons usable.

## Validation

- `pytest tests/unit/tooling/test_codex_visibility.py -q` — 18 passed
- paid smoke test with `gpt-5.4-mini`, high reasoning: `matrix.determinant.compute` completed successfully instead of being cancelled
- remote diff verified to contain only the harness and its unit test