### PR TITLE
Default exact capability inspection to runnable contracts

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -44,8 +44,8 @@ Payloads:
 For other outcomes, query `math.find` by plain-language outcome; no ID is
 required. Use low `limit` only for query search, never with `capability_id`. For
 a selected operation's schema, call
-`math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never put
-`CONTRACT` in a query. A card's
+`math.find({"capability_id":"<exact-id>"})`; exact lookup returns the runnable
+contract by default; never put `CONTRACT` in a query. A card's
 `invocation_example`, or required top-level fields, may be enough.
 
 Add no domain filter unless its installed spelling is known. Follow exposed

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -117,26 +117,23 @@ arguments, or inspect `capability://catalog`. Array position is not a preferred
 next step. These paths do not imply that the requested operation is
 mathematically impossible or absent in principle.
 
-Passing one `capability_id` returns the default `SUMMARY` exact projection. It
-contains the one-line outcome, tags, provider availability, input/output field
-summaries, and whether descriptor-owned invocation examples are available
-(legacy mode lists may still appear on the wire until
-[#1143](https://github.com/morluto/jacobian/issues/1143)):
+Passing one `capability_id` returns the default `CONTRACT` exact projection. It
+contains the complete validation-equivalent input schema (annotation/default
+and discriminator routing metadata are omitted), concise output/runtime
+summaries, related operations, and descriptor-owned validated invocation
+examples:
 
 ```json
 {"capability_id": "universal_algebra.search.countermodel"}
 ```
 
-The `CONTRACT` view adds the complete validation-equivalent input schema
-(annotation/default and discriminator routing metadata are omitted), concise
-output/runtime summaries, related operations, and descriptor-owned validated
-invocation examples. It is available whenever an agent does not already have
-the exact contract needed to construct a call:
+The explicit `SUMMARY` view returns compact fit metadata when an agent does not
+need a runnable contract:
 
 ```json
 {
   "capability_id": "universal_algebra.search.countermodel",
-  "view": "CONTRACT"
+  "view": "SUMMARY"
 }
 ```
 

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -44,8 +44,8 @@ Payloads:
 For other outcomes, query `math.find` by plain-language outcome; no ID is
 required. Use low `limit` only for query search, never with `capability_id`. For
 a selected operation's schema, call
-`math.find({"capability_id":"<exact-id>","view":"CONTRACT"})`; never put
-`CONTRACT` in a query. A card's
+`math.find({"capability_id":"<exact-id>"})`; exact lookup returns the runnable
+contract by default; never put `CONTRACT` in a query. A card's
 `invocation_example`, or required top-level fields, may be enough.
 
 Add no domain filter unless its installed spelling is known. Follow exposed

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -41,20 +41,22 @@ Forms:
 - Optional `domain` filter; `limit` 1-20 (default 5).
 - Omit arguments to browse; follow `next_cursor` with the same filters to continue.
 - Ranking is deterministic lexical retrieval; matches are not recommendations.
-- `capability_id`: exact inspect (SUMMARY / CONTRACT / FULL views).
+- `capability_id`: exact inspect; omitting `view` returns the runnable contract.
+  Use SUMMARY only for fit metadata or FULL for operator audit metadata.
 
 Checker tools are separate IDs (often `*.verify`), not a switch on producers.
 
 Examples:
 - `{"query":"compute an exact matrix determinant","domain":"matrix","limit":3}`
 - `{"query":"find a counterexample to associativity","domain":"universal_algebra"}`
-- `{"capability_id":"polynomial.compute.gcd","view":"CONTRACT"}`
+- `{"capability_id":"polynomial.compute.gcd"}`
 """
 
 MATH_RUN_DESCRIPTION = """\
 Run one installed math tool by ID with its typed `payload`. Read the mathematical
 value in `output` first, then execution status. If the payload shape is unknown,
-use math.find with view CONTRACT.
+use math.find with the exact capability ID; its default response is the runnable
+contract.
 
 Ordinary tools return calculations. Independent checking uses a separate checker
 tool ID (for example `polynomial.identity.verify` or `case.partition.finite.verify`),
@@ -90,11 +92,12 @@ metadata; `matched_on` and `matched_terms` make that retrieval visible. Ranking 
 not a recommendation. Follow `next_cursor` with unchanged filters and limit when a
 discovery result is truncated. Omit all arguments to browse.
 
-The same tool accepts `capability_id` for exact inspection. SUMMARY is the compact
-projection, CONTRACT adds the validation-equivalent input schema and examples, and
-FULL adds complete provider and audit metadata. An agent that already has an exact
-contract may invoke the operation directly. Related operations describe compatibility
-and evidence flow; they do not prescribe what to do next.
+The same tool accepts `capability_id` for exact inspection. The default exact response
+is the runnable CONTRACT with the validation-equivalent input schema and examples.
+SUMMARY is an explicit compact fit-only override; FULL adds complete provider and
+operator audit metadata. An agent that already has an exact contract may invoke the
+operation directly. Related operations describe compatibility and evidence flow; they
+do not prescribe what to do next.
 
 `math.run` returns the canonical complete `CapabilityResult` directly as MCP
 structured content. Calls may be composed in any sequence the mathematical

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -529,15 +529,15 @@ async def capability_describe(
         ),
     ] = None,
     view: Annotated[
-        CapabilityDescriptionView,
+        CapabilityDescriptionView | None,
         Field(
             description=(
-                "Exact lookup only: SUMMARY judges fit; CONTRACT adds the validated "
-                "input schema and invocation examples; FULL adds audit metadata. "
-                "Omit for discovery."
+                "Optional exact-lookup override: omit for the runnable CONTRACT; "
+                "SUMMARY returns fit metadata only; FULL adds operator audit "
+                "metadata. Omit for discovery."
             )
         ),
-    ] = "SUMMARY",
+    ] = None,
     *,
     ctx: Context[AppState, Any],
 ) -> CapabilityDiscoveryToolResult:
@@ -559,7 +559,7 @@ async def capability_describe(
                 "discovery arguments or one exact capability_id in this call."
             )
         if capability_id is None:
-            if view != "SUMMARY":
+            if view not in {None, "SUMMARY"}:
                 raise ValueError(
                     "view applies only to an exact capability_id inspection; omit it "
                     "for search or browse."
@@ -574,6 +574,7 @@ async def capability_describe(
                 cursor=cursor,
             )
             return _find_result(discovery_response)
+        resolved_view: CapabilityDescriptionView = view or "CONTRACT"
         capability_catalog = active_runtime.core.capabilities.catalog()
         descriptors = {
             item.capability_id: item for item in capability_catalog.capabilities
@@ -597,10 +598,13 @@ async def capability_describe(
             return _find_result(error_response)
         response: dict[str, Any] = {
             "kind": "capability",
-            "view": view,
+            "view": resolved_view,
             "policy_profile": capability_catalog.policy_profile,
             "policy_digest": capability_catalog.policy_digest,
-            "capability": _capability_descriptor_view(descriptor, view=view),
+            "capability": _capability_descriptor_view(
+                descriptor,
+                view=resolved_view,
+            ),
             "scope_rule": _CAPABILITY_SCOPE_RULE,
             "related_capabilities_byte_limit": (
                 CAPABILITY_INSPECTION_RELATIONSHIPS_BYTE_LIMIT
@@ -608,7 +612,7 @@ async def capability_describe(
             "truncation_reason": None,
             "related_capabilities_truncated": False,
         }
-        if view == "SUMMARY":
+        if resolved_view == "SUMMARY":
             response["next_views"] = {
                 "CONTRACT": (
                     "Request before invocation for the validation-equivalent input "
@@ -628,7 +632,7 @@ async def capability_describe(
                         {
                             "description": example.description,
                         }
-                        if view == "FULL"
+                        if resolved_view == "FULL"
                         else {}
                     ),
                     "tool": "math.run",
@@ -643,7 +647,7 @@ async def capability_describe(
                 _capability_inspection_extensions(capability_id, descriptors)
             )
         if (
-            view != "SUMMARY"
+            resolved_view != "SUMMARY"
             and capability_id == "lean.check"
             and active_runtime.portfolio.lean_checkers
         ):

--- a/tests/boundary/mcp/test_mcp_discovery_projection.py
+++ b/tests/boundary/mcp/test_mcp_discovery_projection.py
@@ -168,9 +168,20 @@ def test_mcp_exact_description_layers_summary_contract_and_full_views(
         from mcp import Client
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            summary_result = await client.call_tool(
+            legacy_discovery_result = await client.call_tool(
+                "math.find",
+                {"query": "normalize polynomial", "view": "SUMMARY"},
+            )
+            default_result = await client.call_tool(
                 "math.find",
                 {"capability_id": "polynomial.expression.normalize"},
+            )
+            summary_result = await client.call_tool(
+                "math.find",
+                {
+                    "capability_id": "polynomial.expression.normalize",
+                    "view": "SUMMARY",
+                },
             )
             contract_result = await client.call_tool(
                 "math.find",
@@ -186,9 +197,13 @@ def test_mcp_exact_description_layers_summary_contract_and_full_views(
                     "view": "FULL",
                 },
             )
+            assert isinstance(legacy_discovery_result.structured_content, dict)
+            assert legacy_discovery_result.structured_content["kind"] == "discovery"
+            assert isinstance(default_result.structured_content, dict)
             assert isinstance(summary_result.structured_content, dict)
             assert isinstance(contract_result.structured_content, dict)
             assert isinstance(full_result.structured_content, dict)
+            default = default_result.structured_content
             summary = summary_result.structured_content
             contract = contract_result.structured_content
             full = full_result.structured_content
@@ -205,6 +220,9 @@ def test_mcp_exact_description_layers_summary_contract_and_full_views(
             assert "CONTRACT" in summary["next_views"]
             assert "all-orders" in summary["scope_rule"]["bounded_repetition"]
             assert contract["view"] == "CONTRACT"
+            assert default["view"] == "CONTRACT"
+            assert default["capability"] == contract["capability"]
+            assert default["invocations"] == contract["invocations"]
             assert contract["capability"]["input_schema"]["type"] == "object"
             assert contract["capability"]["accepted_input_kinds"] == [
                 "STRUCTURED_REQUEST"

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -205,7 +205,8 @@ def test_codex_skill_routes_exact_outcomes_without_catalog_projection() -> None:
     skill_flat = re.sub(r"\s+", " ", skill)
     assert "Do not enumerate, filter, or print `ALL_TOOLS`" in skill_flat
     assert "text(r.structuredContent ?? r)" in skill
-    assert 'math.find({"capability_id":"<exact-id>","view":"CONTRACT"})' in skill
+    assert 'math.find({"capability_id":"<exact-id>"})' in skill
+    assert "exact lookup returns the runnable contract by default" in skill_flat
     assert "never put `CONTRACT` in a query" in skill_flat
     assert "`matrix.determinant.verify` for an independent check" in skill_flat
     assert "never reconstruct or paraphrase such a record" in skill_flat


### PR DESCRIPTION
## What changed

- make an exact `math.find(capability_id=...)` lookup return the runnable `CONTRACT` projection by default
- retain explicit `SUMMARY`, `CONTRACT`, and `FULL` views
- preserve compatibility for discovery calls that explicitly send `view="SUMMARY"`
- align MCP guidance, bundled skills, reference docs, and boundary coverage

## Why

Agents currently need a compact exact lookup followed by a second exact lookup with `view="CONTRACT"` before invocation. For a known capability ID, the first lookup does not provide the validated input schema needed to run the operation. Returning the runnable contract directly removes that promotion step while keeping compact fit-only and full audit projections available as explicit overrides.

## Evaluation

A corrected paired evaluation used `gpt-5.4-mini` at high reasoning across integer GCD, polynomial GCD, and independently verified determinant cases, with three repetitions per case and identical harness behavior in both conditions.

| Metric | Baseline | Pilot | Change |
|---|---:|---:|---:|
| Successful contracts | 5/9 | 7/9 | +2 |
| Verified runs | 0/9 | 3/9 | +3 |
| MCP calls | 35 | 23 | -34.3% |
| Tool errors | 11 | 3 | -72.7% |
| Model-visible MCP bytes | 94,288 | 67,081 | -28.9% |
| Uncached input tokens | 154,266 | 104,161 | -32.5% |
| Output tokens | 21,135 | 12,762 | -39.6% |
| Elapsed time | 504.7 s | 349.0 s | -30.9% |

Polynomial success remained 3/3. Independent verification improved from 0/3 to 3/3. Integer-GCD adoption varied from 2/3 to 1/3, so the evaluation does not claim universally higher tool adoption on simple tasks.

A deterministic matched pilot also measured 50% fewer calls, 31.2% fewer model-visible response bytes, and 27.2% lower summed median latency.

## Validation

- 23 focused unit and MCP boundary tests passed
- Ruff lint passed
- Ruff formatting check passed
- mypy passed for the changed MCP source files
- packaged and repository skills remain byte-identical

This PR is independent of #1183; it does not include the evaluation-harness approval fix.