### PR TITLE
Check execution status before using math output

### DIFF
--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -52,9 +52,10 @@ Examples:
 """
 
 MATH_RUN_DESCRIPTION = """\
-Run one installed math tool by ID with its typed `payload`. Read the mathematical
-value in `output` first, then execution status. If the payload shape is unknown,
-use math.find with view CONTRACT.
+Run one installed math tool by ID with its typed `payload`. Check execution status
+before treating `output` as mathematical evidence. For a completed run, also inspect
+conclusion, completeness, and assurance before using the mathematical value. If the
+payload shape is unknown, use math.find with view CONTRACT.
 
 Ordinary tools return calculations. Independent checking uses a separate checker
 tool ID (for example `polynomial.identity.verify` or `case.partition.finite.verify`),

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -56,3 +56,12 @@ def test_guidance_rejects_verification_transfer_to_derived_claims() -> None:
     combined = "\n".join((SERVER_INSTRUCTIONS, MATH_RUN_DESCRIPTION))
     assert "does not verify a model-derived conclusion" in combined
     assert "record must be bound to the exact final claim" in combined
+
+
+def test_math_run_guidance_checks_execution_before_using_output() -> None:
+    guidance = MATH_RUN_DESCRIPTION.lower()
+
+    status_position = guidance.index("check execution status")
+    output_position = guidance.index("treating `output` as mathematical evidence")
+    assert status_position < output_position
+    assert "conclusion, completeness, and assurance" in guidance


### PR DESCRIPTION
## What changed

- make the `math.run` tool description tell agents to check execution status before treating `output` as mathematical evidence
- require completed runs to be interpreted through conclusion, completeness, and assurance before their mathematical value is used
- add a focused regression test that preserves the safety ordering

## Why

The current description says to read the mathematical output first and execution status second. That ordering conflicts with Jacobian's fail-closed contract: cancelled, invalid, timed-out, incomplete, or otherwise non-conclusive runs must not be promoted into mathematical evidence.

Recent held-out trajectories repeatedly showed the reliability risk around cancelled calls and unsupported assurance promotion. Those trajectories do not establish a backend mathematics defect, but they make the contradictory instruction unsafe to retain. This is a narrow contract-guidance correction adjacent to issue #28; it does not change mathematical operations, schemas, or assurance semantics.

## Validation

- focused unit and MCP boundary tests passed
- Ruff lint passed
- Ruff formatting check passed
- mypy passed for the changed source file
- `git diff --check` passed

This PR is independent of draft #1185 and does not alter exact capability inspection.