### PR TITLE
fix(polynomials): canonicalize Gaussian moment polynomial inputs

### DIFF
--- a/docs/reference/capabilities/polynomial/gaussian-polynomial-moments.md
+++ b/docs/reference/capabilities/polynomial/gaussian-polynomial-moments.md
@@ -22,25 +22,34 @@ operation, not a Gaussian-identity search or proof workflow.
 
 ## Contract and scope
 
-The request bounds are:
+The request accepts either bounded loose wire terms or the strict canonical
+`GaussianPolynomial` value emitted by parsing those terms. The bounds are:
 
 | Field | Bound |
 | --- | --- |
 | Gaussian variables | 1–8 |
 | Raw sparse terms | 1–16 before canonicalization |
+| Canonical nonzero sparse terms | 1–16 after canonicalization |
 | Total degree of each input term | at most 8 |
 | Fixed moment order \(m\) | 0–16 |
 | Raw ordered expansion paths | `term_count ** m <= 65536` |
-| Input rational numerator/denominator | at most 128 decimal digits |
+| Each raw rational numerator/denominator | at most 128 decimal digits |
+| Each strict canonical rational component | at most 4,096 decimal digits |
 
-Wire terms use exponent vectors of length `variable_count`. They may arrive in
-any order, repeat an exponent vector, or carry an exact zero coefficient. The
-request boundary combines duplicates over \(\mathbb Q(i)\), removes exact zero
-terms, and orders the surviving terms lexicographically before constructing the
-strict `GaussianPolynomial` value used by the producer and checker. A request
-whose terms cancel completely is rejected, as are negative exponents,
-inconsistent dimensions, more than 16 raw terms, and requests beyond the
-complete-expansion bound.
+Loose wire terms use exponent vectors of length `variable_count`. They may arrive
+in any order, repeat an exponent vector, or carry an exact zero coefficient. The
+request boundary checks the raw 16-term and 128-digit limits before combining
+duplicates over \(\mathbb Q(i)\), removes exact zero terms, and orders the
+surviving terms lexicographically. Exact accumulation may grow beyond 128 digits,
+but the strict canonical value retains the 4,096-digit component bound and can be
+serialized and parsed again by the producer or checker without reapplying the
+per-raw-term limit.
+
+A request whose terms cancel completely is rejected, as are negative exponents,
+inconsistent dimensions, more than 16 raw terms, canonical values with more than
+16 nonzero terms, and requests beyond the complete-expansion bound. Direct
+`GaussianPolynomial` values remain strict: terms must already be nonzero, unique,
+and lexicographically ordered.
 
 The producer exactly expands \(P^m\) via pinned Python-FLINT `fmpq_mpoly`
 binary exponentiation over a typed real/imaginary coefficient pair,

--- a/docs/reference/capabilities/polynomial/gaussian-polynomial-moments.md
+++ b/docs/reference/capabilities/polynomial/gaussian-polynomial-moments.md
@@ -27,17 +27,20 @@ The request bounds are:
 | Field | Bound |
 | --- | --- |
 | Gaussian variables | 1–8 |
-| Nonzero sparse terms | 1–16 |
+| Raw sparse terms | 1–16 before canonicalization |
 | Total degree of each input term | at most 8 |
 | Fixed moment order \(m\) | 0–16 |
 | Raw ordered expansion paths | `term_count ** m <= 65536` |
 | Input rational numerator/denominator | at most 128 decimal digits |
 
-Terms use exponent vectors of length `variable_count`, in strictly increasing
-lexicographic order. A coefficient has separate canonical rational `real` and
-`imaginary` components. Duplicate monomials, zero coefficients, negative
-exponents, inconsistent dimensions, and requests beyond the complete-expansion
-bound fail validation before computation or artifact writes.
+Wire terms use exponent vectors of length `variable_count`. They may arrive in
+any order, repeat an exponent vector, or carry an exact zero coefficient. The
+request boundary combines duplicates over \(\mathbb Q(i)\), removes exact zero
+terms, and orders the surviving terms lexicographically before constructing the
+strict `GaussianPolynomial` value used by the producer and checker. A request
+whose terms cancel completely is rejected, as are negative exponents,
+inconsistent dimensions, more than 16 raw terms, and requests beyond the
+complete-expansion bound.
 
 The producer exactly expands \(P^m\) via pinned Python-FLINT `fmpq_mpoly`
 binary exponentiation over a typed real/imaginary coefficient pair,

--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -111,12 +111,6 @@ class GaussianPolynomialTerm(ContractModel):
             )
         if self.coefficient.as_fractions() == (Fraction(), Fraction()):
             raise ValueError("Gaussian polynomial terms must have nonzero coefficients")
-        for component in (self.coefficient.real, self.coefficient.imaginary):
-            require_bounded_rational(
-                component,
-                max_digits=MAX_INPUT_RATIONAL_DIGITS,
-                label="Gaussian polynomial input coefficient",
-            )
         return self
 
 

--- a/src/jacobian/domains/probability/bundle.py
+++ b/src/jacobian/domains/probability/bundle.py
@@ -1,12 +1,30 @@
 """Finite-probability domain bundle."""
 
+from dataclasses import replace
+from typing import Any
+
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.domain_bundles import DomainBundle
 from jacobian.domains.probability.checkers import PROBABILITY_EXACT_REPLAY_CHECKERS
+from jacobian.domains.probability.gaussian_inputs import (
+    CanonicalGaussianPolynomialMomentRequest,
+)
 from jacobian.domains.probability.operations import FINITE_PROBABILITY_CAPABILITIES
 from jacobian.operations import DomainDiagnostics, DomainSemantics
 from jacobian.provider_runtime import PYTHON_FLINT_VERSION
 from jacobian.providers.flint_runtime import python_flint_probability_provider_runtime
+
+
+def _operation_with_canonical_gaussian_input(operation: Any) -> Any:
+    if operation.spec.operation_id != "probability.gaussian_polynomial.moment.compute":
+        return operation
+    return replace(
+        operation,
+        spec=replace(
+            operation.spec,
+            request_type=CanonicalGaussianPolynomialMomentRequest,
+        ),
+    )
 
 
 def build_finite_probability_bundle() -> DomainBundle:
@@ -31,15 +49,18 @@ def build_finite_probability_bundle() -> DomainBundle:
         ),
         provider_runtime=python_flint_probability_provider_runtime(),
         backend_version=f"python-flint-{PYTHON_FLINT_VERSION}",
-        capabilities=FINITE_PROBABILITY_CAPABILITIES,
+        capabilities=tuple(
+            _operation_with_canonical_gaussian_input(operation)
+            for operation in FINITE_PROBABILITY_CAPABILITIES
+        ),
         diagnostics=DomainDiagnostics(
             invalid_request=CapabilityDiagnostic(
                 code="INVALID_FINITE_PROBABILITY_REQUEST",
                 stage="finite_probability_input_validation",
                 message="Input does not satisfy the bounded exact-probability contract.",
                 hint=(
-                    "Use a bounded normalized finite distribution or a canonical "
-                    "bounded Gaussian polynomial, or a fully weighted small graph."
+                    "Use a bounded normalized finite distribution or a bounded "
+                    "Gaussian polynomial request, or a fully weighted small graph."
                 ),
             )
         ),

--- a/src/jacobian/domains/probability/bundle.py
+++ b/src/jacobian/domains/probability/bundle.py
@@ -1,30 +1,12 @@
 """Finite-probability domain bundle."""
 
-from dataclasses import replace
-from typing import Any
-
 from jacobian.contracts.capabilities import CapabilityDiagnostic
 from jacobian.domain_bundles import DomainBundle
 from jacobian.domains.probability.checkers import PROBABILITY_EXACT_REPLAY_CHECKERS
-from jacobian.domains.probability.gaussian_inputs import (
-    CanonicalGaussianPolynomialMomentRequest,
-)
 from jacobian.domains.probability.operations import FINITE_PROBABILITY_CAPABILITIES
 from jacobian.operations import DomainDiagnostics, DomainSemantics
 from jacobian.provider_runtime import PYTHON_FLINT_VERSION
 from jacobian.providers.flint_runtime import python_flint_probability_provider_runtime
-
-
-def _operation_with_canonical_gaussian_input(operation: Any) -> Any:
-    if operation.spec.operation_id != "probability.gaussian_polynomial.moment.compute":
-        return operation
-    return replace(
-        operation,
-        spec=replace(
-            operation.spec,
-            request_type=CanonicalGaussianPolynomialMomentRequest,
-        ),
-    )
 
 
 def build_finite_probability_bundle() -> DomainBundle:
@@ -49,10 +31,7 @@ def build_finite_probability_bundle() -> DomainBundle:
         ),
         provider_runtime=python_flint_probability_provider_runtime(),
         backend_version=f"python-flint-{PYTHON_FLINT_VERSION}",
-        capabilities=tuple(
-            _operation_with_canonical_gaussian_input(operation)
-            for operation in FINITE_PROBABILITY_CAPABILITIES
-        ),
+        capabilities=FINITE_PROBABILITY_CAPABILITIES,
         diagnostics=DomainDiagnostics(
             invalid_request=CapabilityDiagnostic(
                 code="INVALID_FINITE_PROBABILITY_REQUEST",

--- a/src/jacobian/domains/probability/checkers.py
+++ b/src/jacobian/domains/probability/checkers.py
@@ -5,10 +5,12 @@ from jacobian.contracts.probability import (
     FiniteConvolutionRequest,
     FiniteEventRequest,
     FinitePushforwardRequest,
-    GaussianPolynomialMomentRequest,
     GraphConnectionProbabilityRequest,
 )
 from jacobian.contracts.validated_analysis import FiniteRawMomentRequest
+from jacobian.domains.probability.gaussian_inputs import (
+    CanonicalGaussianPolynomialMomentRequest,
+)
 
 _ENTRYPOINT = "jacobian_checkers.exact_probability_operations"
 _REASON = (
@@ -64,7 +66,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
     ),
     ExactReplayCheckerDeclaration(
         "probability.gaussian_polynomial.moment.compute",
-        GaussianPolynomialMomentRequest,
+        CanonicalGaussianPolynomialMomentRequest,
         "check_gaussian_polynomial_moment",
         "probability.gaussian-polynomial-moment.fraction-replay",
         entrypoint_module=_ENTRYPOINT,

--- a/src/jacobian/domains/probability/gaussian_inputs.py
+++ b/src/jacobian/domains/probability/gaussian_inputs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Annotated, Self
 
-from pydantic import BeforeValidator, Field, StrictInt, model_validator
+from pydantic import BeforeValidator, Field, StrictInt, ValidationError, model_validator
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
@@ -79,10 +79,20 @@ def _rational(value: Fraction) -> CanonicalRational:
 
 
 def canonical_gaussian_polynomial(value: object) -> GaussianPolynomial:
-    """Parse bounded loose wire terms into one strict canonical domain value."""
+    """Parse a strict canonical value or canonicalize bounded loose wire terms."""
 
     if isinstance(value, GaussianPolynomial):
         return value
+
+    # A canonical request is itself a valid public boundary form. Parsing it first
+    # makes the canonical JSON projection replayable after duplicate raw terms have
+    # legitimately accumulated beyond the per-raw-term 128-digit bound. The strict
+    # value still enforces the 16-term and 4,096-digit component bounds.
+    try:
+        return GaussianPolynomial.model_validate(value)
+    except ValidationError:
+        pass
+
     raw = RawGaussianPolynomial.model_validate(value)
     combined: dict[tuple[int, ...], tuple[Fraction, Fraction]] = {}
     for term in raw.terms:
@@ -113,7 +123,7 @@ def canonical_gaussian_polynomial(value: object) -> GaussianPolynomial:
 
 
 class CanonicalGaussianPolynomialMomentRequest(GaussianPolynomialMomentRequest):
-    """Request that parses loose wire terms once into ``GaussianPolynomial``."""
+    """Request accepting strict canonical values or bounded loose wire terms."""
 
     polynomial: Annotated[
         GaussianPolynomial,

--- a/src/jacobian/domains/probability/gaussian_inputs.py
+++ b/src/jacobian/domains/probability/gaussian_inputs.py
@@ -1,0 +1,132 @@
+"""Boundary parser for canonical Gaussian sparse-polynomial requests."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Annotated, Self
+
+from pydantic import BeforeValidator, Field, StrictInt, model_validator
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
+from jacobian.contracts.probability import (
+    MAX_GAUSSIAN_POLYNOMIAL_TERMS,
+    MAX_GAUSSIAN_TERM_DEGREE,
+    MAX_GAUSSIAN_VARIABLES,
+    MAX_INPUT_RATIONAL_DIGITS,
+    ExactComplexRational,
+    GaussianPolynomial,
+    GaussianPolynomialMomentRequest,
+    GaussianPolynomialTerm,
+)
+from jacobian.contracts.results import ContractModel
+
+
+class RawGaussianPolynomialTerm(ContractModel):
+    """One bounded wire term before duplicate/zero canonicalization."""
+
+    coefficient: ExactComplexRational
+    exponents: tuple[StrictInt, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_VARIABLES,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_term(self) -> Self:
+        if any(
+            type(exponent) is not int or exponent < 0 for exponent in self.exponents
+        ):
+            raise ValueError(
+                "Gaussian polynomial exponents must be nonnegative integers"
+            )
+        if sum(self.exponents) > MAX_GAUSSIAN_TERM_DEGREE:
+            raise ValueError(
+                "Gaussian polynomial term exceeds the "
+                f"{MAX_GAUSSIAN_TERM_DEGREE}-degree bound"
+            )
+        for component in (self.coefficient.real, self.coefficient.imaginary):
+            require_bounded_rational(
+                component,
+                max_digits=MAX_INPUT_RATIONAL_DIGITS,
+                label="Gaussian polynomial input coefficient",
+            )
+        return self
+
+
+class RawGaussianPolynomial(ContractModel):
+    """Bounded public representation accepted only at the request boundary."""
+
+    variable_count: StrictInt = Field(ge=1, le=MAX_GAUSSIAN_VARIABLES)
+    terms: tuple[RawGaussianPolynomialTerm, ...] = Field(
+        min_length=1,
+        max_length=MAX_GAUSSIAN_POLYNOMIAL_TERMS,
+    )
+
+    @model_validator(mode="after")
+    def require_consistent_dimension(self) -> Self:
+        if any(len(term.exponents) != self.variable_count for term in self.terms):
+            raise ValueError(
+                "every Gaussian polynomial exponent vector must match variable_count"
+            )
+        return self
+
+
+def _rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
+
+
+def canonical_gaussian_polynomial(value: object) -> GaussianPolynomial:
+    """Parse bounded loose wire terms into one strict canonical domain value."""
+
+    if isinstance(value, GaussianPolynomial):
+        return value
+    raw = RawGaussianPolynomial.model_validate(value)
+    combined: dict[tuple[int, ...], tuple[Fraction, Fraction]] = {}
+    for term in raw.terms:
+        real, imaginary = term.coefficient.as_fractions()
+        previous_real, previous_imaginary = combined.get(
+            term.exponents,
+            (Fraction(), Fraction()),
+        )
+        combined[term.exponents] = (
+            previous_real + real,
+            previous_imaginary + imaginary,
+        )
+
+    terms = tuple(
+        GaussianPolynomialTerm(
+            coefficient=ExactComplexRational(
+                real=_rational(real),
+                imaginary=_rational(imaginary),
+            ),
+            exponents=exponents,
+        )
+        for exponents, (real, imaginary) in sorted(combined.items())
+        if real or imaginary
+    )
+    if not terms:
+        raise ValueError("Gaussian polynomial canonicalization removed every zero term")
+    return GaussianPolynomial(variable_count=raw.variable_count, terms=terms)
+
+
+class CanonicalGaussianPolynomialMomentRequest(GaussianPolynomialMomentRequest):
+    """Request that parses loose wire terms once into ``GaussianPolynomial``."""
+
+    polynomial: Annotated[
+        GaussianPolynomial,
+        BeforeValidator(
+            canonical_gaussian_polynomial,
+            json_schema_input_type=RawGaussianPolynomial | GaussianPolynomial,
+        ),
+    ]
+
+
+__all__ = [
+    "CanonicalGaussianPolynomialMomentRequest",
+    "RawGaussianPolynomial",
+    "RawGaussianPolynomialTerm",
+    "canonical_gaussian_polynomial",
+]

--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -35,6 +35,9 @@ from jacobian.contracts.validated_analysis import (
     FiniteRawMomentResult,
 )
 from jacobian.domains._examples import example
+from jacobian.domains.probability.gaussian_inputs import (
+    CanonicalGaussianPolynomialMomentRequest,
+)
 from jacobian.operation_bindings import inline_operation
 from jacobian.operations import (
     OperationRefusalError,
@@ -598,7 +601,7 @@ FINITE_PROBABILITY_CAPABILITIES = (
                 "preserving the complete coefficient-contraction ledger. This does not "
                 "establish an identity for every order."
             ),
-            request_type=GaussianPolynomialMomentRequest,
+            request_type=CanonicalGaussianPolynomialMomentRequest,
             result_type=GaussianPolynomialMomentResult,
             execute=_gaussian_polynomial_moment,
             tags=(

--- a/tests/domain/probability/test_finite_probability.py
+++ b/tests/domain/probability/test_finite_probability.py
@@ -335,7 +335,7 @@ def test_multivariate_gaussian_polynomial_moment_uses_independence(
     assert result.output["result"]["expanded_monomial_count"] == 5
 
 
-def test_gaussian_polynomial_rejects_nonlexicographic_terms_with_recovery_detail(
+def test_gaussian_polynomial_canonicalizes_nonlexicographic_terms(
     domain_services: DomainTestServices,
 ) -> None:
     result = domain_services.core.capabilities.invoke(
@@ -354,12 +354,10 @@ def test_gaussian_polynomial_rejects_nonlexicographic_terms_with_recovery_detail
         )
     )
 
-    assert result.execution.status is ExecutionStatus.ERROR
-    diagnostic = result.diagnostics[0]
-    assert diagnostic.code == "INVALID_FINITE_PROBABILITY_REQUEST"
-    assert diagnostic.hint is not None
-    assert "lexicographic exponent-vector order" in diagnostic.hint
-    assert "[1, 0] then [0, 1]" in diagnostic.hint
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["moment"] == _complex(2)
+    assert result.output["result"]["expansion_path_count"] == 4
+    assert result.output["result"]["expanded_monomial_count"] == 3
     assert result.artifact_uris == ()
 
 

--- a/tests/domain/probability/test_gaussian_input_canonicalization.py
+++ b/tests/domain/probability/test_gaussian_input_canonicalization.py
@@ -47,6 +47,19 @@ def test_request_canonicalizes_unordered_duplicates_and_zero_terms() -> None:
     ) == ((4, 0), (3, 0))
 
 
+def test_request_schema_advertises_raw_polynomial_input() -> None:
+    schema = CanonicalGaussianPolynomialMomentRequest.model_json_schema(
+        mode="validation"
+    )
+    polynomial = schema["properties"]["polynomial"]
+
+    assert "anyOf" in polynomial
+    references = {item.get("$ref") for item in polynomial["anyOf"]}
+    assert any(
+        reference and "RawGaussianPolynomial" in reference for reference in references
+    )
+
+
 def test_raw_term_limit_is_enforced_before_duplicates_are_combined() -> None:
     with pytest.raises(ValidationError, match="16"):
         CanonicalGaussianPolynomialMomentRequest.model_validate(
@@ -71,6 +84,23 @@ def test_request_rejects_a_polynomial_that_canonicalizes_to_zero() -> None:
                 "order": 1,
             }
         )
+
+
+def test_canonicalization_preserves_valid_bounded_coefficient_sums() -> None:
+    component = int("9" * 128)
+    request = CanonicalGaussianPolynomialMomentRequest.model_validate(
+        {
+            "polynomial": {
+                "variable_count": 1,
+                "terms": [_term([0], real=component), _term([0], real=component)],
+            },
+            "order": 1,
+        }
+    )
+
+    (term,) = request.polynomial.terms
+    assert len(term.coefficient.real.num) == 129
+    assert term.coefficient.real.num == str(component * 2)
 
 
 def test_direct_gaussian_polynomial_value_remains_strict() -> None:

--- a/tests/domain/probability/test_gaussian_input_canonicalization.py
+++ b/tests/domain/probability/test_gaussian_input_canonicalization.py
@@ -1,0 +1,100 @@
+"""Canonical Gaussian request parsing at the probability-domain boundary."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.probability import GaussianPolynomial
+from jacobian.domains.probability.bundle import build_finite_probability_bundle
+from jacobian.domains.probability.gaussian_inputs import (
+    CanonicalGaussianPolynomialMomentRequest,
+)
+
+
+def _q(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _term(
+    exponents: list[int], *, real: int = 0, imaginary: int = 0
+) -> dict[str, object]:
+    return {
+        "coefficient": {"real": _q(real), "imaginary": _q(imaginary)},
+        "exponents": exponents,
+    }
+
+
+def test_request_canonicalizes_unordered_duplicates_and_zero_terms() -> None:
+    request = CanonicalGaussianPolynomialMomentRequest.model_validate(
+        {
+            "polynomial": {
+                "variable_count": 2,
+                "terms": [
+                    _term([1, 0], real=1, imaginary=1),
+                    _term([0, 1], real=4),
+                    _term([1, 0], real=2, imaginary=-1),
+                    _term([0, 0]),
+                ],
+            },
+            "order": 2,
+        }
+    )
+    assert tuple(term.exponents for term in request.polynomial.terms) == (
+        (0, 1),
+        (1, 0),
+    )
+    assert tuple(
+        term.coefficient.as_fractions() for term in request.polynomial.terms
+    ) == ((4, 0), (3, 0))
+
+
+def test_raw_term_limit_is_enforced_before_duplicates_are_combined() -> None:
+    with pytest.raises(ValidationError, match="16"):
+        CanonicalGaussianPolynomialMomentRequest.model_validate(
+            {
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [_term([0], real=1) for _ in range(17)],
+                },
+                "order": 1,
+            }
+        )
+
+
+def test_request_rejects_a_polynomial_that_canonicalizes_to_zero() -> None:
+    with pytest.raises(ValidationError, match="removed every zero term"):
+        CanonicalGaussianPolynomialMomentRequest.model_validate(
+            {
+                "polynomial": {
+                    "variable_count": 1,
+                    "terms": [_term([1], real=3), _term([1], real=-3)],
+                },
+                "order": 1,
+            }
+        )
+
+
+def test_direct_gaussian_polynomial_value_remains_strict() -> None:
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        GaussianPolynomial.model_validate(
+            {
+                "variable_count": 2,
+                "terms": [_term([1, 0], real=1), _term([0, 1], real=1)],
+            }
+        )
+
+
+def test_producer_and_checker_share_the_canonical_request_owner() -> None:
+    bundle = build_finite_probability_bundle()
+    producer = next(
+        operation
+        for operation in bundle.capabilities
+        if operation.spec.operation_id
+        == "probability.gaussian_polynomial.moment.compute"
+    )
+    checker = next(
+        declaration
+        for declaration in bundle.checker_declarations
+        if declaration.capability_id == "probability.gaussian_polynomial.moment.compute"
+    )
+    assert producer.spec.request_type is CanonicalGaussianPolynomialMomentRequest
+    assert checker.request_model is CanonicalGaussianPolynomialMomentRequest

--- a/tests/domain/probability/test_gaussian_input_canonicalization.py
+++ b/tests/domain/probability/test_gaussian_input_canonicalization.py
@@ -47,7 +47,7 @@ def test_request_canonicalizes_unordered_duplicates_and_zero_terms() -> None:
     ) == ((4, 0), (3, 0))
 
 
-def test_request_schema_advertises_raw_polynomial_input() -> None:
+def test_request_schema_advertises_raw_and_canonical_polynomial_inputs() -> None:
     schema = CanonicalGaussianPolynomialMomentRequest.model_json_schema(
         mode="validation"
     )
@@ -57,6 +57,10 @@ def test_request_schema_advertises_raw_polynomial_input() -> None:
     references = {item.get("$ref") for item in polynomial["anyOf"]}
     assert any(
         reference and "RawGaussianPolynomial" in reference for reference in references
+    )
+    assert any(
+        reference and reference.endswith("/GaussianPolynomial")
+        for reference in references
     )
 
 
@@ -101,6 +105,11 @@ def test_canonicalization_preserves_valid_bounded_coefficient_sums() -> None:
     (term,) = request.polynomial.terms
     assert len(term.coefficient.real.num) == 129
     assert term.coefficient.real.num == str(component * 2)
+
+    replayed = CanonicalGaussianPolynomialMomentRequest.model_validate(
+        request.model_dump(mode="json")
+    )
+    assert replayed == request
 
 
 def test_direct_gaussian_polynomial_value_remains_strict() -> None:


### PR DESCRIPTION
## What changed

- canonicalize bounded Gaussian-moment sparse polynomial inputs before capability validation
- sort exponent vectors, combine duplicate monomials exactly over `Q(i)`, and remove zero terms
- preserve the strict canonical `GaussianPolynomial` value contract and all raw-input/resource bounds
- add focused regressions for unordered terms, duplicate/zero handling, canonical stored values, raw term limits, and all-zero rejection

## Why

Merged PR #920 canonicalizes the shared rational sparse-polynomial boundary, but `probability.gaussian_polynomial.moment.compute` uses a separate complex-rational sparse representation and retained its strict caller-side ordering requirement.

A saved held-out trajectory based on Long's resolved Gaussian Moments conjecture supplied a mathematically valid ten-term polynomial in intuitive rather than lexicographic order. Current main rejected it before computation. Replaying that exact saved payload against this branch now canonicalizes exponents from `(0,0,2)` through `(2,0,2)` and computes the exact zero first moment.

This is a localized extension of #920's deterministic-input principle. PR #943 improved the ordering diagnostic but did not remove the caller-side normalization burden. Issue #1140 owns the broader reusable-wire-type architecture; this PR does not attempt that redesign.

## Safety boundary

- raw requests remain capped at 16 terms before any combining
- exponent dimensions, degrees, coefficient digit bounds, and expansion budgets still fail closed
- an all-zero polynomial remains invalid
- direct `GaussianPolynomial` values remain strictly ordered, unique, and nonzero
- producer mathematics and independent-checker semantics are unchanged
- verifier requests use the same canonical request model, preserving exact input binding

## Validation

- probability domain suite: 22 passed
- exact-probability checker/component and capability-contract focused suite: 47 passed
- Ruff lint and formatting: passed
- mypy for changed source: passed
- `git diff --check`: passed
- exact saved Long-trajectory payload: parsed and computed successfully with exact zero moment

The repository planner requests the broad standard lanes because the central probability contract has no narrower ownership. Local `make` orchestration could not create its separate uv environment because this host has no package-network access; hosted CI is expected to run the complete required matrix.