### PR TITLE
fix(discovery): link polynomial interval verifiers

### DIFF
--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -40,6 +40,9 @@ from jacobian.checker_operations import CheckerOperation
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCatalogRelationship,
+    CapabilityCatalogRelationshipKind,
+    CapabilityCatalogRelationshipRegistration,
     CapabilityCompleteness,
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
@@ -115,6 +118,7 @@ class PolynomialIntervalInstallation:
     claim_schema_uri: str
     certificate_schema_uri: str
     checker_id: str | None
+    catalog_relationships: tuple[CapabilityCatalogRelationshipRegistration, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,6 +222,28 @@ def install_polynomial_interval_capabilities(
         )
         .checker_id
     )
+    catalog_relationships = (
+        (
+            CapabilityCatalogRelationshipRegistration(
+                source_capability_id="polynomial.interval.enclose",
+                related_capability=CapabilityCatalogRelationship(
+                    capability_id="polynomial.interval.enclosure.verify",
+                    kind=CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+                    relationship="independently verify this exact interval enclosure",
+                ),
+            ),
+            CapabilityCatalogRelationshipRegistration(
+                source_capability_id="polynomial.interval.enclosure.verify",
+                related_capability=CapabilityCatalogRelationship(
+                    capability_id="polynomial.interval.enclose",
+                    kind=CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER,
+                    relationship="produce the exact enclosure accepted by this verifier",
+                ),
+            ),
+        )
+        if checker_id is not None
+        else ()
+    )
     installation = PolynomialIntervalInstallation(
         semantics_uri=semantics_uri,
         polynomial_semantics_uri=polynomial_semantics_uri,
@@ -227,6 +253,7 @@ def install_polynomial_interval_capabilities(
         claim_schema_uri=claim_schema_uri,
         certificate_schema_uri=certificate_schema_uri,
         checker_id=checker_id,
+        catalog_relationships=catalog_relationships,
     )
     resources = PolynomialIntervalResources(
         store=store,

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -35,6 +35,9 @@ from jacobian.checker_operations import CheckerOperation
 from jacobian.contracts.capabilities import (
     CapabilityAssurance,
     CapabilityAssuranceLevel,
+    CapabilityCatalogRelationship,
+    CapabilityCatalogRelationshipKind,
+    CapabilityCatalogRelationshipRegistration,
     CapabilityCompleteness,
     CapabilityCompletenessStatus,
     CapabilityDescriptor,
@@ -118,6 +121,7 @@ class PolynomialPositivityInstallation:
     claim_schema_uri: str
     certificate_schema_uri: str
     checker_id: str | None
+    catalog_relationships: tuple[CapabilityCatalogRelationshipRegistration, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,6 +221,28 @@ def install_polynomial_positivity_capabilities(
         )
         .checker_id
     )
+    catalog_relationships = (
+        (
+            CapabilityCatalogRelationshipRegistration(
+                source_capability_id="polynomial.interval.positivity.decide",
+                related_capability=CapabilityCatalogRelationship(
+                    capability_id="polynomial.interval.positivity.verify",
+                    kind=CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+                    relationship="independently verify this exact positivity decision",
+                ),
+            ),
+            CapabilityCatalogRelationshipRegistration(
+                source_capability_id="polynomial.interval.positivity.verify",
+                related_capability=CapabilityCatalogRelationship(
+                    capability_id="polynomial.interval.positivity.decide",
+                    kind=(CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER),
+                    relationship="produce the exact decision accepted by this verifier",
+                ),
+            ),
+        )
+        if checker_id is not None
+        else ()
+    )
     installation = PolynomialPositivityInstallation(
         semantics_uri=semantics_uri,
         polynomial_semantics_uri=polynomial_semantics_uri,
@@ -225,6 +251,7 @@ def install_polynomial_positivity_capabilities(
         claim_schema_uri=claim_schema_uri,
         certificate_schema_uri=certificate_schema_uri,
         checker_id=checker_id,
+        catalog_relationships=catalog_relationships,
     )
     resources = PolynomialPositivityResources(
         store=store,

--- a/src/jacobian/portfolio/resource_installation.py
+++ b/src/jacobian/portfolio/resource_installation.py
@@ -58,7 +58,6 @@ class ResourceCapabilityInstaller:
         for interval_adapter in interval_adapters:
             if interval_adapter is not None:
                 ctx.register_capability(interval_adapter)
-
         positivity_adapters, result.polynomial_positivity = (
             install_polynomial_positivity_capabilities(
                 ctx.store,
@@ -72,7 +71,10 @@ class ResourceCapabilityInstaller:
         for positivity_adapter in positivity_adapters:
             if positivity_adapter is not None:
                 ctx.register_capability(positivity_adapter)
-        for relationship in result.polynomial_positivity.catalog_relationships:
+        for relationship in (
+            *result.polynomial_interval.catalog_relationships,
+            *result.polynomial_positivity.catalog_relationships,
+        ):
             ctx.register_checker_relationship(
                 relationship.source_capability_id,
                 relationship.related_capability,

--- a/src/jacobian/portfolio/resource_installation.py
+++ b/src/jacobian/portfolio/resource_installation.py
@@ -72,6 +72,11 @@ class ResourceCapabilityInstaller:
         for positivity_adapter in positivity_adapters:
             if positivity_adapter is not None:
                 ctx.register_capability(positivity_adapter)
+        for relationship in result.polynomial_positivity.catalog_relationships:
+            ctx.register_checker_relationship(
+                relationship.source_capability_id,
+                relationship.related_capability,
+            )
 
         lean_runtime = self.provider_resolver.resolve_lean_frontend()
         result.lean_statement_runtime = lean_runtime

--- a/tests/boundary/mcp/test_mcp_invocation_journey.py
+++ b/tests/boundary/mcp/test_mcp_invocation_journey.py
@@ -89,6 +89,25 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
                 }
             ]
 
+            positivity_description = await client.call_tool(
+                "math.find",
+                {
+                    "capability_id": "polynomial.interval.positivity.decide",
+                    "view": "CONTRACT",
+                },
+            )
+            assert isinstance(positivity_description.structured_content, dict)
+            positivity_contract = positivity_description.structured_content
+            assert positivity_contract["related_capabilities"] == [
+                {
+                    "capability_id": "polynomial.interval.positivity.verify",
+                    "kind": "INDEPENDENT_VERIFIER",
+                    "relationship": (
+                        "independently verify this exact positivity decision"
+                    ),
+                }
+            ]
+
             reliability_verifier_discovery = await client.call_tool(
                 "math.find",
                 {

--- a/tests/boundary/mcp/test_mcp_invocation_journey.py
+++ b/tests/boundary/mcp/test_mcp_invocation_journey.py
@@ -89,6 +89,25 @@ def test_mcp_describes_and_invokes_capabilities(tmp_path: Path) -> None:
                 }
             ]
 
+            enclosure_description = await client.call_tool(
+                "math.find",
+                {
+                    "capability_id": "polynomial.interval.enclose",
+                    "view": "CONTRACT",
+                },
+            )
+            assert isinstance(enclosure_description.structured_content, dict)
+            enclosure_contract = enclosure_description.structured_content
+            assert enclosure_contract["related_capabilities"] == [
+                {
+                    "capability_id": "polynomial.interval.enclosure.verify",
+                    "kind": "INDEPENDENT_VERIFIER",
+                    "relationship": (
+                        "independently verify this exact interval enclosure"
+                    ),
+                }
+            ]
+
             positivity_description = await client.call_tool(
                 "math.find",
                 {

--- a/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
+++ b/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
@@ -11,6 +11,7 @@ from tests.support.polynomials import univariate_term as _term
 
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityCatalogRelationshipKind,
     CapabilityRelationshipStatus,
     CapabilityRequest,
 )
@@ -282,6 +283,24 @@ def test_verify_adapter_rejects_missing_authorized_checker(installation) -> None
 
     with pytest.raises(RuntimeError, match="requires an authorized checker"):
         PolynomialIntervalPositivityVerifyAdapter(resources)
+
+
+def test_installation_declares_reciprocal_checker_navigation(installation) -> None:
+    _adapters, installed, _store = installation
+    relationships = installed.catalog_relationships
+
+    assert [item.source_capability_id for item in relationships] == [
+        "polynomial.interval.positivity.decide",
+        "polynomial.interval.positivity.verify",
+    ]
+    assert [item.related_capability.capability_id for item in relationships] == [
+        "polynomial.interval.positivity.verify",
+        "polynomial.interval.positivity.decide",
+    ]
+    assert [item.related_capability.kind for item in relationships] == [
+        CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+        CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER,
+    ]
 
 
 def test_decide_capability_finds_positive_linear(installation) -> None:

--- a/tests/domain/polynomial/test_polynomial_interval_capabilities.py
+++ b/tests/domain/polynomial/test_polynomial_interval_capabilities.py
@@ -9,6 +9,7 @@ import pytest
 from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityAssuranceLevel,
+    CapabilityCatalogRelationshipKind,
     CapabilityRelationshipStatus,
     CapabilityRequest,
 )
@@ -57,6 +58,24 @@ def test_verify_adapter_rejects_missing_authorized_checker(installation) -> None
 
     with pytest.raises(RuntimeError, match="requires an authorized checker"):
         PolynomialIntervalEnclosureVerifyAdapter(resources)
+
+
+def test_installation_declares_reciprocal_checker_navigation(installation) -> None:
+    _adapters, installed, _store = installation
+    relationships = installed.catalog_relationships
+
+    assert [item.source_capability_id for item in relationships] == [
+        "polynomial.interval.enclose",
+        "polynomial.interval.enclosure.verify",
+    ]
+    assert [item.related_capability.capability_id for item in relationships] == [
+        "polynomial.interval.enclosure.verify",
+        "polynomial.interval.enclose",
+    ]
+    assert [item.related_capability.kind for item in relationships] == [
+        CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+        CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER,
+    ]
 
 
 def test_enclose_capability_computes_a_valid_bernstein_enclosure(


### PR DESCRIPTION
## Summary

- publish reciprocal catalog relationships for both exact polynomial-interval producer/verifier pairs:
  - `polynomial.interval.enclose` ↔ `polynomial.interval.enclosure.verify`
  - `polynomial.interval.positivity.decide` ↔ `polynomial.interval.positivity.verify`
- register each relationship only when its authorized checker is installed
- add component, domain, and MCP discovery regressions

## Why

Held-out reliability work exposed two operations whose mathematics and independent checkers already worked, but whose catalog navigation was incomplete. `math.find` returned no related verifier from either producer contract even though each producer and verifier were installed and compatible.

The positivity omission surfaced in a held-out graph-energy replay. A subsequent deterministic portfolio audit found the same localized omission for the neighboring Bernstein-enclosure pair. Keeping both fixes in this draft avoids a competing PR and duplicate edits to the portfolio attachment seam.

This is a discovery-metadata fix. It does not change mathematical execution, request or result schemas, assurance, checker authority, or verification semantics.

## Impact

Agents can navigate directly from either interval producer to its exact independent verifier, and back from the verifier to the accepted producer. The relationships remain absent when checker authority is unavailable.

## Validation

- focused interval/positivity/MCP regressions: 22 passed after rebasing onto the latest PR head
- Ruff and formatting: passed
- strict mypy: 430 source files passed
- unit: 891 passed
- component: 809 passed, 3 expected macOS skips
- domain: 376 passed
- composition: 270 passed, 2 expected Lean skips
- storage: 127 passed
- process: 247 passed, 1 expected platform skip; the sandbox-blocked loopback test passed separately with local permission
- MCP: 47 passed in the parallel lane; the crashed-worker test passed serially and the sandbox-blocked loopback test passed with local permission
- end-to-end: 7 passed, 1 expected Lean skip

One unrelated process test requires Bash 4 `mapfile`; macOS supplies Bash 3.2, so Linux CI remains authoritative for that test. The npm gate is unavailable because this host has no `npm` executable; JavaScript files are untouched.

This PR remains draft and must not be merged by Codex.