### PR TITLE
fix(discovery): link polynomial-system verifier

### DIFF
--- a/src/jacobian/portfolio/core_installation.py
+++ b/src/jacobian/portfolio/core_installation.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 
 from jacobian.atomic_capabilities import install_atomic_capabilities
 from jacobian.conjecture_ingestion import ConjectureIngestionInstallation
+from jacobian.contracts.capabilities import (
+    CapabilityCatalogRelationship,
+    CapabilityCatalogRelationshipKind,
+)
 from jacobian.exact_domain_checkers import install_exact_domain_verification
 from jacobian.finite_coverage import install_finite_coverage
 from jacobian.finite_partition import install_finite_partition
@@ -35,6 +39,28 @@ class CoreApplicationInstaller:
     """Install core application adapters and domain-dependent checkers."""
 
     context: InstallationContext
+
+    def _register_polynomial_system_relationships(
+        self, *, verifier_installed: bool
+    ) -> None:
+        if not verifier_installed:
+            return
+        self.context.register_checker_relationship(
+            "polynomial.system.rational_solution.search",
+            CapabilityCatalogRelationship(
+                capability_id="polynomial.system.solution.verify",
+                kind=CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+                relationship="independently verify a found exact assignment",
+            ),
+        )
+        self.context.register_checker_relationship(
+            "polynomial.system.solution.verify",
+            CapabilityCatalogRelationship(
+                capability_id="polynomial.system.rational_solution.search",
+                kind=CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER,
+                relationship="search for an exact assignment accepted by this verifier",
+            ),
+        )
 
     def _install_graph_capabilities(
         self,
@@ -174,6 +200,9 @@ class CoreApplicationInstaller:
                 ctx.artifacts,
                 result.polynomial_system,
             )
+        )
+        self._register_polynomial_system_relationships(
+            verifier_installed=polynomial_system_adapter is not None
         )
 
         universal_adapters, result.universal_algebra = (

--- a/tests/composition/runtime/test_polynomial_system_catalog_relationships.py
+++ b/tests/composition/runtime/test_polynomial_system_catalog_relationships.py
@@ -1,0 +1,34 @@
+"""Polynomial-system search/checker discovery contract."""
+
+from __future__ import annotations
+
+from jacobian.contracts.capabilities import CapabilityCatalogRelationshipKind
+
+# Composition-lane admission category for architecture ratchets.
+COMPOSITION_ADMISSION = "AUTHORITY"
+
+
+def test_polynomial_system_search_and_verifier_are_reciprocal(
+    authorized_complete_runtime,
+) -> None:
+    catalog = {
+        descriptor.capability_id: descriptor
+        for descriptor in authorized_complete_runtime.core.capabilities.catalog().capabilities
+    }
+    producer_id = "polynomial.system.rational_solution.search"
+    verifier_id = "polynomial.system.solution.verify"
+    assert catalog[verifier_id].provider_runtime.checker_ids != ()
+
+    producer_links = {
+        item.capability_id: item for item in catalog[producer_id].related_capabilities
+    }
+    verifier_links = {
+        item.capability_id: item for item in catalog[verifier_id].related_capabilities
+    }
+
+    assert producer_links[verifier_id].kind is (
+        CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER
+    )
+    assert verifier_links[producer_id].kind is (
+        CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER
+    )


### PR DESCRIPTION
## What changed

- expose `polynomial.system.solution.verify` from bounded rational solution search as its independent verifier
- expose the reciprocal search producer from the verifier
- register both edges only when the bundled checker is operator-authorized and installed
- add a whole-runtime composition regression for both relationship kinds and checker authority

## Why

Current main installs `polynomial.system.rational_solution.search` and `polynomial.system.solution.verify` as a natural producer/verifier pair. The search returns an exact assignment candidate, and the verifier independently checks that assignment against every equation and inequation. Exact `math.find(..., view="CONTRACT")` inspection nevertheless returned no related capabilities for either endpoint, forcing agents to rediscover the verification boundary separately.

## Impact

This is discovery metadata only. It does not change polynomial search, evaluation, schemas, resource bounds, checker authorization, or assurance. Search remains computed and bounded; only the existing authorized verifier can return verified assurance.

## Validation

- user-facing `math.find` replay shows reciprocal `INDEPENDENT_VERIFIER` / `VERIFIABLE_RESULT_PRODUCER` links
- focused producer, checker, catalog, and whole-runtime tests: 14 passed
- full unit lane: 891 passed
- Ruff lint and format: passed
- mypy for changed source: passed
- `git diff --check`: passed

The standard `make test-unit` wrapper attempted dependency synchronization and could not reach PyPI in the sandbox, so the same unit topology was run directly with the existing locked environment.