### PR TITLE
fix(discovery): restore finite-partition verifier link

### DIFF
--- a/src/jacobian/portfolio/core_installation.py
+++ b/src/jacobian/portfolio/core_installation.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 
 from jacobian.atomic_capabilities import install_atomic_capabilities
 from jacobian.conjecture_ingestion import ConjectureIngestionInstallation
+from jacobian.contracts.capabilities import (
+    CapabilityCatalogRelationship,
+    CapabilityCatalogRelationshipKind,
+)
 from jacobian.exact_domain_checkers import install_exact_domain_verification
 from jacobian.finite_coverage import install_finite_coverage
 from jacobian.finite_partition import install_finite_partition
@@ -108,6 +112,22 @@ class CoreApplicationInstaller:
         self.context.register_capability(finite_partition_adapter)
         if finite_partition_verify is not None:
             self.context.register_capability(finite_partition_verify)
+            self.context.register_checker_relationship(
+                "case.partition.finite",
+                CapabilityCatalogRelationship(
+                    capability_id="case.partition.finite.verify",
+                    kind=CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER,
+                    relationship="independently verify the finite partition",
+                ),
+            )
+            self.context.register_checker_relationship(
+                "case.partition.finite.verify",
+                CapabilityCatalogRelationship(
+                    capability_id="case.partition.finite",
+                    kind=(CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER),
+                    relationship="materialize a finite partition accepted by this verifier",
+                ),
+            )
         finite_coverage_adapter, result.finite_coverage = install_finite_coverage(
             ctx.store,
             ctx.schemas,

--- a/tests/composition/runtime/test_finite_partition_catalog_relationships.py
+++ b/tests/composition/runtime/test_finite_partition_catalog_relationships.py
@@ -1,0 +1,34 @@
+"""Finite-partition producer/checker discovery contract."""
+
+from __future__ import annotations
+
+from jacobian.contracts.capabilities import CapabilityCatalogRelationshipKind
+
+# Composition-lane admission category for architecture ratchets.
+COMPOSITION_ADMISSION = "AUTHORITY"
+
+
+def test_finite_partition_producer_and_verifier_are_reciprocal(
+    authorized_complete_runtime,
+) -> None:
+    catalog = {
+        descriptor.capability_id: descriptor
+        for descriptor in authorized_complete_runtime.core.capabilities.catalog().capabilities
+    }
+    producer_id = "case.partition.finite"
+    verifier_id = "case.partition.finite.verify"
+    assert catalog[verifier_id].provider_runtime.checker_ids != ()
+
+    producer_links = {
+        item.capability_id: item for item in catalog[producer_id].related_capabilities
+    }
+    verifier_links = {
+        item.capability_id: item for item in catalog[verifier_id].related_capabilities
+    }
+
+    assert producer_links[verifier_id].kind is (
+        CapabilityCatalogRelationshipKind.INDEPENDENT_VERIFIER
+    )
+    assert verifier_links[producer_id].kind is (
+        CapabilityCatalogRelationshipKind.VERIFIABLE_RESULT_PRODUCER
+    )


### PR DESCRIPTION
## What changed

- restore the discovery link from `case.partition.finite` to its independent verifier
- restore the reciprocal producer link from `case.partition.finite.verify`
- register both edges only when the finite-partition checker is operator-authorized and installed
- add a whole-runtime composition regression for both relationship kinds and checker authority

## Why

PR #1158 split finite partitioning into separate producer and checker IDs and stated that catalog relationships were updated. On current main, however, exact `math.find(..., view="CONTRACT")` inspection returns no related capabilities for either endpoint. Agents can therefore find the producer yet miss the checker that independently replays its coverage/disjointness certificate.

## Impact

This restores factual navigation only. It does not change finite-partition semantics, schemas, equality-only scope, checker authorization, execution, or assurance. The producer remains computed; only the existing checker can return verified assurance.

## Validation

- user-facing `math.find` replay shows reciprocal `INDEPENDENT_VERIFIER` / `VERIFIABLE_RESULT_PRODUCER` links
- focused finite-partition, checker, authority, and whole-runtime tests passed
- full unit lane: 891 passed
- Ruff lint and format: passed
- mypy for changed source: passed
- `git diff --check`: passed