### PR TITLE
Fix discrete-log example startup budget

### DIFF
--- a/src/jacobian/domains/number_theory/discrete_logarithm.py
+++ b/src/jacobian/domains/number_theory/discrete_logarithm.py
@@ -168,7 +168,7 @@ DISCRETE_LOGARITHM_CAPABILITY = BoundedSearchOperation(
                 "base": 2,
                 "target": 1,
                 "modulus": 3,
-                "resource_budget": {"wall_seconds": 1},
+                "resource_budget": {"wall_seconds": 5},
             },
         ),
     ),

--- a/tests/unit/domains/number_theory/test_discrete_logarithm_protocol.py
+++ b/tests/unit/domains/number_theory/test_discrete_logarithm_protocol.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.domains.number_theory.discrete_logarithm import (
+    DISCRETE_LOGARITHM_CAPABILITY,
+)
 from jacobian.domains.number_theory.discrete_logarithm_protocol import (
     PROTOCOL,
     DiscreteLogarithmWorkerResult,
 )
+
+
+def test_discrete_logarithm_example_budgets_isolated_worker_startup() -> None:
+    example = DISCRETE_LOGARITHM_CAPABILITY.invocation_examples[0]
+
+    assert example.input["resource_budget"]["wall_seconds"] == 5
 
 
 def test_discrete_logarithm_worker_result_rejects_unknown_fields() -> None:


### PR DESCRIPTION
## What changed

- raise the advertised `modular.compute.discrete_logarithm` example budget from 1 second to 5 seconds
- add a regression test that freezes enough time for isolated-worker startup

## Why

The example launches a bounded worker process. On current `main`, its one-second budget can expire during worker startup before the trivial discrete-logarithm calculation runs. This reproduced locally and caused the domain lane on draft PR #1196 to fail with `DISCRETE_LOGARITHM_TIMEOUT`.

The change affects only the advertised example input. It does not change the operation's mathematics, global request bounds, isolation model, or user-supplied budgets.

## Validation

- focused advertised-example and protocol tests: 4 passed
- Ruff check and format: passed
- mypy: 470 source files passed
- unit lane: 892 passed
- component lane: 945 passed, 3 platform skips; two unrelated parallel workers crashed, and both affected tests passed serially (2 passed)
- domain lane: the changed discrete-log example passed; five unrelated factorization examples timed out only under four-worker load and all five passed serially
- diff check: passed

This is intentionally a draft and should not be merged by Codex.