### PR TITLE
Add independent rational arithmetic replay

### DIFF
--- a/src/jacobian/domains/arithmetic/bundle.py
+++ b/src/jacobian/domains/arithmetic/bundle.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import platform
 
 from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.domains.arithmetic.checkers import ARITHMETIC_EXACT_REPLAY_CHECKERS
 from jacobian.domains.arithmetic.integers import INTEGER_CAPABILITIES
 from jacobian.domains.arithmetic.rationals import RATIONAL_CAPABILITIES
 from jacobian.operations import (
@@ -39,7 +40,10 @@ def build_arithmetic_bundle() -> DomainBundle:
                 "integer_encoding": "canonical decimal string",
                 "rational_encoding": "canonical reduced num/den with positive denominator",
                 "arithmetic": "exact via stdlib and maintained SymPy APIs",
-                "assurance": "computed; no independent checker",
+                "assurance": (
+                    "producers are computed; core binary rational arithmetic "
+                    "supports operator-authorized independent replay"
+                ),
             },
         ),
         provider_runtime=known_provider_runtime(
@@ -65,11 +69,12 @@ def build_arithmetic_bundle() -> DomainBundle:
         ),
         scope_description="the complete supplied bounded exact arithmetic input",
         completeness_basis=(
-            "deterministic exact computation covered the supplied input; "
-            "not independently verified"
+            "deterministic exact computation covered the supplied input; core "
+            "binary rational arithmetic can additionally be independently replayed"
         ),
         assurance_basis=(
             "deterministic exact arithmetic from the pinned stdlib/SymPy runtime; "
-            "no independent checker invoked"
+            "VERIFIED only after an operator-authorized independent checker accepts"
         ),
+        checker_declarations=ARITHMETIC_EXACT_REPLAY_CHECKERS,
     )

--- a/src/jacobian/domains/arithmetic/checkers.py
+++ b/src/jacobian/domains/arithmetic/checkers.py
@@ -1,0 +1,46 @@
+"""Independent checker declarations owned by the arithmetic domain."""
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.rationals import RationalPairRequest
+
+_ENTRYPOINT = "jacobian_checkers.exact_arithmetic"
+_REASON = (
+    "operator-authorized Python-FLINT rational replay independent of the "
+    "standard-library Fraction producer"
+)
+
+ARITHMETIC_EXACT_REPLAY_CHECKERS = tuple(
+    ExactReplayCheckerDeclaration(
+        capability_id,
+        RationalPairRequest,
+        function,
+        format_id,
+        entrypoint_module=_ENTRYPOINT,
+        replay_method="Python-FLINT exact rational replay",
+        reason=_REASON,
+    )
+    for capability_id, function, format_id in (
+        (
+            "rational.compute.sum",
+            "check_rational_sum",
+            "rational.sum.flint-replay",
+        ),
+        (
+            "rational.compute.difference",
+            "check_rational_difference",
+            "rational.difference.flint-replay",
+        ),
+        (
+            "rational.compute.product",
+            "check_rational_product",
+            "rational.product.flint-replay",
+        ),
+        (
+            "rational.compute.quotient",
+            "check_rational_quotient",
+            "rational.quotient.flint-replay",
+        ),
+    )
+)
+
+__all__ = ["ARITHMETIC_EXACT_REPLAY_CHECKERS"]

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -76,6 +76,7 @@ from jacobian.verification import VerificationService
 _LOGGER = logging.getLogger(__name__)
 _OPTIONAL_EXACT_REPLAY_PROVIDER_KEYS = frozenset({"python-flint"})
 _ENTRYPOINT_PROVIDER_RUNTIME_KEYS = {
+    "jacobian_checkers.exact_arithmetic": "python-flint",
     "jacobian_checkers.exact_domain_operations": "python-flint",
     "jacobian_checkers.graph_exact_operations": "finite-graph",
     "jacobian_checkers.exact_probability_operations": "finite-probability",

--- a/src/jacobian_checkers/exact_arithmetic.py
+++ b/src/jacobian_checkers/exact_arithmetic.py
@@ -1,0 +1,136 @@
+"""Independent Python-FLINT replay for bounded scalar rational arithmetic.
+
+The checked producers use standard-library ``Fraction`` arithmetic. This
+module imports neither producer implementation nor Jacobian code; only passive
+JSON values cross the checker boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+import flint
+from flint import fmpq, fmpz
+
+from jacobian_checkers.bound_artifacts import bound_request
+
+_INTEGER = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_MAX_COMPONENT_DIGITS = 32_768
+_PYTHON_FLINT_VERSION = "0.9.0"
+_FLINT_VERSION = "3.6.0"
+
+
+def _decision(accepted: bool, detail: str) -> dict[str, Any]:
+    return {
+        "accepted": accepted,
+        "conclusion": "TRUE" if accepted else "UNKNOWN",
+        "arithmetic": "EXACT_RATIONAL",
+        "method": "DIRECT_WITNESS",
+        "coverage": "NOT_APPLICABLE",
+        "detail": detail,
+    }
+
+
+def _integer(value: object) -> fmpz:
+    if (
+        not isinstance(value, str)
+        or _INTEGER.fullmatch(value) is None
+        or len(value.lstrip("-")) > _MAX_COMPONENT_DIGITS
+    ):
+        raise ValueError("integer is malformed or outside checker scope")
+    return fmpz(value)
+
+
+def _rational(value: object) -> fmpq:
+    if not isinstance(value, dict) or set(value) != {"num", "den"}:
+        raise ValueError("rational is malformed")
+    numerator = _integer(value["num"])
+    denominator = _integer(value["den"])
+    if denominator <= 0:
+        raise ValueError("rational denominator must be positive")
+    rational = fmpq(numerator, denominator)
+    if rational.numer() != numerator or rational.denom() != denominator:
+        raise ValueError("rational is not canonical and reduced")
+    return rational
+
+
+def _replay(
+    request: object,
+    *,
+    operation_id: str,
+    witness_format: str,
+    operation: Callable[[fmpq, fmpq], fmpq],
+) -> dict[str, Any]:
+    try:
+        if (
+            flint.__version__ != _PYTHON_FLINT_VERSION
+            or flint.__FLINT_VERSION__ != _FLINT_VERSION
+        ):
+            return _decision(False, "authorized Python-FLINT runtime is unavailable")
+        source, result = bound_request(
+            request,
+            operation_id=operation_id,
+            witness_format=witness_format,
+        )
+        if set(source) != {"left", "right"} or set(result) != {"value"}:
+            raise ValueError("rational operation payload is malformed")
+        left = _rational(source["left"])
+        right = _rational(source["right"])
+        candidate = _rational(result["value"])
+        if operation(left, right) != candidate:
+            return _decision(
+                False,
+                "declared result does not match independent Python-FLINT replay",
+            )
+        return _decision(
+            True,
+            f"independent Python-FLINT replay accepted {operation_id}",
+        )
+    except (KeyError, TypeError, ValueError, ZeroDivisionError, OverflowError):
+        return _decision(False, "malformed, unsupported, or mismatched checker request")
+
+
+def check_rational_sum(request: object) -> dict[str, Any]:
+    return _replay(
+        request,
+        operation_id="rational.compute.sum",
+        witness_format="rational.sum.flint-replay",
+        operation=lambda left, right: left + right,
+    )
+
+
+def check_rational_difference(request: object) -> dict[str, Any]:
+    return _replay(
+        request,
+        operation_id="rational.compute.difference",
+        witness_format="rational.difference.flint-replay",
+        operation=lambda left, right: left - right,
+    )
+
+
+def check_rational_product(request: object) -> dict[str, Any]:
+    return _replay(
+        request,
+        operation_id="rational.compute.product",
+        witness_format="rational.product.flint-replay",
+        operation=lambda left, right: left * right,
+    )
+
+
+def check_rational_quotient(request: object) -> dict[str, Any]:
+    return _replay(
+        request,
+        operation_id="rational.compute.quotient",
+        witness_format="rational.quotient.flint-replay",
+        operation=lambda left, right: left / right,
+    )
+
+
+__all__ = [
+    "check_rational_difference",
+    "check_rational_product",
+    "check_rational_quotient",
+    "check_rational_sum",
+]

--- a/tests/component/checkers/test_exact_arithmetic_checkers.py
+++ b/tests/component/checkers/test_exact_arithmetic_checkers.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from tests.component.checkers.exact_domain_checker_support import _request
+from tests.support.artifacts import canonical_digest
+from tests.support.rationals import rational_payload as q
+
+from jacobian_checkers.exact_arithmetic import (
+    check_rational_difference,
+    check_rational_product,
+    check_rational_quotient,
+    check_rational_sum,
+)
+
+_Case = tuple[
+    Callable[[object], dict[str, Any]],
+    str,
+    str,
+    dict[str, str],
+]
+
+_CASES: tuple[_Case, ...] = (
+    (
+        check_rational_sum,
+        "rational.compute.sum",
+        "rational.sum.flint-replay",
+        q(5, 6),
+    ),
+    (
+        check_rational_difference,
+        "rational.compute.difference",
+        "rational.difference.flint-replay",
+        q(1, 6),
+    ),
+    (
+        check_rational_product,
+        "rational.compute.product",
+        "rational.product.flint-replay",
+        q(1, 6),
+    ),
+    (
+        check_rational_quotient,
+        "rational.compute.quotient",
+        "rational.quotient.flint-replay",
+        q(3, 2),
+    ),
+)
+
+
+def _checker_request(
+    operation_id: str,
+    witness_format: str,
+    result: dict[str, str],
+) -> dict[str, Any]:
+    return _request(
+        operation_id,
+        witness_format,
+        {"left": q(1, 2), "right": q(1, 3)},
+        {"value": result},
+    )
+
+
+@pytest.mark.parametrize(
+    ("checker", "operation_id", "witness_format", "result"), _CASES
+)
+def test_rational_arithmetic_checker_accepts_independent_exact_replay(
+    checker: Callable[[object], dict[str, Any]],
+    operation_id: str,
+    witness_format: str,
+    result: dict[str, str],
+) -> None:
+    decision = checker(_checker_request(operation_id, witness_format, result))
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+@pytest.mark.parametrize(
+    ("checker", "operation_id", "witness_format", "result"), _CASES
+)
+def test_rational_arithmetic_checker_rejects_forged_freshly_bound_result(
+    checker: Callable[[object], dict[str, Any]],
+    operation_id: str,
+    witness_format: str,
+    result: dict[str, str],
+) -> None:
+    request = _checker_request(operation_id, witness_format, result)
+    request["candidate"]["payload"]["value"] = q(7, 9)
+    request["candidate"]["payload_digest"] = canonical_digest(
+        request["candidate"]["payload"]
+    )
+
+    decision = checker(request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
+def test_rational_arithmetic_checker_rejects_cross_operation_witness() -> None:
+    request = _checker_request(
+        "rational.compute.sum",
+        "rational.sum.flint-replay",
+        q(5, 6),
+    )
+    request["witness"]["payload"]["payload"]["operation_id"] = (
+        "rational.compute.product"
+    )
+    request["witness"]["payload_digest"] = canonical_digest(
+        request["witness"]["payload"]
+    )
+
+    decision = check_rational_sum(copy.deepcopy(request))
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"

--- a/tests/domain/arithmetic/test_arithmetic_capabilities.py
+++ b/tests/domain/arithmetic/test_arithmetic_capabilities.py
@@ -2,9 +2,10 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from tests.support.exact_domain import open_exact_domain_services
 from tests.support.services import DomainTestServices, open_domain_services
 
-from jacobian.contracts.capabilities import CapabilityRequest
+from jacobian.contracts.capabilities import CapabilityAssuranceLevel, CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.arithmetic import build_arithmetic_bundle
 
@@ -17,6 +18,84 @@ def domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
         tmp_path / "state", build_arithmetic_bundle()
     ) as services:
         yield services
+
+
+@pytest.fixture
+def verified_domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
+    with open_exact_domain_services(
+        tmp_path / "verified-state", build_arithmetic_bundle()
+    ) as services:
+        yield services
+
+
+@pytest.mark.parametrize(
+    ("producer_id", "verifier_id", "expected"),
+    (
+        ("rational.compute.sum", "rational.sum.verify", {"num": "5", "den": "6"}),
+        (
+            "rational.compute.difference",
+            "rational.difference.verify",
+            {"num": "1", "den": "6"},
+        ),
+        (
+            "rational.compute.product",
+            "rational.product.verify",
+            {"num": "1", "den": "6"},
+        ),
+        (
+            "rational.compute.quotient",
+            "rational.quotient.verify",
+            {"num": "3", "den": "2"},
+        ),
+    ),
+)
+def test_core_rational_arithmetic_has_independent_replay(
+    verified_domain_services: DomainTestServices,
+    producer_id: str,
+    verifier_id: str,
+    expected: dict[str, str],
+) -> None:
+    payload = {
+        "left": {"num": "1", "den": "2"},
+        "right": {"num": "1", "den": "3"},
+    }
+    computed = verified_domain_services.core.capabilities.invoke(
+        CapabilityRequest(capability_id=producer_id, input=payload)
+    )
+    verified = verified_domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=verifier_id,
+            input={"input": payload, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert computed.output["result"] == {"value": expected}
+    assert computed.assurance.level is CapabilityAssuranceLevel.COMPUTED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
+    assert verified.assurance.verification_record_uri is not None
+
+
+def test_rational_sum_verifier_rejects_wrong_schema_valid_fraction(
+    verified_domain_services: DomainTestServices,
+) -> None:
+    rejected = verified_domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.sum.verify",
+            input={
+                "input": {
+                    "left": {"num": "1", "den": "2"},
+                    "right": {"num": "1", "den": "3"},
+                },
+                "candidate": {"value": {"num": "7", "den": "9"}},
+            },
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
 
 
 def test_arithmetic_capabilities_return_exact_results(
@@ -65,6 +144,29 @@ def test_rational_product_formats_results_above_python_digit_limit(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["result"] == {"value": {"num": "1" + "0" * 5000, "den": "1"}}
+
+
+def test_rational_product_verifier_replays_result_above_python_digit_limit(
+    verified_domain_services: DomainTestServices,
+) -> None:
+    factor = "1" + "0" * 2500
+    payload = {
+        "left": {"num": factor, "den": "1"},
+        "right": {"num": factor, "den": "1"},
+    }
+    computed = verified_domain_services.core.capabilities.invoke(
+        CapabilityRequest(capability_id="rational.compute.product", input=payload)
+    )
+    verified = verified_domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.product.verify",
+            input={"input": payload, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert computed.output["result"] == {"value": {"num": "1" + "0" * 5000, "den": "1"}}
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.assurance.level is CapabilityAssuranceLevel.VERIFIED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add independent Python-FLINT replay checkers for bounded rational sum, difference, product, and quotient
- expose reciprocal producer → verifier navigation through the existing exact-domain installation path
- bind exact inputs and candidate artifacts and reject schema-valid forged results
- preserve `COMPUTED` producer assurance and grant `VERIFIED` only after authorized independent replay

## Why

Resolved-conjecture trajectories across analysis, probability, and number theory repeatedly retained correct final conclusions while displaying incorrect exact intermediate fractions, products, or scaled values. The existing rational producers use standard-library `Fraction` and were exact, but had no independent replay path.

This change adds a reusable trust boundary for the four core binary rational operations. It does not add theorem-specific logic, sequence-wide arithmetic, ordering predicates, or approximate numerics.

## Independence and safety

The producers use standard-library `Fraction`. The checker is a separate entrypoint using Python-FLINT `fmpq`, imports neither producer code nor Jacobian runtime code, requires canonical reduced rationals with positive denominators, enforces 32,768-digit component bounds, binds source/result digests, and fails closed on malformed, cross-operation, or division-by-zero requests.

## Validation

- focused checker and public producer→verifier tests: 23 passed
- changed-file Ruff and formatting: passed
- targeted source mypy: passed
- full static validation: passed (472 source files in the validated checkout)
- unit: 891 passed
- component: 955 passed, 3 platform skips; one unrelated parallel worker crash passed on isolated rerun
- MCP: 47 passed apart from a sandbox-only loopback-bind denial
- composition: 139 passed, 2 pinned-Lean skips
- storage: 126 passed
- E2E: 7 passed, 1 pinned-Lean skip
- full domain validation was blocked only by the reproducible current-main advertised discrete-log startup timeout now isolated in draft PR #1200
- process-only local limitations: sandbox loopback denial and macOS Bash 3.2 lacking `mapfile`

This PR is intentionally draft and must not be merged by Codex.