### PR TITLE
fix(matrices): repair one-row lattice reduction

### DIFF
--- a/src/jacobian/domains/matrix_lattice/lll_worker.py
+++ b/src/jacobian/domains/matrix_lattice/lll_worker.py
@@ -77,13 +77,20 @@ def _run(worker_request: LllWorkerRequest) -> LllWorkerResponse:
             for row in worker_request.request.basis.entries
         ]
         source = flint.fmpz_mat(entries)
-        reduced, transformation = source.lll(
-            transform=True,
-            delta=0.99,
-            eta=0.51,
-            rep="zbasis",
-            gram="exact",
-        )
+        if source.nrows() == 1:
+            # Every one-row integer basis is already LLL-reduced.  FLINT rejects
+            # this mathematically valid boundary case, so preserve it exactly
+            # with the unique one-dimensional identity transformation.
+            reduced = source
+            transformation = flint.fmpz_mat([[1]])
+        else:
+            reduced, transformation = source.lll(
+                transform=True,
+                delta=0.99,
+                eta=0.51,
+                rep="zbasis",
+                gram="exact",
+            )
         if transformation * source != reduced:
             raise WorkerError(LllWorkerErrorCode.RELATION_INVALID)
     except WorkerError:

--- a/tests/domain/matrix/test_matrix_lattice_domain.py
+++ b/tests/domain/matrix/test_matrix_lattice_domain.py
@@ -544,6 +544,26 @@ def test_lattice_lll_returns_exact_left_transformation(
     assert len(result.artifact_uris) == 2
 
 
+def test_lattice_lll_supports_advertised_one_row_basis(
+    matrix_domain_services: DomainTestServices,
+) -> None:
+    runtime = matrix_domain_services
+    for entries, expected_rank in (([["1"]], 1), ([["3", "-4"]], 1)):
+        result = runtime.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id="lattice.basis.reduce",
+                input={"basis": {"domain": "ZZ", "entries": entries}},
+            )
+        )
+
+        assert result.execution.status is ExecutionStatus.COMPLETED
+        computed = _result_payload(runtime, result)
+        assert computed["reduced_basis"]["entries"] == entries
+        assert computed["transformation"]["entries"] == [["1"]]
+        assert computed["rank"] == expected_rank
+        assert len(result.artifact_uris) == 2
+
+
 def test_lattice_lll_timeout_retains_no_operation_artifacts(
     matrix_domain_services: DomainTestServices,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## Summary

- handle valid one-row integer bases inside the isolated LLL worker
- return the unchanged row basis with the exact 1×1 identity transformation
- cover both the advertised unit-basis example and a rectangular one-row basis

## Root cause

`lattice.basis.reduce` accepts and advertises one-row bases, but Python-FLINT 0.9.0 / FLINT 3.6.0 rejects that degenerate LLL call. Every one-row basis is already LLL-reduced, so asking the backend to reduce it turned a valid public request into `FLINT_LLL_WORKER_FAILED`.

The fix remains inside the pinned isolated worker. It does not change the public contract, backend identity checks, materialization, relation binding, or COMPUTED assurance.

## Validation

- focused matrix-lattice file: 16 passed
- unit lane: 891 passed
- component lane: 947 passed, 3 platform skips
- lint, format, complexity, and mypy: passed
- package build: passed
- full domain lane: 459 passed; one unrelated failure in `modular.compute.discrete_logarithm` because its advertised one-second startup budget timed out, already owned by draft PR #1200
- diff check: passed
