### PR TITLE
Fix published Arb and Gröbner cold-worker examples

### DIFF
--- a/src/jacobian/domains/analysis/operations.py
+++ b/src/jacobian/domains/analysis/operations.py
@@ -139,12 +139,29 @@ POINT_ENCLOSURE_CAPABILITIES = (
             title="Enclose a real function at a rational point",
             description=(
                 "Use pinned Arb ball arithmetic to enclose one supported real "
-                "function at one exact rational point within a wall-clock budget."
+                "function (square root, logarithm, exponential, sine, or cosine) "
+                "at one exact rational point within a wall-clock budget."
             ),
             request_type=ArbPointEnclosureRequest,
             result_type=ArbPointEnclosureResult,
             execute=_point_enclosure,
-            tags=("analysis", "validated", "arb", "enclosure", "bounded"),
+            tags=(
+                "analysis",
+                "validated",
+                "arb",
+                "enclosure",
+                "bounded",
+                "square-root",
+                "sqrt",
+                "logarithm",
+                "log",
+                "exponential",
+                "exp",
+                "sine",
+                "sin",
+                "cosine",
+                "cos",
+            ),
             invocation_examples=(
                 example(
                     "sqrt_zero",
@@ -153,7 +170,7 @@ POINT_ENCLOSURE_CAPABILITIES = (
                         "function": "SQRT",
                         "argument": {"num": "0", "den": "1"},
                         "precision_bits": 32,
-                        "wall_seconds": 1,
+                        "wall_seconds": 10,
                     },
                 ),
             ),

--- a/src/jacobian/domains/polynomial/groebner.py
+++ b/src/jacobian/domains/polynomial/groebner.py
@@ -149,7 +149,7 @@ POLYNOMIAL_GROEBNER_CAPABILITY = durable_operation(
                         }
                     ],
                     "monomial_order": "lex",
-                    "resource_budget": {"wall_seconds": 1},
+                    "resource_budget": {"wall_seconds": 10},
                 },
             ),
         ),

--- a/tests/domain/analysis/test_real_analysis.py
+++ b/tests/domain/analysis/test_real_analysis.py
@@ -22,6 +22,28 @@ def domain_services(tmp_path: Path) -> Iterator[DomainTestServices]:
         yield services
 
 
+def test_advertised_arb_example_preserves_worker_startup_budget(
+    domain_services: DomainTestServices,
+) -> None:
+    operation = next(
+        operation
+        for operation in build_real_analysis_bundle().capabilities
+        if operation.spec.operation_id
+        == "analysis.real_function.point_enclosure.compute"
+    )
+    example = operation.spec.invocation_examples[0]
+
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id=operation.spec.operation_id,
+            input=example.input,
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["status"] == "ENCLOSED"
+
+
 def test_arb_point_enclosure_returns_exact_dyadics(
     domain_services: DomainTestServices,
 ) -> None:

--- a/tests/domain/polynomial/test_polynomial_operation_bundle.py
+++ b/tests/domain/polynomial/test_polynomial_operation_bundle.py
@@ -43,6 +43,24 @@ def _polynomial(
     }
 
 
+def test_groebner_advertised_example_completes(
+    polynomial_services: DomainTestServices,
+) -> None:
+    descriptor = next(
+        item
+        for item in polynomial_services.core.capabilities.catalog().capabilities
+        if item.capability_id == "polynomial.groebner_basis.compute"
+    )
+
+    result = _invoke(
+        polynomial_services,
+        descriptor.capability_id,
+        descriptor.invocation_examples[0].input,
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+
+
 def test_polynomial_bundle_installs_and_computes_exact_invariants(
     polynomial_services,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/domains/analysis/test_point_enclosure_discovery.py
+++ b/tests/unit/domains/analysis/test_point_enclosure_discovery.py
@@ -1,0 +1,25 @@
+"""Discovery vocabulary for Arb real-function enclosures."""
+
+from jacobian.domains.analysis.operations import POINT_ENCLOSURE_CAPABILITIES
+
+
+def test_point_enclosure_advertises_every_supported_function() -> None:
+    operation = POINT_ENCLOSURE_CAPABILITIES[0]
+    spec = operation.spec
+
+    assert {
+        "square-root",
+        "sqrt",
+        "logarithm",
+        "log",
+        "exponential",
+        "exp",
+        "sine",
+        "sin",
+        "cosine",
+        "cos",
+    } <= set(spec.tags)
+    assert "square root, logarithm, exponential, sine, or cosine" in (
+        spec.description
+    )
+    assert spec.invocation_examples[0].input["wall_seconds"] == 10


### PR DESCRIPTION
## Summary

Ports the surviving cold-worker example fixes onto the post-#1276 typed ownership model.

- raise the published Gröbner-basis example budget from one second to ten seconds;
- raise the published Arb point-enclosure example budget from one second to ten seconds;
- name every supported Arb function in the operation description and tags so square-root, logarithm, exponential, sine, and cosine queries discover it;
- execute both operation-owned examples through the current typed dispatch path;
- keep one Arb budget owner here and leave #1239 superseded.

## Architecture boundary

This branch was rebuilt as one commit directly on current `main` (`195c4c1`). It changes only two `OperationSpec` declarations and three focused tests. It does not carry forward the old inverse-verifier refactor, generic result construction, reciprocal relationships, workflow navigation, or an alternate MCP surface.

The inverse-synthesis example was deliberately removed from this refresh: #1276 changed that publisher/checker path, and preserving its old branch-local refactor would mix an architectural migration into a metadata fix. Any remaining inverse startup defect should be handled against its current owner in a separate narrow patch.

## Validation

CI is authoritative for the rebuilt head. The focused tests assert that the advertised examples complete and that every supported Arb function remains discoverable.

Supersedes the surviving Arb portion of #1239.