### PR TITLE
fix(skills): align math.run payload envelope

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -22,7 +22,7 @@ Keep decomposition and routing decisions agent-owned; composing already-known
 supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-No discovery for stable producers: `{"capability_id":"<id>","input":<JSON>}`.
+No discovery for stable producers: `{"capability_id":"<id>","payload":<JSON>}`.
 Payloads:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or `integer.compute.extended_gcd`:

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -22,7 +22,7 @@ Keep decomposition and routing decisions agent-owned; composing already-known
 supporting operations remains allowed when clearer.
 Do not call Jacobian for definitions, formatting, or non-execution tasks.
 
-No discovery for stable producers: `{"capability_id":"<id>","input":<JSON>}`.
+No discovery for stable producers: `{"capability_id":"<id>","payload":<JSON>}`.
 Payloads:
 
 - `integer.compute.gcd`, `integer.compute.lcm`, or `integer.compute.extended_gcd`:

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import re
+from inspect import Parameter, signature
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,7 @@ from benchmarks.tooling.codex_visibility import (
 from benchmarks.tooling.command_runner import ToolCommandResult, ToolCommandStatus
 from pydantic import ValidationError
 
+from jacobian.adapters.mcp.tools import capability_invoke
 from jacobian.contracts.combinatorics import CyclicDifferenceSetExtensionRequest
 from jacobian.contracts.matrix_operations import MatrixDeterminantRequest
 from jacobian.contracts.number_theory import IntegerPairRequest
@@ -179,7 +181,12 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     assert polynomial in skill
     extension_payload = '{"base_elements":["1","2","4","8","13"],"target_order":7}'
     assert extension_payload in skill
-    assert '"input":<JSON>' in skill
+    run_parameters = signature(capability_invoke).parameters
+    assert tuple(run_parameters) == ("capability_id", "payload", "ctx")
+    assert run_parameters["ctx"].kind is Parameter.KEYWORD_ONLY
+    direct_envelope = f'{{"capability_id":"<id>","{tuple(run_parameters)[1]}":<JSON>}}'
+    assert direct_envelope in skill
+    assert '{"capability_id":"<id>","input":<JSON>}' not in skill
     assert "No discovery for stable producers" in skill
     assert "never with `capability_id`" in skill
     assert '"candidate":<producer output.result>' in skill


### PR DESCRIPTION
## Problem

The managed Jacobian Codex skill advertises stable direct `math.run` calls as `{"capability_id":"<id>","input":...}`. The MCP 2.0 tool schema and `math.find(..., view="CONTRACT")` invocation examples require `payload`, so following the skill fails with `INVALID_INPUT` before the mathematical operation runs.

## Change

- restore `payload` in both repository and packaged skill copies while keeping the mode-less wire contract
- bind the visibility regression to the real `capability_invoke` signature and explicitly reject the stale `input` envelope
- preserve byte identity between both packaged copies and keep the skill below 4 KiB

This changes only agent guidance and its regression test; the MCP server wire contract is unchanged.

## Validation

- skill creator `quick_validate.py` on both skill copies
- `make check-changed PATHS='...'`: 4/4 passed (lint/typecheck, npm, docs, 891 unit tests)
- `make test-mcp TESTS=tests/boundary/mcp/test_mcp_adapter_inventory.py`: 1 passed
- `make npm-test`: 59 passed plus successful package dry-run
- live reproduction on MCP `0.11.0`: `input` rejected with `INVALID_INPUT`; `payload` completed and returned `gcd(84,30)=6`
