### PR TITLE
fix(skills): correct determinant verifier payload

### DIFF
--- a/.agents/skills/jacobian-math/SKILL.md
+++ b/.agents/skills/jacobian-math/SKILL.md
@@ -35,7 +35,7 @@ Payloads:
 - For expression normalization, inspect the known
   `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` for an independent check:
-  `{"determinant_uri":"<determinant_uri from compute output>"}`.
+  `{"input":<same determinant payload>,"candidate":<producer output.result>}`.
 - `combinatorics.cyclic_difference_set.extension.decide`:
   `{"base_elements":["1","2","4","8","13"],"target_order":7}`.
   `combinatorics.cyclic_difference_set.extension.verify` uses

--- a/npm/skills/jacobian-math/SKILL.md
+++ b/npm/skills/jacobian-math/SKILL.md
@@ -35,7 +35,7 @@ Payloads:
 - For expression normalization, inspect the known
   `polynomial.expression.normalize` contract directly.
 - `matrix.determinant.verify` for an independent check:
-  `{"determinant_uri":"<determinant_uri from compute output>"}`.
+  `{"input":<same determinant payload>,"candidate":<producer output.result>}`.
 - `combinatorics.cyclic_difference_set.extension.decide`:
   `{"base_elements":["1","2","4","8","13"],"target_order":7}`.
   `combinatorics.cyclic_difference_set.extension.verify` uses

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -23,10 +23,14 @@ from pydantic import ValidationError
 
 from jacobian.adapters.mcp.tools import capability_invoke
 from jacobian.contracts.combinatorics import CyclicDifferenceSetExtensionRequest
-from jacobian.contracts.matrix_operations import MatrixDeterminantRequest
+from jacobian.contracts.matrix_operations import (
+    MatrixDeterminantRequest,
+    MatrixDeterminantResult,
+)
 from jacobian.contracts.number_theory import IntegerPairRequest
 from jacobian.contracts.polynomial_operations import PolynomialGcdRequest
 from jacobian.eval.telemetry import parse_agent_transcript
+from jacobian.exact_domain_checkers import ExactComputedVerificationRequest
 
 _ROOT = Path(__file__).resolve().parents[3]
 
@@ -181,6 +185,18 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     assert polynomial in skill
     extension_payload = '{"base_elements":["1","2","4","8","13"],"target_order":7}'
     assert extension_payload in skill
+    determinant_verify_payload = {
+        "input": json.loads(matrix_payload),
+        "candidate": {
+            "determinant": {"num": "1", "den": "1"},
+            "method": "FRACTION_FREE_BAREISS",
+        },
+    }
+    assert (
+        '`{"input":<same determinant payload>,'
+        '"candidate":<producer output.result>}`' in skill
+    )
+    assert "determinant_uri" not in skill
     run_parameters = signature(capability_invoke).parameters
     assert tuple(run_parameters) == ("capability_id", "payload", "ctx")
     assert run_parameters["ctx"].kind is Parameter.KEYWORD_ONLY
@@ -192,6 +208,9 @@ def test_codex_skill_keeps_bounded_stable_direct_run_contracts() -> None:
     assert '"candidate":<producer output.result>' in skill
     IntegerPairRequest.model_validate_json(integer_payload)
     MatrixDeterminantRequest.model_validate_json(matrix_payload)
+    ExactComputedVerificationRequest[
+        MatrixDeterminantRequest, MatrixDeterminantResult
+    ].model_validate(determinant_verify_payload)
     polynomial_value = json.loads(polynomial)
     PolynomialGcdRequest.model_validate(
         {"left": polynomial_value, "right": polynomial_value}


### PR DESCRIPTION
## What changed

- replace the stale `determinant_uri` example for `matrix.determinant.verify` with the live inline `{input, candidate}` envelope
- keep the repository and packaged Jacobian skill copies identical
- validate a concrete determinant verifier payload against the runtime's generic exact-replay request model

## Why

PR #1206 corrected the outer `math.run` argument from `input` to `payload`, but the stable determinant verifier example still described the retired artifact-URI contract. Agents copying the skill would therefore submit a schema-invalid verification request even though the producer and checker are installed and linked.

This changes guidance and regression coverage only. It does not alter determinant mathematics, checker authority, schemas, execution, or assurance.

## Validation

- focused skill/visibility tests: 18 passed
- full unit lane: 891 passed
- Ruff lint and formatting: passed
- complexity baseline: passed
- strict mypy: 470 source files passed
- documentation command validation: passed
- `git diff --check`: passed

The change planner also selects npm packaging and Markdown link checks. This macOS host has neither `npm` nor `npx`, so hosted CI is authoritative for those two environment-only gates.

This PR is intentionally draft and must not be merged by Codex.