### PR TITLE
Fix certified Smith input schema bound

### DIFF
--- a/src/jacobian/contracts/certified_snf.py
+++ b/src/jacobian/contracts/certified_snf.py
@@ -48,8 +48,15 @@ class CertifiedIntegerMatrix(ContractModel):
         return self
 
 
+class CertifiedSmithInputMatrix(CertifiedIntegerMatrix):
+    """An integer matrix within the certified Smith producer's input budget."""
+
+    row_count: StrictInt = Field(ge=1, le=MAX_CERTIFIED_SNF_INPUT_DIMENSION)
+    column_count: StrictInt = Field(ge=1, le=MAX_CERTIFIED_SNF_INPUT_DIMENSION)
+
+
 class CertifiedSmithNormalFormRequest(ContractModel):
-    matrix: CertifiedIntegerMatrix
+    matrix: CertifiedSmithInputMatrix
 
     @model_validator(mode="after")
     def require_nonempty_bounded_input(self) -> Self:
@@ -161,6 +168,7 @@ __all__ = [
     "MAX_CERTIFIED_SNF_INPUT_DIMENSION",
     "MAX_CERTIFIED_SNF_OUTPUT_DIGITS",
     "CertifiedIntegerMatrix",
+    "CertifiedSmithInputMatrix",
     "CertifiedSmithNormalFormRequest",
     "CertifiedSmithNormalFormResult",
     "SmithNormalFormCertificate",

--- a/src/jacobian/domains/certified_snf/operations.py
+++ b/src/jacobian/domains/certified_snf/operations.py
@@ -35,7 +35,8 @@ CERTIFIED_SNF_CAPABILITIES: tuple[MaterializedOperation[Any, Any, Any, Any], ...
         title="Compute a transformation-certified Smith normal form",
         description=(
             "Compute the canonical Smith diagonal D and explicit unimodular "
-            "matrices U and V satisfying D = U A V for one bounded integer matrix."
+            "matrices U and V satisfying D = U A V for one integer matrix of "
+            "at most 16 by 16."
         ),
         request_model=CertifiedSmithNormalFormRequest,
         result_model=CertifiedSmithNormalFormResult,

--- a/tests/unit/contracts/test_certified_snf_contracts.py
+++ b/tests/unit/contracts/test_certified_snf_contracts.py
@@ -34,6 +34,25 @@ def test_certified_smith_request_rejects_large_input_scalars() -> None:
         )
 
 
+def test_certified_smith_request_schema_publishes_the_enforced_dimension_cap() -> None:
+    schema = CertifiedSmithNormalFormRequest.model_json_schema()
+    matrix_ref = schema["properties"]["matrix"]["$ref"]
+    matrix_schema = schema["$defs"][matrix_ref.rsplit("/", maxsplit=1)[-1]]
+
+    assert matrix_schema["properties"]["row_count"] == {
+        "maximum": 16,
+        "minimum": 1,
+        "title": "Row Count",
+        "type": "integer",
+    }
+    assert matrix_schema["properties"]["column_count"] == {
+        "maximum": 16,
+        "minimum": 1,
+        "title": "Column Count",
+        "type": "integer",
+    }
+
+
 def test_certificate_contract_requires_a_canonical_divisibility_diagonal() -> None:
     source = CertifiedIntegerMatrix.model_validate(_matrix([[2, 0], [0, 6]]))
     identity = CertifiedIntegerMatrix.model_validate(_matrix([[1, 0], [0, 1]]))


### PR DESCRIPTION
## What changed

- publish the certified Smith producer's enforced 16×16 input limit in its JSON schema
- state the same bound directly in the capability description
- add a regression test that checks both row and column limits in the generated schema

## Root cause

`CertifiedIntegerMatrix` is shared by producer input and certificate output. Its fields allow dimensions up to 32 because certificate matrices may use that broader output envelope. `CertifiedSmithNormalFormRequest` enforced the producer's stricter 16×16 limit only in a model-level validator, so generated JSON Schema incorrectly advertised 32×32 inputs.

A proof-critical 19×19 integer Gram matrix from Speyer's 2026 minimal counterexample to James's conjecture reproduced the mismatch: the CONTRACT view advertised 32, while execution failed with the correct 16×16 diagnostic. The compatible non-transformation Smith producer and independent verifier both succeeded on the matrix, so this PR changes presentation only.

## Impact

This does not expand or reduce accepted inputs, alter computation, or change assurance. It gives callers the actual producer bound before invocation and preserves the broader certificate-output model.

## Validation

- focused certified-Smith contract/domain tests: 11 passed
- `make lint typecheck`
- `make test-unit`
- direct current-main replay: the 19×19 certified request still fails closed; `matrix.normal_form.smith.compute` returns invariant factors `1` × 12 and `14`, and `matrix.normal_form.smith.verify` returns VERIFIED
