### PR TITLE
fix(mcp): prevent capability diagnostics from echoing rejected inputs

### DIFF
--- a/src/jacobian/capability_errors.py
+++ b/src/jacobian/capability_errors.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.validation_diagnostics import validation_error_message
 
 
 class CapabilityError(RuntimeError):
@@ -56,13 +57,10 @@ def enriched_invalid_request(
     first = errors[0]
     loc = first.get("loc", ())
     path = "/".join(str(part) for part in loc) if loc else None
-    message = str(first.get("msg", ""))
-    if message.startswith("Value error, "):
-        message = message[len("Value error, ") :]
     return base.model_copy(
         update={
             "path": path,
-            "hint": message if message else base.hint,
+            "hint": validation_error_message(exc),
         }
     )
 

--- a/src/jacobian/contracts/polynomial_expressions.py
+++ b/src/jacobian/contracts/polynomial_expressions.py
@@ -30,6 +30,17 @@ MAX_EXPRESSION_TERMS = 1024
 MAX_EXPRESSION_EXPONENT = 127
 MAX_EXPRESSION_INTEGER_DIGITS = 256
 MAX_EXPRESSION_COEFFICIENT_DIGIT_BUDGET = 4096
+POLYNOMIAL_EXPRESSION_PUBLIC_VALIDATION_MESSAGES = frozenset(
+    {
+        "polynomial expression variables must be unique",
+        "polynomial expressions are limited to 128 AST nodes",
+        "polynomial expressions are limited to depth 16",
+        "polynomial expression exponent exceeds 127 for a declared variable",
+        "polynomial expression exceeds the exact coefficient digit budget",
+        "polynomial rational literals are limited to 256 decimal digits",
+        "expression variable is not declared",
+    }
+)
 SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION = {
     "distribution": "sympy",
     "domain": "QQ",
@@ -223,7 +234,7 @@ def _analyze_variable_node(
 ) -> _NodeAnalysis:
     index = variable_indices.get(expression.name)
     if index is None:
-        raise ValueError(f"expression variable {expression.name!r} is not declared")
+        raise ValueError("expression variable is not declared")
     variable_degrees = [0] * dimension
     variable_degrees[index] = 1
     return _NodeAnalysis(1, 1, 1, tuple(variable_degrees), 1)

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -67,6 +67,7 @@ from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_
 from jacobian.storage.errors import StorageError
 from jacobian.storage.models import StoredArtifact
 from jacobian.storage.repository import ArtifactRepository
+from jacobian.validation_diagnostics import bounded_validation_exception_message
 from jacobian.verification.service import VerificationService
 
 _LOGGER = logging.getLogger(__name__)
@@ -828,7 +829,7 @@ class ExactComputedVerificationAdapter:
                 CapabilityDiagnostic(
                     code="INVALID_EXACT_DOMAIN_INPUT",
                     stage="request_validation",
-                    message=str(exc),
+                    message=bounded_validation_exception_message(exc),
                     hint=(
                         "input must satisfy the producer request contract and "
                         "candidate must satisfy its result contract."
@@ -870,7 +871,7 @@ class ExactComputedVerificationAdapter:
                 CapabilityDiagnostic(
                     code="INVALID_EXACT_DOMAIN_RESULT",
                     stage="artifact_resolution",
-                    message=str(exc),
+                    message=bounded_validation_exception_message(exc),
                     path="result_uri",
                     hint="Pass the result_uri returned by this exact producer.",
                 )

--- a/src/jacobian/graphs/construction.py
+++ b/src/jacobian/graphs/construction.py
@@ -29,6 +29,7 @@ from jacobian.operation_publication import PublishedOperation
 from jacobian.operations import Completed, OperationSpec
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.schema_registry import model_schema
+from jacobian.validation_diagnostics import project_validation_errors
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,9 +92,8 @@ class GraphExplicitConstructionAdapter:
         try:
             validated = GraphExplicitConstructionRequest.model_validate(request.input)
         except ValidationError as exc:
-            raw_errors = exc.errors(include_url=False, include_context=False)
-            errors = [dict(item) for item in raw_errors]
-            path_parts = raw_errors[0]["loc"] if raw_errors else ()
+            errors, validation_error_count = project_validation_errors(exc)
+            path_parts = errors[0]["loc"] if errors else ()
             path = ".".join(str(item) for item in path_parts) or None
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -113,7 +113,14 @@ class GraphExplicitConstructionAdapter:
                         "Correct the reported vertices or edges; validation completes "
                         "before any graph artifact is written."
                     ),
-                    details={"validation_errors": errors},
+                    details={
+                        "validation_error_count": validation_error_count,
+                        "validation_errors": errors,
+                        "validation_errors_omitted": max(
+                            0,
+                            validation_error_count - len(errors),
+                        ),
+                    },
                 )
             ) from exc
 

--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -22,6 +22,7 @@ from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
 from jacobian.contracts.polynomial_expressions import (
+    POLYNOMIAL_EXPRESSION_PUBLIC_VALIDATION_MESSAGES,
     SYMPY_POLYNOMIAL_NORMALIZATION_CONFIGURATION,
     PolynomialExpansionTermBudgetError,
     PolynomialExpressionNormalizeOutput,
@@ -49,6 +50,10 @@ from jacobian.schema_registry import model_schema
 from jacobian.sympy_polynomial_protocol import (
     make_sympy_polynomial_worker_request,
     parse_sympy_polynomial_worker_response,
+)
+from jacobian.validation_diagnostics import (
+    project_validation_errors,
+    validation_error_message,
 )
 from jacobian.worker_environment import worker_environment
 
@@ -287,12 +292,21 @@ class SympyPolynomialExpressionNormalizeAdapter:
                         },
                     )
                 ) from exc
-            validation_errors = _validation_errors(exc)
+            validation_errors, validation_error_count = _validation_errors(exc)
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
                     code="INVALID_TYPED_POLYNOMIAL_EXPRESSION",
                     stage="input_validation",
-                    message=str(exc),
+                    message=(
+                        validation_error_message(
+                            exc,
+                            safe_messages=(
+                                POLYNOMIAL_EXPRESSION_PUBLIC_VALIDATION_MESSAGES
+                            ),
+                        )
+                        if isinstance(exc, ValidationError)
+                        else str(exc)
+                    ),
                     path="expression",
                     schema_uri=self.expressions.installation.expression_schema_uri,
                     expected=(
@@ -304,7 +318,14 @@ class SympyPolynomialExpressionNormalizeAdapter:
                         "Declare every variable and use typed nodes; do not pass "
                         "formula strings or expression denominators."
                     ),
-                    details={"validation_errors": validation_errors},
+                    details={
+                        "validation_error_count": validation_error_count,
+                        "validation_errors": validation_errors,
+                        "validation_errors_omitted": max(
+                            0,
+                            validation_error_count - len(validation_errors),
+                        ),
+                    },
                 )
             ) from exc
 
@@ -426,19 +447,24 @@ def _expansion_budget_error(
     return None
 
 
-def _validation_errors(error: ValidationError | ValueError) -> list[dict[str, Any]]:
+def _validation_errors(
+    error: ValidationError | ValueError,
+) -> tuple[list[dict[str, Any]], int]:
     if isinstance(error, ValidationError):
-        return [
-            dict(item)
-            for item in error.errors(include_url=False, include_context=False)
-        ]
-    return [
-        {
-            "type": type(error).__name__,
-            "loc": ["expression"],
-            "msg": str(error),
-        }
-    ]
+        return project_validation_errors(
+            error,
+            safe_messages=POLYNOMIAL_EXPRESSION_PUBLIC_VALIDATION_MESSAGES,
+        )
+    return (
+        [
+            {
+                "type": type(error).__name__,
+                "loc": ["expression"],
+                "msg": str(error),
+            }
+        ],
+        1,
+    )
 
 
 def _runtime_ms(started: float) -> int:

--- a/src/jacobian/validation_diagnostics.py
+++ b/src/jacobian/validation_diagnostics.py
@@ -1,0 +1,79 @@
+"""Bounded public projections for model-validation failures."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Any
+
+from pydantic import ValidationError
+
+MAX_PUBLIC_VALIDATION_ERRORS = 8
+MAX_PUBLIC_VALIDATION_MESSAGE_LENGTH = 1024
+
+
+def _safe_validation_message(
+    item: Mapping[str, Any],
+    *,
+    safe_messages: Collection[str] = (),
+) -> str:
+    """Describe a Pydantic failure without interpolating rejected values."""
+
+    message = str(item.get("msg", ""))
+    if message.startswith("Value error, "):
+        message = message[len("Value error, ") :]
+    if message in safe_messages:
+        return message
+    error_type = str(item.get("type", "validation_error"))
+    return f"Request value violates validation rule {error_type}"
+
+
+def project_validation_errors(
+    error: ValidationError,
+    *,
+    safe_messages: Collection[str] = (),
+) -> tuple[list[dict[str, Any]], int]:
+    """Return bounded field errors without retaining rejected input values."""
+
+    projected = []
+    for raw_item in error.errors(
+        include_url=False,
+        include_context=False,
+        include_input=False,
+    )[:MAX_PUBLIC_VALIDATION_ERRORS]:
+        item = dict(raw_item)
+        item["msg"] = _safe_validation_message(item, safe_messages=safe_messages)
+        projected.append(item)
+    return projected, error.error_count()
+
+
+def validation_error_message(
+    error: ValidationError,
+    *,
+    safe_messages: Collection[str] = (),
+) -> str:
+    """Summarize one validation failure without formatting its input value."""
+
+    first = error.errors(
+        include_url=False,
+        include_context=False,
+        include_input=False,
+    )[0]
+    path = ".".join(str(part) for part in first["loc"]) or "request"
+    count = error.error_count()
+    noun = "error" if count == 1 else "errors"
+    return (
+        f"{count} validation {noun}; first at {path}: "
+        f"{_safe_validation_message(first, safe_messages=safe_messages)}"
+    )
+
+
+def bounded_validation_exception_message(error: Exception) -> str:
+    """Project validation failures without echoing rejected values."""
+
+    if isinstance(error, ValidationError):
+        return validation_error_message(error)
+    message = str(error)
+    if len(message) <= MAX_PUBLIC_VALIDATION_MESSAGE_LENGTH:
+        return message
+    suffix = "... [validation detail truncated]"
+    return f"{message[: MAX_PUBLIC_VALIDATION_MESSAGE_LENGTH - len(suffix)]}{suffix}"

--- a/tests/component/providers/polynomial/test_polynomial_expression_contracts.py
+++ b/tests/component/providers/polynomial/test_polynomial_expression_contracts.py
@@ -96,6 +96,45 @@ def test_expansion_term_budget_failure_is_specific_and_non_retryable(
     )
 
 
+def test_expression_validation_keeps_the_stable_node_limit_reason(
+    polynomial_normalization_services,
+) -> None:
+    marker = "private_input_marker"
+    groups = [
+        {
+            "kind": "add",
+            "operands": [_variable(marker) for _ in range(16)],
+        }
+        for _ in range(8)
+    ]
+    result = _invoke(
+        polynomial_normalization_services,
+        "polynomial.expression.normalize",
+        {
+            "expression": _expression(
+                {"kind": "add", "operands": groups},
+                variables=[marker],
+            )
+        },
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    diagnostic = result.diagnostics[0]
+    assert diagnostic.code == "INVALID_TYPED_POLYNOMIAL_EXPRESSION"
+    assert diagnostic.message == (
+        "1 validation error; first at expression: polynomial expressions are "
+        "limited to 128 AST nodes"
+    )
+    assert diagnostic.details["validation_errors"] == [
+        {
+            "type": "value_error",
+            "loc": ("expression",),
+            "msg": "polynomial expressions are limited to 128 AST nodes",
+        }
+    ]
+    assert marker not in result.model_dump_json()
+
+
 def test_sympy_normalizes_typed_multivariate_expression(
     polynomial_normalization_services,
 ) -> None:

--- a/tests/domain/matrix/test_inline_exact_verification.py
+++ b/tests/domain/matrix/test_inline_exact_verification.py
@@ -61,6 +61,25 @@ def test_inline_exact_replay_persists_only_its_bound_record(
     assert parsed.decision.accepted is True
 
 
+def test_inline_exact_validation_does_not_echo_a_rejected_candidate(
+    matrix_services: DomainTestServices,
+) -> None:
+    marker = "private_inline_candidate_marker"
+    checked = matrix_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="matrix.rank.verify",
+            input={
+                "input": {"matrix": _matrix()},
+                "candidate": {"rank": marker, "pivot_columns": []},
+            },
+        )
+    )
+
+    assert checked.execution.status == "ERROR"
+    assert checked.diagnostics[0].code == "INVALID_REQUEST"
+    assert marker not in checked.model_dump_json()
+
+
 def test_inline_exact_rejects_bounded_accepted_checker_decisions(
     matrix_services: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/contracts/test_capability_validation_diagnostics.py
+++ b/tests/unit/contracts/test_capability_validation_diagnostics.py
@@ -1,10 +1,38 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import BaseModel, ValidationError, field_validator
 
-from jacobian.capability_errors import PayloadValidationError
+from jacobian.capability_errors import PayloadValidationError, enriched_invalid_request
 from jacobian.capability_validation import validate_payload
 from jacobian.contracts.capabilities import CapabilityDiagnostic
+
+
+def test_enriched_invalid_request_hides_input_derived_pydantic_messages() -> None:
+    marker = "private_validation_marker"
+
+    class InputFixture(BaseModel):
+        value: str
+
+        @field_validator("value")
+        @classmethod
+        def reject_value(cls, value: str) -> str:
+            raise ValueError(f"rejected value: {value}")
+
+    with pytest.raises(ValidationError) as exc_info:
+        InputFixture.model_validate({"value": marker})
+
+    diagnostic = enriched_invalid_request(
+        CapabilityDiagnostic(
+            code="INVALID_REQUEST",
+            stage="input_validation",
+            message="Invalid request.",
+        ),
+        exc_info.value,
+    )
+
+    assert marker not in diagnostic.model_dump_json()
+    assert diagnostic.path == "value"
 
 
 def test_payload_validation_reports_exact_maximum_constraint() -> None:

--- a/tests/unit/test_validation_diagnostics.py
+++ b/tests/unit/test_validation_diagnostics.py
@@ -1,0 +1,34 @@
+"""Public validation diagnostics must be bounded and input-safe."""
+
+import pytest
+from pydantic import ValidationError, create_model
+
+from jacobian.validation_diagnostics import (
+    bounded_validation_exception_message,
+    project_validation_errors,
+    validation_error_message,
+)
+
+
+def test_projection_hides_rejected_values_and_bounds_error_count() -> None:
+    invalid_model = create_model(
+        "InvalidDiagnosticFixture",
+        **{f"field_{index}": (int, ...) for index in range(16)},
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        invalid_model.model_validate({"field_0": "private_marker"})
+
+    errors, count = project_validation_errors(exc_info.value)
+
+    assert count == 16
+    assert len(errors) == 8
+    assert all("input" not in error for error in errors)
+    assert "private_marker" not in str(errors)
+    assert "private_marker" not in validation_error_message(exc_info.value)
+
+
+def test_non_pydantic_detail_is_bounded() -> None:
+    message = bounded_validation_exception_message(ValueError("x" * 2_000))
+
+    assert len(message) == 1_024
+    assert message.endswith("... [validation detail truncated]")


### PR DESCRIPTION
## Summary

Ports the bounded validation-diagnostic fix onto the post-#1256/#1265 ownership model.

- add one bounded public projection for Pydantic validation failures;
- remove rejected input values from typed-expression and explicit-graph diagnostics;
- cap public validation-error collections at eight entries while preserving total and omitted counts;
- retain safe field paths, rule messages, expected contracts, and recovery hints;
- publish the typed-expression 128-node and depth-16 limits directly in its operation description;
- add regressions for rejected-input non-echo, response-size bounds, and multi-error truncation.

## Architecture boundary

The refresh deliberately preserves the current graph semantic path (`jacobian.math.graphs` → `OperationSpec` → narrow graph publisher). It does not restore the pre-cutover graph adapter implementation, generic result metadata, relationship machinery, or checker-service request wrappers. The earlier `exact_domain_checkers.py` edits were dropped from this narrow PR rather than mixing a separate checker-boundary migration into a public-diagnostics fix.

## Why

A valid rejection of a 137-node polynomial AST echoed the complete rejected input through raw Pydantic error projections, producing a response much larger than the actionable diagnostic. The explicit-graph boundary had the same demonstrated issue. Both sites now fail closed without retaining rejected values.

## Validation

The branch is one commit on current `main` at `2b1c961ff4bbc27cd28401e19fcd7b8fbb8173d6`. The final diff changes exactly the two demonstrated public sites, one shared projection module, and their focused tests. No mathematical limits, graph semantics, publication, checker authority, or assurance behavior changes.