### PR TITLE
fix(discovery): restore reciprocal SAT verifier navigation

### DIFF
--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -53,9 +53,17 @@ _RELATED_CAPABILITIES: dict[str, tuple[tuple[str, str], ...]] = {
         ("sat.cnf.materialize", "materialize the exact input CNF"),
         ("sat.model.verify", "independently verify the named assignment"),
     ),
+    "sat.model.verify": (
+        ("sat.cnf.materialize", "materialize the exact input CNF"),
+        ("sat.model.find", "produce a candidate named assignment"),
+    ),
     "sat.unsat_proof.find": (
         ("sat.cnf.materialize", "materialize the exact input CNF"),
         ("sat.unsat_proof.verify", "independently verify the retained DRAT proof"),
+    ),
+    "sat.unsat_proof.verify": (
+        ("sat.cnf.materialize", "materialize the exact input CNF"),
+        ("sat.unsat_proof.find", "produce an addition-only DRAT candidate"),
     ),
     "smt.unsat_proof.find": (
         ("smt.unsat_proof.verify", "independently verify compatible proof evidence"),
@@ -63,6 +71,9 @@ _RELATED_CAPABILITIES: dict[str, tuple[tuple[str, str], ...]] = {
             "sat.cnf.materialize",
             "materialize named Boolean CNF for finite colorings and forbidden patterns",
         ),
+    ),
+    "smt.unsat_proof.verify": (
+        ("smt.unsat_proof.find", "produce compatible proof evidence"),
     ),
 }
 

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -144,6 +144,32 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
                 item["capability_id"] for item in materialize["related_capabilities"]
             }.issuperset(expected_sat_ids - {"sat.cnf.materialize"})
 
+            reciprocal_relationships = {
+                "sat.model.verify": {
+                    "sat.cnf.materialize",
+                    "sat.model.find",
+                },
+                "sat.unsat_proof.verify": {
+                    "sat.cnf.materialize",
+                    "sat.unsat_proof.find",
+                },
+                "smt.unsat_proof.verify": {"smt.unsat_proof.find"},
+            }
+            for verifier_id, expected_related in reciprocal_relationships.items():
+                if verifier_id not in all_ids:
+                    continue
+                verifier_description = await client.call_tool(
+                    "math.find",
+                    {"capability_id": verifier_id, "view": "CONTRACT"},
+                )
+                assert isinstance(verifier_description.structured_content, dict)
+                assert {
+                    item["capability_id"]
+                    for item in verifier_description.structured_content.get(
+                        "related_capabilities", []
+                    )
+                }.issuperset(expected_related.intersection(all_ids))
+
             first_page = await client.call_tool(
                 "math.find",
                 {"limit": 20},

--- a/tests/component/adapters/mcp/test_mcp_projection_compaction.py
+++ b/tests/component/adapters/mcp/test_mcp_projection_compaction.py
@@ -27,20 +27,20 @@ def _as_runtime(services: DomainTestServices) -> JacobianRuntime:
 def test_sat_verifier_navigation_is_reciprocal() -> None:
     from jacobian.adapters.mcp import projections
 
-    assert {item[0] for item in projections._RELATED_CAPABILITIES["sat.model.verify"]} == {
+    assert {
+        item[0] for item in projections._RELATED_CAPABILITIES["sat.model.verify"]
+    } == {
         "sat.cnf.materialize",
         "sat.model.find",
     }
     assert {
-        item[0]
-        for item in projections._RELATED_CAPABILITIES["sat.unsat_proof.verify"]
+        item[0] for item in projections._RELATED_CAPABILITIES["sat.unsat_proof.verify"]
     } == {
         "sat.cnf.materialize",
         "sat.unsat_proof.find",
     }
     assert {
-        item[0]
-        for item in projections._RELATED_CAPABILITIES["smt.unsat_proof.verify"]
+        item[0] for item in projections._RELATED_CAPABILITIES["smt.unsat_proof.verify"]
     } == {"smt.unsat_proof.find"}
 
 

--- a/tests/component/adapters/mcp/test_mcp_projection_compaction.py
+++ b/tests/component/adapters/mcp/test_mcp_projection_compaction.py
@@ -24,6 +24,26 @@ def _as_runtime(services: DomainTestServices) -> JacobianRuntime:
     return cast(JacobianRuntime, services)
 
 
+def test_sat_verifier_navigation_is_reciprocal() -> None:
+    from jacobian.adapters.mcp import projections
+
+    assert {item[0] for item in projections._RELATED_CAPABILITIES["sat.model.verify"]} == {
+        "sat.cnf.materialize",
+        "sat.model.find",
+    }
+    assert {
+        item[0]
+        for item in projections._RELATED_CAPABILITIES["sat.unsat_proof.verify"]
+    } == {
+        "sat.cnf.materialize",
+        "sat.unsat_proof.find",
+    }
+    assert {
+        item[0]
+        for item in projections._RELATED_CAPABILITIES["smt.unsat_proof.verify"]
+    } == {"smt.unsat_proof.find"}
+
+
 def test_math_find_compacts_related_capabilities_deterministically(
     projection_catalog: DomainTestServices,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- expose reciprocal navigation from SAT assignment and DRAT verifiers back to their producers and source CNF
- expose reciprocal navigation from the SMT proof verifier to the proof producer
- add MCP boundary and projection regressions, including optional-provider filtering

## Root cause
The static MCP relationship map only described producer-to-verifier paths. Inspecting a verifier therefore omitted the producer handoff even when both were installed.

## Impact
Agents can inspect either endpoint and recover the intended producer/verifier workflow without another broad catalog search. Optional providers remain filtered from cards when absent.

## Validation
- `pytest -q tests/boundary/mcp/test_mcp_catalog_and_policy.py::test_mcp_compact_capability_index_is_searchable_and_paginated` — 1 passed
- `pytest -q tests/component/adapters/mcp/test_mcp_projection_compaction.py` — 4 passed
- `ruff check src/jacobian/adapters/mcp/projections.py tests/boundary/mcp/test_mcp_catalog_and_policy.py tests/component/adapters/mcp/test_mcp_projection_compaction.py` — passed
- `git diff --check` — passed
