### PR TITLE
fix(discovery): improve plain-language polynomial resultant discovery

### DIFF
--- a/src/jacobian/domains/polynomial/invariants.py
+++ b/src/jacobian/domains/polynomial/invariants.py
@@ -86,6 +86,8 @@ POLYNOMIAL_INVARIANT_CAPABILITIES = (
         "polynomial",
         "resultant",
         "elimination",
+        "univariate",
+        "rational",
         invocation_examples=(
             example(
                 "resultant_x2_minus_one_x_minus_two",

--- a/tests/composition/runtime/test_portfolio_capability_discovery.py
+++ b/tests/composition/runtime/test_portfolio_capability_discovery.py
@@ -106,6 +106,30 @@ def test_discovery_ranks_lexical_matches_and_returns_no_synthetic_fit_labels(
     assert absent.matches == ()
 
 
+def test_discovery_finds_resultant_producer_from_plain_language(
+    attached_complete_runtime_read_only: JacobianRuntime,
+) -> None:
+    capabilities = attached_complete_runtime_read_only.core.capabilities
+
+    for query in (
+        "compute the exact resultant of two univariate rational polynomials",
+        "compute and independently verify the exact resultant of two univariate rational polynomials",
+    ):
+        discovered = capabilities.discover(
+            CapabilityDiscoveryRequest(query=query, limit=8)
+        )
+
+        ids = [match.capability_id for match in discovered.matches]
+        assert "polynomial.compute.resultant" in ids
+        assert ids.index("polynomial.compute.resultant") <= 1
+        resultant = next(
+            match
+            for match in discovered.matches
+            if match.capability_id == "polynomial.compute.resultant"
+        )
+        assert resultant.relevance_score > 0
+
+
 def test_domain_intents_discover_poset_and_topology_operations(
     attached_complete_runtime_read_only: JacobianRuntime,
 ) -> None:


### PR DESCRIPTION
## Summary

- add factual `univariate` and `rational` discovery tags to `polynomial.compute.resultant`
- add a full-portfolio regression for natural compute and compute-plus-verify queries
- leave schemas, bounds, execution, assurance, and checker authority unchanged

## Motivation

A proof-critical resultant replay from Chinyere's 2026 Noferini–Williams proof exposed a deterministic routing gap. The exact producer and reciprocal verifier both work, but `math.find` omitted the producer for ordinary queries such as “compute the exact resultant of two univariate rational polynomials.” The terse catalog phrase `polynomial resultant` worked.

The descriptor already states the QQ/univariate semantics in its contract. This patch exposes those factual terms to deterministic lexical retrieval.

## Validation

- `uv run pytest -q tests/composition/runtime/test_portfolio_capability_discovery.py tests/domain/polynomial/test_polynomial_operation_bundle.py tests/domain/polynomial/test_polynomial_verification.py` — 13 passed
- Ruff check and format — passed
- mypy — passed (470 source files)
- unit lane — 891 passed

The broad change-aware fallback was also attempted. Unrelated bounded subprocess tests timed out and several parallel workers were killed under host-wide resource pressure; the focused affected suites above remained green. The composition fallback was stopped instead of spending further resources reproducing unrelated load failures.

## Scope

This is a navigation-only correction. It does not prescribe a workflow, weaken result binding, or change the producer/verifier trust boundary.