### PR TITLE
fix(discovery): improve finite expectation discovery

### DIFF
--- a/src/jacobian/domains/probability/operations.py
+++ b/src/jacobian/domains/probability/operations.py
@@ -446,12 +446,22 @@ FINITE_PROBABILITY_CAPABILITIES = (
             title="Exact finite-distribution raw moment",
             description=(
                 "Compute one bounded raw moment of a normalized finite exact "
-                "rational distribution, preserving every atom contribution."
+                "rational distribution, preserving every atom contribution. "
+                "Order one is the distribution's exact expectation or expected value."
             ),
             request_type=FiniteRawMomentRequest,
             result_type=FiniteRawMomentResult,
             execute=_raw_moment,
-            tags=("probability", "moment", "finite", "exact", "python-flint"),
+            tags=(
+                "probability",
+                "moment",
+                "expectation",
+                "expected-value",
+                "discrete-random-variable",
+                "finite",
+                "exact",
+                "python-flint",
+            ),
             invocation_examples=(
                 example(
                     "fair_bit_second_moment",

--- a/tests/boundary/mcp/test_mcp_discovery_projection.py
+++ b/tests/boundary/mcp/test_mcp_discovery_projection.py
@@ -10,6 +10,33 @@ from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.capabilities import CapabilityDescriptor
 
 
+def test_math_find_discovers_finite_expectation_by_natural_vocabulary(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            discovered = await client.call_tool(
+                "math.find",
+                {
+                    "request": {
+                        "op": "search",
+                        "query": "expectation of a discrete random variable",
+                        "domain": "probability",
+                        "limit": 5,
+                    }
+                },
+            )
+
+        assert isinstance(discovered.structured_content, dict)
+        assert "probability.finite_distribution.raw_moment.compute" in {
+            match["capability_id"] for match in discovered.structured_content["matches"]
+        }
+
+    asyncio.run(scenario())
+
+
 def test_math_find_search_returns_compact_lexical_and_availability_facts(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- describe the order-one finite raw moment as an exact expectation / expected value
- add expectation, expected-value, and discrete-random-variable discovery tags
- add a model-facing `math.find` regression for the natural query `expectation of a discrete random variable`

## Root cause

`probability.finite_distribution.raw_moment.compute` already computes exact finite expectations when `order=1`, but its public metadata used only the specialist phrase `raw moment`. As a result, a natural expectation query omitted the capability even though a more contract-shaped finite-distribution query found it.

This changes discovery metadata only. It does not change computation, schemas, resource bounds, checker authority, or assurance.

## Evaluation evidence

A deterministic MCP reproduction on current main showed:

- `compute the exact expected value of a finite distribution` ranked the raw-moment operation first;
- `expectation of a discrete random variable` omitted it and returned only convolution;
- after this patch, the natural query includes `probability.finite_distribution.raw_moment.compute` within the bounded five-result probability search.

## Validation

- focused probability and MCP discovery tests passed
- unit: 891 passed
- MCP: 49 passed
- lint, formatting, complexity, mypy (470 files), and package build passed
- broad component: 943 passed, 3 platform skips; four unrelated parallel workers crashed and their exact tests were rerun serially successfully
- broad domain: 454 passed; unrelated worker-startup timeouts remained in integer divisors, discrete logarithm, and Gröbner paths. Serial rerun passed the reported component cases and all domain cases except the two existing advertised-example startup timeouts (`integer.compute.divisors` and `modular.compute.discrete_logarithm`).

No benchmark mathematics or evaluation reward behavior is changed.