### PR TITLE
docs(examples): add runnable topology invocation examples

### DIFF
--- a/src/jacobian/domains/topology/operations.py
+++ b/src/jacobian/domains/topology/operations.py
@@ -505,6 +505,21 @@ _CIRCLE = {
     "facets": [["a", "b"], ["b", "c"], ["a", "c"]],
 }
 
+_CANONICAL_CIRCLE = {
+    "vertices": ["a", "b", "c"],
+    "maximal_simplices": [["a", "b"], ["a", "c"], ["b", "c"]],
+    "faces_by_dimension": [
+        {"dimension": 0, "faces": [["a"], ["b"], ["c"]]},
+        {"dimension": 1, "faces": [["a", "b"], ["a", "c"], ["b", "c"]]},
+    ],
+    "dimension": 1,
+    "f_vector": [3, 3],
+    "closure_size": 6,
+    "complex_digest": (
+        "sha256:6f797991bac967e2a8e572707df487061655df0f094cbde0f52f82c5401fc043"
+    ),
+}
+
 type TopologyOperation = (
     InstalledOperation[
         SimplicialComplexRequest, SimplicialComplexCanonicalizationResult
@@ -566,6 +581,17 @@ TOPOLOGY_CAPABILITIES: tuple[TopologyOperation, ...] = (
                 "boundary-matrix",
                 "exact",
             ),
+            invocation_examples=(
+                example(
+                    "circle_integer_chain_complex",
+                    "Construct the oriented integer boundary matrices of a circle.",
+                    {
+                        "complex": _CANONICAL_CIRCLE,
+                        "coefficient_ring": "INTEGER",
+                        "convention": "UNREDUCED",
+                    },
+                ),
+            ),
             version="4",
         )
     ),
@@ -587,6 +613,17 @@ TOPOLOGY_CAPABILITIES: tuple[TopologyOperation, ...] = (
                 "cycle-basis",
                 "prime-field",
                 "exact",
+            ),
+            invocation_examples=(
+                example(
+                    "circle_homology_mod_two",
+                    "Compute H_0 and H_1 over F_2 for a triangle boundary.",
+                    {
+                        "complex": _CANONICAL_CIRCLE,
+                        "prime": 2,
+                        "convention": "UNREDUCED",
+                    },
+                ),
             ),
             version="4",
         )

--- a/tests/domain/topology/test_topology_capabilities.py
+++ b/tests/domain/topology/test_topology_capabilities.py
@@ -22,6 +22,28 @@ def topology_services(tmp_path: Path) -> Iterator[DomainTestServices]:
         yield services
 
 
+def test_every_topology_operation_advertises_an_executable_example(
+    topology_services: DomainTestServices,
+) -> None:
+    bundle = build_topology_bundle()
+
+    for operation in bundle.capabilities:
+        spec = operation.spec
+        assert spec.invocation_examples, spec.operation_id
+        example = spec.invocation_examples[0]
+        result = topology_services.core.capabilities.invoke(
+            CapabilityRequest(
+                capability_id=spec.operation_id,
+                input=example.input,
+            )
+        )
+
+        assert result.execution.status is ExecutionStatus.COMPLETED, (
+            spec.operation_id,
+            result.diagnostics,
+        )
+
+
 _CIRCLE = {
     "vertices": ["a", "b", "c"],
     "facets": [["a", "b"], ["b", "c"], ["a", "c"]],


### PR DESCRIPTION
## Summary

- add runnable discovery examples for oriented simplicial chain-complex construction
- add a runnable finite-field simplicial-homology example
- reuse the same canonical circle fixture already advertised by integral homology
- require every public topology operation to keep one executable example

## Why

Agents copy invocation examples from discovery cards. Two public topology producers had no example at all, even though their inputs require a fully canonical simplicial complex, including its digest and face closure. That made correct calls substantially harder to construct than the neighboring canonicalization and integral-homology operations.

The repository's general executable-example test currently covers several core bundles but not topology. This focused topology invariant closes that gap without changing mathematical behavior, contracts, assurance, or checker authority.

## Validation

- all topology capability tests: 20 passed
- complete unit lane: 891 passed
- focused Ruff check and formatting: passed
- focused mypy: passed
- discovery payload sizes: 446 bytes (chain complex) and 427 bytes (finite-field homology)
- required parallel component lane was stopped after repeated worker-process crashes unrelated to the two metadata-only files; hosted CI is authoritative for the full matrix

This PR is intentionally draft and must not be merged by Codex.