### PR TITLE
fix(runtime): reject volatile shared-memory install roots

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -250,8 +250,8 @@ validate_install_root() {
         /home/* | /root/* | /tmp/* | /var/tmp/*)
             die "--install-root must remain visible through the systemd sandbox; do not place it below /home, /root, /tmp, or /var/tmp"
             ;;
-        /run/*)
-            die "--install-root must be durable across reboots; do not place it below /run"
+        /run/* | /dev/shm/*)
+            die "--install-root must be durable across reboots; do not place it below /run or /dev/shm"
             ;;
     esac
     effective="$(resolve_effective_path "${value}")" || die \
@@ -262,8 +262,8 @@ validate_install_root() {
         /home/* | /root/* | /tmp/* | /var/tmp/*)
             die "--install-root resolves below a path hidden by the systemd sandbox: ${effective}"
             ;;
-        /run/*)
-            die "--install-root resolves below the volatile /run hierarchy: ${effective}"
+        /run/* | /dev/shm/*)
+            die "--install-root resolves below a volatile runtime hierarchy: ${effective}"
             ;;
     esac
     VALIDATED_INSTALL_ROOT="${effective}"

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -105,11 +105,11 @@ upgrade. State under `/var/lib/jacobian-mcp` and secrets under
 `/etc/jacobian-mcp` remain separate host data: copy and validate them explicitly
 during a VPS migration rather than treating an application release as a backup.
 The selected root must be durable across reboots and remain visible through the
-hardened systemd unit. The installer rejects `/run` and its descendants because
-they are volatile, and rejects `/home`, `/root`, `/tmp`, `/var/tmp`, and their
-descendants because `ProtectHome=true` and `PrivateTmp=true` hide those host
-paths from the service. Use an application path such as `/opt/jacobian` or
-`/srv/math/jacobian` instead.
+hardened systemd unit. The installer rejects `/run`, `/dev/shm`, and their
+descendants because they are volatile, and rejects `/home`, `/root`, `/tmp`,
+`/var/tmp`, and their descendants because `ProtectHome=true` and
+`PrivateTmp=true` hide those host paths from the service. Use an application
+path such as `/opt/jacobian` or `/srv/math/jacobian` instead.
 
 With the default installation root, core releases remain under
 `/opt/jacobian/releases/<git-sha>`; Lean-enabled releases use

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -18,13 +17,41 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _run(*arguments: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    *arguments: str,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", str(INSTALLER), *arguments],
         cwd=REPOSITORY_ROOT,
         check=False,
         capture_output=True,
         text=True,
+        env=environment,
+    )
+
+
+def _run_with_resolved_ancestor(
+    tmp_path: Path,
+    *,
+    resolved_ancestor: str,
+) -> subprocess.CompletedProcess[str]:
+    tool_directory = tmp_path / "tools"
+    tool_directory.mkdir()
+    readlink = tool_directory / "readlink"
+    readlink.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$JACOBIAN_TEST_READLINK_TARGET\"\n",
+        encoding="utf-8",
+    )
+    readlink.chmod(0o755)
+    environment = dict(os.environ)
+    environment["JACOBIAN_TEST_READLINK_TARGET"] = resolved_ancestor
+    environment["PATH"] = f"{tool_directory}:{environment['PATH']}"
+    return _run(
+        "--install-root",
+        "/srv/jacobian-test-alias/release-root/jacobian",
+        "--dry-run",
+        environment=environment,
     )
 
 
@@ -106,6 +133,7 @@ def test_dry_run_derives_every_runtime_path_from_custom_install_root() -> None:
         "/root",
         "/run/jacobian",
         "/run/user/1000/jacobian",
+        "/dev/shm/jacobian",
         "/tmp/jacobian",
         "/var/tmp/jacobian",
     ),
@@ -120,104 +148,58 @@ def test_install_root_rejects_unsafe_or_ambiguous_paths(root: str) -> None:
 def test_install_root_rejects_an_allowed_symlink_into_a_hidden_path(
     tmp_path: Path,
 ) -> None:
-    shared_memory = Path("/dev/shm")
-    if not shared_memory.is_dir() or not os.access(shared_memory, os.W_OK):
-        pytest.skip("a writable /dev/shm is required for the symlink sandbox check")
-    visible_parent = Path(
-        tempfile.mkdtemp(prefix="jacobian-install-root-", dir=shared_memory)
+    completed = _run_with_resolved_ancestor(
+        tmp_path,
+        resolved_ancestor=str(tmp_path),
     )
-    visible_link = visible_parent / "release-root"
-    try:
-        visible_link.symlink_to(tmp_path, target_is_directory=True)
 
-        completed = _run(
-            "--install-root",
-            str(visible_link / "jacobian"),
-            "--dry-run",
-        )
-
-        assert completed.returncode != 0
-        assert "resolves below a path hidden by the systemd sandbox" in completed.stderr
-    finally:
-        shutil.rmtree(visible_parent)
+    assert completed.returncode != 0
+    assert "resolves below a path hidden by the systemd sandbox" in completed.stderr
 
 
-def test_install_root_rejects_an_allowed_symlink_into_volatile_run() -> None:
-    shared_memory = Path("/dev/shm")
-    if not shared_memory.is_dir() or not os.access(shared_memory, os.W_OK):
-        pytest.skip("a writable /dev/shm is required for the symlink durability check")
-    visible_parent = Path(
-        tempfile.mkdtemp(prefix="jacobian-install-root-", dir=shared_memory)
+@pytest.mark.parametrize("resolved_ancestor", ("/run", "/dev/shm"))
+def test_install_root_rejects_an_allowed_symlink_into_volatile_runtime(
+    tmp_path: Path,
+    resolved_ancestor: str,
+) -> None:
+    completed = _run_with_resolved_ancestor(
+        tmp_path,
+        resolved_ancestor=resolved_ancestor,
     )
-    visible_link = visible_parent / "release-root"
-    try:
-        visible_link.symlink_to("/run", target_is_directory=True)
 
-        completed = _run(
-            "--install-root",
-            str(visible_link / "jacobian"),
-            "--dry-run",
-        )
-
-        assert completed.returncode != 0
-        assert "resolves below the volatile /run hierarchy" in completed.stderr
-    finally:
-        shutil.rmtree(visible_parent)
+    assert completed.returncode != 0
+    assert "resolves below a volatile runtime hierarchy" in completed.stderr
 
 
-def test_install_root_canonicalizes_an_allowed_symlink_ancestor() -> None:
-    shared_memory = Path("/dev/shm")
-    if not shared_memory.is_dir() or not os.access(shared_memory, os.W_OK):
-        pytest.skip("a writable /dev/shm is required for the symlink sandbox check")
-    visible_parent = Path(
-        tempfile.mkdtemp(prefix="jacobian-install-root-", dir=shared_memory)
+def test_install_root_canonicalizes_an_allowed_symlink_ancestor(
+    tmp_path: Path,
+) -> None:
+    completed = _run_with_resolved_ancestor(
+        tmp_path,
+        resolved_ancestor="/opt",
     )
-    actual_root = visible_parent / "actual"
-    visible_link = visible_parent / "release-root"
-    try:
-        actual_root.mkdir()
-        visible_link.symlink_to(actual_root, target_is_directory=True)
 
-        completed = _run(
-            "--install-root",
-            str(visible_link / "jacobian"),
-            "--dry-run",
-        )
-
-        assert completed.returncode == 0, completed.stderr
-        assert f"install:     {actual_root}/jacobian" in completed.stdout
-    finally:
-        shutil.rmtree(visible_parent)
+    assert completed.returncode == 0, completed.stderr
+    assert (
+        "install:     /opt/jacobian-test-alias/release-root/jacobian"
+        in completed.stdout
+    )
 
 
 @pytest.mark.parametrize("target_name", ("actual root", "actual|root"))
 def test_install_root_rejects_unsafe_resolved_symlink_targets(
+    tmp_path: Path,
     target_name: str,
 ) -> None:
-    shared_memory = Path("/dev/shm")
-    if not shared_memory.is_dir() or not os.access(shared_memory, os.W_OK):
-        pytest.skip("a writable /dev/shm is required for the symlink sandbox check")
-    visible_parent = Path(
-        tempfile.mkdtemp(prefix="jacobian-install-root-", dir=shared_memory)
+    completed = _run_with_resolved_ancestor(
+        tmp_path,
+        resolved_ancestor=f"/srv/{target_name}",
     )
-    actual_root = visible_parent / target_name
-    visible_link = visible_parent / "release-root"
-    try:
-        actual_root.mkdir()
-        visible_link.symlink_to(actual_root, target_is_directory=True)
 
-        completed = _run(
-            "--install-root",
-            str(visible_link / "jacobian"),
-            "--dry-run",
-        )
-
-        assert completed.returncode != 0
-        assert "resolves to a non-root path with unsupported characters" in (
-            completed.stderr
-        )
-    finally:
-        shutil.rmtree(visible_parent)
+    assert completed.returncode != 0
+    assert "resolves to a non-root path with unsupported characters" in (
+        completed.stderr
+    )
 
 
 def test_dry_run_never_echoes_supplied_credentials(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- reject /dev/shm install roots both directly and after ancestor resolution
- document durable installation-root constraints for VPS migrations
- preserve deterministic coverage for safe and unsafe resolved ancestors without treating shared memory as durable

## Validation

- make lint typecheck
- make test-process (264 passed)
- make deploy-check (37 passed)
- make docs-linkcheck
- git diff --check

Follow-up for the final review thread on #1246.