### PR TITLE
fix(runtime): normalize immutable runtime permissions

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -638,12 +638,12 @@ if [[ ! -d "${RELEASE_DIR}" ]]; then
                 "${LEAN_ELAN_HOME}/bin/elan" run "${LEAN_TOOLCHAIN}" \
                 lake build repl JacobianLeanRuntime jacobian_lean_proof_state
         )
-        # Mathlib's binary cache may preserve owner-only modes from its archive.
-        # The release is immutable and root-owned, but every runtime input must
-        # remain readable (and every executable runnable) by the service user.
-        chmod -R a+rX "${RELEASE_DIR}/lean"
     fi
     chown -R root:root "${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}"
+    # uv and backend caches honor the invoking root umask and may create
+    # owner-only directories or executables. The immutable release contains no
+    # secrets, so normalize every runtime input before service-user validation.
+    chmod -R a+rX "${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}"
     RELEASE_WAS_BUILT=1
 elif [[ "$(cat "${RELEASE_DIR}/.git-revision" 2>/dev/null || true)" != "${REVISION}" ]]; then
     die "existing release directory is not bound to revision ${REVISION}"

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -301,6 +301,12 @@ def test_deployment_lock_is_host_global_and_precedes_shared_host_mutations() -> 
 def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
 
+    ownership = source.index(
+        'chown -R root:root "${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}"'
+    )
+    runtime_permissions = source.index(
+        'chmod -R a+rX "${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}"'
+    )
     validation = source.index('validate_release_runtime "${RELEASE_DIR}"')
     revision_marker = source.index(
         'printf \'%s\\n\' "${REVISION}" >"${RELEASE_DIR}/.git-revision"'
@@ -308,6 +314,7 @@ def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
     marker_permissions = source.index('chmod 0644 "${RELEASE_DIR}/.git-revision"')
     current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
 
+    assert ownership < runtime_permissions < validation
     assert validation < revision_marker < marker_permissions < current_link
     assert '"${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version' in source
 
@@ -335,7 +342,7 @@ def test_lean_profile_is_built_and_validated_before_activation() -> None:
     assert validate < revision_marker < current_link
     assert '"ELAN_HOME=${LEAN_ELAN_HOME}"' in source
     assert '"PATH=${LEAN_SERVICE_PATH}"' in source
-    assert 'chmod -R a+rX "${RELEASE_DIR}/lean"' in source
+    assert 'chmod -R a+rX "${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}"' in source
     assert "lean_provider_runtime(" in source
     assert "CapabilityProviderAvailability.AVAILABLE" in source
 


### PR DESCRIPTION
## Summary

- normalize read and traversal/execution permissions on immutable release and managed Python trees after root ownership
- perform normalization before the jacobian service-user runtime validation
- replace the redundant Lean-subtree-only normalization with the complete runtime boundary

## Evidence

A real --with-lean deployment launched under umask 0077 failed closed before activation because the generated .venv entrypoint was not traversable by the jacobian service user. The old production release remained active and the incomplete candidate was removed.

## Validation

- make lint typecheck
- make deploy-check (37 passed)
- bash -n deploy/install.sh
- git diff --check

After merge, deployment will be retried under umask 0077 and must pass the service-user and remote Lean/Mathlib smokes.