### PR TITLE
fix(release): harden final release permission audit

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -8,6 +8,11 @@
 
 set -Eeuo pipefail
 
+# Root-run validation and smoke probes must not mutate an immutable release by
+# creating bytecode caches that inherit the operator's (possibly restrictive)
+# umask. The long-running service has its own systemd environment.
+export PYTHONDONTWRITEBYTECODE=1
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/lib/service_state.sh"
@@ -293,6 +298,29 @@ validate_release_runtime() {
     esac
     "${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version >/dev/null \
         || die "release entrypoint is not executable by the jacobian service user"
+}
+
+validate_service_readability() {
+    local issue
+    local runtime_root
+
+    for runtime_root in "$@"; do
+        [[ -d "${runtime_root}" ]] || die \
+            "runtime input root is unavailable: ${runtime_root}"
+        if ! issue="$(
+            "${RUNUSER_BIN}" --user jacobian -- \
+                find "${runtime_root}" \
+                \( \
+                    \( -type d \( ! -readable -o ! -executable \) \) -o \
+                    \( -type f ! -readable \) \
+                \) \
+                -print -quit 2>&1
+        )"; then
+            die "jacobian service user could not inspect ${runtime_root}: ${issue}"
+        fi
+        [[ -z "${issue}" ]] || die \
+            "runtime input is not readable by the jacobian service user: ${issue}"
+    done
 }
 
 validate_lean_release_runtime() {
@@ -662,7 +690,17 @@ fi
 if ((RELEASE_WAS_BUILT)); then
     printf '%s\n' "${RELEASE_PROFILE}" >"${RELEASE_DIR}/.release-profile"
     printf '%s\n' "${REVISION}" >"${RELEASE_DIR}/.git-revision"
-    chmod 0644 "${RELEASE_DIR}/.git-revision"
+    chmod 0644 \
+        "${RELEASE_DIR}/.release-profile" \
+        "${RELEASE_DIR}/.git-revision"
+fi
+
+RUNTIME_READ_ROOTS=("${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}")
+if ((WITH_LEAN)); then
+    RUNTIME_READ_ROOTS+=("${LEAN_ELAN_HOME}")
+fi
+validate_service_readability "${RUNTIME_READ_ROOTS[@]}"
+if ((RELEASE_WAS_BUILT)); then
     RELEASE_BUILD_DIR=""
 fi
 
@@ -886,6 +924,10 @@ if ((!SKIP_SMOKE)); then
     ((SMOKE_SUCCEEDED)) || die \
         "deployment smoke failed; inspect jacobian-mcp and ingress journals"
 fi
+
+# Recheck after root-run authentication and smoke probes. With rollback still
+# armed, any post-build mutation that makes runtime input private fails closed.
+validate_service_readability "${RUNTIME_READ_ROOTS[@]}"
 
 DEPLOYMENT_ACCEPTED=1
 ROLLBACK_ARMED=0

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -227,7 +227,12 @@ project references never retain a temporary build path. uv-managed Python
 runtimes live under `/opt/jacobian/python`, outside root's home directory. The
 installer checks the final console-script shebang, resolved Python path, and
 execution as the `jacobian` service user before atomically selecting the
-release through `/opt/jacobian/current`.
+release through `/opt/jacobian/current`. It disables Python bytecode writes in
+its root-run probes and audits the release, managed Python, and optional Lean
+toolchain as the service user both before activation and after smoke. This keeps
+runtime readability independent of the operator's `umask` and makes a
+post-build permission regression trigger rollback instead of accepting a
+partially private release.
 Before copying them manually, replace `math-tools.example.org`, verify the
 service accounts, Caddy binary, and `/opt/jacobian/current` checkout, and decide
 between the static-token baseline and the anonymous test override. Keep each

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -311,12 +311,37 @@ def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
     revision_marker = source.index(
         'printf \'%s\\n\' "${REVISION}" >"${RELEASE_DIR}/.git-revision"'
     )
-    marker_permissions = source.index('chmod 0644 "${RELEASE_DIR}/.git-revision"')
+    marker_permissions = source.index(
+        '"${RELEASE_DIR}/.release-profile"', revision_marker
+    )
     current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
 
     assert ownership < runtime_permissions < validation
     assert validation < revision_marker < marker_permissions < current_link
     assert '"${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version' in source
+
+
+def test_runtime_inputs_remain_service_readable_after_root_probes() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    assert "export PYTHONDONTWRITEBYTECODE=1" in source
+    assert 'find "${runtime_root}"' in source
+    assert "-type d \\( ! -readable -o ! -executable \\)" in source
+    assert "-type f ! -readable" in source
+    assert 'RUNTIME_READ_ROOTS=("${RELEASE_DIR}" "${PYTHON_INSTALL_ROOT}")' in source
+    assert 'RUNTIME_READ_ROOTS+=("${LEAN_ELAN_HOME}")' in source
+
+    first_audit = source.index(
+        'validate_service_readability "${RUNTIME_READ_ROOTS[@]}"'
+    )
+    current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
+    smoke = source.index('log "running the read-only deployment smoke"')
+    final_audit = source.rindex(
+        'validate_service_readability "${RUNTIME_READ_ROOTS[@]}"'
+    )
+    accepted = source.index("DEPLOYMENT_ACCEPTED=1")
+
+    assert first_audit < current_link < smoke < final_audit < accepted
 
 
 def test_lean_profile_is_built_and_validated_before_activation() -> None:


### PR DESCRIPTION
## Summary

- prevent root-run installer probes from creating restrictive Python bytecode caches inside immutable releases
- make release profile metadata service-readable and audit release, managed Python, and optional Lean roots before activation and after smoke
- fail closed through the existing rollback path when any runtime input is unreadable or untraversable by the service user

## Validation

- `make test-plan BASE=origin/main`
- `make check-changed BASE=origin/main` (12/12 selected commands passed)
- restrictive-umask production redeploy will be run after merge and exact revision verification