### PR TITLE
build: require the maintained Python backend stack

### DIFF
--- a/.github/scripts/plan-local-tests
+++ b/.github/scripts/plan-local-tests
@@ -634,7 +634,7 @@ def main() -> None:
         provider_profile = (
             "external-proof"
             if any("external_sat" in test for test in tests)
-            else "full-python"
+            else "core"
         )
         print(f"recovery: make setup PROFILE={provider_profile}")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,15 +293,19 @@ jobs:
         run: make security-audit
 
   validate-built-package:
-    name: Validate Built Package
+    name: Validate Built Package (Python ${{ matrix.python-version }})
     needs: [plan, build]
     if: needs.plan.outputs.run-build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.28"
@@ -309,12 +313,18 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Smoke-test the built wheel
+      - name: Install and start the built wheel
         run: |
           wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
           test -n "$wheel"
-          uvx --from "$wheel" jacobian --help
-          uvx --from "$wheel" jacobian-mcp --help
+          environment="$RUNNER_TEMP/jacobian-wheel-${{ matrix.python-version }}"
+          state_dir="$RUNNER_TEMP/jacobian-state-${{ matrix.python-version }}"
+          uv venv --python "${{ matrix.python-version }}" "$environment"
+          uv pip install --python "$environment/bin/python" \
+            --only-binary :all: "$wheel"
+          "$environment/bin/jacobian" --help
+          "$environment/bin/jacobian-mcp" --help
+          "$environment/bin/jacobian" --state-dir "$state_dir" init
 
   unit-test:
     name: Tests (unit, Python 3.12)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,8 +172,9 @@ checker authorization out of plugins and search code.
   mathematical conclusion.
 - Include every first-class artifact reference, including verification records,
   in the result's `artifact_uris`.
-- An unavailable optional provider must remove only the affected capabilities;
-  unrelated kernel startup and catalog entries remain available.
+- An unavailable optional native or formal provider must remove only the
+  affected capabilities. A missing or mismatched maintained Python backend is
+  a broken installation and must fail runtime construction clearly.
 - Keep `deep_review.md` local; it is ignored and is not design source material.
 - Keep worked cases in reference scenarios and benchmarks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ make check-changed BASE=origin/main
 ```
 
 Then open a pull request. `make setup PROFILE=core` installs the locked
-development environment and requires only the core provider surface (NetworkX,
-SymPy, and Z3). `make check-changed BASE=origin/main`
+development environment with the complete maintained Python backend stack.
+`make check-changed BASE=origin/main`
 runs format, type-checking, and the exact tests selected from your changed
 paths against that base ref. Open the PR once it is green, and add any
 explicitly relevant specialist validation called out below.
@@ -74,8 +74,7 @@ classification detail live in the
 Jacobian uses Python 3.12 and the uv release pinned in [`.uv-version`](.uv-version).
 
 ```sh
-make setup PROFILE=core          # locked dev environment; core readiness
-make setup PROFILE=full-python    # also require every maintained Python extra
+make setup PROFILE=core          # locked dev environment and Python backends
 ```
 
 `make check` runs Ruff, mypy, and the unit lane; it is a useful local handoff.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 COPY lean ./lean
 
-RUN uv sync --locked --no-dev --extra flint --extra smt
+RUN uv sync --locked --no-dev
 
 EXPOSE 8000
 VOLUME ["/var/lib/jacobian"]

--- a/README.md
+++ b/README.md
@@ -68,10 +68,15 @@ python -m pip install jacobian
 
 That package includes Jacobian's exact maintained Python backend stack: SymPy,
 NetworkX, Z3, Python-FLINT, and cvc5. A normal Python or npm installation
-therefore exposes the same built-in Python-backed operation portfolio.
+therefore exposes the same built-in Python-backed operation portfolio. The
+tested binary-install contract is CPython 3.12 or 3.13 on glibc Linux x86-64;
+the release gate installs the built wheel and starts Jacobian on both Python
+versions. Other systems may have compatible upstream wheels, but are not part
+of the tested release contract yet. In particular, Alpine/musl cannot install
+the complete mandatory stack from PyPI.
 
 The launcher supports Claude, Codex, Cursor, Gemini, and OpenCode. It requires
-Node.js 18 or newer plus Python 3.12/3.13 or
+Node.js 18 or newer plus CPython 3.12/3.13 or
 [`uv`](https://docs.astral.sh/uv/); the guided installer can install its pinned
 `uv` release after confirmation. Run `jacobian mcp` to start the server
 directly.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ For the Python distribution:
 python -m pip install jacobian
 ```
 
+That package includes Jacobian's exact maintained Python backend stack: SymPy,
+NetworkX, Z3, Python-FLINT, and cvc5. A normal Python or npm installation
+therefore exposes the same built-in Python-backed operation portfolio.
+
 The launcher supports Claude, Codex, Cursor, Gemini, and OpenCode. It requires
 Node.js 18 or newer plus Python 3.12/3.13 or
 [`uv`](https://docs.astral.sh/uv/); the guided installer can install its pinned
@@ -98,8 +102,8 @@ determinant pair through the public MCP surface.
 
 ## Available mathematics
 
-The installed operations vary with local providers, but the maintained
-portfolio covers work in:
+The installed operations vary with optional external providers, but the
+maintained portfolio covers work in:
 
 - polynomial maps and polynomial algebra;
 - exact linear algebra;
@@ -109,8 +113,9 @@ portfolio covers work in:
 - polytopes; and
 - Lean declaration discovery and proof checking.
 
-Some operations require optional local backends. Catalog membership means an
-operation is installed and invocable; it does not grant verification authority.
+Some operations require optional native or formal backends. Catalog membership
+means an operation is installed and invocable; it does not grant verification
+authority.
 Read `capability://catalog` or use `math.find` to inspect the current
 environment. Use `math.run` to invoke a selected operation.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,6 +75,10 @@ Python 发行版可以直接安装稳定版本：
 python -m pip install jacobian
 ```
 
+该 package 包含 Jacobian 维护的完整 Python backend：SymPy、NetworkX、Z3、
+Python-FLINT 和 cvc5。因此普通 Python 与 npm 安装会提供相同的内置 Python
+操作集合。
+
 启动器支持 Claude、Codex、Cursor、Gemini 和 OpenCode。它需要 Node.js 18 或更高版本，以及 Python 3.12 或 [`uv`](https://docs.astral.sh/uv/)；引导安装器可以在确认后安装仓库固定的 `uv` 版本。运行 `jacobian mcp` 可以直接启动服务器。这个不足 100 KB 的 npm 启动器没有 npm 运行时依赖；较大的下载来自本地 Python 数学运行时，而不是 JavaScript 依赖树。
 
 <details>
@@ -83,10 +87,10 @@ python -m pip install jacobian
 ```sh
 git clone https://github.com/morluto/jacobian.git
 cd jacobian
-./scripts/setup-agent --client codex --profile full-python --yes
+./scripts/setup-agent --client codex --profile core --yes
 ```
 
-该命令会执行锁定的完整 Python 环境同步，并配置所选智能体，让 MCP 从绝对源代码路径和状态路径启动，同时使用 `--no-sync`。它还会记录一份 doctor 报告，其中包含 Git 修订版本、包版本、catalog 摘要和 provider 可用性。关于 `core`、`full-python`、`lean` 和 `external-proof` 配置档案、试运行、可重复性及回滚行为，请参阅[从源代码检出配置智能体](docs/how-to/setup-agent-from-source.md)。
+该命令会执行锁定的完整 Python 环境同步，并配置所选智能体，让 MCP 从绝对源代码路径和状态路径启动，同时使用 `--no-sync`。它还会记录一份 doctor 报告，其中包含 Git 修订版本、包版本、catalog 摘要和 provider 可用性。关于 `core`、`lean` 和 `external-proof` 配置档案、试运行、可重复性及回滚行为，请参阅[从源代码检出配置智能体](docs/how-to/setup-agent-from-source.md)。
 
 使用 `uv run jacobian --help` 查看 CLI，或使用 `uv run jacobian-mcp` 启动 MCP 适配器。
 
@@ -173,7 +177,7 @@ Jacobian 将四项职责分开：
 
 `jacobian setup` 会向一个或多个受支持的客户端注册本地服务器。`jacobian upgrade` 会刷新启动器所管理环境中的固定 Python 内核；若要升级 npm 启动器本身，请使用 `npm install -g jacobian@latest`。
 
-对于代码仓库副本，`jacobian setup --source <checkout> --state-dir <path> --profile full-python` 会显式地将客户端绑定到该源代码环境；受维护的 `scripts/setup-agent` 封装器会先完成所需的锁定同步和 doctor 检查。
+对于代码仓库副本，`jacobian setup --source <checkout> --state-dir <path> --profile core` 会显式地将客户端绑定到该源代码环境；受维护的 `scripts/setup-agent` 封装器会先完成所需的锁定同步和 doctor 检查。
 
 服务器只公布两个能力入口：`math.find` 用于搜索或检查已安装的数学操作，`math.run` 用于执行其中一个操作。完整 inventory 位于 `capability://catalog`。这些工具不规定研究顺序；数学表示、分解、探索、验证时机和停止条件都由智能体决定。
 
@@ -193,11 +197,11 @@ sudo ./deploy/install.sh --mode tailscale
 
 ## 可选 backend
 
-部分能力使用默认未安装的 backend：
+维护的 Python backend 随 Jacobian 一起安装。以下原生可执行程序和形式化
+运行时仍由 operator 单独安装：
 
 - CaDiCaL 用于查找 SAT 模型和 UNSAT 证明 artifact。
-- cvc5 生成 SMT UNSAT 证明；Carcara 独立检查 Alethe。
-- `flint` extra 提供 Python-FLINT/Arb 操作，用于精确有理数系统、整数矩阵与格、多项式以及经过验证的数值计算。具体能力和独立重放支持取决于已安装的 catalog。
+- Carcara 独立检查 cvc5 生成的 Alethe 证明。
 - 固定版本的 Lean `CORE` 和 `MATHLIB` 环境用于检查形式化证书。
 
 Backend 可用不等于验证授权。Provider 的输出在相应的独立检查器接受其绑定的见证或证书之前，始终保持未验证状态。

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -633,7 +633,6 @@ if [[ ! -d "${RELEASE_DIR}" ]]; then
             "${UV_BIN}" sync \
             --locked \
             --no-dev \
-            --all-extras \
             --managed-python \
             --link-mode copy
     )

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -266,9 +266,11 @@ later prove a common semantic need.
 ## Provider optionality
 
 Importing `jacobian.math` performs no provider probe. Private backend imports
-are lazy, optional providers are installation extras, and an unavailable
-provider removes only its affected installed operations. Provider identity is
-invocation provenance rather than mathematical value identity.
+are lazy even though the maintained Python backends are exact base-package
+dependencies. A missing or mismatched maintained Python backend is a broken
+installation and fails runtime construction; optional native/formal providers
+remain absent without affecting unrelated installed operations. Provider
+identity is invocation provenance rather than mathematical value identity.
 
 ## Host and protocol boundaries
 

--- a/docs/how-to/install-optional-backends.md
+++ b/docs/how-to/install-optional-backends.md
@@ -2,19 +2,18 @@
 
 [Documentation home](../index.md)
 
-Some Jacobian capabilities use mathematical backends that are not installed by
-default. Backend availability is not verification authority. Provider output
+Jacobian installs its maintained Python mathematical backends—SymPy, NetworkX,
+Z3, Python-FLINT, and cvc5—as exact package dependencies. A missing or
+mismatched Python backend is a broken installation, not a supported reduced
+catalog. Backend availability is not verification authority: provider output
 remains unverified until the appropriate independent checker accepts its bound
 witness or certificate.
 
-The optional providers currently include:
+Native executables and formal runtimes remain optional operator-installed
+components:
 
 - CaDiCaL, which finds SAT models and UNSAT proof artifacts;
-- cvc5, which produces SMT UNSAT proofs, with Carcara independently checking
-  Alethe;
-- the `flint` extra, which provides Python-FLINT/Arb operations for exact
-  rational systems, integer matrices and lattices, polynomials, and validated
-  numerical computation; and
+- Carcara, which independently checks Alethe proofs produced by cvc5; and
 - pinned Lean `CORE` and `MATHLIB` environments, which check formal
   certificates.
 
@@ -23,14 +22,12 @@ catalog. The [provider runtime contract](../reference/provider-runtime.md)
 defines how Jacobian measures provider availability, compatibility, identity,
 and checker runtimes. The
 [source setup profiles](setup-agent-from-source.md#profiles) provide maintained
-installation paths for `full-python`, `lean`, and `external-proof` checkouts.
+installation paths for `core`, `lean`, and `external-proof` checkouts.
 
-For ordinary contributor work, `make setup PROFILE=core` installs the locked
-development environment and diagnoses only the core provider surface
-(NetworkX, SymPy, and Z3); that is the contributor quick path described in
-[CONTRIBUTING.md](../../CONTRIBUTING.md). Use
-`make setup PROFILE=full-python` when the change requires every maintained
-Python extra. CI owns the full Lean and optional-provider environments, so you
+For ordinary contributor work, `make setup PROFILE=core` installs and diagnoses
+the complete locked Python backend surface; that is the contributor quick path
+described in [CONTRIBUTING.md](../../CONTRIBUTING.md). CI owns the full Lean and
+optional native-provider environments, so you
 do not need to prepare them locally unless you are reproducing a
 boundary-specific failure.
 

--- a/docs/how-to/invoke-domain-capabilities.md
+++ b/docs/how-to/invoke-domain-capabilities.md
@@ -14,7 +14,8 @@ installed tool ID or payload. The product surface is
    `*.verify` ID)—not a second mode on the producer.
 
 Do not infer availability or payload fields from examples. Provider health,
-configured exclusions, optional backends, and checker authorization all affect
+configured exclusions, optional native/formal backends, and checker
+authorization all affect
 the installed catalog.
 
 ## Discover and describe

--- a/docs/how-to/setup-agent-from-source.md
+++ b/docs/how-to/setup-agent-from-source.md
@@ -18,7 +18,9 @@ uv run --project /absolute/path/to/jacobian --locked --no-sync \
 ```
 
 The bootstrap requires the uv version in [`.uv-version`](../../.uv-version),
-Python 3.12 or 3.13, Git, and Node.js 18 or newer. It requires a clean checkout,
+CPython 3.12 or 3.13, Git, and Node.js 18 or newer. The tested binary-install
+platform is glibc Linux x86-64; other platforms require a compatible wheel for
+every mandatory Python backend. It requires a clean checkout,
 performs a locked sync, initializes the state directory, and audits the exact
 Git revision, package version, catalog digest, and provider runtimes before it
 writes any client configuration. The audit is saved as

--- a/docs/how-to/setup-agent-from-source.md
+++ b/docs/how-to/setup-agent-from-source.md
@@ -5,7 +5,7 @@ clone rather than the latest published Python package. From the repository
 root, run:
 
 ```sh
-./scripts/setup-agent --client codex --profile full-python --yes
+./scripts/setup-agent --client codex --profile core --yes
 ```
 
 Replace `codex` with `claude`, `cursor`, `gemini`, or `opencode`; repeat
@@ -54,10 +54,9 @@ not install prompts, skills, or client-specific mathematical workflows.
 
 | Profile | Installed or checked surface |
 | --- | --- |
-| `core` | Locked base dependencies, including SymPy and Z3 |
-| `full-python` | `core` plus all maintained Python extras: python-flint and cvc5 |
-| `lean` | `full-python` plus a build of the pinned `lean/lean-toolchain` project; `elan`/`lake` must already be on `PATH` |
-| `external-proof` | `full-python` plus fail-closed availability checks for pinned CaDiCaL, DRAT-trim, and Carcara executables |
+| `core` | Complete locked Python backend stack: SymPy, NetworkX, Z3, Python-FLINT, and cvc5 |
+| `lean` | `core` plus a build of the pinned `lean/lean-toolchain` project; `elan`/`lake` must already be on `PATH` |
+| `external-proof` | `core` plus fail-closed availability checks for pinned CaDiCaL, DRAT-trim, and Carcara executables |
 
 The `external-proof` profile does not download or trust native executables on
 the user's behalf. Their exact version and provenance contracts are defined in
@@ -69,11 +68,9 @@ instead of a floating Lean installation.
 
 These profiles configure an agent client against a source checkout. For
 ordinary contributor work that only needs to run the test suite, the
-`make setup PROFILE=core` quick path installs the same locked base surface
-(NetworkX, SymPy, and Z3) without writing client configuration; see
-[CONTRIBUTING.md](../../CONTRIBUTING.md). `make setup PROFILE=full-python`
-additionally requires every maintained Python extra. Optional backend
-installation is described in
+`make setup PROFILE=core` quick path installs the same complete Python backend
+stack without writing client configuration; see
+[CONTRIBUTING.md](../../CONTRIBUTING.md). Optional native backend installation is described in
 [Install optional backends](install-optional-backends.md).
 
 Add `--dev` when the clone also needs the locked development group. Use

--- a/docs/how-to/troubleshoot-z3-macos.md
+++ b/docs/how-to/troubleshoot-z3-macos.md
@@ -5,6 +5,8 @@
 The locked environment uses `z3-solver` 5.0.0.0. Its upstream macOS wheels
 target macOS 13 or newer on Apple silicon and Intel. On an older release, `uv`
 falls back to a source build that requires CMake, `make`, and a C++20 compiler.
+macOS is not currently in Jacobian's tested binary-install matrix, so this is
+upstream installation guidance rather than a supported release configuration.
 
 Install the Xcode Command Line Tools and CMake before retrying `uv sync --dev`.
 These commands report the relevant environment without changing it:

--- a/docs/reference/capabilities/linear-algebra/linear-rational-solutions.md
+++ b/docs/reference/capabilities/linear-algebra/linear-rational-solutions.md
@@ -19,12 +19,8 @@ outcomes. Their producers and verifiers are also separate operations:
 | `linear.rational_inconsistency.compute` | One normalized left witness `y` with proposed relations `y^T A = 0` and `y^T b = 1`, or no witness | `COMPUTED` when the bounded provider attempt completes; never self-verified |
 | `linear.rational_inconsistency.verify` | Independent replay of every left-witness equation and the nonzero pairing | `VERIFIED` only after the operator-authorized checker creates a durable verification record |
 
-The producers run only when the exact optional Python-FLINT distribution is
-available. Install the pinned wheel with:
-
-```sh
-uv sync --extra flint
-```
+The exact Python-FLINT distribution is pinned by the base Jacobian package and
+the locked source environment.
 
 The verifiers do not import Python-FLINT, SymPy, or the producers. They use
 standard-library `fractions.Fraction` arithmetic in the existing clean-process

--- a/docs/reference/capabilities/matrix/matrix-hermite-normal-form.md
+++ b/docs/reference/capabilities/matrix/matrix-hermite-normal-form.md
@@ -25,7 +25,7 @@ The request includes a wall-clock budget from 1 to 60 seconds. The default is
 
 ## Computed evidence
 
-The optional `flint` extra pins Python-FLINT 0.9.0 and its linked FLINT 3.6.0
+The base package pins Python-FLINT 0.9.0 and its linked FLINT 3.6.0
 library for this profile. Its HNF operation calls
 `fmpz_mat.hnf(transform=True)` in an isolated process and returns two exact
 integer matrices:

--- a/docs/reference/capabilities/sat-smt/smt-artifacts.md
+++ b/docs/reference/capabilities/sat-smt/smt-artifacts.md
@@ -3,8 +3,8 @@
 [Documentation home](../../../index.md)
 
 - Status: Experimental pre-stable producer and verifier contracts
-- Optional operation: `smt.unsat_proof.find` when the exact cvc5 1.3.4
-  Python distribution is installed
+- Producer operation: `smt.unsat_proof.find`, backed by the exact packaged
+  cvc5 1.3.4 Python distribution
 - Verification operation: `smt.unsat_proof.verify` for the pinned zero-hole
   `QF_UF` compatibility profile when an operator-authorized Carcara runtime is
   installed
@@ -15,14 +15,8 @@ and the raw Alethe bytes emitted by cvc5. It does not expose a broad
 of lexical `hole` markers is computed evidence, not independent verification.
 Every producer result therefore carries `conclusion: UNKNOWN`.
 
-Install the optional wheel-backed provider with:
-
-```sh
-uv sync --extra smt
-```
-
-The locked development environment also includes the exact provider so the
-producer contract and public reproduction cases run in CI.
+The base package and locked development environment both include this exact
+provider. Carcara remains separately operator-installed for independent replay.
 
 ## Registered descriptors
 
@@ -36,9 +30,7 @@ URIs registered by the current runtime:
 | Schema | `jacobian.smt-alethe-proof@1` | Raw cvc5 Alethe bytes bound to one exact input |
 
 The schemas are model backed. Their closed structural and cross-field
-invariants apply before the SMT producer publishes a typed artifact. Runtime
-construction registers the artifact boundary even when cvc5 is absent; only
-the producer operation is conditional.
+invariants apply before the SMT producer publishes a typed artifact.
 
 ## Pinned SMT-LIB profile
 

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -1,9 +1,11 @@
 # Provider runtime contract
 
-Jacobian advertises a capability only when its exact provider runtime is
-installed and passes its local health probe. Provider availability is a catalog
-condition. An absent optional backend is not left for the agent to discover
-during invocation.
+Jacobian's maintained Python backends are exact package dependencies. Runtime
+construction checks their distribution identity without importing their
+implementation, and a missing or mismatched dependency is an installation
+failure rather than a supported reduced catalog. Operator-installed native and
+formal providers remain optional: their absence removes only the operations
+that depend on them and is not left for the agent to discover during invocation.
 
 This contract describes operational provenance. It does not change
 mathematical assurance: an available provider, successful measurement, solver
@@ -78,10 +80,11 @@ still starts. Capabilities requiring the failed profile are absent from
 operator-installed adapters fail registration instead of silently falling
 back to another provider.
 
-The optional cvc5 Alethe producer follows the same rule. The exact 1.3.4 wheel
-must expose the required SMT-LIB parser and proof APIs and have a hashed RECORD
-manifest. Otherwise `smt.unsat_proof.find` is absent while the base runtime and
-SMT artifact schemas remain available.
+The cvc5 Alethe producer is part of the packaged Python portfolio. Its exact
+1.3.4 wheel must have a hashed RECORD manifest at runtime construction; its
+SMT-LIB parser and proof APIs are checked lazily at first use. Missing or
+mismatched package identity is a broken installation, while a first-use
+readiness failure fails the selected invocation closed.
 
 Source-backed adapters can construct metadata without importing their
 implementation:

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -73,10 +73,10 @@ In short, Jacobian wraps semantic contracts, not entire libraries.
 Finite-extension values bind the exact modulus, generator, ordered power basis,
 and coordinate encoding. Matrix, subspace, projective, and linear-map values
 also bind their parents and ordered axes. SymPy validates presentations and
-normalizes projective values. Python-FLINT conversion stays private and lazy;
-importing `jacobian.math` does not probe or import the optional backend. Install
-the `flint` extra only for FLINT-backed polynomial evaluation, restriction of
-scalars, and rank operations.
+normalizes projective values. Backend conversion stays private and lazy;
+importing `jacobian.math` does not probe or import backend implementations until
+a corresponding function is called. The maintained backends are exact package
+dependencies, but they do not become mathematical value identity.
 
 This API is the authoritative mathematical implementation rather than a facade
 over `math.run`. Installed operations parse their typed request once, convert

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -115,7 +115,8 @@ behavioral regression proof is infeasible, state the proof gap.
 - removed operation IDs and resources are absent from catalog/MCP inventory;
 - retained mathematical operations and independently authorized checkers still
   start and run;
-- missing optional providers remove only their affected operations;
+- missing optional native or formal providers remove only their affected
+  operations; a missing packaged Python backend is an installation failure;
 - runtime startup and shutdown have fewer states and owners; and
 - source, tests, and documentation show material net deletion.
 
@@ -129,7 +130,7 @@ For each migrated domain:
 - Python callers construct no runtime, catalog, store, or MCP object;
 - installed operations call the same public semantic implementation;
 - every public function has one canonical semantic input type;
-- provider conversion stays private and optional imports are lazy;
+- provider conversion stays private and backend imports are lazy;
 - request parsing and result serialization each occur once;
 - no internal `CapabilityRequest` or `CapabilityResult` call remains;
 - constructor/backend and large-exact-value round trips are covered where the

--- a/make/development.mk
+++ b/make/development.mk
@@ -11,7 +11,7 @@ setup: ## Install and diagnose a locked development profile (PROFILE=core).
 doctor: ## Diagnose a development profile without changing it (PROFILE=core).
 	uv run --locked --no-sync python tools/development_profiles.py doctor --profile "$(PROFILE)" --repo .
 
-setup-agent: ## Configure an agent against this source checkout (ARGS="--client codex --profile full-python").
+setup-agent: ## Configure an agent against this source checkout (ARGS="--client codex --profile core").
 	./scripts/setup-agent $(ARGS)
 
 JACOBIAN_REGISTRY_IMAGE ?= ghcr.io/morluto/jacobian

--- a/npm/bin/setup.cjs
+++ b/npm/bin/setup.cjs
@@ -204,7 +204,7 @@ function buildSourceLauncher(
   elanHome = process.env.ELAN_HOME || "",
   leanRuntime = process.env.JACOBIAN_LEAN_RUNTIME || "",
 ) {
-  const profiles = new Set(["core", "full-python", "lean", "external-proof"]);
+  const profiles = new Set(["core", "lean", "external-proof"]);
   if (!profiles.has(profile)) {
     throw new Error(`Unknown Jacobian source profile: ${profile}.`);
   }

--- a/npm/npm-packaging.test.mjs
+++ b/npm/npm-packaging.test.mjs
@@ -301,7 +301,7 @@ test("buildSourceLauncher binds the exact checkout and state directory", () => {
     source,
     state,
     "/opt/uv",
-    "full-python",
+    "core",
     "/providers/bin:/usr/bin",
     "/environments/jacobian",
   );
@@ -316,7 +316,7 @@ test("buildSourceLauncher binds the exact checkout and state directory", () => {
     "--state-dir",
     state,
   ]);
-  assert.equal(launcher.profile, "full-python");
+  assert.equal(launcher.profile, "core");
   assert.equal(launcher.package, null);
   assert.deepEqual(launcher.env, {
     PATH: "/providers/bin:/usr/bin",
@@ -595,7 +595,7 @@ process.stdin.on("data", (chunk) => {
         source,
         stateDir,
         fakeUv,
-        "full-python",
+        "core",
         process.env.PATH,
       );
       const claude = clientDefinitions(home).find((definition) => definition.id === "claude");
@@ -1273,7 +1273,7 @@ test("source setup rejects an unsupported client before writing config", async (
         "--source",
         join(npmRoot, ".."),
         "--profile",
-        "full-python",
+        "core",
         "--client",
         "codxe",
         "--yes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,24 +11,18 @@ requires-python = ">=3.12,<3.14"
 license = { text = "MIT" }
 authors = [{ name = "Jacobian contributors" }]
 dependencies = [
+    "cvc5==1.3.4",
     "filelock>=3.20,<4",
     "jsonschema>=4.23,<5",
     "mcp==2.0.0",
     "mcp-types==2.0.0",
-    "networkx>=3.4,<4",
+    "networkx==3.6.1",
     "pydantic>=2.12,<3",
+    "python-flint==0.9.0",
     "rfc8785==0.1.4",
     "sympy==1.14.0",
     "typer>=0.20,<1",
-    "z3-solver>=4.15.4,<6",
-]
-
-[project.optional-dependencies]
-flint = [
-    "python-flint==0.9.0",
-]
-smt = [
-    "cvc5==1.3.4",
+    "z3-solver==5.0.0.0",
 ]
 
 [project.scripts]
@@ -59,8 +53,6 @@ dev-core = [
 ]
 dev = [
     { include-group = "dev-core" },
-    "cvc5==1.3.4",
-    "python-flint==0.9.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -131,7 +123,7 @@ known_first_party = ["jacobian", "jacobian_checkers"]
 # exactly pinned MCP transport; deploy/ is not part of the Python wheel.
 # The Harbor manifest writer is repository tooling and uses the direct dev-only
 # tomli-w dependency; it is intentionally absent from the runtime wheel.
-per_rule_ignores = { "DEP001" = ["harbor"], "DEP002" = ["cvc5", "mcp-types", "python-flint"], "DEP003" = ["httpx2"], "DEP004" = ["tomli_w"] }
+per_rule_ignores = { "DEP001" = ["harbor"], "DEP002" = ["cvc5", "python-flint"], "DEP003" = ["httpx2"], "DEP004" = ["tomli_w"] }
 
 [tool.importlinter]
 root_package = "jacobian"
@@ -153,7 +145,7 @@ forbidden_modules = [
 ]
 
 [[tool.importlinter.contracts]]
-name = "Finite-field values do not import the optional backend"
+name = "Finite-field values do not import their private backend"
 type = "forbidden"
 source_modules = ["jacobian.math.finite_fields.values"]
 forbidden_modules = ["jacobian.math.finite_fields._flint"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 license = { text = "MIT" }
 authors = [{ name = "Jacobian contributors" }]
+classifiers = [
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
 dependencies = [
     "cvc5==1.3.4",
     "filelock>=3.20,<4",

--- a/scripts/setup-agent
+++ b/scripts/setup-agent
@@ -18,13 +18,12 @@ usage() {
 # Source-aware Jacobian agent bootstrap.
 #
 # Usage:
-#   ./scripts/setup-agent --client codex --profile full-python [options]
+#   ./scripts/setup-agent --client codex --profile core [options]
 #
 # Profiles:
-#   core            Locked base Python dependencies.
-#   full-python     Base plus all maintained Python extras (Flint and cvc5).
-#   lean            full-python plus the pinned Lean project build.
-#   external-proof  full-python plus fail-closed checks for pinned external
+#   core            Complete maintained Python backend stack.
+#   lean            core plus the pinned Lean project build.
+#   external-proof  core plus fail-closed checks for pinned external
 #                   CaDiCaL, DRAT-trim, and Carcara executables.
 #
 # Options:

--- a/src/jacobian/domains/posets/operations.py
+++ b/src/jacobian/domains/posets/operations.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import Any
-
-import networkx as nx
 
 from jacobian.contracts.posets import (
     FinitePoset,
@@ -39,8 +38,14 @@ from jacobian.operation_bindings import (
 from jacobian.operations import OperationSpec
 
 
-def _presentation_graph(request: FinitePosetRequest) -> nx.DiGraph[str]:
-    graph: nx.DiGraph[str] = nx.DiGraph()
+def _networkx() -> Any:
+    """Load the maintained graph backend only when a poset operation runs."""
+
+    return importlib.import_module("networkx")
+
+
+def _presentation_graph(request: FinitePosetRequest, nx: Any) -> Any:
+    graph = nx.DiGraph()
     graph.add_nodes_from(request.elements)
     graph.add_edges_from(
         (pair.lower, pair.upper)
@@ -51,7 +56,8 @@ def _presentation_graph(request: FinitePosetRequest) -> nx.DiGraph[str]:
 
 
 def _materialized_poset(request: FinitePosetRequest) -> FinitePoset:
-    graph = _presentation_graph(request)
+    nx = _networkx()
+    graph = _presentation_graph(request, nx)
     if request.interpretation is RelationInterpretation.COVER_EDGES:
         reduction_graph = graph
         closure_graph = nx.transitive_closure_dag(graph)
@@ -111,11 +117,12 @@ def _materialize(
 
 
 def _width(request: PosetRequest) -> PosetWidthResult:
+    nx = _networkx()
     poset = request.poset
     elements = poset.elements
     left_nodes = tuple(("L", element) for element in elements)
     right_nodes = tuple(("R", element) for element in elements)
-    graph: nx.Graph[tuple[str, str]] = nx.Graph()
+    graph = nx.Graph()
     graph.add_nodes_from(left_nodes, bipartite=0)
     graph.add_nodes_from(right_nodes, bipartite=1)
     graph.add_edges_from(
@@ -245,8 +252,9 @@ def _compute_mobius(
     *,
     include_recurrence: bool,
 ) -> MobiusFunctionResult:
+    nx = _networkx()
     poset = request.poset
-    graph: nx.DiGraph[str] = nx.DiGraph()
+    graph = nx.DiGraph()
     graph.add_nodes_from(poset.elements)
     graph.add_edges_from((pair.lower, pair.upper) for pair in poset.strict_order_pairs)
     topological = tuple(nx.lexicographical_topological_sort(graph, key=str))

--- a/src/jacobian/portfolio/foundation_installation.py
+++ b/src/jacobian/portfolio/foundation_installation.py
@@ -43,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class FoundationInstaller:
-    """Install foundational checkers and optional-provider adapters."""
+    """Install foundational checkers and solver adapters."""
 
     context: InstallationContext
 
@@ -118,15 +118,15 @@ class FoundationInstaller:
             result,
             runtimes.sympy_polynomial_normalization,
         )
-        self.install_optional_provider_components(core, result, runtimes)
+        self.install_solver_components(core, result, runtimes)
 
-    def install_optional_provider_components(
+    def install_solver_components(
         self,
         core: CoreServices,
         result: PortfolioInstallation,
         runtimes: ProviderRuntimePlan,
     ) -> None:
-        """Install capabilities backed by declared optional solver providers."""
+        """Install the packaged cvc5 adapter and optional CaDiCaL adapter."""
 
         result.cadical_runtime = runtimes.cadical
         if (
@@ -145,13 +145,9 @@ class FoundationInstaller:
                     self.context.register_capability(adapter)
 
         result.cvc5_runtime = runtimes.cvc5
-        if result.cvc5_runtime.availability is CapabilityProviderAvailability.AVAILABLE:
-            try:
-                adapter = install_cvc5_capability(core.smt, result.cvc5_runtime)
-            except OSError as exc:
-                _LOGGER.warning("cvc5 SMT proof exploration is not installed: %s", exc)
-            else:
-                self.context.register_capability(adapter)
+        self.context.register_capability(
+            install_cvc5_capability(core.smt, result.cvc5_runtime)
+        )
 
     # ------------------------------------------------------------------
     # Private installation helpers
@@ -179,20 +175,9 @@ class FoundationInstaller:
             self.context.register_capability(verification_adapter)
 
         result.sympy_polynomial_normalization_runtime = runtime
-        if (
-            result.sympy_polynomial_normalization_runtime.availability
-            is not CapabilityProviderAvailability.AVAILABLE
-        ):
-            return
-        try:
-            adapter = install_sympy_polynomial_normalization_capability(
+        self.context.register_capability(
+            install_sympy_polynomial_normalization_capability(
                 core.polynomial_expressions,
                 result.sympy_polynomial_normalization_runtime,
             )
-        except (OSError, ValueError) as exc:
-            _LOGGER.warning(
-                "SymPy typed polynomial normalization is not installed: %s",
-                exc,
-            )
-        else:
-            self.context.register_capability(adapter)
+        )

--- a/src/jacobian/portfolio/provider_resolution.py
+++ b/src/jacobian/portfolio/provider_resolution.py
@@ -91,11 +91,18 @@ def _require_packaged_python_backends(
 ) -> None:
     """Reject an incomplete or version-skewed base installation."""
 
+    failures: dict[str, str] = {}
     for runtime in runtimes:
         if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
             continue
         detail = runtime.diagnostic or "the pinned runtime identity is unavailable"
-        raise ProviderRuntimeError(
-            f"required Python provider {runtime.provider} is unavailable: {detail}",
-            code=ProviderRuntimeErrorCode.UNAVAILABLE,
-        )
+        failures.setdefault(runtime.provider, detail[:256])
+    if not failures:
+        return
+    diagnostic = "; ".join(
+        f"{provider}: {detail}" for provider, detail in failures.items()
+    )
+    raise ProviderRuntimeError(
+        f"required Python providers are unavailable: {diagnostic}",
+        code=ProviderRuntimeErrorCode.UNAVAILABLE,
+    )

--- a/src/jacobian/portfolio/provider_resolution.py
+++ b/src/jacobian/portfolio/provider_resolution.py
@@ -1,11 +1,19 @@
-"""Explicit resolution of optional provider runtime availability."""
+"""Resolve packaged and operator-installed provider runtimes once."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.capabilities import (
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
+from jacobian.provider_runtime import (
+    ProviderRuntimeError,
+    ProviderRuntimeErrorCode,
+    known_provider_runtime,
+)
 from jacobian.providers.external_solver_runtime import (
     cadical_provider_runtime,
     carcara_provider_runtime,
@@ -13,7 +21,6 @@ from jacobian.providers.external_solver_runtime import (
     drat_trim_provider_runtime,
 )
 from jacobian.providers.flint_runtime import (
-    python_flint_hnf_provider_runtime,
     python_flint_provider_runtime,
 )
 from jacobian.providers.lean_runtime import (
@@ -33,8 +40,6 @@ class ProviderRuntimePlan:
     carcara: CapabilityProviderRuntime
     cvc5: CapabilityProviderRuntime
     drat_trim: CapabilityProviderRuntime
-    python_flint: CapabilityProviderRuntime
-    python_flint_hnf: CapabilityProviderRuntime
     sympy_polynomial_normalization: CapabilityProviderRuntime
 
 
@@ -43,16 +48,26 @@ class ProviderAvailabilityResolver:
     """Resolve provider availability before capability installation begins."""
 
     def resolve(self) -> ProviderRuntimePlan:
+        cvc5 = cvc5_provider_runtime()
+        sympy_polynomial_normalization = (
+            sympy_polynomial_normalization_provider_runtime()
+        )
+        _require_packaged_python_backends(
+            (
+                known_provider_runtime("jacobian.networkx"),
+                known_provider_runtime("jacobian.sympy"),
+                known_provider_runtime("jacobian.z3"),
+                python_flint_provider_runtime(),
+                cvc5,
+                sympy_polynomial_normalization,
+            )
+        )
         return ProviderRuntimePlan(
             cadical=cadical_provider_runtime(),
             carcara=carcara_provider_runtime(),
-            cvc5=cvc5_provider_runtime(),
+            cvc5=cvc5,
             drat_trim=drat_trim_provider_runtime(),
-            python_flint=python_flint_provider_runtime(),
-            python_flint_hnf=python_flint_hnf_provider_runtime(),
-            sympy_polynomial_normalization=(
-                sympy_polynomial_normalization_provider_runtime()
-            ),
+            sympy_polynomial_normalization=sympy_polynomial_normalization,
         )
 
     def resolve_lean(
@@ -69,3 +84,18 @@ class ProviderAvailabilityResolver:
         """Resolve the pinned CORE Lean frontend before statement registration."""
 
         return lean_frontend_provider_runtime()
+
+
+def _require_packaged_python_backends(
+    runtimes: tuple[CapabilityProviderRuntime, ...],
+) -> None:
+    """Reject an incomplete or version-skewed base installation."""
+
+    for runtime in runtimes:
+        if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+            continue
+        detail = runtime.diagnostic or "the pinned runtime identity is unavailable"
+        raise ProviderRuntimeError(
+            f"required Python provider {runtime.provider} is unavailable: {detail}",
+            code=ProviderRuntimeErrorCode.UNAVAILABLE,
+        )

--- a/src/jacobian/providers/__init__.py
+++ b/src/jacobian/providers/__init__.py
@@ -3,12 +3,11 @@
 This package provides two independent, composable primitives:
 
 * :func:`distribution_version` and :func:`distribution_summary` read installed
-  distribution metadata through ``importlib.metadata`` without ever importing
-  the provider package, so a missing or heavy optional dependency cannot
-  affect runtime startup.
-* :class:`LazyLoader` defers importing or constructing a heavy optional
-  implementation until first use, caches success and failure, owns the
-  implementation lifecycle, and exposes a typed :class:`LoaderState`.
+  distribution metadata through ``importlib.metadata`` without importing the
+  provider implementation.
+* :class:`LazyLoader` defers importing or constructing a heavy implementation
+  until first use, caches success and failure, owns the implementation
+  lifecycle, and exposes a typed :class:`LoaderState`.
 
 The package deliberately avoids registries, package discovery, import-time
 registration, and compatibility shims. Each loader is an independent, owned

--- a/src/jacobian/providers/external_solver_runtime.py
+++ b/src/jacobian/providers/external_solver_runtime.py
@@ -1,4 +1,4 @@
-"""Provider-owned probes for optional SAT and SMT runtimes."""
+"""Provider-owned probes for packaged and external SAT/SMT runtimes."""
 
 from __future__ import annotations
 
@@ -107,7 +107,7 @@ def cadical_provider_runtime(
 
 
 def cvc5_provider_runtime() -> CapabilityProviderRuntime:
-    """Inspect the exact optional cvc5 Python distribution used for Alethe."""
+    """Inspect the exact packaged cvc5 Python distribution used for Alethe."""
 
     runtime = python_distribution_provider_runtime(
         "cvc5",

--- a/src/jacobian/providers/flint_runtime.py
+++ b/src/jacobian/providers/flint_runtime.py
@@ -59,7 +59,7 @@ def python_flint_provider_runtime(
     *,
     refresh: bool = False,
 ) -> CapabilityProviderRuntime:
-    """Identify the exact optional Python-FLINT compatibility profile."""
+    """Identify the exact packaged Python-FLINT compatibility profile."""
 
     return _python_flint_runtime(
         required_attributes=("fmpq", "fmpq_mat"),
@@ -84,7 +84,7 @@ def python_flint_finite_field_provider_runtime(
     *,
     refresh: bool = False,
 ) -> CapabilityProviderRuntime:
-    """Identify the exact optional Python-FLINT finite-field API."""
+    """Identify the exact packaged Python-FLINT finite-field API."""
 
     return _python_flint_runtime(
         required_attributes=("fmpz_mod_poly_ctx", "fq_default_ctx", "nmod_mat"),

--- a/src/jacobian/providers/metadata.py
+++ b/src/jacobian/providers/metadata.py
@@ -1,8 +1,8 @@
 """Cheap provider metadata inspection without importing implementations.
 
 These helpers read installed distribution metadata through ``importlib.metadata``
-only. They never import the provider package itself, so a missing or heavy
-optional dependency cannot affect runtime startup or capability discovery.
+only. They never import the provider package itself during runtime assembly;
+missing distributions are reported through metadata instead.
 """
 
 from __future__ import annotations

--- a/tests/boundary/process/public_api/test_import_isolation.py
+++ b/tests/boundary/process/public_api/test_import_isolation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def _imported_modules(target: str) -> set[str]:
@@ -41,6 +42,33 @@ def test_native_namespace_does_not_eagerly_import_packaged_backends() -> None:
         _imported_modules("jacobian.math"),
         ("networkx", "sympy", "flint"),
     )
+
+
+def test_runtime_assembly_does_not_import_packaged_backends(tmp_path: Path) -> None:
+    script = """
+import sys
+from pathlib import Path
+from jacobian.runtime import create_runtime
+
+runtime = create_runtime(Path(sys.argv[1]))
+try:
+    forbidden = {"networkx", "sympy", "flint", "z3", "cvc5"}
+    imported = sorted(forbidden.intersection(sys.modules))
+    if imported:
+        raise AssertionError(f"packaged backends imported during assembly: {imported}")
+finally:
+    runtime.close()
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path / "runtime")],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "SYMPY_GROUND_TYPES": "python"},
+        text=True,
+        timeout=120,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_native_matrices_does_not_import_capabilities_or_provider_loading() -> None:

--- a/tests/boundary/process/public_api/test_import_isolation.py
+++ b/tests/boundary/process/public_api/test_import_isolation.py
@@ -36,7 +36,7 @@ def test_native_namespace_does_not_import_runtime_or_transport() -> None:
     _assert_not_imported(_imported_modules("jacobian.math"), forbidden)
 
 
-def test_native_namespace_does_not_eagerly_import_optional_backends() -> None:
+def test_native_namespace_does_not_eagerly_import_packaged_backends() -> None:
     _assert_not_imported(
         _imported_modules("jacobian.math"),
         ("networkx", "sympy", "flint"),

--- a/tests/boundary/process/tooling/test_source_agent_bootstrap.py
+++ b/tests/boundary/process/tooling/test_source_agent_bootstrap.py
@@ -144,7 +144,10 @@ def test_version_identity_uses_uv_normalization(
 
 def test_active_uv_surfaces_share_the_repository_pin() -> None:
     pinned = (ROOT / ".uv-version").read_text().strip()
-    assert f"ghcr.io/astral-sh/uv:{pinned}-" in (ROOT / "Dockerfile").read_text()
+    dockerfile = (ROOT / "Dockerfile").read_text()
+    assert f"ghcr.io/astral-sh/uv:{pinned}-" in dockerfile
+    assert "RUN uv sync --locked --no-dev\n" in dockerfile
+    assert "--extra" not in dockerfile
     setup_files = [
         ROOT / ".github" / "actions" / "setup-python-tests" / "action.yml",
         ROOT / ".github" / "actions" / "setup-lean" / "action.yml",

--- a/tests/boundary/providers/cvc5/startup/test_cvc5.py
+++ b/tests/boundary/providers/cvc5/startup/test_cvc5.py
@@ -314,6 +314,6 @@ def test_runtime_rejects_a_base_installation_without_cvc5(
 
     with pytest.raises(
         ProviderRuntimeError,
-        match="required Python provider cvc5 is unavailable",
+        match="required Python providers are unavailable: cvc5",
     ):
         create_runtime(tmp_path)

--- a/tests/boundary/providers/cvc5/startup/test_cvc5.py
+++ b/tests/boundary/providers/cvc5/startup/test_cvc5.py
@@ -17,6 +17,7 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.process_policy import ProcessRequest, ProcessResult, ProcessTermination
 from jacobian.provider_measurements import measure_provider
+from jacobian.provider_runtime import ProviderRuntimeError
 from jacobian.providers.external_solver_runtime import cvc5_provider_runtime
 from jacobian.runtime import create_runtime
 from jacobian.sat_smt.cvc5 import install_cvc5_capability
@@ -129,7 +130,6 @@ def test_qf_uf_proof_is_durable_computed_evidence(
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["status"] == "PROOF_PRODUCED"
     assert result.output["solver_status"] == "UNSATISFIABLE"
-    assert result.output["conclusion"] == "UNKNOWN"
     assert result.output["contains_holes"] is False
     assert result.output["alethe_hole_count"] == 0
     assert len(result.artifact_uris) == 2
@@ -157,7 +157,6 @@ def test_linear_arithmetic_holes_stay_explicit_and_unverified(
 
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output["status"] == "PROOF_PRODUCED"
-    assert result.output["conclusion"] == "UNKNOWN"
     assert result.output["contains_holes"] is True
     assert result.output["alethe_hole_count"] >= 1
 
@@ -170,7 +169,6 @@ def test_sat_report_produces_no_unsat_artifact_or_conclusion(
     assert result.execution.status is ExecutionStatus.COMPLETED
     assert result.output == {
         "alethe_hole_count": None,
-        "conclusion": "UNKNOWN",
         "contains_holes": None,
         "detail": (
             "cvc5 reported SATISFIABLE without producing an UNSAT proof; "
@@ -297,7 +295,7 @@ def test_worker_timeout_fails_without_solver_conclusion(
     assert len(result.artifact_uris) == 1
 
 
-def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
+def test_runtime_rejects_a_base_installation_without_cvc5(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -314,11 +312,8 @@ def test_missing_optional_cvc5_leaves_artifact_boundary_but_no_capability(
         lambda: unavailable,
     )
 
-    with create_runtime(tmp_path) as without_cvc5:
-        assert "smt.unsat_proof.find" not in {
-            descriptor.capability_id
-            for descriptor in without_cvc5.core.capabilities.catalog().capabilities
-        }
-        assert without_cvc5.core.smt.installation.problem_schema_uri.startswith(
-            "artifact://sha256/"
-        )
+    with pytest.raises(
+        ProviderRuntimeError,
+        match="required Python provider cvc5 is unavailable",
+    ):
+        create_runtime(tmp_path)

--- a/tests/boundary/providers/flint/startup/test_required_provider_startup.py
+++ b/tests/boundary/providers/flint/startup/test_required_provider_startup.py
@@ -4,29 +4,51 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 
-def test_runtime_rejects_a_base_installation_without_flint(
+
+@pytest.mark.parametrize(
+    ("import_name", "provider"),
+    (
+        ("networkx", "jacobian.networkx"),
+        ("sympy", "jacobian.sympy"),
+        ("flint", "python-flint"),
+        ("z3", "jacobian.z3"),
+        ("cvc5", "cvc5"),
+    ),
+)
+def test_runtime_rejects_a_base_installation_without_required_provider(
     tmp_path: Path,
+    import_name: str,
+    provider: str,
 ) -> None:
     script = """
 import importlib.abc
 import sys
 from pathlib import Path
 
-class BlockFlint(importlib.abc.MetaPathFinder):
+blocked = sys.argv[1]
+
+class BlockProvider(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path=None, target=None):
-        if fullname == "flint" or fullname.startswith("flint."):
-            raise ImportError("python-flint intentionally unavailable")
+        if fullname == blocked or fullname.startswith(f"{blocked}."):
+            raise ImportError(f"{blocked} intentionally unavailable")
         return None
 
-sys.meta_path.insert(0, BlockFlint())
+sys.meta_path.insert(0, BlockProvider())
 
 from jacobian.runtime import create_runtime
 
-create_runtime(Path(sys.argv[1]))
+create_runtime(Path(sys.argv[2]))
 """
     completed = subprocess.run(
-        [sys.executable, "-c", script, str(tmp_path / "runtime")],
+        [
+            sys.executable,
+            "-c",
+            script,
+            import_name,
+            str(tmp_path / "runtime"),
+        ],
         check=False,
         capture_output=True,
         text=True,
@@ -34,36 +56,5 @@ create_runtime(Path(sys.argv[1]))
     )
 
     assert completed.returncode != 0
-    assert "required Python provider python-flint is unavailable" in completed.stderr
-
-
-def test_runtime_rejects_a_base_installation_without_z3(
-    tmp_path: Path,
-) -> None:
-    script = """
-import importlib.abc
-import sys
-from pathlib import Path
-
-class BlockZ3(importlib.abc.MetaPathFinder):
-    def find_spec(self, fullname, path=None, target=None):
-        if fullname == "z3" or fullname.startswith("z3."):
-            raise ImportError("z3-solver intentionally unavailable")
-        return None
-
-sys.meta_path.insert(0, BlockZ3())
-
-from jacobian.runtime import create_runtime
-
-create_runtime(Path(sys.argv[1]))
-"""
-    completed = subprocess.run(
-        [sys.executable, "-c", script, str(tmp_path / "runtime")],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    assert completed.returncode != 0
-    assert "required Python provider jacobian.z3 is unavailable" in completed.stderr
+    assert "required Python providers are unavailable" in completed.stderr
+    assert f"{provider}:" in completed.stderr

--- a/tests/boundary/providers/flint/startup/test_required_provider_startup.py
+++ b/tests/boundary/providers/flint/startup/test_required_provider_startup.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 
-def test_runtime_starts_and_exposes_unrelated_capabilities_without_flint(
+def test_runtime_rejects_a_base_installation_without_flint(
     tmp_path: Path,
 ) -> None:
     script = """
@@ -21,16 +21,9 @@ class BlockFlint(importlib.abc.MetaPathFinder):
 
 sys.meta_path.insert(0, BlockFlint())
 
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
-from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime import create_runtime
 
-runtime = create_runtime(Path(sys.argv[1]))
-ids = {
-    descriptor.capability_id
-    for descriptor in runtime.core.capabilities.catalog().capabilities
-}
-assert "integer.compute.gcd" in ids
-assert "probability.finite_distribution.raw_moment.compute" not in ids
+create_runtime(Path(sys.argv[1]))
 """
     completed = subprocess.run(
         [sys.executable, "-c", script, str(tmp_path / "runtime")],
@@ -40,10 +33,11 @@ assert "probability.finite_distribution.raw_moment.compute" not in ids
         timeout=120,
     )
 
-    assert completed.returncode == 0, completed.stderr
+    assert completed.returncode != 0
+    assert "required Python provider python-flint is unavailable" in completed.stderr
 
 
-def test_runtime_starts_and_exposes_unrelated_capabilities_without_z3(
+def test_runtime_rejects_a_base_installation_without_z3(
     tmp_path: Path,
 ) -> None:
     script = """
@@ -59,17 +53,9 @@ class BlockZ3(importlib.abc.MetaPathFinder):
 
 sys.meta_path.insert(0, BlockZ3())
 
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
-from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime import create_runtime
 
-runtime = create_runtime(Path(sys.argv[1]))
-ids = {
-    descriptor.capability_id
-    for descriptor in runtime.core.capabilities.catalog().capabilities
-}
-assert "integer.compute.gcd" in ids
-assert "graph.invariant.girth.compute" in ids
-assert "graph.domination.minimum.compute" not in ids
+create_runtime(Path(sys.argv[1]))
 """
     completed = subprocess.run(
         [sys.executable, "-c", script, str(tmp_path / "runtime")],
@@ -79,4 +65,5 @@ assert "graph.domination.minimum.compute" not in ids
         timeout=120,
     )
 
-    assert completed.returncode == 0, completed.stderr
+    assert completed.returncode != 0
+    assert "required Python provider jacobian.z3 is unavailable" in completed.stderr

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -385,7 +385,7 @@ def test_installer_omits_exact_replay_when_its_provider_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An unavailable optional backend omits its replay instead of failing install.
+    """An unavailable checker runtime omits its replay instead of failing install.
 
     Without an authorized checker the affected capabilities cannot reach
     ``VERIFIED``; they stay producer-only. Installation must still complete.

--- a/tests/unit/contracts/test_provider_package_contracts.py
+++ b/tests/unit/contracts/test_provider_package_contracts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from jacobian.provider_runtime import (
+    NETWORKX_VERSION,
+    PYTHON_FLINT_VERSION,
+    SYMPY_VERSION,
+    Z3_SOLVER_VERSION,
+)
+from jacobian.providers.external_solver_runtime import CVC5_VERSION
+
+ROOT = Path(__file__).parents[3]
+
+
+def test_required_provider_dependencies_match_exact_runtime_pins() -> None:
+    with (ROOT / "pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)["project"]
+
+    dependencies = set(project["dependencies"])
+
+    assert {
+        f"networkx=={NETWORKX_VERSION}",
+        f"python-flint=={PYTHON_FLINT_VERSION}",
+        f"sympy=={SYMPY_VERSION}",
+        f"z3-solver=={Z3_SOLVER_VERSION}",
+        f"cvc5=={CVC5_VERSION}",
+    } <= dependencies
+    assert "optional-dependencies" not in project

--- a/tests/unit/contracts/test_provider_runtime.py
+++ b/tests/unit/contracts/test_provider_runtime.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
 import jacobian.provider_runtime as provider_runtime
+import jacobian.providers.external_solver_runtime as external_solver_runtime
 import jacobian.providers.flint_runtime as flint_runtime
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -30,6 +32,7 @@ from jacobian.provider_runtime import (
 from jacobian.providers.flint_runtime import (
     exact_domain_checker_provider_runtime,
     python_flint_exact_checker_provider_runtime,
+    python_flint_provider_runtime,
 )
 from jacobian.providers.lean_runtime import (
     LeanRuntimeIdentityError,
@@ -350,23 +353,57 @@ def test_python_provider_readiness_checks_required_attributes(
     assert raised.value.code is ProviderRuntimeErrorCode.READINESS_FAILED
 
 
-def test_z3_version_mismatch_reports_smt_solver_profile(
+@pytest.mark.parametrize(
+    ("module", "resolve", "diagnostic"),
+    (
+        (
+            provider_runtime,
+            lambda: provider_runtime.known_provider_runtime("jacobian.networkx"),
+            "NetworkX is installed but does not match the pinned",
+        ),
+        (
+            provider_runtime,
+            lambda: provider_runtime.known_provider_runtime("jacobian.sympy"),
+            "SymPy is installed but does not match the pinned",
+        ),
+        (
+            flint_runtime,
+            python_flint_provider_runtime,
+            "Python-FLINT is installed but does not match the pinned",
+        ),
+        (
+            provider_runtime,
+            lambda: provider_runtime.known_provider_runtime("jacobian.z3"),
+            "Z3 is installed but does not match the pinned",
+        ),
+        (
+            external_solver_runtime,
+            external_solver_runtime.cvc5_provider_runtime,
+            "The pinned cvc5",
+        ),
+    ),
+    ids=("networkx", "sympy", "flint", "z3", "cvc5"),
+)
+def test_required_python_provider_rejects_version_skew(
     monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+    resolve: Callable[[], CapabilityProviderRuntime],
+    diagnostic: str,
 ) -> None:
-    mismatched = _runtime(provider="jacobian.z3", version="0.0.0")
+    mismatched = _runtime(version="0.0.0")
     monkeypatch.setattr(
-        provider_runtime,
+        module,
         "python_distribution_provider_runtime",
         lambda *_args, **_kwargs: mismatched,
     )
 
-    runtime = provider_runtime.known_provider_runtime("jacobian.z3")
+    runtime = resolve()
 
     assert runtime.availability is CapabilityProviderAvailability.UNAVAILABLE
-    assert runtime.diagnostic == (
-        "Z3 is installed but does not match the pinned "
-        f"{provider_runtime.Z3_SOLVER_VERSION} SMT solver profile."
-    )
+    assert runtime.version is None
+    assert runtime.digest is None
+    assert runtime.diagnostic is not None
+    assert diagnostic in runtime.diagnostic
 
 
 def test_disappeared_executable_is_unavailable(tmp_path: Path) -> None:

--- a/tests/unit/portfolio/test_portfolio_installation_phases.py
+++ b/tests/unit/portfolio/test_portfolio_installation_phases.py
@@ -11,9 +11,11 @@ import pytest
 from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityProviderAvailability,
+    CapabilityProviderDigestKind,
     CapabilityProviderRuntime,
 )
 from jacobian.installation.context import InstallationContext
+from jacobian.portfolio import foundation_installation
 from jacobian.portfolio.checker_installation import CheckerPortfolioInstaller
 from jacobian.portfolio.core_installation import CoreApplicationInstaller
 from jacobian.portfolio.foundation_installation import FoundationInstaller
@@ -39,29 +41,48 @@ def _unavailable_runtime(provider: str) -> CapabilityProviderRuntime:
     )
 
 
-def _unavailable_provider_plan() -> ProviderRuntimePlan:
+def _available_runtime(provider: str) -> CapabilityProviderRuntime:
+    return CapabilityProviderRuntime(
+        provider=provider,
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="1",
+        digest="sha256:" + "0" * 64,
+        digest_kind=CapabilityProviderDigestKind.SOURCE_TREE,
+        platform="test-platform",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="MIT",
+    )
+
+
+def _provider_plan_with_unavailable_external_solvers() -> ProviderRuntimePlan:
     return ProviderRuntimePlan(
         cadical=_unavailable_runtime("cadical"),
         carcara=_unavailable_runtime("carcara"),
-        cvc5=_unavailable_runtime("cvc5"),
+        cvc5=_available_runtime("cvc5"),
         drat_trim=_unavailable_runtime("drat-trim"),
-        python_flint=_unavailable_runtime("python-flint"),
-        python_flint_hnf=_unavailable_runtime("python-flint-hnf"),
-        sympy_polynomial_normalization=_unavailable_runtime(
+        sympy_polynomial_normalization=_available_runtime(
             "sympy-polynomial-normalization"
         ),
     )
 
 
-def test_foundation_optional_provider_phase_skips_unavailable_solvers() -> None:
+def test_foundation_solver_phase_skips_unavailable_external_solver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     result = PortfolioInstallation()
+    registered: list[object] = []
+    context = SimpleNamespace(register_capability=registered.append)
+    adapter = object()
+    monkeypatch.setattr(
+        foundation_installation,
+        "install_cvc5_capability",
+        lambda _smt, _runtime: adapter,
+    )
 
-    FoundationInstaller(
-        cast(InstallationContext, object())
-    ).install_optional_provider_components(
-        cast(CoreServices, object()),
+    FoundationInstaller(cast(InstallationContext, context)).install_solver_components(
+        cast(CoreServices, SimpleNamespace(smt=object())),
         result,
-        _unavailable_provider_plan(),
+        _provider_plan_with_unavailable_external_solvers(),
     )
 
     assert result.cadical_runtime is not None
@@ -69,10 +90,7 @@ def test_foundation_optional_provider_phase_skips_unavailable_solvers() -> None:
         result.cadical_runtime.availability
         is CapabilityProviderAvailability.UNAVAILABLE
     )
-    assert result.cvc5_runtime is not None
-    assert (
-        result.cvc5_runtime.availability is CapabilityProviderAvailability.UNAVAILABLE
-    )
+    assert registered == [adapter]
 
 
 def test_core_domain_verification_phase_accepts_empty_bundle_result() -> None:

--- a/tests/unit/portfolio/test_portfolio_provider_resolution.py
+++ b/tests/unit/portfolio/test_portfolio_provider_resolution.py
@@ -6,10 +6,14 @@ from collections.abc import Callable
 
 import pytest
 
-from jacobian.contracts.capabilities import CapabilityProviderRuntime
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderAvailability,
+    CapabilityProviderRuntime,
+)
 from jacobian.portfolio import provider_resolution
 from jacobian.portfolio.provider_resolution import ProviderAvailabilityResolver
-from jacobian.provider_runtime import known_provider_runtime
+from jacobian.provider_runtime import ProviderRuntimeError, known_provider_runtime
 
 
 def test_resolve_builds_one_typed_plan_from_each_declared_probe(
@@ -25,13 +29,11 @@ def test_resolve_builds_one_typed_plan_from_each_declared_probe(
         return resolve
 
     names = (
+        "cvc5",
+        "sympy_polynomial_normalization",
         "cadical",
         "carcara",
-        "cvc5",
         "drat_trim",
-        "python_flint",
-        "python_flint_hnf",
-        "sympy_polynomial_normalization",
     )
     for name in names:
         monkeypatch.setattr(
@@ -39,11 +41,42 @@ def test_resolve_builds_one_typed_plan_from_each_declared_probe(
             f"{name}_provider_runtime",
             probe(name),
         )
+    monkeypatch.setattr(
+        provider_resolution,
+        "python_flint_provider_runtime",
+        lambda: known_provider_runtime("python_flint"),
+    )
 
     plan = ProviderAvailabilityResolver().resolve()
 
     assert calls == list(names)
     assert tuple(getattr(plan, name).provider for name in names) == names
+
+
+def test_resolve_rejects_a_missing_packaged_python_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable = CapabilityProviderRuntime(
+        provider="jacobian.networkx",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="test-platform",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="BSD-3-Clause",
+        diagnostic="NetworkX is missing",
+    )
+    monkeypatch.setattr(
+        provider_resolution,
+        "known_provider_runtime",
+        lambda name: (
+            unavailable if name == "jacobian.networkx" else known_provider_runtime(name)
+        ),
+    )
+
+    with pytest.raises(
+        ProviderRuntimeError,
+        match=r"required Python provider jacobian\.networkx is unavailable",
+    ):
+        ProviderAvailabilityResolver().resolve()
 
 
 def test_lean_resolution_preserves_installed_checker_profile_inputs(

--- a/tests/unit/portfolio/test_portfolio_provider_resolution.py
+++ b/tests/unit/portfolio/test_portfolio_provider_resolution.py
@@ -74,9 +74,37 @@ def test_resolve_rejects_a_missing_packaged_python_backend(
 
     with pytest.raises(
         ProviderRuntimeError,
-        match=r"required Python provider jacobian\.networkx is unavailable",
+        match=r"required Python providers are unavailable: jacobian\.networkx",
     ):
         ProviderAvailabilityResolver().resolve()
+
+
+def test_packaged_backend_failure_reports_every_broken_provider() -> None:
+    missing = CapabilityProviderRuntime(
+        provider="jacobian.networkx",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="test-platform",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="BSD-3-Clause",
+        diagnostic="NetworkX is missing",
+    )
+    skewed = CapabilityProviderRuntime(
+        provider="jacobian.sympy",
+        availability=CapabilityProviderAvailability.UNAVAILABLE,
+        platform="test-platform",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="BSD-3-Clause",
+        diagnostic="SymPy version does not match the pin",
+    )
+
+    with pytest.raises(ProviderRuntimeError) as raised:
+        provider_resolution._require_packaged_python_backends((missing, skewed))
+
+    assert str(raised.value) == (
+        "required Python providers are unavailable: "
+        "jacobian.networkx: NetworkX is missing; "
+        "jacobian.sympy: SymPy version does not match the pin"
+    )
 
 
 def test_lean_resolution_preserves_installed_checker_profile_inputs(

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -35,6 +35,17 @@ def test_python_313_uses_the_narrow_compatibility_smoke() -> None:
     assert "make test\n" not in compatibility
 
 
+def test_built_wheel_is_started_on_each_supported_python() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    validation = workflow.split("  validate-built-package:", 1)[1].split(
+        "  unit-test:", 1
+    )[0]
+
+    assert 'python-version: ["3.12", "3.13"]' in validation
+    assert "--only-binary :all:" in validation
+    assert '"$environment/bin/jacobian" --state-dir "$state_dir" init' in validation
+
+
 @pytest.mark.parametrize(
     ("rule_name", "expected_suites", "excluded_suites"),
     (

--- a/tests/unit/tooling/test_development_profiles.py
+++ b/tests/unit/tooling/test_development_profiles.py
@@ -25,34 +25,23 @@ def test_profiles_share_locked_sync_contracts() -> None:
 
     assert profiles.PROFILE_NAMES == (
         "core",
-        "full-python",
         "lean",
         "external-proof",
     )
-    assert profiles.sync_arguments("core") == (
-        "sync",
-        "--locked",
-        "--only-group",
-        "dev-core",
-    )
+    assert profiles.sync_arguments("core") == ("sync", "--locked", "--dev")
     assert profiles.sync_arguments("core", development=False) == (
         "sync",
         "--locked",
         "--no-dev",
     )
-    for name in ("full-python", "lean", "external-proof"):
-        assert profiles.sync_arguments(name) == (
-            "sync",
-            "--locked",
-            "--dev",
-            "--all-extras",
-        )
+    for name in ("lean", "external-proof"):
+        assert profiles.sync_arguments(name) == ("sync", "--locked", "--dev")
 
 
 def test_invalid_profile_reports_all_supported_choices() -> None:
     profiles = _load_profiles()
 
-    with pytest.raises(ValueError, match="core, full-python, lean, external-proof"):
+    with pytest.raises(ValueError, match="core, lean, external-proof"):
         profiles.profile("everything")
 
 
@@ -83,7 +72,7 @@ def test_lean_setup_installs_pin_then_gets_cache_and_builds_without_update(
     profiles.setup_profile(repo, "lean", run=record)
 
     assert commands[:4] == [
-        (("uv", "sync", "--locked", "--dev", "--all-extras"), repo),
+        (("uv", "sync", "--locked", "--dev"), repo),
         (
             ("elan", "toolchain", "install", "leanprover/lean4:v4.31.0"),
             repo,
@@ -132,7 +121,6 @@ def test_external_proof_setup_never_downloads_executables(
         "sync",
         "--locked",
         "--dev",
-        "--all-extras",
     )
     assert commands == [*first_run, *first_run]
     assert all(command[0] == "uv" for command in commands)
@@ -148,14 +136,14 @@ def test_doctor_distinguishes_available_unavailable_and_incompatible_imports(
         requirement="cvc5",
         distribution="cvc5",
         expected="==1.3.4",
-        profile_name="full-python",
+        profile_name="core",
     )
     monkeypatch.setattr(profiles.importlib.metadata, "version", lambda _name: "1.2.0")
     incompatible = profiles._distribution_diagnostic(
         requirement="cvc5",
         distribution="cvc5",
         expected="==1.3.4",
-        profile_name="full-python",
+        profile_name="core",
     )
 
     def missing(_name: str) -> str:
@@ -166,7 +154,7 @@ def test_doctor_distinguishes_available_unavailable_and_incompatible_imports(
         requirement="cvc5",
         distribution="cvc5",
         expected="==1.3.4",
-        profile_name="full-python",
+        profile_name="core",
     )
 
     assert [available.status, incompatible.status, unavailable.status] == [
@@ -174,5 +162,5 @@ def test_doctor_distinguishes_available_unavailable_and_incompatible_imports(
         "incompatible",
         "unavailable",
     ]
-    assert unavailable.recovery == "Run `make setup PROFILE=full-python`"
-    assert unavailable.documentation == profiles.OPTIONAL_BACKEND_DOCUMENTATION
+    assert unavailable.recovery == "Run `make setup PROFILE=core`"
+    assert unavailable.documentation == profiles.PROFILE_DOCUMENTATION

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -123,7 +123,7 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
             "test_smt_unsat_proof_verification.py"
         ),
         PurePosixPath(
-            "tests/boundary/providers/flint/startup/test_optional_provider_startup.py"
+            "tests/boundary/providers/flint/startup/test_required_provider_startup.py"
         ),
         PurePosixPath(
             "tests/boundary/providers/lean/test_lean_statement_capabilities.py"

--- a/tools/development_profiles.py
+++ b/tools/development_profiles.py
@@ -27,20 +27,16 @@ class DevelopmentProfile:
     """One supported, deterministic development environment."""
 
     name: str
-    all_extras: bool
     providers: tuple[str, ...]
 
 
 PROFILES = {
-    "core": DevelopmentProfile("core", False, ("networkx", "sympy", "z3")),
-    "full-python": DevelopmentProfile(
-        "full-python",
-        True,
+    "core": DevelopmentProfile(
+        "core",
         ("networkx", "sympy", "z3", "python-flint", "python-flint-hnf", "cvc5"),
     ),
     "lean": DevelopmentProfile(
         "lean",
-        True,
         (
             "networkx",
             "sympy",
@@ -53,7 +49,6 @@ PROFILES = {
     ),
     "external-proof": DevelopmentProfile(
         "external-proof",
-        True,
         (
             "networkx",
             "sympy",
@@ -98,14 +93,8 @@ def profile(name: str) -> DevelopmentProfile:
 def sync_arguments(name: str, *, development: bool = True) -> tuple[str, ...]:
     """Return locked uv sync arguments for a profile."""
 
-    selected = profile(name)
-    if name == "core" and development:
-        arguments = ["sync", "--locked", "--only-group", "dev-core"]
-    else:
-        arguments = ["sync", "--locked", "--dev" if development else "--no-dev"]
-    if selected.all_extras:
-        arguments.append("--all-extras")
-    return tuple(arguments)
+    profile(name)
+    return ("sync", "--locked", "--dev" if development else "--no-dev")
 
 
 def _run(arguments: Sequence[str], cwd: Path) -> int:
@@ -204,8 +193,6 @@ def _requirements(repo: Path) -> dict[str, str]:
     with (repo / "pyproject.toml").open("rb") as stream:
         pyproject = tomllib.load(stream)
     values = list(pyproject["project"]["dependencies"])
-    for extra in pyproject["project"].get("optional-dependencies", {}).values():
-        values.extend(extra)
     requirements: dict[str, str] = {}
     for value in values:
         match = re.match(r"([A-Za-z0-9_-]+)\s*(.*)", value)

--- a/uv.lock
+++ b/uv.lock
@@ -534,29 +534,22 @@ name = "jacobian"
 version = "0.11.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cvc5" },
     { name = "filelock" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "mcp-types" },
     { name = "networkx" },
     { name = "pydantic" },
+    { name = "python-flint" },
     { name = "rfc8785" },
     { name = "sympy" },
     { name = "typer" },
     { name = "z3-solver" },
 ]
 
-[package.optional-dependencies]
-flint = [
-    { name = "python-flint" },
-]
-smt = [
-    { name = "cvc5" },
-]
-
 [package.dev-dependencies]
 dev = [
-    { name = "cvc5" },
     { name = "deptry" },
     { name = "hypothesis" },
     { name = "import-linter" },
@@ -571,7 +564,6 @@ dev = [
     { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "python-flint" },
     { name = "ruff" },
     { name = "tomli-w" },
     { name = "types-jsonschema" },
@@ -602,24 +594,22 @@ dev-core = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cvc5", marker = "extra == 'smt'", specifier = "==1.3.4" },
+    { name = "cvc5", specifier = "==1.3.4" },
     { name = "filelock", specifier = ">=3.20,<4" },
     { name = "jsonschema", specifier = ">=4.23,<5" },
     { name = "mcp", specifier = "==2.0.0" },
     { name = "mcp-types", specifier = "==2.0.0" },
-    { name = "networkx", specifier = ">=3.4,<4" },
+    { name = "networkx", specifier = "==3.6.1" },
     { name = "pydantic", specifier = ">=2.12,<3" },
-    { name = "python-flint", marker = "extra == 'flint'", specifier = "==0.9.0" },
+    { name = "python-flint", specifier = "==0.9.0" },
     { name = "rfc8785", specifier = "==0.1.4" },
     { name = "sympy", specifier = "==1.14.0" },
     { name = "typer", specifier = ">=0.20,<1" },
-    { name = "z3-solver", specifier = ">=4.15.4,<6" },
+    { name = "z3-solver", specifier = "==5.0.0.0" },
 ]
-provides-extras = ["flint", "smt"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "cvc5", specifier = "==1.3.4" },
     { name = "deptry", specifier = ">=0.21,<1" },
     { name = "hypothesis", specifier = ">=6.130,<7" },
     { name = "import-linter", specifier = ">=2,<3" },
@@ -634,7 +624,6 @@ dev = [
     { name = "pytest-split", specifier = "==0.11.0" },
     { name = "pytest-timeout", specifier = ">=2.4,<3" },
     { name = "pytest-xdist", specifier = ">=3.6,<4" },
-    { name = "python-flint", specifier = "==0.9.0" },
     { name = "ruff", specifier = "==0.16.1" },
     { name = "tomli-w", specifier = "==1.2.0" },
     { name = "types-jsonschema", specifier = ">=4.23,<5" },


### PR DESCRIPTION
## Problem

Jacobian's packaging and runtime described the maintained Python backends inconsistently. NetworkX, SymPy, and Z3 were base dependencies, Python-FLINT and cvc5 were extras, and all five could still be treated as normally unavailable at runtime. Packaging also admitted NetworkX and Z3 versions that the runtime rejected.

This PR implements the explicit batteries-included alternative discussed in #1231: the built-in tools get one complete Python backend stack, while native and formal providers remain optional.

## Solution

- Require exact base versions of NetworkX, SymPy, Z3, Python-FLINT, and cvc5.
- Fail runtime construction for a missing or version-skewed packaged backend instead of silently shrinking the catalog.
- Keep backend implementation imports lazy: startup inspects distribution metadata and RECORD identity; callable readiness remains a first-use check.
- Remove the `full-python` profile, extras flags, duplicate dev dependencies, unused provider-plan fields, and conditional cvc5/SymPy installation branches.
- Keep Lean, CaDiCaL, DRAT-trim, and Carcara operator-installed and optional.
- Align source setup, deployment, containers, npm, and documentation with that contract.

Suggested review order:

1. `39c2a81bb` establishes package/runtime/setup behavior and regression tests.
2. `e57173760` updates supported terminology and operator guidance.
3. `5d73334bb` removes stale container extra flags and updates the renamed subprocess fixture allowlist.

## Testing

- `make check-static` — all static, typing, dependency, architecture, and import checks passed.
- `make test-unit` — 890 passed.
- `make test-provider TESTS=tests/boundary/providers/flint/startup/test_required_provider_startup.py` — 2 passed.
- `make test-process TESTS=tests/boundary/process/public_api/test_import_isolation.py` — 5 passed.
- `make test-process TESTS=tests/boundary/process/tooling/test_source_agent_bootstrap.py` — 7 passed.
- `make npm-test` — 58 passed and package dry-run succeeded.
- `make deploy-check` — 38 passed.
- `make docs-linkcheck` and `make build` passed; wheel metadata contains all five exact backend requirements.
- A temporary `jacobian init` smoke initialized 355 operations.
- GitHub Actions — container image, lint/format, all selected Python lanes, npm, deployment, documentation, build, security, duplicate detection, and coverage passed.

- Specialist validation run: provider startup, import isolation, setup/deploy, npm packaging, and container lanes listed above.

## Trust & Compatibility Impact

A missing or mismatched maintained Python backend is now a broken base installation rather than a supported reduced catalog. `import jacobian.math` remains backend-lazy, and provider identity/readiness checks remain fail-closed.

Checker authorization, verification records, mathematical value identity, artifact formats, and MCP contracts are unchanged. Optional native and formal providers continue to affect only their own operations.

## Architecture Budget

No mathematical operation, shared abstraction, registry, codec, or publication policy is added. This deletes optionality knobs and branches that had no honest product owner under the monolithic package decision.

## Checklist

- [x] Relevant static, unit, boundary, packaging, deployment, container, and CI checks pass
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier validation is not applicable
- [x] No ordinary operation or shared abstraction is introduced
