### PR TITLE
Clarify local Jacobian tool routing

### DIFF
--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -3,35 +3,32 @@
 from __future__ import annotations
 
 SERVER_DESCRIPTION = (
-    "Use atomic exact and symbolic mathematics, with separate checker operations "
-    "when independent verification is needed."
+    "Search and run installed Jacobian exact-math operations, with separate checker "
+    "operations for independent verification."
 )
 
 SERVER_INSTRUCTIONS = (
-    "Use Jacobian whenever a task may benefit from a specialized exact mathematical "
-    "operation, including matrix or polynomial computation, symbolic transformation, "
-    "structural analysis, examples or counterexamples, bounded search, formal-environment "
-    "inspection, or requested independent verification. This applies even when the "
-    "user does not name Jacobian and shell code could also calculate the result. Unless "
-    "an exact installed capability ID and its typed contract are already available, call "
-    "math.find with a plain-language desired local mathematical outcome; no capability "
-    "ID is required. math.run may execute a known contract directly. "
-    "Do not report that no specialized mathematical operation is available without "
-    "checking math.find. When independent checking is requested, multiple calculations "
-    "or programs authored by the same model are not independent checker evidence. "
-    "Search again whenever the objective or available evidence changes. "
+    "math.find searches the locally installed Jacobian toolbox; internet search cannot "
+    "show which operations are available in this runtime. math.run executes one selected "
+    "operation. Use these tools when exact computation, symbolic transformation, finite "
+    "search, formal inspection, or independent checking would add relevant mathematical "
+    "evidence, even when the user does not name Jacobian or shell code could calculate "
+    "the result. If the exact installed ID and typed contract are unknown, search by the "
+    "desired local mathematical outcome and inspect a selected ID. A known contract may "
+    "run directly. Repeating the same lookup against an unchanged catalog returns the "
+    "same operation facts; math.find is operation lookup, not confirmation. Merely "
+    "restating an accepted value without new evidence is not a mathematical-tool use case. "
     "The model owns representation, decomposition, composition, iteration, verification "
-    "timing, and stopping. Results keep execution status, mathematical conclusion, "
-    "and verification record separate. No descriptor match, timeout, "
-    "bounded or exhausted search, or failure to find a witness is a mathematical "
-    "conclusion. Only a result with a local verification record URI is "
-    "verified. A verification record for an input, premise, factorization, or related "
-    "artifact does not verify a model-derived conclusion; the record must be bound to "
-    "the exact final claim."
+    "timing, and stopping. An operation match, timeout, incomplete search, or failure to "
+    "find a witness is not a mathematical conclusion. Independent checking uses a "
+    "separate checker operation; model-authored duplicate calculations are not independent "
+    "evidence. Only a result with a local verification record URI is verified, and that "
+    "record must be bound to the exact final claim."
 )
 
 MATH_FIND_DESCRIPTION = """\
-Search or inspect installed math tools by desired outcome or exact ID. Use when a
+Search or inspect locally installed Jacobian math tools by desired outcome or exact ID.
+This is the authoritative runtime inventory; internet search is not. Use when a
 task may benefit from exact computation, search, structural analysis, or a separate
 checker tool—even if shell code could also calculate the answer.
 

--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -139,7 +139,7 @@ class JacobianCoreExtension(Extension):
                 capability_describe,
                 kwargs={
                     "name": "math.find",
-                    "title": "Find an exact mathematical operation",
+                    "title": "Search installed Jacobian math tools",
                     "description": MATH_FIND_DESCRIPTION,
                     "annotations": _tool_annotations(read_only=True, idempotent=True),
                     "structured_output": True,
@@ -149,7 +149,7 @@ class JacobianCoreExtension(Extension):
                 capability_invoke,
                 kwargs={
                     "name": "math.run",
-                    "title": "Run a mathematical operation",
+                    "title": "Run one installed Jacobian math tool",
                     "description": MATH_RUN_DESCRIPTION,
                     # The selected operation may publish artifacts, so math.run is
                     # not globally read-only or idempotent. Retained operations are

--- a/tests/boundary/mcp/test_mcp_tool_surface.py
+++ b/tests/boundary/mcp/test_mcp_tool_surface.py
@@ -21,8 +21,11 @@ def test_math_tool_surface_is_consistent_across_discovery(tmp_path: Path) -> Non
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
             assert set(tools) == {"math.find", "math.run"}
-            assert tools["math.find"].title == "Find an exact mathematical operation"
-            assert tools["math.run"].title == "Run a mathematical operation"
+            assert tools["math.find"].title == "Search installed Jacobian math tools"
+            assert tools["math.run"].title == "Run one installed Jacobian math tool"
+            assert "authoritative runtime inventory" in (
+                tools["math.find"].description or ""
+            )
             assert "math.find" in (tools["math.run"].description or "")
 
             described = await client.call_tool(

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -41,18 +41,24 @@ def test_model_visible_guidance_exposes_affordances_without_research_order() -> 
 def test_server_instructions_front_load_implicit_activation_signal() -> None:
     prefix = SERVER_INSTRUCTIONS[:512].lower()
 
-    assert "specialized exact mathematical operation" in prefix
-    assert "matrix or polynomial" in prefix
-    assert "even when the user does not name jacobian" in prefix
     assert "math.find" in prefix
+    assert "locally installed jacobian toolbox" in prefix
+    assert "internet search cannot" in prefix
+    assert "even when the user does not name jacobian" in prefix
 
 
 def test_server_instructions_allow_known_contracts_to_run_directly() -> None:
-    assert "exact installed capability ID" in SERVER_INSTRUCTIONS
-    assert "math.run may execute a known contract directly" in SERVER_INSTRUCTIONS
+    assert "exact installed ID and typed contract" in SERVER_INSTRUCTIONS
+    assert "known contract may run directly" in SERVER_INSTRUCTIONS
+    assert "math.find is operation lookup, not confirmation" in SERVER_INSTRUCTIONS
+
+
+def test_server_instructions_preserve_evidence_sensitive_abstention() -> None:
+    assert "restating an accepted value without new evidence" in SERVER_INSTRUCTIONS
+    assert "not a mathematical-tool use case" in SERVER_INSTRUCTIONS
 
 
 def test_guidance_rejects_verification_transfer_to_derived_claims() -> None:
     combined = "\n".join((SERVER_INSTRUCTIONS, MATH_RUN_DESCRIPTION))
-    assert "does not verify a model-derived conclusion" in combined
     assert "record must be bound to the exact final claim" in combined
+    assert "model-authored duplicate calculations are not independent" in combined


### PR DESCRIPTION
## What changed

- brand `math.find` and `math.run` as installed Jacobian tools in MCP titles and server metadata
- state explicitly that `math.find`, not internet search, is the authoritative inventory for the current runtime
- replace unconditional adoption prose with shorter evidence-sensitive guidance for unknown contracts, repeated identical lookup, supplied values, and independent checker evidence
- add focused unit and MCP boundary regressions for the model-visible surface

The combined server/tool guidance is shorter (3,096 to 2,955 characters); this is not a prompt-length expansion.

## Root cause and experiment

This follows up #845, #938, #1031, and #1141 after reconciling the just-merged #1256 simplification.

Frozen suite SHA-256: `b90a59dd8f4bf2c60bcc7ac61c61c2ac3902b11132728acb4cc31c01a021271e`.
Oracle SHA-256: `24cc374bc5398e86dce9fd5b42e1310715b52ddf3ffb5686680bb892554f38f6`.

The suite used three exact tasks, two repetitions each, authenticated Codex CLI 0.147.0, `gpt-5.4-mini`, and low reasoning:

1. Petersen line-graph clique number (latent positive)
2. exact rational determinant plus a separate checker (explicit nested/schema-sensitive positive)
3. supplied trusted GCD restatement (negative abstention control)

On latest-main baseline `88fdfaa4`, one Petersen repetition made four web searches for the local Jacobian operation, asserted that the tool was not exposed, and made zero Jacobian calls despite a healthy MCP connection. The other positive trajectories found the correct operation, inspected its contract, and had valid first executions. This isolated an adoption/interface ambiguity rather than a ranking miss.

Baseline -> treatment:

- positive discovery/invocation and task contract: 3/4 -> 4/4
- valid first execution across positive tasks: 3/4 -> 4/4
- determinant producer + independent checker success: 2/2 -> 2/2
- negative-control abstention: 2/2 -> 2/2
- false verification claims: 0 -> 0
- average input tokens per successful positive: 101,329 -> 99,086
- average MCP calls per successful positive: 4.33 -> 4.25
- average elapsed time per successful positive: 47.0s -> 49.8s
- average model-visible MCP bytes per successful positive: 8.2KB -> 10.4KB

The byte/time increase is disclosed: one treatment run made a relevant post-producer search for the separately requested checker. The change does not prescribe mathematical strategy or add a hidden planner.

## Validation

- `make test-plan BASE=origin/main` (selective: unit, component, MCP, E2E, npm, static)
- `make lint typecheck npm-test test-unit test-component test-mcp test-e2e`
  - Ruff/format/complexity passed
  - mypy passed (444 source files)
  - npm: 58 passed; package dry-run passed
  - unit: 889 passed
  - component: 889 passed
  - MCP: 47 passed
  - E2E: 2 passed, 1 expected skip (Lean unavailable)

## Remaining scope

This is a focused adoption fix, not closure of the issue cluster. #938's broader context/latency question and #1031's generic schema-bound execution design remain open. #1256 removed the pre-merge compact-card schema ambiguity observed in an earlier frozen run. #1141 still needs broader task coverage and cost-policy evidence, and #845 still needs larger-sample adoption evaluation.