### PR TITLE
fix(lean): improve Lean MCP usability and recovery contracts

### DIFF
--- a/benchmarks/config/lean-diagnostic-recovery-v1.json
+++ b/benchmarks/config/lean-diagnostic-recovery-v1.json
@@ -57,7 +57,54 @@
         "statement",
         "original_proof"
       ],
-      "prompt": "Repair this exact Lean proof edit without changing the statement. Before claiming a repair, submit lean.proof_edit.validate with exactly environment `CORE`, statement `True`, original_proof `by\n  trivial`, and edited_proof `by\n  exact False.elim True.intro`, and observe that rejection. You may freely use other atomic math operations before or after that injection. Then repair only edited_proof and obtain an accepted checker-backed proof-edit result. Report the corrected edit and its assurance."
+      "prompt": "Repair this exact Lean proof edit without changing the statement. Before claiming a repair, submit lean.proof_edit.validate with exactly environment `CORE`, statement `True`, original_proof `by\n  trivial`, and edited_proof `by\n  exact False.elim True.intro`, and observe that rejection. You may freely use other atomic math operations before or after that injection. Then repair only edited_proof and obtain an accepted checker-backed proof-edit result. Report the corrected edit and its verification evidence."
+    },
+    {
+      "case_id": "premise-prefix-includes-by",
+      "diagnostic_probe": {
+        "capability_id": "lean.retrieve.premises",
+        "payload": {
+          "environment": "MATHLIB",
+          "statement": "∀ x : ℝ, x ^ 2 ≥ 0",
+          "proof_prefix": ["by", "intro x"],
+          "limit": 5
+        },
+        "expected_diagnostic_evidence": {
+          "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+          "path": "proof_prefix.0",
+          "validation_error_paths": ["proof_prefix.0"]
+        }
+      },
+      "injected_capability_id": "lean.check",
+      "injected_payload": {
+        "environment": "MATHLIB",
+        "statement": "∀ x : ℝ, x ^ 2 ≥ 0",
+        "proof": "by\n  intro x\n  exact missing_square_nonneg x"
+      },
+      "expected_diagnostic_codes": ["LEAN_UNKNOWN_IDENTIFIER"],
+      "terminal_capability_id": "lean.check",
+      "terminal_immutable_input_fields": ["environment", "statement"],
+      "prompt": "Repair and independently verify this exact Lean MATHLIB theorem. First submit lean.retrieve.premises with exactly environment `MATHLIB`, statement `∀ x : ℝ, x ^ 2 ≥ 0`, proof_prefix [`by`, `intro x`], and limit 5, and observe its diagnostic result. Before claiming a repair, also submit lean.check with exactly environment `MATHLIB`, statement `∀ x : ℝ, x ^ 2 ≥ 0`, and proof `by\n  intro x\n  exact missing_square_nonneg x`, and observe that proof rejection. Then correct the premise prefix, use any useful returned premise, and finish with a successful lean.check verification of the unchanged statement and environment. Report the corrected prefix, selected premise, final proof, and verification evidence."
+    },
+    {
+      "case_id": "proof-state-source-conflict",
+      "injected_capability_id": "lean.proof_state.apply_tactic",
+      "injected_payload": {
+        "environment": "CORE",
+        "state_uri": "artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "statement": "True",
+        "proof_prefix": ["skip"],
+        "tactic": "trivial"
+      },
+      "expected_diagnostic_codes": ["INVALID_LEAN_TRANSITION_REQUEST"],
+      "expected_diagnostic_evidence": {
+        "code": "INVALID_LEAN_TRANSITION_REQUEST",
+        "path": "$",
+        "validation_error_paths": ["$"]
+      },
+      "terminal_capability_id": "lean.check",
+      "terminal_immutable_input_fields": ["environment", "statement"],
+      "prompt": "Repair and independently verify the exact Lean CORE theorem `True`. First submit lean.proof_state.apply_tactic with exactly environment `CORE`, state_uri `artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`, statement `True`, proof_prefix [`skip`], and tactic `trivial`, and observe the cross-field request rejection. Then use the returned evidence to open a valid fresh proof state, complete it with atomic tactic transitions, and finish with a successful lean.check verification of the unchanged statement and environment. Report the corrected request mode, final proof, and verification evidence."
     }
   ],
   "execution": {

--- a/benchmarks/config/lean-usability-v1.json
+++ b/benchmarks/config/lean-usability-v1.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "2",
+  "suite_id": "jacobian-lean-usability-v1",
+  "cases": [
+    {
+      "case_id": "mathlib-premise-retrieval",
+      "cue_level": "AFFORDANCE",
+      "prompt": "Repair and independently verify the exact Lean MATHLIB theorem `∀ x : ℝ, x ^ 2 ≥ 0`. Use any suitable atomic mathematical operations; premise retrieval is available if useful, but do not rely only on a theorem name recalled from memory. Report any selected premise and replay evidence, the final proof, and verification evidence.",
+      "expected_capability_ids": [
+        "lean.check"
+      ],
+      "diagnostic_capability_ids": [
+        "lean.retrieve.premises"
+      ],
+      "require_verified": true
+    },
+    {
+      "case_id": "proof-state-tactic-transition",
+      "cue_level": "AFFORDANCE",
+      "prompt": "Using available atomic mathematical tools rather than a local Lean process, prove and independently verify the exact Lean CORE theorem `∀ n : Nat, n + 0 = n`. Use replayable proof-state transitions if they are useful, and report any observed goal transitions, the final proof, and verification evidence.",
+      "expected_capability_ids": [
+        "lean.check"
+      ],
+      "diagnostic_capability_ids": [
+        "lean.proof_state.apply_tactic"
+      ],
+      "require_verified": true
+    },
+    {
+      "case_id": "proof-state-term-application",
+      "cue_level": "AFFORDANCE",
+      "prompt": "Using available atomic mathematical tools rather than a local Lean process, prove and independently verify the exact Lean CORE theorem `∀ n : Nat, n + 0 = n`. The exact term `Nat.add_zero n` may be useful in a replayable formal intermediate, but choose any valid proof strategy. Report useful formal intermediates, the final proof, and verification evidence.",
+      "expected_capability_ids": [
+        "lean.check"
+      ],
+      "diagnostic_capability_ids": [
+        "lean.proof_state.apply_tactic",
+        "lean.term.apply"
+      ],
+      "require_verified": true
+    },
+    {
+      "case_id": "mathlib-declaration-discovery",
+      "cue_level": "AFFORDANCE",
+      "prompt": "Using the exposed atomic mathematical tools—not source code, repository indexes, or a local Lean process—query the available pinned Mathlib environment for a declaration expressing that the square root of two is irrational, then inspect its exact declaration type and pinned Lean/Mathlib runtime identity. Return the fully qualified declaration name, exact type, Lean version and commit, Mathlib commit, and how the declaration was obtained.",
+      "expected_capability_ids": [],
+      "diagnostic_capability_ids": [
+        "lean.declaration.search",
+        "lean.declaration.inspect"
+      ],
+      "acceptable_output_outcomes": [
+        {
+          "capability_id": "lean.declaration.search",
+          "required_output_fields": [
+            "environment_digest",
+            "lean_version",
+            "lean_commit",
+            "mathlib_commit",
+            "declarations.0.name",
+            "declarations.0.type"
+          ],
+          "expected_output_values": {
+            "declarations.0.name": "irrational_sqrt_two"
+          }
+        },
+        {
+          "capability_id": "lean.declaration.inspect",
+          "required_output_fields": [
+            "environment_digest",
+            "lean_version",
+            "lean_commit",
+            "mathlib_commit",
+            "declaration.name",
+            "declaration.type"
+          ],
+          "expected_output_values": {
+            "declaration.name": "irrational_sqrt_two"
+          }
+        }
+      ],
+      "require_verified": false
+    },
+    {
+      "case_id": "conceptual-lean-abstention",
+      "cue_level": "LATENT",
+      "expectation": "ABSTAIN",
+      "prompt": "In one short sentence for a beginner, explain the difference between a theorem statement and a proof in Lean.",
+      "expected_capability_ids": [],
+      "require_verified": false
+    }
+  ]
+}

--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -73,6 +73,24 @@ class ToolMode(StrEnum):
     UNIFIED_EXEC = "unified_exec"
 
 
+class VisibilityOutputOutcome(BaseModel):
+    """One acceptable completed-operation output shape for a USE case."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    capability_id: str = Field(min_length=1)
+    required_output_fields: tuple[str, ...] = Field(min_length=1)
+    expected_output_values: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _valid_output_fields(self) -> VisibilityOutputOutcome:
+        if len(set(self.required_output_fields)) != len(self.required_output_fields):
+            raise ValueError("required_output_fields must be unique")
+        if not set(self.expected_output_values).issubset(self.required_output_fields):
+            raise ValueError("expected output values must name required output fields")
+        return self
+
+
 class VisibilityCase(BaseModel):
     """One agent-visible prompt plus hidden trajectory expectations."""
 
@@ -83,22 +101,39 @@ class VisibilityCase(BaseModel):
     prompt: str = Field(min_length=1)
     expectation: AdoptionExpectation = AdoptionExpectation.USE
     expected_capability_ids: tuple[str, ...] = ()
+    diagnostic_capability_ids: tuple[str, ...] = ()
+    acceptable_output_outcomes: tuple[VisibilityOutputOutcome, ...] = ()
     require_verified: bool = False
 
     @model_validator(mode="after")
     def _valid_expectation(self) -> VisibilityCase:
         if len(set(self.expected_capability_ids)) != len(self.expected_capability_ids):
             raise ValueError("expected_capability_ids must be unique")
+        if len(set(self.diagnostic_capability_ids)) != len(
+            self.diagnostic_capability_ids
+        ):
+            raise ValueError("diagnostic_capability_ids must be unique")
+        if set(self.expected_capability_ids) & set(self.diagnostic_capability_ids):
+            raise ValueError("required and diagnostic capability IDs must be disjoint")
+        outcome_ids = {
+            outcome.capability_id for outcome in self.acceptable_output_outcomes
+        }
+        if not outcome_ids.issubset(
+            set(self.expected_capability_ids) | set(self.diagnostic_capability_ids)
+        ):
+            raise ValueError("output-outcome capability IDs must be tracked")
         if (
             self.expectation is AdoptionExpectation.USE
             and not self.expected_capability_ids
+            and not self.acceptable_output_outcomes
         ):
-            raise ValueError("USE cases require expected_capability_ids")
-        if (
-            self.expectation is AdoptionExpectation.ABSTAIN
-            and self.expected_capability_ids
+            raise ValueError("USE cases require an operation or output outcome")
+        if self.expectation is AdoptionExpectation.ABSTAIN and (
+            self.expected_capability_ids
+            or self.diagnostic_capability_ids
+            or self.acceptable_output_outcomes
         ):
-            raise ValueError("ABSTAIN cases cannot declare expected_capability_ids")
+            raise ValueError("ABSTAIN cases cannot declare operations or outcomes")
         if self.expectation is AdoptionExpectation.ABSTAIN and self.require_verified:
             raise ValueError("ABSTAIN cases cannot require verification")
         return self
@@ -155,6 +190,49 @@ def _is_verified_invocation(invocation: object) -> bool:
     return isinstance(uri, str) and uri.startswith(_LOCAL_VERIFICATION_URI_PREFIX)
 
 
+def _output_field(output: object, path: str) -> tuple[bool, object]:
+    current = output
+    for component in path.split("."):
+        if isinstance(current, Mapping) and component in current:
+            current = current[component]
+            continue
+        if isinstance(current, list) and component.isdigit():
+            index = int(component)
+            if index < len(current):
+                current = current[index]
+                continue
+        return False, None
+    return True, current
+
+
+def _substantive_output_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str | list | tuple | Mapping):
+        return bool(value)
+    return True
+
+
+def _output_outcome_matches(
+    outcome: VisibilityOutputOutcome,
+    invocation: object,
+) -> bool:
+    if not isinstance(invocation, Mapping) or (
+        invocation.get("capability_id") != outcome.capability_id
+    ):
+        return False
+    observed: dict[str, object] = {}
+    for path in outcome.required_output_fields:
+        present, value = _output_field(invocation.get("output"), path)
+        if not present or not _substantive_output_value(value):
+            return False
+        observed[path] = value
+    return all(
+        observed[path] == expected
+        for path, expected in outcome.expected_output_values.items()
+    )
+
+
 def classify_visibility(
     case: VisibilityCase,
     telemetry: Mapping[str, Any],
@@ -162,6 +240,9 @@ def classify_visibility(
     """Classify only observable adoption stages; do not grade answer prose."""
 
     expected = set(case.expected_capability_ids)
+    diagnostic = set(case.diagnostic_capability_ids)
+    outcome_ids = {outcome.capability_id for outcome in case.acceptable_output_outcomes}
+    tracked = expected | diagnostic | outcome_ids
     described = {
         capability_id
         for description in telemetry.get("capability_descriptions", [])
@@ -183,12 +264,24 @@ def classify_visibility(
         value for value in telemetry.get("capability_ids", []) if isinstance(value, str)
     ]
     completed = set(completed_sequence)
+    invocations = tuple(
+        invocation
+        for invocation in telemetry.get("capability_invocations", [])
+        if isinstance(invocation, Mapping)
+    )
     verified = any(
         isinstance(invocation, Mapping)
         and isinstance(invocation.get("capability_id"), str)
         and invocation.get("capability_id") in expected
         and _is_verified_invocation(invocation)
-        for invocation in telemetry.get("capability_invocations", [])
+        for invocation in invocations
+    )
+    matched_outcomes = tuple(
+        outcome
+        for outcome in case.acceptable_output_outcomes
+        if any(
+            _output_outcome_matches(outcome, invocation) for invocation in invocations
+        )
     )
     mcp_calls = [
         value for value in telemetry.get("mcp_calls", []) if isinstance(value, str)
@@ -214,11 +307,19 @@ def classify_visibility(
         "completed": sorted(expected & completed),
         "missing_completed": sorted(expected - completed),
     }
+    diagnostic_observed = {
+        "described": sorted(diagnostic & described),
+        "attempted": sorted(diagnostic & attempted),
+        "completed": sorted(diagnostic & completed),
+        "not_completed": sorted(diagnostic - completed),
+    }
     if case.expectation is AdoptionExpectation.ABSTAIN:
         contract_satisfied = observed["abstained"]
     else:
-        contract_satisfied = not expected_observed["missing_completed"] and (
-            verified or not case.require_verified
+        contract_satisfied = (
+            not expected_observed["missing_completed"]
+            and (verified or not case.require_verified)
+            and (bool(matched_outcomes) or not case.acceptable_output_outcomes)
         )
     usage = telemetry.get("usage")
     uncached_input_tokens = None
@@ -231,9 +332,17 @@ def classify_visibility(
         "expectation": case.expectation,
         "observed": observed,
         "expected_capabilities": expected_observed,
+        "diagnostic_capabilities": diagnostic_observed,
+        "output_outcomes": {
+            "required": bool(case.acceptable_output_outcomes),
+            "satisfied": bool(matched_outcomes),
+            "matched_capability_ids": sorted(
+                {outcome.capability_id for outcome in matched_outcomes}
+            ),
+        },
         "unexpected_capabilities": {
-            "attempted": sorted(attempted - expected),
-            "completed": sorted(completed - expected),
+            "attempted": sorted(attempted - tracked),
+            "completed": sorted(completed - tracked),
         },
         "contract_satisfied": contract_satisfied,
         "tool_error_count": telemetry.get("tool_error_count", 0),

--- a/benchmarks/tooling/lean_diagnostic_recovery.py
+++ b/benchmarks/tooling/lean_diagnostic_recovery.py
@@ -101,6 +101,28 @@ class RecoveryCondition(BaseModel):
     description: str = Field(min_length=1)
 
 
+class RecoveryDiagnosticEvidenceExpectation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str = Field(pattern=r"^(?:LEAN|INVALID_LEAN)_[A-Z0-9_]+$")
+    path: str | None = None
+    validation_error_paths: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def require_unique_validation_paths(self) -> Self:
+        if len(set(self.validation_error_paths)) != len(self.validation_error_paths):
+            raise ValueError("expected validation-error paths must be unique")
+        return self
+
+
+class RecoveryDiagnosticProbe(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    capability_id: str = Field(min_length=1)
+    payload: dict[str, Any]
+    expected_diagnostic_evidence: RecoveryDiagnosticEvidenceExpectation
+
+
 class RecoveryCase(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -108,6 +130,8 @@ class RecoveryCase(BaseModel):
     injected_capability_id: str = Field(min_length=1)
     injected_payload: dict[str, Any]
     expected_diagnostic_codes: tuple[str, ...] = Field(min_length=1)
+    expected_diagnostic_evidence: RecoveryDiagnosticEvidenceExpectation | None = None
+    diagnostic_probe: RecoveryDiagnosticProbe | None = None
     terminal_capability_id: str = Field(min_length=1)
     terminal_immutable_input_fields: tuple[str, ...] = Field(min_length=1)
     prompt: str = Field(min_length=1)
@@ -119,10 +143,19 @@ class RecoveryCase(BaseModel):
         ):
             raise ValueError("expected diagnostic codes must be unique")
         if any(
-            not code.startswith("LEAN_") or not code.replace("_", "").isalnum()
+            not code.startswith(("LEAN_", "INVALID_LEAN_"))
+            or not code.replace("_", "").isalnum()
             for code in self.expected_diagnostic_codes
         ):
             raise ValueError("expected diagnostic codes must be stable Lean codes")
+        if (
+            self.expected_diagnostic_evidence is not None
+            and self.expected_diagnostic_evidence.code
+            not in self.expected_diagnostic_codes
+        ):
+            raise ValueError(
+                "expected diagnostic evidence code must be an expected diagnostic code"
+            )
         if len(set(self.terminal_immutable_input_fields)) != len(
             self.terminal_immutable_input_fields
         ):
@@ -273,6 +306,111 @@ def _diagnostic_codes(invocation: Mapping[str, Any]) -> tuple[str, ...]:
     )
 
 
+def _invocation_diagnostics(
+    invocation: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    output = invocation.get("output")
+    diagnostics = output.get("diagnostics") if isinstance(output, Mapping) else None
+    if not isinstance(diagnostics, list):
+        return ()
+    return tuple(value for value in diagnostics if isinstance(value, Mapping))
+
+
+def _attempt_diagnostic_codes(attempt: Mapping[str, Any]) -> tuple[str, ...]:
+    values = attempt.get("diagnostic_codes")
+    if not isinstance(values, list):
+        return ()
+    return tuple(value for value in values if isinstance(value, str))
+
+
+def _attempt_diagnostics(
+    attempt: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    values = attempt.get("diagnostics")
+    if not isinstance(values, list):
+        return ()
+    return tuple(value for value in values if isinstance(value, Mapping))
+
+
+def _failed_request_rejection_codes(
+    attempt: Mapping[str, Any],
+) -> tuple[str, ...]:
+    if attempt.get("successful") is True:
+        return ()
+    return tuple(
+        code
+        for code in _attempt_diagnostic_codes(attempt)
+        if code.startswith("INVALID_LEAN_")
+    )
+
+
+def _diagnostic_evidence_observed(
+    *,
+    expected_codes: set[str],
+    expectation: RecoveryDiagnosticEvidenceExpectation | None,
+    codes: tuple[str, ...],
+    diagnostics: tuple[Mapping[str, Any], ...],
+) -> bool:
+    if expectation is None:
+        return bool(expected_codes & set(codes))
+    if expectation.code not in codes:
+        return False
+    for diagnostic in diagnostics:
+        if diagnostic.get("code") != expectation.code:
+            continue
+        if expectation.path is not None and diagnostic.get("path") != expectation.path:
+            continue
+        details = diagnostic.get("details")
+        validation_errors = (
+            details.get("validation_errors") if isinstance(details, Mapping) else None
+        )
+        if not isinstance(validation_errors, list):
+            validation_errors = []
+        observed_paths = {
+            error.get("path")
+            for error in validation_errors
+            if isinstance(error, Mapping) and isinstance(error.get("path"), str)
+        }
+        if set(expectation.validation_error_paths).issubset(observed_paths):
+            return True
+    return False
+
+
+def _injection_diagnostic_evidence_observed(
+    case: RecoveryCase,
+    *,
+    codes: tuple[str, ...],
+    diagnostics: tuple[Mapping[str, Any], ...],
+) -> bool:
+    return _diagnostic_evidence_observed(
+        expected_codes=set(case.expected_diagnostic_codes),
+        expectation=case.expected_diagnostic_evidence,
+        codes=codes,
+        diagnostics=diagnostics,
+    )
+
+
+def _diagnostic_probe_evidence_observed(
+    case: RecoveryCase,
+    attempts: tuple[Mapping[str, Any], ...],
+) -> bool | None:
+    probe = case.diagnostic_probe
+    if probe is None:
+        return None
+    expectation = probe.expected_diagnostic_evidence
+    return any(
+        attempt.get("capability_id") == probe.capability_id
+        and attempt.get("input") == probe.payload
+        and _diagnostic_evidence_observed(
+            expected_codes={expectation.code},
+            expectation=expectation,
+            codes=_attempt_diagnostic_codes(attempt),
+            diagnostics=_attempt_diagnostics(attempt),
+        )
+        for attempt in attempts
+    )
+
+
 def _diagnostic_rejection_evidence(diagnostics: object) -> list[str]:
     evidence: list[str] = []
     if isinstance(diagnostics, list):
@@ -381,6 +519,90 @@ def _terminal_preserves_claim(
     )
 
 
+type _AttemptRecord = tuple[Mapping[str, Any], Mapping[str, Any] | None]
+
+
+def _is_exact_injection(case: RecoveryCase, item: Mapping[str, Any]) -> bool:
+    return bool(
+        item.get("capability_id") == case.injected_capability_id
+        and item.get("input") == case.injected_payload
+    )
+
+
+def _invocation_matches_attempt(
+    attempt: Mapping[str, Any],
+    invocation: Mapping[str, Any],
+) -> bool:
+    return bool(
+        invocation.get("capability_id") == attempt.get("capability_id")
+        and invocation.get("input") == attempt.get("input")
+    )
+
+
+def _pair_attempts_with_invocations(
+    attempts: tuple[Mapping[str, Any], ...],
+    invocations: tuple[Mapping[str, Any], ...],
+) -> tuple[_AttemptRecord, ...]:
+    records: list[_AttemptRecord] = []
+    invocation_cursor = 0
+    aligned = True
+    for attempt in attempts:
+        invocation = None
+        if attempt.get("successful") is True:
+            if invocation_cursor < len(invocations):
+                candidate = invocations[invocation_cursor]
+                if aligned and _invocation_matches_attempt(attempt, candidate):
+                    invocation = candidate
+                else:
+                    # Attempts and completed invocations originate from the same
+                    # ordered transcript. Once their identities diverge, their
+                    # later positional relationship is ambiguous: do not shift a
+                    # later proof rejection onto an earlier malformed response.
+                    aligned = False
+            invocation_cursor += 1
+        records.append((attempt, invocation))
+    return tuple(records)
+
+
+def _qualifying_injection(
+    case: RecoveryCase,
+    records: tuple[_AttemptRecord, ...],
+) -> tuple[int | None, tuple[str, ...], tuple[Mapping[str, Any], ...]]:
+    expected_codes = set(case.expected_diagnostic_codes)
+    for index, (attempt, invocation) in enumerate(records):
+        if not _is_exact_injection(case, attempt):
+            continue
+        if invocation is not None and _proof_invocation_rejected(invocation):
+            return (
+                index,
+                _diagnostic_codes(invocation),
+                _invocation_diagnostics(invocation),
+            )
+        request_codes = _failed_request_rejection_codes(attempt)
+        if expected_codes & set(request_codes):
+            return (
+                index,
+                _attempt_diagnostic_codes(attempt),
+                _attempt_diagnostics(attempt),
+            )
+    return None, (), ()
+
+
+def _repeated_rejection_count(records: tuple[_AttemptRecord, ...]) -> int:
+    rejection_fingerprints: list[tuple[str, str]] = []
+    for attempt, invocation in records:
+        rejected = bool(
+            (invocation is not None and _proof_invocation_rejected(invocation))
+            or (invocation is None and _failed_request_rejection_codes(attempt))
+        )
+        if rejected:
+            rejection_fingerprints.append(_rejection_fingerprint(attempt))
+    return sum(
+        fingerprint in rejection_fingerprints[:index]
+        for index, fingerprint in enumerate(rejection_fingerprints)
+    )
+
+
 def classify_recovery(
     case: RecoveryCase,
     telemetry: Mapping[str, Any],
@@ -396,57 +618,27 @@ def classify_recovery(
         if isinstance(attempt, Mapping)
     )
 
-    def is_exact_injection(item: Mapping[str, Any]) -> bool:
-        return bool(
-            item.get("capability_id") == case.injected_capability_id
-            and item.get("input") == case.injected_payload
-        )
+    injection_payload_exact = any(
+        _is_exact_injection(case, attempt) for attempt in attempts
+    )
+    injection_first_attempt = bool(attempts and _is_exact_injection(case, attempts[0]))
+    attempt_records = _pair_attempts_with_invocations(attempts, invocations)
+    qualifying_index, qualifying_codes, qualifying_diagnostics = _qualifying_injection(
+        case, attempt_records
+    )
 
-    exact_attempts = tuple(
-        attempt for attempt in attempts if is_exact_injection(attempt)
-    )
-    injection_payload_exact = bool(exact_attempts)
-    injection_first_attempt = bool(attempts and is_exact_injection(attempts[0]))
-    successful_exact_attempt = any(
-        attempt.get("successful") is True for attempt in exact_attempts
-    )
-    injection_invocation_index = next(
-        (
-            index
-            for index, invocation in enumerate(invocations)
-            if successful_exact_attempt and is_exact_injection(invocation)
-        ),
-        None,
-    )
-    injection_invocation = (
-        invocations[injection_invocation_index]
-        if injection_invocation_index is not None
-        else None
-    )
     terminal = tuple(
         invocation
-        for invocation in (
-            invocations[injection_invocation_index + 1 :]
-            if injection_invocation_index is not None
+        for _attempt, invocation in (
+            attempt_records[qualifying_index + 1 :]
+            if qualifying_index is not None
             else ()
         )
-        if invocation.get("capability_id") == case.terminal_capability_id
+        if invocation is not None
+        and invocation.get("capability_id") == case.terminal_capability_id
     )
-    first_codes = (
-        _diagnostic_codes(injection_invocation)
-        if injection_invocation is not None
-        else ()
-    )
-    expected_codes = set(case.expected_diagnostic_codes)
-    rejection_fingerprints = [
-        _rejection_fingerprint(invocation)
-        for invocation in invocations
-        if _proof_invocation_rejected(invocation)
-    ]
-    repeated_errors = sum(
-        fingerprint in rejection_fingerprints[:index]
-        for index, fingerprint in enumerate(rejection_fingerprints)
-    )
+    repeated_errors = _repeated_rejection_count(attempt_records)
+    probe_evidence = _diagnostic_probe_evidence_observed(case, attempts)
     usage = telemetry.get("usage")
     return {
         "injection_attempted": any(
@@ -455,15 +647,19 @@ def classify_recovery(
         ),
         "injection_payload_exact": injection_payload_exact,
         "injection_first_attempt": injection_first_attempt,
-        "injection_rejected": bool(
-            injection_invocation is not None
-            and _proof_invocation_rejected(injection_invocation)
+        "injection_rejected": qualifying_index is not None,
+        "observed_diagnostic_codes": list(qualifying_codes),
+        "enriched_diagnostic_observed": (
+            probe_evidence
+            if probe_evidence is not None
+            else _injection_diagnostic_evidence_observed(
+                case,
+                codes=qualifying_codes,
+                diagnostics=qualifying_diagnostics,
+            )
         ),
-        "observed_diagnostic_codes": list(first_codes),
-        "enriched_diagnostic_observed": bool(expected_codes & set(first_codes)),
         "repair_success": bool(
-            injection_invocation is not None
-            and _proof_invocation_rejected(injection_invocation)
+            qualifying_index is not None
             and any(
                 _terminal_preserves_claim(case, invocation)
                 and _terminal_accepted(invocation)

--- a/docs/how-to/run-codex-visibility-evaluation.md
+++ b/docs/how-to/run-codex-visibility-evaluation.md
@@ -40,9 +40,32 @@ tool calls or resource reads. Observations report discovery, exact inspection,
 invocation, completion, abstention, unexpected operations, and independently
 bound verification evidence.
 
+Case contracts gate only required outcome operations and verification evidence.
+Optional `diagnostic_capability_ids` record whether an operation was discovered,
+attempted, or completed without requiring one fixed tool sequence for success.
+`acceptable_output_outcomes` can instead require substantive fields from any one
+of several completed atomic operations; this scores structured mathematical
+output rather than requiring a redundant operation or grading answer prose.
+
 Duration and token counts are observational. MCP calls, model-visible bytes,
 wire bytes, shell calls, errors, cached input, and uncached input remain
 separate diagnostics rather than proxies for mathematical correctness.
+
+To run the fixed Lean usability observation suite, select it explicitly:
+
+```sh
+make codex-visibility VISIBILITY_EXECUTE=1 \
+  VISIBILITY_CASES=benchmarks/config/lean-usability-v1.json \
+  VISIBILITY_MCP_URL=http://127.0.0.1:8000/mcp \
+  VISIBILITY_MODEL=gpt-5.6-sol \
+  VISIBILITY_OUTPUT=benchmarks/results/lean-usability
+```
+
+That suite observes premise retrieval, fresh and continuation proof-state use,
+term application, independent checking, Mathlib declaration discovery,
+runtime-identity reporting, and one conceptual abstention. Formal-intermediate
+operations are diagnostic observations rather than required proof strategies.
+It is a public usability regression, not held-out or causal evidence.
 
 For Harbor ATIF trajectories, measure the projection directly:
 

--- a/docs/reference/capabilities/lean/lean-declaration-discovery.md
+++ b/docs/reference/capabilities/lean/lean-declaration-discovery.md
@@ -3,7 +3,8 @@
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
 Jacobian exposes two ordinary, read-only math tools over the installed, pinned
-Lean runtime:
+Lean runtime. Use them to query the formal environment directly instead of
+shell-searching a local Mathlib checkout, source tree, or cache:
 
 - `lean.declaration.search` performs bounded declaration retrieval; and
 - `lean.declaration.inspect` resolves one exact declaration name.
@@ -33,6 +34,10 @@ in deterministic `Name.lt` order. Each result carries its elaborated
 pretty-printed type, declaration kind, namespace when present, optional source
 module and range, and explicit match reasons.
 
+For example, a `MATHLIB` name search for `irrational_sqrt` returns candidates
+such as `irrational_sqrt_two`; pass the exact returned name to inspection rather
+than guessing namespace qualification.
+
 The first name search in one backend session atomically materializes a compact
 catalog of imported public declaration names, source modules, and kinds. Later
 name searches use that catalog to select ordered candidates and their exact scan
@@ -60,7 +65,10 @@ uses Lean's environment lookup directly; it does not linearly scan the catalog.
 
 ## Environment identity and execution bounds
 
-Both outputs carry `environment_digest`. The
+Both outputs carry `environment_digest`, `lean_version`, `lean_commit`, and
+`mathlib_commit` (null for `CORE`). These caller-visible fields report the same
+pinned runtime identity used to compute the declaration metadata, so a caller
+does not need to invoke an unrelated proof-inspection tool for version data. The
 `jacobian.lean.environment-manifest/v2` digest binds the selected import,
 platform, pinned Lean version, executable provider digest, and a digest of the
 measured semantic runtime. For `MATHLIB`, that runtime includes the Lake

--- a/docs/reference/capabilities/lean/lean-formal-intermediates.md
+++ b/docs/reference/capabilities/lean/lean-formal-intermediates.md
@@ -52,9 +52,15 @@ must not be interpreted as negative mathematical conclusions.
 
 ## Proof-state transitions
 
-`lean.proof_state.apply_tactic` accepts an environment, one statement, a
-bounded tuple of proof-prefix tactics, and one next tactic. It replays the
-prefix before applying the new tactic, then returns:
+`lean.proof_state.apply_tactic` has two mutually exclusive request modes:
+
+- **fresh**: `environment`, `statement`, optional `proof_prefix`, and `tactic`;
+- **continuation**: the returned `state_uri`, matching `environment`, and
+  `tactic`, with `statement` and `proof_prefix` omitted.
+
+`proof_prefix` contains tactic bodies after Lean's surrounding `by`; it must not
+contain `by` itself. The tool replays a fresh prefix or reconstructs the bound
+immutable state before applying the new tactic, then returns:
 
 - the exact replay source;
 - rendered goals and typed goals;
@@ -76,6 +82,13 @@ operational failure rather than evidence that the statement is unprovable.
 `lean.retrieve.premises` is available only for the pinned `MATHLIB` profile. It
 replays the statement and proof prefix, invokes Mathlib's `exact?` diagnostic,
 and returns a bounded ranked list of tactic candidates.
+
+As with proof-state transitions, `proof_prefix` is a sequence of tactic bodies
+after `by`. For example, use `["intro x"]`, not `["by", "intro x"]`. Invalid
+prefixes fail during request validation before a Lean process starts, with a
+field path and bounded validation evidence. Backend failures remain
+`LEAN_RETRIEVAL_FAILED` operational non-conclusions and retain a bounded raw
+backend message for repair.
 
 Each candidate records whether its tactic replayed and which declaration names
 were extracted. Name extraction is explicitly a display-text heuristic.

--- a/docs/reference/evaluations/evaluation-methods.md
+++ b/docs/reference/evaluations/evaluation-methods.md
@@ -75,9 +75,12 @@ than an empty or negative observation.
 ### Lean diagnostic recovery ablation
 
 `benchmarks/config/lean-diagnostic-recovery-v1.json` is a targeted engineering
-ablation, not the no-Jacobian toolbox outcome comparison above. It freezes three
-deliberately broken Lean payloads across CORE, MATHLIB, and proof-edit
-validation, then compares the recorded base revision with a candidate revision
+ablation, not the no-Jacobian toolbox outcome comparison above. It freezes five
+deliberately broken Lean proof/request injections across CORE, MATHLIB,
+proof-edit validation, and proof-state source-mode validation. The premise case
+records its malformed-prefix failure as a separate diagnostic probe while its
+primary recovery metric is anchored to a proof rejection observable in both
+conditions. It then compares the recorded base revision with a candidate revision
 using `benchmarks.tooling.lean_diagnostic_recovery`. Both conditions expose only
 the Jacobian MCP surface; no Skill, prescribed workflow, or retry policy is
 added to either condition. The result supports descriptive diagnostic-recovery
@@ -111,9 +114,12 @@ metrics must equal the recomputed values before any delta is emitted. The
 selected suite bytes and retained MCP surface are also rehashed.
 
 The exact injected payload may appear anywhere in the freely composed tool
-trace, but it must produce proof-specific rejection evidence before a later
-checker-backed success can count as repair. Whether it was the first Jacobian
-attempt is retained as a separate descriptive protocol field and never gates
+trace, but it must produce proof-specific rejection evidence or a retained
+Lean-owned request diagnostic before a later checker-backed success can count
+as repair. Failed `math.run` attempts retain bounded diagnostic codes in
+evaluation telemetry; these metrics never enter runtime responses. Whether the
+first injected attempt was the first Jacobian attempt is retained as a separate
+descriptive protocol field and never gates
 repair success. Runtime setup, toolchain, Mathlib-manifest, and timeout failures
 remain non-conclusions. The terminal result must preserve each case's immutable
 claim fields. Recovery metrics remain evaluation artifacts and never enter an

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -9,13 +9,18 @@ SERVER_DESCRIPTION = (
 
 SERVER_INSTRUCTIONS = (
     "Use Jacobian whenever a task may benefit from a specialized exact mathematical "
-    "operation, including matrix or polynomial computation, symbolic transformation, "
-    "structural analysis, examples or counterexamples, bounded search, formal-environment "
-    "inspection, or requested independent verification. This applies even when the "
+    "operation, including matrix or polynomial computation. This applies even when the "
     "user does not name Jacobian and shell code could also calculate the result. Unless "
     "an exact installed capability ID and its typed contract are already available, call "
     "math.find with a plain-language desired local mathematical outcome; no capability "
     "ID is required. math.run may execute a known contract directly. "
+    "For declaration queries explicitly targeting Jacobian's pinned CORE or MATHLIB "
+    "environment, use the pinned mathematical operation because repository search or "
+    "a local Lean process may not match that server environment. Project-local Lean "
+    "declarations are outside the server catalog and may require project-local tools. "
+    "Other uses include symbolic transformation, structural analysis, examples or "
+    "counterexamples, bounded search, Lean/Mathlib declaration search or formal-"
+    "environment inspection, and requested independent verification. "
     "Do not report that no specialized mathematical operation is available without "
     "checking math.find. When independent checking is requested, multiple calculations "
     "or programs authored by the same model are not independent checker evidence. "
@@ -47,6 +52,7 @@ Checker tools are separate IDs (often `*.verify`), not a switch on producers.
 Examples:
 - `{"request":{"op":"search","query":"exact matrix determinant","domain":"matrix","limit":3}}`
 - `{"request":{"op":"search","query":"counterexample to associativity"}}`
+- `{"request":{"op":"search","query":"find a theorem declaration in pinned Mathlib","domain":"lean"}}`
 - `{"request":{"op":"inspect","capability_id":"polynomial.compute.gcd"}}`
 """
 

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -150,18 +150,47 @@ class LeanDeclarationSearchAdapter:
         self.declarations = declarations
         self._descriptor = CapabilityDescriptor(
             capability_id="lean.declaration.search",
-            version="1",
-            title="Search Lean declarations",
+            version="2",
+            title="Search pinned Lean and Mathlib declarations",
             description=(
-                "Search a pinned Lean environment by a case-sensitive name substring "
-                "and/or exact constants occurring in elaborated declaration types."
+                "Find theorem, definition, and other declaration names directly in "
+                "the installed pinned Lean CORE or MATHLIB environment. Search by a "
+                "case-sensitive name substring and/or exact constants occurring in "
+                "elaborated declaration types; use this instead of shell-searching "
+                "local Mathlib source or caches. Results include portable pinned "
+                "Lean/Mathlib version and commit identity."
             ),
             provider="jacobian.lean4",
             provider_runtime=provider_runtime,
             input_schema=model_schema(LeanDeclarationSearchRequest),
             output_schema=model_schema(LeanDeclarationSearchOutput),
             read_only=True,
-            tags=("lean", "declaration", "retrieval", "premise-discovery"),
+            tags=(
+                "lean",
+                "mathlib",
+                "declaration",
+                "theorem-search",
+                "formal-environment",
+                "retrieval",
+                "premise-discovery",
+            ),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="find_sqrt_two_irrationality",
+                    description=(
+                        "Search pinned Mathlib for declarations whose name mentions "
+                        "irrational square root."
+                    ),
+                    input=LeanDeclarationSearchRequest.model_validate(
+                        {
+                            "environment": "MATHLIB",
+                            "name_contains": "irrational_sqrt",
+                            "kinds": ["THEOREM"],
+                            "result_limit": 10,
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property
@@ -191,19 +220,43 @@ class LeanDeclarationInspectAdapter:
         self.declarations = declarations
         self._descriptor = CapabilityDescriptor(
             capability_id="lean.declaration.inspect",
-            version="1",
-            title="Inspect a Lean declaration",
+            version="2",
+            title="Inspect an exact Lean or Mathlib declaration",
             description=(
-                "Resolve one exact declaration in a pinned Lean environment and "
-                "return its elaborated type, kind, docs, source metadata, and "
-                "environment digest."
+                "Resolve one exact fully qualified declaration name directly in the "
+                "installed pinned Lean CORE or MATHLIB environment. Return its "
+                "elaborated type, kind, docs, source metadata, environment digest, "
+                "and portable pinned Lean/Mathlib version and commit identity."
             ),
             provider="jacobian.lean4",
             provider_runtime=provider_runtime,
             input_schema=model_schema(LeanDeclarationInspectRequest),
             output_schema=model_schema(LeanDeclarationInspectOutput),
             read_only=True,
-            tags=("lean", "declaration", "retrieval", "inspection"),
+            tags=(
+                "lean",
+                "mathlib",
+                "declaration",
+                "theorem-inspection",
+                "formal-environment",
+                "retrieval",
+                "inspection",
+            ),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="inspect_sqrt_two_irrationality",
+                    description=(
+                        "Inspect the exact Mathlib declaration returned by declaration "
+                        "search."
+                    ),
+                    input=LeanDeclarationInspectRequest.model_validate(
+                        {
+                            "environment": "MATHLIB",
+                            "declaration_name": "irrational_sqrt_two",
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property

--- a/src/jacobian/checker_authorization.py
+++ b/src/jacobian/checker_authorization.py
@@ -202,6 +202,8 @@ def install_lean_checkers(
         )
         profiles[environment.value] = {
             "semantics_uri": semantics_uri,
+            "lean_version": lean_version,
+            "lean_commit": lean_commit,
             "import_name": import_name,
             "mathlib_commit": pinned_mathlib,
             "allowed_axioms": list(allowed_axioms),

--- a/src/jacobian/contracts/lean.py
+++ b/src/jacobian/contracts/lean.py
@@ -175,12 +175,42 @@ class LeanDeclarationTypePattern(ContractModel):
 
 
 class LeanDeclarationSearchRequest(ContractModel):
-    environment: LeanEnvironment = LeanEnvironment.CORE
-    name_contains: str | None = Field(default=None, min_length=1, max_length=256)
-    type_pattern: LeanDeclarationTypePattern | None = None
-    namespace_prefixes: tuple[str, ...] = Field(default=(), max_length=16)
-    kinds: tuple[LeanDeclarationKind, ...] = ()
-    result_limit: StrictInt = Field(default=10, ge=1, le=50)
+    environment: LeanEnvironment = Field(
+        default=LeanEnvironment.CORE,
+        description=(
+            "Pinned declaration environment to search; use MATHLIB for Mathlib "
+            "theorems and CORE for Lean's core declarations."
+        ),
+    )
+    name_contains: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description=(
+            "Case-sensitive substring of the fully qualified declaration name."
+        ),
+    )
+    type_pattern: LeanDeclarationTypePattern | None = Field(
+        default=None,
+        description=(
+            "Optional exact named constants that must all occur in the elaborated type."
+        ),
+    )
+    namespace_prefixes: tuple[str, ...] = Field(
+        default=(),
+        max_length=16,
+        description="Optional fully qualified namespace prefixes used as filters.",
+    )
+    kinds: tuple[LeanDeclarationKind, ...] = Field(
+        default=(),
+        description="Optional declaration-kind filters such as THEOREM or DEFINITION.",
+    )
+    result_limit: StrictInt = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Maximum declarations returned by the deterministic bounded scan.",
+    )
 
     @model_validator(mode="after")
     def require_query_and_distinct_filters(self) -> Self:
@@ -197,9 +227,25 @@ class LeanDeclarationSearchRequest(ContractModel):
         return self
 
 
-class LeanDeclarationSearchOutput(ContractModel):
+class LeanDeclarationEnvironmentIdentity(ContractModel):
+    """Portable pinned runtime identity attached to declaration results."""
+
     environment: LeanEnvironment
     environment_digest: Sha256Digest
+    lean_version: str = Field(min_length=1, max_length=64)
+    lean_commit: str = Field(min_length=7, max_length=64)
+    mathlib_commit: str | None = Field(default=None, min_length=7, max_length=64)
+
+    @model_validator(mode="after")
+    def bind_mathlib_commit_to_environment(self) -> Self:
+        if self.environment is LeanEnvironment.MATHLIB and self.mathlib_commit is None:
+            raise ValueError("MATHLIB declaration identity requires mathlib_commit")
+        if self.environment is LeanEnvironment.CORE and self.mathlib_commit is not None:
+            raise ValueError("CORE declaration identity cannot include mathlib_commit")
+        return self
+
+
+class LeanDeclarationSearchOutput(LeanDeclarationEnvironmentIdentity):
     query: LeanDeclarationSearchRequest
     declarations: tuple[LeanDeclarationRecord, ...]
     scanned_declarations: StrictInt = Field(ge=0)
@@ -240,8 +286,17 @@ class LeanDeclarationSearchOutput(ContractModel):
 
 
 class LeanDeclarationInspectRequest(ContractModel):
-    environment: LeanEnvironment = LeanEnvironment.CORE
-    declaration_name: str = Field(min_length=1, max_length=512)
+    environment: LeanEnvironment = Field(
+        default=LeanEnvironment.CORE,
+        description=(
+            "Pinned declaration environment containing the exact declaration name."
+        ),
+    )
+    declaration_name: str = Field(
+        min_length=1,
+        max_length=512,
+        description="Exact fully qualified Lean declaration name to inspect.",
+    )
 
     @model_validator(mode="after")
     def require_exact_name_text(self) -> Self:
@@ -249,9 +304,7 @@ class LeanDeclarationInspectRequest(ContractModel):
         return self
 
 
-class LeanDeclarationInspectOutput(ContractModel):
-    environment: LeanEnvironment
-    environment_digest: Sha256Digest
+class LeanDeclarationInspectOutput(LeanDeclarationEnvironmentIdentity):
     query: LeanDeclarationInspectRequest
     declaration: LeanDeclarationRecord
 

--- a/src/jacobian/contracts/lean_exploration.py
+++ b/src/jacobian/contracts/lean_exploration.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictBool, StrictInt, model_validator
+from pydantic import AfterValidator, Field, StrictBool, StrictInt, model_validator
 
 from jacobian.contracts.common import ArtifactUri, Sha256Digest
 from jacobian.contracts.lean import (
@@ -16,22 +17,79 @@ from jacobian.contracts.results import ContractModel
 LeanNormalizedGoal = Annotated[str, Field(min_length=1, max_length=20_000)]
 
 
+def _require_tactic_body(value: str) -> str:
+    if not value.strip():
+        raise ValueError("tactic bodies must be nonempty")
+    if re.match(r"^by(?:\s|$)", value.lstrip()):
+        raise ValueError(
+            "tactic bodies must not include `by`, the surrounding proof introducer"
+        )
+    return value
+
+
+LeanTacticBody = Annotated[
+    str,
+    Field(min_length=1, max_length=1_000),
+    AfterValidator(_require_tactic_body),
+]
+
+
 class LeanProofStateRequest(ContractModel):
-    state_uri: ArtifactUri | None = None
-    environment: LeanEnvironment = LeanEnvironment.CORE
-    statement: str | None = Field(default=None, min_length=1, max_length=2_000)
-    proof_prefix: tuple[str, ...] = Field(default=(), max_length=32)
-    tactic: str = Field(min_length=1, max_length=1_000)
-    max_goals: StrictInt = Field(default=32, ge=1, le=64)
-    max_local_declarations: StrictInt = Field(default=128, ge=1, le=256)
-    max_rendered_bytes: StrictInt = Field(default=65_536, ge=1_024, le=262_144)
+    state_uri: ArtifactUri | None = Field(
+        default=None,
+        description=(
+            "Continuation mode: an immutable successor state URI returned by an "
+            "earlier tactic transition. When supplied, omit statement and proof_prefix."
+        ),
+    )
+    environment: LeanEnvironment = Field(
+        default=LeanEnvironment.CORE,
+        description=(
+            "Pinned Lean environment. It must match the bound state in continuation "
+            "mode."
+        ),
+    )
+    statement: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=2_000,
+        description=(
+            "Fresh mode: one proposition expression to prove. Required when state_uri "
+            "is omitted and forbidden in continuation mode."
+        ),
+    )
+    proof_prefix: tuple[LeanTacticBody, ...] = Field(
+        default=(),
+        max_length=32,
+        description=(
+            "Fresh-mode tactic bodies already applied after Lean's `by`. Do not "
+            "include `by`; omit this field in continuation mode."
+        ),
+    )
+    tactic: LeanTacticBody = Field(
+        description="Exactly one next tactic body to apply; do not include `by`."
+    )
+    max_goals: StrictInt = Field(
+        default=32,
+        ge=1,
+        le=64,
+        description="Maximum successor goals returned by the typed state extractor.",
+    )
+    max_local_declarations: StrictInt = Field(
+        default=128,
+        ge=1,
+        le=256,
+        description="Maximum local declarations returned across one typed goal.",
+    )
+    max_rendered_bytes: StrictInt = Field(
+        default=65_536,
+        ge=1_024,
+        le=262_144,
+        description="Maximum rendered bytes returned by typed goal extraction.",
+    )
 
     @model_validator(mode="after")
     def require_one_state_source_and_bounded_prefix(self) -> Self:
-        if any(
-            not tactic.strip() or len(tactic) > 1_000 for tactic in self.proof_prefix
-        ):
-            raise ValueError("proof-prefix tactics must be nonempty and bounded")
         if self.state_uri is None and self.statement is None:
             raise ValueError("statement is required when state_uri is omitted")
         if self.state_uri is not None and (
@@ -148,18 +206,29 @@ class LeanProofStateOutput(LeanProofStateTransitionArtifact):
 
 
 class LeanPremiseRetrievalRequest(ContractModel):
-    environment: Literal["MATHLIB"] = "MATHLIB"
-    statement: str = Field(min_length=1, max_length=2_000)
-    proof_prefix: tuple[str, ...] = Field(default=(), max_length=32)
-    limit: int = Field(default=5, ge=1, le=20)
-
-    @model_validator(mode="after")
-    def require_bounded_prefix(self) -> Self:
-        if any(
-            not tactic.strip() or len(tactic) > 1_000 for tactic in self.proof_prefix
-        ):
-            raise ValueError("proof-prefix tactics must be nonempty and bounded")
-        return self
+    environment: Literal["MATHLIB"] = Field(
+        default="MATHLIB",
+        description="Premise retrieval is available only in the pinned MATHLIB profile.",
+    )
+    statement: str = Field(
+        min_length=1,
+        max_length=2_000,
+        description="One Lean proposition expression whose current goal needs a premise.",
+    )
+    proof_prefix: tuple[LeanTacticBody, ...] = Field(
+        default=(),
+        max_length=32,
+        description=(
+            "Tactic bodies already applied after Lean's `by`, for example "
+            "[`intro x`]. Do not include `by`."
+        ),
+    )
+    limit: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum non-exhaustive Mathlib exact? candidates to return.",
+    )
 
 
 class LeanPremiseCandidate(ContractModel):

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -337,6 +337,7 @@ def _record_describe_and_attempt(
     arguments: object,
     *,
     successful: bool,
+    response: Mapping[str, Any] | None,
 ) -> None:
     if tool == "math.find":
         request = arguments.get("request") if isinstance(arguments, Mapping) else None
@@ -350,23 +351,104 @@ def _record_describe_and_attempt(
         arguments.get("capability_id") if isinstance(arguments, Mapping) else None
     )
     payload = arguments.get("payload") if isinstance(arguments, Mapping) else None
-    telemetry.capability_attempts.append(
-        {
-            "capability_id": capability_id if isinstance(capability_id, str) else None,
-            "input": payload,
-            "successful": successful,
-        }
-    )
+    attempt = {
+        "capability_id": capability_id if isinstance(capability_id, str) else None,
+        "input": payload,
+        "successful": successful,
+    }
+    diagnostic_codes = _capability_diagnostic_codes(response)
+    if diagnostic_codes:
+        attempt["diagnostic_codes"] = diagnostic_codes
+    diagnostics = _capability_diagnostics(response)
+    if diagnostics:
+        attempt["diagnostics"] = diagnostics
+    telemetry.capability_attempts.append(attempt)
     if isinstance(capability_id, str):
         telemetry.capability_attempt_ids.append(capability_id)
+
+
+def _capability_diagnostic_codes(
+    response: Mapping[str, Any] | None,
+) -> list[str]:
+    if not isinstance(response, Mapping):
+        return []
+    codes: list[str] = []
+    diagnostics = response.get("diagnostics")
+    if isinstance(diagnostics, list):
+        codes.extend(
+            diagnostic["code"]
+            for diagnostic in diagnostics
+            if isinstance(diagnostic, Mapping)
+            and isinstance(diagnostic.get("code"), str)
+        )
+    output = response.get("output")
+    error = output.get("error") if isinstance(output, Mapping) else None
+    if isinstance(error, Mapping) and isinstance(error.get("code"), str):
+        codes.append(error["code"])
+    return list(dict.fromkeys(codes))
+
+
+def _bounded_capability_diagnostic(diagnostic: Mapping[str, Any]) -> dict[str, Any]:
+    retained = {
+        key: diagnostic[key]
+        for key in ("code", "phase", "stage", "path")
+        if isinstance(diagnostic.get(key), str)
+    }
+    details = diagnostic.get("details")
+    validation_errors = (
+        details.get("validation_errors") if isinstance(details, Mapping) else None
+    )
+    if isinstance(validation_errors, list):
+        retained_errors = [
+            {
+                key: error[key]
+                for key in ("path", "reason", "type")
+                if isinstance(error.get(key), str)
+            }
+            for error in validation_errors
+            if isinstance(error, Mapping)
+        ]
+        if retained_errors:
+            retained["details"] = {"validation_errors": retained_errors}
+    return retained
+
+
+def _capability_diagnostics(
+    response: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(response, Mapping):
+        return []
+    candidates: list[Mapping[str, Any]] = []
+    diagnostics = response.get("diagnostics")
+    if isinstance(diagnostics, list):
+        candidates.extend(
+            diagnostic for diagnostic in diagnostics if isinstance(diagnostic, Mapping)
+        )
+    output = response.get("output")
+    error = output.get("error") if isinstance(output, Mapping) else None
+    if isinstance(error, Mapping):
+        candidates.append(error)
+    retained: list[dict[str, Any]] = []
+    seen: set[bytes] = set()
+    for candidate in candidates:
+        bounded = _bounded_capability_diagnostic(candidate)
+        if not isinstance(bounded.get("code"), str):
+            continue
+        identity = canonicalize_json(bounded)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        retained.append(bounded)
+    return retained
 
 
 def _mcp_call_failed(
     item: Mapping[str, Any],
     result: object,
-    text_response: Mapping[str, Any] | None,
+    response: Mapping[str, Any] | None,
     status: object,
 ) -> bool:
+    execution = response.get("execution") if isinstance(response, Mapping) else None
     return bool(
         (isinstance(status, str) and status in {"error", "failed"})
         or item.get("error")
@@ -375,8 +457,11 @@ def _mcp_call_failed(
             and (result.get("isError") is True or result.get("is_error") is True)
         )
         or (
-            isinstance(text_response, Mapping)
-            and isinstance(text_response.get("error"), Mapping)
+            isinstance(response, Mapping) and isinstance(response.get("error"), Mapping)
+        )
+        or (
+            isinstance(execution, Mapping)
+            and execution.get("status") in {"CANCELLED", "ERROR", "TIMEOUT"}
         )
         or _contains_value(
             item,
@@ -489,12 +574,13 @@ def _process_mcp_tool_call(
     result = item.get("result")
     response = structured_response or text_response
     status = item.get("status")
-    failed = _mcp_call_failed(item, result, text_response, status)
+    failed = _mcp_call_failed(item, result, response, status)
     _record_describe_and_attempt(
         telemetry,
         tool,
         arguments,
         successful=not failed,
+        response=response,
     )
     if failed:
         telemetry.tool_error_count += 1

--- a/src/jacobian/lean_frontend/declaration_protocol.py
+++ b/src/jacobian/lean_frontend/declaration_protocol.py
@@ -136,6 +136,9 @@ class LeanDeclarationErrorEnvelope(ContractModel):
 
 class LeanDeclarationBackendResult(ContractModel):
     environment_digest: Sha256Digest
+    lean_version: StrictStr = Field(min_length=1, max_length=64)
+    lean_commit: StrictStr = Field(min_length=7, max_length=64)
+    mathlib_commit: StrictStr | None = Field(default=None, min_length=7, max_length=64)
     payload: LeanDeclarationDiscriminatedPayload
 
 

--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -473,6 +473,9 @@ class LeanSubprocessDeclarationBackend:
     ) -> LeanDeclarationBackendResult:
         with self._session_locks[environment]:
             environment_digest = self.environment_digest(environment)
+            lean_version, lean_commit, mathlib_commit = self._runtime_identity(
+                environment
+            )
             entry = self._resolve_session(environment, environment_digest)
             output = self._execute_session_request(
                 environment,
@@ -483,8 +486,40 @@ class LeanSubprocessDeclarationBackend:
             self._validate_session_unchanged(environment, environment_digest)
             return LeanDeclarationBackendResult(
                 environment_digest=environment_digest,
+                lean_version=lean_version,
+                lean_commit=lean_commit,
+                mathlib_commit=mathlib_commit,
                 payload=output,
             )
+
+    def _runtime_identity(
+        self,
+        environment: LeanEnvironment,
+    ) -> tuple[str, str, str | None]:
+        profiles = self.provider_runtime.configuration.get("profiles")
+        profile = (
+            profiles.get(environment.value) if isinstance(profiles, dict) else None
+        )
+        lean_version = self.provider_runtime.version
+        lean_commit = profile.get("lean_commit") if isinstance(profile, dict) else None
+        mathlib_commit = (
+            profile.get("mathlib_commit") if isinstance(profile, dict) else None
+        )
+        if not isinstance(lean_version, str) or not isinstance(lean_commit, str):
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_UNAVAILABLE",
+                "The pinned Lean runtime identity is incomplete.",
+            )
+        if environment is LeanEnvironment.MATHLIB and not isinstance(
+            mathlib_commit, str
+        ):
+            raise LeanDeclarationBackendError(
+                "LEAN_ENVIRONMENT_UNAVAILABLE",
+                "The pinned Mathlib runtime identity is incomplete.",
+            )
+        if environment is LeanEnvironment.CORE:
+            mathlib_commit = None
+        return lean_version, lean_commit, mathlib_commit
 
     def close(self) -> None:
         """Terminate all active query sessions."""
@@ -665,6 +700,9 @@ class LeanDeclarationService:
             return LeanDeclarationSearchOutput(
                 environment=query.environment,
                 environment_digest=result.environment_digest,
+                lean_version=result.lean_version,
+                lean_commit=result.lean_commit,
+                mathlib_commit=result.mathlib_commit,
                 query=query,
                 declarations=payload.declarations,
                 scanned_declarations=payload.scanned_declarations,
@@ -693,6 +731,9 @@ class LeanDeclarationService:
             return LeanDeclarationInspectOutput(
                 environment=query.environment,
                 environment_digest=result.environment_digest,
+                lean_version=result.lean_version,
+                lean_commit=result.lean_commit,
+                mathlib_commit=result.mathlib_commit,
                 query=query,
                 declaration=payload.declaration,
             )

--- a/src/jacobian/lean_frontend/exploration.py
+++ b/src/jacobian/lean_frontend/exploration.py
@@ -21,6 +21,7 @@ from jacobian.canonical import (
 )
 from jacobian.checker_authorization import LeanCheckerInstallation
 from jacobian.contracts.capabilities import (
+    CapabilityDiagnostic,
     CapabilityProviderRuntime,
 )
 from jacobian.contracts.lean import (
@@ -242,6 +243,53 @@ def _validate_source_parts(statement: str, tactics: tuple[str, ...]) -> None:
     for tactic in tactics:
         if "\x00" in tactic or _FORBIDDEN.search(tactic):
             raise ValueError("tactic contains a forbidden command")
+
+
+def _request_validation_diagnostic(
+    error: ValidationError | ValueError,
+    *,
+    code: str,
+    subject: str,
+    hint: str,
+) -> CapabilityDiagnostic:
+    """Project bounded Pydantic/source-validation evidence for Lean requests."""
+
+    if isinstance(error, ValidationError):
+        validation_errors = []
+        for item in error.errors(
+            include_url=False,
+            include_context=False,
+            include_input=False,
+        ):
+            location = item.get("loc", ())
+            path = ".".join(str(part) for part in location) or "$"
+            reason = str(item.get("msg", "invalid value"))
+            if reason.startswith("Value error, "):
+                reason = reason.removeprefix("Value error, ")
+            validation_errors.append(
+                {
+                    "path": path[:512],
+                    "reason": reason[:500],
+                    "type": str(item.get("type", "value_error"))[:128],
+                }
+            )
+    else:
+        validation_errors = [
+            {
+                "path": "$",
+                "reason": str(error)[:500],
+                "type": "value_error",
+            }
+        ]
+    first = validation_errors[0]
+    return CapabilityDiagnostic(
+        code=code,
+        stage="request_validation",
+        message=f"{subject}: {first['reason']}",
+        path=first["path"],
+        hint=hint,
+        details={"validation_errors": validation_errors},
+    )
 
 
 def _normalized_response_goals(

--- a/src/jacobian/lean_frontend/premise_retrieval.py
+++ b/src/jacobian/lean_frontend/premise_retrieval.py
@@ -12,6 +12,7 @@ from jacobian.capability_service import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
+    CapabilityInvocationExample,
     CapabilityRequest,
     CapabilityResult,
 )
@@ -27,6 +28,7 @@ from jacobian.lean_frontend.artifacts import _proof_state_command
 from jacobian.lean_frontend.exploration import (
     _DECLARATION,
     _SUGGESTION,
+    _request_validation_diagnostic,
     _Resources,
     _response_messages,
     _run_repl,
@@ -45,14 +47,34 @@ class LeanPremiseRetrievalAdapter:
             version="2",
             title="Retrieve Lean premises",
             description=(
-                "Ask pinned Mathlib exact? for bounded candidate tactics at one "
-                "explicit proof prefix; an empty result is non-exhaustive."
+                "Retrieve bounded premise-backed tactic candidates for one explicit "
+                "statement and tactic-body prefix with pinned Mathlib's `exact?` "
+                "tactic. "
+                "proof_prefix contains only tactics after `by` (for example "
+                "[`intro x`]); never include `by`. Each candidate reports whether "
+                "the first tactic replayed, and an empty result is non-exhaustive."
             ),
             provider="jacobian.lean4",
             provider_runtime=resources.provider_runtime,
             input_schema=LeanPremiseRetrievalRequest.model_json_schema(),
             output_schema=LeanPremiseRetrievalOutput.model_json_schema(),
             tags=("lean", "mathlib", "premise-retrieval", "exploration"),
+            invocation_examples=(
+                CapabilityInvocationExample(
+                    name="square_nonnegative_after_intro",
+                    description=(
+                        "Ask Mathlib exact? for a premise after introducing x; "
+                        "proof_prefix omits the surrounding `by`."
+                    ),
+                    input=LeanPremiseRetrievalRequest.model_validate(
+                        {
+                            "statement": "∀ x : Real, x ^ 2 ≥ 0",
+                            "proof_prefix": ["intro x"],
+                            "limit": 5,
+                        }
+                    ).model_dump(mode="json"),
+                ),
+            ),
         )
 
     @property
@@ -65,10 +87,14 @@ class LeanPremiseRetrievalAdapter:
             _validate_source_parts(validated.statement, validated.proof_prefix)
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
-                CapabilityDiagnostic(
+                _request_validation_diagnostic(
+                    exc,
                     code="INVALID_LEAN_RETRIEVAL_REQUEST",
-                    stage="request_validation",
-                    message="The Lean premise-retrieval request is invalid.",
+                    subject="The Lean premise-retrieval request is invalid",
+                    hint=(
+                        "Use one proposition and a bounded sequence of tactic bodies "
+                        "after `by`; do not include the `by` introducer."
+                    ),
                 )
             ) from exc
         started = time.monotonic()
@@ -78,12 +104,27 @@ class LeanPremiseRetrievalAdapter:
             statement=validated.statement,
             proof_prefix=validated.proof_prefix,
         )
-        command_response, tactic_response = _run_repl(
-            self.resources,
-            command=command,
-            tactic="exact?",
-            environment=environment,
-        )
+        try:
+            command_response, tactic_response = _run_repl(
+                self.resources,
+                command=command,
+                tactic="exact?",
+                environment=environment,
+            )
+        except RuntimeError as exc:
+            raw_backend_message = str(exc)[:1_000]
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="LEAN_RETRIEVAL_FAILED",
+                    stage="premise_retrieval",
+                    message="Pinned Mathlib premise retrieval did not return a result.",
+                    hint=(
+                        "Inspect raw_backend_message, correct the statement or tactic "
+                        "prefix when applicable, and retry."
+                    ),
+                    details={"raw_backend_message": raw_backend_message},
+                )
+            ) from exc
         command_errors = _response_errors(command_response)
         tactic_errors = _response_errors(tactic_response)
         if command_errors:

--- a/src/jacobian/lean_frontend/proof_state.py
+++ b/src/jacobian/lean_frontend/proof_state.py
@@ -36,6 +36,7 @@ from jacobian.lean_frontend.artifacts import (
 )
 from jacobian.lean_frontend.exploration import (
     _normalized_response_goals,
+    _request_validation_diagnostic,
     _Resources,
     _runtime_ms,
     _tactic_diagnostics,
@@ -56,10 +57,13 @@ class LeanProofStateAdapter:
             version="3",
             title="Apply one Lean tactic and inspect resulting goals",
             description=(
-                "Reconstruct and validate an immutable proof state in a clean "
-                "Lean process, apply exactly one tactic, and return typed goals plus "
-                "a durable successor state. Tactic failures return stable repair "
-                "diagnostics, a goal index, and payload-relative source spans."
+                "Apply exactly one tactic in either fresh mode "
+                "(statement plus optional proof_prefix) or continuation mode "
+                "(state_uri plus tactic). Continuation requests must omit statement "
+                "and proof_prefix. A clean Lean process reconstructs the immutable "
+                "state and returns typed goals plus a durable successor state. "
+                "Tactic failures return stable repair diagnostics, a goal index, "
+                "and payload-relative source spans."
             ),
             provider="jacobian.lean4",
             provider_runtime=resources.provider_runtime,
@@ -91,6 +95,23 @@ class LeanProofStateAdapter:
                         }
                     ).model_dump(mode="json"),
                 ),
+                CapabilityInvocationExample(
+                    name="continue_returned_state",
+                    description=(
+                        "Continue an immutable successor state using only its URI, "
+                        "the matching environment, and one tactic."
+                    ),
+                    input=LeanProofStateRequest.model_validate(
+                        {
+                            "environment": "CORE",
+                            "state_uri": "artifact://sha256/" + "a" * 64,
+                            "tactic": "rfl",
+                        }
+                    ).model_dump(
+                        mode="json",
+                        exclude={"statement", "proof_prefix"},
+                    ),
+                ),
             ),
         )
 
@@ -111,13 +132,14 @@ class LeanProofStateAdapter:
                 _validate_source_parts("True", (validated.tactic,))
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
-                CapabilityDiagnostic(
+                _request_validation_diagnostic(
+                    exc,
                     code="INVALID_LEAN_TRANSITION_REQUEST",
-                    stage="request_validation",
-                    message="The Lean statement or tactic sequence is invalid.",
+                    subject="The Lean proof-state transition request is invalid",
                     hint=(
-                        "Use one proposition and bounded tactic bodies without "
-                        "commands, imports, declarations, sorry, or run_tac."
+                        "For a fresh state use environment, statement, optional "
+                        "proof_prefix, and tactic. For a continuation use only the "
+                        "returned state_uri, matching environment, and tactic."
                     ),
                 )
             ) from exc

--- a/src/jacobian/providers/lean_runtime.py
+++ b/src/jacobian/providers/lean_runtime.py
@@ -340,7 +340,9 @@ def lean_frontend_provider_runtime() -> CapabilityProviderRuntime:
             "profiles": {
                 "CORE": {
                     "import_name": "Init.Prelude",
+                    "lean_version": lean4.LEAN_VERSION,
                     "lean_commit": lean4.LEAN_COMMIT,
+                    "mathlib_commit": None,
                 }
             },
         },

--- a/tests/boundary/providers/lean/test_lean_replayable_state_capability.py
+++ b/tests/boundary/providers/lean/test_lean_replayable_state_capability.py
@@ -341,3 +341,48 @@ def test_apply_tactic_rejects_environment_stale_state_before_replay(
         )
 
     assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"
+
+
+def test_apply_tactic_preserves_cross_field_validation_evidence(tmp_path: Path) -> None:
+    adapter = _adapter(tmp_path)
+    continuation = adapter.descriptor.invocation_examples[1].input
+    assert set(continuation) == {
+        "environment",
+        "state_uri",
+        "tactic",
+        "max_goals",
+        "max_local_declarations",
+        "max_rendered_bytes",
+    }
+    assert "statement" not in continuation
+    assert "proof_prefix" not in continuation
+
+    with pytest.raises(CapabilityInvocationError) as raised:
+        adapter.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.apply_tactic",
+                input={
+                    "environment": "CORE",
+                    "state_uri": "artifact://sha256/" + "a" * 64,
+                    "statement": "True",
+                    "proof_prefix": ["skip"],
+                    "tactic": "trivial",
+                },
+            )
+        )
+
+    diagnostic = raised.value.diagnostic
+    assert diagnostic.code == "INVALID_LEAN_TRANSITION_REQUEST"
+    assert diagnostic.stage == "request_validation"
+    assert diagnostic.path == "$"
+    assert (
+        "state_uri cannot be combined with statement or proof_prefix"
+        in diagnostic.message
+    )
+    assert diagnostic.details["validation_errors"] == [
+        {
+            "path": "$",
+            "reason": "state_uri cannot be combined with statement or proof_prefix",
+            "type": "value_error",
+        }
+    ]

--- a/tests/component/providers/lean/test_lean_declaration_adapters.py
+++ b/tests/component/providers/lean/test_lean_declaration_adapters.py
@@ -49,6 +49,20 @@ _RUNTIME = CapabilityProviderRuntime(
     install_tier=CapabilityInstallTier.T3,
     license_id="Apache-2.0",
     features=("CORE", "MATHLIB"),
+    configuration={
+        "profiles": {
+            "CORE": {
+                "lean_version": "4.31.0",
+                "lean_commit": "lean-commit",
+                "mathlib_commit": None,
+            },
+            "MATHLIB": {
+                "lean_version": "4.31.0",
+                "lean_commit": "lean-commit",
+                "mathlib_commit": "mathlib-commit",
+            },
+        }
+    },
 )
 
 
@@ -71,6 +85,11 @@ class FakeBackend(LeanDeclarationBackend):
         ).payload
         return LeanDeclarationBackendResult(
             environment_digest=_DIGEST,
+            lean_version="4.31.0",
+            lean_commit="lean-commit",
+            mathlib_commit=(
+                "mathlib-commit" if environment is LeanEnvironment.MATHLIB else None
+            ),
             payload=payload,
         )
 
@@ -114,6 +133,10 @@ def test_search_adapter_exposes_bounded_computed_retrieval() -> None:
         }
     )
     adapter = LeanDeclarationSearchAdapter(LeanDeclarationService(backend), _RUNTIME)
+    assert adapter.descriptor.invocation_examples[0].input["name_contains"] == (
+        "irrational_sqrt"
+    )
+    assert "shell-searching" in adapter.descriptor.description
     result = adapter.invoke(
         CapabilityRequest(
             capability_id="lean.declaration.search",
@@ -125,6 +148,9 @@ def test_search_adapter_exposes_bounded_computed_retrieval() -> None:
         )
     )
     assert result.output["environment_digest"] == _DIGEST
+    assert result.output["lean_version"] == "4.31.0"
+    assert result.output["lean_commit"] == "lean-commit"
+    assert result.output["mathlib_commit"] == "mathlib-commit"
     assert result.output["declarations"][0]["name"] == "irrational_sqrt_two"
     assert backend.calls[0][1] == LeanDeclarationSearchQuery(
         name_contains="irrational_sqrt_two",
@@ -152,6 +178,9 @@ def test_inspect_adapter_returns_docs_without_promoting_the_theorem() -> None:
         }
     )
     adapter = LeanDeclarationInspectAdapter(LeanDeclarationService(backend), _RUNTIME)
+    assert adapter.descriptor.invocation_examples[0].input["declaration_name"] == (
+        "irrational_sqrt_two"
+    )
     result = adapter.invoke(
         CapabilityRequest(
             capability_id="lean.declaration.inspect",
@@ -160,6 +189,9 @@ def test_inspect_adapter_returns_docs_without_promoting_the_theorem() -> None:
     )
     assert result.output["declaration"]["docstring"].startswith("Addition")
     assert result.output["environment_digest"] == _DIGEST
+    assert result.output["lean_version"] == "4.31.0"
+    assert result.output["lean_commit"] == "lean-commit"
+    assert result.output["mathlib_commit"] is None
 
 
 def test_dependency_adapter_exposes_partial_typed_subgraph(tmp_path: Path) -> None:

--- a/tests/component/providers/lean/test_lean_declaration_sessions.py
+++ b/tests/component/providers/lean/test_lean_declaration_sessions.py
@@ -46,6 +46,20 @@ _RUNTIME = CapabilityProviderRuntime(
     install_tier=CapabilityInstallTier.T3,
     license_id="Apache-2.0",
     features=("CORE", "MATHLIB"),
+    configuration={
+        "profiles": {
+            "CORE": {
+                "lean_version": "4.31.0",
+                "lean_commit": "lean-commit",
+                "mathlib_commit": None,
+            },
+            "MATHLIB": {
+                "lean_version": "4.31.0",
+                "lean_commit": "lean-commit",
+                "mathlib_commit": "mathlib-commit",
+            },
+        }
+    },
 )
 
 

--- a/tests/component/providers/lean/test_lean_exploration_fail_closed.py
+++ b/tests/component/providers/lean/test_lean_exploration_fail_closed.py
@@ -17,6 +17,7 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.contracts.lean_exploration import LeanProofStateRequest
 from jacobian.lean_frontend.exploration import _resolve_typed_goal_helper, _Resources
+from jacobian.lean_frontend.premise_retrieval import LeanPremiseRetrievalAdapter
 from jacobian.lean_frontend.proof_state import LeanProofStateAdapter
 from jacobian.lean_frontend.repl import _single_proof_state
 from jacobian.lean_frontend.repl_protocol import (
@@ -165,3 +166,107 @@ def test_single_proof_state_raises_with_lean_errors() -> None:
 
     with pytest.raises(RuntimeError, match=r"unknown identifier.*type mismatch"):
         _single_proof_state(response)
+
+
+def test_premise_retrieval_rejects_by_prefix_before_starting_lean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = CapabilityProviderRuntime(
+        provider="jacobian.lean4",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="4.31.0",
+        digest="sha256:" + "a" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="test",
+        install_tier=CapabilityInstallTier.T3,
+        license_id="Apache-2.0",
+    )
+    resources = cast(
+        _Resources,
+        SimpleNamespace(provider_runtime=runtime),
+    )
+
+    def unexpected_repl(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("invalid proof prefixes must not start Lean")
+
+    monkeypatch.setattr(
+        "jacobian.lean_frontend.premise_retrieval._run_repl",
+        unexpected_repl,
+    )
+
+    adapter = LeanPremiseRetrievalAdapter(resources)
+    example = adapter.descriptor.invocation_examples[0].input
+    assert example["proof_prefix"] == ["intro x"]
+    assert adapter.descriptor.input_schema["properties"]["proof_prefix"][
+        "description"
+    ].endswith("Do not include `by`.")
+
+    with pytest.raises(CapabilityInvocationError) as error:
+        adapter.invoke(
+            CapabilityRequest(
+                capability_id="lean.retrieve.premises",
+                input={
+                    "environment": "MATHLIB",
+                    "statement": "∀ x : Real, x ^ 2 ≥ 0",
+                    "proof_prefix": ["by", "intro x"],
+                },
+            )
+        )
+
+    diagnostic = error.value.diagnostic
+    assert diagnostic.code == "INVALID_LEAN_RETRIEVAL_REQUEST"
+    assert diagnostic.stage == "request_validation"
+    assert diagnostic.path == "proof_prefix.0"
+    assert "must not include `by`" in diagnostic.message
+    assert diagnostic.details["validation_errors"][0]["path"] == "proof_prefix.0"
+
+
+def test_premise_retrieval_maps_repl_runtime_failure_to_domain_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = CapabilityProviderRuntime(
+        provider="jacobian.lean4",
+        availability=CapabilityProviderAvailability.AVAILABLE,
+        version="4.31.0",
+        digest="sha256:" + "a" * 64,
+        digest_kind=CapabilityProviderDigestKind.EXECUTABLE,
+        platform="test",
+        install_tier=CapabilityInstallTier.T3,
+        license_id="Apache-2.0",
+    )
+    resources = cast(
+        _Resources,
+        SimpleNamespace(
+            provider_runtime=runtime,
+            installations={
+                LeanEnvironment.MATHLIB: SimpleNamespace(
+                    lean_version="4.31.0",
+                    lean_commit="lean-commit",
+                    mathlib_commit="mathlib-commit",
+                )
+            },
+        ),
+    )
+
+    def fail_repl(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("Lean did not expose one replayable proof state")
+
+    monkeypatch.setattr(
+        "jacobian.lean_frontend.premise_retrieval._run_repl",
+        fail_repl,
+    )
+
+    with pytest.raises(CapabilityInvocationError) as error:
+        LeanPremiseRetrievalAdapter(resources).invoke(
+            CapabilityRequest(
+                capability_id="lean.retrieve.premises",
+                input={"statement": "True"},
+            )
+        )
+
+    diagnostic = error.value.diagnostic
+    assert diagnostic.code == "LEAN_RETRIEVAL_FAILED"
+    assert diagnostic.stage == "premise_retrieval"
+    assert diagnostic.details["raw_backend_message"] == (
+        "Lean did not expose one replayable proof state"
+    )

--- a/tests/unit/contracts/test_lean_declaration_contracts.py
+++ b/tests/unit/contracts/test_lean_declaration_contracts.py
@@ -116,6 +116,8 @@ def test_search_stop_reason_and_match_reasons_bind_the_query() -> None:
         LeanDeclarationSearchOutput(
             environment="CORE",
             environment_digest="sha256:" + "a" * 64,
+            lean_version="4.31.0",
+            lean_commit="lean-commit",
             query=query,
             declarations=(
                 {
@@ -133,6 +135,8 @@ def test_search_stop_reason_and_match_reasons_bind_the_query() -> None:
         LeanDeclarationSearchOutput(
             environment="CORE",
             environment_digest="sha256:" + "a" * 64,
+            lean_version="4.31.0",
+            lean_commit="lean-commit",
             query=query,
             declarations=(
                 {

--- a/tests/unit/contracts/test_lean_exploration_contracts.py
+++ b/tests/unit/contracts/test_lean_exploration_contracts.py
@@ -10,6 +10,7 @@ from jacobian.contracts.lean import (
     LeanDiagnosticSourceSpan,
 )
 from jacobian.contracts.lean_exploration import (
+    LeanPremiseRetrievalRequest,
     LeanProofStateRequest,
     LeanProofStateTransitionArtifact,
 )
@@ -24,6 +25,37 @@ def test_proof_state_request_has_hard_structured_output_bounds() -> None:
             tactic="trivial",
             max_local_declarations=257,
         )
+
+
+@pytest.mark.parametrize(
+    "request_model",
+    [
+        LeanProofStateRequest,
+        LeanPremiseRetrievalRequest,
+    ],
+)
+def test_proof_prefix_is_the_tactic_body_after_by(request_model: type[object]) -> None:
+    payload = {
+        "statement": "True",
+        "proof_prefix": ["by", "trivial"],
+    }
+    if request_model is LeanProofStateRequest:
+        payload["tactic"] = "trivial"
+
+    with pytest.raises(ValidationError, match="must not include `by`"):
+        request_model.model_validate(payload)  # type: ignore[attr-defined]
+
+
+def test_lean_exploration_request_schemas_explain_fresh_and_continuation_modes() -> (
+    None
+):
+    state_schema = LeanProofStateRequest.model_json_schema()["properties"]
+    premise_schema = LeanPremiseRetrievalRequest.model_json_schema()["properties"]
+
+    assert "continuation" in state_schema["state_uri"]["description"].lower()
+    assert "fresh" in state_schema["statement"]["description"].lower()
+    assert "Do not include `by`" in state_schema["proof_prefix"]["description"]
+    assert "Do not include `by`" in premise_schema["proof_prefix"]["description"]
 
 
 def test_transition_binds_rendered_and_typed_goal_counts() -> None:

--- a/tests/unit/contracts/test_provider_runtime.py
+++ b/tests/unit/contracts/test_provider_runtime.py
@@ -443,6 +443,13 @@ def test_lean_frontend_runtime_binds_the_pinned_executable(
     assert runtime.features == ("CORE", "elaboration", "lean-statement")
     assert runtime.configuration["executable"] == str(executable)
     assert runtime.configuration["profiles"]["CORE"]["import_name"] == "Init.Prelude"
+    assert runtime.configuration["profiles"]["CORE"]["lean_version"] == (
+        lean4.LEAN_VERSION
+    )
+    assert runtime.configuration["profiles"]["CORE"]["lean_commit"] == (
+        lean4.LEAN_COMMIT
+    )
+    assert runtime.configuration["profiles"]["CORE"]["mathlib_commit"] is None
 
 
 def test_lean_frontend_runtime_preserves_actionable_probe_diagnostic(

--- a/tests/unit/eval/test_lean_diagnostic_recovery.py
+++ b/tests/unit/eval/test_lean_diagnostic_recovery.py
@@ -327,7 +327,7 @@ def test_recovery_suite_freezes_control_treatment_and_injected_cases() -> None:
         "control",
         "enriched-diagnostics",
     }
-    assert len(suite.cases) == 3
+    assert len(suite.cases) == 5
     assert any("MATHLIB" in case.prompt for case in suite.cases)
     assert suite.cases[0].terminal_immutable_input_fields == (
         "statement",
@@ -338,7 +338,344 @@ def test_recovery_suite_freezes_control_treatment_and_injected_cases() -> None:
         "statement",
         "original_proof",
     )
+    premise_probe = suite.cases[3].diagnostic_probe
+    assert premise_probe is not None
+    assert premise_probe.capability_id == "lean.retrieve.premises"
+    assert premise_probe.expected_diagnostic_evidence.path == "proof_prefix.0"
+    assert suite.cases[4].expected_diagnostic_evidence is not None
+    assert suite.cases[4].expected_diagnostic_evidence.path == "$"
+    assert suite.cases[4].expected_diagnostic_evidence.validation_error_paths == ("$",)
     assert suite.causal_claim_authorized is False
+
+
+def test_recovery_classifies_failed_request_diagnostic_before_verified_repair() -> None:
+    case = load_suite(SUITE).cases[3]
+    probe = case.diagnostic_probe
+    assert probe is not None
+    terminal_input = {
+        "environment": case.injected_payload["environment"],
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  intro x\n  exact sq_nonneg x",
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": probe.capability_id,
+                    "input": probe.payload,
+                    "successful": False,
+                    "diagnostic_codes": ["INVALID_LEAN_RETRIEVAL_REQUEST"],
+                    "diagnostics": [
+                        {
+                            "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                            "path": "proof_prefix.0",
+                            "details": {
+                                "validation_errors": [
+                                    {
+                                        "path": "proof_prefix.0",
+                                        "reason": "must not include by",
+                                        "type": "value_error",
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                },
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": True,
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "successful": True,
+                },
+            ],
+            "capability_invocations": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "output": {
+                        "conclusion": "UNKNOWN",
+                        "diagnostics": [
+                            {
+                                "code": "LEAN_UNKNOWN_IDENTIFIER",
+                                "phase": "KERNEL_CHECK",
+                            }
+                        ],
+                    },
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "output": {"conclusion": "TRUE"},
+                    "verification_record_uri": ("artifact://sha256/" + "a" * 64),
+                },
+            ],
+            "mcp_calls": ["math.run", "math.run", "math.run"],
+        },
+    )
+
+    assert result["injection_rejected"] is True
+    assert result["observed_diagnostic_codes"] == ["LEAN_UNKNOWN_IDENTIFIER"]
+    assert result["enriched_diagnostic_observed"] is True
+    assert result["repair_success"] is True
+
+
+def test_premise_probe_does_not_bias_control_repair_classification() -> None:
+    case = load_suite(SUITE).cases[3]
+    probe = case.diagnostic_probe
+    assert probe is not None
+    terminal_input = {
+        "environment": case.injected_payload["environment"],
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  intro x\n  exact sq_nonneg x",
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": probe.capability_id,
+                    "input": probe.payload,
+                    "successful": False,
+                    "diagnostic_codes": ["LEAN_RETRIEVAL_FAILED"],
+                },
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": True,
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "successful": True,
+                },
+            ],
+            "capability_invocations": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "output": {
+                        "conclusion": "UNKNOWN",
+                        "diagnostics": ["Lean rejected the proof: unknown identifier"],
+                    },
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "output": {"conclusion": "TRUE"},
+                    "verification_record_uri": "artifact://sha256/" + "b" * 64,
+                },
+            ],
+        },
+    )
+
+    assert result["injection_rejected"] is True
+    assert result["enriched_diagnostic_observed"] is False
+    assert result["repair_success"] is True
+
+
+@pytest.mark.parametrize(
+    "generic_code",
+    ("UNKNOWN_CAPABILITY", "INVALID_REQUEST", "ADAPTER_EXECUTION_FAILED"),
+)
+def test_recovery_does_not_credit_generic_failed_injection(
+    generic_code: str,
+) -> None:
+    case = load_suite(SUITE).cases[0]
+    terminal_input = {
+        "environment": case.injected_payload["environment"],
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  intro x\n  exact sq_nonneg x",
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": False,
+                    "diagnostic_codes": [generic_code],
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "successful": True,
+                },
+            ],
+            "capability_invocations": [
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "output": {"conclusion": "TRUE"},
+                    "verification_record_uri": "artifact://sha256/" + "a" * 64,
+                }
+            ],
+        },
+    )
+
+    assert result["injection_rejected"] is False
+    assert result["repair_success"] is False
+    assert result["observed_diagnostic_codes"] == []
+
+
+def test_recovery_uses_later_exact_retry_after_operational_failure() -> None:
+    case = load_suite(SUITE).cases[0]
+    repaired_input = {
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  trivial",
+        "environment": case.injected_payload["environment"],
+    }
+    rejected = {
+        "capability_id": case.injected_capability_id,
+        "input": case.injected_payload,
+        "output": {
+            "conclusion": "UNKNOWN",
+            "diagnostics": [{"code": "LEAN_TYPE_MISMATCH", "phase": "KERNEL_CHECK"}],
+        },
+    }
+    repaired = {
+        "capability_id": case.terminal_capability_id,
+        "input": repaired_input,
+        "output": {"conclusion": "TRUE", "diagnostics": []},
+        "verification_record_uri": "artifact://sha256/" + "b" * 64,
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": False,
+                    "diagnostic_codes": ["LEAN_CHECKER_TIMEOUT"],
+                },
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": True,
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": repaired_input,
+                    "successful": True,
+                },
+            ],
+            "capability_invocations": [rejected, repaired],
+        },
+    )
+
+    assert result["injection_first_attempt"] is True
+    assert result["injection_rejected"] is True
+    assert result["observed_diagnostic_codes"] == ["LEAN_TYPE_MISMATCH"]
+    assert result["repair_success"] is True
+
+
+def test_recovery_does_not_shift_invocations_after_malformed_success() -> None:
+    case = load_suite(SUITE).cases[0]
+    unrelated_input = {
+        "statement": "False",
+        "proof": "by\n  trivial",
+        "environment": case.injected_payload["environment"],
+    }
+    repaired_input = {
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  trivial",
+        "environment": case.injected_payload["environment"],
+    }
+    unrelated_rejection = {
+        "capability_id": case.injected_capability_id,
+        "input": unrelated_input,
+        "output": {
+            "conclusion": "UNKNOWN",
+            "diagnostics": [{"code": "LEAN_TYPE_MISMATCH", "phase": "KERNEL_CHECK"}],
+        },
+    }
+    repaired = {
+        "capability_id": case.terminal_capability_id,
+        "input": repaired_input,
+        "output": {"conclusion": "TRUE", "diagnostics": []},
+        "verification_record_uri": "artifact://sha256/" + "d" * 64,
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": True,
+                },
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": unrelated_input,
+                    "successful": True,
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": repaired_input,
+                    "successful": True,
+                },
+            ],
+            # The first response was malformed, so telemetry retained no
+            # completed invocation for it. Later invocations must not shift.
+            "capability_invocations": [unrelated_rejection, repaired],
+        },
+    )
+
+    assert result["injection_payload_exact"] is True
+    assert result["injection_rejected"] is False
+    assert result["repair_success"] is False
+    assert result["observed_diagnostic_codes"] == []
+
+
+def test_enrichment_requires_expected_field_level_evidence() -> None:
+    case = load_suite(SUITE).cases[4]
+    terminal_input = {
+        "environment": case.injected_payload["environment"],
+        "statement": case.injected_payload["statement"],
+        "proof": "by\n  trivial",
+    }
+    result = classify_recovery(
+        case,
+        {
+            "capability_attempts": [
+                {
+                    "capability_id": case.injected_capability_id,
+                    "input": case.injected_payload,
+                    "successful": False,
+                    "diagnostic_codes": ["INVALID_LEAN_TRANSITION_REQUEST"],
+                    "diagnostics": [
+                        {
+                            "code": "INVALID_LEAN_TRANSITION_REQUEST",
+                            "path": None,
+                        }
+                    ],
+                },
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "successful": True,
+                },
+            ],
+            "capability_invocations": [
+                {
+                    "capability_id": case.terminal_capability_id,
+                    "input": terminal_input,
+                    "output": {"conclusion": "TRUE"},
+                    "verification_record_uri": "artifact://sha256/" + "c" * 64,
+                }
+            ],
+        },
+    )
+
+    assert result["injection_rejected"] is True
+    assert result["repair_success"] is True
+    assert result["enriched_diagnostic_observed"] is False
 
 
 def test_recovery_suite_bytes_have_a_stable_evaluation_identity() -> None:

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -10,6 +10,7 @@ from benchmarks.tooling.codex_visibility import (
     CueLevel,
     ToolMode,
     VisibilityCase,
+    VisibilityOutputOutcome,
     _build_summary,
     _codex_arguments,
     _run_case,
@@ -104,10 +105,12 @@ def test_committed_visibility_v1_suite_remains_loadable() -> None:
 def test_committed_visibility_v2_suite_covers_domains_and_abstention() -> None:
     suite = load_suite(_ROOT / "benchmarks/config/codex-visibility-v2.json")
 
-    expected_ids = {
+    tracked_ids = {
         capability_id
         for case in suite.cases
-        for capability_id in case.expected_capability_ids
+        for capability_id in (
+            case.expected_capability_ids + case.diagnostic_capability_ids
+        )
     }
     assert suite.schema_version == "2"
     assert {
@@ -116,11 +119,33 @@ def test_committed_visibility_v2_suite_covers_domains_and_abstention() -> None:
         "matrix.determinant.compute",
         "matrix.rank.compute",
         "polynomial.compute.gcd",
-    } <= expected_ids
+    } <= tracked_ids
     assert (
         sum(case.expectation is AdoptionExpectation.ABSTAIN for case in suite.cases)
         >= 2
     )
+
+
+def test_committed_lean_usability_suite_covers_atomic_formal_tools() -> None:
+    suite = load_suite(_ROOT / "benchmarks/config/lean-usability-v1.json")
+    tracked_ids = {
+        capability_id
+        for case in suite.cases
+        for capability_id in (
+            case.expected_capability_ids + case.diagnostic_capability_ids
+        )
+    }
+
+    assert suite.schema_version == "2"
+    assert {
+        "lean.check",
+        "lean.declaration.inspect",
+        "lean.declaration.search",
+        "lean.proof_state.apply_tactic",
+        "lean.retrieve.premises",
+        "lean.term.apply",
+    } <= tracked_ids
+    assert any(case.expectation is AdoptionExpectation.ABSTAIN for case in suite.cases)
 
 
 def test_unified_exec_mode_is_opt_in(tmp_path: Path) -> None:
@@ -276,6 +301,126 @@ def test_visibility_case_rejects_inconsistent_expectations() -> None:
             prompt="Define a matrix.",
             expected_capability_ids=("matrix.rank.compute",),
         )
+    with pytest.raises(ValidationError, match="cannot declare operations or outcomes"):
+        VisibilityCase(
+            case_id="negative-with-diagnostic-capability",
+            cue_level=CueLevel.LATENT,
+            expectation=AdoptionExpectation.ABSTAIN,
+            prompt="Define a matrix.",
+            diagnostic_capability_ids=("matrix.rank.compute",),
+        )
+    with pytest.raises(ValidationError, match="must be tracked"):
+        VisibilityCase(
+            case_id="untracked-outcome",
+            cue_level=CueLevel.LATENT,
+            prompt="Find a declaration.",
+            acceptable_output_outcomes=(
+                VisibilityOutputOutcome(
+                    capability_id="lean.declaration.search",
+                    required_output_fields=("declarations.0.name",),
+                ),
+            ),
+        )
+    with pytest.raises(ValidationError, match="must be disjoint"):
+        VisibilityCase(
+            case_id="overlapping-capabilities",
+            cue_level=CueLevel.LATENT,
+            prompt="Compute a rank.",
+            expected_capability_ids=("matrix.rank.compute",),
+            diagnostic_capability_ids=("matrix.rank.compute",),
+        )
+
+
+def test_diagnostic_operation_observation_does_not_gate_outcome_contract() -> None:
+    case = VisibilityCase(
+        case_id="verified-proof-with-optional-term-transition",
+        cue_level=CueLevel.AFFORDANCE,
+        prompt="Prove and verify a theorem.",
+        expected_capability_ids=("lean.check",),
+        diagnostic_capability_ids=("lean.term.apply",),
+        require_verified=True,
+    )
+    telemetry = {
+        "capability_attempt_ids": ["lean.check"],
+        "capability_ids": ["lean.check"],
+        "capability_invocations": [
+            {
+                "capability_id": "lean.check",
+                "verification_record_uri": "artifact://sha256/record",
+            }
+        ],
+    }
+
+    result = classify_visibility(case, telemetry)
+
+    assert result["contract_satisfied"] is True
+    assert result["expected_capabilities"]["missing_completed"] == []
+    assert result["diagnostic_capabilities"]["not_completed"] == ["lean.term.apply"]
+    assert result["unexpected_capabilities"]["completed"] == []
+
+
+def test_declaration_outcome_accepts_complete_search_without_inspect() -> None:
+    case = load_suite(_ROOT / "benchmarks/config/lean-usability-v1.json").cases[3]
+    telemetry = {
+        "capability_attempt_ids": ["lean.declaration.search"],
+        "capability_ids": ["lean.declaration.search"],
+        "capability_invocations": [
+            {
+                "capability_id": "lean.declaration.search",
+                "output": {
+                    "environment_digest": "sha256:" + "a" * 64,
+                    "lean_version": "4.31.0",
+                    "lean_commit": "lean-commit",
+                    "mathlib_commit": "mathlib-commit",
+                    "declarations": [
+                        {
+                            "name": "irrational_sqrt_two",
+                            "type": "Irrational √2",
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    result = classify_visibility(case, telemetry)
+
+    assert result["contract_satisfied"] is True
+    assert result["expected_capabilities"]["missing_completed"] == []
+    assert result["diagnostic_capabilities"]["not_completed"] == [
+        "lean.declaration.inspect"
+    ]
+    assert result["output_outcomes"] == {
+        "required": True,
+        "satisfied": True,
+        "matched_capability_ids": ["lean.declaration.search"],
+    }
+
+
+def test_declaration_outcome_rejects_incomplete_structured_output() -> None:
+    case = load_suite(_ROOT / "benchmarks/config/lean-usability-v1.json").cases[3]
+    result = classify_visibility(
+        case,
+        {
+            "capability_attempt_ids": ["lean.declaration.search"],
+            "capability_ids": ["lean.declaration.search"],
+            "capability_invocations": [
+                {
+                    "capability_id": "lean.declaration.search",
+                    "output": {
+                        "environment_digest": "sha256:" + "a" * 64,
+                        "lean_version": "4.31.0",
+                        "lean_commit": "lean-commit",
+                        "mathlib_commit": "mathlib-commit",
+                        "declarations": [{"name": "irrational_sqrt_two"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    assert result["contract_satisfied"] is False
+    assert result["output_outcomes"]["satisfied"] is False
 
 
 def test_visibility_classification_requires_bound_verified_evidence(

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -174,9 +174,35 @@ def test_agent_telemetry_retains_failed_math_run_attempts(tmp_path: Path) -> Non
             "output": {"conclusion": "UNKNOWN"},
         },
     )
+    domain_failure = _tool_event(
+        "math.run",
+        {
+            "capability_id": "lean.retrieve.premises",
+            "payload": {"statement": "True", "proof_prefix": ["by"]},
+        },
+        {
+            "capability_id": "lean.retrieve.premises",
+            "execution": {"status": "ERROR"},
+            "output": {
+                "error": {
+                    "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                    "stage": "request_validation",
+                    "message": "proof_prefix must not include by",
+                }
+            },
+            "diagnostics": [
+                {
+                    "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                    "stage": "request_validation",
+                    "message": "proof_prefix must not include by",
+                }
+            ],
+        },
+    )
     transcript = tmp_path / "transcript.jsonl"
     transcript.write_text(
-        "\n".join(json.dumps(event) for event in (failed, succeeded)) + "\n",
+        "\n".join(json.dumps(event) for event in (failed, domain_failure, succeeded))
+        + "\n",
         encoding="utf-8",
     )
 
@@ -185,12 +211,27 @@ def test_agent_telemetry_retains_failed_math_run_attempts(tmp_path: Path) -> Non
     assert telemetry["capability_attempts"] == [
         {"capability_id": None, "input": {"malformed": True}, "successful": False},
         {
+            "capability_id": "lean.retrieve.premises",
+            "input": {"statement": "True", "proof_prefix": ["by"]},
+            "successful": False,
+            "diagnostic_codes": ["INVALID_LEAN_RETRIEVAL_REQUEST"],
+            "diagnostics": [
+                {
+                    "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                    "stage": "request_validation",
+                }
+            ],
+        },
+        {
             "capability_id": "lean.check",
             "input": {"statement": "True"},
             "successful": True,
         },
     ]
-    assert telemetry["capability_attempt_ids"] == ["lean.check"]
+    assert telemetry["capability_attempt_ids"] == [
+        "lean.retrieve.premises",
+        "lean.check",
+    ]
     assert telemetry["capability_ids"] == ["lean.check"]
 
 

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -52,6 +52,14 @@ def test_server_instructions_allow_known_contracts_to_run_directly() -> None:
     assert "math.run may execute a known contract directly" in SERVER_INSTRUCTIONS
 
 
+def test_server_instructions_route_pinned_lean_declaration_queries() -> None:
+    assert (
+        "explicitly targeting Jacobian's pinned CORE or MATHLIB" in SERVER_INSTRUCTIONS
+    )
+    assert "Project-local Lean declarations are outside" in SERVER_INSTRUCTIONS
+    assert "may require project-local tools" in SERVER_INSTRUCTIONS
+
+
 def test_guidance_rejects_verification_transfer_to_derived_claims() -> None:
     combined = "\n".join((SERVER_INSTRUCTIONS, MATH_RUN_DESCRIPTION))
     assert "does not verify a model-derived conclusion" in combined


### PR DESCRIPTION
## What changed

- reject malformed Lean tactic prefixes before starting the Lean REPL and return bounded field-level request diagnostics
- preserve exact `apply_tactic` cross-field validation evidence for fresh versus continuation requests
- add agent-visible fresh, continuation, premise, and declaration examples with authoritative input-field descriptions
- improve Lean/Mathlib declaration search and inspection discoverability without adding workflow behavior
- bind declaration outputs to the pinned Lean version/commit, Mathlib commit, and environment digest
- add fixed Lean usability and diagnostic-recovery benchmark cases, including failed MCP attempt telemetry

## Why

Premise requests containing the surrounding `by` token reached an expensive Lean subprocess and leaked a generic adapter failure. Cross-field request errors and field usage rules were also weakened at the MCP projection layer because compact `CONTRACT` schemas discarded descriptions. Declaration results exposed an environment digest but not enough portable pinned-runtime identity for callers to report or compare the exact Lean/Mathlib environment.

This keeps Jacobian's existing atomic-tool and independent-checker model: the changes improve each tool's typed contract and negative evidence without prescribing a workflow.

## User and agent impact

- malformed premise and proof-state requests fail immediately with stable domain-owned codes, paths, reasons, and recovery hints
- Codex can distinguish fresh and continuation modes and can see that proof prefixes contain tactic bodies after `by`
- declaration tools are easier to discover and return portable pinned runtime identity directly in typed output
- usability and recovery drift is covered by reproducible public observation suites
- recovery scoring fails closed on generic/operational failures, follows exact retries to qualifying Lean evidence, and can require field-level paths/details
- recovery scoring binds each completed invocation to the matching capability ID and input, and fails closed after malformed or identity-shifted telemetry
- the premise-prefix failure is a separate diagnostic probe; comparative repair success is anchored to a proof rejection observable in both control and treatment
- usability contracts gate mathematical/checker outcomes while formal-intermediate operations remain non-gating diagnostic observations
- declaration usability accepts complete structured declaration/runtime identity from either search or inspection, without requiring a redundant call
- server guidance routes only pinned CORE/MATHLIB queries away from local tools and explicitly preserves project-local Lean tooling

## Validation

- `make test-lean`: 111 tests passed in the full run; the sole host-contention declaration timeout then passed in its isolated owning rerun (`1 passed in 137.05s`)
- `make check-changed BASE=origin/main`: 11/11 commands passed
  - lint, format, complexity, mypy
  - 58 npm tests plus package dry-run
  - documentation command and link checks
  - unit 912, component 891, domain 470, composition 94, storage 82, process 267, MCP 47, e2e 3
- local Streamable HTTP MCP smoke rejected the malformed premise request in 0.033 seconds with field-level evidence and exposed examples plus pinned provider identities through exact inspection
- retained unified-exec Codex usability observation: 5/5 contracts satisfied, 0 command failures, 3/3 proof cases returned claim-bound verification records, and the conceptual case correctly abstained
- final declaration-discovery rerun: 1/1 contract satisfied, 0 shell calls, 0 tool errors; Codex used `math.find` then `lean.declaration.search`/`inspect`
- review-driven visibility/recovery/telemetry/tool-surface tests: 80 passed
