### PR TITLE
docs(skills): add recent-conjecture reliability evaluation skill

### DIFF
--- a/.agents/skills/recent-conjecture-evaluations/SKILL.md
+++ b/.agents/skills/recent-conjecture-evaluations/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: recent-conjecture-evaluations
+description: Run source-grounded Jacobian reliability evaluations using recently resolved conjectures as held-out probes. Use for source selection and deduplication, exact input-bound oracles, current-main math.find/math.run contract audits, frozen control/treatment comparisons, observable trajectory scoring, failure attribution, and independent review of another evaluation. Do not use merely to solve a conjecture or create benchmark-specific mathematical helpers.
+---
+
+# Recent Conjecture Evaluations
+
+Treat conjectures as probes. The objective is to improve Jacobian from discovery
+through final-answer use, not to accumulate solved examples.
+
+This skill owns source selection, deterministic capability audits, optional
+control/treatment evaluation, attribution, and repository-action decisions. It
+does not create Harbor tasks. Use `harbor-benchmarks` and
+`verifier-evaluations` when a selected case is later packaged as a benchmark.
+
+## Select a mode
+
+- **Probe:** run one new source cycle.
+- **Review:** independently audit a completed cycle without repeating model calls.
+- **Coordinate:** check reservations, duplicates, and ownership before another evaluator proceeds.
+
+Run one cycle by default. Continue looping only when the operator explicitly
+requests it. A loop does not authorize unlimited model calls.
+
+## Preserve these invariants
+
+1. Prefer primary sources and record the precise theorem status and date.
+2. Bind every oracle, prompt, suite, and tool payload to the intended input.
+3. Reconstruct the gold result independently of evaluated model arms.
+4. Audit current main deterministically before any model call.
+5. Keep `COMPUTED`, `VERIFIED`, source-imported, and unproved claims separate.
+6. Treat missing capability, timeout, cancellation, transport failure, and failure to find evidence as non-conclusions.
+7. Never attribute a model-authored fallback error to Jacobian when no Jacobian result produced it.
+8. Never weaken verification, artifact binding, scope, or assurance to make a case pass.
+9. Never merge a PR. Open only a draft PR when the localized-fix gate passes.
+10. Never create a benchmark-specific capability from one conjecture family.
+
+## Run the workflow
+
+### 1. Inventory before research
+
+Search saved reports, suites, trajectories, issues, PRs of every state,
+branches, and active reservations. Search in layers: exact identifier/title,
+artifact, mathematical family, required capability/provider, and suspected root
+cause. One exact-source miss does not establish independence.
+
+Run the local helper with positional arguments, then search GitHub separately:
+
+```bash
+python .agents/skills/recent-conjecture-evaluations/scripts/search_inventory.py \
+  "source or root-cause phrase" outputs benchmarks/results
+```
+
+Classify the source as selected, rejected, reserved elsewhere, or completed
+duplicate. Read [source-gating.md](references/source-gating.md).
+
+### 2. Establish the source gate
+
+Read enough of the primary source to identify the prior conjecture, exact
+resolution status, proof-carrying theorem or construction, finite obligations,
+and imported boundaries.
+
+Reject before model calls when the bounded task is illustrative, leaks the
+answer, tests literature recall, requires private data, cannot represent the
+decisive obligation faithfully, duplicates prior work, or only exercises a
+near-match.
+
+### 3. Build the independent oracle
+
+Reconstruct every finite obligation with a clean-room script or exact
+derivation. Hash the canonical input. Stop if it disagrees with the primary
+source. Label author-supplied code as `SOURCE-SUPPLIED REPLAY`; reserve
+`INDEPENDENT ORACLE` for separately implemented or derived evidence.
+
+Record acceptable alternative witnesses and representations. Define what
+remains imported or uncertain.
+
+### 4. Audit current main
+
+On a clean current-main worktree, preflight installed providers, authorized
+checkers, input bounds, and estimated payload/runtime before materializing a
+large artifact. Stop early when the decisive operation is unavailable and the
+boundary is already documented.
+
+Then:
+
+1. Search with natural task language.
+2. Inspect returned cards, schemas, examples, domains, bounds, providers, relationships, and assurance.
+3. Inspect the exact producer and independent verifier contracts.
+4. Execute the frozen input directly.
+5. Run the independent verifier when installed.
+6. Replay relevant malformed, wrong-input, over-bound, and unsupported-domain cases.
+7. Run focused deterministic tests.
+
+Persist complete machine-readable discovery and invocation outputs, including
+failures, before summarizing them. Hash the input, probe, raw output, and
+report. Never support an artifact URI, elapsed time, ranking, or diagnostic
+only with terminal scrollback.
+
+If this phase identifies the root cause, do not run model arms merely to
+demonstrate it again.
+
+### 5. Decide whether model arms have information value
+
+Read [evaluation-and-scoring.md](references/evaluation-and-scoring.md). Run
+paired arms only if every gate passes. Otherwise record a deterministic-only
+cycle. Freeze the suite and its digest before execution; use the repository's
+evaluation harness to validate the applicable suite shape.
+
+Use fresh isolated contexts and identical settings except for Jacobian
+availability. The control must not see Jacobian tools, skills, catalog content,
+or routing hints.
+
+### 6. Score observable evidence
+
+Score final correctness, certificate validity, input binding, source fidelity,
+scope, completeness, assurance, discovery, contract inspection, execution,
+recovery, stopping, elapsed time, token use, and model-visible tool bytes.
+
+Do not claim access to hidden chain-of-thought. Score observable calls, outputs,
+retries, concise visible reasoning, and final answers.
+
+### 7. Attribute before acting
+
+Assign each failure to one primary class: Jacobian implementation; tool
+interface or contract; discovery or routing; evaluator or telemetry;
+infrastructure or transport; model transcription or input binding; model
+mathematical reasoning; unsupported capability; or no issue.
+
+Reproduce suspected Jacobian failures directly on current main and search
+ownership again. Read [action-policy.md](references/action-policy.md) before
+opening an issue or draft PR.
+
+### 8. Publish the cycle record
+
+Write a persistent report using [report-schema.md](references/report-schema.md).
+Include rejected and deterministic-only cycles because they prevent duplicate
+work. Update the shared reservation ledger. End with a distinct next source
+direction, not an unsupported claim that the search space is exhausted.
+
+## Manage cost and stalls
+
+- Prefer deterministic checks.
+- Require explicit model-call authorization and cost boundaries.
+- Checkpoint after source gate, oracle, current-main replay, each model arm, scoring, and repository action.
+- Inspect any phase that produces no checkpoint for 30 minutes.
+- Do not retry a cancelled call without new diagnostic evidence.
+- Stop collecting examples for an owned root cause once the agreed independence threshold is met.
+- Do not use a weaker model merely to manufacture errors; use it only in a frozen comparison with a falsifiable question.

--- a/.agents/skills/recent-conjecture-evaluations/SKILL.md
+++ b/.agents/skills/recent-conjecture-evaluations/SKILL.md
@@ -85,12 +85,17 @@ boundary is already documented.
 Then:
 
 1. Search with natural task language.
-2. Inspect returned cards, schemas, examples, domains, bounds, providers, relationships, and assurance.
-3. Inspect the exact producer and independent verifier contracts.
-4. Execute the frozen input directly.
-5. Run the independent verifier when installed.
-6. Replay relevant malformed, wrong-input, over-bound, and unsupported-domain cases.
-7. Run focused deterministic tests.
+2. Treat bounded `math.find` search as candidate retrieval, not complete inventory;
+   use `capability://catalog` when full installed membership matters.
+3. Inspect returned cards and exact IDs for schemas, examples, domains, bounds,
+   and provider availability. Treat these as operation facts, not workflow advice.
+4. Inspect the producer and independent checker as separate operation contracts.
+   A checker-backed result is verified only when the top-level result envelope
+   contains a verification-record URI bound to the exact final claim.
+5. Execute the frozen input directly.
+6. Run the independent checker when installed.
+7. Replay relevant malformed, wrong-input, over-bound, and unsupported-domain cases.
+8. Run focused deterministic tests.
 
 Persist complete machine-readable discovery and invocation outputs, including
 failures, before summarizing them. Hash the input, probe, raw output, and

--- a/.agents/skills/recent-conjecture-evaluations/agents/openai.yaml
+++ b/.agents/skills/recent-conjecture-evaluations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recent Conjecture Evaluations"
+  short_description: "Run source-grounded Jacobian reliability probes"
+  default_prompt: "Use $recent-conjecture-evaluations to run one source-grounded Jacobian reliability cycle."

--- a/.agents/skills/recent-conjecture-evaluations/references/action-policy.md
+++ b/.agents/skills/recent-conjecture-evaluations/references/action-policy.md
@@ -1,0 +1,42 @@
+# Repository action policy
+
+## Search ownership first
+
+Search current main, branches, issues and comments, PRs of every state, saved
+evaluations, and copied implementation lineages.
+
+## Outcomes
+
+- **No action:** product behaved correctly or failure is model-local.
+- **Existing issue evidence:** independent evidence strengthens an owned root cause.
+- **Documentation clarification:** factual guidance is missing but behavior is sound.
+- **Maintainer issue:** strong architectural question, cross-family capability gap, or policy choice.
+- **Localized draft PR:** small reproducible defect with an unambiguous safe correction.
+
+## Draft-PR gate
+
+Open a draft PR only when:
+
+- the failure reproduces on current main;
+- no existing PR owns the correction;
+- the change is localized and low risk;
+- verification, assurance, and binding remain intact;
+- focused tests cover the failure and safe negative cases;
+- the change-aware plan and relevant checks pass.
+
+Use an isolated branch or worktree, commit only scoped files, describe source
+independence and overlap, and never merge.
+
+## Capability-gap threshold
+
+Require independent evidence from at least two mathematical families unless
+the missing primitive is already accepted repository architecture. Do not
+count repeated executions, parameter variants, copied adapters, or one
+benchmark family as independent.
+
+## Attribution guard
+
+Do not file against Jacobian for a model-transcribed wrong input, local fallback
+mistake, honest stop on an unsupported domain, unreplicated transport
+cancellation, model-authored false `VERIFIED` label, or benchmark-specific
+convenience request.

--- a/.agents/skills/recent-conjecture-evaluations/references/evaluation-and-scoring.md
+++ b/.agents/skills/recent-conjecture-evaluations/references/evaluation-and-scoring.md
@@ -1,0 +1,58 @@
+# Paired evaluation and scoring
+
+## Model-call gate
+
+Require all items before running model arms:
+
+- exact source and artifact are new and unreserved;
+- source gate passes;
+- oracle matches the source and is input-hashed;
+- current-main producer/verifier replay is complete;
+- the comparison asks a question not answered deterministically;
+- no issue or PR already owns the proposed root cause;
+- control and treatment isolation is real;
+- model, reasoning, temperature, output limit, timeout, execution budget, environment, revision, prompt hash, and suite hash are frozen;
+- checker availability is captured before expensive materialization;
+- JSONL, elapsed-time, token, and visible-byte accounting work;
+- the operator authorized the applicable cost boundary.
+
+## Arm isolation
+
+The control sees no Jacobian MCP server, skill, catalog, tool description,
+routing hint, or artifact. The treatment sees exactly the frozen Jacobian
+surface. Keep unrelated tools and settings identical. Use fresh workspaces and
+contexts.
+
+## Observable scoring
+
+Score each arm independently:
+
+1. final mathematical correctness;
+2. evidence or certificate validity;
+3. exact input binding;
+4. source fidelity;
+5. scope calibration and completeness;
+6. assurance calibration;
+7. discovery and contract inspection;
+8. useful executions;
+9. invalid, cancelled, redundant, and post-terminal calls;
+10. recovery, stopping, and use of evidence in the final answer;
+11. elapsed time, total and uncached tokens, and model-visible bytes.
+
+## Assurance rules
+
+- A producer result is not independently verified.
+- A local calculation can be correct without being Jacobian-verified.
+- A checker record must bind the input, result, capability version, and checker authority.
+- A correct scalar with a missing required certificate is incomplete.
+- Failure to find evidence is not evidence of nonexistence.
+- Infrastructure-invalid runs do not count as mathematical evidence.
+
+Accept alternative valid strategies. Do not prescribe one tool sequence or
+score hidden reasoning.
+
+## Evidence retention
+
+Save raw discovery and invocation responses as JSON or JSONL, including safe
+failures. Record hashes for the frozen input, probe, raw output, and report. A
+prose reconstruction of terminal output is not independently auditable.

--- a/.agents/skills/recent-conjecture-evaluations/references/report-schema.md
+++ b/.agents/skills/recent-conjecture-evaluations/references/report-schema.md
@@ -1,0 +1,23 @@
+# Persistent cycle report
+
+Include these sections in every completed cycle:
+
+1. **Decision** — selected, rejected, deferred, reserved, or duplicate.
+2. **Primary source** — exact status, date, version, and proof carrier.
+3. **Frozen artifact** — canonical input, retained bytes, hashes, obligations, alternatives, and imported boundaries.
+4. **Oracle evidence** — label each item `INDEPENDENT ORACLE`, `SOURCE-SUPPLIED REPLAY`, or `IMPORTED METADATA`.
+5. **Current-main audit** — revision, discovery chronology, contracts, examples, bounds, providers, executions, verifier records, and negative tests.
+6. **Evaluation freeze** — or why model arms were unnecessary.
+7. **Per-arm scoring** — answers, calls, failures, recovery, stopping, time, tokens, and visible bytes.
+8. **Failure attribution** — one primary class per failure with replay evidence.
+9. **Overlap** — source, artifact, family, implementation, and ownership.
+10. **Outcome** — no action, issue comment, issue, or draft PR with validation.
+11. **Next direction** — a distinct source family or contract question.
+
+Attach the machine-readable discovery/invocation trace and record SHA-256
+hashes of the input, probe, trace, and report. Mark an unavailable trace
+unreviewable; do not reconstruct it from memory or terminal scrollback.
+
+Never omit a failed or partial trajectory. Mark unavailable telemetry as
+unavailable rather than zero. Keep corrected reruns symmetric across arms and
+exclude defective originals from causal totals.

--- a/.agents/skills/recent-conjecture-evaluations/references/source-gating.md
+++ b/.agents/skills/recent-conjecture-evaluations/references/source-gating.md
@@ -1,0 +1,50 @@
+# Source gating
+
+## Selection order
+
+1. Prefer resolved work from 2024 onward.
+2. Expand through 2020 after checking the newer inventory.
+3. Use 2016–2019 only as a documented fallback.
+4. Prefer a proof-critical exact artifact over an interesting headline.
+
+## Required source record
+
+- title, authors, identifier, version, and first-publication date;
+- exact prior conjecture or open question;
+- theorem, proposition, example, or construction that resolves it;
+- solved, disproved, conditional, partial-case, or disputed status;
+- finite obligations and imported mathematical boundaries;
+- relevant installed producer and verifier candidates;
+- source, artifact, family, implementation, capability, provider, diagnostic, and root-cause overlap;
+- source decision and reason.
+
+## Accept only when
+
+- a primary source establishes the resolution status;
+- the bounded task is genuinely used in the result;
+- the prompt can be self-contained without revealing the conclusion;
+- success is externally scoreable without hidden reasoning;
+- the artifact fits current contracts or deliberately tests a documented boundary;
+- an independent clean-room oracle is feasible.
+
+## Reject or defer when
+
+- a headline exaggerates the theorem status;
+- the source only asks a question or presents a new classification;
+- the artifact is illustrative rather than proof-critical;
+- a rational substitution changes an algebraic or finite-field theorem;
+- checking a nearby determinant, rank, flat lattice, or specialization does not certify the published obligation;
+- the task requires private data or inaccessible certificates;
+- the same conjecture or artifact was already evaluated;
+- only one family supports a speculative new capability.
+
+Record rejections immediately. Do not run model arms to confirm a known mismatch.
+
+## Independence labels
+
+- **Independent oracle:** separately implemented or derived exact evidence.
+- **Source-supplied replay:** rerun of author code, manifests, or certificates.
+- **Imported metadata:** a hash, count, theorem, or status not reproduced from retained bytes.
+
+Do not merge these labels. Retain archive bytes when citing an archive-level
+digest; otherwise mark the digest as imported metadata.

--- a/.agents/skills/recent-conjecture-evaluations/scripts/search_inventory.py
+++ b/.agents/skills/recent-conjecture-evaluations/scripts/search_inventory.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Search persistent evaluation files for source, artifact, or root-cause overlap."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+TEXT_SUFFIXES = {".md", ".json", ".jsonl", ".txt", ".yaml", ".yml"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("query", help="Case-insensitive overlap phrase")
+    parser.add_argument("roots", nargs="+", type=Path, help="Report or trajectory roots")
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+
+    needle = args.query.casefold()
+    found = 0
+    for root in args.roots:
+        paths = [root] if root.is_file() else sorted(root.rglob("*"))
+        for path in paths:
+            if not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
+                continue
+            try:
+                lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError:
+                continue
+            for number, line in enumerate(lines, 1):
+                if needle in line.casefold():
+                    print(f"{path}:{number}:{line.strip()}")
+                    found += 1
+                    if found >= args.limit:
+                        return 0
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,8 +211,9 @@ checker authorization out of plugins and search code.
   mathematical conclusion.
 - Include every first-class artifact reference, including verification records,
   in the result's `artifact_uris`.
-- An unavailable optional provider must remove only the affected capabilities;
-  unrelated kernel startup and catalog entries remain available.
+- An unavailable optional native or formal provider must remove only the
+  affected capabilities. A missing or mismatched maintained Python backend is
+  a broken installation and must fail runtime construction clearly.
 - Keep `deep_review.md` local; it is ignored and is not design source material.
 - Keep worked cases in reference scenarios and benchmarks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,9 +211,8 @@ checker authorization out of plugins and search code.
   mathematical conclusion.
 - Include every first-class artifact reference, including verification records,
   in the result's `artifact_uris`.
-- An unavailable optional native or formal provider must remove only the
-  affected capabilities. A missing or mismatched maintained Python backend is
-  a broken installation and must fail runtime construction clearly.
+- An unavailable optional provider must remove only the affected capabilities;
+  unrelated kernel startup and catalog entries remain available.
 - Keep `deep_review.md` local; it is ignored and is not design source material.
 - Keep worked cases in reference scenarios and benchmarks.
 
@@ -224,6 +223,9 @@ development workflow. For Harbor task authoring and verifier changes, use the
 repository-local [`harbor-benchmarks`](.agents/skills/harbor-benchmarks/SKILL.md)
 skill and its exact task validation path. Control/treatment model evaluations
 are explicit operator-run evidence exercises, not routine development gates.
+For source-grounded held-out reliability probes based on recently resolved
+conjectures, use
+[`recent-conjecture-evaluations`](.agents/skills/recent-conjecture-evaluations/SKILL.md).
 
 For remote MCP operation, use
 [Deploy the remote MCP server](docs/how-to/deploy-remote-mcp.md) and the

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,8 @@ documentation.
 
 Harbor benchmark authoring and verifier work uses the repository-local
 [`harbor-benchmarks`](../.agents/skills/harbor-benchmarks/SKILL.md) skill.
+Source-grounded reliability probes based on recently resolved conjectures use
+[`recent-conjecture-evaluations`](../.agents/skills/recent-conjecture-evaluations/SKILL.md).
 For hosted operation, follow
 [Deploy the remote MCP server](how-to/deploy-remote-mcp.md); ignored `tmp/`
 records are host evidence, not source of truth.


### PR DESCRIPTION
## Summary

- add a repository-local `recent-conjecture-evaluations` Codex skill
- encode source gating, clean-room oracle construction, current-main contract replay, optional paired evaluation, observable scoring, and failure attribution
- add reusable overlap-search support and link the workflow from contributor guidance
- keep Harbor task authoring and verifier design in the existing specialist skills

## Why

Recent resolved-conjecture probes have exposed useful Jacobian reliability defects, but the workflow was spread across long prompts and evaluator-specific notes. This packages the general method as repository-owned guidance while preserving Jacobian's product boundary: conjectures are probes, deterministic current-main evidence comes first, model calls require information value, and one benchmark family cannot justify a benchmark-specific capability.

## Validation

- skill-creator `quick_validate.py`
- Ruff on `search_inventory.py`
- `tools/check_doc_commands.py`
- repository Markdown link check
- `git diff --check`
- change-aware planner inspected; it conservatively selects the full suite because the new skill path is not yet classified exactly

The full local suite was not rerun because this documentation/skill-only branch was validated in an isolated clone whose dependency sync could not reach PyPI. Hosted CI remains authoritative for the planner-selected lanes.