### PR TITLE
fix(eval): repair Lean usability evaluation isolation

### DIFF
--- a/benchmarks/config/lean-usability-v1.json
+++ b/benchmarks/config/lean-usability-v1.json
@@ -5,7 +5,7 @@
     {
       "case_id": "mathlib-premise-retrieval",
       "cue_level": "AFFORDANCE",
-      "prompt": "Repair and independently verify the exact Lean MATHLIB theorem `∀ x : ℝ, x ^ 2 ≥ 0`. Use any suitable atomic mathematical operations; premise retrieval is available if useful, but do not rely only on a theorem name recalled from memory. Report any selected premise and replay evidence, the final proof, and verification evidence.",
+      "prompt": "Using the exposed atomic mathematical tools—not source code, repository indexes, or a local Lean process—repair and independently verify the exact Lean MATHLIB theorem `∀ x : ℝ, x ^ 2 ≥ 0`. Premise retrieval is available if useful, but do not rely only on a theorem name recalled from memory. Report any selected premise and replay evidence, the final proof, and verification evidence.",
       "expected_capability_ids": [
         "lean.check"
       ],
@@ -52,29 +52,29 @@
         {
           "capability_id": "lean.declaration.search",
           "required_output_fields": [
-            "environment_digest",
-            "lean_version",
-            "lean_commit",
-            "mathlib_commit",
-            "declarations.0.name",
-            "declarations.0.type"
+            "result.environment_digest",
+            "result.lean_version",
+            "result.lean_commit",
+            "result.mathlib_commit",
+            "result.declarations.0.name",
+            "result.declarations.0.type"
           ],
           "expected_output_values": {
-            "declarations.0.name": "irrational_sqrt_two"
+            "result.declarations.0.name": "irrational_sqrt_two"
           }
         },
         {
           "capability_id": "lean.declaration.inspect",
           "required_output_fields": [
-            "environment_digest",
-            "lean_version",
-            "lean_commit",
-            "mathlib_commit",
-            "declaration.name",
-            "declaration.type"
+            "result.environment_digest",
+            "result.lean_version",
+            "result.lean_commit",
+            "result.mathlib_commit",
+            "result.declaration.name",
+            "result.declaration.type"
           ],
           "expected_output_values": {
-            "declaration.name": "irrational_sqrt_two"
+            "result.declaration.name": "irrational_sqrt_two"
           }
         }
       ],

--- a/benchmarks/tooling/codex_visibility.py
+++ b/benchmarks/tooling/codex_visibility.py
@@ -7,8 +7,11 @@ import asyncio
 import hashlib
 import json
 import os
+import re
+import shutil
 import tempfile
 import time
+from collections import defaultdict
 from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import Path
@@ -49,6 +52,12 @@ _CODEX_ENVIRONMENT = (
     "no_proxy",
 )
 _MCP_TOOL_APPROVAL_MODE = "approve"
+_SKILLS_BLOCK = re.compile(r"<skills_instructions>.*?</skills_instructions>", re.DOTALL)
+_SKILL_ENTRY = re.compile(
+    r"^- (?P<name>[^:\n]+): .* \((?P<kind>file|environment resource|"
+    r"orchestrator resource|custom resource): (?P<source>[^)\n]+)\)$",
+    re.MULTILINE,
+)
 
 
 class CueLevel(StrEnum):
@@ -357,6 +366,11 @@ def classify_visibility(
         "mcp_wire_bytes": telemetry.get("mcp_wire_bytes", 0),
         "mcp_model_visible_bytes": telemetry.get("mcp_model_visible_bytes", 0),
         "mcp_logical_payload_bytes": telemetry.get("mcp_logical_payload_bytes", 0),
+        "empty_payload_probe_count": telemetry.get("empty_payload_probe_count", 0),
+        "failed_operation_attempt_count": telemetry.get(
+            "failed_operation_attempt_count", 0
+        ),
+        "repeated_error_count": telemetry.get("repeated_error_count", 0),
     }
 
 
@@ -455,6 +469,7 @@ def _codex_arguments(
         "--ephemeral",
         "--skip-git-repo-check",
         "--ignore-user-config",
+        "--ignore-rules",
         "-C",
         str(workspace),
         "-s",
@@ -484,13 +499,146 @@ def _codex_arguments(
     return (*arguments, prompt)
 
 
-def _command_version(workspace: Path) -> str:
+def _prepare_isolated_codex_environment(
+    root: Path,
+    *,
+    source_environment: Mapping[str, str] | None = None,
+) -> tuple[Mapping[str, str], dict[str, Any]]:
+    """Build a clean Codex HOME/CODEX_HOME and copy authentication only."""
+
+    source = os.environ if source_environment is None else source_environment
+    isolated_home = root / "home"
+    isolated_codex_home = root / "codex-home"
+    isolated_home.mkdir(parents=True)
+    isolated_codex_home.mkdir()
+    source_home = Path(source.get("HOME", str(Path.home())))
+    source_codex_home = Path(source.get("CODEX_HOME", source_home / ".codex"))
+    source_auth = source_codex_home / "auth.json"
+    auth_seeded = source_auth.is_file()
+    if auth_seeded:
+        target_auth = isolated_codex_home / "auth.json"
+        shutil.copyfile(source_auth, target_auth)
+        target_auth.chmod(0o600)
+    environment = dict(
+        operator_environment(
+            source=source,
+            include=_CODEX_ENVIRONMENT,
+            declared={
+                "HOME": str(isolated_home),
+                "CODEX_HOME": str(isolated_codex_home),
+            },
+        )
+    )
+    return environment, {
+        "schema_version": "1",
+        "home_isolated": True,
+        "codex_home_isolated": True,
+        "user_config_loaded": False,
+        "user_rules_loaded": False,
+        "authentication_seeded": auth_seeded,
+    }
+
+
+def _normalized_skill_source(
+    source: str,
+    *,
+    workspace: Path,
+    environment: Mapping[str, str],
+) -> tuple[str, bool]:
+    roots = (
+        ("$CODEX_HOME", Path(environment["CODEX_HOME"])),
+        ("$HOME", Path(environment["HOME"])),
+        ("$WORKSPACE", workspace),
+    )
+    candidate = Path(source)
+    if not candidate.is_absolute():
+        return source, False
+    for label, root in roots:
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError:
+            continue
+        return str(Path(label) / relative), False
+    return source, True
+
+
+def _inspect_codex_skill_surface(
+    workspace: Path,
+    environment: Mapping[str, str],
+) -> dict[str, Any]:
+    """Render and record the skills actually visible to the evaluated Codex."""
+
+    result = run_operator_command(
+        "codex",
+        ("debug", "prompt-input", "evaluation skill-surface snapshot"),
+        cwd=workspace,
+        timeout_seconds=30,
+        stdout_limit_bytes=4 * 1024 * 1024,
+        stderr_limit_bytes=1024 * 1024,
+        environment=environment,
+    )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        raise RuntimeError("codex skill-surface inspection failed")
+    try:
+        messages = json.loads(result.stdout)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(
+            "codex skill-surface inspection returned invalid JSON"
+        ) from error
+    blocks = [
+        match.group(0)
+        for message in messages
+        if isinstance(message, Mapping)
+        for content in message.get("content", [])
+        if isinstance(content, Mapping) and isinstance(content.get("text"), str)
+        for match in _SKILLS_BLOCK.finditer(content["text"])
+    ]
+    if len(blocks) != 1:
+        raise RuntimeError("codex prompt must expose exactly one skill surface")
+    records = []
+    external_file_sources = []
+    for match in _SKILL_ENTRY.finditer(blocks[0]):
+        source, external = _normalized_skill_source(
+            match.group("source"),
+            workspace=workspace,
+            environment=environment,
+        )
+        record = {
+            "name": match.group("name"),
+            "source_kind": match.group("kind"),
+            "source": source,
+        }
+        records.append(record)
+        if external and match.group("kind") == "file":
+            external_file_sources.append(source)
+    candidate_entries = [
+        line for line in blocks[0].splitlines() if line.startswith("- ")
+    ]
+    if len(records) != len(candidate_entries):
+        raise RuntimeError("codex skill-surface entries use an unknown format")
+    normalized_block = blocks[0]
+    for variable in ("CODEX_HOME", "HOME"):
+        normalized_block = normalized_block.replace(
+            environment[variable], f"${variable}"
+        )
+    normalized_block = normalized_block.replace(str(workspace), "$WORKSPACE")
+    return {
+        "skill_count": len(records),
+        "skills": records,
+        "external_file_sources": sorted(external_file_sources),
+        "model_visible_instructions_sha256": _sha256_bytes(
+            normalized_block.encode("utf-8")
+        ),
+    }
+
+
+def _command_version(workspace: Path, environment: Mapping[str, str]) -> str:
     result = run_operator_command(
         "codex",
         ("--version",),
         cwd=workspace,
         timeout_seconds=30,
-        environment=operator_environment(include=_CODEX_ENVIRONMENT),
+        environment=environment,
     )
     if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
         raise RuntimeError("codex --version failed")
@@ -508,11 +656,11 @@ def _run_case(
     mcp_url: str,
     timeout_seconds: float,
     tool_mode: ToolMode,
+    environment: Mapping[str, str],
 ) -> dict[str, Any]:
     stem = f"{case.case_id}-r{repetition:02d}"
     transcript_path = output / f"{stem}.jsonl"
     stderr_path = output / f"{stem}.stderr"
-    environment = operator_environment(include=_CODEX_ENVIRONMENT)
     command_start = time.monotonic()
     result = run_operator_command(
         "codex",
@@ -619,6 +767,52 @@ def _validate_mcp_url(value: str) -> None:
 def _build_summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate per-run observations into the report summary block."""
 
+    runs_by_case: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for run in runs:
+        runs_by_case[run["case_id"]].append(run)
+
+    def rate(numerator: int, denominator: int) -> float | None:
+        return round(numerator / denominator, 6) if denominator else None
+
+    case_repetition_metrics = []
+    for case_id, case_runs in sorted(runs_by_case.items()):
+        run_count = len(case_runs)
+        satisfied = sum(
+            run["classification"]["contract_satisfied"] for run in case_runs
+        )
+        command_failures = sum(
+            run["command"]["status"] != ToolCommandStatus.EXITED
+            or run["command"]["exit_code"] != 0
+            for run in case_runs
+        )
+        failed_attempts = sum(
+            run["classification"]["failed_operation_attempt_count"] for run in case_runs
+        )
+        repeated_errors = sum(
+            run["classification"]["repeated_error_count"] for run in case_runs
+        )
+        runs_with_empty_probe = sum(
+            run["classification"]["empty_payload_probe_count"] > 0 for run in case_runs
+        )
+        case_repetition_metrics.append(
+            {
+                "case_id": case_id,
+                "run_count": run_count,
+                "command_failure_count": command_failures,
+                "contract_satisfied_count": satisfied,
+                "contract_satisfaction_rate": rate(satisfied, run_count),
+                "empty_payload_probe_count": sum(
+                    run["classification"]["empty_payload_probe_count"]
+                    for run in case_runs
+                ),
+                "runs_with_empty_payload_probe": runs_with_empty_probe,
+                "empty_payload_probe_run_rate": rate(runs_with_empty_probe, run_count),
+                "failed_operation_attempt_count": failed_attempts,
+                "repeated_error_count": repeated_errors,
+                "repeated_error_rate": rate(repeated_errors, failed_attempts),
+            }
+        )
+
     return {
         "run_count": len(runs),
         "command_failure_count": sum(
@@ -671,6 +865,18 @@ def _build_summary(runs: list[dict[str, Any]]) -> dict[str, Any]:
                 sum(run["command"]["elapsed_seconds"] for run in runs), 6
             ),
         },
+        "recovery_totals": {
+            "empty_payload_probe_count": sum(
+                run["classification"]["empty_payload_probe_count"] for run in runs
+            ),
+            "failed_operation_attempt_count": sum(
+                run["classification"]["failed_operation_attempt_count"] for run in runs
+            ),
+            "repeated_error_count": sum(
+                run["classification"]["repeated_error_count"] for run in runs
+            ),
+        },
+        "case_repetition_metrics": case_repetition_metrics,
     }
 
 
@@ -696,9 +902,18 @@ def main() -> None:
         raise SystemExit(f"output directory already exists: {output}")
     surface = asyncio.run(inspect_surface(args.mcp_url, args.timeout_seconds))
     output.mkdir(parents=True)
-    with tempfile.TemporaryDirectory(prefix="jacobian-codex-visibility-") as raw:
+    with (
+        tempfile.TemporaryDirectory(prefix="jacobian-codex-visibility-") as raw,
+        tempfile.TemporaryDirectory(prefix="jacobian-codex-isolation-") as isolated,
+    ):
         workspace = Path(raw)
-        codex_version = _command_version(workspace)
+        environment, isolation = _prepare_isolated_codex_environment(Path(isolated))
+        skill_surface = _inspect_codex_skill_surface(workspace, environment)
+        if skill_surface["external_file_sources"]:
+            raise RuntimeError(
+                "isolated Codex prompt exposed external file-backed skills"
+            )
+        codex_version = _command_version(workspace, environment)
         runs = [
             _run_case(
                 case=case,
@@ -710,6 +925,7 @@ def main() -> None:
                 mcp_url=args.mcp_url,
                 timeout_seconds=args.timeout_seconds,
                 tool_mode=args.tool_mode,
+                environment=environment,
             )
             for case in selected_cases
             for repetition in range(1, args.repetitions + 1)
@@ -732,6 +948,8 @@ def main() -> None:
                 "telemetry_parser_sha256": _sha256_bytes(
                     (_ROOT / "src/jacobian/eval/telemetry.py").read_bytes()
                 ),
+                "isolation": isolation,
+                "skill_surface": skill_surface,
             },
             "codex_version": codex_version,
             "model": args.model,

--- a/benchmarks/tooling/lean_diagnostic_recovery.py
+++ b/benchmarks/tooling/lean_diagnostic_recovery.py
@@ -61,6 +61,7 @@ _SHARED_REPORT_FIELDS = (
     "repetitions",
     "timeout_seconds",
     "codex_version",
+    "evaluator",
     "selected_case_ids",
 )
 _DELTA_METRICS = (
@@ -894,6 +895,8 @@ def _validate_shared_report_invariants(
         raise ValueError("control report must use the control condition")
     if treatment.get("condition") != "enriched-diagnostics":
         raise ValueError("treatment report must use the enriched-diagnostics condition")
+    _validate_evaluator_identity(control)
+    _validate_evaluator_identity(treatment)
     for field in _SHARED_REPORT_FIELDS:
         if control.get(field) != treatment.get(field):
             raise ValueError(f"recovery comparison invariant differs: {field}")
@@ -901,6 +904,28 @@ def _validate_shared_report_invariants(
         raise ValueError("recovery comparison requires report schema version 1")
     if control.get("causal_claim_authorized") is not False:
         raise ValueError("recovery reports cannot authorize causal claims")
+
+
+def _validate_evaluator_identity(report: Mapping[str, Any]) -> None:
+    evaluator = report.get("evaluator")
+    if not isinstance(evaluator, Mapping):
+        raise ValueError("recovery reports require evaluator identity")
+    isolation = evaluator.get("isolation")
+    skill_surface = evaluator.get("skill_surface")
+    if not isinstance(isolation, Mapping) or not isinstance(skill_surface, Mapping):
+        raise ValueError(
+            "recovery reports require evaluator isolation and skill surface"
+        )
+    if (
+        isolation.get("home_isolated") is not True
+        or isolation.get("codex_home_isolated") is not True
+    ):
+        raise ValueError("recovery reports require isolated evaluator homes")
+    if skill_surface.get("external_file_sources") != []:
+        raise ValueError("recovery evaluator skill surface is not isolated")
+    digest = skill_surface.get("model_visible_instructions_sha256")
+    if not isinstance(digest, str) or _DIGEST.fullmatch(digest) is None:
+        raise ValueError("recovery evaluator skill surface digest is invalid")
 
 
 def _validate_selected_case_ids(report: Mapping[str, Any]) -> None:

--- a/benchmarks/tooling/lean_diagnostic_recovery.py
+++ b/benchmarks/tooling/lean_diagnostic_recovery.py
@@ -24,10 +24,11 @@ from pydantic import (
 )
 
 from benchmarks.tooling.codex_visibility import (
-    _CODEX_ENVIRONMENT,
     ToolMode,
     _codex_arguments,
     _command_version,
+    _inspect_codex_skill_surface,
+    _prepare_isolated_codex_environment,
     _sha256_bytes,
     _validate_mcp_url,
     inspect_surface,
@@ -37,7 +38,6 @@ from benchmarks.tooling.command_runner import (
     ToolCommandStatus,
     git_head_sha,
     git_tracked_worktree_is_clean,
-    operator_environment,
     run_operator_command,
 )
 from jacobian.canonical import canonicalize_json, loads_strict_json
@@ -687,6 +687,7 @@ def _run_case(
     mcp_url: str,
     timeout_seconds: float,
     tool_mode: ToolMode,
+    environment: Mapping[str, str],
 ) -> dict[str, Any]:
     stem = f"{case.case_id}-r{repetition:02d}"
     command_path = output / f"{stem}.command.json"
@@ -707,7 +708,7 @@ def _run_case(
         timeout_seconds=timeout_seconds,
         stdout_limit_bytes=16 * 1024 * 1024,
         stderr_limit_bytes=2 * 1024 * 1024,
-        environment=operator_environment(include=_CODEX_ENVIRONMENT),
+        environment=environment,
     )
     transcript_path.write_bytes(result.stdout)
     stderr_path.write_bytes(result.stderr)
@@ -1289,6 +1290,17 @@ def _compare_from_arguments(args: argparse.Namespace) -> dict[str, Any]:
     )
 
 
+def _prepare_evaluator(
+    isolated_root: Path,
+    workspace: Path,
+) -> tuple[Mapping[str, str], dict[str, Any], dict[str, Any]]:
+    environment, isolation = _prepare_isolated_codex_environment(isolated_root)
+    skill_surface = _inspect_codex_skill_surface(workspace, environment)
+    if skill_surface["external_file_sources"]:
+        raise RuntimeError("isolated Codex prompt exposed external file-backed skills")
+    return environment, isolation, skill_surface
+
+
 def main() -> None:
     args = _parser().parse_args()
     if args.compare:
@@ -1356,9 +1368,17 @@ def main() -> None:
         expected_revision=expected_revision,
     )
     output.mkdir(parents=True)
-    with tempfile.TemporaryDirectory(prefix="jacobian-lean-recovery-") as raw:
+    with (
+        tempfile.TemporaryDirectory(prefix="jacobian-lean-recovery-") as raw,
+        tempfile.TemporaryDirectory(
+            prefix="jacobian-lean-recovery-isolation-"
+        ) as isolated,
+    ):
         workspace = Path(raw)
-        codex_version = _command_version(workspace)
+        environment, isolation, skill_surface = _prepare_evaluator(
+            Path(isolated), workspace
+        )
+        codex_version = _command_version(workspace, environment)
         runs = [
             _run_case(
                 case=case,
@@ -1370,6 +1390,7 @@ def main() -> None:
                 mcp_url=args.mcp_url,
                 timeout_seconds=timeout,
                 tool_mode=args.tool_mode,
+                environment=environment,
             )
             for case in selected
             for repetition in range(1, repetitions + 1)
@@ -1392,6 +1413,10 @@ def main() -> None:
         "repetitions": repetitions,
         "timeout_seconds": timeout,
         "codex_version": codex_version,
+        "evaluator": {
+            "isolation": isolation,
+            "skill_surface": skill_surface,
+        },
         "surface": surface,
         "selected_case_ids": [case.case_id for case in selected],
         "runs": runs,

--- a/deploy/smoke_lean.py
+++ b/deploy/smoke_lean.py
@@ -85,7 +85,13 @@ def _require_transition(
 def _require_mathlib_declaration(result: dict[str, Any]) -> None:
     if result.get("execution", {}).get("status") != "COMPLETED":
         raise RuntimeError("MATHLIB declaration search did not complete")
-    declarations = result.get("output", {}).get("declarations")
+    output = result.get("output", {})
+    native_result = output.get("result") if isinstance(output, dict) else None
+    declarations = (
+        native_result.get("declarations")
+        if isinstance(native_result, dict)
+        else None
+    )
     if not isinstance(declarations, list) or not declarations:
         raise RuntimeError("MATHLIB declaration search returned no exact match")
     if declarations[0].get("name") != "irrational_sqrt_two":

--- a/docs/how-to/run-codex-visibility-evaluation.md
+++ b/docs/how-to/run-codex-visibility-evaluation.md
@@ -34,6 +34,12 @@ effort, evaluator and telemetry-parser digests, MCP server metadata, tool
 schemas and descriptions, and catalog digest. Raw JSONL and stderr are retained
 with SHA-256 digests.
 
+Each Codex process receives a temporary isolated `HOME` and `CODEX_HOME` seeded
+with authentication only; user config, plugins, rules, memories, and ambient
+skills are not copied. Before model execution, the runner renders Codex's actual
+model-visible prompt, records the normalized skill names, sources, and digest,
+and fails if any file-backed skill escapes the isolated homes or workspace.
+
 The suite covers matrix, integer, polynomial, and independent-checker outcomes.
 It also includes negative cases whose `ABSTAIN` expectation permits no Jacobian
 tool calls or resource reads. Observations report discovery, exact inspection,
@@ -50,6 +56,9 @@ output rather than requiring a redundant operation or grading answer prose.
 Duration and token counts are observational. MCP calls, model-visible bytes,
 wire bytes, shell calls, errors, cached input, and uncached input remain
 separate diagnostics rather than proxies for mathematical correctness.
+The report also records empty-payload probes, failed operation attempts, exact
+repeated errors, and per-case rates across repetitions. These recovery metrics
+remain observational and never change a mathematical or verification verdict.
 
 To run the fixed Lean usability observation suite, select it explicitly:
 

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -15,8 +15,9 @@ SERVER_INSTRUCTIONS = (
     "math.find with a plain-language desired local mathematical outcome; no capability "
     "ID is required. math.run may execute a known contract directly. "
     "For declaration queries explicitly targeting Jacobian's pinned CORE or MATHLIB "
-    "environment, use the pinned mathematical operation because repository search or "
-    "a local Lean process may not match that server environment. Project-local Lean "
+    "environment, use the pinned mathematical operation; do not substitute repository "
+    "search, cached Mathlib files, or a local Lean process because they may not match "
+    "that server environment. Project-local Lean "
     "declarations are outside the server catalog and may require project-local tools. "
     "Other uses include symbolic transformation, structural analysis, examples or "
     "counterexamples, bounded search, Lean/Mathlib declaration search or formal-"
@@ -59,7 +60,9 @@ Examples:
 MATH_RUN_DESCRIPTION = """\
 Run one installed math tool by ID with its typed `payload`. Read the mathematical
 value in `output` first, then execution status. If the payload shape is unknown,
-inspect the exact operation with math.find.
+inspect the exact operation with math.find, then copy and adapt one of its
+`invocation_examples`. Do not call math.run with an empty `payload` merely to
+discover required fields; the inspect result is the authoritative contract.
 
 Ordinary tools return calculations. Independent checking uses a separate checker
 tool ID (for example `polynomial.identity.verify`), not a switch on the producer.

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -258,6 +258,40 @@ def _mcp_call_signature(tool: str, arguments: object) -> tuple[str, str]:
     return tool, f"sha256:{hashlib.sha256(encoded).hexdigest()}"
 
 
+def _operation_recovery_metrics(
+    attempts: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Count neutral recovery signals without interpreting mathematical outcomes."""
+
+    failed_signatures: Counter[tuple[str, str]] = Counter()
+    empty_payload_probe_count = 0
+    failed_operation_attempt_count = 0
+    for attempt in attempts:
+        if attempt.get("input") == {}:
+            empty_payload_probe_count += 1
+        if attempt.get("successful") is not False:
+            continue
+        failed_operation_attempt_count += 1
+        failed_signatures[
+            _mcp_call_signature(
+                "math.run.error",
+                {
+                    "capability_id": attempt.get("capability_id"),
+                    "input": attempt.get("input"),
+                    "diagnostic_codes": attempt.get("diagnostic_codes", []),
+                    "diagnostics": attempt.get("diagnostics", []),
+                },
+            )
+        ] += 1
+    return {
+        "empty_payload_probe_count": empty_payload_probe_count,
+        "failed_operation_attempt_count": failed_operation_attempt_count,
+        "repeated_error_count": sum(
+            count - 1 for count in failed_signatures.values() if count > 1
+        ),
+    }
+
+
 @dataclass
 class _AgentTranscriptTelemetry:
     mcp_calls: list[str] = field(default_factory=list)
@@ -653,6 +687,7 @@ def _transcript_payload(telemetry: _AgentTranscriptTelemetry) -> dict[str, Any]:
         ],
         "capability_describe_index_calls": telemetry.capability_describe_index_calls,
         "capability_describe_exact_calls": telemetry.capability_describe_exact_calls,
+        **_operation_recovery_metrics(telemetry.capability_attempts),
     }
 
 

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -267,17 +267,19 @@ def _operation_recovery_metrics(
     empty_payload_probe_count = 0
     failed_operation_attempt_count = 0
     for attempt in attempts:
-        if attempt.get("input") == {}:
-            empty_payload_probe_count += 1
         if attempt.get("successful") is not False:
             continue
         failed_operation_attempt_count += 1
+        if attempt.get("input") == {} and attempt.get("request_validation_failure"):
+            empty_payload_probe_count += 1
         failed_signatures[
             _mcp_call_signature(
                 "math.run.error",
                 {
                     "capability_id": attempt.get("capability_id"),
                     "input": attempt.get("input"),
+                    "terminal_status": attempt.get("terminal_status"),
+                    "error_digest": attempt.get("error_digest"),
                     "diagnostic_codes": attempt.get("diagnostic_codes", []),
                     "diagnostics": attempt.get("diagnostics", []),
                 },
@@ -371,6 +373,7 @@ def _record_describe_and_attempt(
     arguments: object,
     *,
     successful: bool,
+    item: Mapping[str, Any],
     response: Mapping[str, Any] | None,
 ) -> None:
     if tool == "math.find":
@@ -390,6 +393,8 @@ def _record_describe_and_attempt(
         "input": payload,
         "successful": successful,
     }
+    if not successful:
+        attempt.update(_mcp_failure_metadata(item, response))
     diagnostic_codes = _capability_diagnostic_codes(response)
     if diagnostic_codes:
         attempt["diagnostic_codes"] = diagnostic_codes
@@ -399,6 +404,52 @@ def _record_describe_and_attempt(
     telemetry.capability_attempts.append(attempt)
     if isinstance(capability_id, str):
         telemetry.capability_attempt_ids.append(capability_id)
+
+
+def _mcp_failure_metadata(
+    item: Mapping[str, Any],
+    response: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return bounded failure identity for exact recovery aggregation."""
+
+    execution = response.get("execution") if isinstance(response, Mapping) else None
+    execution_status = (
+        execution.get("status") if isinstance(execution, Mapping) else None
+    )
+    item_status = item.get("status")
+    terminal_status = (
+        execution_status
+        if isinstance(execution_status, str)
+        else item_status
+        if isinstance(item_status, str)
+        else None
+    )
+    output = response.get("output") if isinstance(response, Mapping) else None
+    error_identity = {
+        "item_error": item.get("error"),
+        "response_error": response.get("error")
+        if isinstance(response, Mapping)
+        else None,
+        "output_error": output.get("error") if isinstance(output, Mapping) else None,
+        "diagnostics": (
+            response.get("diagnostics") if isinstance(response, Mapping) else None
+        ),
+    }
+    _, error_digest = _mcp_call_signature("math.run.error", error_identity)
+    request_validation_failure = _contains_value(
+        item,
+        field="code",
+        accepted=set(_PARAMETER_ERROR_CODES),
+    ) or _contains_value(
+        response,
+        field="stage",
+        accepted={"request_validation"},
+    )
+    return {
+        "terminal_status": terminal_status,
+        "error_digest": error_digest,
+        "request_validation_failure": request_validation_failure,
+    }
 
 
 def _capability_diagnostic_codes(
@@ -614,6 +665,7 @@ def _process_mcp_tool_call(
         tool,
         arguments,
         successful=not failed,
+        item=item,
         response=response,
     )
     if failed:

--- a/src/jacobian/lean_frontend/declaration_operations.py
+++ b/src/jacobian/lean_frontend/declaration_operations.py
@@ -119,15 +119,15 @@ def build_lean_declaration_query_bundle(
                         CapabilityInvocationExample(
                             name="find_sqrt_two_irrationality",
                             description=(
-                                "Search pinned Mathlib for declarations whose name "
-                                "mentions irrational square root."
+                                "Find the exact square-root-of-two irrationality "
+                                "declaration in pinned Mathlib."
                             ),
                             input=LeanDeclarationSearchRequest.model_validate(
                                 {
                                     "environment": "MATHLIB",
-                                    "name_contains": "irrational_sqrt",
+                                    "name_contains": "irrational_sqrt_two",
                                     "kinds": ["THEOREM"],
-                                    "result_limit": 10,
+                                    "result_limit": 1,
                                 }
                             ).model_dump(mode="json"),
                         ),

--- a/tests/boundary/process/tooling/test_deploy_smoke_lean.py
+++ b/tests/boundary/process/tooling/test_deploy_smoke_lean.py
@@ -74,14 +74,24 @@ def test_transition_smoke_requires_exactly_one_bound_successor_on_acceptance() -
 def test_mathlib_declaration_smoke_requires_the_exact_declaration() -> None:
     result = {
         "execution": {"status": "COMPLETED"},
-        "output": {"declarations": [{"name": "irrational_sqrt_two"}]},
+        "output": {
+            "result": {"declarations": [{"name": "irrational_sqrt_two"}]},
+            "backend_version": "Lean 4.31.0 + Mathlib",
+        },
     }
     _require_mathlib_declaration(result)
 
     for mutation in (
         {**result, "execution": {"status": "ERROR"}},
-        {**result, "output": {"declarations": []}},
-        {**result, "output": {"declarations": [{"name": "Nat.add"}]}},
+        {**result, "output": {"result": {"declarations": []}}},
+        {
+            **result,
+            "output": {"result": {"declarations": [{"name": "Nat.add"}]}},
+        },
+        {
+            **result,
+            "output": {"declarations": [{"name": "irrational_sqrt_two"}]},
+        },
     ):
         with pytest.raises(RuntimeError):
             _require_mathlib_declaration(mutation)

--- a/tests/component/providers/lean/test_lean_declaration_adapters.py
+++ b/tests/component/providers/lean/test_lean_declaration_adapters.py
@@ -152,8 +152,9 @@ def test_search_adapter_exposes_bounded_computed_retrieval(tmp_path: Path) -> No
     )
     adapter = _query_adapter(tmp_path, backend, "lean.declaration.search")
     assert adapter.descriptor.invocation_examples[0].input["name_contains"] == (
-        "irrational_sqrt"
+        "irrational_sqrt_two"
     )
+    assert adapter.descriptor.invocation_examples[0].input["result_limit"] == 1
     assert "shell-searching" in adapter.descriptor.description
     result = adapter.invoke(
         CapabilityRequest(

--- a/tests/unit/eval/test_lean_diagnostic_recovery.py
+++ b/tests/unit/eval/test_lean_diagnostic_recovery.py
@@ -47,6 +47,42 @@ def _classify(
     return classify_recovery(case, retained)
 
 
+def test_recovery_run_uses_supplied_isolated_codex_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    def run_operator_command(*_args: object, **kwargs: object) -> object:
+        observed["environment"] = kwargs["environment"]
+        return command_runner_module.ToolCommandResult(
+            status=command_runner_module.ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(recovery_module, "run_operator_command", run_operator_command)
+    environment = {"HOME": "/isolated/home", "CODEX_HOME": "/isolated/codex"}
+    output = tmp_path / "output"
+    output.mkdir()
+
+    recovery_module._run_case(
+        case=load_suite(SUITE).cases[0],
+        repetition=1,
+        workspace=tmp_path,
+        output=output,
+        model="gpt-test",
+        reasoning_effort="high",
+        mcp_url="http://127.0.0.1:8000/mcp",
+        timeout_seconds=30,
+        tool_mode=recovery_module.ToolMode.DIRECT,
+        environment=environment,
+    )
+
+    assert observed["environment"] is environment
+
+
 def _surface(seed: str, deployed_revision: str) -> dict[str, object]:
     observed_revision = deployed_revision.ljust(40, "0")
     snapshot = {

--- a/tests/unit/eval/test_lean_diagnostic_recovery.py
+++ b/tests/unit/eval/test_lean_diagnostic_recovery.py
@@ -306,6 +306,22 @@ def _comparison_report(
         "repetitions": 1,
         "timeout_seconds": 300.0,
         "codex_version": "codex-test",
+        "evaluator": {
+            "isolation": {
+                "schema_version": "1",
+                "home_isolated": True,
+                "codex_home_isolated": True,
+                "user_config_loaded": False,
+                "user_rules_loaded": False,
+                "authentication_seeded": True,
+            },
+            "skill_surface": {
+                "skill_count": 0,
+                "skills": [],
+                "external_file_sources": [],
+                "model_visible_instructions_sha256": "sha256:" + "d" * 64,
+            },
+        },
         "selected_case_ids": ["core-check-type-mismatch"],
         "surface": _surface(
             surface_seed or ("b" if control else "c"),
@@ -1165,6 +1181,29 @@ def test_recovery_comparison_rejects_model_drift(tmp_path: Path) -> None:
     treatment = _comparison_report("enriched-diagnostics")
     with pytest.raises(ValueError, match="model"):
         _compare(tmp_path, control, {**treatment, "model": "second"})
+
+
+def test_recovery_comparison_rejects_missing_evaluator_identity(
+    tmp_path: Path,
+) -> None:
+    control = _comparison_report("control")
+    treatment = _comparison_report("enriched-diagnostics")
+    treatment.pop("evaluator")
+
+    with pytest.raises(ValueError, match="evaluator identity"):
+        _compare(tmp_path, control, treatment)
+
+
+def test_recovery_comparison_rejects_skill_surface_drift(tmp_path: Path) -> None:
+    control = _comparison_report("control")
+    treatment = _comparison_report("enriched-diagnostics")
+    changed = deepcopy(treatment)
+    changed["evaluator"]["skill_surface"]["model_visible_instructions_sha256"] = (
+        "sha256:" + "e" * 64
+    )
+
+    with pytest.raises(ValueError, match="evaluator"):
+        _compare(tmp_path, control, changed)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -13,6 +13,8 @@ from benchmarks.tooling.codex_visibility import (
     VisibilityOutputOutcome,
     _build_summary,
     _codex_arguments,
+    _inspect_codex_skill_surface,
+    _prepare_isolated_codex_environment,
     _run_case,
     classify_visibility,
     load_suite,
@@ -20,6 +22,8 @@ from benchmarks.tooling.codex_visibility import (
 from benchmarks.tooling.command_runner import ToolCommandResult, ToolCommandStatus
 from pydantic import ValidationError
 
+from jacobian.contracts.domain_operations import InlineOperationOutput
+from jacobian.contracts.lean import LeanDeclarationSearchOutput
 from jacobian.eval.telemetry import parse_agent_transcript
 
 _ROOT = Path(__file__).resolve().parents[3]
@@ -163,6 +167,123 @@ def test_unified_exec_mode_is_opt_in(tmp_path: Path) -> None:
     assert "unified_exec" not in direct
     assert unified[-3:-1] == ("--enable", "unified_exec")
     assert 'mcp_servers.jacobian.default_tools_approval_mode="approve"' in unified
+    assert "--ignore-user-config" in direct
+    assert "--ignore-rules" in direct
+
+
+def test_codex_isolation_copies_only_authentication(tmp_path: Path) -> None:
+    source_home = tmp_path / "source-home"
+    source_codex_home = source_home / ".codex"
+    source_codex_home.mkdir(parents=True)
+    (source_codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    (source_codex_home / "config.toml").write_text(
+        "model = 'ambient'", encoding="utf-8"
+    )
+    (source_codex_home / "skills").mkdir()
+
+    environment, isolation = _prepare_isolated_codex_environment(
+        tmp_path / "isolation",
+        source_environment={
+            "HOME": str(source_home),
+            "CODEX_HOME": str(source_codex_home),
+            "PATH": "/bin",
+        },
+    )
+
+    isolated_codex_home = Path(environment["CODEX_HOME"])
+    assert environment["HOME"] != str(source_home)
+    assert isolated_codex_home != source_codex_home
+    assert sorted(path.name for path in isolated_codex_home.iterdir()) == ["auth.json"]
+    assert isolation == {
+        "schema_version": "1",
+        "home_isolated": True,
+        "codex_home_isolated": True,
+        "user_config_loaded": False,
+        "user_rules_loaded": False,
+        "authentication_seeded": True,
+    }
+
+
+def test_codex_skill_surface_records_model_visible_sources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    isolated_home = tmp_path / "home"
+    codex_home = tmp_path / "codex-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    prompt = f"""<skills_instructions>
+## Skills
+- imagegen: Generate images. (file: {codex_home}/skills/.system/imagegen/SKILL.md)
+- leantoken: Explore repositories. (file: /home/operator/.agents/skills/leantoken/SKILL.md)
+</skills_instructions>"""
+    result = ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=0,
+        stdout=json.dumps(
+            [
+                {
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": prompt}],
+                }
+            ]
+        ).encode(),
+        stderr=b"",
+    )
+    monkeypatch.setattr(
+        "benchmarks.tooling.codex_visibility.run_operator_command",
+        lambda *_args, **_kwargs: result,
+    )
+
+    surface = _inspect_codex_skill_surface(
+        workspace,
+        {"HOME": str(isolated_home), "CODEX_HOME": str(codex_home)},
+    )
+
+    assert [skill["name"] for skill in surface["skills"]] == [
+        "imagegen",
+        "leantoken",
+    ]
+    assert surface["skills"][0]["source"].startswith("$CODEX_HOME/")
+    assert surface["external_file_sources"] == [
+        "/home/operator/.agents/skills/leantoken/SKILL.md"
+    ]
+
+
+def test_codex_skill_surface_rejects_unparsed_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = ToolCommandResult(
+        status=ToolCommandStatus.EXITED,
+        exit_code=0,
+        stdout=json.dumps(
+            [
+                {
+                    "role": "developer",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": (
+                                "<skills_instructions>\n## Skills\n"
+                                "- unknown format without a source\n"
+                                "</skills_instructions>"
+                            ),
+                        }
+                    ],
+                }
+            ]
+        ).encode(),
+        stderr=b"",
+    )
+    monkeypatch.setattr(
+        "benchmarks.tooling.codex_visibility.run_operator_command",
+        lambda *_args, **_kwargs: result,
+    )
+
+    with pytest.raises(RuntimeError, match="unknown format"):
+        _inspect_codex_skill_surface(
+            tmp_path,
+            {"HOME": str(tmp_path / "home"), "CODEX_HOME": str(tmp_path / "codex")},
+        )
 
 
 def test_visibility_classification_records_adoption_without_grading_shell(
@@ -229,6 +350,7 @@ def test_visibility_classification_records_adoption_without_grading_shell(
     assert result["mcp_call_count"] == 3
     assert result["math_find_call_count"] == 2
     assert result["math_run_call_count"] == 1
+    assert result["empty_payload_probe_count"] == 1
 
 
 def test_visibility_classification_records_discovery_free_invocation(
@@ -359,26 +481,47 @@ def test_diagnostic_operation_observation_does_not_gate_outcome_contract() -> No
     assert result["unexpected_capabilities"]["completed"] == []
 
 
-def test_declaration_outcome_accepts_complete_search_without_inspect() -> None:
+def test_declaration_outcome_accepts_native_inline_search_without_inspect() -> None:
     case = load_suite(_ROOT / "benchmarks/config/lean-usability-v1.json").cases[3]
+    native_output = (
+        InlineOperationOutput[LeanDeclarationSearchOutput]
+        .model_validate(
+            {
+                "result": {
+                    "environment": "MATHLIB",
+                    "environment_digest": "sha256:" + "a" * 64,
+                    "lean_version": "4.31.0",
+                    "lean_commit": "lean-commit",
+                    "mathlib_commit": "mathlib-commit",
+                    "query": {
+                        "environment": "MATHLIB",
+                        "name_contains": "irrational_sqrt_two",
+                        "kinds": ["THEOREM"],
+                        "result_limit": 1,
+                    },
+                    "declarations": [
+                        {
+                            "name": "irrational_sqrt_two",
+                            "type": "Irrational √2",
+                            "kind": "THEOREM",
+                            "match_reasons": ["NAME_SUBSTRING"],
+                        }
+                    ],
+                    "scanned_declarations": 42,
+                    "stop_reason": "RESULT_LIMIT",
+                },
+                "backend_version": "Lean 4.31.0 + Mathlib",
+            }
+        )
+        .model_dump(mode="json")
+    )
     telemetry = {
         "capability_attempt_ids": ["lean.declaration.search"],
         "capability_ids": ["lean.declaration.search"],
         "capability_invocations": [
             {
                 "capability_id": "lean.declaration.search",
-                "output": {
-                    "environment_digest": "sha256:" + "a" * 64,
-                    "lean_version": "4.31.0",
-                    "lean_commit": "lean-commit",
-                    "mathlib_commit": "mathlib-commit",
-                    "declarations": [
-                        {
-                            "name": "irrational_sqrt_two",
-                            "type": "Irrational √2",
-                        }
-                    ],
-                },
+                "output": native_output,
             }
         ],
     }
@@ -408,11 +551,14 @@ def test_declaration_outcome_rejects_incomplete_structured_output() -> None:
                 {
                     "capability_id": "lean.declaration.search",
                     "output": {
-                        "environment_digest": "sha256:" + "a" * 64,
-                        "lean_version": "4.31.0",
-                        "lean_commit": "lean-commit",
-                        "mathlib_commit": "mathlib-commit",
-                        "declarations": [{"name": "irrational_sqrt_two"}],
+                        "result": {
+                            "environment_digest": "sha256:" + "a" * 64,
+                            "lean_version": "4.31.0",
+                            "lean_commit": "lean-commit",
+                            "mathlib_commit": "mathlib-commit",
+                            "declarations": [{"name": "irrational_sqrt_two"}],
+                        },
+                        "backend_version": "Lean 4.31.0 + Mathlib",
                     },
                 }
             ],
@@ -519,6 +665,7 @@ def _patched_run_case(
         mcp_url="https://example.test/mcp",
         timeout_seconds=5.0,
         tool_mode=ToolMode.DIRECT,
+        environment={},
     )
 
 
@@ -618,6 +765,7 @@ def test_visibility_report_serializes_duration_fields(
             mcp_url="https://example.test/mcp",
             timeout_seconds=5.0,
             tool_mode=ToolMode.DIRECT,
+            environment={},
         )
         for rep in (1, 2)
     ]
@@ -645,3 +793,23 @@ def test_visibility_report_serializes_duration_fields(
     assert parsed["summary"]["duration_totals"]["elapsed_seconds"] >= 0
     assert parsed["summary"]["run_count"] == 2
     assert parsed["summary"]["command_failure_count"] == 1
+    assert parsed["summary"]["recovery_totals"] == {
+        "empty_payload_probe_count": 0,
+        "failed_operation_attempt_count": 0,
+        "repeated_error_count": 0,
+    }
+    assert parsed["summary"]["case_repetition_metrics"] == [
+        {
+            "case_id": "exact-determinant",
+            "run_count": 2,
+            "command_failure_count": 1,
+            "contract_satisfied_count": 0,
+            "contract_satisfaction_rate": 0.0,
+            "empty_payload_probe_count": 0,
+            "runs_with_empty_payload_probe": 0,
+            "empty_payload_probe_run_rate": 0.0,
+            "failed_operation_attempt_count": 0,
+            "repeated_error_count": 0,
+            "repeated_error_rate": None,
+        }
+    ]

--- a/tests/unit/tooling/test_codex_visibility.py
+++ b/tests/unit/tooling/test_codex_visibility.py
@@ -350,7 +350,7 @@ def test_visibility_classification_records_adoption_without_grading_shell(
     assert result["mcp_call_count"] == 3
     assert result["math_find_call_count"] == 2
     assert result["math_run_call_count"] == 1
-    assert result["empty_payload_probe_count"] == 1
+    assert result["empty_payload_probe_count"] == 0
 
 
 def test_visibility_classification_records_discovery_free_invocation(

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -209,11 +209,51 @@ def test_agent_telemetry_retains_failed_math_run_attempts(tmp_path: Path) -> Non
     telemetry = parse_agent_transcript(transcript)
 
     assert telemetry["capability_attempts"] == [
-        {"capability_id": None, "input": {"malformed": True}, "successful": False},
+        {
+            "capability_id": None,
+            "input": {"malformed": True},
+            "successful": False,
+            "terminal_status": "failed",
+            "error_digest": "sha256:"
+            + hashlib.sha256(
+                canonicalize_json(
+                    {
+                        "item_error": "invalid request",
+                        "response_error": None,
+                        "output_error": None,
+                        "diagnostics": None,
+                    }
+                )
+            ).hexdigest(),
+            "request_validation_failure": False,
+        },
         {
             "capability_id": "lean.retrieve.premises",
             "input": {"statement": "True", "proof_prefix": ["by"]},
             "successful": False,
+            "terminal_status": "ERROR",
+            "error_digest": "sha256:"
+            + hashlib.sha256(
+                canonicalize_json(
+                    {
+                        "item_error": None,
+                        "response_error": None,
+                        "output_error": {
+                            "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                            "stage": "request_validation",
+                            "message": "proof_prefix must not include by",
+                        },
+                        "diagnostics": [
+                            {
+                                "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                                "stage": "request_validation",
+                                "message": "proof_prefix must not include by",
+                            }
+                        ],
+                    }
+                )
+            ).hexdigest(),
+            "request_validation_failure": True,
             "diagnostic_codes": ["INVALID_LEAN_RETRIEVAL_REQUEST"],
             "diagnostics": [
                 {
@@ -283,6 +323,58 @@ def test_agent_telemetry_records_empty_payload_and_exact_repeated_errors(
     telemetry = parse_agent_transcript(transcript)
 
     assert telemetry["empty_payload_probe_count"] == 2
+    assert telemetry["failed_operation_attempt_count"] == 3
+    assert telemetry["repeated_error_count"] == 1
+
+
+def test_agent_telemetry_does_not_count_successful_empty_payload_as_probe(
+    tmp_path: Path,
+) -> None:
+    event = _tool_event(
+        "math.run",
+        {"capability_id": "example.all_defaults", "payload": {}},
+        {
+            "capability_id": "example.all_defaults",
+            "execution": {"status": "COMPLETED"},
+            "output": {"value": 1},
+        },
+    )
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["empty_payload_probe_count"] == 0
+
+
+def test_agent_telemetry_distinguishes_terminal_failure_identity(
+    tmp_path: Path,
+) -> None:
+    events = []
+    for status, message in (
+        ("TIMEOUT", "deadline exceeded"),
+        ("CANCELLED", "request cancelled"),
+        ("TIMEOUT", "deadline exceeded"),
+    ):
+        events.append(
+            _tool_event(
+                "math.run",
+                {"capability_id": "lean.check", "payload": {"statement": "True"}},
+                {
+                    "capability_id": "lean.check",
+                    "execution": {"status": status},
+                    "output": {"error": {"code": status, "message": message}},
+                },
+            )
+        )
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_agent_transcript(transcript)
+
     assert telemetry["failed_operation_attempt_count"] == 3
     assert telemetry["repeated_error_count"] == 1
 

--- a/tests/unit/tooling/test_eval_telemetry.py
+++ b/tests/unit/tooling/test_eval_telemetry.py
@@ -235,6 +235,58 @@ def test_agent_telemetry_retains_failed_math_run_attempts(tmp_path: Path) -> Non
     assert telemetry["capability_ids"] == ["lean.check"]
 
 
+def test_agent_telemetry_records_empty_payload_and_exact_repeated_errors(
+    tmp_path: Path,
+) -> None:
+    invalid = {
+        "capability_id": "lean.check",
+        "execution": {"status": "ERROR"},
+        "output": {
+            "error": {
+                "code": "INVALID_REQUEST",
+                "stage": "request_validation",
+                "path": "$",
+            }
+        },
+    }
+    events = [
+        _tool_event(
+            "math.run", {"capability_id": "lean.check", "payload": {}}, invalid
+        ),
+        _tool_event(
+            "math.run", {"capability_id": "lean.check", "payload": {}}, invalid
+        ),
+        _tool_event(
+            "math.run",
+            {
+                "capability_id": "lean.retrieve.premises",
+                "payload": {"statement": "True", "proof_prefix": ["by"]},
+            },
+            {
+                "capability_id": "lean.retrieve.premises",
+                "execution": {"status": "ERROR"},
+                "output": {
+                    "error": {
+                        "code": "INVALID_LEAN_RETRIEVAL_REQUEST",
+                        "stage": "request_validation",
+                    }
+                },
+            },
+        ),
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+
+    telemetry = parse_agent_transcript(transcript)
+
+    assert telemetry["empty_payload_probe_count"] == 2
+    assert telemetry["failed_operation_attempt_count"] == 3
+    assert telemetry["repeated_error_count"] == 1
+
+
 def test_agent_telemetry_counts_response_bytes_and_repeated_calls(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- update Lean declaration benchmark and deployment smoke consumers for native `output.result.*` values
- run visibility evaluations with isolated temporary `HOME`/`CODEX_HOME`, authentication only, ignored user rules/config, and a fail-closed recorded skill surface
- record empty-payload probes, failed operation attempts, exact repeated errors, and per-case repetition rates without affecting mathematical verdicts
- make `math.run` guidance tell agents to copy inspected invocation examples instead of probing with `{}`
- narrow the Mathlib irrational-square-root discovery example to the exact name and one result

## Why

The native typed-operation migration changed declaration output wrapping while the evaluator and Lean deployment smoke still read the previous shape. Ambient file-backed skills could also contaminate Codex observations, and recovery inefficiencies were not measured explicitly.

## Validation

- `make check-changed PATHS='[...]'`: 12/12 selected gates passed (lint/typecheck, npm, docs, unit, component, domain, composition, storage, process, MCP, e2e, deploy)
- local CORE/MATHLIB Lean smoke: CORE and MATHLIB verification, declaration search, accepted tactic, rejected diagnostic all passed
- isolated Codex premise case: VERIFIED, 8 MCP calls, 0 shell calls, 0 empty payload probes, 0 failed attempts, 0 repeated errors
- isolated Codex declaration case, 3 repetitions: 3/3 contracts satisfied, 0 shell calls, 0 empty payload probes, 0 failed attempts, 0 repeated errors

The evaluation metrics remain observational and do not alter checker conclusions or verification authority.