### PR TITLE
Expose exact polynomial-power normalization

### DIFF
--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -181,8 +181,9 @@ class SympyPolynomialExpressionNormalizeAdapter:
             version="1",
             title="Normalize a typed rational polynomial expression",
             description=(
-                "Convert one bounded, versioned QQ-polynomial AST to canonical "
-                "sparse coefficients without parsing or evaluating user strings. "
+                "Exactly expand sums, products, and bounded integer powers in one "
+                "versioned QQ-polynomial AST to canonical sparse coefficients, "
+                "without parsing or evaluating user strings. "
                 "This is one concrete-expression outcome: finitely many "
                 "normalizations do not verify an identity parameterized over all "
                 "orders. Verify each full expression relation separately."
@@ -195,6 +196,10 @@ class SympyPolynomialExpressionNormalizeAdapter:
                 "polynomial",
                 "symbolic",
                 "normalization",
+                "expansion",
+                "product",
+                "power",
+                "coefficients",
                 "typed-expression",
                 "exact-rational",
                 "sympy",

--- a/tests/component/providers/polynomial/test_polynomial_normalization_discovery.py
+++ b/tests/component/providers/polynomial/test_polynomial_normalization_discovery.py
@@ -1,0 +1,20 @@
+"""Discovery metadata for typed polynomial-expression normalization."""
+
+
+def test_normalizer_exposes_expansion_vocabulary(
+    polynomial_normalization_services,
+) -> None:
+    descriptor = next(
+        descriptor
+        for descriptor in (
+            polynomial_normalization_services.core.capabilities.catalog().capabilities
+        )
+        if descriptor.capability_id == "polynomial.expression.normalize"
+    )
+
+    assert {"expansion", "product", "power", "coefficients"} <= set(
+        descriptor.tags
+    )
+    assert "Exactly expand sums, products, and bounded integer powers" in (
+        descriptor.description
+    )


### PR DESCRIPTION
## Summary

Ports the useful discovery portion of #936 onto the post-#1276 ownership model.

- describe `polynomial.expression.normalize` as the exact expansion operation it already implements for sums, products, and bounded integer powers;
- add factual `expansion`, `product`, `power`, and `coefficients` search vocabulary;
- add a focused descriptor regression;
- deliberately omit reciprocal producer/checker relationship registration and relationship-graph tests.

## Architecture boundary

The normalizer remains one existing typed adapter with its current runtime, artifact, and final-projection ownership. This PR changes only its model-facing description/tags and one focused test. It does not prescribe a workflow, register capability relationships, create a second catalog, or alter checker authority.

## Validation

The branch was rebuilt directly from current `main` and contains no files from the former `foundation_installation.py` relationship patch.

Supersedes #936.