### PR TITLE
Clarify local Jacobian tool routing

### DIFF
--- a/src/jacobian/adapters/mcp/core.py
+++ b/src/jacobian/adapters/mcp/core.py
@@ -103,7 +103,7 @@ class JacobianCoreExtension(Extension):
                 capability_describe,
                 kwargs={
                     "name": "math.find",
-                    "title": "Find an exact mathematical operation",
+                    "title": "Search installed Jacobian math tools",
                     "description": MATH_FIND_DESCRIPTION,
                     "annotations": _tool_annotations(read_only=True, idempotent=True),
                     "structured_output": True,
@@ -113,7 +113,7 @@ class JacobianCoreExtension(Extension):
                 capability_invoke,
                 kwargs={
                     "name": "math.run",
-                    "title": "Run a mathematical operation",
+                    "title": "Run one installed Jacobian math tool",
                     "description": MATH_RUN_DESCRIPTION,
                     "annotations": _tool_annotations(),
                     "structured_output": True,

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -3,41 +3,38 @@
 from __future__ import annotations
 
 SERVER_DESCRIPTION = (
-    "Use atomic exact and symbolic mathematics, with separate checker operations "
-    "when independent verification is needed."
+    "Search and run installed Jacobian exact-math operations, with separate checker "
+    "operations for independent verification."
 )
 
 SERVER_INSTRUCTIONS = (
-    "Use Jacobian whenever a task may benefit from a specialized exact mathematical "
-    "operation, including matrix or polynomial computation. This applies even when the "
-    "user does not name Jacobian and shell code could also calculate the result. Unless "
-    "an exact installed capability ID and its typed contract are already available, call "
-    "math.find with a plain-language desired local mathematical outcome; no capability "
-    "ID is required. math.run may execute a known contract directly. "
+    "math.find searches the locally installed Jacobian toolbox; internet search cannot "
+    "show which operations are available in this runtime. math.run executes one selected "
+    "operation. Use these tools when exact computation, symbolic transformation, finite "
+    "search, formal inspection, or independent checking would add relevant mathematical "
+    "evidence, even when the user does not name Jacobian or shell code could calculate "
+    "the result. If the exact installed ID and typed contract are unknown, search by the "
+    "desired local mathematical outcome and inspect a selected ID. A known contract may "
+    "run directly. "
     "For declaration queries explicitly targeting Jacobian's pinned CORE or MATHLIB "
     "environment, use the pinned mathematical operation; do not substitute repository "
     "search, cached Mathlib files, or a local Lean process because they may not match "
-    "that server environment. Project-local Lean "
-    "declarations are outside the server catalog and may require project-local tools. "
-    "Other uses include symbolic transformation, structural analysis, examples or "
-    "counterexamples, bounded search, Lean/Mathlib declaration search or formal-"
-    "environment inspection, and requested independent verification. "
-    "Do not report that no specialized mathematical operation is available without "
-    "checking math.find. When independent checking is requested, multiple calculations "
-    "or programs authored by the same model are not independent checker evidence. "
-    "Search again whenever the objective or available evidence changes. "
+    "that server environment. Project-local Lean declarations are outside the server "
+    "catalog and may require project-local tools. "
+    "Repeating the same lookup against an unchanged catalog returns the same operation "
+    "facts; math.find is operation lookup, not confirmation. Merely restating an accepted "
+    "value without new evidence is not a mathematical-tool use case. "
     "The model owns representation, decomposition, composition, iteration, verification "
-    "timing, and stopping. Results keep execution status, mathematical conclusion, "
-    "and verification record separate. No descriptor match, timeout, "
-    "bounded or exhausted search, or failure to find a witness is a mathematical "
-    "conclusion. Only a result with a local verification record URI is "
-    "verified. A verification record for an input, premise, factorization, or related "
-    "artifact does not verify a model-derived conclusion; the record must be bound to "
-    "the exact final claim."
+    "timing, and stopping. An operation match, timeout, incomplete search, or failure to "
+    "find a witness is not a mathematical conclusion. Independent checking uses a "
+    "separate checker operation; model-authored duplicate calculations are not independent "
+    "evidence. Only a result with a local verification record URI is verified, and that "
+    "record must be bound to the exact final claim."
 )
 
 MATH_FIND_DESCRIPTION = """\
-Search or inspect installed math tools by desired outcome or exact ID. Use when a
+Search or inspect locally installed Jacobian math tools by desired outcome or exact ID.
+This is the authoritative runtime inventory; internet search is not. Use when a
 task may benefit from exact computation, search, structural analysis, or a separate
 checker tool—even if shell code could also calculate the answer.
 
@@ -58,11 +55,11 @@ Examples:
 """
 
 MATH_RUN_DESCRIPTION = """\
-Run one installed math tool by ID with its typed `payload`. Read the mathematical
-value in `output` first, then execution status. If the payload shape is unknown,
-inspect the exact operation with math.find, then copy and adapt one of its
-`invocation_examples`. Do not call math.run with an empty `payload` merely to
-discover required fields; the inspect result is the authoritative contract.
+Run one installed Jacobian math tool by ID with its typed `payload`. Check execution
+status before treating `output` as mathematical evidence. If the payload shape is
+unknown, inspect the exact operation with math.find, then copy and adapt one of its
+`invocation_examples`. Do not call math.run with an empty `payload` merely to discover
+required fields; the inspect result is the authoritative contract.
 
 Ordinary tools return calculations. Independent checking uses a separate checker
 tool ID (for example `polynomial.identity.verify`), not a switch on the producer.

--- a/tests/boundary/mcp/test_mcp_tool_surface.py
+++ b/tests/boundary/mcp/test_mcp_tool_surface.py
@@ -21,8 +21,11 @@ def test_math_tool_surface_is_consistent_across_discovery(tmp_path: Path) -> Non
             listed = await client.list_tools()
             tools = {tool.name: tool for tool in listed.tools}
             assert set(tools) == {"math.find", "math.run"}
-            assert tools["math.find"].title == "Find an exact mathematical operation"
-            assert tools["math.run"].title == "Run a mathematical operation"
+            assert tools["math.find"].title == "Search installed Jacobian math tools"
+            assert tools["math.run"].title == "Run one installed Jacobian math tool"
+            assert "authoritative runtime inventory" in (
+                tools["math.find"].description or ""
+            )
             assert "math.find" in (tools["math.run"].description or "")
 
             described = await client.call_tool(

--- a/tests/unit/tooling/test_mcp_tool_surface.py
+++ b/tests/unit/tooling/test_mcp_tool_surface.py
@@ -42,18 +42,24 @@ def test_model_visible_guidance_exposes_affordances_without_research_order() -> 
     assert "partition larger searches" not in combined
 
 
-def test_server_instructions_front_load_implicit_activation_signal() -> None:
+def test_server_instructions_front_load_local_inventory_signal() -> None:
     prefix = SERVER_INSTRUCTIONS[:512].lower()
 
-    assert "specialized exact mathematical operation" in prefix
-    assert "matrix or polynomial" in prefix
-    assert "even when the user does not name jacobian" in prefix
     assert "math.find" in prefix
+    assert "locally installed jacobian toolbox" in prefix
+    assert "internet search cannot" in prefix
+    assert "even when the user does not name jacobian" in prefix
 
 
 def test_server_instructions_allow_known_contracts_to_run_directly() -> None:
-    assert "exact installed capability ID" in SERVER_INSTRUCTIONS
-    assert "math.run may execute a known contract directly" in SERVER_INSTRUCTIONS
+    assert "exact installed ID and typed contract" in SERVER_INSTRUCTIONS
+    assert "known contract may run directly" in SERVER_INSTRUCTIONS
+    assert "math.find is operation lookup, not confirmation" in SERVER_INSTRUCTIONS
+
+
+def test_server_instructions_preserve_evidence_sensitive_abstention() -> None:
+    assert "restating an accepted value without new evidence" in SERVER_INSTRUCTIONS
+    assert "not a mathematical-tool use case" in SERVER_INSTRUCTIONS
 
 
 def test_server_instructions_route_pinned_lean_declaration_queries() -> None:
@@ -66,5 +72,9 @@ def test_server_instructions_route_pinned_lean_declaration_queries() -> None:
 
 def test_guidance_rejects_verification_transfer_to_derived_claims() -> None:
     combined = "\n".join((SERVER_INSTRUCTIONS, MATH_RUN_DESCRIPTION))
-    assert "does not verify a model-derived conclusion" in combined
     assert "record must be bound to the exact final claim" in combined
+    assert "model-authored duplicate calculations are not independent" in combined
+
+
+def test_math_run_checks_execution_before_evidence() -> None:
+    assert "Check execution status before treating `output`" in MATH_RUN_DESCRIPTION


### PR DESCRIPTION
## Summary

Rebuilds the surviving guidance work from #1258 on the post-#1276 MCP ownership boundary.

- brand `math.find` and `math.run` as installed Jacobian tools in the transport-neutral core extension;
- state that `math.find`, not internet search, is the authoritative inventory for the current runtime;
- keep evidence-sensitive activation, direct execution for known contracts, deterministic repeated lookup, and abstention for mere restatement;
- preserve the current pinned CORE/Mathlib routing exception;
- tell callers to check execution status before treating `output` as mathematical evidence;
- retain exactly the fixed `math.find` + `math.run` surface.

## Architecture boundary

This is the single post-simplification guidance cleanup. It changes guidance, two tool titles, and focused boundary/unit tests only. It does not add dynamic tools, relationship navigation, planning policy, generic assurance fields, or a workflow engine.

Supersedes #1258 and absorbs the still-valid status-ordering correction from #1187.