### PR TITLE
fix(lean): remove unchanged corrupt declaration caches

### DIFF
--- a/src/jacobian/lean_frontend/declarations.py
+++ b/src/jacobian/lean_frontend/declarations.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import shutil
+import stat
 import tempfile
 import threading
 import time
@@ -323,7 +324,13 @@ class _ReusableLeanQuerySession:
 
     def _restore_index_cache(self) -> None:
         cache_path = self._index_cache_path
-        if cache_path is None or cache_path.is_symlink() or not cache_path.is_file():
+        if cache_path is None:
+            return
+        try:
+            source_stat = cache_path.lstat()
+        except OSError:
+            return
+        if not stat.S_ISREG(source_stat.st_mode):
             return
         try:
             _copy_bounded_file(
@@ -338,6 +345,18 @@ class _ReusableLeanQuerySession:
             self._index_digest = _sha256_file(self._index_path)
         except (OSError, ValueError):
             self._index_path.unlink(missing_ok=True)
+            try:
+                current_stat = cache_path.lstat()
+                unchanged = (
+                    current_stat.st_dev == source_stat.st_dev
+                    and current_stat.st_ino == source_stat.st_ino
+                )
+                if unchanged:
+                    cache_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
             self._index_digest = None
 
     def _publish_index_cache(self) -> None:
@@ -950,9 +969,6 @@ class LeanSubprocessDeclarationBackend:
                     "LEAN_ENVIRONMENT_UNAVAILABLE",
                     "The pinned Lean MATHLIB environment is not installed.",
                 )
-            # MATHLIB needs the host PATH (for elan/lake toolchain discovery)
-            # and host HOME (for elan toolchain installs), with the pinned
-            # Lean bin directory prepended to PATH.
             existing_path = os.environ.get("PATH", "")
             mathlib_path = (
                 f"{lean_bin}{os.pathsep}{existing_path}" if existing_path else lean_bin
@@ -964,7 +980,6 @@ class LeanSubprocessDeclarationBackend:
                     **lean_mathlib_git_config(mathlib_runtime),
                 },
             )
-        # CORE uses an isolated HOME and a toolchain-only PATH.
         return worker_environment(
             overrides={
                 "PATH": lean_bin,

--- a/tests/component/providers/lean/test_lean_declaration_corrupt_cache.py
+++ b/tests/component/providers/lean/test_lean_declaration_corrupt_cache.py
@@ -1,0 +1,101 @@
+"""Portable Lean declaration-cache corruption recovery."""
+
+from pathlib import Path
+
+import pytest
+
+import jacobian.lean_frontend.declarations as declarations
+
+_ENVIRONMENT_DIGEST = "sha256:" + "c" * 64
+
+
+def _session(tmp_path: Path, cache_path: Path) -> declarations._ReusableLeanQuerySession:
+    return declarations._ReusableLeanQuerySession(
+        command=[str(tmp_path / "lean")],
+        cwd=tmp_path,
+        process_environment={},
+        source="import Init.Prelude",
+        memory_mb="1024",
+        isolated_home=True,
+        environment_digest=_ENVIRONMENT_DIGEST,
+        index_cache_path=cache_path,
+        cache_results=True,
+    )
+
+
+def test_corrupt_regular_cache_is_removed_after_failed_restore(tmp_path: Path) -> None:
+    cache_path = tmp_path / "state" / "core.index"
+    cache_path.parent.mkdir()
+    cache_path.write_text(
+        f"{_ENVIRONMENT_DIGEST}\nmalformed-row\n",
+        encoding="utf-8",
+    )
+
+    session = _session(tmp_path, cache_path)
+
+    assert session._index_digest is None
+    assert not session._index_path.exists()
+    assert not cache_path.exists()
+    session.close()
+
+
+def test_oversized_regular_cache_is_removed_before_next_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache_path = tmp_path / "state" / "core.index"
+    cache_path.parent.mkdir()
+    cache_path.write_bytes(b"x" * 65)
+    monkeypatch.setattr(declarations, "_MAX_INDEX_BYTES", 64)
+
+    session = _session(tmp_path, cache_path)
+
+    assert session._index_digest is None
+    assert not session._index_path.exists()
+    assert not cache_path.exists()
+    session.close()
+
+
+def test_cache_symlink_is_rejected_without_deleting_its_target(tmp_path: Path) -> None:
+    cache_path = tmp_path / "state" / "core.index"
+    cache_path.parent.mkdir()
+    target = tmp_path / "external.index"
+    target.write_text("external cache", encoding="utf-8")
+    cache_path.symlink_to(target)
+
+    session = _session(tmp_path, cache_path)
+
+    assert session._index_digest is None
+    assert not session._index_path.exists()
+    assert cache_path.is_symlink()
+    assert target.read_text(encoding="utf-8") == "external cache"
+    session.close()
+
+
+def test_concurrent_atomic_replacement_is_not_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache_path = tmp_path / "state" / "core.index"
+    cache_path.parent.mkdir()
+    cache_path.write_text("stale cache", encoding="utf-8")
+
+    def replace_then_fail(
+        source: Path,
+        destination: Path,
+        *,
+        max_bytes: int,
+    ) -> None:
+        del destination, max_bytes
+        replacement = source.with_name("replacement.index")
+        replacement.write_text("new cache", encoding="utf-8")
+        replacement.replace(source)
+        raise ValueError("simulated corrupt source")
+
+    monkeypatch.setattr(declarations, "_copy_bounded_file", replace_then_fail)
+
+    session = _session(tmp_path, cache_path)
+
+    assert session._index_digest is None
+    assert cache_path.read_text(encoding="utf-8") == "new cache"
+    session.close()

--- a/tests/component/providers/lean/test_lean_declaration_corrupt_cache.py
+++ b/tests/component/providers/lean/test_lean_declaration_corrupt_cache.py
@@ -9,7 +9,9 @@ import jacobian.lean_frontend.declarations as declarations
 _ENVIRONMENT_DIGEST = "sha256:" + "c" * 64
 
 
-def _session(tmp_path: Path, cache_path: Path) -> declarations._ReusableLeanQuerySession:
+def _session(
+    tmp_path: Path, cache_path: Path
+) -> declarations._ReusableLeanQuerySession:
     return declarations._ReusableLeanQuerySession(
         command=[str(tmp_path / "lean")],
         cwd=tmp_path,


### PR DESCRIPTION
## Summary

Follow-up to #1272 for persistent declaration-index corruption recovery.

- reject symlink and other non-regular portable cache entries before copying;
- when restore or validation fails, remove the corrupt source cache only if it is still the exact same device/inode inspected before the copy;
- preserve a concurrent atomic replacement instead of deleting a newly published cache;
- cover malformed, oversized, symlink, and concurrent-replacement cases.

## Why

The merged cache implementation correctly ignored a corrupt portable index for the current session, but it left the corrupt source file under the state root. Every subsequent startup therefore repeated the same bounded copy and validation failure.

Deleting by pathname alone would introduce a race with atomic publication. This patch records the original regular file identity and unlinks only when the pathname still resolves to that same file after recovery fails.

## Architecture boundary

- no change to Lean declaration schemas or MCP tools;
- clean replay remains the production default;
- persistent REPL behavior is unchanged;
- cache identity remains pinned to the environment digest;
- failures remain bounded and fall back to rebuilding the index.

## Validation

The branch is based directly on current `main` at `236df591495ad522a00e9243da4f36b78aadcfda`. Focused component regressions are included; hosted CI is authoritative for the pushed head.