### PR TITLE
refactor(checkers): bind manifests into verification records

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -228,6 +228,11 @@ compatibility reads do not repeat that filesystem scan. A producer or unrelated
 checker edit therefore cannot change the identity, while a changed executable
 dependency cannot retain it.
 
+Verification record v4 snapshots that complete manifest and binds its canonical
+digest, so interpreting the checker identity never depends on a mutable
+authorization row. Record v3 belongs to state revision 10 and remains readable
+with the matching older checkout; the current runtime has no dual record shape.
+
 `VerificationResult` is the internal typed outcome of that checker execution,
 not a generic mathematical result envelope. Capability adapters project it
 once into the ordinary operation response. Ordinary producers do not use it,

--- a/docs/reference/state-format.md
+++ b/docs/reference/state-format.md
@@ -1,6 +1,6 @@
 # Persistent state format
 
-The current and minimum supported state format is revision 10. Older stores are
+The current and minimum supported state format is revision 11. Older stores are
 rejected before any migration code runs.
 
 To recover data from an older store, keep that directory unchanged and open it
@@ -15,4 +15,10 @@ upgrade path. Revisions 9 and 10 replace the broad checker-package digest with
 a versioned per-checker manifest that separates checker and worker source,
 records exact Python distributions, and produces one implementation digest;
 existing checker authorization rows are deliberately not reinterpreted. New
-stores apply the complete ordered schema and record revision 10.
+stores apply the complete ordered schema and record revision 11.
+
+Verification records are immutable artifacts rather than state-table rows.
+Record schema v4 payloads snapshot the accepting checker's full manifest.
+Revision 11 is an explicit cutover: revision-10 stores and their v3 records
+remain readable with a matching older checkout and are not reinterpreted by the
+current runtime. There is no legacy checker-authorization or record import path.

--- a/src/jacobian/checker_identity.py
+++ b/src/jacobian/checker_identity.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from types import FrameType, ModuleType
 from typing import Any, cast
 
-from jacobian.canonical import canonicalize_json
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.checkers import (
     CheckerManifest,
@@ -180,13 +179,7 @@ def build_checker_manifest(
 def checker_implementation_digest(manifest: CheckerManifest) -> str:
     """Return the identity digest of one versioned checker execution manifest."""
 
-    return (
-        "sha256:"
-        + hashlib.sha256(
-            b"jacobian.checker-implementation.v2\x00"
-            + canonicalize_json(manifest.model_dump(mode="json", exclude_none=True))
-        ).hexdigest()
-    )
+    return manifest.implementation_digest()
 
 
 def require_manifest_unchanged(manifest: CheckerManifest) -> str:

--- a/src/jacobian/contracts/checkers.py
+++ b/src/jacobian/contracts/checkers.py
@@ -8,6 +8,7 @@ from typing import Annotated, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
+from jacobian.canonical import canonicalize_json, sha256_digest
 from jacobian.contracts._verification_rules import (
     validate_certified_relationship_endpoints,
     validate_decisive_replayable_evidence,
@@ -145,6 +146,14 @@ class CheckerManifest(ContractModel):
         _require_exact_external_runtime(self.provider_runtime, self.entrypoint)
         return self
 
+    def implementation_digest(self) -> str:
+        """Return the canonical identity digest bound by checker records."""
+
+        return sha256_digest(
+            b"jacobian.checker-implementation.v2\x00"
+            + canonicalize_json(self.model_dump(mode="json", exclude_none=True))
+        )
+
 
 _REQUIRED_WORKER_DISTRIBUTIONS = frozenset({"pydantic", "pydantic-core", "rfc8785"})
 
@@ -218,6 +227,8 @@ class CheckerRegistration(ContractModel):
 
     @model_validator(mode="after")
     def require_manifest_scope(self) -> Self:
+        if self.implementation_digest != self.implementation.implementation_digest():
+            raise ValueError("checker implementation digest must match its manifest")
         expected_contracts = tuple(
             sorted(
                 {

--- a/src/jacobian/contracts/exact_domain_verification.py
+++ b/src/jacobian/contracts/exact_domain_verification.py
@@ -22,7 +22,7 @@ from pydantic import model_validator
 
 from jacobian.canonical import canonicalize_json, sha256_digest
 from jacobian.contracts.capabilities import CapabilityId
-from jacobian.contracts.checkers import CheckerDecision, EvidenceKind
+from jacobian.contracts.checkers import CheckerDecision, CheckerManifest, EvidenceKind
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.evidence import EvidenceBindings
 from jacobian.contracts.results import ContractModel
@@ -115,13 +115,14 @@ class InlineExactVerificationRecord(ContractModel):
     being promoted into artifacts merely to support verification.
     """
 
-    record_schema_version: Literal["3"] = "3"
+    record_schema_version: Literal["4"] = "4"
     evidence_kind: Literal[EvidenceKind.WITNESS] = EvidenceKind.WITNESS
     witness_format: str
     operation_id: CapabilityId
     format_version: Literal["1"] = "1"
     checker_id: CheckerUri
     implementation_digest: Sha256Digest
+    checker_manifest: CheckerManifest
     runtime_digest: Sha256Digest | None = None
     environment_digest: Sha256Digest
     input_schema_uri: ArtifactUri
@@ -133,6 +134,10 @@ class InlineExactVerificationRecord(ContractModel):
 
     @model_validator(mode="after")
     def accepted_inline_replay_is_fully_bound(self) -> Self:
+        if self.implementation_digest != self.checker_manifest.implementation_digest():
+            raise ValueError(
+                "inline verification record digest must match its checker manifest"
+            )
         if (
             not self.decision.accepted
             or self.bindings.candidate_digest is None

--- a/src/jacobian/contracts/verification.py
+++ b/src/jacobian/contracts/verification.py
@@ -11,7 +11,7 @@ from jacobian.contracts._verification_rules import (
     validate_decisive_replayable_evidence,
 )
 from jacobian.contracts.capabilities import CapabilityId
-from jacobian.contracts.checkers import EvidenceKind
+from jacobian.contracts.checkers import CheckerManifest, EvidenceKind
 from jacobian.contracts.common import ArtifactUri, CheckerUri, Sha256Digest
 from jacobian.contracts.evidence import EvidenceBindings
 from jacobian.contracts.results import (
@@ -24,9 +24,10 @@ from jacobian.contracts.results import (
 
 
 class VerificationRecord(ContractModel):
-    record_schema_version: Literal["3"] = "3"
+    record_schema_version: Literal["4"] = "4"
     checker_id: CheckerUri
     implementation_digest: Sha256Digest
+    checker_manifest: CheckerManifest
     evidence_kind: EvidenceKind
     evidence_uri: ArtifactUri
     bindings: EvidenceBindings
@@ -43,6 +44,10 @@ class VerificationRecord(ContractModel):
 
     @model_validator(mode="after")
     def require_decisive_replayable_record(self) -> Self:
+        if self.implementation_digest != self.checker_manifest.implementation_digest():
+            raise ValueError(
+                "verification record implementation digest must match its manifest"
+            )
         validate_decisive_replayable_evidence(
             self.conclusion,
             self.arithmetic,

--- a/src/jacobian/persistence/migrations.py
+++ b/src/jacobian/persistence/migrations.py
@@ -512,6 +512,16 @@ def _install_checker_distribution_identity_boundary(
     )
 
 
+def _install_verification_record_manifest_boundary(
+    connection: sqlite3.Connection,
+) -> None:
+    """Cut over durable verification records to embedded checker manifests."""
+
+    connection.execute(
+        "UPDATE jacobian_state_format SET format_revision = 11 WHERE id = 0"
+    )
+
+
 STATE_MIGRATIONS = (
     Migration(
         revision=1,
@@ -591,7 +601,17 @@ STATE_MIGRATIONS = (
         ),
         apply=_install_checker_distribution_identity_boundary,
     ),
+    Migration(
+        revision=11,
+        name="verification-record-manifest-boundary-v1",
+        definition=(
+            "Require verification record v4 payloads to snapshot their complete "
+            "checker execution manifest; older record shapes remain owned by "
+            "their matching state revision and checkout."
+        ),
+        apply=_install_verification_record_manifest_boundary,
+    ),
 )
 
-SUPPORTED_STATE_FLOOR = 10
-CURRENT_STATE_FORMAT_REVISION = 10
+SUPPORTED_STATE_FLOOR = 11
+CURRENT_STATE_FORMAT_REVISION = 11

--- a/src/jacobian/verification/service.py
+++ b/src/jacobian/verification/service.py
@@ -105,31 +105,34 @@ class VerificationService:
         self.record_schema_uri = store.register_descriptor(
             kind="schema",
             name="jacobian.verification-record",
-            version="1",
+            version="2",
             definition=model_schema(VerificationRecord),
         )
         self.record_semantics_uri = store.register_descriptor(
             kind="semantics",
             name="jacobian.verification-record",
-            version="1",
+            version="2",
             definition={
-                "description": "authorized checker result bound to exact evidence"
+                "description": (
+                    "authorized checker result bound to exact evidence and its "
+                    "measured execution manifest"
+                )
             },
         )
         self.inline_exact_record_schema_uri = store.register_descriptor(
             kind="schema",
             name="jacobian.inline-exact-verification-record",
-            version="1",
+            version="2",
             definition=model_schema(InlineExactVerificationRecord),
         )
         self.inline_exact_record_semantics_uri = store.register_descriptor(
             kind="semantics",
             name="jacobian.inline-exact-verification-record",
-            version="1",
+            version="2",
             definition={
                 "description": (
                     "authorized checker decision bound to canonical inline exact "
-                    "input and candidate values"
+                    "input and candidate values plus its measured execution manifest"
                 )
             },
         )
@@ -236,6 +239,7 @@ class VerificationService:
                 operation_id=operation_id,
                 checker_id=checker.checker_id,
                 implementation_digest=checker.implementation_digest,
+                checker_manifest=checker.implementation,
                 runtime_digest=(
                     checker.implementation.provider_runtime.digest
                     if checker.implementation.provider_runtime is not None
@@ -433,6 +437,7 @@ class VerificationService:
         return VerificationRecord(
             checker_id=checker.checker_id,
             implementation_digest=checker.implementation_digest,
+            checker_manifest=checker.implementation,
             evidence_kind=evidence_kind,
             evidence_uri=evidence_uri,
             bindings=bindings,

--- a/tests/boundary/storage/transactions/test_state_database_migrations.py
+++ b/tests/boundary/storage/transactions/test_state_database_migrations.py
@@ -361,6 +361,25 @@ def test_previous_pre_stable_head_requires_fresh_store(tmp_path: Path) -> None:
     assert exc_info.value.minimum_revision == SUPPORTED_STATE_FLOOR
 
 
+def test_record_v3_state_requires_its_matching_checkout(tmp_path: Path) -> None:
+    with ArtifactRepository(tmp_path):
+        pass
+    connection = sqlite3.connect(tmp_path / "metadata.sqlite3")
+    try:
+        connection.execute("DELETE FROM jacobian_schema_migrations WHERE revision = 11")
+        connection.execute(
+            "UPDATE jacobian_state_format SET format_revision = 10 WHERE id = 0"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(UnsupportedStateVersionError) as exc_info:
+        ArtifactRepository(tmp_path)
+    assert exc_info.value.detected_revision == 10
+    assert exc_info.value.minimum_revision == 11
+
+
 def test_checker_distribution_identity_rejects_existing_authorizations(
     tmp_path: Path,
 ) -> None:
@@ -368,7 +387,9 @@ def test_checker_distribution_identity_rejects_existing_authorizations(
         pass
     connection = sqlite3.connect(tmp_path / "metadata.sqlite3")
     try:
-        connection.execute("DELETE FROM jacobian_schema_migrations WHERE revision = 10")
+        connection.execute(
+            "DELETE FROM jacobian_schema_migrations WHERE revision >= 10"
+        )
         connection.execute(
             "UPDATE jacobian_state_format SET format_revision = 9 WHERE id = 0"
         )

--- a/tests/component/capabilities/test_sat_assignment_verification.py
+++ b/tests/component/capabilities/test_sat_assignment_verification.py
@@ -209,6 +209,14 @@ def test_sat_assignment_is_verified_by_an_authorized_clean_process(
     record = VerificationRecord.model_validate(record_artifact.payload)
     assert record.checker_id == sat_assignment_services.assignment.checker_id
     assert record.evidence_uri == result.output["witness_uri"]
+    registration = sat_assignment_services.core.checkers.require_active(
+        record.checker_id
+    )
+    assert record.record_schema_version == "4"
+    assert record.checker_manifest == registration.implementation
+    assert (
+        record.implementation_digest == record.checker_manifest.implementation_digest()
+    )
     assert set(record_artifact.manifest.parents) == {
         cnf_uri,
         assignment_uri,

--- a/tests/domain/matrix/test_inline_exact_verification.py
+++ b/tests/domain/matrix/test_inline_exact_verification.py
@@ -59,6 +59,12 @@ def test_inline_exact_replay_persists_only_its_bound_record(
     assert record.manifest.parents == (parsed.semantics_uri,)
     assert parsed.semantics_uri in verified.artifact_uris
     assert parsed.decision.accepted is True
+    registration = runtime.core.checkers.require_active(parsed.checker_id)
+    assert parsed.record_schema_version == "4"
+    assert parsed.checker_manifest == registration.implementation
+    assert (
+        parsed.implementation_digest == parsed.checker_manifest.implementation_digest()
+    )
 
 
 def test_inline_exact_validation_does_not_echo_a_rejected_candidate(

--- a/tests/unit/contracts/test_checker_registration.py
+++ b/tests/unit/contracts/test_checker_registration.py
@@ -60,40 +60,41 @@ def _python_distribution_runtime(
 
 
 def _registration(runtime: CapabilityProviderRuntime) -> CheckerRegistration:
+    manifest = CheckerManifest(
+        entrypoint="jacobian_checkers.reject:check",
+        checker_source_modules=(
+            CheckerSourceModule(
+                module="jacobian_checkers.reject",
+                source_digest="sha256:" + "d" * 64,
+            ),
+        ),
+        worker_source_modules=(
+            CheckerSourceModule(
+                module="jacobian.checker_worker",
+                source_digest="sha256:" + "d" * 64,
+            ),
+        ),
+        python_distributions=_worker_distributions(),
+        python_runtime=CheckerPythonRuntime(
+            implementation="cpython",
+            version="3.12.0",
+            executable_digest="sha256:" + "f" * 64,
+        ),
+        provider_runtime=runtime,
+        passive_contract_uris=(_ARTIFACT_URI,),
+        sandbox=CheckerSandboxPolicy(
+            max_wall_seconds=30,
+            max_cpu_seconds=31,
+            max_address_space_bytes=1024,
+            max_stdout_bytes=1024,
+            max_stderr_bytes=1024,
+        ),
+    )
     return CheckerRegistration(
         checker_id="checker://sha256/" + "c" * 64,
         name="distribution-backed checker",
-        implementation=CheckerManifest(
-            entrypoint="jacobian_checkers.reject:check",
-            checker_source_modules=(
-                CheckerSourceModule(
-                    module="jacobian_checkers.reject",
-                    source_digest="sha256:" + "d" * 64,
-                ),
-            ),
-            worker_source_modules=(
-                CheckerSourceModule(
-                    module="jacobian.checker_worker",
-                    source_digest="sha256:" + "d" * 64,
-                ),
-            ),
-            python_distributions=_worker_distributions(),
-            python_runtime=CheckerPythonRuntime(
-                implementation="cpython",
-                version="3.12.0",
-                executable_digest="sha256:" + "f" * 64,
-            ),
-            provider_runtime=runtime,
-            passive_contract_uris=(_ARTIFACT_URI,),
-            sandbox=CheckerSandboxPolicy(
-                max_wall_seconds=30,
-                max_cpu_seconds=31,
-                max_address_space_bytes=1024,
-                max_stdout_bytes=1024,
-                max_stderr_bytes=1024,
-            ),
-        ),
-        implementation_digest="sha256:" + "d" * 64,
+        implementation=manifest,
+        implementation_digest=manifest.implementation_digest(),
         evidence_kind=EvidenceKind.WITNESS,
         format_id="tests.distribution",
         format_version="1",
@@ -101,6 +102,16 @@ def _registration(runtime: CapabilityProviderRuntime) -> CheckerRegistration:
         semantics_uris=(_ARTIFACT_URI,),
         candidate_schema_uris=(_ARTIFACT_URI,),
     )
+
+
+def test_checker_registration_rejects_a_manifest_digest_mismatch() -> None:
+    registration = _registration(_python_distribution_runtime())
+
+    with pytest.raises(ValidationError, match="digest must match its manifest"):
+        CheckerRegistration.model_validate(
+            registration.model_dump(mode="json")
+            | {"implementation_digest": "sha256:" + "0" * 64}
+        )
 
 
 def _source_tree_runtime(

--- a/tests/unit/contracts/test_exact_domain_verification_contracts.py
+++ b/tests/unit/contracts/test_exact_domain_verification_contracts.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.checker_identity import build_checker_manifest
+from jacobian.contracts.checkers import CheckerDecision
+from jacobian.contracts.evidence import EvidenceBindings
 from jacobian.contracts.exact_domain_verification import (
     ExactComputedVerificationOutput,
+    InlineExactVerificationRecord,
 )
+from jacobian.contracts.results import Arithmetic, Conclusion, Coverage, Method
 
 _ARTIFACT_URI = "artifact://sha256/" + "a" * 64
 _CHECKER_URI = "checker://sha256/" + "b" * 64
@@ -52,3 +57,55 @@ def test_rejected_exact_output_may_still_identify_examined_witness() -> None:
 
     assert rejected.status == "REJECTED"
     assert rejected.witness_uri == _ARTIFACT_URI
+
+
+def _inline_v4_record() -> InlineExactVerificationRecord:
+    manifest = build_checker_manifest(
+        "jacobian_checkers.reject:check",
+        provider_runtime=None,
+        passive_contract_uris=(),
+    )
+    digest = "sha256:" + "c" * 64
+    return InlineExactVerificationRecord(
+        witness_format="tests.inline",
+        operation_id="integer.compute.gcd",
+        checker_id=_CHECKER_URI,
+        implementation_digest=manifest.implementation_digest(),
+        checker_manifest=manifest,
+        environment_digest=digest,
+        input_schema_uri=_ARTIFACT_URI,
+        candidate_schema_uri=_ARTIFACT_URI,
+        semantics_uri=_ARTIFACT_URI,
+        bindings=EvidenceBindings(
+            claim_digest=digest,
+            semantics_digest=digest,
+            candidate_digest=digest,
+        ),
+        decision=CheckerDecision(
+            accepted=True,
+            conclusion=Conclusion.TRUE,
+            arithmetic=Arithmetic.EXACT_INTEGER,
+            method=Method.DIRECT_WITNESS,
+            coverage=Coverage.NOT_APPLICABLE,
+        ),
+        request_digest=digest,
+    )
+
+
+def test_inline_v4_record_binds_the_exact_checker_manifest() -> None:
+    record = _inline_v4_record()
+
+    assert record.record_schema_version == "4"
+    assert (
+        record.implementation_digest == record.checker_manifest.implementation_digest()
+    )
+
+    payload = record.model_dump(mode="json")
+    with pytest.raises(ValidationError):
+        InlineExactVerificationRecord.model_validate(
+            payload | {"checker_manifest": None}
+        )
+    with pytest.raises(ValidationError, match="digest must match"):
+        InlineExactVerificationRecord.model_validate(
+            payload | {"implementation_digest": "sha256:" + "0" * 64}
+        )

--- a/tests/unit/contracts/test_verification_record.py
+++ b/tests/unit/contracts/test_verification_record.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from pydantic import ValidationError
 
+from jacobian.checker_identity import build_checker_manifest
 from jacobian.contracts.verification import VerificationRecord
 
 _ARTIFACT_URI = "artifact://sha256/" + "a" * 64
@@ -11,9 +14,16 @@ _DIGEST = "sha256:" + "c" * 64
 
 
 def _record(**updates: object) -> dict[str, object]:
+    manifest = build_checker_manifest(
+        "jacobian_checkers.reject:check",
+        provider_runtime=None,
+        passive_contract_uris=(),
+    )
     payload: dict[str, object] = {
+        "record_schema_version": "4",
         "checker_id": _CHECKER_URI,
-        "implementation_digest": _DIGEST,
+        "implementation_digest": manifest.implementation_digest(),
+        "checker_manifest": manifest.model_dump(mode="json"),
         "evidence_kind": "WITNESS",
         "evidence_uri": _ARTIFACT_URI,
         "bindings": {
@@ -32,6 +42,34 @@ def _record(**updates: object) -> dict[str, object]:
     return payload
 
 
+def test_v4_verification_record_requires_its_exact_checker_manifest() -> None:
+    payload = _record()
+    record = VerificationRecord.model_validate(payload)
+    assert (
+        record.implementation_digest == record.checker_manifest.implementation_digest()
+    )
+
+    with pytest.raises(ValidationError):
+        VerificationRecord.model_validate(payload | {"checker_manifest": None})
+
+    with pytest.raises(ValidationError, match="digest must match its manifest"):
+        VerificationRecord.model_validate(
+            payload | {"implementation_digest": "sha256:" + "0" * 64}
+        )
+
+
+def test_v4_verification_record_rejects_a_mutated_manifest_snapshot() -> None:
+    payload = _record()
+    manifest = dict(cast(dict[str, object], payload["checker_manifest"]))
+    sandbox = dict(cast(dict[str, object], manifest["sandbox"]))
+    sandbox["max_wall_seconds"] = cast(int, sandbox["max_wall_seconds"]) + 1
+    sandbox["max_cpu_seconds"] = cast(int, sandbox["max_cpu_seconds"]) + 1
+    manifest["sandbox"] = sandbox
+
+    with pytest.raises(ValidationError, match="digest must match its manifest"):
+        VerificationRecord.model_validate(payload | {"checker_manifest": manifest})
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -46,23 +84,28 @@ def test_verification_record_rejects_non_replayable_evidence(
     value: str,
 ) -> None:
     with pytest.raises(ValidationError):
-        VerificationRecord.model_validate(_record(**{field: value}))
+        VerificationRecord.model_validate(_record() | {field: value})
 
 
 def test_verification_record_requires_complete_unique_relationship_endpoints() -> None:
     with pytest.raises(ValidationError, match="requires exact endpoints"):
         VerificationRecord.model_validate(
-            _record(
-                relation_id="graph.isomorphism.relation",
-                relationship_source_artifact_uris=(_ARTIFACT_URI,),
-            )
+            _record()
+            | {
+                "relation_id": "graph.isomorphism.relation",
+                "relationship_source_artifact_uris": (_ARTIFACT_URI,),
+            }
         )
 
     with pytest.raises(ValidationError, match="must be unique"):
         VerificationRecord.model_validate(
-            _record(
-                relation_id="graph.isomorphism.relation",
-                relationship_source_artifact_uris=(_ARTIFACT_URI, _ARTIFACT_URI),
-                relationship_target_artifact_uris=(_ARTIFACT_URI,),
-            )
+            _record()
+            | {
+                "relation_id": "graph.isomorphism.relation",
+                "relationship_source_artifact_uris": (
+                    _ARTIFACT_URI,
+                    _ARTIFACT_URI,
+                ),
+                "relationship_target_artifact_uris": (_ARTIFACT_URI,),
+            }
         )


### PR DESCRIPTION
## Problem

Verification records currently retain only an aggregate checker implementation
digest. The exact source closures, worker runtime, Python distributions,
provider identity, passive contracts, and sandbox policy remain in the mutable
checker authorization row. A detached durable record therefore cannot explain
the execution identity that accepted it without consulting live registry state.

This advances #1228.

## Solution

Verification record schema v4 snapshots the complete `CheckerManifest` and
requires its canonical digest to equal `implementation_digest`. The same
invariant now applies when a checker registration is parsed, so a manifest and
its durable identity cannot diverge at either boundary.

Both ordinary and inline-exact verification paths emit the v4 record directly
from the authorized registration. Their schema and semantics descriptors move
to version 2. The state format advances from revision 10 to 11 as an explicit
pre-stable cutover: revision-10 stores and v3 records remain owned by their
matching older checkout, and the current runtime has no dual record or legacy
authorization path.

The change deliberately does not add a generic checker-material abstraction.
Current first-party checker and worker closures contain Python modules only;
installed third-party distributions already bind every file listed in their
`RECORD`, while external runtimes retain their existing measured provider
identity.

Suggested review order:

1. `contracts/checkers.py`, `contracts/verification.py`, and
   `contracts/exact_domain_verification.py` for the digest invariant.
2. `verification/service.py` and `persistence/migrations.py` for record emission
   and the state cutover.
3. Contract, persistence, component, and domain tests for tamper and replay
   coverage.

## Testing

- `make check` — passed: 874 unit, 907 component, 479 domain, 156 composition,
  4 end-to-end, and 64 provider tests, plus Ruff, formatting, complexity, and
  mypy.
- `make import-contracts` — 7 contracts kept.
- `make architecture` — 1,689 files checked.
- `make docs-linkcheck` — passed.
- Focused record, checker identity, and verification tests — 49 passed.
- Storage migration boundary tests — 19 passed.

- Specialist validation run: provider, storage, and end-to-end verification
  paths are included above because this changes durable checker identity.

## Trust & Compatibility Impact

This changes the verification artifact schema and minimum state revision.
Records now carry the decomposed manifest whose digest they claim, and nested
manifest tampering fails validation. Checker authorization and worker-side
remeasurement are unchanged.

Revision-10 state is intentionally rejected by this checkout. Preserve that
state directory and use its matching older Jacobian checkout to inspect it, or
start the current version with a fresh state directory. The runtime does not
reinterpret v3 records as v4.

## Architecture Budget

No operation, registry, facade, publication policy, or generic provenance layer
is added. `CheckerManifest` remains the single owner of decomposed checker
identity and now owns calculation of its canonical digest. Verification records
snapshot that existing value at the final durable boundary.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier validation is not applicable
- [x] No ordinary operation is added
- [x] No shared abstraction is added
