### PR TITLE
refactor(portfolio): remove the package re-export facade

### DIFF
--- a/src/jacobian/composition.py
+++ b/src/jacobian/composition.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from jacobian.installation.context import create_installation_context
-from jacobian.portfolio import install_portfolio
+from jacobian.portfolio.assembler import install_portfolio
 from jacobian.runtime.bootstrap import bootstrap_services
 from jacobian.runtime.config import RuntimeOptions
 from jacobian.runtime.model import JacobianRuntime

--- a/src/jacobian/portfolio/__init__.py
+++ b/src/jacobian/portfolio/__init__.py
@@ -1,23 +1,3 @@
-"""Explicit mathematical portfolio installation."""
+"""Internal owners for explicit mathematical portfolio installation."""
 
-from jacobian.portfolio.assembler import install_portfolio
-from jacobian.portfolio.builtin import build_builtin_portfolio
-from jacobian.portfolio.model import PortfolioPlan
-from jacobian.portfolio.result import (
-    PROVIDER_UNAVAILABLE,
-    BundleInstallation,
-    BundleInstallationStatus,
-    PortfolioDiagnostic,
-    PortfolioInstallationResult,
-)
-
-__all__ = [
-    "PROVIDER_UNAVAILABLE",
-    "BundleInstallation",
-    "BundleInstallationStatus",
-    "PortfolioDiagnostic",
-    "PortfolioInstallationResult",
-    "PortfolioPlan",
-    "build_builtin_portfolio",
-    "install_portfolio",
-]
+__all__: tuple[str, ...] = ()

--- a/tests/boundary/process/public_api/test_import_isolation.py
+++ b/tests/boundary/process/public_api/test_import_isolation.py
@@ -71,6 +71,43 @@ finally:
     assert completed.returncode == 0, completed.stderr
 
 
+def test_portfolio_leaf_import_does_not_load_assembly_or_domains() -> None:
+    _assert_not_imported(
+        _imported_modules("jacobian.portfolio.provider_resolution"),
+        (
+            "jacobian.domains",
+            "jacobian.portfolio.assembler",
+            "jacobian.portfolio.builtin",
+            "jacobian.runtime",
+        ),
+    )
+
+
+def test_portfolio_root_is_an_import_transparent_internal_namespace() -> None:
+    script = """
+import jacobian.portfolio as portfolio
+import sys
+
+assert portfolio.__all__ == ()
+assert not hasattr(portfolio, "PortfolioPlan")
+assert not hasattr(portfolio, "install_portfolio")
+children = sorted(
+    name for name in sys.modules if name.startswith("jacobian.portfolio.")
+)
+if children:
+    raise AssertionError(f"portfolio root imported child modules: {children}")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "SYMPY_GROUND_TYPES": "python"},
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
 def test_native_matrices_does_not_import_capabilities_or_provider_loading() -> None:
     _assert_not_imported(
         _imported_modules("jacobian.math.matrices"),

--- a/tests/composition/portfolio/test_builtin_portfolio_installation.py
+++ b/tests/composition/portfolio/test_builtin_portfolio_installation.py
@@ -8,7 +8,7 @@ from jacobian.domains.polynomial_nullstellensatz.core import (
 from jacobian.domains.polynomial_nullstellensatz.singular import (
     PRODUCE_CAPABILITY_ID,
 )
-from jacobian.portfolio import build_builtin_portfolio
+from jacobian.portfolio.builtin import build_builtin_portfolio
 from jacobian.providers.singular_runtime import singular_provider_runtime
 from jacobian.runtime.model import JacobianRuntime
 

--- a/tests/composition/portfolio/test_portfolio_assembler.py
+++ b/tests/composition/portfolio/test_portfolio_assembler.py
@@ -34,9 +34,10 @@ from jacobian.operations import (
     DomainSemantics,
     OperationSpec,
 )
-from jacobian.portfolio import PROVIDER_UNAVAILABLE, PortfolioPlan
 from jacobian.portfolio.domain_installation import DomainBundleInstaller
+from jacobian.portfolio.model import PortfolioPlan
 from jacobian.portfolio.result import (
+    PROVIDER_UNAVAILABLE,
     BundleInstallationStatus,
     PortfolioInstallationResult,
 )

--- a/tests/composition/portfolio/test_portfolio_plan.py
+++ b/tests/composition/portfolio/test_portfolio_plan.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import pytest
 
 from jacobian.domain_bundles import DomainBundle
-from jacobian.portfolio import PortfolioPlan, build_builtin_portfolio
-from jacobian.portfolio.builtin import build_builtin_portfolio_components
+from jacobian.portfolio.builtin import (
+    build_builtin_portfolio,
+    build_builtin_portfolio_components,
+)
+from jacobian.portfolio.model import PortfolioPlan
 
 
 def test_builtin_portfolio_is_an_explicit_plan_of_components() -> None:

--- a/tests/composition/runtime/test_portfolio_installation.py
+++ b/tests/composition/runtime/test_portfolio_installation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 from types import SimpleNamespace
 
-from jacobian.portfolio import assembler
+import jacobian.portfolio.assembler as assembler
 from jacobian.runtime.portfolio import PortfolioResources
 
 

--- a/tests/unit/portfolio/test_portfolio_installation_phases.py
+++ b/tests/unit/portfolio/test_portfolio_installation_phases.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 import pytest
 
+import jacobian.portfolio.foundation_installation as foundation_installation
 from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityProviderAvailability,
@@ -15,7 +16,6 @@ from jacobian.contracts.capabilities import (
     CapabilityProviderRuntime,
 )
 from jacobian.installation.context import InstallationContext
-from jacobian.portfolio import foundation_installation
 from jacobian.portfolio.checker_installation import CheckerPortfolioInstaller
 from jacobian.portfolio.core_installation import CoreApplicationInstaller
 from jacobian.portfolio.foundation_installation import FoundationInstaller

--- a/tests/unit/portfolio/test_portfolio_provider_resolution.py
+++ b/tests/unit/portfolio/test_portfolio_provider_resolution.py
@@ -6,12 +6,12 @@ from collections.abc import Callable
 
 import pytest
 
+import jacobian.portfolio.provider_resolution as provider_resolution
 from jacobian.contracts.capabilities import (
     CapabilityInstallTier,
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
 )
-from jacobian.portfolio import provider_resolution
 from jacobian.portfolio.provider_resolution import ProviderAvailabilityResolver
 from jacobian.provider_runtime import ProviderRuntimeError, known_provider_runtime
 

--- a/tools/check_test_architecture.py
+++ b/tools/check_test_architecture.py
@@ -22,10 +22,9 @@ from tools.test_architecture.runtime_owners import allows_create_runtime
 
 _TEST_FILE = "test_*.py"
 
-# These are deliberately narrow names.  Importing a typed domain model from
-# ``jacobian.portfolio`` is fine; importing the explicit built-in plan or its
-# complete installer is the operation that couples a lower tier to the whole
-# application.
+# These are deliberately narrow names. Typed portfolio models come from their
+# concrete owner modules; importing the built-in plan or assembler is the
+# operation that couples a lower tier to the whole application.
 _BUILTIN_PORTFOLIO_NAMES = frozenset(
     {
         "BUILTIN_PORTFOLIO",


### PR DESCRIPTION
## Problem

`jacobian.portfolio` re-exported its assembler, built-in inventory, plan, and
installation result types from the package root. Importing any portfolio leaf
therefore executed the root first, which eagerly loaded the assembler and every
built-in domain bundle. The aggregate also hid the concrete owner behind an
undocumented internal facade.

This advances #1222 and the #1148 cleanup roadmap.

## Solution

- Make `jacobian.portfolio` an import-transparent internal namespace with no
  re-exports.
- Import assembly, plan, result, built-in inventory, and provider phases from
  their concrete owner modules.
- Add isolated import regressions proving the package root loads no child
  modules and a provider-resolution leaf does not pull in the assembler,
  built-in domain inventory, domains, or runtime.
- Correct the test-architecture guidance so typed portfolio models are also
  imported from their concrete owners.

## Testing

```sh
make check
make test-process TESTS=tests/boundary/process/public_api/test_import_isolation.py
make test-unit TESTS='tests/unit/portfolio tests/unit/tooling/test_architecture_policy.py'
make test-composition TESTS='tests/composition/portfolio/test_builtin_portfolio_installation.py tests/composition/portfolio/test_portfolio_plan.py tests/composition/portfolio/test_portfolio_assembler.py tests/composition/runtime/test_portfolio_installation.py'
make import-contracts
make architecture
make test-architecture
```

`make check` passed 870 unit, 905 component, 479 domain, 157 composition,
4 end-to-end, and 64 provider-boundary tests. The focused process, unit, and
composition lanes passed 8, 20, and 16 tests respectively; all seven import
contracts were kept and the architecture scan checked 1,685 files.

- Specialist validation run: the process import-isolation lane listed above.

## Trust & Compatibility Impact

Runtime construction, installed portfolio membership, checker authority, and
artifact behavior are unchanged. Code importing undocumented symbols from the
private `jacobian.portfolio` root must import their owning internal module
instead. The supported native Python API remains `jacobian.math`; no
compatibility alias is retained during this pre-stable cutover.

## Architecture Budget

No shared abstraction or operation is added. The change deletes one re-export
facade and makes the existing assembler, built-in inventory, model, result, and
provider modules visible as their own owners.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] New ordinary operations fit the documented operation budget (not applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; no abstraction added)
