### PR TITLE
refactor(runtime): parse capability inputs before provider work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,11 @@ checker authorization out of plugins and search code.
   validation. Exercise incompatible-but-individually-valid values through the
   serialized installed-operation boundary and assert an invalid-request result
   with no execution or publication.
+- Parse agent-supplied JSON strictly into the owning Pydantic request model;
+  advertised integers must not accept numeric strings or other coercions. An
+  adapter prepares that typed request before provider readiness and executes
+  only the prepared value. At the final projection, require the published
+  Pydantic model to match the installed output contract before serializing it.
 - Mathematical inputs are not presumed confidential. Public diagnostics should
   expose a stable domain reason, path, limit, and recovery direction—not
   arbitrary rejected values, which may be unbounded or user-controlled. This

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,9 @@ checker authorization out of plugins and search code.
 - Parse agent-supplied JSON strictly into the owning Pydantic request model;
   advertised integers must not accept numeric strings or other coercions. An
   adapter prepares that typed request before provider readiness and executes
-  only the prepared value. At the final projection, require the published
+  only the prepared value. Strict transport encoding is lossless: do not reduce
+  rationals, normalize Unicode, or otherwise repair semantic input before the
+  owning model validates it. At the final projection, require the published
   Pydantic model to match the installed output contract before serializing it.
 - Mathematical inputs are not presumed confidential. Public diagnostics should
   expose a stable domain reason, path, limit, and recovery direction—not

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -165,10 +165,12 @@ external payload
 Pydantic owns complete request validation, including relationships among
 otherwise valid fields. Required agreement of parents, characteristics,
 presentations, axes, bases, labels, and bound identities is checked during the
-single request parse, before preflight or any provider call. JSON Schema is
-generated for discovery and is not executed as an additional validation pass
-for built-ins. Provider and subprocess output is a separate untrusted boundary
-and is parsed independently.
+single strict request parse, before provider readiness, preflight, or execution.
+JSON Schema is generated for discovery and is not executed as an additional
+validation pass for built-ins. Before the single final serialization, dispatch
+checks that the published Pydantic model still generates the installed output
+contract. Provider and subprocess output is a separate untrusted boundary and
+is parsed independently.
 
 Preflight distinguishes supported, unsupported, provider unavailable, and
 resource-limit-exceeded outcomes. Where practical it estimates work, output
@@ -273,8 +275,8 @@ Using a request-local carrier does not change a value or grant assurance.
 ## Structural JSON
 
 The runtime retains direct bounded JSON functions rather than a codec
-framework: a strict loader, deterministic serializer, Pydantic adapters, and
-one explicit schema-only adapter. Generic JSON rejects duplicate keys and
+framework: a strict loader, deterministic serializer, and Pydantic adapters.
+Generic JSON rejects duplicate keys and
 unsupported numbers, enforces depth/member/byte limits, preserves keys and
 strings exactly, and performs no Unicode or mathematical normalization.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -165,7 +165,10 @@ external payload
 Pydantic owns complete request validation, including relationships among
 otherwise valid fields. Required agreement of parents, characteristics,
 presentations, axes, bases, labels, and bound identities is checked during the
-single strict request parse, before provider readiness, preflight, or execution.
+single strict, lossless request parse, before provider readiness, preflight, or
+execution. Domain canonicalization happens only after the owning request model
+has accepted the original values; transport parsing does not reduce rationals
+or normalize Unicode.
 JSON Schema is generated for discovery and is not executed as an additional
 validation pass for built-ins. Before the single final serialization, dispatch
 checks that the published Pydantic model still generates the installed output

--- a/docs/reference/provider-runtime.md
+++ b/docs/reference/provider-runtime.md
@@ -86,26 +86,28 @@ SMT-LIB parser and proof APIs are checked lazily at first use. Missing or
 mismatched package identity is a broken installation, while a first-use
 readiness failure fails the selected invocation closed.
 
-Source-backed adapters can construct metadata without importing their
-implementation:
+Source-backed checker implementations can construct metadata without importing
+their implementation:
 
 ```python
 from jacobian.contracts.capabilities import CapabilityInstallTier
 from jacobian.provider_runtime import source_provider_runtime
 
 runtime = source_provider_runtime(
-    "example.provider",
+    "example.checker",
     version="1",
-    entrypoint="example_adapter:create_adapter",
+    entrypoint="example_checker:check",
     install_tier=CapabilityInstallTier.T1,
     license_id="MIT",
     license_files=("LICENSE",),
-    features=("exact-example-operation",),
+    features=("exact-example-check",),
 )
 ```
 
-The adapter places `runtime` in its descriptor. Registration remains
-fail-closed if the source identity cannot be resolved.
+The checker registration binds `runtime` to its independently authorized
+entrypoint. Registration remains fail-closed if the source identity cannot be
+resolved. External operation packages and adapter entrypoint discovery are not
+supported.
 
 ### External checker runtimes
 

--- a/src/jacobian/builtin_capabilities.py
+++ b/src/jacobian/builtin_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
@@ -11,7 +12,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.lean import (
     LeanCheckOutput,
-    LeanEnvironment,
+    LeanCheckRequest,
 )
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.lean_frontend.service import LeanService
@@ -40,16 +41,7 @@ class LeanCheckAdapter:
             ),
             provider="jacobian.lean4",
             provider_runtime=provider_runtime,
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "statement": {"type": "string", "minLength": 1, "maxLength": 2000},
-                    "proof": {"type": "string", "minLength": 1, "maxLength": 20000},
-                    "environment": {"enum": ["CORE", "MATHLIB"]},
-                },
-                "required": ["statement", "proof"],
-                "additionalProperties": False,
-            },
+            input_schema=LeanCheckRequest.model_json_schema(),
             output_schema=LeanCheckOutput.model_json_schema(),
             tags=(
                 "lean",
@@ -84,12 +76,14 @@ class LeanCheckAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        payload = request.input
+    def prepare(self, request: CapabilityRequest) -> LeanCheckRequest:
+        return parse_capability_input(LeanCheckRequest, request.input)
+
+    def invoke(self, payload: LeanCheckRequest) -> OperationProjection:
         checked = self.lean.verify(
-            statement=str(payload["statement"]),
-            proof=str(payload["proof"]),
-            environment=LeanEnvironment(str(payload.get("environment", "CORE"))),
+            statement=payload.statement,
+            proof=payload.proof,
+            environment=payload.environment,
         )
         verified = checked.result.verification_record_uri is not None
         evidence = (checked.certificate_uri,)

--- a/src/jacobian/canonical.py
+++ b/src/jacobian/canonical.py
@@ -169,6 +169,68 @@ def _normalize(value: Any, *, limits: CanonicalLimits, depth: int) -> Any:
     raise CanonicalizationError("unsupported JSON value type")
 
 
+def _validate_json_value(value: Any, *, limits: CanonicalLimits, depth: int) -> None:
+    """Validate bounded interoperable JSON without changing semantic values."""
+
+    if depth > limits.max_depth:
+        raise CanonicalizationError("JSON nesting exceeds the configured depth limit")
+    if isinstance(value, float):
+        raise CanonicalizationError("JSON floating-point numbers are not allowed")
+    if isinstance(value, int):
+        _validate_json_integer(value)
+        return
+    if isinstance(value, list):
+        _validate_json_items(value, limits=limits, depth=depth)
+        return
+    if isinstance(value, dict):
+        _validate_json_object(value, limits=limits, depth=depth)
+        return
+    if value is None or isinstance(value, str):
+        return
+    raise CanonicalizationError("unsupported JSON value type")
+
+
+def _validate_json_integer(value: int) -> None:
+    if abs(value) > _MAX_SAFE_JSON_INTEGER:
+        raise CanonicalizationError(
+            "JSON integers outside the interoperable range must be encoded as strings"
+        )
+
+
+def _validate_json_items(
+    values: list[Any], *, limits: CanonicalLimits, depth: int
+) -> None:
+    for value in values:
+        _validate_json_value(value, limits=limits, depth=depth + 1)
+
+
+def _validate_json_object(
+    value: dict[Any, Any], *, limits: CanonicalLimits, depth: int
+) -> None:
+    for key, nested in value.items():
+        if not isinstance(key, str):
+            raise CanonicalizationError("JSON object keys must be strings")
+        _validate_json_value(nested, limits=limits, depth=depth + 1)
+
+
+def encode_strict_json(
+    value: Any,
+    *,
+    limits: CanonicalLimits | None = None,
+) -> bytes:
+    """Encode bounded JSON deterministically without semantic normalization."""
+
+    active_limits = limits or CanonicalLimits()
+    _validate_json_value(value, limits=active_limits, depth=0)
+    try:
+        encoded = rfc8785.dumps(value)
+    except (rfc8785.CanonicalizationError, RecursionError) as exc:
+        raise CanonicalizationError("value cannot be encoded as strict JSON") from exc
+    if len(encoded) > active_limits.max_output_bytes:
+        raise CanonicalizationError("JSON exceeds the configured size limit")
+    return encoded
+
+
 def _normalize_object(
     value: dict[str, Any], *, limits: CanonicalLimits, depth: int
 ) -> dict[str, Any]:

--- a/src/jacobian/capability_adapters.py
+++ b/src/jacobian/capability_adapters.py
@@ -2,29 +2,53 @@
 
 from __future__ import annotations
 
-from typing import Literal, Protocol, runtime_checkable
+from typing import Any, Protocol, TypeVar
 
+from pydantic import BaseModel
+
+from jacobian.canonical import CanonicalizationError, canonicalize_json
+from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
+    CapabilityDiagnostic,
     CapabilityRequest,
 )
 from jacobian.operation_projection import OperationProjection
 
+PreparedT = TypeVar("PreparedT")
 
-class CapabilityAdapter(Protocol):
-    """Operator-installed adapter; registration requires no MCP changes."""
+
+def parse_capability_input[ModelT: BaseModel](
+    model: type[ModelT], payload: dict[str, Any]
+) -> ModelT:
+    """Parse one JSON capability payload strictly into its owning model."""
+
+    try:
+        encoded = canonicalize_json(payload)
+    except CanonicalizationError as exc:
+        raise CapabilityInvocationError(
+            CapabilityDiagnostic(
+                code="INVALID_REQUEST",
+                stage="capability_input_validation",
+                message="The capability request is not valid bounded JSON.",
+                hint=(
+                    "Use only JSON objects, arrays, strings, booleans, null, "
+                    "and supported finite numbers within the configured limits."
+                ),
+            )
+        ) from exc
+    return model.model_validate_json(encoded, strict=True)
+
+
+class CapabilityAdapter(Protocol[PreparedT]):
+    """Installed typed adapter; registration requires no MCP changes."""
 
     @property
     def descriptor(self) -> CapabilityDescriptor: ...
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection: ...
+    def prepare(self, request: CapabilityRequest) -> PreparedT: ...
+
+    def invoke(self, prepared: PreparedT) -> OperationProjection: ...
 
 
-@runtime_checkable
-class TypedInputAdapter(Protocol):
-    """Adapter that owns one typed input parse and needs no schema execution."""
-
-    typed_input: Literal[True]
-
-
-__all__ = ["CapabilityAdapter", "TypedInputAdapter"]
+__all__ = ["CapabilityAdapter", "parse_capability_input"]

--- a/src/jacobian/capability_adapters.py
+++ b/src/jacobian/capability_adapters.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol, TypeVar
 
 from pydantic import BaseModel
 
-from jacobian.canonical import CanonicalizationError, canonicalize_json
+from jacobian.canonical import CanonicalizationError, encode_strict_json
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -24,7 +24,7 @@ def parse_capability_input[ModelT: BaseModel](
     """Parse one JSON capability payload strictly into its owning model."""
 
     try:
-        encoded = canonicalize_json(payload)
+        encoded = encode_strict_json(payload)
     except CanonicalizationError as exc:
         raise CapabilityInvocationError(
             CapabilityDiagnostic(

--- a/src/jacobian/capability_dispatch.py
+++ b/src/jacobian/capability_dispatch.py
@@ -8,15 +8,13 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.capability_adapters import CapabilityAdapter, TypedInputAdapter
+from jacobian.capability_adapters import CapabilityAdapter
 from jacobian.capability_errors import (
     CapabilityError,
     CapabilityInvocationError,
-    PayloadValidationError,
     enriched_invalid_request,
 )
 from jacobian.capability_telemetry import log_invocation
-from jacobian.capability_validation import json_value_type, validate_payload
 from jacobian.contracts.capabilities import (
     CapabilityDiagnostic,
     CapabilityRequest,
@@ -29,6 +27,7 @@ from jacobian.provider_runtime import (
     ProviderRuntimeError,
     require_provider_runtime_ready,
 )
+from jacobian.schema_registry import model_schema
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +38,7 @@ class CapabilityDispatchMixin:
     def invoke(self: Any, request: CapabilityRequest) -> CapabilityResult:
         started = time.monotonic()
         try:
-            adapter: CapabilityAdapter = self._adapters[request.capability_id]
+            adapter: CapabilityAdapter[Any] = self._adapters[request.capability_id]
         except KeyError:
             result = _unknown_capability_failure(request)
             log_invocation(result, started)
@@ -49,17 +48,17 @@ class CapabilityDispatchMixin:
         if resolution is not None:
             log_invocation(resolution, started)
             return resolution
-        try:
-            normalized_request = _normalize_request(adapter, descriptor, request)
-        except CapabilityError as exc:
-            result = _input_validation_failure(descriptor, request, exc)
+        invalid_inputs = _undeclared_value_inputs_failure(descriptor, request)
+        if invalid_inputs is not None:
+            result = invalid_inputs
             log_invocation(result, started)
             return result
         try:
+            prepared = adapter.prepare(request)
             result = invoke_ready_adapter(
                 adapter=adapter,
                 descriptor=descriptor,
-                request=normalized_request,
+                prepared=prepared,
             )
         except CapabilityInvocationError as exc:
             result = failed_result(
@@ -90,40 +89,31 @@ class CapabilityDispatchMixin:
         if invalid is not None:
             log_invocation(invalid, started)
             return invalid
-        if result.execution.status is ExecutionStatus.COMPLETED and not isinstance(
-            adapter, TypedInputAdapter
-        ):
-            result = _normalize_completed_adapter_output(
-                descriptor=descriptor,
-                result=result,
-                started=started,
-            )
-            if result.execution.status is not ExecutionStatus.COMPLETED:
-                return result
         self._validate_verified_result(result)
         log_invocation(result, started)
         return result
 
 
-def _normalize_request(
-    adapter: CapabilityAdapter,
+def _undeclared_value_inputs_failure(
     descriptor: Any,
     request: CapabilityRequest,
-) -> CapabilityRequest:
-    """Use the adapter's typed parser or the external schema-only boundary."""
-
-    if request.inputs and not descriptor.input_ports:
-        raise PayloadValidationError(
-            "the selected capability declares no typed value inputs",
+) -> CapabilityResult | None:
+    if not request.inputs or descriptor.input_ports:
+        return None
+    return failed_result(
+        operation_id=descriptor.capability_id,
+        version=descriptor.version,
+        diagnostic=CapabilityDiagnostic(
+            code="INVALID_REQUEST",
+            stage="capability_input_validation",
+            message="The selected capability declares no typed value inputs.",
             path="inputs",
-            actual_type="object",
             expected="no value references",
+            actual_type="object",
+            hint="Remove the undeclared value-reference inputs and retry.",
             details={"unknown_input_ports": sorted(request.inputs)},
-        )
-    if isinstance(adapter, TypedInputAdapter):
-        return request
-    normalized_input = validate_payload(descriptor.input_schema, request.input)
-    return request.model_copy(update={"input": normalized_input})
+        ),
+    )
 
 
 def _unknown_capability_failure(request: CapabilityRequest) -> CapabilityResult:
@@ -214,50 +204,6 @@ def _adapter_execution_failure(
     )
 
 
-def _input_validation_failure(
-    descriptor: Any,
-    request: CapabilityRequest,
-    exc: CapabilityError,
-) -> CapabilityResult:
-    path = exc.path if isinstance(exc, PayloadValidationError) else error_path(exc)
-    return failed_result(
-        operation_id=descriptor.capability_id,
-        version=descriptor.version,
-        diagnostic=CapabilityDiagnostic(
-            code="INVALID_REQUEST",
-            stage="capability_input_validation",
-            message=(
-                "The capability input does not match its advertised schema"
-                + (f" at {path}." if path else ".")
-            ),
-            path=path,
-            expected=(
-                exc.expected
-                if isinstance(exc, PayloadValidationError)
-                else "input matching the capability descriptor JSON Schema"
-            ),
-            actual_type=(
-                exc.actual_type
-                if isinstance(exc, PayloadValidationError)
-                else json_value_type(request.input)
-            ),
-            hint=(
-                "Correct the reported field. The exact violated constraint "
-                "and any required or missing top-level fields are included "
-                "in diagnostic details."
-            ),
-            details={
-                "required_fields": descriptor.input_schema.get("required", []),
-                "missing_fields": sorted(
-                    set(descriptor.input_schema.get("required", []))
-                    - set(request.input)
-                ),
-                **(exc.details if isinstance(exc, PayloadValidationError) else {}),
-            },
-        ),
-    )
-
-
 def _adapter_result_identity_failure(
     *,
     descriptor: Any,
@@ -280,40 +226,6 @@ def _adapter_result_identity_failure(
     return None
 
 
-def _normalize_completed_adapter_output(
-    *,
-    descriptor: Any,
-    result: CapabilityResult,
-    started: float,
-) -> CapabilityResult:
-    try:
-        normalized_output = validate_payload(descriptor.output_schema, result.output)
-    except PayloadValidationError as exc:
-        invalid = failed_result(
-            operation_id=descriptor.capability_id,
-            version=descriptor.version,
-            diagnostic=CapabilityDiagnostic(
-                code="ADAPTER_RESULT_INVALID",
-                stage="adapter_execution",
-                message=(
-                    "The adapter output does not match its advertised "
-                    f"schema at {exc.path}."
-                ),
-                path=exc.path,
-                expected=exc.expected,
-                actual_type=exc.actual_type,
-                hint=(
-                    "Fix the capability adapter to return output matching "
-                    "its descriptor schema."
-                ),
-                details=exc.details,
-            ),
-        )
-        log_invocation(invalid, started)
-        return invalid
-    return result.model_copy(update={"output": normalized_output})
-
-
 def failed_result(
     *,
     operation_id: str,
@@ -333,7 +245,7 @@ def failed_result(
 
 
 def invoke_ready_adapter(
-    *, adapter: CapabilityAdapter, descriptor: Any, request: CapabilityRequest
+    *, adapter: CapabilityAdapter[Any], descriptor: Any, prepared: Any
 ) -> CapabilityResult:
     runtime = descriptor.provider_runtime
     if runtime is None:
@@ -357,13 +269,46 @@ def invoke_ready_adapter(
                 details={"provider_failure_code": exc.code.value},
             ),
         )
-    outcome = adapter.invoke(request)
+    outcome = adapter.invoke(prepared)
+    invalid = _adapter_output_model_failure(descriptor, outcome)
+    if invalid is not None:
+        outcome = invalid
     return project_operation_result(outcome)
 
 
-def error_path(exc: Exception) -> str | None:
-    path, separator, _ = str(exc).partition(": ")
-    return path if separator else None
+def _adapter_output_model_failure(
+    descriptor: Any, outcome: OperationProjection
+) -> OperationProjection | None:
+    publication = outcome.publication
+    output = publication.output if publication is not None else None
+    if output is None:
+        return None
+    output_type = type(output)
+    if model_schema(output_type) == descriptor.output_schema:
+        try:
+            output_type.model_validate(
+                output.model_dump(mode="python", warnings="error"), strict=True
+            )
+        except (TypeError, ValueError, ValidationError):
+            pass
+        else:
+            return None
+    return OperationProjection(
+        operation_id=descriptor.capability_id,
+        version=descriptor.version,
+        terminal=Failed(
+            status=ExecutionStatus.ERROR,
+            diagnostic=CapabilityDiagnostic(
+                code="ADAPTER_RESULT_INVALID",
+                stage="adapter_execution",
+                message=(
+                    "The adapter returned a typed result that does not match "
+                    "its installed output model."
+                ),
+                hint="Fix the adapter output type or its capability descriptor.",
+            ),
+        ),
+    )
 
 
 __all__ = ["CapabilityDispatchMixin"]

--- a/src/jacobian/capability_registry.py
+++ b/src/jacobian/capability_registry.py
@@ -2,32 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any
 
+from jacobian.capability_adapters import CapabilityAdapter
 from jacobian.capability_errors import CapabilityError
 from jacobian.capability_validation import validator
 from jacobian.contracts.capabilities import (
     CapabilityCatalog,
-    CapabilityDescriptor,
     CapabilityProviderAvailability,
 )
-
-
-class AdapterLike(Protocol):
-    @property
-    def descriptor(self) -> Any: ...
-
-
-class RegistryOwner(Protocol):
-    policy: Any
-    _adapters: dict[str, AdapterLike]
-    _descriptors: dict[str, CapabilityDescriptor]
 
 
 class CapabilityRegistryMixin:
     """Own descriptor admission and deterministic catalog projection."""
 
-    def register(self: Any, adapter: AdapterLike) -> None:
+    def register(self: Any, adapter: CapabilityAdapter[Any]) -> None:
         descriptor = adapter.descriptor
         if descriptor.capability_id in self._adapters:
             raise CapabilityError(

--- a/src/jacobian/capability_service.py
+++ b/src/jacobian/capability_service.py
@@ -9,7 +9,7 @@ those boundaries behind a second compatibility API.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from jacobian.canonical import canonicalize_json
 from jacobian.capability_adapters import CapabilityAdapter
@@ -142,7 +142,7 @@ class CapabilityService(
     ) -> None:
         self.store = store
         self.policy = policy or CapabilityPolicy()
-        self._adapters: dict[str, CapabilityAdapter] = {}
+        self._adapters: dict[str, CapabilityAdapter[Any]] = {}
         self._descriptors: dict[str, CapabilityDescriptor] = {}
 
 

--- a/src/jacobian/contracts/lean.py
+++ b/src/jacobian/contracts/lean.py
@@ -89,6 +89,12 @@ class LeanCandidate(ContractModel):
     proof: str = Field(min_length=1, max_length=20_000)
 
 
+class LeanCheckRequest(ContractModel):
+    statement: str = Field(min_length=1, max_length=2_000)
+    proof: str = Field(min_length=1, max_length=20_000)
+    environment: LeanEnvironment = LeanEnvironment.CORE
+
+
 class LeanVerifyResult(ContractModel):
     claim_uri: ArtifactUri
     candidate_uri: ArtifactUri

--- a/src/jacobian/domains/polynomial_nullstellensatz/core.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/core.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -131,9 +132,14 @@ class JacobianDegreeSliceMaterializeAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> JacobianDegreeSliceMaterializeRequest:
         try:
-            JacobianDegreeSliceMaterializeRequest.model_validate(request.input)
+            return parse_capability_input(
+                JacobianDegreeSliceMaterializeRequest,
+                request.input,
+            )
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 _diagnostic(
@@ -143,6 +149,10 @@ class JacobianDegreeSliceMaterializeAdapter:
                     "Use the fixed statement ID and coefficient_domain=QQ.",
                 )
             ) from exc
+
+    def invoke(
+        self, prepared: JacobianDegreeSliceMaterializeRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         system = materialize_degree_23_system()
         stored = self.context.artifacts.put(
@@ -209,10 +219,48 @@ class NullstellensatzVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> NullstellensatzVerificationRequest:
+        try:
+            return parse_capability_input(
+                NullstellensatzVerificationRequest,
+                request.input,
+            )
+        except ValidationError as exc:
+            requested_system_uri = _request_value_summary(
+                request.input.get("system_uri")
+            )
+            requested_bundle_uri = _request_value_summary(
+                request.input.get("certificate_bundle_uri")
+            )
+            raise CapabilityInvocationError(
+                _diagnostic(
+                    "INVALID_NULLSTELLENSATZ_VERIFICATION_REQUEST",
+                    "artifact_resolution",
+                    "The system and certificate bundle are not a compatible bound pair.",
+                    (
+                        "Use the exact materialized system URI and a certificate bundle "
+                        "created for that system by a compatible installed producer. Do not "
+                        "substitute unrelated artifacts. Without a compatible producer, this "
+                        "verifier cannot establish infeasibility."
+                    ),
+                    expected=(
+                        f"system schema {self.installation.system_schema_uri}; "
+                        "certificate bundle schema "
+                        f"{self.installation.certificate_bundle_schema_uri}"
+                    ),
+                    details={
+                        **_failure_details(exc),
+                        "system_uri": requested_system_uri,
+                        "certificate_bundle_uri": requested_bundle_uri,
+                    },
+                )
+            ) from exc
+
+    def invoke(
+        self, validated: NullstellensatzVerificationRequest
+    ) -> OperationProjection:
         actual_artifact_type: str | None = None
         try:
-            validated = NullstellensatzVerificationRequest.model_validate(request.input)
             system_artifact = self.context.store.get(validated.system_uri)
             bundle_artifact = self.context.store.get(validated.certificate_bundle_uri)
             if (
@@ -256,15 +304,9 @@ class NullstellensatzVerificationAdapter:
             ArtifactNotFoundError,
             StorageError,
         ) as exc:
-            requested_system_uri = (
-                _request_value_summary(validated.system_uri)
-                if "validated" in locals()
-                else _request_value_summary(request.input.get("system_uri"))
-            )
-            requested_bundle_uri = (
-                _request_value_summary(validated.certificate_bundle_uri)
-                if "validated" in locals()
-                else _request_value_summary(request.input.get("certificate_bundle_uri"))
+            requested_system_uri = _request_value_summary(validated.system_uri)
+            requested_bundle_uri = _request_value_summary(
+                validated.certificate_bundle_uri
             )
             raise CapabilityInvocationError(
                 _diagnostic(

--- a/src/jacobian/domains/polynomial_nullstellensatz/singular.py
+++ b/src/jacobian/domains/polynomial_nullstellensatz/singular.py
@@ -11,6 +11,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json, format_canonical_integer
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -379,16 +380,31 @@ class SingularNullstellensatzCertificateAdapter:
             ),
         )
 
+    def prepare(self, request: CapabilityRequest) -> NullstellensatzCertificateRequest:
+        try:
+            return parse_capability_input(
+                NullstellensatzCertificateRequest,
+                request.input,
+            )
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code="INVALID_NULLSTELLENSATZ_CERTIFICATE_REQUEST",
+                    stage="artifact_resolution",
+                    message="The request does not name the frozen producer-owned system artifact.",
+                    hint="Invoke the materialization capability and pass its system_uri.",
+                )
+            ) from exc
+
     def _resolve_request(
         self,
-        request: CapabilityRequest,
+        validated: NullstellensatzCertificateRequest,
     ) -> tuple[
         NullstellensatzCertificateRequest,
         StoredArtifact,
         NormalizedJacobianDegreeSliceSystem,
     ]:
         try:
-            validated = NullstellensatzCertificateRequest.model_validate(request.input)
             system_artifact = self.context.store.get(validated.system_uri)
             identity = (
                 system_artifact.manifest.schema_uri,
@@ -441,8 +457,10 @@ class SingularNullstellensatzCertificateAdapter:
             )
         )
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated, system_artifact, system = self._resolve_request(request)
+    def invoke(
+        self, validated: NullstellensatzCertificateRequest
+    ) -> OperationProjection:
+        validated, system_artifact, system = self._resolve_request(validated)
         started = time.monotonic()
         executable = self.provider_runtime.configuration.get("executable")
         if not isinstance(executable, str):

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -6,12 +6,12 @@ import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityError, CapabilityInvocationError
 from jacobian.checker_artifacts import put_witness_envelope
 from jacobian.checker_installation import CheckerInstaller
@@ -88,6 +88,11 @@ _ENTRYPOINT_PROVIDER_RUNTIME_KEYS = {
     "jacobian_checkers.finite_field_rank": "sympy",
     "jacobian_checkers.finite_field_polynomial": "finite-field-polynomial",
 }
+
+_ExactVerificationPrepared = (
+    ExactDomainResultVerificationRequest
+    | ExactComputedVerificationRequest[ContractModel, ContractModel]
+)
 
 
 def _finite_field_rank_checker_runtime(
@@ -328,7 +333,7 @@ def install_exact_domain_verification(
     *,
     bundles: Mapping[str, tuple[DomainBundle, InstalledDomainBundle]],
     authorize: bool,
-) -> tuple[tuple[CapabilityAdapter, ...], ExactDomainCheckerInstallation]:
+) -> tuple[tuple[CapabilityAdapter[Any], ...], ExactDomainCheckerInstallation]:
     """Authorize exact replay and expose per-producer verification capabilities.
 
     Each authorized exact replay declaration becomes one
@@ -359,7 +364,7 @@ def install_exact_domain_verification(
         checker_id is not None for checker_id in installation.checker_ids.values()
     ):
         return (), installation
-    adapters: list[CapabilityAdapter] = []
+    adapters: list[CapabilityAdapter[Any]] = []
     result_models = {
         operation.spec.operation_id: operation.spec.result_type
         for bundle, _installed_bundle in bundles.values()
@@ -539,17 +544,59 @@ class ExactComputedVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> _ExactVerificationPrepared:
+        try:
+            if self.stored_result_input:
+                return parse_capability_input(
+                    ExactDomainResultVerificationRequest,
+                    request.input,
+                )
+            return cast(
+                ExactComputedVerificationRequest[ContractModel, ContractModel],
+                parse_capability_input(self.input_model, request.input),
+            )
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                CapabilityDiagnostic(
+                    code=(
+                        "INVALID_EXACT_DOMAIN_RESULT"
+                        if self.stored_result_input
+                        else "INVALID_EXACT_DOMAIN_INPUT"
+                    ),
+                    stage=(
+                        "artifact_resolution"
+                        if self.stored_result_input
+                        else "request_validation"
+                    ),
+                    message=bounded_validation_exception_message(exc),
+                    path="result_uri" if self.stored_result_input else None,
+                    hint=(
+                        "Pass the result_uri returned by this exact producer."
+                        if self.stored_result_input
+                        else (
+                            "input must satisfy the producer request contract and "
+                            "candidate must satisfy its result contract."
+                        )
+                    ),
+                )
+            ) from exc
+
+    def invoke(self, prepared: _ExactVerificationPrepared) -> OperationProjection:
         declaration = self.declaration
         source_artifacts: tuple[StoredArtifact, StoredArtifact, StoredArtifact] | None
         normalized_candidate: dict[str, object] | None
         if self.stored_result_input:
-            source_artifacts = self._resolve_stored_result(request)
+            source_artifacts = self._resolve_stored_result(
+                cast(ExactDomainResultVerificationRequest, prepared)
+            )
             normalized_input = source_artifacts[0].payload
             normalized_candidate = None
         else:
             normalized_input, normalized_candidate = self._validated_inline_payloads(
-                request
+                cast(
+                    ExactComputedVerificationRequest[ContractModel, ContractModel],
+                    prepared,
+                )
             )
             source_artifacts = None
         # Check the authorized checker's bounded input scope before any artifact write.
@@ -811,11 +858,11 @@ class ExactComputedVerificationAdapter:
         return statuses.get(execution_status, "ERROR")
 
     def _validated_inline_payloads(
-        self, request: CapabilityRequest
+        self,
+        validated: ExactComputedVerificationRequest[ContractModel, ContractModel],
     ) -> tuple[dict[str, object], dict[str, object]]:
         declaration = self.declaration
         try:
-            validated = self.input_model.model_validate(request.input)
             normalized_input = self.schemas.validate(
                 declaration.input_schema_uri,
                 validated.input.model_dump(mode="json"),
@@ -839,15 +886,13 @@ class ExactComputedVerificationAdapter:
         return normalized_input, normalized_candidate
 
     def _resolve_stored_result(
-        self, request: CapabilityRequest
+        self, validated: ExactDomainResultVerificationRequest
     ) -> tuple[StoredArtifact, StoredArtifact, StoredArtifact]:
         """Resolve the declared producer's exact materialized lineage."""
 
         declaration = self.declaration
         try:
-            result_uri = ExactDomainResultVerificationRequest.model_validate(
-                request.input
-            ).result_uri
+            result_uri = validated.result_uri
             result_artifact = self.store.get(result_uri)
             if (
                 result_artifact.manifest.schema_uri != declaration.result_schema_uri

--- a/src/jacobian/finite_coverage.py
+++ b/src/jacobian/finite_coverage.py
@@ -10,8 +10,11 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
-from jacobian.capability_errors import CapabilityInvocationError
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
+from jacobian.capability_errors import (
+    CapabilityInvocationError,
+    enriched_invalid_request,
+)
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
 from jacobian.contracts.capabilities import (
@@ -81,7 +84,7 @@ def install_finite_coverage(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, FiniteCoverageInstallation]:
+) -> tuple[CapabilityAdapter[Any] | None, FiniteCoverageInstallation]:
     """Register v1 finite-coverage artifacts and optionally authorize replay."""
 
     semantics_uri = store.register_descriptor(
@@ -255,25 +258,22 @@ class FiniteCoverageVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> FiniteCoverageVerifyRequest:
         try:
-            validated = FiniteCoverageVerifyRequest.model_validate(request.input)
+            return parse_capability_input(FiniteCoverageVerifyRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INVALID_FINITE_COVERAGE_REQUEST",
-                    stage="request_validation",
-                    message=(
-                        "The complete finite-coverage request is invalid: "
-                        f"{exc.errors()[0].get('msg', 'validation failed')}"
+                enriched_invalid_request(
+                    CapabilityDiagnostic(
+                        code="INVALID_FINITE_COVERAGE_REQUEST",
+                        stage="request_validation",
+                        message="The complete finite-coverage request is invalid.",
                     ),
-                    hint=(
-                        "Use one registered v1 canonicalizer, 1 to 4096 typed scope "
-                        "items, and 1 to 64 pages containing at most 4096 items total."
-                    ),
+                    exc,
                 )
             ) from exc
 
+    def invoke(self, validated: FiniteCoverageVerifyRequest) -> OperationProjection:
         canonicalizer_id = validated.canonicalizer_id
         canonicalizer_uri = self.installation.canonicalizer_uris[canonicalizer_id]
         canonicalizer = self.store.get(canonicalizer_uri)

--- a/src/jacobian/graphs/atlas_search.py
+++ b/src/jacobian/graphs/atlas_search.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import ValidationError
 
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -52,8 +53,6 @@ class GraphAtlasSearchResources:
 class GraphAtlasSearchAdapter:
     """Search NetworkX's bounded Graph Atlas using exact computed properties."""
 
-    typed_input = True
-
     def __init__(self, resources: GraphAtlasSearchResources) -> None:
         self.resources = resources
         self._descriptor = CapabilityDescriptor(
@@ -85,10 +84,9 @@ class GraphAtlasSearchAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        started = time.monotonic()
+    def prepare(self, request: CapabilityRequest) -> GraphAtlasSearchRequest:
         try:
-            validated = GraphAtlasSearchRequest.model_validate(request.input)
+            return parse_capability_input(GraphAtlasSearchRequest, request.input)
         except ValidationError as exc:
             error = exc.errors()[0]
             error_message = str(error.get("msg", ""))
@@ -125,6 +123,9 @@ class GraphAtlasSearchAdapter:
                     ),
                 )
             ) from exc
+
+    def invoke(self, validated: GraphAtlasSearchRequest) -> OperationProjection:
+        started = time.monotonic()
         order = validated.order
         constraints = validated.constraints
         limit = validated.limit

--- a/src/jacobian/graphs/composition.py
+++ b/src/jacobian/graphs/composition.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, cast
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -201,9 +202,9 @@ class GraphComposeAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> GraphCompositionRequest:
         try:
-            validated = GraphCompositionRequest.model_validate(request.input)
+            return parse_capability_input(GraphCompositionRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -217,6 +218,7 @@ class GraphComposeAdapter:
                 )
             ) from exc
 
+    def invoke(self, validated: GraphCompositionRequest) -> OperationProjection:
         graph_resources = _artifact_resources(self.resources)
         left = load_graph_value(graph_resources, validated.left_graph_uri)
         right = None
@@ -331,11 +333,9 @@ class GraphEnumerateNonisomorphicAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        backend_module = networkx_loader.get()
-        started = time.monotonic()
+    def prepare(self, request: CapabilityRequest) -> GraphEnumerationRequest:
         try:
-            validated = GraphEnumerationRequest.model_validate(request.input)
+            return parse_capability_input(GraphEnumerationRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -346,6 +346,9 @@ class GraphEnumerateNonisomorphicAdapter:
                 )
             ) from exc
 
+    def invoke(self, validated: GraphEnumerationRequest) -> OperationProjection:
+        backend_module = networkx_loader.get()
+        started = time.monotonic()
         order = validated.order
         limit = validated.limit
         offset = validated.offset

--- a/src/jacobian/graphs/construction.py
+++ b/src/jacobian/graphs/construction.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from pydantic import ValidationError
 
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -88,9 +89,11 @@ class GraphExplicitConstructionAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> GraphExplicitConstructionRequest:
         try:
-            validated = GraphExplicitConstructionRequest.model_validate(request.input)
+            return parse_capability_input(
+                GraphExplicitConstructionRequest, request.input
+            )
         except ValidationError as exc:
             errors, validation_error_count = project_validation_errors(exc)
             path_parts = errors[0]["loc"] if errors else ()
@@ -124,6 +127,9 @@ class GraphExplicitConstructionAdapter:
                 )
             ) from exc
 
+    def invoke(
+        self, validated: GraphExplicitConstructionRequest
+    ) -> OperationProjection:
         terminal = execute_operation(self.spec, validated)
         if not isinstance(terminal, Completed):
             return OperationProjection(

--- a/src/jacobian/graphs/degree_sequence.py
+++ b/src/jacobian/graphs/degree_sequence.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, cast
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -93,9 +94,9 @@ class GraphDegreeSequenceAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> GraphDegreeSequenceRequest:
         try:
-            validated = GraphDegreeSequenceRequest.model_validate(request.input)
+            return parse_capability_input(GraphDegreeSequenceRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -105,6 +106,8 @@ class GraphDegreeSequenceAdapter:
                     hint=("Provide between 1 and 512 nonnegative integer degrees."),
                 )
             ) from exc
+
+    def invoke(self, validated: GraphDegreeSequenceRequest) -> OperationProjection:
         started = time.monotonic()
         sequence = tuple(validated.degree_sequence)
         obstruction = _degree_sequence_obstruction(sequence)

--- a/src/jacobian/graphs/installation.py
+++ b/src/jacobian/graphs/installation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from jacobian.artifacts import ArtifactService
 from jacobian.capability_adapters import CapabilityAdapter
@@ -73,7 +74,7 @@ def install_graph_capabilities(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[tuple[CapabilityAdapter, ...], GraphInstallation]:
+) -> tuple[tuple[CapabilityAdapter[Any], ...], GraphInstallation]:
     """Register graph artifact contracts and return the bundled adapters."""
 
     semantics_uri = store.register_descriptor(
@@ -238,7 +239,7 @@ def install_graph_capabilities(
         certificate_schema_uri=certificate_schema_uri,
         neighborhood_checker_id=neighborhood_checker_id,
     )
-    adapters: tuple[CapabilityAdapter, ...] = (
+    adapters: tuple[CapabilityAdapter[Any], ...] = (
         GraphExplicitConstructionAdapter(construction_resources),
         GraphAtlasSearchAdapter(atlas_resources),
         GraphPropertyAdapter(invariant_resources),

--- a/src/jacobian/graphs/invariants.py
+++ b/src/jacobian/graphs/invariants.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 from pydantic import ValidationError
 
 from jacobian.canonical import format_canonical_integer
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -103,10 +104,9 @@ class GraphPropertyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        started = time.monotonic()
+    def prepare(self, request: CapabilityRequest) -> GraphInvariantBatchRequest:
         try:
-            validated = GraphInvariantBatchRequest.model_validate(request.input)
+            return parse_capability_input(GraphInvariantBatchRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -122,6 +122,9 @@ class GraphPropertyAdapter:
                     ),
                 )
             ) from exc
+
+    def invoke(self, validated: GraphInvariantBatchRequest) -> OperationProjection:
+        started = time.monotonic()
         graph_uri = validated.graph_uri
         graph = load_graph(self.resources.graph, graph_uri)
         names = tuple(sorted(validated.properties))

--- a/src/jacobian/graphs/isomorphism.py
+++ b/src/jacobian/graphs/isomorphism.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -196,8 +197,10 @@ class GraphIsomorphismAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = GraphIsomorphismVerifyRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> GraphIsomorphismVerifyRequest:
+        return parse_capability_input(GraphIsomorphismVerifyRequest, request.input)
+
+    def invoke(self, validated: GraphIsomorphismVerifyRequest) -> OperationProjection:
         checker_id = self.installation.checker_id
         if checker_id is None:
             raise CapabilityInvocationError(

--- a/src/jacobian/graphs/neighborhood_independence.py
+++ b/src/jacobian/graphs/neighborhood_independence.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json, format_canonical_integer
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -88,10 +89,12 @@ class GraphNeighborhoodIndependenceAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> GraphNeighborhoodIndependenceRequest:
         try:
-            validated = GraphNeighborhoodIndependenceRequest.model_validate(
-                request.input
+            return parse_capability_input(
+                GraphNeighborhoodIndependenceRequest, request.input
             )
         except ValidationError as exc:
             raise CapabilityInvocationError(
@@ -103,6 +106,10 @@ class GraphNeighborhoodIndependenceAdapter:
                     ),
                 )
             ) from exc
+
+    def invoke(
+        self, validated: GraphNeighborhoodIndependenceRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         graph = load_graph(self.resources.graph, validated.graph_uri)
         if graph.number_of_nodes() > 256:

--- a/src/jacobian/installation/context.py
+++ b/src/jacobian/installation/context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from jacobian.artifacts import ArtifactService
 from jacobian.capability_adapters import CapabilityAdapter
@@ -33,7 +33,7 @@ class InstallationContext:
     verification: VerificationService
     operations: OperationInstaller
     checker_authority: CheckerAuthorityMode
-    register_capability: Callable[[CapabilityAdapter], None]
+    register_capability: Callable[[CapabilityAdapter[Any]], None]
 
     @property
     def authorizes_bundled_checkers(self) -> bool:
@@ -56,8 +56,7 @@ def create_installation_context(
 
     The registrar is the only place where capability exclusions are applied;
     installers can therefore remain independent of runtime configuration while
-    every adapter (including adapters loaded from an entrypoint) follows the
-    same policy.
+    every built-in adapter follows the same policy.
     """
 
     if services.core is not core:
@@ -65,7 +64,7 @@ def create_installation_context(
 
     excluded = options.capability_exclusions
 
-    def register(adapter: CapabilityAdapter) -> None:
+    def register(adapter: CapabilityAdapter[Any]) -> None:
         if adapter.descriptor.capability_id not in excluded:
             core.capabilities.register(adapter)
 

--- a/src/jacobian/lean_frontend/metavariable_fields.py
+++ b/src/jacobian/lean_frontend/metavariable_fields.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 import jacobian.lean_frontend.exploration as _exploration_support
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -83,9 +84,11 @@ class LeanMetavariableFieldsAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanMetavariableFieldsRequest:
         try:
-            validated = LeanMetavariableFieldsRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanMetavariableFieldsRequest, request.input
+            )
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -95,6 +98,9 @@ class LeanMetavariableFieldsAdapter:
                     hint="Supply a state_uri returned by a proof-state capability.",
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanMetavariableFieldsRequest) -> OperationProjection:
         started = time.monotonic()
         installation = self.resources.installations[validated.environment]
         environment_digest = _environment_digest(

--- a/src/jacobian/lean_frontend/premise_retrieval.py
+++ b/src/jacobian/lean_frontend/premise_retrieval.py
@@ -8,6 +8,7 @@ import time
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -82,9 +83,11 @@ class LeanPremiseRetrievalAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanPremiseRetrievalRequest:
         try:
-            validated = LeanPremiseRetrievalRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanPremiseRetrievalRequest, request.input
+            )
             _validate_source_parts(validated.statement, validated.proof_prefix)
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
@@ -98,6 +101,9 @@ class LeanPremiseRetrievalAdapter:
                     ),
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanPremiseRetrievalRequest) -> OperationProjection:
         started = time.monotonic()
         environment = LeanEnvironment.MATHLIB
         installation = self.resources.installations[environment]

--- a/src/jacobian/lean_frontend/proof_axioms.py
+++ b/src/jacobian/lean_frontend/proof_axioms.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -162,9 +163,11 @@ class LeanProofAxiomsAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanProofAxiomsInspectRequest:
         try:
-            validated = LeanProofAxiomsInspectRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanProofAxiomsInspectRequest, request.input
+            )
             _validate_source(validated.statement, validated.proof)
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
@@ -178,6 +181,9 @@ class LeanProofAxiomsAdapter:
                     ),
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanProofAxiomsInspectRequest) -> OperationProjection:
         if validated.environment not in self.resources.installations:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(

--- a/src/jacobian/lean_frontend/proof_edit.py
+++ b/src/jacobian/lean_frontend/proof_edit.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -125,9 +126,9 @@ class LeanProofEditAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanProofEditRequest:
         try:
-            validated = LeanProofEditRequest.model_validate(request.input)
+            validated = parse_capability_input(LeanProofEditRequest, request.input)
             if _FORBIDDEN_PROOF_HOLE.search(
                 validated.original_proof
             ) or _FORBIDDEN_PROOF_HOLE.search(validated.edited_proof):
@@ -144,6 +145,9 @@ class LeanProofEditAdapter:
                     ),
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanProofEditRequest) -> OperationProjection:
         started = time.monotonic()
         baseline = self.lean.verify(
             environment=validated.environment,

--- a/src/jacobian/lean_frontend/proof_state.py
+++ b/src/jacobian/lean_frontend/proof_state.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 import jacobian.lean_frontend.exploration as _exploration_support
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -131,10 +132,9 @@ class LeanProofStateAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    @staticmethod
-    def _validate_request(request: CapabilityRequest) -> LeanProofStateRequest:
+    def prepare(self, request: CapabilityRequest) -> LeanProofStateRequest:
         try:
-            return LeanProofStateRequest.model_validate(request.input)
+            return parse_capability_input(LeanProofStateRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 _request_validation_diagnostic(
@@ -272,8 +272,8 @@ class LeanProofStateAdapter:
                     ) from exc
         return responses, typed_goals, accepted
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        applied = self.apply(self._validate_request(request))
+    def invoke(self, validated: LeanProofStateRequest) -> OperationProjection:
+        applied = self.apply(validated)
         return OperationProjection(
             operation_id=self.descriptor.capability_id,
             version=self.descriptor.version,

--- a/src/jacobian/lean_frontend/proof_state_inspect.py
+++ b/src/jacobian/lean_frontend/proof_state_inspect.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_authorization import LeanCheckerInstallation
 from jacobian.contracts.capabilities import (
@@ -85,9 +86,11 @@ class LeanProofStateInspectAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanProofStateInspectRequest:
         try:
-            validated = LeanProofStateInspectRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanProofStateInspectRequest, request.input
+            )
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -97,6 +100,9 @@ class LeanProofStateInspectAdapter:
                     hint="Supply a state_uri returned by a proof-state capability.",
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanProofStateInspectRequest) -> OperationProjection:
         started = time.monotonic()
         installation: LeanCheckerInstallation = self.resources.installations[
             validated.environment

--- a/src/jacobian/lean_frontend/statement.py
+++ b/src/jacobian/lean_frontend/statement.py
@@ -29,6 +29,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -652,9 +653,11 @@ class LeanStatementProposalAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanStatementProposalRequest:
         try:
-            validated = LeanStatementProposalRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanStatementProposalRequest, request.input
+            )
             _validate_statement(validated.proposed_statement)
         except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
@@ -668,6 +671,9 @@ class LeanStatementProposalAdapter:
                     ),
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanStatementProposalRequest) -> OperationProjection:
         try:
             elaboration = (
                 _elaborate_statement(
@@ -795,9 +801,11 @@ class LeanStatementCompareAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanStatementComparisonRequest:
         try:
-            validated = LeanStatementComparisonRequest.model_validate(request.input)
+            validated = parse_capability_input(
+                LeanStatementComparisonRequest, request.input
+            )
             _validate_statement(validated.statement_a)
             _validate_statement(validated.statement_b)
         except (ValidationError, ValueError) as exc:
@@ -812,6 +820,9 @@ class LeanStatementCompareAdapter:
                     ),
                 )
             ) from exc
+        return validated
+
+    def invoke(self, validated: LeanStatementComparisonRequest) -> OperationProjection:
         statements_identical = _normalize_whitespace(
             validated.statement_a
         ) == _normalize_whitespace(validated.statement_b)

--- a/src/jacobian/lean_frontend/term_apply.py
+++ b/src/jacobian/lean_frontend/term_apply.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from pydantic import ValidationError
 
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -101,9 +102,9 @@ class LeanTermApplyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> LeanTermApplyRequest:
         try:
-            validated = LeanTermApplyRequest.model_validate(request.input)
+            validated = parse_capability_input(LeanTermApplyRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -128,6 +129,9 @@ class LeanTermApplyAdapter:
                     ),
                 )
             )
+        return validated
+
+    def invoke(self, validated: LeanTermApplyRequest) -> OperationProjection:
         delegated = self._proof_state.apply(
             LeanProofStateRequest(
                 state_uri=validated.state_uri,

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import CanonicalizationError, canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import (
     CapabilityInvocationError,
     enriched_invalid_request,
@@ -49,7 +49,7 @@ from jacobian.value_references import ValueReferenceError, ValueReferenceStore
 class InstalledDomainBundle:
     """Resources and adapters created for one installed domain bundle."""
 
-    adapters: tuple[CapabilityAdapter, ...]
+    adapters: tuple[CapabilityAdapter[Any], ...]
     semantics_uri: str
     input_schema_uris: dict[type[ContractModel], str]
     result_schema_uris: dict[str, str]
@@ -149,7 +149,7 @@ class OperationInstaller:
         operation: DomainOperation,
         bundle: DomainBundle,
         resources: OperationResources,
-    ) -> CapabilityAdapter:
+    ) -> CapabilityAdapter[Any]:
         return InstalledOperationAdapter(operation, bundle, resources)
 
     @staticmethod
@@ -165,8 +165,6 @@ class OperationInstaller:
 
 class InstalledOperationAdapter:
     """Execute one semantic operation, then apply its publication policy."""
-
-    typed_input = True
 
     def __init__(
         self,
@@ -240,7 +238,7 @@ class InstalledOperationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> ContractModel:
         maximum_bytes = self.resources.artifacts.store.limits.max_artifact_bytes
         try:
             assembled_input = self._bind_inputs(request)
@@ -272,7 +270,10 @@ class InstalledOperationAdapter:
                 )
             )
         try:
-            parsed_request = self.spec.request_type.model_validate(assembled_input)
+            parsed_request = cast(
+                ContractModel,
+                parse_capability_input(self.spec.request_type, bounded_input),
+            )
         except ValidationError as exc:
             base = self.spec.invalid_request or self.bundle.diagnostics.invalid_request
             raise CapabilityInvocationError(
@@ -281,6 +282,10 @@ class InstalledOperationAdapter:
                 else enriched_invalid_request(base, exc)
             ) from exc
 
+        return parsed_request
+
+    def invoke(self, prepared: ContractModel) -> OperationProjection:
+        parsed_request = prepared
         try:
             terminal = execute_operation(self.spec, parsed_request)
         except ValidationError as exc:

--- a/src/jacobian/operation_installation.py
+++ b/src/jacobian/operation_installation.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
-from jacobian.canonical import CanonicalizationError, canonicalize_json
+from jacobian.canonical import CanonicalizationError, encode_strict_json
 from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import (
     CapabilityInvocationError,
@@ -250,7 +250,7 @@ class InstalledOperationAdapter:
                 )
                 for key, value in assembled_input.items()
             }
-            request_bytes = canonicalize_json(bounded_input)
+            request_bytes = encode_strict_json(bounded_input)
         except CanonicalizationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(

--- a/src/jacobian/polynomial_expression_capabilities.py
+++ b/src/jacobian/polynomial_expression_capabilities.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from jacobian.artifacts import ArtifactService
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -55,7 +55,10 @@ def install_polynomial_expression_checker(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, PolynomialExpressionCheckerInstallation]:
+) -> tuple[
+    CapabilityAdapter[Any] | None,
+    PolynomialExpressionCheckerInstallation,
+]:
     """Install the witness schema and optionally authorize exact AST replay."""
 
     witness_schema_uri = schemas.register_model(
@@ -92,7 +95,7 @@ def install_polynomial_expression_checker(
         witness_schema_uri=witness_schema_uri,
         checker_id=checker_id,
     )
-    adapter: CapabilityAdapter | None = None
+    adapter: CapabilityAdapter[Any] | None = None
     if checker_id is not None:
         adapter = PolynomialExpressionNormalizationVerificationAdapter(
             store=store,
@@ -106,8 +109,6 @@ def install_polynomial_expression_checker(
 
 class PolynomialExpressionNormalizationVerificationAdapter:
     """Verify canonical coefficients against every node of one bound AST."""
-
-    typed_input = True
 
     def __init__(
         self,
@@ -166,10 +167,17 @@ class PolynomialExpressionNormalizationVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = PolynomialExpressionNormalizationVerificationRequest.model_validate(
-            request.input
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialExpressionNormalizationVerificationRequest:
+        return parse_capability_input(
+            PolynomialExpressionNormalizationVerificationRequest,
+            request.input,
         )
+
+    def invoke(
+        self, validated: PolynomialExpressionNormalizationVerificationRequest
+    ) -> OperationProjection:
         try:
             resolved = self.expressions.resolve_normalization(
                 validated.normalization_uri

--- a/src/jacobian/polynomial_interval_capabilities.py
+++ b/src/jacobian/polynomial_interval_capabilities.py
@@ -302,14 +302,18 @@ class PolynomialIntervalEncloseAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialIntervalEnclosureRequest:
+        return _validate_request(
             PolynomialIntervalEnclosureRequest,
             request.input,
             code="INVALID_POLYNOMIAL_INTERVAL_ENCLOSURE_REQUEST",
             operation="interval enclosure",
             error_factory=_interval_error,
         )
+
+    def invoke(
+        self, validated: PolynomialIntervalEnclosureRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         polynomial = validated.polynomial
         interval = validated.interval
@@ -417,14 +421,20 @@ class PolynomialIntervalEnclosureVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialIntervalEnclosureVerifyRequest:
+        return _validate_request(
             PolynomialIntervalEnclosureVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_INTERVAL_ENCLOSURE_VERIFY_REQUEST",
             operation="interval enclosure verification",
             error_factory=_interval_error,
         )
+
+    def invoke(
+        self, validated: PolynomialIntervalEnclosureVerifyRequest
+    ) -> OperationProjection:
         installation = self.resources.installation
         checker_id = installation.checker_id
         if checker_id is None:

--- a/src/jacobian/polynomial_positivity_capabilities.py
+++ b/src/jacobian/polynomial_positivity_capabilities.py
@@ -306,14 +306,20 @@ class PolynomialIntervalPositivityDecideAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialIntervalPositivityRequest:
+        return _validate_request(
             PolynomialIntervalPositivityRequest,
             request.input,
             code="INVALID_POLYNOMIAL_POSITIVITY_REQUEST",
             operation="positivity decision",
             error_factory=_positivity_error,
         )
+
+    def invoke(
+        self, validated: PolynomialIntervalPositivityRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         polynomial = validated.polynomial
         interval = validated.interval
@@ -431,14 +437,20 @@ class PolynomialIntervalPositivityVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialIntervalPositivityVerifyRequest:
+        return _validate_request(
             PolynomialIntervalPositivityVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_POSITIVITY_VERIFY_REQUEST",
             operation="positivity verification",
             error_factory=_positivity_error,
         )
+
+    def invoke(
+        self, validated: PolynomialIntervalPositivityVerifyRequest
+    ) -> OperationProjection:
         installation = self.resources.installation
         checker_id = installation.checker_id
         if checker_id is None:

--- a/src/jacobian/polynomial_system_capabilities.py
+++ b/src/jacobian/polynomial_system_capabilities.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json, format_canonical_integer
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -148,8 +149,6 @@ def install_polynomial_system_capabilities(
 class PolynomialSystemSolutionAdapter:
     """Verify one exact assignment against every declared constraint."""
 
-    typed_input = True
-
     def __init__(self, resources: PolynomialSystemResources) -> None:
         self.resources = resources
         checker_id = resources.installation.checker_id
@@ -180,10 +179,12 @@ class PolynomialSystemSolutionAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> PolynomialSystemSolutionRequest:
         try:
-            validated = PolynomialSystemSolutionRequest.model_validate(request.input)
-        except ValidationError as exc:
+            return parse_capability_input(
+                PolynomialSystemSolutionRequest, request.input
+            )
+        except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
                     code="INVALID_POLYNOMIAL_SYSTEM_SOLUTION_REQUEST",
@@ -202,6 +203,8 @@ class PolynomialSystemSolutionAdapter:
                     ),
                 )
             ) from exc
+
+    def invoke(self, validated: PolynomialSystemSolutionRequest) -> OperationProjection:
         installation = self.resources.installation
         checker_id = installation.checker_id
         if checker_id is None:

--- a/src/jacobian/polynomial_system_search.py
+++ b/src/jacobian/polynomial_system_search.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import format_canonical_integer
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -80,12 +81,14 @@ class PolynomialSystemRationalSearchAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialSystemRationalSearchRequest:
         try:
-            validated = PolynomialSystemRationalSearchRequest.model_validate(
-                request.input
+            return parse_capability_input(
+                PolynomialSystemRationalSearchRequest, request.input
             )
-        except ValidationError as exc:
+        except (ValidationError, ValueError) as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
                     code="INVALID_POLYNOMIAL_SYSTEM_SEARCH_REQUEST",
@@ -93,6 +96,10 @@ class PolynomialSystemRationalSearchAdapter:
                     message="The bounded rational solution search request is invalid.",
                 )
             ) from exc
+
+    def invoke(
+        self, validated: PolynomialSystemRationalSearchRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         values = tuple(
             CanonicalRational(

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Self, cast
 from pydantic import Field, ValidationError, model_validator
 
 from jacobian.canonical import (
-    canonicalize_json,
+    encode_strict_json,
     format_canonical_integer,
     loads_strict_json,
 )
@@ -159,7 +159,7 @@ def _structural_sparse_polynomial(
     """Build a cheap shape representative without applying operation budgets."""
 
     parsed = _SparsePolynomialInput.model_validate_json(
-        canonicalize_json(value), strict=True
+        encode_strict_json(value), strict=True
     )
     _require_bounded_duplicate_accumulation(parsed)
     representatives: dict[tuple[int, ...], _SparsePolynomialInputTerm] = {}
@@ -181,7 +181,7 @@ def _canonical_sparse_polynomial(
     value: object,
 ) -> SparseRationalPolynomial:
     parsed = _SparsePolynomialInput.model_validate_json(
-        canonicalize_json(value), strict=True
+        encode_strict_json(value), strict=True
     )
     _require_bounded_duplicate_accumulation(parsed)
     coefficients: dict[tuple[int, ...], Fraction] = {}
@@ -654,13 +654,13 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
-        strict_payload = loads_strict_json(canonicalize_json(payload))
+        strict_payload = loads_strict_json(encode_strict_json(payload))
         structural_payload = _normalize_sparse_polynomial_inputs(
             strict_payload,
             normalize=_structural_sparse_polynomial,
         )
         model.model_validate_json(
-            canonicalize_json(structural_payload),
+            encode_strict_json(structural_payload),
             context={_CANONICALIZATION_PREFLIGHT_CONTEXT_KEY: True},
             strict=True,
         )
@@ -669,7 +669,7 @@ def _validate_request[RequestModel: ContractModel](
             normalize=_canonical_sparse_polynomial,
         )
         return model.model_validate_json(
-            canonicalize_json(canonical_payload), strict=True
+            encode_strict_json(canonical_payload), strict=True
         )
     except (ValidationError, ValueError) as exc:
         raise (error_factory or _polynomial_error)(

--- a/src/jacobian/polynomials/_support.py
+++ b/src/jacobian/polynomials/_support.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING, Any, Self, cast
 
 from pydantic import Field, ValidationError, model_validator
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import (
+    canonicalize_json,
+    format_canonical_integer,
+    loads_strict_json,
+)
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -154,7 +158,9 @@ def _structural_sparse_polynomial(
 ) -> SparseRationalPolynomial:
     """Build a cheap shape representative without applying operation budgets."""
 
-    parsed = _SparsePolynomialInput.model_validate(value)
+    parsed = _SparsePolynomialInput.model_validate_json(
+        canonicalize_json(value), strict=True
+    )
     _require_bounded_duplicate_accumulation(parsed)
     representatives: dict[tuple[int, ...], _SparsePolynomialInputTerm] = {}
     for term in parsed.terms:
@@ -174,7 +180,9 @@ def _structural_sparse_polynomial(
 def _canonical_sparse_polynomial(
     value: object,
 ) -> SparseRationalPolynomial:
-    parsed = _SparsePolynomialInput.model_validate(value)
+    parsed = _SparsePolynomialInput.model_validate_json(
+        canonicalize_json(value), strict=True
+    )
     _require_bounded_duplicate_accumulation(parsed)
     coefficients: dict[tuple[int, ...], Fraction] = {}
     for term in parsed.terms:
@@ -646,19 +654,23 @@ def _validate_request[RequestModel: ContractModel](
     error_factory: Callable[[str, str, str], CapabilityInvocationError] | None = None,
 ) -> RequestModel:
     try:
+        strict_payload = loads_strict_json(canonicalize_json(payload))
         structural_payload = _normalize_sparse_polynomial_inputs(
-            payload,
+            strict_payload,
             normalize=_structural_sparse_polynomial,
         )
-        model.model_validate(
-            structural_payload,
+        model.model_validate_json(
+            canonicalize_json(structural_payload),
             context={_CANONICALIZATION_PREFLIGHT_CONTEXT_KEY: True},
+            strict=True,
         )
         canonical_payload = _normalize_sparse_polynomial_inputs(
-            payload,
+            strict_payload,
             normalize=_canonical_sparse_polynomial,
         )
-        return model.model_validate(canonical_payload)
+        return model.model_validate_json(
+            canonicalize_json(canonical_payload), strict=True
+        )
     except (ValidationError, ValueError) as exc:
         raise (error_factory or _polynomial_error)(
             code,

--- a/src/jacobian/polynomials/collision.py
+++ b/src/jacobian/polynomials/collision.py
@@ -120,13 +120,15 @@ class PolynomialCollisionAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialCollisionRequest:
+        return _validate_request(
             PolynomialCollisionRequest,
             request.input,
             code="INVALID_POLYNOMIAL_COLLISION_REQUEST",
             operation="collision construction",
         )
+
+    def invoke(self, validated: PolynomialCollisionRequest) -> OperationProjection:
         started = time.monotonic()
         first_evaluation, first_evaluation_artifact = _load_evaluation(
             self.resources,
@@ -280,16 +282,17 @@ class PolynomialCollisionSearchAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(
-        self,
-        request: CapabilityRequest,
-    ) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialCollisionSearchRequest:
+        return _validate_request(
             PolynomialCollisionSearchRequest,
             request.input,
             code="INVALID_POLYNOMIAL_COLLISION_SEARCH_REQUEST",
             operation="collision search",
         )
+
+    def invoke(
+        self, validated: PolynomialCollisionSearchRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         polynomial_map, map_uri = _materialize_map(self.resources, validated.map)
         scalar_values = tuple(
@@ -504,13 +507,17 @@ class PolynomialCollisionVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialCollisionVerifyRequest:
+        return _validate_request(
             PolynomialCollisionVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_COLLISION_VERIFY_REQUEST",
             operation="collision verification",
         )
+
+    def invoke(
+        self, validated: PolynomialCollisionVerifyRequest
+    ) -> OperationProjection:
         _, map_uri = _materialize_map(self.resources, validated.map)
         candidate = self.resources.store.get(map_uri)
         claim_artifact = self.resources.artifacts.put(
@@ -617,13 +624,19 @@ class PolynomialMapInverseCollisionVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialMapInverseCollisionVerifyRequest:
+        return _validate_request(
             PolynomialMapInverseCollisionVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_MAP_INVERSE_COLLISION_REQUEST",
             operation="polynomial-map inverse obstruction",
         )
+
+    def invoke(
+        self, validated: PolynomialMapInverseCollisionVerifyRequest
+    ) -> OperationProjection:
         checker_id = self.resources.installation.inverse_collision_checker_id
         if checker_id is None:
             raise _polynomial_error(

--- a/src/jacobian/polynomials/evaluation.py
+++ b/src/jacobian/polynomials/evaluation.py
@@ -101,13 +101,15 @@ class PolynomialMapEvaluationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialEvaluationRequest:
+        return _validate_request(
             PolynomialEvaluationRequest,
             request.input,
             code="INVALID_POLYNOMIAL_EVALUATION_REQUEST",
             operation="evaluation",
         )
+
+    def invoke(self, validated: PolynomialEvaluationRequest) -> OperationProjection:
         started = time.monotonic()
         polynomial_map = validated.map
         polynomial_map, map_uri = _materialize_map(self.resources, polynomial_map)
@@ -187,13 +189,15 @@ class PolynomialJacobianAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialJacobianRequest:
+        return _validate_request(
             PolynomialJacobianRequest,
             request.input,
             code="INVALID_POLYNOMIAL_JACOBIAN_REQUEST",
             operation="Jacobian computation",
         )
+
+    def invoke(self, validated: PolynomialJacobianRequest) -> OperationProjection:
         return self.compute(validated)
 
     def compute(
@@ -370,13 +374,19 @@ class PolynomialKellerConditionVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialKellerConditionVerifyRequest:
+        return _validate_request(
             PolynomialKellerConditionVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_KELLER_CONDITION_REQUEST",
             operation="Keller-condition verification",
         )
+
+    def invoke(
+        self, validated: PolynomialKellerConditionVerifyRequest
+    ) -> OperationProjection:
         checker_id = self.resources.installation.keller_checker_id
         if checker_id is None:
             raise _polynomial_error(

--- a/src/jacobian/polynomials/identity.py
+++ b/src/jacobian/polynomials/identity.py
@@ -98,13 +98,15 @@ class PolynomialIdentityAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialIdentityRequest:
+        return _validate_request(
             PolynomialIdentityRequest,
             request.input,
             code="INVALID_POLYNOMIAL_IDENTITY_REQUEST",
             operation="identity verification",
         )
+
+    def invoke(self, validated: PolynomialIdentityRequest) -> OperationProjection:
         return self.verify(validated).project(self.descriptor)
 
     def verify(

--- a/src/jacobian/polynomials/installation.py
+++ b/src/jacobian/polynomials/installation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from jacobian.artifacts import ArtifactService
 from jacobian.capability_adapters import CapabilityAdapter
 from jacobian.checker_installation import CheckerInstaller
@@ -58,7 +60,7 @@ def install_polynomial_capabilities(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[tuple[CapabilityAdapter, ...], PolynomialInstallation]:
+) -> tuple[tuple[CapabilityAdapter[Any], ...], PolynomialInstallation]:
     """Register exact polynomial-map schemas, adapters, and optional checker."""
 
     semantics_uri = store.register_descriptor(

--- a/src/jacobian/polynomials/inverse.py
+++ b/src/jacobian/polynomials/inverse.py
@@ -430,17 +430,20 @@ class PolynomialMapInverseSynthesizeAdapter:
             verification_artifact_uri,
         )
 
-    def invoke(
-        self,
-        request: CapabilityRequest,
-    ) -> OperationProjection:
-        started = time.monotonic()
-        validated = _validate_request(
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> PolynomialMapInverseSynthesisRequest:
+        return _validate_request(
             PolynomialMapInverseSynthesisRequest,
             request.input,
             code="INVALID_POLYNOMIAL_MAP_INVERSE_SYNTHESIS_REQUEST",
             operation="map inverse candidate synthesis",
         )
+
+    def invoke(
+        self, validated: PolynomialMapInverseSynthesisRequest
+    ) -> OperationProjection:
+        started = time.monotonic()
         forward_artifact = self.resources.artifacts.put(
             schema_uri=self.resources.installation.map_schema_uri,
             semantics_uri=self.resources.installation.inverse_semantics_uri,
@@ -629,13 +632,17 @@ class PolynomialMapInverseVerifyAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> PolynomialMapInverseVerifyRequest:
+        return _validate_request(
             PolynomialMapInverseVerifyRequest,
             request.input,
             code="INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST",
             operation="map inverse verification",
         )
+
+    def invoke(
+        self, validated: PolynomialMapInverseVerifyRequest
+    ) -> OperationProjection:
         return self.verify(validated).project(self.descriptor)
 
     def verify(

--- a/src/jacobian/polynomials/rational_identity.py
+++ b/src/jacobian/polynomials/rational_identity.py
@@ -124,13 +124,15 @@ class RationalFunctionIdentityAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = _validate_request(
+    def prepare(self, request: CapabilityRequest) -> RationalFunctionIdentityRequest:
+        return _validate_request(
             RationalFunctionIdentityRequest,
             request.input,
             code="INVALID_RATIONAL_FUNCTION_IDENTITY_REQUEST",
             operation="rational-function identity verification",
         )
+
+    def invoke(self, validated: RationalFunctionIdentityRequest) -> OperationProjection:
         checker_id = self.resources.installation.rational_function_identity_checker_id
         if checker_id is None:
             raise _polynomial_error(

--- a/src/jacobian/polytope_capabilities.py
+++ b/src/jacobian/polytope_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
@@ -45,8 +46,10 @@ class PolytopeSeparationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        parsed = PolytopeSeparateRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> PolytopeSeparateRequest:
+        return parse_capability_input(PolytopeSeparateRequest, request.input)
+
+    def invoke(self, parsed: PolytopeSeparateRequest) -> OperationProjection:
         value = self._service.separate(parsed)
         terminal = (
             Completed(

--- a/src/jacobian/sat_smt/cadical.py
+++ b/src/jacobian/sat_smt/cadical.py
@@ -11,10 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from pydantic import ValidationError
-
 from jacobian.bounded_process import bounded_process_cancelled
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -79,7 +77,10 @@ def install_cadical_capabilities(
     runtime: CapabilityProviderRuntime,
     *,
     executable: str | Path | None = None,
-) -> tuple[CapabilityAdapter, CapabilityAdapter]:
+) -> tuple[
+    CapabilityAdapter[SatExplorationRequest],
+    CapabilityAdapter[SatExplorationRequest],
+]:
     """Install model and proof producers for one exact available runtime."""
 
     if (
@@ -336,8 +337,6 @@ class _CadicalBackend:
 class CadicalModelFindAdapter:
     """Attempt to produce one total assignment without validating it."""
 
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -377,8 +376,11 @@ class CadicalModelFindAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated, resolved = _resolve_request(self.sat, request)
+    def prepare(self, request: CapabilityRequest) -> SatExplorationRequest:
+        return parse_capability_input(SatExplorationRequest, request.input)
+
+    def invoke(self, validated: SatExplorationRequest) -> OperationProjection:
+        resolved = _resolve_request(self.sat, validated)
         run = self.backend.run_model(resolved.cnf, validated.resource_budget)
         if (
             run.execution_status is ExecutionStatus.COMPLETED
@@ -463,8 +465,6 @@ class CadicalModelFindAdapter:
 class CadicalUnsatProofFindAdapter:
     """Attempt to preserve raw text DRAT without validating the proof."""
 
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -504,8 +504,11 @@ class CadicalUnsatProofFindAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated, resolved = _resolve_request(self.sat, request)
+    def prepare(self, request: CapabilityRequest) -> SatExplorationRequest:
+        return parse_capability_input(SatExplorationRequest, request.input)
+
+    def invoke(self, validated: SatExplorationRequest) -> OperationProjection:
+        resolved = _resolve_request(self.sat, validated)
         run = self.backend.run_proof(resolved.cnf, validated.resource_budget)
         if (
             run.execution_status is ExecutionStatus.COMPLETED
@@ -557,12 +560,11 @@ class CadicalUnsatProofFindAdapter:
 
 def _resolve_request(
     sat: SatArtifactService,
-    request: CapabilityRequest,
-) -> tuple[SatExplorationRequest, ResolvedSatCnf]:
+    request: SatExplorationRequest,
+) -> ResolvedSatCnf:
     try:
-        validated = SatExplorationRequest.model_validate(request.input)
-        resolved = sat.resolve_cnf(validated.cnf_uri)
-    except (SatArtifactError, ValidationError) as exc:
+        return sat.resolve_cnf(request.cnf_uri)
+    except SatArtifactError as exc:
         raise CapabilityInvocationError(
             CapabilityDiagnostic(
                 code="INVALID_SAT_EXPLORATION_REQUEST",
@@ -578,7 +580,6 @@ def _resolve_request(
                 ),
             )
         ) from exc
-    return validated, resolved
 
 
 def _completed_result(

--- a/src/jacobian/sat_smt/cvc5.py
+++ b/src/jacobian/sat_smt/cvc5.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 
 from jacobian.bounded_process import bounded_process_cancelled
 from jacobian.canonical import loads_strict_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -69,7 +69,7 @@ class _Cvc5Run:
 def install_cvc5_capability(
     smt: SmtArtifactService,
     runtime: CapabilityProviderRuntime,
-) -> CapabilityAdapter:
+) -> CapabilityAdapter[SmtUnsatProofFindRequest]:
     """Install the Alethe producer for one exact available cvc5 runtime."""
 
     if (
@@ -189,8 +189,6 @@ class _Cvc5Backend:
 class Cvc5UnsatProofFindAdapter:
     """Preserve raw cvc5 Alethe evidence without validating it."""
 
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -250,31 +248,24 @@ class Cvc5UnsatProofFindAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> SmtUnsatProofFindRequest:
         try:
-            validated = SmtUnsatProofFindRequest.model_validate(request.input)
+            return parse_capability_input(SmtUnsatProofFindRequest, request.input)
+        except ValidationError as exc:
+            raise CapabilityInvocationError(
+                _invalid_smt_unsat_proof_request_diagnostic(self.smt, exc)
+            ) from exc
+
+    def invoke(self, validated: SmtUnsatProofFindRequest) -> OperationProjection:
+        try:
             problem_uri = self.smt.put_problem(
                 logic=validated.logic,
                 smtlib_text=validated.smtlib_text,
             ).artifact_uri
             resolved = self.smt.resolve_problem(problem_uri)
-        except (ValidationError, ValueError) as exc:
+        except ValueError as exc:
             raise CapabilityInvocationError(
-                CapabilityDiagnostic(
-                    code="INVALID_SMT_UNSAT_PROOF_REQUEST",
-                    stage="input_validation",
-                    message=str(exc),
-                    path="smtlib_text",
-                    schema_uri=self.smt.installation.problem_schema_uri,
-                    expected=(
-                        "one exact QF_UF, QF_LIA, or QF_LRA SMT-LIB 2.6 query "
-                        "within an enforceable wall-time budget"
-                    ),
-                    hint=(
-                        "Use one set-logic, declarations and assertions, then one "
-                        "final check-sat; incremental and result commands are excluded."
-                    ),
-                )
+                _invalid_smt_unsat_proof_request_diagnostic(self.smt, exc)
             ) from exc
         run = self.backend.run(resolved, validated)
         if (
@@ -340,6 +331,26 @@ class Cvc5UnsatProofFindAdapter:
             output,
             tuple(artifacts),
         )
+
+
+def _invalid_smt_unsat_proof_request_diagnostic(
+    smt: SmtArtifactService, exc: Exception
+) -> CapabilityDiagnostic:
+    return CapabilityDiagnostic(
+        code="INVALID_SMT_UNSAT_PROOF_REQUEST",
+        stage="input_validation",
+        message=str(exc),
+        path="smtlib_text",
+        schema_uri=smt.installation.problem_schema_uri,
+        expected=(
+            "one exact QF_UF, QF_LIA, or QF_LRA SMT-LIB 2.6 query within an "
+            "enforceable wall-time budget"
+        ),
+        hint=(
+            "Use one set-logic, declarations and assertions, then one final "
+            "check-sat; incremental and result commands are excluded."
+        ),
+    )
 
 
 def _completed_result(

--- a/src/jacobian/sat_smt/sat_capabilities.py
+++ b/src/jacobian/sat_smt/sat_capabilities.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_artifacts import put_witness_envelope
 from jacobian.checker_installation import CheckerInstaller
@@ -73,8 +73,6 @@ class SatUnsatProofCheckerInstallation:
 
 class SatCnfMaterializationAdapter:
     """Create one canonical CNF artifact without making a SAT conclusion."""
-
-    typed_input = True
 
     def __init__(self, sat: SatArtifactService) -> None:
         self.sat = sat
@@ -151,9 +149,9 @@ class SatCnfMaterializationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> SatCnfMaterializationRequest:
         try:
-            validated = SatCnfMaterializationRequest.model_validate(request.input)
+            return parse_capability_input(SatCnfMaterializationRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -171,6 +169,7 @@ class SatCnfMaterializationAdapter:
                 )
             ) from exc
 
+    def invoke(self, validated: SatCnfMaterializationRequest) -> OperationProjection:
         terminal = execute_operation(self.spec, validated)
         if not isinstance(terminal, Completed):
             return OperationProjection(
@@ -242,7 +241,10 @@ def install_sat_assignment_checker(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, SatAssignmentCheckerInstallation]:
+) -> tuple[
+    CapabilityAdapter[SatAssignmentVerificationRequest] | None,
+    SatAssignmentCheckerInstallation,
+]:
     """Install the assignment evidence schema and optionally authorize replay."""
 
     witness_schema_uri = schemas.register_model(
@@ -272,7 +274,7 @@ def install_sat_assignment_checker(
         witness_schema_uri=witness_schema_uri,
         checker_id=checker_id,
     )
-    adapter: CapabilityAdapter | None = None
+    adapter: CapabilityAdapter[SatAssignmentVerificationRequest] | None = None
     if checker_id is not None:
         adapter = SatAssignmentVerificationAdapter(
             store=store,
@@ -294,7 +296,10 @@ def install_sat_unsat_proof_checker(
     runtime: CapabilityProviderRuntime,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, SatUnsatProofCheckerInstallation]:
+) -> tuple[
+    CapabilityAdapter[SatUnsatProofVerificationRequest] | None,
+    SatUnsatProofCheckerInstallation,
+]:
     """Install the proof certificate schema and optionally authorize DRAT replay."""
 
     certificate_schema_uri = schemas.register_model(
@@ -328,7 +333,7 @@ def install_sat_unsat_proof_checker(
         certificate_schema_uri=certificate_schema_uri,
         checker_id=checker_id,
     )
-    adapter: CapabilityAdapter | None = None
+    adapter: CapabilityAdapter[SatUnsatProofVerificationRequest] | None = None
     if checker_id is not None:
         adapter = SatUnsatProofVerificationAdapter(
             store=store,
@@ -343,8 +348,6 @@ def install_sat_unsat_proof_checker(
 
 class SatAssignmentVerificationAdapter:
     """Verify one assignment; never infer UNSAT from assignment rejection."""
-
-    typed_input = True
 
     def __init__(
         self,
@@ -400,8 +403,12 @@ class SatAssignmentVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = SatAssignmentVerificationRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> SatAssignmentVerificationRequest:
+        return parse_capability_input(SatAssignmentVerificationRequest, request.input)
+
+    def invoke(
+        self, validated: SatAssignmentVerificationRequest
+    ) -> OperationProjection:
         try:
             resolved = self.sat.resolve_assignment(validated.assignment_uri)
             semantics = self.store.get(self.sat.installation.semantics_uri)
@@ -514,8 +521,6 @@ class SatAssignmentVerificationAdapter:
 class SatUnsatProofVerificationAdapter:
     """Verify one raw proof; rejection never establishes satisfiability."""
 
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -571,8 +576,12 @@ class SatUnsatProofVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = SatUnsatProofVerificationRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> SatUnsatProofVerificationRequest:
+        return parse_capability_input(SatUnsatProofVerificationRequest, request.input)
+
+    def invoke(
+        self, validated: SatUnsatProofVerificationRequest
+    ) -> OperationProjection:
         try:
             resolved = self.sat.resolve_proof(validated.proof_uri)
             semantics = self.store.get(self.sat.installation.semantics_uri)

--- a/src/jacobian/sat_smt/sat_lrat.py
+++ b/src/jacobian/sat_smt/sat_lrat.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -61,7 +61,7 @@ def install_sat_lrat_verifier(
     checkers: CheckerRegistry,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, SatLratInstallation]:
+) -> tuple[CapabilityAdapter[SatLratVerificationRequest] | None, SatLratInstallation]:
     proof_schema_uri = schemas.register_model(
         name="jacobian.sat-lrat-proof", version="1", model=SatLratProofArtifact
     )
@@ -106,8 +106,6 @@ def install_sat_lrat_verifier(
 
 
 class SatLratVerificationAdapter:
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -161,8 +159,10 @@ class SatLratVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = SatLratVerificationRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> SatLratVerificationRequest:
+        return parse_capability_input(SatLratVerificationRequest, request.input)
+
+    def invoke(self, validated: SatLratVerificationRequest) -> OperationProjection:
         try:
             resolved = self.sat.resolve_cnf(validated.cnf_uri)
             semantics = self.store.get(self.sat.installation.semantics_uri)

--- a/src/jacobian/sat_smt/smt_capabilities.py
+++ b/src/jacobian/sat_smt/smt_capabilities.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -59,7 +59,10 @@ def install_smt_unsat_proof_checker(
     runtime: CapabilityProviderRuntime,
     *,
     authorize_checker: bool,
-) -> tuple[CapabilityAdapter | None, SmtUnsatProofCheckerInstallation]:
+) -> tuple[
+    CapabilityAdapter[SmtUnsatProofVerificationRequest] | None,
+    SmtUnsatProofCheckerInstallation,
+]:
     """Install the certificate schema and optionally authorize strict replay."""
 
     certificate_schema_uri = schemas.register_model(
@@ -96,7 +99,7 @@ def install_smt_unsat_proof_checker(
         certificate_schema_uri=certificate_schema_uri,
         checker_id=checker_id,
     )
-    adapter: CapabilityAdapter | None = None
+    adapter: CapabilityAdapter[SmtUnsatProofVerificationRequest] | None = None
     if checker_id is not None:
         adapter = SmtUnsatProofVerificationAdapter(
             store=store,
@@ -111,8 +114,6 @@ def install_smt_unsat_proof_checker(
 
 class SmtUnsatProofVerificationAdapter:
     """Verify one compatible Alethe proof; rejection establishes nothing."""
-
-    typed_input = True
 
     def __init__(
         self,
@@ -165,8 +166,12 @@ class SmtUnsatProofVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        validated = SmtUnsatProofVerificationRequest.model_validate(request.input)
+    def prepare(self, request: CapabilityRequest) -> SmtUnsatProofVerificationRequest:
+        return parse_capability_input(SmtUnsatProofVerificationRequest, request.input)
+
+    def invoke(
+        self, validated: SmtUnsatProofVerificationRequest
+    ) -> OperationProjection:
         try:
             resolved = self.smt.resolve_proof(validated.proof_uri)
             semantics = self.store.get(self.smt.installation.semantics_uri)

--- a/src/jacobian/sympy_polynomial_normalization.py
+++ b/src/jacobian/sympy_polynomial_normalization.py
@@ -11,7 +11,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json, loads_strict_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
@@ -72,7 +72,7 @@ class _SympyNormalizationRun:
 def install_sympy_polynomial_normalization_capability(
     expressions: PolynomialExpressionArtifactService,
     runtime: CapabilityProviderRuntime,
-) -> CapabilityAdapter:
+) -> CapabilityAdapter[Any]:
     """Install the producer only for the exact supported SymPy profile."""
 
     if (
@@ -171,8 +171,6 @@ class _SympyPolynomialNormalizationBackend:
 class SympyPolynomialExpressionNormalizeAdapter:
     """Normalize one safe typed expression to canonical sparse coefficients."""
 
-    typed_input = True
-
     def __init__(
         self,
         *,
@@ -232,17 +230,15 @@ class SympyPolynomialExpressionNormalizeAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(
+    def prepare(
         self,
         request: CapabilityRequest,
-    ) -> OperationProjection:
+    ) -> PolynomialExpressionNormalizeRequest:
         try:
-            validated = PolynomialExpressionNormalizeRequest.model_validate(
-                request.input
+            return parse_capability_input(
+                PolynomialExpressionNormalizeRequest,
+                request.input,
             )
-            expression_uri = self.expressions.put_expression(
-                validated.expression
-            ).artifact_uri
         except (ValidationError, ValueError) as exc:
             budget_error = _expansion_budget_error(exc)
             if budget_error is not None:
@@ -329,6 +325,13 @@ class SympyPolynomialExpressionNormalizeAdapter:
                 )
             ) from exc
 
+    def invoke(
+        self,
+        validated: PolynomialExpressionNormalizeRequest,
+    ) -> OperationProjection:
+        expression_uri = self.expressions.put_expression(
+            validated.expression
+        ).artifact_uri
         run = self.backend.run(validated)
         normalization_uri: str | None = None
         if (

--- a/src/jacobian/universal_algebra_capabilities.py
+++ b/src/jacobian/universal_algebra_capabilities.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 
 from jacobian.artifacts import ArtifactService
 from jacobian.canonical import canonicalize_json
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import CapabilityInvocationError
 from jacobian.checker_installation import CheckerInstaller
 from jacobian.checker_operations import CheckerOperation
@@ -92,7 +92,7 @@ def install_universal_algebra_capabilities(
     *,
     authorize_checker: bool,
 ) -> tuple[
-    tuple[CapabilityAdapter, ...],
+    tuple[CapabilityAdapter[Any], ...],
     UniversalAlgebraInstallation,
 ]:
     """Install exact bounded finite-magma law evaluation."""
@@ -188,7 +188,7 @@ def install_universal_algebra_capabilities(
         "jacobian.z3",
         features=("finite-magma-countermodel-search",),
     )
-    adapters: tuple[CapabilityAdapter, ...] = (evaluation,)
+    adapters: tuple[CapabilityAdapter[Any], ...] = (evaluation,)
     if search_runtime.availability is CapabilityProviderAvailability.AVAILABLE:
         adapters += (
             UniversalAlgebraSearchCountermodelAdapter(resources, search_runtime),
@@ -271,9 +271,12 @@ class UniversalAlgebraEvaluateLawsAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> UniversalAlgebraEvaluationRequest:
         try:
-            validated = UniversalAlgebraEvaluationRequest.model_validate(request.input)
+            return parse_capability_input(
+                UniversalAlgebraEvaluationRequest,
+                request.input,
+            )
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -282,6 +285,10 @@ class UniversalAlgebraEvaluateLawsAdapter:
                     message="The complete finite-magma law request is invalid.",
                 )
             ) from exc
+
+    def invoke(
+        self, validated: UniversalAlgebraEvaluationRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         problem = validated.problem
         problem_artifact = self.resources.artifacts.put(
@@ -490,10 +497,13 @@ class UniversalAlgebraSearchCountermodelAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(
+        self, request: CapabilityRequest
+    ) -> UniversalAlgebraCountermodelSearchRequest:
         try:
-            validated = UniversalAlgebraCountermodelSearchRequest.model_validate(
-                request.input
+            return parse_capability_input(
+                UniversalAlgebraCountermodelSearchRequest,
+                request.input,
             )
         except ValidationError as exc:
             raise CapabilityInvocationError(
@@ -503,6 +513,10 @@ class UniversalAlgebraSearchCountermodelAdapter:
                     message="The complete finite-magma countermodel request is invalid.",
                 )
             ) from exc
+
+    def invoke(
+        self, validated: UniversalAlgebraCountermodelSearchRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         try:
             search = _search_countermodel(validated)
@@ -575,9 +589,12 @@ class FiniteMagmaTableEnumerateAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> FiniteMagmaTableEnumerationRequest:
         try:
-            validated = FiniteMagmaTableEnumerationRequest.model_validate(request.input)
+            return parse_capability_input(
+                FiniteMagmaTableEnumerationRequest,
+                request.input,
+            )
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 CapabilityDiagnostic(
@@ -589,6 +606,10 @@ class FiniteMagmaTableEnumerateAdapter:
                     ),
                 )
             ) from exc
+
+    def invoke(
+        self, validated: FiniteMagmaTableEnumerationRequest
+    ) -> OperationProjection:
         started = time.monotonic()
         order = validated.order
         table_uris: list[str] = []

--- a/src/jacobian/verification_capabilities.py
+++ b/src/jacobian/verification_capabilities.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import ValidationError
 
-from jacobian.capability_adapters import CapabilityAdapter
+from jacobian.capability_adapters import CapabilityAdapter, parse_capability_input
 from jacobian.capability_errors import (
     CapabilityInvocationError,
     enriched_invalid_request,
@@ -138,8 +139,6 @@ class _VerificationProjection:
 class CertificateVerificationAdapter:
     """Replay one domain certificate with its installation-bound checker."""
 
-    typed_input = True
-
     def __init__(self, projection: _VerificationProjection) -> None:
         self.projection = projection
         self._descriptor = projection.descriptor(CertificateReplayRequest)
@@ -148,13 +147,15 @@ class CertificateVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> CertificateReplayRequest:
         try:
-            validated = CertificateReplayRequest.model_validate(request.input)
+            return parse_capability_input(CertificateReplayRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 enriched_invalid_request(_INVALID_REPLAY_REQUEST, exc)
             ) from exc
+
+    def invoke(self, validated: CertificateReplayRequest) -> OperationProjection:
         result = self.projection.verification.verify_certificate(
             certificate_uri=validated.certificate_uri,
             checker_id=self.projection.checker_id,
@@ -165,8 +166,6 @@ class CertificateVerificationAdapter:
 class WitnessVerificationAdapter:
     """Replay one domain witness with its installation-bound checker."""
 
-    typed_input = True
-
     def __init__(self, projection: _VerificationProjection) -> None:
         self.projection = projection
         self._descriptor = projection.descriptor(WitnessReplayRequest)
@@ -175,13 +174,15 @@ class WitnessVerificationAdapter:
     def descriptor(self) -> CapabilityDescriptor:
         return self._descriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> WitnessReplayRequest:
         try:
-            validated = WitnessReplayRequest.model_validate(request.input)
+            return parse_capability_input(WitnessReplayRequest, request.input)
         except ValidationError as exc:
             raise CapabilityInvocationError(
                 enriched_invalid_request(_INVALID_REPLAY_REQUEST, exc)
             ) from exc
+
+    def invoke(self, validated: WitnessReplayRequest) -> OperationProjection:
         result = self.projection.verification.verify_witness(
             claim_uri=validated.claim_uri,
             candidate_uri=validated.candidate_uri,
@@ -199,7 +200,7 @@ def certificate_verification_adapter(
     checker_id: CheckerUri | None,
     tags: tuple[str, ...],
     verification: VerificationService,
-) -> CapabilityAdapter | None:
+) -> CapabilityAdapter[Any] | None:
     if checker_id is None:
         return None
     return CertificateVerificationAdapter(
@@ -222,7 +223,7 @@ def witness_verification_adapter(
     checker_id: CheckerUri | None,
     tags: tuple[str, ...],
     verification: VerificationService,
-) -> CapabilityAdapter | None:
+) -> CapabilityAdapter[Any] | None:
     if checker_id is None:
         return None
     return WitnessVerificationAdapter(

--- a/tests/boundary/providers/lean/startup/test_provider_runtime_integration.py
+++ b/tests/boundary/providers/lean/startup/test_provider_runtime_integration.py
@@ -43,6 +43,9 @@ class UnavailableAdapter:
         output_schema={"type": "object"},
     )
 
+    def prepare(self, request: CapabilityRequest) -> CapabilityRequest:
+        return request
+
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
         raise AssertionError(f"unavailable adapter invoked: {request.capability_id}")
 

--- a/tests/boundary/providers/lean/test_lean_replayable_state_capability.py
+++ b/tests/boundary/providers/lean/test_lean_replayable_state_capability.py
@@ -173,27 +173,31 @@ def test_apply_tactic_materializes_and_reuses_replayable_state(
 
     first = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "(P Q : Prop) → P ∧ Q",
-                    "proof_prefix": ["intro P Q"],
-                    "tactic": "constructor",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "(P Q : Prop) → P ∧ Q",
+                        "proof_prefix": ["intro P Q"],
+                        "tactic": "constructor",
+                    },
+                )
             )
         )
     )
     successor_uri = first.output["successor_states"][0]["state_uri"]
     second = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "state_uri": successor_uri,
-                    "tactic": "all_goals assumption",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": successor_uri,
+                        "tactic": "all_goals assumption",
+                    },
+                )
             )
         )
     )
@@ -231,14 +235,16 @@ def test_apply_tactic_returns_rejection_without_successor(
 
     result = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "(P Q : Prop) → P → Q",
-                    "proof_prefix": ["intro P Q hP"],
-                    "tactic": "exact hP",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "(P Q : Prop) → P → Q",
+                        "proof_prefix": ["intro P Q hP"],
+                        "tactic": "exact hP",
+                    },
+                )
             )
         )
     )
@@ -288,13 +294,15 @@ def test_rejected_transition_persists_all_protocol_diagnostics(
 
     result = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "True",
-                    "tactic": "skip",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "tactic": "skip",
+                    },
+                )
             )
         )
     )
@@ -319,13 +327,15 @@ def test_apply_tactic_rejects_environment_stale_state_before_replay(
     )
     opened = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "True",
-                    "tactic": "trivial",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "tactic": "trivial",
+                    },
+                )
             )
         )
     )
@@ -341,13 +351,15 @@ def test_apply_tactic_rejects_environment_stale_state_before_replay(
 
     with pytest.raises(CapabilityInvocationError) as raised:
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "state_uri": stale.artifact_uri,
-                    "tactic": "trivial",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": stale.artifact_uri,
+                        "tactic": "trivial",
+                    },
+                )
             )
         )
 
@@ -370,15 +382,17 @@ def test_apply_tactic_preserves_cross_field_validation_evidence(tmp_path: Path) 
 
     with pytest.raises(CapabilityInvocationError) as raised:
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "state_uri": "artifact://sha256/" + "a" * 64,
-                    "statement": "True",
-                    "proof_prefix": ["skip"],
-                    "tactic": "trivial",
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": "artifact://sha256/" + "a" * 64,
+                        "statement": "True",
+                        "proof_prefix": ["skip"],
+                        "tactic": "trivial",
+                    },
+                )
             )
         )
 

--- a/tests/boundary/providers/lean/test_lean_residual_contracts.py
+++ b/tests/boundary/providers/lean/test_lean_residual_contracts.py
@@ -235,13 +235,15 @@ def _stored_input_state_uri(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": environment.value,
-                    "statement": "True",
-                    "tactic": "skip",
-                },
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": environment.value,
+                        "statement": "True",
+                        "tactic": "skip",
+                    },
+                )
             )
         )
     )
@@ -272,9 +274,11 @@ def _invoke_stored_state_consumer(
         adapter = metavariable
         capability_id = "lean.proof_state.metavariable_fields"
     adapter.invoke(
-        CapabilityRequest(
-            capability_id=capability_id,
-            input=request_input,
+        adapter.prepare(
+            CapabilityRequest(
+                capability_id=capability_id,
+                input=request_input,
+            )
         )
     )
 
@@ -302,14 +306,16 @@ def test_term_apply_elaborates_exact_term_and_returns_successor(
 
     result = project_operation_result(
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "P → P",
-                    "proof_prefix": ["intro P"],
-                    "term": "P",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "P → P",
+                        "proof_prefix": ["intro P"],
+                        "term": "P",
+                    },
+                )
             )
         )
     )
@@ -331,13 +337,15 @@ def test_term_apply_rejects_multiline_term(
     _, term_apply, _, _, _ = _adapters(tmp_path)
     with pytest.raises(CapabilityInvocationError) as raised:
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "True",
-                    "term": "trivial\nsorry",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "term": "trivial\nsorry",
+                    },
+                )
             )
         )
     assert raised.value.diagnostic.code == "INVALID_LEAN_TERM_APPLY_REQUEST"
@@ -359,14 +367,16 @@ def test_term_apply_fails_closed_on_rejected_term(
     )
     result = project_operation_result(
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "n = 0",
-                    "proof_prefix": ["intro n"],
-                    "term": "trivial",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "n = 0",
+                        "proof_prefix": ["intro n"],
+                        "term": "trivial",
+                    },
+                )
             )
         )
     )
@@ -411,14 +421,16 @@ def test_inspect_returns_recorded_goals_without_replay(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "(P Q : Prop) → P ∧ Q",
-                    "proof_prefix": ["intro P Q"],
-                    "tactic": "constructor",
-                },
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "(P Q : Prop) → P ∧ Q",
+                        "proof_prefix": ["intro P Q"],
+                        "tactic": "constructor",
+                    },
+                )
             )
         )
     )
@@ -426,12 +438,14 @@ def test_inspect_returns_recorded_goals_without_replay(
 
     result = project_operation_result(
         inspect.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.inspect",
-                input={
-                    "environment": "CORE",
-                    "state_uri": successor_uri,
-                },
+            inspect.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.inspect",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": successor_uri,
+                    },
+                )
             )
         )
     )
@@ -460,9 +474,15 @@ def test_inspect_rejects_stale_state(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={"environment": "CORE", "statement": "True", "tactic": "skip"},
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "tactic": "skip",
+                    },
+                )
             )
         )
     )
@@ -477,12 +497,14 @@ def test_inspect_rejects_stale_state(
     )
     with pytest.raises(CapabilityInvocationError) as raised:
         inspect.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.inspect",
-                input={
-                    "environment": "CORE",
-                    "state_uri": stale.artifact_uri,
-                },
+            inspect.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.inspect",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": stale.artifact_uri,
+                    },
+                )
             )
         )
     assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"
@@ -541,14 +563,16 @@ def test_metavariable_fields_expose_structured_fields_and_unavailable_coercion(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "P → P",
-                    "proof_prefix": ["intro P"],
-                    "tactic": "skip",
-                },
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "P → P",
+                        "proof_prefix": ["intro P"],
+                        "tactic": "skip",
+                    },
+                )
             )
         )
     )
@@ -564,9 +588,11 @@ def test_metavariable_fields_expose_structured_fields_and_unavailable_coercion(
 
     result = project_operation_result(
         metavariable.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.metavariable_fields",
-                input={"environment": "CORE", "state_uri": state_uri},
+            metavariable.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.metavariable_fields",
+                    input={"environment": "CORE", "state_uri": state_uri},
+                )
             )
         )
     )
@@ -621,11 +647,14 @@ def test_premise_retrieval_projects_completed_value_at_dispatch_boundary(
         "jacobian.lean_frontend.premise_retrieval._run_repl",
         retrieve,
     )
+    adapter = LeanPremiseRetrievalAdapter(resources)
     result = project_operation_result(
-        LeanPremiseRetrievalAdapter(resources).invoke(
-            CapabilityRequest(
-                capability_id="lean.retrieve.premises",
-                input={"statement": "True", "limit": 1},
+        adapter.invoke(
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.retrieve.premises",
+                    input={"statement": "True", "limit": 1},
+                )
             )
         )
     )
@@ -647,18 +676,26 @@ def test_metavariable_fields_reject_completed_state(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={"environment": "CORE", "statement": "True", "tactic": "trivial"},
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "tactic": "trivial",
+                    },
+                )
             )
         )
     )
     state_uri = opened.output["successor_states"][0]["state_uri"]
     with pytest.raises(CapabilityInvocationError) as raised:
         metavariable.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.metavariable_fields",
-                input={"environment": "CORE", "state_uri": state_uri},
+            metavariable.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.metavariable_fields",
+                    input={"environment": "CORE", "state_uri": state_uri},
+                )
             )
         )
     assert raised.value.diagnostic.code == "LEAN_PROOF_STATE_COMPLETED"
@@ -676,14 +713,16 @@ def test_metavariable_fields_fails_closed_on_helper_failure(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "P → P",
-                    "proof_prefix": ["intro P"],
-                    "tactic": "skip",
-                },
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "P → P",
+                        "proof_prefix": ["intro P"],
+                        "tactic": "skip",
+                    },
+                )
             )
         )
     )
@@ -703,9 +742,11 @@ def test_metavariable_fields_fails_closed_on_helper_failure(
     )
     with pytest.raises(CapabilityInvocationError) as raised:
         metavariable.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.metavariable_fields",
-                input={"environment": "CORE", "state_uri": state_uri},
+            metavariable.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.metavariable_fields",
+                    input={"environment": "CORE", "state_uri": state_uri},
+                )
             )
         )
     assert raised.value.diagnostic.code == "LEAN_METAVARIABLE_FIELDS_EXTRACTION_FAILED"
@@ -791,13 +832,15 @@ def test_term_apply_rejects_sorry_at_own_boundary(
     _, term_apply, _, _, _ = _adapters(tmp_path)
     with pytest.raises(CapabilityInvocationError) as raised:
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "True",
-                    "term": "sorry",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "term": "sorry",
+                    },
+                )
             )
         )
     assert raised.value.diagnostic.code == "INVALID_LEAN_TERM_APPLY_REQUEST"
@@ -811,13 +854,15 @@ def test_term_apply_rejects_admit_at_own_boundary(
     _, term_apply, _, _, _ = _adapters(tmp_path)
     with pytest.raises(CapabilityInvocationError) as raised:
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "True",
-                    "term": "admit",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "True",
+                        "term": "admit",
+                    },
+                )
             )
         )
     assert raised.value.diagnostic.code == "INVALID_LEAN_TERM_APPLY_REQUEST"
@@ -830,13 +875,15 @@ def test_term_apply_rejects_forbidden_statement_before_execution(
 
     with pytest.raises(CapabilityInvocationError) as raised:
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "run_tac pure ()",
-                    "term": "True.intro",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "run_tac pure ()",
+                        "term": "True.intro",
+                    },
+                )
             )
         )
 
@@ -969,12 +1016,14 @@ def test_inspect_adapter_available_without_lean_runtime(
     )
     result = project_operation_result(
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.inspect",
-                input={
-                    "environment": "CORE",
-                    "state_uri": state.artifact_uri,
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.inspect",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": state.artifact_uri,
+                    },
+                )
             )
         )
     )
@@ -1102,12 +1151,14 @@ def test_metavariable_fields_rejects_stale_state_before_replay(
     monkeypatch.setattr(resources.repl, "execute_clean", _unexpected_replay)
     with pytest.raises(CapabilityInvocationError) as raised:
         metavariable.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.metavariable_fields",
-                input={
-                    "environment": "CORE",
-                    "state_uri": stale.artifact_uri,
-                },
+            metavariable.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.metavariable_fields",
+                    input={
+                        "environment": "CORE",
+                        "state_uri": stale.artifact_uri,
+                    },
+                )
             )
         )
 
@@ -1159,12 +1210,14 @@ def test_inspect_rejects_forged_environment_metadata(
     )
     with pytest.raises(CapabilityInvocationError) as raised:
         inspect.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.inspect",
-                input={
-                    "environment": environment.value,
-                    "state_uri": forged.artifact_uri,
-                },
+            inspect.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.inspect",
+                    input={
+                        "environment": environment.value,
+                        "state_uri": forged.artifact_uri,
+                    },
+                )
             )
         )
     assert raised.value.diagnostic.code == "STALE_LEAN_PROOF_STATE"
@@ -1191,14 +1244,16 @@ def test_term_apply_output_is_validated_through_typed_model(
     )
     result = project_operation_result(
         term_apply.invoke(
-            CapabilityRequest(
-                capability_id="lean.term.apply",
-                input={
-                    "environment": "CORE",
-                    "statement": "P → P",
-                    "proof_prefix": ["intro P"],
-                    "term": "P",
-                },
+            term_apply.prepare(
+                CapabilityRequest(
+                    capability_id="lean.term.apply",
+                    input={
+                        "environment": "CORE",
+                        "statement": "P → P",
+                        "proof_prefix": ["intro P"],
+                        "term": "P",
+                    },
+                )
             )
         )
     )
@@ -1229,14 +1284,16 @@ def test_metavariable_fields_rejects_goal_count_mismatch(
     )
     opened = project_operation_result(
         proof_state.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={
-                    "environment": "CORE",
-                    "statement": "(P Q : Prop) → P ∧ Q",
-                    "proof_prefix": ["intro P Q"],
-                    "tactic": "constructor",
-                },
+            proof_state.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={
+                        "environment": "CORE",
+                        "statement": "(P Q : Prop) → P ∧ Q",
+                        "proof_prefix": ["intro P Q"],
+                        "tactic": "constructor",
+                    },
+                )
             )
         )
     )
@@ -1252,9 +1309,11 @@ def test_metavariable_fields_rejects_goal_count_mismatch(
     )
     with pytest.raises(CapabilityInvocationError) as raised:
         metavariable.invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.metavariable_fields",
-                input={"environment": "CORE", "state_uri": state_uri},
+            metavariable.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.metavariable_fields",
+                    input={"environment": "CORE", "state_uri": state_uri},
+                )
             )
         )
     assert raised.value.diagnostic.code == "LEAN_METAVARIABLE_FIELDS_EXTRACTION_FAILED"

--- a/tests/boundary/providers/lean/test_lean_residual_live_smoke.py
+++ b/tests/boundary/providers/lean/test_lean_residual_live_smoke.py
@@ -92,13 +92,15 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
     # 1. lean.term.apply: open a state for `True` and apply the term `True.intro`.
     #    `exact True.intro` closes the goal `⊢ True` via the constructor term.
     opened = term_apply.invoke(
-        CapabilityRequest(
-            capability_id="lean.term.apply",
-            input={
-                "environment": "CORE",
-                "statement": "True",
-                "term": "True.intro",
-            },
+        term_apply.prepare(
+            CapabilityRequest(
+                capability_id="lean.term.apply",
+                input={
+                    "environment": "CORE",
+                    "statement": "True",
+                    "term": "True.intro",
+                },
+            )
         )
     )
     assert opened.output["accepted"] is True
@@ -109,21 +111,25 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
     # 2. lean.proof_state.inspect: read the input state without replay.
     #    Reopen a non-completed state for inspection.
     reopened = proof_state.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.apply_tactic",
-            input={
-                "environment": "CORE",
-                "statement": "P → P",
-                "proof_prefix": ["intro P"],
-                "tactic": "skip",
-            },
+        proof_state.prepare(
+            CapabilityRequest(
+                capability_id="lean.proof_state.apply_tactic",
+                input={
+                    "environment": "CORE",
+                    "statement": "P → P",
+                    "proof_prefix": ["intro P"],
+                    "tactic": "skip",
+                },
+            )
         )
     )
     open_state_uri = reopened.output["successor_states"][0]["state_uri"]
     inspected = inspect.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.inspect",
-            input={"environment": "CORE", "state_uri": open_state_uri},
+        inspect.prepare(
+            CapabilityRequest(
+                capability_id="lean.proof_state.inspect",
+                input={"environment": "CORE", "state_uri": open_state_uri},
+            )
         )
     )
     assert inspected.output["inspection"] == "READ_ONLY_NO_REPLAY"
@@ -132,9 +138,11 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
 
     # 3. lean.proof_state.metavariable_fields: structured fields via the helper.
     fields = metavariable.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.metavariable_fields",
-            input={"environment": "CORE", "state_uri": open_state_uri},
+        metavariable.prepare(
+            CapabilityRequest(
+                capability_id="lean.proof_state.metavariable_fields",
+                input={"environment": "CORE", "state_uri": open_state_uri},
+            )
         )
     )
     assert fields.output["coercion_provenance"] == "UNAVAILABLE"

--- a/tests/boundary/providers/lean/test_lean_statement_capabilities.py
+++ b/tests/boundary/providers/lean/test_lean_statement_capabilities.py
@@ -65,13 +65,15 @@ def test_propose_elaborates_valid_statement(tmp_path: Path) -> None:
 
     result = project_operation_result(
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "environment": "CORE",
-                    "informal_claim": "one plus one equals two",
-                    "proposed_statement": "1 + 1 = 2",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "environment": "CORE",
+                        "informal_claim": "one plus one equals two",
+                        "proposed_statement": "1 + 1 = 2",
+                    },
+                )
             )
         )
     )
@@ -91,13 +93,15 @@ def test_propose_reports_elaboration_failure(tmp_path: Path) -> None:
 
     result = project_operation_result(
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "environment": "CORE",
-                    "informal_claim": "bogus claim",
-                    "proposed_statement": "1 + + 1 = 2",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "environment": "CORE",
+                        "informal_claim": "bogus claim",
+                        "proposed_statement": "1 + + 1 = 2",
+                    },
+                )
             )
         )
     )
@@ -113,13 +117,15 @@ def test_propose_rejects_forbidden_statement(tmp_path: Path) -> None:
 
     with pytest.raises(CapabilityInvocationError) as exc_info:
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "environment": "CORE",
-                    "informal_claim": "bogus",
-                    "proposed_statement": "sorry",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "environment": "CORE",
+                        "informal_claim": "bogus",
+                        "proposed_statement": "sorry",
+                    },
+                )
             )
         )
 
@@ -131,13 +137,15 @@ def test_propose_rejects_mathlib_environment(tmp_path: Path) -> None:
 
     with pytest.raises(CapabilityInvocationError) as exc_info:
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "environment": "MATHLIB",
-                    "informal_claim": "claim",
-                    "proposed_statement": "1 + 1 = 2",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "environment": "MATHLIB",
+                        "informal_claim": "claim",
+                        "proposed_statement": "1 + 1 = 2",
+                    },
+                )
             )
         )
 
@@ -160,13 +168,15 @@ def test_propose_returns_diagnostic_when_lean_unavailable(
 
     with pytest.raises(CapabilityInvocationError) as exc_info:
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "environment": "CORE",
-                    "informal_claim": "one plus one equals two",
-                    "proposed_statement": "1 + 1 = 2",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "environment": "CORE",
+                        "informal_claim": "one plus one equals two",
+                        "proposed_statement": "1 + 1 = 2",
+                    },
+                )
             )
         )
 
@@ -211,13 +221,15 @@ def test_propose_directly_elaborates_environment_bound_proposition(
 
     result = project_operation_result(
         propose.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.propose",
-                input={
-                    "operation": "ELABORATE_PROPOSITION",
-                    "environment": "CORE",
-                    "proposed_statement": "1 = 1",
-                },
+            propose.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.propose",
+                    input={
+                        "operation": "ELABORATE_PROPOSITION",
+                        "environment": "CORE",
+                        "proposed_statement": "1 = 1",
+                    },
+                )
             )
         )
     )
@@ -312,15 +324,17 @@ def test_compare_identical_statements(tmp_path: Path) -> None:
 
     result = project_operation_result(
         compare.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.compare",
-                input={
-                    "environment": "CORE",
-                    "statement_a": "1 + 1 = 2",
-                    "statement_b": "1 + 1 = 2",
-                    "axiom_set_a": [],
-                    "axiom_set_b": [],
-                },
+            compare.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.compare",
+                    input={
+                        "environment": "CORE",
+                        "statement_a": "1 + 1 = 2",
+                        "statement_b": "1 + 1 = 2",
+                        "axiom_set_a": [],
+                        "axiom_set_b": [],
+                    },
+                )
             )
         )
     )
@@ -342,15 +356,17 @@ def test_compare_different_statements(tmp_path: Path) -> None:
 
     result = project_operation_result(
         compare.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.compare",
-                input={
-                    "environment": "CORE",
-                    "statement_a": "1 + 1 = 2",
-                    "statement_b": "1 + 1 = 3",
-                    "axiom_set_a": ["Classical.choice"],
-                    "axiom_set_b": [],
-                },
+            compare.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.compare",
+                    input={
+                        "environment": "CORE",
+                        "statement_a": "1 + 1 = 2",
+                        "statement_b": "1 + 1 = 3",
+                        "axiom_set_a": ["Classical.choice"],
+                        "axiom_set_b": [],
+                    },
+                )
             )
         )
     )
@@ -375,13 +391,15 @@ def test_compare_works_without_lean_for_syntactic_comparison(
 
     result = project_operation_result(
         compare.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.compare",
-                input={
-                    "environment": "CORE",
-                    "statement_a": "1 + 1 = 2",
-                    "statement_b": "1 + 1 = 2",
-                },
+            compare.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.compare",
+                    input={
+                        "environment": "CORE",
+                        "statement_a": "1 + 1 = 2",
+                        "statement_b": "1 + 1 = 2",
+                    },
+                )
             )
         )
     )
@@ -487,13 +505,15 @@ def test_compare_normalizes_whitespace(tmp_path: Path) -> None:
 
     result = project_operation_result(
         compare.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.compare",
-                input={
-                    "environment": "CORE",
-                    "statement_a": "1 + 1  =  2",
-                    "statement_b": "1 + 1 = 2",
-                },
+            compare.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.compare",
+                    input={
+                        "environment": "CORE",
+                        "statement_a": "1 + 1  =  2",
+                        "statement_b": "1 + 1 = 2",
+                    },
+                )
             )
         )
     )
@@ -506,13 +526,15 @@ def test_compare_rejects_forbidden_statement(tmp_path: Path) -> None:
 
     with pytest.raises(CapabilityInvocationError) as exc_info:
         compare.invoke(
-            CapabilityRequest(
-                capability_id="lean.statement.compare",
-                input={
-                    "environment": "CORE",
-                    "statement_a": "sorry",
-                    "statement_b": "True",
-                },
+            compare.prepare(
+                CapabilityRequest(
+                    capability_id="lean.statement.compare",
+                    input={
+                        "environment": "CORE",
+                        "statement_a": "sorry",
+                        "statement_b": "True",
+                    },
+                )
             )
         )
 

--- a/tests/component/capabilities/capability_service_support.py
+++ b/tests/component/capabilities/capability_service_support.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pydantic import ConfigDict
+
+from jacobian.capability_adapters import parse_capability_input
 from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityInstallTier,
@@ -22,6 +25,7 @@ from jacobian.contracts.results import (
 from jacobian.operation_projection import OperationProjection
 from jacobian.operation_publication import PublishedOperation
 from jacobian.operations import Completed
+from jacobian.schema_registry import model_schema
 
 TEST_RUNTIME = CapabilityProviderRuntime(
     provider="tests",
@@ -71,7 +75,15 @@ class _Value(ContractModel):
     value: int
 
 
-class _InvalidValue(ContractModel):
+class _ValueRequest(ContractModel):
+    value: int
+
+
+class _EmptyRequest(ContractModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _WrongValue(ContractModel):
     value: str
 
 
@@ -84,44 +96,16 @@ class ComputedAdapter:
         description="Small adapter used to prove no MCP or runtime edit is required.",
         provider="tests",
         provider_runtime=TEST_RUNTIME,
-        input_schema={
-            "type": "object",
-            "properties": {"value": {"type": "integer"}},
-            "required": ["value"],
-            "additionalProperties": False,
-        },
-        output_schema={
-            "type": "object",
-            "properties": {"value": {"type": "integer"}},
-            "required": ["value"],
-            "additionalProperties": False,
-        },
+        input_schema=model_schema(_ValueRequest),
+        output_schema=model_schema(_Value),
         tags=("test",),
     )
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        value = _Value(value=int(request.input["value"]) * 2)
-        return OperationProjection(
-            operation_id=self.descriptor.capability_id,
-            version=self.descriptor.version,
-            terminal=Completed(value=value),
-            publication=PublishedOperation(output=value),
-        )
+    def prepare(self, request: CapabilityRequest) -> _ValueRequest:
+        return parse_capability_input(_ValueRequest, request.input)
 
-
-@dataclass(frozen=True)
-class InvalidOutputAdapter:
-    descriptor = ComputedAdapter.descriptor.model_copy(
-        update={
-            "capability_id": "example.invalid-output",
-            "title": "Return schema-invalid output",
-            "description": "Fixture for the adapter result validation boundary.",
-        }
-    )
-
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        del request
-        value = _InvalidValue(value="not-an-integer")
+    def invoke(self, parsed: _ValueRequest) -> OperationProjection:
+        value = _Value(value=parsed.value * 2)
         return OperationProjection(
             operation_id=self.descriptor.capability_id,
             version=self.descriptor.version,
@@ -143,16 +127,74 @@ class NotReadyProviderAdapter:
         output_schema={"type": "object"},
     )
 
-    def invoke(self, _request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> _EmptyRequest:
+        return parse_capability_input(_EmptyRequest, request.input)
+
+    def invoke(self, _request: _EmptyRequest) -> OperationProjection:
         raise AssertionError("provider must be rejected before adapter invocation")
+
+
+@dataclass(frozen=True)
+class MismatchedOutputAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.mismatched-output",
+        version="1",
+        title="Return the wrong typed value",
+        description="Fixture for the installed output-model boundary.",
+        provider="tests",
+        provider_runtime=TEST_RUNTIME,
+        input_schema=model_schema(_EmptyRequest),
+        output_schema=model_schema(_Value),
+    )
+
+    def prepare(self, request: CapabilityRequest) -> _EmptyRequest:
+        return parse_capability_input(_EmptyRequest, request.input)
+
+    def invoke(self, _request: _EmptyRequest) -> OperationProjection:
+        value = _WrongValue(value="not-an-integer")
+        return OperationProjection(
+            operation_id=self.descriptor.capability_id,
+            version=self.descriptor.version,
+            terminal=Completed(value=value),
+            publication=PublishedOperation(output=value),
+        )
+
+
+@dataclass(frozen=True)
+class InvalidOutputValueAdapter:
+    descriptor = CapabilityDescriptor(
+        capability_id="example.invalid-output-value",
+        version="1",
+        title="Return an invalid typed value",
+        description="Fixture for unchecked model construction at publication.",
+        provider="tests",
+        provider_runtime=TEST_RUNTIME,
+        input_schema=model_schema(_EmptyRequest),
+        output_schema=model_schema(_Value),
+    )
+
+    def prepare(self, request: CapabilityRequest) -> _EmptyRequest:
+        return parse_capability_input(_EmptyRequest, request.input)
+
+    def invoke(self, _request: _EmptyRequest) -> OperationProjection:
+        value = _Value.model_construct(value="not-an-integer")
+        return OperationProjection(
+            operation_id=self.descriptor.capability_id,
+            version=self.descriptor.version,
+            terminal=Completed(value=value),
+            publication=PublishedOperation(output=value),
+        )
 
 
 @dataclass(frozen=True)
 class DiscoveryAdapter:
     descriptor: CapabilityDescriptor
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
-        value = _Value(value=int(request.input["value"]))
+    def prepare(self, request: CapabilityRequest) -> _ValueRequest:
+        return parse_capability_input(_ValueRequest, request.input)
+
+    def invoke(self, request: _ValueRequest) -> OperationProjection:
+        value = _Value(value=request.value)
         return OperationProjection(
             operation_id=self.descriptor.capability_id,
             version=self.descriptor.version,
@@ -174,7 +216,10 @@ class CrashingAdapter:
         output_schema={"type": "object"},
     )
 
-    def invoke(self, _request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> _EmptyRequest:
+        return parse_capability_input(_EmptyRequest, request.input)
+
+    def invoke(self, _request: _EmptyRequest) -> OperationProjection:
         raise RuntimeError("provider=fixture internal-adapter-id=secret")
 
 
@@ -188,10 +233,13 @@ class ForgedVerifiedAdapter:
         provider="tests",
         provider_runtime=TEST_RUNTIME,
         input_schema={"type": "object"},
-        output_schema={"type": "object"},
+        output_schema=model_schema(_Value),
     )
 
-    def invoke(self, request: CapabilityRequest) -> OperationProjection:
+    def prepare(self, request: CapabilityRequest) -> _EmptyRequest:
+        return parse_capability_input(_EmptyRequest, request.input)
+
+    def invoke(self, request: _EmptyRequest) -> OperationProjection:
         del request
         record_uri = "artifact://sha256/" + "f" * 64
         value = _Value(value=0)

--- a/tests/component/capabilities/test_capability_adapter_authority.py
+++ b/tests/component/capabilities/test_capability_adapter_authority.py
@@ -7,17 +7,21 @@ verified status, and verification record binding.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any, cast
 
 import pytest
 from tests.component.capabilities.capability_service_support import (
+    TEST_RUNTIME,
     ComputedAdapter,
     CrashingAdapter,
     ForgedVerifiedAdapter,
-    InvalidOutputAdapter,
+    InvalidOutputValueAdapter,
+    MismatchedOutputAdapter,
     NotReadyProviderAdapter,
 )
 from tests.support.services import DomainTestServices, open_domain_services
 
+from jacobian.builtin_capabilities import LeanCheckAdapter
 from jacobian.capability_errors import CapabilityError
 from jacobian.capability_service import CapabilityPolicy
 from jacobian.contracts.capabilities import (
@@ -67,6 +71,57 @@ def test_provider_required_attributes_are_checked_before_first_use(
     assert result.diagnostics[0].details == {
         "provider_failure_code": "READINESS_FAILED"
     }
+
+
+def test_invalid_request_precedes_provider_readiness(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(NotReadyProviderAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="example.not-ready-provider",
+            input={"unexpected": True},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert result.diagnostics[0].stage == "capability_input_validation"
+
+
+def test_published_model_must_match_installed_output_contract(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(MismatchedOutputAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(capability_id="example.mismatched-output", input={})
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "ADAPTER_RESULT_INVALID"
+    assert result.output == {
+        "error": result.diagnostics[0].model_dump(mode="json", exclude_none=True)
+    }
+
+
+def test_published_model_instance_must_satisfy_its_contract(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(
+        InvalidOutputValueAdapter()
+    )
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(capability_id="example.invalid-output-value", input={})
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "ADAPTER_RESULT_INVALID"
 
 
 def test_unknown_capability_returns_an_actionable_result(
@@ -154,19 +209,73 @@ def test_invalid_capability_input_does_not_echo_payload(
     diagnostic = result.diagnostics[0]
     assert diagnostic.code == "INVALID_REQUEST"
     assert diagnostic.path == "value"
-    assert diagnostic.message == (
-        "The capability input does not match its advertised schema at value."
-    )
-    assert diagnostic.actual_type == "string"
-    assert diagnostic.expected == "JSON type integer"
+    assert diagnostic.message == "The capability request is invalid."
+    assert diagnostic.actual_type is None
+    assert diagnostic.expected is None
     assert "fixture-secret-value" not in diagnostic.message
-    assert diagnostic.details == {
-        "required_fields": ["value"],
-        "missing_fields": [],
-        "validator": "type",
-        "constraint": "integer",
-    }
+    assert diagnostic.hint == (
+        "1 validation error; first at value: "
+        "Request value violates validation rule int_type"
+    )
+    assert diagnostic.details == {}
     assert "fixture-secret-value" not in repr(diagnostic)
+
+
+def test_capability_input_does_not_coerce_numeric_strings(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(capability_id="example.double", input={"value": "21"})
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert result.diagnostics[0].path == "value"
+
+
+def test_non_json_capability_input_is_an_invalid_request(
+    capability_core_services: DomainTestServices,
+) -> None:
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(ComputedAdapter())
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(capability_id="example.double", input={"value": object()})
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert result.diagnostics[0].stage == "capability_input_validation"
+    assert result.diagnostics[0].path is None
+
+
+def test_lean_check_parses_its_typed_request_before_execution(
+    capability_core_services: DomainTestServices,
+) -> None:
+    class _UnexpectedLean:
+        def verify(self, **_kwargs: object) -> None:
+            raise AssertionError("invalid Lean input must not execute")
+
+    adapter = LeanCheckAdapter(
+        cast(Any, _UnexpectedLean()),
+        TEST_RUNTIME.model_copy(update={"provider": "jacobian.lean4"}),
+    )
+    core = capability_core_services.core
+    capability_core_services.installation.register_capability(adapter)
+
+    result = core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="lean.check",
+            input={"statement": "True"},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert result.diagnostics[0].path == "proof"
 
 
 def test_adapter_failure_does_not_expose_internal_exception_text(
@@ -193,27 +302,6 @@ def test_adapter_failure_does_not_expose_internal_exception_text(
     )
     assert "fixture" not in result.execution.detail
     assert "RuntimeError" not in result.execution.detail
-
-
-def test_schema_invalid_adapter_output_returns_a_typed_failure(
-    capability_core_services: DomainTestServices,
-) -> None:
-    core = capability_core_services.core
-    capability_core_services.installation.register_capability(InvalidOutputAdapter())
-
-    result = core.capabilities.invoke(
-        CapabilityRequest(
-            capability_id="example.invalid-output",
-            input={"value": 21},
-        )
-    )
-
-    assert result.execution.status is ExecutionStatus.ERROR
-    assert result.diagnostics[0].code == "ADAPTER_RESULT_INVALID"
-    assert result.diagnostics[0].stage == "adapter_execution"
-    assert result.diagnostics[0].path == "value"
-    assert result.diagnostics[0].actual_type == "string"
-    assert result.diagnostics[0].expected == "JSON type integer"
 
 
 def test_adapter_cannot_promote_without_a_local_verification_record(

--- a/tests/component/capabilities/test_graph_composition.py
+++ b/tests/component/capabilities/test_graph_composition.py
@@ -274,21 +274,41 @@ def test_enumerate_paginates_with_limit_and_offset(
     assert first_uris.isdisjoint(second_uris)
 
 
-def test_enumerate_rejects_order_outside_backend_boundary(
-    graph_services: DomainTestServices,
+def test_enumerate_rejects_invalid_order_before_provider_or_publication(
+    graph_services: DomainTestServices, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     runtime = graph_services
+
+    def unexpected_provider_load() -> None:
+        pytest.fail("invalid input must not load the NetworkX provider")
+
+    def unexpected_artifact_publication(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("invalid input must not publish graph artifacts")
+
+    class UnavailableProvider:
+        def get(self) -> None:
+            unexpected_provider_load()
+
+    monkeypatch.setattr(
+        "jacobian.graphs.composition.networkx_loader",
+        UnavailableProvider(),
+    )
+    monkeypatch.setattr(
+        runtime.core.artifacts,
+        "put",
+        unexpected_artifact_publication,
+    )
 
     result = runtime.core.capabilities.invoke(
         CapabilityRequest(
             capability_id="graph.enumerate.nonisomorphic",
-            input={"order": 10},
+            input={"order": "4"},
         )
     )
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.diagnostics
-    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert result.diagnostics[0].code == "INVALID_ENUMERATION_REQUEST"
 
 
 def test_enumerate_order_zero_returns_single_empty_graph(

--- a/tests/component/providers/lean/test_lean_declaration_adapters.py
+++ b/tests/component/providers/lean/test_lean_declaration_adapters.py
@@ -65,10 +65,10 @@ _RUNTIME = CapabilityProviderRuntime(
 
 
 def _invoke_public(
-    adapter: CapabilityAdapter,
+    adapter: CapabilityAdapter[Any],
     request: CapabilityRequest,
 ):
-    projection = adapter.invoke(request)
+    projection = adapter.invoke(adapter.prepare(request))
     assert isinstance(projection, OperationProjection)
     return project_operation_result(projection)
 

--- a/tests/component/providers/lean/test_lean_exploration_fail_closed.py
+++ b/tests/component/providers/lean/test_lean_exploration_fail_closed.py
@@ -132,11 +132,14 @@ def test_typed_goal_extraction_failure_is_a_structured_non_conclusion(
         fail_extraction,
     )
 
+    adapter = LeanProofStateAdapter(resources)
     with pytest.raises(CapabilityInvocationError) as error:
-        LeanProofStateAdapter(resources).invoke(
-            CapabilityRequest(
-                capability_id="lean.proof_state.apply_tactic",
-                input={"statement": "True", "tactic": "skip"},
+        adapter.invoke(
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.proof_state.apply_tactic",
+                    input={"statement": "True", "tactic": "skip"},
+                )
             )
         )
 
@@ -203,13 +206,15 @@ def test_premise_retrieval_rejects_by_prefix_before_starting_lean(
 
     with pytest.raises(CapabilityInvocationError) as error:
         adapter.invoke(
-            CapabilityRequest(
-                capability_id="lean.retrieve.premises",
-                input={
-                    "environment": "MATHLIB",
-                    "statement": "∀ x : Real, x ^ 2 ≥ 0",
-                    "proof_prefix": ["by", "intro x"],
-                },
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.retrieve.premises",
+                    input={
+                        "environment": "MATHLIB",
+                        "statement": "∀ x : Real, x ^ 2 ≥ 0",
+                        "proof_prefix": ["by", "intro x"],
+                    },
+                )
             )
         )
 
@@ -256,11 +261,14 @@ def test_premise_retrieval_maps_repl_runtime_failure_to_domain_diagnostic(
         fail_repl,
     )
 
+    adapter = LeanPremiseRetrievalAdapter(resources)
     with pytest.raises(CapabilityInvocationError) as error:
-        LeanPremiseRetrievalAdapter(resources).invoke(
-            CapabilityRequest(
-                capability_id="lean.retrieve.premises",
-                input={"statement": "True"},
+        adapter.invoke(
+            adapter.prepare(
+                CapabilityRequest(
+                    capability_id="lean.retrieve.premises",
+                    input={"statement": "True"},
+                )
             )
         )
 

--- a/tests/component/providers/lean/test_lean_proof_axioms.py
+++ b/tests/component/providers/lean/test_lean_proof_axioms.py
@@ -67,13 +67,15 @@ def test_proof_hole_inspection_ignores_strings_and_identifiers(
         )
         result = project_operation_result(
             adapter.invoke(
-                CapabilityRequest(
-                    capability_id="lean.proof.axioms.inspect",
-                    input={
-                        "environment": "CORE",
-                        "statement": "True",
-                        "proof": proof,
-                    },
+                adapter.prepare(
+                    CapabilityRequest(
+                        capability_id="lean.proof.axioms.inspect",
+                        input={
+                            "environment": "CORE",
+                            "statement": "True",
+                            "proof": proof,
+                        },
+                    )
                 )
             )
         )

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -60,7 +60,7 @@ def test_invalid_request_uri_values_are_summarized_without_echoing(
     ) as services:
         adapter = services.core.capabilities._adapters[VERIFY_CAPABILITY_ID]
         with pytest.raises(CapabilityInvocationError) as caught:
-            adapter.invoke(
+            adapter.prepare(
                 CapabilityRequest(
                     capability_id=VERIFY_CAPABILITY_ID,
                     input={

--- a/tests/component/providers/polynomial/test_polynomial_capabilities.py
+++ b/tests/component/providers/polynomial/test_polynomial_capabilities.py
@@ -249,7 +249,7 @@ def test_polynomial_map_evaluation_is_exact_and_materialized(
                 ],
                 "second_point": [{"num": "0", "den": "1"}],
             },
-            "INVALID_REQUEST",
+            "INVALID_POLYNOMIAL_COLLISION_REQUEST",
         ),
         (
             "polynomial.map.collision_witness",

--- a/tests/component/providers/polynomial/test_polynomial_map_inverse_verify.py
+++ b/tests/component/providers/polynomial/test_polynomial_map_inverse_verify.py
@@ -178,8 +178,8 @@ def test_sparse_input_normalization_rejects_malformed_terms_before_artifacts(
     )
 
     assert result.execution.status is ExecutionStatus.ERROR
-    assert result.output["error"]["code"] == "INVALID_REQUEST"
-    assert result.output["error"]["stage"] == "capability_input_validation"
+    assert result.output["error"]["code"] == "INVALID_POLYNOMIAL_MAP_INVERSE_REQUEST"
+    assert result.output["error"]["stage"] == "request_validation"
     assert result.artifact_uris == ()
 
 

--- a/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
+++ b/tests/component/providers/polynomial/test_polynomial_positivity_capabilities.py
@@ -25,6 +25,10 @@ from jacobian_checkers.polynomial_positivity import check_positivity
 # ---------------------------------------------------------------------------
 
 
+def _invoke(adapter: Any, request: CapabilityRequest):
+    return adapter.invoke(adapter.prepare(request))
+
+
 def _polynomial(variable: str, terms: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "polynomial_schema_version": "1",
@@ -288,14 +292,15 @@ def test_decide_capability_finds_positive_linear(installation) -> None:
     decide, _verify = adapters
 
     result = project_operation_result(
-        decide.invoke(
+        _invoke(
+            decide,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.decide",
                 input={
                     "polynomial": _polynomial("x", [_term(2, 1), _term(1, 0)]),
                     "interval": _interval("0", "1"),
                 },
-            )
+            ),
         )
     )
 
@@ -313,14 +318,15 @@ def test_decide_capability_detects_root_in_interval(installation) -> None:
 
     # p(x) = x - 1 on [0, 2] — root at x=1, not strictly positive.
     result = project_operation_result(
-        decide.invoke(
+        _invoke(
+            decide,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.decide",
                 input={
                     "polynomial": _polynomial("x", [_term(1, 1), _term(-1, 0)]),
                     "interval": _interval("0", "2"),
                 },
-            )
+            ),
         )
     )
 
@@ -337,14 +343,15 @@ def test_decide_capability_detects_endpoint_root(installation) -> None:
 
     # p(x) = x on [0, 1] — root at x=0 (the left endpoint), not strictly positive.
     result = project_operation_result(
-        decide.invoke(
+        _invoke(
+            decide,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.decide",
                 input={
                     "polynomial": _polynomial("x", [_term(1, 1)]),
                     "interval": _interval("0", "1"),
                 },
-            )
+            ),
         )
     )
 
@@ -359,20 +366,22 @@ def test_verify_capability_confirms_positive_decision(installation) -> None:
     assert verify is not None
 
     decide_result = project_operation_result(
-        decide.invoke(
+        _invoke(
+            decide,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.decide",
                 input={
                     "polynomial": _polynomial("x", [_term(2, 1), _term(1, 0)]),
                     "interval": _interval("0", "1"),
                 },
-            )
+            ),
         )
     )
     claimed = decide_result.output
 
     result = project_operation_result(
-        verify.invoke(
+        _invoke(
+            verify,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.verify",
                 input={
@@ -384,7 +393,7 @@ def test_verify_capability_confirms_positive_decision(installation) -> None:
                     "claimed_roots_in_open_interval": claimed["roots_in_open_interval"],
                     "claimed_endpoint_root": claimed["endpoint_root"],
                 },
-            )
+            ),
         )
     )
 
@@ -403,7 +412,8 @@ def test_verify_capability_refutes_false_positive_claim(installation) -> None:
     # inconsistent sign-change counts — the checker independently finds the
     # root and returns FALSE.
     result = project_operation_result(
-        verify.invoke(
+        _invoke(
+            verify,
             CapabilityRequest(
                 capability_id="polynomial.interval.positivity.verify",
                 input={
@@ -415,7 +425,7 @@ def test_verify_capability_refutes_false_positive_claim(installation) -> None:
                     "claimed_roots_in_open_interval": 0,
                     "claimed_endpoint_root": False,
                 },
-            )
+            ),
         )
     )
 

--- a/tests/domain/arithmetic/test_arithmetic_capabilities.py
+++ b/tests/domain/arithmetic/test_arithmetic_capabilities.py
@@ -48,6 +48,21 @@ def test_arithmetic_capabilities_return_exact_results(
         assert result.output["result"] == expected, capability_id
 
 
+def test_rational_operation_rejects_unreduced_input_before_execution(
+    domain_services: DomainTestServices,
+) -> None:
+    result = domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="rational.compute.reciprocal",
+            input={"value": {"num": "2", "den": "4"}},
+        )
+    )
+
+    assert result.execution.status is ExecutionStatus.ERROR
+    assert result.diagnostics[0].code == "INVALID_ARITHMETIC_REQUEST"
+    assert result.artifact_uris == ()
+
+
 def test_rational_product_formats_results_above_python_digit_limit(
     domain_services: DomainTestServices,
 ) -> None:

--- a/tests/domain/finite/test_finite_coverage_capability.py
+++ b/tests/domain/finite/test_finite_coverage_capability.py
@@ -107,12 +107,11 @@ def test_finite_coverage_unknown_canonicalizer_reports_precise_schema_error(
 
     assert result.execution.status is ExecutionStatus.ERROR
     diagnostic = result.diagnostics[0]
-    assert diagnostic.code == "INVALID_REQUEST"
+    assert diagnostic.code == "INVALID_FINITE_COVERAGE_REQUEST"
     assert diagnostic.path == "canonicalizer_id"
-    assert diagnostic.actual_type == "string"
-    assert diagnostic.expected == (
-        'one of: "finite.integer.decimal@1", "finite.string.nfc@1"'
-    )
+    assert diagnostic.actual_type is None
+    assert diagnostic.expected is None
+    assert "literal_error" in (diagnostic.hint or "")
 
 
 def test_finite_coverage_rejects_nfc_collisions_in_scope(

--- a/tests/domain/formal_datasets/test_formal_dataset_materialization.py
+++ b/tests/domain/formal_datasets/test_formal_dataset_materialization.py
@@ -25,7 +25,7 @@ class _PublicAdapter:
         self.resources = adapter.resources
 
     def invoke(self, request: CapabilityRequest) -> CapabilityResult:
-        projection = self._adapter.invoke(request)
+        projection = self._adapter.invoke(self._adapter.prepare(request))
         assert isinstance(projection, OperationProjection)
         return project_operation_result(projection)
 

--- a/tests/domain/matrix/test_inline_exact_verification.py
+++ b/tests/domain/matrix/test_inline_exact_verification.py
@@ -76,7 +76,7 @@ def test_inline_exact_validation_does_not_echo_a_rejected_candidate(
     )
 
     assert checked.execution.status == "ERROR"
-    assert checked.diagnostics[0].code == "INVALID_REQUEST"
+    assert checked.diagnostics[0].code == "INVALID_EXACT_DOMAIN_INPUT"
     assert marker not in checked.model_dump_json()
 
 

--- a/tests/domain/polynomial/test_polynomial_interval_capabilities.py
+++ b/tests/domain/polynomial/test_polynomial_interval_capabilities.py
@@ -20,6 +20,10 @@ from tests.support.capability_installations import install_capability_bundle
 from tests.support.polynomials import univariate_term as _term
 
 
+def _invoke(adapter: Any, request: CapabilityRequest):
+    return adapter.invoke(adapter.prepare(request))
+
+
 def _polynomial(variable: str, terms: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "polynomial_schema_version": "1",
@@ -65,14 +69,15 @@ def test_enclose_capability_computes_a_valid_bernstein_enclosure(
     enclose, _verify = adapters
 
     result = project_operation_result(
-        enclose.invoke(
+        _invoke(
+            enclose,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclose",
                 input={
                     "polynomial": _polynomial("x", [_term(2, 1), _term(1, 0)]),
                     "interval": _interval("0", "1"),
                 },
-            )
+            ),
         )
     )
 
@@ -98,14 +103,15 @@ def test_enclose_capability_handles_a_quadratic_on_a_shifted_interval(
 
     # p(x) = x^2 on [-1, 1]; Bernstein bound is [-1, 1] (valid, not exact range).
     result = project_operation_result(
-        enclose.invoke(
+        _invoke(
+            enclose,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclose",
                 input={
                     "polynomial": _polynomial("x", [_term(1, 2)]),
                     "interval": _interval("-1", "1"),
                 },
-            )
+            ),
         )
     )
 
@@ -128,20 +134,22 @@ def test_verify_capability_confirms_a_valid_enclosure(installation) -> None:
 
     # First compute the enclosure, then verify the claimed values.
     enclose_result = project_operation_result(
-        enclose.invoke(
+        _invoke(
+            enclose,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclose",
                 input={
                     "polynomial": _polynomial("x", [_term(2, 1), _term(1, 0)]),
                     "interval": _interval("0", "1"),
                 },
-            )
+            ),
         )
     )
     claimed = enclose_result.output
 
     result = project_operation_result(
-        verify.invoke(
+        _invoke(
+            verify,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclosure.verify",
                 input={
@@ -151,7 +159,7 @@ def test_verify_capability_confirms_a_valid_enclosure(installation) -> None:
                     "claimed_lo": claimed["lo"],
                     "claimed_hi": claimed["hi"],
                 },
-            )
+            ),
         )
     )
 
@@ -169,7 +177,8 @@ def test_verify_capability_rejects_a_false_enclosure(installation) -> None:
     # Claim Bernstein coefficients [0, 3] for p(x) = 2x + 1 on [0, 1]; the
     # independent replay computes [1, 3], so the checker must return FALSE.
     result = project_operation_result(
-        verify.invoke(
+        _invoke(
+            verify,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclosure.verify",
                 input={
@@ -182,7 +191,7 @@ def test_verify_capability_rejects_a_false_enclosure(installation) -> None:
                     "claimed_lo": {"num": "0", "den": "1"},
                     "claimed_hi": {"num": "3", "den": "1"},
                 },
-            )
+            ),
         )
     )
 
@@ -196,12 +205,13 @@ def test_enclose_capability_rejects_a_degenerate_interval(installation) -> None:
     enclose, _verify = adapters
 
     with pytest.raises(CapabilityInvocationError):
-        enclose.invoke(
+        _invoke(
+            enclose,
             CapabilityRequest(
                 capability_id="polynomial.interval.enclose",
                 input={
                     "polynomial": _polynomial("x", [_term(1, 0)]),
                     "interval": _interval("1", "1"),
                 },
-            )
+            ),
         )

--- a/tests/domain/universal_algebra/test_universal_algebra_capabilities.py
+++ b/tests/domain/universal_algebra/test_universal_algebra_capabilities.py
@@ -300,5 +300,7 @@ def test_finite_magma_table_enumeration_rejects_unsupported_order_before_writes(
     )
 
     assert result.execution.status.value == "ERROR"
-    assert result.diagnostics[0].code == "INVALID_REQUEST"
+    assert (
+        result.diagnostics[0].code == "INVALID_FINITE_MAGMA_TABLE_ENUMERATION_REQUEST"
+    )
     assert artifact_put_calls == 0

--- a/tests/unit/contracts/test_canonical_json.py
+++ b/tests/unit/contracts/test_canonical_json.py
@@ -11,6 +11,7 @@ from jacobian.canonical import (
     CanonicalizationError,
     CanonicalLimits,
     canonicalize_json,
+    encode_strict_json,
     sha256_digest,
 )
 from jacobian.contracts.exact import CanonicalRational, require_bounded_rational
@@ -26,6 +27,19 @@ def test_equivalent_rationals_have_identical_canonical_bytes() -> None:
     second = canonicalize_json({"weight": {"num": "1", "den": "2"}})
 
     assert first == second == b'{"weight":{"den":"2","num":"1"}}'
+
+
+def test_strict_json_encoding_preserves_unreduced_rationals_and_unicode() -> None:
+    decomposed = "e\u0301"
+
+    encoded = encode_strict_json(
+        {"weight": {"num": "2", "den": "4"}, "label": decomposed}
+    )
+
+    assert encoded.decode("utf-8") == (
+        f'{{"label":"{decomposed}","weight":{{"den":"4","num":"2"}}}}'
+    )
+    assert encode_strict_json(decomposed) == b'"e\xcc\x81"'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/contracts/test_lean_check_contracts.py
+++ b/tests/unit/contracts/test_lean_check_contracts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.lean import LeanCheckRequest, LeanEnvironment
+
+
+def test_lean_check_request_defaults_to_the_core_environment() -> None:
+    request = LeanCheckRequest(statement="True", proof="by trivial")
+
+    assert request.environment is LeanEnvironment.CORE
+
+
+def test_lean_check_request_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        LeanCheckRequest(
+            statement="True",
+            proof="by trivial",
+            hidden_mode=True,  # type: ignore[call-arg]
+        )

--- a/tests/unit/tooling/test_architecture_math_boundaries.py
+++ b/tests/unit/tooling/test_architecture_math_boundaries.py
@@ -112,6 +112,31 @@ def test_final_projection_may_construct_public_result_envelopes(
     assert "capability-result-projection" not in _codes(tmp_path)
 
 
+def test_product_code_cannot_restore_marker_selected_adapter_modes(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path,
+        "src/jacobian/polynomials/adapter.py",
+        "class Adapter:\n    typed_input = True\n",
+    )
+    _write(
+        tmp_path,
+        "src/jacobian/graphs/adapter.py",
+        "from jacobian.capability_adapters import TypedInputAdapter\n",
+    )
+
+    violations = [
+        item
+        for item in check_architecture(tmp_path).violations
+        if item.code == "legacy-adapter-mode"
+    ]
+    assert {item.path for item in violations} == {
+        "src/jacobian/graphs/adapter.py",
+        "src/jacobian/polynomials/adapter.py",
+    }
+
+
 def test_contracts_can_import_canonical_and_contract_modules(tmp_path: Path) -> None:
     _write(
         tmp_path,

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -61,6 +61,9 @@ runtime.  It enforces sixteen focused invariants:
 16. **capability-result-projection**: only the final operation projection may
     construct the generic public result envelope.
 
+17. **legacy-adapter-mode**: built-in adapters may not restore marker-selected
+    schema execution paths; every adapter owns its typed parse.
+
 The checker excludes ``wt-438/`` and generated directories from all scans.
 ``CHANGELOG.md`` is excluded from the unsupported-surface text scan as
 genuinely historical record.
@@ -260,6 +263,8 @@ _CAPABILITY_REQUEST_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
 _CAPABILITY_RESULT_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
     {PurePosixPath("src/jacobian/operation_projection.py")}
 )
+
+_LEGACY_ADAPTER_MODE_NAMES = frozenset({"TypedInputAdapter", "typed_input"})
 
 # Public-contract checks apply to datasets with agent-visible contract projections.
 _PUBLIC_CONTRACT_DATASET_PREFIXES = (
@@ -566,6 +571,32 @@ def _capability_result_projection_violations(
         )
         for node in ast.walk(tree)
         if isinstance(node, ast.Call) and is_result_constructor(node)
+    )
+
+
+def _legacy_adapter_mode_violations(
+    relative: PurePosixPath,
+    tree: ast.AST,
+) -> tuple[Violation, ...]:
+    if not str(relative).startswith("src/jacobian/"):
+        return ()
+    return tuple(
+        Violation(
+            str(relative),
+            "legacy-adapter-mode",
+            "adapters own one typed parse; marker-selected schema execution "
+            "modes are not supported",
+            node.lineno,
+        )
+        for node in ast.walk(tree)
+        if (
+            isinstance(node, ast.Name) and node.id in _LEGACY_ADAPTER_MODE_NAMES
+        ) or (
+            isinstance(node, ast.ImportFrom)
+            and any(
+                alias.name in _LEGACY_ADAPTER_MODE_NAMES for alias in node.names
+            )
+        )
     )
 
 
@@ -1484,6 +1515,7 @@ def _check_python_file(root: Path, path: Path) -> tuple[Violation, ...]:
     violations: list[Violation] = []
     violations.extend(_internal_capability_request_violations(relative, tree))
     violations.extend(_capability_result_projection_violations(relative, tree))
+    violations.extend(_legacy_adapter_mode_violations(relative, tree))
     violations.extend(_subprocess_violations(relative, tree))
     violations.extend(_run_bounded_process_violations(relative, tree))
     violations.extend(_shutil_which_violations(relative, tree))


### PR DESCRIPTION
## Problem

Jacobian's installed adapters had two request paths. Most adapters first ran a generic JSON Schema validator and then parsed the same payload into a Pydantic model, while marker-bearing adapters skipped that first pass. The split contradicted the parse-once architecture, allowed validation order to vary by adapter, and kept a schema-only extension path even though external operation packages are unsupported.

Removing the generic pass alone exposed two boundary gaps: Pydantic's default coercion could accept numeric strings that the catalog advertised as integers, and provider readiness could run before the adapter had validated its complete request. Published values also needed a typed invariant after removing the generic output-schema execution pass.

This PR is stacked on #1311, which centralizes final `CapabilityResult` projection.

Relates to #1210, #1212, and #1219.

## Solution

- Replace the marker-selected adapter modes with one generic `CapabilityAdapter[PreparedT]` contract. Every installed adapter now strictly parses and prepares its typed request before provider readiness, then executes only that prepared value.
- Encode the supplied JSON losslessly and parse it through Pydantic in JSON mode with `strict=True`, preserving enum wire values while rejecting coercions such as `"21"` to `int`. Non-JSON and over-limit inputs become bounded `INVALID_REQUEST` diagnostics.
- Check the published Pydantic model against the installed output contract and strictly revalidate its in-memory projection before the single wire serialization. Mismatched model types and unchecked `model_construct` values fail with `ADAPTER_RESULT_INVALID`.
- Add a real `LeanCheckRequest` model, remove the descriptor-only registration facade, and update every surviving SAT/SMT, polynomial, graph, Lean, finite, and exact-checker adapter to the same boundary.
- Remove stale documentation for external adapter entry-point loading and add an architecture ratchet that prevents marker-selected adapter modes from returning.

No MCP tool shape, operation ID, artifact format, checker authorization rule, or mathematical implementation changes. The stricter parser intentionally makes runtime acceptance match the catalog's generated JSON Schema.

## Testing

- `make lint typecheck` — Ruff, formatting, complexity, and mypy passed; 459 source files typechecked.
- `make test-unit` — 877 passed on the final tree.
- Component suite — 905 unaffected tests passed in the full lane; the corrected direct installed-operation helper passed 4/4, and the final adapter-boundary regression file passed 14/14.
- Domain suite — 477 unaffected tests passed; the two updated typed-diagnostic regressions passed 2/2.
- `make test-composition` — 157 passed.
- `make test-e2e` — 4 passed.
- `make test-provider` — 64 passed.
- `make import-contracts` — 7 contracts kept.
- `make architecture` — 1,685 files checked.
- `make test-architecture` — 406 files checked.
- `make docs-linkcheck` — passed.

## Trust & Compatibility Impact

The adapter protocol is internal and pre-stable. Invalid requests now fail before provider readiness or execution, and invalid typed outputs fail before publication. Verification records, checker identity, evidence binding, and artifact lineage are unchanged.

External operation adapters remain unsupported; this change removes stale prose that implied an entry-point loader existed.

## Architecture Budget

This deletes the `TypedInputAdapter` compatibility mode and the schema-first/schema-bypass branch. The shared strict parser and two-phase adapter contract replace both former production paths across all 58 installed adapters in this PR; no registry, facade, codec protocol, or external extension mechanism is added.

Suggested review order:

1. `capability_adapters.py` and `capability_dispatch.py` for the parse/readiness/projection invariants.
2. `operation_installation.py` for value-reference binding and typed execution.
3. One representative direct adapter in `graphs/composition.py`, `polynomials/_support.py`, and `exact_domain_checkers.py`.
4. `test_capability_adapter_authority.py`, the graph numeric-string regression, and the architecture ratchet.

## Checklist

- [x] Ordinary Python validation is covered by the final-tree static/unit run and affected-lane reruns listed above.
- [x] Relevant composition, end-to-end, and maintained-provider specialist lanes are listed above.
- [x] No Harbor task or verifier contract changed.
- [x] No ordinary mathematical operation or publication binding was added.
- [x] The shared boundary replaces two surviving production paths and deletes the prior mode split.