### PR TITLE
fix(benchmarks): remove hidden Farkas evidence cap

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="63ab71931d2312ef7d7a296f3caf1d2ae40024e783be96c302d3e151338b84dd"
+LABEL jacobian.checksum="6036fee901aab3df23258e3cbbbaa97da624f0bbd14ae34d0602d58927ad0a1e"
 LABEL jacobian.task="jacobian/exact-farkas-ldl-slice"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier.py
@@ -15,7 +15,6 @@ from verifier_support import (
 W, E = Path("/app"), Path("/tests")
 MAX_INPUT_BYTES = 1_048_576
 MAX_SUBMISSION_BYTES = 1_048_576
-MAX_EVIDENCE_BYTES = 1_048_576
 
 
 def _load_frozen():
@@ -198,12 +197,10 @@ def main():
         and isinstance(submission.get("evidence"), list)
         and len(submission["evidence"]) == 1
     ):
-        evidence_path = W / "evidence" / "farkas-slice-certificate.json"
-        if is_regular_bounded_file(evidence_path, max_bytes=MAX_EVIDENCE_BYTES):
-            evidence = read_evidence_json(
-                submission["evidence"][0],
-                expected_path="evidence/farkas-slice-certificate.json",
-            )
+        evidence = read_evidence_json(
+            submission["evidence"][0],
+            expected_path="evidence/farkas-slice-certificate.json",
+        )
     evidence_valid = bool(
         evidence
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import codecs
 import hashlib
 import json
 import math
@@ -262,6 +263,49 @@ def resolve_evidence(
     return target
 
 
+_JSON_WHITESPACE = frozenset(" \t\n\r")
+_JSON_WHITESPACE_CHARS = " \t\n\r"
+
+
+def _drain_stream_tail(stream, decoder) -> None:
+    """Reject any non-whitespace content after the parsed JSON value."""
+
+    while True:
+        block = stream.read(65_536)
+        if not block:
+            break
+        tail = decoder.decode(block)
+        if tail and not all(character in _JSON_WHITESPACE for character in tail):
+            raise ValueError("non-whitespace after evidence JSON value")
+    tail = decoder.decode(b"", final=True)
+    if tail and not all(character in _JSON_WHITESPACE for character in tail):
+        raise ValueError("non-whitespace after evidence JSON value")
+
+
+def _read_streaming_json_value(stream) -> Any:
+    """Parse one JSON value without retaining arbitrary whitespace padding."""
+
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    parser = json.JSONDecoder(object_pairs_hook=_reject_duplicate_keys)
+    buffer = ""
+    while True:
+        block = stream.read(65_536)
+        if block:
+            buffer += decoder.decode(block)
+        if buffer[:1] in _JSON_WHITESPACE:
+            buffer = buffer.lstrip(_JSON_WHITESPACE_CHARS)
+        try:
+            value, end = parser.raw_decode(buffer)
+        except json.JSONDecodeError:
+            if not block:
+                raise
+            continue
+        if not all(character in _JSON_WHITESPACE for character in buffer[end:]):
+            raise ValueError("non-whitespace after evidence JSON value")
+        _drain_stream_tail(stream, decoder)
+        return value
+
+
 def read_evidence_json(
     descriptor: object,
     *,
@@ -269,7 +313,7 @@ def read_evidence_json(
     workspace: Path = WORKSPACE,
     max_bytes: int | None = None,
 ) -> dict[str, Any] | None:
-    """Resolve and parse a digest-bound evidence object."""
+    """Resolve and stream a digest-bound evidence object without a byte cap."""
 
     target = resolve_evidence(
         descriptor,
@@ -280,10 +324,8 @@ def read_evidence_json(
     if target is None:
         return None
     try:
-        value = json.loads(
-            target.read_text(),
-            object_pairs_hook=_reject_duplicate_keys,
-        )
+        with target.open("rb") as stream:
+            value = _read_streaming_json_value(stream)
     except (OSError, ValueError, RecursionError, MemoryError):
         return None
     return value if isinstance(value, dict) else None

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
@@ -139,3 +139,58 @@ def test_exact_farkas_slice_rejects_missing_evidence_envelope(tmp_path: Path) ->
     rejected = support._run_verifier(task, app, logs)
     assert rejected.details["evidence_validity"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_exact_farkas_slice_accepts_large_valid_evidence_padding(
+    tmp_path: Path,
+) -> None:
+    """Legal JSON whitespace must not create a hidden evidence-size limit."""
+    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    evidence_path = app / "evidence" / "farkas-slice-certificate.json"
+    evidence_path.write_text(
+        " \n" * (600 * 1024)
+        + json.dumps(
+            {
+                "schema_version": "1",
+                "task_id": submission["task_id"],
+                "result": submission["result"],
+                "limitations": submission["limitations"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+        + " " * (600 * 1024)
+    )
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(app / "submission.json", submission)
+
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.reward == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("prefix,suffix", [("garbage", ""), ("", "garbage")])
+def test_exact_farkas_slice_rejects_evidence_json_garbage(
+    tmp_path: Path,
+    prefix: str,
+    suffix: str,
+) -> None:
+    """Streaming acceptance must still reject content outside the JSON value."""
+    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    evidence_path = app / "evidence" / "farkas-slice-certificate.json"
+    payload = {
+        "schema_version": "1",
+        "task_id": submission["task_id"],
+        "result": submission["result"],
+        "limitations": submission["limitations"],
+    }
+    evidence_path.write_text(prefix + json.dumps(payload) + suffix)
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0


### PR DESCRIPTION
## Summary

This is one bounded benchmark-integrity change based on an audit of historical PR #876 against the current Harbor architecture at `413e3846c2529af9e8f90a96d6f5679b23ed04f2`.

The audited Farkas task accepted schema-valid evidence with arbitrary JSON whitespace in its public contract, but the hidden verifier rejected files above 1 MiB. This removes that unpublished cap and ports the task-local loader to the repository's existing streaming JSON pattern. No product/runtime behavior, evaluator strategy, or general agent skill is added.

## Integrity audit

| Invariant | Current assessment |
| --- | --- |
| Hidden task material is isolated | Already solved: Harbor runs agents and verifiers in separate Docker environments, with static guards against hidden copies, widened build contexts, visibility leaks, and symlink escapes. |
| Revisions are reachable and immutable | Already solved: source SHA, clean snapshot identity, task digests, and observation records bind current reachable Git trees. |
| Terminal labels do not depend on a reasoning-log protocol | Historical/obsolete: terminal states come from the exact task verifier; telemetry is passive and has no verdict authority. |
| Evidence has no hidden size limit | Reproducibly broken here: `exact-farkas-ldl-slice` had a hidden 1 MiB cap. This PR fixes that one task. |
| Equivalent encodings are accepted | Solved for the audited tasks through explicit canonical rules or semantic comparison. |
| Limits are task-owned | Solved: Harbor task limits live in `task.toml`; timeout/error states remain non-conclusions. |
| Every validity rule is public | Partially solved before this PR because the Farkas size cap was unpublished; fixed for this task. |
| Alternate valid witnesses are accepted | Solved in the sampled tasks (including alternate LDL/Sylvester evidence, RP2 witnesses, primes, and prose). |
| Malformed/false assurance fails closed | Solved through task-local and generic adversarial matrices. |
| Local versus generic verifier ownership is clear | Solved: task semantics stay local; generic metadata/integrity attacks remain in the shared matrix. |

## Frozen task sample

Source SHA: `413e3846c2529af9e8f90a96d6f5679b23ed04f2`

- `exact-farkas-ldl-slice`: `sha256:5ff1eed2a5ff443222d181f3c676ac5012b4cd01189f1d983ef2e5256e447848`
- `polynomial-map-collision`: `sha256:9243ca8ee4800cb8eae039a08e0414c7fcfd8e111c3d1a3c8d6fbbfc44884abd`
- `rp2-homology-lattice`: `sha256:35c60550453aa1979b4694a399813023844ab3a6524643e106a9e983836b6539`
- `apollonius-gap-repair`: `sha256:701b5fc809ec6973a55d8a30568d89829c9c7f683b80c04241a4df2d6bc61636`
- `elementwise-fixed-no-global-invariant`: `sha256:ce3612dd2ebff71eb14234c965ef1d8959e19e43f0953b3366df13f04446f2ae`

Prospective changed-task digest: `sha256:174ddb8eb0f35a81f21a196aaa7dc562f5af399278da763b5bc6f7f5c0bf2e58`.

## Pilot evidence

The planned paired pilot was gpt-5.6-luna at medium reasoning, with a no-Jacobian control and a current-Jacobian-MCP treatment, and no general evaluation skill exposed. Both substantive attempts ran in named tmux sessions.

The host has no Docker daemon, so a Bubblewrap clean room was used after proving that the repository and verifier files were not visible. The attempt was stopped after repeated infrastructure failures: the installed standalone Codex package lacked its code-mode host executable inside the clean room, so the model could not read or write the task workspace. The control produced only a blocker trajectory (59,307 input, 52,992 cached input, 552 output, 142 reasoning tokens); neither condition produced a mathematical submission. The comparison is therefore **INCONCLUSIVE**, not a treatment result. It provides no evidence for adding a general tool-use skill, and this PR adds none.

## Change

- Remove the unpublished `MAX_EVIDENCE_BYTES` rejection.
- Stream one JSON value while discarding arbitrarily large legal leading/trailing whitespace.
- Continue to reject leading/trailing non-whitespace garbage and duplicate JSON values.
- Add a regression above 1 MiB plus adversarial garbage cases.
- Refresh the task verifier checksum.

## Validation

- `make harbor-plan BASE=origin/main`: selects only the Farkas host leaf, its generic verifier-contract leaf, and its Oracle.
- Focused task leaf: **10 passed**.
- Generic verifier-contract leaf: **12 passed**, 1,658 deselected.
- Static task quality and contract checks: passed.
- `git diff --check origin/main...HEAD`: passed.
- `make check`: Ruff, formatting, complexity, mypy, and 869/870 unit tests passed. The remaining unrelated `test_python_distribution_identity_binds_installed_file_bytes` failed due same-timestamp metadata caching; its isolated reproduction failed once and passed immediately on retry without a code change, and the full retry hit the same pre-existing timing condition.
- Exact Harbor Oracle: not run because Docker is absent (`/bin/sh: docker: not found`), so no Oracle verdict is claimed.

## Deferred proof gaps

A Docker-capable host should run the selected exact-task Oracle and the frozen five-task paired pilot. Those are explicit evidence gaps; they do not broaden this PR beyond the single reproducible verifier-contract defect.
