### PR TITLE
fix(benchmarks): accept natural local-ring evidence phrasing

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact local-ring diagonal-similarity verifier.
 LABEL jacobian.task="jacobian/local-ring-diagonal-similarity-certificate" \
-      jacobian.checksum="ec64fe8821de722f6543eaaa95496721206e800196889887ac9d55497bc6626f"
+      jacobian.checksum="8456d6f115dfaecd8566ca694029b57729a21ad98e929764f1e179ceedd6ae8e"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json verifier_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/local-ring-diagonal-similarity-certificate/tests/verifier.py
@@ -50,6 +50,7 @@ _PRODUCTS_AGREE = (
     "pa and bp coincide",
     "pa and bp agree",
     "pa=bp",
+    "pa = bp",
     "pa equals bp",
     "pa and bp match",
     "pa and bp are equal",
@@ -71,6 +72,7 @@ _DETERMINANT_UNIT = (
 _DIAGONAL_MATCH = (
     "unit entries",
     "unit entry",
+    "diagonal entries match",
     "matched diagonal pair",
     "diagonal pair",
     "matched pairs agree",

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_local_ring_diagonal_similarity_certificate.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_local_ring_diagonal_similarity_certificate.py
@@ -195,6 +195,22 @@ def test_equivalent_explanation_paraphrase_is_accepted(tmp_path: Path) -> None:
     assert reward.reward == 1.0
 
 
+def test_diagonal_entries_match_paraphrase_is_accepted(tmp_path: Path) -> None:
+    """Accept the natural subject-before-verb wording observed in evaluation."""
+    task, app, logs = _prepare(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    _set_evidence(
+        app,
+        submission,
+        "Direct modular multiplication gives PA = BP. The determinant of P is a "
+        "unit modulo 125, and along the selected unit permutation the diagonal "
+        "entries match as b[row] = a[column].\n",
+    )
+    reward = support._run_verifier(task, app, logs)
+    assert reward.details["evidence_validity"] == 1.0
+    assert reward.reward == 1.0
+
+
 def test_contradictory_explanation_is_rejected(tmp_path: Path) -> None:
     """Text that negates the certified relationships is rejected."""
     task, app, logs = _prepare(tmp_path)


### PR DESCRIPTION
## What changed

- accept the natural `PA = BP` spelling in the local-ring evidence explanation
- accept subject-before-verb wording such as “the diagonal entries match”
- add a focused regression using the exact equivalent phrasing observed in the paired benchmark evaluation
- refresh the task verifier checksum

## Why

Round 5 of the controlled Harbor evaluation produced a mathematically correct, fully bound certificate. The verifier recomputed the certificate successfully but assigned zero evidence validity because its phrase list recognized `PA=BP` without spaces and “match the diagonal,” while rejecting the equivalent `PA = BP` and “the diagonal entries match.”

This is a localized alternative-valid-representation rejection. It does not change the mathematical certificate, assurance ceiling, scope, or fail-closed behavior.

## Overlap

PR #1256 changes Jacobian's typed tool interface and does not touch this benchmark verifier. Open issue #861 concerns affirmative false limitation claims being accepted; it does not own this inverse failure mode.

## Validation

- focused task regression: 20 passed
- selected generic verifier attacks: 12 passed
- selected task contract validation: passed
- exact task Oracle: passed
- `make check`: passed
- `git diff --check`: passed
