### PR TITLE
fix(graph): raise distance matrix order bound

### DIFF
--- a/docs/reference/capabilities/graphs/graph-distance-matrix.md
+++ b/docs/reference/capabilities/graphs/graph-distance-matrix.md
@@ -4,8 +4,10 @@
 
 `graph.distance_matrix.compute` returns one complete matrix of exact
 unweighted shortest-path distances for a bounded finite simple undirected
-graph. The producer uses the existing `GraphInvariantRequest` graph contract,
-so inputs retain the established limit of 32 vertices and 496 edges.
+graph. The producer has a distance-matrix-owned polynomial-time contract with
+a limit of 64 vertices and 2,016 edges. This dedicated boundary does not widen
+the shared 32-vertex graph contract used by NP-hard coloring and optimization
+operations or the 18-vertex Hamiltonian-path search boundary.
 
 ## Result semantics
 

--- a/src/jacobian/contracts/graph_distance_matrix.py
+++ b/src/jacobian/contracts/graph_distance_matrix.py
@@ -1,0 +1,133 @@
+"""Typed contract for bounded exact graph distance matrices."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictBool, StrictInt, model_validator
+
+from jacobian.contracts.graph_coloring import ChromaticGraph, GraphVertex
+from jacobian.contracts.results import ContractModel
+
+MAX_GRAPH_DISTANCE_MATRIX_ORDER = 64
+MAX_GRAPH_DISTANCE_MATRIX_EDGES = 2_016
+MAX_GRAPH_DISTANCE = MAX_GRAPH_DISTANCE_MATRIX_ORDER - 1
+
+
+class GraphDistanceMatrixGraph(ChromaticGraph):
+    """A simple graph bounded for polynomial-time all-source BFS replay."""
+
+    vertices: tuple[GraphVertex, ...] = Field(
+        max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
+    )
+    edges: tuple[tuple[GraphVertex, GraphVertex], ...] = Field(
+        max_length=MAX_GRAPH_DISTANCE_MATRIX_EDGES
+    )
+
+
+class GraphDistanceMatrixRequest(ContractModel):
+    """One complete graph input for an exact distance matrix."""
+
+    graph: GraphDistanceMatrixGraph
+
+
+GraphDistance = (
+    Annotated[
+        StrictInt,
+        Field(ge=0, le=MAX_GRAPH_DISTANCE),
+    ]
+    | None
+)
+GraphDistanceRow = Annotated[
+    tuple[GraphDistance, ...],
+    Field(max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER),
+]
+
+
+def _validate_distance_matrix_shape(
+    vertices: tuple[GraphVertex, ...],
+    distances: tuple[GraphDistanceRow, ...],
+) -> int:
+    order = len(vertices)
+    if tuple(sorted(vertices)) != vertices or len(set(vertices)) != order:
+        raise ValueError("distance-matrix vertices must be unique and sorted")
+    if len(distances) != order or any(len(row) != order for row in distances):
+        raise ValueError("distance matrix must be square on the declared vertices")
+    return order
+
+
+def _validate_distance_matrix_diagonal_and_symmetry(
+    distances: tuple[GraphDistanceRow, ...],
+    order: int,
+) -> None:
+    for source in range(order):
+        for target in range(order):
+            distance = distances[source][target]
+            if source == target:
+                if distance != 0:
+                    raise ValueError("distance-matrix diagonal must be zero")
+            elif distance == 0:
+                raise ValueError("off-diagonal distances must be positive or null")
+            if distance != distances[target][source]:
+                raise ValueError("undirected distance matrix must be symmetric")
+
+
+def _validate_distance_matrix_triangle_inequality(
+    distances: tuple[GraphDistanceRow, ...],
+    order: int,
+) -> None:
+    for source in range(order):
+        for intermediate in range(order):
+            left = distances[source][intermediate]
+            if left is None:
+                continue
+            for target in range(order):
+                right = distances[intermediate][target]
+                if right is None:
+                    continue
+                direct = distances[source][target]
+                if direct is None or direct > left + right:
+                    raise ValueError(
+                        "finite distances must satisfy component closure and "
+                        "the triangle inequality"
+                    )
+
+
+class GraphDistanceMatrixResult(ContractModel):
+    """All exact unweighted shortest-path distances in canonical vertex order."""
+
+    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v1"]
+    vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
+    pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
+    unreachable_representation: Literal["JSON_NULL"]
+    vertices: tuple[GraphVertex, ...] = Field(
+        max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
+    )
+    distances: tuple[GraphDistanceRow, ...] = Field(
+        max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
+    )
+    connected: StrictBool
+
+    @model_validator(mode="after")
+    def bind_complete_metric(self) -> Self:
+        order = _validate_distance_matrix_shape(self.vertices, self.distances)
+        _validate_distance_matrix_diagonal_and_symmetry(self.distances, order)
+        _validate_distance_matrix_triangle_inequality(self.distances, order)
+        expected_connected = order > 0 and all(
+            distance is not None for row in self.distances for distance in row
+        )
+        if self.connected != expected_connected:
+            raise ValueError("connected must match all-pairs finite reachability")
+        return self
+
+
+__all__ = [
+    "MAX_GRAPH_DISTANCE",
+    "MAX_GRAPH_DISTANCE_MATRIX_EDGES",
+    "MAX_GRAPH_DISTANCE_MATRIX_ORDER",
+    "GraphDistance",
+    "GraphDistanceMatrixGraph",
+    "GraphDistanceMatrixRequest",
+    "GraphDistanceMatrixResult",
+    "GraphDistanceRow",
+]

--- a/src/jacobian/contracts/graph_invariant_operations.py
+++ b/src/jacobian/contracts/graph_invariant_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Literal, Self
 
 from pydantic import Field, StrictBool, StrictInt, model_validator
 
@@ -28,86 +28,6 @@ class GraphMaximumMatchingGraph(ChromaticGraph):
 
 class GraphMaximumMatchingRequest(ContractModel):
     graph: GraphMaximumMatchingGraph
-
-
-GraphDistance = Annotated[StrictInt, Field(ge=0, le=31)] | None
-GraphDistanceRow = Annotated[
-    tuple[GraphDistance, ...],
-    Field(max_length=32),
-]
-
-
-def _validate_distance_matrix_shape(
-    vertices: tuple[GraphVertex, ...],
-    distances: tuple[GraphDistanceRow, ...],
-) -> int:
-    order = len(vertices)
-    if tuple(sorted(vertices)) != vertices or len(set(vertices)) != order:
-        raise ValueError("distance-matrix vertices must be unique and sorted")
-    if len(distances) != order or any(len(row) != order for row in distances):
-        raise ValueError("distance matrix must be square on the declared vertices")
-    return order
-
-
-def _validate_distance_matrix_diagonal_and_symmetry(
-    distances: tuple[GraphDistanceRow, ...],
-    order: int,
-) -> None:
-    for source in range(order):
-        for target in range(order):
-            distance = distances[source][target]
-            if source == target:
-                if distance != 0:
-                    raise ValueError("distance-matrix diagonal must be zero")
-            elif distance == 0:
-                raise ValueError("off-diagonal distances must be positive or null")
-            if distance != distances[target][source]:
-                raise ValueError("undirected distance matrix must be symmetric")
-
-
-def _validate_distance_matrix_triangle_inequality(
-    distances: tuple[GraphDistanceRow, ...],
-    order: int,
-) -> None:
-    for source in range(order):
-        for intermediate in range(order):
-            left = distances[source][intermediate]
-            if left is None:
-                continue
-            for target in range(order):
-                right = distances[intermediate][target]
-                if right is None:
-                    continue
-                direct = distances[source][target]
-                if direct is None or direct > left + right:
-                    raise ValueError(
-                        "finite distances must satisfy component closure and "
-                        "the triangle inequality"
-                    )
-
-
-class GraphDistanceMatrixResult(ContractModel):
-    """All exact unweighted shortest-path distances in canonical vertex order."""
-
-    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v1"]
-    vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
-    pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
-    unreachable_representation: Literal["JSON_NULL"]
-    vertices: tuple[GraphVertex, ...] = Field(max_length=32)
-    distances: tuple[GraphDistanceRow, ...] = Field(max_length=32)
-    connected: StrictBool
-
-    @model_validator(mode="after")
-    def bind_complete_metric(self) -> Self:
-        order = _validate_distance_matrix_shape(self.vertices, self.distances)
-        _validate_distance_matrix_diagonal_and_symmetry(self.distances, order)
-        _validate_distance_matrix_triangle_inequality(self.distances, order)
-        expected_connected = order > 0 and all(
-            distance is not None for row in self.distances for distance in row
-        )
-        if self.connected != expected_connected:
-            raise ValueError("connected must match all-pairs finite reachability")
-        return self
 
 
 class GraphGirthResult(ContractModel):

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -1,6 +1,7 @@
 """Independent checker declarations owned by the graph-optimization domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.graph_distance_matrix import GraphDistanceMatrixRequest
 from jacobian.contracts.graph_invariant_operations import (
     GraphInvariantRequest,
     GraphMaximumMatchingRequest,
@@ -136,7 +137,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
     ),
     ExactReplayCheckerDeclaration(
         "graph.distance_matrix.compute",
-        GraphInvariantRequest,
+        GraphDistanceMatrixRequest,
         "check_graph_distance_matrix",
         "graph.distance-matrix.all-sources-bfs-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,

--- a/src/jacobian/domains/graph_optimization/distance_matrix.py
+++ b/src/jacobian/domains/graph_optimization/distance_matrix.py
@@ -1,0 +1,104 @@
+"""Exact all-pairs distances under a distance-matrix-owned graph bound."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from jacobian.contracts.capabilities import CapabilityDiagnostic
+from jacobian.contracts.graph_distance_matrix import (
+    MAX_GRAPH_DISTANCE_MATRIX_EDGES,
+    MAX_GRAPH_DISTANCE_MATRIX_ORDER,
+    GraphDistanceMatrixRequest,
+    GraphDistanceMatrixResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.graph_optimization.operations import build_simple_graph
+from jacobian.operation_bindings import inline_operation
+from jacobian.operations import OperationRefusalError, OperationSpec
+
+_INVALID_REQUEST = CapabilityDiagnostic(
+    code="INVALID_GRAPH_DISTANCE_MATRIX_REQUEST",
+    stage="graph_distance_matrix_input_validation",
+    message=(
+        "Input does not satisfy the bounded finite simple-graph distance contract."
+    ),
+    hint=(
+        "Supply a simple graph with at most "
+        f"{MAX_GRAPH_DISTANCE_MATRIX_ORDER} vertices and "
+        f"{MAX_GRAPH_DISTANCE_MATRIX_EDGES:,} edges."
+    ),
+)
+
+
+def compute_distance_matrix(
+    request: GraphDistanceMatrixRequest,
+) -> GraphDistanceMatrixResult:
+    """Compute every exact unweighted distance in canonical vertex order."""
+
+    import networkx as nx
+
+    try:
+        graph = cast(Any, build_simple_graph(request.graph))
+        vertices = tuple(sorted(graph.nodes))
+        shortest_paths = {
+            source: nx.single_source_shortest_path_length(graph, source)
+            for source in vertices
+        }
+        distances = tuple(
+            tuple(shortest_paths[source].get(target) for target in vertices)
+            for source in vertices
+        )
+        connected = bool(vertices) and all(
+            distance is not None for row in distances for distance in row
+        )
+        return GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v1",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=vertices,
+            distances=distances,
+            connected=connected,
+        )
+    except (ArithmeticError, nx.NetworkXError, TypeError, ValueError) as exc:
+        raise OperationRefusalError(
+            CapabilityDiagnostic(
+                code="GRAPH_DISTANCE_MATRIX_NOT_APPLICABLE",
+                stage="graph_distance_matrix_computation",
+                message=str(exc),
+                hint="Check the distance matrix graph preconditions.",
+            )
+        ) from exc
+
+
+DISTANCE_MATRIX_OPERATION = inline_operation(
+    OperationSpec(
+        operation_id="graph.distance_matrix.compute",
+        version="2",
+        title="All-pairs distance matrix",
+        description=(
+            "Compute every exact unweighted shortest-path distance in a finite "
+            "simple graph of at most 64 vertices, using JSON null for unreachable "
+            "vertex pairs."
+        ),
+        request_type=GraphDistanceMatrixRequest,
+        result_type=GraphDistanceMatrixResult,
+        execute=compute_distance_matrix,
+        tags=("graph", "invariant", "distance", "matrix", "exact"),
+        invalid_request=_INVALID_REQUEST,
+        invocation_examples=(
+            example(
+                "path_three_distance_matrix",
+                "Compute all ordered-pair distances in a three-vertex path.",
+                {
+                    "graph": {
+                        "vertices": ["c", "a", "b"],
+                        "edges": [["a", "b"], ["b", "c"]],
+                    }
+                },
+            ),
+        ),
+    )
+)
+
+__all__ = ["DISTANCE_MATRIX_OPERATION", "compute_distance_matrix"]

--- a/src/jacobian/domains/graph_optimization/invariant_bundle.py
+++ b/src/jacobian/domains/graph_optimization/invariant_bundle.py
@@ -7,6 +7,9 @@ from jacobian.domain_bundles import DomainBundle
 from jacobian.domains.graph_optimization.checkers import (
     GRAPH_INVARIANT_EXACT_REPLAY_CHECKERS,
 )
+from jacobian.domains.graph_optimization.distance_matrix import (
+    DISTANCE_MATRIX_OPERATION,
+)
 from jacobian.domains.graph_optimization.invariants import (
     EXACT_GRAPH_INVARIANT_CAPABILITIES,
 )
@@ -31,7 +34,10 @@ def build_graph_invariant_bundle() -> DomainBundle:
                 "graph_class": "finite simple undirected",
                 "maximum_order": 32,
                 "maximum_edges": 496,
+                "distance_matrix_maximum_order": 64,
+                "distance_matrix_maximum_edges": 2_016,
                 "exact_computations": [
+                    "distance_matrix",
                     "girth",
                     "diameter",
                     "edge_connectivity",
@@ -66,7 +72,7 @@ def build_graph_invariant_bundle() -> DomainBundle:
             ),
         ),
         backend_version=f"networkx-{NETWORKX_VERSION};sympy-{SYMPY_VERSION}",
-        capabilities=EXACT_GRAPH_INVARIANT_CAPABILITIES,
+        capabilities=(DISTANCE_MATRIX_OPERATION, *EXACT_GRAPH_INVARIANT_CAPABILITIES),
         diagnostics=DomainDiagnostics(
             invalid_request=CapabilityDiagnostic(
                 code="INVALID_GRAPH_INVARIANT_REQUEST",

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -16,7 +16,6 @@ from jacobian.contracts.graph_invariant_operations import (
     GraphCoreRequest,
     GraphCoreResult,
     GraphDiameterResult,
-    GraphDistanceMatrixResult,
     GraphEdgeConnectivityResult,
     GraphEulerianResult,
     GraphGirthResult,
@@ -114,32 +113,6 @@ def _girth(graph: Any) -> GraphGirthResult:
     value = nx.girth(graph)
     girth = 0 if math.isinf(value) else int(value)
     return GraphGirthResult(girth=girth, has_cycle=girth > 0)
-
-
-def _distance_matrix(graph: Any) -> GraphDistanceMatrixResult:
-    import networkx as nx
-
-    vertices = tuple(sorted(graph.nodes))
-    shortest_paths = {
-        source: nx.single_source_shortest_path_length(graph, source)
-        for source in vertices
-    }
-    distances = tuple(
-        tuple(shortest_paths[source].get(target) for target in vertices)
-        for source in vertices
-    )
-    connected = bool(vertices) and all(
-        distance is not None for row in distances for distance in row
-    )
-    return GraphDistanceMatrixResult(
-        semantics_version="unweighted-shortest-path-distance-matrix.v1",
-        vertex_ordering="LEXICOGRAPHIC_ASCENDING",
-        pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
-        unreachable_representation="JSON_NULL",
-        vertices=vertices,
-        distances=distances,
-        connected=connected,
-    )
 
 
 def _diameter(graph: Any) -> GraphDiameterResult:
@@ -496,31 +469,6 @@ BOUNDED_GRAPH_INVARIANT_CAPABILITIES = (
 )
 
 EXACT_GRAPH_INVARIANT_CAPABILITIES = (
-    _computed(
-        "graph.distance_matrix.compute",
-        "All-pairs distance matrix",
-        (
-            "Compute every exact unweighted shortest-path distance in a bounded "
-            "finite simple graph, using JSON null for unreachable vertex pairs."
-        ),
-        GraphDistanceMatrixResult,
-        _distance_matrix,
-        "distance",
-        "matrix",
-        "exact",
-        invocation_examples=(
-            example(
-                "path_three_distance_matrix",
-                "Compute all ordered-pair distances in a three-vertex path.",
-                {
-                    "graph": {
-                        "vertices": ["c", "a", "b"],
-                        "edges": [["a", "b"], ["b", "c"]],
-                    }
-                },
-            ),
-        ),
-    ),
     _computed(
         "graph.invariant.triangle_count.compute",
         "Triangle count",

--- a/src/jacobian_checkers/graph_exact_operations.py
+++ b/src/jacobian_checkers/graph_exact_operations.py
@@ -896,7 +896,7 @@ def _validate_distance_matrix_entries(
     for source_index, row in enumerate(matrix):
         for target_index, distance in enumerate(row):
             if distance is not None and (
-                type(distance) is not int or distance < 0 or distance > 31
+                type(distance) is not int or distance < 0 or distance > 63
             ):
                 return False
             if source_index == target_index:
@@ -931,7 +931,7 @@ def _validate_distance_matrix_triangle(
 def _distance_matrix(source: dict[str, Any], result: dict[str, Any]) -> bool:
     input_vertices, normalized_edges, adjacency = _finite_simple_graph(
         source,
-        maximum_order=32,
+        maximum_order=64,
     )
     vertices = tuple(sorted(input_vertices))
     if not _validate_distance_matrix_header(result, vertices):

--- a/tests/component/checkers/test_exact_graph_checkers.py
+++ b/tests/component/checkers/test_exact_graph_checkers.py
@@ -278,6 +278,46 @@ def test_distance_matrix_checker_accepts_exact_boundary_claims(
     assert decision["coverage"] == "EXHAUSTIVE"
 
 
+def test_distance_matrix_checker_handles_dedicated_order_boundary() -> None:
+    vertices = [f"v{index:02d}" for index in range(64)]
+    distances = [
+        [0 if source == target else None for target in range(64)]
+        for source in range(64)
+    ]
+    checker_request = _distance_matrix_checker_request(
+        vertices=vertices,
+        edges=[],
+        result_vertices=vertices,
+        distances=distances,
+        connected=False,
+    )
+
+    decision = check_graph_distance_matrix(checker_request)
+
+    assert decision["accepted"] is True
+    assert decision["conclusion"] == "TRUE"
+
+
+def test_distance_matrix_checker_rejects_order_above_dedicated_bound() -> None:
+    vertices = [f"v{index:02d}" for index in range(65)]
+    distances = [
+        [0 if source == target else None for target in range(65)]
+        for source in range(65)
+    ]
+    checker_request = _distance_matrix_checker_request(
+        vertices=vertices,
+        edges=[],
+        result_vertices=vertices,
+        distances=distances,
+        connected=False,
+    )
+
+    decision = check_graph_distance_matrix(checker_request)
+
+    assert decision["accepted"] is False
+    assert decision["conclusion"] == "UNKNOWN"
+
+
 @pytest.mark.parametrize(
     "mutate",
     (

--- a/tests/domain/graph/test_graph_distance_matrix.py
+++ b/tests/domain/graph/test_graph_distance_matrix.py
@@ -5,12 +5,22 @@ from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
+from tests.support.graph_distance_cases import (
+    c7_strong_c7_distance,
+    c7_strong_c7_graph,
+    hoffman_singleton_graph,
+)
 from tests.support.services import DomainTestServices, open_domain_services
 
 from jacobian.contracts.capabilities import (
     CapabilityRequest,
 )
-from jacobian.contracts.graph_invariant_operations import GraphDistanceMatrixResult
+from jacobian.contracts.graph_coloring import GraphChromaticNumberRequest
+from jacobian.contracts.graph_distance_matrix import GraphDistanceMatrixResult
+from jacobian.contracts.graph_optimization import (
+    GraphHamiltonianPathRequest,
+    GraphOptimizationRequest,
+)
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.domains.graph_optimization import build_graph_invariant_bundle
 
@@ -28,6 +38,15 @@ def _invoke(domain_services, vertices: list[str], edges: list[list[str]]):
         CapabilityRequest(
             capability_id="graph.distance_matrix.compute",
             input={"graph": {"vertices": vertices, "edges": edges}},
+        )
+    )
+
+
+def _invoke_graph(domain_services, graph: dict[str, object]):
+    return domain_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input={"graph": graph},
         )
     )
 
@@ -95,14 +114,100 @@ def test_distance_matrix_empty_and_singleton_conventions(domain_services) -> Non
     assert singleton.output["result"]["connected"] is True
 
 
-def test_distance_matrix_rejects_graph_above_existing_order_bound(
+def test_distance_matrix_rejects_graph_above_dedicated_order_bound(
     domain_services,
 ) -> None:
-    result = _invoke(domain_services, [f"v{index:02d}" for index in range(33)], [])
+    result = _invoke(domain_services, [f"v{index:02d}" for index in range(65)], [])
 
     assert result.execution.status is ExecutionStatus.ERROR
     assert result.artifact_uris == ()
-    assert result.diagnostics[0].code == "INVALID_GRAPH_INVARIANT_REQUEST"
+    assert result.diagnostics[0].code == "INVALID_GRAPH_DISTANCE_MATRIX_REQUEST"
+
+
+def test_distance_matrix_accepts_connected_order_64_boundary(domain_services) -> None:
+    vertices = [f"v{index:02d}" for index in range(64)]
+    result = _invoke(
+        domain_services,
+        vertices,
+        [[vertices[index], vertices[index + 1]] for index in range(63)],
+    )
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    assert result.output["result"]["vertices"] == vertices
+    assert result.output["result"]["distances"][0][-1] == 63
+    assert result.output["result"]["connected"] is True
+
+
+def test_distance_matrix_accepts_disconnected_order_64_boundary(
+    domain_services,
+) -> None:
+    vertices = [f"v{index:02d}" for index in range(64)]
+    result = _invoke(domain_services, vertices, [])
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    matrix = result.output["result"]["distances"]
+    assert len(matrix) == 64
+    assert matrix[0][0] == 0
+    assert matrix[0][1] is None
+    assert result.output["result"]["connected"] is False
+
+
+def test_unrelated_np_hard_graph_contract_bounds_are_unchanged() -> None:
+    graph_33 = {
+        "vertices": [f"v{index:02d}" for index in range(33)],
+        "edges": [],
+    }
+    graph_19 = {
+        "vertices": [f"v{index:02d}" for index in range(19)],
+        "edges": [],
+    }
+
+    with pytest.raises(ValidationError):
+        GraphChromaticNumberRequest.model_validate({"graph": graph_33})
+    with pytest.raises(ValidationError):
+        GraphOptimizationRequest.model_validate({"graph": graph_33})
+    with pytest.raises(ValidationError):
+        GraphHamiltonianPathRequest.model_validate({"graph": graph_19})
+
+
+def test_distance_matrix_computes_hoffman_singleton_case(domain_services) -> None:
+    graph = hoffman_singleton_graph()
+    result = _invoke_graph(domain_services, graph)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    output = result.output["result"]
+    assert len(output["vertices"]) == 50
+    assert len(graph["edges"]) == 175
+    edge_set = {tuple(edge) for edge in graph["edges"]}
+    expected = [
+        [
+            0
+            if source == target
+            else 1
+            if tuple(sorted((source, target))) in edge_set
+            else 2
+            for target in output["vertices"]
+        ]
+        for source in output["vertices"]
+    ]
+    assert output["distances"] == expected
+    assert output["connected"] is True
+
+
+def test_distance_matrix_computes_c7_strong_c7_case(domain_services) -> None:
+    graph = c7_strong_c7_graph()
+    result = _invoke_graph(domain_services, graph)
+
+    assert result.execution.status is ExecutionStatus.COMPLETED
+    output = result.output["result"]
+    assert len(output["vertices"]) == 49
+    assert len(graph["edges"]) == 196
+    expected = [
+        [c7_strong_c7_distance(source, target) for target in output["vertices"]]
+        for source in output["vertices"]
+    ]
+    assert output["distances"] == expected
+    assert output["connected"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/domain/graph/test_graph_verification.py
+++ b/tests/domain/graph/test_graph_verification.py
@@ -7,6 +7,10 @@ from typing import Any
 
 import pytest
 from tests.support.exact_domain import open_exact_domain_services
+from tests.support.graph_distance_cases import (
+    c7_strong_c7_graph,
+    hoffman_singleton_graph,
+)
 from tests.support.services import DomainTestServices
 
 from jacobian.contracts.capabilities import (
@@ -358,3 +362,132 @@ def test_distance_matrix_result_uses_independent_all_sources_bfs_replay(
     assert rejected.output["status"] == "REJECTED"
     assert rejected.output["conclusion"] == "UNKNOWN"
     assert rejected.output["verification_record_uri"] is None
+
+
+@pytest.mark.parametrize(
+    "graph_factory",
+    (hoffman_singleton_graph, c7_strong_c7_graph),
+    ids=("hoffman-singleton-order-50", "c7-strong-c7-order-49"),
+)
+def test_distance_matrix_checker_verifies_proof_critical_large_cases(
+    graph_verification_services: DomainTestServices,
+    graph_factory,
+) -> None:
+    producer_input = {"graph": graph_factory()}
+    computed = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input=producer_input,
+        )
+    )
+    verified = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            input={"input": producer_input, "candidate": computed.output["result"]},
+        )
+    )
+
+    assert computed.execution.status is ExecutionStatus.COMPLETED
+    assert verified.execution.status is ExecutionStatus.COMPLETED
+    assert verified.output["status"] == "VERIFIED"
+    assert verified.output["conclusion"] == "TRUE"
+    assert verified.output["verification_record_uri"] in verified.artifact_uris
+
+
+def test_distance_matrix_checker_rejects_one_wrong_edge_distance(
+    graph_verification_services: DomainTestServices,
+) -> None:
+    producer_input = {"graph": hoffman_singleton_graph()}
+    computed = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input=producer_input,
+        )
+    )
+    candidate = deepcopy(computed.output["result"])
+    left, right = producer_input["graph"]["edges"][0]
+    left_index = candidate["vertices"].index(left)
+    right_index = candidate["vertices"].index(right)
+    candidate["distances"][left_index][right_index] = 2
+    candidate["distances"][right_index][left_index] = 2
+
+    rejected = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            input={"input": producer_input, "candidate": candidate},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
+def test_distance_matrix_checker_rejects_candidate_rebound_to_changed_graph(
+    graph_verification_services: DomainTestServices,
+) -> None:
+    original_graph = c7_strong_c7_graph()
+    computed = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input={"graph": original_graph},
+        )
+    )
+    changed_graph = deepcopy(original_graph)
+    changed_graph["edges"].pop(0)
+
+    rejected = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            input={
+                "input": {"graph": changed_graph},
+                "candidate": computed.output["result"],
+            },
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.COMPLETED
+    assert rejected.output["status"] == "REJECTED"
+    assert rejected.output["conclusion"] == "UNKNOWN"
+    assert rejected.output["verification_record_uri"] is None
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda candidate: candidate.pop("vertices"),
+        lambda candidate: candidate.update(
+            vertices=list(reversed(candidate["vertices"]))
+        ),
+    ),
+    ids=("missing-label-binding", "noncanonical-label-binding"),
+)
+def test_distance_matrix_verifier_fails_closed_on_malformed_label_binding(
+    graph_verification_services: DomainTestServices,
+    mutate,
+) -> None:
+    producer_input = {
+        "graph": {
+            "vertices": ["a", "b", "c"],
+            "edges": [["a", "b"], ["b", "c"]],
+        }
+    }
+    computed = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.compute",
+            input=producer_input,
+        )
+    )
+    candidate = deepcopy(computed.output["result"])
+    mutate(candidate)
+
+    rejected = graph_verification_services.core.capabilities.invoke(
+        CapabilityRequest(
+            capability_id="graph.distance_matrix.verify",
+            input={"input": producer_input, "candidate": candidate},
+        )
+    )
+
+    assert rejected.execution.status is ExecutionStatus.ERROR
+    assert rejected.artifact_uris == ()

--- a/tests/support/graph_distance_cases.py
+++ b/tests/support/graph_distance_cases.py
@@ -1,0 +1,99 @@
+"""Proof-critical graph cases for the distance-matrix order boundary."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+
+def _canonical_edge(left: str, right: str) -> tuple[str, str]:
+    return (left, right) if left < right else (right, left)
+
+
+def hoffman_singleton_graph() -> dict[str, object]:
+    """Return the standard 50-vertex Hoffman--Singleton construction."""
+
+    vertices = sorted(
+        [f"P_{index}_{offset}" for index in range(5) for offset in range(5)]
+        + [f"Q_{index}_{offset}" for index in range(5) for offset in range(5)]
+    )
+    edges: set[tuple[str, str]] = set()
+    for index in range(5):
+        for offset in range(5):
+            edges.add(
+                _canonical_edge(
+                    f"P_{index}_{offset}",
+                    f"P_{index}_{(offset + 1) % 5}",
+                )
+            )
+            edges.add(
+                _canonical_edge(
+                    f"Q_{index}_{offset}",
+                    f"Q_{index}_{(offset + 2) % 5}",
+                )
+            )
+    for left_index in range(5):
+        for left_offset in range(5):
+            for right_index in range(5):
+                edges.add(
+                    _canonical_edge(
+                        f"P_{left_index}_{left_offset}",
+                        f"Q_{right_index}_{(left_index * right_index + left_offset) % 5}",
+                    )
+                )
+    return {
+        "graph_schema_version": "1",
+        "vertices": vertices,
+        "edges": [list(edge) for edge in sorted(edges)],
+    }
+
+
+def _cycle_seven_distance(left: int, right: int) -> int:
+    difference = abs(left - right)
+    return min(difference, 7 - difference)
+
+
+def c7_strong_c7_graph() -> dict[str, object]:
+    """Return the 49-vertex strong product of two seven-cycles."""
+
+    coordinates = {
+        f"{left},{right}": (left, right) for left in range(7) for right in range(7)
+    }
+    vertices = sorted(coordinates)
+    edges = [
+        [left, right]
+        for left, right in combinations(vertices, 2)
+        if max(
+            _cycle_seven_distance(
+                coordinates[left][0],
+                coordinates[right][0],
+            ),
+            _cycle_seven_distance(
+                coordinates[left][1],
+                coordinates[right][1],
+            ),
+        )
+        == 1
+    ]
+    return {
+        "graph_schema_version": "1",
+        "vertices": vertices,
+        "edges": edges,
+    }
+
+
+def c7_strong_c7_distance(source: str, target: str) -> int:
+    """Evaluate the exact strong-product distance formula."""
+
+    source_left, source_right = (int(value) for value in source.split(","))
+    target_left, target_right = (int(value) for value in target.split(","))
+    return max(
+        _cycle_seven_distance(source_left, target_left),
+        _cycle_seven_distance(source_right, target_right),
+    )
+
+
+__all__ = [
+    "c7_strong_c7_distance",
+    "c7_strong_c7_graph",
+    "hoffman_singleton_graph",
+]


### PR DESCRIPTION
Fixes #1305.

## Summary

- give `graph.distance_matrix.compute` a dedicated polynomial-time graph contract with bounds of 64 vertices, 2,016 edges, and distance entries through 63
- preserve the existing 32-vertex shared coloring/optimization contract and the 18-vertex Hamiltonian-path boundary
- bind the independent standard-library BFS checker to the dedicated request type and the same 64-vertex limit
- retain lexicographic vertex binding, all ordered-pair coverage, JSON-null unreachable pairs, and the separate checker operation

## Regression coverage

- exact 50-vertex Hoffman–Singleton producer output and independent verification
- exact 49-vertex `C_7 \boxtimes C_7` producer output and independent verification
- connected and disconnected order-64 inputs, plus fail-closed order-65 rejection
- one-entry matrix mutation, changed-graph rebinding, missing labels, and noncanonical labels
- explicit assertions that coloring, general optimization, and Hamiltonian-path bounds remain unchanged

## Evaluation

The source-grounded oracles were frozen from arXiv:2607.27452v1 and arXiv:2607.26844v1 before the product edit. Current main deterministically rejected both 49/50-vertex producer inputs as `INVALID_GRAPH_INVARIANT_REQUEST`. A clean fixed install produced matrices identical to both frozen oracles, and `graph.distance_matrix.verify` returned `VERIFIED` for each while rejecting the adversarial candidates.

A small frozen `gpt-5.6-luna` medium-effort comparison used one control/current/fixed replicate per case, normal MCP exposure, and no custom skill or prompt scaffolding. Neither current-main nor fixed treatments discovered `math.find`, invoked `math.run`, or used the checker. This PR therefore claims a deterministic contract repair, not autonomous no-skill adoption or model-level uplift.

## Validation

- focused graph producer/checker suite: 71 passed
- `make quick` on the final tip: 831 passed, 1 upstream test deselected
- `make check` on the immediately preceding main tip: 2,430 passed, 11 expected optional-runtime skips, 1 upstream test deselected
- final-tip focused suite and `make quick` repeated after rebasing onto the latest `origin/main`

The deselected upstream test is `test_python_distribution_identity_binds_installed_file_bytes`, untouched by this PR. On this filesystem it passed 7 and failed 13 times across 20 isolated repeats because same-size rewrites can retain the cached stat identity.