### PR TITLE
fix(benchmarks): honor integer audit limitation fields

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact semantic verifier for an integer-to-natural perturbation-domain mismatch.
 LABEL jacobian.task="jacobian/integer-perturbation-domain-audit" \
-      jacobian.checksum="12e3d17839765b958111051e7c1d1f4bf98e98c9ea4e8c0940cc9234071b09f1"
+      jacobian.checksum="9700c992e66052d810c82c3aaaefdf907fbb87e25d0bf30a3cf989364b28e089"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh

--- a/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/integer-perturbation-domain-audit/tests/verifier.py
@@ -216,15 +216,7 @@ def _audit_prose_valid(text):
     has_integer_domain = bool(
         re.search(r"\binteger\b|\bz[- ]valued\b|\bz[- ]value\b", text)
     )
-    has_nonclaim = bool(
-        re.search(r"\bnot\s+assessed\b", text)
-        or re.search(
-            r"\bno\b.{0,80}\b(?:lean|irrationality|theorem)\b.{0,40}"
-            r"\b(?:claim|claimed|claims|made)\b",
-            text,
-        )
-    )
-    return has_natural_domain and has_integer_domain and has_nonclaim
+    return has_natural_domain and has_integer_domain
 
 
 def _raw_submission():

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_integer_perturbation_domain_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_integer_perturbation_domain_audit.py
@@ -208,6 +208,30 @@ def test_accepts_equivalent_concise_audit_evidence(tmp_path: Path) -> None:
     assert accepted.reward == pytest.approx(1.0)
 
 
+def test_limitations_need_not_be_duplicated_in_evidence(tmp_path: Path) -> None:
+    """The public contract assigns excluded claims to the limitations field."""
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    evidence_path = app / "evidence" / "answer.txt"
+    result_marker = next(
+        line
+        for line in evidence_path.read_text().splitlines()
+        if line.startswith("RESULT_JSON:")
+    )
+    evidence_path.write_text(
+        "Over the Nat domain the nonzero-sum condition is redundant. Over bounded "
+        "integer-valued perturbations, the submitted periodic witness has two "
+        "cancellations.\n"
+        f"{result_marker}\n"
+    )
+    submission = json.loads((app / "submission.json").read_text())
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(app / "submission.json", submission)
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.details["limitation_accuracy"] == 1.0
+    assert accepted.reward == pytest.approx(1.0)
+
+
 def test_rejects_multiple_result_markers(tmp_path: Path) -> None:
     """Evidence must bind exactly one unambiguous result marker."""
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")


### PR DESCRIPTION
## What changed

- stop requiring Lean/irrationality disclaimers to be duplicated inside `evidence/answer.txt`
- continue rejecting affirmative prohibited claims in evidence
- continue requiring and validating both disclaimers in the structured `limitations` field
- add a regression using the valid separation observed in the paired benchmark evaluation
- refresh the verifier checksum

## Why

The public task contract explicitly assigns both excluded-claim disclosures to the `limitations` field. Round 5's treatment supplied both valid limitations and a mathematically correct, digest-bound Nat/integer audit, but the verifier assigned zero evidence validity because its prose matcher imposed an additional undocumented disclaimer requirement.

The verifier already validates the structured limitation field independently. Removing the duplicate prose requirement accepts the published contract without weakening overclaim rejection.

## Overlap

PR #1256 does not modify this task or verifier. No open issue or PR mentions this task or owns this exact duplicate-evidence obligation.

## Validation

- focused verifier regressions: 26 passed
- selected generic verifier attacks: 12 passed
- selected task contract validation: passed
- exact task Oracle: passed
- `make check`: passed
- `git diff --check`: passed
