### PR TITLE
test(mcp): focus MCP protocol tests on explicit production runtimes

### DIFF
--- a/src/jacobian/adapters/mcp/server.py
+++ b/src/jacobian/adapters/mcp/server.py
@@ -26,6 +26,7 @@ from jacobian.adapters.mcp.resources import register_resources
 from jacobian.adapters.mcp.tooling import MCPBlockingWorkerRegistry
 from jacobian.capability_service import CapabilityPolicy
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
+from jacobian.runtime.model import JacobianRuntime
 
 
 def create_server(
@@ -43,14 +44,34 @@ def create_server(
         capability_exclusions=capability_exclusions,
         capability_policy=capability_policy,
     )
+    return create_server_from_runtime(
+        runtime,
+        close_owner=runtime.close,
+        start_owner=lambda: _start_lean_warmup(runtime),
+    )
+
+
+def create_server_from_runtime(
+    runtime: JacobianRuntime,
+    *,
+    close_owner: Callable[[], None],
+    start_owner: Callable[[], None] | None = None,
+) -> MCPServer[AppState]:
+    """Register the local MCP projection over an explicitly owned runtime.
+
+    The caller supplies lifecycle actions so deployment bootstrap and focused
+    compositions exercise identical SDK registration without obscuring which
+    layer owns runtime startup and teardown.
+    """
+
     state = AppState(
         acquire_runtime=lambda: RuntimeLease(runtime),
         worker_registry=MCPBlockingWorkerRegistry(),
     )
     return _build_local_server(
         state=state,
-        close_owner=runtime.close,
-        start_owner=lambda: _start_lean_warmup(runtime),
+        close_owner=close_owner,
+        start_owner=start_owner,
     )
 
 
@@ -91,4 +112,4 @@ if __name__ == "__main__":
     main()
 
 
-__all__ = ["create_server"]
+__all__ = ["create_server", "create_server_from_runtime"]

--- a/tests/boundary/mcp/mcp_support.py
+++ b/tests/boundary/mcp/mcp_support.py
@@ -1,0 +1,41 @@
+"""Focused production MCP compositions owned by the MCP boundary suite."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from mcp.server import MCPServer
+
+from jacobian.adapters.mcp.context import AppState
+from jacobian.adapters.mcp.server import create_server_from_runtime
+from jacobian.domain_bundles import DomainBundle
+from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime.portfolio import PortfolioResources
+from tests.support.services import open_domain_services
+
+
+@contextmanager
+def open_focused_mcp_server(
+    root: Path,
+    *bundles: DomainBundle,
+) -> Iterator[MCPServer[AppState]]:
+    """Open the real MCP projection over selected production domain bundles."""
+
+    with open_domain_services(
+        root,
+        *bundles,
+        checker_authority=CheckerAuthorityMode.NONE,
+    ) as services:
+        runtime = JacobianRuntime(
+            services.core,
+            services.application,
+            PortfolioResources(),
+            lambda: None,
+        )
+        yield create_server_from_runtime(
+            runtime,
+            close_owner=lambda: None,
+        )

--- a/tests/boundary/mcp/test_mcp_adapter_inventory.py
+++ b/tests/boundary/mcp/test_mcp_adapter_inventory.py
@@ -10,6 +10,8 @@ from mcp.shared.exceptions import MCPError
 
 from jacobian.adapters.mcp.deployment_identity import DeploymentIdentity
 from jacobian.adapters.mcp.server import create_server
+from jacobian.runtime import CheckerAuthorityMode
+from tests.boundary.mcp.mcp_support import open_focused_mcp_server
 
 MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
@@ -27,7 +29,6 @@ def test_managed_server_advertises_immutable_deployment_identity(
         "jacobian.adapters.mcp.server.load_deployment_identity",
         lambda: identity,
     )
-    server = create_server(tmp_path)
 
     async def scenario() -> None:
         from mcp import Client
@@ -45,13 +46,14 @@ def test_managed_server_advertises_immutable_deployment_identity(
                 mode="json"
             )
 
-    asyncio.run(scenario())
+    with open_focused_mcp_server(tmp_path) as server:
+        asyncio.run(scenario())
 
 
 def test_mcp_exposes_only_math_tools_with_read_only_resources(
     tmp_path: Path,
 ) -> None:
-    server = create_server(tmp_path)
+    server = create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE)
     assert server.instructions is not None
     assert "local verification record URI" in server.instructions
 

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from jacobian.adapters.mcp.server import create_server
 from jacobian.capability_service import CapabilityPolicy
+from jacobian.runtime import CheckerAuthorityMode
 
 
 def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
@@ -18,7 +19,11 @@ def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
 
         policy = CapabilityPolicy(profile="COMPUTE_VERIFY_NO_RETRIEVAL")
         async with Client(
-            create_server(tmp_path, capability_policy=policy),
+            create_server(
+                tmp_path,
+                checker_authority=CheckerAuthorityMode.NONE,
+                capability_policy=policy,
+            ),
             raise_exceptions=True,
         ) as client:
             resource = await client.read_resource("capability://catalog")
@@ -39,7 +44,10 @@ def test_mcp_compact_capability_index_is_searchable_and_paginated(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE),
+            raise_exceptions=True,
+        ) as client:
             resource_result = await client.read_resource("capability://catalog")
             full_catalog = json.loads(resource_result.contents[0].text)
             all_ids = {
@@ -203,7 +211,10 @@ def test_mcp_text_projection_preserves_produced_artifact_types(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE),
+            raise_exceptions=True,
+        ) as client:
             listed = await client.call_tool(
                 "math.find",
                 {"request": {"op": "search", "query": "poset", "limit": 20}},

--- a/tests/boundary/mcp/test_mcp_discovery_projection.py
+++ b/tests/boundary/mcp/test_mcp_discovery_projection.py
@@ -6,8 +6,11 @@ from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
-from jacobian.adapters.mcp.server import create_server
 from jacobian.contracts.capabilities import CapabilityDescriptor
+from jacobian.domains.matrix_lattice import build_matrix_bundle
+from jacobian.domains.polynomial import build_polynomial_bundle
+from jacobian.domains.probability import build_finite_probability_bundle
+from tests.boundary.mcp.mcp_support import open_focused_mcp_server
 
 
 def test_math_find_discovers_finite_expectation_by_natural_vocabulary(
@@ -16,18 +19,22 @@ def test_math_find_discovers_finite_expectation_by_natural_vocabulary(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            discovered = await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "search",
-                        "query": "expectation of a discrete random variable",
-                        "domain": "probability",
-                        "limit": 5,
-                    }
-                },
-            )
+        with open_focused_mcp_server(
+            tmp_path,
+            build_finite_probability_bundle(),
+        ) as server:
+            async with Client(server, raise_exceptions=True) as client:
+                discovered = await client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "search",
+                            "query": "expectation of a discrete random variable",
+                            "domain": "probability",
+                            "limit": 5,
+                        }
+                    },
+                )
 
         assert isinstance(discovered.structured_content, dict)
         assert "probability.finite_distribution.raw_moment.compute" in {
@@ -43,18 +50,19 @@ def test_math_find_search_returns_compact_lexical_and_availability_facts(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            result = await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "search",
-                        "query": "compute an exact matrix determinant",
-                        "domain": "matrix",
-                        "limit": 3,
-                    }
-                },
-            )
+        with open_focused_mcp_server(tmp_path, build_matrix_bundle()) as server:
+            async with Client(server, raise_exceptions=True) as client:
+                result = await client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "search",
+                            "query": "compute an exact matrix determinant",
+                            "domain": "matrix",
+                            "limit": 3,
+                        }
+                    },
+                )
 
         assert isinstance(result.structured_content, dict)
         match = next(
@@ -85,16 +93,17 @@ def test_math_find_exact_inspection_returns_one_authoritative_descriptor(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            result = await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "inspect",
-                        "capability_id": "polynomial.expression.normalize",
-                    }
-                },
-            )
+        with open_focused_mcp_server(tmp_path, build_polynomial_bundle()) as server:
+            async with Client(server, raise_exceptions=True) as client:
+                result = await client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "inspect",
+                            "capability_id": "polynomial.compute.gcd",
+                        }
+                    },
+                )
 
         assert isinstance(result.structured_content, dict)
         structured = result.structured_content
@@ -103,7 +112,7 @@ def test_math_find_exact_inspection_returns_one_authoritative_descriptor(
             "capability",
         }
         descriptor = CapabilityDescriptor.model_validate(structured["capability"])
-        assert descriptor.capability_id == "polynomial.expression.normalize"
+        assert descriptor.capability_id == "polynomial.compute.gcd"
         assert descriptor.invocation_examples
         payload = descriptor.invocation_examples[0].input
         validator = Draft202012Validator(descriptor.input_schema)

--- a/tests/boundary/mcp/test_mcp_errors_and_tracing.py
+++ b/tests/boundary/mcp/test_mcp_errors_and_tracing.py
@@ -12,6 +12,9 @@ import pytest
 from jacobian.adapters.mcp.context import _public_tool_error
 from jacobian.adapters.mcp.remote import create_remote_server
 from jacobian.adapters.mcp.server import create_server
+from jacobian.domains.number_theory import build_number_theory_bundle
+from jacobian.runtime import CheckerAuthorityMode
+from tests.boundary.mcp.mcp_support import open_focused_mcp_server
 
 
 def test_mcp_logs_bounded_tool_metrics_without_arguments(
@@ -24,25 +27,29 @@ def test_mcp_logs_bounded_tool_metrics_without_arguments(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "search",
-                        "query": "private-query-marker",
-                    }
-                },
-            )
-            failed = await client.call_tool(
-                "math.run",
-                {
-                    "capability_id": "missing.capability",
-                    "payload": {"private": "private-payload-marker"},
-                },
-            )
-            response = json.loads(failed.content[0].text)
-            assert response["execution"]["status"] == "ERROR"
+        with open_focused_mcp_server(
+            tmp_path,
+            build_number_theory_bundle(),
+        ) as server:
+            async with Client(server, raise_exceptions=True) as client:
+                await client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "search",
+                            "query": "private-query-marker",
+                        }
+                    },
+                )
+                failed = await client.call_tool(
+                    "math.run",
+                    {
+                        "capability_id": "missing.capability",
+                        "payload": {"private": "private-payload-marker"},
+                    },
+                )
+                response = json.loads(failed.content[0].text)
+                assert response["execution"]["status"] == "ERROR"
 
     asyncio.run(scenario())
 
@@ -85,28 +92,29 @@ def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=False) as client:
-            unknown_capability = await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "inspect",
-                        "capability_id": "missing.capability",
-                    }
-                },
-            )
-            response = json.loads(unknown_capability.content[0].text)
-            assert response["error"]["code"] == "UNKNOWN_CAPABILITY"
-            assert "search installed capabilities" in response["error"]["hint"]
-            assert "available_capability_ids" not in response["error"]
-            assert isinstance(unknown_capability.structured_content, dict)
-            error = unknown_capability.structured_content["error"]
-            assert len(error["nearby_capability_ids"]) <= 5
-            assert error["available_recovery_paths"][-1] == {
-                "action": "inspect_catalog",
-                "resource_uri": "capability://catalog",
-            }
-            assert len(json.dumps(error).encode("utf-8")) < 2_048
+        with open_focused_mcp_server(tmp_path) as server:
+            async with Client(server, raise_exceptions=False) as client:
+                unknown_capability = await client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "inspect",
+                            "capability_id": "missing.capability",
+                        }
+                    },
+                )
+                response = json.loads(unknown_capability.content[0].text)
+                assert response["error"]["code"] == "UNKNOWN_CAPABILITY"
+                assert "search installed capabilities" in response["error"]["hint"]
+                assert "available_capability_ids" not in response["error"]
+                assert isinstance(unknown_capability.structured_content, dict)
+                error = unknown_capability.structured_content["error"]
+                assert len(error["nearby_capability_ids"]) <= 5
+                assert error["available_recovery_paths"][-1] == {
+                    "action": "inspect_catalog",
+                    "resource_uri": "capability://catalog",
+                }
+                assert len(json.dumps(error).encode("utf-8")) < 2_048
 
     asyncio.run(scenario())
 
@@ -117,7 +125,7 @@ def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None
 def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) -> None:
     from mcp.shared.exceptions import MCPError
 
-    server = create_server(tmp_path)
+    server = create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE)
 
     @server.tool(name="fixture.protocol-error")
     async def protocol_error() -> None:
@@ -149,21 +157,20 @@ def test_direct_tool_calls_reject_removed_and_malformed_arguments(
     from mcp.server.mcpserver.exceptions import ToolError
 
     async def scenario() -> None:
-        server = create_server(tmp_path)
+        with open_focused_mcp_server(tmp_path) as server:
+            with pytest.raises(ToolError):
+                await server.call_tool("workspace.write", {})
 
-        with pytest.raises(ToolError):
-            await server.call_tool("workspace.write", {})
-
-        with pytest.raises(ToolError):
-            await server.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "search",
-                        "query": "matrix",
-                        "limit": "not-an-integer",
-                    }
-                },
-            )
+            with pytest.raises(ToolError):
+                await server.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "search",
+                            "query": "matrix",
+                            "limit": "not-an-integer",
+                        }
+                    },
+                )
 
     asyncio.run(scenario())

--- a/tests/boundary/mcp/test_mcp_invocation_journey.py
+++ b/tests/boundary/mcp/test_mcp_invocation_journey.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from jacobian.adapters.mcp.server import create_server
+from jacobian.runtime import CheckerAuthorityMode
 
 MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
@@ -167,7 +168,10 @@ def test_mcp_composes_finite_field_values_by_opaque_reference(tmp_path: Path) ->
             finite_polynomial(presentation, (zero, zero, zero, one))
         )
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE),
+            raise_exceptions=True,
+        ) as client:
             inspected = await client.call_tool(
                 "math.find",
                 {

--- a/tests/boundary/mcp/test_mcp_resource_links.py
+++ b/tests/boundary/mcp/test_mcp_resource_links.py
@@ -5,6 +5,9 @@ import json
 from pathlib import Path
 
 from jacobian.adapters.mcp.server import create_server
+from jacobian.domains.number_theory import build_number_theory_bundle
+from jacobian.runtime import CheckerAuthorityMode
+from tests.boundary.mcp.mcp_support import open_focused_mcp_server
 
 MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
@@ -16,19 +19,23 @@ def test_mcp_inline_results_do_not_emit_resource_links(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
-            result = await client.call_tool(
-                "math.run",
-                {
-                    "capability_id": "integer.compute.gcd",
-                    "payload": {"left": "84", "right": "30"},
-                },
-            )
-            assert isinstance(result.structured_content, dict)
-            assert result.structured_content["artifact_uris"] == []
-            assert [
-                block for block in result.content if block.type == "resource_link"
-            ] == []
+        with open_focused_mcp_server(
+            tmp_path,
+            build_number_theory_bundle(),
+        ) as server:
+            async with Client(server, raise_exceptions=True) as client:
+                result = await client.call_tool(
+                    "math.run",
+                    {
+                        "capability_id": "integer.compute.gcd",
+                        "payload": {"left": "84", "right": "30"},
+                    },
+                )
+                assert isinstance(result.structured_content, dict)
+                assert result.structured_content["artifact_uris"] == []
+                assert [
+                    block for block in result.content if block.type == "resource_link"
+                ] == []
 
     asyncio.run(scenario())
 
@@ -39,7 +46,10 @@ def test_mcp_materialized_results_emit_readable_native_resource_links(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(
+            create_server(tmp_path, checker_authority=CheckerAuthorityMode.NONE),
+            raise_exceptions=True,
+        ) as client:
             result = await client.call_tool(
                 "math.run",
                 {

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -15,6 +15,7 @@ from jacobian.adapters.mcp.context import AppState
 from jacobian.adapters.mcp.server import JacobianCoreExtension, create_server
 from jacobian.adapters.mcp.tooling import MCPBlockingWorkerRegistry
 from jacobian.contracts.capabilities import CapabilityResult
+from jacobian.runtime import CheckerAuthorityMode
 
 
 def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
@@ -47,7 +48,10 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
         from mcp import Client
         from mcp.shared.exceptions import MCPError
 
-        server = create_server(tmp_path)
+        server = create_server(
+            tmp_path,
+            checker_authority=CheckerAuthorityMode.NONE,
+        )
         assert not hasattr(server_module, "Context")
         async with Client(server, raise_exceptions=True) as client:
             listed = await client.list_tools()

--- a/tests/boundary/mcp/test_mcp_tool_surface.py
+++ b/tests/boundary/mcp/test_mcp_tool_surface.py
@@ -3,17 +3,14 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from jacobian.adapters.mcp.server import create_server
+from jacobian.domains.number_theory import build_number_theory_bundle
+from tests.boundary.mcp.mcp_support import open_focused_mcp_server
 
 MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
 
 
 def test_math_tool_surface_is_consistent_across_discovery(tmp_path: Path) -> None:
-    server = create_server(tmp_path)
-    assert server.instructions is not None
-    assert "math.find" in server.instructions
-
     async def scenario() -> None:
         from mcp import Client
 
@@ -52,4 +49,10 @@ def test_math_tool_surface_is_consistent_across_discovery(tmp_path: Path) -> Non
                 "capability://catalog"
             )
 
-    asyncio.run(scenario())
+    with open_focused_mcp_server(
+        tmp_path,
+        build_number_theory_bundle(),
+    ) as server:
+        assert server.instructions is not None
+        assert "math.find" in server.instructions
+        asyncio.run(scenario())


### PR DESCRIPTION
Closes #1359.

## Problem

MCP metadata, schema, discovery, error, and resource-link tests repeatedly entered through the broad public deployment bootstrap. Omitting checker authority selected `INSTALL_BUNDLED`, so ordinary protocol assertions first constructed and authorized the complete mathematical portfolio.

The issue's hosted baseline was 47 tests in 562.84 seconds. A local measurement on this base showed default server construction at 19.00 seconds versus 5.94 seconds for the same complete producer catalog with explicit `CheckerAuthorityMode.NONE`.

## Solution

Add a production-owned `create_server_from_runtime` constructor. The existing public `create_server` still owns default runtime construction and delegates to this constructor, so focused and default paths register the same `JacobianMCPServer`, extension, resources, lifespan, worker registry, schemas, and SDK dispatch.

MCP boundary support can now compose that real server over explicit production `DomainBundle` inputs. Tests use the smallest semantic owner that satisfies their contract—for example number theory for GCD, matrix for determinant discovery, probability for finite expectation, and polynomial for descriptor validation. Tests that genuinely inspect the complete producer catalog keep `create_server` but choose `CheckerAuthorityMode.NONE` explicitly.

Broad default-authority construction remains where it is the asserted boundary: the complete in-process invocation journey, stdio entrypoint, authenticated HTTP host, and tenant-runtime lifecycle. The finite-field composition journey retains the complete producer portfolio but does not authorize unrelated checkers.

## Testing

- `make test-mcp` — 47 passed in 66.34 seconds on the final tree, down from the issue's 562.84-second hosted baseline. No test nodes were removed or skipped.
- Focused tool-surface and discovery projection — 4 passed in 2.89 seconds.
- Focused adapter, error, and resource-link cases — 8 passed in 9.08 seconds.
- `make check` — lint, formatting, complexity, and mypy passed; 832 unit, 901 component, 472 domain, 154 composition, 3 end-to-end, and 64 provider-boundary tests passed. Three Lean-dependent tests skipped because the pinned runtime is unavailable.

- Specialist validation run: complete MCP boundary lane through `make test-mcp`.

## Trust & Compatibility Impact

The default deployment behavior, checker authority default, MCP tools, schemas, resources, authentication, persistence, and public mathematical APIs are unchanged. Runtime lifecycle ownership is explicit: public bootstrap passes `runtime.close`; focused tests retain ownership in their outer service context and pass a no-op MCP close action, while the MCP lifespan still owns and closes its blocking-worker registry.

Verification and default-bootstrap coverage are not weakened. Real checker journeys remain in the end-to-end suite, and broad MCP transport/default-runtime smokes remain in the MCP boundary lane.

## Architecture Budget

No mathematical operation is added. `create_server_from_runtime` is the deliberate production composition seam used by both the default server path and focused explicit-runtime paths; it replaces direct reliance on the former private registration helper without introducing a service locator or test-only server.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier validation (not applicable)
- [x] New ordinary operation budget (not applicable)
- [x] Shared abstraction serves default bootstrap and focused runtime composition
