### PR TITLE
refactor(ci): bound Harbor contract checks to their owning test lanes

### DIFF
--- a/.agents/skills/harbor-benchmarks/SKILL.md
+++ b/.agents/skills/harbor-benchmarks/SKILL.md
@@ -176,9 +176,14 @@ serially and reports timings, digests, and evidence paths.
 
 Both commands require an explicit task selection. The lower-level
 `harbor-sync`, `harbor-check-task`, and `harbor-oracle-task` targets remain
-available for a narrow edit loop. Use the full `make harbor-check` and explicitly
-scoped `make harbor-oracle` paths for shared tooling, schemas, registry, suite
-policy, or other control-plane changes. A full dataset Oracle requires `FULL=1`;
+available for a narrow edit loop. Use `make harbor-check` for shared static
+contracts, execution configuration, adapters, schemas, registry, suite policy,
+or other control-plane changes. Run `make harbor-plan BASE=...` to identify the
+focused executable host regressions owned by the changed paths. Reserve
+`make harbor-check-all` for changes to the shared verifier execution harness or
+an explicitly requested local portfolio-wide reproduction; ordinary
+control-plane changes must not pay for every task verifier merely because they
+live under `benchmarks/tooling`. A full dataset Oracle requires `FULL=1`;
 ordinary Oracle runs require `TASKS` and never expand an omitted selection
 implicitly.
 
@@ -210,7 +215,8 @@ contract change:
    secrets, host paths, raw caches, and floating dependencies.
 
 For a cross-cutting reward or diagnostic migration, run the complete generic
-verifier matrix in addition to selected task leaves and Oracles. Leaf tests can
+verifier matrix with `make harbor-check-all` in addition to selected task leaves
+and Oracles. Leaf tests can
 miss a task-local exception or a metadata-driven contract regression; the
 generic matrix should cover replaced and malformed visible input, malformed
 and wrong-shaped submissions, unhashable assurance values, false assurance,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,11 +134,11 @@ once, fails fast through static quality and contracts, runs the selected host
 tests serially, then runs each exact Oracle serially. Neither command starts an
 Oracle or model.
 
-`make harbor-execution-check` validates repository-wide Harbor contracts (job
-JSON, MCP config, job-level Compose overlays, execution helpers) and the unit
-tests that own them; it deliberately excludes the task-specific verifier
-regressions under `benchmarks/validation/`, where `make harbor-check` retains
-the full integration role. Task `environment/docker-compose.yaml` files are
+`make harbor-check` validates repository-wide Harbor contracts (job JSON, MCP
+config, job-level Compose overlays, adapters, and execution helpers) and the
+unit tests that own them; it deliberately excludes unrelated task-specific
+verifier regressions. `make harbor-check-all` is the explicit full integration
+reproduction. Task `environment/docker-compose.yaml` files are
 executable benchmark input, not job overlays, and remain gated by
 `make harbor-check-task` and `make harbor-oracle-task`. Use
 `make harbor-plan BASE=origin/main` for benchmark contracts and Oracle scope;

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -73,6 +73,7 @@ make benchmark-snapshot-validate LOCK=benchmarks/snapshots/mathematical-benchmar
 make benchmark-publish LOCK=benchmarks/snapshots/mathematical-benchmarks-v1/<digest>.lock.json
 make harbor-oracle-task DATASET=mathematical-benchmarks-v1 TASKS="task-id"
 make harbor-check
+make harbor-check-all  # explicit full host-verifier reproduction
 make harbor-oracle DATASET=mathematical-benchmarks-v1 FULL=1
 make harbor-oracle-all
 make provider-eval PROVIDER=cgal

--- a/benchmarks/tooling/benchmark_contracts.py
+++ b/benchmarks/tooling/benchmark_contracts.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import tomllib
-from functools import lru_cache
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +28,32 @@ from benchmarks.tooling.strict_boundaries import (
 
 SCHEMAS = BENCHMARKS / "schemas"
 SNAPSHOTS = BENCHMARKS / "snapshots"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkContractInventory:
+    """Deterministic repository-owned inputs outside suite membership."""
+
+    schemas: tuple[Path, ...]
+    proxy_jobs: tuple[Path, ...]
+    snapshot_locks: tuple[Path, ...]
+
+
+def benchmark_contract_inventory() -> BenchmarkContractInventory:
+    """Discover the fixed repository contracts used by the aggregate gate."""
+
+    return BenchmarkContractInventory(
+        schemas=tuple(sorted(SCHEMAS.glob("*.schema.json"))),
+        proxy_jobs=(
+            BENCHMARKS / "config" / "mathematical-benchmarks-v1-control-proxy.json",
+            BENCHMARKS
+            / "datasets"
+            / "mathematical-benchmarks-v1"
+            / "jobs"
+            / "jacobian-observation-proxy.json",
+        ),
+        snapshot_locks=tuple(sorted(SNAPSHOTS.rglob("*.lock.json"))),
+    )
 
 
 def _read_json(path: Path) -> Any:
@@ -137,8 +165,14 @@ def _task_selection_failures(
     return failures
 
 
-def _validate_job(path: Path, suite: Suite | None = None) -> list[str]:
-    raw = _read_json(path)
+def validate_job_contract(
+    raw: object,
+    *,
+    path: Path,
+    suite: Suite | None = None,
+) -> list[str]:
+    """Validate one parsed Harbor job through the aggregate gate's contract."""
+
     failures = _validate(raw, "harbor-job.schema.json", path)
     if not isinstance(raw, dict):
         return failures
@@ -168,6 +202,10 @@ def _validate_job(path: Path, suite: Suite | None = None) -> list[str]:
         _task_selection_failures(raw.get("tasks", []), path=path, suite=suite)
     )
     return failures
+
+
+def _validate_job(path: Path, suite: Suite | None = None) -> list[str]:
+    return validate_job_contract(_read_json(path), path=path, suite=suite)
 
 
 def _validate_task(suite: Suite, task_dir: Path) -> list[str]:
@@ -291,9 +329,9 @@ def _suite_contract_failures(suites: tuple[Suite, ...]) -> list[str]:
     return failures
 
 
-def _snapshot_contract_failures() -> list[str]:
+def _snapshot_contract_failures(lock_paths: Iterable[Path]) -> list[str]:
     failures: list[str] = []
-    for lock_path in sorted(SNAPSHOTS.rglob("*.lock.json")):
+    for lock_path in lock_paths:
         try:
             lock = validate_lock(lock_path)
         except HarborSuiteError as exc:
@@ -311,9 +349,18 @@ def _snapshot_contract_failures() -> list[str]:
     return failures
 
 
+def collect_contract_failures(
+    validators: Iterable[Callable[[], list[str]]],
+) -> list[str]:
+    """Run every aggregate contract phase and retain deterministic failure order."""
+
+    return [failure for validate in validators for failure in validate()]
+
+
 def validate_all() -> list[str]:
     """Return every benchmark contract failure without stopping at the first."""
-    for schema_path in sorted(SCHEMAS.glob("*.schema.json")):
+    inventory = benchmark_contract_inventory()
+    for schema_path in inventory.schemas:
         _validator(schema_path.name)
     failures = _validate(
         _read_toml(BENCHMARKS / "registry.toml"),
@@ -328,24 +375,19 @@ def validate_all() -> list[str]:
         )
     )
     failures.extend(
-        _validate_job(
-            BENCHMARKS / "config" / "mathematical-benchmarks-v1-control-proxy.json",
-            suites[0],
-        )
-    )
-    failures.extend(
-        _validate_job(
-            BENCHMARKS
-            / "datasets"
-            / "mathematical-benchmarks-v1"
-            / "jobs"
-            / "jacobian-observation-proxy.json",
-            suites[0],
+        collect_contract_failures(
+            partial(_validate_job, path, suites[0]) for path in inventory.proxy_jobs
         )
     )
     failures.extend(_observation_pair_failures())
-    failures.extend(_snapshot_contract_failures())
+    failures.extend(_snapshot_contract_failures(inventory.snapshot_locks))
     return failures
 
 
-__all__ = ["validate_all"]
+__all__ = [
+    "BenchmarkContractInventory",
+    "benchmark_contract_inventory",
+    "collect_contract_failures",
+    "validate_all",
+    "validate_job_contract",
+]

--- a/benchmarks/tooling/validation_plan.py
+++ b/benchmarks/tooling/validation_plan.py
@@ -63,6 +63,9 @@ CONTROL_PLANE_HOST_TESTS = {
     "benchmarks/tooling/benchmark_validation.py": (
         "benchmarks/validation/test_benchmark_validation.py",
     ),
+    "benchmarks/tooling/benchmark_contracts.py": (
+        "benchmarks/validation/test_benchmark_contracts.py",
+    ),
     "benchmarks/tooling/host_validation.py": (
         "benchmarks/validation/test_host_validation.py",
     ),

--- a/benchmarks/validation/test_benchmark_planner.py
+++ b/benchmarks/validation/test_benchmark_planner.py
@@ -470,6 +470,23 @@ def test_shared_verifier_harness_states_full_suite_reason() -> None:
     _assert_plan_valid(result)
 
 
+def test_benchmark_contract_tool_selects_its_owned_host_contract() -> None:
+    path = "benchmarks/tooling/benchmark_contracts.py"
+
+    result = planner.plan([path], event="pull_request")
+
+    assert _host_matrix(result) == [
+        {
+            "name": "control-test_benchmark_contracts",
+            "selector": "benchmarks/validation/test_benchmark_contracts.py",
+            "keyword": "",
+            "splits": 0,
+            "group": 0,
+        }
+    ]
+    _assert_plan_valid(result)
+
+
 def test_membership_change_defers_dataset_oracle_until_merge_queue() -> None:
     result = planner.plan(
         ["benchmarks/datasets/mathematical-benchmarks-v1/members/new-task.toml"],

--- a/docs/how-to/author-harbor-benchmark-task.md
+++ b/docs/how-to/author-harbor-benchmark-task.md
@@ -40,8 +40,10 @@ make harbor-oracle-task DATASET=<dataset-id> TASKS="<task-id>"
 
 The focused gate requires an explicit dataset and one or more task IDs; it does
 not silently expand to the full corpus. Use `make harbor-check` for changes to
-shared Harbor tooling, schemas, the registry, suite policy, or other
-control-plane files. For `mathematical-benchmarks-v1` pytest regressions, put verifier
+shared Harbor contracts, schemas, the registry, suite policy, or other
+control-plane files. Reserve `make harbor-check-all` for shared verifier-harness
+changes or an intentional full local reproduction. For
+`mathematical-benchmarks-v1` pytest regressions, put verifier
 attack cases in
 `benchmarks/validation/mathematical_benchmarks_v1/test_<task_id_with_underscores>.py`
 rather than a shared dump; see the Harbor skill's validation regression layout

--- a/docs/how-to/run-agent-evaluations.md
+++ b/docs/how-to/run-agent-evaluations.md
@@ -36,9 +36,10 @@ make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="graph-counterex
 make harbor-oracle-task DATASET=mathematical-benchmarks-v1 TASKS="graph-counterexample"
 ```
 
-Use the full `make harbor-check` and explicitly scoped `make harbor-oracle`
-paths only for shared Harbor tooling, schemas, registry, suite policy, or
-other control-plane changes. Pass `TASKS="..."` for a bounded dataset Oracle;
+Use `make harbor-check` and explicitly scoped `make harbor-oracle` paths for
+shared Harbor contracts, schemas, registry, suite policy, or other control-plane
+changes. Use `make harbor-check-all` only for shared verifier-harness changes or
+an intentional portfolio-wide reproduction. Pass `TASKS="..."` for a bounded dataset Oracle;
 pass `FULL=1` only when a complete dataset sweep is intentional.
 
 Oracle attempts are serialized on a shared Docker host and receive a unique

--- a/docs/reference/evaluations/benchmark-contracts.md
+++ b/docs/reference/evaluations/benchmark-contracts.md
@@ -86,12 +86,14 @@ make harbor-oracle-task DATASET=<dataset-id> TASKS="<task-id>"
 ```
 
 The focused commands require explicit task IDs and do not fall back to all
-tasks. The full repository gate remains the appropriate check for
-`registry.toml`, suite headers and policy, shared tooling, schemas, global
-task-ID uniqueness, or other control-plane changes:
+tasks. The repository control-plane gate checks `registry.toml`, suite headers
+and policy, shared contracts, schemas, global task-ID uniqueness, adapters, and
+execution configuration. Add the explicit full-host gate only when the shared
+verifier harness changes or a portfolio-wide reproduction is intended:
 
 ```sh
 make harbor-check
+make harbor-check-all
 make benchmark-inventory OUTPUT=/tmp/benchmark-inventory.json
 make harbor-oracle DATASET=mathematical-benchmarks-v1 FULL=1
 ```

--- a/make/harbor.mk
+++ b/make/harbor.mk
@@ -34,7 +34,7 @@ case "$$docker_build_mode" in \
 esac;
 endef
 
-.PHONY: harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke
+.PHONY: harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-all harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke
 
 harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 	@set -eu; \
@@ -130,9 +130,11 @@ harbor-host-validation: ## Run the full host suite in timing-balanced local shar
 	$(UV_RUN) python -m benchmarks.tooling.host_validation run-full \
 		--total-workers $(HARBOR_VALIDATION_TOTAL_WORKERS) --max-parallel 4
 
-harbor-validate: harbor-contracts harbor-adapter-checks harbor-host-validation ## Run all repository-owned Harbor checks under the pinned Harbor runtime.
+harbor-check: harbor-execution-check harbor-adapter-checks ## Check Harbor contracts and control-plane behavior.
 
-harbor-check: harbor-validate ## Run Harbor topology, digest, provenance, and host-side validation checks.
+harbor-check-all: harbor-check harbor-host-validation ## Explicitly run every repository-owned Harbor host regression.
+
+harbor-validate: harbor-check-all ## Backward-compatible exhaustive Harbor validation alias.
 
 harbor-check-task: ## Validate selected Harbor leaf tasks (DATASET=..., TASKS="task-a task-b").
 	@test -n "$(DATASET)" || { echo "DATASET is required" >&2; exit 2; }
@@ -230,7 +232,7 @@ harbor-oracle-run: ## Run a dataset Oracle after an already-successful contract 
 		--result "benchmarks/results/$(DATASET)-oracle/$$job_name/result.json" \
 		$(if $(TASKS),--tasks $(TASKS),)
 
-harbor-oracle-all: harbor-check ## Run every registered dataset Oracle with tasks.
+harbor-oracle-all: harbor-check-all ## Run every registered dataset Oracle with tasks.
 	@set -e; for dataset in mathematical-benchmarks-v1 symbolic-coordination-v1 public-reproductions-v1 conjecture-probes-v1 research-diagnostics-v1 provider-feasibility-v1; do \
 		$(MAKE) --no-print-directory harbor-oracle-run DATASET=$$dataset FULL=1 EVAL_ARGS="$(EVAL_ARGS)"; \
 	done

--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 
-import pytest
-from benchmarks.tooling.benchmark_contracts import validate_all
+from benchmarks.tooling.benchmark_contracts import (
+    benchmark_contract_inventory,
+    collect_contract_failures,
+    validate_job_contract,
+)
+from benchmarks.tooling.harbor_suite import load_registry
 
 ROOT = Path(__file__).parents[3]
 
@@ -44,46 +49,63 @@ def test_observation_job_uses_harbor_dataset_selection() -> None:
     ]
 
 
-@pytest.mark.timeout(30)
-def test_validate_all_covers_proxy_control_and_observation_jobs() -> None:
+def test_benchmark_inventory_covers_proxy_control_and_observation_jobs() -> None:
     """The execution-config gate must validate proxied job configs, not skip them.
 
-    ``validate_all`` is the contract layer beneath ``make harbor-contracts``,
-    which is the first step of ``make harbor-execution-check``.  A malformed
-    proxied control or observation job must be caught here rather than only
-    failing when an operator runs the proxied evaluation.
+    The inventory is consumed by ``validate_all``, the contract layer beneath
+    ``make harbor-contracts``. A missing proxy entry would therefore remove it
+    from the repository gate.
     """
-    failures = validate_all()
+    inventory = benchmark_contract_inventory()
 
-    # The committed proxy jobs are valid, so there must be no failures.
-    assert failures == [], "benchmark contract failures:\n" + "\n".join(failures)
+    assert tuple(path.name for path in inventory.proxy_jobs) == (
+        "mathematical-benchmarks-v1-control-proxy.json",
+        "jacobian-observation-proxy.json",
+    )
 
 
-@pytest.mark.timeout(30)
-def test_validate_all_catches_a_malformed_proxy_control_job(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_job_contract_rejects_a_malformed_proxy_control_job() -> None:
     """A malformed proxied control job must not pass the execution-config gate."""
-    from benchmarks.tooling import benchmark_contracts
+    path = benchmark_contract_inventory().proxy_jobs[0]
+    malformed = _read_json(path)
+    malformed["artifacts"] = ["logs/agent/trajectory.json"]
 
-    original_read_json = benchmark_contracts._read_json
-
-    def patched_read_json(path: Path) -> object:
-        if path.name == "mathematical-benchmarks-v1-control-proxy.json":
-            malformed = original_read_json(path)
-            assert isinstance(malformed, dict)
-            malformed["artifacts"] = ["logs/agent/trajectory.json"]
-            return malformed
-        return original_read_json(path)
-
-    monkeypatch.setattr(benchmark_contracts, "_read_json", patched_read_json)
-
-    failures = validate_all()
+    failures = validate_job_contract(
+        malformed,
+        path=path,
+        suite=load_registry()[0],
+    )
 
     assert any("control-proxy" in f and "artifacts" in f for f in failures), (
         f"expected a contract failure for the malformed proxy control job, "
         f"got: {failures}"
     )
+
+
+def test_contract_failure_collection_runs_every_phase_in_order() -> None:
+    calls: list[str] = []
+
+    def phase(name: str, *failures: str) -> Callable[[], list[str]]:
+        def validate() -> list[str]:
+            calls.append(name)
+            return list(failures)
+
+        return validate
+
+    failures = collect_contract_failures(
+        (
+            phase("schemas", "schema failure"),
+            phase("proxy jobs"),
+            phase("snapshots", "snapshot failure 1", "snapshot failure 2"),
+        )
+    )
+
+    assert calls == ["schemas", "proxy jobs", "snapshots"]
+    assert failures == [
+        "schema failure",
+        "snapshot failure 1",
+        "snapshot failure 2",
+    ]
 
 
 def test_paired_jobs_use_three_attempts_per_condition() -> None:


### PR DESCRIPTION
Fixes #1367.

## Problem

Targeted tests for Harbor job contracts called the complete benchmark contract gate, so two unit assertions repeatedly scanned every schema, suite, task, job, observation pair, and snapshot. The local `make harbor-check` command also bundled those control-plane checks with every executable host-verifier regression, making routine benchmark tooling closeout unexpectedly expensive.

The benchmark planner compounded this by treating `benchmark_contracts.py` as unknown shared verifier tooling and escalating it to four shards that each collected the complete roughly 900-test host inventory.

## Solution

Expose production-owned contract inventory and leaf job validation while keeping `validate_all()` as the complete deterministic contract gate. Focused tests now exercise malformed job behavior through the same validator without rediscovering the entire portfolio, and an orchestration test proves that the aggregate gate still runs every phase and accumulates failures in order.

Split the developer commands by evidence role:

- `make harbor-check` validates contracts, adapters, execution configuration, and their owning unit tests.
- `make harbor-check-all` explicitly adds every host-verifier regression.
- `make harbor-validate` remains a compatibility alias for the exhaustive gate.

The benchmark planner now maps changes to `benchmark_contracts.py` to `test_benchmark_contracts.py` rather than the four full-host shards. Contributor docs and the repository Harbor skill describe the same ownership rule.

## Testing

- `uv run pytest -n 0 benchmarks/validation/test_benchmark_planner.py::test_benchmark_contract_tool_selects_its_owned_host_contract tests/unit/tooling/test_harbor_jobs.py --durations=10` — 7 passed in 0.49s
- `time make harbor-check` — 62 tests passed; complete command finished in 8.22s
- `make harbor-plan PATHS="benchmarks/tooling/benchmark_contracts.py tests/unit/tooling/test_harbor_jobs.py"` — selected one focused host-validation entry
- `make check` — 833 unit, 901 component, 472 domain, 156 composition, 3 end-to-end, and 66 provider-boundary tests passed; 3 expected Lean skips

## Trust & Compatibility Impact

No verification, persistence, authorization, artifact, or public API contract changes. The complete Harbor host gate remains available under the explicit `harbor-check-all` target and the backward-compatible `harbor-validate` alias.

## Architecture Budget

No operation or shared production abstraction is introduced.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task/verifier preparation is not applicable; no task bundle or verifier changed
- [x] Operation budget is not applicable
- [x] Shared abstraction budget is not applicable