### PR TITLE
test(process): limit subprocess coverage to the checker-worker contract lane

### DIFF
--- a/.coveragerc-subprocess
+++ b/.coveragerc-subprocess
@@ -1,0 +1,11 @@
+[run]
+branch = true
+parallel = true
+patch = subprocess
+source =
+    jacobian
+
+[report]
+fail_under = 50
+show_missing = true
+skip_covered = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,24 @@ jobs:
           path: .coverage.${{ matrix.lane }}
           include-hidden-files: true
 
+  subprocess_coverage:
+    name: checker subprocess coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - run: make test-checker-subprocess-coverage
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-data-checker-subprocess
+          path: .coverage.checker-subprocess
+          include-hidden-files: true
+
   wheel:
     name: wheel (Python ${{ matrix.python-version }})
     needs: [static]
@@ -198,7 +216,7 @@ jobs:
   coverage:
     name: Coverage
     if: ${{ always() && !cancelled() }}
-    needs: [python, boundaries]
+    needs: [python, boundaries, subprocess_coverage]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -209,9 +227,11 @@ jobs:
         env:
           PYTHON_RESULT: ${{ needs.python.result }}
           BOUNDARIES_RESULT: ${{ needs.boundaries.result }}
+          SUBPROCESS_COVERAGE_RESULT: ${{ needs.subprocess_coverage.result }}
         run: |
           test "$PYTHON_RESULT" = success
           test "$BOUNDARIES_RESULT" = success
+          test "$SUBPROCESS_COVERAGE_RESULT" = success
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ reproducing an environment-specific failure. The
 [testing strategy](docs/reference/testing-strategy.md) is the authoritative
 source for the change matrix, directory ownership, and the escalation rules.
 
+Coverage follows the same ownership rule. Ordinary lanes collect parent-process
+branch coverage without instrumenting every checker child. Changes to checker
+worker startup or coverage transport additionally run
+`make test-checker-subprocess-coverage`, the small lane that explicitly enables
+and verifies child-process coverage collection.
+
 ### When the quick path is not enough
 
 - **Documentation only:** `make docs-linkcheck` is the dedicated lane; CI runs

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,13 @@ test-compatibility: ## Supported-version import/API compatibility smoke.
 		tests/unit/tooling/test_ci_compatibility.py \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
+test-checker-subprocess-coverage: ## Prove focused checker-worker child coverage collection.
+	COVERAGE_FILE=.coverage.checker-subprocess $(UV_RUN) pytest -n 0 --timeout=30 \
+		tests/unit/test_checker_worker_manifest.py \
+		--cov --cov-config=.coveragerc-subprocess --cov-report= --cov-fail-under=0
+	COVERAGE_FILE=.coverage.checker-subprocess $(UV_RUN) coverage report \
+		--include=src/jacobian/checker_worker.py --fail-under=1
+
 test-all-ci: ## Explicitly run every semantic lane locally (exceptional).
 	$(MAKE) test-unit
 	$(MAKE) test-component

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -78,6 +78,7 @@ make test-provider
 make test-lean
 make test-e2e
 make test-exhaustive
+make test-checker-subprocess-coverage
 make quick
 make check
 make check-external
@@ -88,6 +89,16 @@ make check-static
 Before starting it, confirm that no other pytest job from this checkout is
 running. Concurrent runtime/store/subprocess suites can turn per-test
 timeouts into host-contention noise.
+
+Ordinary CI coverage instruments each pytest process but does not automatically
+instrument every child it launches. Independent checker calls therefore retain
+their real fresh-process behavior without each short-lived worker producing a
+coverage database. `make test-checker-subprocess-coverage` is the focused
+coverage-transport contract: it enables coverage.py's subprocess patch in an
+isolated profile, exercises accepted, rejected, malformed, and undeclared-import
+worker outcomes, and fails unless child execution is present in the combined
+data. The required aggregate coverage job includes that focused database and
+retains the repository threshold.
 
 Broad finite reference sweeps that are valuable but disproportionate for pull
 requests use the `exhaustive` marker. The component lane excludes them, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,6 @@ forbidden_modules = ["jacobian.portfolio"]
 
 [tool.coverage.run]
 branch = true
-patch = ["subprocess"]
 source = ["jacobian", "jacobian_checkers"]
 
 [tool.coverage.report]

--- a/tests/unit/test_checker_worker_manifest.py
+++ b/tests/unit/test_checker_worker_manifest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 from jacobian.canonical import canonicalize_json, loads_strict_json
 from jacobian.checker_identity import build_checker_manifest
 from jacobian.process_policy import (
@@ -13,19 +15,79 @@ from jacobian.process_policy import (
 from jacobian.worker_environment import worker_environment
 
 
-def _run_checker_worker(manifest_json: str, tmp_path: Path):
+def _install_decision_checker(tmp_path: Path) -> str:
+    package = tmp_path / "decision_checker_fixture"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "checker.py").write_text(
+        "def run(request):\n"
+        "    accepted = request.get('accept') is True\n"
+        "    return {\n"
+        "        'accepted': accepted,\n"
+        "        'conclusion': 'TRUE' if accepted else 'UNKNOWN',\n"
+        "        'arithmetic': 'EXACT_INTEGER',\n"
+        "        'method': 'DIRECT_WITNESS',\n"
+        "        'coverage': 'NOT_APPLICABLE',\n"
+        "        'detail': 'fixture decision',\n"
+        "    }\n",
+        encoding="utf-8",
+    )
+    return "decision_checker_fixture.checker:run"
+
+
+def _run_checker_worker(
+    manifest_json: str, tmp_path: Path, request: object | None = None
+):
     return execute_process(
         ProcessRequest(
             executable=sys.executable,
             arguments=("-m", "jacobian.checker_worker", manifest_json),
-            environment=worker_environment(overrides={"PYTHONPATH": str(tmp_path)}),
+            environment=worker_environment(
+                extra_variables=("COVERAGE_FILE", "COVERAGE_PROCESS_CONFIG"),
+                overrides={"PYTHONPATH": str(tmp_path)},
+            ),
             cwd=str(tmp_path),
             timeout_seconds=10.0,
-            stdin_bytes=canonicalize_json({}),
+            stdin_bytes=canonicalize_json({} if request is None else request),
             stdout_limit_bytes=16_384,
             stderr_limit_bytes=16_384,
         ),
     )
+
+
+@pytest.mark.parametrize("accepted", [True, False])
+def test_worker_returns_manifest_bound_checker_decisions(
+    tmp_path: Path, accepted: bool
+) -> None:
+    entrypoint = _install_decision_checker(tmp_path)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        manifest = build_checker_manifest(
+            entrypoint,
+            provider_runtime=None,
+            passive_contract_uris=(),
+        )
+        completed = _run_checker_worker(
+            canonicalize_json(manifest.model_dump(mode="json")).decode("utf-8"),
+            tmp_path,
+            {"accept": accepted},
+        )
+    finally:
+        sys.path.remove(str(tmp_path))
+
+    assert completed.termination is ProcessTermination.EXITED
+    assert completed.returncode == 0
+    response = loads_strict_json(completed.stdout)
+    assert response["decision"]["accepted"] is accepted
+    assert response["decision"]["conclusion"] == ("TRUE" if accepted else "UNKNOWN")
+
+
+def test_worker_rejects_a_malformed_manifest(tmp_path: Path) -> None:
+    completed = _run_checker_worker("{}", tmp_path)
+
+    assert completed.termination is ProcessTermination.EXITED
+    assert completed.returncode == 1
+    assert loads_strict_json(completed.stdout) == {"error_code": "MALFORMED_RUNTIME"}
 
 
 def test_worker_rejects_dynamic_first_party_imports(tmp_path: Path) -> None:

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -258,6 +258,26 @@ def test_required_ci_gates_fail_closed_without_extending_cancelled_runs() -> Non
     assert "needs.lean.result" in required
 
 
+def test_subprocess_coverage_is_owned_by_one_focused_worker_lane() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    subprocess_config = (ROOT / ".coveragerc-subprocess").read_text(encoding="utf-8")
+    target = (
+        (ROOT / "Makefile")
+        .read_text(encoding="utf-8")
+        .split("test-checker-subprocess-coverage:", 1)[1]
+        .split("test-all-ci:", 1)[0]
+    )
+
+    assert 'patch = ["subprocess"]' not in pyproject
+    assert "patch = subprocess" in subprocess_config
+    assert "tests/unit/test_checker_worker_manifest.py" in target
+    assert "--cov-config=.coveragerc-subprocess" in target
+    assert "--include=src/jacobian/checker_worker.py --fail-under=1" in target
+    assert workflow.count("make test-checker-subprocess-coverage") == 1
+    assert "needs: [python, boundaries, subprocess_coverage]" in workflow
+
+
 def test_local_oracle_targets_require_explicit_scope() -> None:
     harbor = (ROOT / "make" / "harbor.mk").read_text(encoding="utf-8")
     oracle = harbor.split("harbor-oracle:", 1)[1].split("harbor-oracle-task:", 1)[0]


### PR DESCRIPTION
Fixes #1338.

## Problem

Every ordinary Python and boundary lane enabled branch coverage while the global coverage.py configuration patched subprocess creation. Each fresh checker worker therefore started coverage and wrote parallel data, coupling correctness tests to coverage transport and amplifying the suite’s process-heavy paths.

## Solution

Ordinary lanes now retain parent-process branch coverage without globally patching subprocesses. A dedicated coverage profile and CI job run the real checker-worker entrypoint for accepted, rejected, malformed-manifest, and undeclared-import outcomes. The target fails unless child execution appears in the combined coverage data, then uploads that database into the unchanged aggregate coverage gate.

The checker worker environment remains fail closed: coverage variables are forwarded only by the focused test helper, not by the production executor or the default worker allowlist.

## Performance evidence

Three local repetitions of the same five-worker workload on Python 3.12.13 produced these medians:

- no coverage: 3.76s
- parent-only coverage: 4.73s
- subprocess coverage: 6.65s

The focused subprocess patch added 1.92s over parent-only coverage for five short-lived workers. Hosted lane timings and aggregate coverage from this PR will provide the representative CI comparison.

## Testing

- `make test-checker-subprocess-coverage` — 5 passed; `checker_worker.py` child coverage measured at 46%
- `uv run pytest -n 0 tests/unit/tooling/test_ci_execution_policy.py tests/unit/test_checker_worker_manifest.py` — 29 passed
- `make lint-full` — passed
- `make typecheck` — passed
- `make docs-linkcheck` — passed
- `make check` — unit, component, domain, composition, and end-to-end completed successfully; the final provider lane was interrupted during closeout and is left to CI

## Trust & Compatibility Impact

Checker execution, fresh-process isolation, manifest/runtime checks, authorization, persistence, and public APIs are unchanged. The aggregate coverage threshold remains 50%, and focused child-process data is included in the required coverage job.

## Architecture Budget

No ordinary operation or shared production abstraction is introduced.

## Checklist

- [ ] `make check` passes in CI
- [x] Focused checker subprocess coverage is listed above
- [x] Harbor task/verifier preparation is not applicable
- [x] Operation budget is not applicable
- [x] Shared abstraction budget is not applicable