### PR TITLE
chore(devex): make the routine local check a bounded handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,8 @@ checker authorization out of plugins and search code.
 
 ## Repository Gotchas
 
-- Before final validation, use `make check` (and `make check-external` when
+- Before final validation, use `make check` plus the named lane that owns the
+  changed behavior (and `make check-external` when
   Lean or optional providers change) on the final tree. In a shared checkout,
   agents must own
   disjoint paths and must not switch branches, stage, commit, clean, or rewrite
@@ -262,9 +263,9 @@ Non-obvious caveats:
   not break the kernel, catalog, or the core test suites. Only install Lean/elan
   or those executables when specifically exercising `lean_runtime` tests or SAT
   proof-artifact capabilities.
-- `make test-unit` is the cheap unit lane. `make quick` adds lint and
-  typecheck. `make check` is the PR-equivalent ordinary pytest run (Lean-free
-  default `testpaths`, same flags as CI `python`). Use `make test-all-ci` only
+- `make test-unit` is the cheap unit lane. `make quick` adds lint; `make check`
+  adds lint and typecheck. `make check-all` explicitly reproduces the Lean-free
+  ordinary CI matrix. Use `make test-all-ci` only
   for an explicit exhaustive local reproduction. Default `uv run pytest` does
   not collect Lean, storage, process, or MCP; use the matching `make test-*`
   target for those trees. Never run bare `uv run pytest` as a substitute for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Use the installed catalog and current references for present tool membership.
 
 ## Contributor quick path
 
-Most changes need only the locked environment and the ordinary check:
+Most changes need only the locked environment and the bounded local handoff:
 
 ```sh
 make setup
@@ -25,12 +25,12 @@ make check
 
 Then open a pull request. `make setup` installs the locked development
 environment with the complete maintained Python backend stack. `make check`
-runs Ruff, mypy, and the same Lean-free ordinary test suite CI covers in fixed
-semantic groups.
+runs Ruff, mypy, and the unit lane. Add the named `make test-*` lane for the
+behavior or boundary changed; CI runs the complete fixed semantic matrix.
 Open the PR once it is green, and add any explicitly relevant specialist
 validation called out below.
 
-`make quick` is the cheaper loop: lint, types, and `tests/unit` only. The
+`make quick` is the cheaper loop: lint and `tests/unit` only. The
 pre-push hook stays `make lint typecheck`. Focused debugging uses
 `uv run pytest path/to/test.py`. Default `uv run pytest` collects the ordinary
 Lean-free `testpaths`; it does not run storage, process, MCP, or Lean trees.
@@ -79,8 +79,10 @@ Jacobian uses Python 3.12 and the uv release pinned in [`.uv-version`](.uv-versi
 make setup          # locked dev environment and Python backends
 ```
 
-`make check` is the PR-equivalent ordinary Python validation. `make quick` is
-lint, types, and unit tests. The pre-push hook intentionally runs only
+`make check` is the bounded lint, type, and unit handoff; `make quick` omits
+typechecking for a shorter edit loop.
+`make check-all` explicitly reproduces every ordinary Python CI lane. The
+pre-push hook intentionally runs only
 `make lint typecheck` so it stays below the interactive feedback budget.
 `make check-static` adds dependency/dead-code checks and a package build when a
 focused change needs them. Run `make help` for the common command index and
@@ -114,12 +116,12 @@ while another agent is working. Integrate their edits first, then run the
 planned checks on the final tree. Use isolated worktrees only when the workflow
 explicitly assigns them.
 
-Before final validation, run `make check` on the final tree. If the tree
-changes during validation, rerun checks whose evidence was invalidated by
-that change; do not describe results from an earlier tree as final-tree
-validation. `make check` is the normal local handoff; CI owns the exhaustive
-evidence described above. Use `make check-external` when Lean or optional
-providers change.
+Before final validation, run `make check` plus the named lane that owns the
+changed behavior. If the tree changes during validation, rerun checks whose
+evidence was invalidated by that change; do not describe results from an
+earlier tree as final-tree validation. `make check-all` is an explicit broad
+reproduction, not a routine closeout requirement. CI owns the complete matrix.
+Use `make check-external` when Lean or optional providers change.
 
 ## Harbor and Oracle validation
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 PYTEST_RUNNER := $(UV_RUN) python tools/pytest_lifecycle.py
 # Fixed semantic lanes covering the Lean-free ordinary testpaths. CI runs these
-# independently; `make check` runs the same lanes locally in this order.
+# independently; `make check-all` reproduces them locally in this order.
 ORDINARY_TEST_LANES := unit component domain composition e2e provider
-PUBLIC_COMMANDS := setup quick check check-external fix
+PUBLIC_COMMANDS := setup quick check check-all check-external fix
 
 include make/development.mk
 include make/harbor.mk
@@ -150,15 +150,17 @@ coverage: ## Combine coverage data files and enforce the repository threshold.
 build: ## Build Python source and wheel distributions.
 	uv build
 
-quick: lint typecheck test-unit ## Cheap iteration: lint, types, unit tests.
+quick: lint test-unit ## Cheap iteration: lint and unit tests.
 
-check: lint typecheck test-ordinary ## PR-equivalent ordinary Python validation.
+check: lint typecheck test-unit ## Routine local handoff: lint, types, and unit tests.
+
+check-all: lint typecheck test-ordinary ## Explicitly reproduce all ordinary CI lanes.
 
 check-external: test-lean test-provider ## Lean and maintained-provider isolation.
 
 precommit: ## Fix and run every routine local handoff check.
 	$(MAKE) fix
-	$(MAKE) quick
+	$(MAKE) check
 
 check-static: lint-full typecheck import-contracts architecture todo-check build ## CI-owned static checks plus a local package build.
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -11,7 +11,7 @@ encode a required research sequence.
 | Change | First local check | Escalate when |
 | --- | --- | --- |
 | Documentation | `make docs-linkcheck` | Checked examples also run when their supported contract changes |
-| Python behavior | `make quick`, then `make check` | Add a named specialist lane when the change crosses that boundary |
+| Python behavior | `make check`, then the owning named lane | Use `make check-all` only for an intentional complete ordinary reproduction |
 | Mathematical domain | Owning domain/component tests | Add composition only for real cross-domain handoff |
 | MCP projection | Focused MCP boundary tests | Add stdio/HTTP parity when transport behavior changes |
 | Checker protocol or authority | Focused checker and authority tests | Require an independent exact-diff review |
@@ -31,10 +31,11 @@ Make targets that own storage, process, MCP, and Lean isolation. `make
 check-external` covers Lean and maintained-provider probes when those trees
 change.
 
-Hosted CI runs that same ordinary suite as six fixed semantic lanes: `unit`,
+`make check` is the bounded local handoff: lint, typecheck, and unit tests.
+Hosted CI runs the complete ordinary suite as six fixed semantic lanes: `unit`,
 `component`, `domain`, `composition`, `e2e`, and `provider`. These are static
-Make targets, not path-selected or timing-planned shards; `make check` runs all
-six in the same order.
+Make targets, not path-selected or timing-planned shards. Use the named lane
+that owns the change; `make check-all` runs all six locally in the same order.
 
 ## Test ownership
 
@@ -81,6 +82,7 @@ make test-exhaustive
 make test-checker-subprocess-coverage
 make quick
 make check
+make check-all
 make check-external
 make check-static
 ```
@@ -291,11 +293,11 @@ skill and exact task validation path when those files change.
 
 After implementation freezes the behavioral tree:
 
-1. run `make check`;
+1. run `make check` and the named lane that owns the change;
 2. run any named specialist lane the change actually crossed;
 3. complete any required independent exact-diff review;
 4. resolve its consolidated findings;
-5. rerun `make check` on the final tree; and
+5. rerun the invalidated focused checks on the final tree; and
 6. report only evidence that actually ran, including material proof gaps.
 
 After any edit, rerun only checks whose evidence the edit invalidated. Do not

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -125,8 +125,9 @@ def test_python_jobs_use_fixed_local_semantic_targets() -> None:
         "ORDINARY_TEST_LANES := unit component domain composition e2e provider"
         in makefile
     )
-    assert "check: lint typecheck test-ordinary" in makefile
-    assert "quick: lint typecheck test-unit" in makefile
+    assert "quick: lint test-unit" in makefile
+    assert "check: lint typecheck test-unit" in makefile
+    assert "check-all: lint typecheck test-ordinary" in makefile
 
 
 def test_exhaustive_local_reproduction_includes_exhaustive_marker_lane() -> None:


### PR DESCRIPTION
## Problem

`make check` was documented as the normal local handoff but ran all six ordinary CI lanes. On the current suite that includes multi-minute composition, end-to-end, and provider work unrelated to many changes, turning routine closeout into a roughly 12-minute broad reproduction.

## Solution

- `make quick` runs lint and unit tests for the edit loop.
- `make check` runs lint, mypy, and unit tests as the routine handoff.
- `make check-all` preserves the former complete ordinary CI reproduction.
- Contributors add the named `make test-*` lane that owns the changed behavior or boundary.

CI is unchanged and continues to run every ordinary and boundary lane independently. AGENTS.md, contributor guidance, the testing strategy, help output, and CI policy tests now describe the same evidence model.

## Testing

- `time make check` — Ruff and mypy passed; 837 unit tests passed; 15.7s wall time
- `uv run python tools/check_doc_commands.py` — documentation commands valid
- `make help` — exposes `check` and `check-all` with their distinct roles

## Trust & Compatibility Impact

No verification, persistence, authorization, coverage threshold, public API, or hosted CI gate changes. This changes only the local Make target contract; the old broad behavior remains available as `make check-all`.

## Architecture Budget

No production operation or shared abstraction is introduced.

## Checklist

- [x] `make check` passes
- [x] Relevant Make/documentation policy validation is listed above
- [x] Harbor task/verifier preparation is not applicable
- [x] Operation and shared-abstraction budgets are not applicable