### PR TITLE
test: validate pytest ownership without full collection

### DIFF
--- a/tests/boundary/process/tooling/test_supervised_make_lanes.py
+++ b/tests/boundary/process/tooling/test_supervised_make_lanes.py
@@ -85,20 +85,8 @@ def test_ordinary_unit_lane_invokes_pytest_directly() -> None:
     assert "tests/unit" in output
 
 
-def test_default_collection_omits_lean_nodeids() -> None:
-    completed = subprocess.run(
-        ["uv", "run", "--locked", "pytest", "--collect-only", "-q"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    output = completed.stdout + completed.stderr
-
-    assert "tests/boundary/providers/lean" not in output
-
-
-def test_explicit_lean_path_still_collects() -> None:
+def test_explicit_lean_module_still_collects() -> None:
+    representative = "tests/boundary/providers/lean/test_lean_residual_contracts.py"
     completed = subprocess.run(
         [
             "uv",
@@ -107,7 +95,7 @@ def test_explicit_lean_path_still_collects() -> None:
             "pytest",
             "--collect-only",
             "-q",
-            "tests/boundary/providers/lean",
+            representative,
         ],
         cwd=ROOT,
         check=True,
@@ -116,4 +104,4 @@ def test_explicit_lean_path_still_collects() -> None:
     )
     output = completed.stdout + completed.stderr
 
-    assert "tests/boundary/providers/lean" in output
+    assert representative in output

--- a/tests/unit/tooling/test_pytest_collection_ownership.py
+++ b/tests/unit/tooling/test_pytest_collection_ownership.py
@@ -1,0 +1,66 @@
+"""Static ownership contracts for pytest's configured default roots."""
+
+from __future__ import annotations
+
+import tomllib
+from itertools import combinations
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).parents[3]
+SPECIALIST_ROOTS = (
+    PurePosixPath("tests/boundary/storage"),
+    PurePosixPath("tests/boundary/process"),
+    PurePosixPath("tests/boundary/mcp"),
+    PurePosixPath("tests/boundary/providers/lean"),
+)
+ORDINARY_OWNERS = frozenset({"unit", "component", "domain", "composition", "e2e"})
+
+
+def _configured_testpaths() -> tuple[PurePosixPath, ...]:
+    with (ROOT / "pyproject.toml").open("rb") as project_file:
+        project = tomllib.load(project_file)
+    configured = project["tool"]["pytest"]["ini_options"]["testpaths"]
+    assert isinstance(configured, list)
+    assert all(isinstance(path, str) for path in configured)
+    return tuple(PurePosixPath(path) for path in configured)
+
+
+def _overlap(left: PurePosixPath, right: PurePosixPath) -> bool:
+    return left == right or left in right.parents or right in left.parents
+
+
+def test_default_testpaths_are_normalized_existing_ordinary_roots() -> None:
+    for relative in _configured_testpaths():
+        assert not relative.is_absolute()
+        assert relative.parts[:1] == ("tests",)
+        assert "." not in relative.parts and ".." not in relative.parts
+        assert (ROOT / relative).is_dir()
+
+        owner = relative.parts[1:2]
+        maintained_provider = (
+            relative.parts[:3]
+            == (
+                "tests",
+                "boundary",
+                "providers",
+            )
+            and len(relative.parts) >= 4
+        )
+        assert owner and (owner[0] in ORDINARY_OWNERS or maintained_provider)
+
+
+def test_default_testpaths_do_not_overlap_specialist_roots() -> None:
+    configured = _configured_testpaths()
+
+    assert all(
+        not _overlap(default_root, specialist_root)
+        for default_root in configured
+        for specialist_root in SPECIALIST_ROOTS
+    )
+
+
+def test_default_testpaths_do_not_overlap_each_other() -> None:
+    assert all(
+        not _overlap(left, right)
+        for left, right in combinations(_configured_testpaths(), 2)
+    )


### PR DESCRIPTION
Fixes #1376.

## Problem

The routine process lane proved that Lean was excluded from default pytest collection by recursively collecting the entire ordinary suite. It also collected the complete Lean tree merely to prove that an explicit Lean path remained reachable. On current main, those two assertions took 7.74 seconds locally and scaled with unrelated test growth rather than with the configuration they protected.

## Solution

Parse `[tool.pytest.ini_options].testpaths` directly with `tomllib` and validate the checked-in ownership declaration:

- every configured root is normalized, repository-relative, existing, and owned by an ordinary semantic lane or a maintained provider;
- default roots cannot overlap storage, process, MCP, or Lean specialist roots, including through a broad ancestor;
- configured default roots cannot overlap each other.

The existing Make dry-run contract continues to prove that `test-lean` is serial, supervised, signal-timed, and points at the complete Lean directory. One real pytest subprocess remains, narrowed to a stable Lean module, to prove explicit collection reachability and hook behavior.

No custom collector, duplicated exact testpath registry, or source-text scan is introduced.

## Testing

- `make check` — lint, formatting, complexity, mypy, and 865 unit tests passed.
- `make test-process` — 178 process-boundary tests passed in 12.55 seconds.
- Current-main focused baseline: broad default plus full-Lean collection took 7.74 seconds of testcase time.
- Candidate focused evidence: static ownership checks took 0.14 seconds and the real Lean collection smoke took 0.92 seconds, an 86% reduction.

- Specialist validation run: `make test-process`

## Trust & Compatibility Impact

No production, verification, persistence, authorization, public API, or provider behavior changes. The explicit Lean reachability proof and the complete `test-lean` command contract remain covered.

## Architecture Budget

No production operation or shared abstraction is introduced.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier validation is not applicable
- [x] Operation budget is not applicable
- [x] Shared production abstraction requirement is not applicable