### PR TITLE
refactor(tests): simplify the test ownership import ratchet

### DIFF
--- a/tests/unit/tooling/test_architecture_test_ownership.py
+++ b/tests/unit/tooling/test_architecture_test_ownership.py
@@ -34,11 +34,11 @@ def test_historical_composition_bucket_is_rejected(
     assert any("historical status" in message for message in messages)
 
 
-def test_unit_module_cannot_create_a_runtime(tmp_path: Path) -> None:
+def test_unit_module_cannot_import_jacobian_runtime(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "tests/unit/contracts/test_runtime.py",
-        "from jacobian.runtime import create_runtime\ncreate_runtime('state')\n",
+        "from jacobian.runtime import CheckerAuthorityMode\n",
     )
 
     assert _ownership_messages(tmp_path) == [
@@ -46,11 +46,11 @@ def test_unit_module_cannot_create_a_runtime(tmp_path: Path) -> None:
     ]
 
 
-def test_domain_module_cannot_create_a_complete_runtime(tmp_path: Path) -> None:
+def test_domain_module_cannot_import_runtime_constructor(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "tests/domain/polynomial/test_runtime.py",
-        "from jacobian.runtime import create_runtime\ncreate_runtime('state')\n",
+        "from jacobian.runtime import create_runtime\n",
     )
 
     assert _ownership_messages(tmp_path) == [
@@ -58,14 +58,13 @@ def test_domain_module_cannot_create_a_complete_runtime(tmp_path: Path) -> None:
     ]
 
 
-def test_domain_module_cannot_alias_complete_runtime_construction(
+def test_domain_module_cannot_alias_runtime_import(
     tmp_path: Path,
 ) -> None:
     _write(
         tmp_path,
         "tests/domain/polynomial/test_runtime.py",
-        "from jacobian.runtime import create_runtime as open_everything\n"
-        "open_everything('state')\n",
+        "from jacobian.runtime import create_runtime as open_everything\n",
     )
 
     assert _ownership_messages(tmp_path) == [
@@ -77,7 +76,7 @@ def test_domain_module_cannot_import_runtime_as_a_module(tmp_path: Path) -> None
     _write(
         tmp_path,
         "tests/domain/polynomial/test_runtime.py",
-        "import jacobian.runtime as runtime\nruntime.create_runtime('state')\n",
+        "import jacobian.runtime as runtime\n",
     )
 
     assert _ownership_messages(tmp_path) == [
@@ -119,11 +118,11 @@ def test_domain_module_cannot_import_complete_runtime_fixtures(
     ]
 
 
-def test_parent_fixture_cannot_construct_complete_runtime(tmp_path: Path) -> None:
+def test_parent_fixture_cannot_import_jacobian_runtime(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "tests/conftest.py",
-        "from jacobian.runtime import create_runtime\ncreate_runtime('state')\n",
+        "from jacobian.runtime import create_runtime\n",
     )
 
     assert any(

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1368,15 +1368,13 @@ def _imports_complete_runtime_fixtures(tree: ast.AST) -> bool:
     )
 
 
-def _imports_complete_runtime_constructor(tree: ast.AST) -> bool:
+def _imports_jacobian_runtime(tree: ast.AST) -> bool:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(alias.name == "jacobian.runtime" for alias in node.names):
                 return True
         elif isinstance(node, ast.ImportFrom):
-            if node.module == "jacobian.runtime" and any(
-                alias.name == "create_runtime" for alias in node.names
-            ):
+            if node.module == "jacobian.runtime":
                 return True
             if node.module == "jacobian" and any(
                 alias.name == "runtime" for alias in node.names
@@ -1395,7 +1393,7 @@ def _test_ownership_violations(
     violations: list[Violation] = []
     focused_suite = len(parts) >= 2 and parts[1] in {"component", "domain", "unit"}
     imports_complete_runtime = _imports_complete_runtime_fixtures(tree)
-    imports_runtime = _imports_complete_runtime_constructor(tree)
+    imports_runtime = _imports_jacobian_runtime(tree)
     if focused_suite and (imports_runtime or imports_complete_runtime):
         violations.append(
             Violation(


### PR DESCRIPTION
### Problem

The test-ownership ratchet described a complete-runtime construction rule, but the durable boundary is simpler: focused suites must not import `jacobian.runtime` or the complete-runtime fixture module.

Encoding construction behavior invites partial name and call resolution, with false positives for unrelated local functions and gaps for ordinary Python import styles.

### Change

- Treat any exact `jacobian.runtime` import as the focused-suite violation, including module, member, and aliased imports.
- Keep the exact prohibition on `tests.support.complete_runtime_fixtures`.
- Keep deterministic composition owner directories and literal historical bucket-name rejection.
- Express the regression tests entirely through import syntax; no call-name analysis is needed.

Passive submodules such as `jacobian.runtime.services`, unrelated local `create_runtime` functions, and versioned composition filenames remain accepted.

### Validation

- `uv run --locked pytest -n 0 tests/unit/tooling/test_architecture_test_ownership.py` — 16 passed
- `uv run --locked python tools/check_architecture.py` — passed
- `make check` — passed
- `git diff --check` — passed