### PR TITLE
fix(benchmarks): accept reordered spectral checkpoints

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="6fe02bcf29f843830c5807a65fa10a0e0c443f6c02268ddbc799f4ca7ef2958a"
+LABEL jacobian.checksum="aa70552653e820310b26be21021aee03f73fa6df10bceb2b9c482322aeabca0f"
 # Exact rational verifier for a rank-one spectral limit certificate.
 LABEL jacobian.task="jacobian/rank-one-spectral-limit-certificate"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rank-one-spectral-limit-certificate/tests/verifier.py
@@ -97,7 +97,7 @@ def certificate_valid(result: object) -> bool:
     if ns is None:
         return False
     return bool(
-        ns == sorted(set(ns))
+        len(ns) == len(set(ns))
         and result["rank_one_sign"] == "DIAGONAL_MINUS_LAMBDA_ONES"
         and result["root_formula"] == "4*n*(n+1)/((n-1)*(n+2))"
         and rat(result["limit"]) == 4

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_rank_one_spectral_limit_certificate.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_rank_one_spectral_limit_certificate.py
@@ -45,6 +45,14 @@ def test_accepts_alternative_exact_checkpoints(tmp_path: Path) -> None:
     assert support._run_verifier(task, app, logs).reward == 1.0
 
 
+def test_accepts_reordered_distinct_checkpoints(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["checkpoints"].reverse()
+    _rewrite(app, submission)
+    assert support._run_verifier(task, app, logs).reward == 1.0
+
+
 def test_rejects_sampled_but_corrupt_root(tmp_path: Path) -> None:
     task, app, logs = _case(tmp_path)
     submission = json.loads((app / "submission.json").read_text())


### PR DESCRIPTION
## Problem

`rank-one-spectral-limit-certificate` publicly asks for three to eight distinct exact checkpoints, but its verifier additionally required the checkpoint list to be sorted. Reversing the canonical checkpoints to `[12, 7, 4]` preserved every rational value, evidence digest, scope, and assurance while incorrectly producing `correctness = 0` and zero reward.

The defect came from using `ns == sorted(set(ns))` to enforce distinctness. The public schema imposes no ordering, and the instruction only requires distinct checkpoint values.

## Change

- accept distinct checkpoint sizes in any submission order;
- retain the existing bounds, exact rational replay, and duplicate rejection;
- add a focused regression for a reversed valid checkpoint list;
- refresh the task-local verifier bundle checksum.

This changes no Jacobian product tool, mathematical result, assurance ceiling, evidence contract, or task instruction.

## Audit scope

Four current tasks were sampled for ordering/representation drift:

- `rank-one-spectral-limit-certificate`: unpublished checkpoint-order constraint reproduced and fixed here;
- `valuation-gcd-quantifier-audit`: increasing prime-row order is explicitly public;
- `extremal-subset-sum-semantic-audit`: increasing list-as-set encoding is explicitly public;
- `graph-artifact-composition`: separate vertex-set ordering concern, intentionally outside this focused change.

No open PR or issue was found for this checkpoint-order defect.

## Validation

Source base: `50c3fceb81c1696d2b4f50eb6efa4816d0ae0e50`
Head: `fb902b9460f246432567cfe036cf39c4221fcdce`
Prospective task digest: `sha256:f6c2f44eda6acdf81df8385f84315c4777cc562c5a5a63b8c4640d61ce91ccce`

- red regression on the base behavior: reversed checkpoints produced reward `0.0` with correctness `0.0`;
- focused task verifier leaf: 4 passed, including alternate checkpoints, reordered checkpoints, corrupt roots, and duplicate rejection;
- planner-selected generic verifier attacks: 12 passed, 1,658 deselected;
- `make harbor-prepare-task DATASET=mathematical-benchmarks-v1 TASKS="rank-one-spectral-limit-certificate"`;
- selected benchmark static quality and `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="rank-one-spectral-limit-certificate"`;
- `make harbor-plan BASE=origin/main`: selected only this task, its two host leaves, and its exact Oracle;
- `make check`: Ruff, formatting, complexity, mypy, and 871 unit tests passed;
- `git diff --check`.

## Deferred proof gap

Neither Docker nor Podman is installed on this host. The exact Harbor Oracle and the Oracle phase of `harbor-validate-task` were therefore not run. The planner-selected host/static stages were run separately and passed; no substitute runtime or Oracle verdict is claimed.