### PR TITLE
test: stop constructing the universe for local facts

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -18,6 +18,7 @@ runs:
       with:
         lake-package-directory: lean
         use-mathlib-cache: true
+        use-github-cache: false
         build: false
         test: false
         lint: false
@@ -55,8 +56,17 @@ runs:
       run: |
         started=$SECONDS
         set +e
-        lake build repl jacobian_lean_proof_state
+        lake build JacobianLeanRuntime repl jacobian_lean_proof_state
         status=$?
         set -e
         echo "| Build Jacobian Lean exploration runtime | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
         exit "$status"
+    - name: Prove CORE and MATHLIB runtimes are available
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        JACOBIAN_LEAN_REQUIRED: "1"
+      run: |
+        started=$SECONDS
+        uv run --locked python tools/preflight_lean_runtime.py --required
+        echo "| Lean runtime preflight | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,6 @@ jobs:
 
   lean:
     name: Lean Runtime
-    if: >-
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:lean') ||
-      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -212,6 +208,8 @@ jobs:
       - name: Prepare Lean test environment
         uses: ./.github/actions/setup-lean
       - run: make test-lean
+        env:
+          JACOBIAN_LEAN_REQUIRED: "1"
 
   coverage:
     name: Coverage
@@ -317,10 +315,7 @@ jobs:
           test "$BOUNDARIES_RESULT" = success
           test "$WHEEL_RESULT" = success
           test "$COVERAGE_RESULT" = success
-          case "$LEAN_RESULT" in
-            success|skipped) ;;
-            *) exit 1 ;;
-          esac
+          test "$LEAN_RESULT" = success
 
   python-test:
     name: Python Tests
@@ -341,14 +336,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Accept skipped Lean on ordinary PRs
+      - name: Require Lean on the exact merge candidate
         env:
           LEAN_RESULT: ${{ needs.lean.result }}
-        run: |
-          case "$LEAN_RESULT" in
-            success|skipped) exit 0 ;;
-            *) exit 1 ;;
-          esac
+        run: test "$LEAN_RESULT" = success
 
   deployment-test:
     name: Deployment Tests

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ lean/.lake/
 
 # Test infrastructure state
 .test_durations
+.jacobian-validation.lock
 tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,10 @@ repos:
     hooks:
       - id: jacobian-pre-push
         name: Jacobian pre-push static checks
-        # Keep the push hook below the interactive feedback budget.  The
-        # affected test planner and CI own the resource-heavy correctness
-        # lanes; running the complete unit loop here caused routine pushes to
-        # take roughly a minute and encouraged --no-verify bypasses.
+        # Keep the push hook below the interactive feedback budget. CI owns
+        # the resource-heavy correctness lanes; running the complete unit loop
+        # here caused routine pushes to take roughly a minute and encouraged
+        # --no-verify bypasses.
         entry: make lint typecheck
         language: system
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,11 +193,11 @@ checker authorization out of plugins and search code.
 ## Repository Gotchas
 
 - Before final validation, use `make check` plus the named lane that owns the
-  changed behavior (and `make check-external` when
-  Lean or optional providers change) on the final tree. In a shared checkout,
-  agents must own
-  disjoint paths and must not switch branches, stage, commit, clean, or rewrite
-  shared files until their work is integrated.
+  changed behavior on the final tree (`make check-external` for Lean/Mathlib,
+  `make test-provider` for optional or maintained Python providers). In a
+  shared checkout, agents must own disjoint paths and must not switch
+  branches, stage, commit, clean, or rewrite shared files until their work
+  is integrated.
 - Jacobian is pre-stable. Current reference documents and the installed catalog
   define the supported surface; they do not order capability research.
 - Validate the complete Pydantic request model before preflight, provider calls,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,8 @@ Non-obvious caveats:
 - `make test-unit` is the cheap unit lane. `make quick` adds lint; `make check`
   adds lint and typecheck. `make check-all` explicitly reproduces the Lean-free
   ordinary CI matrix. Use `make test-all-ci` only
-  for an explicit exhaustive local reproduction. Default `uv run pytest` does
+  for an explicit exhaustive local reproduction; it takes this worktree's
+  exhaustive validation lease (`make validation-status`). Default `uv run pytest` does
   not collect Lean, storage, process, or MCP; use the matching `make test-*`
   target for those trees. Never run bare `uv run pytest` as a substitute for
   the complete specialist matrix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,11 @@ and verifies child-process coverage collection.
 - **Broad or unknown impact** (CI, dependencies, shared infrastructure): run
   `make check-static` plus the affected tests, and let CI own the fail-closed
   functional lanes.
-- **Lean or optional providers:** `make check-external` when those trees
-  change. CI owns the full Lean and optional-provider environments.
+- **Lean:** `make check-external` when Lean or Mathlib trees change. That
+  target is the pinned Lean specialist lane only (`test-lean`).
+- **Optional or maintained Python providers:** `make test-provider` when those
+  trees change. `make check-all` already includes that lane; `check-external`
+  does not rerun it. CI owns the full Lean and optional-provider environments.
 - **Exhaustive local reproduction:** `make test-all-ci` is an explicit exception
   path, not a routine gate. It takes this worktree's exhaustive validation
   lease; `make validation-status` shows whether that lease is held. Before it,
@@ -123,7 +126,8 @@ changed behavior. If the tree changes during validation, rerun checks whose
 evidence was invalidated by that change; do not describe results from an
 earlier tree as final-tree validation. `make check-all` is an explicit broad
 reproduction, not a routine closeout requirement. CI owns the complete matrix.
-Use `make check-external` when Lean or optional providers change.
+Use `make check-external` when Lean or Mathlib change, and `make test-provider`
+when optional or maintained Python providers change.
 
 ## Harbor and Oracle validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ pre-push hook stays `make lint typecheck`. Focused debugging uses
 Lean-free `testpaths`; it does not run storage, process, MCP, or Lean trees.
 
 CI always runs that ordinary Python surface plus storage/process/MCP,
-maintained Python provider boundaries, and the wheel smoke. Lean runs on
-merge/main or with the `ci:lean` / `ci:full` labels. You do not need to
-reproduce those locally for a routine change.
+maintained Python provider boundaries, the wheel smoke, and Lean. You do not
+need to reproduce Lean locally for a routine change unless you edited Lean
+sources, fixtures, or provider identity.
 
 Specialist lanes (`make test-lean`, `make test-provider`, `make test-storage`,
 `make test-process`, `make test-mcp`, `make test-e2e`, `make test-domain`, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,13 @@ and verifies child-process coverage collection.
 - **Lean or optional providers:** `make check-external` when those trees
   change. CI owns the full Lean and optional-provider environments.
 - **Exhaustive local reproduction:** `make test-all-ci` is an explicit exception
-  path, not a routine gate. Before it, verify that no other pytest or
-  delegated-agent validation is running on the host, and never assign it to a
-  parallel agent sharing the checkout. The manually dispatched Python Debug and
-  Lean Debug workflows reproduce one pytest file or node in a prepared remote
-  environment when the relevant local runtime is impractical.
+  path, not a routine gate. It takes this worktree's exhaustive validation
+  lease; `make validation-status` shows whether that lease is held. Before it,
+  verify that no other pytest or delegated-agent validation is running on the
+  host, and never assign it to a parallel agent sharing the checkout. The
+  manually dispatched Python Debug and Lean Debug workflows reproduce one
+  pytest file or node in a prepared remote environment when the relevant local
+  runtime is impractical.
 
 ## Development environment
 
@@ -146,12 +148,24 @@ Oracle or model.
 config, job-level Compose overlays, adapters, and execution helpers) and the
 unit tests that own them; it deliberately excludes unrelated task-specific
 verifier regressions. `make harbor-check-all` is the explicit full integration
-reproduction. Task `environment/docker-compose.yaml` files are
+reproduction and takes the same worktree admission lease as other exhaustive
+local targets. `make harbor-plan` normalizes changed paths once and feeds that
+canonical file to the planner, validator, and receipt; temps live only inside
+the recipe. Task `environment/docker-compose.yaml` files are
 executable benchmark input, not job overlays, and remain gated by
 `make harbor-check-task` and `make harbor-oracle-task`. Use
 `make harbor-plan BASE=origin/main` for benchmark contracts and Oracle scope;
 run it through Make because the planner requires the pinned Harbor runtime to
 compute task digests.
+
+Current GitHub Actions identity is the workflow YAML on the default branch.
+Historical registrations whose files are gone, including leftover
+`agent-port-*` and `agent-rebase-*` workflows, stay disabled in the GitHub UI
+with their run history retained; do not add an auto-disable bot.
+`python tools/inventory_github_workflows.py` is the non-mutating inventory.
+To rebuild a leaf from `main` (or another declared parent) plus unique
+commits, run `python tools/restack_feature_branch.py`; the helper reports
+duplicate subjects and never force-pushes.
 
 For the exact task authoring workflow and verifier changes, use the
 [`harbor-benchmarks`](.agents/skills/harbor-benchmarks/SKILL.md) skill. The

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-unit: ## Pure contracts and models (sequential, 10s).
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-component: ## One-service component tests (4 workers, 30s).
-	$(UV_RUN) pytest -n 4 --dist worksteal --timeout=30 -m "not exhaustive" \
+	$(UV_RUN) pytest -n 4 --dist loadscope --timeout=30 -m "not exhaustive" \
 		$(if $(TESTS),$(TESTS),tests/component) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
@@ -99,7 +99,7 @@ test-checker-subprocess-coverage: ## Prove focused checker-worker child coverage
 	COVERAGE_FILE=.coverage.checker-subprocess $(UV_RUN) coverage report \
 		--include=src/jacobian/checker_worker.py --fail-under=1
 
-test-all-ci: ## Explicitly run every semantic lane locally (exceptional).
+test-all-ci: ## Every local semantic pytest/Lean lane; not hosted CI, coverage, or docs.
 	$(MAKE) test-unit
 	$(MAKE) test-component
 	$(MAKE) test-exhaustive
@@ -154,11 +154,11 @@ quick: lint test-unit ## Cheap iteration: lint and unit tests.
 
 check: lint typecheck test-unit ## Routine local handoff: lint, types, and unit tests.
 
-check-all: lint typecheck test-ordinary ## Explicitly reproduce all ordinary CI lanes.
+check-all: lint typecheck test-ordinary ## Reproduce the six ordinary Python CI lanes locally.
 
-check-external: test-lean test-provider ## Lean and maintained-provider isolation.
+check-external: test-lean ## Pinned Lean/Mathlib specialist lane only.
 
-precommit: ## Fix and run every routine local handoff check.
+precommit: ## Apply safe fixes, then run lint, types, and unit tests (mutates the tree).
 	$(MAKE) fix
 	$(MAKE) check
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ORDERING_DEFAULT_SEED := --randomly-seed=17
 PYTEST_DIAGNOSTIC_ARGS ?= --durations=10
 RUFF_PATHS := src tests benchmarks
 PYTEST_RUNNER := $(UV_RUN) python tools/pytest_lifecycle.py
+WORKTREE_ADMISSION := $(UV_RUN) python tools/worktree_admission.py
 # Fixed semantic lanes covering the Lean-free ordinary testpaths. CI runs these
 # independently; `make check-all` reproduces them locally in this order.
 ORDINARY_TEST_LANES := unit component domain composition e2e provider
@@ -100,6 +101,9 @@ test-checker-subprocess-coverage: ## Prove focused checker-worker child coverage
 		--include=src/jacobian/checker_worker.py --fail-under=1
 
 test-all-ci: ## Every local semantic pytest/Lean lane; not hosted CI, coverage, or docs.
+	$(WORKTREE_ADMISSION) run --target test-all-ci -- $(MAKE) _test-all-ci-unlocked
+
+_test-all-ci-unlocked:
 	$(MAKE) test-unit
 	$(MAKE) test-component
 	$(MAKE) test-exhaustive
@@ -118,7 +122,7 @@ test-stress: ## Repeat explicitly marked property tests on the scheduled lane.
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
 test-exhaustive: ## Broad finite reference sweeps reserved for scheduled validation.
-	$(UV_RUN) pytest -n 0 --timeout=180 --timeout-method=thread -m exhaustive \
+	$(WORKTREE_ADMISSION) run --target test-exhaustive -- $(UV_RUN) pytest -n 0 --timeout=180 --timeout-method=thread -m exhaustive \
 		$(if $(TESTS),$(TESTS),tests) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 
@@ -161,6 +165,9 @@ check-external: test-lean ## Pinned Lean/Mathlib specialist lane only.
 precommit: ## Apply safe fixes, then run lint, types, and unit tests (mutates the tree).
 	$(MAKE) fix
 	$(MAKE) check
+
+validation-status: ## Show whether this worktree holds an exhaustive validation lease.
+	$(WORKTREE_ADMISSION) status
 
 check-static: lint-full typecheck import-contracts architecture todo-check build ## CI-owned static checks plus a local package build.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -199,7 +199,10 @@ obligation records around an already-typed result.
 A checker is a separate installed operation governed by a typed
 `VerificationProtocol[SubjectT, CandidateT, EvidenceT, DecisionT]`. Operator
 configuration authorizes checker identities; producer declarations and search
-code cannot authorize themselves.
+code cannot authorize themselves. Exact replay declarations bind their own
+provider-runtime factory. Installation groups those factories by the provider
+identity they probe; it does not keep a central entrypoint map or support
+matrix.
 
 The runtime keeps four narrow responsibilities:
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -28,8 +28,7 @@ make check
 
 Default `uv run pytest` collects the Lean-free ordinary `testpaths`. Use the
 Make targets that own storage, process, MCP, and Lean isolation. `make
-check-external` covers Lean and maintained-provider probes when those trees
-change.
+check-external` covers the pinned Lean specialist lane when that tree changes.
 
 `make check` is the bounded local handoff: lint, typecheck, and unit tests.
 Hosted CI runs the complete ordinary suite as six fixed semantic lanes: `unit`,

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -105,7 +105,20 @@ make check-static
 `make test-all-ci` is an explicit exhaustive reproduction, not a routine gate.
 Before starting it, confirm that no other pytest job from this checkout is
 running. Concurrent runtime/store/subprocess suites can turn per-test
-timeouts into host-contention noise.
+timeouts into host-contention noise. Exhaustive local targets
+(`test-all-ci`, `test-exhaustive`, `harbor-check-all`,
+`harbor-host-validation`, `harbor-oracle-all`) take an OS-locked lease in
+this worktree; focused `make test-unit` stays free. `make validation-status`
+reports whether the lease is held.
+
+GitHub Actions identity is the YAML under `.github/workflows` on the default
+branch. Registrations whose files are gone, including historical
+`agent-port-*` and `agent-rebase-*` leftovers, are historical: disable them in
+the GitHub UI and retain their run history.
+`python tools/inventory_github_workflows.py` compares files to registrations
+and never disables workflows. `python tools/restack_feature_branch.py` reports
+unique feature commits and duplicate subjects against a declared parent; it
+never force-pushes.
 
 Ordinary CI coverage instruments each pytest process but does not automatically
 instrument every child it launches. Independent checker calls therefore retain

--- a/make/harbor.mk
+++ b/make/harbor.mk
@@ -1,8 +1,5 @@
 # Harbor-only. Product CI does not classify or plan from PATHS.
-ifneq ($(strip $(PATHS)),)
-PATHS_FILE := $(shell mktemp)
-$(file >$(PATHS_FILE),$(PATHS))
-endif
+# Changed-path temps live only inside recipes (EXIT trap); never at parse time.
 
 HARBOR_VERSION ?= 0.20.0
 HARBOR_RUNNER ?= uvx --from harbor==$(HARBOR_VERSION) harbor
@@ -36,10 +33,11 @@ endef
 
 .PHONY: harbor-plan harbor-prepare-task harbor-validate-task harbor-sync harbor-contracts harbor-execution-check harbor-adapter-checks harbor-validation-tests harbor-host-validation harbor-validate harbor-check harbor-check-all harbor-check-task benchmark-inventory benchmark-snapshot benchmark-snapshot-validate benchmark-publish harbor-oracle harbor-oracle-task harbor-oracle-run harbor-oracle-all harbor-adapter-check heldout-validate heldout-render heldout-smoke
 
+harbor-plan: export JACOBIAN_HARBOR_PATHS := $(PATHS)
 harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 	@set -eu; \
 	tmp_dir=$$(mktemp -d); \
-	trap 'rm -rf "$$tmp_dir"; if [ -n "$(PATHS_FILE)" ]; then rm -f "$(PATHS_FILE)"; fi' EXIT; \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
 	base_sha=""; \
 	base_arg=""; \
 	if [ -n "$(BASE)" ]; then \
@@ -47,23 +45,18 @@ harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 		base_arg="--base $$base_sha"; \
 	fi; \
 	head_sha=$$(git rev-parse HEAD); \
-	if [ -n "$(PATHS)" ]; then \
-		$(UV_RUN) python .github/scripts/normalize-ci-paths --file "$(PATHS_FILE)" > "$$tmp_dir/changed-paths.txt"; \
+	if [ -n "$$JACOBIAN_HARBOR_PATHS" ]; then \
+		printf '%s\n' "$$JACOBIAN_HARBOR_PATHS" > "$$tmp_dir/raw-paths.txt"; \
 	else \
 		{ \
 			if [ -n "$(BASE)" ]; then git diff --name-only "$(BASE)" HEAD; fi; \
 			git diff --name-only HEAD; \
 			git ls-files --others --exclude-standard; \
-		} | sort -u > "$$tmp_dir/changed-paths.txt"; \
+		} | sort -u > "$$tmp_dir/raw-paths.txt"; \
 	fi; \
-	if [ -n "$(PATHS)" ]; then \
-		$(HARBOR_PYTHON) .github/scripts/plan-benchmarks \
-			$$base_arg --head "$$head_sha" --paths-file "$(PATHS_FILE)" > "$$tmp_dir/plan.txt"; \
-	else \
-		changed_paths=$$(tr '\n' ' ' < "$$tmp_dir/changed-paths.txt"); \
-		$(HARBOR_PYTHON) .github/scripts/plan-benchmarks \
-			$$base_arg --head "$$head_sha" -- $$changed_paths > "$$tmp_dir/plan.txt"; \
-	fi; \
+	$(UV_RUN) python .github/scripts/normalize-ci-paths --file "$$tmp_dir/raw-paths.txt" > "$$tmp_dir/changed-paths.txt"; \
+	$(HARBOR_PYTHON) .github/scripts/plan-benchmarks \
+		$$base_arg --head "$$head_sha" --paths-file "$$tmp_dir/changed-paths.txt" > "$$tmp_dir/plan.txt"; \
 	$(UV_RUN) python .github/scripts/validate-benchmark-plan < "$$tmp_dir/plan.txt"; \
 	$(UV_RUN) python .github/scripts/emit-plan-receipt \
 		--kind benchmark --event pull_request \
@@ -75,6 +68,7 @@ harbor-plan: ## Print the independent Harbor benchmark plan (BASE=... optional).
 		--config benchmarks/environment-profiles.toml \
 		--config .github/workflows/benchmarks.yml \
 		--config Makefile \
+		--config make/harbor.mk \
 		--config tools/check_benchmark_adapters.py \
 		--config tools/check_benchmark_contracts.py \
 		--config tools/check_harbor_dataset.py \
@@ -127,12 +121,15 @@ harbor-validation-tests: ## Run Harbor's host-side validation test suite.
 		$(PYTEST_DIAGNOSTIC_ARGS) $(if $(TESTS),$(TESTS),benchmarks/validation) $(PYTEST_ARGS)
 
 harbor-host-validation: ## Run the full host suite in timing-balanced local shards.
-	$(UV_RUN) python -m benchmarks.tooling.host_validation run-full \
+	$(WORKTREE_ADMISSION) run --target harbor-host-validation -- $(UV_RUN) python -m benchmarks.tooling.host_validation run-full \
 		--total-workers $(HARBOR_VALIDATION_TOTAL_WORKERS) --max-parallel 4
 
 harbor-check: harbor-execution-check harbor-adapter-checks ## Check Harbor contracts and control-plane behavior.
 
-harbor-check-all: harbor-check harbor-host-validation ## Explicitly run every repository-owned Harbor host regression.
+harbor-check-all: ## Explicitly run every repository-owned Harbor host regression.
+	$(WORKTREE_ADMISSION) run --target harbor-check-all -- $(MAKE) _harbor-check-all-unlocked
+
+_harbor-check-all-unlocked: harbor-check harbor-host-validation
 
 harbor-validate: harbor-check-all ## Backward-compatible exhaustive Harbor validation alias.
 
@@ -232,7 +229,10 @@ harbor-oracle-run: ## Run a dataset Oracle after an already-successful contract 
 		--result "benchmarks/results/$(DATASET)-oracle/$$job_name/result.json" \
 		$(if $(TASKS),--tasks $(TASKS),)
 
-harbor-oracle-all: harbor-check-all ## Run every registered dataset Oracle with tasks.
+harbor-oracle-all: ## Run every registered dataset Oracle with tasks.
+	$(WORKTREE_ADMISSION) run --target harbor-oracle-all -- $(MAKE) _harbor-oracle-all-unlocked
+
+_harbor-oracle-all-unlocked: harbor-check-all
 	@set -e; for dataset in mathematical-benchmarks-v1 symbolic-coordination-v1 public-reproductions-v1 conjecture-probes-v1 research-diagnostics-v1 provider-feasibility-v1; do \
 		$(MAKE) --no-print-directory harbor-oracle-run DATASET=$$dataset FULL=1 EVAL_ARGS="$(EVAL_ARGS)"; \
 	done

--- a/src/jacobian/adapters/mcp/remote.py
+++ b/src/jacobian/adapters/mcp/remote.py
@@ -468,6 +468,7 @@ def create_remote_server(
     capability_policy: CapabilityPolicy | None = None,
     max_tenant_runtimes: int | None = None,
     tenant_idle_timeout_seconds: float | None = None,
+    runtime_factory: Callable[..., JacobianRuntime] | None = None,
 ) -> MCPServer[AppState]:
     """Create one remote host routing requests to isolated tenant runtimes."""
 
@@ -489,6 +490,7 @@ def create_remote_server(
             if tenant_idle_timeout_seconds is None
             else tenant_idle_timeout_seconds
         ),
+        runtime_factory=create_runtime if runtime_factory is None else runtime_factory,
     )
 
     def acquire_runtime() -> RuntimeLease:

--- a/src/jacobian/checker_identity.py
+++ b/src/jacobian/checker_identity.py
@@ -9,13 +9,14 @@ import importlib
 import importlib.abc
 import importlib.machinery
 import importlib.util
+import os
 import re
+import stat
 import sys
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from functools import lru_cache
 from importlib import metadata
 from pathlib import Path
 from types import FrameType, ModuleType
@@ -596,15 +597,7 @@ def _distribution_file_closure(
                 + relative
             )
         try:
-            stat = unresolved.stat()
-            content_digest = _installed_file_digest(
-                str(unresolved),
-                stat.st_dev,
-                stat.st_ino,
-                stat.st_size,
-                stat.st_mtime_ns,
-                stat.st_ctime_ns,
-            )
+            content_digest = _hash_installed_regular_file(unresolved)
         except OSError as exc:
             raise CheckerManifestError(
                 "cannot read checker Python distribution file: " + relative
@@ -616,19 +609,38 @@ def _distribution_file_closure(
     return len(paths), "sha256:" + closure.hexdigest()
 
 
-@lru_cache(maxsize=16_384)
-def _installed_file_digest(
-    path: str,
-    device: int,
-    inode: int,
-    size: int,
-    modified_ns: int,
-    changed_ns: int,
-) -> str:
-    """Hash an installed file once for each observable filesystem identity."""
+def _hash_installed_regular_file(path: Path) -> str:
+    """Hash one declared regular file through a single opened descriptor."""
 
-    del device, inode, size, modified_ns, changed_ns
-    return _source_digest(Path(path).read_bytes())
+    flags = os.O_RDONLY
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    fd = os.open(path, flags)
+    try:
+        before = os.fstat(fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise CheckerManifestError(
+                "checker Python distribution contains a missing or non-regular file"
+            )
+        hasher = hashlib.sha256()
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+        after = os.fstat(fd)
+        if (
+            before.st_dev != after.st_dev
+            or before.st_ino != after.st_ino
+            or before.st_size != after.st_size
+        ):
+            raise CheckerManifestError(
+                "checker Python distribution file changed during measurement"
+            )
+        return "sha256:" + hasher.hexdigest()
+    finally:
+        os.close(fd)
 
 
 def _distribution_key(name: str) -> str:

--- a/src/jacobian/checker_operations.py
+++ b/src/jacobian/checker_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from jacobian.contracts.capabilities import CapabilityProviderRuntime
@@ -106,6 +107,8 @@ class ExactReplayCheckerDeclaration:
     verification_title: str | None = None
     verification_description: str | None = None
     verification_tags: tuple[str, ...] = ()
+    provider_runtime_factory: Callable[..., CapabilityProviderRuntime] | None = None
+    supports_input: Callable[[object], bool] | None = None
 
     def __post_init__(self) -> None:
         for field, value in {
@@ -120,6 +123,10 @@ class ExactReplayCheckerDeclaration:
                 raise ValueError(
                     f"exact replay checker declaration {field} must not be empty"
                 )
+        if self.provider_runtime_factory is None:
+            raise ValueError(
+                "exact replay checker declaration requires a provider runtime factory"
+            )
         derived_id = derive_verification_capability_id(self.capability_id)
         explicit_text = (
             self.verification_title,

--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -17,6 +18,8 @@ from jacobian.runtime.config import CheckerAuthorityMode
 
 if TYPE_CHECKING:
     from jacobian.runtime.model import JacobianRuntime
+
+RuntimeOpener = Callable[..., Any]
 
 
 class JacobianGroup(TyperGroup):
@@ -54,31 +57,28 @@ class JacobianGroup(TyperGroup):
                     active_failure.add_note(f"CLI cleanup also failed: {cleanup_exc}")
 
 
-app = typer.Typer(
-    name="jacobian",
-    cls=JacobianGroup,
-    help="Run installed atomic mathematical operations.",
-    no_args_is_help=True,
-)
-
-
 class CliState:
     def __init__(
         self,
         state_dir: Path,
         *,
         checker_authority: CheckerAuthorityMode,
+        runtime_opener: RuntimeOpener | None = None,
     ) -> None:
         self.state_dir = state_dir
         self.checker_authority = checker_authority
+        self._runtime_opener = runtime_opener
         self._runtime: JacobianRuntime | None = None
 
     @property
     def runtime(self) -> JacobianRuntime:
         if self._runtime is None:
-            from jacobian.runtime import create_runtime
+            opener = self._runtime_opener
+            if opener is None:
+                from jacobian.runtime import create_runtime
 
-            self._runtime = create_runtime(
+                opener = create_runtime
+            self._runtime = opener(
                 self.state_dir,
                 checker_authority=self.checker_authority,
             )
@@ -90,25 +90,6 @@ class CliState:
             self._runtime = None
 
 
-@app.callback()
-def configure(
-    context: typer.Context,
-    state_dir: Annotated[
-        Path,
-        typer.Option("--state-dir", help="Local artifact and metadata directory."),
-    ] = Path(".jacobian"),
-    checker_authority: Annotated[
-        CheckerAuthorityMode,
-        typer.Option(
-            "--checker-authority",
-            help="Checker authority policy for this runtime.",
-        ),
-    ] = CheckerAuthorityMode.INSTALL_BUNDLED,
-) -> None:
-    context.obj = CliState(state_dir, checker_authority=checker_authority)
-
-
-@app.command("init")
 def initialize(context: typer.Context) -> None:
     """Initialize storage and report the installed operation count."""
 
@@ -118,7 +99,6 @@ def initialize(context: typer.Context) -> None:
     typer.echo(f"Installed {count} mathematical operations.")
 
 
-@app.command("catalog")
 def catalog(context: typer.Context) -> None:
     """Print the complete installed operation catalog."""
 
@@ -126,7 +106,6 @@ def catalog(context: typer.Context) -> None:
     _emit(value.model_dump(mode="json"))
 
 
-@app.command("inspect")
 def inspect_operation(context: typer.Context, operation_id: str) -> None:
     """Print one exact installed operation declaration."""
 
@@ -144,7 +123,6 @@ def inspect_operation(context: typer.Context, operation_id: str) -> None:
     _emit(descriptor.model_dump(mode="json"))
 
 
-@app.command("run")
 def run_operation(
     context: typer.Context,
     operation_id: str,
@@ -175,7 +153,6 @@ def run_operation(
     _emit(result.model_dump(mode="json"))
 
 
-@app.command("provider-measure")
 def provider_measure(
     context: typer.Context,
     operation_id: str,
@@ -205,6 +182,48 @@ def provider_measure(
             include_cold_install=include_cold_install,
         ).model_dump(mode="json")
     )
+
+
+def create_cli_app(*, runtime_opener: RuntimeOpener | None = None) -> typer.Typer:
+    """Create the operator CLI, optionally over a caller-owned runtime opener."""
+
+    application = typer.Typer(
+        name="jacobian",
+        cls=JacobianGroup,
+        help="Run installed atomic mathematical operations.",
+        no_args_is_help=True,
+    )
+
+    @application.callback()
+    def configure(
+        context: typer.Context,
+        state_dir: Annotated[
+            Path,
+            typer.Option("--state-dir", help="Local artifact and metadata directory."),
+        ] = Path(".jacobian"),
+        checker_authority: Annotated[
+            CheckerAuthorityMode,
+            typer.Option(
+                "--checker-authority",
+                help="Checker authority policy for this runtime.",
+            ),
+        ] = CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) -> None:
+        context.obj = CliState(
+            state_dir,
+            checker_authority=checker_authority,
+            runtime_opener=runtime_opener,
+        )
+
+    application.command("init")(initialize)
+    application.command("catalog")(catalog)
+    application.command("inspect")(inspect_operation)
+    application.command("run")(run_operation)
+    application.command("provider-measure")(provider_measure)
+    return application
+
+
+app = create_cli_app()
 
 
 def _state(context: typer.Context) -> CliState:

--- a/src/jacobian/domains/certified_snf/checkers.py
+++ b/src/jacobian/domains/certified_snf/checkers.py
@@ -1,7 +1,16 @@
 """Independent checker declaration for certified Smith normal forms."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.certified_snf import CertifiedSmithNormalFormRequest
+from jacobian.providers import flint_runtime
+
+
+def _certified_snf_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.certified_snf_checker_provider_runtime(checker_ids=checker_ids)
+
 
 CERTIFIED_SNF_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -10,6 +19,7 @@ CERTIFIED_SNF_EXACT_REPLAY_CHECKERS = (
         "check_certified_smith_normal_form",
         "matrix.smith-normal-form.transformation-certificate-v1",
         entrypoint_module="jacobian_checkers.certified_snf",
+        provider_runtime_factory=_certified_snf_runtime,
         replay_method="independent Smith transformation-certificate replay",
         reason=(
             "operator-authorized independent checker validates D=UAV, both "

--- a/src/jacobian/domains/combinatorics/checkers.py
+++ b/src/jacobian/domains/combinatorics/checkers.py
@@ -1,6 +1,7 @@
 """Independent checker declarations owned by exact combinatorics."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.combinatorics import (
     CyclicDifferenceSetExtensionRequest,
     CyclicPerfectDifferenceSetRequest,
@@ -9,12 +10,22 @@ from jacobian.contracts.combinatorics import (
     PolynomialCoefficientRecurrenceEvaluationRequest,
     RationalGeneratingFunctionCoefficientsRequest,
 )
+from jacobian.providers import flint_runtime
 
 _ENTRYPOINT = "jacobian_checkers.recurrence_series"
 _REASON = (
     "operator-authorized standard-library Fraction replay independent of the "
     "SymPy recurrence and rational-series producer"
 )
+
+
+def _combinatorics_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.combinatorics_exact_checker_provider_runtime(
+        checker_ids=checker_ids
+    )
+
 
 COMBINATORICS_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -23,6 +34,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_integer_sidon",
         "combinatorics.integer-sidon.ordered-difference-replay",
         entrypoint_module="jacobian_checkers.additive_combinatorics",
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library ordered-difference replay",
         reason=(
             "operator-authorized standard-library checker independently enumerates "
@@ -35,6 +47,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_cyclic_perfect_difference_set",
         "combinatorics.cyclic-pds.residue-profile-replay",
         entrypoint_module="jacobian_checkers.additive_combinatorics",
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library cyclic residue-profile replay",
         reason=(
             "operator-authorized standard-library checker independently rebuilds "
@@ -47,6 +60,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_cyclic_difference_set_extension",
         "combinatorics.cyclic-pds-extension.exhaustive-replay",
         entrypoint_module="jacobian_checkers.additive_combinatorics",
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library fixed-order exhaustive extension replay",
         reason=(
             "operator-authorized checker independently enumerates every bounded "
@@ -59,6 +73,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_linear_recurrence_evaluation",
         "combinatorics.linear-recurrence.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library Fraction recurrence replay",
         reason=_REASON,
     ),
@@ -68,6 +83,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_polynomial_coefficient_recurrence_evaluation",
         "combinatorics.p-recursive.fraction-residual-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library Fraction polynomial recurrence replay",
         reason=_REASON,
     ),
@@ -77,6 +93,7 @@ COMBINATORICS_EXACT_REPLAY_CHECKERS = (
         "check_rational_generating_function_coefficients",
         "combinatorics.rational-series.fraction-residual-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_combinatorics_runtime,
         replay_method="standard-library Fraction residual replay",
         reason=_REASON,
     ),

--- a/src/jacobian/domains/finite_fields/checkers.py
+++ b/src/jacobian/domains/finite_fields/checkers.py
@@ -1,6 +1,10 @@
 """Independent checker declarations for finite-field operations."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderRuntime,
+)
 from jacobian.domains.finite_fields.contracts import (
     CollisionCertificateRequest,
     FiberPartitionRequest,
@@ -9,6 +13,60 @@ from jacobian.domains.finite_fields.contracts import (
     PermutationCertificateRequest,
     RestrictScalarsRequest,
 )
+from jacobian.provider_runtime import (
+    composite_provider_runtime,
+    known_provider_runtime,
+    source_provider_runtime,
+)
+
+
+def _finite_field_rank_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    source = source_provider_runtime(
+        "jacobian.finite-field-rank-checker-source",
+        version="1",
+        entrypoint=(
+            "jacobian_checkers.finite_field_rank:check_finite_field_linear_map_rank"
+        ),
+        install_tier=CapabilityInstallTier.T0,
+        license_id="MIT",
+        features=("clean-process-checker",),
+    )
+    sympy = known_provider_runtime(
+        "jacobian.sympy",
+        features=("prime-field-rank-replay",),
+    )
+    return composite_provider_runtime(
+        "jacobian.finite-field-rank-checker",
+        components=(source, sympy),
+        features=("independent-prime-field-rank-replay",),
+        checker_ids=checker_ids,
+    )
+
+
+def _finite_field_polynomial_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    source = source_provider_runtime(
+        "jacobian.finite-field-polynomial-checker-source",
+        version="1",
+        entrypoint="jacobian_checkers.finite_field_polynomial:check_finite_map_table",
+        install_tier=CapabilityInstallTier.T0,
+        license_id="MIT",
+        features=("clean-process-checker",),
+    )
+    sympy = known_provider_runtime(
+        "jacobian.sympy",
+        features=("finite-field-polynomial-replay",),
+    )
+    return composite_provider_runtime(
+        "jacobian.finite-field-polynomial-checker",
+        components=(source, sympy),
+        features=("independent-finite-field-polynomial-replay",),
+        checker_ids=checker_ids,
+    )
+
 
 FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -17,6 +75,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_field_restriction",
         "finite-field.restriction.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_rank",
+        provider_runtime_factory=_finite_field_rank_runtime,
         replay_method="SymPy polynomial-quotient replay",
         reason=(
             "operator-authorized SymPy replay independent of the Python-FLINT producer"
@@ -28,6 +87,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_field_linear_map_rank",
         "finite-field.linear-map-rank.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_rank",
+        provider_runtime_factory=_finite_field_rank_runtime,
         replay_method="SymPy prime-field rank replay",
         reason=(
             "operator-authorized SymPy replay independent of the Python-FLINT producer"
@@ -39,6 +99,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_map_table",
         "finite-field.polynomial-map-table.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_polynomial",
+        provider_runtime_factory=_finite_field_polynomial_runtime,
         replay_method="SymPy finite-field polynomial replay",
         reason="operator-authorized SymPy replay independent of the FLINT producer",
     ),
@@ -48,6 +109,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_map_fibers",
         "finite-field.polynomial-map-fibers.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_polynomial",
+        provider_runtime_factory=_finite_field_polynomial_runtime,
         replay_method="SymPy finite-map fiber replay",
         reason="operator-authorized SymPy replay of the exact map and its fibers",
     ),
@@ -57,6 +119,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_map_collision",
         "finite-field.polynomial-map-collision.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_polynomial",
+        provider_runtime_factory=_finite_field_polynomial_runtime,
         replay_method="SymPy finite-map collision replay",
         reason="operator-authorized SymPy replay of the exact map and collision",
     ),
@@ -66,6 +129,7 @@ FINITE_FIELD_EXACT_REPLAY_CHECKERS = (
         "check_finite_map_permutation",
         "finite-field.polynomial-map-permutation.sympy-replay",
         entrypoint_module="jacobian_checkers.finite_field_polynomial",
+        provider_runtime_factory=_finite_field_polynomial_runtime,
         replay_method="SymPy finite-map permutation replay",
         reason="operator-authorized SymPy replay of the exact map and inverse",
     ),

--- a/src/jacobian/domains/geometry/checkers.py
+++ b/src/jacobian/domains/geometry/checkers.py
@@ -19,7 +19,9 @@ from jacobian.provider_runtime import source_provider_runtime
 _ENTRYPOINT = "jacobian_checkers.exact_geometry"
 
 
-def _geometry_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+def _geometry_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
     return source_provider_runtime(
         "jacobian.exact-geometry-checker",
         version="1",

--- a/src/jacobian/domains/geometry/checkers.py
+++ b/src/jacobian/domains/geometry/checkers.py
@@ -1,6 +1,10 @@
 """Per-producer independent replay declarations for exact geometry."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.geometry import (
     ConvexPolygonTriangulationRequest,
     PointPairRequest,
@@ -10,8 +14,23 @@ from jacobian.contracts.geometry import (
     SegmentIntersectionRequest,
     SimplePolygonPointRequest,
 )
+from jacobian.provider_runtime import source_provider_runtime
 
 _ENTRYPOINT = "jacobian_checkers.exact_geometry"
+
+
+def _geometry_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+    return source_provider_runtime(
+        "jacobian.exact-geometry-checker",
+        version="1",
+        entrypoint="jacobian_checkers.exact_geometry:check_exact_geometry",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        features=("standard-library-rational-replay", "clean-process-checker"),
+        checker_ids=checker_ids,
+    )
+
+
 _OPERATIONS = (
     (
         "geometry.polygon.triangulation.minimum_weight.compute",
@@ -34,6 +53,7 @@ GEOMETRY_EXACT_REPLAY_CHECKERS = tuple(
         "check_exact_geometry",
         "geometry.exact_rational_result",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_geometry_runtime,
         replay_method="standard-library exact-rational replay",
         reason=(
             "operator-authorized standard-library rational replay independent of "

--- a/src/jacobian/domains/graph_optimization/checkers.py
+++ b/src/jacobian/domains/graph_optimization/checkers.py
@@ -1,6 +1,9 @@
 """Independent checker declarations owned by the graph-optimization domain."""
 
+from collections.abc import Callable
+
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.graph_distance_matrix import GraphDistanceMatrixRequest
 from jacobian.contracts.graph_invariant_operations import (
     GraphInvariantRequest,
@@ -11,8 +14,26 @@ from jacobian.contracts.graph_optimization import (
     GraphMinimumSpanningTreeRequest,
     GraphOptimizationRequest,
 )
+from jacobian.providers import flint_runtime
 
 _GRAPH_ENTRYPOINT = "jacobian_checkers.graph_exact_operations"
+
+
+def _graph_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+    return flint_runtime.graph_exact_checker_provider_runtime(checker_ids=checker_ids)
+
+
+def _graph_order_at_most(maximum: int) -> Callable[[object], bool]:
+    def supports(payload: object) -> bool:
+        return (
+            isinstance(payload, dict)
+            and isinstance(payload.get("graph"), dict)
+            and isinstance(payload["graph"].get("vertices"), list)
+            and len(payload["graph"]["vertices"]) <= maximum
+        )
+
+    return supports
+
 
 GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -21,6 +42,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_hamiltonian_path",
         "graph.hamiltonian-path.exhaustive-replay",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="finite Hamiltonian-path exhaustive replay",
         reason=(
             "operator-authorized standard-library checker independent of the "
@@ -38,6 +60,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
             "graph",
             "hamiltonian-path",
         ),
+        supports_input=_graph_order_at_most(18),
     ),
     ExactReplayCheckerDeclaration(
         "graph.induced_tree.maximum.compute",
@@ -45,6 +68,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_induced_tree_maximum",
         "graph.induced-tree.maximum.exhaustive-replay",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="finite-subset exhaustive replay",
         reason=(
             "operator-authorized finite exhaustive checker independent of the "
@@ -57,6 +81,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
             "exact maximum induced-tree result against its exact graph input."
         ),
         verification_tags=("verification", "exact", "graph", "induced-tree"),
+        supports_input=_graph_order_at_most(16),
     ),
     ExactReplayCheckerDeclaration(
         "graph.spanning_tree.minimum.compute",
@@ -64,6 +89,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_minimum_spanning_tree",
         "graph.minimum-spanning-tree.cycle-certificate-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="fundamental-cycle optimality certificate replay",
         reason=(
             "operator-authorized standard-library exact-rational checker "
@@ -91,6 +117,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_diameter",
         "graph.diameter.all-sources-bfs-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="all-sources breadth-first replay",
         reason=(
             "operator-authorized standard-library BFS checker independent of "
@@ -116,6 +143,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_radius",
         "graph.radius.all-sources-bfs-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="all-sources breadth-first replay",
         reason=(
             "operator-authorized standard-library BFS checker independent of "
@@ -141,6 +169,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_distance_matrix",
         "graph.distance-matrix.all-sources-bfs-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="all-sources breadth-first distance-matrix replay",
         reason=(
             "operator-authorized standard-library BFS checker independent of "
@@ -167,6 +196,7 @@ GRAPH_OPTIMIZATION_EXACT_REPLAY_CHECKERS = (
         "check_graph_maximum_matching",
         "graph.maximum-matching.tutte-berge-v1",
         entrypoint_module=_GRAPH_ENTRYPOINT,
+        provider_runtime_factory=_graph_runtime,
         replay_method="Tutte-Berge barrier replay",
         reason=(
             "operator-authorized standard-library Tutte-Berge checker independent "

--- a/src/jacobian/domains/graph_symmetry/checkers.py
+++ b/src/jacobian/domains/graph_symmetry/checkers.py
@@ -1,7 +1,14 @@
 """Independent checker declaration owned by the graph-symmetry domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.graph_symmetry import GraphSymmetryOrbitRequest
+from jacobian.providers import flint_runtime
+
+
+def _graph_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+    return flint_runtime.graph_exact_checker_provider_runtime(checker_ids=checker_ids)
+
 
 GRAPH_SYMMETRY_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -10,6 +17,7 @@ GRAPH_SYMMETRY_EXACT_REPLAY_CHECKERS = (
         "check_graph_symmetry_generator_orbits",
         "graph.symmetry.generator-orbits.stdlib-replay",
         entrypoint_module="jacobian_checkers.graph_exact_operations",
+        provider_runtime_factory=_graph_runtime,
         replay_method="declared color-preserving generator orbit replay",
         reason=(
             "operator-authorized standard-library checker independently validates "

--- a/src/jacobian/domains/matrix_lattice/checkers.py
+++ b/src/jacobian/domains/matrix_lattice/checkers.py
@@ -1,6 +1,10 @@
 """Independent checker declarations owned by the matrix domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.matrix_lattice import HermiteNormalFormRequest
 from jacobian.contracts.matrix_operations import (
     IntegerMatrixRequest,
@@ -10,6 +14,30 @@ from jacobian.contracts.matrix_operations import (
     RationalMatrixRequest,
     SquareRationalMatrixRequest,
 )
+from jacobian.provider_runtime import source_provider_runtime
+from jacobian.providers import flint_runtime
+
+
+def _flint_exact_replay_runtime(
+    *, checker_ids: tuple[str, ...] = (), refresh: bool = False
+) -> CapabilityProviderRuntime:
+    return flint_runtime.exact_domain_checker_provider_runtime(
+        checker_ids=checker_ids,
+        refresh=refresh,
+    )
+
+
+def _hnf_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+    return source_provider_runtime(
+        "jacobian.matrix-hnf-checker",
+        version="1",
+        entrypoint="jacobian_checkers.matrix_normal_forms:check_hermite_normal_form",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        features=("standard-library-integer-replay", "clean-process-checker"),
+        checker_ids=checker_ids,
+    )
+
 
 MATRIX_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -30,48 +58,56 @@ MATRIX_EXACT_REPLAY_CHECKERS = (
             "stored integer matrix input."
         ),
         verification_tags=("verification", "exact", "matrix", "hermite-normal-form"),
+        provider_runtime_factory=_hnf_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.determinant.compute",
         MatrixDeterminantRequest,
         "check_matrix_determinant",
         "matrix.determinant.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.rank.compute",
         MatrixRankRequest,
         "check_matrix_rank",
         "matrix.rank.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.multiply.compute",
         RationalMatrixProductRequest,
         "check_matrix_product",
         "matrix.product.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.normal_form.rref.compute",
         RationalMatrixRequest,
         "check_matrix_rref",
         "matrix.rref.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.nullspace.compute",
         RationalMatrixRequest,
         "check_matrix_nullspace",
         "matrix.nullspace.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.characteristic_polynomial.compute",
         SquareRationalMatrixRequest,
         "check_matrix_characteristic_polynomial",
         "matrix.characteristic-polynomial.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "matrix.normal_form.smith.compute",
         IntegerMatrixRequest,
         "check_matrix_smith_normal_form",
         "matrix.smith-normal-form.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
     ),
 )
 

--- a/src/jacobian/domains/number_theory/checkers.py
+++ b/src/jacobian/domains/number_theory/checkers.py
@@ -1,13 +1,25 @@
 """Independent checker declarations owned by the number-theory domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.number_theory import (
     FactorizationRequest,
     ModularPolynomialResidueImageRequest,
     PowerfulNumberRequest,
 )
+from jacobian.providers import flint_runtime
 
 _EXACT_DOMAIN_ENTRYPOINT = "jacobian_checkers.exact_domain_operations"
+
+
+def _flint_exact_replay_runtime(
+    *, checker_ids: tuple[str, ...] = (), refresh: bool = False
+) -> CapabilityProviderRuntime:
+    return flint_runtime.exact_domain_checker_provider_runtime(
+        checker_ids=checker_ids,
+        refresh=refresh,
+    )
+
 
 NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -16,6 +28,7 @@ NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
         "check_integer_prime_factorization",
         "integer.prime-factorization.flint-replay",
         entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        provider_runtime_factory=_flint_exact_replay_runtime,
         replay_method="Python-FLINT prime-factorization replay",
         reason=(
             "operator-authorized Python-FLINT checker independent of the "
@@ -41,6 +54,7 @@ NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
         "check_integer_powerful_number",
         "integer.powerful.flint-replay",
         entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        provider_runtime_factory=_flint_exact_replay_runtime,
         replay_method="Python-FLINT powerful-number replay",
         reason=(
             "operator-authorized Python-FLINT checker independent of the "
@@ -67,6 +81,7 @@ NUMBER_THEORY_EXACT_REPLAY_CHECKERS = (
         "check_modular_polynomial_residue_image",
         "modular.polynomial-residue-image.flint-replay",
         entrypoint_module=_EXACT_DOMAIN_ENTRYPOINT,
+        provider_runtime_factory=_flint_exact_replay_runtime,
         replay_method="Python-FLINT exhaustive modular-polynomial replay",
         reason=(
             "operator-authorized Python-FLINT checker independently reconstructs "

--- a/src/jacobian/domains/polynomial/checkers.py
+++ b/src/jacobian/domains/polynomial/checkers.py
@@ -1,6 +1,9 @@
 """Independent checker declarations owned by the polynomial domain."""
 
+from collections.abc import Callable
+
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.jacobian_syzygy import GradedJacobianSyzygyRequest
 from jacobian.contracts.polynomial_operations import (
     PolynomialDiscriminantRequest,
@@ -9,6 +12,35 @@ from jacobian.contracts.polynomial_operations import (
     PolynomialResultantRequest,
     PolynomialSquareFreeRequest,
 )
+from jacobian.providers import flint_runtime
+
+
+def _flint_exact_replay_runtime(
+    *, checker_ids: tuple[str, ...] = (), refresh: bool = False
+) -> CapabilityProviderRuntime:
+    return flint_runtime.exact_domain_checker_provider_runtime(
+        checker_ids=checker_ids,
+        refresh=refresh,
+    )
+
+
+def _graded_syzygy_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.graded_syzygy_checker_provider_runtime(checker_ids=checker_ids)
+
+
+def _univariate_polynomial(*fields: str) -> Callable[[object], bool]:
+    def supports(payload: object) -> bool:
+        return isinstance(payload, dict) and all(
+            isinstance(payload.get(field), dict)
+            and payload[field].get("variables")
+            and len(payload[field]["variables"]) == 1
+            for field in fields
+        )
+
+    return supports
+
 
 POLYNOMIAL_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -36,36 +68,47 @@ POLYNOMIAL_EXACT_REPLAY_CHECKERS = (
             "jacobian",
             "syzygy",
         ),
+        provider_runtime_factory=_graded_syzygy_runtime,
     ),
     ExactReplayCheckerDeclaration(
         "polynomial.compute.gcd",
         PolynomialGcdRequest,
         "check_polynomial_gcd",
         "polynomial.gcd.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
+        supports_input=_univariate_polynomial("left", "right"),
     ),
     ExactReplayCheckerDeclaration(
         "polynomial.compute.resultant",
         PolynomialResultantRequest,
         "check_polynomial_resultant",
         "polynomial.resultant.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
+        supports_input=_univariate_polynomial("left", "right"),
     ),
     ExactReplayCheckerDeclaration(
         "polynomial.compute.discriminant",
         PolynomialDiscriminantRequest,
         "check_polynomial_discriminant",
         "polynomial.discriminant.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
+        supports_input=_univariate_polynomial("polynomial"),
     ),
     ExactReplayCheckerDeclaration(
         "polynomial.compute.square_free_decomposition",
         PolynomialSquareFreeRequest,
         "check_polynomial_square_free",
         "polynomial.square-free.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
+        supports_input=_univariate_polynomial("polynomial"),
     ),
     ExactReplayCheckerDeclaration(
         "polynomial.factor.compute",
         PolynomialFactorRequest,
         "check_polynomial_factorization",
         "polynomial.factorization.flint-replay",
+        provider_runtime_factory=_flint_exact_replay_runtime,
+        supports_input=_univariate_polynomial("polynomial"),
     ),
 )
 

--- a/src/jacobian/domains/posets/checkers.py
+++ b/src/jacobian/domains/posets/checkers.py
@@ -1,18 +1,25 @@
 """Independent checker declarations owned by the finite-poset domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.posets import (
     FinitePosetRequest,
     LinearExtensionRequest,
     MobiusFunctionRequest,
     PosetRequest,
 )
+from jacobian.providers import flint_runtime
 
 _ENTRYPOINT = "jacobian_checkers.finite_posets"
 _REASON = (
     "operator-authorized clean-process standard-library replay that imports "
     "neither NetworkX nor the poset producer or contracts"
 )
+
+
+def _poset_runtime(*, checker_ids: tuple[str, ...] = ()) -> CapabilityProviderRuntime:
+    return flint_runtime.poset_exact_checker_provider_runtime(checker_ids=checker_ids)
+
 
 FINITE_POSET_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -21,6 +28,7 @@ FINITE_POSET_EXACT_REPLAY_CHECKERS = (
         "check_finite_poset_materialization",
         "poset.finite.closure-reduction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_poset_runtime,
         replay_method="independent closure and transitive-reduction replay",
         reason=_REASON,
     ),
@@ -30,6 +38,7 @@ FINITE_POSET_EXACT_REPLAY_CHECKERS = (
         "check_poset_width",
         "poset.width.dilworth-dual-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_poset_runtime,
         replay_method="independent antichain and chain-partition replay",
         reason=_REASON,
     ),
@@ -39,6 +48,7 @@ FINITE_POSET_EXACT_REPLAY_CHECKERS = (
         "check_linear_extension_count",
         "poset.linear-extensions.complete-ideal-dp-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_poset_runtime,
         replay_method="independent complete order-ideal recurrence replay",
         reason=_REASON,
     ),
@@ -48,6 +58,7 @@ FINITE_POSET_EXACT_REPLAY_CHECKERS = (
         "check_poset_mobius_function",
         "poset.mobius.interval-convolution-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_poset_runtime,
         replay_method="independent interval-convolution recurrence replay",
         reason=_REASON,
     ),

--- a/src/jacobian/domains/probability/checkers.py
+++ b/src/jacobian/domains/probability/checkers.py
@@ -1,6 +1,7 @@
 """Independent checker declarations owned by the probability domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.probability import (
     FiniteConvolutionRequest,
     FiniteEventRequest,
@@ -11,12 +12,22 @@ from jacobian.contracts.validated_analysis import FiniteRawMomentRequest
 from jacobian.domains.probability.gaussian_inputs import (
     CanonicalGaussianPolynomialMomentRequest,
 )
+from jacobian.providers import flint_runtime
 
 _ENTRYPOINT = "jacobian_checkers.exact_probability_operations"
 _REASON = (
     "operator-authorized standard-library Fraction replay independent of the "
     "Python-FLINT producer"
 )
+
+
+def _probability_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.probability_exact_checker_provider_runtime(
+        checker_ids=checker_ids
+    )
+
 
 PROBABILITY_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -25,6 +36,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_finite_raw_moment",
         "probability.finite-raw-moment.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="standard-library Fraction replay",
         reason=_REASON,
     ),
@@ -34,6 +46,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_finite_event_probability",
         "probability.finite-event.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="standard-library Fraction replay",
         reason=_REASON,
     ),
@@ -43,6 +56,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_finite_condition",
         "probability.finite-condition.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="standard-library Fraction replay",
         reason=_REASON,
     ),
@@ -52,6 +66,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_finite_pushforward",
         "probability.finite-pushforward.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="standard-library Fraction replay",
         reason=_REASON,
     ),
@@ -61,6 +76,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_finite_convolution",
         "probability.finite-convolution.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="standard-library Fraction replay",
         reason=_REASON,
     ),
@@ -70,6 +86,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_gaussian_polynomial_moment",
         "probability.gaussian-polynomial-moment.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="independent standard-library coefficient contraction",
         reason=_REASON,
     ),
@@ -79,6 +96,7 @@ PROBABILITY_EXACT_REPLAY_CHECKERS = (
         "check_graph_connection_probability",
         "probability.graph-reliability-connection.fraction-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_probability_runtime,
         replay_method="independent exhaustive edge-subset replay",
         reason=_REASON,
         verification_capability_id=(

--- a/src/jacobian/domains/projective_geometry/checkers.py
+++ b/src/jacobian/domains/projective_geometry/checkers.py
@@ -1,7 +1,31 @@
 """Independent checker declaration for projective arrangements."""
 
+from collections.abc import Callable
+
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.projective_geometry import ProjectiveLineArrangementRequest
+from jacobian.providers import flint_runtime
+
+
+def _projective_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.projective_arrangement_checker_provider_runtime(
+        checker_ids=checker_ids
+    )
+
+
+def _at_most_lines(maximum: int) -> Callable[[object], bool]:
+    def supports(payload: object) -> bool:
+        return (
+            isinstance(payload, dict)
+            and isinstance(payload.get("lines"), list)
+            and len(payload["lines"]) <= maximum
+        )
+
+    return supports
+
 
 PROJECTIVE_GEOMETRY_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -10,6 +34,8 @@ PROJECTIVE_GEOMETRY_EXACT_REPLAY_CHECKERS = (
         "check_projective_line_arrangement_flats",
         "geometry.projective-line-arrangement.flats.exhaustive-replay",
         entrypoint_module="jacobian_checkers.projective_arrangements",
+        provider_runtime_factory=_projective_runtime,
+        supports_input=_at_most_lines(64),
         replay_method="exact projective pair-incidence exhaustive replay",
         reason=(
             "operator-authorized standard-library checker independently normalizes "

--- a/src/jacobian/domains/rational_linear/checkers.py
+++ b/src/jacobian/domains/rational_linear/checkers.py
@@ -1,12 +1,46 @@
 """Independent checker declarations for inline rational-linear candidates."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import (
+    CapabilityInstallTier,
+    CapabilityProviderRuntime,
+)
 from jacobian.contracts.linear import (
     LinearRationalInconsistencyFindRequest,
     LinearRationalSolutionFindRequest,
 )
+from jacobian.provider_runtime import source_provider_runtime
 
 _ENTRYPOINT = "jacobian_checkers.linear"
+
+
+def _linear_solution_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return source_provider_runtime(
+        "jacobian.rational-linear-checker",
+        version="1",
+        entrypoint="jacobian_checkers.linear:check_rational_solution",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        features=("standard-library-rational-replay", "clean-process-checker"),
+        checker_ids=checker_ids,
+    )
+
+
+def _linear_inconsistency_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return source_provider_runtime(
+        "jacobian.rational-linear-inconsistency-checker",
+        version="1",
+        entrypoint="jacobian_checkers.linear:check_rational_inconsistency",
+        install_tier=CapabilityInstallTier.T1,
+        license_id="MIT",
+        features=("standard-library-rational-replay", "clean-process-checker"),
+        checker_ids=checker_ids,
+    )
+
 
 RATIONAL_LINEAR_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -15,6 +49,7 @@ RATIONAL_LINEAR_EXACT_REPLAY_CHECKERS = (
         "check_rational_solution",
         "linear.rational_solution",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_linear_solution_runtime,
         replay_method="independent exact rational equation replay",
         reason="standard-library checker independently replays every equation",
     ),
@@ -24,6 +59,7 @@ RATIONAL_LINEAR_EXACT_REPLAY_CHECKERS = (
         "check_rational_inconsistency",
         "linear.rational_inconsistency",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_linear_inconsistency_runtime,
         replay_method="independent exact rational left-nullspace replay",
         reason="standard-library checker independently replays the left witness",
     ),

--- a/src/jacobian/domains/topology/checkers.py
+++ b/src/jacobian/domains/topology/checkers.py
@@ -20,7 +20,9 @@ _REASON = (
 def _topology_runtime(
     *, checker_ids: tuple[str, ...] = ()
 ) -> CapabilityProviderRuntime:
-    return flint_runtime.topology_exact_checker_provider_runtime(checker_ids=checker_ids)
+    return flint_runtime.topology_exact_checker_provider_runtime(
+        checker_ids=checker_ids
+    )
 
 
 TOPOLOGY_EXACT_REPLAY_CHECKERS = (

--- a/src/jacobian/domains/topology/checkers.py
+++ b/src/jacobian/domains/topology/checkers.py
@@ -1,18 +1,27 @@
 """Independent checker declarations owned by the topology domain."""
 
 from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.capabilities import CapabilityProviderRuntime
 from jacobian.contracts.topology import (
     ChainComplexRequest,
     IntegralSimplicialHomologyRequest,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
 )
+from jacobian.providers import flint_runtime
 
 _ENTRYPOINT = "jacobian_checkers.simplicial_topology"
 _REASON = (
     "operator-authorized clean-process modular replay that imports no topology "
     "producer or contract implementation"
 )
+
+
+def _topology_runtime(
+    *, checker_ids: tuple[str, ...] = ()
+) -> CapabilityProviderRuntime:
+    return flint_runtime.topology_exact_checker_provider_runtime(checker_ids=checker_ids)
+
 
 TOPOLOGY_EXACT_REPLAY_CHECKERS = (
     ExactReplayCheckerDeclaration(
@@ -21,6 +30,7 @@ TOPOLOGY_EXACT_REPLAY_CHECKERS = (
         "check_simplicial_complex_canonicalization",
         "topology.simplicial-complex.closure-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_topology_runtime,
         replay_method="independent finite face-closure replay",
         reason=_REASON,
     ),
@@ -30,6 +40,7 @@ TOPOLOGY_EXACT_REPLAY_CHECKERS = (
         "check_simplicial_chain_complex",
         "topology.simplicial-chain.boundary-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_topology_runtime,
         replay_method="independent oriented-boundary replay",
         reason=_REASON,
     ),
@@ -39,6 +50,7 @@ TOPOLOGY_EXACT_REPLAY_CHECKERS = (
         "check_simplicial_homology",
         "topology.simplicial-homology.modular-replay",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_topology_runtime,
         replay_method="independent modular quotient replay",
         reason=_REASON,
     ),
@@ -48,6 +60,7 @@ TOPOLOGY_EXACT_REPLAY_CHECKERS = (
         "check_integral_simplicial_homology",
         "topology.simplicial-homology.integral-smith-certificate-v1",
         entrypoint_module=_ENTRYPOINT,
+        provider_runtime_factory=_topology_runtime,
         replay_method=(
             "independent integral chain and Smith transformation-certificate replay"
         ),

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -102,9 +102,9 @@ def _declaration_factory(
 def _declared_runtime_groups(
     pairs: tuple[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration], ...],
 ) -> tuple[_DeclaredRuntimeGroup, ...]:
-    probes: dict[Callable[..., CapabilityProviderRuntime], CapabilityProviderRuntime] = (
-        {}
-    )
+    probes: dict[
+        Callable[..., CapabilityProviderRuntime], CapabilityProviderRuntime
+    ] = {}
     grouped: dict[
         str,
         tuple[

--- a/src/jacobian/exact_domain_checkers.py
+++ b/src/jacobian/exact_domain_checkers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from functools import partial
 from typing import Any, Literal
 
 from pydantic import ValidationError
@@ -21,7 +20,6 @@ from jacobian.contracts.capabilities import (
     CapabilityDescriptor,
     CapabilityDiagnostic,
     CapabilityInputKind,
-    CapabilityInstallTier,
     CapabilityProviderAvailability,
     CapabilityProviderRuntime,
     CapabilityRequest,
@@ -46,22 +44,8 @@ from jacobian.operation_installation import InstalledDomainBundle
 from jacobian.operation_projection import OperationProjection
 from jacobian.operation_publication import PublishedOperation
 from jacobian.operations import Completed, Failed
-from jacobian.provider_runtime import (
-    composite_provider_runtime,
-    known_provider_runtime,
-    source_provider_runtime,
-)
 from jacobian.providers.flint_runtime import (
-    certified_snf_checker_provider_runtime,
-    combinatorics_exact_checker_provider_runtime,
-    exact_domain_checker_provider_runtime,
     exact_domain_checker_source_provider_runtime,
-    graded_syzygy_checker_provider_runtime,
-    graph_exact_checker_provider_runtime,
-    poset_exact_checker_provider_runtime,
-    probability_exact_checker_provider_runtime,
-    projective_arrangement_checker_provider_runtime,
-    topology_exact_checker_provider_runtime,
 )
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry, SchemaRegistryError, model_schema
@@ -72,71 +56,7 @@ from jacobian.validation_diagnostics import bounded_validation_exception_message
 from jacobian.verification.service import VerificationService
 
 _LOGGER = logging.getLogger(__name__)
-_OPTIONAL_EXACT_REPLAY_PROVIDER_KEYS = frozenset({"python-flint"})
-_ENTRYPOINT_PROVIDER_RUNTIME_KEYS = {
-    "jacobian_checkers.exact_domain_operations": "python-flint",
-    "jacobian_checkers.graph_exact_operations": "finite-graph",
-    "jacobian_checkers.exact_probability_operations": "finite-probability",
-    "jacobian_checkers.recurrence_series": "combinatorics",
-    "jacobian_checkers.additive_combinatorics": "combinatorics",
-    "jacobian_checkers.jacobian_syzygy": "graded-syzygy",
-    "jacobian_checkers.projective_arrangements": "projective-arrangement",
-    "jacobian_checkers.simplicial_topology": "topology",
-    "jacobian_checkers.certified_snf": "certified-snf",
-    "jacobian_checkers.finite_posets": "poset",
-    "jacobian_checkers.exact_geometry": "geometry",
-    "jacobian_checkers.matrix_normal_forms": "matrix-hnf",
-    "jacobian_checkers.finite_field_rank": "sympy",
-    "jacobian_checkers.finite_field_polynomial": "finite-field-polynomial",
-}
-
-
-def _finite_field_rank_checker_runtime(
-    *, checker_ids: tuple[str, ...] = ()
-) -> CapabilityProviderRuntime:
-    source = source_provider_runtime(
-        "jacobian.finite-field-rank-checker-source",
-        version="1",
-        entrypoint=(
-            "jacobian_checkers.finite_field_rank:check_finite_field_linear_map_rank"
-        ),
-        install_tier=CapabilityInstallTier.T0,
-        license_id="MIT",
-        features=("clean-process-checker",),
-    )
-    sympy = known_provider_runtime(
-        "jacobian.sympy",
-        features=("prime-field-rank-replay",),
-    )
-    return composite_provider_runtime(
-        "jacobian.finite-field-rank-checker",
-        components=(source, sympy),
-        features=("independent-prime-field-rank-replay",),
-        checker_ids=checker_ids,
-    )
-
-
-def _finite_field_polynomial_checker_runtime(
-    *, checker_ids: tuple[str, ...] = ()
-) -> CapabilityProviderRuntime:
-    source = source_provider_runtime(
-        "jacobian.finite-field-polynomial-checker-source",
-        version="1",
-        entrypoint="jacobian_checkers.finite_field_polynomial:check_finite_map_table",
-        install_tier=CapabilityInstallTier.T0,
-        license_id="MIT",
-        features=("clean-process-checker",),
-    )
-    sympy = known_provider_runtime(
-        "jacobian.sympy",
-        features=("finite-field-polynomial-replay",),
-    )
-    return composite_provider_runtime(
-        "jacobian.finite-field-polynomial-checker",
-        components=(source, sympy),
-        features=("independent-finite-field-polynomial-replay",),
-        checker_ids=checker_ids,
-    )
+_OPTIONAL_EXACT_REPLAY_PROVIDERS = frozenset({"jacobian.exact-domain-checkers"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,6 +65,7 @@ class ExactDomainCheckerInstallation:
 
     checker_ids: dict[str, str | None]
     provider_runtimes: dict[str, CapabilityProviderRuntime]
+    declaration_providers: dict[str, str]
     witness_schema_uri: str | None = None
     diagnostics: tuple[CapabilityDiagnostic, ...] = ()
 
@@ -159,18 +80,137 @@ class _InstalledDeclaration:
     checker_id: str
 
 
-def _provider_runtime_key(declaration: ExactReplayCheckerDeclaration) -> str:
-    if declaration.entrypoint_module == "jacobian_checkers.linear":
-        return {
-            "check_rational_solution": "linear-solution",
-            "check_rational_inconsistency": "linear-inconsistency",
-        }[declaration.function]
-    try:
-        return _ENTRYPOINT_PROVIDER_RUNTIME_KEYS[declaration.entrypoint_module]
-    except KeyError as exc:
+@dataclass(frozen=True, slots=True)
+class _DeclaredRuntimeGroup:
+    probe: CapabilityProviderRuntime
+    factory: Callable[..., CapabilityProviderRuntime]
+    members: tuple[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration], ...]
+    factories: tuple[Callable[..., CapabilityProviderRuntime], ...]
+
+
+def _declaration_factory(
+    declaration: ExactReplayCheckerDeclaration,
+) -> Callable[..., CapabilityProviderRuntime]:
+    factory = declaration.provider_runtime_factory
+    if factory is None:
         raise ValueError(
-            "exact replay checker declaration uses an unsupported provider runtime"
-        ) from exc
+            "exact replay checker declaration requires a provider runtime factory"
+        )
+    return factory
+
+
+def _declared_runtime_groups(
+    pairs: tuple[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration], ...],
+) -> tuple[_DeclaredRuntimeGroup, ...]:
+    probes: dict[Callable[..., CapabilityProviderRuntime], CapabilityProviderRuntime] = (
+        {}
+    )
+    grouped: dict[
+        str,
+        tuple[
+            CapabilityProviderRuntime,
+            list[Callable[..., CapabilityProviderRuntime]],
+            list[tuple[InstalledDomainBundle, ExactReplayCheckerDeclaration]],
+        ],
+    ] = {}
+    for installed, declaration in pairs:
+        factory = _declaration_factory(declaration)
+        probe = probes.setdefault(factory, factory())
+        current = grouped.get(probe.provider)
+        if current is None:
+            grouped[probe.provider] = (probe, [factory], [(installed, declaration)])
+            continue
+        existing_probe, factories, members = current
+        if existing_probe != probe:
+            raise ValueError(
+                "exact replay grouped distinct probes under one provider "
+                f"identity: {probe.provider}"
+            )
+        if factory not in factories:
+            factories.append(factory)
+        members.append((installed, declaration))
+    return tuple(
+        _DeclaredRuntimeGroup(
+            probe=probe,
+            factory=factories[0],
+            members=tuple(members),
+            factories=tuple(factories),
+        )
+        for probe, factories, members in grouped.values()
+    )
+
+
+def _authorize_replay_operation(
+    installer: CheckerInstaller,
+    operation: CheckerOperation,
+    *,
+    authorize: bool,
+    provider_runtime: CapabilityProviderRuntime,
+    source_available: bool,
+    capability_id: str,
+    diagnostics: list[CapabilityDiagnostic],
+) -> str | None:
+    if provider_runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+        return installer.install(operation, authorize=authorize).checker_id
+    can_omit = (
+        provider_runtime.provider in _OPTIONAL_EXACT_REPLAY_PROVIDERS
+        and source_available
+    )
+    if not can_omit:
+        return installer.install(operation, authorize=authorize).checker_id
+    diagnostic = CapabilityDiagnostic(
+        code="EXACT_REPLAY_PROVIDER_UNAVAILABLE",
+        stage="provider_availability",
+        message=(
+            f"Independent replay for {capability_id!r} is not installed: "
+            f"{provider_runtime.diagnostic or 'the provider is unavailable.'}"
+        ),
+        hint="Install or repair the optional python-flint backend, then retry.",
+        details={
+            "capability_id": capability_id,
+            "provider": provider_runtime.provider,
+            "checker_authorization_affected": True,
+        },
+    )
+    diagnostics.append(diagnostic)
+    _LOGGER.warning("%s", diagnostic.message)
+    return None
+
+
+def _authorized_provider_runtimes(
+    groups: tuple[_DeclaredRuntimeGroup, ...],
+    checker_ids: Mapping[str, str | None],
+) -> dict[str, CapabilityProviderRuntime]:
+    provider_runtimes: dict[str, CapabilityProviderRuntime] = {}
+    for group in groups:
+        authorized = tuple(
+            checker_id
+            for _installed, declaration in group.members
+            if (checker_id := checker_ids[declaration.capability_id]) is not None
+        )
+        runtime = group.factory(checker_ids=authorized)
+        for factory in group.factories:
+            if factory is group.factory:
+                continue
+            other = factory(checker_ids=authorized)
+            if other != runtime:
+                raise ValueError(
+                    "exact replay grouped distinct runtimes under one provider "
+                    f"identity: {group.probe.provider}"
+                )
+        existing = provider_runtimes.get(runtime.provider)
+        if existing is not None and existing != runtime:
+            raise ValueError(
+                "exact replay grouped distinct runtimes under one provider "
+                f"identity: {runtime.provider}"
+            )
+        if runtime.provider != group.probe.provider:
+            raise ValueError(
+                "exact replay authorized runtime changed provider identity: "
+                f"{group.probe.provider} -> {runtime.provider}"
+            )
+        provider_runtimes[runtime.provider] = runtime
+    return provider_runtimes
 
 
 def install_exact_domain_checkers(
@@ -182,144 +222,53 @@ def install_exact_domain_checkers(
     """Install independent exact replay against dynamically registered schemas."""
 
     installer = CheckerInstaller(checkers)
-    runtime_factories: dict[
-        str,
-        Callable[..., CapabilityProviderRuntime],
-    ] = {
-        "python-flint": exact_domain_checker_provider_runtime,
-        "certified-snf": certified_snf_checker_provider_runtime,
-        "finite-graph": graph_exact_checker_provider_runtime,
-        "finite-probability": probability_exact_checker_provider_runtime,
-        "combinatorics": combinatorics_exact_checker_provider_runtime,
-        "poset": poset_exact_checker_provider_runtime,
-        "graded-syzygy": graded_syzygy_checker_provider_runtime,
-        "projective-arrangement": projective_arrangement_checker_provider_runtime,
-        "topology": topology_exact_checker_provider_runtime,
-        "sympy": _finite_field_rank_checker_runtime,
-        "finite-field-polynomial": _finite_field_polynomial_checker_runtime,
-        "geometry": partial(
-            source_provider_runtime,
-            "jacobian.exact-geometry-checker",
-            version="1",
-            entrypoint="jacobian_checkers.exact_geometry:check_exact_geometry",
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            features=("standard-library-rational-replay", "clean-process-checker"),
-        ),
-        "matrix-hnf": partial(
-            source_provider_runtime,
-            "jacobian.matrix-hnf-checker",
-            version="1",
-            entrypoint="jacobian_checkers.matrix_normal_forms:check_hermite_normal_form",
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            features=("standard-library-integer-replay", "clean-process-checker"),
-        ),
-        "linear-solution": partial(
-            source_provider_runtime,
-            "jacobian.rational-linear-checker",
-            version="1",
-            entrypoint="jacobian_checkers.linear:check_rational_solution",
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            features=("standard-library-rational-replay", "clean-process-checker"),
-        ),
-        "linear-inconsistency": partial(
-            source_provider_runtime,
-            "jacobian.rational-linear-inconsistency-checker",
-            version="1",
-            entrypoint="jacobian_checkers.linear:check_rational_inconsistency",
-            install_tier=CapabilityInstallTier.T1,
-            license_id="MIT",
-            features=("standard-library-rational-replay", "clean-process-checker"),
-        ),
-    }
-    provider_runtimes = {
-        runtime_key: factory() for runtime_key, factory in runtime_factories.items()
-    }
+    groups = _declared_runtime_groups(_available_declaration_bundles(bundles))
     checker_ids: dict[str, str | None] = {}
-    declarations_by_id: dict[str, ExactReplayCheckerDeclaration] = {}
+    declaration_providers: dict[str, str] = {}
     diagnostics: list[CapabilityDiagnostic] = []
-    exact_checker_source_available = (
+    source_available = (
         exact_domain_checker_source_provider_runtime().availability
         is CapabilityProviderAvailability.AVAILABLE
     )
     with batch_checker_manifest_measurement():
-        for installed, declaration in _available_declaration_bundles(bundles):
-            declarations_by_id[declaration.capability_id] = declaration
-            runtime_key = _provider_runtime_key(declaration)
-            provider_runtime = provider_runtimes[runtime_key]
-            operation = CheckerOperation(
-                name=f"{declaration.capability_id} independent {declaration.replay_method}",
-                entrypoint=(f"{declaration.entrypoint_module}:{declaration.function}"),
-                evidence_kind=EvidenceKind.WITNESS,
-                format_id=declaration.format_id,
-                format_version="1",
-                claim_schema_uris=(
-                    installed.input_schema_uris[declaration.request_model],
-                ),
-                semantics_uris=(installed.semantics_uri,),
-                candidate_schema_uris=(
-                    installed.result_schema_uris[declaration.capability_id],
-                ),
-                reason=declaration.reason,
-                provider_runtime=provider_runtime,
-            )
-            if (
-                provider_runtime.availability
-                is not CapabilityProviderAvailability.AVAILABLE
-            ):
-                can_omit = (
-                    runtime_key in _OPTIONAL_EXACT_REPLAY_PROVIDER_KEYS
-                    and exact_checker_source_available
-                )
-                if not can_omit:
-                    checker_ids[declaration.capability_id] = installer.install(
-                        operation,
-                        authorize=authorize,
-                    ).checker_id
-                    continue
-                diagnostic = CapabilityDiagnostic(
-                    code="EXACT_REPLAY_PROVIDER_UNAVAILABLE",
-                    stage="provider_availability",
-                    message=(
-                        f"Independent replay for {declaration.capability_id!r} is "
-                        "not installed: "
-                        f"{provider_runtime.diagnostic or 'the provider is unavailable.'}"
+        for group in groups:
+            for installed, declaration in group.members:
+                declaration_providers[declaration.capability_id] = group.probe.provider
+                operation = CheckerOperation(
+                    name=(
+                        f"{declaration.capability_id} independent "
+                        f"{declaration.replay_method}"
                     ),
-                    hint=(
-                        "Install or repair the optional python-flint backend, then retry."
+                    entrypoint=(
+                        f"{declaration.entrypoint_module}:{declaration.function}"
                     ),
-                    details={
-                        "capability_id": declaration.capability_id,
-                        "provider": provider_runtime.provider,
-                        "checker_authorization_affected": True,
-                    },
+                    evidence_kind=EvidenceKind.WITNESS,
+                    format_id=declaration.format_id,
+                    format_version="1",
+                    claim_schema_uris=(
+                        installed.input_schema_uris[declaration.request_model],
+                    ),
+                    semantics_uris=(installed.semantics_uri,),
+                    candidate_schema_uris=(
+                        installed.result_schema_uris[declaration.capability_id],
+                    ),
+                    reason=declaration.reason,
+                    provider_runtime=group.probe,
                 )
-                diagnostics.append(diagnostic)
-                _LOGGER.warning("%s", diagnostic.message)
-                checker_ids[declaration.capability_id] = None
-                continue
-            checker_ids[declaration.capability_id] = installer.install(
-                operation,
-                authorize=authorize,
-            ).checker_id
-    authorized_ids = {
-        runtime_key: tuple(
-            checker_id
-            for capability_id, checker_id in checker_ids.items()
-            if checker_id is not None
-            and _provider_runtime_key(declarations_by_id[capability_id]) == runtime_key
-        )
-        for runtime_key in provider_runtimes
-    }
+                checker_ids[declaration.capability_id] = _authorize_replay_operation(
+                    installer,
+                    operation,
+                    authorize=authorize,
+                    provider_runtime=group.probe,
+                    source_available=source_available,
+                    capability_id=declaration.capability_id,
+                    diagnostics=diagnostics,
+                )
     return ExactDomainCheckerInstallation(
         checker_ids=checker_ids,
         diagnostics=tuple(diagnostics),
-        provider_runtimes={
-            runtime_key: factory(checker_ids=authorized_ids[runtime_key])
-            for runtime_key, factory in runtime_factories.items()
-        },
+        provider_runtimes=_authorized_provider_runtimes(groups, checker_ids),
+        declaration_providers=declaration_providers,
     )
 
 
@@ -358,6 +307,7 @@ def install_exact_domain_verification(
         witness_schema_uri=witness_schema_uri,
         diagnostics=installed.diagnostics,
         provider_runtimes=installed.provider_runtimes,
+        declaration_providers=installed.declaration_providers,
     )
     if not any(
         checker_id is not None for checker_id in installation.checker_ids.values()
@@ -395,7 +345,7 @@ def install_exact_domain_verification(
                 verification=verification,
                 witness_schema_uri=witness_schema_uri,
                 provider_runtime=installation.provider_runtimes[
-                    _provider_runtime_key(declaration)
+                    installation.declaration_providers[declaration.capability_id]
                 ],
                 stored_result_input=declaration.capability_id in stored_producers,
             )
@@ -557,10 +507,8 @@ class ExactComputedVerificationAdapter:
             )
             source_artifacts = None
         # Check the authorized checker's bounded input scope before any artifact write.
-        if not _checker_supports(
-            declaration.declaration.capability_id,
-            normalized_input,
-        ):
+        supports_input = declaration.declaration.supports_input
+        if supports_input is not None and not supports_input(normalized_input):
             output = ExactComputedVerificationOutput(
                 status="UNSUPPORTED",
                 conclusion="UNKNOWN",
@@ -881,47 +829,6 @@ class ExactComputedVerificationAdapter:
                 )
             ) from exc
         return input_artifact, result_artifact, semantics_artifact
-
-
-def _checker_supports(operation_id: str, payload: object) -> bool:
-    if operation_id in {
-        "graph.hamiltonian_path.decide",
-        "graph.induced_tree.maximum.compute",
-    }:
-        maximum_order = 18 if operation_id == "graph.hamiltonian_path.decide" else 16
-        return (
-            isinstance(payload, dict)
-            and isinstance(payload.get("graph"), dict)
-            and isinstance(payload["graph"].get("vertices"), list)
-            and len(payload["graph"]["vertices"]) <= maximum_order
-        )
-    if operation_id == "geometry.projective_line_arrangement.flats.materialize":
-        return (
-            isinstance(payload, dict)
-            and isinstance(payload.get("lines"), list)
-            and len(payload["lines"]) <= 64
-        )
-    if not operation_id.startswith("polynomial."):
-        return True
-    if not isinstance(payload, dict):
-        return False
-    if operation_id == "polynomial.jacobian_syzygy.minimum_degree.compute":
-        return True
-    polynomial_fields = {
-        "polynomial.compute.gcd": ("left", "right"),
-        "polynomial.compute.resultant": ("left", "right"),
-        "polynomial.compute.discriminant": ("polynomial",),
-        "polynomial.compute.square_free_decomposition": ("polynomial",),
-        "polynomial.factor.compute": ("polynomial",),
-    }.get(operation_id)
-    if polynomial_fields is None:
-        return False
-    return all(
-        isinstance(payload.get(field), dict)
-        and payload[field].get("variables")
-        and len(payload[field]["variables"]) == 1
-        for field in polynomial_fields
-    )
 
 
 __all__ = [

--- a/src/jacobian/providers/lean_runtime.py
+++ b/src/jacobian/providers/lean_runtime.py
@@ -284,14 +284,18 @@ def lean_provider_runtime(
             executable=executable,
             mathlib_runtime=mathlib_runtime,
         )
-    except (OSError, RuntimeError):
+    except (OSError, RuntimeError) as exc:
+        detail = str(exc).strip()
+        diagnostic = (
+            detail
+            if detail
+            else f"The pinned Lean {lean4.LEAN_VERSION} runtime is unavailable."
+        )
         return _unavailable_runtime(
             provider="jacobian.lean4",
             install_tier=CapabilityInstallTier.T3,
             license_id="Apache-2.0",
-            diagnostic=(
-                f"The pinned Lean {lean4.LEAN_VERSION} runtime is unavailable."
-            ),
+            diagnostic=diagnostic,
         )
     configuration: dict[str, Any] = {
         "executable": str(executable),

--- a/tests/boundary/mcp/test_remote_mcp_http.py
+++ b/tests/boundary/mcp/test_remote_mcp_http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import socket
 import threading
@@ -65,10 +66,11 @@ def test_authenticated_streamable_http_isolates_tenant_data(
     ) as port:
         asyncio.run(_remote_tenant_scenario(port))
         tenant_roots = sorted((tmp_path / "state" / "tenants").iterdir())
-        assert len(tenant_roots) == 2
-        alpha_db = (tenant_roots[0] / "metadata.sqlite3").read_bytes()
-        beta_db = (tenant_roots[1] / "metadata.sqlite3").read_bytes()
-        assert alpha_db != beta_db
+        assert {path.name for path in tenant_roots} == {
+            hashlib.sha256(b"alpha").hexdigest(),
+            hashlib.sha256(b"beta").hexdigest(),
+        }
+        assert all((path / "metadata.sqlite3").is_file() for path in tenant_roots)
 
 
 def test_default_authority_remote_mcp_matches_deployment_identity(

--- a/tests/boundary/mcp/test_remote_mcp_http.py
+++ b/tests/boundary/mcp/test_remote_mcp_http.py
@@ -7,6 +7,7 @@ import json
 import socket
 import threading
 import time
+from collections.abc import Callable
 from importlib.metadata import version
 from pathlib import Path
 
@@ -22,9 +23,55 @@ from jacobian.adapters.mcp.remote import (
     create_remote_server,
     load_static_token_file,
 )
+from jacobian.domains.matrix_lattice import build_matrix_bundle
+from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.model import JacobianRuntime
+from tests.support.selected_runtime import create_selected_runtime
 
 
-def test_authenticated_streamable_http_isolates_tenant_memory(
+def test_authenticated_streamable_http_rejects_before_runtime_construction(
+    tmp_path: Path,
+) -> None:
+    def fail_if_called(*_args: object, **_kwargs: object) -> JacobianRuntime:
+        raise AssertionError("auth rejection must not construct a tenant runtime")
+
+    with _RunningRemoteServer(
+        tmp_path,
+        runtime_factory=fail_if_called,
+        checker_authority=CheckerAuthorityMode.NONE,
+    ) as port:
+        asyncio.run(_remote_auth_rejections(port))
+
+
+def test_authenticated_streamable_http_isolates_tenant_data(
+    tmp_path: Path,
+) -> None:
+    def matrix_runtime(
+        root: str | Path,
+        *,
+        checker_authority: CheckerAuthorityMode = CheckerAuthorityMode.NONE,
+        **_kwargs: object,
+    ) -> JacobianRuntime:
+        return create_selected_runtime(
+            root,
+            (build_matrix_bundle(),),
+            checker_authority=checker_authority,
+        )
+
+    with _RunningRemoteServer(
+        tmp_path,
+        runtime_factory=matrix_runtime,
+        checker_authority=CheckerAuthorityMode.NONE,
+    ) as port:
+        asyncio.run(_remote_tenant_scenario(port))
+        tenant_roots = sorted((tmp_path / "state" / "tenants").iterdir())
+        assert len(tenant_roots) == 2
+        alpha_db = (tenant_roots[0] / "metadata.sqlite3").read_bytes()
+        beta_db = (tenant_roots[1] / "metadata.sqlite3").read_bytes()
+        assert alpha_db != beta_db
+
+
+def test_default_authority_remote_mcp_matches_deployment_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -36,79 +83,101 @@ def test_authenticated_streamable_http_isolates_tenant_memory(
             package_version=version("jacobian"),
         ),
     )
-    token_file = tmp_path / "tokens.json"
-    token_file.write_text(
-        json.dumps(
-            {
-                "tokens": [
-                    {"tenant_id": "alpha", "token": "a" * 32},
-                    {"tenant_id": "beta", "token": "b" * 32},
-                    {
-                        "tenant_id": "wrong-scope",
-                        "token": "s" * 32,
-                        "scopes": ["jacobian:other"],
-                    },
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    with socket.socket() as listener:
-        listener.bind(("127.0.0.1", 0))
-        listener.listen()
-        port = int(listener.getsockname()[1])
-        public_base_url = f"http://127.0.0.1:{port}"
+    with _RunningRemoteServer(tmp_path) as port:
+        monkeypatch.setenv("JACOBIAN_MCP_BEARER_TOKEN", "a" * 32)
+        report = asyncio.run(
+            inspect_remote_deployment(
+                url=f"http://127.0.0.1:{port}/mcp",
+                expected_version=version("jacobian"),
+                expected_revision=revision,
+                expected_policy_profile="DEFAULT",
+                required_capabilities={"matrix.determinant.compute"},
+                query="exact matrix determinant",
+                timeout_seconds=60,
+            )
+        )
+        assert report["server"]["version"] == version("jacobian")
+        assert report["deployment"]["revision"] == revision
+        assert report["catalog"]["policy_profile"] == "DEFAULT"
+        assert report["catalog"]["catalog_digest"].startswith("sha256:")
+
+
+class _RunningRemoteServer:
+    def __init__(
+        self,
+        tmp_path: Path,
+        *,
+        runtime_factory: Callable[..., JacobianRuntime] | None = None,
+        checker_authority: CheckerAuthorityMode | None = None,
+    ) -> None:
+        self._tmp_path = tmp_path
+        self._runtime_factory = runtime_factory
+        self._checker_authority = checker_authority
+        self._http_server: Server | None = None
+        self._thread: threading.Thread | None = None
+        self._listener: socket.socket | None = None
+        self.port = 0
+
+    def __enter__(self) -> int:
+        token_file = self._tmp_path / "tokens.json"
+        token_file.write_text(
+            json.dumps(
+                {
+                    "tokens": [
+                        {"tenant_id": "alpha", "token": "a" * 32},
+                        {"tenant_id": "beta", "token": "b" * 32},
+                        {
+                            "tenant_id": "wrong-scope",
+                            "token": "s" * 32,
+                            "scopes": ["jacobian:other"],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self._listener = socket.socket()
+        self._listener.bind(("127.0.0.1", 0))
+        self._listener.listen()
+        self.port = int(self._listener.getsockname()[1])
+        public_base_url = f"http://127.0.0.1:{self.port}"
         mcp_server = create_remote_server(
-            tmp_path / "state",
+            self._tmp_path / "state",
             allow_anonymous=False,
+            checker_authority=self._checker_authority,
             token_verifier=StaticTokenVerifier(load_static_token_file(token_file)),
             auth=AuthSettings(
                 issuer_url=AnyHttpUrl(public_base_url),
                 resource_server_url=AnyHttpUrl(f"{public_base_url}/mcp"),
                 required_scopes=["jacobian:use"],
             ),
+            runtime_factory=self._runtime_factory,
         )
-        http_server = Server(
+        self._http_server = Server(
             Config(
                 mcp_server.streamable_http_app(),
                 host="127.0.0.1",
-                port=port,
+                port=self.port,
                 log_level="warning",
             )
         )
-        server_thread = threading.Thread(
-            target=http_server.run,
-            kwargs={"sockets": [listener]},
+        self._thread = threading.Thread(
+            target=self._http_server.run,
+            kwargs={"sockets": [self._listener]},
             daemon=True,
         )
-        server_thread.start()
-        try:
-            _wait_for_server(http_server, server_thread)
-            asyncio.run(_remote_auth_rejections(port))
-            asyncio.run(_remote_tenant_scenario(port))
-            tenant_roots = sorted((tmp_path / "state" / "tenants").iterdir())
-            assert len(tenant_roots) == 2
-            assert tenant_roots[0].name != tenant_roots[1].name
-            monkeypatch.setenv("JACOBIAN_MCP_BEARER_TOKEN", "a" * 32)
-            report = asyncio.run(
-                inspect_remote_deployment(
-                    url=f"http://127.0.0.1:{port}/mcp",
-                    expected_version=version("jacobian"),
-                    expected_revision=revision,
-                    expected_policy_profile="DEFAULT",
-                    required_capabilities={"matrix.determinant.compute"},
-                    query="exact matrix determinant",
-                    timeout_seconds=60,
-                )
-            )
-            assert report["server"]["version"] == version("jacobian")
-            assert report["deployment"]["revision"] == revision
-            assert report["catalog"]["policy_profile"] == "DEFAULT"
-            assert report["catalog"]["catalog_digest"].startswith("sha256:")
-        finally:
-            http_server.should_exit = True
-            server_thread.join(timeout=10)
-            assert not server_thread.is_alive()
+        self._thread.start()
+        _wait_for_server(self._http_server, self._thread)
+        return self.port
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._http_server is not None:
+            self._http_server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+            assert not self._thread.is_alive()
+        if self._listener is not None:
+            self._listener.close()
 
 
 async def _remote_auth_rejections(port: int) -> None:
@@ -134,13 +203,11 @@ async def _remote_tenant_scenario(port: int) -> None:
 
     url = f"http://127.0.0.1:{port}/mcp"
 
-    async def invoke(token: str) -> dict[str, object]:
+    async def invoke(token: str, value: str) -> dict[str, object]:
         async with (
             httpx2.AsyncClient(
                 headers={"Authorization": f"Bearer {token}"},
                 trust_env=False,
-                # The first request constructs the tenant's complete capability
-                # runtime; keep transport tolerance separate from backend budgets.
                 timeout=60,
             ) as http,
             Client(
@@ -158,7 +225,7 @@ async def _remote_tenant_scenario(port: int) -> None:
                         "matrix": {
                             "matrix_schema_version": "1",
                             "domain": "QQ",
-                            "entries": [[{"num": "4", "den": "1"}]],
+                            "entries": [[{"num": value, "den": "1"}]],
                         }
                     },
                 },
@@ -166,17 +233,10 @@ async def _remote_tenant_scenario(port: int) -> None:
             assert isinstance(result.structured_content, dict)
             return result.structured_content["output"]
 
-    alpha_output = await invoke("a" * 32)
-    beta_output = await invoke("b" * 32)
-    expected = {
-        "result": {
-            "determinant": {"num": "4", "den": "1"},
-            "method": "FRACTION_FREE_BAREISS",
-        },
-        "backend_version": "1.14.0",
-    }
-    assert alpha_output == expected
-    assert beta_output == expected
+    alpha_output = await invoke("a" * 32, "4")
+    beta_output = await invoke("b" * 32, "9")
+    assert alpha_output["result"]["determinant"] == {"num": "4", "den": "1"}
+    assert beta_output["result"]["determinant"] == {"num": "9", "den": "1"}
 
 
 def _wait_for_server(

--- a/tests/boundary/process/tooling/test_make_help.py
+++ b/tests/boundary/process/tooling/test_make_help.py
@@ -3,26 +3,16 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from tools.command_contract import (
+    COMMAND_BY_NAME,
+    PUBLIC_COMMAND_NAMES,
+    PUBLIC_COMMANDS,
+)
+
 ROOT = Path(__file__).parents[4]
-PRIMARY_COMMANDS = {
-    "setup",
-    "quick",
-    "check",
-    "check-all",
-    "check-external",
-    "fix",
-}
-PRIMARY_COMMAND_ORDER = [
-    "setup",
-    "quick",
-    "check",
-    "check-all",
-    "check-external",
-    "fix",
-]
 
 
-def _listed_command_order(target: str) -> list[str]:
+def _listed_help_lines(target: str) -> list[str]:
     completed = subprocess.run(
         ["make", "--no-print-directory", target],
         cwd=ROOT,
@@ -31,20 +21,53 @@ def _listed_command_order(target: str) -> list[str]:
         text=True,
     )
     return [
-        line.split()[0]
+        line.strip()
         for line in completed.stdout.splitlines()
         if line.startswith("  ") and line.split()
     ]
 
 
+def _listed_command_order(target: str) -> list[str]:
+    return [line.split()[0] for line in _listed_help_lines(target)]
+
+
 def test_help_lists_only_the_primary_developer_workflow() -> None:
-    assert _listed_command_order("help") == PRIMARY_COMMAND_ORDER
+    assert _listed_command_order("help") == list(PUBLIC_COMMAND_NAMES)
+
+
+def test_help_descriptions_match_the_command_contract() -> None:
+    listed = {
+        line.split()[0]: line.split(None, 1)[1]
+        for line in _listed_help_lines("help")
+        if len(line.split(None, 1)) == 2
+    }
+    for command in PUBLIC_COMMANDS:
+        assert listed[command.name] == command.help
+        assert command.scope
+        assert command.ci_relationship
+        assert command.cost_class
+        assert command.name in COMMAND_BY_NAME
+
+
+def test_makefile_public_commands_match_the_command_contract() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    declared = next(
+        line.split(":=", 1)[1].split()
+        for line in makefile.splitlines()
+        if line.startswith("PUBLIC_COMMANDS :=")
+    )
+    assert tuple(declared) == PUBLIC_COMMAND_NAMES
+    assert COMMAND_BY_NAME["check"].mutates_checkout is False
+    assert COMMAND_BY_NAME["fix"].mutates_checkout is True
+    assert "not PR-equivalent" in COMMAND_BY_NAME["check"].ci_relationship
+    assert "not all CI" in COMMAND_BY_NAME["check-all"].ci_relationship
+    assert COMMAND_BY_NAME["check-external"].scope == "tests/boundary/providers/lean"
 
 
 def test_help_all_retains_specialist_and_compatibility_commands() -> None:
     commands = set(_listed_command_order("help-all"))
 
-    assert commands >= PRIMARY_COMMANDS
+    assert commands >= set(PUBLIC_COMMAND_NAMES)
     assert commands >= {
         "test-unit",
         "test-component",
@@ -63,3 +86,4 @@ def test_help_all_retains_specialist_and_compatibility_commands() -> None:
         "npm-test",
         "test-all-ci",
     }
+    assert "precommit" in commands

--- a/tests/boundary/process/tooling/test_make_help.py
+++ b/tests/boundary/process/tooling/test_make_help.py
@@ -85,5 +85,6 @@ def test_help_all_retains_specialist_and_compatibility_commands() -> None:
         "deploy-check",
         "npm-test",
         "test-all-ci",
+        "validation-status",
     }
     assert "precommit" in commands

--- a/tests/boundary/providers/external_sat/external_sat_support.py
+++ b/tests/boundary/providers/external_sat/external_sat_support.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from tests.support.artifacts import sha256_file
 from tests.support.services import (
     DomainTestServices,
     atomic_installation,
@@ -22,6 +24,76 @@ from jacobian.sat_smt.sat_capabilities import (
     install_sat_unsat_proof_checker,
 )
 from jacobian.sat_smt.smt_capabilities import install_smt_unsat_proof_checker
+
+
+def fake_drat_trim(tmp_path: Path, body: str) -> Path:
+    executable = tmp_path / "drat-trim"
+    executable.write_text(
+        (
+            f"#!{sys.executable}\n"
+            "import sys\n"
+            "if '-h' in sys.argv:\n"
+            "    print('usage: drat-trim [INPUT] [<PROOF>] [<option> ...]')\n"
+            "    raise SystemExit(0)\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
+    manifest.write_text(
+        (
+            "{\n"
+            '  "runtime_manifest_version": "1",\n'
+            '  "provider": "drat-trim",\n'
+            '  "release_tag": "v05.22.2023",\n'
+            '  "source_repository": '
+            '"https://github.com/marijnheule/drat-trim",\n'
+            '  "source_commit": '
+            '"2e5e29cb0019d5cfd547d4208dca1b3ec290349f",\n'
+            f'  "executable_sha256": "{sha256_file(executable)}"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    return executable
+
+
+def fake_carcara(tmp_path: Path, body: str) -> Path:
+    executable = tmp_path / "carcara"
+    executable.write_text(
+        (
+            f"#!{sys.executable}\n"
+            "import sys\n"
+            "if '--version' in sys.argv:\n"
+            "    print('carcara 1.1.0 [git master 394edbb]')\n"
+            "    raise SystemExit(0)\n"
+            "if sys.argv[1:] == ['check', '--help']:\n"
+            "    print('--strict-parsing --parse-hole-args '\n"
+            "          '--allow-int-real-subtyping --expand-let-bindings')\n"
+            "    raise SystemExit(0)\n"
+            f"{body}\n"
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
+    manifest.write_text(
+        (
+            "{\n"
+            '  "runtime_manifest_version": "1",\n'
+            '  "provider": "carcara",\n'
+            '  "version": "1.1.0",\n'
+            '  "source_repository": "https://github.com/ufmg-smite/carcara",\n'
+            '  "source_commit": '
+            '"394edbb15ba95c47893f1d821fddde7e016af178",\n'
+            '  "compatible_cvc5_version": "1.3.4",\n'
+            f'  "executable_sha256": "{sha256_file(executable)}"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    return executable
 
 
 @contextmanager

--- a/tests/boundary/providers/external_sat/startup/test_complete_external_proof_verifier_inclusion.py
+++ b/tests/boundary/providers/external_sat/startup/test_complete_external_proof_verifier_inclusion.py
@@ -1,0 +1,48 @@
+"""One complete-portfolio smoke for both external proof-verifier families."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from tests.boundary.providers.external_sat.external_sat_support import (
+    fake_carcara,
+    fake_drat_trim,
+)
+
+from jacobian.providers.external_solver_runtime import (
+    carcara_provider_runtime,
+    drat_trim_provider_runtime,
+)
+from jacobian.runtime import CheckerAuthorityMode, create_runtime
+
+
+def test_complete_portfolio_includes_authorized_external_proof_verifiers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    drat_trim = drat_trim_provider_runtime(
+        fake_drat_trim(tmp_path, "print('s VERIFIED')\nraise SystemExit(0)")
+    )
+    carcara = carcara_provider_runtime(
+        fake_carcara(tmp_path, "print('valid')\nraise SystemExit(0)")
+    )
+    monkeypatch.setattr(
+        "jacobian.portfolio.provider_resolution.drat_trim_provider_runtime",
+        lambda *_args, **_kwargs: drat_trim,
+    )
+    monkeypatch.setattr(
+        "jacobian.portfolio.provider_resolution.carcara_provider_runtime",
+        lambda *_args, **_kwargs: carcara,
+    )
+
+    with create_runtime(
+        tmp_path / "complete-state",
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as complete:
+        capability_ids = {
+            descriptor.capability_id
+            for descriptor in complete.core.capabilities.catalog().capabilities
+        }
+
+    assert {"sat.unsat_proof.verify", "smt.unsat_proof.verify"} <= capability_ids

--- a/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_sat_unsat_proof_verification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -8,9 +7,9 @@ from typing import Any, Never
 
 import pytest
 from tests.boundary.providers.external_sat.external_sat_support import (
+    fake_drat_trim,
     open_sat_proof_verifier_services,
 )
-from tests.support.artifacts import sha256_file as _sha256_file
 from tests.support.services import DomainTestServices
 
 import jacobian_checkers.sat
@@ -27,41 +26,8 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.sat import SatResourceBudget
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.providers.external_solver_runtime import drat_trim_provider_runtime
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
+from jacobian.runtime import CheckerAuthorityMode
 from jacobian.verification.errors import CheckerExecutionError
-
-
-def _fake_drat_trim(tmp_path: Path, body: str) -> Path:
-    executable = tmp_path / "drat-trim"
-    executable.write_text(
-        (
-            f"#!{sys.executable}\n"
-            "import sys\n"
-            "if '-h' in sys.argv:\n"
-            "    print('usage: drat-trim [INPUT] [<PROOF>] [<option> ...]')\n"
-            "    raise SystemExit(0)\n"
-            f"{body}\n"
-        ),
-        encoding="utf-8",
-    )
-    executable.chmod(0o755)
-    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
-    manifest.write_text(
-        (
-            "{\n"
-            '  "runtime_manifest_version": "1",\n'
-            '  "provider": "drat-trim",\n'
-            '  "release_tag": "v05.22.2023",\n'
-            '  "source_repository": '
-            '"https://github.com/marijnheule/drat-trim",\n'
-            '  "source_commit": '
-            '"2e5e29cb0019d5cfd547d4208dca1b3ec290349f",\n'
-            f'  "executable_sha256": "{_sha256_file(executable)}"\n'
-            "}\n"
-        ),
-        encoding="utf-8",
-    )
-    return executable
 
 
 def _producer() -> CapabilityProviderRuntime:
@@ -102,7 +68,7 @@ def test_drat_trim_runtime_requires_exact_operator_provenance(
     tmp_path: Path,
     attack: str,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
@@ -127,30 +93,6 @@ def test_drat_trim_runtime_requires_exact_operator_provenance(
     assert runtime.version is None
     assert runtime.digest is None
     assert runtime.diagnostic is not None
-
-
-def test_complete_portfolio_includes_authorized_sat_proof_verifier(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    executable = _fake_drat_trim(
-        tmp_path,
-        "print('s VERIFIED')\nraise SystemExit(0)",
-    )
-    runtime = drat_trim_provider_runtime(executable)
-    monkeypatch.setattr(
-        "jacobian.portfolio.provider_resolution.drat_trim_provider_runtime",
-        lambda *_args, **_kwargs: runtime,
-    )
-
-    with create_runtime(
-        tmp_path / "complete-state",
-        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
-    ) as complete:
-        assert "sat.unsat_proof.verify" in {
-            descriptor.capability_id
-            for descriptor in complete.core.capabilities.catalog().capabilities
-        }
 
 
 def _proof(runtime: DomainTestServices) -> tuple[str, str]:
@@ -180,7 +122,7 @@ def test_unsat_proof_is_verified_by_authorized_external_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
@@ -238,7 +180,7 @@ def test_rejected_proof_never_establishes_sat_or_unsat(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s NOT VERIFIED')\nraise SystemExit(1)",
     )
@@ -255,7 +197,7 @@ def test_rejected_proof_never_establishes_sat_or_unsat(
 def test_proof_verify_requires_runtime_and_operator_authorization(
     tmp_path: Path,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
@@ -302,7 +244,7 @@ def test_checker_operational_failure_never_creates_a_conclusion(
     expected_status: ExecutionStatus,
     expected_output_status: str,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )
@@ -327,7 +269,7 @@ def test_runtime_replacement_after_authorization_fails_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = _fake_drat_trim(
+    executable = fake_drat_trim(
         tmp_path,
         "print('s VERIFIED')\nraise SystemExit(0)",
     )

--- a/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
+++ b/tests/boundary/providers/external_sat/startup/test_smt_unsat_proof_verification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -8,9 +7,9 @@ from typing import Any, Never
 
 import pytest
 from tests.boundary.providers.external_sat.external_sat_support import (
+    fake_carcara,
     open_smt_proof_verifier_services,
 )
-from tests.support.artifacts import sha256_file as _sha256_file
 from tests.support.services import DomainTestServices
 
 import jacobian_checkers.smt
@@ -27,49 +26,12 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.smt import SmtResourceBudget
 from jacobian.contracts.verification import VerificationRecord
 from jacobian.providers.external_solver_runtime import carcara_provider_runtime
-from jacobian.runtime import CheckerAuthorityMode, create_runtime
+from jacobian.runtime import CheckerAuthorityMode
 from jacobian.verification.errors import CheckerExecutionError
 
 _FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 _PROBLEM = (_FIXTURES / "qf_uf_equality_unsat.smt2").read_text(encoding="ascii")
 _PROOF = (_FIXTURES / "qf_uf_equality_unsat.alethe").read_bytes()
-
-
-def _fake_carcara(tmp_path: Path, body: str) -> Path:
-    executable = tmp_path / "carcara"
-    executable.write_text(
-        (
-            f"#!{sys.executable}\n"
-            "import sys\n"
-            "if '--version' in sys.argv:\n"
-            "    print('carcara 1.1.0 [git master 394edbb]')\n"
-            "    raise SystemExit(0)\n"
-            "if sys.argv[1:] == ['check', '--help']:\n"
-            "    print('--strict-parsing --parse-hole-args '\n"
-            "          '--allow-int-real-subtyping --expand-let-bindings')\n"
-            "    raise SystemExit(0)\n"
-            f"{body}\n"
-        ),
-        encoding="utf-8",
-    )
-    executable.chmod(0o755)
-    manifest = executable.with_name(executable.name + ".jacobian-runtime.json")
-    manifest.write_text(
-        (
-            "{\n"
-            '  "runtime_manifest_version": "1",\n'
-            '  "provider": "carcara",\n'
-            '  "version": "1.1.0",\n'
-            '  "source_repository": "https://github.com/ufmg-smite/carcara",\n'
-            '  "source_commit": '
-            '"394edbb15ba95c47893f1d821fddde7e016af178",\n'
-            '  "compatible_cvc5_version": "1.3.4",\n'
-            f'  "executable_sha256": "{_sha256_file(executable)}"\n'
-            "}\n"
-        ),
-        encoding="utf-8",
-    )
-    return executable
 
 
 def _producer() -> CapabilityProviderRuntime:
@@ -115,7 +77,7 @@ def test_carcara_runtime_requires_exact_operator_provenance(
     tmp_path: Path,
     attack: str,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
@@ -142,30 +104,6 @@ def test_carcara_runtime_requires_exact_operator_provenance(
     assert runtime.diagnostic is not None
 
 
-def test_complete_portfolio_includes_authorized_smt_proof_verifier(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    executable = _fake_carcara(
-        tmp_path,
-        "print('valid')\nraise SystemExit(0)",
-    )
-    runtime = carcara_provider_runtime(executable)
-    monkeypatch.setattr(
-        "jacobian.portfolio.provider_resolution.carcara_provider_runtime",
-        lambda *_args, **_kwargs: runtime,
-    )
-
-    with create_runtime(
-        tmp_path / "complete-state",
-        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
-    ) as complete:
-        assert "smt.unsat_proof.verify" in {
-            descriptor.capability_id
-            for descriptor in complete.core.capabilities.catalog().capabilities
-        }
-
-
 def _proof(runtime: DomainTestServices) -> tuple[str, str]:
     problem = runtime.core.smt.put_problem(logic="QF_UF", smtlib_text=_PROBLEM)
     proof = runtime.core.smt.put_proof(
@@ -189,7 +127,7 @@ def _verify(runtime: DomainTestServices, proof_uri: str) -> CapabilityResult:
 def test_invalid_proof_diagnostic_routes_through_public_capabilities(
     tmp_path: Path,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
@@ -209,7 +147,7 @@ def test_unsat_proof_is_verified_by_authorized_strict_carcara(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
@@ -266,7 +204,7 @@ def test_unsat_proof_is_verified_by_authorized_strict_carcara(
 def test_holey_checker_report_never_establishes_sat_or_unsat(
     tmp_path: Path,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('holey')\nraise SystemExit(0)",
     )
@@ -283,7 +221,7 @@ def test_holey_checker_report_never_establishes_sat_or_unsat(
 def test_proof_verify_requires_runtime_and_operator_authorization(
     tmp_path: Path,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
@@ -330,7 +268,7 @@ def test_checker_operational_failure_never_creates_a_conclusion(
     expected_status: ExecutionStatus,
     expected_output_status: str,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )
@@ -354,7 +292,7 @@ def test_checker_operational_failure_never_creates_a_conclusion(
 def test_runtime_replacement_after_authorization_fails_closed(
     tmp_path: Path,
 ) -> None:
-    executable = _fake_carcara(
+    executable = fake_carcara(
         tmp_path,
         "print('valid')\nraise SystemExit(0)",
     )

--- a/tests/boundary/providers/lean/conftest.py
+++ b/tests/boundary/providers/lean/conftest.py
@@ -6,10 +6,12 @@ from tests.support.complete_runtime_fixtures import (
     attached_complete_runtime,
     authorized_complete_runtime,
     authorized_portfolio_template,
+    complete_portfolio_template,
 )
 
 __all__ = (
     "attached_complete_runtime",
     "authorized_complete_runtime",
     "authorized_portfolio_template",
+    "complete_portfolio_template",
 )

--- a/tests/boundary/providers/lean/startup/test_lean.py
+++ b/tests/boundary/providers/lean/startup/test_lean.py
@@ -7,8 +7,10 @@ from typing import Any, cast
 
 import pytest
 from tests.support.provider_lean import (
+    PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
-    pinned_mathlib_runtime_available,
+    skip_unless_pinned_lean_core_runtime,
+    skip_unless_pinned_mathlib_runtime,
 )
 from tests.support.state import copy_template
 
@@ -34,24 +36,10 @@ from jacobian.lean_frontend.declarations import (
 )
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
 
-PROJECT_ROOT = Path(__file__).resolve().parents[5]
-MATHLIB_OLEAN = (
-    PROJECT_ROOT
-    / "lean"
-    / ".lake"
-    / "packages"
-    / "mathlib"
-    / ".lake"
-    / "build"
-    / "lib"
-    / "lean"
-    / "Mathlib.olean"
-)
-
 pytestmark = [
     pytest.mark.skipif(
-        not pinned_mathlib_runtime_available(),
-        reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+        skip_unless_pinned_lean_core_runtime(),
+        reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     ),
 ]
 
@@ -142,8 +130,8 @@ def test_core_dependency_graph_is_bounded_and_materialized(tmp_path: Path) -> No
 
 
 @pytest.mark.skipif(
-    not MATHLIB_OLEAN.is_file(),
-    reason="the pinned mathlib runtime has not been built",
+    skip_unless_pinned_mathlib_runtime(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
 )
 @pytest.mark.timeout(240)
 def test_mathlib_discovery_composes_with_bound_sqrt_two_verification(
@@ -515,6 +503,10 @@ def test_lean_cache_does_not_reuse_a_revoked_checker_result(
     assert repeated.result.verification_record_uri is None
 
 
+@pytest.mark.skipif(
+    skip_unless_pinned_mathlib_runtime(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+)
 def test_mathlib_warmup_starts_only_once(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/boundary/providers/lean/startup/test_lean_exploration_capabilities.py
+++ b/tests/boundary/providers/lean/startup/test_lean_exploration_capabilities.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 import pytest
 from tests.support.provider_lean import (
+    PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
-    pinned_mathlib_runtime_available,
+    skip_unless_pinned_lean_core_runtime,
+    skip_unless_pinned_mathlib_runtime,
 )
 
 from jacobian.contracts.capabilities import (
@@ -15,8 +17,8 @@ from jacobian.runtime import CheckerAuthorityMode, create_runtime
 
 pytestmark = [
     pytest.mark.skipif(
-        not pinned_mathlib_runtime_available(),
-        reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+        skip_unless_pinned_lean_core_runtime(),
+        reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     ),
 ]
 
@@ -86,6 +88,10 @@ def test_apply_tactic_returns_structured_failure_without_conclusion(
     )
 
 
+@pytest.mark.skipif(
+    skip_unless_pinned_mathlib_runtime(),
+    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+)
 def test_retrieve_premises_returns_exact_mathlib_suggestion(tmp_path: Path) -> None:
     runtime = create_runtime(
         tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED

--- a/tests/boundary/providers/lean/startup/test_provider_runtime_integration.py
+++ b/tests/boundary/providers/lean/startup/test_provider_runtime_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from tests.support.state import copy_template
 
 from jacobian.capability_errors import CapabilityError
 from jacobian.contracts.capabilities import (
@@ -134,10 +135,10 @@ def test_graph_domain_runtime_identities_bind_every_executed_backend() -> None:
 
 def test_unhealthy_optional_lean_runtime_is_absent_from_catalog(
     tmp_path: Path,
-    authorized_complete_runtime: None,
+    authorized_portfolio_template: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _ = authorized_complete_runtime
+    state = copy_template(authorized_portfolio_template, tmp_path / "state")
     unavailable = CapabilityProviderRuntime(
         provider="jacobian.lean4",
         availability=CapabilityProviderAvailability.UNAVAILABLE,
@@ -152,21 +153,24 @@ def test_unhealthy_optional_lean_runtime_is_absent_from_catalog(
     )
 
     runtime = create_runtime(
-        tmp_path, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
+        state, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
     )
-
-    assert runtime.portfolio_resources.lean is None
-    capability_ids = {
-        item.capability_id for item in runtime.core.capabilities.catalog().capabilities
-    }
-    assert {
-        "lean.check",
-        "lean.declaration.dependencies",
-        "lean.declaration.inspect",
-        "lean.declaration.search",
-        "lean.proof.axioms.inspect",
-        "lean.proof_edit.validate",
-    }.isdisjoint(capability_ids)
+    try:
+        assert runtime.portfolio_resources.lean is None
+        capability_ids = {
+            item.capability_id
+            for item in runtime.core.capabilities.catalog().capabilities
+        }
+        assert {
+            "lean.check",
+            "lean.declaration.dependencies",
+            "lean.declaration.inspect",
+            "lean.declaration.search",
+            "lean.proof.axioms.inspect",
+            "lean.proof_edit.validate",
+        }.isdisjoint(capability_ids)
+    finally:
+        runtime.close()
 
 
 def test_unhealthy_lean_frontend_is_absent_from_catalog(
@@ -187,13 +191,16 @@ def test_unhealthy_lean_frontend_is_absent_from_catalog(
     )
 
     runtime = create_runtime(tmp_path, checker_authority=CheckerAuthorityMode.NONE)
-
-    capability_ids = {
-        item.capability_id for item in runtime.core.capabilities.catalog().capabilities
-    }
-    assert {"lean.statement.propose", "lean.statement.compare"}.isdisjoint(
-        capability_ids
-    )
+    try:
+        capability_ids = {
+            item.capability_id
+            for item in runtime.core.capabilities.catalog().capabilities
+        }
+        assert {"lean.statement.propose", "lean.statement.compare"}.isdisjoint(
+            capability_ids
+        )
+    finally:
+        runtime.close()
 
 
 def test_failed_invocation_keeps_provider_identity_in_the_descriptor(

--- a/tests/boundary/providers/lean/test_lean_proof_edit.py
+++ b/tests/boundary/providers/lean/test_lean_proof_edit.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 from tests.support.provider_lean import (
-    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
-    pinned_mathlib_runtime_available,
+    PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime,
 )
 
 from jacobian.contracts.capabilities import (
@@ -12,8 +12,8 @@ from jacobian.contracts.capabilities import (
 
 pytestmark = [
     pytest.mark.skipif(
-        not pinned_mathlib_runtime_available(),
-        reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+        skip_unless_pinned_lean_core_runtime(),
+        reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     ),
 ]
 

--- a/tests/boundary/providers/lean/test_lean_residual_live_smoke.py
+++ b/tests/boundary/providers/lean/test_lean_residual_live_smoke.py
@@ -20,6 +20,7 @@ from jacobian.contracts.capabilities import (
 )
 from jacobian.contracts.lean import LeanEnvironment
 from jacobian.lean_frontend.exploration import install_lean_exploration_capabilities
+from jacobian.operation_projection import project_operation_result
 from jacobian.providers.lean_runtime import lean_provider_runtime
 from jacobian.schema_registry import SchemaRegistry
 from jacobian.storage.repository import ArtifactRepository
@@ -91,14 +92,16 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
 
     # 1. lean.term.apply: open a state for `True` and apply the term `True.intro`.
     #    `exact True.intro` closes the goal `⊢ True` via the constructor term.
-    opened = term_apply.invoke(
-        CapabilityRequest(
-            capability_id="lean.term.apply",
-            input={
-                "environment": "CORE",
-                "statement": "True",
-                "term": "True.intro",
-            },
+    opened = project_operation_result(
+        term_apply.invoke(
+            CapabilityRequest(
+                capability_id="lean.term.apply",
+                input={
+                    "environment": "CORE",
+                    "statement": "True",
+                    "term": "True.intro",
+                },
+            )
         )
     )
     assert opened.output["accepted"] is True
@@ -108,22 +111,26 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
 
     # 2. lean.proof_state.inspect: read the input state without replay.
     #    Reopen a non-completed state for inspection.
-    reopened = proof_state.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.apply_tactic",
-            input={
-                "environment": "CORE",
-                "statement": "P → P",
-                "proof_prefix": ["intro P"],
-                "tactic": "skip",
-            },
+    reopened = project_operation_result(
+        proof_state.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.apply_tactic",
+                input={
+                    "environment": "CORE",
+                    "statement": "P → P",
+                    "proof_prefix": ["intro P"],
+                    "tactic": "skip",
+                },
+            )
         )
     )
     open_state_uri = reopened.output["successor_states"][0]["state_uri"]
-    inspected = inspect.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.inspect",
-            input={"environment": "CORE", "state_uri": open_state_uri},
+    inspected = project_operation_result(
+        inspect.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.inspect",
+                input={"environment": "CORE", "state_uri": open_state_uri},
+            )
         )
     )
     assert inspected.output["inspection"] == "READ_ONLY_NO_REPLAY"
@@ -131,10 +138,12 @@ def test_live_term_apply_and_inspect_and_metavariable_round_trip(
     assert "⊢ P" in inspected.output["normalized_goals"][0]
 
     # 3. lean.proof_state.metavariable_fields: structured fields via the helper.
-    fields = metavariable.invoke(
-        CapabilityRequest(
-            capability_id="lean.proof_state.metavariable_fields",
-            input={"environment": "CORE", "state_uri": open_state_uri},
+    fields = project_operation_result(
+        metavariable.invoke(
+            CapabilityRequest(
+                capability_id="lean.proof_state.metavariable_fields",
+                input={"environment": "CORE", "state_uri": open_state_uri},
+            )
         )
     )
     assert fields.output["coercion_provenance"] == "UNAVAILABLE"

--- a/tests/boundary/storage/durability/startup/test_suite_fixtures.py
+++ b/tests/boundary/storage/durability/startup/test_suite_fixtures.py
@@ -5,9 +5,11 @@ import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from tests.support.state import quiesce_sqlite_template
+from tests.support.state import publish_template, quiesce_sqlite_template
 
 from jacobian.runtime import CheckerAuthorityMode, create_runtime
+from jacobian.runtime.bootstrap import bootstrap_services
+from jacobian.runtime.config import RuntimeOptions
 from jacobian.storage.repository import ArtifactRepository
 
 
@@ -50,21 +52,56 @@ def _polynomial_expression_schema_uri(root: Path) -> str:
     return str(row[0])
 
 
-def test_runtime_close_removes_deferred_wal_files(tmp_path: Path) -> None:
-    template = tmp_path / "template"
-    runtime = create_runtime(template)
-    runtime.close()
+def _build_sentinel_store(staging: Path) -> None:
+    core = bootstrap_services(staging, RuntimeOptions())
+    core.close()
+    quiesce_sqlite_template(staging)
 
-    assert not (template / "metadata.sqlite3-wal").exists()
-    assert not (template / "metadata.sqlite3-shm").exists()
 
-    _freeze_runtime_store(template)
+def test_store_close_removes_deferred_wal_files(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    core = bootstrap_services(root, RuntimeOptions())
+    core.close()
 
-    connection = sqlite3.connect(template / "metadata.sqlite3")
+    assert not (root / "metadata.sqlite3-wal").exists()
+    assert not (root / "metadata.sqlite3-shm").exists()
+
+    _freeze_runtime_store(root)
+
+    connection = sqlite3.connect(root / "metadata.sqlite3")
     try:
         assert connection.execute("PRAGMA journal_mode").fetchone() == ("delete",)
     finally:
         connection.close()
+
+
+def test_sentinel_store_is_copyable_under_concurrent_readers(tmp_path: Path) -> None:
+    template = publish_template(tmp_path / "sentinel-template", _build_sentinel_store)
+    database = template / "metadata.sqlite3"
+    assert not database.with_name(f"{database.name}-wal").exists()
+    assert not database.with_name(f"{database.name}-shm").exists()
+
+    connection = sqlite3.connect(database)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone() == ("delete",)
+        assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        connection.close()
+
+    descriptor_uri = _polynomial_expression_schema_uri(template)
+    destinations = [tmp_path / f"clone-{index}" for index in range(8)]
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(
+                _copy_and_check_store,
+                template,
+                destination,
+                descriptor_uri=descriptor_uri,
+            )
+            for destination in destinations
+        ]
+        for future in futures:
+            future.result(timeout=30)
 
 
 def test_complete_portfolio_template_is_quiescent_and_copyable(
@@ -82,61 +119,11 @@ def test_complete_portfolio_template_is_quiescent_and_copyable(
     finally:
         connection.close()
 
-    descriptor_uri = _polynomial_expression_schema_uri(complete_portfolio_template)
-    destinations = [tmp_path / f"clone-{index}" for index in range(8)]
-    with ThreadPoolExecutor(max_workers=4) as executor:
-        futures = [
-            executor.submit(
-                _copy_and_check_store,
-                complete_portfolio_template,
-                destination,
-                descriptor_uri=descriptor_uri,
-            )
-            for destination in destinations
-        ]
-        for future in futures:
-            future.result(timeout=30)
-
-
-def test_authorized_portfolio_template_is_quiescent_and_copyable(
-    authorized_portfolio_template: Path,
-    tmp_path: Path,
-) -> None:
-    database = authorized_portfolio_template / "metadata.sqlite3"
-    assert not database.with_name(f"{database.name}-wal").exists()
-    assert not database.with_name(f"{database.name}-shm").exists()
-
-    connection = sqlite3.connect(database)
-    try:
-        assert connection.execute("PRAGMA journal_mode").fetchone() == ("delete",)
-        assert connection.execute("PRAGMA integrity_check").fetchone() == ("ok",)
-    finally:
-        connection.close()
-
-    descriptor_uri = _polynomial_expression_schema_uri(authorized_portfolio_template)
-    destination = tmp_path / "authorized-clone"
+    destination = tmp_path / "complete-clone"
     _copy_and_check_store(
-        authorized_portfolio_template,
+        complete_portfolio_template,
         destination,
-        descriptor_uri=descriptor_uri,
+        descriptor_uri=_polynomial_expression_schema_uri(complete_portfolio_template),
     )
-    with create_runtime(
-        destination,
-        checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING,
-    ) as runtime:
-        assert runtime.core.checkers.select_compatible(
-            evidence_kind="WITNESS",
-            format_id="polytope.convex_combination",
-            format_version="1",
-            claim_schema_uri=runtime.services.polytope.claim_schema_uri,
-            semantics_uri=runtime.services.polytope.semantics_uri,
-            candidate_schema_uri=runtime.services.polytope.point_schema_uri,
-        )
-        assert runtime.core.checkers.select_compatible(
-            evidence_kind="CERTIFICATE",
-            format_id="polytope.linear_separator",
-            format_version="1",
-            claim_schema_uri=runtime.services.polytope.claim_schema_uri,
-            semantics_uri=runtime.services.polytope.semantics_uri,
-            candidate_schema_uri=runtime.services.polytope.point_schema_uri,
-        )
+    with create_runtime(destination, checker_authority=CheckerAuthorityMode.NONE) as runtime:
+        assert runtime.core.capabilities.catalog().capabilities

--- a/tests/boundary/storage/durability/startup/test_suite_fixtures.py
+++ b/tests/boundary/storage/durability/startup/test_suite_fixtures.py
@@ -125,5 +125,7 @@ def test_complete_portfolio_template_is_quiescent_and_copyable(
         destination,
         descriptor_uri=_polynomial_expression_schema_uri(complete_portfolio_template),
     )
-    with create_runtime(destination, checker_authority=CheckerAuthorityMode.NONE) as runtime:
+    with create_runtime(
+        destination, checker_authority=CheckerAuthorityMode.NONE
+    ) as runtime:
         assert runtime.core.capabilities.catalog().capabilities

--- a/tests/component/capabilities/graph_capabilities_support.py
+++ b/tests/component/capabilities/graph_capabilities_support.py
@@ -12,7 +12,7 @@ from tests.support.services import (
 )
 
 from jacobian.graphs.installation import GraphInstallation, install_graph_capabilities
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/component/capabilities/test_graph_isomorphism.py
+++ b/tests/component/capabilities/test_graph_isomorphism.py
@@ -21,7 +21,7 @@ from jacobian.graphs.isomorphism import (
     GraphIsomorphismInstallation,
     install_graph_isomorphism,
 )
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/component/capabilities/test_polynomial_system_capabilities.py
+++ b/tests/component/capabilities/test_polynomial_system_capabilities.py
@@ -21,7 +21,7 @@ from jacobian.contracts.results import ExecutionStatus
 from jacobian.polynomial_system_capabilities import (
     install_polynomial_system_capabilities,
 )
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 from jacobian.verification.errors import CheckerExecutionError
 
 

--- a/tests/component/capabilities/test_sat_assignment_verification.py
+++ b/tests/component/capabilities/test_sat_assignment_verification.py
@@ -26,7 +26,7 @@ from jacobian.contracts.capabilities import (
 from jacobian.contracts.results import ExecutionStatus
 from jacobian.contracts.sat import SatResourceBudget
 from jacobian.contracts.verification import VerificationRecord
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 from jacobian.sat_smt.sat_capabilities import (
     SatAssignmentCheckerInstallation,
     install_sat_assignment_checker,

--- a/tests/component/capabilities/test_sat_lrat_verification.py
+++ b/tests/component/capabilities/test_sat_lrat_verification.py
@@ -14,7 +14,7 @@ from tests.support.services import (
 
 from jacobian.contracts.capabilities import CapabilityRequest
 from jacobian.contracts.results import ExecutionStatus
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 from jacobian.sat_smt.sat_lrat import install_sat_lrat_verifier
 
 

--- a/tests/component/checkers/test_exact_domain_checker_installation.py
+++ b/tests/component/checkers/test_exact_domain_checker_installation.py
@@ -222,19 +222,37 @@ def test_installer_authorizes_all_exact_domain_replays(tmp_path: Path) -> None:
             )
         )
         assert registration.implementation.entrypoint.startswith(expected_module)
-    graph_runtime = installation.provider_runtimes["finite-graph"]
+    graph_runtime = installation.provider_runtimes["jacobian.graph-exact-checkers"]
     assert graph_runtime.provider == "jacobian.graph-exact-checkers"
     assert {
         component["provider"] for component in graph_runtime.configuration["components"]
     } == {"jacobian.graph-exact-checker-source"}
-    syzygy_runtime = installation.provider_runtimes["graded-syzygy"]
+    syzygy_runtime = installation.provider_runtimes["jacobian.graded-syzygy-checkers"]
     assert syzygy_runtime.provider == "jacobian.graded-syzygy-checkers"
     assert {
         component["provider"]
         for component in syzygy_runtime.configuration["components"]
     } == {"jacobian.graded-syzygy-checker-source"}
-    projective_runtime = installation.provider_runtimes["projective-arrangement"]
+    projective_runtime = installation.provider_runtimes[
+        "jacobian.projective-arrangement-checkers"
+    ]
     assert projective_runtime.provider == "jacobian.projective-arrangement-checkers"
+    assert (
+        installation.declaration_providers["polynomial.compute.gcd"]
+        == "jacobian.exact-domain-checkers"
+    )
+    assert (
+        installation.declaration_providers["matrix.normal_form.rref.compute"]
+        == "jacobian.exact-domain-checkers"
+    )
+    assert (
+        installation.declaration_providers["integer.compute.prime_factorization"]
+        == "jacobian.exact-domain-checkers"
+    )
+    assert (
+        installation.declaration_providers["graph.hamiltonian_path.decide"]
+        == "jacobian.graph-exact-checkers"
+    )
 
 
 def test_installer_preserves_operator_control(tmp_path: Path) -> None:
@@ -302,7 +320,7 @@ def test_installer_omits_exact_replay_when_its_provider_is_unavailable(
         }
     )
     monkeypatch.setattr(
-        "jacobian.exact_domain_checkers.exact_domain_checker_provider_runtime",
+        "jacobian.providers.flint_runtime.exact_domain_checker_provider_runtime",
         lambda **_: unavailable,
     )
     matrix_ids = (
@@ -368,8 +386,7 @@ def test_installer_does_not_omit_replay_when_bundled_source_is_unavailable(
         lambda: unavailable_source,
     )
     monkeypatch.setattr(
-        exact_domain_checkers,
-        "exact_domain_checker_provider_runtime",
+        "jacobian.providers.flint_runtime.exact_domain_checker_provider_runtime",
         lambda **_: unavailable_provider,
     )
 

--- a/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
+++ b/tests/component/providers/polynomial/test_nullstellensatz_capabilities.py
@@ -31,7 +31,7 @@ from jacobian.domains.polynomial_nullstellensatz.core import (
     VERIFY_CAPABILITY_ID,
     _failure_details,
 )
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 
 
 def test_failure_details_are_bounded_and_summarize_validation_errors() -> None:

--- a/tests/component/search/test_polynomial_system_search.py
+++ b/tests/component/search/test_polynomial_system_search.py
@@ -10,7 +10,7 @@ from jacobian.polynomial_system_capabilities import (
     install_polynomial_system_capabilities,
 )
 from jacobian.polynomial_system_search import PolynomialSystemRationalSearchAdapter
-from jacobian.runtime import CheckerAuthorityMode
+from jacobian.runtime.config import CheckerAuthorityMode
 
 
 def _request(constant: int) -> CapabilityRequest:

--- a/tests/composition/authority/test_hydrate_authorized.py
+++ b/tests/composition/authority/test_hydrate_authorized.py
@@ -6,7 +6,9 @@ import sqlite3
 from pathlib import Path
 
 from tests.support.exact_domain import open_exact_domain_services
+from tests.support.services import atomic_installation, open_domain_services
 
+from jacobian.checker_authorization import install_polytope_checkers
 from jacobian.domains.matrix_lattice import build_matrix_bundle
 from jacobian.runtime import CheckerAuthorityMode
 from jacobian.runtime.services import CoreServices
@@ -60,3 +62,56 @@ def test_hydrate_authorized_on_empty_store_is_fail_closed(tmp_path: Path) -> Non
     ) as services:
         assert _audit_count(tmp_path) == 0
         assert "matrix.determinant.verify" not in _verify_ids(services.core)
+
+
+def test_hydrate_authorized_polytope_checkers_without_complete_portfolio(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    with open_domain_services(
+        root,
+        checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED,
+    ) as services:
+        polytope = services.application.polytope
+        with atomic_installation(services.core):
+            installed = install_polytope_checkers(
+                services.core.checkers,
+                claim_schema_uri=polytope.claim_schema_uri,
+                semantics_uri=polytope.semantics_uri,
+                point_schema_uri=polytope.point_schema_uri,
+            )
+        assert installed.witness_checker_id is not None
+        assert installed.certificate_checker_id is not None
+        baseline_audit = _audit_count(root)
+
+    with open_domain_services(
+        root,
+        checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING,
+    ) as hydrated:
+        polytope = hydrated.application.polytope
+        with atomic_installation(hydrated.core):
+            rebound = install_polytope_checkers(
+                hydrated.core.checkers,
+                claim_schema_uri=polytope.claim_schema_uri,
+                semantics_uri=polytope.semantics_uri,
+                point_schema_uri=polytope.point_schema_uri,
+            )
+        assert rebound.witness_checker_id == installed.witness_checker_id
+        assert rebound.certificate_checker_id == installed.certificate_checker_id
+        assert hydrated.core.checkers.select_compatible(
+            evidence_kind="WITNESS",
+            format_id="polytope.convex_combination",
+            format_version="1",
+            claim_schema_uri=polytope.claim_schema_uri,
+            semantics_uri=polytope.semantics_uri,
+            candidate_schema_uri=polytope.point_schema_uri,
+        )
+        assert hydrated.core.checkers.select_compatible(
+            evidence_kind="CERTIFICATE",
+            format_id="polytope.linear_separator",
+            format_version="1",
+            claim_schema_uri=polytope.claim_schema_uri,
+            semantics_uri=polytope.semantics_uri,
+            candidate_schema_uri=polytope.point_schema_uri,
+        )
+        assert _audit_count(root) == baseline_audit

--- a/tests/composition/cli/test_cli.py
+++ b/tests/composition/cli/test_cli.py
@@ -7,8 +7,11 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from jacobian.cli import CliState, JacobianGroup, app
+from jacobian.cli import CliState, JacobianGroup, app, create_cli_app
+from jacobian.domains.arithmetic import build_arithmetic_bundle
+from jacobian.domains.matrix_lattice import build_matrix_bundle
 from jacobian.runtime import CheckerAuthorityMode
+from tests.support.selected_runtime import selected_runtime_opener
 
 
 def test_cli_help_exposes_only_math_and_operator_commands() -> None:
@@ -35,6 +38,9 @@ def test_cli_init_reports_installed_operation_count(tmp_path: Path) -> None:
 
 def test_cli_catalog_and_inspect_share_installed_declaration(tmp_path: Path) -> None:
     runner = CliRunner()
+    selected = create_cli_app(
+        runtime_opener=selected_runtime_opener(build_matrix_bundle())
+    )
     common = [
         "--state-dir",
         str(tmp_path),
@@ -42,9 +48,9 @@ def test_cli_catalog_and_inspect_share_installed_declaration(tmp_path: Path) -> 
         "NONE",
     ]
 
-    catalog_call = runner.invoke(app, [*common, "catalog"])
+    catalog_call = runner.invoke(selected, [*common, "catalog"])
     inspect_call = runner.invoke(
-        app,
+        selected,
         [*common, "inspect", "matrix.determinant.compute"],
     )
 
@@ -75,9 +81,12 @@ def test_cli_run_executes_one_installed_operation_from_inline_json(
             ],
         }
     }
+    selected = create_cli_app(
+        runtime_opener=selected_runtime_opener(build_matrix_bundle())
+    )
 
     result = CliRunner().invoke(
-        app,
+        selected,
         [
             "--state-dir",
             str(tmp_path),
@@ -102,9 +111,12 @@ def test_cli_run_executes_one_installed_operation_from_inline_json(
 def test_cli_run_reads_strict_json_file(tmp_path: Path) -> None:
     payload = tmp_path / "payload.json"
     payload.write_text('{"left":"12","right":"18"}', encoding="utf-8")
+    selected = create_cli_app(
+        runtime_opener=selected_runtime_opener(build_arithmetic_bundle())
+    )
 
     result = CliRunner().invoke(
-        app,
+        selected,
         [
             "--state-dir",
             str(tmp_path / "state"),

--- a/tests/composition/cli/test_cli.py
+++ b/tests/composition/cli/test_cli.py
@@ -9,8 +9,8 @@ from tests.support.selected_runtime import selected_runtime_opener
 from typer.testing import CliRunner
 
 from jacobian.cli import CliState, JacobianGroup, app, create_cli_app
-from jacobian.domains.arithmetic import build_arithmetic_bundle
 from jacobian.domains.matrix_lattice import build_matrix_bundle
+from jacobian.domains.number_theory import build_number_theory_bundle
 from jacobian.runtime import CheckerAuthorityMode
 
 
@@ -112,7 +112,7 @@ def test_cli_run_reads_strict_json_file(tmp_path: Path) -> None:
     payload = tmp_path / "payload.json"
     payload.write_text('{"left":"12","right":"18"}', encoding="utf-8")
     selected = create_cli_app(
-        runtime_opener=selected_runtime_opener(build_arithmetic_bundle())
+        runtime_opener=selected_runtime_opener(build_number_theory_bundle())
     )
 
     result = CliRunner().invoke(

--- a/tests/composition/cli/test_cli.py
+++ b/tests/composition/cli/test_cli.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 import pytest
 import typer
+from tests.support.selected_runtime import selected_runtime_opener
 from typer.testing import CliRunner
 
 from jacobian.cli import CliState, JacobianGroup, app, create_cli_app
 from jacobian.domains.arithmetic import build_arithmetic_bundle
 from jacobian.domains.matrix_lattice import build_matrix_bundle
 from jacobian.runtime import CheckerAuthorityMode
-from tests.support.selected_runtime import selected_runtime_opener
 
 
 def test_cli_help_exposes_only_math_and_operator_commands() -> None:

--- a/tests/composition/runtime/test_capability_lean_projection.py
+++ b/tests/composition/runtime/test_capability_lean_projection.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 from tests.support.provider_lean import (
-    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
-    pinned_mathlib_runtime_available,
+    PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime,
 )
 
 from jacobian.contracts.capabilities import (
@@ -15,8 +15,8 @@ from jacobian.runtime.model import JacobianRuntime
 
 
 @pytest.mark.skipif(
-    not pinned_mathlib_runtime_available(),
-    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime(),
+    reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
 )
 def test_lean_capability_returns_bound_verified_result(
     authorized_complete_runtime: JacobianRuntime,
@@ -40,8 +40,8 @@ def test_lean_capability_returns_bound_verified_result(
 
 
 @pytest.mark.skipif(
-    not pinned_mathlib_runtime_available(),
-    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime(),
+    reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
 )
 def test_lean_capability_projects_repairable_checker_diagnostics(
     authorized_complete_runtime: JacobianRuntime,

--- a/tests/composition/runtime/test_exact_checker_unavailable.py
+++ b/tests/composition/runtime/test_exact_checker_unavailable.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 from tests.support.exact_domain import open_exact_domain_services
 
-import jacobian.exact_domain_checkers as exact_domain_checkers
 from jacobian.contracts.capabilities import CapabilityProviderAvailability
 from jacobian.domains.graph_optimization import build_graph_optimization_bundle
 from jacobian.domains.matrix_lattice import build_matrix_bundle
@@ -26,8 +25,7 @@ def test_unavailable_flint_replay_preserves_runtime_and_reports_diagnostics(
         }
     )
     monkeypatch.setattr(
-        exact_domain_checkers,
-        "exact_domain_checker_provider_runtime",
+        "jacobian.providers.flint_runtime.exact_domain_checker_provider_runtime",
         lambda **_: unavailable,
     )
 

--- a/tests/e2e/capability_workflows/test_capability_round_trips.py
+++ b/tests/e2e/capability_workflows/test_capability_round_trips.py
@@ -8,8 +8,8 @@ from typing import Any
 import pytest
 from mcp import Client
 from tests.support.provider_lean import (
-    PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
-    pinned_mathlib_runtime_available,
+    PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime,
 )
 from tests.support.rationals import rational_payload as _q
 
@@ -240,8 +240,8 @@ def test_computed_domain_operation_remains_available_without_checker_authority(
 
 
 @pytest.mark.skipif(
-    not pinned_mathlib_runtime_available(),
-    reason=PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    skip_unless_pinned_lean_core_runtime(),
+    reason=PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
 )
 def test_lean_proof_edit_verifies_through_mcp_and_replays_after_restart(
     tmp_path: Path,

--- a/tests/e2e/capability_workflows/test_capability_round_trips.py
+++ b/tests/e2e/capability_workflows/test_capability_round_trips.py
@@ -13,6 +13,8 @@ from tests.support.provider_lean import (
 )
 from tests.support.rationals import rational_payload as _q
 
+from tests.support.state import copy_template
+
 from jacobian.adapters.mcp.server import create_server
 from jacobian.runtime import CheckerAuthorityMode
 
@@ -105,7 +107,7 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
             ]
 
         restarted = create_server(
-            tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
+            tmp_path, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
         )
         async with Client(restarted, raise_exceptions=True) as client:
             replayed = await _tool(
@@ -123,10 +125,14 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
     asyncio.run(scenario())
 
 
-def test_polynomial_factor_result_verifies_through_mcp(tmp_path: Path) -> None:
+def test_polynomial_factor_result_verifies_through_mcp(
+    tmp_path: Path,
+    authorized_portfolio_template: Path,
+) -> None:
     async def scenario() -> None:
+        state = copy_template(authorized_portfolio_template, tmp_path / "state")
         server = create_server(
-            tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
+            state, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
         )
         async with Client(server, raise_exceptions=True) as client:
             factor_input = {"polynomial": _polynomial(-1, 0, 1)}
@@ -278,7 +284,7 @@ def test_lean_proof_edit_verifies_through_mcp_and_replays_after_restart(
             assert record["payload"]["evidence_uri"] in verified["artifact_uris"]
 
         restarted = create_server(
-            tmp_path, checker_authority=CheckerAuthorityMode.INSTALL_BUNDLED
+            tmp_path, checker_authority=CheckerAuthorityMode.HYDRATE_EXISTING
         )
         async with Client(restarted, raise_exceptions=True) as client:
             replayed = await validate(client)

--- a/tests/e2e/capability_workflows/test_capability_round_trips.py
+++ b/tests/e2e/capability_workflows/test_capability_round_trips.py
@@ -12,7 +12,6 @@ from tests.support.provider_lean import (
     skip_unless_pinned_lean_core_runtime,
 )
 from tests.support.rationals import rational_payload as _q
-
 from tests.support.state import copy_template
 
 from jacobian.adapters.mcp.server import create_server

--- a/tests/support/provider_lean.py
+++ b/tests/support/provider_lean.py
@@ -1,23 +1,64 @@
 """Readiness probe for the pinned Lean and Mathlib test runtime."""
 
+from __future__ import annotations
+
+import os
+
+from jacobian.contracts.capabilities import CapabilityProviderAvailability
+
 PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON = (
     "the pinned Lean and Mathlib runtime is unavailable"
 )
 PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON = (
     "the pinned Lean CORE runtime is unavailable"
 )
+_HOSTED_LEAN_REQUIRED = "JACOBIAN_LEAN_REQUIRED"
+
+
+def hosted_lean_runtime_required() -> bool:
+    """Return whether missing Lean runtimes must fail instead of skip."""
+
+    return os.environ.get(_HOSTED_LEAN_REQUIRED) == "1"
+
+
+def pinned_lean_core_runtime_diagnostic() -> str | None:
+    """Return the CORE frontend diagnostic when that runtime is unavailable."""
+
+    from jacobian.providers.lean_runtime import lean_frontend_provider_runtime
+
+    runtime = lean_frontend_provider_runtime()
+    if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+        return None
+    return runtime.diagnostic or PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON
+
+
+def pinned_mathlib_runtime_diagnostic() -> str | None:
+    """Return the Mathlib runtime diagnostic when that runtime is unavailable."""
+
+    from jacobian.providers.lean_runtime import lean_provider_runtime
+
+    runtime = lean_provider_runtime(
+        profiles={"mathlib": {"mathlib_commit": "pinned"}},
+        checker_ids=(),
+    )
+    if runtime.availability is CapabilityProviderAvailability.AVAILABLE:
+        return None
+    return runtime.diagnostic or PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON
+
+
+def _skip_unavailable(diagnostic: str | None, fallback: str) -> bool:
+    if diagnostic is None:
+        return False
+    if hosted_lean_runtime_required():
+        raise RuntimeError(diagnostic)
+    del fallback
+    return True
 
 
 def pinned_lean_core_runtime_available() -> bool:
     """Return whether the production pinned Lean CORE frontend probe succeeds."""
 
-    from jacobian.contracts.capabilities import CapabilityProviderAvailability
-    from jacobian.providers.lean_runtime import lean_frontend_provider_runtime
-
-    return (
-        lean_frontend_provider_runtime().availability
-        is CapabilityProviderAvailability.AVAILABLE
-    )
+    return pinned_lean_core_runtime_diagnostic() is None
 
 
 def pinned_mathlib_runtime_available() -> bool:
@@ -27,11 +68,22 @@ def pinned_mathlib_runtime_available() -> bool:
     during collection of unit and component tests.
     """
 
-    from jacobian.contracts.capabilities import CapabilityProviderAvailability
-    from jacobian.providers.lean_runtime import lean_provider_runtime
+    return pinned_mathlib_runtime_diagnostic() is None
 
-    runtime = lean_provider_runtime(
-        profiles={"mathlib": {"mathlib_commit": "pinned"}},
-        checker_ids=(),
+
+def skip_unless_pinned_lean_core_runtime() -> bool:
+    """Skip CORE Lean tests locally; fail when the hosted lane requires them."""
+
+    return _skip_unavailable(
+        pinned_lean_core_runtime_diagnostic(),
+        PINNED_LEAN_CORE_RUNTIME_UNAVAILABLE_REASON,
     )
-    return runtime.availability is CapabilityProviderAvailability.AVAILABLE
+
+
+def skip_unless_pinned_mathlib_runtime() -> bool:
+    """Skip Mathlib Lean tests locally; fail when the hosted lane requires them."""
+
+    return _skip_unavailable(
+        pinned_mathlib_runtime_diagnostic(),
+        PINNED_MATHLIB_RUNTIME_UNAVAILABLE_REASON,
+    )

--- a/tests/support/selected_runtime.py
+++ b/tests/support/selected_runtime.py
@@ -1,0 +1,81 @@
+"""Selected-bundle runtimes for tests that must not assemble the portfolio."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from jacobian.domain_bundles import DomainBundle
+from jacobian.installation.context import create_installation_context
+from jacobian.portfolio.domain_installation import DomainBundleInstaller
+from jacobian.portfolio.model import PortfolioPlan
+from jacobian.runtime.bootstrap import bootstrap_services
+from jacobian.runtime.config import CheckerAuthorityMode, RuntimeOptions
+from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime.portfolio import PortfolioResources
+from jacobian.runtime.services import build_runtime_services
+from tests.support.services import atomic_installation
+
+
+def create_selected_runtime(
+    root: str | Path,
+    bundles: Sequence[DomainBundle] = (),
+    *,
+    checker_authority: CheckerAuthorityMode = CheckerAuthorityMode.NONE,
+    **_kwargs: object,
+) -> JacobianRuntime:
+    """Compose one runtime that installs only the supplied domain bundles."""
+
+    options = RuntimeOptions(checker_authority=checker_authority)
+    core = bootstrap_services(root, options)
+    services = None
+    try:
+        services = build_runtime_services(core)
+        installation = create_installation_context(core, services, options)
+        if bundles:
+            with atomic_installation(core):
+                DomainBundleInstaller(installation).install(
+                    PortfolioPlan(components=tuple(bundles))
+                )
+        return JacobianRuntime(
+            core,
+            services,
+            PortfolioResources(),
+            start_lean_warmup=lambda: None,
+        )
+    except BaseException as error:
+        cleanup_failures: list[BaseException] = []
+        if services is not None:
+            try:
+                services.close()
+            except BaseException as cleanup_error:
+                cleanup_failures.append(cleanup_error)
+        try:
+            core.close()
+        except BaseException as cleanup_error:
+            cleanup_failures.append(cleanup_error)
+        if cleanup_failures:
+            error.add_note(
+                "selected runtime construction cleanup also failed: "
+                + "; ".join(str(failure) for failure in cleanup_failures)
+            )
+        raise
+
+
+def selected_runtime_opener(*bundles: DomainBundle):
+    """Return a ``create_runtime``-shaped opener for the supplied bundles."""
+
+    def opener(
+        root: str | Path,
+        *,
+        checker_authority: CheckerAuthorityMode = CheckerAuthorityMode.NONE,
+        **kwargs: object,
+    ) -> JacobianRuntime:
+        return create_selected_runtime(
+            root,
+            bundles,
+            checker_authority=checker_authority,
+            **kwargs,
+        )
+
+    return opener

--- a/tests/unit/contracts/test_exact_replay_declaration.py
+++ b/tests/unit/contracts/test_exact_replay_declaration.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jacobian.checker_operations import ExactReplayCheckerDeclaration
+from jacobian.contracts.matrix_operations import MatrixDeterminantRequest
+
+ROOT = Path(__file__).parents[3]
+
+
+def test_exact_replay_declaration_requires_provider_runtime_factory() -> None:
+    with pytest.raises(ValueError, match="provider runtime factory"):
+        ExactReplayCheckerDeclaration(
+            "matrix.determinant.compute",
+            MatrixDeterminantRequest,
+            "check_matrix_determinant",
+            "matrix.determinant.flint-replay",
+        )
+
+
+def test_exact_domain_checkers_has_no_central_semantic_maps() -> None:
+    source = (ROOT / "src/jacobian/exact_domain_checkers.py").read_text(encoding="utf-8")
+
+    assert "_ENTRYPOINT_PROVIDER_RUNTIME_KEYS" not in source
+    assert "def _checker_supports" not in source
+    assert "def _provider_runtime_key" not in source
+

--- a/tests/unit/contracts/test_exact_replay_declaration.py
+++ b/tests/unit/contracts/test_exact_replay_declaration.py
@@ -21,9 +21,10 @@ def test_exact_replay_declaration_requires_provider_runtime_factory() -> None:
 
 
 def test_exact_domain_checkers_has_no_central_semantic_maps() -> None:
-    source = (ROOT / "src/jacobian/exact_domain_checkers.py").read_text(encoding="utf-8")
+    source = (ROOT / "src/jacobian/exact_domain_checkers.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "_ENTRYPOINT_PROVIDER_RUNTIME_KEYS" not in source
     assert "def _checker_supports" not in source
     assert "def _provider_runtime_key" not in source
-

--- a/tests/unit/tooling/test_architecture_process_policies.py
+++ b/tests/unit/tooling/test_architecture_process_policies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from tools.check_architecture import check_architecture
 
 
@@ -93,6 +94,24 @@ def test_subprocess_in_development_profiles_is_allowed(tmp_path: Path) -> None:
         "tools/development_profiles.py",
         "import subprocess\n\nsubprocess.run(['uv', 'sync'])\n",
     )
+    report = check_architecture(tmp_path)
+    assert all(v.code != "subprocess-confined" for v in report.violations)
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "tools/inventory_github_workflows.py",
+        "tools/restack_feature_branch.py",
+        "tools/worktree_admission.py",
+        "tests/unit/tooling/test_restack_feature_branch.py",
+        "tests/unit/tooling/test_worktree_admission.py",
+    ],
+)
+def test_subprocess_in_listed_developer_tooling_is_allowed(
+    tmp_path: Path, relative: str
+) -> None:
+    _write(tmp_path, relative, "import subprocess\n\nsubprocess.run(['true'])\n")
     report = check_architecture(tmp_path)
     assert all(v.code != "subprocess-confined" for v in report.violations)
 

--- a/tests/unit/tooling/test_architecture_test_ownership.py
+++ b/tests/unit/tooling/test_architecture_test_ownership.py
@@ -154,6 +154,21 @@ def test_composition_module_requires_a_semantic_owner_directory(tmp_path: Path) 
     ]
 
 
+def test_discarded_complete_runtime_fixture_is_rejected(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "tests/boundary/providers/lean/startup/test_discard.py",
+        "def test_hydration(authorized_complete_runtime, tmp_path):\n"
+        "    _ = authorized_complete_runtime\n"
+        "    create_runtime(tmp_path)\n",
+    )
+
+    assert _ownership_messages(tmp_path) == [
+        "expensive runtime fixtures must be the subject under test, "
+        "not discarded setup: authorized_complete_runtime"
+    ]
+
+
 def test_owned_composition_module_is_accepted(tmp_path: Path) -> None:
     _write(tmp_path, "tests/composition/interoperability/test_value_handoff.py")
 

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -155,9 +155,32 @@ def test_exhaustive_local_reproduction_includes_exhaustive_marker_lane() -> None
 
     assert "$(MAKE) test-component" in all_ci
     assert "$(MAKE) test-exhaustive" in all_ci
+    assert "$(WORKTREE_ADMISSION) run --target test-all-ci" in all_ci
     assert all_ci.index("$(MAKE) test-component") < all_ci.index(
         "$(MAKE) test-exhaustive"
     )
+
+
+def test_focused_unit_lane_skips_worktree_admission() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    unit = makefile.split("test-unit:", 1)[1].split("test-component:", 1)[0]
+    exhaustive = makefile.split("test-exhaustive:", 1)[1].split("test-ordering:", 1)[0]
+    harbor = (ROOT / "make" / "harbor.mk").read_text(encoding="utf-8")
+
+    assert "WORKTREE_ADMISSION" not in unit
+    assert "$(WORKTREE_ADMISSION) run --target test-exhaustive" in exhaustive
+    assert "$(WORKTREE_ADMISSION) run --target harbor-check-all" in harbor
+    assert "$(WORKTREE_ADMISSION) run --target harbor-host-validation" in harbor
+    assert "$(WORKTREE_ADMISSION) run --target harbor-oracle-all" in harbor
+
+
+def test_component_lane_uses_module_fixture_affinity() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    component = makefile.split("test-component:", 1)[1].split("test-domain:", 1)[0]
+    domain = makefile.split("test-domain:", 1)[1].split("test-composition:", 1)[0]
+
+    assert "--dist loadscope" in component
+    assert "--dist worksteal" in domain
 
 
 def test_benchmark_workflow_has_distinct_pr_merge_and_full_portfolio_tiers() -> None:
@@ -233,7 +256,11 @@ def test_paths_file_stays_on_harbor_planning() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
     assert "PATHS_FILE" not in makefile
-    assert "PATHS_FILE" in harbor
+    assert "PATHS_FILE :=" not in harbor
+    assert "$(shell mktemp)" not in harbor
+    assert "tr '\\n' ' '" not in harbor
+    assert "--paths-file \"$$tmp_dir/changed-paths.txt\"" in harbor
+    assert "--config make/harbor.mk" in harbor
     assert "PATHS_FILE" not in workflow
 
 
@@ -307,6 +334,8 @@ def test_local_oracle_targets_require_explicit_scope() -> None:
     assert '"$(TASKS)" -o "$(FULL)" = "1"' in oracle
     assert '"$(TASKS)" -o "$(FULL)" = "1"' in runner
     assert "DATASET=$$dataset FULL=1" in harbor
+    assert "$(MAKE) harbor-check\n" in oracle
+    assert "harbor-check-all" not in oracle
 
 
 def test_local_oracle_attempts_are_serialized_on_a_shared_docker_host() -> None:

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -100,10 +100,24 @@ def test_process_lane_is_invoked_by_ci() -> None:
     assert "run: make test-${{ matrix.lane }}" in workflow
 
 
+def test_lean_job_is_required_on_every_event_and_builds_semantic_targets() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    action = (ROOT / ".github/actions/setup-lean/action.yml").read_text(
+        encoding="utf-8"
+    )
+
+    lean = workflow.split("  lean:", 1)[1].split("  coverage:", 1)[0]
+    assert "if: >-" not in lean
+    assert "JACOBIAN_LEAN_REQUIRED" in lean
+    assert "use-github-cache: false" in action
+    assert "use-mathlib-cache: true" in action
+    assert "lake build JacobianLeanRuntime repl jacobian_lean_proof_state" in action
+    assert "tools/preflight_lean_runtime.py --required" in action
+
+
 def test_optional_boundary_and_deployment_jobs_have_explicit_workflow_gates() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert "ci:lean" in workflow
     assert "ci:full" in workflow
     assert "run: make deploy-check" in workflow
     assert "name: Deployment Tests" in workflow
@@ -128,12 +142,14 @@ def test_python_jobs_use_fixed_local_semantic_targets() -> None:
     assert "quick: lint test-unit" in makefile
     assert "check: lint typecheck test-unit" in makefile
     assert "check-all: lint typecheck test-ordinary" in makefile
+    assert "check-external: test-lean ##" in makefile
+    assert "check-external: test-lean test-provider" not in makefile
 
 
 def test_exhaustive_local_reproduction_includes_exhaustive_marker_lane() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     all_ci = makefile.split(
-        "test-all-ci: ## Explicitly run every semantic lane locally (exceptional).",
+        "test-all-ci: ## Every local semantic pytest/Lean lane; not hosted CI, coverage, or docs.",
         1,
     )[1].split("test-stress:", 1)[0]
 
@@ -255,8 +271,12 @@ def test_required_ci_gates_fail_closed_without_extending_cancelled_runs() -> Non
     assert "name: Lean Tests" in workflow
     assert "name: Deployment Tests" in workflow
     assert ("needs: [static, python, boundaries, wheel, coverage, lean]") in required
-    assert "success|skipped" in required
+    assert "success|skipped" not in required
+    assert 'test "$LEAN_RESULT" = success' in required
     assert "needs.lean.result" in required
+    lean_job = workflow.split("  lean:", 1)[1].split("  coverage:", 1)[0]
+    assert "github.event_name != 'pull_request'" not in lean_job
+    assert "JACOBIAN_LEAN_REQUIRED" in lean_job
 
 
 def test_subprocess_coverage_is_owned_by_one_focused_worker_lane() -> None:

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -118,7 +118,8 @@ def test_lean_job_is_required_on_every_event_and_builds_semantic_targets() -> No
 def test_optional_boundary_and_deployment_jobs_have_explicit_workflow_gates() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert "ci:full" in workflow
+    assert "ci:full" not in workflow
+    assert "ci:lean" not in workflow
     assert "run: make deploy-check" in workflow
     assert "name: Deployment Tests" in workflow
     assert "name: required" in workflow

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -259,7 +259,7 @@ def test_paths_file_stays_on_harbor_planning() -> None:
     assert "PATHS_FILE :=" not in harbor
     assert "$(shell mktemp)" not in harbor
     assert "tr '\\n' ' '" not in harbor
-    assert "--paths-file \"$$tmp_dir/changed-paths.txt\"" in harbor
+    assert '--paths-file "$$tmp_dir/changed-paths.txt"' in harbor
     assert "--config make/harbor.mk" in harbor
     assert "PATHS_FILE" not in workflow
 

--- a/tests/unit/tooling/test_github_workflow_inventory.py
+++ b/tests/unit/tooling/test_github_workflow_inventory.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.inventory_github_workflows import classify, workflow_stems
+
+
+def test_workflow_stems_read_yaml_files(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    (workflows / "benchmarks.yaml").write_text("name: benchmarks\n", encoding="utf-8")
+    (workflows / "notes.txt").write_text("ignored\n", encoding="utf-8")
+
+    assert workflow_stems(tmp_path) == {"ci", "benchmarks"}
+
+
+def test_classify_historical_agent_leftovers() -> None:
+    report = classify(
+        {"ci", "agent-port-alpha", "agent-rebase-beta", "retired-other"},
+        {"ci"},
+    )
+
+    assert report["historical_agent_leftovers"] == (
+        "agent-port-alpha",
+        "agent-rebase-beta",
+    )
+    assert report["registered_without_files"] == (
+        "agent-port-alpha",
+        "agent-rebase-beta",
+        "retired-other",
+    )
+    assert report["files_without_registration"] == ()

--- a/tests/unit/tooling/test_github_workflow_inventory.py
+++ b/tests/unit/tooling/test_github_workflow_inventory.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tools.inventory_github_workflows import classify, workflow_stems
+import pytest
+from tools.inventory_github_workflows import (
+    WORKFLOW_LIST_LIMIT,
+    _stems_from_workflow_rows,
+    _workflow_list_command,
+    classify,
+    workflow_stems,
+)
 
 
 def test_workflow_stems_read_yaml_files(tmp_path: Path) -> None:
@@ -31,3 +38,23 @@ def test_classify_historical_agent_leftovers() -> None:
         "retired-other",
     )
     assert report["files_without_registration"] == ()
+
+
+def test_workflow_list_command_requests_every_registration() -> None:
+    command = _workflow_list_command()
+
+    assert "--all" in command
+    assert "--limit" in command
+    limit = int(command[command.index("--limit") + 1])
+    assert limit >= 1000
+    assert limit == WORKFLOW_LIST_LIMIT
+
+
+def test_workflow_list_fails_closed_when_gh_hits_the_limit() -> None:
+    with pytest.raises(SystemExit, match="hit the requested limit"):
+        _stems_from_workflow_rows(
+            [
+                {"path": f".github/workflows/w{index}.yml"}
+                for index in range(WORKFLOW_LIST_LIMIT)
+            ]
+        )

--- a/tests/unit/tooling/test_restack_feature_branch.py
+++ b/tests/unit/tooling/test_restack_feature_branch.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from tools.restack_feature_branch import restack
+
+
+def _git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def test_restack_reports_unique_and_duplicate_subjects(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "restack@example.test")
+    _git(repo, "config", "user.name", "Restack")
+    (repo / "README").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "README")
+    _git(repo, "commit", "-m", "shared subject")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "README").write_text("two\n", encoding="utf-8")
+    _git(repo, "add", "README")
+    _git(repo, "commit", "-m", "shared subject")
+    (repo / "UNIQUE").write_text("leaf\n", encoding="utf-8")
+    _git(repo, "add", "UNIQUE")
+    _git(repo, "commit", "-m", "unique leaf work")
+
+    assert restack(cwd=repo, parent="main", feature="feature") == 0
+    output = capsys.readouterr().out
+    assert "unique commits: 2" in output
+    assert "shared subject" in output
+    assert "unique leaf work" in output
+    assert "does not rewrite published branches" in output

--- a/tests/unit/tooling/test_worktree_admission.py
+++ b/tests/unit/tooling/test_worktree_admission.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from tools.worktree_admission import TOKEN_ENV, main
+
+ROOT = Path(__file__).parents[3]
+ADMISSION = ROOT / "tools" / "worktree_admission.py"
+
+
+def _worktree(tmp_path: Path) -> Path:
+    (tmp_path / "Makefile").write_text("# test worktree\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def test_status_reports_free_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_worktree(tmp_path))
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+
+    assert main(["status"]) == 0
+
+
+def test_nested_make_reenters_with_unforgeable_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_worktree(tmp_path))
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+
+    assert (
+        main(
+            [
+                "run",
+                "--target",
+                "test-all-ci",
+                "--",
+                sys.executable,
+                str(ADMISSION),
+                "run",
+                "--target",
+                "nested",
+                "--",
+                "true",
+            ]
+        )
+        == 0
+    )
+
+
+def test_second_exhaustive_run_is_rejected_while_lease_is_held(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_worktree(tmp_path))
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            str(ADMISSION),
+            "run",
+            "--target",
+            "test-all-ci",
+            "--",
+            sys.executable,
+            "-c",
+            "open('held', 'w').write('1'); import time; time.sleep(8)",
+        ],
+        cwd=tmp_path,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if (tmp_path / "held").exists():
+                break
+            time.sleep(0.05)
+        else:
+            raise AssertionError("holder did not take the validation lease")
+        with pytest.raises(SystemExit, match="already running exhaustive validation"):
+            main(["run", "--target", "test-exhaustive", "--", "true"])
+    finally:
+        holder.wait(timeout=15)
+    assert holder.returncode == 0
+    assert TOKEN_ENV not in os.environ

--- a/tests/unit/tooling/test_worktree_admission.py
+++ b/tests/unit/tooling/test_worktree_admission.py
@@ -69,7 +69,7 @@ def test_second_exhaustive_run_is_rejected_while_lease_is_held(
             "--",
             sys.executable,
             "-c",
-                    "open('held', 'w').write('1'); import time; time.sleep(2)",
+            "open('held', 'w').write('1'); import time; time.sleep(2)",
         ],
         cwd=tmp_path,
     )

--- a/tests/unit/tooling/test_worktree_admission.py
+++ b/tests/unit/tooling/test_worktree_admission.py
@@ -69,7 +69,7 @@ def test_second_exhaustive_run_is_rejected_while_lease_is_held(
             "--",
             sys.executable,
             "-c",
-            "open('held', 'w').write('1'); import time; time.sleep(8)",
+                    "open('held', 'w').write('1'); import time; time.sleep(2)",
         ],
         cwd=tmp_path,
     )

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1426,6 +1426,27 @@ def _imports_jacobian_runtime(tree: ast.AST) -> bool:
     return False
 
 
+def _discarded_runtime_setup_violations(
+    relative: PurePosixPath, tree: ast.AST
+) -> tuple[Violation, ...]:
+    violations: list[Violation] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        discarded = _discarded_expensive_runtime_fixtures(node)
+        if discarded and _calls_create_runtime(node):
+            names = ", ".join(sorted(discarded))
+            violations.append(
+                Violation(
+                    str(relative),
+                    "test-ownership",
+                    "expensive runtime fixtures must be the subject under test, "
+                    f"not discarded setup: {names}",
+                )
+            )
+    return tuple(violations)
+
+
 def _test_ownership_violations(
     relative: PurePosixPath, tree: ast.AST
 ) -> tuple[Violation, ...]:
@@ -1445,21 +1466,7 @@ def _test_ownership_violations(
                 "focused tests must use their owning seam instead of the complete runtime",
             )
         )
-
-    for node in tree.body:
-        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
-            continue
-        discarded = _discarded_expensive_runtime_fixtures(node)
-        if discarded and _calls_create_runtime(node):
-            names = ", ".join(sorted(discarded))
-            violations.append(
-                Violation(
-                    str(relative),
-                    "test-ownership",
-                    "expensive runtime fixtures must be the subject under test, "
-                    f"not discarded setup: {names}",
-                )
-            )
+    violations.extend(_discarded_runtime_setup_violations(relative, tree))
 
     if (
         not focused_suite

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1352,6 +1352,49 @@ def _unsupported_surface_text_violations(
     return tuple(violations)
 
 
+_EXPENSIVE_RUNTIME_FIXTURES = frozenset(
+    {
+        "attached_complete_runtime",
+        "attached_complete_runtime_read_only",
+        "authorized_complete_runtime",
+        "authorized_complete_runtime_read_only",
+        "fresh_complete_runtime",
+    }
+)
+
+
+def _calls_create_runtime(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name) and func.id == "create_runtime":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "create_runtime":
+            return True
+    return False
+
+
+def _discarded_expensive_runtime_fixtures(node: ast.FunctionDef) -> frozenset[str]:
+    params = {arg.arg for arg in node.args.args}
+    requested = params & _EXPENSIVE_RUNTIME_FIXTURES
+    if not requested:
+        return frozenset()
+    discarded: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Assign) or len(child.targets) != 1:
+            continue
+        target = child.targets[0]
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "_"
+            and isinstance(child.value, ast.Name)
+            and child.value.id in requested
+        ):
+            discarded.add(child.value.id)
+    return frozenset(discarded)
+
+
 _HISTORICAL_TEST_BUCKET_WORDS = frozenset(
     {"frontier", "migration", "regression", "release"}
 )
@@ -1402,6 +1445,21 @@ def _test_ownership_violations(
                 "focused tests must use their owning seam instead of the complete runtime",
             )
         )
+
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        discarded = _discarded_expensive_runtime_fixtures(node)
+        if discarded and _calls_create_runtime(node):
+            names = ", ".join(sorted(discarded))
+            violations.append(
+                Violation(
+                    str(relative),
+                    "test-ownership",
+                    "expensive runtime fixtures must be the subject under test, "
+                    f"not discarded setup: {names}",
+                )
+            )
 
     if (
         not focused_suite

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -93,6 +93,11 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         # The tooling command runner.
         PurePosixPath("benchmarks/tooling/command_runner.py"),
         PurePosixPath("tools/development_profiles.py"),
+        # Developer helpers that shell out to git, gh, or Make. They are not
+        # product process callers.
+        PurePosixPath("tools/inventory_github_workflows.py"),
+        PurePosixPath("tools/restack_feature_branch.py"),
+        PurePosixPath("tools/worktree_admission.py"),
         # This clean-room verifier must independently replay the pinned Lean
         # protocol inside its isolated verifier image.  It cannot import the
         # repository command runner without widening the verifier build
@@ -159,6 +164,8 @@ _SUBPROCESS_ALLOWED_EXACT: frozenset[PurePosixPath] = frozenset(
         PurePosixPath("tests/unit/tooling/test_architecture_harbor_contracts.py"),
         PurePosixPath("tests/unit/tooling/test_architecture_unsupported_surfaces.py"),
         PurePosixPath("tests/unit/tooling/test_architecture_diagnostics.py"),
+        PurePosixPath("tests/unit/tooling/test_restack_feature_branch.py"),
+        PurePosixPath("tests/unit/tooling/test_worktree_admission.py"),
         # Benchmark regressions spawn task-owned solution or Oracle entrypoints.
         PurePosixPath(
             "benchmarks/validation/mathematical_benchmarks_v1/"

--- a/tools/command_contract.py
+++ b/tools/command_contract.py
@@ -1,0 +1,74 @@
+"""Single developer-command contract consumed by help text and tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CommandContract:
+    name: str
+    help: str
+    mutates_checkout: bool
+    scope: str
+    ci_relationship: str
+    cost_class: str
+
+
+PUBLIC_COMMANDS: tuple[CommandContract, ...] = (
+    CommandContract(
+        name="setup",
+        help="Install the locked contributor environment and diagnose Python backends.",
+        mutates_checkout=False,
+        scope="environment",
+        ci_relationship="local setup only; CI uses its own setup actions",
+        cost_class="once",
+    ),
+    CommandContract(
+        name="quick",
+        help="Cheap iteration: lint and unit tests.",
+        mutates_checkout=False,
+        scope="lint + tests/unit",
+        ci_relationship="subset of the unit CI lane plus lint",
+        cost_class="fast",
+    ),
+    CommandContract(
+        name="check",
+        help="Routine local handoff: lint, types, and unit tests.",
+        mutates_checkout=False,
+        scope="lint + typecheck + tests/unit",
+        ci_relationship="subset of required PR jobs, not PR-equivalent",
+        cost_class="bounded",
+    ),
+    CommandContract(
+        name="check-all",
+        help="Reproduce the six ordinary Python CI lanes locally.",
+        mutates_checkout=False,
+        scope="lint + typecheck + unit/component/domain/composition/e2e/provider",
+        ci_relationship="local equivalent of the python matrix, not all CI jobs",
+        cost_class="broad",
+    ),
+    CommandContract(
+        name="check-external",
+        help="Pinned Lean/Mathlib specialist lane only.",
+        mutates_checkout=False,
+        scope="tests/boundary/providers/lean",
+        ci_relationship="local equivalent of the Lean job when the toolchain exists",
+        cost_class="specialist",
+    ),
+    CommandContract(
+        name="fix",
+        help="Apply Ruff fixes and formatting.",
+        mutates_checkout=True,
+        scope="src tests benchmarks formatting",
+        ci_relationship="not a CI job; CI expects an already-formatted tree",
+        cost_class="fast",
+    ),
+)
+
+PUBLIC_COMMAND_NAMES: tuple[str, ...] = tuple(
+    command.name for command in PUBLIC_COMMANDS
+)
+COMMAND_BY_NAME: dict[str, CommandContract] = {
+    command.name: command for command in PUBLIC_COMMANDS
+}

--- a/tools/inventory_github_workflows.py
+++ b/tools/inventory_github_workflows.py
@@ -14,18 +14,13 @@ import subprocess
 from pathlib import Path
 
 HISTORICAL_PREFIXES = ("agent-port-", "agent-rebase-")
+WORKFLOW_LIST_LIMIT = 1000
 
 
 def workflow_stems(root: Path) -> set[str]:
     workflow_dir = root / ".github" / "workflows"
-    return {
-        path.stem
-        for path in workflow_dir.glob("*.yml")
-        if path.is_file()
-    } | {
-        path.stem
-        for path in workflow_dir.glob("*.yaml")
-        if path.is_file()
+    return {path.stem for path in workflow_dir.glob("*.yml") if path.is_file()} | {
+        path.stem for path in workflow_dir.glob("*.yaml") if path.is_file()
     }
 
 
@@ -49,18 +44,31 @@ def classify(
     }
 
 
-def _registered_from_gh() -> set[str]:
-    completed = subprocess.run(
-        ["gh", "workflow", "list", "--all", "--json", "name,path,state"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if completed.returncode != 0:
-        raise SystemExit(completed.stderr.strip() or "gh workflow list failed")
-    rows = json.loads(completed.stdout)
+def _workflow_list_command() -> list[str]:
+    return [
+        "gh",
+        "workflow",
+        "list",
+        "--all",
+        "--limit",
+        str(WORKFLOW_LIST_LIMIT),
+        "--json",
+        "name,path,state",
+    ]
+
+
+def _stems_from_workflow_rows(rows: object) -> set[str]:
+    if not isinstance(rows, list):
+        raise SystemExit("gh workflow list must return a JSON array")
+    if len(rows) >= WORKFLOW_LIST_LIMIT:
+        raise SystemExit(
+            "gh workflow list hit the requested limit; raise --limit so "
+            "historical registrations are not dropped"
+        )
     stems: set[str] = set()
     for row in rows:
+        if not isinstance(row, dict):
+            raise SystemExit("gh workflow list entries must be objects")
         path = row.get("path")
         if isinstance(path, str) and path:
             stems.add(Path(path).stem)
@@ -69,6 +77,18 @@ def _registered_from_gh() -> set[str]:
         if isinstance(name, str):
             stems.add(name)
     return stems
+
+
+def _registered_from_gh() -> set[str]:
+    completed = subprocess.run(
+        _workflow_list_command(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(completed.stderr.strip() or "gh workflow list failed")
+    return _stems_from_workflow_rows(json.loads(completed.stdout))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/inventory_github_workflows.py
+++ b/tools/inventory_github_workflows.py
@@ -1,0 +1,94 @@
+"""Compare default-branch workflow files with GitHub-registered workflows.
+
+Current Actions identity is the YAML under ``.github/workflows`` on the default
+branch. Registrations whose files are gone (including historical
+``agent-port-*`` / ``agent-rebase-*`` leftovers) are historical: disable them in
+the GitHub UI and retain their run history. This tool never disables workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+HISTORICAL_PREFIXES = ("agent-port-", "agent-rebase-")
+
+
+def workflow_stems(root: Path) -> set[str]:
+    workflow_dir = root / ".github" / "workflows"
+    return {
+        path.stem
+        for path in workflow_dir.glob("*.yml")
+        if path.is_file()
+    } | {
+        path.stem
+        for path in workflow_dir.glob("*.yaml")
+        if path.is_file()
+    }
+
+
+def classify(
+    registered: set[str],
+    current: set[str],
+) -> dict[str, tuple[str, ...]]:
+    historical = tuple(
+        sorted(
+            name
+            for name in registered - current
+            if name.startswith(HISTORICAL_PREFIXES)
+        )
+    )
+    missing_files = tuple(sorted(registered - current))
+    extra_files = tuple(sorted(current - registered)) if registered else ()
+    return {
+        "historical_agent_leftovers": historical,
+        "registered_without_files": missing_files,
+        "files_without_registration": extra_files,
+    }
+
+
+def _registered_from_gh() -> set[str]:
+    completed = subprocess.run(
+        ["gh", "workflow", "list", "--all", "--json", "name,path,state"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(completed.stderr.strip() or "gh workflow list failed")
+    rows = json.loads(completed.stdout)
+    stems: set[str] = set()
+    for row in rows:
+        path = row.get("path")
+        if isinstance(path, str) and path:
+            stems.add(Path(path).stem)
+            continue
+        name = row.get("name")
+        if isinstance(name, str):
+            stems.add(name)
+    return stems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--registered",
+        help="JSON array of registered workflow stems; omit to query gh.",
+    )
+    args = parser.parse_args(argv)
+    current = workflow_stems(args.root)
+    if args.registered is not None:
+        loaded = json.loads(args.registered)
+        registered = {str(name) for name in loaded}
+    else:
+        registered = _registered_from_gh()
+    report = classify(registered, current)
+    print(json.dumps({"current": sorted(current), **report}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/preflight_lean_runtime.py
+++ b/tools/preflight_lean_runtime.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Fail closed when a hosted Lean lane cannot measure its required runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from jacobian.contracts.capabilities import (  # noqa: E402
+    CapabilityProviderAvailability,
+)
+from jacobian.providers.lean_runtime import (  # noqa: E402
+    lean_frontend_provider_runtime,
+    lean_provider_runtime,
+)
+
+
+def _report(name: str, runtime: object) -> bool:
+    availability = runtime.availability
+    diagnostic = getattr(runtime, "diagnostic", None) or ""
+    print(f"{name}: {availability.value}")
+    if diagnostic:
+        print(f"  diagnostic: {diagnostic}")
+    configuration = getattr(runtime, "configuration", None)
+    if isinstance(configuration, dict):
+        semantic = configuration.get("semantic_runtime")
+        if isinstance(semantic, dict) and "digest" in semantic:
+            print(f"  semantic digest: {semantic['digest']}")
+    return availability is CapabilityProviderAvailability.AVAILABLE
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--required",
+        action="store_true",
+        help="Exit nonzero when CORE or MATHLIB is unavailable.",
+    )
+    args = parser.parse_args()
+    core = lean_frontend_provider_runtime()
+    mathlib = lean_provider_runtime(
+        profiles={"mathlib": {"mathlib_commit": "pinned"}},
+        checker_ids=(),
+    )
+    core_ok = _report("CORE", core)
+    mathlib_ok = _report("MATHLIB", mathlib)
+    if args.required and not (core_ok and mathlib_ok):
+        print(
+            "hosted Lean preflight failed: required CORE and MATHLIB runtimes "
+            "must be AVAILABLE",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/restack_feature_branch.py
+++ b/tools/restack_feature_branch.py
@@ -52,6 +52,8 @@ def restack(
     print(f"parent: {parent} ({parent_sha[:12]})")
     print(f"feature: {feature} ({feature_sha[:12]})")
     print(f"unique commits: {len(unique)}")
+    for sha, subject in unique:
+        print(f"  {sha[:12]} {subject}")
     if duplicates:
         print("duplicate-subject patches already on parent:")
         for sha, subject in duplicates:

--- a/tools/restack_feature_branch.py
+++ b/tools/restack_feature_branch.py
@@ -1,0 +1,77 @@
+"""Rebuild a leaf feature branch from its parent plus unique commits.
+
+This helper is advisory. It never force-pushes. Duplicate patches that already
+exist on the declared parent are reported rather than dropped automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def _run(args: list[str], *, cwd: Path) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _commit_subjects(cwd: Path, revision_range: str) -> list[tuple[str, str]]:
+    output = _run(
+        ["git", "log", "--reverse", "--format=%H%x09%s", revision_range],
+        cwd=cwd,
+    )
+    if not output:
+        return []
+    rows: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        sha, _, subject = line.partition("\t")
+        rows.append((sha, subject))
+    return rows
+
+
+def restack(
+    *,
+    cwd: Path,
+    parent: str,
+    feature: str,
+) -> int:
+    parent_sha = _run(["git", "rev-parse", parent], cwd=cwd)
+    feature_sha = _run(["git", "rev-parse", feature], cwd=cwd)
+    unique = _commit_subjects(cwd, f"{parent_sha}..{feature_sha}")
+    parent_subjects = {subject for _, subject in _commit_subjects(cwd, parent_sha)}
+    duplicates = [
+        (sha, subject) for sha, subject in unique if subject in parent_subjects
+    ]
+    print(f"parent: {parent} ({parent_sha[:12]})")
+    print(f"feature: {feature} ({feature_sha[:12]})")
+    print(f"unique commits: {len(unique)}")
+    if duplicates:
+        print("duplicate-subject patches already on parent:")
+        for sha, subject in duplicates:
+            print(f"  {sha[:12]} {subject}")
+    else:
+        print("duplicate-subject patches already on parent: none")
+    print(
+        "restack is advisory: rebuild the leaf from the parent plus unique "
+        "commits yourself; this helper does not rewrite published branches"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parent", default="main")
+    parser.add_argument("--feature", default="HEAD")
+    args = parser.parse_args(argv)
+    return restack(cwd=Path.cwd(), parent=args.parent, feature=args.feature)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/worktree_admission.py
+++ b/tools/worktree_admission.py
@@ -1,0 +1,147 @@
+"""OS-locked admission for exhaustive local validation in one worktree."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+TOKEN_ENV = "JACOBIAN_WORKTREE_ADMISSION_TOKEN"
+LOCK_NAME = ".jacobian-validation.lock"
+
+
+def _repo_root() -> Path:
+    marker = Path("Makefile")
+    cwd = Path.cwd()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / marker).is_file() and (candidate / ".git").exists():
+            return candidate
+    return cwd
+
+
+def _lock_path(root: Path) -> Path:
+    return root / LOCK_NAME
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("ascii")).hexdigest()
+
+
+def _read_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"validation lock is unreadable: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit("validation lock payload must be an object")
+    return payload
+
+
+def _assert_reentry(token: str, path: Path) -> None:
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            payload = _read_payload(path)
+            expected = payload.get("token_hash")
+            if not isinstance(expected, str) or not hmac.compare_digest(
+                expected, _token_hash(token)
+            ):
+                raise SystemExit("invalid worktree admission token") from None
+            return
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+    raise SystemExit("stale worktree admission token; the exhaustive lease is free")
+
+
+def _run(target: str, command: list[str]) -> int:
+    if not command:
+        raise SystemExit("worktree admission run requires a command")
+    root = _repo_root()
+    path = _lock_path(root)
+    existing = os.environ.get(TOKEN_ENV)
+    if existing:
+        _assert_reentry(existing, path)
+        return subprocess.call(command)
+
+    token = secrets.token_hex(32)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            payload = _read_payload(path)
+            holder = payload.get("target", "unknown")
+            pid = payload.get("pid", "unknown")
+            raise SystemExit(
+                f"worktree already running exhaustive validation {holder!r} (pid {pid})"
+            ) from exc
+        payload = {
+            "token_hash": _token_hash(token),
+            "target": target,
+            "pid": os.getpid(),
+            "started": time.time(),
+        }
+        encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, encoded)
+        os.fsync(fd)
+        env = os.environ.copy()
+        env[TOKEN_ENV] = token
+        return subprocess.call(command, env=env)
+    finally:
+        os.close(fd)
+
+
+def _status() -> int:
+    path = _lock_path(_repo_root())
+    if not path.exists():
+        print("validation lease: free")
+        return 0
+    fd = os.open(path, os.O_RDWR)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            payload = _read_payload(path)
+            print(
+                "validation lease: held "
+                f"target={payload.get('target')} pid={payload.get('pid')}"
+            )
+            return 0
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+    print("validation lease: free")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run", help="Hold the lease while a command runs")
+    run_parser.add_argument("--target", required=True)
+    run_parser.add_argument("command", nargs=argparse.REMAINDER)
+    subparsers.add_parser("status", help="Print whether this worktree holds the lease")
+    args = parser.parse_args(argv)
+    if args.command == "status":
+        return _status()
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    return _run(args.target, command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The suite’s doctrine is already right (narrowest production graph that proves the assertion), but tests still defaulted to `create_runtime()` / `INSTALL_BUNDLED`, then compensated with skips, caches, and copied complete-portfolio fixtures. Skipped Lean was treated as success, checker identity trusted `stat`, and exact replay still owned a central entrypoint map.

This implements the DX and test-suite cleanup plan in deletion order, as sequenced commits rather than one unstructured mega-diff.

## Solution

**Phase 1–2:** hosted Lean must prove the runtime it installed; skipped Lean is not success; checker identity hashes installed bytes through one opened descriptor; Lean hydration opens the authorized copy it claims to test.

**Phase 3:** a test’s constructed subject is the claim in its name.
- Storage WAL/close uses `bootstrap_services`; concurrent copy uses a sentinel template; one complete-template smoke remains; polytope hydration moved to authority tests.
- CLI gains a typed `runtime_opener`; catalog/inspect/run use selected matrix/GCD graphs; `init` stays the complete bootstrap smoke.
- E2E keeps one fresh bundled install plus `HYDRATE_EXISTING` restart; other authorized journeys copy the published template; `NONE` stays off that template.
- Remote MCP forwards an explicit `runtime_factory`; auth rejection never constructs a runtime; tenant isolation uses distinct hashed tenant directories; one default-authority complete smoke remains.
- SAT+SMT keep one assembled inclusion smoke instead of two complete-portfolio membership tests.

**Phase 4:** Harbor normalizes changed paths once and feeds that file to planner, validator, and receipt. Exhaustive Make targets take an OS-locked worktree lease; focused `make test-unit` stays free. Workflow inventory and restack helpers are advisory (no auto-disable bot, no force-push). Component lane keeps `--dist loadscope`; Lean setup already disables the whole-`.lake` GitHub cache.

**Phase 5:** every `ExactReplayCheckerDeclaration` binds a provider-runtime factory. Installation groups those factories by the provider identity they probe and deletes `_ENTRYPOINT_PROVIDER_RUNTIME_KEYS` / `_checker_supports`. Declarations still do not self-authorize.

## Review follow-up

`make check-external` stays Lean-only (`test-lean`). CONTRIBUTING and AGENTS now send optional or maintained Python provider changes to `make test-provider`, which `check-all` already includes.

`tools/inventory_github_workflows.py` requests `gh workflow list --limit 1000` and fails closed if that page is full, so historical leftover registrations cannot be dropped by the default 50-row cap.

## CI follow-up

Hosted Lean is now required on every PR, so the residual live-smoke test actually runs. Adapter `invoke` returns `OperationProjection`; public `.output` lives on `CapabilityResult` after `project_operation_result`, matching sibling Lean contract tests.

Static `make architecture` failed because focused component tests imported `CheckerAuthorityMode` from the complete `jacobian.runtime` package, and because the new git/gh/Make helpers used direct `subprocess`. Those tests now import the enum from `jacobian.runtime.config`. The developer helpers and the tests that spawn them are listed on the subprocess allowlist, matching `tools/development_profiles.py`.

MCP `test_authenticated_streamable_http_isolates_tenant_data` compared `metadata.sqlite3` bytes. Selected matrix runtimes write isomorphic catalogs, so those files can be identical. Isolation is now the hashed alpha/beta tenant directories plus independent sqlite files, with different HTTP determinants already asserted.

## Testing

```sh
make check
make architecture
make docs-linkcheck
make test-process TESTS=tests/boundary/process/tooling/test_make_help.py
make test-storage TESTS=tests/boundary/storage/durability/startup/test_suite_fixtures.py
make test-component TESTS=tests/component/checkers/test_exact_domain_checker_installation.py
make test-composition TESTS="tests/composition/cli/test_cli.py tests/composition/authority/test_hydrate_authorized.py tests/composition/runtime/test_exact_checker_unavailable.py"
make test-provider TESTS=tests/boundary/providers/external_sat
make test-mcp TESTS=tests/boundary/mcp/test_remote_mcp_http.py::test_authenticated_streamable_http_isolates_tenant_data
make test-e2e TESTS=tests/e2e/capability_workflows/test_capability_round_trips.py
make test-unit TESTS="tests/unit/tooling/test_github_workflow_inventory.py tests/unit/tooling/test_architecture_process_policies.py tests/unit/tooling/test_architecture_test_ownership.py tests/unit/tooling/test_restack_feature_branch.py tests/unit/tooling/test_worktree_admission.py"
```

`make architecture` and the listed unit tooling tests passed on the architecture revision. The tenant-isolation MCP test passed on this revision. `make test-all-ci` was not run. Hosted Lean evidence is owned by CI (`JACOBIAN_LEAN_REQUIRED=1`); local Lean CORE was skipped as unavailable.

## Trust & Compatibility Impact

Checker identity hashing (Phase 2) and exact-replay installation grouping (Phase 5) affect checker authorization and provider runtime identity. Public MCP/CLI behavior is unchanged: production still defaults to `create_runtime()` / complete portfolio. Remote MCP gains an optional `runtime_factory` argument with the same default.

## Architecture Budget

No new ordinary mathematical operation. The shared selected-runtime test helper is test-only. Exact replay deletes the central semantic map in the same change that binds factories on declarations (two surviving production paths: domain-owned factories and declaration-grouped installation).

## Checklist
- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ca13657-7bce-49ff-b4de-0b2b1a8b0344?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca13657-7bce-49ff-b4de-0b2b1a8b0344&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

