### PR TITLE
fix(benchmarks): accept reordered cubic residue coverage

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="842a6675b735e9db965a4673a5b8b642d171cc06580689905b2c9e7b8a711433"
+LABEL jacobian.checksum="64fae5a499672a82e654a58279f153e624a21180049647dc6742c18dddb97545"
 LABEL jacobian.task="jacobian/cubic-image-classification"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cubic-image-classification/tests/verifier.py
@@ -103,7 +103,11 @@ def _family(value: object) -> set[int] | None:
         return None
     residues = {(target[1] * (minimum + step) + target[0]) % 9 for step in range(9)}
     declared = value["covered_residues"]
-    if not _strict_int_list(declared) or declared != sorted(residues):
+    if (
+        not _strict_int_list(declared)
+        or len(declared) != len(residues)
+        or set(declared) != residues
+    ):
         return None
     return residues
 

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_cubic_image_classification.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_cubic_image_classification.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmarks.validation.mathematical_benchmarks_v1 import support
+
+TASK = "cubic-image-classification"
+
+
+def _case(tmp_path: Path):
+    return support._prepare_case(tmp_path, TASK, "computed")
+
+
+def _rewrite(app: Path, submission: dict) -> None:
+    support._bind_result_evidence(app, submission)
+    support._write_json(app / "submission.json", submission)
+
+
+def test_accepts_reordered_covered_residues(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["families"][0]["covered_residues"].reverse()
+    _rewrite(app, submission)
+
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.reward == 1.0
+
+
+def test_rejects_duplicate_covered_residue(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["families"][0]["covered_residues"] = [1, 1, 4, 7]
+    _rewrite(app, submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 0.0
+    assert rejected.reward == 0.0


### PR DESCRIPTION
## Summary

- accept any duplicate-free ordering of a cubic affine family's declared residue coverage
- keep symbolic replay, exact residue-set equality, and duplicate rejection intact
- add task-local positive and adversarial regressions

## Reproduction

Reversing the first valid family from `covered_residues: [1, 4, 7]` to `[7, 4, 1]` remains valid under the published submission schema and denotes the same residue set, but the current verifier assigns correctness and reward `0.0` because it compares the list to `sorted(residues)`.

## Validation

- `uv run pytest -q benchmarks/validation/mathematical_benchmarks_v1/test_cubic_image_classification.py` — 2 passed
- selected generic verifier contracts — 12 passed
- `uv run --locked python tools/check_benchmark_static.py` — passed
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="cubic-image-classification"` — passed
- `make harbor-plan BASE=origin/main` — selected only the dedicated leaf, generic slice, and changed-task Oracle
- `git diff --check` — passed
- `make check` — lint, formatting, complexity, and mypy passed; unit suite had 870 passed and one unrelated failure in `test_python_distribution_identity_binds_installed_file_bytes`. The same focused failure reproduces on untouched `origin/main` at `50c3fceb81c1696d2b4f50eb6efa4816d0ae0e50`.

## Oracle gap

Docker and Podman are absent on this host, so the local Harbor Oracle was deferred. The planner schedules the exact `cubic-image-classification` Oracle in CI.