### PR TITLE
fix(benchmarks): normalize symmetry edge orbit ordering

### DIFF
--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/symmetry-cycle-rotation" \
-      jacobian.checksum="6dfc54f70d4a0dcd6df65f4d128fe264bcb879674467573e54191da35abf98f0"
+      jacobian.checksum="4a127ede9d874a682bd8aadba9a0e07f005fc1750a7d41baadb509ee4bd91a37"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/symmetry-cycle-rotation/tests/verifier.py
@@ -15,9 +15,22 @@ ALLOWED = frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"})
 
 
 def _norm_edges(orbits):
-    norm = []
+    if not isinstance(orbits, list):
+        return None
+    norm: list[tuple[tuple[str, str], ...]] = []
     for orbit in orbits:
-        norm.append([sorted([sorted(e) for e in edge]) for edge in orbit])
+        if not isinstance(orbit, list):
+            return None
+        normalized_orbit: list[tuple[str, str]] = []
+        for edge in orbit:
+            if (
+                not isinstance(edge, list)
+                or len(edge) != 2
+                or not all(type(vertex) is str for vertex in edge)
+            ):
+                return None
+            normalized_orbit.append(tuple(sorted(edge)))
+        norm.append(tuple(sorted(normalized_orbit)))
     return sorted(norm)
 
 

--- a/benchmarks/validation/public_reproductions_v1/test_symmetry_cycle_rotation.py
+++ b/benchmarks/validation/public_reproductions_v1/test_symmetry_cycle_rotation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmarks.validation.public_reproductions_v1 import support
+
+TASK = "symmetry-cycle-rotation"
+
+
+def _case(tmp_path: Path):
+    return support._prepare_case(tmp_path, TASK, "computed")
+
+
+def _rewrite(app: Path, submission: dict) -> None:
+    support._bind_result_evidence(app, submission)
+    support._write_json(app / "submission.json", submission)
+
+
+def test_reference_passes(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    assert support._run_verifier(task, app, logs).reward == 1.0
+
+
+def test_reordered_edges_and_endpoints_pass(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["edge_orbits"] = [
+        [["b", "c"], ["d", "c"], ["d", "a"], ["b", "a"]]
+    ]
+    _rewrite(app, submission)
+    assert support._run_verifier(task, app, logs).reward == 1.0
+
+
+def test_edge_moved_to_separate_orbit_is_rejected(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    edges = submission["result"]["edge_orbits"][0]
+    submission["result"]["edge_orbits"] = [edges[:3], edges[3:]]
+    _rewrite(app, submission)
+    assert support._run_verifier(task, app, logs).reward == 0.0
+
+
+def test_malformed_edge_is_rejected(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["edge_orbits"][0][0] = ["a"]
+    _rewrite(app, submission)
+    assert support._run_verifier(task, app, logs).reward == 0.0


### PR DESCRIPTION
## Problem

The Round 7 paired Harbor evaluation exposed a valid `symmetry-cycle-rotation` treatment submission that received zero reward. It reported the same single edge orbit as the control, but listed the four undirected edges in cyclic order. The verifier normalized edge endpoints yet preserved the submitted edge order inside each orbit, so it compared ordered lists rather than orbit sets.

## Solution

- canonicalize every undirected edge by endpoint order;
- sort the edges within each orbit and then sort the orbit partition;
- reject malformed orbit and edge shapes before normalization;
- add focused regressions for reordered edges/endpoints, a genuinely split orbit, and a malformed edge;
- refresh the task-local verifier checksum.

This changes no graph mathematics, scope, evidence, or assurance policy.

## Validation

- focused symmetry verifier regressions: 4 passed
- `make harbor-check-task DATASET=public-reproductions-v1 TASKS="symmetry-cycle-rotation"`: passed
- Linux Docker Oracle: reward 1.0, no exception, task digest `4d1722711dbceb06731f41f404ed06d46ed3254f414a1299f4a24c5c447dde5b`
- `make check`: passed, including Ruff, formatting, complexity, mypy, and 871 unit tests
- `git diff --check`: passed

The modern `harbor-prepare-task` workflow correctly reported that this older public-reproduction bundle has no owned host-validation leaf, so validation used the bundle's documented `harbor-check-task`, explicit checksum sync, focused host tests, and Linux Oracle path.

## Overlap

PR #1256 was reviewed before this action and does not modify benchmark verifier orbit semantics. Searches of current main and all directly relevant issues/PRs found no owner for this edge-orbit ordering defect. Closed issues #533 and #545 concern malformed nested values and evidence digests, not equivalent orbit ordering.
