### PR TITLE
fix(benchmarks): clarify perfect-cuboid evidence schema version

### DIFF
--- a/benchmarks/datasets/conjecture-probes-v1/perfect-cuboid-scope-audit/instruction.md
+++ b/benchmarks/datasets/conjecture-probes-v1/perfect-cuboid-scope-audit/instruction.md
@@ -18,9 +18,9 @@ be reported in any common order; the verifier compares the three aligned
 radicand/root pairs as an unordered set.
 
 `evidence/answer.txt` must be a JSON object with exactly `schema_version`,
-`task_id`, `result`, and `limitations`. Use schema version `1`, the task ID and
-limitations from the submission contract, and the same `result` object as in
-`submission.json`. The file must be no larger than 2 MiB.
+`task_id`, `result`, and `limitations`. Use schema version `1` (the JSON string
+`"1"`), the task ID and limitations from the submission contract, and the same
+`result` object as in `submission.json`. The file must be no larger than 2 MiB.
 
 This is a finite semantic-scope audit. An Euler brick is not a perfect cuboid,
 and finding no perfect cuboid in these twelve cases is not evidence of global

--- a/benchmarks/validation/conjecture_probes_v1/test_perfect_cuboid_scope_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_perfect_cuboid_scope_audit.py
@@ -13,6 +13,11 @@ ROOT = Path(__file__).parents[3]
 TASK = ROOT / "benchmarks/datasets/conjecture-probes-v1/perfect-cuboid-scope-audit"
 
 
+def test_public_instruction_specifies_schema_version_as_json_string() -> None:
+    instruction = (TASK / "instruction.md").read_text()
+    assert 'Use schema version `1` (the JSON string\n`"1"`)' in instruction
+
+
 def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app = tmp_path / "app"
     logs = tmp_path / "logs"


### PR DESCRIPTION
## Problem

Round 8 of the paired Linux Harbor evaluation produced the same otherwise-correct failure in both arms of `perfect-cuboid-scope-audit`. Both submissions wrote numeric `1` for `evidence/answer.txt.schema_version`, while the verifier correctly requires the JSON string `"1"`.

The public instruction said only “Use schema version `1`,” so it did not expose the type distinction that determines reward. A neighboring conjecture probe already uses the unambiguous “the string `"1"`” wording.

## Change

- clarify that the evidence schema version is the JSON string `"1"`;
- add a focused public-contract regression so the type guidance cannot silently disappear.

The verifier, mathematics, assurance ceiling, scope, and fail-closed evidence checks are unchanged.

## Evidence and overlap

- observed independently in both Round 8 arms using identical task bytes;
- reproduced on current `main` at `50c3fceb81c1696d2b4f50eb6efa4816d0ae0e50`;
- reviewed PR #1256 before acting; it changes the Jacobian tool architecture, not this benchmark contract;
- searched open/closed issues and PRs, including merged task PR #592; no existing owner covers this ambiguity.

## Validation

- focused benchmark regressions: 8 passed;
- `make harbor-prepare-task DATASET=conjecture-probes-v1 TASKS="perfect-cuboid-scope-audit"`: passed, no generated drift;
- scoped static contracts and host validation: passed;
- `make harbor-plan BASE=origin/main`: selects the exact task Oracle and focused host leaf;
- `make check`: passed (Ruff, formatting, complexity, mypy, 871 unit tests);
- `git diff --check`: passed.

The local macOS Docker Oracle still fails closed before task startup because Harbor 0.20 reports the required no-network mode unsupported. The draft PR's Linux benchmark workflow owns the selected exact-task Oracle.