### PR TITLE
fix(benchmarks): accept reordered zero residual indices

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="25fe39f24a874be4a5b06f72775e7e7eeef810a8d1ec3682d8fa291759e6b543"
+LABEL jacobian.checksum="11e77aa72373a116d9b695c95190204edb64c8743ce667821adb670fbc814d80"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY test.sh verifier.py verifier_support.py public_contract.json input.json expected.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier.py
@@ -101,11 +101,15 @@ def result_ok(result):
             return False
         parsed.append(p)
     zeros = [i for i, v in enumerate(actual) if not any(v)]
+    submitted_zeros = result["zero_residual_indices"]
     return (
         parsed == actual
         and rank(vs) == 4
         and result["rank"] == 4
-        and result["zero_residual_indices"] == zeros == [4, 5]
+        and isinstance(submitted_zeros, list)
+        and all(type(index) is int for index in submitted_zeros)
+        and len(submitted_zeros) == len(zeros)
+        and set(submitted_zeros) == set(zeros) == {4, 5}
         and result["formal_selected_indices"] == list(range(6))
         and result["intended_selected_indices"] == [0, 1, 2, 3]
     )

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_gram_schmidt_nonzero_filter_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_gram_schmidt_nonzero_filter_audit.py
@@ -49,6 +49,24 @@ def test_oracle_and_orthogonally_transformed_system(tmp_path):
     assert verify(tmp_path / "alt", alt).reward == 1.0
 
 
+def test_reordered_zero_residual_indices_are_accepted(tmp_path):
+    reordered = oracle()
+    reordered["result"]["zero_residual_indices"].reverse()
+
+    accepted = verify(tmp_path, reordered)
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.reward == 1.0
+
+
+def test_duplicate_zero_residual_index_is_rejected(tmp_path):
+    duplicate = oracle()
+    duplicate["result"]["zero_residual_indices"] = [4, 4]
+
+    rejected = verify(tmp_path, duplicate)
+    assert rejected.details["correctness"] == 0.0
+    assert rejected.reward == 0.0
+
+
 def test_residual_rank_and_assurance_attacks_fail(tmp_path):
     bad = oracle()
     bad["result"]["residuals"][3][0] = {"numerator": 0, "denominator": 1}


### PR DESCRIPTION
## Problem

`gram-schmidt-nonzero-filter-audit` publicly asks for the zero-residual indices and declares that array with `uniqueItems`, but its verifier additionally requires the exact serialization `[4, 5]`.

Reversing the canonical collection to `[5, 4]` preserves the independently replayed vectors, residuals, rank, filter outcomes, evidence, scope, and assurance. It is valid under the published schema and denotes the same index set, yet the base verifier reports `correctness = 0.0` and reward `0.0`.

This is distinct from the checkpoint ordering fixed in #1414 and cubic residue coverage fixed in #1422.

## Change

- compare the submitted zero indices by exact typed set equality and cardinality;
- preserve duplicate rejection, wrong-index rejection, exact rational Gram–Schmidt/rank replay, and all protocol gates;
- add a positive reversed-order regression and a nearby duplicate-index adversarial regression;
- refresh the task-local verifier checksum.

## Audit scope

The targeted `uniqueItems` search sampled six current verifiers:

- `gram-schmidt-nonzero-filter-audit` — full three-part gate reproduced; fixed here;
- `disjoint-closed-distance-scope-audit`;
- `finite-magma-countermodel`;
- `continuant-reversal-certificate`;
- `grid-independent-set-transfer` — sorted mask order is explicitly public;
- `lean-guard-scope-assurance` — current finding collections are singleton or empty.

Per the one-task/one-PR scope, no second candidate was edited after the first real defect was confirmed. No open PR was found for this task/order defect; issue #862 concerns separate JSON numeric coercion behavior.

## Validation

Base: `50c3fceb81c1696d2b4f50eb6efa4816d0ae0e50`
Head: `3a77f6267d73a3282c72db4e9fa71c13702078fa`
Prospective task digest: `sha256:755fb38ad771989c48014ec4c810966e8675cda4f9e8c5a3368c0c8c227cab22`

- red reproduction: schema-valid `[5, 4]`, same set `{4, 5}`, correctness/reward `0.0` on base;
- focused task leaf: 5 passed;
- selected generic verifier attacks: 12 passed, 1,658 deselected;
- `uv run --locked python tools/check_benchmark_static.py`;
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="gram-schmidt-nonzero-filter-audit"`;
- `make harbor-plan BASE=origin/main` — selected only this task, its two host entries, and its exact Oracle;
- `git diff --check`;
- `make check` — Ruff, formatting, complexity, and mypy passed; unit suite had 870 passed and one unrelated failure in `test_python_distribution_identity_binds_installed_file_bytes`. The focused failure reproduces on the clean untouched base checkout at the same `origin/main` SHA.

## Deferred proof gap

Neither Docker nor Podman is installed on this host, so the exact Harbor Oracle and the Oracle stage of `harbor-validate-task` were deferred. No replacement runner was used; CI receives the exact changed-task Oracle selected by the planner.