### PR TITLE
fix(benchmarks): publish radical-system certificate conventions

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/environment/submission_schema.json
@@ -56,6 +56,7 @@
       "additionalProperties": false,
       "properties": {
         "elimination_coefficients": {
+          "description": "Coefficients of the elimination polynomial in ascending power order: [u^0, u^1, u^2, u^3, u^4].",
           "items": {
             "type": "integer"
           },
@@ -168,6 +169,7 @@
       "type": "object"
     },
     "scope": {
+      "const": "Complete real solution set under principal-root semantics.",
       "type": "string"
     },
     "task_id": {

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/instruction.md
@@ -24,7 +24,7 @@ Write `/app/submission.json` to the exact schema in `environment/submission_sche
 
 - **Conclusion:** one of `UNIQUE_REAL_SOLUTION`, `MULTIPLE_REAL_SOLUTIONS`, `INSUFFICIENT_EVIDENCE`
 - **Assurance:** scoreable values are `UNVERIFIED`, `COMPUTED` (ceiling `COMPUTED`); the submission schema accepts any of `UNVERIFIED`, `COMPUTED`, `CHECKED`, `VERIFIED` but only scoreable assurances receive credit.
-- **Scope:** a string value
+- **Scope:** the exact value declared in `submission_schema.json`
 - **Completeness:** one of `COMPLETE`, `PARTIAL`, `UNKNOWN`.
 - **Evidence:** 1-1 item(s); allowed path(s): `evidence/answer.txt`; digest must match `^sha256:[0-9a-f]{64}$`.
 - **Evidence media types:** `text/plain`.

--- a/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit/tests/public_contract.json
@@ -41,7 +41,7 @@
   "schema_definitions": {},
   "schema_version": "1",
   "scope": {
-    "const": null,
+    "const": "Complete real solution set under principal-root semantics.",
     "enum": null,
     "pattern": null,
     "type": "string"
@@ -51,6 +51,7 @@
     "additionalProperties": false,
     "properties": {
       "elimination_coefficients": {
+        "description": "Coefficients of the elimination polynomial in ascending power order: [u^0, u^1, u^2, u^3, u^4].",
         "items": {
           "type": "integer"
         },
@@ -220,6 +221,7 @@
         "additionalProperties": false,
         "properties": {
           "elimination_coefficients": {
+            "description": "Coefficients of the elimination polynomial in ascending power order: [u^0, u^1, u^2, u^3, u^4].",
             "items": {
               "type": "integer"
             },
@@ -332,6 +334,7 @@
         "type": "object"
       },
       "scope": {
+        "const": "Complete real solution set under principal-root semantics.",
         "type": "string"
       },
       "task_id": {

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_radical_system_uniqueness_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_radical_system_uniqueness_audit.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+TASK = Path(
+    "benchmarks/datasets/mathematical-benchmarks-v1/radical-system-uniqueness-audit"
+)
+
+
+def test_public_schema_exposes_coefficient_order_and_scope() -> None:
+    schema = json.loads((TASK / "environment/submission_schema.json").read_text())
+    properties = schema["properties"]
+
+    assert properties["scope"] == {
+        "const": "Complete real solution set under principal-root semantics.",
+        "type": "string",
+    }
+    coefficient_schema = properties["result"]["properties"]["elimination_coefficients"]
+    assert "ascending power order" in coefficient_schema["description"]
+    assert "[u^0, u^1, u^2, u^3, u^4]" in coefficient_schema["description"]


### PR DESCRIPTION
## Problem

Round 9 of the post-#1256 paired Harbor campaign independently reproduced a public-contract ambiguity in `radical-system-uniqueness-audit`. Both control and treatment derived the correct unique real solution and an internally consistent factorization, but both used descending coefficient order and equivalent scope prose. The verifier requires ascending coefficients and one exact scope string, while the agent-visible schema previously described only five integers and an arbitrary string.

The hidden scope requirement was also identified during review of merged PR #316, but it remains present on current `main`. PR #1256 explicitly changed no Harbor task or verifier dataset and does not own this defect.

## Fix

- Publish the elimination coefficient order in the authoritative public contract and generated schema.
- Publish the verifier's existing canonical scope string as a schema constant.
- Regenerate the agent instruction from that contract.
- Add a focused regression that prevents either requirement from becoming hidden again.

This does not change the expected mathematics, relax the verifier, alter assurance, or reveal the expected coefficients or solution.

## Validation

- Focused public-contract regression: 1 passed.
- Existing generic adversarial verifier checks selected for this task: 12 passed.
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS=radical-system-uniqueness-audit`: passed.
- `make harbor-plan BASE=origin/main`: selected only this task's generic/focused host checks and Oracle.
- `make check`: Ruff, formatting, complexity, mypy, and 915 unit tests passed.

The aggregate `harbor-validate-task` wrapper reached host validation but its nested process could not import repository-local `tools` in this isolated macOS checkout. Running the exact two planned host selectors directly with the repository root on `PYTHONPATH` passed 13/13. The selected Docker Oracle is left to Linux CI because macOS Harbor correctly fails closed at the no-network capability boundary.
