### PR TITLE
fix(benchmarks): accept exact subset determinant parity notation

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/instruction.md
@@ -12,7 +12,9 @@ subsets and the resulting determinant.
 The public determinant values alone are insufficient.  The verifier rebuilds
 the intersection matrix and checks the submitted factorization exactly, then
 recomputes the parity formula.  Bind `/app/evidence/answer.txt`; do not claim
-`VERIFIED`.
+`VERIFIED`. Scope the claim to all nonempty-subset intersection matrices for
+`n>=1`. In `limitations`, state that the finite incidence-factorization replay
+does not replay the universal theorem in Lean.
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->
 ## Submission

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="de94905d92e2c4ee723e4f0032af83cf1e14a698c00af95e74a4e1866bc6dc7c"
+LABEL jacobian.checksum="911c5df0c2553d4c92500d9b37fe0373e1d35452aa1427e837654d0e00873dc5"
 LABEL jacobian.task="jacobian/subset-incidence-determinant"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/subset-incidence-determinant/tests/verifier.py
@@ -76,6 +76,18 @@ def _trace_valid(trace: list, expected_trace: list) -> bool:
     return trace_by_n == {entry["n"]: entry for entry in expected_trace}
 
 
+def _general_determinant_valid(value: object) -> bool:
+    """Accept canonical and exact parity notations induced by the proof."""
+    if not isinstance(value, str):
+        return False
+    compact = re.sub(r"\s+", "", value).casefold()
+    return compact in {
+        "1_if_n_eq_1_else_minus_1",
+        "(-1)^(2^(n-1)-1)",
+        "(-1)**(2**(n-1)-1)",
+    }
+
+
 def _result(value: object, source: dict[str, Any]) -> bool:
     required = {
         "sample_n",
@@ -126,7 +138,7 @@ def _result(value: object, source: dict[str, Any]) -> bool:
         return False
     return bool(
         value["general_even_count"] == "2^(n-1)-1"
-        and value["general_determinant"] == "1_if_n_eq_1_else_minus_1"
+        and _general_determinant_valid(value["general_determinant"])
     )
 
 

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_subset_incidence_determinant.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_subset_incidence_determinant.py
@@ -64,3 +64,26 @@ def test_rejects_duplicate_evidence_descriptors(tmp_path: Path) -> None:
     rejected = support._run_verifier(task, app, logs)
     assert rejected.details["evidence_validity"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_accepts_parity_formula_notation_from_agent_evaluation(tmp_path: Path) -> None:
+    """The exact parity expression must not be rejected as prose variance."""
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["general_determinant"] = "(-1)^(2^(n-1)-1)"
+    support._write_json(app / "submission.json", submission)
+
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.reward == 1.0
+
+
+def test_rejects_wrong_general_determinant_formula(tmp_path: Path) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["general_determinant"] = "(-1)^(2^(n-1))"
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 0.0
+    assert rejected.reward == 0.0


### PR DESCRIPTION
## Problem

Round 10 of the paired Linux Harbor evaluation produced the same mathematically correct failure in both arms of `subset-incidence-determinant`. Both agents derived the exact factorization, parity trace, and determinant formula

```text
(-1)^(2^(n-1)-1)
```

but the verifier accepted only the private spelling `1_if_n_eq_1_else_minus_1`. The agent-visible schema advertises only a string, so this was verifier prose sensitivity rather than wrong mathematics. Both arms also used a broad scope and omitted the verifier's Lean-replay limitation because those requirements were not stated in the instruction.

## Change

- accept the exact parity expression in caret or Python exponent notation, while retaining the existing canonical spelling;
- keep rejecting a wrong parity exponent;
- state the required nonempty-subset scope and finite-replay/Lean limitation in the public instruction;
- update the verifier checksum generated by the scoped Harbor preparation workflow.

This does not expose the expected determinant in the public schema, relax the factorization or trace checks, change assurance, or alter Jacobian tools.

## Evidence and overlap

- reproduced independently in both Round 10 arms with identical task digest `9c5e3b5a...f7b2fe7`;
- both submitted the same exact mathematical formula and full valid factorization/trace;
- reviewed PR #1256 before acting; it explicitly changed no Harbor task/verifier dataset;
- searched open and closed issues/PRs and inspected merged task PR #323 plus its review history;
- no current issue, PR, or pending branch owns this exact alternate-formula rejection.

## Validation

- focused task leaf plus generic verifier selector: **19 passed**;
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="subset-incidence-determinant"`: passed;
- `make harbor-plan BASE=origin/main`: selected only the task leaf, generic selector, and exact task Oracle;
- `make check`: passed (Ruff, formatting, complexity, mypy, **931 unit tests**);
- `git diff --check`: passed.

The aggregate `harbor-validate-task` wrapper encountered an environment-only import failure in its isolated subprocess (`ModuleNotFoundError: tools`). The exact planner-selected host selectors passed directly. Linux CI owns the selected Docker Oracle.
