### PR TITLE
fix(benchmarks): clarify sharp Cauchy certificate definitions

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/instruction.md
@@ -10,11 +10,20 @@ registered proof modes, and a positive rational equality witness proving
 sharpness. In `CS_COMPOSITION` mode, provide the four quadratic forms used by
 the two Cauchy--Schwarz steps and both exact sum-square residual identities. In
 `AMGM_SQUARES` mode, first normalize the coefficient triple by its positive
-sum, then provide the normalized polynomial residual and its exact
-sum-of-squares decomposition. In `DIRECT_SOS` mode, provide the core
-polynomials `d`, `u`, `v`, the `residual`, the `constraint_residual`, and a
+sum, so `a+b+c=1`. In both `AMGM_SQUARES` and `DIRECT_SOS` modes, use the
+following core polynomials exactly:
+
+- `d = a*x+b*y+c*z`;
+- `u = a*b+b*c+c*a`;
+- `v = x*y+y*z+z*x`;
+- `residual = 1-d-u-v`;
+- `constraint_residual = 2-(a+b+c)^2-(x+y+z)^2`.
+
+In `AMGM_SQUARES` mode, `sos_twice` is
+`(a-x)^2+(b-y)^2+(c-z)^2`, and must satisfy
+`2*residual-sos_twice=constraint_residual`. In `DIRECT_SOS` mode, provide a
 list `sos_factors` of sparse polynomials whose squared sum equals
-`2*residual - constraint_residual`; any independently checkable sum-of-squares
+`2*residual-constraint_residual`; any independently checkable sum-of-squares
 decomposition is accepted. Sparse polynomials use variables ordered
 `[a,b,c,x,y,z]`, integer coefficients, and lexicographically ordered exponent
 vectors. Numerical sampling and prose-only proofs are not accepted.

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_sharp_cauchy_inequality.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_sharp_cauchy_inequality.py
@@ -11,6 +11,21 @@ from benchmarks.validation.mathematical_benchmarks_v1 import support
 TASK = "sharp-cauchy-inequality"
 
 
+def test_sharp_cauchy_inequality_publishes_certificate_definitions() -> None:
+    instruction = (
+        support.TASKS / "sharp-cauchy-inequality" / "instruction.md"
+    ).read_text()
+    for definition in (
+        "`d = a*x+b*y+c*z`",
+        "`u = a*b+b*c+c*a`",
+        "`v = x*y+y*z+z*x`",
+        "`residual = 1-d-u-v`",
+        "`constraint_residual = 2-(a+b+c)^2-(x+y+z)^2`",
+        "`2*residual-sos_twice=constraint_residual`",
+    ):
+        assert definition in instruction
+
+
 def test_sharp_cauchy_inequality_accepts_symbolic_certificate(tmp_path: Path) -> None:
     task, app, logs = support._prepare_case(
         tmp_path, "sharp-cauchy-inequality", "computed"


### PR DESCRIPTION
## What changed

- publish the exact meanings of `d`, `u`, `v`, `residual`, and `constraint_residual` for the AM-GM and direct-SOS certificate modes
- publish the required `sos_twice` identity
- add a focused regression that keeps these verifier-required definitions in the public task contract

## Why

A paired Harbor evaluation exposed a hidden-contract failure. The control arm used the canonical certificate and received full mathematical correctness. The Jacobian-enabled arm derived a valid-looking local SOS relationship but assigned a different meaning to `d`; it then received zero mathematical correctness because the verifier requires definitions that were not stated publicly.

This change makes the existing verifier contract visible. It does not relax verification, change the accepted constant, alter assurance, or modify mathematical semantics.

## Validation

- focused Sharp Cauchy validation: 8 passed
- selected Harbor task contract check: passed
- benchmark change planner selected the task leaf, generic verifier contracts, and changed-task Oracle
- `make check`: passed, including formatting, lint, mypy, and 931 unit tests
