### PR TITLE
fix(deploy): harden remote deployment lifecycle

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -94,7 +94,8 @@ Configuration:
                                 provider and checker portfolio.
   --retain-releases COUNT       Keep the active release plus the newest rollback
                                 releases (default: 2 total).
-  --skip-smoke                  Do not run the read-only MCP deployment smoke.
+  --skip-smoke                  Do not run the read-only MCP deployment smoke;
+                                services are still started.
   --dry-run                     Validate host prerequisites and print the plan.
   -h, --help                    Show this help.
 
@@ -484,6 +485,11 @@ if ((ALLOW_ANONYMOUS)) && [[ "${MODE}" != "local" ]] \
 fi
 if [[ -n "${AUTH_TOKENS_FILE}" && ! -f "${AUTH_TOKENS_FILE}" ]]; then
     die "auth token file does not exist: ${AUTH_TOKENS_FILE}"
+fi
+if ((SKIP_SMOKE)) && [[ "${MODE}" != "local" ]]; then
+    printf '%s\n' \
+        'warning: --skip-smoke does not keep public ingress offline; use --mode local while staging a VPS migration, then rerun in the final public mode after restoring state' \
+        >&2
 fi
 
 GIT=(git -c "safe.directory=${REPO_ROOT}" -C "${REPO_ROOT}")

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -776,6 +776,7 @@ else
 fi
 "${RELEASE_DIR}/.venv/bin/python" \
     "${RELEASE_DIR}/deploy/preflight_state.py" \
+    --run-as-user jacobian \
     "${STATE_PREFLIGHT_ARGS[@]}" \
     || die "configured tenant state is incompatible with revision ${REVISION}"
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -551,6 +551,7 @@ esac
 AUTH_DESCRIPTION="generated or existing static bearer token"
 if ((ALLOW_ANONYMOUS)); then
     AUTH_DESCRIPTION="anonymous shared tenant ${ANONYMOUS_TENANT_ID}"
+    STATE_DIR="${ANONYMOUS_STATE_ROOT}"
 elif [[ -n "${AUTH_TOKENS_FILE}" ]]; then
     AUTH_DESCRIPTION="static bearer tokens from ${AUTH_TOKENS_FILE}"
 fi
@@ -603,7 +604,11 @@ while [[ ! -e "${DISK_PROBE_PATH}" ]]; do
     DISK_PROBE_PATH="${DISK_PROBE_PATH%/*}"
     [[ -n "${DISK_PROBE_PATH}" ]] || DISK_PROBE_PATH="/"
 done
-AVAILABLE_INSTALL_KIB="$(df -Pk "${DISK_PROBE_PATH}" | awk 'NR == 2 {print $4}')"
+INSTALL_DISK_INFO="$(
+    df -Pk "${DISK_PROBE_PATH}" | awk 'NR == 2 {print $1, $4}'
+)"
+INSTALL_FILESYSTEM="${INSTALL_DISK_INFO%% *}"
+AVAILABLE_INSTALL_KIB="${INSTALL_DISK_INFO##* }"
 REQUIRED_INSTALL_KIB=$((2 * 1024 * 1024))
 if ((WITH_LEAN)); then
     REQUIRED_INSTALL_KIB=$((12 * 1024 * 1024))
@@ -614,8 +619,32 @@ if [[ -d "${RELEASE_DIR}" \
         == "${RELEASE_PROFILE}" ]]; then
     REQUIRED_INSTALL_KIB=0
 fi
-((AVAILABLE_INSTALL_KIB >= REQUIRED_INSTALL_KIB)) || die \
-    "insufficient free space below ${DISK_PROBE_PATH}: need ${REQUIRED_INSTALL_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+
+ROLLBACK_PROBE_PATH="${TMPDIR:-/tmp}"
+[[ -d "${ROLLBACK_PROBE_PATH}" && -w "${ROLLBACK_PROBE_PATH}" ]] || die \
+    "rollback temporary directory is not writable: ${ROLLBACK_PROBE_PATH}"
+ROLLBACK_DISK_INFO="$(
+    df -Pk "${ROLLBACK_PROBE_PATH}" | awk 'NR == 2 {print $1, $4}'
+)"
+ROLLBACK_FILESYSTEM="${ROLLBACK_DISK_INFO%% *}"
+AVAILABLE_ROLLBACK_KIB="${ROLLBACK_DISK_INFO##* }"
+STATE_SIZE_KIB=0
+if [[ -e "${STATE_DIR}" || -L "${STATE_DIR}" ]]; then
+    STATE_SIZE_KIB="$(du -sk -- "${STATE_DIR}" | awk '{print $1}')" \
+        || die "could not measure state rollback size at ${STATE_DIR}"
+fi
+REQUIRED_ROLLBACK_KIB=$((STATE_SIZE_KIB + 64 * 1024))
+
+if [[ "${INSTALL_FILESYSTEM}" == "${ROLLBACK_FILESYSTEM}" ]]; then
+    REQUIRED_SHARED_KIB=$((REQUIRED_INSTALL_KIB + REQUIRED_ROLLBACK_KIB))
+    ((AVAILABLE_INSTALL_KIB >= REQUIRED_SHARED_KIB)) || die \
+        "insufficient shared free space for release and rollback: need ${REQUIRED_SHARED_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+else
+    ((AVAILABLE_INSTALL_KIB >= REQUIRED_INSTALL_KIB)) || die \
+        "insufficient free space below ${DISK_PROBE_PATH}: need ${REQUIRED_INSTALL_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+    ((AVAILABLE_ROLLBACK_KIB >= REQUIRED_ROLLBACK_KIB)) || die \
+        "insufficient rollback space at ${ROLLBACK_PROBE_PATH}: need ${REQUIRED_ROLLBACK_KIB} KiB, found ${AVAILABLE_ROLLBACK_KIB} KiB"
+fi
 
 if ((DRY_RUN)); then
     cat <<EOF
@@ -633,7 +662,8 @@ Jacobian deployment plan
   lean:        $(((WITH_LEAN)) && printf 'pinned CORE + MATHLIB runtime' || printf 'disabled')
   retention:   ${RETAIN_RELEASES} completed releases including active
   smoke:       $(((SKIP_SMOKE)) && printf 'skipped' || printf 'required')
-  free space:  ${AVAILABLE_INSTALL_KIB} KiB at ${DISK_PROBE_PATH}
+  free space:  ${AVAILABLE_INSTALL_KIB} KiB at ${DISK_PROBE_PATH} for release
+  rollback:    ${AVAILABLE_ROLLBACK_KIB} KiB at ${ROLLBACK_PROBE_PATH}; ${REQUIRED_ROLLBACK_KIB} KiB reserved
   tools:       uv=${UV_BIN}, systemctl=${SYSTEMCTL_BIN}$(((WITH_LEAN)) && printf ', elan=%s' "${ELAN_BIN}")$([[ "${MODE}" != "local" ]] && printf ', caddy=%s' "${CADDY_BIN}")
 EOF
     exit 0

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -27,9 +27,13 @@ CONFIRM_PUBLIC_ANONYMOUS=0
 SKIP_SMOKE=0
 DRY_RUN=0
 WITH_LEAN=0
+RETAIN_RELEASES=2
 
 BACKEND_PORT=8765
 INGRESS_PORT=8766
+AUTH_STATE_ROOT="/var/lib/jacobian-mcp"
+ANONYMOUS_STATE_ROOT="/var/lib/jacobian-mcp-test"
+TRANSIENT_SMOKE_EXIT=75
 INSTALL_ROOT="/opt/jacobian"
 CONFIG_ROOT="/etc/jacobian-mcp"
 CADDY_CONFIG_ROOT="/etc/caddy-jacobian"
@@ -88,8 +92,10 @@ Configuration:
                                 Python, and Lean (default: /opt/jacobian).
   --with-lean                   Build and require the pinned Lean CORE + MATHLIB
                                 provider and checker portfolio.
+  --retain-releases COUNT       Keep the active release plus the newest rollback
+                                releases (default: 2 total).
   --skip-smoke                  Do not run the read-only MCP deployment smoke.
-  --dry-run                     Validate arguments and print the deployment plan.
+  --dry-run                     Validate host prerequisites and print the plan.
   -h, --help                    Show this help.
 
 Examples:
@@ -219,6 +225,13 @@ validate_tenant_id() {
     local value="$1"
     [[ "${value}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || die \
         "tenant IDs must start with a letter or digit, use only letters, digits, '.', '_', or '-', and be at most 128 characters"
+}
+
+validate_retain_releases() {
+    local value="$1"
+    [[ "${value}" =~ ^[1-9][0-9]*$ ]] || die \
+        "--retain-releases must be a positive integer"
+    ((value <= 100)) || die "--retain-releases must not exceed 100"
 }
 
 validate_domain() {
@@ -413,6 +426,11 @@ while (($#)); do
             WITH_LEAN=1
             shift
             ;;
+        --retain-releases)
+            (($# >= 2)) || die "--retain-releases requires a value"
+            RETAIN_RELEASES="$2"
+            shift 2
+            ;;
         --skip-smoke)
             SKIP_SMOKE=1
             shift
@@ -448,6 +466,7 @@ esac
 
 validate_tenant_id "${TENANT_ID}"
 validate_tenant_id "${ANONYMOUS_TENANT_ID}"
+validate_retain_releases "${RETAIN_RELEASES}"
 
 if [[ "${MODE}" == "domain" ]]; then
     [[ -n "${DOMAIN}" ]] || die "--mode domain requires --domain"
@@ -529,34 +548,11 @@ elif [[ -n "${AUTH_TOKENS_FILE}" ]]; then
     AUTH_DESCRIPTION="static bearer tokens from ${AUTH_TOKENS_FILE}"
 fi
 
-if ((DRY_RUN)); then
-    cat <<EOF
-Jacobian deployment plan
-  revision:    ${REVISION}
-  install:     ${INSTALL_ROOT}
-  release:     ${RELEASE_DIR}
-  python:      ${PYTHON_INSTALL_ROOT}
-  mode:        ${MODE}
-  connector:   ${CONNECTOR_URL}
-  auth:        ${AUTH_DESCRIPTION}
-  backend:     jacobian-mcp.service on 127.0.0.1:${BACKEND_PORT}
-  caddy:       $([[ "${MODE}" == "local" ]] && printf 'disabled' || printf 'enabled')
-  funnel:      $([[ "${MODE}" == "tailscale" ]] && printf 'enabled' || printf 'disabled')
-  lean:        $(((WITH_LEAN)) && printf 'pinned CORE + MATHLIB runtime' || printf 'disabled')
-  smoke:       $(((SKIP_SMOKE)) && printf 'skipped' || printf 'required')
-EOF
-    exit 0
-fi
-
-((EUID == 0)) || die "run this installer with sudo"
-"${GIT[@]}" diff --quiet --ignore-submodules -- \
-    || die "tracked working-tree changes exist; commit or stash them before deployment"
-"${GIT[@]}" diff --cached --quiet --ignore-submodules -- \
-    || die "staged changes exist; commit or stash them before deployment"
-
 INVOKING_HOME=""
 if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
     INVOKING_HOME="$(getent passwd "${SUDO_USER}" | cut -d: -f6 || true)"
+elif [[ -n "${HOME:-}" ]]; then
+    INVOKING_HOME="${HOME}"
 fi
 
 UV_BIN="$(find_executable uv /usr/local/bin/uv /usr/bin/uv || true)"
@@ -564,7 +560,7 @@ if [[ -z "${UV_BIN}" && -n "${INVOKING_HOME}" ]]; then
     UV_BIN="$(find_executable uv "${INVOKING_HOME}/.local/bin/uv" || true)"
 fi
 [[ -n "${UV_BIN}" ]] || die \
-    "uv is required; install it first or make it available on root's PATH"
+    "uv is required; install it first or make it available on the operator path"
 
 SYSTEMCTL_BIN="$(find_executable systemctl /usr/bin/systemctl || true)"
 SYSTEMD_ANALYZE_BIN="$(find_executable systemd-analyze /usr/bin/systemd-analyze || true)"
@@ -594,6 +590,53 @@ if [[ "${MODE}" != "local" ]]; then
     [[ -n "${CADDY_BIN}" ]] || die \
         "caddy is required for public ingress; install it first"
 fi
+
+DISK_PROBE_PATH="${INSTALL_ROOT}"
+while [[ ! -e "${DISK_PROBE_PATH}" ]]; do
+    DISK_PROBE_PATH="${DISK_PROBE_PATH%/*}"
+    [[ -n "${DISK_PROBE_PATH}" ]] || DISK_PROBE_PATH="/"
+done
+AVAILABLE_INSTALL_KIB="$(df -Pk "${DISK_PROBE_PATH}" | awk 'NR == 2 {print $4}')"
+REQUIRED_INSTALL_KIB=$((2 * 1024 * 1024))
+if ((WITH_LEAN)); then
+    REQUIRED_INSTALL_KIB=$((12 * 1024 * 1024))
+fi
+if [[ -d "${RELEASE_DIR}" \
+    && "$(cat "${RELEASE_DIR}/.git-revision" 2>/dev/null || true)" == "${REVISION}" \
+    && "$(cat "${RELEASE_DIR}/.release-profile" 2>/dev/null || printf 'core')" \
+        == "${RELEASE_PROFILE}" ]]; then
+    REQUIRED_INSTALL_KIB=0
+fi
+((AVAILABLE_INSTALL_KIB >= REQUIRED_INSTALL_KIB)) || die \
+    "insufficient free space below ${DISK_PROBE_PATH}: need ${REQUIRED_INSTALL_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+
+if ((DRY_RUN)); then
+    cat <<EOF
+Jacobian deployment plan
+  revision:    ${REVISION}
+  install:     ${INSTALL_ROOT}
+  release:     ${RELEASE_DIR}
+  python:      ${PYTHON_INSTALL_ROOT}
+  mode:        ${MODE}
+  connector:   ${CONNECTOR_URL}
+  auth:        ${AUTH_DESCRIPTION}
+  backend:     jacobian-mcp.service on 127.0.0.1:${BACKEND_PORT}
+  caddy:       $([[ "${MODE}" == "local" ]] && printf 'disabled' || printf 'enabled')
+  funnel:      $([[ "${MODE}" == "tailscale" ]] && printf 'enabled' || printf 'disabled')
+  lean:        $(((WITH_LEAN)) && printf 'pinned CORE + MATHLIB runtime' || printf 'disabled')
+  retention:   ${RETAIN_RELEASES} completed releases including active
+  smoke:       $(((SKIP_SMOKE)) && printf 'skipped' || printf 'required')
+  free space:  ${AVAILABLE_INSTALL_KIB} KiB at ${DISK_PROBE_PATH}
+  tools:       uv=${UV_BIN}, systemctl=${SYSTEMCTL_BIN}$(((WITH_LEAN)) && printf ', elan=%s' "${ELAN_BIN}")$([[ "${MODE}" != "local" ]] && printf ', caddy=%s' "${CADDY_BIN}")
+EOF
+    exit 0
+fi
+
+((EUID == 0)) || die "run this installer with sudo"
+"${GIT[@]}" diff --quiet --ignore-submodules -- \
+    || die "tracked working-tree changes exist; commit or stash them before deployment"
+"${GIT[@]}" diff --cached --quiet --ignore-submodules -- \
+    || die "staged changes exist; commit or stash them before deployment"
 
 install -d -m 0755 "$(dirname -- "${DEPLOY_LOCK_PATH}")"
 exec 9>"${DEPLOY_LOCK_PATH}"
@@ -707,6 +750,34 @@ validate_service_readability "${RUNTIME_READ_ROOTS[@]}"
 if ((RELEASE_WAS_BUILT)); then
     RELEASE_BUILD_DIR=""
 fi
+
+log "checking configured tenant state compatibility"
+STATE_PREFLIGHT_ARGS=()
+if ((ALLOW_ANONYMOUS)); then
+    STATE_PREFLIGHT_ARGS=(
+        --state-root "${ANONYMOUS_STATE_ROOT}"
+        --tenant-id "${ANONYMOUS_TENANT_ID}"
+    )
+elif [[ -n "${AUTH_TOKENS_FILE}" ]]; then
+    STATE_PREFLIGHT_ARGS=(
+        --state-root "${AUTH_STATE_ROOT}"
+        --auth-tokens-file "${AUTH_TOKENS_FILE}"
+    )
+elif [[ -f "${TOKEN_DESTINATION}" ]]; then
+    STATE_PREFLIGHT_ARGS=(
+        --state-root "${AUTH_STATE_ROOT}"
+        --auth-tokens-file "${TOKEN_DESTINATION}"
+    )
+else
+    STATE_PREFLIGHT_ARGS=(
+        --state-root "${AUTH_STATE_ROOT}"
+        --tenant-id "${TENANT_ID}"
+    )
+fi
+"${RELEASE_DIR}/.venv/bin/python" \
+    "${RELEASE_DIR}/deploy/preflight_state.py" \
+    "${STATE_PREFLIGHT_ARGS[@]}" \
+    || die "configured tenant state is incompatible with revision ${REVISION}"
 
 if [[ -e "${CURRENT_LINK}" && ! -L "${CURRENT_LINK}" ]]; then
     die "${CURRENT_LINK} exists and is not a symlink"
@@ -923,21 +994,34 @@ if ((!SKIP_SMOKE)); then
             --expect-revision "${REVISION}" \
             --expect-policy-profile DEFAULT \
             "${SMOKE_REQUIREMENTS[@]}"; then
-            if ((WITH_LEAN)) && ! \
-                JACOBIAN_MCP_AUTH_TOKENS_FILE="${SMOKE_TOKEN_FILE}" \
-                "${RELEASE_DIR}/.venv/bin/python" \
-                "${RELEASE_DIR}/deploy/smoke_lean.py" \
-                "${CONNECTOR_URL}"; then
-                if ((attempt < 12)); then
-                    sleep 5
-                    continue
+            if ((WITH_LEAN)); then
+                if JACOBIAN_MCP_AUTH_TOKENS_FILE="${SMOKE_TOKEN_FILE}" \
+                    "${RELEASE_DIR}/.venv/bin/python" \
+                    "${RELEASE_DIR}/deploy/smoke_lean.py" \
+                    "${CONNECTOR_URL}"; then
+                    SMOKE_SUCCEEDED=1
+                    break
+                else
+                    SMOKE_STATUS=$?
+                    if ((SMOKE_STATUS != TRANSIENT_SMOKE_EXIT)); then
+                        printf 'error: Lean deployment smoke failed deterministically; not retrying\n' >&2
+                        break
+                    fi
                 fi
+            else
+                SMOKE_SUCCEEDED=1
                 break
             fi
-            SMOKE_SUCCEEDED=1
-            break
+        else
+            SMOKE_STATUS=$?
+            if ((SMOKE_STATUS != TRANSIENT_SMOKE_EXIT)); then
+                printf 'error: deployment smoke failed deterministically; not retrying\n' >&2
+                break
+            fi
         fi
         if ((attempt < 12)); then
+            printf 'warning: transient deployment smoke failure; retrying (%s/12)\n' \
+                "${attempt}" >&2
             sleep 5
         fi
     done
@@ -951,6 +1035,21 @@ validate_service_readability "${RUNTIME_READ_ROOTS[@]}"
 
 DEPLOYMENT_ACCEPTED=1
 ROLLBACK_ARMED=0
+
+log "pruning completed releases beyond retention ${RETAIN_RELEASES}"
+RETENTION_ARGS=(
+    --release-root "${RELEASE_ROOT}"
+    --current-link "${CURRENT_LINK}"
+    --retain "${RETAIN_RELEASES}"
+)
+if [[ -n "${PREVIOUS_RELEASE}" ]]; then
+    RETENTION_ARGS+=(--preserve-release "${PREVIOUS_RELEASE}")
+fi
+if ! "${RELEASE_DIR}/.venv/bin/python" \
+    "${RELEASE_DIR}/deploy/release_retention.py" \
+    "${RETENTION_ARGS[@]}"; then
+    printf 'warning: deployment succeeded but release retention failed; prune old releases manually\n' >&2
+fi
 
 cat <<EOF
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -232,7 +232,8 @@ validate_retain_releases() {
     local value="$1"
     [[ "${value}" =~ ^[1-9][0-9]*$ ]] || die \
         "--retain-releases must be a positive integer"
-    ((value <= 100)) || die "--retain-releases must not exceed 100"
+    [[ "${value}" =~ ^([1-9]|[1-9][0-9]|100)$ ]] || die \
+        "--retain-releases must not exceed 100"
 }
 
 validate_domain() {

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -823,7 +823,7 @@ snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
 snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
     jacobian-funnel.service
 ROLLBACK_ARMED=1
-if [[ -f "${ROLLBACK_ROOT}/jacobian-mcp.service.active" ]]; then
+if [[ -f "${ROLLBACK_ROOT}/mcp-service.present" ]]; then
     "${SYSTEMCTL_BIN}" stop jacobian-mcp.service
 fi
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -630,20 +630,37 @@ ROLLBACK_FILESYSTEM="${ROLLBACK_DISK_INFO%% *}"
 AVAILABLE_ROLLBACK_KIB="${ROLLBACK_DISK_INFO##* }"
 STATE_SIZE_KIB=0
 if [[ -e "${STATE_DIR}" || -L "${STATE_DIR}" ]]; then
-    STATE_SIZE_KIB="$(du -sk -- "${STATE_DIR}" | awk '{print $1}')" \
-        || die "could not measure state rollback size at ${STATE_DIR}"
+    if ! STATE_SIZE_KIB="$(
+        du -sk -- "${STATE_DIR}" 2>/dev/null | awk '{print $1}'
+    )"; then
+        if ((DRY_RUN && EUID != 0)); then
+            STATE_SIZE_KIB=""
+            printf 'warning: rollback capacity is unverified because %s is not readable; rerun the dry-run with sudo before deployment\n' \
+                "${STATE_DIR}" >&2
+        else
+            die "could not measure state rollback size at ${STATE_DIR}"
+        fi
+    fi
 fi
-REQUIRED_ROLLBACK_KIB=$((STATE_SIZE_KIB + 64 * 1024))
-
-if [[ "${INSTALL_FILESYSTEM}" == "${ROLLBACK_FILESYSTEM}" ]]; then
-    REQUIRED_SHARED_KIB=$((REQUIRED_INSTALL_KIB + REQUIRED_ROLLBACK_KIB))
-    ((AVAILABLE_INSTALL_KIB >= REQUIRED_SHARED_KIB)) || die \
-        "insufficient shared free space for release and rollback: need ${REQUIRED_SHARED_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
-else
+if [[ -z "${STATE_SIZE_KIB}" ]]; then
     ((AVAILABLE_INSTALL_KIB >= REQUIRED_INSTALL_KIB)) || die \
         "insufficient free space below ${DISK_PROBE_PATH}: need ${REQUIRED_INSTALL_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
-    ((AVAILABLE_ROLLBACK_KIB >= REQUIRED_ROLLBACK_KIB)) || die \
-        "insufficient rollback space at ${ROLLBACK_PROBE_PATH}: need ${REQUIRED_ROLLBACK_KIB} KiB, found ${AVAILABLE_ROLLBACK_KIB} KiB"
+    ROLLBACK_PLAN="${AVAILABLE_ROLLBACK_KIB} KiB at ${ROLLBACK_PROBE_PATH}; required capacity unverified"
+else
+    [[ "${STATE_SIZE_KIB}" =~ ^[0-9]+$ ]] || die \
+        "could not measure state rollback size at ${STATE_DIR}"
+    REQUIRED_ROLLBACK_KIB=$((STATE_SIZE_KIB + 64 * 1024))
+    if [[ "${INSTALL_FILESYSTEM}" == "${ROLLBACK_FILESYSTEM}" ]]; then
+        REQUIRED_SHARED_KIB=$((REQUIRED_INSTALL_KIB + REQUIRED_ROLLBACK_KIB))
+        ((AVAILABLE_INSTALL_KIB >= REQUIRED_SHARED_KIB)) || die \
+            "insufficient shared free space for release and rollback: need ${REQUIRED_SHARED_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+    else
+        ((AVAILABLE_INSTALL_KIB >= REQUIRED_INSTALL_KIB)) || die \
+            "insufficient free space below ${DISK_PROBE_PATH}: need ${REQUIRED_INSTALL_KIB} KiB, found ${AVAILABLE_INSTALL_KIB} KiB"
+        ((AVAILABLE_ROLLBACK_KIB >= REQUIRED_ROLLBACK_KIB)) || die \
+            "insufficient rollback space at ${ROLLBACK_PROBE_PATH}: need ${REQUIRED_ROLLBACK_KIB} KiB, found ${AVAILABLE_ROLLBACK_KIB} KiB"
+    fi
+    ROLLBACK_PLAN="${AVAILABLE_ROLLBACK_KIB} KiB at ${ROLLBACK_PROBE_PATH}; ${REQUIRED_ROLLBACK_KIB} KiB reserved"
 fi
 
 if ((DRY_RUN)); then
@@ -663,7 +680,7 @@ Jacobian deployment plan
   retention:   ${RETAIN_RELEASES} completed releases including active
   smoke:       $(((SKIP_SMOKE)) && printf 'skipped' || printf 'required')
   free space:  ${AVAILABLE_INSTALL_KIB} KiB at ${DISK_PROBE_PATH} for release
-  rollback:    ${AVAILABLE_ROLLBACK_KIB} KiB at ${ROLLBACK_PROBE_PATH}; ${REQUIRED_ROLLBACK_KIB} KiB reserved
+  rollback:    ${ROLLBACK_PLAN}
   tools:       uv=${UV_BIN}, systemctl=${SYSTEMCTL_BIN}$(((WITH_LEAN)) && printf ', elan=%s' "${ELAN_BIN}")$([[ "${MODE}" != "local" ]] && printf ', caddy=%s' "${CADDY_BIN}")
 EOF
     exit 0
@@ -788,7 +805,29 @@ if ((RELEASE_WAS_BUILT)); then
     RELEASE_BUILD_DIR=""
 fi
 
-log "checking configured tenant state compatibility"
+if [[ -e "${CURRENT_LINK}" && ! -L "${CURRENT_LINK}" ]]; then
+    die "${CURRENT_LINK} exists and is not a symlink"
+fi
+ROLLBACK_ROOT="$(mktemp -d)"
+PREVIOUS_RELEASE="$(readlink "${CURRENT_LINK}" 2>/dev/null || true)"
+snapshot_file token "${TOKEN_DESTINATION}"
+snapshot_file mcp-service "${SYSTEMD_ROOT}/jacobian-mcp.service"
+snapshot_file anonymous "${SYSTEMD_ROOT}/jacobian-mcp.service.d/anonymous.conf"
+snapshot_file caddy-config "${CADDY_CONFIG_ROOT}/Caddyfile"
+snapshot_file caddy-service "${SYSTEMD_ROOT}/jacobian-caddy.service"
+snapshot_file funnel-service "${SYSTEMD_ROOT}/jacobian-funnel.service"
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-mcp.service
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-caddy.service
+snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
+    jacobian-funnel.service
+ROLLBACK_ARMED=1
+if [[ -f "${ROLLBACK_ROOT}/jacobian-mcp.service.active" ]]; then
+    "${SYSTEMCTL_BIN}" stop jacobian-mcp.service
+fi
+
+log "checking configured tenant state compatibility with writers stopped"
 STATE_PREFLIGHT_ARGS=()
 if ((ALLOW_ANONYMOUS)); then
     STATE_PREFLIGHT_ARGS=(
@@ -817,27 +856,6 @@ fi
     "${STATE_PREFLIGHT_ARGS[@]}" \
     || die "configured tenant state is incompatible with revision ${REVISION}"
 
-if [[ -e "${CURRENT_LINK}" && ! -L "${CURRENT_LINK}" ]]; then
-    die "${CURRENT_LINK} exists and is not a symlink"
-fi
-ROLLBACK_ROOT="$(mktemp -d)"
-PREVIOUS_RELEASE="$(readlink "${CURRENT_LINK}" 2>/dev/null || true)"
-snapshot_file token "${TOKEN_DESTINATION}"
-snapshot_file mcp-service "${SYSTEMD_ROOT}/jacobian-mcp.service"
-snapshot_file anonymous "${SYSTEMD_ROOT}/jacobian-mcp.service.d/anonymous.conf"
-snapshot_file caddy-config "${CADDY_CONFIG_ROOT}/Caddyfile"
-snapshot_file caddy-service "${SYSTEMD_ROOT}/jacobian-caddy.service"
-snapshot_file funnel-service "${SYSTEMD_ROOT}/jacobian-funnel.service"
-snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
-    jacobian-mcp.service
-snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
-    jacobian-caddy.service
-snapshot_systemd_service_state "${SYSTEMCTL_BIN}" "${ROLLBACK_ROOT}" \
-    jacobian-funnel.service
-ROLLBACK_ARMED=1
-if [[ -f "${ROLLBACK_ROOT}/jacobian-mcp.service.active" ]]; then
-    "${SYSTEMCTL_BIN}" stop jacobian-mcp.service
-fi
 snapshot_file state "${STATE_DIR}"
 
 install -d -m 0755 "$(dirname -- "${CURRENT_LINK}")"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -827,6 +827,23 @@ if [[ -f "${ROLLBACK_ROOT}/jacobian-mcp.service.active" ]]; then
     "${SYSTEMCTL_BIN}" stop jacobian-mcp.service
 fi
 
+QUIESCENT_AVAILABLE_ROLLBACK_KIB="$(
+    df -Pk "${ROLLBACK_ROOT}" | awk 'NR == 2 {print $4}'
+)" || die "could not remeasure rollback space at ${ROLLBACK_ROOT}"
+[[ "${QUIESCENT_AVAILABLE_ROLLBACK_KIB}" =~ ^[0-9]+$ ]] || die \
+    "could not remeasure rollback space at ${ROLLBACK_ROOT}"
+QUIESCENT_STATE_SIZE_KIB=0
+if [[ -e "${STATE_DIR}" || -L "${STATE_DIR}" ]]; then
+    QUIESCENT_STATE_SIZE_KIB="$(
+        du -sk -- "${STATE_DIR}" | awk '{print $1}'
+    )" || die "could not remeasure state rollback size at ${STATE_DIR}"
+fi
+[[ "${QUIESCENT_STATE_SIZE_KIB}" =~ ^[0-9]+$ ]] || die \
+    "could not remeasure state rollback size at ${STATE_DIR}"
+QUIESCENT_REQUIRED_ROLLBACK_KIB=$((QUIESCENT_STATE_SIZE_KIB + 64 * 1024))
+((QUIESCENT_AVAILABLE_ROLLBACK_KIB >= QUIESCENT_REQUIRED_ROLLBACK_KIB)) || die \
+    "insufficient rollback space after stopping writers: need ${QUIESCENT_REQUIRED_ROLLBACK_KIB} KiB, found ${QUIESCENT_AVAILABLE_ROLLBACK_KIB} KiB"
+
 log "checking configured tenant state compatibility with writers stopped"
 STATE_PREFLIGHT_ARGS=()
 if ((ALLOW_ANONYMOUS)); then

--- a/deploy/lib/service_state.sh
+++ b/deploy/lib/service_state.sh
@@ -4,16 +4,24 @@ snapshot_systemd_service_state() {
     local systemctl_bin="$1"
     local snapshot_root="$2"
     local unit="$3"
+    local active_state
     if "${systemctl_bin}" is-enabled --quiet "${unit}"; then
         : >"${snapshot_root}/${unit}.enabled"
     else
         : >"${snapshot_root}/${unit}.disabled"
     fi
-    if "${systemctl_bin}" is-active --quiet "${unit}"; then
-        : >"${snapshot_root}/${unit}.active"
-    else
-        : >"${snapshot_root}/${unit}.inactive"
-    fi
+    active_state="$(
+        "${systemctl_bin}" show --property=ActiveState --value "${unit}" \
+            2>/dev/null || true
+    )"
+    case "${active_state}" in
+        active | activating | reloading)
+            : >"${snapshot_root}/${unit}.active"
+            ;;
+        *)
+            : >"${snapshot_root}/${unit}.inactive"
+            ;;
+    esac
 }
 
 restore_systemd_service_state() {

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import pwd
+import re
 import sqlite3
 import stat
 from collections.abc import Iterator
@@ -99,6 +100,102 @@ _CURRENT_STATE_SCHEMA = {
         }
     ),
 }
+_COMMON_PRIMARY_KEYS = {
+    "jacobian_schema_migrations": ("revision",),
+    "jacobian_state_format": ("id",),
+    "artifacts": ("artifact_uri",),
+    "artifact_parents": ("artifact_uri", "position"),
+    "blob_quota": ("id",),
+    "checkers": ("checker_id",),
+    "checker_audit": ("sequence",),
+}
+_CURRENT_PRIMARY_KEYS = {
+    "operation_catalog_snapshots": ("revision",),
+    "operation_catalog_entries": ("snapshot_revision", "operation_id"),
+    "active_operation_catalog": ("id",),
+    "operation_checker_bindings": (
+        "snapshot_revision",
+        "operation_id",
+        "binding_index",
+    ),
+}
+_COMMON_UNIQUE_KEYS = {
+    "jacobian_schema_migrations": frozenset({("name",)}),
+    "artifacts": frozenset({("manifest_digest",)}),
+}
+_CURRENT_UNIQUE_KEYS = {
+    "active_operation_catalog": frozenset({("snapshot_revision",)}),
+}
+_COMMON_FOREIGN_KEYS = {
+    "artifact_parents": frozenset(
+        {("artifact_uri", "artifacts", "artifact_uri", "RESTRICT")}
+    ),
+    "checker_audit": frozenset({("checker_id", "checkers", "checker_id", "RESTRICT")}),
+}
+_CURRENT_FOREIGN_KEYS = {
+    "operation_catalog_entries": frozenset(
+        {
+            (
+                "snapshot_revision",
+                "operation_catalog_snapshots",
+                "revision",
+                "RESTRICT",
+            )
+        }
+    ),
+    "active_operation_catalog": frozenset(
+        {
+            (
+                "snapshot_revision",
+                "operation_catalog_snapshots",
+                "revision",
+                "RESTRICT",
+            )
+        }
+    ),
+    "operation_checker_bindings": frozenset(
+        {
+            (
+                "snapshot_revision",
+                "operation_catalog_snapshots",
+                "revision",
+                "RESTRICT",
+            ),
+            ("checker_id", "checkers", "checker_id", "RESTRICT"),
+        }
+    ),
+}
+_COMMON_CHECK_EXPRESSIONS = {
+    "jacobian_state_format": frozenset({("id", "=", "0")}),
+    "blob_quota": frozenset(
+        {
+            ("id", "=", "0"),
+            ("size_bytes", ">=", "0"),
+            ("reconciliation_required", "in", "(", "0", ",", "1", ")"),
+        }
+    ),
+    "checkers": frozenset({("authorized", "in", "(", "0", ",", "1", ")")}),
+    "checker_audit": frozenset(
+        {("action", "in", "(", "'AUTHORIZED'", ",", "'REVOKED'", ")")}
+    ),
+}
+_CURRENT_CHECK_EXPRESSIONS = {
+    "active_operation_catalog": frozenset({("id", "=", "0")}),
+    "operation_checker_bindings": frozenset({("binding_index", ">=", "0")}),
+}
+_SQL_TOKEN = re.compile(
+    r"""
+    (?P<space>\s+)
+    |(?P<comment>--[^\r\n]*|/\*.*?\*/)
+    |(?P<string>'(?:''|[^'])*')
+    |(?P<quoted_identifier>"(?:""|[^"])*"|`(?:``|[^`])*`|\[[^]]*\])
+    |(?P<word>[A-Za-z_][A-Za-z0-9_]*)
+    |(?P<number>[0-9]+)
+    |(?P<operator>>=|<=|<>|!=|==|[(),=<>+*/%-])
+    |(?P<invalid>.)
+    """,
+    re.DOTALL | re.VERBOSE,
+)
 
 
 def _blob_path(state_dir: Path, digest: str) -> Path | None:
@@ -309,11 +406,12 @@ def _blob_tree_measurement(state_dir: Path) -> tuple[int | None, str | None]:
 
 
 def _quota_diagnostic(connection: sqlite3.Connection, state_dir: Path) -> str | None:
-    row = connection.execute(
-        "SELECT size_bytes, reconciliation_required FROM blob_quota WHERE id = 0"
-    ).fetchone()
-    if row is None:
+    rows = connection.execute(
+        "SELECT id, size_bytes, reconciliation_required FROM blob_quota LIMIT 2"
+    ).fetchall()
+    if len(rows) != 1 or rows[0]["id"] != 0:
         return "artifact blob quota metadata is missing"
+    row = rows[0]
     size_bytes = row["size_bytes"]
     reconciliation_required = row["reconciliation_required"]
     if (
@@ -334,6 +432,128 @@ def _quota_diagnostic(connection: sqlite3.Connection, state_dir: Path) -> str | 
     return None
 
 
+def _unique_keys(
+    connection: sqlite3.Connection, table: str
+) -> frozenset[tuple[str, ...]]:
+    keys: set[tuple[str, ...]] = set()
+    for index in connection.execute(
+        'SELECT name, "unique" FROM pragma_index_list(?)', (table,)
+    ):
+        if int(index["unique"]) != 1:
+            continue
+        columns = tuple(
+            str(column["name"])
+            for column in connection.execute(
+                "SELECT name FROM pragma_index_info(?)", (str(index["name"]),)
+            )
+            if column["name"] is not None
+        )
+        if columns:
+            keys.add(columns)
+    return frozenset(keys)
+
+
+def _foreign_keys(
+    connection: sqlite3.Connection, table: str
+) -> frozenset[tuple[str, str, str, str]]:
+    return frozenset(
+        (
+            str(row["from"]),
+            str(row["table"]),
+            str(row["to"]),
+            str(row["on_delete"]),
+        )
+        for row in connection.execute(
+            "SELECT * FROM pragma_foreign_key_list(?)", (table,)
+        )
+    )
+
+
+def _schema_tokens(schema_sql: str) -> tuple[str, ...]:
+    tokens: list[str] = []
+    for match in _SQL_TOKEN.finditer(schema_sql):
+        kind = match.lastgroup
+        if kind in {"space", "comment"}:
+            continue
+        if kind == "invalid" or kind is None:
+            return ()
+        token = match.group()
+        if kind == "word":
+            token = token.casefold()
+        elif kind == "quoted_identifier":
+            token = token[1:-1].casefold()
+        tokens.append(token)
+    return tuple(tokens)
+
+
+def _table_check_expressions(
+    connection: sqlite3.Connection, table: str
+) -> frozenset[tuple[str, ...]]:
+    row = connection.execute(
+        "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if row is None or not isinstance(row["sql"], str):
+        return frozenset()
+    tokens = _schema_tokens(row["sql"])
+    expressions: set[tuple[str, ...]] = set()
+    for start in range(len(tokens) - 1):
+        if tokens[start] != "check" or tokens[start + 1] != "(":
+            continue
+        depth = 1
+        expression: list[str] = []
+        for token in tokens[start + 2 :]:
+            if token == "(":
+                depth += 1
+            elif token == ")":
+                depth -= 1
+                if depth == 0:
+                    expressions.add(tuple(expression))
+                    break
+            expression.append(token)
+    return frozenset(expressions)
+
+
+def _schema_constraint_diagnostic(
+    connection: sqlite3.Connection, *, current: bool
+) -> str | None:
+    primary_keys = dict(_COMMON_PRIMARY_KEYS)
+    unique_keys = dict(_COMMON_UNIQUE_KEYS)
+    foreign_keys = dict(_COMMON_FOREIGN_KEYS)
+    check_expressions = dict(_COMMON_CHECK_EXPRESSIONS)
+    if current:
+        primary_keys.update(_CURRENT_PRIMARY_KEYS)
+        unique_keys.update(_CURRENT_UNIQUE_KEYS)
+        foreign_keys.update(_CURRENT_FOREIGN_KEYS)
+        check_expressions.update(_CURRENT_CHECK_EXPRESSIONS)
+
+    for table, expected_key in primary_keys.items():
+        actual_key = tuple(
+            str(column["name"])
+            for column in sorted(
+                connection.execute(
+                    "SELECT name, pk FROM pragma_table_info(?)", (table,)
+                ),
+                key=lambda column: int(column["pk"]),
+            )
+            if int(column["pk"]) > 0
+        )
+        if actual_key != expected_key:
+            return "tenant database is missing required schema constraints"
+    for table, expected_keys in unique_keys.items():
+        if not expected_keys.issubset(_unique_keys(connection, table)):
+            return "tenant database is missing required schema constraints"
+    for table, expected_keys in foreign_keys.items():
+        if not expected_keys.issubset(_foreign_keys(connection, table)):
+            return "tenant database is missing required schema constraints"
+    for table, expected_expressions in check_expressions.items():
+        if not expected_expressions.issubset(
+            _table_check_expressions(connection, table)
+        ):
+            return "tenant database is missing required schema constraints"
+    return None
+
+
 def _schema_diagnostic(
     connection: sqlite3.Connection, persisted_revision: int
 ) -> str | None:
@@ -344,7 +564,8 @@ def _schema_diagnostic(
         return "tenant database contains broken foreign-key references"
 
     required_schema = dict(_COMMON_STATE_SCHEMA)
-    if persisted_revision >= CURRENT_STATE_FORMAT_REVISION:
+    current = persisted_revision >= CURRENT_STATE_FORMAT_REVISION
+    if current:
         required_schema.update(_CURRENT_STATE_SCHEMA)
     for table, required_columns in required_schema.items():
         actual_columns = {
@@ -353,6 +574,10 @@ def _schema_diagnostic(
         }
         if not required_columns.issubset(actual_columns):
             return "tenant database is missing required schema"
+
+    constraint_diagnostic = _schema_constraint_diagnostic(connection, current=current)
+    if constraint_diagnostic is not None:
+        return constraint_diagnostic
 
     format_rows = connection.execute(
         "SELECT id, format_revision FROM jacobian_state_format LIMIT 2"
@@ -363,6 +588,12 @@ def _schema_diagnostic(
         or format_rows[0]["format_revision"] != persisted_revision
     ):
         return "tenant state-format metadata does not match the migration ledger"
+    if current:
+        active_rows = connection.execute(
+            "SELECT id FROM active_operation_catalog LIMIT 2"
+        ).fetchall()
+        if len(active_rows) > 1 or (active_rows and active_rows[0]["id"] != 0):
+            return "active operation catalog metadata is invalid"
     return None
 
 

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -302,11 +302,28 @@ def _drop_privileges(user_name: str) -> None:
 
 def _existing_path_stat(path: Path, *, label: str) -> os.stat_result | None:
     try:
+        if path.is_symlink():
+            raise PermissionError(f"{label} must not be a symbolic link")
         return path.stat()
     except FileNotFoundError:
         return None
     except OSError as exc:
         raise PermissionError(f"{label} is not accessible: {exc}") from exc
+
+
+def _require_no_symlink_components(path: Path, *, label: str) -> None:
+    absolute = path.absolute()
+    candidate = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        candidate /= component
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise PermissionError(f"{label} is not accessible: {exc}") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise PermissionError(f"{label} must not contain symbolic links")
 
 
 def _require_directory_access(path: Path, *, label: str) -> bool:
@@ -355,7 +372,11 @@ def _require_blob_prefix_access(blob_root: Path, *, tenant_key: str) -> None:
     if not blob_root.is_dir():
         return
     for prefix in _iter_directory(blob_root, label=f"tenant blob root {tenant_key}"):
-        if prefix.is_dir() and not prefix.is_symlink():
+        if prefix.is_symlink():
+            raise PermissionError(
+                f"tenant blob prefix {tenant_key} must not be a symbolic link"
+            )
+        if prefix.is_dir():
             _require_directory_access(
                 prefix,
                 label=f"tenant blob prefix {tenant_key} ({prefix.name})",
@@ -363,11 +384,10 @@ def _require_blob_prefix_access(blob_root: Path, *, tenant_key: str) -> None:
             for blob in _iter_directory(
                 prefix, label=f"tenant blob prefix {tenant_key}"
             ):
-                if not blob.is_symlink():
-                    _require_readable_file(
-                        blob,
-                        label=(f"tenant blob file {tenant_key} ({prefix.name} prefix)"),
-                    )
+                _require_readable_file(
+                    blob,
+                    label=(f"tenant blob file {tenant_key} ({prefix.name} prefix)"),
+                )
 
 
 def _require_existing_tenant_access(state_dir: Path, *, tenant_key: str) -> None:
@@ -397,6 +417,7 @@ def _require_probe_access(state_root: Path, tenant_ids: tuple[str, ...]) -> None
         tenant_key = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()
         state_dir = state_root / "tenants" / tenant_key
         state_label = f"tenant state {tenant_key}"
+        _require_no_symlink_components(state_dir, label=state_label)
         if not _require_directory_access(state_dir, label=state_label):
             tenants_root = state_dir.parent
             if _existing_path_stat(tenants_root, label="tenant state root") is not None:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
+import pwd
 from pathlib import Path
 
 from jacobian.adapters.mcp.remote import load_static_token_file
@@ -27,6 +29,7 @@ def _parser() -> argparse.ArgumentParser:
     selection = parser.add_mutually_exclusive_group(required=True)
     selection.add_argument("--tenant-id", action="append")
     selection.add_argument("--auth-tokens-file", type=Path)
+    parser.add_argument("--run-as-user")
     return parser
 
 
@@ -60,11 +63,58 @@ def inspect_selected_state(
     return tuple(reports)
 
 
+def _drop_privileges(user_name: str) -> None:
+    account = pwd.getpwnam(user_name)
+    effective_uid = os.geteuid()
+    if effective_uid == account.pw_uid:
+        return
+    if effective_uid != 0:
+        raise PermissionError(
+            f"cannot inspect state as {user_name!r} from effective uid {effective_uid}"
+        )
+    os.initgroups(user_name, account.pw_gid)
+    os.setgid(account.pw_gid)
+    os.setuid(account.pw_uid)
+
+
+def _require_probe_access(state_root: Path, tenant_ids: tuple[str, ...]) -> None:
+    for tenant_id in tenant_ids:
+        tenant_key = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()
+        state_dir = state_root / "tenants" / tenant_key
+        try:
+            state_dir.stat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise PermissionError(
+                f"tenant state {tenant_key} is not accessible: {exc}"
+            ) from exc
+        try:
+            (state_dir / "metadata.sqlite3").stat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise PermissionError(
+                f"tenant database {tenant_key} is not accessible: {exc}"
+            ) from exc
+
+
 def main() -> int:
     args = _parser().parse_args()
     tenant_ids = _tenant_ids(args)
     if not tenant_ids:
         raise SystemExit("no jacobian:use tenant is configured")
+    if args.run_as_user is not None:
+        try:
+            _drop_privileges(args.run_as_user)
+        except (KeyError, OSError) as exc:
+            raise SystemExit(
+                f"could not assume state service identity: {exc}"
+            ) from None
+    try:
+        _require_probe_access(args.state_root, tenant_ids)
+    except OSError as exc:
+        raise SystemExit(f"configured tenant state is unreadable: {exc}") from None
     reports = inspect_selected_state(args.state_root, tenant_ids)
     print(json.dumps({"state_preflight": reports}, indent=2, sort_keys=True))
     return 1 if any(bool(report["blocking"]) for report in reports) else 0

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -14,6 +14,12 @@ from pathlib import Path
 from urllib.parse import quote
 
 from jacobian.adapters.mcp.remote import load_static_token_file
+from jacobian.canonical import CanonicalizationError, loads_strict_json
+from jacobian.contracts.artifacts import ArtifactManifest
+from jacobian.persistence.decoding import (
+    PersistenceCorruptionError,
+    decode_persisted_model,
+)
 from jacobian.persistence.migrations import (
     CURRENT_STATE_FORMAT_REVISION,
     STATE_MIGRATIONS,
@@ -21,7 +27,16 @@ from jacobian.persistence.migrations import (
 )
 from jacobian.persistence.state_health import inspect_state_health
 from jacobian.storage.errors import ArtifactNotFoundError
-from jacobian.storage.identity import digest_from_uri
+from jacobian.storage.identity import (
+    BOOTSTRAP_SCHEMA_URI,
+    BOOTSTRAP_SEMANTICS_URI,
+    OBJECT_FORMAT_VERSION,
+    digest_from_uri,
+    framed_digest,
+)
+from jacobian.storage.models import StorageLimits
+
+_MAX_BLOB_BYTES = StorageLimits().max_artifact_bytes
 
 
 def _blob_path(state_dir: Path, digest: str) -> Path | None:
@@ -35,12 +50,157 @@ def _blob_path(state_dir: Path, digest: str) -> Path | None:
     return state_dir / "blobs" / "sha256" / value[:2] / value[2:]
 
 
-def _blob_matches_digest(path: Path, digest: str) -> bool:
+def _read_referenced_blob(
+    state_dir: Path, digest: str
+) -> tuple[bytes | None, str | None]:
+    path = _blob_path(state_dir, digest)
+    if path is None:
+        return None, "artifact metadata contains an invalid blob reference"
+    if path.is_symlink() or not path.is_file():
+        return (
+            None,
+            "artifact metadata references a missing blob; restore the complete "
+            "tenant state",
+        )
+
     measured = hashlib.sha256()
+    contents = bytearray()
     with path.open("rb") as blob:
         while chunk := blob.read(1024 * 1024):
             measured.update(chunk)
-    return f"sha256:{measured.hexdigest()}" == digest
+            contents.extend(chunk)
+            if len(contents) > _MAX_BLOB_BYTES:
+                return None, "artifact metadata references an oversized blob"
+    if f"sha256:{measured.hexdigest()}" != digest:
+        return (
+            None,
+            "artifact metadata references a corrupt blob; restore the complete "
+            "tenant state",
+        )
+    return bytes(contents), None
+
+
+def _decode_manifest(
+    state_dir: Path, artifact_uri: str, manifest_digest: str
+) -> tuple[ArtifactManifest | None, str | None]:
+    manifest_bytes, diagnostic = _read_referenced_blob(state_dir, manifest_digest)
+    if diagnostic is not None:
+        return None, diagnostic
+    if manifest_bytes is None:
+        return None, "artifact metadata contains an unreadable manifest"
+    try:
+        return (
+            decode_persisted_model(
+                ArtifactManifest,
+                manifest_bytes,
+                record_kind="artifact_manifest",
+                record_id=artifact_uri,
+                field="manifest_json",
+            ),
+            None,
+        )
+    except PersistenceCorruptionError:
+        return None, "artifact metadata contains an invalid manifest"
+
+
+def _manifest_metadata_diagnostic(
+    connection: sqlite3.Connection,
+    row: sqlite3.Row,
+    manifest: ArtifactManifest,
+) -> str | None:
+    artifact_uri = str(row["artifact_uri"])
+    parent_rows = connection.execute(
+        """
+        SELECT
+            parent.parent_uri,
+            committed.artifact_uri AS committed_parent_uri
+        FROM artifact_parents AS parent
+        LEFT JOIN artifacts AS committed
+            ON committed.artifact_uri = parent.parent_uri
+        WHERE parent.artifact_uri = ?
+        ORDER BY parent.position
+        """,
+        (artifact_uri,),
+    ).fetchall()
+    if any(parent["committed_parent_uri"] is None for parent in parent_rows):
+        return "artifact metadata references an uncommitted parent"
+    database_parents = tuple(str(parent["parent_uri"]) for parent in parent_rows)
+    if manifest.parents != database_parents:
+        return "artifact manifest parents differ from committed metadata"
+    if (
+        manifest.object_digest != str(row["object_digest"])
+        or manifest.payload_digest != str(row["payload_digest"])
+        or manifest.schema_uri != str(row["schema_uri"])
+        or manifest.semantics_uri != str(row["semantics_uri"])
+        or manifest.canonicalizer_digest != str(row["canonicalizer_digest"])
+        or manifest.summary != str(row["summary"])
+    ):
+        return "artifact manifest differs from committed metadata"
+
+    descriptor_uris = (str(manifest.schema_uri), str(manifest.semantics_uri))
+    if descriptor_uris != (BOOTSTRAP_SCHEMA_URI, BOOTSTRAP_SEMANTICS_URI):
+        committed_references = {
+            str(reference["artifact_uri"])
+            for reference in connection.execute(
+                "SELECT artifact_uri FROM artifacts WHERE artifact_uri IN (?, ?)",
+                descriptor_uris,
+            ).fetchall()
+        }
+        if set(descriptor_uris) != committed_references:
+            return "artifact metadata references an uncommitted descriptor"
+    return None
+
+
+def _payload_binding_diagnostic(
+    state_dir: Path, manifest: ArtifactManifest
+) -> str | None:
+    payload_bytes, diagnostic = _read_referenced_blob(
+        state_dir, str(manifest.payload_digest)
+    )
+    if diagnostic is not None:
+        return diagnostic
+    if payload_bytes is None:
+        return "artifact metadata contains an unreadable payload"
+    recomputed_object_digest = framed_digest(
+        OBJECT_FORMAT_VERSION,
+        (
+            str(manifest.schema_uri).encode(),
+            str(manifest.semantics_uri).encode(),
+            str(manifest.canonicalizer_digest).encode(),
+            payload_bytes,
+        ),
+    )
+    if recomputed_object_digest != manifest.object_digest:
+        return "artifact payload differs from its mathematical object digest"
+    try:
+        loads_strict_json(payload_bytes)
+    except CanonicalizationError:
+        return "artifact metadata contains an invalid payload"
+    return None
+
+
+def _artifact_binding_diagnostic(
+    connection: sqlite3.Connection,
+    state_dir: Path,
+    row: sqlite3.Row,
+) -> str | None:
+    artifact_uri = str(row["artifact_uri"])
+    try:
+        manifest_digest = digest_from_uri(artifact_uri)
+    except ArtifactNotFoundError:
+        return "artifact metadata contains an invalid blob reference"
+    if manifest_digest != str(row["manifest_digest"]):
+        return "artifact metadata contains an inconsistent blob reference"
+
+    manifest, diagnostic = _decode_manifest(state_dir, artifact_uri, manifest_digest)
+    if diagnostic is not None:
+        return diagnostic
+    if manifest is None:
+        return "artifact metadata contains an unreadable manifest"
+    diagnostic = _manifest_metadata_diagnostic(connection, row, manifest)
+    if diagnostic is not None:
+        return diagnostic
+    return _payload_binding_diagnostic(state_dir, manifest)
 
 
 def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
@@ -48,30 +208,12 @@ def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
     try:
         uri = f"file:{quote(str(database_path.resolve()), safe='/')}?mode=ro"
         with sqlite3.connect(uri, uri=True) as connection:
-            rows = connection.execute(
-                "SELECT artifact_uri, manifest_digest, payload_digest FROM artifacts"
-            )
-            for artifact_uri, manifest_digest, payload_digest in rows:
-                try:
-                    uri_digest = digest_from_uri(str(artifact_uri))
-                except ArtifactNotFoundError:
-                    return "artifact metadata contains an invalid blob reference"
-                if uri_digest != str(manifest_digest):
-                    return "artifact metadata contains an inconsistent blob reference"
-                for digest in (uri_digest, str(payload_digest)):
-                    blob_path = _blob_path(state_dir, digest)
-                    if blob_path is None:
-                        return "artifact metadata contains an invalid blob reference"
-                    if blob_path.is_symlink() or not blob_path.is_file():
-                        return (
-                            "artifact metadata references a missing blob; restore "
-                            "the complete tenant state"
-                        )
-                    if not _blob_matches_digest(blob_path, digest):
-                        return (
-                            "artifact metadata references a corrupt blob; restore "
-                            "the complete tenant state"
-                        )
+            connection.row_factory = sqlite3.Row
+            rows = connection.execute("SELECT * FROM artifacts")
+            for row in rows:
+                diagnostic = _artifact_binding_diagnostic(connection, state_dir, row)
+                if diagnostic is not None:
+                    return diagnostic
     except (OSError, sqlite3.DatabaseError) as exc:
         return f"could not inspect artifact blob references: {exc}"
     return None

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -39,66 +39,89 @@ from jacobian.storage.models import StorageLimits
 
 _MAX_BLOB_BYTES = StorageLimits().max_artifact_bytes
 _MAX_TOTAL_BLOB_BYTES = StorageLimits().max_total_blob_bytes
+_INTEGER_PRIMARY = ("INTEGER", 0, None)
+_TEXT_PRIMARY = ("TEXT", 0, None)
+_INTEGER_REQUIRED = ("INTEGER", 1, None)
+_TEXT_REQUIRED = ("TEXT", 1, None)
+_BLOB_REQUIRED = ("BLOB", 1, None)
+_TIMESTAMPED_TEXT = ("TEXT", 1, "current_timestamp")
 _COMMON_STATE_SCHEMA = {
-    "jacobian_schema_migrations": frozenset(
-        {"revision", "name", "checksum", "applied_at"}
-    ),
-    "jacobian_state_format": frozenset({"id", "format_revision", "recorded_at"}),
-    "artifacts": frozenset(
-        {
-            "artifact_uri",
-            "manifest_digest",
-            "object_digest",
-            "payload_digest",
-            "schema_uri",
-            "semantics_uri",
-            "canonicalizer_digest",
-            "summary",
-            "committed_at",
-        }
-    ),
-    "artifact_parents": frozenset({"artifact_uri", "position", "parent_uri"}),
-    "blob_quota": frozenset({"id", "size_bytes", "reconciliation_required"}),
-    "checkers": frozenset(
-        {"checker_id", "registration_json", "authorized", "implementation_digest"}
-    ),
-    "checker_audit": frozenset(
-        {"sequence", "checker_id", "action", "reason", "recorded_at"}
-    ),
+    "jacobian_schema_migrations": {
+        "revision": _INTEGER_PRIMARY,
+        "name": _TEXT_REQUIRED,
+        "checksum": _TEXT_REQUIRED,
+        "applied_at": _TIMESTAMPED_TEXT,
+    },
+    "jacobian_state_format": {
+        "id": _INTEGER_PRIMARY,
+        "format_revision": _INTEGER_REQUIRED,
+        "recorded_at": _TIMESTAMPED_TEXT,
+    },
+    "artifacts": {
+        "artifact_uri": _TEXT_PRIMARY,
+        "manifest_digest": _TEXT_REQUIRED,
+        "object_digest": _TEXT_REQUIRED,
+        "payload_digest": _TEXT_REQUIRED,
+        "schema_uri": _TEXT_REQUIRED,
+        "semantics_uri": _TEXT_REQUIRED,
+        "canonicalizer_digest": _TEXT_REQUIRED,
+        "summary": _TEXT_REQUIRED,
+        "committed_at": _TIMESTAMPED_TEXT,
+    },
+    "artifact_parents": {
+        "artifact_uri": _TEXT_REQUIRED,
+        "position": _INTEGER_REQUIRED,
+        "parent_uri": _TEXT_REQUIRED,
+    },
+    "blob_quota": {
+        "id": _INTEGER_PRIMARY,
+        "size_bytes": _INTEGER_REQUIRED,
+        "reconciliation_required": ("INTEGER", 1, "1"),
+    },
+    "checkers": {
+        "checker_id": _TEXT_PRIMARY,
+        "registration_json": _BLOB_REQUIRED,
+        "authorized": _INTEGER_REQUIRED,
+        "implementation_digest": _TEXT_REQUIRED,
+    },
+    "checker_audit": {
+        "sequence": _INTEGER_PRIMARY,
+        "checker_id": _TEXT_REQUIRED,
+        "action": _TEXT_REQUIRED,
+        "reason": _TEXT_REQUIRED,
+        "recorded_at": _TIMESTAMPED_TEXT,
+    },
 }
 _CURRENT_STATE_SCHEMA = {
-    "operation_catalog_snapshots": frozenset(
-        {
-            "revision",
-            "package_version",
-            "format_version",
-            "checker_binding_digest",
-            "diagnostics_json",
-            "created_at",
-        }
-    ),
-    "operation_catalog_entries": frozenset(
-        {
-            "snapshot_revision",
-            "operation_id",
-            "search_card_json",
-            "descriptor_json",
-            "input_schema_json",
-            "output_schema_json",
-            "declaration_module",
-            "declaration_digest",
-        }
-    ),
-    "active_operation_catalog": frozenset({"id", "snapshot_revision"}),
-    "operation_checker_bindings": frozenset(
-        {
-            "snapshot_revision",
-            "operation_id",
-            "binding_index",
-            "checker_id",
-            "manifest_digest",
-        }
-    ),
+    "operation_catalog_snapshots": {
+        "revision": _INTEGER_PRIMARY,
+        "package_version": _TEXT_REQUIRED,
+        "format_version": _INTEGER_REQUIRED,
+        "checker_binding_digest": _TEXT_REQUIRED,
+        "diagnostics_json": _BLOB_REQUIRED,
+        "created_at": _TIMESTAMPED_TEXT,
+    },
+    "operation_catalog_entries": {
+        "snapshot_revision": _INTEGER_REQUIRED,
+        "operation_id": _TEXT_REQUIRED,
+        "search_card_json": _BLOB_REQUIRED,
+        "descriptor_json": _BLOB_REQUIRED,
+        "input_schema_json": _BLOB_REQUIRED,
+        "output_schema_json": _BLOB_REQUIRED,
+        "declaration_module": _TEXT_REQUIRED,
+        "declaration_digest": _TEXT_REQUIRED,
+    },
+    "active_operation_catalog": {
+        "id": _INTEGER_PRIMARY,
+        "snapshot_revision": _INTEGER_REQUIRED,
+    },
+    "operation_checker_bindings": {
+        "snapshot_revision": _INTEGER_REQUIRED,
+        "operation_id": _TEXT_REQUIRED,
+        "binding_index": _INTEGER_REQUIRED,
+        "checker_id": _TEXT_REQUIRED,
+        "manifest_digest": _TEXT_REQUIRED,
+    },
 }
 _COMMON_PRIMARY_KEYS = {
     "jacobian_schema_migrations": ("revision",),
@@ -514,6 +537,37 @@ def _table_check_expressions(
     return frozenset(expressions)
 
 
+def _column_definition(column: sqlite3.Row) -> tuple[str, int, str | None]:
+    declared_type = " ".join(str(column["type"]).split()).upper()
+    default = column["dflt_value"]
+    normalized_default = (
+        None if default is None else "".join(str(default).split()).casefold()
+    )
+    return declared_type, int(column["notnull"]), normalized_default
+
+
+def _schema_column_diagnostic(
+    connection: sqlite3.Connection,
+    required_schema: dict[str, dict[str, tuple[str, int, str | None]]],
+) -> str | None:
+    for table, required_columns in required_schema.items():
+        actual_columns = {
+            str(column["name"]): _column_definition(column)
+            for column in connection.execute(
+                'SELECT name, type, "notnull", dflt_value FROM pragma_table_info(?)',
+                (table,),
+            )
+        }
+        if not required_columns.keys() <= actual_columns.keys():
+            return "tenant database is missing required schema"
+        if any(
+            actual_columns[name] != definition
+            for name, definition in required_columns.items()
+        ):
+            return "tenant database has incompatible required column definitions"
+    return None
+
+
 def _schema_constraint_diagnostic(
     connection: sqlite3.Connection, *, current: bool
 ) -> str | None:
@@ -567,13 +621,9 @@ def _schema_diagnostic(
     current = persisted_revision >= CURRENT_STATE_FORMAT_REVISION
     if current:
         required_schema.update(_CURRENT_STATE_SCHEMA)
-    for table, required_columns in required_schema.items():
-        actual_columns = {
-            str(column["name"])
-            for column in connection.execute(f'PRAGMA table_info("{table}")')
-        }
-        if not required_columns.issubset(actual_columns):
-            return "tenant database is missing required schema"
+    column_diagnostic = _schema_column_diagnostic(connection, required_schema)
+    if column_diagnostic is not None:
+        return column_diagnostic
 
     constraint_diagnostic = _schema_constraint_diagnostic(connection, current=current)
     if constraint_diagnostic is not None:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -37,6 +37,7 @@ from jacobian.storage.identity import (
 from jacobian.storage.models import StorageLimits
 
 _MAX_BLOB_BYTES = StorageLimits().max_artifact_bytes
+_MAX_TOTAL_BLOB_BYTES = StorageLimits().max_total_blob_bytes
 
 
 def _blob_path(state_dir: Path, digest: str) -> Path | None:
@@ -203,6 +204,75 @@ def _artifact_binding_diagnostic(
     return _payload_binding_diagnostic(state_dir, manifest)
 
 
+def _measure_cas_blob(
+    state_dir: Path, prefix: Path, blob: Path
+) -> tuple[int | None, str | None]:
+    if blob.is_symlink() or not blob.is_file():
+        return None, "artifact blob storage contains a non-regular entry"
+    digest = f"sha256:{prefix.name}{blob.name}"
+    if _blob_path(state_dir, digest) != blob:
+        return None, "artifact blob storage contains an invalid content address"
+
+    measured = hashlib.sha256()
+    size_bytes = 0
+    with blob.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            measured.update(chunk)
+            size_bytes += len(chunk)
+            if size_bytes > _MAX_BLOB_BYTES:
+                return None, "artifact blob storage contains an oversized blob"
+    if f"sha256:{measured.hexdigest()}" != digest:
+        return None, "artifact blob storage contains a corrupt blob"
+    return size_bytes, None
+
+
+def _blob_tree_measurement(state_dir: Path) -> tuple[int | None, str | None]:
+    blob_root = state_dir / "blobs" / "sha256"
+    if not blob_root.is_dir() or blob_root.is_symlink():
+        return None, "artifact blob storage is missing or invalid"
+
+    total_bytes = 0
+    for prefix in _iter_directory(blob_root, label="artifact blob storage"):
+        if prefix.is_symlink() or not prefix.is_dir():
+            return None, "artifact blob storage contains an invalid prefix"
+        for blob in _iter_directory(prefix, label="artifact blob prefix"):
+            size_bytes, diagnostic = _measure_cas_blob(state_dir, prefix, blob)
+            if diagnostic is not None:
+                return None, diagnostic
+            if size_bytes is None:
+                return None, "artifact blob storage contains an unreadable blob"
+            total_bytes += size_bytes
+            if total_bytes > _MAX_TOTAL_BLOB_BYTES:
+                return None, "artifact blob storage exceeds the runtime quota"
+    return total_bytes, None
+
+
+def _quota_diagnostic(connection: sqlite3.Connection, state_dir: Path) -> str | None:
+    row = connection.execute(
+        "SELECT size_bytes, reconciliation_required FROM blob_quota WHERE id = 0"
+    ).fetchone()
+    if row is None:
+        return "artifact blob quota metadata is missing"
+    size_bytes = row["size_bytes"]
+    reconciliation_required = row["reconciliation_required"]
+    if (
+        not isinstance(size_bytes, int)
+        or isinstance(size_bytes, bool)
+        or not isinstance(reconciliation_required, int)
+        or isinstance(reconciliation_required, bool)
+    ):
+        return "artifact blob quota metadata is invalid"
+    if reconciliation_required != 0:
+        return "artifact blob quota metadata requires recovery before deployment"
+
+    measured_bytes, diagnostic = _blob_tree_measurement(state_dir)
+    if diagnostic is not None:
+        return diagnostic
+    if measured_bytes != size_bytes:
+        return "artifact blob quota differs from restored blob storage"
+    return None
+
+
 def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
     database_path = state_dir / "metadata.sqlite3"
     try:
@@ -214,9 +284,9 @@ def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
                 diagnostic = _artifact_binding_diagnostic(connection, state_dir, row)
                 if diagnostic is not None:
                     return diagnostic
+            return _quota_diagnostic(connection, state_dir)
     except (OSError, sqlite3.DatabaseError) as exc:
         return f"could not inspect artifact blob references: {exc}"
-    return None
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -7,9 +7,11 @@ import hashlib
 import json
 import os
 import pwd
+import sqlite3
 import stat
 from collections.abc import Iterator
 from pathlib import Path
+from urllib.parse import quote
 
 from jacobian.adapters.mcp.remote import load_static_token_file
 from jacobian.persistence.migrations import (
@@ -18,6 +20,48 @@ from jacobian.persistence.migrations import (
     SUPPORTED_STATE_FLOOR,
 )
 from jacobian.persistence.state_health import inspect_state_health
+from jacobian.storage.errors import ArtifactNotFoundError
+from jacobian.storage.identity import digest_from_uri
+
+
+def _blob_path(state_dir: Path, digest: str) -> Path | None:
+    value = digest.removeprefix("sha256:")
+    if (
+        not digest.startswith("sha256:")
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        return None
+    return state_dir / "blobs" / "sha256" / value[:2] / value[2:]
+
+
+def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
+    database_path = state_dir / "metadata.sqlite3"
+    try:
+        uri = f"file:{quote(str(database_path.resolve()), safe='/')}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute(
+                "SELECT artifact_uri, manifest_digest, payload_digest FROM artifacts"
+            )
+            for artifact_uri, manifest_digest, payload_digest in rows:
+                try:
+                    uri_digest = digest_from_uri(str(artifact_uri))
+                except ArtifactNotFoundError:
+                    return "artifact metadata contains an invalid blob reference"
+                if uri_digest != str(manifest_digest):
+                    return "artifact metadata contains an inconsistent blob reference"
+                for digest in (uri_digest, str(payload_digest)):
+                    blob_path = _blob_path(state_dir, digest)
+                    if blob_path is None:
+                        return "artifact metadata contains an invalid blob reference"
+                    if blob_path.is_symlink() or not blob_path.is_file():
+                        return (
+                            "artifact metadata references a missing blob; restore "
+                            "the complete tenant state"
+                        )
+    except (OSError, sqlite3.DatabaseError) as exc:
+        return f"could not inspect artifact blob references: {exc}"
+    return None
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -72,6 +116,17 @@ def inspect_selected_state(
                 ),
                 blocking=True,
             )
+        elif not health.blocking and health.status in {
+            "COMPATIBLE",
+            "MIGRATION_PENDING",
+        }:
+            blob_diagnostic = _referenced_blob_diagnostic(state_dir)
+            if blob_diagnostic is not None:
+                report.update(
+                    status="CORRUPT",
+                    diagnostic=blob_diagnostic,
+                    blocking=True,
+                )
         reports.append(report)
     return tuple(reports)
 

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -1,0 +1,74 @@
+"""Read-only compatibility gate for tenant state selected by a deployment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from jacobian.adapters.mcp.remote import load_static_token_file
+from jacobian.persistence.migrations import (
+    CURRENT_STATE_FORMAT_REVISION,
+    STATE_MIGRATIONS,
+    SUPPORTED_STATE_FLOOR,
+)
+from jacobian.persistence.state_health import inspect_state_health
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect the configured tenant stores without creating files or applying "
+            "migrations."
+        )
+    )
+    parser.add_argument("--state-root", required=True, type=Path)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--tenant-id", action="append")
+    selection.add_argument("--auth-tokens-file", type=Path)
+    return parser
+
+
+def _tenant_ids(args: argparse.Namespace) -> tuple[str, ...]:
+    if args.auth_tokens_file is not None:
+        return tuple(
+            dict.fromkeys(
+                grant.tenant_id
+                for grant in load_static_token_file(args.auth_tokens_file)
+                if "jacobian:use" in grant.scopes
+            )
+        )
+    return tuple(dict.fromkeys(args.tenant_id))
+
+
+def inspect_selected_state(
+    state_root: Path, tenant_ids: tuple[str, ...]
+) -> tuple[dict[str, object], ...]:
+    """Return bounded health reports without exposing authentication tokens."""
+
+    reports: list[dict[str, object]] = []
+    for tenant_id in tenant_ids:
+        tenant_key = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()
+        health = inspect_state_health(
+            state_root / "tenants" / tenant_key,
+            STATE_MIGRATIONS,
+            supported_floor=SUPPORTED_STATE_FLOOR,
+            current_revision=CURRENT_STATE_FORMAT_REVISION,
+        )
+        reports.append({"tenant_key": tenant_key, **health.as_dict()})
+    return tuple(reports)
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    tenant_ids = _tenant_ids(args)
+    if not tenant_ids:
+        raise SystemExit("no jacobian:use tenant is configured")
+    reports = inspect_selected_state(args.state_root, tenant_ids)
+    print(json.dumps({"state_preflight": reports}, indent=2, sort_keys=True))
+    return 1 if any(bool(report["blocking"]) for report in reports) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -55,13 +55,24 @@ def inspect_selected_state(
     reports: list[dict[str, object]] = []
     for tenant_id in tenant_ids:
         tenant_key = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()
+        state_dir = state_root / "tenants" / tenant_key
         health = inspect_state_health(
-            state_root / "tenants" / tenant_key,
+            state_dir,
             STATE_MIGRATIONS,
             supported_floor=SUPPORTED_STATE_FLOOR,
             current_revision=CURRENT_STATE_FORMAT_REVISION,
         )
-        reports.append({"tenant_key": tenant_key, **health.as_dict()})
+        report = {"tenant_key": tenant_key, **health.as_dict()}
+        if state_dir.exists() and health.status in {"MISSING", "UNINITIALIZED"}:
+            report.update(
+                status="CORRUPT",
+                diagnostic=(
+                    "the tenant directory exists without initialized metadata; "
+                    "restore or remove the incomplete tenant state"
+                ),
+                blocking=True,
+            )
+        reports.append(report)
     return tuple(reports)
 
 

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -35,6 +35,14 @@ def _blob_path(state_dir: Path, digest: str) -> Path | None:
     return state_dir / "blobs" / "sha256" / value[:2] / value[2:]
 
 
+def _blob_matches_digest(path: Path, digest: str) -> bool:
+    measured = hashlib.sha256()
+    with path.open("rb") as blob:
+        while chunk := blob.read(1024 * 1024):
+            measured.update(chunk)
+    return f"sha256:{measured.hexdigest()}" == digest
+
+
 def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
     database_path = state_dir / "metadata.sqlite3"
     try:
@@ -57,6 +65,11 @@ def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
                     if blob_path.is_symlink() or not blob_path.is_file():
                         return (
                             "artifact metadata references a missing blob; restore "
+                            "the complete tenant state"
+                        )
+                    if not _blob_matches_digest(blob_path, digest):
+                        return (
+                            "artifact metadata references a corrupt blob; restore "
                             "the complete tenant state"
                         )
     except (OSError, sqlite3.DatabaseError) as exc:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -8,6 +8,7 @@ import json
 import os
 import pwd
 import stat
+from collections.abc import Iterator
 from pathlib import Path
 
 from jacobian.adapters.mcp.remote import load_static_token_file
@@ -112,21 +113,40 @@ def _require_file_access(path: Path, *, label: str) -> None:
         )
 
 
+def _require_readable_file(path: Path, *, label: str) -> None:
+    metadata = _existing_path_stat(path, label=label)
+    if metadata is None or not stat.S_ISREG(metadata.st_mode):
+        return
+    if not os.access(path, os.R_OK, effective_ids=True):
+        raise PermissionError(f"{label} is not readable by the service identity")
+
+
+def _iter_directory(path: Path, *, label: str) -> Iterator[Path]:
+    try:
+        with os.scandir(path) as entries:
+            for entry in entries:
+                yield Path(entry.path)
+    except OSError as exc:
+        raise PermissionError(f"{label} is not accessible: {exc}") from exc
+
+
 def _require_blob_prefix_access(blob_root: Path, *, tenant_key: str) -> None:
     if not blob_root.is_dir():
         return
-    try:
-        prefixes = tuple(blob_root.iterdir())
-    except OSError as exc:
-        raise PermissionError(
-            f"tenant blob root {tenant_key} is not accessible: {exc}"
-        ) from exc
-    for prefix in prefixes:
+    for prefix in _iter_directory(blob_root, label=f"tenant blob root {tenant_key}"):
         if prefix.is_dir() and not prefix.is_symlink():
             _require_directory_access(
                 prefix,
                 label=f"tenant blob prefix {tenant_key} ({prefix.name})",
             )
+            for blob in _iter_directory(
+                prefix, label=f"tenant blob prefix {tenant_key}"
+            ):
+                if not blob.is_symlink():
+                    _require_readable_file(
+                        blob,
+                        label=(f"tenant blob file {tenant_key} ({prefix.name} prefix)"),
+                    )
 
 
 def _require_existing_tenant_access(state_dir: Path, *, tenant_key: str) -> None:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import pwd
+import stat
 from pathlib import Path
 
 from jacobian.adapters.mcp.remote import load_static_token_file
@@ -77,26 +78,92 @@ def _drop_privileges(user_name: str) -> None:
     os.setuid(account.pw_uid)
 
 
+def _existing_path_stat(path: Path, *, label: str) -> os.stat_result | None:
+    try:
+        return path.stat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PermissionError(f"{label} is not accessible: {exc}") from exc
+
+
+def _require_directory_access(path: Path, *, label: str) -> bool:
+    metadata = _existing_path_stat(path, label=label)
+    if metadata is None:
+        return False
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise PermissionError(f"{label} is not a directory")
+    if not os.access(path, os.R_OK | os.W_OK | os.X_OK, effective_ids=True):
+        raise PermissionError(
+            f"{label} is not readable, writable, and traversable by the service identity"
+        )
+    return True
+
+
+def _require_file_access(path: Path, *, label: str) -> None:
+    metadata = _existing_path_stat(path, label=label)
+    if metadata is None:
+        return
+    if not stat.S_ISREG(metadata.st_mode):
+        raise PermissionError(f"{label} is not a regular file")
+    if not os.access(path, os.R_OK | os.W_OK, effective_ids=True):
+        raise PermissionError(
+            f"{label} is not readable and writable by the service identity"
+        )
+
+
+def _require_blob_prefix_access(blob_root: Path, *, tenant_key: str) -> None:
+    if not blob_root.is_dir():
+        return
+    try:
+        prefixes = tuple(blob_root.iterdir())
+    except OSError as exc:
+        raise PermissionError(
+            f"tenant blob root {tenant_key} is not accessible: {exc}"
+        ) from exc
+    for prefix in prefixes:
+        if prefix.is_dir() and not prefix.is_symlink():
+            _require_directory_access(
+                prefix,
+                label=f"tenant blob prefix {tenant_key} ({prefix.name})",
+            )
+
+
+def _require_existing_tenant_access(state_dir: Path, *, tenant_key: str) -> None:
+    database = state_dir / "metadata.sqlite3"
+    _require_file_access(database, label=f"tenant database {tenant_key}")
+    for suffix in ("-journal", "-shm", "-wal", ".lifecycle.lock"):
+        _require_file_access(
+            database.with_name(database.name + suffix),
+            label=f"tenant database runtime file {tenant_key} ({suffix})",
+        )
+    for name in (".blob-quota.lock", ".transaction-recovery"):
+        _require_file_access(
+            state_dir / name,
+            label=f"tenant runtime file {tenant_key} ({name})",
+        )
+
+    for relative in (Path("blobs"), Path("blobs/sha256"), Path("staging")):
+        _require_directory_access(
+            state_dir / relative,
+            label=f"tenant runtime directory {tenant_key} ({relative})",
+        )
+    _require_blob_prefix_access(state_dir / "blobs" / "sha256", tenant_key=tenant_key)
+
+
 def _require_probe_access(state_root: Path, tenant_ids: tuple[str, ...]) -> None:
     for tenant_id in tenant_ids:
         tenant_key = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()
         state_dir = state_root / "tenants" / tenant_key
-        try:
-            state_dir.stat()
-        except FileNotFoundError:
+        state_label = f"tenant state {tenant_key}"
+        if not _require_directory_access(state_dir, label=state_label):
+            tenants_root = state_dir.parent
+            if _existing_path_stat(tenants_root, label="tenant state root") is not None:
+                _require_directory_access(tenants_root, label="tenant state root")
+            elif _existing_path_stat(state_root, label="state root") is not None:
+                _require_directory_access(state_root, label="state root")
             continue
-        except OSError as exc:
-            raise PermissionError(
-                f"tenant state {tenant_key} is not accessible: {exc}"
-            ) from exc
-        try:
-            (state_dir / "metadata.sqlite3").stat()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            raise PermissionError(
-                f"tenant database {tenant_key} is not accessible: {exc}"
-            ) from exc
+        _require_existing_tenant_access(state_dir, tenant_key=tenant_key)
 
 
 def main() -> int:

--- a/deploy/preflight_state.py
+++ b/deploy/preflight_state.py
@@ -38,6 +38,67 @@ from jacobian.storage.models import StorageLimits
 
 _MAX_BLOB_BYTES = StorageLimits().max_artifact_bytes
 _MAX_TOTAL_BLOB_BYTES = StorageLimits().max_total_blob_bytes
+_COMMON_STATE_SCHEMA = {
+    "jacobian_schema_migrations": frozenset(
+        {"revision", "name", "checksum", "applied_at"}
+    ),
+    "jacobian_state_format": frozenset({"id", "format_revision", "recorded_at"}),
+    "artifacts": frozenset(
+        {
+            "artifact_uri",
+            "manifest_digest",
+            "object_digest",
+            "payload_digest",
+            "schema_uri",
+            "semantics_uri",
+            "canonicalizer_digest",
+            "summary",
+            "committed_at",
+        }
+    ),
+    "artifact_parents": frozenset({"artifact_uri", "position", "parent_uri"}),
+    "blob_quota": frozenset({"id", "size_bytes", "reconciliation_required"}),
+    "checkers": frozenset(
+        {"checker_id", "registration_json", "authorized", "implementation_digest"}
+    ),
+    "checker_audit": frozenset(
+        {"sequence", "checker_id", "action", "reason", "recorded_at"}
+    ),
+}
+_CURRENT_STATE_SCHEMA = {
+    "operation_catalog_snapshots": frozenset(
+        {
+            "revision",
+            "package_version",
+            "format_version",
+            "checker_binding_digest",
+            "diagnostics_json",
+            "created_at",
+        }
+    ),
+    "operation_catalog_entries": frozenset(
+        {
+            "snapshot_revision",
+            "operation_id",
+            "search_card_json",
+            "descriptor_json",
+            "input_schema_json",
+            "output_schema_json",
+            "declaration_module",
+            "declaration_digest",
+        }
+    ),
+    "active_operation_catalog": frozenset({"id", "snapshot_revision"}),
+    "operation_checker_bindings": frozenset(
+        {
+            "snapshot_revision",
+            "operation_id",
+            "binding_index",
+            "checker_id",
+            "manifest_digest",
+        }
+    ),
+}
 
 
 def _blob_path(state_dir: Path, digest: str) -> Path | None:
@@ -273,12 +334,47 @@ def _quota_diagnostic(connection: sqlite3.Connection, state_dir: Path) -> str | 
     return None
 
 
-def _referenced_blob_diagnostic(state_dir: Path) -> str | None:
+def _schema_diagnostic(
+    connection: sqlite3.Connection, persisted_revision: int
+) -> str | None:
+    quick_check = connection.execute("PRAGMA quick_check(1)").fetchone()
+    if quick_check is None or str(quick_check[0]) != "ok":
+        return "tenant database failed the SQLite integrity check"
+    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        return "tenant database contains broken foreign-key references"
+
+    required_schema = dict(_COMMON_STATE_SCHEMA)
+    if persisted_revision >= CURRENT_STATE_FORMAT_REVISION:
+        required_schema.update(_CURRENT_STATE_SCHEMA)
+    for table, required_columns in required_schema.items():
+        actual_columns = {
+            str(column["name"])
+            for column in connection.execute(f'PRAGMA table_info("{table}")')
+        }
+        if not required_columns.issubset(actual_columns):
+            return "tenant database is missing required schema"
+
+    format_rows = connection.execute(
+        "SELECT id, format_revision FROM jacobian_state_format LIMIT 2"
+    ).fetchall()
+    if (
+        len(format_rows) != 1
+        or format_rows[0]["id"] != 0
+        or format_rows[0]["format_revision"] != persisted_revision
+    ):
+        return "tenant state-format metadata does not match the migration ledger"
+    return None
+
+
+def _referenced_blob_diagnostic(state_dir: Path, persisted_revision: int) -> str | None:
     database_path = state_dir / "metadata.sqlite3"
     try:
         uri = f"file:{quote(str(database_path.resolve()), safe='/')}?mode=ro"
         with sqlite3.connect(uri, uri=True) as connection:
             connection.row_factory = sqlite3.Row
+            diagnostic = _schema_diagnostic(connection, persisted_revision)
+            if diagnostic is not None:
+                return diagnostic
             rows = connection.execute("SELECT * FROM artifacts")
             for row in rows:
                 diagnostic = _artifact_binding_diagnostic(connection, state_dir, row)
@@ -345,7 +441,14 @@ def inspect_selected_state(
             "COMPATIBLE",
             "MIGRATION_PENDING",
         }:
-            blob_diagnostic = _referenced_blob_diagnostic(state_dir)
+            persisted_revision = health.persisted_revision
+            blob_diagnostic: str | None
+            if persisted_revision is None:
+                blob_diagnostic = "the migration ledger has no persisted revision"
+            else:
+                blob_diagnostic = _referenced_blob_diagnostic(
+                    state_dir, persisted_revision
+                )
             if blob_diagnostic is not None:
                 report.update(
                     status="CORRUPT",

--- a/deploy/release_retention.py
+++ b/deploy/release_retention.py
@@ -1,0 +1,95 @@
+"""Prune completed inactive releases after a deployment is accepted."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+from pathlib import Path
+
+_RELEASE_NAME = re.compile(r"[0-9a-f]{12}(?:-lean)?")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Retain the active release and the newest completed rollbacks."
+    )
+    parser.add_argument("--release-root", required=True, type=Path)
+    parser.add_argument("--current-link", required=True, type=Path)
+    parser.add_argument("--retain", required=True, type=int)
+    parser.add_argument("--preserve-release", action="append", default=[], type=Path)
+    return parser
+
+
+def prune_releases(
+    release_root: Path,
+    current_link: Path,
+    *,
+    retain: int,
+    preserve_releases: tuple[Path, ...] = (),
+) -> tuple[Path, ...]:
+    """Remove only recognized, completed releases outside the retained set."""
+
+    if retain < 1:
+        raise ValueError("retain must be at least one")
+    root = release_root.resolve(strict=True)
+    active = current_link.resolve(strict=True)
+    if active.parent != root:
+        raise ValueError("the active release is not directly below the release root")
+
+    completed = sorted(
+        (
+            path
+            for path in root.iterdir()
+            if path.is_dir()
+            and not path.is_symlink()
+            and _RELEASE_NAME.fullmatch(path.name)
+            and (path / ".git-revision").is_file()
+            and (path / ".release-profile").is_file()
+        ),
+        key=lambda path: path.stat().st_mtime_ns,
+        reverse=True,
+    )
+    if active not in completed:
+        raise ValueError("the active release is not a completed recognized release")
+
+    retained = {active}
+    preserved = tuple(
+        dict.fromkeys(path.resolve(strict=True) for path in preserve_releases)
+    )
+    if any(path not in completed for path in preserved):
+        raise ValueError("a preserved rollback is not a completed recognized release")
+    inactive = [path for path in completed if path != active]
+    preferred = [path for path in preserved if path != active]
+    preferred.extend(path for path in inactive if path not in preferred)
+    retained.update(preferred[: retain - 1])
+    pruned = tuple(path for path in completed if path not in retained)
+    for path in pruned:
+        shutil.rmtree(path)
+    return pruned
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        pruned = prune_releases(
+            args.release_root,
+            args.current_link,
+            retain=args.retain,
+            preserve_releases=tuple(args.preserve_release),
+        )
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"release retention failed: {exc}") from None
+    print(
+        json.dumps(
+            {"pruned_releases": [path.name for path in pruned]},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/smoke_lean.py
+++ b/deploy/smoke_lean.py
@@ -12,6 +12,8 @@ import httpx2
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 
+from jacobian._deployment_smoke import TransientSmokeError, exit_for_smoke_failure
+
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -54,7 +56,12 @@ async def _run(
 
 
 def _require_verified(result: dict[str, Any], *, environment: str) -> None:
-    if result.get("execution", {}).get("status") != "COMPLETED":
+    status = result.get("execution", {}).get("status")
+    if status in {"TIMEOUT", "CANCELLED"}:
+        raise TransientSmokeError(
+            f"{environment} lean.check ended with transient status {status}"
+        )
+    if status != "COMPLETED":
         raise RuntimeError(f"{environment} lean.check did not complete")
     if result.get("output", {}).get("conclusion") != "TRUE":
         raise RuntimeError(f"{environment} lean.check did not accept True")
@@ -88,9 +95,7 @@ def _require_mathlib_declaration(result: dict[str, Any]) -> None:
     output = result.get("output", {})
     native_result = output.get("result") if isinstance(output, dict) else None
     declarations = (
-        native_result.get("declarations")
-        if isinstance(native_result, dict)
-        else None
+        native_result.get("declarations") if isinstance(native_result, dict) else None
     )
     if not isinstance(declarations, list) or not declarations:
         raise RuntimeError("MATHLIB declaration search returned no exact match")
@@ -175,5 +180,5 @@ async def _main() -> None:
 if __name__ == "__main__":
     try:
         asyncio.run(_main())
-    except RuntimeError as exc:
-        raise SystemExit(f"Lean smoke failed: {exc}") from None
+    except Exception as exc:
+        exit_for_smoke_failure("Lean smoke", exc)

--- a/deploy/smoke_lean.py
+++ b/deploy/smoke_lean.py
@@ -12,7 +12,11 @@ import httpx2
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 
-from jacobian._deployment_smoke import TransientSmokeError, exit_for_smoke_failure
+from jacobian._deployment_smoke import (
+    TransientSmokeError,
+    exit_for_smoke_failure,
+    raise_for_http_error,
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -109,6 +113,7 @@ async def inspect(*, url: str, timeout_seconds: float) -> dict[str, Any]:
     async with (
         httpx2.AsyncClient(
             headers=headers,
+            event_hooks={"response": [raise_for_http_error]},
             trust_env=False,
             timeout=timeout_seconds,
         ) as http,

--- a/deploy/smoke_lean.py
+++ b/deploy/smoke_lean.py
@@ -59,14 +59,16 @@ async def _run(
     return response.structured_content
 
 
-def _require_verified(result: dict[str, Any], *, environment: str) -> None:
+def _require_completed(result: dict[str, Any], *, operation: str) -> None:
     status = result.get("execution", {}).get("status")
     if status in {"TIMEOUT", "CANCELLED"}:
-        raise TransientSmokeError(
-            f"{environment} lean.check ended with transient status {status}"
-        )
+        raise TransientSmokeError(f"{operation} ended with transient status {status}")
     if status != "COMPLETED":
-        raise RuntimeError(f"{environment} lean.check did not complete")
+        raise RuntimeError(f"{operation} did not complete")
+
+
+def _require_verified(result: dict[str, Any], *, environment: str) -> None:
+    _require_completed(result, operation=f"{environment} lean.check")
     if result.get("output", {}).get("conclusion") != "TRUE":
         raise RuntimeError(f"{environment} lean.check did not accept True")
     if not result.get("verification_record_uri"):
@@ -76,8 +78,7 @@ def _require_verified(result: dict[str, Any], *, environment: str) -> None:
 def _require_transition(
     result: dict[str, Any], *, accepted: bool, completed: bool
 ) -> None:
-    if result.get("execution", {}).get("status") != "COMPLETED":
-        raise RuntimeError("Lean tactic transition did not complete operationally")
+    _require_completed(result, operation="Lean tactic transition")
     output = result.get("output", {})
     if (
         output.get("accepted") is not accepted
@@ -94,8 +95,7 @@ def _require_transition(
 
 
 def _require_mathlib_declaration(result: dict[str, Any]) -> None:
-    if result.get("execution", {}).get("status") != "COMPLETED":
-        raise RuntimeError("MATHLIB declaration search did not complete")
+    _require_completed(result, operation="MATHLIB declaration search")
     output = result.get("output", {})
     native_result = output.get("result") if isinstance(output, dict) else None
     declarations = (

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -16,6 +16,7 @@ from mcp.client.streamable_http import streamable_http_client
 from mcp_types import Implementation, TextContent, TextResourceContents
 
 from jacobian import __version__
+from jacobian._deployment_smoke import exit_for_smoke_failure
 from jacobian.canonical import canonicalize_json
 
 REQUIRED_TOOLS = {
@@ -275,5 +276,5 @@ async def _main() -> None:
 if __name__ == "__main__":
     try:
         asyncio.run(_main())
-    except RuntimeError as exc:
-        raise SystemExit(f"smoke failed: {exc}") from None
+    except Exception as exc:
+        exit_for_smoke_failure("smoke", exc)

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -16,7 +16,7 @@ from mcp.client.streamable_http import streamable_http_client
 from mcp_types import Implementation, TextContent, TextResourceContents
 
 from jacobian import __version__
-from jacobian._deployment_smoke import exit_for_smoke_failure
+from jacobian._deployment_smoke import exit_for_smoke_failure, raise_for_http_error
 from jacobian.canonical import canonicalize_json
 
 REQUIRED_TOOLS = {
@@ -154,6 +154,7 @@ async def inspect(
     async with (
         httpx2.AsyncClient(
             headers=headers,
+            event_hooks={"response": [raise_for_http_error]},
             trust_env=False,
             timeout=timeout_seconds,
         ) as http,

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -208,8 +208,10 @@ VPS must preserve them. The maintained authenticated unit uses
    reference resolves to a local regular file whose SHA-256 matches its content
    address, and each manifest remains bound to its committed metadata, parents,
    descriptors, and mathematical object digest. Existing blob files must be
-   readable, and the tenant, staging, blob, and existing blob-prefix directories
-   must be readable, writable, and traversable. It may report `MISSING` only when
+   readable and match their content addresses, and the persisted blob quota must
+   match the full restored CAS tree without a pending recovery marker. The
+   tenant, staging, blob, and existing blob-prefix directories must be readable,
+   writable, and traversable. It may report `MISSING` only when
    the selected tenant directory does not exist; an existing directory with
    missing or uninitialized metadata is a blocking partial restore. Every
    selected tenant must report `MISSING`, `COMPATIBLE`, or a supported

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -199,15 +199,16 @@ VPS must preserve them. The maintained authenticated unit uses
    The candidate-state preflight reads the token mapping while privileged,
    drops permanently to the `jacobian` service identity, and then checks every
    selected tenant. In that identity it verifies that SQLite and its runtime
-   files are readable and writable, existing blob files are readable, and the
-   tenant, staging, blob, and existing blob-prefix directories are readable,
-   writable, and traversable. It may report `MISSING` only when the selected
-   tenant directory does not exist; an existing directory with missing or
-   uninitialized metadata is a blocking partial restore. Every selected tenant
-   must report `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state
-   before activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`,
-   or `UNREADABLE` result; an access failure means destination ownership or mode
-   restoration is incomplete.
+   files are readable and writable, every persisted manifest and payload blob
+   reference resolves to a local regular file, existing blob files are
+   readable, and the tenant, staging, blob, and existing blob-prefix directories
+   are readable, writable, and traversable. It may report `MISSING` only when
+   the selected tenant directory does not exist; an existing directory with
+   missing or uninitialized metadata is a blocking partial restore. Every
+   selected tenant must report `MISSING`, `COMPATIBLE`, or a supported
+   `MIGRATION_PENDING` state before activation. Do not bypass an `UNSUPPORTED`,
+   `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result; an access failure means
+   destination ownership or mode restoration is incomplete.
 7. Verify `deployment://identity`, the two-tool surface, catalog policy,
    required capabilities, and any provider-specific smoke before updating
    remaining client configuration. Keep the source VPS and its unchanged state

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -201,9 +201,10 @@ VPS must preserve them. The maintained authenticated unit uses
    selected tenant. In that identity it verifies that SQLite and its runtime
    files are readable and writable, every persisted manifest and payload blob
    reference resolves to a local regular file whose SHA-256 matches its content
-   address, existing blob files are readable, and the tenant, staging, blob, and
-   existing blob-prefix directories are readable, writable, and traversable. It
-   may report `MISSING` only when
+   address, and each manifest remains bound to its committed metadata, parents,
+   descriptors, and mathematical object digest. Existing blob files must be
+   readable, and the tenant, staging, blob, and existing blob-prefix directories
+   must be readable, writable, and traversable. It may report `MISSING` only when
    the selected tenant directory does not exist; an existing directory with
    missing or uninitialized metadata is a blocking partial restore. Every
    selected tenant must report `MISSING`, `COMPATIBLE`, or a supported

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -181,9 +181,12 @@ VPS must preserve them. The maintained authenticated unit uses
    `/etc/jacobian-mcp` owned by root with mode `0700` and its token file at mode
    `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
 6. Rerun the same installer command without `--skip-smoke`. Its candidate-state
-   preflight must report every selected tenant as `MISSING`, `COMPATIBLE`, or a
-   supported `MIGRATION_PENDING` state before activation. Do not bypass an
-   `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result.
+   preflight reads the token mapping while privileged, drops permanently to the
+   `jacobian` service identity, and then checks every selected tenant. It must
+   report `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state
+   before activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`,
+   or `UNREADABLE` result; an access failure means destination ownership or mode
+   restoration is incomplete.
 7. Verify `deployment://identity`, the two-tool surface, catalog policy, required
    capabilities, and any provider-specific smoke before switching DNS or client
    configuration. Keep the source VPS and its unchanged state available until

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -152,7 +152,10 @@ advertising it.
 `uv`, systemd, Caddy, Tailscale, and optional elan executables and checks free
 space at the installation filesystem. A new Lean release requires at least 12
 GiB free; a new core release requires at least 2 GiB. Existing complete release
-directories do not require that build-space reserve.
+directories do not require that build-space reserve. The rollback temporary
+filesystem must also retain the full current state snapshot plus 64 MiB for
+configuration and metadata; when it shares the installation filesystem, both
+reserves are added before deployment work begins.
 
 ## Migrate to another VPS
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -132,7 +132,9 @@ state, including a unit waiting for an automatic restart. The SQLite/CAS scan
 therefore observes a quiescent snapshot. After stopping the writer, the
 installer remeasures both the state and the rollback filesystem before scanning
 or copying state, so writes received during a long release build cannot stale
-the earlier capacity plan.
+the earlier capacity plan. Rollback records active, activating (including
+automatic-restart delay), and reloading services as running services and
+restarts them if candidate validation or activation fails.
 Unsupported, corrupt, unreadable, or migration-incompatible state stops the
 deployment without changing the active release and restores the prior service
 state. A missing tenant store is valid and remains uncreated until first use.

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -128,10 +128,12 @@ Before activation, the candidate release performs a read-only compatibility
 check against every tenant selected by the configured token file, or against
 the selected anonymous tenant. It first records the existing service state,
 arms rollback, and stops an active MCP writer so the SQLite/CAS scan observes a
-quiescent snapshot. Unsupported, corrupt, unreadable, or migration-incompatible
-state stops the deployment without changing the active release and restores the
-prior service state. A missing tenant store is valid and remains uncreated until
-first use.
+quiescent snapshot. After stopping the writer, it remeasures both the state and
+the rollback filesystem before scanning or copying state, so writes received
+during a long release build cannot stale the earlier capacity plan.
+Unsupported, corrupt, unreadable, or migration-incompatible state stops the
+deployment without changing the active release and restores the prior service
+state. A missing tenant store is valid and remains uncreated until first use.
 
 After the deployment smoke and final permission audit succeed, the installer
 keeps the active release and prioritizes the release that was active immediately

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -127,10 +127,12 @@ After reviewing and pulling a new revision, run the same command to upgrade.
 Before activation, the candidate release performs a read-only compatibility
 check against every tenant selected by the configured token file, or against
 the selected anonymous tenant. It first records the existing service state,
-arms rollback, and stops an active MCP writer so the SQLite/CAS scan observes a
-quiescent snapshot. After stopping the writer, it remeasures both the state and
-the rollback filesystem before scanning or copying state, so writes received
-during a long release build cannot stale the earlier capacity plan.
+arms rollback, and stops any existing MCP unit without relying on its active
+state, including a unit waiting for an automatic restart. The SQLite/CAS scan
+therefore observes a quiescent snapshot. After stopping the writer, the
+installer remeasures both the state and the rollback filesystem before scanning
+or copying state, so writes received during a long release build cannot stale
+the earlier capacity plan.
 Unsupported, corrupt, unreadable, or migration-incompatible state stops the
 deployment without changing the active release and restores the prior service
 state. A missing tenant store is valid and remains uncreated until first use.

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -126,9 +126,12 @@ Untracked files are not archived. Re-running the same revision is idempotent.
 After reviewing and pulling a new revision, run the same command to upgrade.
 Before activation, the candidate release performs a read-only compatibility
 check against every tenant selected by the configured token file, or against
-the selected anonymous tenant. Unsupported, corrupt, unreadable, or
-migration-incompatible state stops the deployment without changing the active
-release. A missing tenant store is valid and remains uncreated until first use.
+the selected anonymous tenant. It first records the existing service state,
+arms rollback, and stops an active MCP writer so the SQLite/CAS scan observes a
+quiescent snapshot. Unsupported, corrupt, unreadable, or migration-incompatible
+state stops the deployment without changing the active release and restores the
+prior service state. A missing tenant store is valid and remains uncreated until
+first use.
 
 After the deployment smoke and final permission audit succeed, the installer
 keeps the active release and prioritizes the release that was active immediately
@@ -155,7 +158,10 @@ GiB free; a new core release requires at least 2 GiB. Existing complete release
 directories do not require that build-space reserve. The rollback temporary
 filesystem must also retain the full current state snapshot plus 64 MiB for
 configuration and metadata; when it shares the installation filesystem, both
-reserves are added before deployment work begins.
+reserves are added before deployment work begins. A non-root dry-run that
+cannot read an existing protected state directory reports rollback capacity as
+unverified and tells the operator to repeat the preflight with `sudo`; the real
+deployment never proceeds without the measurement.
 
 ## Migrate to another VPS
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -182,7 +182,9 @@ VPS must preserve them. The maintained authenticated unit uses
    its blobs independently.
 5. On the destination, restore state ownership to `jacobian:jacobian`. Keep
    `/etc/jacobian-mcp` owned by root with mode `0700` and its token file at mode
-   `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
+   `0600`. Rebuildable `cache/lean-declarations` data may be omitted. Restore
+   tenant state as real directories and regular files, not symbolic links;
+   links can resolve outside the filesystem view allowed by the hardened unit.
 6. Choose the final activation sequence for the ingress mode while the source
    service remains stopped:
 

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -200,9 +200,10 @@ VPS must preserve them. The maintained authenticated unit uses
    drops permanently to the `jacobian` service identity, and then checks every
    selected tenant. In that identity it verifies that SQLite and its runtime
    files are readable and writable, every persisted manifest and payload blob
-   reference resolves to a local regular file, existing blob files are
-   readable, and the tenant, staging, blob, and existing blob-prefix directories
-   are readable, writable, and traversable. It may report `MISSING` only when
+   reference resolves to a local regular file whose SHA-256 matches its content
+   address, existing blob files are readable, and the tenant, staging, blob, and
+   existing blob-prefix directories are readable, writable, and traversable. It
+   may report `MISSING` only when
    the selected tenant directory does not exist; an existing directory with
    missing or uninitialized metadata is a blocking partial restore. Every
    selected tenant must report `MISSING`, `COMPATIBLE`, or a supported

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -182,19 +182,23 @@ VPS must preserve them. The maintained authenticated unit uses
    `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
 6. Rerun the same installer command without `--skip-smoke`. Its candidate-state
    preflight reads the token mapping while privileged, drops permanently to the
-   `jacobian` service identity, and then checks every selected tenant. It must
-   report `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state
-   before activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`,
-   or `UNREADABLE` result; an access failure means destination ownership or mode
+   `jacobian` service identity, and then checks every selected tenant. In that
+   identity it verifies that SQLite and its runtime files are readable and
+   writable, and that the tenant, staging, blob, and existing blob-prefix
+   directories are readable, writable, and traversable. It must report
+   `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state before
+   activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or
+   `UNREADABLE` result; an access failure means destination ownership or mode
    restoration is incomplete.
 7. Verify `deployment://identity`, the two-tool surface, catalog policy, required
    capabilities, and any provider-specific smoke before switching DNS or client
    configuration. Keep the source VPS and its unchanged state available until
    the destination has passed these checks.
 
-Current Jacobian accepts state revision 11. Older revisions have no direct
-import bridge; retain the old state unchanged with a compatible checkout and
-start fresh state on current Jacobian as described in
+Current Jacobian writes state revision 12 and accepts revision 11 for an
+in-place migration. Earlier revisions have no direct import bridge; retain the
+old state unchanged with a compatible checkout and start fresh state on current
+Jacobian as described in
 [Persistent state format](../reference/state-format.md).
 
 Migration reminders:

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -183,20 +183,32 @@ VPS must preserve them. The maintained authenticated unit uses
 5. On the destination, restore state ownership to `jacobian:jacobian`. Keep
    `/etc/jacobian-mcp` owned by root with mode `0700` and its token file at mode
    `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
-6. Rerun the installer in the intended final mode, add its ingress options, and
-   omit `--skip-smoke`. Its candidate-state preflight reads the token mapping
-   while privileged, drops permanently to the `jacobian` service identity, and
-   then checks every selected tenant. In that identity it verifies that SQLite
-   and its runtime files are readable and writable, and that the tenant,
-   staging, blob, and existing blob-prefix directories are readable, writable,
-   and traversable. It must report `MISSING`, `COMPATIBLE`, or a supported
-   `MIGRATION_PENDING` state before activation. Do not bypass an `UNSUPPORTED`,
-   `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result; an access failure means
-   destination ownership or mode restoration is incomplete.
-7. Verify `deployment://identity`, the two-tool surface, catalog policy, required
-   capabilities, and any provider-specific smoke before switching DNS or client
-   configuration. Keep the source VPS and its unchanged state available until
-   the destination has passed these checks.
+6. Choose the final activation sequence for the ingress mode while the source
+   service remains stopped:
+
+   - For `--mode domain`, run the final domain-mode command once with
+     `--skip-smoke` after state restoration. Switch DNS to the destination, wait
+     until the domain resolves to it from the destination host, then rerun the
+     same command without `--skip-smoke`. This lets Caddy establish the
+     destination endpoint before the revision-bound smoke follows the public
+     hostname.
+   - For `--mode tailscale`, run the final command without `--skip-smoke`, then
+     update clients if the destination node has a different Tailscale DNS name.
+   - For `--mode local`, rerun the final local command without `--skip-smoke`.
+
+   The candidate-state preflight reads the token mapping while privileged,
+   drops permanently to the `jacobian` service identity, and then checks every
+   selected tenant. In that identity it verifies that SQLite and its runtime
+   files are readable and writable, existing blob files are readable, and the
+   tenant, staging, blob, and existing blob-prefix directories are readable,
+   writable, and traversable. It must report `MISSING`, `COMPATIBLE`, or a
+   supported `MIGRATION_PENDING` state before activation. Do not bypass an
+   `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result; an access
+   failure means destination ownership or mode restoration is incomplete.
+7. Verify `deployment://identity`, the two-tool surface, catalog policy,
+   required capabilities, and any provider-specific smoke before updating
+   remaining client configuration. Keep the source VPS and its unchanged state
+   available, but stopped, until the destination has passed these checks.
 
 Current Jacobian writes state revision 12 and accepts revision 11 for an
 in-place migration. Earlier revisions have no direct import bridge; retain the

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -167,11 +167,14 @@ VPS must preserve them. The maintained authenticated unit uses
    deployed and run the final installer command with `--dry-run`.
 2. Securely transfer the existing token file when authentication is enabled.
    Do not place it in the repository, shell history, or an unencrypted archive.
-3. Run the installer once on the destination with the final mode, install root,
-   profile, tenant options, and `--skip-smoke`. For authenticated operation,
-   pass the transferred file with `--auth-tokens-file`. This provisions the
-   service users, immutable release, units, and destination directories without
-   advertising a passing deployment.
+3. Run the installer once on the destination with `--mode local`, the final
+   install root, profile, tenant options, and `--skip-smoke`. For authenticated
+   operation, pass the transferred file with `--auth-tokens-file`. Omit
+   ingress-only options such as `--domain` until the final deployment. Local
+   mode provisions the service users, immutable release, units, and destination
+   directories while disabling Caddy and Funnel. Do not use `--mode domain` or
+   `--mode tailscale` for this staging pass: `--skip-smoke` skips validation but
+   still starts the selected services.
 4. Stop `jacobian-mcp.service` on the destination. Stop it on the source, or
    quiesce all writers and take a storage-level snapshot, before the final copy.
    Copy the complete selected state root, including `metadata.sqlite3`, blobs,
@@ -180,16 +183,16 @@ VPS must preserve them. The maintained authenticated unit uses
 5. On the destination, restore state ownership to `jacobian:jacobian`. Keep
    `/etc/jacobian-mcp` owned by root with mode `0700` and its token file at mode
    `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
-6. Rerun the same installer command without `--skip-smoke`. Its candidate-state
-   preflight reads the token mapping while privileged, drops permanently to the
-   `jacobian` service identity, and then checks every selected tenant. In that
-   identity it verifies that SQLite and its runtime files are readable and
-   writable, and that the tenant, staging, blob, and existing blob-prefix
-   directories are readable, writable, and traversable. It must report
-   `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state before
-   activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or
-   `UNREADABLE` result; an access failure means destination ownership or mode
-   restoration is incomplete.
+6. Rerun the installer in the intended final mode, add its ingress options, and
+   omit `--skip-smoke`. Its candidate-state preflight reads the token mapping
+   while privileged, drops permanently to the `jacobian` service identity, and
+   then checks every selected tenant. In that identity it verifies that SQLite
+   and its runtime files are readable and writable, and that the tenant,
+   staging, blob, and existing blob-prefix directories are readable, writable,
+   and traversable. It must report `MISSING`, `COMPATIBLE`, or a supported
+   `MIGRATION_PENDING` state before activation. Do not bypass an `UNSUPPORTED`,
+   `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result; an access failure means
+   destination ownership or mode restoration is incomplete.
 7. Verify `deployment://identity`, the two-tool surface, catalog policy, required
    capabilities, and any provider-specific smoke before switching DNS or client
    configuration. Keep the source VPS and its unchanged state available until

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -209,9 +209,11 @@ VPS must preserve them. The maintained authenticated unit uses
    address, and each manifest remains bound to its committed metadata, parents,
    descriptors, and mathematical object digest. Existing blob files must be
    readable and match their content addresses, and the persisted blob quota must
-   match the full restored CAS tree without a pending recovery marker. The
-   tenant, staging, blob, and existing blob-prefix directories must be readable,
-   writable, and traversable. It may report `MISSING` only when
+   match the full restored CAS tree without a pending recovery marker. SQLite
+   integrity, foreign keys, required schema, and the state-format row must agree
+   with the migration ledger. The tenant, staging, blob, and existing
+   blob-prefix directories must be readable, writable, and traversable. It may
+   report `MISSING` only when
    the selected tenant directory does not exist; an existing directory with
    missing or uninitialized metadata is a blocking partial restore. Every
    selected tenant must report `MISSING`, `COMPATIBLE`, or a supported

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -201,10 +201,13 @@ VPS must preserve them. The maintained authenticated unit uses
    selected tenant. In that identity it verifies that SQLite and its runtime
    files are readable and writable, existing blob files are readable, and the
    tenant, staging, blob, and existing blob-prefix directories are readable,
-   writable, and traversable. It must report `MISSING`, `COMPATIBLE`, or a
-   supported `MIGRATION_PENDING` state before activation. Do not bypass an
-   `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result; an access
-   failure means destination ownership or mode restoration is incomplete.
+   writable, and traversable. It may report `MISSING` only when the selected
+   tenant directory does not exist; an existing directory with missing or
+   uninitialized metadata is a blocking partial restore. Every selected tenant
+   must report `MISSING`, `COMPATIBLE`, or a supported `MIGRATION_PENDING` state
+   before activation. Do not bypass an `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`,
+   or `UNREADABLE` result; an access failure means destination ownership or mode
+   restoration is incomplete.
 7. Verify `deployment://identity`, the two-tool surface, catalog policy,
    required capabilities, and any provider-specific smoke before updating
    remaining client configuration. Keep the source VPS and its unchanged state

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -124,9 +124,90 @@ environment, and atomically selects it through `/opt/jacobian/current`.
 Tracked or staged changes fail closed; commit them or deploy a clean checkout.
 Untracked files are not archived. Re-running the same revision is idempotent.
 After reviewing and pulling a new revision, run the same command to upgrade.
+Before activation, the candidate release performs a read-only compatibility
+check against every tenant selected by the configured token file, or against
+the selected anonymous tenant. Unsupported, corrupt, unreadable, or
+migration-incompatible state stops the deployment without changing the active
+release. A missing tenant store is valid and remains uncreated until first use.
+
+After the deployment smoke and final permission audit succeed, the installer
+keeps the active release and prioritizes the release that was active immediately
+before the switch as its rollback. Additional retained slots use the newest
+completed releases. Override the total retained count when the host has a
+different rollback policy:
+
+```sh
+sudo ./deploy/install.sh --retain-releases 3
+```
+
+Only recognized release directories with complete revision and profile markers
+are eligible for pruning. The active release, incomplete directories, and
+operator-created paths are never pruned. A cleanup failure is reported as a
+warning after the accepted deployment and does not roll back healthy traffic.
 Use `--skip-smoke` only when the endpoint cannot yet be reached from the host,
 then run [`deploy/smoke_remote.py`](../../deploy/smoke_remote.py) before
 advertising it.
+
+`--dry-run` is a host preflight as well as a plan. It resolves the required
+`uv`, systemd, Caddy, Tailscale, and optional elan executables and checks free
+space at the installation filesystem. A new Lean release requires at least 12
+GiB free; a new core release requires at least 2 GiB. Existing complete release
+directories do not require that build-space reserve.
+
+## Migrate to another VPS
+
+Application releases are reproducible; persistent tenant state and
+authentication secrets are separate host data. Use this sequence when the new
+VPS must preserve them. The maintained authenticated unit uses
+`/var/lib/jacobian-mcp`; the anonymous test override uses
+`/var/lib/jacobian-mcp-test`:
+
+1. Install Git, Python, `uv`, systemd, the selected ingress dependencies, and
+   elan for `--with-lean` on the destination. Check out the exact revision to be
+   deployed and run the final installer command with `--dry-run`.
+2. Securely transfer the existing token file when authentication is enabled.
+   Do not place it in the repository, shell history, or an unencrypted archive.
+3. Run the installer once on the destination with the final mode, install root,
+   profile, tenant options, and `--skip-smoke`. For authenticated operation,
+   pass the transferred file with `--auth-tokens-file`. This provisions the
+   service users, immutable release, units, and destination directories without
+   advertising a passing deployment.
+4. Stop `jacobian-mcp.service` on the destination. Stop it on the source, or
+   quiesce all writers and take a storage-level snapshot, before the final copy.
+   Copy the complete selected state root, including `metadata.sqlite3`, blobs,
+   manifests, and tenant directories. Do not copy a live SQLite database and
+   its blobs independently.
+5. On the destination, restore state ownership to `jacobian:jacobian`. Keep
+   `/etc/jacobian-mcp` owned by root with mode `0700` and its token file at mode
+   `0600`. Rebuildable `cache/lean-declarations` data may be omitted.
+6. Rerun the same installer command without `--skip-smoke`. Its candidate-state
+   preflight must report every selected tenant as `MISSING`, `COMPATIBLE`, or a
+   supported `MIGRATION_PENDING` state before activation. Do not bypass an
+   `UNSUPPORTED`, `INCOMPATIBLE`, `CORRUPT`, or `UNREADABLE` result.
+7. Verify `deployment://identity`, the two-tool surface, catalog policy, required
+   capabilities, and any provider-specific smoke before switching DNS or client
+   configuration. Keep the source VPS and its unchanged state available until
+   the destination has passed these checks.
+
+Current Jacobian accepts state revision 11. Older revisions have no direct
+import bridge; retain the old state unchanged with a compatible checkout and
+start fresh state on current Jacobian as described in
+[Persistent state format](../reference/state-format.md).
+
+Migration reminders:
+
+- `/etc/jacobian-mcp/tokens.json` is not part of an immutable release. Copying
+  only `/opt/jacobian` will leave existing authenticated clients unable to
+  connect.
+- An anonymous tenant's directory key is derived from its tenant ID. Reuse the
+  exact `--anonymous-tenant-id` to preserve copied state, or deliberately choose
+  a new ID for disposable fresh state.
+- A Tailscale Funnel connector is derived from the destination node's Tailscale
+  DNS name and may differ after a VPS move. Update clients explicitly, or use a
+  stable operator-owned domain and perform a DNS cutover.
+- Never allow the source and destination to accept writes against independently
+  copied state after the final snapshot. Jacobian does not merge divergent
+  stores.
 
 ## Create the auth secret
 

--- a/src/jacobian/_deployment_smoke.py
+++ b/src/jacobian/_deployment_smoke.py
@@ -1,0 +1,59 @@
+"""Stable deployment-smoke exit semantics shared by smoke entry points."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+
+import httpx2
+
+TRANSIENT_SMOKE_EXIT = 75
+
+
+class TransientSmokeError(RuntimeError):
+    """A bounded operational failure that may clear without changing inputs."""
+
+
+def _leaves(exc: BaseException) -> Iterable[BaseException]:
+    if isinstance(exc, BaseExceptionGroup):
+        for nested in exc.exceptions:
+            yield from _leaves(nested)
+        return
+    yield exc
+
+
+def is_transient_transport_failure(exc: BaseException) -> bool:
+    """Return true only when every failure is a retryable transport problem."""
+
+    leaves = tuple(_leaves(exc))
+    return bool(leaves) and all(
+        isinstance(
+            leaf,
+            (
+                TransientSmokeError,
+                httpx2.TransportError,
+                TimeoutError,
+                ConnectionError,
+            ),
+        )
+        for leaf in leaves
+    )
+
+
+def exit_for_smoke_failure(label: str, exc: BaseException) -> None:
+    """Print one bounded diagnostic and exit with stable retry semantics."""
+
+    leaves = tuple(_leaves(exc))
+    detail = "; ".join(
+        dict.fromkeys(str(leaf) or type(leaf).__name__ for leaf in leaves)
+    )
+    print(f"{label} failed: {detail}", file=sys.stderr)
+    raise SystemExit(TRANSIENT_SMOKE_EXIT if is_transient_transport_failure(exc) else 1)
+
+
+__all__ = [
+    "TRANSIENT_SMOKE_EXIT",
+    "TransientSmokeError",
+    "exit_for_smoke_failure",
+    "is_transient_transport_failure",
+]

--- a/src/jacobian/_deployment_smoke.py
+++ b/src/jacobian/_deployment_smoke.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 import httpx2
 
 TRANSIENT_SMOKE_EXIT = 75
+_TRANSIENT_HTTP_STATUSES = frozenset({502, 503, 504})
 
 
 class TransientSmokeError(RuntimeError):
@@ -26,18 +27,27 @@ def is_transient_transport_failure(exc: BaseException) -> bool:
     """Return true only when every failure is a retryable transport problem."""
 
     leaves = tuple(_leaves(exc))
-    return bool(leaves) and all(
-        isinstance(
-            leaf,
-            (
-                TransientSmokeError,
-                httpx2.TransportError,
-                TimeoutError,
-                ConnectionError,
-            ),
-        )
-        for leaf in leaves
+    return bool(leaves) and all(_is_transient_leaf(leaf) for leaf in leaves)
+
+
+def _is_transient_leaf(exc: BaseException) -> bool:
+    if isinstance(exc, httpx2.HTTPStatusError):
+        return exc.response.status_code in _TRANSIENT_HTTP_STATUSES
+    return isinstance(
+        exc,
+        (
+            TransientSmokeError,
+            httpx2.TransportError,
+            TimeoutError,
+            ConnectionError,
+        ),
     )
+
+
+async def raise_for_http_error(response: httpx2.Response) -> None:
+    """Preserve HTTP status identity before the MCP transport projects errors."""
+
+    response.raise_for_status()
 
 
 def exit_for_smoke_failure(label: str, exc: BaseException) -> None:
@@ -56,4 +66,5 @@ __all__ = [
     "TransientSmokeError",
     "exit_for_smoke_failure",
     "is_transient_transport_failure",
+    "raise_for_http_error",
 ]

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -239,6 +239,182 @@ def test_state_preflight_rejects_an_incomplete_current_schema(
     assert report["diagnostic"] == "tenant database is missing required schema"
 
 
+def test_state_preflight_rejects_duplicate_quota_without_schema_constraints(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "constraint-damaged-quota"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute("ALTER TABLE blob_quota RENAME TO damaged_blob_quota")
+        connection.execute(
+            """
+            CREATE TABLE blob_quota (
+                id INTEGER,
+                size_bytes INTEGER NOT NULL,
+                reconciliation_required INTEGER NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO blob_quota(id, size_bytes, reconciliation_required)
+            SELECT id, size_bytes, reconciliation_required FROM damaged_blob_quota
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO blob_quota(id, size_bytes, reconciliation_required)
+            SELECT id, size_bytes, reconciliation_required FROM damaged_blob_quota
+            """
+        )
+        connection.execute("DROP TABLE damaged_blob_quota")
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant database is missing required schema constraints"
+    )
+
+
+def test_state_preflight_does_not_accept_check_text_in_a_default_literal(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "constraint-damaged-quota-checks"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute("ALTER TABLE blob_quota RENAME TO damaged_blob_quota")
+        connection.execute(
+            """
+            CREATE TABLE blob_quota (
+                id INTEGER PRIMARY KEY,
+                size_bytes INTEGER NOT NULL,
+                reconciliation_required INTEGER NOT NULL,
+                decoy TEXT DEFAULT 'CHECK (id = 0) CHECK (size_bytes >= 0)
+                    CHECK (reconciliation_required IN (0, 1))'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO blob_quota(id, size_bytes, reconciliation_required)
+            SELECT id, size_bytes, reconciliation_required FROM damaged_blob_quota
+            """
+        )
+        connection.execute("DROP TABLE damaged_blob_quota")
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant database is missing required schema constraints"
+    )
+
+
+def test_state_preflight_rejects_a_missing_migration_name_unique_key(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "constraint-damaged-migration-ledger"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute(
+            "ALTER TABLE jacobian_schema_migrations RENAME TO damaged_schema_migrations"
+        )
+        connection.execute(
+            """
+            CREATE TABLE jacobian_schema_migrations (
+                revision INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                checksum TEXT NOT NULL,
+                applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO jacobian_schema_migrations(
+                revision, name, checksum, applied_at
+            )
+            SELECT revision, name, checksum, applied_at
+            FROM damaged_schema_migrations
+            """
+        )
+        connection.execute("DROP TABLE damaged_schema_migrations")
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant database is missing required schema constraints"
+    )
+
+
+def test_state_preflight_rejects_a_missing_catalog_foreign_key(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "constraint-damaged-catalog-foreign-key"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute(
+            "ALTER TABLE operation_checker_bindings "
+            "RENAME TO damaged_operation_checker_bindings"
+        )
+        connection.execute(
+            """
+            CREATE TABLE operation_checker_bindings (
+                snapshot_revision INTEGER NOT NULL,
+                operation_id TEXT NOT NULL,
+                binding_index INTEGER NOT NULL CHECK (binding_index >= 0),
+                checker_id TEXT NOT NULL,
+                manifest_digest TEXT NOT NULL,
+                PRIMARY KEY (snapshot_revision, operation_id, binding_index)
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO operation_checker_bindings(
+                snapshot_revision,
+                operation_id,
+                binding_index,
+                checker_id,
+                manifest_digest
+            )
+            SELECT
+                snapshot_revision,
+                operation_id,
+                binding_index,
+                checker_id,
+                manifest_digest
+            FROM damaged_operation_checker_bindings
+            """
+        )
+        connection.execute("DROP TABLE damaged_operation_checker_bindings")
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant database is missing required schema constraints"
+    )
+
+
 def test_state_preflight_binds_state_format_to_the_migration_ledger(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -254,7 +254,7 @@ def test_state_preflight_rejects_duplicate_quota_without_schema_constraints(
             CREATE TABLE blob_quota (
                 id INTEGER,
                 size_bytes INTEGER NOT NULL,
-                reconciliation_required INTEGER NOT NULL
+                reconciliation_required INTEGER NOT NULL DEFAULT 1
             )
             """
         )
@@ -296,7 +296,7 @@ def test_state_preflight_does_not_accept_check_text_in_a_default_literal(
             CREATE TABLE blob_quota (
                 id INTEGER PRIMARY KEY,
                 size_bytes INTEGER NOT NULL,
-                reconciliation_required INTEGER NOT NULL,
+                reconciliation_required INTEGER NOT NULL DEFAULT 1,
                 decoy TEXT DEFAULT 'CHECK (id = 0) CHECK (size_bytes >= 0)
                     CHECK (reconciliation_required IN (0, 1))'
             )
@@ -412,6 +412,56 @@ def test_state_preflight_rejects_a_missing_catalog_foreign_key(
     assert report["blocking"] is True
     assert report["diagnostic"] == (
         "tenant database is missing required schema constraints"
+    )
+
+
+def test_state_preflight_rejects_a_missing_artifact_timestamp_default(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "column-damaged-artifact-default"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute("DROP TABLE artifact_parents")
+        connection.execute("ALTER TABLE artifacts RENAME TO damaged_artifacts")
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                artifact_uri TEXT PRIMARY KEY,
+                manifest_digest TEXT NOT NULL UNIQUE,
+                object_digest TEXT NOT NULL,
+                payload_digest TEXT NOT NULL,
+                schema_uri TEXT NOT NULL,
+                semantics_uri TEXT NOT NULL,
+                canonicalizer_digest TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                committed_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute("DROP TABLE damaged_artifacts")
+        connection.execute(
+            """
+            CREATE TABLE artifact_parents (
+                artifact_uri TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                parent_uri TEXT NOT NULL,
+                PRIMARY KEY (artifact_uri, position),
+                FOREIGN KEY (artifact_uri)
+                    REFERENCES artifacts(artifact_uri)
+                    ON DELETE RESTRICT
+            )
+            """
+        )
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant database has incompatible required column definitions"
     )
 
 

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -80,9 +80,10 @@ def test_state_preflight_rejects_an_incomplete_existing_tenant(
     )
 
 
-@pytest.mark.parametrize("missing_blob", ("manifest", "payload"))
-def test_state_preflight_rejects_missing_referenced_blobs(
-    tmp_path: Path, missing_blob: str
+@pytest.mark.parametrize("blob_kind", ("manifest", "payload"))
+@pytest.mark.parametrize("damage", ("missing", "corrupt"))
+def test_state_preflight_rejects_damaged_referenced_blobs(
+    tmp_path: Path, blob_kind: str, damage: str
 ) -> None:
     tenant_id = "incomplete-blob-restore"
     tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
@@ -101,15 +102,20 @@ def test_state_preflight_rejects_missing_referenced_blobs(
             (artifact_uri,),
         ).fetchone()
     assert row is not None
-    digest = str(row[0 if missing_blob == "manifest" else 1]).removeprefix("sha256:")
-    (state / "blobs" / "sha256" / digest[:2] / digest[2:]).unlink()
+    digest = str(row[0 if blob_kind == "manifest" else 1]).removeprefix("sha256:")
+    blob_path = state / "blobs" / "sha256" / digest[:2] / digest[2:]
+    if damage == "missing":
+        blob_path.unlink()
+    else:
+        blob_path.write_bytes(b"incomplete restore")
 
     report = inspect_selected_state(tmp_path, (tenant_id,))[0]
 
     assert report["status"] == "CORRUPT"
     assert report["blocking"] is True
     assert report["diagnostic"] == (
-        "artifact metadata references a missing blob; restore the complete tenant state"
+        f"artifact metadata references a {damage} blob; restore the complete "
+        "tenant state"
     )
 
 

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -49,8 +49,31 @@ def test_state_preflight_accepts_missing_and_current_tenant_state(
 
     tenant_id = "current-tenant"
     tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
-    with ArtifactRepository(tmp_path / "tenants" / tenant_key):
-        pass
+    with ArtifactRepository(tmp_path / "tenants" / tenant_key) as repository:
+        schema_uri = repository.register_descriptor(
+            kind="schema",
+            name="current-schema",
+            version="1",
+            definition={"type": "object"},
+        )
+        semantics_uri = repository.register_descriptor(
+            kind="semantics",
+            name="current-semantics",
+            version="1",
+            definition={"meaning": "deployment preflight fixture"},
+        )
+        parent_uri = repository.register_descriptor(
+            kind="schema",
+            name="current-parent",
+            version="1",
+            definition={"type": "boolean"},
+        )
+        repository.put(
+            schema_uri=schema_uri,
+            semantics_uri=semantics_uri,
+            payload={"restored": True},
+            parents=(parent_uri,),
+        )
 
     current = inspect_selected_state(tmp_path, (tenant_id,))
     assert current[0]["status"] == "COMPATIBLE"
@@ -117,6 +140,43 @@ def test_state_preflight_rejects_damaged_referenced_blobs(
         f"artifact metadata references a {damage} blob; restore the complete "
         "tenant state"
     )
+
+
+def test_state_preflight_rejects_inconsistent_manifest_bindings(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "inconsistent-artifact-restore"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state) as repository:
+        first_uri = repository.register_descriptor(
+            kind="schema",
+            name="first",
+            version="1",
+            definition={"type": "object"},
+        )
+        second_uri = repository.register_descriptor(
+            kind="schema",
+            name="second",
+            version="1",
+            definition={"type": "string"},
+        )
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        second_payload_digest = connection.execute(
+            "SELECT payload_digest FROM artifacts WHERE artifact_uri = ?",
+            (second_uri,),
+        ).fetchone()
+        assert second_payload_digest is not None
+        connection.execute(
+            "UPDATE artifacts SET payload_digest = ? WHERE artifact_uri = ?",
+            (second_payload_digest[0], first_uri),
+        )
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == ("artifact manifest differs from committed metadata")
 
 
 def test_state_preflight_rejects_state_below_the_supported_floor(

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -220,6 +220,75 @@ def test_state_preflight_rejects_unreconciled_blob_quota(
     assert report["diagnostic"] == diagnostic
 
 
+@pytest.mark.parametrize("missing_table", ("blob_quota", "operation_catalog_snapshots"))
+def test_state_preflight_rejects_an_incomplete_current_schema(
+    tmp_path: Path, missing_table: str
+) -> None:
+    tenant_id = "incomplete-current-schema"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute(f'DROP TABLE "{missing_table}"')
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == "tenant database is missing required schema"
+
+
+def test_state_preflight_binds_state_format_to_the_migration_ledger(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "mismatched-state-format"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute(
+            "UPDATE jacobian_state_format SET format_revision = 11 WHERE id = 0"
+        )
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "tenant state-format metadata does not match the migration ledger"
+    )
+
+
+def test_state_preflight_accepts_the_supported_migration_source_schema(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "revision-eleven-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        for table in (
+            "operation_checker_bindings",
+            "active_operation_catalog",
+            "operation_catalog_entries",
+            "operation_catalog_snapshots",
+        ):
+            connection.execute(f'DROP TABLE "{table}"')
+        connection.execute("DELETE FROM jacobian_schema_migrations WHERE revision = 12")
+        connection.execute(
+            "UPDATE jacobian_state_format SET format_revision = 11 WHERE id = 0"
+        )
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "MIGRATION_PENDING"
+    assert report["persisted_revision"] == 11
+    assert report["blocking"] is False
+
+
 def test_state_preflight_rejects_state_below_the_supported_floor(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -1,0 +1,188 @@
+"""Behavioral coverage for deployment preflight, smoke, and retention helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import httpx2
+import pytest
+from deploy.preflight_state import inspect_selected_state
+from deploy.preflight_state import main as preflight_main
+from deploy.release_retention import prune_releases
+
+from jacobian._deployment_smoke import (
+    TRANSIENT_SMOKE_EXIT,
+    TransientSmokeError,
+    exit_for_smoke_failure,
+    is_transient_transport_failure,
+)
+from jacobian.storage.repository import ArtifactRepository
+
+
+def _completed_release(root: Path, name: str, *, modified_ns: int) -> Path:
+    release = root / name
+    release.mkdir()
+    (release / ".git-revision").write_text("a" * 40 + "\n", encoding="utf-8")
+    (release / ".release-profile").write_text("lean\n", encoding="utf-8")
+    os.utime(release, ns=(modified_ns, modified_ns))
+    return release
+
+
+def test_state_preflight_accepts_missing_and_current_tenant_state(
+    tmp_path: Path,
+) -> None:
+    missing = inspect_selected_state(tmp_path, ("missing-tenant",))
+    assert missing[0]["status"] == "MISSING"
+    assert missing[0]["blocking"] is False
+
+    tenant_id = "current-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    with ArtifactRepository(tmp_path / "tenants" / tenant_key):
+        pass
+
+    current = inspect_selected_state(tmp_path, (tenant_id,))
+    assert current[0]["status"] == "COMPATIBLE"
+    assert current[0]["persisted_revision"] == 11
+    assert current[0]["blocking"] is False
+
+
+def test_state_preflight_rejects_state_below_the_supported_floor(
+    tmp_path: Path,
+) -> None:
+    tenant_id = "legacy-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute("DELETE FROM jacobian_schema_migrations WHERE revision > 8")
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+    assert report["status"] == "UNSUPPORTED"
+    assert report["persisted_revision"] == 8
+    assert report["blocking"] is True
+
+
+def test_state_preflight_cli_does_not_print_bearer_tokens(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    token = "sentinel-secret-token-that-must-stay-private"
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "tokens": [
+                    {
+                        "tenant_id": "tenant-a",
+                        "token": token,
+                        "scopes": ["jacobian:use"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "preflight_state.py",
+            "--state-root",
+            str(tmp_path / "state"),
+            "--auth-tokens-file",
+            str(token_file),
+        ],
+    )
+    assert preflight_main() == 0
+    output = capsys.readouterr()
+
+    assert '"status": "MISSING"' in output.out
+    assert token not in output.out
+    assert token not in output.err
+
+
+def test_release_retention_keeps_active_and_explicit_previous_release(
+    tmp_path: Path,
+) -> None:
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    oldest = _completed_release(releases, "111111111111-lean", modified_ns=1)
+    newest = _completed_release(releases, "222222222222-lean", modified_ns=3)
+    active = _completed_release(releases, "333333333333-lean", modified_ns=2)
+    unknown = releases / "operator-notes"
+    unknown.mkdir()
+    incomplete = releases / "444444444444-lean"
+    incomplete.mkdir()
+    current = tmp_path / "current"
+    current.symlink_to(active)
+
+    pruned = prune_releases(
+        releases,
+        current,
+        retain=2,
+        preserve_releases=(oldest,),
+    )
+
+    assert pruned == (newest,)
+    assert oldest.is_dir()
+    assert active.is_dir()
+    assert not newest.exists()
+    assert unknown.is_dir()
+    assert incomplete.is_dir()
+
+
+def test_release_retention_refuses_to_prune_without_the_active_release(
+    tmp_path: Path,
+) -> None:
+    releases = tmp_path / "releases"
+    releases.mkdir()
+    active = releases / "not-a-release"
+    active.mkdir()
+    current = tmp_path / "current"
+    current.symlink_to(active)
+
+    with pytest.raises(ValueError, match="active release is not a completed"):
+        prune_releases(releases, current, retain=1)
+
+
+def test_smoke_retry_classification_is_transport_only() -> None:
+    transient = ExceptionGroup(
+        "transport",
+        [httpx2.ConnectError("refused"), httpx2.ReadTimeout("cold start")],
+    )
+    deterministic = ExceptionGroup(
+        "contract",
+        [httpx2.ConnectError("refused"), RuntimeError("version mismatch")],
+    )
+
+    assert is_transient_transport_failure(transient) is True
+    assert is_transient_transport_failure(TransientSmokeError("cold worker")) is True
+    assert is_transient_transport_failure(deterministic) is False
+    assert is_transient_transport_failure(RuntimeError("catalog mismatch")) is False
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    (
+        (httpx2.ConnectError("refused"), TRANSIENT_SMOKE_EXIT),
+        (RuntimeError("revision mismatch"), 1),
+    ),
+)
+def test_smoke_failure_exit_codes_are_stable(
+    failure: Exception,
+    expected_code: int,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        exit_for_smoke_failure("smoke", failure)
+
+    assert exc_info.value.code == expected_code
+    assert str(failure) in capsys.readouterr().err

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -234,6 +234,36 @@ def test_state_preflight_rejects_an_unwritable_runtime_directory(
         _require_probe_access(tmp_path, (tenant_id,))
 
 
+def test_state_preflight_rejects_an_unreadable_existing_blob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant_id = "unreadable-blob-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    blob = state / "blobs" / "sha256" / "ab" / ("0" * 62)
+    blob.parent.mkdir()
+    blob.write_bytes(b"restored artifact")
+    original_access = os.access
+
+    def guarded_access(
+        path: os.PathLike[str],
+        mode: int,
+        *,
+        effective_ids: bool = False,
+    ) -> bool:
+        if Path(path) == blob and mode & os.R_OK:
+            return False
+        return original_access(path, mode, effective_ids=effective_ids)
+
+    monkeypatch.setattr("deploy.preflight_state.os.access", guarded_access)
+
+    with pytest.raises(PermissionError, match=r"tenant blob file.*not readable"):
+        _require_probe_access(tmp_path, (tenant_id,))
+
+
 def test_state_preflight_requires_a_missing_tenant_to_be_creatable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -409,6 +409,20 @@ def test_state_preflight_requires_a_missing_tenant_to_be_creatable(
         _require_probe_access(tmp_path, ("missing-tenant",))
 
 
+def test_state_preflight_rejects_symlinked_tenant_state(tmp_path: Path) -> None:
+    tenant_id = "symlinked-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    external_state = tmp_path / "external-state"
+    with ArtifactRepository(external_state):
+        pass
+    tenants_root = tmp_path / "state" / "tenants"
+    tenants_root.mkdir(parents=True)
+    (tenants_root / tenant_key).symlink_to(external_state, target_is_directory=True)
+
+    with pytest.raises(PermissionError, match="must not contain symbolic links"):
+        _require_probe_access(tmp_path / "state", (tenant_id,))
+
+
 def test_release_retention_keeps_active_and_explicit_previous_release(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -80,6 +80,39 @@ def test_state_preflight_rejects_an_incomplete_existing_tenant(
     )
 
 
+@pytest.mark.parametrize("missing_blob", ("manifest", "payload"))
+def test_state_preflight_rejects_missing_referenced_blobs(
+    tmp_path: Path, missing_blob: str
+) -> None:
+    tenant_id = "incomplete-blob-restore"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state) as repository:
+        artifact_uri = repository.register_descriptor(
+            kind="schema",
+            name="restored",
+            version="1",
+            definition={"type": "object"},
+        )
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        row = connection.execute(
+            "SELECT manifest_digest, payload_digest FROM artifacts "
+            "WHERE artifact_uri = ?",
+            (artifact_uri,),
+        ).fetchone()
+    assert row is not None
+    digest = str(row[0 if missing_blob == "manifest" else 1]).removeprefix("sha256:")
+    (state / "blobs" / "sha256" / digest[:2] / digest[2:]).unlink()
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "artifact metadata references a missing blob; restore the complete tenant state"
+    )
+
+
 def test_state_preflight_rejects_state_below_the_supported_floor(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -8,10 +8,15 @@ import os
 import sqlite3
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx2
 import pytest
-from deploy.preflight_state import inspect_selected_state
+from deploy.preflight_state import (
+    _drop_privileges,
+    _require_probe_access,
+    inspect_selected_state,
+)
 from deploy.preflight_state import main as preflight_main
 from deploy.release_retention import prune_releases
 
@@ -20,6 +25,7 @@ from jacobian._deployment_smoke import (
     TransientSmokeError,
     exit_for_smoke_failure,
     is_transient_transport_failure,
+    raise_for_http_error,
 )
 from jacobian.storage.repository import ArtifactRepository
 
@@ -109,6 +115,58 @@ def test_state_preflight_cli_does_not_print_bearer_tokens(
     assert token not in output.err
 
 
+def test_state_preflight_drops_to_the_service_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+    account = SimpleNamespace(pw_uid=1234, pw_gid=5678)
+    monkeypatch.setattr("deploy.preflight_state.pwd.getpwnam", lambda _name: account)
+    monkeypatch.setattr("deploy.preflight_state.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "deploy.preflight_state.os.initgroups",
+        lambda name, gid: calls.append(("initgroups", (name, gid))),
+    )
+    monkeypatch.setattr(
+        "deploy.preflight_state.os.setgid",
+        lambda gid: calls.append(("setgid", gid)),
+    )
+    monkeypatch.setattr(
+        "deploy.preflight_state.os.setuid",
+        lambda uid: calls.append(("setuid", uid)),
+    )
+
+    _drop_privileges("jacobian")
+
+    assert calls == [
+        ("initgroups", ("jacobian", 5678)),
+        ("setgid", 5678),
+        ("setuid", 1234),
+    ]
+
+
+def test_state_preflight_rejects_a_tenant_database_the_service_cannot_stat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant_id = "unreadable-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    state.mkdir(parents=True)
+    database = state / "metadata.sqlite3"
+    database.touch()
+    original_stat = Path.stat
+
+    def guarded_stat(path: Path, *args: object, **kwargs: object) -> os.stat_result:
+        if path == database:
+            raise PermissionError("service account cannot traverse copied state")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+
+    with pytest.raises(PermissionError, match="tenant database"):
+        _require_probe_access(tmp_path, (tenant_id,))
+
+
 def test_release_retention_keeps_active_and_explicit_previous_release(
     tmp_path: Path,
 ) -> None:
@@ -167,6 +225,30 @@ def test_smoke_retry_classification_is_transport_only() -> None:
     assert is_transient_transport_failure(TransientSmokeError("cold worker")) is True
     assert is_transient_transport_failure(deterministic) is False
     assert is_transient_transport_failure(RuntimeError("catalog mismatch")) is False
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    ((401, False), (403, False), (500, False), (502, True), (503, True), (504, True)),
+)
+def test_smoke_retry_classification_preserves_http_status(
+    status_code: int, expected: bool
+) -> None:
+    request = httpx2.Request("POST", "https://math.example.org/mcp")
+    response = httpx2.Response(status_code, request=request)
+    with pytest.raises(httpx2.HTTPStatusError) as exc_info:
+        response.raise_for_status()
+
+    assert is_transient_transport_failure(exc_info.value) is expected
+
+
+@pytest.mark.anyio
+async def test_smoke_response_hook_surfaces_http_status() -> None:
+    request = httpx2.Request("POST", "https://math.example.org/mcp")
+    response = httpx2.Response(503, request=request)
+
+    with pytest.raises(httpx2.HTTPStatusError):
+        await raise_for_http_error(response)
 
 
 @pytest.mark.parametrize(

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -27,6 +27,7 @@ from jacobian._deployment_smoke import (
     is_transient_transport_failure,
     raise_for_http_error,
 )
+from jacobian.persistence.migrations import CURRENT_STATE_FORMAT_REVISION
 from jacobian.storage.repository import ArtifactRepository
 
 
@@ -53,7 +54,7 @@ def test_state_preflight_accepts_missing_and_current_tenant_state(
 
     current = inspect_selected_state(tmp_path, (tenant_id,))
     assert current[0]["status"] == "COMPATIBLE"
-    assert current[0]["persisted_revision"] == 11
+    assert current[0]["persisted_revision"] == CURRENT_STATE_FORMAT_REVISION
     assert current[0]["blocking"] is False
 
 
@@ -165,6 +166,96 @@ def test_state_preflight_rejects_a_tenant_database_the_service_cannot_stat(
 
     with pytest.raises(PermissionError, match="tenant database"):
         _require_probe_access(tmp_path, (tenant_id,))
+
+
+def test_state_preflight_rejects_a_readable_but_unwritable_tenant_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenant_id = "read-only-database-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    database = state / "metadata.sqlite3"
+    original_access = os.access
+
+    def guarded_access(
+        path: os.PathLike[str],
+        mode: int,
+        *,
+        effective_ids: bool = False,
+    ) -> bool:
+        if Path(path) == database and mode & os.W_OK:
+            return False
+        return original_access(path, mode, effective_ids=effective_ids)
+
+    monkeypatch.setattr("deploy.preflight_state.os.access", guarded_access)
+
+    with pytest.raises(
+        PermissionError, match=r"tenant database.*not readable and writable"
+    ):
+        _require_probe_access(tmp_path, (tenant_id,))
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (Path("staging"), Path("blobs/sha256"), Path("blobs/sha256/ab")),
+)
+def test_state_preflight_rejects_an_unwritable_runtime_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: Path,
+) -> None:
+    tenant_id = "read-only-runtime-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state):
+        pass
+    denied = state / relative_path
+    denied.mkdir(parents=True, exist_ok=True)
+    original_access = os.access
+
+    def guarded_access(
+        path: os.PathLike[str],
+        mode: int,
+        *,
+        effective_ids: bool = False,
+    ) -> bool:
+        if Path(path) == denied and mode & os.W_OK:
+            return False
+        return original_access(path, mode, effective_ids=effective_ids)
+
+    monkeypatch.setattr("deploy.preflight_state.os.access", guarded_access)
+
+    with pytest.raises(
+        PermissionError, match="not readable, writable, and traversable"
+    ):
+        _require_probe_access(tmp_path, (tenant_id,))
+
+
+def test_state_preflight_requires_a_missing_tenant_to_be_creatable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tenants_root = tmp_path / "tenants"
+    tenants_root.mkdir()
+    original_access = os.access
+
+    def guarded_access(
+        path: os.PathLike[str],
+        mode: int,
+        *,
+        effective_ids: bool = False,
+    ) -> bool:
+        if Path(path) == tenants_root and mode & os.W_OK:
+            return False
+        return original_access(path, mode, effective_ids=effective_ids)
+
+    monkeypatch.setattr("deploy.preflight_state.os.access", guarded_access)
+
+    with pytest.raises(PermissionError, match="tenant state root"):
+        _require_probe_access(tmp_path, ("missing-tenant",))
 
 
 def test_release_retention_keeps_active_and_explicit_previous_release(

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -179,6 +179,47 @@ def test_state_preflight_rejects_inconsistent_manifest_bindings(
     assert report["diagnostic"] == ("artifact manifest differs from committed metadata")
 
 
+@pytest.mark.parametrize(
+    ("size_delta", "reconciliation_required", "diagnostic"),
+    (
+        (1, 0, "artifact blob quota differs from restored blob storage"),
+        (
+            0,
+            1,
+            "artifact blob quota metadata requires recovery before deployment",
+        ),
+    ),
+)
+def test_state_preflight_rejects_unreconciled_blob_quota(
+    tmp_path: Path,
+    size_delta: int,
+    reconciliation_required: int,
+    diagnostic: str,
+) -> None:
+    tenant_id = "stale-blob-quota"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    with ArtifactRepository(state) as repository:
+        repository.register_descriptor(
+            kind="schema",
+            name="quota-fixture",
+            version="1",
+            definition={"type": "object"},
+        )
+    with sqlite3.connect(state / "metadata.sqlite3") as connection:
+        connection.execute(
+            "UPDATE blob_quota SET size_bytes = size_bytes + ?, "
+            "reconciliation_required = ? WHERE id = 0",
+            (size_delta, reconciliation_required),
+        )
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == diagnostic
+
+
 def test_state_preflight_rejects_state_below_the_supported_floor(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_helpers.py
+++ b/tests/boundary/process/tooling/test_deploy_helpers.py
@@ -58,6 +58,28 @@ def test_state_preflight_accepts_missing_and_current_tenant_state(
     assert current[0]["blocking"] is False
 
 
+@pytest.mark.parametrize("database_present", (False, True))
+def test_state_preflight_rejects_an_incomplete_existing_tenant(
+    tmp_path: Path,
+    database_present: bool,
+) -> None:
+    tenant_id = "incomplete-restored-tenant"
+    tenant_key = hashlib.sha256(tenant_id.encode()).hexdigest()
+    state = tmp_path / "tenants" / tenant_key
+    state.mkdir(parents=True)
+    if database_present:
+        (state / "metadata.sqlite3").touch()
+
+    report = inspect_selected_state(tmp_path, (tenant_id,))[0]
+
+    assert report["status"] == "CORRUPT"
+    assert report["blocking"] is True
+    assert report["diagnostic"] == (
+        "the tenant directory exists without initialized metadata; "
+        "restore or remove the incomplete tenant state"
+    )
+
+
 def test_state_preflight_rejects_state_below_the_supported_floor(
     tmp_path: Path,
 ) -> None:

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -378,12 +378,16 @@ def test_candidate_state_is_checked_with_writers_stopped_and_rollback_armed() ->
     state_preflight = source.index('"${RELEASE_DIR}/deploy/preflight_state.py"')
     rollback_snapshot = source.index('ROLLBACK_ROOT="$(mktemp -d)"')
     rollback_armed = source.index("ROLLBACK_ARMED=1")
+    writer_stop_guard = source.index(
+        'if [[ -f "${ROLLBACK_ROOT}/mcp-service.present" ]]'
+    )
     writer_stop = source.index('"${SYSTEMCTL_BIN}" stop jacobian-mcp.service')
     state_snapshot = source.index('snapshot_file state "${STATE_DIR}"')
     current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
 
-    assert rollback_snapshot < rollback_armed < writer_stop
+    assert rollback_snapshot < rollback_armed < writer_stop_guard < writer_stop
     assert writer_stop < state_preflight < state_snapshot < current_link
+    assert 'jacobian-mcp.service.active" ]]' not in source[rollback_armed:writer_stop]
     assert "--run-as-user jacobian" in source
 
 

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -632,7 +632,7 @@ def test_generated_token_is_written_only_to_the_restricted_file() -> None:
     assert "retrieve it explicitly with privileged access" in source
 
 
-def test_rollback_restores_prior_service_activity_and_enablement(
+def test_rollback_restores_activity_enablement_and_restart_pending_state(
     tmp_path: Path,
 ) -> None:
     state = tmp_path / "systemd-state"
@@ -647,10 +647,22 @@ action="$1"
 case "$action" in
   is-enabled) test -f "$FAKE_SYSTEMD_STATE/$3.enabled" ;;
   is-active) test -f "$FAKE_SYSTEMD_STATE/$3.active" ;;
+  show)
+    if test -f "$FAKE_SYSTEMD_STATE/$4.active"; then
+      printf 'active\n'
+    elif test -f "$FAKE_SYSTEMD_STATE/$4.restart-pending"; then
+      printf 'activating\n'
+    else
+      printf 'inactive\n'
+    fi
+    ;;
   enable) : >"$FAKE_SYSTEMD_STATE/$2.enabled" ;;
   disable) rm -f -- "$FAKE_SYSTEMD_STATE/$2.enabled" ;;
-  restart) : >"$FAKE_SYSTEMD_STATE/$2.active" ;;
-  stop) rm -f -- "$FAKE_SYSTEMD_STATE/$2.active" ;;
+  restart)
+    rm -f -- "$FAKE_SYSTEMD_STATE/$2.restart-pending"
+    : >"$FAKE_SYSTEMD_STATE/$2.active"
+    ;;
+  stop) rm -f -- "$FAKE_SYSTEMD_STATE/$2.active" "$FAKE_SYSTEMD_STATE/$2.restart-pending" ;;
   *) exit 2 ;;
 esac
 """,
@@ -660,6 +672,7 @@ esac
     (state / "jacobian-mcp.service.enabled").touch()
     (state / "jacobian-mcp.service.active").touch()
     (state / "jacobian-caddy.service.enabled").touch()
+    (state / "jacobian-caddy.service.restart-pending").touch()
     environment = os.environ | {"FAKE_SYSTEMD_STATE": str(state)}
     units = (
         "jacobian-mcp.service",
@@ -704,6 +717,7 @@ esac
     assert (state / "jacobian-mcp.service.enabled").is_file()
     assert (state / "jacobian-mcp.service.active").is_file()
     assert (state / "jacobian-caddy.service.enabled").is_file()
-    assert not (state / "jacobian-caddy.service.active").exists()
+    assert (state / "jacobian-caddy.service.active").is_file()
+    assert not (state / "jacobian-caddy.service.restart-pending").exists()
     assert not (state / "jacobian-funnel.service.enabled").exists()
     assert not (state / "jacobian-funnel.service.active").exists()

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -372,15 +372,18 @@ def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
     assert '"${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version' in source
 
 
-def test_candidate_state_is_checked_before_rollback_or_activation_is_armed() -> None:
+def test_candidate_state_is_checked_with_writers_stopped_and_rollback_armed() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
 
     state_preflight = source.index('"${RELEASE_DIR}/deploy/preflight_state.py"')
     rollback_snapshot = source.index('ROLLBACK_ROOT="$(mktemp -d)"')
     rollback_armed = source.index("ROLLBACK_ARMED=1")
+    writer_stop = source.index('"${SYSTEMCTL_BIN}" stop jacobian-mcp.service')
+    state_snapshot = source.index('snapshot_file state "${STATE_DIR}"')
     current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
 
-    assert state_preflight < rollback_snapshot < rollback_armed < current_link
+    assert rollback_snapshot < rollback_armed < writer_stop
+    assert writer_stop < state_preflight < state_snapshot < current_link
     assert "--run-as-user jacobian" in source
 
 
@@ -418,12 +421,24 @@ def test_disk_preflight_reserves_state_snapshot_space_before_dry_run() -> None:
         source.index('INSTALL_DISK_INFO="$(') : source.index("if ((DRY_RUN)); then")
     ]
 
-    assert 'STATE_SIZE_KIB="$(du -sk -- "${STATE_DIR}"' in disk_block
+    assert 'du -sk -- "${STATE_DIR}"' in disk_block
     assert "REQUIRED_ROLLBACK_KIB=$((STATE_SIZE_KIB + 64 * 1024))" in disk_block
     assert "REQUIRED_SHARED_KIB=$((REQUIRED_INSTALL_KIB + REQUIRED_ROLLBACK_KIB))" in (
         disk_block
     )
     assert 'AVAILABLE_ROLLBACK_KIB="${ROLLBACK_DISK_INFO##* }"' in disk_block
+
+
+def test_non_root_dry_run_marks_protected_state_capacity_unverified() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    disk_block = source[
+        source.index("STATE_SIZE_KIB=0") : source.index("if ((DRY_RUN)); then")
+    ]
+
+    assert "if ((DRY_RUN && EUID != 0)); then" in disk_block
+    assert "rollback capacity is unverified" in disk_block
+    assert "rerun the dry-run with sudo before deployment" in disk_block
+    assert "required capacity unverified" in disk_block
 
 
 def test_anonymous_deployment_snapshots_the_anonymous_state_root() -> None:

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -76,6 +76,7 @@ def test_installer_help_exposes_three_deployment_modes() -> None:
     assert "--mode tailscale" in completed.stdout
     assert "--install-root" in completed.stdout
     assert "--with-lean" in completed.stdout
+    assert "--retain-releases" in completed.stdout
 
 
 def test_lean_dry_run_uses_a_distinct_release_profile() -> None:
@@ -89,6 +90,17 @@ def test_lean_dry_run_uses_a_distinct_release_profile() -> None:
     )
     assert release_line.endswith("-lean")
     assert "lean:        pinned CORE + MATHLIB runtime" in completed.stdout
+    assert "retention:   2 completed releases including active" in completed.stdout
+    assert "free space:" in completed.stdout
+    assert "tools:       uv=" in completed.stdout
+
+
+@pytest.mark.parametrize("value", ("0", "-1", "all", "101"))
+def test_release_retention_rejects_invalid_counts(value: str) -> None:
+    completed = _run("--retain-releases", value, "--dry-run")
+
+    assert completed.returncode != 0
+    assert "--retain-releases" in completed.stderr
 
 
 def test_domain_dry_run_reports_connector_without_requiring_root() -> None:
@@ -321,6 +333,45 @@ def test_release_runtime_is_checked_before_current_symlink_is_changed() -> None:
     assert '"${RUNUSER_BIN}" --user jacobian -- "${entrypoint}" --version' in source
 
 
+def test_candidate_state_is_checked_before_rollback_or_activation_is_armed() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    state_preflight = source.index('"${RELEASE_DIR}/deploy/preflight_state.py"')
+    rollback_snapshot = source.index('ROLLBACK_ROOT="$(mktemp -d)"')
+    rollback_armed = source.index("ROLLBACK_ARMED=1")
+    current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
+
+    assert state_preflight < rollback_snapshot < rollback_armed < current_link
+
+
+def test_dry_run_validates_host_tools_and_disk_before_reporting_a_plan() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    uv = source.index('UV_BIN="$(find_executable uv')
+    systemd = source.index('SYSTEMCTL_BIN="$(find_executable systemctl')
+    disk = source.index('AVAILABLE_INSTALL_KIB="$(df -Pk')
+    dry_run = source.index("if ((DRY_RUN)); then")
+
+    assert uv < dry_run
+    assert systemd < dry_run
+    assert disk < dry_run
+
+
+def test_dry_run_waives_build_space_only_for_a_reusable_release() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    disk_block = source[
+        source.index("REQUIRED_INSTALL_KIB=$((2 * 1024 * 1024))") : source.index(
+            "if ((DRY_RUN)); then"
+        )
+    ]
+
+    assert 'cat "${RELEASE_DIR}/.git-revision"' in disk_block
+    assert '== "${REVISION}"' in disk_block
+    assert 'cat "${RELEASE_DIR}/.release-profile"' in disk_block
+    assert '== "${RELEASE_PROFILE}"' in disk_block
+    assert "REQUIRED_INSTALL_KIB=0" in disk_block
+
+
 def test_runtime_inputs_remain_service_readable_after_root_probes() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
 
@@ -419,6 +470,27 @@ def test_lean_profile_requires_catalog_and_behavior_smokes() -> None:
         assert f"--require-operation {operation_id}" in smoke_block
     assert '--expect-revision "${REVISION}"' in smoke_block
     assert '"${RELEASE_DIR}/deploy/smoke_lean.py"' in smoke_block
+
+
+def test_smoke_retries_only_the_stable_transient_exit_code() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    smoke_block = source[source.index('log "running the read-only deployment smoke"') :]
+
+    assert "TRANSIENT_SMOKE_EXIT=75" in source
+    assert smoke_block.count("SMOKE_STATUS != TRANSIENT_SMOKE_EXIT") == 2
+    assert "failed deterministically; not retrying" in smoke_block
+    assert "transient deployment smoke failure; retrying" in smoke_block
+
+
+def test_release_retention_runs_only_after_deployment_is_accepted() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    accepted = source.index("DEPLOYMENT_ACCEPTED=1")
+    disarmed = source.index("ROLLBACK_ARMED=0", accepted)
+    retention = source.index('"${RELEASE_DIR}/deploy/release_retention.py"')
+
+    assert accepted < disarmed < retention
+    assert 'RETENTION_ARGS+=(--preserve-release "${PREVIOUS_RELEASE}")' in source
 
 
 def test_activation_arms_rollback_before_switching_current() -> None:

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -387,6 +387,24 @@ def test_candidate_state_is_checked_with_writers_stopped_and_rollback_armed() ->
     assert "--run-as-user jacobian" in source
 
 
+def test_rollback_capacity_is_rechecked_after_writers_stop_before_snapshot() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    writer_stop = source.index('"${SYSTEMCTL_BIN}" stop jacobian-mcp.service')
+    fresh_free_space = source.index('df -Pk "${ROLLBACK_ROOT}"', writer_stop)
+    fresh_state_size = source.index('du -sk -- "${STATE_DIR}"', writer_stop)
+    state_preflight = source.index('"${RELEASE_DIR}/deploy/preflight_state.py"')
+    state_snapshot = source.index('snapshot_file state "${STATE_DIR}"')
+
+    assert writer_stop < fresh_free_space < fresh_state_size
+    assert fresh_state_size < state_preflight < state_snapshot
+    assert "QUIESCENT_REQUIRED_ROLLBACK_KIB" in source[fresh_state_size:state_preflight]
+    assert (
+        "insufficient rollback space after stopping writers"
+        in source[fresh_state_size:state_preflight]
+    )
+
+
 def test_dry_run_validates_host_tools_and_disk_before_reporting_a_plan() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
 

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -133,6 +133,28 @@ def test_domain_dry_run_reports_connector_without_requiring_root() -> None:
     assert "funnel:      disabled" in completed.stdout
 
 
+def test_public_skip_smoke_warns_that_ingress_still_starts() -> None:
+    completed = _run(
+        "--mode",
+        "domain",
+        "--domain",
+        "math.example.org",
+        "--skip-smoke",
+        "--dry-run",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "--skip-smoke does not keep public ingress offline" in completed.stderr
+    assert "use --mode local while staging a VPS migration" in completed.stderr
+
+
+def test_local_skip_smoke_does_not_emit_a_public_ingress_warning() -> None:
+    completed = _run("--mode", "local", "--skip-smoke", "--dry-run")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "public ingress offline" not in completed.stderr
+
+
 def test_dry_run_derives_every_runtime_path_from_custom_install_root() -> None:
     completed = _run(
         "--install-root",

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -20,14 +20,18 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture(autouse=True)
 def _provide_optional_host_tools(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+) -> Path:
     tool_directory = tmp_path / "deployment-tools"
     tool_directory.mkdir()
     for tool_name in ("caddy", "elan"):
         tool = tool_directory / tool_name
         tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         tool.chmod(0o755)
+    du = tool_directory / "du"
+    du.write_text("#!/bin/sh\nprintf '0\\t%s\\n' \"$3\"\n", encoding="utf-8")
+    du.chmod(0o755)
     monkeypatch.setenv("PATH", f"{tool_directory}:{os.environ['PATH']}")
+    return tool_directory
 
 
 def _run(
@@ -385,7 +389,7 @@ def test_dry_run_validates_host_tools_and_disk_before_reporting_a_plan() -> None
 
     uv = source.index('UV_BIN="$(find_executable uv')
     systemd = source.index('SYSTEMCTL_BIN="$(find_executable systemctl')
-    disk = source.index('AVAILABLE_INSTALL_KIB="$(df -Pk')
+    disk = source.index('INSTALL_DISK_INFO="$(')
     dry_run = source.index("if ((DRY_RUN)); then")
 
     assert uv < dry_run
@@ -406,6 +410,28 @@ def test_dry_run_waives_build_space_only_for_a_reusable_release() -> None:
     assert 'cat "${RELEASE_DIR}/.release-profile"' in disk_block
     assert '== "${RELEASE_PROFILE}"' in disk_block
     assert "REQUIRED_INSTALL_KIB=0" in disk_block
+
+
+def test_disk_preflight_reserves_state_snapshot_space_before_dry_run() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    disk_block = source[
+        source.index('INSTALL_DISK_INFO="$(') : source.index("if ((DRY_RUN)); then")
+    ]
+
+    assert 'STATE_SIZE_KIB="$(du -sk -- "${STATE_DIR}"' in disk_block
+    assert "REQUIRED_ROLLBACK_KIB=$((STATE_SIZE_KIB + 64 * 1024))" in disk_block
+    assert "REQUIRED_SHARED_KIB=$((REQUIRED_INSTALL_KIB + REQUIRED_ROLLBACK_KIB))" in (
+        disk_block
+    )
+    assert 'AVAILABLE_ROLLBACK_KIB="${ROLLBACK_DISK_INFO##* }"' in disk_block
+
+
+def test_anonymous_deployment_snapshots_the_anonymous_state_root() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+    state_selection = source.index('STATE_DIR="${ANONYMOUS_STATE_ROOT}"')
+    rollback_snapshot = source.index('snapshot_file state "${STATE_DIR}"')
+
+    assert state_selection < rollback_snapshot
 
 
 def test_runtime_inputs_remain_service_readable_after_root_probes() -> None:

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -108,7 +108,7 @@ def test_lean_dry_run_uses_a_distinct_release_profile() -> None:
     assert "tools:       uv=" in completed.stdout
 
 
-@pytest.mark.parametrize("value", ("0", "-1", "all", "101"))
+@pytest.mark.parametrize("value", ("0", "-1", "all", "101", "18446744073709551616"))
 def test_release_retention_rejects_invalid_counts(value: str) -> None:
     completed = _run("--retain-releases", value, "--dry-run")
 

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -355,6 +355,7 @@ def test_candidate_state_is_checked_before_rollback_or_activation_is_armed() -> 
     current_link = source.index('ln -sfn "${RELEASE_DIR}" "${CURRENT_LINK}.new"')
 
     assert state_preflight < rollback_snapshot < rollback_armed < current_link
+    assert "--run-as-user jacobian" in source
 
 
 def test_dry_run_validates_host_tools_and_disk_before_reporting_a_plan() -> None:

--- a/tests/boundary/process/tooling/test_deploy_installer.py
+++ b/tests/boundary/process/tooling/test_deploy_installer.py
@@ -17,6 +17,19 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _provide_optional_host_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tool_directory = tmp_path / "deployment-tools"
+    tool_directory.mkdir()
+    for tool_name in ("caddy", "elan"):
+        tool = tool_directory / tool_name
+        tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        tool.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tool_directory}:{os.environ['PATH']}")
+
+
 def _run(
     *arguments: str,
     environment: dict[str, str] | None = None,

--- a/tests/boundary/process/tooling/test_deploy_smoke_lean.py
+++ b/tests/boundary/process/tooling/test_deploy_smoke_lean.py
@@ -7,6 +7,8 @@ from deploy.smoke_lean import (
     _require_verified,
 )
 
+from jacobian._deployment_smoke import TransientSmokeError
+
 
 def test_verified_smoke_requires_completed_checker_backing() -> None:
     result = {
@@ -24,6 +26,18 @@ def test_verified_smoke_requires_completed_checker_backing() -> None:
     ):
         with pytest.raises(RuntimeError):
             _require_verified(mutation, environment="MATHLIB")
+
+
+@pytest.mark.parametrize("status", ("TIMEOUT", "CANCELLED"))
+def test_all_bounded_lean_smoke_probes_retry_transient_statuses(status: str) -> None:
+    result = {"execution": {"status": status}}
+
+    with pytest.raises(TransientSmokeError, match=status):
+        _require_verified(result, environment="CORE")
+    with pytest.raises(TransientSmokeError, match=status):
+        _require_transition(result, accepted=True, completed=True)
+    with pytest.raises(TransientSmokeError, match=status):
+        _require_mathlib_declaration(result)
 
 
 def test_transition_smoke_keeps_rejection_distinct_from_execution_failure() -> None:


### PR DESCRIPTION
## Summary

- Fail closed before activation when selected tenant state is incompatible or unusable by the `jacobian` service identity.
- Retry only transient deployment smoke failures, preserve deterministic rollback behavior, and verify the deployed package revision.
- Retain the active and previous completed releases while pruning stale completed releases.
- Document and print VPS migration reminders for secrets, tenant identity, endpoint changes, and state cutover.
- Align the deployment guide with state revision 12 and the supported revision-11 migration.

## Validation

- `make check` (mypy and 936 unit tests)
- `make test-process` (213 tests)
- focused deployment tests (70 tests)
- `make docs-linkcheck`
- `bash -n deploy/install.sh`