### PR TITLE
refactor(catalog): restructure selected-operation ownership around runtime-local family bindings

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -83,10 +83,13 @@ declarations live outside `jacobian.math`.
 
 Domain declaration modules export immutable operation tuples and perform no
 installation. The catalog compiler imports them during `jacobian init` or
-`jacobian update`; serving imports only the declaration module selected by
-`math.run`. An operation may call a private computational backend, but that
-backend owns no runtime, storage, publication, installation, or checker
-authority.
+`jacobian update`; serving resolves either the declaration module or an
+explicit family binding origin selected by `math.run`. Graph, polynomial,
+Lean, and SAT/SMT families own their selected IDs and binding logic; the
+runtime-local resolver only chooses that fixed family seam, validates identity,
+caches the adapter, and participates in shutdown. An operation may call a
+private computational backend, but that backend owns no runtime, storage,
+publication, installation, or checker authority.
 
 ## Mathematical value and backend layers
 

--- a/docs/explanation/operation-runtime-target.md
+++ b/docs/explanation/operation-runtime-target.md
@@ -50,10 +50,14 @@ materialized only when explicitly requested. Visibility filtering is applied
 to search, inspection, execution, and the resource without rebuilding the
 compiled snapshot.
 
-The catalog is inert searchable data. A declaration-module locator plus
-operation ID is resolved by `OperationRegistry` only after an operation is
-selected. The registry then verifies the loaded declaration against the
-persisted identity, schemas, and digest.
+The catalog is inert searchable data. Each entry carries either a declaration
+module locator or an explicit `family:<name>` binding origin. The
+runtime-local `OperationRegistry` reads that locator only after an operation is
+selected, validates the loaded declaration or family adapter against the
+persisted identity, schemas, and digest, and caches the result. The fixed
+family table is assembled by the runtime; graph, polynomial, Lean, and SAT/SMT
+modules own their selected IDs and binding logic. The runtime owns any
+closeable resources acquired by those binders and releases them at shutdown.
 
 ## Mathematical backends, execution, and publication
 

--- a/src/jacobian/catalog_compiler.py
+++ b/src/jacobian/catalog_compiler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
 
 from jacobian import __version__
@@ -17,6 +16,7 @@ from jacobian.operation_catalog import (
     declaration_digest,
     exact_checker_declaration_digest,
     operation_declaration_digest,
+    operation_declaration_digest_from_descriptor,
     public_operation_descriptor,
 )
 from jacobian.operation_visibility import OperationVisibilityPolicy
@@ -24,6 +24,7 @@ from jacobian.polytope import PolytopeService
 from jacobian.registry import CheckerRegistry
 from jacobian.runtime.bootstrap import bootstrap_services
 from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime.selected_families import selected_operation_origin
 from jacobian.verification.service import VerificationService
 
 
@@ -62,7 +63,7 @@ def compile_operation_catalog(
         descriptors = tuple(
             public_operation_descriptor(descriptor) for descriptor in bound_descriptors
         )
-        entries = _compiled_entries(core.operations._adapters, descriptors)
+        entries = _compiled_entries(descriptors)
         return OperationCatalogStore(state_dir / "metadata.sqlite3").commit(
             package_version=__version__,
             checker_binding_digest=declaration_digest(
@@ -88,7 +89,6 @@ def compile_operation_catalog(
 
 
 def _compiled_entries(
-    adapters: Mapping[str, object],
     descriptors: tuple[OperationDescriptor, ...],
 ) -> tuple[CompiledCatalogEntry, ...]:
     loaded_modules = load_builtin_operation_modules()
@@ -111,7 +111,7 @@ def _compiled_entries(
                 if descriptor.operation_id in declarations
                 else exact_verifiers[descriptor.operation_id][0]
                 if descriptor.operation_id in exact_verifiers
-                else type(adapters[descriptor.operation_id]).__module__
+                else _selected_operation_origin(descriptor.operation_id)
             ),
             declaration_digest=(
                 operation_declaration_digest(declarations[descriptor.operation_id][1])
@@ -121,18 +121,21 @@ def _compiled_entries(
                     descriptor,
                 )
                 if descriptor.operation_id in exact_verifiers
-                else declaration_digest(
-                    {
-                        "operation_id": descriptor.operation_id,
-                        "version": descriptor.version,
-                        "input_schema": descriptor.input_schema,
-                        "output_schema": descriptor.output_schema,
-                    }
-                )
+                else operation_declaration_digest_from_descriptor(descriptor)
             ),
         )
         for descriptor in descriptors
     )
+
+
+def _selected_operation_origin(operation_id: str) -> str:
+    origin = selected_operation_origin(operation_id)
+    if origin is None:
+        raise ValueError(
+            "catalog operation has no declaration or selected family owner: "
+            f"{operation_id}"
+        )
+    return origin
 
 
 def _checker_bindings(

--- a/src/jacobian/graphs/operation_resources.py
+++ b/src/jacobian/graphs/operation_resources.py
@@ -50,6 +50,21 @@ from jacobian.storage.repository import ArtifactRepository
 from jacobian.verification.service import VerificationService
 from jacobian.verification_operations import certificate_verification_adapter
 
+SELECTED_GRAPH_OPERATION_IDS = frozenset(
+    {
+        "graph.construct.explicit",
+        "graph.search.atlas",
+        "graph.compute.properties",
+        "graph.construct.compose",
+        "graph.enumerate.nonisomorphic",
+        "graph.realize.degree_sequence",
+        "graph.compute.neighborhood_independence",
+        "graph.degree_sequence.verify",
+        "graph.neighborhood_independence.verify",
+        "graph.isomorphism.verify",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class GraphOperationResources:
@@ -178,18 +193,7 @@ def bind_selected_graph_operation(
 ) -> OperationAdapter[Any] | None:
     """Bind one ordinary graph operation without checker or portfolio setup."""
 
-    if operation_id not in {
-        "graph.construct.explicit",
-        "graph.search.atlas",
-        "graph.compute.properties",
-        "graph.construct.compose",
-        "graph.enumerate.nonisomorphic",
-        "graph.realize.degree_sequence",
-        "graph.compute.neighborhood_independence",
-        "graph.degree_sequence.verify",
-        "graph.neighborhood_independence.verify",
-        "graph.isomorphism.verify",
-    }:
+    if operation_id not in SELECTED_GRAPH_OPERATION_IDS:
         return None
     resources = register_graph_resources(store, schemas)
     if operation_id == "graph.isomorphism.verify":

--- a/src/jacobian/lean_frontend/selected.py
+++ b/src/jacobian/lean_frontend/selected.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from jacobian.builtin_operations import LeanCheckAdapter
@@ -27,25 +26,49 @@ from jacobian.operation_catalog import OperationCatalog, OperationCatalogError
 from jacobian.providers.lean_runtime import lean_provider_runtime
 from jacobian.registry import CheckerRegistry
 from jacobian.schema_registry import SchemaRegistry
+from jacobian.selected_operation_bindings import SelectedOperationBinding
 from jacobian.storage.repository import ArtifactRepository
 from jacobian.verification.service import VerificationService
 
-_STATEMENT_OPERATIONS = {
-    "lean.statement.propose",
-    "lean.statement.compare",
-}
-_DECLARATION_OPERATIONS = {
-    "lean.declaration.search",
-    "lean.declaration.inspect",
-    "lean.declaration.dependencies",
-}
-_EXPLORATION_OPERATIONS = {
-    "lean.proof_state.apply_tactic",
-    "lean.retrieve.premises",
-    "lean.term.apply",
-    "lean.proof_state.inspect",
-    "lean.proof_state.metavariable_fields",
-}
+_STATEMENT_OPERATIONS = frozenset(
+    {
+        "lean.statement.propose",
+        "lean.statement.compare",
+    }
+)
+_DECLARATION_OPERATIONS = frozenset(
+    {
+        "lean.declaration.search",
+        "lean.declaration.inspect",
+        "lean.declaration.dependencies",
+    }
+)
+_EXPLORATION_OPERATIONS = frozenset(
+    {
+        "lean.proof_state.apply_tactic",
+        "lean.retrieve.premises",
+        "lean.term.apply",
+        "lean.proof_state.inspect",
+        "lean.proof_state.metavariable_fields",
+    }
+)
+SELECTED_LEAN_OPERATION_IDS = frozenset(
+    {
+        "lean.check",
+        "lean.declaration.dependencies",
+        "lean.declaration.inspect",
+        "lean.declaration.search",
+        "lean.proof.axioms.inspect",
+        "lean.proof_edit.validate",
+        "lean.proof_state.apply_tactic",
+        "lean.proof_state.inspect",
+        "lean.proof_state.metavariable_fields",
+        "lean.retrieve.premises",
+        "lean.statement.compare",
+        "lean.statement.propose",
+        "lean.term.apply",
+    }
+)
 
 
 def bind_selected_lean_operation(
@@ -57,8 +80,7 @@ def bind_selected_lean_operation(
     schemas: SchemaRegistry,
     verification: VerificationService,
     checkers: CheckerRegistry,
-    own: Callable[[object], None],
-) -> OperationAdapter[Any] | None:
+) -> SelectedOperationBinding | None:
     """Construct only the Lean service family selected by ``operation_id``."""
 
     installations = _lean_installations(catalog, store, schemas, checkers)
@@ -80,6 +102,7 @@ def bind_selected_lean_operation(
         if installation.checker_id is not None
     )
     runtime = lean_provider_runtime(profiles=profiles, checker_ids=checker_ids)
+    resources: list[object] = []
     if operation_id in _STATEMENT_OPERATIONS:
         statement_adapters, _ = install_lean_statement_operations(
             store,
@@ -87,25 +110,30 @@ def bind_selected_lean_operation(
             binder.artifacts,
             runtime,
         )
-        return _select(statement_adapters, operation_id)
+        return SelectedOperationBinding(_select(statement_adapters, operation_id))
     if operation_id in _DECLARATION_OPERATIONS:
         declarations = installed_lean_declaration_service(
             runtime,
             cache_root=store.root / "cache" / "lean-declarations",
         )
-        own(declarations)
-        return _select(
-            binder.bind(lean_declaration_query_operations(declarations)).adapters,
-            operation_id,
+        resources.append(declarations)
+        return SelectedOperationBinding(
+            _select(
+                binder.bind(lean_declaration_query_operations(declarations)).adapters,
+                operation_id,
+            ),
+            tuple(resources),
         )
 
     if operation_id == "lean.proof_state.inspect":
-        return install_lean_proof_state_inspect_only(
-            store,
-            schemas,
-            binder.artifacts,
-            installations,
-            runtime,
+        return SelectedOperationBinding(
+            install_lean_proof_state_inspect_only(
+                store,
+                schemas,
+                binder.artifacts,
+                installations,
+                runtime,
+            )
         )
     if operation_id in _EXPLORATION_OPERATIONS:
         exploration_adapters, exploration = install_lean_exploration_operations(
@@ -115,8 +143,10 @@ def bind_selected_lean_operation(
             installations,
             runtime,
         )
-        own(exploration.repl)
-        return _select(exploration_adapters, operation_id)
+        resources.append(exploration.repl)
+        return SelectedOperationBinding(
+            _select(exploration_adapters, operation_id), tuple(resources)
+        )
     if operation_id == "lean.proof.axioms.inspect":
         axioms_adapter, _ = install_lean_proof_axioms_operation(
             store,
@@ -125,7 +155,7 @@ def bind_selected_lean_operation(
             installations,
             runtime,
         )
-        return axioms_adapter
+        return SelectedOperationBinding(axioms_adapter)
     if operation_id in {"lean.check", "lean.proof_edit.validate"}:
         lean = LeanService(
             store,
@@ -133,9 +163,11 @@ def bind_selected_lean_operation(
             verification,
             installations,
         )
-        own(lean)
+        resources.append(lean)
         if operation_id == "lean.check":
-            return LeanCheckAdapter(lean, runtime)
+            return SelectedOperationBinding(
+                LeanCheckAdapter(lean, runtime), tuple(resources)
+            )
         proof_edit_adapter, _ = install_lean_proof_edit_operation(
             store,
             schemas,
@@ -143,7 +175,7 @@ def bind_selected_lean_operation(
             lean,
             runtime,
         )
-        return proof_edit_adapter
+        return SelectedOperationBinding(proof_edit_adapter, tuple(resources))
     return None
 
 
@@ -187,4 +219,4 @@ def _select(
     )
 
 
-__all__ = ["bind_selected_lean_operation"]
+__all__ = ["SELECTED_LEAN_OPERATION_IDS", "bind_selected_lean_operation"]

--- a/src/jacobian/operation_catalog.py
+++ b/src/jacobian/operation_catalog.py
@@ -475,6 +475,21 @@ def declaration_digest(value: dict[str, Any]) -> str:
     return "sha256:" + sha256(canonicalize_json(value)).hexdigest()
 
 
+def operation_declaration_digest_from_descriptor(
+    descriptor: OperationDescriptor,
+) -> str:
+    """Digest the persisted identity of a resource-backed operation."""
+
+    return declaration_digest(
+        {
+            "operation_id": descriptor.operation_id,
+            "version": descriptor.version,
+            "input_schema": descriptor.input_schema,
+            "output_schema": descriptor.output_schema,
+        }
+    )
+
+
 def operation_declaration_digest(
     declaration: OperationDeclaration[Any, Any],
 ) -> str:
@@ -551,5 +566,6 @@ __all__ = [
     "declaration_digest",
     "exact_checker_declaration_digest",
     "operation_declaration_digest",
+    "operation_declaration_digest_from_descriptor",
     "public_operation_descriptor",
 ]

--- a/src/jacobian/operation_registry.py
+++ b/src/jacobian/operation_registry.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
-from jacobian.builtin_operation_modules import load_builtin_operation_module
+from jacobian.builtin_operation_modules import (
+    BUILTIN_OPERATION_MODULES,
+    load_builtin_operation_module,
+)
 from jacobian.checker_operations import AuthorizedChecker
 from jacobian.contracts.operations import OperationDescriptor
 from jacobian.operation_adapters import OperationAdapter
@@ -16,108 +18,21 @@ from jacobian.operation_catalog import (
     OperationDeclarationRecord,
     exact_checker_declaration_digest,
     operation_declaration_digest,
+    operation_declaration_digest_from_descriptor,
     public_operation_descriptor,
 )
 from jacobian.operation_declarations import OperationDeclarations
-from jacobian.polynomial_expressions import PolynomialExpressionArtifactService
-from jacobian.polytope import PolytopeService
 from jacobian.registry import CheckerRegistry
-from jacobian.sat_smt.sat import SatArtifactService
-from jacobian.sat_smt.smt import SmtArtifactService
+from jacobian.selected_operation_bindings import (
+    ResourceOwner,
+    RuntimeSelectedFamily,
+    SelectedOperationBinding,
+)
 from jacobian.verification.service import VerificationService
-
-_SELECTED_GRAPH_OPERATIONS = frozenset(
-    {
-        "graph.construct.explicit",
-        "graph.search.atlas",
-        "graph.compute.properties",
-        "graph.construct.compose",
-        "graph.enumerate.nonisomorphic",
-        "graph.realize.degree_sequence",
-        "graph.compute.neighborhood_independence",
-        "graph.degree_sequence.verify",
-        "graph.neighborhood_independence.verify",
-        "graph.isomorphism.verify",
-    }
-)
-_SELECTED_POLYNOMIAL_OPERATIONS = frozenset(
-    {
-        "polynomial.expression.normalize",
-        "polynomial.expression_normalization.verify",
-        "polynomial.interval.positivity.decide",
-        "polynomial.interval.positivity.verify",
-        "polynomial.interval.enclose",
-        "polynomial.interval.enclosure.verify",
-        "polynomial.map.evaluate",
-        "polynomial.map.compute_jacobian",
-        "polynomial.map.keller_condition.verify",
-        "polynomial.map.collision_witness",
-        "polynomial.map.collision.search",
-        "polynomial.map.collision.verify",
-        "polynomial.map.collision_evidence.verify",
-        "polynomial.map.inverse.refute_by_collision",
-        "polynomial.identity.verify",
-        "polynomial.rational_function.identity.verify",
-        "polynomial.map.inverse.candidate_synthesize",
-        "polynomial.map.inverse.verify",
-        "polynomial.system.solution.verify",
-        "polynomial.system.rational_solution.search",
-        "polynomial.jacobian_degree_slice.system.materialize",
-        "polynomial.nullstellensatz.infeasibility_certificate.compute",
-        "polynomial.nullstellensatz.infeasibility_certificate.verify",
-    }
-)
-_SELECTED_DIRECT_OPERATIONS = frozenset(
-    {
-        "polytope.separate",
-        "finite.coverage.verify",
-        "finite_magma.table.enumerate",
-        "universal_algebra.evaluate_laws",
-        "universal_algebra.search.countermodel",
-        "universal_algebra.law_evaluation.verify",
-        "sat.cnf.materialize",
-        "sat.model.verify",
-        "sat.unsat_proof.verify",
-        "sat.lrat.verify",
-        "smt.unsat_proof.verify",
-        "sat.model.find",
-        "sat.unsat_proof.find",
-        "smt.unsat_proof.find",
-    }
-)
-_SELECTED_LEAN_OPERATIONS = frozenset(
-    {
-        "lean.check",
-        "lean.declaration.dependencies",
-        "lean.declaration.inspect",
-        "lean.declaration.search",
-        "lean.proof.axioms.inspect",
-        "lean.proof_edit.validate",
-        "lean.proof_state.apply_tactic",
-        "lean.proof_state.inspect",
-        "lean.proof_state.metavariable_fields",
-        "lean.retrieve.premises",
-        "lean.statement.compare",
-        "lean.statement.propose",
-        "lean.term.apply",
-    }
-)
-_SELECTED_RESOURCE_OPERATIONS = (
-    _SELECTED_GRAPH_OPERATIONS
-    | _SELECTED_POLYNOMIAL_OPERATIONS
-    | _SELECTED_DIRECT_OPERATIONS
-    | _SELECTED_LEAN_OPERATIONS
-)
-
-
-def supports_selected_operation(operation_id: str) -> bool:
-    """Return whether a non-declaration operation has a narrow selected binder."""
-
-    return operation_id in _SELECTED_RESOURCE_OPERATIONS
 
 
 class OperationRegistry:
-    """Import, verify, and cache only selected built-in declarations."""
+    """Resolve persisted declarations through one runtime-local family table."""
 
     def __init__(
         self,
@@ -125,42 +40,21 @@ class OperationRegistry:
         binder: OperationBinder,
         verification: VerificationService,
         checkers: CheckerRegistry,
-        polynomial_expressions: PolynomialExpressionArtifactService,
-        polytope: PolytopeService,
-        sat: SatArtifactService,
-        smt: SmtArtifactService,
+        selected_families: tuple[RuntimeSelectedFamily, ...],
+        resource_owner: ResourceOwner,
     ) -> None:
         self.catalog = catalog
         self.binder = binder
         self.verification = verification
         self.checkers = checkers
-        self.polynomial_expressions = polynomial_expressions
-        self.polytope = polytope
-        self.sat = sat
-        self.smt = smt
+        self._selected_families = selected_families
+        self._resource_owner = resource_owner
         self._adapters: dict[str, OperationAdapter[Any]] = {}
-        self._owned_close: list[Callable[[], None]] = []
 
     def close(self) -> None:
-        """Close lazily selected subprocess-backed services in reverse order."""
+        """Discard cached adapters before the runtime closes their resources."""
 
-        failures: list[Exception] = []
-        while self._owned_close:
-            close = self._owned_close.pop()
-            try:
-                close()
-            except Exception as exc:
-                failures.append(exc)
-        if failures:
-            raise ExceptionGroup(
-                "selected operation services failed to close", failures
-            )
-
-    def _own(self, resource: object) -> None:
-        close = getattr(resource, "close", None)
-        if not callable(close):
-            raise TypeError("owned selected-operation resource must be closeable")
-        self._owned_close.append(close)
+        self._adapters.clear()
 
     def resolve(self, operation_id: str) -> OperationAdapter[Any]:
         cached = self._adapters.get(operation_id)
@@ -170,21 +64,20 @@ class OperationRegistry:
         record = self.catalog.declaration_record(operation_id)
         if descriptor is None or record is None:
             raise OperationCatalogError(f"unknown or hidden operation: {operation_id}")
-        try:
-            _module_name, operations, checker_declarations = (
-                load_builtin_operation_module(record.module)
-            )
-        except ValueError as exc:
-            adapter = self._resolve_selected_resource_operation(
-                operation_id,
-                descriptor,
-                record,
-            )
-            if adapter is not None:
-                return adapter
+
+        if record.module.startswith("family:"):
+            return self._resolve_selected_family(operation_id, descriptor, record)
+
+        if record.module not in {
+            module_name for module_name, _factory_name in BUILTIN_OPERATION_MODULES
+        }:
             raise OperationCatalogError(
-                f"operation {operation_id} is not a declared built-in operation"
-            ) from exc
+                "operation catalog locator is stale; run `jacobian update`: "
+                f"{operation_id}"
+            )
+        _module_name, operations, checker_declarations = load_builtin_operation_module(
+            record.module
+        )
         matches = tuple(
             operation
             for operation in operations
@@ -208,7 +101,8 @@ class OperationRegistry:
         declaration = matches[0]
         if declaration.version != descriptor.version:
             raise OperationCatalogError(
-                f"operation declaration version changed; run `jacobian update`: {operation_id}"
+                "operation declaration version changed; run `jacobian update`: "
+                f"{operation_id}"
             )
         if operation_declaration_digest(declaration) != record.declaration_digest:
             raise OperationCatalogError(
@@ -227,320 +121,54 @@ class OperationRegistry:
         self._adapters[operation_id] = adapter
         return adapter
 
-    def _resolve_selected_resource_operation(
+    def _resolve_selected_family(
         self,
         operation_id: str,
         descriptor: OperationDescriptor,
         record: OperationDeclarationRecord,
-    ) -> OperationAdapter[Any] | None:
-        if not supports_selected_operation(operation_id):
-            return None
-        adapter = self._bind_selected_resource(operation_id, descriptor)
-        if adapter is None:
+    ) -> OperationAdapter[Any]:
+        family = next(
+            (
+                family
+                for family in self._selected_families
+                if family.spec.origin == record.module
+            ),
+            None,
+        )
+        if family is None:
+            raise OperationCatalogError(
+                f"selected operation family is unavailable: {operation_id}"
+            )
+        binding = family.bind(operation_id, descriptor)
+        if binding is None:
             raise OperationCatalogError(
                 f"selected operation binder is missing: {operation_id}"
             )
-        expected_digest = operation_declaration_digest_from_descriptor(descriptor)
-        if expected_digest != record.declaration_digest:
-            raise OperationCatalogError(
-                f"operation declaration changed; run `jacobian update`: {operation_id}"
-            )
-        if public_operation_descriptor(adapter.descriptor) != descriptor:
-            raise OperationCatalogError(
-                f"operation schema changed; run `jacobian update`: {operation_id}"
-            )
+        self._validate_selected_binding(operation_id, descriptor, record, binding)
+        for resource in binding.resources:
+            self._resource_owner.own(resource)
+        adapter = binding.adapter
         self._adapters[operation_id] = adapter
         return adapter
 
-    def _bind_selected_resource(
-        self,
+    @staticmethod
+    def _validate_selected_binding(
         operation_id: str,
         descriptor: OperationDescriptor,
-    ) -> OperationAdapter[Any] | None:
-        if operation_id in _SELECTED_LEAN_OPERATIONS:
-            from jacobian.lean_frontend.selected import bind_selected_lean_operation
-
-            adapter = bind_selected_lean_operation(
-                operation_id,
-                descriptor,
-                self.catalog,
-                self.binder,
-                self.binder.store,
-                self.binder.schemas,
-                self.verification,
-                self.checkers,
-                self._own,
-            )
-        elif operation_id in _SELECTED_GRAPH_OPERATIONS:
-            from jacobian.graphs.operation_resources import (
-                bind_selected_graph_operation,
-            )
-
-            adapter = bind_selected_graph_operation(
-                operation_id,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        elif operation_id in _SELECTED_POLYNOMIAL_OPERATIONS:
-            adapter = self._bind_selected_polynomial_operation(operation_id, descriptor)
-        elif operation_id == "polytope.separate":
-            from jacobian.polytope_operations import PolytopeSeparationAdapter
-
-            adapter = PolytopeSeparationAdapter(self.polytope)
-        elif operation_id == "finite.coverage.verify":
-            from jacobian.finite_coverage import bind_selected_finite_coverage
-
-            adapter = bind_selected_finite_coverage(
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        elif operation_id in {
-            "finite_magma.table.enumerate",
-            "universal_algebra.evaluate_laws",
-            "universal_algebra.search.countermodel",
-            "universal_algebra.law_evaluation.verify",
-        }:
-            from jacobian.universal_algebra_operations import (
-                bind_selected_universal_algebra_operation,
-            )
-
-            adapter = bind_selected_universal_algebra_operation(
-                operation_id,
-                descriptor,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        elif operation_id.startswith(("sat.", "smt.")):
-            adapter = self._bind_selected_sat_operation(operation_id, descriptor)
-        else:
-            adapter = None
-        return adapter
-
-    def _bind_selected_polynomial_operation(
-        self,
-        operation_id: str,
-        descriptor: OperationDescriptor,
-    ) -> OperationAdapter[Any] | None:
-        if operation_id == "polynomial.expression.normalize":
-            from jacobian.providers.sympy_runtime import (
-                sympy_polynomial_normalization_provider_runtime,
-            )
-            from jacobian.sympy_polynomial_normalization import (
-                bind_sympy_polynomial_normalization,
-            )
-
-            adapter = bind_sympy_polynomial_normalization(
-                self.polynomial_expressions,
-                sympy_polynomial_normalization_provider_runtime(),
-            )
-            return adapter
-        if operation_id == "polynomial.expression_normalization.verify":
-            from jacobian.polynomial_expression_operations import (
-                bind_selected_polynomial_expression_checker,
-            )
-
-            return bind_selected_polynomial_expression_checker(
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.polynomial_expressions,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        if operation_id in {
-            "polynomial.interval.positivity.decide",
-            "polynomial.interval.positivity.verify",
-        }:
-            from jacobian.polynomial_positivity_operations import (
-                bind_selected_polynomial_positivity_operation,
-            )
-
-            return bind_selected_polynomial_positivity_operation(
-                operation_id,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        if operation_id in {
-            "polynomial.interval.enclose",
-            "polynomial.interval.enclosure.verify",
-        }:
-            from jacobian.polynomial_interval_operations import (
-                bind_selected_polynomial_interval_operation,
-            )
-
-            return bind_selected_polynomial_interval_operation(
-                operation_id,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        from jacobian.polynomials.operation_build import (
-            bind_selected_polynomial_operation,
-        )
-
-        polynomial_adapter = bind_selected_polynomial_operation(
-            operation_id,
-            self.binder.store,
-            self.binder.schemas,
-            self.binder.artifacts,
-            self.verification,
-            self.checkers,
-            self.catalog,
-        )
-        if polynomial_adapter is not None:
-            return polynomial_adapter
-        from jacobian.polynomial_system_operations import (
-            bind_selected_polynomial_system_operation,
-        )
-
-        system_adapter = bind_selected_polynomial_system_operation(
-            operation_id,
-            self.binder.store,
-            self.binder.schemas,
-            self.binder.artifacts,
-            self.verification,
-            self.checkers,
-            self.catalog,
-        )
-        if system_adapter is not None:
-            return system_adapter
-        if operation_id == (
-            "polynomial.nullstellensatz.infeasibility_certificate.compute"
+        record: OperationDeclarationRecord,
+        binding: SelectedOperationBinding,
+    ) -> None:
+        if (
+            operation_declaration_digest_from_descriptor(descriptor)
+            != record.declaration_digest
         ):
-            from jacobian.domains.polynomial_nullstellensatz.singular import (
-                bind_selected_singular_producer,
+            raise OperationCatalogError(
+                f"operation declaration changed; run `jacobian update`: {operation_id}"
             )
-            from jacobian.providers.singular_runtime import singular_provider_runtime
-
-            return bind_selected_singular_producer(
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                singular_provider_runtime(),
+        if public_operation_descriptor(binding.adapter.descriptor) != descriptor:
+            raise OperationCatalogError(
+                f"operation schema changed; run `jacobian update`: {operation_id}"
             )
-        from jacobian.domains.polynomial_nullstellensatz.core import (
-            bind_selected_nullstellensatz_operation,
-        )
-        from jacobian.provider_runtime import known_provider_runtime
-
-        provider_runtime = known_provider_runtime(
-            "jacobian.nullstellensatz-core",
-            features=(
-                "normalized-jacobian-degree-slice",
-                "rabinowitsch-chart-cover",
-                "independent-exact-replay",
-            ),
-        )
-        binding = self.catalog.checker_binding(operation_id)
-        if binding is not None:
-            provider_runtime = provider_runtime.model_copy(
-                update={"checker_ids": (binding.checker_id,)}
-            )
-        return bind_selected_nullstellensatz_operation(
-            operation_id,
-            self.binder.store,
-            self.binder.schemas,
-            self.binder.artifacts,
-            self.verification,
-            self.checkers,
-            self.catalog,
-            provider_runtime,
-        )
-
-    def _bind_selected_sat_operation(
-        self,
-        operation_id: str,
-        descriptor: OperationDescriptor,
-    ) -> OperationAdapter[Any] | None:
-        if operation_id in {"sat.model.find", "sat.unsat_proof.find"}:
-            from jacobian.providers.external_solver_runtime import (
-                cadical_provider_runtime,
-            )
-            from jacobian.sat_smt.cadical import install_cadical_operations
-
-            return next(
-                adapter
-                for adapter in install_cadical_operations(
-                    self.sat,
-                    cadical_provider_runtime(),
-                )
-                if adapter.descriptor.operation_id == operation_id
-            )
-        if operation_id == "smt.unsat_proof.find":
-            from jacobian.providers.external_solver_runtime import (
-                cvc5_provider_runtime,
-            )
-            from jacobian.sat_smt.cvc5 import bind_cvc5_operation
-
-            return bind_cvc5_operation(self.smt, cvc5_provider_runtime())
-        if operation_id == "sat.cnf.materialize":
-            from jacobian.sat_smt.sat_operations import SatCnfMaterializationAdapter
-
-            return SatCnfMaterializationAdapter(self.sat)
-        if operation_id in {"sat.model.verify", "sat.unsat_proof.verify"}:
-            from jacobian.sat_smt.sat_operations import (
-                bind_selected_sat_verification,
-            )
-
-            return bind_selected_sat_verification(
-                operation_id,
-                descriptor,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.sat,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        if operation_id == "sat.lrat.verify":
-            from jacobian.sat_smt.sat_lrat import bind_selected_sat_lrat_verifier
-
-            return bind_selected_sat_lrat_verifier(
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.sat,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        if operation_id == "smt.unsat_proof.verify":
-            from jacobian.sat_smt.smt_operations import (
-                bind_selected_smt_unsat_proof_checker,
-            )
-
-            return bind_selected_smt_unsat_proof_checker(
-                descriptor,
-                self.binder.store,
-                self.binder.schemas,
-                self.binder.artifacts,
-                self.smt,
-                self.verification,
-                self.checkers,
-                self.catalog,
-            )
-        return None
 
     def _resolve_exact_verifier(
         self,
@@ -581,21 +209,4 @@ class OperationRegistry:
         return adapter
 
 
-def operation_declaration_digest_from_descriptor(
-    descriptor: OperationDescriptor,
-) -> str:
-    """Match the catalog digest used by retained resource-backed operations."""
-
-    from jacobian.operation_catalog import declaration_digest
-
-    return declaration_digest(
-        {
-            "operation_id": descriptor.operation_id,
-            "version": descriptor.version,
-            "input_schema": descriptor.input_schema,
-            "output_schema": descriptor.output_schema,
-        }
-    )
-
-
-__all__ = ["OperationRegistry", "supports_selected_operation"]
+__all__ = ["OperationRegistry"]

--- a/src/jacobian/polynomials/selected.py
+++ b/src/jacobian/polynomials/selected.py
@@ -1,0 +1,215 @@
+"""Lazy binding for the selected polynomial operation family."""
+
+from __future__ import annotations
+
+from jacobian.contracts.operations import OperationDescriptor
+from jacobian.operation_binding import OperationBinder
+from jacobian.operation_catalog import OperationCatalog
+from jacobian.polynomial_expressions import PolynomialExpressionArtifactService
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.selected_operation_bindings import SelectedOperationBinding
+from jacobian.storage.repository import ArtifactRepository
+from jacobian.verification.service import VerificationService
+
+SELECTED_POLYNOMIAL_OPERATION_IDS = frozenset(
+    {
+        "polynomial.expression.normalize",
+        "polynomial.expression_normalization.verify",
+        "polynomial.interval.positivity.decide",
+        "polynomial.interval.positivity.verify",
+        "polynomial.interval.enclose",
+        "polynomial.interval.enclosure.verify",
+        "polynomial.map.evaluate",
+        "polynomial.map.compute_jacobian",
+        "polynomial.map.keller_condition.verify",
+        "polynomial.map.collision_witness",
+        "polynomial.map.collision.search",
+        "polynomial.map.collision.verify",
+        "polynomial.map.collision_evidence.verify",
+        "polynomial.map.inverse.refute_by_collision",
+        "polynomial.identity.verify",
+        "polynomial.rational_function.identity.verify",
+        "polynomial.map.inverse.candidate_synthesize",
+        "polynomial.map.inverse.verify",
+        "polynomial.system.solution.verify",
+        "polynomial.system.rational_solution.search",
+        "polynomial.jacobian_degree_slice.system.materialize",
+        "polynomial.nullstellensatz.infeasibility_certificate.compute",
+        "polynomial.nullstellensatz.infeasibility_certificate.verify",
+    }
+)
+
+
+def bind_selected_polynomial_operation(
+    operation_id: str,
+    descriptor: OperationDescriptor,
+    *,
+    binder: OperationBinder,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    polynomial_expressions: PolynomialExpressionArtifactService,
+    catalog: OperationCatalog,
+    store: ArtifactRepository,
+    schemas: SchemaRegistry,
+) -> SelectedOperationBinding | None:
+    """Bind one selected polynomial operation and its exact dependencies."""
+
+    if operation_id not in SELECTED_POLYNOMIAL_OPERATION_IDS:
+        return None
+    if operation_id == "polynomial.expression.normalize":
+        from jacobian.providers.sympy_runtime import (
+            sympy_polynomial_normalization_provider_runtime,
+        )
+        from jacobian.sympy_polynomial_normalization import (
+            bind_sympy_polynomial_normalization,
+        )
+
+        adapter = bind_sympy_polynomial_normalization(
+            polynomial_expressions,
+            sympy_polynomial_normalization_provider_runtime(),
+        )
+        return SelectedOperationBinding(adapter)
+    if operation_id == "polynomial.expression_normalization.verify":
+        from jacobian.polynomial_expression_operations import (
+            bind_selected_polynomial_expression_checker,
+        )
+
+        return SelectedOperationBinding(
+            bind_selected_polynomial_expression_checker(
+                store,
+                schemas,
+                binder.artifacts,
+                polynomial_expressions,
+                verification,
+                checkers,
+                catalog,
+            )
+        )
+    if operation_id in {
+        "polynomial.interval.positivity.decide",
+        "polynomial.interval.positivity.verify",
+    }:
+        from jacobian.polynomial_positivity_operations import (
+            bind_selected_polynomial_positivity_operation,
+        )
+
+        positivity_adapter = bind_selected_polynomial_positivity_operation(
+            operation_id,
+            store,
+            schemas,
+            binder.artifacts,
+            verification,
+            checkers,
+            catalog,
+        )
+        return (
+            None
+            if positivity_adapter is None
+            else SelectedOperationBinding(positivity_adapter)
+        )
+    if operation_id in {
+        "polynomial.interval.enclose",
+        "polynomial.interval.enclosure.verify",
+    }:
+        from jacobian.polynomial_interval_operations import (
+            bind_selected_polynomial_interval_operation,
+        )
+
+        interval_adapter = bind_selected_polynomial_interval_operation(
+            operation_id,
+            store,
+            schemas,
+            binder.artifacts,
+            verification,
+            checkers,
+            catalog,
+        )
+        return (
+            None
+            if interval_adapter is None
+            else SelectedOperationBinding(interval_adapter)
+        )
+    from jacobian.polynomials.operation_build import (
+        bind_selected_polynomial_operation as bind_operation,
+    )
+
+    polynomial_adapter = bind_operation(
+        operation_id,
+        store,
+        schemas,
+        binder.artifacts,
+        verification,
+        checkers,
+        catalog,
+    )
+    if polynomial_adapter is not None:
+        return SelectedOperationBinding(polynomial_adapter)
+    from jacobian.polynomial_system_operations import (
+        bind_selected_polynomial_system_operation,
+    )
+
+    system_adapter = bind_selected_polynomial_system_operation(
+        operation_id,
+        store,
+        schemas,
+        binder.artifacts,
+        verification,
+        checkers,
+        catalog,
+    )
+    if system_adapter is not None:
+        return SelectedOperationBinding(system_adapter)
+    if operation_id == ("polynomial.nullstellensatz.infeasibility_certificate.compute"):
+        from jacobian.domains.polynomial_nullstellensatz.singular import (
+            bind_selected_singular_producer,
+        )
+        from jacobian.providers.singular_runtime import singular_provider_runtime
+
+        return SelectedOperationBinding(
+            bind_selected_singular_producer(
+                store,
+                schemas,
+                binder.artifacts,
+                singular_provider_runtime(),
+            )
+        )
+    from jacobian.domains.polynomial_nullstellensatz.core import (
+        bind_selected_nullstellensatz_operation,
+    )
+    from jacobian.provider_runtime import known_provider_runtime
+
+    provider_runtime = known_provider_runtime(
+        "jacobian.nullstellensatz-core",
+        features=(
+            "normalized-jacobian-degree-slice",
+            "rabinowitsch-chart-cover",
+            "independent-exact-replay",
+        ),
+    )
+    binding = catalog.checker_binding(operation_id)
+    if binding is not None:
+        provider_runtime = provider_runtime.model_copy(
+            update={"checker_ids": (binding.checker_id,)}
+        )
+    nullstellensatz_adapter = bind_selected_nullstellensatz_operation(
+        operation_id,
+        store,
+        schemas,
+        binder.artifacts,
+        verification,
+        checkers,
+        catalog,
+        provider_runtime,
+    )
+    return (
+        None
+        if nullstellensatz_adapter is None
+        else SelectedOperationBinding(nullstellensatz_adapter)
+    )
+
+
+__all__ = [
+    "SELECTED_POLYNOMIAL_OPERATION_IDS",
+    "bind_selected_polynomial_operation",
+]

--- a/src/jacobian/runtime/execution.py
+++ b/src/jacobian/runtime/execution.py
@@ -12,6 +12,7 @@ from jacobian.polytope import PolytopeService
 from jacobian.registry import CheckerRegistry
 from jacobian.runtime.bootstrap import bootstrap_services
 from jacobian.runtime.model import JacobianRuntime
+from jacobian.runtime.selected_families import create_runtime_selected_families
 from jacobian.verification.service import VerificationService
 
 
@@ -39,15 +40,24 @@ def create_execution_runtime(
             checker_timeout_seconds=105,
         )
         polytope = PolytopeService(core.store, core.schemas)
+        selected_families = create_runtime_selected_families(
+            catalog=catalog,
+            binder=core.binder,
+            verification=verification,
+            checkers=core.checkers,
+            polynomial_expressions=core.polynomial_expressions,
+            polytope=polytope,
+            sat=core.sat,
+            smt=core.smt,
+            runtime_resources=core,
+        )
         registry = OperationRegistry(
             catalog,
             core.binder,
             verification,
             core.checkers,
-            core.polynomial_expressions,
-            polytope,
-            core.sat,
-            core.smt,
+            selected_families,
+            core,
         )
         core.operations = OperationDispatcher(catalog, registry)
         return JacobianRuntime(core, verification, polytope)

--- a/src/jacobian/runtime/model.py
+++ b/src/jacobian/runtime/model.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from jacobian.polytope import PolytopeService
 from jacobian.runtime.resources import RuntimeResources
 from jacobian.verification.service import VerificationService
@@ -21,14 +19,11 @@ class JacobianRuntime:
         core: RuntimeResources,
         verification: VerificationService,
         polytope: PolytopeService,
-        *,
-        close_resources: Callable[[], None] | None = None,
     ) -> None:
         self._closed = False
         self.core = core
         self.verification = verification
         self.polytope = polytope
-        self._close_resources = close_resources or (lambda: None)
 
     def close(self) -> None:
         """Release every runtime-owned resource."""
@@ -36,10 +31,7 @@ class JacobianRuntime:
         if self._closed:
             return
         failures: list[BaseException] = []
-        for close in (
-            self._close_resources,
-            self.core.close,
-        ):
+        for close in (self.core.close,):
             try:
                 close()
             except BaseException as exc:

--- a/src/jacobian/runtime/resources.py
+++ b/src/jacobian/runtime/resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, cast
 
 from jacobian.artifacts import ArtifactService
 from jacobian.catalog_operation_collector import CatalogOperationCollector
@@ -31,17 +32,35 @@ class RuntimeResources:
     polynomial_expressions: PolynomialExpressionArtifactService
     checkers: CheckerRegistry
     operations: CatalogOperationCollector | OperationDispatcher
+    _owned_resources: list[object] | None = None
+
+    def own(self, resource: object) -> None:
+        """Add one lazily acquired closeable to the runtime lifecycle."""
+
+        if not callable(getattr(resource, "close", None)):
+            raise TypeError("runtime-owned resource must be closeable")
+        if self._owned_resources is None:
+            self._owned_resources = []
+        if all(owned is not resource for owned in self._owned_resources):
+            self._owned_resources.append(resource)
 
     def close(self) -> None:
         failures: list[Exception] = []
         close_operations = getattr(self.operations, "close", None)
-        for close in (
+        owned_closes = [
+            cast(Any, resource).close
+            for resource in reversed(self._owned_resources or [])
+        ]
+        closes: list[object] = [
             close_operations if callable(close_operations) else None,
+            *owned_closes,
             self.values.close,
             self.store.close,
-        ):
+        ]
+        for close in closes:
             if close is None:
                 continue
+            assert callable(close)
             try:
                 close()
             except Exception as exc:

--- a/src/jacobian/runtime/selected_families.py
+++ b/src/jacobian/runtime/selected_families.py
@@ -1,0 +1,171 @@
+"""The fixed selected-operation family table for one execution runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.contracts.operations import OperationDescriptor
+from jacobian.graphs.operation_resources import (
+    SELECTED_GRAPH_OPERATION_IDS,
+    bind_selected_graph_operation,
+)
+from jacobian.lean_frontend.selected import (
+    SELECTED_LEAN_OPERATION_IDS,
+    bind_selected_lean_operation,
+)
+from jacobian.operation_binding import OperationBinder
+from jacobian.operation_catalog import OperationCatalog
+from jacobian.polynomial_expressions import PolynomialExpressionArtifactService
+from jacobian.polynomials.selected import (
+    SELECTED_POLYNOMIAL_OPERATION_IDS,
+    bind_selected_polynomial_operation,
+)
+from jacobian.polytope import PolytopeService
+from jacobian.registry import CheckerRegistry
+from jacobian.sat_smt.sat import SatArtifactService
+from jacobian.sat_smt.selected import (
+    SELECTED_SAT_SMT_OPERATION_IDS,
+    bind_selected_sat_smt_operation,
+)
+from jacobian.sat_smt.smt import SmtArtifactService
+from jacobian.selected_operation_bindings import (
+    RuntimeSelectedFamily,
+    SelectedFamilySpec,
+    SelectedOperationBinding,
+)
+from jacobian.selected_operations import (
+    SELECTED_CORE_OPERATION_IDS,
+    bind_selected_core_operation,
+)
+from jacobian.verification.service import VerificationService
+
+_FAMILY_SPECS = (
+    SelectedFamilySpec("family:graph", SELECTED_GRAPH_OPERATION_IDS),
+    SelectedFamilySpec("family:polynomial", SELECTED_POLYNOMIAL_OPERATION_IDS),
+    SelectedFamilySpec("family:lean", SELECTED_LEAN_OPERATION_IDS),
+    SelectedFamilySpec("family:sat-smt", SELECTED_SAT_SMT_OPERATION_IDS),
+    SelectedFamilySpec("family:core", SELECTED_CORE_OPERATION_IDS),
+)
+
+
+def selected_family_specs() -> tuple[SelectedFamilySpec, ...]:
+    """Return immutable family ownership metadata used by catalog builds."""
+
+    return _FAMILY_SPECS
+
+
+def selected_operation_origin(operation_id: str) -> str | None:
+    """Return the persisted family origin for one resource-backed operation."""
+
+    for spec in _FAMILY_SPECS:
+        if operation_id in spec.operation_ids:
+            return spec.origin
+    return None
+
+
+def create_runtime_selected_families(
+    *,
+    catalog: OperationCatalog,
+    binder: OperationBinder,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    polynomial_expressions: PolynomialExpressionArtifactService,
+    polytope: PolytopeService,
+    sat: SatArtifactService,
+    smt: SmtArtifactService,
+    runtime_resources: Any,
+) -> tuple[RuntimeSelectedFamily, ...]:
+    """Capture all selected binders in one fixed, runtime-local table."""
+
+    store = runtime_resources.store
+    schemas = runtime_resources.schemas
+    artifacts = runtime_resources.artifacts
+
+    def graph(
+        operation_id: str, _descriptor: OperationDescriptor
+    ) -> SelectedOperationBinding | None:
+        adapter = bind_selected_graph_operation(
+            operation_id,
+            store,
+            schemas,
+            artifacts,
+            verification,
+            checkers,
+            catalog,
+        )
+        return None if adapter is None else SelectedOperationBinding(adapter)
+
+    def polynomial(
+        operation_id: str, descriptor: OperationDescriptor
+    ) -> SelectedOperationBinding | None:
+        return bind_selected_polynomial_operation(
+            operation_id,
+            descriptor,
+            binder=binder,
+            verification=verification,
+            checkers=checkers,
+            polynomial_expressions=polynomial_expressions,
+            catalog=catalog,
+            store=store,
+            schemas=schemas,
+        )
+
+    def lean(
+        operation_id: str, descriptor: OperationDescriptor
+    ) -> SelectedOperationBinding | None:
+        return bind_selected_lean_operation(
+            operation_id,
+            descriptor,
+            catalog,
+            binder,
+            store,
+            schemas,
+            verification,
+            checkers,
+        )
+
+    def sat_smt(
+        operation_id: str, descriptor: OperationDescriptor
+    ) -> SelectedOperationBinding | None:
+        return bind_selected_sat_smt_operation(
+            operation_id,
+            descriptor,
+            binder=binder,
+            verification=verification,
+            checkers=checkers,
+            catalog=catalog,
+            store=store,
+            schemas=schemas,
+            sat=sat,
+            smt=smt,
+        )
+
+    def core(
+        operation_id: str, descriptor: OperationDescriptor
+    ) -> SelectedOperationBinding | None:
+        return bind_selected_core_operation(
+            operation_id,
+            descriptor,
+            binder=binder,
+            verification=verification,
+            checkers=checkers,
+            catalog=catalog,
+            polytope=polytope,
+            store=store,
+            schemas=schemas,
+        )
+
+    return (
+        RuntimeSelectedFamily(_FAMILY_SPECS[0], graph),
+        RuntimeSelectedFamily(_FAMILY_SPECS[1], polynomial),
+        RuntimeSelectedFamily(_FAMILY_SPECS[2], lean),
+        RuntimeSelectedFamily(_FAMILY_SPECS[3], sat_smt),
+        RuntimeSelectedFamily(_FAMILY_SPECS[4], core),
+    )
+
+
+__all__ = [
+    "create_runtime_selected_families",
+    "selected_family_specs",
+    "selected_operation_origin",
+]

--- a/src/jacobian/sat_smt/selected.py
+++ b/src/jacobian/sat_smt/selected.py
@@ -1,0 +1,131 @@
+"""Lazy binding for the selected SAT/SMT operation family."""
+
+from __future__ import annotations
+
+from jacobian.contracts.operations import OperationDescriptor
+from jacobian.operation_binding import OperationBinder
+from jacobian.operation_catalog import OperationCatalog
+from jacobian.registry import CheckerRegistry
+from jacobian.sat_smt.sat import SatArtifactService
+from jacobian.sat_smt.smt import SmtArtifactService
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.selected_operation_bindings import SelectedOperationBinding
+from jacobian.storage.repository import ArtifactRepository
+from jacobian.verification.service import VerificationService
+
+SELECTED_SAT_SMT_OPERATION_IDS = frozenset(
+    {
+        "sat.cnf.materialize",
+        "sat.model.verify",
+        "sat.unsat_proof.verify",
+        "sat.lrat.verify",
+        "smt.unsat_proof.verify",
+        "sat.model.find",
+        "sat.unsat_proof.find",
+        "smt.unsat_proof.find",
+    }
+)
+
+
+def bind_selected_sat_smt_operation(
+    operation_id: str,
+    descriptor: OperationDescriptor,
+    *,
+    binder: OperationBinder,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    catalog: OperationCatalog,
+    store: ArtifactRepository,
+    schemas: SchemaRegistry,
+    sat: SatArtifactService,
+    smt: SmtArtifactService,
+) -> SelectedOperationBinding | None:
+    """Bind one selected SAT/SMT operation from runtime-owned services."""
+
+    if operation_id not in SELECTED_SAT_SMT_OPERATION_IDS:
+        return None
+    if operation_id in {"sat.model.find", "sat.unsat_proof.find"}:
+        from jacobian.providers.external_solver_runtime import (
+            cadical_provider_runtime,
+        )
+        from jacobian.sat_smt.cadical import install_cadical_operations
+
+        adapter = next(
+            adapter
+            for adapter in install_cadical_operations(
+                sat,
+                cadical_provider_runtime(),
+            )
+            if adapter.descriptor.operation_id == operation_id
+        )
+        return SelectedOperationBinding(adapter)
+    if operation_id == "smt.unsat_proof.find":
+        from jacobian.providers.external_solver_runtime import (
+            cvc5_provider_runtime,
+        )
+        from jacobian.sat_smt.cvc5 import bind_cvc5_operation
+
+        return SelectedOperationBinding(
+            bind_cvc5_operation(smt, cvc5_provider_runtime())
+        )
+    if operation_id == "sat.cnf.materialize":
+        from jacobian.sat_smt.sat_operations import SatCnfMaterializationAdapter
+
+        return SelectedOperationBinding(SatCnfMaterializationAdapter(sat))
+    if operation_id in {"sat.model.verify", "sat.unsat_proof.verify"}:
+        from jacobian.sat_smt.sat_operations import (
+            bind_selected_sat_verification,
+        )
+
+        verification_adapter = bind_selected_sat_verification(
+            operation_id,
+            descriptor,
+            store,
+            schemas,
+            binder.artifacts,
+            sat,
+            verification,
+            checkers,
+            catalog,
+        )
+        return (
+            None
+            if verification_adapter is None
+            else SelectedOperationBinding(verification_adapter)
+        )
+    if operation_id == "sat.lrat.verify":
+        from jacobian.sat_smt.sat_lrat import bind_selected_sat_lrat_verifier
+
+        return SelectedOperationBinding(
+            bind_selected_sat_lrat_verifier(
+                store,
+                schemas,
+                binder.artifacts,
+                sat,
+                verification,
+                checkers,
+                catalog,
+            )
+        )
+    from jacobian.sat_smt.smt_operations import (
+        bind_selected_smt_unsat_proof_checker,
+    )
+
+    return SelectedOperationBinding(
+        bind_selected_smt_unsat_proof_checker(
+            descriptor,
+            store,
+            schemas,
+            binder.artifacts,
+            smt,
+            verification,
+            checkers,
+            catalog,
+        )
+    )
+
+
+__all__ = [
+    "SELECTED_SAT_SMT_OPERATION_IDS",
+    "bind_selected_sat_smt_operation",
+]

--- a/src/jacobian/selected_operation_bindings.py
+++ b/src/jacobian/selected_operation_bindings.py
@@ -1,0 +1,48 @@
+"""Fixed selected-operation binding seams used by one execution runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from jacobian.contracts.operations import OperationDescriptor
+from jacobian.operation_adapters import OperationAdapter
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedOperationBinding:
+    """One adapter and resources acquired while constructing that adapter."""
+
+    adapter: OperationAdapter[Any]
+    resources: tuple[object, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedFamilySpec:
+    """Immutable family ownership metadata used at catalog compilation."""
+
+    origin: str
+    operation_ids: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSelectedFamily:
+    """One family binder captured by a single execution runtime."""
+
+    spec: SelectedFamilySpec
+    bind: Callable[[str, OperationDescriptor], SelectedOperationBinding | None]
+
+
+class ResourceOwner(Protocol):
+    """Runtime boundary that owns closeable selected-operation resources."""
+
+    def own(self, resource: object) -> None: ...
+
+
+__all__ = [
+    "ResourceOwner",
+    "RuntimeSelectedFamily",
+    "SelectedFamilySpec",
+    "SelectedOperationBinding",
+]

--- a/src/jacobian/selected_operations.py
+++ b/src/jacobian/selected_operations.py
@@ -1,0 +1,79 @@
+"""Lazy binding for retained resource-backed operations outside domain families."""
+
+from __future__ import annotations
+
+from jacobian.contracts.operations import OperationDescriptor
+from jacobian.operation_binding import OperationBinder
+from jacobian.operation_catalog import OperationCatalog
+from jacobian.polytope import PolytopeService
+from jacobian.registry import CheckerRegistry
+from jacobian.schema_registry import SchemaRegistry
+from jacobian.selected_operation_bindings import SelectedOperationBinding
+from jacobian.storage.repository import ArtifactRepository
+from jacobian.verification.service import VerificationService
+
+SELECTED_CORE_OPERATION_IDS = frozenset(
+    {
+        "polytope.separate",
+        "finite.coverage.verify",
+        "finite_magma.table.enumerate",
+        "universal_algebra.evaluate_laws",
+        "universal_algebra.search.countermodel",
+        "universal_algebra.law_evaluation.verify",
+    }
+)
+
+
+def bind_selected_core_operation(
+    operation_id: str,
+    descriptor: OperationDescriptor,
+    *,
+    binder: OperationBinder,
+    verification: VerificationService,
+    checkers: CheckerRegistry,
+    catalog: OperationCatalog,
+    polytope: PolytopeService,
+    store: ArtifactRepository,
+    schemas: SchemaRegistry,
+) -> SelectedOperationBinding | None:
+    """Bind one retained resource-backed operation from runtime services."""
+
+    if operation_id not in SELECTED_CORE_OPERATION_IDS:
+        return None
+    if operation_id == "polytope.separate":
+        from jacobian.polytope_operations import PolytopeSeparationAdapter
+
+        return SelectedOperationBinding(PolytopeSeparationAdapter(polytope))
+    if operation_id == "finite.coverage.verify":
+        from jacobian.finite_coverage import bind_selected_finite_coverage
+
+        return SelectedOperationBinding(
+            bind_selected_finite_coverage(
+                store,
+                schemas,
+                binder.artifacts,
+                verification,
+                checkers,
+                catalog,
+            )
+        )
+    from jacobian.universal_algebra_operations import (
+        bind_selected_universal_algebra_operation,
+    )
+
+    adapter = bind_selected_universal_algebra_operation(
+        operation_id,
+        descriptor,
+        store,
+        schemas,
+        binder.artifacts,
+        verification,
+        checkers,
+        catalog,
+    )
+    if adapter is None:
+        return None
+    return SelectedOperationBinding(adapter)
+
+
+__all__ = ["SELECTED_CORE_OPERATION_IDS", "bind_selected_core_operation"]

--- a/tests/boundary/process/test_singular_nullstellensatz_boundary.py
+++ b/tests/boundary/process/test_singular_nullstellensatz_boundary.py
@@ -27,10 +27,10 @@ from jacobian.domains.polynomial_nullstellensatz.singular import (
     bind_selected_singular_producer,
     install_singular_producer,
 )
-from jacobian.operation_registry import supports_selected_operation
 from jacobian.process_policy import ProcessResult, ProcessTermination
 from jacobian.provider_runtime import known_provider_runtime
 from jacobian.providers.singular_runtime import singular_provider_runtime
+from jacobian.runtime.selected_families import selected_operation_origin
 
 
 def _runtime() -> ProviderObservation:
@@ -88,7 +88,7 @@ def test_singular_producer_has_a_lazy_selected_binding(tmp_path: Path) -> None:
             _runtime(),
         )
 
-        assert supports_selected_operation(PRODUCE_OPERATION_ID)
+        assert selected_operation_origin(PRODUCE_OPERATION_ID) == "family:polynomial"
         assert adapter.descriptor.operation_id == PRODUCE_OPERATION_ID
 
 

--- a/tests/support/catalog_build_runtime.py
+++ b/tests/support/catalog_build_runtime.py
@@ -30,8 +30,16 @@ class CatalogBuildRuntime(JacobianRuntime):
             core,
             verification,
             polytope,
-            close_resources=resources.close,
         )
+        for resource in (
+            resources.lean_declarations,
+            resources.lean_exploration.repl
+            if resources.lean_exploration is not None
+            else None,
+            resources.lean,
+        ):
+            if resource is not None:
+                core.own(resource)
         self.catalog_build_resources = resources
 
 


### PR DESCRIPTION
## Summary

Selected-operation execution now uses one runtime-local resolver with explicit family ownership.

Previously, the resolver duplicated family ID sets and binding trees, inferred resource-backed operations by catching `ValueError`, and owned Lean cleanup through a private callback stack. That made catalog compilation, serving, and shutdown depend on overlapping ownership tables.

This change:

- moves Graph, Polynomial, Lean, and SAT/SMT selected IDs and binding logic into family-owned modules;
- adds a fixed runtime-local family binding table;
- persists explicit `family:<name>` origins for resource-backed catalog entries;
- keeps the resolver focused on catalog lookup, identity/digest validation, adapter caching, and shutdown participation;
- moves acquired closeable resources into `RuntimeResources` ownership;
- removes the unused `JacobianRuntime(close_resources=...)` hook and the old ValueError routing fallback;
- updates the architecture documentation and test support lifecycle.

A small `family:core` seam remains for retained polytope, finite-coverage, and universal-algebra resource-backed operations that do not belong to the four named families.

Existing catalogs compiled before this change should be refreshed with `jacobian update`; no public operation behavior changes.

## Validation

- `make check` — Ruff, complexity checks, mypy, and 935 unit tests passed.
- `make test-mcp` — 43 MCP boundary tests passed.
- Focused selected-operation/composition tests — 228 passed.
- `make docs-linkcheck` — documentation commands and links passed.
- Catalog smoke compiled 367 operations and confirmed explicit `family:graph`, `family:polynomial`, and `family:sat-smt` origins.

## Review order

1. `operation_registry.py` and `runtime/selected_families.py` for the ownership seam.
2. Family binders and `RuntimeResources` cleanup.
3. Catalog origin compilation and documentation/tests.
