### PR TITLE
ci: drop no-op jobs that only mirrored branch protection names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,39 +286,3 @@ jobs:
           test "$WHEEL_RESULT" = success
           test "$COVERAGE_RESULT" = success
           test "$LEAN_RESULT" = success
-
-  python-test:
-    name: Python Tests
-    if: ${{ always() }}
-    needs: [required]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Mirror required for existing branch protection
-        env:
-          REQUIRED_RESULT: ${{ needs.required.result }}
-        run: test "$REQUIRED_RESULT" = success
-
-  lean-test:
-    name: Lean Tests
-    if: ${{ always() }}
-    needs: [lean]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Require Lean on the exact merge candidate
-        env:
-          LEAN_RESULT: ${{ needs.lean.result }}
-        run: test "$LEAN_RESULT" = success
-
-  deployment-test:
-    name: Deployment Tests
-    if: ${{ always() }}
-    needs: [static]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Deploy check runs inside static
-        env:
-          STATIC_RESULT: ${{ needs.static.result }}
-        run: test "$STATIC_RESULT" = success

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,7 @@ Historical registrations whose files are gone, including leftover
 `agent-port-*` and `agent-rebase-*` workflows, stay disabled in the GitHub UI
 with their run history retained; do not add an auto-disable bot.
 `python tools/inventory_github_workflows.py` is the non-mutating inventory.
+Branch protection should require the CI check named `required`.
 
 For the exact task authoring workflow and verifier changes, use the
 [`harbor-benchmarks`](.agents/skills/harbor-benchmarks/SKILL.md) skill. The

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -116,7 +116,10 @@ branch. Registrations whose files are gone, including historical
 `agent-port-*` and `agent-rebase-*` leftovers, are historical: disable them in
 the GitHub UI and retain their run history.
 `python tools/inventory_github_workflows.py` compares files to registrations
-and never disables workflows.
+and never disables workflows. Branch protection should require the CI job
+named `required`; that aggregate already fail-closes on static, python,
+boundaries, wheel, coverage, and Lean. Do not add no-op jobs that only
+mirror those results under older check names.
 
 Ordinary CI coverage instruments each pytest process but does not automatically
 instrument every child it launches. Independent checker calls therefore retain

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -138,8 +138,8 @@ def test_optional_boundary_and_deployment_jobs_have_explicit_workflow_gates() ->
     assert "ci:full" not in workflow
     assert "ci:lean" not in workflow
     assert "run: make deploy-check" in workflow
-    assert "name: Deployment Tests" in workflow
     assert "name: required" in workflow
+    assert "name: Deployment Tests" not in workflow
 
 
 def test_python_jobs_use_fixed_local_semantic_targets() -> None:
@@ -305,17 +305,19 @@ def test_plan_receipt_digests_are_rendered_as_markdown_code() -> None:
 
 def test_required_ci_gates_fail_closed_after_cancellation() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    required = workflow.split("  required:", 1)[1].split("  python-test:", 1)[0]
-    aggregate_tail = workflow.split("  required:", 1)[1]
+    required = workflow.split("  required:", 1)[1]
 
     assert "treating gate as non-failure" not in workflow
-    assert aggregate_tail.count("if: ${{ always() }}") == 4
-    assert "if: ${{ always() && !cancelled() }}" not in aggregate_tail
+    assert required.count("if: ${{ always() }}") == 1
+    assert "if: ${{ always() && !cancelled() }}" not in required
     assert "if: ${{ always() }}" in required
     assert "name: required" in workflow
-    assert "name: Python Tests" in workflow
-    assert "name: Lean Tests" in workflow
-    assert "name: Deployment Tests" in workflow
+    assert "name: Python Tests" not in workflow
+    assert "name: Lean Tests" not in workflow
+    assert "name: Deployment Tests" not in workflow
+    assert "python-test:" not in workflow
+    assert "lean-test:" not in workflow
+    assert "deployment-test:" not in workflow
     assert ("needs: [static, python, boundaries, wheel, coverage, lean]") in required
     assert "success|skipped" not in required
     assert 'test "$LEAN_RESULT" = success' in required


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CI kept three no-op jobs (`python-test` / Python Tests, `lean-test` / Lean Tests, `deployment-test` / Deployment Tests) whose only purpose was to re-check already-computed results so GitHub branch protection could keep using older check names.

That is extra indirection on top of the `required` aggregate, which already fail-closes when `static`, `python`, `boundaries`, `wheel`, `coverage`, or `lean` is not success.

## Solution

Delete the three mirror jobs. The merge gate is now the existing `required` job.

**Operator follow-up (required for this PR to merge):** retarget branch protection / rulesets from:

- `Python Tests`
- `Lean Tests`
- `Deployment Tests`

to:

- `required`

Then this PR's own required check can go green. Until that settings change, GitHub will still look for the deleted check names.

Docs now say branch protection should require `required` and should not grow new no-op aliases.

## Testing

Local results on this revision:

- `uv run pytest tests/unit/tooling/test_ci_execution_policy.py tests/unit/tooling/test_release_workflow.py`: 34 passed
- `make check`: ruff, complexity ratchet, mypy (484 files), and 935 unit tests passed
- `make docs-linkcheck`: Make/TESTS examples and Markdown links valid

Contributor quick path:

```sh
make setup
make check
```

- Specialist validation run (if any): unit tooling CI policy tests (`tests/unit/tooling/test_ci_execution_policy.py`)

## Trust & Compatibility Impact

None. No mathematical, checker, artifact, or public API change.

## Architecture Budget

Not an operation change.

## Checklist

- [x] `make check` passes
- [ ] Branch protection retargeted to `required`
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18b42396-e268-4cfa-a0ca-94db8753b0b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18b42396-e268-4cfa-a0ca-94db8753b0b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

