### PR TITLE
refactor(matrix): invert unimodular matrices with DomainMatrix.inv_den

### DIFF
--- a/src/jacobian/domains/_certified_snf.py
+++ b/src/jacobian/domains/_certified_snf.py
@@ -88,82 +88,30 @@ def matrix_columns(matrix: Matrix, start: int = 0) -> Matrix:
     ]
 
 
-def _reduce_pivot_to_unit(
-    augmented: list[list[int]],
-    *,
-    column: int,
-    size: int,
-) -> None:
-    """Reduce one diagonal entry to +/-1 by exact integer row reduction."""
-
-    while abs(augmented[column][column]) != 1:
-        selected = next(
-            (row for row in range(column + 1, size) if augmented[row][column] != 0),
-            None,
-        )
-        if selected is None:
-            raise ValueError("matrix is not unimodular")
-        quotient = augmented[column][column] // augmented[selected][column]
-        augmented[column] = [
-            value - quotient * other
-            for value, other in zip(augmented[column], augmented[selected], strict=True)
-        ]
-        augmented[column], augmented[selected] = (
-            augmented[selected],
-            augmented[column],
-        )
-
-
-def _eliminate_column_entries(
-    augmented: list[list[int]],
-    *,
-    column: int,
-    size: int,
-) -> None:
-    """Clear every off-diagonal entry in one column using its +/-1 pivot."""
-
-    pivot = augmented[column][column]
-    if pivot == -1:
-        augmented[column] = [-value for value in augmented[column]]
-    for row in range(size):
-        if row == column:
-            continue
-        factor = augmented[row][column]
-        if factor:
-            augmented[row] = [
-                value - factor * pivot_value
-                for value, pivot_value in zip(
-                    augmented[row], augmented[column], strict=True
-                )
-            ]
-
-
 def inverse_unimodular(matrix: Matrix) -> Matrix:
-    """Invert a unimodular integer matrix by exact Gauss-Jordan elimination."""
+    """Invert a unimodular integer matrix with SymPy ``DomainMatrix.inv_den``."""
 
     size = len(matrix)
     if any(len(row) != size for row in matrix):
         raise ValueError("unimodular inverse requires a square matrix")
     if size == 0:
         return []
-    augmented = [
-        [*row, *(1 if row_index == column else 0 for column in range(size))]
-        for row_index, row in enumerate(matrix)
-    ]
-    for column in range(size):
-        selected = next(
-            (row for row in range(column, size) if augmented[row][column] != 0),
-            None,
-        )
-        if selected is None:
-            raise ValueError("matrix is singular")
-        augmented[column], augmented[selected] = (
-            augmented[selected],
-            augmented[column],
-        )
-        _reduce_pivot_to_unit(augmented, column=column, size=size)
-        _eliminate_column_entries(augmented, column=column, size=size)
-    return [row[size:] for row in augmented]
+
+    from sympy import ZZ, eye
+    from sympy.polys.matrices import DomainMatrix
+    from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
+
+    domain = DomainMatrix.from_list_sympy(size, size, matrix).convert_to(ZZ)
+    try:
+        numerator, denominator = domain.inv_den()
+    except DMNonInvertibleMatrixError as exc:
+        raise ValueError("matrix is singular") from exc
+    numerator, denominator = numerator.cancel_denom(denominator)
+    if denominator != ZZ.one:
+        raise ValueError("matrix is not unimodular")
+    if domain.matmul(numerator).to_Matrix() != eye(size):
+        raise ArithmeticError("unimodular inverse does not recover the identity")
+    return [[int(value) for value in row] for row in numerator.to_Matrix().tolist()]
 
 
 def smith_reduce(

--- a/tests/domain/matrix/test_inverse_unimodular.py
+++ b/tests/domain/matrix/test_inverse_unimodular.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from random import Random
+
+import pytest
+
+from jacobian.domains._certified_snf import (
+    identity_matrix,
+    inverse_unimodular,
+    matrix_multiply,
+)
+
+
+def _random_unimodular(random: Random, size: int) -> list[list[int]]:
+    matrix = identity_matrix(size)
+    for _ in range(size * 6):
+        i, j = random.randrange(size), random.randrange(size)
+        if i == j:
+            if random.random() < 0.5:
+                matrix[i] = [-value for value in matrix[i]]
+            continue
+        factor = random.randint(-5, 5)
+        matrix[i] = [
+            value + factor * other
+            for value, other in zip(matrix[i], matrix[j], strict=True)
+        ]
+    if random.random() < 0.5:
+        a, b = random.randrange(size), random.randrange(size)
+        matrix[a], matrix[b] = matrix[b], matrix[a]
+    return matrix
+
+
+def test_inverse_unimodular_empty_matrix() -> None:
+    assert inverse_unimodular([]) == []
+
+
+def test_inverse_unimodular_recovers_identity_on_sl2() -> None:
+    source = [[1, 1], [0, 1]]
+    inverse = inverse_unimodular(source)
+    assert inverse == [[1, -1], [0, 1]]
+    assert matrix_multiply(source, inverse) == identity_matrix(2)
+    assert matrix_multiply(inverse, source) == identity_matrix(2)
+
+
+def test_inverse_unimodular_accepts_determinant_minus_one() -> None:
+    source = [[0, 1], [1, 0]]
+    inverse = inverse_unimodular(source)
+    assert matrix_multiply(source, inverse) == identity_matrix(2)
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 4, 5])
+def test_inverse_unimodular_round_trips_random_unimodular_matrices(size: int) -> None:
+    random = Random(1127 + size)
+    for _ in range(20):
+        source = _random_unimodular(random, size)
+        inverse = inverse_unimodular(source)
+        assert matrix_multiply(source, inverse) == identity_matrix(size)
+        assert matrix_multiply(inverse, source) == identity_matrix(size)
+
+
+def test_inverse_unimodular_rejects_non_square_matrices() -> None:
+    with pytest.raises(ValueError, match="square"):
+        inverse_unimodular([[1, 0]])
+
+
+def test_inverse_unimodular_rejects_singular_matrices() -> None:
+    with pytest.raises(ValueError, match="singular"):
+        inverse_unimodular([[1, 2], [2, 4]])
+
+
+def test_inverse_unimodular_rejects_non_unimodular_matrices() -> None:
+    with pytest.raises(ValueError, match="unimodular"):
+        inverse_unimodular([[2, 0], [0, 1]])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Issue #1127: `inverse_unimodular()` in `src/jacobian/domains/_certified_snf.py` implemented exact Gauss–Jordan over integers instead of using SymPy’s maintained `DomainMatrix.inv_den`. Topology integral homology is the production caller.

## Solution

Delegate inversion to `DomainMatrix.from_list_sympy(...).convert_to(ZZ).inv_den()`, cancel the denominator, and refuse anything that is not unimodular (`den != 1`). Map `DMNonInvertibleMatrixError` to the existing singular refusal. Require `A * A^{-1} = I` before returning native integer entries.

Keep `smith_reduce()`, matrix helpers, and the independent SNF/topology checkers. They already replay certificates without calling `inverse_unimodular`.

## Testing

- `make check`
- `make test-domain TESTS="tests/domain/matrix/test_inverse_unimodular.py tests/domain/topology/test_topology_operations.py tests/domain/certified_snf/"` (34 passed)

New tests cover empty, SL(2,Z), det −1, random unimodular round-trips, and singular/non-square/non-unimodular refusals.

- Specialist validation run (if any): `make test-domain TESTS=tests/domain/matrix/test_inverse_unimodular.py tests/domain/topology/test_topology_operations.py tests/domain/certified_snf/`

## Trust & Compatibility Impact

Producer-only change. Independent checkers (`jacobian_checkers/certified_snf.py`, simplicial topology integral replay) are unchanged. Public wire contracts are unchanged.

## Architecture Budget

One semantic function (`inverse_unimodular`) now delegates to one maintained backend API (`DomainMatrix.inv_den`). No new shared abstraction.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

Fixes #1127

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

