### PR TITLE
refactor(graph): decode graph6 with NetworkX and keep Jacobian policy

### DIFF
--- a/src/jacobian/math/graphs/_networkx.py
+++ b/src/jacobian/math/graphs/_networkx.py
@@ -70,6 +70,26 @@ def graph_from_value(value: SimpleUndirectedGraph) -> nx.Graph[str]:
     return graph
 
 
+def graph_from_graph6(encoded: str) -> nx.Graph[Any]:
+    """Decode one standard graph6 payload with NetworkX's maintained codec."""
+
+    try:
+        payload = encoded.encode("ascii")
+        graph = nx.from_graph6_bytes(payload)
+    except (UnicodeEncodeError, ValueError, IndexError, nx.NetworkXError) as exc:
+        raise ValueError(
+            "graph6 payload is malformed or uses an extended header"
+        ) from exc
+    return graph
+
+
+def graph6_canonical_bytes(graph: nx.Graph[Any]) -> bytes:
+    """Return headerless graph6 bytes without NetworkX's trailing newline."""
+
+    encoded = bytes(nx.to_graph6_bytes(graph, header=False))
+    return encoded[:-1] if encoded.endswith(b"\n") else encoded
+
+
 def graph_value(graph: nx.Graph[Any]) -> SimpleUndirectedGraph:
     """Canonicalize a transient NetworkX graph as an immutable graph value."""
 

--- a/src/jacobian/math/graphs/graph6.py
+++ b/src/jacobian/math/graphs/graph6.py
@@ -61,20 +61,21 @@ def decode_graph6(encoded: str) -> Graph6DecodeValue:
     bit_count = order * (order - 1) // 2
     if len(codes) != 1 + (bit_count + 5) // 6:
         raise ValueError("graph6 payload length does not match its order header")
-    bits = [(code >> shift) & 1 for code in codes[1:] for shift in range(5, -1, -1)]
-    if any(bits[bit_count:]):
+
+    from jacobian.math.graphs import _networkx
+
+    graph = _networkx.graph_from_graph6(value)
+    if graph.number_of_nodes() != order:
+        raise ValueError("graph6 payload is malformed or uses an extended header")
+    if _networkx.graph6_canonical_bytes(graph) != value.encode("ascii"):
         raise ValueError("unused graph6 padding bits must be zero")
-    pairs = [(first, second) for second in range(1, order) for first in range(second)]
     edges = tuple(
         Graph6Edge(first=first, second=second)
         for first, second in sorted(
-            pair for pair, bit in zip(pairs, bits, strict=False) if bit
+            (min(left, right), max(left, right)) for left, right in graph.edges
         )
     )
-    degrees = [0] * order
-    for edge in edges:
-        degrees[edge.first] += 1
-        degrees[edge.second] += 1
+    degrees = tuple(int(graph.degree(vertex)) for vertex in range(order))
     digest_payload = {
         "order": order,
         "edges": [[edge.first, edge.second] for edge in edges],
@@ -83,7 +84,7 @@ def decode_graph6(encoded: str) -> Graph6DecodeValue:
         graph6=value,
         order=order,
         edges=edges,
-        degrees=tuple(degrees),
+        degrees=degrees,
         graph_digest="sha256:" + sha256(canonicalize_json(digest_payload)).hexdigest(),
     )
 

--- a/tests/domain/graph/test_graph6_networkx.py
+++ b/tests/domain/graph/test_graph6_networkx.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from random import Random
+
+import networkx as nx
+import pytest
+
+from jacobian.math.graphs.graph6 import decode_graph6
+
+
+def test_decode_graph6_matches_networkx_on_standard_encodings() -> None:
+    decoded = decode_graph6("Bw")
+    graph = nx.from_graph6_bytes(b"Bw")
+    assert decoded.order == graph.order() == 3
+    assert [(edge.first, edge.second) for edge in decoded.edges] == sorted(
+        graph.edges()
+    )
+    assert decoded.degrees == (2, 2, 2)
+
+
+def test_decode_graph6_strips_standard_header() -> None:
+    assert decode_graph6(">>graph6<<Bw").graph6 == "Bw"
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        (":A", "only standard graph6"),
+        ("&A", "only standard graph6"),
+        ("~A", "extended header"),
+        ("Bw\n", "malformed"),
+        ("A@", "padding bits"),
+        ("A", "length"),
+    ],
+)
+def test_decode_graph6_rejects_encodings_networkx_would_repair(
+    payload: str, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        decode_graph6(payload)
+
+
+def test_decode_graph6_agrees_with_networkx_for_small_orders() -> None:
+    random = Random(1119)
+    for order in range(63):
+        graph = nx.gnp_random_graph(order, 0.35, seed=random.randrange(10**6))
+        payload = nx.to_graph6_bytes(graph, header=False).decode("ascii").rstrip("\n")
+        decoded = decode_graph6(payload)
+        assert decoded.order == order
+        assert [(edge.first, edge.second) for edge in decoded.edges] == sorted(
+            (min(left, right), max(left, right)) for left, right in graph.edges
+        )
+        assert decoded.degrees == tuple(graph.degree(vertex) for vertex in range(order))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Issue #1119: the graph6 producer in `jacobian.math.graphs.graph6` hand-rolled the bitstream parser even though NetworkX 3.6.1 already ships `from_graph6_bytes` / `to_graph6_bytes`.

## Solution

Keep Jacobian policy in the producer (orders 0–62, reject sparse6/digraph6/extended headers, exact length, **zero padding bits**, no trailing newline, Jacobian-canonical digest). Delegate graph reconstruction to NetworkX in `jacobian.math.graphs._networkx`. Round-trip through `to_graph6_bytes` to refuse encodings NetworkX would silently repair (nonzero padding).

**Unchanged:** `jacobian_checkers/graph6.py` remains a stdlib-only independent replay.

## Testing

- `make check`
- `make test-domain TESTS="tests/domain/graph/test_graph6.py tests/domain/graph/test_graph6_networkx.py"` (11 passed), including H24 compute+verify and differential agreement with NetworkX for orders 0–62

- Specialist validation run (if any): `make test-domain TESTS=tests/domain/graph/test_graph6.py tests/domain/graph/test_graph6_networkx.py`

## Trust & Compatibility Impact

Producer-only. Independent checker does not import NetworkX. Public `Graph6DecodeValue` contract is unchanged.

## Architecture Budget

One public `decode_graph6` function; NetworkX stays in the existing private `_networkx` backend.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

Fixes #1119

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

