### PR TITLE
refactor(math): replace prime-field elimination with DomainMatrix pivots

### DIFF
--- a/src/jacobian/math/prime_field_linear_algebra.py
+++ b/src/jacobian/math/prime_field_linear_algebra.py
@@ -92,72 +92,23 @@ def rank(matrix: PrimeFieldMatrix) -> int:
 def nullspace(matrix: PrimeFieldMatrix) -> tuple[tuple[int, ...], ...]:
     """Return a deterministic basis of the right nullspace."""
 
-    reduced, pivots = rref(matrix)
-    free_columns = tuple(
-        column for column in range(matrix.columns) if column not in pivots
+    if matrix.columns == 0:
+        return ()
+    domain = _domain_matrix(matrix).nullspace(divide_last=True)
+    return tuple(
+        tuple(int(value) % matrix.prime for value in row) for row in domain.to_list()
     )
-    basis: list[tuple[int, ...]] = []
-    for free in free_columns:
-        vector = [0] * matrix.columns
-        vector[free] = 1
-        for row, pivot in enumerate(pivots):
-            vector[pivot] = -reduced[row][free] % matrix.prime
-        basis.append(tuple(vector))
-    return tuple(basis)
-
-
-class _IncrementalVectorBasis:
-    def __init__(self, *, dimension: int, prime: int) -> None:
-        self._prime = prime
-        self._rows: dict[int, list[int]] = {}
-        self._dimension = dimension
-
-    def add(self, vector: Sequence[int]) -> bool:
-        reduced = [value % self._prime for value in vector]
-        if len(reduced) != self._dimension:
-            raise ValueError("basis vector has the wrong dimension")
-        for existing_pivot, row in self._rows.items():
-            factor = reduced[existing_pivot]
-            if factor:
-                reduced = [
-                    (value - factor * basis_value) % self._prime
-                    for value, basis_value in zip(reduced, row, strict=True)
-                ]
-        new_pivot = next(
-            (index for index, value in enumerate(reduced) if value),
-            None,
-        )
-        if new_pivot is None:
-            return False
-        inverse = pow(reduced[new_pivot], -1, self._prime)
-        reduced = [value * inverse % self._prime for value in reduced]
-        for existing_pivot, row in tuple(self._rows.items()):
-            factor = row[new_pivot]
-            if factor:
-                self._rows[existing_pivot] = [
-                    (value - factor * basis_value) % self._prime
-                    for value, basis_value in zip(row, reduced, strict=True)
-                ]
-        self._rows[new_pivot] = reduced
-        self._rows = dict(sorted(self._rows.items()))
-        return True
 
 
 def column_basis(matrix: PrimeFieldMatrix) -> tuple[tuple[int, ...], ...]:
     """Return the first independent columns in source order."""
 
-    if matrix.columns == 0:
+    if matrix.columns == 0 or not matrix.entries:
         return ()
-    selected: list[tuple[int, ...]] = []
-    basis = _IncrementalVectorBasis(
-        dimension=len(matrix.entries),
-        prime=matrix.prime,
+    _, pivots = rref(matrix)
+    return tuple(
+        tuple(row[pivot] % matrix.prime for row in matrix.entries) for pivot in pivots
     )
-    for column in range(matrix.columns):
-        vector = tuple(row[column] % matrix.prime for row in matrix.entries)
-        if basis.add(vector):
-            selected.append(vector)
-    return tuple(selected)
 
 
 def quotient_basis(
@@ -170,13 +121,25 @@ def quotient_basis(
 
     # Validate the prime even for the empty quotient.
     dimension = len(cycles[0]) if cycles else (len(boundaries[0]) if boundaries else 0)
+    if any(len(vector) != dimension for vector in (*cycles, *boundaries)):
+        raise ValueError("basis vector has the wrong dimension")
     PrimeFieldMatrix(prime=prime, entries=(), columns=dimension)
-    basis = _IncrementalVectorBasis(dimension=dimension, prime=prime)
-    for boundary in boundaries:
-        basis.add(boundary)
-    quotient: list[tuple[int, ...]] = []
-    for cycle in cycles:
-        vector = tuple(cycle)
-        if basis.add(vector):
-            quotient.append(vector)
-    return tuple(quotient)
+    if dimension == 0 or not cycles:
+        return ()
+    columns = tuple(
+        tuple(int(value) % prime for value in vector) for vector in boundaries
+    ) + tuple(tuple(int(value) % prime for value in vector) for vector in cycles)
+    stacked = PrimeFieldMatrix(
+        prime=prime,
+        entries=tuple(
+            tuple(vector[row] for vector in columns) for row in range(dimension)
+        ),
+        columns=len(columns),
+    )
+    _, pivots = rref(stacked)
+    boundary_count = len(boundaries)
+    return tuple(
+        tuple(cycles[pivot - boundary_count])
+        for pivot in pivots
+        if pivot >= boundary_count
+    )

--- a/tests/unit/public_api/test_prime_field_linear_algebra.py
+++ b/tests/unit/public_api/test_prime_field_linear_algebra.py
@@ -39,6 +39,25 @@ def test_column_and_quotient_bases_are_source_ordered() -> None:
     ) == ((0, 1, 0), (0, 0, 1))
 
 
+def test_column_basis_returns_original_pivot_columns() -> None:
+    matrix = PrimeFieldMatrix(
+        prime=5,
+        entries=((1, 2, 3, 4), (0, 0, 1, 1)),
+        columns=4,
+    )
+    assert column_basis(matrix) == ((1, 0), (3, 1))
+
+
+def test_quotient_basis_keeps_original_cycle_vectors() -> None:
+    cycles = ((2, 1, 0), (1, 1, 0), (0, 0, 1))
+    assert quotient_basis(cycles, ((1, 3, 0),), prime=5) == ((1, 1, 0), (0, 0, 1))
+
+
+def test_quotient_basis_rejects_ragged_vectors() -> None:
+    with pytest.raises(ValueError, match="dimension"):
+        quotient_basis(((1, 0),), ((1, 0, 0),), prime=3)
+
+
 def test_empty_shapes_remain_explicit() -> None:
     zero_by_three = PrimeFieldMatrix(prime=2, entries=(), columns=3)
     three_by_zero = PrimeFieldMatrix(prime=2, entries=((), (), ()), columns=0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Issue #1126: `jacobian.math.prime_field_linear_algebra` already used SymPy `DomainMatrix` for RREF and rank, then ran a second Gaussian-elimination engine (`_IncrementalVectorBasis`) for column and quotient bases, and reconstructed nullspace by hand from RREF.

## Solution

- `nullspace` → `DomainMatrix.nullspace(divide_last=True)`
- `column_basis` → RREF pivot indices, then those **original matrix columns**
- `quotient_basis` → stack boundary columns then cycle columns, one RREF, keep cycle columns whose indices become new pivots
- Delete `_IncrementalVectorBasis`

Independent checker `jacobian_checkers/simplicial_topology.py` is unchanged.

## Testing

- `make check`
- `make test-unit TESTS=tests/unit/public_api/test_prime_field_linear_algebra.py`
- `make test-domain TESTS=tests/domain/topology/` (26 passed)
- `make test-component TESTS=tests/component/checkers/test_simplicial_topology_checker.py` (16 passed)

- Specialist validation run (if any): `make test-domain TESTS=tests/domain/topology/` and `make test-component TESTS=tests/component/checkers/test_simplicial_topology_checker.py`

## Trust & Compatibility Impact

Producer linear algebra only. Checker replay remains stdlib modular RREF. Public prime-field API signatures are unchanged; provenance of returned basis vectors is preserved.

## Architecture Budget

Same public functions; one maintained DomainMatrix pivot computation replaces the local elimination class.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

Fixes #1126

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

