### PR TITLE
test(cli): ratchet projection tests off complete-portfolio cold starts

### DIFF
--- a/tests/composition/cli/test_cli.py
+++ b/tests/composition/cli/test_cli.py
@@ -24,6 +24,7 @@ def test_cli_help_exposes_only_math_and_operator_commands() -> None:
 
 
 def test_cli_init_reports_installed_operation_count(tmp_path: Path) -> None:
+    """Complete-portfolio smoke: jacobian init compiles the built-in catalog."""
     result = CliRunner().invoke(
         app,
         ["--state-dir", str(tmp_path), "init"],

--- a/tests/unit/tooling/test_architecture_test_ownership.py
+++ b/tests/unit/tooling/test_architecture_test_ownership.py
@@ -169,7 +169,40 @@ def test_discarded_complete_runtime_fixture_is_rejected(tmp_path: Path) -> None:
     ]
 
 
-def test_owned_composition_module_is_accepted(tmp_path: Path) -> None:
+def test_cli_projection_tests_cannot_cold_start_the_complete_portfolio(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path,
+        "tests/composition/cli/test_cli.py",
+        "from jacobian.cli import app, create_cli_app\n"
+        "from tests.support.catalog_build_runtime import create_catalog_build_runtime\n"
+        "\n"
+        "def test_cli_catalog_lists_operations(tmp_path):\n"
+        "    create_catalog_build_runtime(tmp_path)\n"
+        "    create_cli_app()\n"
+        "    CliRunner().invoke(app, ['catalog'])\n",
+    )
+
+    messages = _ownership_messages(tmp_path)
+
+    assert any(
+        "CLI projection tests must use selected_runtime_opener" in message
+        for message in messages
+    )
+
+
+def test_cli_init_complete_smoke_may_use_the_default_app(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "tests/composition/cli/test_cli.py",
+        "from jacobian.cli import app\n"
+        "\n"
+        "def test_cli_init_reports_installed_operation_count(tmp_path):\n"
+        "    CliRunner().invoke(app, ['init'])\n",
+    )
+
+    assert _ownership_messages(tmp_path) == []
     _write(tmp_path, "tests/composition/interoperability/test_value_handoff.py")
 
     assert _ownership_messages(tmp_path) == []

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -1618,6 +1618,13 @@ _HISTORICAL_TEST_BUCKET_WORDS = frozenset(
 _COMPOSITION_OWNERS = frozenset(
     {"authority", "catalog", "cli", "interoperability", "runtime"}
 )
+_CLI_COMPLETE_PORTFOLIO_ALLOWLIST = frozenset(
+    {
+        "test_cli_help_exposes_only_math_and_operator_commands",
+        "test_cli_init_reports_installed_operation_count",
+        "test_cli_run_requires_exactly_one_payload_source",
+    }
+)
 
 
 def _imports_complete_runtime_fixtures(tree: ast.AST) -> bool:
@@ -1643,6 +1650,62 @@ def _imports_jacobian_runtime(tree: ast.AST) -> bool:
             ):
                 return True
     return False
+
+
+def _create_cli_app_call_has_runtime_opener(node: ast.Call) -> bool:
+    return any(keyword.arg == "runtime_opener" for keyword in node.keywords)
+
+
+def _calls_unscoped_cli_runtime(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if (
+            isinstance(func, ast.Name)
+            and func.id == "create_cli_app"
+            and (not _create_cli_app_call_has_runtime_opener(child))
+        ):
+            return True
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "create_cli_app"
+            and (not _create_cli_app_call_has_runtime_opener(child))
+        ):
+            return True
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "invoke"
+            and child.args
+            and isinstance(child.args[0], ast.Name)
+            and child.args[0].id == "app"
+        ):
+            return True
+    return _calls_catalog_build_runtime(node)
+
+
+def _cli_projection_violations(
+    relative: PurePosixPath, tree: ast.AST
+) -> tuple[Violation, ...]:
+    parts = relative.parts
+    if len(parts) < 3 or parts[1] != "composition" or parts[2] != "cli":
+        return ()
+    violations: list[Violation] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        if node.name in _CLI_COMPLETE_PORTFOLIO_ALLOWLIST:
+            continue
+        if _calls_unscoped_cli_runtime(node):
+            violations.append(
+                Violation(
+                    str(relative),
+                    "test-ownership",
+                    "CLI projection tests must use selected_runtime_opener; "
+                    f"{node.name} cold-starts the complete portfolio",
+                )
+            )
+    return tuple(violations)
 
 
 def _discarded_runtime_setup_violations(
@@ -1686,6 +1749,7 @@ def _test_ownership_violations(
             )
         )
     violations.extend(_discarded_runtime_setup_violations(relative, tree))
+    violations.extend(_cli_projection_violations(relative, tree))
 
     if (
         not focused_suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Issue #1377: CLI command-projection tests used to cold-start the complete portfolio. Catalog/inspect/run tests already use `selected_runtime_opener`; `jacobian init` remains the one complete compile smoke. Nothing prevented a new projection test from calling `create_catalog_build_runtime` or the default `app`.

## Solution

Architecture ratchet in `tools/check_architecture.py`: composition CLI tests that are not on the complete-portfolio allowlist must use `create_cli_app(runtime_opener=...)`. Allowlisted smokes: help, `test_cli_init_reports_installed_operation_count`, and the payload-source error path.

## Testing

- `make check`
- `make test-unit TESTS=tests/unit/tooling/test_architecture_test_ownership.py`

- Specialist validation run (if any): none; this is a unit/architecture ratchet. Existing selected-runtime CLI projection tests are unchanged.

## Trust & Compatibility Impact

Test-only. Production CLI and catalog compilation are unchanged.

## Architecture Budget

No new product abstraction. One architecture check plus allowlist for the remaining complete-portfolio CLI smokes.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

Fixes #1377

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

