### PR TITLE
test(storage): stop catalog-build reopen on snapshot copy smoke

### DIFF
--- a/tests/boundary/storage/conftest.py
+++ b/tests/boundary/storage/conftest.py
@@ -2,22 +2,6 @@
 
 from __future__ import annotations
 
-from tests.support.complete_runtime_fixtures import (
-    attached_complete_runtime,
-    attached_complete_runtime_read_only,
-    authorized_complete_runtime,
-    authorized_complete_runtime_read_only,
-    authorized_portfolio_template,
-    complete_portfolio_template,
-    fresh_complete_runtime,
-)
+from tests.support.complete_runtime_fixtures import complete_portfolio_template
 
-__all__ = (
-    "attached_complete_runtime",
-    "attached_complete_runtime_read_only",
-    "authorized_complete_runtime",
-    "authorized_complete_runtime_read_only",
-    "authorized_portfolio_template",
-    "complete_portfolio_template",
-    "fresh_complete_runtime",
-)
+__all__ = ("complete_portfolio_template",)

--- a/tests/boundary/storage/durability/startup/test_suite_fixtures.py
+++ b/tests/boundary/storage/durability/startup/test_suite_fixtures.py
@@ -5,10 +5,11 @@ import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from tests.support.catalog_build_options import CheckerAuthorityMode
-from tests.support.catalog_build_runtime import create_catalog_build_runtime
 from tests.support.state import publish_template, quiesce_sqlite_template
 
+from jacobian import __version__
+from jacobian.operation_catalog import OperationCatalog
+from jacobian.operation_visibility import OperationVisibilityPolicy
 from jacobian.runtime.bootstrap import bootstrap_services
 from jacobian.storage.repository import ArtifactRepository
 
@@ -125,7 +126,9 @@ def test_complete_portfolio_template_is_quiescent_and_copyable(
         destination,
         descriptor_uri=_polynomial_expression_schema_uri(complete_portfolio_template),
     )
-    with create_catalog_build_runtime(
-        destination, checker_authority=CheckerAuthorityMode.NONE
-    ) as runtime:
-        assert runtime.core.operations.snapshot().operations
+    catalog = OperationCatalog(
+        destination / "metadata.sqlite3",
+        OperationVisibilityPolicy(),
+        expected_package_version=__version__,
+    )
+    assert catalog.snapshot().operations

--- a/tests/boundary/storage/durability/startup/test_suite_fixtures.py
+++ b/tests/boundary/storage/durability/startup/test_suite_fixtures.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 from tests.support.state import publish_template, quiesce_sqlite_template
 
-from jacobian import __version__
-from jacobian.operation_catalog import OperationCatalog
-from jacobian.operation_visibility import OperationVisibilityPolicy
 from jacobian.runtime.bootstrap import bootstrap_services
 from jacobian.storage.repository import ArtifactRepository
 
@@ -51,6 +48,16 @@ def _polynomial_expression_schema_uri(root: Path) -> str:
         connection.close()
     assert row is not None
     return str(row[0])
+
+
+def _artifact_count(root: Path) -> int:
+    connection = sqlite3.connect(root / "metadata.sqlite3")
+    try:
+        row = connection.execute("SELECT COUNT(*) FROM artifacts").fetchone()
+    finally:
+        connection.close()
+    assert row is not None
+    return int(row[0])
 
 
 def _build_sentinel_store(staging: Path) -> None:
@@ -126,9 +133,6 @@ def test_complete_portfolio_template_is_quiescent_and_copyable(
         destination,
         descriptor_uri=_polynomial_expression_schema_uri(complete_portfolio_template),
     )
-    catalog = OperationCatalog(
-        destination / "metadata.sqlite3",
-        OperationVisibilityPolicy(),
-        expected_package_version=__version__,
-    )
-    assert catalog.snapshot().operations
+    original_artifacts = _artifact_count(complete_portfolio_template)
+    assert original_artifacts > 0
+    assert _artifact_count(destination) == original_artifacts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #1375.

Storage durability snapshot tests still reopened a catalog-build runtime after copying the complete-portfolio template, and `tests/boundary/storage/conftest.py` re-exported unused complete/authorized runtime fixtures that can trigger session builds.

Clone-stress already uses the sentinel store, and polytope hydration already lives in `tests/composition/authority/test_hydrate_authorized.py`. The leftover work is fixture-scope and reopen cost on the remaining complete-template smoke.

The complete-portfolio template persists artifacts, not an `OperationCatalog` snapshot, so a serving-catalog open is the wrong reader.

## Solution

- Trim `tests/boundary/storage/conftest.py` to the one fixture storage tests use: `complete_portfolio_template`.
- Keep the complete-template quiescence/copy smoke.
- After copy, assert SQLite integrity, readable schema artifacts, and equal artifact counts. Do not call `create_catalog_build_runtime`.

## Testing

Contributor quick path:

```sh
make setup
make check
```

- Specialist validation run: `make test-storage TESTS=tests/boundary/storage/durability/startup/test_suite_fixtures.py`

## Trust & Compatibility Impact

None. Test-only change. Does not affect the verification kernel, checker registry, artifact format, or public API.

## Architecture Budget

Not an ordinary operation. No new shared abstraction.

## Checklist
- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

