### PR TITLE
test(e2e): stop reinstalling bundled checkers on MCP journeys

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,58 +2,30 @@
 
 from __future__ import annotations
 
-import sqlite3
-import time
 from pathlib import Path
 
 import pytest
-from tests.support.runtime_templates import template_target
-from tests.support.state import publish_template, quiesce_sqlite_template
 
 from jacobian.operator_lifecycle import CheckerAuthorization, initialize_state
-
-
-def _quiesce_initialized_state(root: Path) -> None:
-    """Checkpoint after ``initialize_state`` once SQLite releases the store."""
-
-    last_error: sqlite3.OperationalError | None = None
-    for _ in range(20):
-        try:
-            quiesce_sqlite_template(root)
-            return
-        except sqlite3.OperationalError as exc:
-            last_error = exc
-            time.sleep(0.05)
-    assert last_error is not None
-    raise last_error
 
 
 @pytest.fixture(scope="session")
 def initialized_authorized_state_template(
     tmp_path_factory: pytest.TempPathFactory,
-    request: pytest.FixtureRequest,
 ) -> Path:
-    """Publish one immutable operator-initialized bundled-checker MCP snapshot.
+    """Publish one operator-initialized bundled-checker MCP snapshot.
 
     MCP serving reads ``OperationCatalog``. Complete catalog-build templates do
     not persist that snapshot, so this fixture uses ``initialize_state`` once
     and every non-install journey copies the result.
     """
 
-    target, lock = template_target(
-        tmp_path_factory,
-        request,
-        "initialized-authorized-state-template",
+    root = tmp_path_factory.mktemp("initialized-authorized-state")
+    initialize_state(
+        root,
+        checker_authorization=CheckerAuthorization.BUNDLED,
     )
-
-    def build(staging: Path) -> None:
-        initialize_state(
-            staging,
-            checker_authorization=CheckerAuthorization.BUNDLED,
-        )
-        _quiesce_initialized_state(staging)
-
-    return publish_template(target, build, lock=lock)
+    return root
 
 
 __all__ = ("initialized_authorized_state_template",)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,23 +1,42 @@
-"""Small public-surface test configuration."""
+"""End-to-end caller-visible journey fixtures."""
 
 from __future__ import annotations
 
-from tests.support.complete_runtime_fixtures import (
-    attached_complete_runtime,
-    attached_complete_runtime_read_only,
-    authorized_complete_runtime,
-    authorized_complete_runtime_read_only,
-    authorized_portfolio_template,
-    complete_portfolio_template,
-    fresh_complete_runtime,
-)
+from pathlib import Path
 
-__all__ = (
-    "attached_complete_runtime",
-    "attached_complete_runtime_read_only",
-    "authorized_complete_runtime",
-    "authorized_complete_runtime_read_only",
-    "authorized_portfolio_template",
-    "complete_portfolio_template",
-    "fresh_complete_runtime",
-)
+import pytest
+from tests.support.runtime_templates import template_target
+from tests.support.state import publish_template, quiesce_sqlite_template
+
+from jacobian.operator_lifecycle import CheckerAuthorization, initialize_state
+
+
+@pytest.fixture(scope="session")
+def initialized_authorized_state_template(
+    tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
+) -> Path:
+    """Publish one immutable operator-initialized bundled-checker MCP snapshot.
+
+    MCP serving reads ``OperationCatalog``. Complete catalog-build templates do
+    not persist that snapshot, so this fixture uses ``initialize_state`` once
+    and every non-install journey copies the result.
+    """
+
+    target, lock = template_target(
+        tmp_path_factory,
+        request,
+        "initialized-authorized-state-template",
+    )
+
+    def build(staging: Path) -> None:
+        initialize_state(
+            staging,
+            checker_authorization=CheckerAuthorization.BUNDLED,
+        )
+        quiesce_sqlite_template(staging)
+
+    return publish_template(target, build, lock=lock)
+
+
+__all__ = ("initialized_authorized_state_template",)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+import time
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,21 @@ from tests.support.runtime_templates import template_target
 from tests.support.state import publish_template, quiesce_sqlite_template
 
 from jacobian.operator_lifecycle import CheckerAuthorization, initialize_state
+
+
+def _quiesce_initialized_state(root: Path) -> None:
+    """Checkpoint after ``initialize_state`` once SQLite releases the store."""
+
+    last_error: sqlite3.OperationalError | None = None
+    for _ in range(20):
+        try:
+            quiesce_sqlite_template(root)
+            return
+        except sqlite3.OperationalError as exc:
+            last_error = exc
+            time.sleep(0.05)
+    assert last_error is not None
+    raise last_error
 
 
 @pytest.fixture(scope="session")
@@ -34,7 +51,7 @@ def initialized_authorized_state_template(
             staging,
             checker_authorization=CheckerAuthorization.BUNDLED,
         )
-        quiesce_sqlite_template(staging)
+        _quiesce_initialized_state(staging)
 
     return publish_template(target, build, lock=lock)
 

--- a/tests/e2e/operation_workflows/test_operation_round_trips.py
+++ b/tests/e2e/operation_workflows/test_operation_round_trips.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from mcp import Client
@@ -15,7 +16,11 @@ from tests.support.rationals import rational_payload as _q
 from tests.support.state import copy_template
 
 from jacobian.adapters.mcp.server import create_server
-from jacobian.operator_lifecycle import CheckerAuthorization, initialize_state
+from jacobian.operator_lifecycle import (
+    CheckerAuthorization,
+    active_catalog_revision,
+    initialize_state,
+)
 
 
 def _polynomial(*coefficients_ascending: int) -> dict[str, object]:
@@ -107,32 +112,38 @@ def test_exact_domain_result_verifies_and_replays_after_restart(
                 record["payload"]["semantics_uri"],
             ]
 
-        restarted = create_server(tmp_path)
-        async with Client(restarted, raise_exceptions=True) as client:
-            replayed = await _tool(
-                client,
-                "math.run",
-                {
-                    "operation_id": "polynomial.gcd.verify",
-                    "payload": {"input": gcd_input, "candidate": candidate},
-                },
-            )
-            assert replayed["output"]["status"] == "VERIFIED"
-            assert replayed["output"]["verification_record_uri"] == record_uri
-            assert (await _artifact(client, record_uri))["artifact_uri"] == record_uri
+        revision = active_catalog_revision(tmp_path)
+        assert revision is not None
+        with patch("jacobian.operator_lifecycle._build_catalog") as build_catalog:
+            restarted = create_server(tmp_path)
+            async with Client(restarted, raise_exceptions=True) as client:
+                replayed = await _tool(
+                    client,
+                    "math.run",
+                    {
+                        "operation_id": "polynomial.gcd.verify",
+                        "payload": {"input": gcd_input, "candidate": candidate},
+                    },
+                )
+                assert replayed["output"]["status"] == "VERIFIED"
+                assert replayed["output"]["verification_record_uri"] == record_uri
+                assert (await _artifact(client, record_uri))[
+                    "artifact_uri"
+                ] == record_uri
+            build_catalog.assert_not_called()
+        assert active_catalog_revision(tmp_path) == revision
 
     asyncio.run(scenario())
 
 
 def test_polynomial_factor_result_verifies_through_mcp(
     tmp_path: Path,
-    authorized_portfolio_template: Path,
+    initialized_authorized_state_template: Path,
 ) -> None:
     async def scenario() -> None:
-        state = copy_template(authorized_portfolio_template, tmp_path / "state")
-        initialize_state(
-            state,
-            checker_authorization=CheckerAuthorization.BUNDLED,
+        state = copy_template(
+            initialized_authorized_state_template,
+            tmp_path / "state",
         )
         server = create_server(state)
         async with Client(server, raise_exceptions=True) as client:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #1385.

E2E MCP journeys were paying complete bundled-checker installation more than once. `test_polynomial_factor_result_verifies_through_mcp` copied `authorized_portfolio_template` (itself a catalog-build `INSTALL_BUNDLED` snapshot) and then called `initialize_state(..., BUNDLED)` again so `create_server` could read an `OperationCatalog`. Catalog-build templates do not persist that snapshot, so the second call recompiled and reauthorized the portfolio.

The restart path already used a second `create_server` only; this PR makes that contract explicit.

## Solution

- Keep `test_exact_domain_result_verifies_and_replays_after_restart` as the one fresh `initialize_state(BUNDLED)` journey. After the first server closes, reopen with `create_server` only and assert the catalog revision is unchanged and `operator_lifecycle._build_catalog` is not called.
- Keep `test_computed_domain_operation_remains_available_without_checker_authority` as the `NONE` fail-closed journey.
- Publish one session-scoped operator-initialized snapshot (`initialized_authorized_state_template`) and copy it for the factor/verify/reject/over-bound journey. Do not call `initialize_state` on that copy.
- Stop re-exporting unused complete-runtime fixtures from `tests/e2e/conftest.py`, which can trigger extra session builds.

`authorized_portfolio_template` is the wrong snapshot for MCP serving: it authorizes checkers through catalog-build and does not write `OperationCatalog`. The new fixture uses the public `initialize_state` path that `create_server` actually reads.

## Testing

Contributor quick path:

```sh
make setup
make check
```

- Specialist validation run: `make test-e2e TESTS=tests/e2e/operation_workflows/test_operation_round_trips.py`

Local result: 3 passed, 1 skipped (Lean CORE unavailable). Factor/verify call time is 1.63s after an 8.72s session template setup; the fresh bundled journey remains the one empty-state install (14.81s). Restart does not call `_build_catalog`.

## Trust & Compatibility Impact

None. Test-only change. Does not affect the verification kernel, checker registry, artifact format, or public API.

## Architecture Budget

Not an ordinary operation. No new shared abstraction.

## Checklist
- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

