### PR TITLE
ci: report Lean cache mode without round-tripping .lake

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -28,6 +28,7 @@ runs:
         TIMING_HEADING: ${{ inputs.timing-heading }}
       run: |
         duration=$(($(date +%s) - LEAN_SETUP_STARTED_AT))
+        echo "LEAN_MATHLIB_CACHE_SECONDS=$duration" >> "$GITHUB_ENV"
         {
           echo "## $TIMING_HEADING"
           echo ""
@@ -59,7 +60,12 @@ runs:
         lake build JacobianLeanRuntime repl jacobian_lean_proof_state
         status=$?
         set -e
-        echo "| Build Jacobian Lean exploration runtime | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
+        build_seconds=$((SECONDS - started))
+        lake_bytes=$(du -sb .lake 2>/dev/null | cut -f1)
+        lake_bytes=${lake_bytes:-0}
+        echo "LEAN_LAKE_BUILD_SECONDS=$build_seconds" >> "$GITHUB_ENV"
+        echo "LEAN_LAKE_BYTES=$lake_bytes" >> "$GITHUB_ENV"
+        echo "| Build Jacobian Lean exploration runtime | $build_seconds |" >> "$GITHUB_STEP_SUMMARY"
         exit "$status"
     - name: Prove CORE and MATHLIB runtimes are available
       shell: bash
@@ -70,3 +76,28 @@ runs:
         started=$SECONDS
         uv run --locked python tools/preflight_lean_runtime.py --required
         echo "| Lean runtime preflight | $((SECONDS - started)) |" >> "$GITHUB_STEP_SUMMARY"
+    - name: Record Lean cache telemetry
+      if: always()
+      shell: bash
+      run: |
+        mathlib_seconds=${LEAN_MATHLIB_CACHE_SECONDS:-0}
+        build_seconds=${LEAN_LAKE_BUILD_SECONDS:-0}
+        lake_bytes=${LEAN_LAKE_BYTES:-0}
+        net_seconds=$((mathlib_seconds + build_seconds))
+        {
+          echo ""
+          echo "## Lean cache"
+          echo ""
+          echo "| Field | Value |"
+          echo "| --- | --- |"
+          echo "| GitHub .lake cache mode | disabled |"
+          echo "| GitHub .lake restore | skipped |"
+          echo "| Restored bytes | 0 |"
+          echo "| Restore seconds | 0 |"
+          echo "| Saved bytes | 0 |"
+          echo "| Save seconds | 0 |"
+          echo "| Toolchain and Mathlib cache seconds | $mathlib_seconds |"
+          echo "| Local lake build seconds | $build_seconds |"
+          echo "| lean/.lake bytes after build | $lake_bytes |"
+          echo "| Net Lean setup seconds | $net_seconds |"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -130,6 +130,11 @@ def test_lean_job_is_required_on_every_event_and_builds_semantic_targets() -> No
     assert "use-mathlib-cache: true" in action
     assert "lake build JacobianLeanRuntime repl jacobian_lean_proof_state" in action
     assert "tools/preflight_lean_runtime.py --required" in action
+    assert "GitHub .lake cache mode | disabled" in action
+    assert "Restored bytes | 0" in action
+    assert "Saved bytes | 0" in action
+    assert "lean/.lake bytes after build" in action
+    assert "uses: actions/cache" not in action
 
 
 def test_optional_boundary_and_deployment_jobs_have_explicit_workflow_gates() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #1396.

The Lean job previously restored and re-uploaded a ~2.45 GB whole-`lean/.lake` GitHub cache on every commit, then still ran `lake exe cache get`. `lean-action` is already configured with `use-github-cache: false` and `use-mathlib-cache: true`. Hosted evidence on `main` (`70204cd0`, run 31791198437, Lean Runtime job 94740913244) shows `actions/cache/restore` and `actions/cache/save` skipped, Mathlib cache downloaded, and local `lake build JacobianLeanRuntime repl jacobian_lean_proof_state` completing in about 16 seconds.

The leftover gap is visibility: the step summary still reported one opaque "Toolchain and Mathlib cache" duration, so a whole-`.lake` snapshot could return unnoticed.

## Solution

- Keep GitHub whole-`.lake` caching disabled. Mathlib artifacts stay on `lake exe cache get`.
- Do not add a narrow GitHub cache keyed on commit SHA or on `lean/.lake`. Hosted local build time is ~16s after Mathlib restore, so a second cache layer is not justified.
- Publish cache-mode telemetry: disabled GitHub `.lake` restore/save, 0 restored/saved bytes, Mathlib/toolchain seconds, local lake build seconds, `lean/.lake` bytes after build, and net Lean setup seconds.
- Ratchet those fields in `tests/unit/tooling/test_ci_execution_policy.py`.

## Testing

Contributor quick path:

```sh
make setup
make check
```

`make check` passed locally, including the CI policy ratchet.

- Specialist validation: inspect the Lean Runtime job on this PR. Confirm `use-github-cache: false`, skipped `actions/cache/restore` and `actions/cache/save`, and the new Lean cache table in the job summary.

## Trust & Compatibility Impact

None. CI telemetry only. Does not affect the verification kernel, checker registry, artifact format, or public API.

## Architecture Budget

Not an ordinary operation. No new shared abstraction.

## Checklist
- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, provider, Harbor/Oracle)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11655748-183d-4a97-b465-52df883a9b33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11655748-183d-4a97-b465-52df883a9b33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

