### PR TITLE
Declare checker module exports

### DIFF
--- a/src/jacobian_checkers/exact_domain_operations.py
+++ b/src/jacobian_checkers/exact_domain_operations.py
@@ -1161,6 +1161,7 @@ __all__ = [
     "check_matrix_rank",
     "check_matrix_rref",
     "check_matrix_smith_normal_form",
+    "check_modular_polynomial_residue_image",
     "check_polynomial_discriminant",
     "check_polynomial_factorization",
     "check_polynomial_gcd",

--- a/src/jacobian_checkers/polynomial_maps.py
+++ b/src/jacobian_checkers/polynomial_maps.py
@@ -892,3 +892,13 @@ def _determinant(
         )
         result = _add_scaled(result, term, -1 if inversions % 2 else 1)
     return result
+
+
+__all__ = [
+    "check_collision",
+    "check_collision_refutes_inverse",
+    "check_identity",
+    "check_jacobian",
+    "check_keller_condition",
+    "check_map_inverse",
+]

--- a/tests/unit/checkers/test_public_exports.py
+++ b/tests/unit/checkers/test_public_exports.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+from jacobian_checkers import exact_domain_operations, polynomial_maps
+
+
+def _public_exports(module: ModuleType) -> tuple[str, ...]:
+    return tuple(module.__all__)
+
+
+def test_polynomial_map_checker_exports_are_explicit() -> None:
+    assert _public_exports(polynomial_maps) == (
+        "check_collision",
+        "check_collision_refutes_inverse",
+        "check_identity",
+        "check_jacobian",
+        "check_keller_condition",
+        "check_map_inverse",
+    )
+
+
+def test_exact_domain_checker_exports_include_modular_residue_replay() -> None:
+    assert "check_modular_polynomial_residue_image" in _public_exports(
+        exact_domain_operations
+    )


### PR DESCRIPTION
## Summary

- declare the six intended public functions in jacobian_checkers.polynomial_maps.__all__
- add check_modular_polynomial_residue_image to the existing exact-domain checker export list
- add focused import-interface coverage for both export surfaces

## Root cause and impact

The polynomial-map checker module had no explicit export manifest, while the exact-domain module's manifest omitted one implemented checker. This made checker module interfaces inconsistent and allowed star-import discovery to diverge from the intended entrypoint surface.

No checker mathematics, certificate binding, authorization, runtime behavior, or package-root exports change.

## Checker handoff

- stage: checker
- status: complete
- exact claim: the two checker modules explicitly expose their implemented, registered checker entrypoints
- obligations: exact module export membership and importability
- producer/checker dependency delta: none
- authorization scope: unchanged
- attack evidence: the focused test failed on main for the missing manifest and missing modular-residue export, then passed with this change

## Validation

- make test-unit TESTS=tests/unit/checkers/test_public_exports.py — 2 passed
- make lint typecheck — Ruff, formatting, complexity, and mypy passed
- git diff --check — passed

Fixes #694
