### PR TITLE
Bound integer sequence input digits

### DIFF
--- a/src/jacobian/contracts/sequences.py
+++ b/src/jacobian/contracts/sequences.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Self
 
-from jacobian.contracts.exact import CanonicalInteger, CanonicalRational
+from pydantic import Field, model_validator
+
+from jacobian.contracts.exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalInteger,
+    CanonicalRational,
+)
 from jacobian.contracts.results import ContractModel
 
 _MAX_SEQUENCE_LENGTH = 256
+MAX_INTEGER_SEQUENCE_ITEM_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
 
 
 class IntegerSequenceRequest(ContractModel):
@@ -17,6 +24,18 @@ class IntegerSequenceRequest(ContractModel):
         min_length=1,
         max_length=_MAX_SEQUENCE_LENGTH,
     )
+
+    @model_validator(mode="after")
+    def require_bounded_items(self) -> Self:
+        if any(
+            len(value.lstrip("-")) > MAX_INTEGER_SEQUENCE_ITEM_DIGITS
+            for value in self.values
+        ):
+            raise ValueError(
+                "sequence item exceeds the "
+                f"{MAX_INTEGER_SEQUENCE_ITEM_DIGITS}-digit bound"
+            )
+        return self
 
 
 class IntegerSequenceValueResult(ContractModel):

--- a/tests/unit/contracts/test_sequence_contracts.py
+++ b/tests/unit/contracts/test_sequence_contracts.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.sequences import (
+    MAX_INTEGER_SEQUENCE_ITEM_DIGITS,
+    IntegerSequenceRequest,
+)
+
+
+@pytest.mark.parametrize("sign", ["", "-"])
+def test_integer_sequence_accepts_items_at_exact_digit_bound(sign: str) -> None:
+    value = sign + "1" * MAX_INTEGER_SEQUENCE_ITEM_DIGITS
+
+    request = IntegerSequenceRequest(values=(value,))
+
+    assert request.values == (value,)
+
+
+@pytest.mark.parametrize("sign", ["", "-"])
+def test_integer_sequence_rejects_items_over_digit_bound(sign: str) -> None:
+    value = sign + "1" * (MAX_INTEGER_SEQUENCE_ITEM_DIGITS + 1)
+
+    with pytest.raises(
+        ValidationError, match=r"sequence item exceeds the .*digit bound"
+    ):
+        IntegerSequenceRequest(values=(value,))


### PR DESCRIPTION
## Summary

- cap every canonical integer in IntegerSequenceRequest.values at 32,768 decimal digits, excluding the sign
- reuse the repository's canonical scalar ceiling instead of introducing a smaller operation-specific magnitude limit
- test positive and negative values exactly at and one digit above the bound

## Root cause and impact

The request contract bounded the number of sequence items but not each item's digit count, allowing every sequence operation to parse arbitrarily large canonical-integer strings. The new validation runs at the authoritative request boundary before any operation parses the values.

Existing sequence requests within the canonical 32,768-digit ceiling remain valid, including values above CPython's default integer-string conversion limit.

## Validation

- make test-unit TESTS=tests/unit/contracts/test_sequence_contracts.py — 4 passed
- make test-domain TESTS=tests/domain/sequences/test_sequence_operations.py — 3 passed
- make lint typecheck — Ruff, formatting, complexity, and mypy passed
- git diff --check — passed

Fixes #866
