### PR TITLE
fix(benchmarks): hard-gate recurrence reward on assurance

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="804c8629b317527fed77d70da689ef3d6e0b304f08e880b323578e7c1b07b856"
+LABEL jacobian.checksum="351f7ffd8a5d029b7d7881da65cdc01297aff178d04335cb6792073f203649b2"
 # Exact verifier for an alternating recurrence stability certificate.
 LABEL jacobian.task="jacobian/alternating-recurrence-stability-certificate"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/alternating-recurrence-stability-certificate/tests/verifier.py
@@ -159,7 +159,7 @@ def main() -> None:
     )
     assurance_ok = bool(contract and submission.get("claimed_assurance") == "COMPUTED")
     false_cert = false_verified_claim(submission, verification_record_bound=False)
-    correct = math_ok and evidence_ok and scope_ok and not false_cert
+    correct = math_ok and evidence_ok and scope_ok and assurance_ok and not false_cert
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     Path("/logs/verifier/reward.json").write_text(
         json.dumps(

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_alternating_recurrence_stability_certificate.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_alternating_recurrence_stability_certificate.py
@@ -45,6 +45,20 @@ def test_accepts_unordered_equivalent_checkpoints(tmp_path: Path) -> None:
     assert support._run_verifier(task, app, logs).reward == 1.0
 
 
+def test_rejects_correct_submission_with_wrong_assurance(tmp_path: Path) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["claimed_assurance"] = "UNVERIFIED"
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.reward == 0.0
+
+
 def test_rejects_finite_simulation_with_wrong_parity_argument(tmp_path: Path) -> None:
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())


### PR DESCRIPTION
## Summary

- include assurance calibration in the alternating-recurrence verifier's aggregate reward gate
- add an adversarial regression showing that a mathematically correct UNVERIFIED submission retains diagnostic scores but earns zero reward
- synchronize the task-local verifier checksum

## Root cause and impact

The verifier calculated assurance_ok but omitted it from the boolean used for aggregate reward. As a result, a submission with correct mathematics, evidence, and scope could receive full reward while failing the required COMPUTED assurance calibration.

This change affects only the task verifier and its regression coverage. The mathematical replay, public task contract, evidence checks, and assurance ceiling are unchanged.

## Validation

- uv run --locked python -m pytest -q -n 0 benchmarks/validation/mathematical_benchmarks_v1/test_alternating_recurrence_stability_certificate.py — 8 passed
- uv run --locked python -m pytest -q -n 0 benchmarks/validation/mathematical_benchmarks_v1/test_generic_verifier_contracts.py -k alternating-recurrence-stability-certificate — 12 passed, 1658 deselected
- uv run --locked python tools/check_benchmark_static.py — passed
- make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="alternating-recurrence-stability-certificate" — passed with pinned Harbor 0.20.0
- make harbor-plan BASE=origin/main — selected the task-specific and generic host tests plus the exact Oracle shard; task digest sha256:4c1853f681f1cadd31e773b29eb3af17b540d6e7563d9f121682eb833a0dd80d
- make lint typecheck — passed
- git diff --check — passed

The containerized make harbor-oracle-task could not start on this host because Docker and flock are unavailable. CI can execute the planned exact Oracle shard.

Fixes #870
