### PR TITLE
fix(benchmarks): bind sharp Cauchy evidence strictly

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="1502fb8e2177d8686b007c3a08204c686142f670096fca8395738688abbc9fd1"
+LABEL jacobian.checksum="1edcabcd729a04994c60e1bd6cba46462621232ca1f97d14abbd29954eaa8178"
 LABEL jacobian.task="jacobian/sharp-cauchy-inequality"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/sharp-cauchy-inequality/tests/verifier.py
@@ -15,6 +15,30 @@ W, E = Path("/app"), Path("/tests")
 ZERO = (0, 0, 0, 0, 0, 0)
 
 
+def _json_equal(left, right):
+    """Compare JSON recursively without Python's bool/int coercion."""
+
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if type(left) is int or type(right) is int:
+        return type(left) is type(right) and left == right
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and set(left) == set(right)
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    return type(left) is type(right) and left == right
+
+
 def _load_frozen():
     try:
         raw = (E / "input.json").read_bytes()
@@ -251,7 +275,7 @@ def main():
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}
         and evidence["schema_version"] == "1"
         and evidence["task_id"] == expected["task_id"]
-        and evidence["result"] == submission.get("result")
+        and _json_equal(evidence["result"], submission.get("result"))
         and evidence["limitations"] == submission.get("limitations")
     )
     scope_ok = bool(

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_sharp_cauchy_inequality.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_sharp_cauchy_inequality.py
@@ -80,6 +80,35 @@ def test_sharp_cauchy_inequality_rejects_nonsharp_constant(tmp_path: Path) -> No
     assert rejected.reward == 0.0
 
 
+@pytest.mark.parametrize("replacement", [True, False])
+def test_sharp_cauchy_inequality_rejects_boolean_integer_evidence_alias(
+    tmp_path: Path,
+    replacement: bool,
+) -> None:
+    task, app, logs = support._prepare_case(
+        tmp_path, "sharp-cauchy-inequality", "computed"
+    )
+    evidence_path = app / "evidence" / "inequality-certificate.json"
+    evidence = json.loads(
+        (task / "solution" / "inequality-certificate.json").read_text()
+    )
+    if replacement:
+        evidence["result"]["certificate"]["residual"][0]["coefficient"] = True
+    else:
+        evidence["result"]["certificate"]["residual"][0]["exponents"][0] = False
+    support._write_json(evidence_path, evidence)
+
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(submission_path, submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0
+
+
 def test_sharp_cauchy_inequality_accepts_cauchy_composition_mode(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Problem

The `sharp-cauchy-inequality` Harbor verifier bound submitted result evidence with Python `==`. Because Python treats booleans as integers, evidence containing `True` in place of `1` or `False` in place of `0` could match a mathematically valid submitted result.

Addresses #862 for the `sharp-cauchy-inequality` task only.

## Solution

- Compare the evidence result and submitted result with recursive, exact-type JSON equality.
- Add adversarial regressions for both `True`/`1` and `False`/`0` aliases while keeping the submitted mathematics correct.
- Regenerate the task verifier checksum.

## Testing

- `make harbor-prepare-task DATASET=mathematical-benchmarks-v1 TASKS="sharp-cauchy-inequality"`
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS="sharp-cauchy-inequality"`
- `make harbor-plan BASE=origin/main` (selected the task leaf, generic verifier contracts, and exact task Oracle)
- `uv run python -m pytest -q -n 0 benchmarks/validation/mathematical_benchmarks_v1/test_generic_verifier_contracts.py -k sharp-cauchy-inequality` (12 passed)
- `uv run python -m pytest -q -n 0 benchmarks/validation/mathematical_benchmarks_v1/test_sharp_cauchy_inequality.py` (10 passed)
- `uv run python tools/check_benchmark_static.py`

`make harbor-validate-task` reached the same static and contract gates locally, but its host subprocess could not import the repository-local `benchmarks` package when invoking the `pytest` console script from this isolated worktree. Running the identical selected host suites via `python -m pytest` passed. GitHub's authoritative selected Harbor workflow subsequently passed both host suites, contracts/static validation, and the exact `sharp-cauchy-inequality` Oracle.

- Specialist validation run: selected Harbor preparation, contracts, planner, static checks, host regressions, and the exact CI Oracle listed above

## Trust & Compatibility Impact

This changes only one benchmark verifier's evidence-binding semantics. It rejects evidence that previously matched only through Python boolean/integer coercion. It does not authorize a checker, raise assurance, or alter product artifacts, schemas, catalog entries, provider state, or public APIs.

Development handoff: base tree `44a0a98286ce0cd84471a5158d6d94e4d4a5174f`; implementation commit `cb681ff22`; prospective task digest `sha256:c3133738f2054290ffbd4dbb37b6a8425a23fe745bb9f2e3fc9ccbe2be150b7b`; catalog and policy digests unchanged; no provider runtime required; deterministic frozen task fixtures; model/prompt settings and raw agent trace are not applicable; no unresolved mathematical or verification obligations.

## Architecture Budget

No product operation or generic verifier framework is introduced. The helper remains local to the affected task.

## Checklist

- [ ] `make check` passes (the Harbor planner is authoritative for benchmark paths; selected static and host gates passed)
- [x] Explicitly relevant specialist validation is listed above
- [x] Selected Harbor static, contract, host, and exact Oracle gates pass in CI
- [x] New ordinary operations are not introduced
- [x] New shared abstractions are not introduced
