### PR TITLE
fix(probability): bound graph reliability state mass

### DIFF
--- a/src/jacobian/contracts/probability.py
+++ b/src/jacobian/contracts/probability.py
@@ -366,6 +366,12 @@ class GraphReliabilityState(ContractModel):
     terminals_connected: bool
     state_probability: CanonicalRational
 
+    @model_validator(mode="after")
+    def require_bounded_probability(self) -> Self:
+        if not 0 <= self.state_probability.as_fraction() <= 1:
+            raise ValueError("graph reliability state probability must lie in [0, 1]")
+        return self
+
 
 class GraphConnectionProbabilityResult(ContractModel):
     terminals: tuple[str, str]

--- a/tests/unit/contracts/test_probability_contracts.py
+++ b/tests/unit/contracts/test_probability_contracts.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import sys
+from fractions import Fraction
 
 import pytest
 from pydantic import ValidationError
 
-from jacobian.contracts.probability import GraphReliabilityEdgeProbability
+from jacobian.contracts.probability import (
+    GraphConnectionProbabilityResult,
+    GraphReliabilityEdgeProbability,
+)
+
+
+def _rational(value: int) -> dict[str, str]:
+    return {"num": str(value), "den": "1"}
 
 
 @pytest.mark.parametrize(
@@ -38,3 +46,42 @@ def test_large_probability_reports_the_contract_digit_bound(
             )
     finally:
         sys.set_int_max_str_digits(previous_limit)
+
+
+@pytest.mark.parametrize(
+    ("state_probabilities", "connection_probability"),
+    (((-1, 2), 2), ((2, -1), -1)),
+    ids=("negative-first", "over-one-first"),
+)
+def test_graph_reliability_rejects_out_of_range_state_probabilities_that_sum_to_one(
+    state_probabilities: tuple[int, int],
+    connection_probability: int,
+) -> None:
+    assert sum((Fraction(value) for value in state_probabilities), Fraction()) == 1
+
+    with pytest.raises(
+        ValidationError,
+        match=r"graph reliability state probability must lie in \[0, 1\]",
+    ):
+        GraphConnectionProbabilityResult.model_validate(
+            {
+                "terminals": ["a", "b"],
+                "connection_probability": _rational(connection_probability),
+                "edge_count": 1,
+                "visited_states": 2,
+                "states": [
+                    {
+                        "state_index": 0,
+                        "open_edges": [],
+                        "terminals_connected": False,
+                        "state_probability": _rational(state_probabilities[0]),
+                    },
+                    {
+                        "state_index": 1,
+                        "open_edges": [["a", "b"]],
+                        "terminals_connected": True,
+                        "state_probability": _rational(state_probabilities[1]),
+                    },
+                ],
+            }
+        )


### PR DESCRIPTION
## Problem

`GraphConnectionProbabilityResult` checked that state probabilities summed to one, but `GraphReliabilityState` did not bound each probability. The concrete aggregate-masking attack documented in #1069 and #1081 could therefore use state masses such as `-1` and `2`, preserve the total of one, and pass the aggregate checks.

Addresses the `GraphReliabilityState` finding in #1069 and #1081.

## Solution

- Add a domain-local `GraphReliabilityState` validator requiring every exact state probability to lie in `[0,1]`.
- Add both orderings of the aggregate-preserving `-1`/`2` attack as contract regressions.
- Keep the fix local; no generic postcondition framework is introduced.

## Testing

- `make check` (978 unit tests plus repository lint, format, complexity, and mypy checks)
- `uv run pytest -q tests/unit/contracts/test_probability_contracts.py` (4 passed)
- `uv run pytest -q tests/component/checkers/test_exact_probability_operation_checkers.py` (20 passed)
- `uv run pytest -q tests/domain/probability/test_finite_probability.py -k graph_reliability` (4 passed, 17 deselected)
- `uv run ruff check src/jacobian/contracts/probability.py tests/unit/contracts/test_probability_contracts.py`
- `uv run mypy src/jacobian/contracts/probability.py`

- Specialist validation run: focused probability contract, independent checker, and graph-reliability domain tests listed above

## Trust & Compatibility Impact

This tightens result-model validation and causes malformed graph-reliability ledgers with negative or over-one state mass to fail closed before checker replay or artifact publication. Valid outputs, checker authorization, assurance, artifact formats, provider availability, and the public API are unchanged.

Development handoff: base tree `44a0a98286ce0cd84471a5158d6d94e4d4a5174f`; implementation commit `54b11b0e0`; catalog and policy digests unchanged; locked provider environment with no live provider dependency for these tests; model/prompt settings and raw agent trace are not applicable; no unresolved mathematical or verification obligations.

## Architecture Budget

No operation or shared abstraction is introduced. The invariant is owned directly by the existing `GraphReliabilityState` domain contract.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] New ordinary operations are not introduced
- [x] New shared abstractions are not introduced
