### PR TITLE
perf(tests): accelerate local validation and CI feedback

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -27,10 +27,12 @@ coverage.xml
 .hypothesis/
 .jacobian/
 .diagnostics/
+.import_linter_cache/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
 .venv/
+node_modules/
 __pycache__/
 *.py[cod]
 build/

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ help: ## Show the primary developer workflow.
 help-all: ## Show every low-level and lifecycle developer command.
 	@awk 'BEGIN {FS = ":.*## "; printf "All Jacobian developer commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-26s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-test-unit: ## Pure contracts and models (sequential, 10s).
-	$(UV_RUN) pytest --timeout=10 \
+test-unit: ## Pure contracts and models (4 workers, 10s).
+	$(UV_RUN) pytest -n 4 --dist worksteal --timeout=10 \
 		$(if $(TESTS),$(TESTS),tests/unit) \
 		$(PYTEST_DIAGNOSTIC_ARGS) $(PYTEST_ARGS)
 

--- a/src/jacobian/family_catalog.py
+++ b/src/jacobian/family_catalog.py
@@ -421,6 +421,20 @@ FAMILY_INDEX_SPECS: tuple[FamilyIndexSpec, ...] = (
         ),
         request_type=LeanCheckRequest,
         result_type=LeanCheckOutput,
+        examples=(
+            OperationExample(
+                name="finite-witness-let",
+                description=(
+                    "Check a finite witness encoded as one let expression without "
+                    "adding declarations."
+                ),
+                input={
+                    "environment": "CORE",
+                    "statement": "let n : Nat := 2; n + n = 4",
+                    "proof": "rfl",
+                },
+            ),
+        ),
     ),
     FamilyIndexSpec(
         operation_id="lean.declaration.dependencies",

--- a/tests/boundary/mcp/conftest.py
+++ b/tests/boundary/mcp/conftest.py
@@ -1,29 +1,32 @@
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import pytest
 
 from jacobian.operator_lifecycle import CheckerAuthorization, initialize_state
+from tests.support.runtime_templates import template_target
+from tests.support.state import copy_template, publish_template
 
 
 @pytest.fixture(scope="session")
-def compiled_mcp_state(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    root = tmp_path_factory.mktemp("compiled-mcp-state")
-    initialize_state(root, checker_authorization=CheckerAuthorization.BUNDLED)
-    return root
-
-
-@pytest.fixture(autouse=True)
-def current_mcp_state(
+def compiled_mcp_state(
+    tmp_path_factory: pytest.TempPathFactory,
     request: pytest.FixtureRequest,
-    compiled_mcp_state: Path,
-) -> None:
-    """MCP serving tests start from the explicit operator lifecycle boundary."""
+) -> Path:
+    target, lock = template_target(tmp_path_factory, request, "compiled-mcp-state")
 
-    if "tmp_path" not in request.fixturenames:
-        return
-    root = request.getfixturevalue("tmp_path")
-    shutil.copytree(compiled_mcp_state, root, dirs_exist_ok=True)
-    shutil.copytree(compiled_mcp_state, root / "state", dirs_exist_ok=True)
+    def build(staging: Path) -> None:
+        initialize_state(staging, checker_authorization=CheckerAuthorization.BUNDLED)
+
+    return publish_template(target, build, lock=lock)
+
+
+@pytest.fixture
+def mcp_state(
+    tmp_path: Path,
+    compiled_mcp_state: Path,
+) -> Path:
+    """Return a private catalog state for an MCP serving test."""
+
+    return copy_template(compiled_mcp_state, tmp_path / "state")

--- a/tests/boundary/mcp/test_mcp_adapter_inventory.py
+++ b/tests/boundary/mcp/test_mcp_adapter_inventory.py
@@ -50,9 +50,9 @@ def test_managed_server_advertises_immutable_deployment_identity(
 
 
 def test_mcp_exposes_only_math_tools_with_read_only_resources(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
-    server = create_server(tmp_path)
+    server = create_server(mcp_state)
     assert server.instructions is not None
     assert "local verification record URI" in server.instructions
 

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -11,7 +11,7 @@ from jacobian.operation_visibility import OperationVisibilityPolicy
 
 
 def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     async def scenario() -> None:
         from mcp import Client
@@ -19,7 +19,7 @@ def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
         policy = OperationVisibilityPolicy(profile="COMPUTE_VERIFY_NO_RETRIEVAL")
         async with Client(
             create_server(
-                tmp_path,
+                mcp_state,
                 operation_policy=policy,
             ),
             raise_exceptions=True,
@@ -37,13 +37,13 @@ def test_mcp_no_retrieval_policy_is_operator_bound_and_fail_closed(
 
 
 def test_mcp_compact_operation_index_is_searchable_and_paginated(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     async def scenario() -> None:
         from mcp import Client
 
         async with Client(
-            create_server(tmp_path),
+            create_server(mcp_state),
             raise_exceptions=True,
         ) as client:
             resource_result = await client.read_resource("operation://catalog")
@@ -195,7 +195,7 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated(
 
 
 def test_mcp_text_projection_preserves_produced_artifact_types(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     """The agent-facing text projection must include produced_artifact_types."""
 
@@ -203,7 +203,7 @@ def test_mcp_text_projection_preserves_produced_artifact_types(
         from mcp import Client
 
         async with Client(
-            create_server(tmp_path),
+            create_server(mcp_state),
             raise_exceptions=True,
         ) as client:
             listed = await client.call_tool(

--- a/tests/boundary/mcp/test_mcp_checker_value_references.py
+++ b/tests/boundary/mcp/test_mcp_checker_value_references.py
@@ -10,12 +10,12 @@ from jacobian.adapters.mcp.server import create_server
 
 @pytest.mark.requires_provider("flint")
 def test_mcp_keeps_two_tools_while_a_checker_consumes_a_typed_candidate(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(create_server(mcp_state), raise_exceptions=True) as client:
             listed = await client.list_tools()
             assert {tool.name for tool in listed.tools} == {"math.find", "math.run"}
 

--- a/tests/boundary/mcp/test_mcp_entrypoint.py
+++ b/tests/boundary/mcp/test_mcp_entrypoint.py
@@ -16,13 +16,13 @@ MCP_TOOL_NAMES = {
 
 
 def test_mcp_stdio_entrypoint_exposes_stable_math_tools(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     async def scenario() -> None:
         from mcp import Client, StdioServerParameters, stdio_client
 
         environment = dict(os.environ)
-        environment["JACOBIAN_STATE_DIR"] = str(tmp_path)
+        environment["JACOBIAN_STATE_DIR"] = str(mcp_state)
         parameters = StdioServerParameters(
             command=sys.executable,
             args=["-m", "jacobian.adapters.mcp.server"],

--- a/tests/boundary/mcp/test_mcp_errors_and_tracing.py
+++ b/tests/boundary/mcp/test_mcp_errors_and_tracing.py
@@ -104,10 +104,12 @@ def test_mcp_tool_failures_return_safe_actionable_errors(tmp_path: Path) -> None
     assert internal["error"]["code"] == "OPERATION_FAILED"
 
 
-def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) -> None:
+def test_mcp_protocol_and_authentication_errors_remain_distinct(
+    mcp_state: Path,
+) -> None:
     from mcp.shared.exceptions import MCPError
 
-    server = create_server(tmp_path)
+    server = create_server(mcp_state)
 
     @server.tool(name="fixture.protocol-error")
     async def protocol_error() -> None:
@@ -121,7 +123,7 @@ def test_mcp_protocol_and_authentication_errors_remain_distinct(tmp_path: Path) 
 
         async with Client(
             create_remote_server(
-                tmp_path,
+                mcp_state,
                 allow_anonymous=False,
             ),
             raise_exceptions=False,

--- a/tests/boundary/mcp/test_mcp_invocation_journey.py
+++ b/tests/boundary/mcp/test_mcp_invocation_journey.py
@@ -1,6 +1,6 @@
 """Owned MCP smoke journey: live SDK find → run without complete-runtime fixtures.
 
-``create_server(tmp_path)`` installs a fresh server-owned runtime. Keep this
+``create_server(mcp_state)`` installs a fresh server-owned runtime. Keep this
 module small; do not grow ordinary projection or operation matrices here.
 """
 
@@ -18,11 +18,11 @@ MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
 
 
-def test_mcp_describes_and_invokes_operations(tmp_path: Path) -> None:
+def test_mcp_describes_and_invokes_operations(mcp_state: Path) -> None:
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(create_server(mcp_state), raise_exceptions=True) as client:
             described = await client.call_tool(
                 "math.find",
                 {
@@ -141,7 +141,9 @@ def test_mcp_describes_and_invokes_operations(tmp_path: Path) -> None:
 
 
 @pytest.mark.requires_provider("flint")
-def test_mcp_composes_finite_field_values_by_opaque_reference(tmp_path: Path) -> None:
+def test_mcp_composes_finite_field_values_by_opaque_reference(
+    mcp_state: Path,
+) -> None:
     async def scenario() -> None:
         from mcp import Client
 
@@ -163,7 +165,7 @@ def test_mcp_composes_finite_field_values_by_opaque_reference(tmp_path: Path) ->
         )
 
         async with Client(
-            create_server(tmp_path),
+            create_server(mcp_state),
             raise_exceptions=True,
         ) as client:
             inspected = await client.call_tool(

--- a/tests/boundary/mcp/test_mcp_resource_links.py
+++ b/tests/boundary/mcp/test_mcp_resource_links.py
@@ -43,7 +43,7 @@ def test_mcp_inline_results_do_not_emit_resource_links(
 
 
 def test_mcp_materialized_results_emit_readable_native_resource_links(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def reject_portfolio_assembly(*_args: object, **_kwargs: object) -> None:
@@ -55,7 +55,7 @@ def test_mcp_materialized_results_emit_readable_native_resource_links(
         from mcp import Client
 
         async with Client(
-            create_server(tmp_path),
+            create_server(mcp_state),
             raise_exceptions=True,
         ) as client:
             result = await client.call_tool(

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -24,7 +24,7 @@ def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
 
 
 def test_mcp_v2_static_validation_context_errors_and_structured_resources(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delattr(server_module, "Context", raising=False)
@@ -39,7 +39,7 @@ def test_mcp_v2_static_validation_context_errors_and_structured_resources(
         from mcp.shared.exceptions import MCPError
 
         server = create_server(
-            tmp_path,
+            mcp_state,
         )
         assert not hasattr(server_module, "Context")
         async with Client(server, raise_exceptions=True) as client:

--- a/tests/boundary/mcp/test_mcp_selected_graph_operations.py
+++ b/tests/boundary/mcp/test_mcp_selected_graph_operations.py
@@ -10,7 +10,7 @@ from jacobian.registry import CheckerRegistry
 
 
 def test_graph_resource_operations_do_not_assemble_the_portfolio(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def reject_portfolio_assembly(*_args: object, **_kwargs: object) -> None:
@@ -23,7 +23,7 @@ def test_graph_resource_operations_do_not_assemble_the_portfolio(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(create_server(mcp_state), raise_exceptions=True) as client:
             constructed = await client.call_tool(
                 "math.run",
                 {

--- a/tests/boundary/mcp/test_mcp_selected_lean_operations.py
+++ b/tests/boundary/mcp/test_mcp_selected_lean_operations.py
@@ -10,7 +10,7 @@ from jacobian.registry import CheckerRegistry
 
 
 def test_lean_operations_do_not_assemble_the_portfolio(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def reject_installation(*_args: object, **_kwargs: object) -> None:
@@ -21,7 +21,7 @@ def test_lean_operations_do_not_assemble_the_portfolio(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(create_server(mcp_state), raise_exceptions=True) as client:
             for operation_id in (
                 "lean.check",
                 "lean.declaration.dependencies",

--- a/tests/boundary/mcp/test_mcp_selected_polynomial_operations.py
+++ b/tests/boundary/mcp/test_mcp_selected_polynomial_operations.py
@@ -10,7 +10,7 @@ from jacobian.registry import CheckerRegistry
 
 
 def test_polynomial_positivity_loads_only_the_selected_path(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def reject_installation(*_args: object, **_kwargs: object) -> None:
@@ -40,7 +40,7 @@ def test_polynomial_positivity_loads_only_the_selected_path(
     async def scenario() -> None:
         from mcp import Client
 
-        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        async with Client(create_server(mcp_state), raise_exceptions=True) as client:
             decided = await client.call_tool(
                 "math.run",
                 {

--- a/tests/boundary/mcp/test_remote_mcp_http.py
+++ b/tests/boundary/mcp/test_remote_mcp_http.py
@@ -30,20 +30,20 @@ from tests.support.selected_runtime import create_selected_runtime
 
 
 def test_authenticated_streamable_http_rejects_before_runtime_construction(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     def fail_if_called(*_args: object, **_kwargs: object) -> JacobianRuntime:
         raise AssertionError("auth rejection must not construct a tenant runtime")
 
     with _RunningRemoteServer(
-        tmp_path,
+        mcp_state.parent,
         runtime_factory=fail_if_called,
     ) as port:
         asyncio.run(_remote_auth_rejections(port))
 
 
 def test_authenticated_streamable_http_isolates_tenant_data(
-    tmp_path: Path,
+    mcp_state: Path,
 ) -> None:
     def matrix_runtime(
         root: str | Path,
@@ -55,11 +55,11 @@ def test_authenticated_streamable_http_isolates_tenant_data(
         )
 
     with _RunningRemoteServer(
-        tmp_path,
+        mcp_state.parent,
         runtime_factory=matrix_runtime,
     ) as port:
         asyncio.run(_remote_tenant_scenario(port))
-        tenant_roots = sorted((tmp_path / "state" / "tenants").iterdir())
+        tenant_roots = sorted((mcp_state / "tenants").iterdir())
         assert {path.name for path in tenant_roots} == {
             hashlib.sha256(b"alpha").hexdigest(),
             hashlib.sha256(b"beta").hexdigest(),
@@ -68,7 +68,7 @@ def test_authenticated_streamable_http_isolates_tenant_data(
 
 
 def test_default_authority_remote_mcp_matches_deployment_identity(
-    tmp_path: Path,
+    mcp_state: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     revision = "a" * 40
@@ -79,7 +79,7 @@ def test_default_authority_remote_mcp_matches_deployment_identity(
             package_version=version("jacobian"),
         ),
     )
-    with _RunningRemoteServer(tmp_path) as port:
+    with _RunningRemoteServer(mcp_state.parent) as port:
         monkeypatch.setenv("JACOBIAN_MCP_BEARER_TOKEN", "a" * 32)
         report = asyncio.run(
             inspect_remote_deployment(

--- a/tests/boundary/providers/lean/startup/test_lean.py
+++ b/tests/boundary/providers/lean/startup/test_lean.py
@@ -283,21 +283,6 @@ def test_core_lean_check_runs_through_operation_mcp_surface(tmp_path: Path) -> N
             create_server(tmp_path),
             raise_exceptions=True,
         ) as client:
-            described = await client.call_tool(
-                "math.find",
-                {
-                    "request": {
-                        "op": "inspect",
-                        "operation_id": "lean.check",
-                    }
-                },
-            )
-            assert isinstance(described.structured_content, dict)
-            descriptor = described.structured_content
-            assert descriptor["operation"]["examples"][0]["name"] == (
-                "finite-witness-let"
-            )
-
             response = await client.call_tool(
                 "math.run",
                 {

--- a/tests/unit/test_package_index.py
+++ b/tests/unit/test_package_index.py
@@ -112,6 +112,7 @@ def test_family_index_covers_selected_family_ids() -> None:
     examples = {entry.operation_id: entry.examples for entry in entries}
     assert examples["polynomial.expression.normalize"][0].name == "combine_like_terms"
     assert examples["sat.cnf.materialize"][0].name == "finite-coloring-cnf"
+    assert examples["lean.check"][0].name == "finite-witness-let"
 
 
 def test_family_graph_properties_schema_lists_supported_invariants() -> None:

--- a/tests/unit/tooling/test_architecture_diagnostics.py
+++ b/tests/unit/tooling/test_architecture_diagnostics.py
@@ -37,6 +37,41 @@ def test_wt438_directory_is_excluded(tmp_path: Path) -> None:
     assert report.violations == ()
 
 
+@pytest.mark.parametrize(
+    "directory",
+    [
+        ".hypothesis",
+        ".import_linter_cache",
+        ".jacobian",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "build",
+        "dist",
+        "htmlcov",
+        "lean/.lake",
+        "node_modules",
+    ],
+)
+def test_generated_directory_is_pruned(tmp_path: Path, directory: str) -> None:
+    _write(
+        tmp_path,
+        f"{directory}/generated.py",
+        "import subprocess\n",
+    )
+    _write(
+        tmp_path,
+        f"{directory}/generated.json",
+        f'{{"operation_id": "{_K}.{_S}"}}\n',
+    )
+
+    report = check_architecture(tmp_path)
+
+    assert report.ok, report.render()
+    assert report.files_scanned == 0
+
+
 def test_clean_tree_passes(tmp_path: Path) -> None:
     _write(tmp_path, "src/jacobian/bounded_process.py", "import subprocess\n")
     _write(

--- a/tests/unit/tooling/test_ci_execution_policy.py
+++ b/tests/unit/tooling/test_ci_execution_policy.py
@@ -14,13 +14,25 @@ from pre_commit.parse_shebang import normalize_cmd
 ROOT = Path(__file__).parents[3]
 
 
-def test_pr_base_edits_trigger_ci() -> None:
-    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    pull_request_trigger = workflow.split("  pull_request:", 1)[1].split(
-        "  merge_group:", 1
-    )[0]
+def _pull_request_trigger(workflow_path: str) -> str:
+    workflow = (ROOT / workflow_path).read_text(encoding="utf-8")
+    return workflow.split("  pull_request:", 1)[1].split("  merge_group:", 1)[0]
 
-    assert "edited" in pull_request_trigger
+
+def test_pr_metadata_edits_do_not_restart_product_ci() -> None:
+    pull_request_trigger = _pull_request_trigger(".github/workflows/ci.yml")
+
+    assert "edited" not in pull_request_trigger
+    assert "labeled" not in pull_request_trigger
+    assert "unlabeled" not in pull_request_trigger
+
+
+def test_benchmark_labels_replan_without_generic_pr_edit_restarts() -> None:
+    pull_request_trigger = _pull_request_trigger(".github/workflows/benchmarks.yml")
+
+    assert "edited" not in pull_request_trigger
+    assert "labeled" in pull_request_trigger
+    assert "unlabeled" in pull_request_trigger
 
 
 def test_wheel_job_covers_supported_pythons_and_313_compatibility_smoke() -> None:
@@ -203,11 +215,24 @@ def test_focused_unit_lane_skips_validation_lock() -> None:
 
 def test_component_lane_uses_module_fixture_affinity() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    unit = makefile.split("test-unit:", 1)[1].split("test-component:", 1)[0]
     component = makefile.split("test-component:", 1)[1].split("test-domain:", 1)[0]
     domain = makefile.split("test-domain:", 1)[1].split("test-composition:", 1)[0]
 
+    assert "pytest -n 4 --dist worksteal" in unit
     assert "--dist loadscope" in component
     assert "--dist worksteal" in domain
+
+
+def test_mcp_catalog_fixture_is_explicit_and_xdist_shared() -> None:
+    conftest = (ROOT / "tests/boundary/mcp/conftest.py").read_text(encoding="utf-8")
+
+    assert "autouse=True" not in conftest
+    assert (
+        'template_target(tmp_path_factory, request, "compiled-mcp-state")' in conftest
+    )
+    assert "publish_template(target, build, lock=lock)" in conftest
+    assert 'copy_template(compiled_mcp_state, tmp_path / "state")' in conftest
 
 
 def test_benchmark_workflow_has_distinct_pr_merge_and_full_portfolio_tiers() -> None:

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import os
 import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -350,10 +351,18 @@ _EXCLUDED_DIRS = frozenset(
     {
         "wt-438",
         ".git",
+        ".hypothesis",
+        ".import_linter_cache",
+        ".jacobian",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
         "__pycache__",
         ".venv",
+        "build",
         "dist",
         ".diagnostics",
+        "htmlcov",
         "node_modules",
         # Lean toolchain packages (third-party Mathlib build artifacts).
         ".lake",
@@ -472,6 +481,10 @@ class ArchitecturePolicyError(RuntimeError):
 
 def _is_excluded(root: Path, path: Path) -> bool:
     relative = PurePosixPath(path.relative_to(root).as_posix())
+    return _relative_is_excluded(relative)
+
+
+def _relative_is_excluded(relative: PurePosixPath) -> bool:
     return any(part in _EXCLUDED_DIRS for part in relative.parts) or any(
         relative == prefix or prefix in relative.parents for prefix in _EXCLUDED_PATHS
     )
@@ -488,6 +501,19 @@ def _is_under(path: PurePosixPath, prefix: PurePosixPath) -> bool:
 # ---------------------------------------------------------------------------
 # AST helpers
 # ---------------------------------------------------------------------------
+
+
+_AST_WALK_CACHE_ATTRIBUTE = "_jacobian_architecture_walk"
+
+
+def _walk_nodes(node: ast.AST) -> tuple[ast.AST, ...]:
+    """Materialize one AST walk once for the lifetime of its root node."""
+
+    cached = getattr(node, _AST_WALK_CACHE_ATTRIBUTE, None)
+    if cached is None:
+        cached = tuple(ast.walk(node))
+        setattr(node, _AST_WALK_CACHE_ATTRIBUTE, cached)
+    return cached
 
 
 def _imported_module(node: ast.Import | ast.ImportFrom) -> str:
@@ -529,7 +555,7 @@ def _internal_operation_request_violations(
             "OperationRequest",
             node.lineno,
         )
-        for node in ast.walk(tree)
+        for node in _walk_nodes(tree)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "OperationRequest"
@@ -595,7 +621,7 @@ def _operation_result_bindings(
 ) -> tuple[set[str], set[str]]:
     constructor_names: set[str] = set()
     module_names: set[str] = set()
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if isinstance(node, ast.ImportFrom):
             constructors, modules = _operation_result_from_import_from(relative, node)
         elif isinstance(node, ast.Import):
@@ -635,7 +661,7 @@ def _operation_result_projection_violations(
             "OperationResult envelope",
             node.lineno,
         )
-        for node in ast.walk(tree)
+        for node in _walk_nodes(tree)
         if isinstance(node, ast.Call) and is_result_constructor(node)
     )
 
@@ -654,7 +680,7 @@ def _legacy_adapter_mode_violations(
             "modes are not supported",
             node.lineno,
         )
-        for node in ast.walk(tree)
+        for node in _walk_nodes(tree)
         if (isinstance(node, ast.Name) and node.id in _LEGACY_ADAPTER_MODE_NAMES)
         or (
             isinstance(node, ast.ImportFrom)
@@ -674,7 +700,7 @@ def _subprocess_violations(
     if relative in _SUBPROCESS_ALLOWED_EXACT:
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             module = _imported_module(node)
             names = _imported_names(node)
@@ -788,7 +814,7 @@ def _run_bounded_process_violations(
     if relative in _RUN_BOUNDED_PROCESS_ALLOWED:
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         violations.extend(_bounded_process_import_violations(relative, node))
         violations.extend(_bounded_process_call_violations(relative, node))
     return tuple(violations)
@@ -805,7 +831,7 @@ def _shutil_which_violations(
     if relative in _SHUTIL_WHICH_ALLOWED:
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if isinstance(node, ast.Attribute) and (
             isinstance(node.value, ast.Name)
             and node.value.id == "shutil"
@@ -896,7 +922,7 @@ def _environ_spread_violations(
     if not any(_is_under(relative, root) for root in _ENVIRON_SPREAD_ROOTS):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if _is_dict_os_environ_call(node):
             violations.append(
                 Violation(
@@ -958,7 +984,7 @@ def _unsafe_canonical_conversion_violations(
     ):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
@@ -1123,7 +1149,7 @@ def _contract_dependency_leaf_violations(
     if not _is_under(relative, PurePosixPath("src/jacobian/contracts")):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         for reference in _import_references(relative, node):
@@ -1146,7 +1172,7 @@ def _native_math_boundary_violations(
     if not _is_under(relative, PurePosixPath("src/jacobian/math")):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         for reference in _import_references(relative, node):
@@ -1216,7 +1242,7 @@ def _inline_executor_boundary_violations(
     if relative != _INLINE_EXECUTOR_PATH:
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         for reference in _import_references(relative, node):
@@ -1239,7 +1265,7 @@ def _private_math_backend_violations(
     if not _is_under(relative, PurePosixPath("src/jacobian/domains")):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         for reference in _import_references(relative, node):
@@ -1262,7 +1288,7 @@ def _checker_producer_isolation_violations(
     if not _is_under(relative, PurePosixPath("src/jacobian_checkers")):
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, (ast.Import, ast.ImportFrom)):
             continue
         for reference in _import_references(relative, node):
@@ -1284,7 +1310,7 @@ def _checker_producer_isolation_violations(
 def _contract_model_occurrences(node: ast.AST) -> int:
     return sum(
         isinstance(descendant, ast.Name) and descendant.id == "ContractModel"
-        for descendant in ast.walk(node)
+        for descendant in _walk_nodes(node)
     )
 
 
@@ -1292,7 +1318,7 @@ def _erased_contract_operation_violations(
     relative: PurePosixPath, tree: ast.AST
 ) -> tuple[Violation, ...]:
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not (
             isinstance(node, ast.Subscript)
             and (
@@ -1320,7 +1346,7 @@ def _output_only_contract_violations(
     relative: PurePosixPath, tree: ast.AST
 ) -> tuple[Violation, ...]:
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         name = (
             node.id
             if isinstance(node, ast.Name)
@@ -1345,7 +1371,7 @@ def _materialization_reason_violations(
 ) -> tuple[Violation, ...]:
     """Require every durable operation declaration to name its resource reason."""
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if not isinstance(node, ast.Call):
             continue
         name = (
@@ -1418,7 +1444,7 @@ def _unsupported_surface_ast_violations(
     if relative in _UNSUPPORTED_SURFACE_AST_EXCLUDED:
         return ()
     violations: list[Violation] = []
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         removed_name = _python_identifier(node)
         if removed_name is not None and _CAPABILITY in removed_name.lower():
             violations.append(
@@ -1484,7 +1510,7 @@ def _contains_rational_component(
 ) -> bool:
     return any(
         isinstance(descendant, ast.Attribute) and descendant.attr in attributes
-        for descendant in ast.walk(node)
+        for descendant in _walk_nodes(node)
     )
 
 
@@ -1562,7 +1588,7 @@ def _unsafe_canonical_rational_output_violations(
         return ()
 
     unsafe_values: dict[int, ast.AST] = {}
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         direct_output = _direct_output_value(node)
         if direct_output is not None:
             for value in _unsafe_rational_render_nodes(
@@ -1625,7 +1651,7 @@ _EXPENSIVE_RUNTIME_FIXTURES = frozenset(
 
 
 def _calls_catalog_build_runtime(node: ast.AST) -> bool:
-    for child in ast.walk(node):
+    for child in _walk_nodes(node):
         if not isinstance(child, ast.Call):
             continue
         func = child.func
@@ -1645,7 +1671,7 @@ def _discarded_expensive_runtime_fixtures(node: ast.FunctionDef) -> frozenset[st
     if not requested:
         return frozenset()
     discarded: set[str] = set()
-    for child in ast.walk(node):
+    for child in _walk_nodes(node):
         if not isinstance(child, ast.Assign) or len(child.targets) != 1:
             continue
         target = child.targets[0]
@@ -1683,7 +1709,7 @@ _CLI_COMPLETE_PORTFOLIO_ALLOWLIST = frozenset(
 
 def _imports_qualified_module(tree: ast.AST, module: str) -> bool:
     parent, _, name = module.rpartition(".")
-    for node in ast.walk(tree):
+    for node in _walk_nodes(tree):
         if isinstance(node, ast.Import):
             if any(alias.name == module for alias in node.names):
                 return True
@@ -1714,7 +1740,7 @@ def _create_cli_app_call_has_runtime_opener(node: ast.Call) -> bool:
 
 
 def _calls_unscoped_cli_runtime(node: ast.AST) -> bool:
-    for child in ast.walk(node):
+    for child in _walk_nodes(node):
         if not isinstance(child, ast.Call):
             continue
         func = child.func
@@ -1876,30 +1902,24 @@ def _test_ownership_violations(
 # ---------------------------------------------------------------------------
 
 
-def _python_files(root: Path) -> list[Path]:
-    """Return all non-excluded Python files under root."""
+def _repository_files(root: Path) -> list[Path]:
+    """Return files under root without descending into generated directories."""
     files: list[Path] = []
-    for path in sorted(root.rglob("*.py")):
-        if _is_excluded(root, path):
-            continue
-        if not path.is_file():
-            continue
-        files.append(path)
-    return files
-
-
-def _text_files(root: Path) -> list[Path]:
-    """Return non-Python text files for unsupported-surface scanning."""
-    files: list[Path] = []
-    for path in sorted(root.rglob("*")):
-        if _is_excluded(root, path):
-            continue
-        if not path.is_file():
-            continue
-        ext = path.suffix
-        if ext not in _TEXT_EXTENSIONS:
-            continue
-        files.append(path)
+    for current, directories, filenames in os.walk(root):
+        current_path = Path(current)
+        current_relative = current_path.relative_to(root)
+        directories[:] = [
+            directory
+            for directory in sorted(directories)
+            if not _relative_is_excluded(
+                PurePosixPath((current_relative / directory).as_posix())
+            )
+        ]
+        files.extend(
+            current_path / filename
+            for filename in sorted(filenames)
+            if not _is_excluded(root, current_path / filename)
+        )
     return files
 
 
@@ -1946,8 +1966,11 @@ def check_architecture(root: Path | str = ROOT) -> ArchitectureReport:
     violations).
     """
     project_root = Path(root).resolve()
-    py_files = _python_files(project_root)
-    text_files = _text_files(project_root)
+    repository_files = _repository_files(project_root)
+    py_files = [path for path in repository_files if path.suffix == ".py"]
+    text_files = [
+        path for path in repository_files if path.suffix in _TEXT_EXTENSIONS
+    ]
 
     violations: list[Violation] = []
     for file_path in py_files:


### PR DESCRIPTION
## Summary

- prune generated/cache trees from architecture discovery and reuse each parsed AST walk
- run the unit lane with four work-stealing workers and avoid product CI restarts for PR metadata edits
- restore the `lean.check` packaged example and keep its catalog regression in the ordinary unit lane
- replace MCP autouse state hydration with an explicit, xdist-shared compiled template and private per-test copies

## Impact

- architecture scan: about 93s with polluted caches to 15s on the final tree
- unit lane: about 43s serial to 19s with four workers on a fixed seed
- MCP lane: one catalog compilation across xdist workers and no state setup for tests that do not serve the catalog

## Root causes

The architecture scanner recursively enumerated generated dependency/cache trees and repeatedly walked the same AST for each rule. The unit lane was unnecessarily serial. MCP tests applied a heavyweight state fixture to every `tmp_path` test and compiled it once per xdist worker. A pure `lean.check` discovery assertion also lived at the end of the external Lean lane, delaying a catalog regression until after expensive runtime setup.

## Validation

- `make check` (Ruff, formatting, complexity, mypy, 990 unit tests)
- `make architecture` (1,769 files)
- `make test-mcp` (43 tests)

The pinned Lean/Mathlib runtime is not installed in this checkout, so `make test-lean` was not run. The moved `lean.check` catalog regression is covered by the unit lane.