### PR TITLE
feat(mcp): add paginated math.find browse and mark math.run read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ SAT and SMT operations use the maintained Z3 Python binding directly. The
 optional `lean.check` operation runs one bounded source snippet in the fixed
 Lean service environment. It creates only a request-scoped temporary directory
 and returns typed diagnostics; it does not expose a proof-state session or
-retain source. Read `operation://catalog` or use `math.find` to inspect the
-immutable catalog, then call `math.run` once.
+retain source. Use `math.find` to search a capability, browse an unfamiliar
+domain, and inspect one operation before calling `math.run` once.
 
 See the [domain operation library](docs/reference/domain-operation-library.md)
 for the maintained operation portfolio and

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SAT and SMT operations use the maintained Z3 Python binding directly. The
 optional `lean.check` operation runs one bounded source snippet in the fixed
 Lean service environment. It creates only a request-scoped temporary directory
 and returns typed diagnostics; it does not expose a proof-state session or
-retain source. Use `math.find` to search a capability, browse an unfamiliar
+retain source. Use `math.find` to search for an operation, browse an unfamiliar
 domain, and inspect one operation before calling `math.run` once.
 
 See the [domain operation library](docs/reference/domain-operation-library.md)

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -1,13 +1,16 @@
 # Discover and invoke domain operations
 
-Use `math.find` to inspect an operation's typed request and result, then call
-`math.run` once with that operation ID and a `payload` matching its request
-model. For example:
+Use `math.find` progressively, then call `math.run` once with the selected
+operation ID and a `payload` matching its request model. Use `search` when the
+capability is unknown, `browse` for compact operation-ID-sorted pages in an
+unfamiliar domain, and `inspect` for the selected operation's exact typed request,
+result, and valid examples. For example:
 
 ```json
 {"operation_id":"integer.compute.gcd","payload":{"left":"84","right":"30"}}
 ```
 
-The result is returned directly. To continue a calculation, pass the relevant
-typed value in the next operation's payload. Jacobian does not retain caller
-values, workflow state, artifacts, ports, or workspace documents.
+The result is returned directly. To continue a calculation, retain the relevant
+typed fields, update the hypothesis, and pass those fields in the next operation's
+payload. Jacobian does not retain caller values, workflow state, artifacts, ports,
+or workspace documents.

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -2,7 +2,7 @@
 
 Use `math.find` progressively, then call `math.run` once with the selected
 operation ID and a `payload` matching its request model. Use `search` when the
-capability is unknown, `browse` for compact operation-ID-sorted pages in an
+operation is unknown, `browse` for compact operation-ID-sorted pages in an
 unfamiliar domain, and `inspect` for the selected operation's exact typed request,
 result, and valid examples. For example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ These documents define the current product contract:
 | What is Jacobian? | [Product model](explanation/product-blueprint.md) | Product and ownership model |
 | How is it structured? | [Architecture](explanation/architecture.md) | Dependencies and trust boundaries |
 | What does MCP expose? | [Tool surface](reference/tools.md) | Fixed MCP projection |
-| What operations are available? | Runtime `operation://catalog` | Current immutable server inventory |
+| What operations are available? | `math.find` browse or runtime `operation://catalog` | Current immutable server inventory |
 | What work is open? | GitHub issues (e.g. architecture epics) | Implementation priorities live in issues, not a parallel goals doc |
 
 ## How-to guides
@@ -69,8 +69,8 @@ operation contract.
 small mathematical workloads for documentation and testing; they are not
 runtime workflows.
 
-Use the runtime `operation://catalog` and `math.find` for the immutable
-operation inventory and exact operation schemas.
+Use `math.find` browse for compact inventory pages and inspection for exact
+operation schemas. `operation://catalog` remains the immutable bulk export.
 
 ## Explanation
 

--- a/docs/reference/operations/index.md
+++ b/docs/reference/operations/index.md
@@ -4,7 +4,7 @@
 
 The immutable `operation://catalog` resource is the exact bulk inventory for a
 server: it contains every operation ID, request schema, result schema, and
-example. For the ordinary agent path, use `math.find` to search a capability,
+example. For the ordinary agent path, use `math.find` to search for an operation,
 browse compact sorted operation cards, or inspect one exact operation.
 
 The only operation references maintained outside that live catalog describe

--- a/docs/reference/operations/index.md
+++ b/docs/reference/operations/index.md
@@ -2,9 +2,10 @@
 
 [Documentation home](../../index.md) · [Tool surface](../tools.md)
 
-The immutable `operation://catalog` resource is the exact inventory for a
+The immutable `operation://catalog` resource is the exact bulk inventory for a
 server: it contains every operation ID, request schema, result schema, and
-example. Use `math.find` for a smaller search or one exact inspection.
+example. For the ordinary agent path, use `math.find` to search a capability,
+browse compact sorted operation cards, or inspect one exact operation.
 
 The only operation references maintained outside that live catalog describe
 the external boundary that needs extra operational context:

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -2,7 +2,8 @@
 
 Jacobian exposes two MCP tools for atomic mathematics.
 
-- `math.find` searches the immutable built-in operation catalog.
+- `math.find` searches, browses, or inspects the immutable built-in operation
+  catalog.
 - `math.run` executes one operation with a typed `payload`.
 
 `math.run` accepts no state directory, artifact input, value reference, port
@@ -18,6 +19,15 @@ generic verification records.
 {"operation_id":"integer.compute.gcd","payload":{"left":"84","right":"30"}}
 ```
 
-Small results are returned directly. The sole built-in MCP resource is
-`operation://catalog`, the immutable catalog view. The server registers its
-typed Pydantic tools directly with the MCP Python SDK.
+Use `math.find` progressively: `search` finds a few relevance-ranked candidates,
+`browse` pages compact operation cards in operation-ID order (optionally within a
+domain), and `inspect` supplies the selected operation's exact input/output
+schemas and valid examples. Reuse relevant fields from each direct `math.run`
+value in the next payload; the agent owns the evolving conjecture and hypothesis.
+
+`browse` is recomputed from immutable declarations on every request. Its cursor is
+only caller-supplied pagination state, so it creates no catalog identity, saved
+session, artifact, value reference, or server-side record. The sole built-in MCP
+resource, `operation://catalog`, remains an exact bulk export rather than the
+ordinary agent discovery path. The server registers typed Pydantic tools directly
+with the MCP Python SDK.

--- a/src/jacobian/adapters/mcp/core.py
+++ b/src/jacobian/adapters/mcp/core.py
@@ -37,7 +37,7 @@ def register_core_projection(
         title="Run one installed Jacobian math tool",
         description=MATH_RUN_DESCRIPTION,
         annotations=ToolAnnotations(
-            read_only_hint=False,
+            read_only_hint=True,
             destructive_hint=False,
             idempotent_hint=False,
             open_world_hint=False,

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -15,20 +15,24 @@ SERVER_INSTRUCTIONS = (
 )
 
 MATH_FIND_DESCRIPTION = """\
-Search or inspect locally installed Jacobian math tools by desired outcome or exact ID.
-This is authoritative for local search and exact operation inspection; internet search
-is not. Read `operation://catalog` when the complete installed inventory is needed. Use
-math.find when a task may benefit from exact computation, search, or structural analysis.
+Search, browse, or inspect locally installed Jacobian math tools. This is authoritative
+for local discovery and exact operation inspection; internet search is not. Use math.find
+when a task may benefit from exact computation, search, or structural analysis.
 
 Forms:
 - `request.op="search"`: plain-language mathematical outcome (compact cards).
-- Optional `domain` filter; `limit` 1-20 (default 5).
-- Follow `next_cursor` with the same query and filters to continue.
+- `request.op="browse"`: compact operation cards in operation-ID order, optionally
+  filtered to one domain; use this to map an unfamiliar domain.
+- `search` accepts optional `domain` and `limit` 1-20 (default 5); `browse` accepts
+  the same filters (default limit 20).
+- Follow `next_cursor` with the same search query or browse filters to continue.
 - Ranking is deterministic lexical retrieval; matches are not recommendations.
 - `request.op="inspect"`: exact ID with authoritative schemas and examples.
+- `operation://catalog` remains an exact bulk export, not the ordinary discovery path.
 
 Examples:
 - `{"request":{"op":"search","query":"exact matrix determinant","domain":"matrix","limit":3}}`
+- `{"request":{"op":"browse","domain":"matrix","limit":20}}`
 - `{"request":{"op":"search","query":"counterexample to associativity"}}`
 - `{"request":{"op":"search","query":"check a bounded Lean source snippet","domain":"lean"}}`
 - `{"request":{"op":"inspect","operation_id":"polynomial.compute.gcd"}}`

--- a/src/jacobian/adapters/mcp/projections.py
+++ b/src/jacobian/adapters/mcp/projections.py
@@ -53,40 +53,92 @@ def _operation_discovery_response(
                 ),
             }
         }
-    discovered_payload = discovered.model_dump(mode="json")
-    response = {
-        "kind": "discovery",
-        **discovered_payload,
-        "catalog_resource": "operation://catalog",
-        "response_byte_limit": OPERATION_DISCOVERY_RESPONSE_BYTE_LIMIT,
-        "truncation_reason": None,
-        "match_metadata_truncated": False,
-    }
-    matches = cast(list[dict[str, Any]], response["matches"])
+    response = _compact_operation_cards_response(
+        {
+            "kind": "discovery",
+            **discovered.model_dump(mode="json"),
+            "catalog_resource": "operation://catalog",
+            "response_byte_limit": OPERATION_DISCOVERY_RESPONSE_BYTE_LIMIT,
+            "truncation_reason": None,
+            "match_metadata_truncated": False,
+        },
+        cards_key="matches",
+        metadata_truncated_key="match_metadata_truncated",
+    )
+    return response
+
+
+def _operation_browse_response(
+    runtime: Any,
+    *,
+    domain: str | None,
+    limit: int | None,
+    cursor: str | None,
+) -> dict[str, Any]:
+    try:
+        operations = getattr(getattr(runtime, "core", None), "operations", runtime)
+        browsed = operations.browse(
+            domain=domain,
+            limit=limit if limit is not None else 20,
+            cursor=cursor,
+        )
+    except OperationDiscoveryCursorError:
+        return {
+            "error": {
+                "code": "INVALID_CURSOR",
+                "stage": "operation_discovery",
+                "message": "The operation browse cursor is not in this result set.",
+                "hint": (
+                    "Restart browsing without a cursor, or reuse the same domain "
+                    "and limit that produced next_cursor."
+                ),
+            }
+        }
+    return _compact_operation_cards_response(
+        {
+            "kind": "browse",
+            **browsed.model_dump(mode="json"),
+            "catalog_resource": "operation://catalog",
+            "response_byte_limit": OPERATION_DISCOVERY_RESPONSE_BYTE_LIMIT,
+            "truncation_reason": None,
+            "operation_metadata_truncated": False,
+        },
+        cards_key="operations",
+        metadata_truncated_key="operation_metadata_truncated",
+    )
+
+
+def _compact_operation_cards_response(
+    response: dict[str, Any],
+    *,
+    cards_key: str,
+    metadata_truncated_key: str,
+) -> dict[str, Any]:
+    """Enforce the adapter's compact-response policy without retaining state."""
+
+    cards = cast(list[dict[str, Any]], response[cards_key])
     while (
         len(_mcp_text_json_bytes(response)) > OPERATION_DISCOVERY_RESPONSE_BYTE_LIMIT
-        and len(matches) > 1
+        and len(cards) > 1
     ):
-        matches.pop()
+        cards.pop()
         response["truncated"] = True
-        response["next_cursor"] = matches[-1]["operation_id"]
+        response["next_cursor"] = cards[-1]["operation_id"]
         response["truncation_reason"] = "BYTE_LIMIT"
     compact_fields = ("tags",)
     while len(_mcp_text_json_bytes(response)) > OPERATION_DISCOVERY_RESPONSE_BYTE_LIMIT:
         removed = False
-        for match in matches:
+        for card in cards:
             for field in compact_fields:
-                values = match.get(field)
+                values = card.get(field)
                 if isinstance(values, list) and values:
                     values.pop()
                     removed = True
-                    response["match_metadata_truncated"] = True
+                    response[metadata_truncated_key] = True
                     response["truncation_reason"] = "BYTE_LIMIT"
                     break
             if removed:
                 break
         if not removed:
-            raise RuntimeError(
-                "compact operation discovery response exceeds its hard byte limit"
-            )
+            raise RuntimeError("compact operation response exceeds its hard byte limit")
     return response

--- a/src/jacobian/adapters/mcp/tools.py
+++ b/src/jacobian/adapters/mcp/tools.py
@@ -12,9 +12,11 @@ from jacobian.adapters.mcp.context import (
     _catalog,
 )
 from jacobian.adapters.mcp.projections import (
+    _operation_browse_response,
     _operation_discovery_response,
 )
 from jacobian.contracts.operation_find import (
+    OperationBrowseRequest,
     OperationFindRequest,
     OperationFindResponse,
     OperationInspectionResult,
@@ -45,6 +47,14 @@ def math_find(
             cursor=request.cursor,
         )
         return _find_result(discovery_response)
+    if isinstance(request, OperationBrowseRequest):
+        browse_response = _operation_browse_response(
+            active_catalog,
+            domain=request.domain,
+            limit=request.limit,
+            cursor=request.cursor,
+        )
+        return _find_result(browse_response)
     operation_id = request.operation_id
     descriptor = active_catalog.inspect(operation_id)
     if descriptor is None:

--- a/src/jacobian/contracts/operation_find.py
+++ b/src/jacobian/contracts/operation_find.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict, Field, RootModel, StrictInt
 
 from jacobian.contracts.base import ContractModel
 from jacobian.contracts.operations import (
+    OperationBrowseCard,
     OperationDescriptor,
     OperationDiscoveryMatch,
     OperationId,
@@ -31,13 +32,29 @@ class OperationSearchRequest(ContractModel):
     ] = None
 
 
+class OperationBrowseRequest(ContractModel):
+    op: Literal["browse"]
+    domain: Annotated[
+        str | None,
+        Field(pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$"),
+    ] = None
+    limit: Annotated[StrictInt, Field(ge=1, le=20)] = 20
+    cursor: Annotated[
+        str | None,
+        Field(
+            max_length=128,
+            pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$",
+        ),
+    ] = None
+
+
 class OperationInspectRequest(ContractModel):
     op: Literal["inspect"]
     operation_id: OperationId
 
 
 OperationFindRequest = Annotated[
-    OperationSearchRequest | OperationInspectRequest,
+    OperationSearchRequest | OperationBrowseRequest | OperationInspectRequest,
     Field(discriminator="op"),
 ]
 
@@ -64,6 +81,20 @@ class OperationSearchResult(ContractModel):
     match_metadata_truncated: bool = False
 
 
+class OperationBrowseResult(ContractModel):
+    kind: Literal["browse"]
+    discovery_version: Literal["1"]
+    domain: str | None = None
+    operations: tuple[OperationBrowseCard, ...]
+    total_operations: StrictInt
+    truncated: bool
+    next_cursor: str | None = None
+    catalog_resource: Literal["operation://catalog"] = "operation://catalog"
+    response_byte_limit: StrictInt
+    truncation_reason: str | None = None
+    operation_metadata_truncated: bool = False
+
+
 class OperationInspectionResult(ContractModel):
     kind: Literal["operation"]
     operation: OperationDescriptor
@@ -77,7 +108,10 @@ class OperationDiscoveryError(ContractModel):
 class OperationFindResponse(
     RootModel[
         Annotated[
-            OperationSearchResult | OperationInspectionResult | OperationDiscoveryError,
+            OperationSearchResult
+            | OperationBrowseResult
+            | OperationInspectionResult
+            | OperationDiscoveryError,
             Field(discriminator="kind"),
         ]
     ]
@@ -88,6 +122,8 @@ class OperationFindResponse(
 
 
 __all__ = [
+    "OperationBrowseRequest",
+    "OperationBrowseResult",
     "OperationDiscoveryError",
     "OperationDiscoveryErrorDetail",
     "OperationFindRequest",

--- a/src/jacobian/contracts/operations.py
+++ b/src/jacobian/contracts/operations.py
@@ -99,6 +99,43 @@ class OperationDiscoveryResult(ContractModel):
         return self
 
 
+class OperationBrowseCard(ContractModel):
+    """One compact operation card in deterministic catalog order."""
+
+    operation_id: OperationId
+    title: str = Field(min_length=1, max_length=128)
+    description: str = Field(min_length=1, max_length=512)
+    tags: tuple[str, ...] = ()
+
+
+class OperationBrowseResult(ContractModel):
+    """One cursor-paged, unranked view of the immutable operation library."""
+
+    discovery_version: Literal["1"] = "1"
+    domain: str | None = None
+    operations: tuple[OperationBrowseCard, ...]
+    total_operations: int = Field(ge=0, strict=True)
+    truncated: bool
+    next_cursor: OperationId | None = None
+
+    @model_validator(mode="after")
+    def bind_page_metadata(self) -> Self:
+        operation_ids = tuple(operation.operation_id for operation in self.operations)
+        if operation_ids != tuple(sorted(set(operation_ids))):
+            raise ValueError("browse operations must have unique sorted operation IDs")
+        if self.total_operations < len(self.operations):
+            raise ValueError(
+                "total_operations cannot be smaller than the returned page"
+            )
+        if self.truncated != (self.next_cursor is not None):
+            raise ValueError("truncated must agree with next_cursor")
+        if self.next_cursor is not None and (
+            not operation_ids or self.next_cursor != operation_ids[-1]
+        ):
+            raise ValueError("next_cursor must identify the final returned operation")
+        return self
+
+
 class OperationDescriptor(ContractModel):
     """One installed operation advertised by an operator-installed adapter."""
 

--- a/src/jacobian/eval/telemetry.py
+++ b/src/jacobian/eval/telemetry.py
@@ -526,7 +526,9 @@ def _build_operation_description(
     arguments: Mapping[str, Any],
     response: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    matches = response.get("matches") if isinstance(response, Mapping) else None
+    cards = None
+    if isinstance(response, Mapping):
+        cards = response.get("matches", response.get("operations"))
     request = arguments.get("request")
     request = request if isinstance(request, Mapping) else {}
     return {
@@ -546,7 +548,7 @@ def _build_operation_description(
             if isinstance(request.get("operation_id"), str)
             else None
         ),
-        "match_ids": _operation_match_ids(matches),
+        "match_ids": _operation_match_ids(cards),
     }
 
 

--- a/src/jacobian/operation_discovery.py
+++ b/src/jacobian/operation_discovery.py
@@ -6,6 +6,8 @@ import re
 from typing import Protocol
 
 from jacobian.contracts.operations import (
+    OperationBrowseCard,
+    OperationBrowseResult,
     OperationCatalogSnapshot,
     OperationDiscoveryMatch,
     OperationDiscoveryRequest,
@@ -96,6 +98,54 @@ def discover_operations(
     )
 
 
+def browse_operations(
+    catalog: OperationCatalogSnapshot,
+    *,
+    domain: str | None,
+    limit: int,
+    cursor: str | None,
+) -> OperationBrowseResult:
+    """Page a filtered immutable snapshot in operation-ID order without ranking."""
+
+    normalized_domain = normalize_domain(domain) if domain is not None else None
+    operations = tuple(
+        OperationBrowseCard(
+            operation_id=descriptor.operation_id,
+            title=descriptor.title,
+            description=descriptor.description,
+            tags=descriptor.tags,
+        )
+        for descriptor in catalog.operations
+        if normalized_domain is None or matches_domain(descriptor, normalized_domain)
+    )
+    start = 0
+    if cursor is not None:
+        try:
+            start = (
+                next(
+                    index
+                    for index, operation in enumerate(operations)
+                    if operation.operation_id == cursor
+                )
+                + 1
+            )
+        except StopIteration:
+            raise OperationDiscoveryCursorError(
+                "cursor is not present in the filtered operation result"
+            ) from None
+    page = operations[start : start + limit]
+    next_cursor = (
+        page[-1].operation_id if page and start + len(page) < len(operations) else None
+    )
+    return OperationBrowseResult(
+        domain=normalized_domain,
+        operations=page,
+        total_operations=len(operations),
+        truncated=next_cursor is not None,
+        next_cursor=next_cursor,
+    )
+
+
 def normalize_discovery_text(value: str) -> str:
     return "-".join(_DISCOVERY_TOKEN_PATTERN.findall(value.casefold()))
 
@@ -159,6 +209,7 @@ def matches_domain(operation: SearchableOperation, normalized_domain: str) -> bo
 
 
 __all__ = [
+    "browse_operations",
     "discover_operations",
     "discovery_relevance",
     "matches_domain",

--- a/src/jacobian/serving_catalog.py
+++ b/src/jacobian/serving_catalog.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from jacobian.builtin_operation_modules import load_builtin_operation_modules
 from jacobian.contracts.operations import (
+    OperationBrowseResult,
     OperationCatalogSnapshot,
     OperationDescriptor,
     OperationDiscoveryRequest,
@@ -13,7 +14,7 @@ from jacobian.contracts.operations import (
     OperationExample,
 )
 from jacobian.math_tools import MathTool
-from jacobian.operation_discovery import discover_operations
+from jacobian.operation_discovery import browse_operations, discover_operations
 
 
 class ServingCatalog:
@@ -45,6 +46,22 @@ class ServingCatalog:
 
     def search(self, request: OperationDiscoveryRequest) -> OperationDiscoveryResult:
         return discover_operations(self.snapshot(), request)
+
+    def browse(
+        self,
+        *,
+        domain: str | None,
+        limit: int,
+        cursor: str | None,
+    ) -> OperationBrowseResult:
+        """Return a fresh compact page from the immutable declaration snapshot."""
+
+        return browse_operations(
+            self.snapshot(),
+            domain=domain,
+            limit=limit,
+            cursor=cursor,
+        )
 
     def snapshot(self) -> OperationCatalogSnapshot:
         operations = tuple(

--- a/tests/boundary/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/boundary/mcp/test_mcp_catalog_and_policy.py
@@ -118,3 +118,62 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
             assert invalid["error"]["code"] == "INVALID_CURSOR"
 
     asyncio.run(scenario())
+
+
+def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(
+            create_server(),
+            raise_exceptions=True,
+        ) as client:
+            resource_result = await client.read_resource("operation://catalog")
+            full_catalog = json.loads(resource_result.contents[0].text)
+            catalog_ids = [
+                descriptor["operation_id"] for descriptor in full_catalog["operations"]
+            ]
+
+            request: dict[str, object] = {"op": "browse", "limit": 20}
+            browsed_ids: list[str] = []
+            while True:
+                page_result = await client.call_tool("math.find", {"request": request})
+                assert isinstance(page_result.structured_content, dict)
+                page = page_result.structured_content
+                assert page["kind"] == "browse"
+                assert len(page_result.content[0].text.encode("utf-8")) <= 16 * 1024
+                assert json.loads(page_result.content[0].text) == page
+                assert page["response_byte_limit"] == 16 * 1024
+                assert len(page["operations"]) <= 20
+                assert all(
+                    "input_schema" not in operation
+                    and "output_schema" not in operation
+                    and "examples" not in operation
+                    for operation in page["operations"]
+                )
+                page_ids = [
+                    operation["operation_id"] for operation in page["operations"]
+                ]
+                assert page_ids == sorted(page_ids)
+                browsed_ids.extend(page_ids)
+                cursor = page["next_cursor"]
+                if cursor is None:
+                    break
+                request["cursor"] = cursor
+
+            assert browsed_ids == catalog_ids
+            assert len(set(browsed_ids)) == len(catalog_ids)
+
+            invalid_cursor = await client.call_tool(
+                "math.find",
+                {
+                    "request": {
+                        "op": "browse",
+                        "cursor": "integer.compute.unknown",
+                    }
+                },
+            )
+            invalid = json.loads(invalid_cursor.content[0].text)
+            assert invalid["error"]["code"] == "INVALID_CURSOR"
+
+    asyncio.run(scenario())

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -40,8 +40,14 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
                 "payload",
             }
             assert invoke.output_schema == OperationResult.model_json_schema()
+            assert invoke.annotations is not None
+            assert invoke.annotations.read_only_hint is True
+            assert invoke.annotations.idempotent_hint is False
 
             find = next(tool for tool in listed.tools if tool.name == "math.find")
+            assert find.annotations is not None
+            assert find.annotations.read_only_hint is True
+            assert find.annotations.idempotent_hint is True
             assert set(find.input_schema["properties"]) == {"request"}
             assert find.input_schema["properties"]["request"]["discriminator"] == {
                 "mapping": {

--- a/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/boundary/mcp/test_mcp_sdk_2_conformance.py
@@ -45,12 +45,20 @@ def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(
             assert set(find.input_schema["properties"]) == {"request"}
             assert find.input_schema["properties"]["request"]["discriminator"] == {
                 "mapping": {
+                    "browse": "#/$defs/OperationBrowseRequest",
                     "inspect": "#/$defs/OperationInspectRequest",
                     "search": "#/$defs/OperationSearchRequest",
                 },
                 "propertyName": "op",
             }
             assert find.output_schema["type"] == "object"
+
+            browse = await client.call_tool(
+                "math.find",
+                {"request": {"op": "browse", "domain": "matrix", "limit": 1}},
+            )
+            assert isinstance(browse.structured_content, dict)
+            assert browse.structured_content["kind"] == "browse"
 
             serialized_tools = serialize_server_result(
                 "tools/list",

--- a/tests/unit/contracts/test_operation_contracts.py
+++ b/tests/unit/contracts/test_operation_contracts.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.contracts.operations import (
+    OperationBrowseResult,
     OperationCatalogSnapshot,
     OperationDiscoveryResult,
 )
@@ -45,6 +46,39 @@ def test_discovery_page_metadata_is_bound_to_returned_matches() -> None:
                 **base,
                 "truncated": True,
                 "next_cursor": "integer.compute.lcm",
+            }
+        )
+
+
+def test_browse_page_metadata_requires_sorted_compact_operation_cards() -> None:
+    base = {
+        "operations": [
+            {
+                "operation_id": "integer.compute.gcd",
+                "title": "Compute gcd",
+                "description": "Compute one exact gcd.",
+            }
+        ],
+        "total_operations": 2,
+    }
+    with pytest.raises(ValidationError, match="truncated must agree"):
+        OperationBrowseResult.model_validate(
+            {**base, "truncated": True, "next_cursor": None}
+        )
+    with pytest.raises(ValidationError, match="unique sorted"):
+        OperationBrowseResult.model_validate(
+            {
+                **base,
+                "operations": [
+                    *base["operations"],
+                    {
+                        "operation_id": "integer.compute.factorial",
+                        "title": "Compute factorial",
+                        "description": "Compute one exact factorial.",
+                    },
+                ],
+                "total_operations": 2,
+                "truncated": False,
             }
         )
 

--- a/tests/unit/tooling/test_harbor_jobs.py
+++ b/tests/unit/tooling/test_harbor_jobs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
@@ -12,6 +11,7 @@ from benchmarks.tooling.benchmark_contracts import (
     collect_contract_failures,
     validate_job_contract,
 )
+from benchmarks.tooling.command_runner import ToolCommandStatus, run_operator_command
 from benchmarks.tooling.harbor_suite import load_registry
 
 ROOT = Path(__file__).parents[3]
@@ -165,9 +165,9 @@ def test_agent_eval_resolves_a_current_image_when_not_explicitly_set(
         "TRACE": str(trace),
     }
 
-    completed = subprocess.run(
-        [
-            "make",
+    completed = run_operator_command(
+        "make",
+        (
             "agent-eval",
             "EVAL_EXECUTE=1",
             "JACOBIAN_MODEL=test-model",
@@ -175,15 +175,14 @@ def test_agent_eval_resolves_a_current_image_when_not_explicitly_set(
             f"UV_RUN={fake_uv}",
             f"HARBOR_RUNNER={fake_harbor}",
             "JACOBIAN_REGISTRY_IMAGE=registry.invalid/jacobian",
-        ],
+        ),
         cwd=ROOT,
-        env=environment,
-        check=False,
-        capture_output=True,
-        text=True,
+        environment=environment,
+        timeout_seconds=120.0,
     )
 
-    assert completed.returncode == 0, completed.stderr
+    assert completed.status is ToolCommandStatus.EXITED
+    assert completed.exit_code == 0, completed.stderr.decode("utf-8", errors="replace")
     assert trace.read_text(encoding="utf-8").splitlines() == [
         "python -m tools.manage_jacobian_image select --registry-image registry.invalid/jacobian",
         f"bind image={selected}",
@@ -217,9 +216,9 @@ def test_agent_eval_keeps_the_local_mcp_endpoint_independent_of_egress_proxy(
     )
     fake_harbor.chmod(0o755)
 
-    completed = subprocess.run(
-        [
-            "make",
+    completed = run_operator_command(
+        "make",
+        (
             "agent-eval",
             "EVAL_EXECUTE=1",
             "JACOBIAN_MODEL=test-model",
@@ -229,15 +228,14 @@ def test_agent_eval_keeps_the_local_mcp_endpoint_independent_of_egress_proxy(
             "JACOBIAN_EVAL_HTTP_PROXY=http://proxy.invalid:7890",
             f"UV_RUN={fake_uv}",
             f"HARBOR_RUNNER={fake_harbor}",
-        ],
+        ),
         cwd=ROOT,
-        env=os.environ | {"TRACE": str(trace)},
-        check=False,
-        capture_output=True,
-        text=True,
+        environment=os.environ | {"TRACE": str(trace)},
+        timeout_seconds=120.0,
     )
 
-    assert completed.returncode == 0, completed.stderr
+    assert completed.status is ToolCommandStatus.EXITED
+    assert completed.exit_code == 0, completed.stderr.decode("utf-8", errors="replace")
     arguments = trace.read_text(encoding="utf-8").splitlines()
     assert arguments[arguments.index("-c") + 1].endswith(expected_job)
     mcp_index = arguments.index("--mcp-config")

--- a/tests/unit/tooling/test_mcp_catalog_isolation.py
+++ b/tests/unit/tooling/test_mcp_catalog_isolation.py
@@ -5,7 +5,10 @@ from typing import Any, cast
 
 from jacobian.adapters.mcp.context import AppState
 from jacobian.adapters.mcp.tools import math_find
-from jacobian.contracts.operation_find import OperationSearchRequest
+from jacobian.contracts.operation_find import (
+    OperationBrowseRequest,
+    OperationSearchRequest,
+)
 from jacobian.contracts.operations import OperationDiscoveryResult
 
 
@@ -21,6 +24,15 @@ class _Catalog:
     def inspect(self, operation_id: str) -> None:
         return None
 
+    def browse(self, **_: Any) -> Any:
+        from jacobian.contracts.operations import OperationBrowseResult
+
+        return OperationBrowseResult(
+            operations=(),
+            total_operations=0,
+            truncated=False,
+        )
+
 
 def test_math_find_does_not_acquire_an_execution_runtime() -> None:
     state = AppState(
@@ -34,3 +46,17 @@ def test_math_find_does_not_acquire_an_execution_runtime() -> None:
     )
 
     assert result.root.kind == "discovery"
+
+
+def test_math_find_browse_does_not_acquire_an_execution_runtime() -> None:
+    state = AppState(
+        operation_catalog=_Catalog(),
+    )
+    context = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=state))
+
+    result = math_find(
+        OperationBrowseRequest(op="browse"),
+        ctx=cast(Any, context),
+    )
+
+    assert result.root.kind == "browse"


### PR DESCRIPTION
Closes #1519
Fixes #1518

## Problem

Agents can search for a few relevance-ranked operations or read the exact bulk catalog, but they cannot page through a compact inventory of an unfamiliar domain. The stateless math.run tool was also advertised as potentially mutating despite dispatching only immutable built-in mathematical operations.

The PR also exposed two static-policy failures: three newly written documentation lines used a removed experimental-surface term, and an existing Harbor job test invoked make directly instead of through the bounded tooling runner.

## Solution

- Add math.find browse with optional domain filtering, a bounded page size, and an operation-ID continuation cursor.
- Recompute every browse page from the immutable in-memory declaration snapshot. Browse returns compact cards; inspect remains the source of exact schemas and examples, and operation://catalog remains the bulk export.
- Advertise math.run with readOnlyHint: true. Keep idempotentHint: false: the stateless contract proves the former, while per-operation idempotence remains a separate claim.
- Use supported operation terminology in the affected docs and route the Harbor test commands through the existing bounded runner.

## Testing

- make test-mcp — 13 passed
- make check — Ruff, mypy, complexity check, and 473 unit tests passed
- make docs-linkcheck — passed
- make architecture — passed
- Focused Harbor job and architecture-policy tests — 44 passed
- MCP Inspector CLI tools/list — confirmed math.find is read-only/idempotent and math.run is read-only/non-idempotent.

## Trust & Compatibility Impact

This is an additive math.find request/response form. Existing search, inspect, and run calls are unchanged. Browse adds no persistence, artifact identifiers, server-side session, or value reference.

## Architecture Budget

The browse path is a fresh projection of the existing immutable ServingCatalog snapshot. The private compact-response helper now serves both search and browse, replacing the former search-only byte-bound implementation. The CI repair uses the existing bounded runner rather than extending the subprocess allowlist.

## Checklist

- [x] make check passes
- [x] Explicitly relevant specialist validation: make test-mcp
- [x] No Harbor task or verifier changes
- [x] No new ordinary operations
- [x] The shared compact-response helper serves both search and browse
