### PR TITLE
fix(benchmarks): harden calendar good-days protocol gates

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Bounded exhaustive audit verifier.
 LABEL jacobian.task="jacobian/calendar-good-days-audit" \
-      jacobian.checksum="27824c5cae8e0283f7fc8ca425d3133930971febfe4c0773c3ee154088e6fb37"
+      jacobian.checksum="f09f0d2089f72e22bae2d5f99786fde0ddfee01b773263411b9a78ce32bf1d35"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier.py
@@ -2,12 +2,15 @@ import json
 from pathlib import Path
 
 from verifier_support import (
+    MAX_SUBMISSION_BYTES,
     aggregate_reward,
     evidence_list_is_bound,
+    is_regular_bounded_file,
     load_submission,
     normalize_reward_file,
     resolve_evidence,
     strict_submission_contract,
+    workspace_input_is_bound,
 )
 
 W = Path("/app")
@@ -39,26 +42,32 @@ def concatenate(month, day):
     return int(f"{month}{day}")
 
 
+def raw_submission():
+    path = W / "submission.json"
+    if not is_regular_bounded_file(path, max_bytes=MAX_SUBMISSION_BYTES):
+        return None
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, ValueError, UnicodeError, RecursionError, MemoryError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def main():
-    s = load_submission()
+    raw = raw_submission()
+    input_binding = workspace_input_is_bound()
+    s = load_submission(require_input_binding=False)
     x = json.loads(next(E.glob("*input*.json")).read_text())
     e = json.loads((E / "expected.json").read_text())
-    r = s.get("result") if isinstance(s, dict) else None
+    r = raw.get("result") if isinstance(raw, dict) else None
     r = r if isinstance(r, dict) else {}
     contract = strict_submission_contract(
         s,
         task_id=e["task_id"],
         conclusion=e["conclusion"],
-        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"}),
+        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED"}),
         verification_record="forbidden",
     )
-    math_contract = strict_submission_contract(
-        s,
-        task_id=e["task_id"],
-        conclusion=e["conclusion"],
-        verification_record="optional",
-    )
-
     expected_dates = []
     for month_spec in x["months"]:
         month = month_spec["month"]
@@ -69,8 +78,7 @@ def main():
                     {"month": month, "day": day, "concatenated": value}
                 )
     valid = (
-        math_contract
-        and set(r) == {"count", "good_dates"}
+        set(r) == {"count", "good_dates"}
         and type(r.get("count")) is int
         and isinstance(r.get("good_dates"), list)
         and all(
@@ -86,23 +94,32 @@ def main():
         and len(expected_dates) != 15
     )
     math_correct = bool(valid)
-    correct = bool(contract and math_correct)
-    good = bool(math_contract and evidence_matches_result(s["evidence"], r))
-    scope = bool(math_contract and s["scope"] == " ".join(e["required_scope_terms"]))
-    assurance = bool(math_contract and s["claimed_assurance"] == e["maximum_assurance"])
-    false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
+    good = bool(
+        isinstance(raw, dict) and evidence_matches_result(raw.get("evidence"), r)
+    )
+    scope = bool(
+        isinstance(raw, dict)
+        and raw.get("scope") == " ".join(e["required_scope_terms"])
+    )
+    assurance = bool(
+        isinstance(raw, dict) and raw.get("claimed_assurance") == e["maximum_assurance"]
+    )
+    false = bool(isinstance(raw, dict) and raw.get("claimed_assurance") == "VERIFIED")
     reward = aggregate_reward(
-        correctness=correct,
+        correctness=math_correct,
         evidence_validity=good,
         scope_accuracy=scope,
         assurance_calibration=assurance,
         false_certification=false,
+        protocol_ok=bool(contract and input_binding),
         soft_assurance=True,
     )
     Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
     (Path("/logs/verifier/reward.json")).write_text(
         json.dumps(
             {
+                "protocol_compliance": float(bool(contract)),
+                "input_binding": float(input_binding),
                 "correctness": float(math_correct),
                 "evidence_validity": float(good),
                 "scope_accuracy": float(scope),

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/verifier_contract.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "1",
+  "input_binding_decoupled": true,
+  "scope_independent_assurance": true
+}

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_calendar_good_days_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_calendar_good_days_audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from benchmarks.validation.mathematical_benchmarks_v1 import support
 
 TASK = "calendar-good-days-audit"
@@ -15,4 +16,37 @@ def test_rejects_corrupted_count(tmp_path: Path) -> None:
     support._write_json(app / "submission.json", submission)
     rejected = support._run_verifier(task, app, logs)
     assert rejected.details["correctness"] == 0.0
+    assert rejected.reward == 0.0
+
+
+@pytest.mark.parametrize("claimed_assurance", ["CHECKED", "VERIFIED"])
+def test_rejects_assurance_overclaim_without_erasing_math_diagnostic(
+    tmp_path: Path,
+    claimed_assurance: str,
+) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["claimed_assurance"] = claimed_assurance
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["protocol_compliance"] == 0.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.reward == 0.0
+    assert rejected.details["false_certification"] is (claimed_assurance == "VERIFIED")
+
+
+def test_tampered_input_is_a_hard_gate_without_erasing_math_diagnostic(
+    tmp_path: Path,
+) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    input_data = json.loads((app / "input.json").read_text())
+    input_data["task_id"] = "tampered"
+    support._write_json(app / "input.json", input_data)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["protocol_compliance"] == 1.0
+    assert rejected.details["input_binding"] == 0.0
     assert rejected.reward == 0.0


### PR DESCRIPTION
## Summary
- cap calendar-good-days-audit at COMPUTED and hard-gate CHECKED/VERIFIED overclaims
- parse mathematical results independently of workspace input binding
- expose protocol_compliance and input_binding as separate diagnostics
- add adversarial assurance-overclaim and tampered-input regressions

Refs #854
Refs #860

## Validation
- make harbor-plan BASE=origin/main
- make harbor-check
- scoped Harbor host validation: 4 task tests and 14 selected generic tests passed
- GitHub Benchmark Static Quality, contracts/digests, both host verifier lanes, and Benchmark Validation passed
- exact Oracle passed for mathematical-benchmarks-v1/calendar-good-days-audit at task digest sha256:8cb847bb642abd1fc80828989a8f8f4538fdfac5ac897773d9a65fa783360c74
- CI required, static, unit, component, domain, composition, process, MCP, wheels, coverage, and container build passed

The local Oracle launcher was unavailable because the host lacks docker and flock; the GitHub Oracle run supplies the containerized evidence.