### PR TITLE
fix(benchmarks): reject boolean aliases in Farkas evidence

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="6036fee901aab3df23258e3cbbbaa97da624f0bbd14ae34d0602d58927ad0a1e"
+LABEL jacobian.checksum="69a42fa5a59b6eb9f3c8e6e74d703f87fff52226914d5d9461b9dd1d88c7eb00"
 LABEL jacobian.task="jacobian/exact-farkas-ldl-slice"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/verifier.py
@@ -17,6 +17,30 @@ MAX_INPUT_BYTES = 1_048_576
 MAX_SUBMISSION_BYTES = 1_048_576
 
 
+def _json_equal(left: object, right: object) -> bool:
+    """Compare JSON recursively without Python's bool/int coercion."""
+
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if type(left) is int or type(right) is int:
+        return type(left) is type(right) and left == right
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    return type(left) is type(right) and left == right
+
+
 def _load_frozen():
     try:
         frozen_path = E / "input.json"
@@ -206,8 +230,8 @@ def main():
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}
         and evidence["schema_version"] == "1"
         and evidence["task_id"] == expected["task_id"]
-        and evidence["result"] == submission.get("result")
-        and evidence["limitations"] == submission.get("limitations")
+        and _json_equal(evidence["result"], submission.get("result"))
+        and _json_equal(evidence["limitations"], submission.get("limitations"))
     )
     scope_ok = bool(
         structure_ok

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
@@ -42,15 +42,7 @@ def _bind_farkas_slice(app: Path, submission: dict) -> None:
     support._write_json(app / "submission.json", submission)
 
 
-def test_exact_farkas_slice_accepts_sylvester_certificate(tmp_path: Path) -> None:
-    task, app, logs = _prepare_farkas_slice_case(tmp_path)
-    accepted = support._run_verifier(task, app, logs)
-    assert accepted.details["correctness"] == 1.0
-    assert accepted.reward == pytest.approx(1.0)
-
-
-def test_exact_farkas_slice_accepts_ldl_certificate(tmp_path: Path) -> None:
-    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+def _ldl_submission(app: Path) -> dict:
     frozen = json.loads((app / "input.json").read_text())
     matrix = [
         [Fraction(item["numerator"], item["denominator"]) for item in row]
@@ -77,11 +69,53 @@ def test_exact_farkas_slice_accepts_ldl_certificate(tmp_path: Path) -> None:
         "l": [[encode(item) for item in row] for row in lower],
         "d": [encode(item) for item in diagonal],
     }
+    return submission
+
+
+def test_exact_farkas_slice_accepts_sylvester_certificate(tmp_path: Path) -> None:
+    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.reward == pytest.approx(1.0)
+
+
+def test_exact_farkas_slice_accepts_ldl_certificate(tmp_path: Path) -> None:
+    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+    submission = _ldl_submission(app)
     _bind_farkas_slice(app, submission)
 
     accepted = support._run_verifier(task, app, logs)
     assert accepted.details["correctness"] == 1.0
     assert accepted.reward == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("row", "column", "replacement"),
+    [(0, 0, True), (0, 1, False)],
+    ids=("true-for-one", "false-for-zero"),
+)
+def test_exact_farkas_slice_rejects_boolean_integer_evidence_alias(
+    tmp_path: Path,
+    row: int,
+    column: int,
+    replacement: bool,
+) -> None:
+    task, app, logs = _prepare_farkas_slice_case(tmp_path)
+    submission = _ldl_submission(app)
+    _bind_farkas_slice(app, submission)
+    evidence_path = app / "evidence" / "farkas-slice-certificate.json"
+    evidence = json.loads(evidence_path.read_text())
+    evidence["result"]["positive_definite_certificate"]["l"][row][column][
+        "numerator"
+    ] = replacement
+    support._write_json(evidence_path, evidence)
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0
 
 
 def test_exact_farkas_slice_rejects_corrupted_minor(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- compare evidence `result` and `limitations` with recursive type-strict JSON equality
- reject nested `true`/`false` aliases for integer `1`/`0`
- preserve mathematical correctness and assurance scoring while zeroing invalid evidence

Addresses #862.

## Validation

- dedicated verifier tests: 13 passed
- generic verifier contract tests: 12 passed
- `make harbor-plan BASE=origin/main`
- `make harbor-check`
- `make check`: 472 passed, 1 skipped
- CI: 20 checks passed; exact Oracle passed
- Oracle artifact SHA-256: `b841f42b656a87fafa3afe5222728f36bab3e43513ccb53f5806926db8b20703`