### PR TITLE
fix(benchmarks): structure elementwise limitation obligations

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/environment/submission_schema.json
@@ -111,12 +111,17 @@
       "type": "array"
     },
     "limitations": {
-      "items": {
-        "minLength": 1,
-        "type": "string"
-      },
-      "maxItems": 1,
-      "minItems": 1,
+      "items": false,
+      "maxItems": 2,
+      "minItems": 2,
+      "prefixItems": [
+        {
+          "const": "claim:finite-action-counterexample"
+        },
+        {
+          "const": "limitation:no-general-classification-theorem"
+        }
+      ],
       "type": "array"
     },
     "result": {

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/instruction.md
@@ -22,7 +22,7 @@ makes the implication fail. Bind that file by SHA-256.
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->
 ## Submission
 
-The verifier independently generates the finite group, checks determinant one and every elementwise fixed vector, and computes the common fixed-space intersection. The evidence file must contain a mathematical explanation covering the elementwise fixed vectors, the absence of a common fixed vector, and the quantifier-order separation; unrelated or empty text does not earn evidence credit. In the solver's own words, the limitations array must disclose that this finite action does not prove a general classification theorem.
+The verifier independently generates the finite group, checks determinant one and every elementwise fixed vector, and computes the common fixed-space intersection. The evidence file remains qualitative prose and must explain the elementwise fixed vectors, absence of a common fixed vector, and quantifier-order separation; unrelated or empty text does not earn evidence credit. The limitations array records the exact obligation IDs `claim:finite-action-counterexample` and `limitation:no-general-classification-theorem` in that order.
 
 Write `/app/submission.json` to the exact schema in `environment/submission_schema.json`. The submission envelope requires `task_id`, `conclusion`, `result`, `claimed_assurance`, `scope`, `completeness`, `evidence`, and `limitations`.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/solution/submission.json
@@ -6,5 +6,8 @@
   "scope": "finite subgroups of SL_3 over one declared allowed prime field",
   "completeness": "COMPLETE",
   "evidence": [{"path":"evidence/answer.txt","sha256":"sha256:471cecd18ea2cfcac72130ad2e68bb3c591dea69a00c4f8b013ab4069f8278d7"}],
-  "limitations": ["The verifier checks one finite linear action and does not machine-prove a general classification theorem."]
+  "limitations": [
+    "claim:finite-action-counterexample",
+    "limitation:no-general-classification-theorem"
+  ]
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/elementwise-fixed-no-global-invariant" \
-      jacobian.checksum="471353e9400a76edcaf56b00e021ba266528fefd2005326cdebe4b792db2a337"
+      jacobian.checksum="05f2fff1e07f764725607a2056d24482dd0b0e1ad8edb48aed897bc37dbae0dd"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json verifier_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/public_contract.json
@@ -16,8 +16,8 @@
   },
   "required_artifact_filenames": ["evidence/answer.txt"],
   "verification_record": null,
-  "limitations": {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "minLength": 1}},
-  "public_notes": "The verifier independently generates the finite group, checks determinant one and every elementwise fixed vector, and computes the common fixed-space intersection. The evidence file must contain a mathematical explanation covering the elementwise fixed vectors, the absence of a common fixed vector, and the quantifier-order separation; unrelated or empty text does not earn evidence credit. In the solver's own words, the limitations array must disclose that this finite action does not prove a general classification theorem.",
+  "limitations": {"type": "array", "minItems": 2, "maxItems": 2, "prefixItems": [{"const": "claim:finite-action-counterexample"}, {"const": "limitation:no-general-classification-theorem"}], "items": false},
+  "public_notes": "The verifier independently generates the finite group, checks determinant one and every elementwise fixed vector, and computes the common fixed-space intersection. The evidence file remains qualitative prose and must explain the elementwise fixed vectors, absence of a common fixed vector, and quantifier-order separation; unrelated or empty text does not earn evidence credit. The limitations array records the exact obligation IDs `claim:finite-action-counterexample` and `limitation:no-general-classification-theorem` in that order.",
   "schema_definitions": {
     "entry": {"type": "integer", "minimum": 0, "maximum": 12},
     "vector": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"$ref": "#/$defs/entry"}},
@@ -58,7 +58,7 @@
           }
         }
       },
-      "limitations": {"type": "array", "minItems": 1, "maxItems": 1, "items": {"type": "string", "minLength": 1}}
+      "limitations": {"type": "array", "minItems": 2, "maxItems": 2, "prefixItems": [{"const": "claim:finite-action-counterexample"}, {"const": "limitation:no-general-classification-theorem"}], "items": false}
     },
     "$defs": {
       "entry": {"type": "integer", "minimum": 0, "maximum": 12},

--- a/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/elementwise-fixed-no-global-invariant/tests/verifier.py
@@ -14,45 +14,14 @@ from verifier_support import (
 
 W = Path("/app")
 E = Path("/tests")
-LIMITATION = (
-    "The verifier checks one finite linear action and does not machine-prove "
-    "a general classification theorem."
+LIMITATION_OBLIGATIONS = (
+    "claim:finite-action-counterexample",
+    "limitation:no-general-classification-theorem",
 )
 
 
 def _limitations_valid(value: object) -> bool:
-    if not (isinstance(value, list) and len(value) == 1 and isinstance(value[0], str)):
-        return False
-    text = value[0].casefold()
-    if any(
-        term in text
-        for term in (
-            "proof-assistant verified",
-            "formally verified",
-            "complete classification",
-        )
-    ):
-        return False
-    return (
-        any(
-            term in text
-            for term in ("finite", "frozen", "one action", "counterexample")
-        )
-        and any(
-            term in text
-            for term in ("classification", "general theorem", "general result")
-        )
-        and any(
-            term in text
-            for term in (
-                "not prove",
-                "does not prove",
-                "not formal",
-                "not machine",
-                "only",
-            )
-        )
-    )
+    return isinstance(value, list) and value == list(LIMITATION_OBLIGATIONS)
 
 
 def matrix(value, q):

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_elementwise_fixed_no_global_invariant.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_elementwise_fixed_no_global_invariant.py
@@ -9,14 +9,19 @@ from benchmarks.validation.mathematical_benchmarks_v1 import support
 TASK = "elementwise-fixed-no-global-invariant"
 
 
-def test_accepts_equivalent_limitation_wording(tmp_path: Path) -> None:
+def test_accepts_semantically_equivalent_explanation_wording(tmp_path: Path) -> None:
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())
-    submission["limitations"] = [
-        "This finite counterexample does not prove a general classification result."
-    ]
+    evidence = app / "evidence" / "answer.txt"
+    evidence.write_text(
+        "Every group element preserves some nontrivial vector, while there is "
+        "no shared invariant nonzero vector. This separates the quantifier "
+        "orders, so the elementwise assertion cannot imply the global one.\n"
+    )
+    submission["evidence"][0]["sha256"] = support._digest(evidence)
     support._write_json(app / "submission.json", submission)
     accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["evidence_validity"] == 1.0
     assert accepted.details["limitation_accuracy"] == 1.0
     assert accepted.reward == 1.0
 
@@ -69,10 +74,29 @@ def test_malformed_assurance_preserves_other_diagnostics(tmp_path: Path) -> None
     assert rejected.reward == 0.0
 
 
-def test_false_limitation_is_rejected(tmp_path: Path) -> None:
+def test_affirmative_generalization_with_limiting_vocabulary_is_rejected(
+    tmp_path: Path,
+) -> None:
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())
-    submission["limitations"] = ["Proof-assistant verified complete classification."]
+    submission["limitations"] = [
+        "This finite counterexample proves a general theorem while only describing "
+        "one action."
+    ]
+    support._write_json(app / "submission.json", submission)
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["limitation_accuracy"] == 0.0
+    assert rejected.reward == 0.0
+
+
+def test_contradictory_limitation_obligations_are_rejected(tmp_path: Path) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["limitations"] = [
+        "claim:finite-action-counterexample",
+        "claim:general-classification-theorem-proved",
+        "limitation:no-general-classification-theorem",
+    ]
     support._write_json(app / "submission.json", submission)
     rejected = support._run_verifier(task, app, logs)
     assert rejected.details["limitation_accuracy"] == 0.0


### PR DESCRIPTION
## Summary

- replace keyword/negation limitation scoring with two exact task-local obligation IDs
- keep free prose in the evidence artifact for semantically equivalent qualitative explanations
- retain all finite-group certificate, alternate-field, assurance, scope, and evidence behavior
- add affirmative-generalization and contradictory-obligation regressions

Addresses #861.

## Reproduced failure

Before this change, `This finite counterexample proves a general theorem while only describing one action.` passed `_limitations_valid`, reported `limitation_accuracy=1.0`, and received reward `1.0`.

On this branch the same submission retains `correctness=1.0`, `evidence_validity=1.0`, and `scope_accuracy=1.0`, but reports `limitation_accuracy=0.0` and reward `0.0`.

## Validation

- focused verifier: 19 passed
- generic verifier contracts: 14 passed
- selected static and Harbor task contracts passed
- planner selects only the dedicated test, generic contracts, and exact task Oracle
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: 20 checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `972a6e7c58d04cb81d246a7fc4f3184bbad8637e3b1cd71d8de6669c632b8ac7`