### PR TITLE
fix(benchmarks): enforce strict Gram-Schmidt evidence equality

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
-LABEL jacobian.checksum="11e77aa72373a116d9b695c95190204edb64c8743ce667821adb670fbc814d80"
+LABEL jacobian.checksum="d596032e1fcf5184c1d890bc57d7b4a3438ad1f45713ff999b999d058540529b"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY test.sh verifier.py verifier_support.py public_contract.json input.json expected.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gram-schmidt-nonzero-filter-audit/tests/verifier.py
@@ -13,6 +13,26 @@ from verifier_support import (
 W, E = Path("/app"), Path("/tests")
 
 
+def _json_equal(left: object, right: object) -> bool:
+    """Compare JSON recursively without Python numeric coercions."""
+
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    return type(left) is type(right) and left == right
+
+
 def rat(value):
     if (
         not isinstance(value, dict)
@@ -151,8 +171,8 @@ def main():
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}
         and evidence["schema_version"] == "1"
         and evidence["task_id"] == submission["task_id"]
-        and evidence["result"] == result
-        and evidence["limitations"] == submission["limitations"]
+        and _json_equal(evidence["result"], result)
+        and _json_equal(evidence["limitations"], submission["limitations"])
     )
     scope_ok = bool(
         contract

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_gram_schmidt_nonzero_filter_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_gram_schmidt_nonzero_filter_audit.py
@@ -3,6 +3,7 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
 from benchmarks.validation.mathematical_benchmarks_v1.support import _run_verifier
 
 TASK = "gram-schmidt-nonzero-filter-audit"
@@ -18,7 +19,7 @@ def oracle():
     )
 
 
-def verify(tmp_path, submission):
+def verify(tmp_path, submission, *, evidence_result=None):
     task = Path("benchmarks/datasets/mathematical-benchmarks-v1") / TASK
     app, logs = tmp_path / "app", tmp_path / "logs"
     (app / "evidence").mkdir(parents=True)
@@ -27,7 +28,7 @@ def verify(tmp_path, submission):
     evidence = {
         "schema_version": "1",
         "task_id": submission["task_id"],
-        "result": submission["result"],
+        "result": submission["result"] if evidence_result is None else evidence_result,
         "limitations": submission["limitations"],
     }
     p = app / "evidence/gram-schmidt-audit.json"
@@ -56,6 +57,26 @@ def test_reordered_zero_residual_indices_are_accepted(tmp_path):
     accepted = verify(tmp_path, reordered)
     assert accepted.details["correctness"] == 1.0
     assert accepted.reward == 1.0
+
+
+@pytest.mark.parametrize(
+    ("position", "replacement"),
+    [(0, False), (1, True)],
+    ids=("false-for-zero", "true-for-one"),
+)
+def test_boolean_integer_alias_in_nested_evidence_is_rejected(
+    tmp_path,
+    position,
+    replacement,
+):
+    submission = oracle()
+    evidence_result = json.loads(json.dumps(submission["result"]))
+    evidence_result["formal_selected_indices"][position] = replacement
+
+    rejected = verify(tmp_path, submission, evidence_result=evidence_result)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0
 
 
 def test_duplicate_zero_residual_index_is_rejected(tmp_path):


### PR DESCRIPTION
## Summary

- compare evidence result and limitations with recursive type-strict JSON equality
- reject booleans as aliases for numbers at any nesting depth
- keep the change task-local without modifying shared verifier support
- add nested `false`/`true` versus `0`/`1` regressions while preserving the unchanged Oracle and alternate witness

Addresses #862.

## Reproduced failure

Before this change, replacing evidence-only `formal_selected_indices[0:2]` values `0,1` with JSON `false,true` preserved `correctness=1.0`, reported `evidence_validity=1.0`, and received reward `1.0`.

On this branch the same digest-bound evidence reports `correctness=1.0`, `evidence_validity=0.0`, and reward `0.0`.

## Validation

- focused verifier: 7 passed
- generic verifier contracts: 12 passed
- selected static and Harbor task contracts passed
- planner selects only the dedicated test, generic contracts, and exact task Oracle
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: 20 checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `7c7379b7c29e109aa8cdfc82160c076d1e3a78ec68297cc59f141d6d7f176e86`