### PR TITLE
fix(benchmarks): hard-gate random-function assurance

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact dependence-aware expectation verifier.
 LABEL jacobian.task="jacobian/random-function-expectation-audit" \
-      jacobian.checksum="65600356180a3fbaecf92d3bfb2606e5ee2f4e5851e962d6e5df931e21840f49"
+      jacobian.checksum="0fc28835ed8900addb7fc2c91229e0a7dcc03b71cb39d620fc3bab9538ea2ea0"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/random-function-expectation-audit/tests/verifier.py
@@ -61,7 +61,7 @@ def main():
         s,
         task_id=e["task_id"],
         conclusion=e["conclusion"],
-        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"}),
+        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED"}),
         verification_record="forbidden",
     )
     math_contract = strict_submission_contract(

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_random_function_expectation_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_random_function_expectation_audit.py
@@ -8,6 +8,54 @@ from benchmarks.validation.mathematical_benchmarks_v1 import support
 TASK = "random-function-expectation-audit"
 
 
+def _run_with_assurance(tmp_path: Path, claimed_assurance: str):
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["claimed_assurance"] = claimed_assurance
+    support._write_json(app / "submission.json", submission)
+    return support._run_verifier(task, app, logs)
+
+
+def test_computed_assurance_receives_full_reward(tmp_path: Path) -> None:
+    accepted = _run_with_assurance(tmp_path, "COMPUTED")
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.details["scope_accuracy"] == 1.0
+    assert accepted.details["assurance_calibration"] == 1.0
+    assert accepted.details["false_certification"] is False
+    assert accepted.reward == 1.0
+
+
+def test_unverified_assurance_retains_lower_assurance_credit(tmp_path: Path) -> None:
+    accepted = _run_with_assurance(tmp_path, "UNVERIFIED")
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.details["scope_accuracy"] == 1.0
+    assert accepted.details["assurance_calibration"] == 0.0
+    assert accepted.details["false_certification"] is False
+    assert accepted.reward == 0.9
+
+
+def test_checked_overclaim_is_a_hard_zero_with_diagnostics(tmp_path: Path) -> None:
+    rejected = _run_with_assurance(tmp_path, "CHECKED")
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.details["false_certification"] is False
+    assert rejected.reward == 0.0
+
+
+def test_verified_overclaim_is_false_certification(tmp_path: Path) -> None:
+    rejected = _run_with_assurance(tmp_path, "VERIFIED")
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.details["false_certification"] is True
+    assert rejected.reward == 0.0
+
+
 def test_rejects_corrupted_expected_value(tmp_path: Path) -> None:
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())


### PR DESCRIPTION
## Summary

- restrict scoreable contract assurance to `UNVERIFIED` and `COMPUTED`
- make otherwise valid `CHECKED` and `VERIFIED` overclaims hard zero-reward failures
- preserve independent correctness, evidence, scope, assurance, and false-certification diagnostics
- retain full reward for `COMPUTED` and documented partial credit for legitimate `UNVERIFIED`
- leave the separate typed-JSON evidence comparison unchanged

Addresses #854.

## Reproduced failure

Before this change, an otherwise valid `CHECKED` submission reported `correctness=1.0`, `evidence_validity=1.0`, `scope_accuracy=1.0`, and received reward `0.9` through soft assurance.

On this branch the same submission preserves those diagnostics but receives reward `0.0`. `COMPUTED` receives `1.0`, `UNVERIFIED` receives `0.9`, and `VERIFIED` receives `0.0` with `false_certification=true`.

## Validation

- focused verifier: 5 passed
- generic verifier contracts: 13 passed
- selected static and Harbor task contracts passed
- planner selects only the dedicated test, generic contracts, and exact task Oracle
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: 20 checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `62011fdf7f9fa5ce62f7b1a59019196c0b886522245ab744d415d412abcfb095`