### PR TITLE
fix(benchmarks): enforce strict nonlinear recurrence evidence equality

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="068e191c390928386abdd9f18cf40d8e943fe17cb9e6c462e6c7288a938b3a31"
+LABEL jacobian.checksum="dcbce80030f8222186e89d75006f04a929616254a5c7fbcc21e6739f5040fa74"
 LABEL jacobian.task="jacobian/nonlinear-recurrence-crossing-certificate"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nonlinear-recurrence-crossing-certificate/tests/verifier.py
@@ -16,6 +16,26 @@ W, E = Path("/app"), Path("/tests")
 NEG_INF, POS_INF = "NEGATIVE_INFINITY", "POSITIVE_INFINITY"
 
 
+def _json_equal(left: object, right: object) -> bool:
+    """Compare JSON recursively without Python numeric coercions."""
+
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    return type(left) is type(right) and left == right
+
+
 def _frozen():
     try:
         raw = (E / "input.json").read_bytes()
@@ -269,8 +289,8 @@ def main():
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}
         and evidence["schema_version"] == "1"
         and evidence["task_id"] == expected["task_id"]
-        and evidence["result"] == submission.get("result")
-        and evidence["limitations"] == submission.get("limitations")
+        and _json_equal(evidence["result"], submission.get("result"))
+        and _json_equal(evidence["limitations"], submission.get("limitations"))
     )
     envelope = bool(
         contract

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_nonlinear_recurrence_crossing.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_nonlinear_recurrence_crossing.py
@@ -133,6 +133,25 @@ def test_nonlinear_recurrence_rejects_boolean_coefficients(
     assert rejected.reward == 0.0
 
 
+def test_nonlinear_recurrence_rejects_boolean_aliases_in_evidence_only(
+    tmp_path: Path,
+) -> None:
+    task, app, logs = _prepare_nonlinear_recurrence_case(tmp_path)
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    evidence_path = app / "evidence" / "nonlinear-recurrence-certificate.json"
+    evidence = json.loads(evidence_path.read_text())
+    evidence["result"]["potential_identity_coefficients"] = [True, -2, True]
+    support._write_json(evidence_path, evidence)
+    submission["evidence"][0]["sha256"] = support._digest(evidence_path)
+    support._write_json(submission_path, submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0
+
+
 def test_nonlinear_recurrence_rejects_float_index_fields(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- compare evidence `result` and `limitations` with recursive type-strict JSON equality
- reject nested boolean aliases for integer coefficients without changing the submitted mathematical result
- preserve the existing alternative-threshold and reordered-terminal-bound certificates
- leave assurance and input-binding policies unchanged

Addresses #862.

## Reproduced failure

On current main, changing only the digest-bound evidence copy of `potential_identity_coefficients` from `[1,-2,1]` to `[true,-2,true]` preserved `correctness=1.0`, reported `evidence_validity=1.0`, and received reward `1.0`.

On this branch the same evidence-only attack reports `correctness=1.0`, `evidence_validity=0.0`, and reward `0.0`. The unchanged Oracle reports full diagnostics and reward `1.0`.

## Validation

- focused verifier: 7 passed
- selected generic contracts: 12 passed
- selected static and Harbor task contracts passed
- planner selects the focused suite, generic contracts, and exact Oracle shard
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: all required checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `85962c7e4a3b72e7511b9749f12323cada9219fa3a7128298f86fb9102b1396b`

The exact Oracle could not launch locally because this host lacks Docker and `flock`; draft PR CI supplies that execution evidence.