### PR TITLE
fix(benchmarks): hard-gate rational-linear assurance

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/rational-linear-solution" \
-      jacobian.checksum="4e579d31c81d0f48249ef90f576b23561b3e8d1cafa37a21cf75ca22fea91ce0"
+      jacobian.checksum="a948f7cffcd85323583177becc704a6fb50f4f566c80164d4da1a87ed50adb2d"
 COPY expected.json mathematical-benchmarks-v1-rational-linear-solution-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-rational-linear-solution-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/rational-linear-solution/tests/verifier.py
@@ -38,7 +38,7 @@ def main():
         s,
         task_id=e["task_id"],
         conclusion=e["conclusion"],
-        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED", "CHECKED"}),
+        allowed_assurances=frozenset({"UNVERIFIED", "COMPUTED"}),
         verification_record="forbidden",
     )
     math_contract = strict_submission_contract(
@@ -64,9 +64,9 @@ def main():
     )
     math_correct = bool(valid)
     correct = bool(contract and math_correct)
-    good = bool(contract and evidence_list_is_bound(s["evidence"]))
-    scope = bool(contract and s["scope"] == " ".join(e["required_scope_terms"]))
-    assurance = bool(contract and s["claimed_assurance"] == e["maximum_assurance"])
+    good = bool(math_contract and evidence_list_is_bound(s["evidence"]))
+    scope = bool(math_contract and s["scope"] == " ".join(e["required_scope_terms"]))
+    assurance = bool(math_contract and s["claimed_assurance"] == e["maximum_assurance"])
     false = bool(isinstance(s, dict) and s.get("claimed_assurance") == "VERIFIED")
     reward = aggregate_reward(
         correctness=correct,

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_rational_linear_solution.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_rational_linear_solution.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.validation.mathematical_benchmarks_v1 import support
+
+TASK = "rational-linear-solution"
+
+
+def _run_with_assurance(tmp_path: Path, claimed_assurance: str):
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["claimed_assurance"] = claimed_assurance
+    support._write_json(app / "submission.json", submission)
+    return support._run_verifier(task, app, logs)
+
+
+def test_computed_assurance_receives_full_reward(tmp_path: Path) -> None:
+    accepted = _run_with_assurance(tmp_path, "COMPUTED")
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.details["scope_accuracy"] == 1.0
+    assert accepted.details["assurance_calibration"] == 1.0
+    assert accepted.details["false_certification"] is False
+    assert accepted.reward == 1.0
+
+
+def test_unverified_assurance_retains_lower_assurance_credit(tmp_path: Path) -> None:
+    accepted = _run_with_assurance(tmp_path, "UNVERIFIED")
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.details["evidence_validity"] == 1.0
+    assert accepted.details["scope_accuracy"] == 1.0
+    assert accepted.details["assurance_calibration"] == 0.0
+    assert accepted.details["false_certification"] is False
+    assert accepted.reward == pytest.approx(0.9)
+
+
+def test_checked_overclaim_is_a_hard_zero_with_diagnostics(tmp_path: Path) -> None:
+    rejected = _run_with_assurance(tmp_path, "CHECKED")
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.details["false_certification"] is False
+    assert rejected.reward == 0.0
+
+
+def test_verified_overclaim_is_false_certification(tmp_path: Path) -> None:
+    rejected = _run_with_assurance(tmp_path, "VERIFIED")
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
+    assert rejected.details["assurance_calibration"] == 0.0
+    assert rejected.details["false_certification"] is True
+    assert rejected.reward == 0.0


### PR DESCRIPTION
## Summary

- limit scoreable assurance to the declared `UNVERIFIED`/`COMPUTED` range
- make valid `CHECKED` and `VERIFIED` overclaims hard zero-reward failures
- preserve independent mathematical, evidence, scope, assurance, and false-certification diagnostics
- retain full `COMPUTED` reward and intentional lower-assurance partial credit
- leave input binding and evidence semantics unchanged

Addresses #854.

## Reproduced failure

On current main, an otherwise valid `CHECKED` submission preserved math/evidence/scope diagnostics at `1.0` and received soft reward `0.9` despite the `COMPUTED` ceiling.

On this branch the same submission preserves those diagnostics but receives reward `0.0`. `COMPUTED` receives `1.0`, `UNVERIFIED` receives `0.9`, and `VERIFIED` receives `0.0` with `false_certification=true`. The unchanged Oracle receives reward `1.0`.

## Validation

- focused verifier: 4 passed
- selected generic contracts: 12 passed
- selected static and Harbor task contracts passed
- planner selects the focused suite, generic contracts, and exact Oracle shard
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: all required checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `0a09fbe95e6f14cd25aa35408db90ce705074eb745a5bfc69bda032cbe2fad2f`

The exact Oracle could not launch locally because this host lacks Docker and `flock`; draft PR CI supplies that execution evidence.