### PR TITLE
fix(benchmarks): decouple finite-magma input binding

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/finite-magma-countermodel" \
-      jacobian.checksum="ed18080a683aaaffc755f2fb33338e523bbb1b0cc124a527277fc86aa27f3316"
+      jacobian.checksum="d97266432fcb27ffb47e8cba5a9e27093c73e4fc88b0403720910aab602d4dd3"
 COPY expected.json mathematical-benchmarks-v1-finite-magma-countermodel-input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY mathematical-benchmarks-v1-finite-magma-countermodel-input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier.py
@@ -8,6 +8,7 @@ from verifier_support import (
     normalize_reward_file,
     resolve_evidence,
     strict_submission_contract,
+    workspace_input_is_bound,
 )
 
 W = Path("/app")
@@ -156,9 +157,9 @@ def result_valid(result, fixture):
 
 
 def main():
-    submission = load_submission()
+    input_binding = workspace_input_is_bound()
+    submission = load_submission(require_input_binding=False)
     fixture = load_json(E / FIXTURE_NAME)
-    canonical_fixture = load_json(E / FIXTURE_NAME)
     expected = load_json(E / "expected.json")
     if not isinstance(expected, dict):
         expected = {}
@@ -176,11 +177,10 @@ def main():
         verification_record="forbidden",
     )
     result = submission.get("result") if isinstance(submission, dict) else None
-    fixture_bound = bool(fixture is not None and fixture == canonical_fixture)
     math_correct = bool(
-        math_contract and fixture_bound and result_valid(result, fixture)
+        math_contract and fixture is not None and result_valid(result, fixture)
     )
-    correct = bool(accepted_contract and math_correct)
+    correct = bool(accepted_contract and input_binding and math_correct)
     evidence = bool(
         math_contract and evidence_matches_result(submission.get("evidence"), result)
     )
@@ -204,6 +204,8 @@ def main():
     Path("/logs/verifier/reward.json").write_text(
         json.dumps(
             {
+                "protocol_compliance": float(bool(math_contract)),
+                "input_binding": float(input_binding),
                 "correctness": float(math_correct),
                 "evidence_validity": float(evidence),
                 "scope_accuracy": float(scope),

--- a/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/finite-magma-countermodel/tests/verifier_contract.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "1",
+  "input_binding_decoupled": true
+}

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_finite_magma_countermodel.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_finite_magma_countermodel.py
@@ -9,6 +9,15 @@ from benchmarks.validation.mathematical_benchmarks_v1 import support
 TASK = "finite-magma-countermodel"
 
 
+def test_oracle_certificate_is_accepted(tmp_path: Path) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    accepted = support._run_verifier(task, app, logs)
+    assert accepted.details["protocol_compliance"] == 1.0
+    assert accepted.details["input_binding"] == 1.0
+    assert accepted.details["correctness"] == 1.0
+    assert accepted.reward == pytest.approx(1.0)
+
+
 def test_accepts_alternate_smallest_countermodel(tmp_path: Path) -> None:
     task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())
@@ -27,5 +36,19 @@ def test_rejects_corrupted_table(tmp_path: Path) -> None:
     submission["result"]["table"][1][1] = 2
     support._write_json(app / "submission.json", submission)
     rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["input_binding"] == 1.0
     assert rejected.details["correctness"] == 0.0
+    assert rejected.reward == 0.0
+
+
+def test_input_tamper_preserves_mathematical_diagnostic(tmp_path: Path) -> None:
+    task, app, logs = support._prepare_case(tmp_path, TASK, "computed")
+    (app / "input.json").write_text("{}")
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["protocol_compliance"] == 1.0
+    assert rejected.details["input_binding"] == 0.0
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 1.0
+    assert rejected.details["scope_accuracy"] == 1.0
     assert rejected.reward == 0.0


### PR DESCRIPTION
## Summary

- parse the submission independently of workspace input binding
- replay the finite-magma certificate against the hidden task-owned fixture
- expose `protocol_compliance` and `input_binding` as separate diagnostics
- keep failed input binding as a hard reward gate
- leave assurance and evidence policies unchanged

Addresses #860.

## Reproduced failure

On current main, changing only `/app/input.json` to `{}` caused the unchanged valid Oracle submission to report `correctness=0.0` and reward `0.0`, conflating input integrity with mathematics.

On this branch the same tamper reports `protocol_compliance=1.0`, `input_binding=0.0`, `correctness=1.0`, and reward `0.0`. A genuinely corrupted table still reports `correctness=0.0`; the unchanged Oracle reports all diagnostics at `1.0` and reward `1.0`.

## Validation

- focused verifier: 4 passed
- selected generic contracts: 13 passed
- selected static and Harbor task contracts passed
- planner selects the focused suite, generic contracts, and exact Oracle shard
- lint, formatting, complexity, and typecheck passed
- two unrelated xdist workers exited in the local unit lane; both owning tests passed serially
- CI: all required checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `4ee2bdb3ffb2c756108fa536528497a2ee346cbdf90826c3ae2cf6d56092872a`

The exact Oracle could not launch locally because this host lacks Docker and `flock`; draft PR CI supplies that execution evidence.