### PR TITLE
fix(benchmarks): harden primitive Eisenstein evidence binding

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact local-arithmetic verifier for a primitive Eisenstein norm audit.
-LABEL jacobian.checksum="93d4418421ddfa2f8525d770386c3892c1082212c5848e12b1b1d5b9d164ea7f"
+LABEL jacobian.checksum="1399eee83da796c59e6da39925128e680a292fc016c0cbda750c456a5167a740"
 LABEL jacobian.task="jacobian/primitive-eisenstein-norm-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/primitive-eisenstein-norm-audit/tests/verifier.py
@@ -21,6 +21,26 @@ LIMITATIONS = [
 ]
 
 
+def _json_equal(left: object, right: object) -> bool:
+    """Compare JSON recursively without Python's bool/int coercion."""
+
+    if isinstance(left, dict) or isinstance(right, dict):
+        return (
+            isinstance(left, dict)
+            and isinstance(right, dict)
+            and left.keys() == right.keys()
+            and all(_json_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list) or isinstance(right, list):
+        return (
+            isinstance(left, list)
+            and isinstance(right, list)
+            and len(left) == len(right)
+            and all(_json_equal(a, b) for a, b in zip(left, right, strict=True))
+        )
+    return type(left) is type(right) and left == right
+
+
 def frozen_contract() -> dict:
     try:
         app = W / "input.json"
@@ -158,8 +178,8 @@ def main() -> None:
         and set(evidence) == {"schema_version", "task_id", "result", "limitations"}
         and evidence.get("schema_version") == "1"
         and evidence.get("task_id") == expected["task_id"]
-        and evidence.get("result") == submission.get("result")
-        and evidence.get("limitations") == LIMITATIONS
+        and _json_equal(evidence.get("result"), submission.get("result"))
+        and _json_equal(evidence.get("limitations"), LIMITATIONS)
     )
     scope_ok = bool(
         contract

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_primitive_eisenstein_norm_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_primitive_eisenstein_norm_audit.py
@@ -93,6 +93,23 @@ def test_rejects_boolean_in_integer_certificate_fields(tmp_path: Path) -> None:
     assert rejected.reward == 0.0
 
 
+def test_rejects_boolean_alias_only_in_evidence(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    submission = _base_submission(app)
+    evidence = json.loads((app / "evidence/local-audit.json").read_text())
+    evidence["result"]["ramified_witness"]["gcd"] = True
+    evidence["result"]["ramified_witness"]["v3"] = True
+    raw = json.dumps(evidence, separators=(",", ":")).encode()
+    (app / "evidence/local-audit.json").write_bytes(raw)
+    submission["evidence"][0]["sha256"] = "sha256:" + hashlib.sha256(raw).hexdigest()
+    support._write_json(app / "submission.json", submission)
+
+    rejected = support._run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == 1.0
+    assert rejected.details["evidence_validity"] == 0.0
+    assert rejected.reward == 0.0
+
+
 def test_rejects_boolean_in_residue_pair_coordinates(tmp_path: Path) -> None:
     task, app, logs = _case(tmp_path)
     submission = _base_submission(app)


### PR DESCRIPTION
## Summary

- compare the digest-bound evidence result and limitations with recursive type-strict JSON equality
- reject boolean aliases for integer-valued evidence fields while leaving the mathematical submission unchanged
- preserve the mathematical certificate parser, input-binding policy, and assurance policy

Addresses #862.

## Reproduced failure

On current main, changing only the evidence copy of `ramified_witness.gcd` and `ramified_witness.v3` from JSON `1` to `true`, then updating its digest, preserved `correctness=1.0`, reported `evidence_validity=1.0`, and received reward `1.0`.

On this branch the same evidence-only attack preserves `correctness=1.0`, reports `evidence_validity=0.0`, and receives reward `0.0`. The unchanged Oracle reports full diagnostics and reward `1.0`.

## Validation

- focused verifier: 11 passed
- selected generic contracts: 12 passed
- benchmark static quality and selected Harbor task contracts passed
- Harbor planner selects the dedicated test, generic contracts, and exact Oracle shard (`sha256:c2c88a6448c68e57147d70d221b48176094849cf343f2a507ebaa7030eb83e17`)
- lint, formatting, complexity, and typecheck passed
- the local unit lane completed 470 passes and one expected skip but lost two unrelated xdist workers; all five selected owning-test cases passed serially
- CI: all checks passed, including exact Oracle and benchmark validation
- Oracle artifact SHA-256: `d2bc0a8108cea8f939004e253ce91525a5bc4c474f220421076e8a953e0ebbe2`

The exact Oracle cannot launch locally because this host lacks Docker and `flock`; draft PR CI supplies that containerized execution evidence.
