### PR TITLE
refactor(cli): remove obsolete CLI lifecycle state

### DIFF
--- a/src/jacobian/cli.py
+++ b/src/jacobian/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -12,10 +11,6 @@ from typer import _click
 from typer.core import TyperGroup
 
 from jacobian.canonical import loads_strict_json
-from jacobian.contracts.operations import (
-    OperationCatalogSnapshot,
-    OperationDescriptor,
-)
 from jacobian.serving_catalog import ServingCatalog
 
 
@@ -45,58 +40,25 @@ class JacobianGroup(TyperGroup):
                 err=True,
             )
             raise typer.Exit(code=1) from None
-        finally:
-            state = ctx.obj
-            if isinstance(state, CliState):
-                active_failure = sys.exception()
-                try:
-                    state.close()
-                except BaseException as cleanup_exc:
-                    if active_failure is None:
-                        raise
-                    active_failure.add_note(f"CLI cleanup also failed: {cleanup_exc}")
 
 
-class CliState:
-    def __init__(
-        self,
-    ) -> None:
-        self._catalog: ServingCatalog | None = None
-
-    @property
-    def catalog(self) -> ServingCatalog:
-        if self._catalog is None:
-            self._catalog = ServingCatalog.open()
-        return self._catalog
-
-    def catalog_snapshot(self) -> OperationCatalogSnapshot:
-        return self.catalog.snapshot()
-
-    def inspect(self, operation_id: str) -> OperationDescriptor | None:
-        return self.catalog.inspect(operation_id)
-
-    def close(self) -> None:
-        pass
-
-
-def catalog(context: typer.Context) -> None:
+def catalog() -> None:
     """Print the complete installed operation catalog."""
 
-    value = _state(context).catalog_snapshot()
+    value = ServingCatalog.open().snapshot()
     _emit(value.model_dump(mode="json"))
 
 
-def inspect_operation(context: typer.Context, operation_id: str) -> None:
+def inspect_operation(operation_id: str) -> None:
     """Print one exact installed operation declaration."""
 
-    descriptor = _state(context).inspect(operation_id)
+    descriptor = ServingCatalog.open().inspect(operation_id)
     if descriptor is None:
         raise ValueError(f"operation {operation_id!r} is not installed")
     _emit(descriptor.model_dump(mode="json"))
 
 
 def run_operation(
-    context: typer.Context,
     operation_id: str,
     json_payload: Annotated[
         str | None,
@@ -119,13 +81,12 @@ def run_operation(
     payload = loads_strict_json(source)
     if not isinstance(payload, dict):
         raise ValueError("operation payload must be a JSON object")
-    state = _state(context)
     from jacobian.operation_dispatcher import invoke_operation
 
     result = invoke_operation(
         operation_id,
         payload,
-        state.catalog,
+        ServingCatalog.open(),
     )
     _emit(result.model_dump(mode="json"))
 
@@ -140,12 +101,6 @@ def create_cli_app() -> typer.Typer:
         no_args_is_help=True,
     )
 
-    @application.callback()
-    def configure(
-        context: typer.Context,
-    ) -> None:
-        context.obj = CliState()
-
     application.command("catalog")(catalog)
     application.command("inspect")(inspect_operation)
     application.command("run")(run_operation)
@@ -153,13 +108,6 @@ def create_cli_app() -> typer.Typer:
 
 
 app = create_cli_app()
-
-
-def _state(context: typer.Context) -> CliState:
-    state = context.obj
-    if not isinstance(state, CliState):
-        raise RuntimeError("CLI state was not initialized")
-    return state
 
 
 def _emit(payload: Any) -> None:

--- a/tests/composition/cli/test_cli.py
+++ b/tests/composition/cli/test_cli.py
@@ -4,10 +4,9 @@ import json
 from pathlib import Path
 
 import pytest
-import typer
 from typer.testing import CliRunner
 
-from jacobian.cli import CliState, JacobianGroup, app
+from jacobian.cli import app
 
 
 def test_cli_exposes_only_stateless_math_commands() -> None:
@@ -20,8 +19,11 @@ def test_cli_exposes_only_stateless_math_commands() -> None:
         assert removed not in result.stdout
 
 
-def test_cli_catalog_inspect_and_run_are_inline(tmp_path: Path) -> None:
+def test_cli_catalog_inspect_and_run_are_inline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
     catalog_call = runner.invoke(app, ["catalog"])
     inspect_call = runner.invoke(app, ["inspect", "matrix.determinant.compute"])
     run_call = runner.invoke(
@@ -41,6 +43,7 @@ def test_cli_catalog_inspect_and_run_are_inline(tmp_path: Path) -> None:
             ),
         ],
     )
+    assert list(tmp_path.iterdir()) == []
 
     assert catalog_call.exit_code == inspect_call.exit_code == run_call.exit_code == 0
     descriptor = json.loads(inspect_call.stdout)
@@ -49,7 +52,6 @@ def test_cli_catalog_inspect_and_run_are_inline(tmp_path: Path) -> None:
         "num": "1",
         "den": "1",
     }
-    assert list(tmp_path.iterdir()) == []
 
 
 @pytest.mark.parametrize("arguments", [(), ("--json", "{}", "--file", "input.json")])
@@ -62,27 +64,3 @@ def test_cli_run_requires_exactly_one_payload_source(
     error = json.loads(result.stderr)["error"]
     assert error["code"] == "INVALID_ARGUMENT"
     assert error["message"] == ("pass exactly one of --json or --file")
-
-
-def test_cli_cleanup_failure_propagates_after_successful_command(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    test_app = typer.Typer(cls=JacobianGroup)
-
-    @test_app.callback()
-    def configure_test_state(context: typer.Context) -> None:
-        context.obj = CliState()
-
-    @test_app.command("succeed")
-    def succeed() -> None:
-        typer.echo("command completed")
-
-    cleanup_error = RuntimeError("state close failure")
-    monkeypatch.setattr(
-        CliState, "close", lambda _state: (_ for _ in ()).throw(cleanup_error)
-    )
-
-    result = CliRunner().invoke(test_app, ["succeed"])
-
-    assert result.exit_code == 1
-    assert result.exception is cleanup_error


### PR DESCRIPTION
## What changed

- removed the no-op `CliState.close()` lifecycle and `JacobianGroup` cleanup/failure-composition branch
- removed `CliState`, callback context plumbing, and lazy per-invocation state
- opened the immutable `ServingCatalog` directly in each of the single-command CLI handlers
- deleted the synthetic cleanup-failure test and made the existing catalog/inspect/run test assert that no filesystem state is created in its working directory

## Why

`ServingCatalog` owns no closable resource and one CLI invocation executes one command. The lifecycle layer represented state that did not exist and added failure behavior unrelated to any real cleanup operation.

Command names, strict payload selection, JSON error translation, and emitted catalog/descriptor/result payloads are unchanged. The diff is net-negative (74 lines removed).

## Validation

- focused `tests/composition/cli/test_cli.py`: 4 passed
- `make check`: 473 passed, 1 skipped (Lean toolchain unavailable), plus lint, formatting, complexity, and mypy
- owning `make test-composition`: 134 passed
- `git diff --check`

The documented `make test-plan` target is not present on current `main`; the owning lane and routine handoff gate were run directly.
