### PR TITLE
perf(catalog): avoid schema materialization during operation discovery

### DIFF
--- a/src/jacobian/operation_discovery.py
+++ b/src/jacobian/operation_discovery.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from typing import Protocol
 
 from jacobian.contracts.operations import (
     OperationBrowseCard,
     OperationBrowseResult,
-    OperationCatalogSnapshot,
     OperationDiscoveryMatch,
     OperationDiscoveryRequest,
     OperationDiscoveryResult,
@@ -40,17 +40,16 @@ class SearchableOperation(Protocol):
 
 
 def discover_operations(
-    catalog: OperationCatalogSnapshot,
+    operations: Sequence[SearchableOperation],
     request: OperationDiscoveryRequest,
 ) -> OperationDiscoveryResult:
-    """Search an immutable operation snapshot deterministically."""
+    """Search immutable operation declarations deterministically."""
 
-    descriptors = catalog.operations
     normalized_domain = (
         normalize_domain(request.domain) if request.domain is not None else None
     )
     ranked: list[tuple[int, OperationDiscoveryMatch]] = []
-    for descriptor in descriptors:
+    for descriptor in operations:
         if normalized_domain is not None and not matches_domain(
             descriptor, normalized_domain
         ):
@@ -99,7 +98,7 @@ def discover_operations(
 
 
 def browse_operations(
-    catalog: OperationCatalogSnapshot,
+    searchable_operations: Sequence[SearchableOperation],
     *,
     domain: str | None,
     limit: int,
@@ -115,7 +114,9 @@ def browse_operations(
             description=descriptor.description,
             tags=descriptor.tags,
         )
-        for descriptor in catalog.operations
+        for descriptor in sorted(
+            searchable_operations, key=lambda operation: operation.operation_id
+        )
         if normalized_domain is None or matches_domain(descriptor, normalized_domain)
     )
     start = 0

--- a/src/jacobian/serving_catalog.py
+++ b/src/jacobian/serving_catalog.py
@@ -45,7 +45,7 @@ class ServingCatalog:
         return _descriptor(operation)
 
     def search(self, request: OperationDiscoveryRequest) -> OperationDiscoveryResult:
-        return discover_operations(self.snapshot(), request)
+        return discover_operations(tuple(self._operations.values()), request)
 
     def browse(
         self,
@@ -57,7 +57,7 @@ class ServingCatalog:
         """Return a fresh compact page from the immutable declaration snapshot."""
 
         return browse_operations(
-            self.snapshot(),
+            tuple(self._operations.values()),
             domain=domain,
             limit=limit,
             cursor=cursor,

--- a/tests/unit/test_serving_catalog.py
+++ b/tests/unit/test_serving_catalog.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from jacobian import serving_catalog as serving_catalog_module
+from jacobian.contracts.operations import OperationDiscoveryRequest
+from jacobian.operation_discovery import browse_operations, discover_operations
 from jacobian.operation_dispatcher import invoke_operation
 from jacobian.serving_catalog import ServingCatalog
 
@@ -44,3 +47,61 @@ def test_invoke_operation_reports_unknown_removed_family_id() -> None:
             {"vertices": ["a"], "edges": []},
             catalog,
         )
+
+
+def test_compact_discovery_matches_full_descriptor_discovery() -> None:
+    catalog = ServingCatalog.open()
+    descriptors = catalog.snapshot().operations
+    operations = tuple(
+        operation
+        for descriptor in descriptors
+        if (operation := catalog.operation(descriptor.operation_id)) is not None
+    )
+    request = OperationDiscoveryRequest(query="matrix determinant", limit=2)
+
+    expected_search = discover_operations(descriptors, request)
+    assert discover_operations(operations, request) == expected_search
+    if expected_search.next_cursor is not None:
+        next_request = request.model_copy(
+            update={"cursor": expected_search.next_cursor}
+        )
+        assert discover_operations(operations, next_request) == discover_operations(
+            descriptors, next_request
+        )
+
+    expected_browse = browse_operations(
+        descriptors, domain="matrix", limit=2, cursor=None
+    )
+    assert (
+        browse_operations(operations, domain="matrix", limit=2, cursor=None)
+        == expected_browse
+    )
+    if expected_browse.next_cursor is not None:
+        assert browse_operations(
+            operations,
+            domain="matrix",
+            limit=2,
+            cursor=expected_browse.next_cursor,
+        ) == browse_operations(
+            descriptors,
+            domain="matrix",
+            limit=2,
+            cursor=expected_browse.next_cursor,
+        )
+
+
+def test_search_and_browse_do_not_materialize_descriptors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = ServingCatalog.open()
+
+    def fail_descriptor(*_args: object) -> None:
+        raise AssertionError("compact discovery must not construct full descriptors")
+
+    monkeypatch.setattr(serving_catalog_module, "_descriptor", fail_descriptor)
+
+    search = catalog.search(OperationDiscoveryRequest(query="matrix", limit=2))
+    browse = catalog.browse(domain="matrix", limit=2, cursor=None)
+
+    assert search.matches
+    assert browse.operations


### PR DESCRIPTION
## What changed

- changed `discover_operations` and `browse_operations` to consume deterministic sequences of compact `SearchableOperation` declarations
- made `ServingCatalog.search()` and `.browse()` pass their immutable `MathTool` declarations directly
- retained `snapshot()` and `inspect()` as the full descriptor/schema materialization boundaries
- added equivalence coverage for ranking, domain filtering, pagination, cursors, counts, and operation ordering, plus a regression that fails if compact discovery calls `_descriptor`

## Why

Every search or browse call previously built both JSON schemas and a full descriptor for all 226 installed operations, even though discovery reads only operation ID, title, description, and tags.

Repeated calls on one already-open catalog (10 searches + 10 browses):

| | Before | After |
| --- | ---: | ---: |
| Full descriptor builds | 4,520 | 0 |
| Elapsed | 2.348s | 0.032s |

This preserves the stateless catalog design and adds no cache, session, or mutable discovery state.

## Validation

- focused serving-catalog/discovery/contracts tests: 9 passed
- `make check`: 475 passed, 1 skipped (Lean toolchain unavailable), plus lint, formatting, complexity, and mypy
- `git diff --check`

The documented `make test-plan` target is not present on current `main`; the owning unit lane and routine handoff gate were run directly.
