### PR TITLE
Fix assertion debt, fixture debt, and sys.path leaks in tests

### DIFF
--- a/benchmarks/validation/conjecture_probes_v1/test_cycle_double_cover_multiplicity_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_cycle_double_cover_multiplicity_audit.py
@@ -20,14 +20,18 @@ CYCLES = [
 
 
 def _module():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "cycle_double_cover_verifier", TASK / "tests/verifier.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "cycle_double_cover_verifier", TASK / "tests/verifier.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def _result(module):

--- a/benchmarks/validation/conjecture_probes_v1/test_mahler_leading_coefficient_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_mahler_leading_coefficient_audit.py
@@ -11,14 +11,18 @@ TASK = (
 
 
 def _module():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "mahler_verifier", TASK / "tests/verifier.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "mahler_verifier", TASK / "tests/verifier.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def _result():

--- a/benchmarks/validation/conjecture_probes_v1/test_normal_projective_chart_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_normal_projective_chart_audit.py
@@ -9,14 +9,18 @@ TASK = ROOT / "benchmarks/datasets/conjecture-probes-v1/normal-projective-chart-
 
 
 def _module():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "normal_chart_verifier", TASK / "tests/verifier.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "normal_chart_verifier", TASK / "tests/verifier.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def _result():

--- a/benchmarks/validation/conjecture_probes_v1/test_thrackle_local_maximality_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_thrackle_local_maximality_certificate.py
@@ -14,14 +14,18 @@ SELECTED = [(0, 2), (0, 3), (1, 3), (1, 4), (2, 4)]
 
 
 def _module():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "thrackle_verifier", TASK / "tests/verifier.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "thrackle_verifier", TASK / "tests/verifier.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def _result(module):

--- a/benchmarks/validation/conjecture_probes_v1/test_total_coloring_contract_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_total_coloring_contract_audit.py
@@ -9,14 +9,18 @@ TASK = ROOT / "benchmarks/datasets/conjecture-probes-v1/total-coloring-contract-
 
 
 def _module():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "total_coloring_verifier", TASK / "tests/verifier.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "total_coloring_verifier", TASK / "tests/verifier.py"
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def test_oracle_mathematics():

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_closed_one_form_polynomial_classification.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_closed_one_form_polynomial_classification.py
@@ -14,12 +14,16 @@ VERIFIER = (
 
 
 def _module():
-    sys.path.insert(0, str(VERIFIER.parent))
-    spec = importlib.util.spec_from_file_location("closed_form_verifier", VERIFIER)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(VERIFIER.parent))
+        spec = importlib.util.spec_from_file_location("closed_form_verifier", VERIFIER)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def test_uses_result_only_protocol(tmp_path: Path) -> None:

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_continuous_spike_integral_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_continuous_spike_integral_separation.py
@@ -16,15 +16,19 @@ TASK_NAME = "continuous-spike-integral-separation"
 
 
 def load_verifier():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "continuous_spike_verifier", TASK / "tests/verifier.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    sys.modules.pop("verifier_support", None)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "continuous_spike_verifier", TASK / "tests/verifier.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        sys.modules.pop("verifier_support", None)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def candidate(alpha=Fraction(1, 4)):

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
@@ -10,12 +10,16 @@ VERIFIER = (
 
 
 def module():
-    sys.path.insert(0, str(VERIFIER.parent))
-    spec = importlib.util.spec_from_file_location("cyclic_dual", VERIFIER)
-    assert spec and spec.loader
-    loaded = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(loaded)
-    return loaded
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(VERIFIER.parent))
+        spec = importlib.util.spec_from_file_location("cyclic_dual", VERIFIER)
+        assert spec and spec.loader
+        loaded = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(loaded)
+        return loaded
+    finally:
+        sys.path[:] = saved_path
 
 
 def test_independent_dual_cost():

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_even_fixed_point_inclusion.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_even_fixed_point_inclusion.py
@@ -9,14 +9,18 @@ TASK = (
 
 
 def load_verifier():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "fixed_point_verifier", TASK / "tests/verifier.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "fixed_point_verifier", TASK / "tests/verifier.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def test_two_derivations_agree():

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_lp_integrability_separator.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_lp_integrability_separator.py
@@ -10,14 +10,18 @@ TASK = (
 
 
 def load_verifier():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "lp_integrability_verifier", TASK / "tests/verifier.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "lp_integrability_verifier", TASK / "tests/verifier.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def result(beta="1", log_exponent="-2", integral="1"):

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_necklace_burnside_certificate.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_necklace_burnside_certificate.py
@@ -18,14 +18,18 @@ LIMITATIONS = ["FINITE_LENGTH_16_INSTANCE", "NO_GENERAL_ENUMERATION_THEOREM"]
 
 
 def load_verifier():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "necklace_verifier", TASK / "tests/verifier.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "necklace_verifier", TASK / "tests/verifier.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def _digest(path: Path) -> str:

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_pythagorean_generator_recurrence.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_pythagorean_generator_recurrence.py
@@ -16,14 +16,18 @@ TASK_NAME = "pythagorean-generator-recurrence"
 
 
 def load_verifier():
-    sys.path.insert(0, str(TASK / "tests"))
-    spec = importlib.util.spec_from_file_location(
-        "pythagorean_recurrence_verifier", TASK / "tests/verifier.py"
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
+    saved_path = sys.path[:]
+    try:
+        sys.path.insert(0, str(TASK / "tests"))
+        spec = importlib.util.spec_from_file_location(
+            "pythagorean_recurrence_verifier", TASK / "tests/verifier.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = saved_path
 
 
 def candidate(seed=(2, 1)):

--- a/tests/component/providers/graph/test_graph_atlas_matching_regression.py
+++ b/tests/component/providers/graph/test_graph_atlas_matching_regression.py
@@ -31,7 +31,6 @@ def _assert_gallai_edmonds_certificate(graphs: list[nx.Graph[int]]) -> None:
             {"graph": _graph_payload(graph)}
         )
         result = operation.run(request)
-        assert isinstance(result, operation.result_type)
         barrier = set(result.certificate.barrier_vertices)
         reduced = graph.subgraph(set(graph) - barrier)
         odd_component_count = sum(

--- a/tests/component/providers/public_api/test_direct_linear_outcomes.py
+++ b/tests/component/providers/public_api/test_direct_linear_outcomes.py
@@ -48,6 +48,7 @@ def test_rational_linear_operations_return_mathematical_outcomes() -> None:
     assert consistency.status == "CONSISTENT"
     assert contradiction.status == "INCONSISTENT"
     assert contradiction.left_witness is not None
+    assert len(contradiction.left_witness) == 2
     assert contradiction.model_dump(mode="json")["rhs_pairing"] == q(1)
 
 

--- a/tests/composition/catalog/test_builtin_invocation_examples.py
+++ b/tests/composition/catalog/test_builtin_invocation_examples.py
@@ -34,4 +34,3 @@ def test_advertised_invocation_example_executes_successfully(operation) -> None:
     assert examples, f"{operation_id} must advertise one executable example"
     request = operation.request_type.model_validate(examples[0].input)
     outcome = operation.run(request)
-    assert isinstance(outcome, operation.result_type), (operation_id, outcome)

--- a/tests/unit/contracts/test_poset_contracts.py
+++ b/tests/unit/contracts/test_poset_contracts.py
@@ -24,7 +24,6 @@ def _materialize(elements: list[str], relation: list[tuple[str, str]]):
             interpretation="COVER_EDGES",
         )
     )
-    assert isinstance(outcome, operation.result_type)
     return outcome.poset
 
 

--- a/tests/unit/domains/test_logic_operations.py
+++ b/tests/unit/domains/test_logic_operations.py
@@ -48,6 +48,9 @@ def test_canonical_cnf_can_be_passed_directly_to_assignment_and_solver() -> None
     solved = solve_sat(SatSolveRequest(cnf=canonical))
     assert solved.outcome == "SAT"
     assert solved.assignment is not None
+    assert check_sat_assignment(
+        SatAssignmentCheckRequest(cnf=canonical, assignment=solved.assignment)
+    ).satisfies
 
 
 def test_tautological_cnf_is_a_typed_invalid_request() -> None:
@@ -100,6 +103,7 @@ def test_smt_solver_uses_the_inline_smtlib_query() -> None:
 
     assert result.outcome == "SAT"
     assert result.model_smtlib is not None
+    assert "(define-fun" in result.model_smtlib or "(:obj" in result.model_smtlib
 
 
 def test_smt_request_rejects_a_logic_name_hidden_in_a_comment() -> None:

--- a/tests/unit/test_operation_adapters.py
+++ b/tests/unit/test_operation_adapters.py
@@ -49,7 +49,6 @@ def test_parse_operation_input_accepts_json_arrays_for_constrained_tuples() -> N
     )
 
     assert parsed.labels == ("left", "right")
-    assert isinstance(parsed.labels, tuple)
 
 
 def test_parse_operation_input_rejects_numeric_strings_for_integers() -> None:

--- a/tests/unit/test_serving_catalog.py
+++ b/tests/unit/test_serving_catalog.py
@@ -32,7 +32,6 @@ def test_invoke_operation_runs_determinant_without_state() -> None:
     )
 
     assert result.runtime_ms >= 0
-    assert result.output is not None
     assert result.output["determinant"] == {"num": "-2", "den": "1"}
 
 

--- a/tests/unit/tooling/conftest.py
+++ b/tests/unit/tooling/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for Harbor tooling tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.tooling.harbor_suite_support import patch_harbor_root
+
+
+@pytest.fixture
+def patched_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    return patch_harbor_root(monkeypatch, tmp_path)

--- a/tests/unit/tooling/test_harbor_registry.py
+++ b/tests/unit/tooling/test_harbor_registry.py
@@ -13,15 +13,9 @@ from tests.unit.tooling.harbor_suite_support import (
     _make_minimal_task,
     _write_registry,
     _write_suite_toml,
-    patch_harbor_root,
 )
 
 ROOT = Path(__file__).resolve().parents[3]
-
-
-@pytest.fixture
-def patched_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    return patch_harbor_root(monkeypatch, tmp_path)
 
 
 def test_load_registry_returns_unique_well_formed_datasets() -> None:

--- a/tests/unit/tooling/test_harbor_validation.py
+++ b/tests/unit/tooling/test_harbor_validation.py
@@ -13,13 +13,7 @@ from benchmarks.tooling.harbor_suite import (
 )
 from tests.unit.tooling.harbor_suite_support import (
     _make_suite_with_task,
-    patch_harbor_root,
 )
-
-
-@pytest.fixture
-def patched_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    return patch_harbor_root(monkeypatch, tmp_path)
 
 
 def test_validate_task_topology_passes_for_minimal_task(

--- a/tests/unit/tooling/test_harbor_verifier_checks.py
+++ b/tests/unit/tooling/test_harbor_verifier_checks.py
@@ -4,19 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from benchmarks.tooling.harbor_suite import check_verifier_support
 from tests.unit.tooling.harbor_suite_support import (
     _make_suite_with_task,
-    patch_harbor_root,
 )
 
 ROOT = Path(__file__).resolve().parents[3]
-
-
-@pytest.fixture
-def patched_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    return patch_harbor_root(monkeypatch, tmp_path)
 
 
 def test_check_verifier_support_allows_task_owned_contents(

--- a/tests/unit/tooling/test_strict_boundaries.py
+++ b/tests/unit/tooling/test_strict_boundaries.py
@@ -32,7 +32,6 @@ from benchmarks.tooling.strict_boundaries import (
 from pydantic import ValidationError
 from tests.unit.tooling.harbor_suite_support import (
     _make_suite_with_task,
-    patch_harbor_root,
 )
 
 # ---------------------------------------------------------------------------
@@ -177,11 +176,6 @@ def test_raise_strict_model_raises_harbor_suite_error() -> None:
 # ---------------------------------------------------------------------------
 # harbor_suite integration: strict task/environment sections
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def patched_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    return patch_harbor_root(monkeypatch, tmp_path)
 
 
 def test_topology_reports_strict_failure_for_extra_environment_field(


### PR DESCRIPTION
## Summary

Fixes assertion debt, fixture debt, and `sys.path` mutation leaks identified in the codebase audit.

### Assertion debt fixes
- **Strengthen SAT solver test** — validate returned assignment satisfies input CNF via `check_sat_assignment` (previously only checked `is not None`)
- **Strengthen SMT solver test** — validate `model_smtlib` contains a model definition (previously only checked `is not None`)
- **Strengthen inconsistency witness test** — assert witness length matches system size (previously only checked `is not None`)
- **Remove 3 redundant `isinstance(result, operation.result_type)` checks** — statically guaranteed by the type system
- **Remove redundant `isinstance` after stronger `==` check** — the equality check is strictly stronger
- **Remove type-guard-only `output is not None` assertion** — only satisfied the type checker, not a behavioral test

### Fixture debt fixes
- **Extract `patched_root` fixture** into `tests/unit/tooling/conftest.py` — was copy-pasted across 4 Harbor test files
- Remove the duplicated fixture definition and unused `patch_harbor_root` import from all 4 files

### sys.path mutation leak fixes
- **12 benchmark validation test files** now use save/restore pattern (`saved_path = sys.path[:]` + `try/finally`) instead of inserting into `sys.path` without restoring it

### Test plan
- [x] `ruff check` passes on all modified files
- [ ] `make check` (CI)
- [ ] `make harbor-check` (CI)

Closes #1548, #1554, #1555