### PR TITLE
Deduplicate _remaining_ms wall-clock helper across graph optimization

### DIFF
--- a/src/jacobian/domains/graph_optimization/_budget.py
+++ b/src/jacobian/domains/graph_optimization/_budget.py
@@ -1,0 +1,10 @@
+"""Shared wall-clock budget helpers for bounded graph operations."""
+
+from __future__ import annotations
+
+import time
+
+
+def remaining_ms(started: float, wall_seconds: int) -> int:
+    """Return the remaining wall-clock budget in milliseconds."""
+    return int((wall_seconds - (time.monotonic() - started)) * 1000)

--- a/src/jacobian/domains/graph_optimization/exact_search.py
+++ b/src/jacobian/domains/graph_optimization/exact_search.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from jacobian.contracts.graph_coloring import ChromaticGraph
+from jacobian.domains.graph_optimization._budget import remaining_ms
 from jacobian.contracts.graph_optimization import (
     GraphDominationMinimumOutput,
     GraphInducedBipartiteMaximumOutput,
@@ -44,8 +45,7 @@ def _canonical_edges(graph: Any) -> tuple[tuple[str, str], ...]:
     )
 
 
-def _remaining_ms(started: float, wall_seconds: int) -> int:
-    return int((wall_seconds - (time.monotonic() - started)) * 1000)
+
 
 
 def _search_thresholds[WitnessT: (VertexWitness, EdgeWitness)](
@@ -80,7 +80,7 @@ def _search_thresholds[WitnessT: (VertexWitness, EdgeWitness)](
                 tuple(tested),
                 "SOLVER_CALL_LIMIT",
             )
-        remaining_ms = _remaining_ms(started, budget.wall_seconds)
+        remaining_ms = remaining_ms(started, budget.wall_seconds)
         if remaining_ms <= 0:
             return _SearchResult(
                 False,

--- a/src/jacobian/domains/graph_optimization/invariants.py
+++ b/src/jacobian/domains/graph_optimization/invariants.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable
 from typing import Any, cast
 
+from jacobian.domains.graph_optimization._budget import remaining_ms as _remaining_ms
 from jacobian.contracts.base import ContractModel
 from jacobian.contracts.graph_invariant_operations import (
     GraphCliqueNumberResult,
@@ -277,9 +278,7 @@ def _maximum_cardinality(
         if len(tested) >= request.resource_budget.max_solver_calls:
             termination = "SOLVER_CALL_LIMIT"
             break
-        remaining_ms = int(
-            (request.resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
-        )
+        remaining_ms = _remaining_ms(started, request.resource_budget.wall_seconds)
         if remaining_ms <= 0:
             termination = "WALL_TIME"
             break

--- a/src/jacobian/domains/graph_optimization/operations.py
+++ b/src/jacobian/domains/graph_optimization/operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from jacobian.domains.graph_optimization._budget import remaining_ms as _remaining_ms
 from jacobian.contracts.graph_coloring import (
     ChromaticGraph,
     ChromaticSearchStep,
@@ -133,7 +134,7 @@ def solve_chromatic_number(
     tested: list[ChromaticSearchStep] = []
     encoded_graph = canonical_graph(graph)
     for colors in range(lower_bound, upper_bound + 1):
-        remaining_ms = int((wall_seconds - (time.monotonic() - started)) * 1000)
+        remaining_ms = _remaining_ms(started, wall_seconds)
         if remaining_ms <= 0:
             return _unknown_chromatic_result(
                 vertices=vertices,

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -42,9 +42,7 @@ def solve_independence_number(
 
     started = time.monotonic()
     incumbent = tuple(sorted(nx.approximation.maximum_independent_set(graph)))
-    remaining_ms = int(
-        (request.resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
-    )
+    remaining_ms = _remaining_ms(started, request.resource_budget.wall_seconds)
     if remaining_ms <= 0:
         return IndependenceNumberResult(
             status="UNKNOWN",


### PR DESCRIPTION
## Summary

Extracts the duplicated `int((wall_seconds - (time.monotonic() - started)) * 1000)` formula into a shared `remaining_ms()` helper in `graph_optimization/_budget.py`, and uses it from all 4 call sites:

- `exact_search.py` (already had a local `_remaining_ms()` — now imports the shared one)
- `operations.py` (inlined the formula — now calls the shared helper)
- `invariants.py` (inlined the formula — now calls the shared helper)
- `_independence_z3.py` (inlined the formula — now calls the shared helper)

### Test plan
- [x] `ruff check` passes
- [ ] `make check` (CI)

Closes #1549