### PR TITLE
refactor(benchmarks): type reliability and Smith benchmark results

### DIFF
--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/environment/submission_schema.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/environment/submission_schema.json
@@ -9,10 +9,11 @@
           "additionalProperties": false,
           "properties": {
             "den": {
-              "type": "string"
+              "minimum": 1,
+              "type": "integer"
             },
             "num": {
-              "type": "string"
+              "type": "integer"
             }
           },
           "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/solution/submission.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/solution/submission.json
@@ -1,8 +1,8 @@
 {
   "result": {
     "probability": {
-      "den": "3",
-      "num": "1"
+      "den": 3,
+      "num": 1
     },
     "states": 4
   },

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-series-path" \
-      jacobian.checksum="295344139469fdd5c67ed24be27ccace8ab3be49031e9239530b3d4e80b1ff80"
+      jacobian.checksum="cb9b6811c44f3fc10bf84d6b2875bf6adb8b1d9b1fc1baea3b645d01bf614725"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-series-path" \
-      jacobian.checksum="cb9b6811c44f3fc10bf84d6b2875bf6adb8b1d9b1fc1baea3b645d01bf614725"
+      jacobian.checksum="2f42aab206c95b99ef28916a7f90ea06be6600c48cabf8b05db0aea2029db09e"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/expected.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/expected.json
@@ -1,1 +1,1 @@
-{"task_id":"jacobian/reliability-series-path","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-series-path","complete finite input"],"expected_probability":{"num":"1","den":"3"},"expected_states":4}
+{"task_id":"jacobian/reliability-series-path","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-series-path","complete finite input"],"expected_probability":{"num":1,"den":3},"expected_states":4}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/public_contract.json
@@ -23,10 +23,11 @@
         "additionalProperties": false,
         "properties": {
           "den": {
-            "type": "string"
+            "minimum": 1,
+            "type": "integer"
           },
           "num": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "required": [
@@ -55,11 +56,12 @@
           "probability": {
             "additionalProperties": false,
             "properties": {
-              "den": {
-                "type": "string"
-              },
-              "num": {
-                "type": "string"
+          "den": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "num": {
+            "type": "integer"
               }
             },
             "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
@@ -1,4 +1,5 @@
 import json
+from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
@@ -18,7 +19,10 @@ def _frac(v):
     num, den = v.get("num"), v.get("den")
     if type(num) is not int or type(den) is not int or den <= 0:
         return None
-    return (num, den)
+    try:
+        return Fraction(num, den)
+    except (OverflowError, ValueError, ZeroDivisionError):
+        return None
 
 
 def _math(s, x, e):

--- a/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-series-path/tests/verifier.py
@@ -16,7 +16,7 @@ def _frac(v):
     if not isinstance(v, dict):
         return None
     num, den = v.get("num"), v.get("den")
-    if not isinstance(num, str) or not isinstance(den, str):
+    if type(num) is not int or type(den) is not int or den <= 0:
         return None
     return (num, den)
 

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/environment/submission_schema.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/environment/submission_schema.json
@@ -9,10 +9,11 @@
           "additionalProperties": false,
           "properties": {
             "den": {
-              "type": "string"
+              "minimum": 1,
+              "type": "integer"
             },
             "num": {
-              "type": "string"
+              "type": "integer"
             }
           },
           "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/solution/submission.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/solution/submission.json
@@ -1,8 +1,8 @@
 {
   "result": {
     "probability": {
-      "den": "3",
-      "num": "1"
+      "den": 3,
+      "num": 1
     },
     "states": 2
   },

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-single-edge" \
-      jacobian.checksum="c3de6136db1d4c0a12e50f236520aa6e37ce07263f5409980796953862695a73"
+      jacobian.checksum="0ff0547b1b61bc537c5c10b825144abab193387ea091cb207ed1a8835b349e10"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-single-edge" \
-      jacobian.checksum="6d98248d20edcb972de7f01dd66527857e45d6812683900c632291daf04dc510"
+      jacobian.checksum="c3de6136db1d4c0a12e50f236520aa6e37ce07263f5409980796953862695a73"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/expected.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/expected.json
@@ -1,1 +1,1 @@
-{"task_id":"jacobian/reliability-single-edge","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-single-edge","complete finite input"],"expected_probability":{"num":"1","den":"3"},"expected_states":2}
+{"task_id":"jacobian/reliability-single-edge","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-single-edge","complete finite input"],"expected_probability":{"num":1,"den":3},"expected_states":2}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/public_contract.json
@@ -23,10 +23,11 @@
         "additionalProperties": false,
         "properties": {
           "den": {
-            "type": "string"
+            "minimum": 1,
+            "type": "integer"
           },
           "num": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "required": [
@@ -55,11 +56,12 @@
           "probability": {
             "additionalProperties": false,
             "properties": {
-              "den": {
-                "type": "string"
-              },
-              "num": {
-                "type": "string"
+          "den": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "num": {
+            "type": "integer"
               }
             },
             "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
@@ -1,4 +1,5 @@
 import json
+from fractions import Fraction
 from pathlib import Path
 
 from verifier_support import (
@@ -18,7 +19,10 @@ def _frac(v):
     num, den = v.get("num"), v.get("den")
     if type(num) is not int or type(den) is not int or den <= 0:
         return None
-    return (num, den)
+    try:
+        return Fraction(num, den)
+    except (OverflowError, ValueError, ZeroDivisionError):
+        return None
 
 
 def _math(s, x, e):

--- a/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-single-edge/tests/verifier.py
@@ -16,7 +16,7 @@ def _frac(v):
     if not isinstance(v, dict):
         return None
     num, den = v.get("num"), v.get("den")
-    if not isinstance(num, str) or not isinstance(den, str):
+    if type(num) is not int or type(den) is not int or den <= 0:
         return None
     return (num, den)
 

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/environment/submission_schema.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/environment/submission_schema.json
@@ -9,10 +9,11 @@
           "additionalProperties": false,
           "properties": {
             "den": {
-              "type": "string"
+              "minimum": 1,
+              "type": "integer"
             },
             "num": {
-              "type": "string"
+              "type": "integer"
             }
           },
           "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/solution/submission.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/solution/submission.json
@@ -1,8 +1,8 @@
 {
   "result": {
     "probability": {
-      "den": "8",
-      "num": "5"
+      "den": 8,
+      "num": 5
     },
     "states": 8
   },

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/reliability-triangle-fair" \
-      jacobian.checksum="4a5105b1fc828b9542e1465510b76d64ce02d5dfb8d11eabcb6ff3d6f61b0a48"
+      jacobian.checksum="438771897fd1276f8b740173f5c12b18f9e6ce93ed23c946531be82bf57823ec"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/expected.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/expected.json
@@ -1,1 +1,1 @@
-{"task_id":"jacobian/reliability-triangle-fair","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-triangle-fair","complete finite input"],"expected_probability":{"num":"5","den":"8"},"expected_states":8}
+{"task_id":"jacobian/reliability-triangle-fair","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/reliability-triangle-fair","complete finite input"],"expected_probability":{"num":5,"den":8},"expected_states":8}

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/public_contract.json
@@ -23,10 +23,11 @@
         "additionalProperties": false,
         "properties": {
           "den": {
-            "type": "string"
+            "minimum": 1,
+            "type": "integer"
           },
           "num": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "required": [
@@ -55,11 +56,12 @@
           "probability": {
             "additionalProperties": false,
             "properties": {
-              "den": {
-                "type": "string"
-              },
-              "num": {
-                "type": "string"
+          "den": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "num": {
+            "type": "integer"
               }
             },
             "required": [

--- a/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/reliability-triangle-fair/tests/verifier.py
@@ -14,7 +14,20 @@ W = Path("/app")
 E = Path("/tests")
 
 
-def _frac(v):
+def _submission_frac(v):
+    if not isinstance(v, dict) or set(v) != {"num", "den"}:
+        return None
+    num, den = v.get("num"), v.get("den")
+    if type(num) is not int or type(den) is not int or den <= 0:
+        return None
+    try:
+        value = Fraction(num, den)
+    except (OverflowError, ValueError, ZeroDivisionError):
+        return None
+    return value
+
+
+def _input_frac(v):
     if not isinstance(v, dict) or set(v) != {"num", "den"}:
         return None
     num, den = v.get("num"), v.get("den")
@@ -26,10 +39,9 @@ def _frac(v):
     ):
         return None
     try:
-        value = Fraction(int(num), int(den))
+        return Fraction(int(num), int(den))
     except (OverflowError, ValueError, ZeroDivisionError):
         return None
-    return value
 
 
 def _graph_parts(x):
@@ -54,7 +66,7 @@ def _probabilities_by_edge(probabilities, edges):
         if not isinstance(item, dict) or set(item) != {"edge", "open_probability"}:
             return None
         edge = item["edge"]
-        probability = _frac(item["open_probability"])
+        probability = _input_frac(item["open_probability"])
         if (
             not isinstance(edge, list)
             or len(edge) != 2
@@ -121,7 +133,9 @@ def _math(s, x, e):
     ):
         return False
     probability, states = expected
-    return _frac(r.get("probability")) == probability and r["states"] == states
+    return (
+        _submission_frac(r.get("probability")) == probability and r["states"] == states
+    )
 
 
 def main():

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/environment/submission_schema.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/environment/submission_schema.json
@@ -7,7 +7,8 @@
       "properties": {
         "invariant_factors": {
           "items": {
-            "type": "string"
+            "minimum": 1,
+            "type": "integer"
           },
           "type": "array"
         },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/solution/submission.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/solution/submission.json
@@ -1,7 +1,7 @@
 {
   "result": {
     "invariant_factors": [
-      "2"
+      2
     ],
     "rank": 1
   },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/smith-rank-deficient" \
-      jacobian.checksum="215b8bed0311a9e5d6a7a1536ed3224a124a39ba74ddc8c3fa19c5589bfef694"
+      jacobian.checksum="c4aae6952cf662eb88f595d4c12426bf4cba9ab3928f5ec07c3ce86ee404c38e"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/expected.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/expected.json
@@ -1,1 +1,1 @@
-{"task_id":"jacobian/smith-rank-deficient","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/smith-rank-deficient","complete finite input"],"expected_rank":1,"expected_invariant_factors":["2"]}
+{"task_id":"jacobian/smith-rank-deficient","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/smith-rank-deficient","complete finite input"],"expected_rank":1,"expected_invariant_factors":[2]}

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/public_contract.json
@@ -21,7 +21,8 @@
     "properties": {
       "invariant_factors": {
         "items": {
-          "type": "string"
+          "minimum": 1,
+          "type": "integer"
         },
         "type": "array"
       },
@@ -43,8 +44,9 @@
         "additionalProperties": false,
         "properties": {
           "invariant_factors": {
-            "items": {
-              "type": "string"
+        "items": {
+          "minimum": 1,
+          "type": "integer"
             },
             "type": "array"
           },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rank-deficient/tests/verifier.py
@@ -22,7 +22,7 @@ def _math(s, x, e):
     ):
         return False
     ifs = r.get("invariant_factors")
-    if not isinstance(ifs, list) or any(not isinstance(value, str) for value in ifs):
+    if not isinstance(ifs, list) or any(type(value) is not int for value in ifs):
         return False
     matrix = x.get("matrix")
     try:
@@ -53,9 +53,9 @@ def _math(s, x, e):
     invariant_factors = (
         []
         if rank == 0
-        else [str(entry_gcd)]
+        else [entry_gcd]
         if rank == 1
-        else [str(entry_gcd), str(minor_gcd // entry_gcd)]
+        else [entry_gcd, minor_gcd // entry_gcd]
     )
     return r["rank"] == rank and ifs == invariant_factors
 

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/environment/submission_schema.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/environment/submission_schema.json
@@ -7,7 +7,8 @@
       "properties": {
         "invariant_factors": {
           "items": {
-            "type": "string"
+            "minimum": 1,
+            "type": "integer"
           },
           "type": "array"
         },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/solution/submission.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/solution/submission.json
@@ -1,8 +1,8 @@
 {
   "result": {
     "invariant_factors": [
-      "2",
-      "6"
+      2,
+      6
     ],
     "rank": 2
   },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/smith-rectangular" \
-      jacobian.checksum="8f8d21f5d479fc93e31eb6b846b0e8c65395d8b735ebc8d18d3bca38f81e9a93"
+      jacobian.checksum="e69241a72dfb91ed192dd89efd7c76cdf7a63590b62fba25f05b872874b355d9"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/expected.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/expected.json
@@ -1,1 +1,1 @@
-{"task_id":"jacobian/smith-rectangular","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/smith-rectangular","complete finite input"],"expected_rank":2,"expected_invariant_factors":["2","6"]}
+{"task_id":"jacobian/smith-rectangular","conclusion":"TRUE","maximum_assurance":"COMPUTED","required_scope_terms":["jacobian/smith-rectangular","complete finite input"],"expected_rank":2,"expected_invariant_factors":[2,6]}

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/public_contract.json
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/public_contract.json
@@ -21,7 +21,8 @@
     "properties": {
       "invariant_factors": {
         "items": {
-          "type": "string"
+          "minimum": 1,
+          "type": "integer"
         },
         "type": "array"
       },
@@ -43,8 +44,9 @@
         "additionalProperties": false,
         "properties": {
           "invariant_factors": {
-            "items": {
-              "type": "string"
+        "items": {
+          "minimum": 1,
+          "type": "integer"
             },
             "type": "array"
           },

--- a/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier.py
+++ b/benchmarks/datasets/public-reproductions-v1/smith-rectangular/tests/verifier.py
@@ -21,7 +21,8 @@ def _math(s, x, e):
     return (
         rank == e["expected_rank"]
         and isinstance(ifs, list)
-        and [str(v) for v in ifs] == [str(v) for v in e["expected_invariant_factors"]]
+        and all(type(value) is int for value in ifs)
+        and ifs == e["expected_invariant_factors"]
     )
 
 

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -57,15 +57,21 @@ def test_reliability_recomputes_input_and_rejects_coerced_state_count(
     assert rejected.reward == 0.0
 
 
+@pytest.mark.parametrize(
+    ("task_name", "probability"),
+    (
+        ("reliability-series-path", {"num": 2, "den": 6}),
+        ("reliability-single-edge", {"num": 2, "den": 6}),
+        ("reliability-triangle-fair", {"num": 10, "den": 16}),
+    ),
+)
 def test_reliability_accepts_equivalent_unreduced_probability(
-    tmp_path: Path,
+    tmp_path: Path, task_name: str, probability: dict[str, int]
 ) -> None:
-    task, app, logs = _solution_case(
-        tmp_path, "public-reproductions-v1", "reliability-triangle-fair"
-    )
+    task, app, logs = _solution_case(tmp_path, "public-reproductions-v1", task_name)
     submission_path = app / "submission.json"
     submission = json.loads(submission_path.read_text())
-    submission["result"]["probability"] = {"num": 10, "den": 16}
+    submission["result"]["probability"] = probability
     _write_json(submission_path, submission)
 
     accepted = _run_verifier(task, app, logs)

--- a/benchmarks/validation/test_verifier_security_regressions.py
+++ b/benchmarks/validation/test_verifier_security_regressions.py
@@ -41,7 +41,7 @@ def test_reliability_recomputes_input_and_rejects_coerced_state_count(
     )
     expected_path = task / "tests" / "expected.json"
     expected = json.loads(expected_path.read_text())
-    expected["expected_probability"] = {"num": "0", "den": "1"}
+    expected["expected_probability"] = {"num": 0, "den": 1}
     copied_task = tmp_path / "reliability-task"
     shutil.copytree(task, copied_task)
     _write_json(copied_task / "tests" / "expected.json", expected)
@@ -65,7 +65,7 @@ def test_reliability_accepts_equivalent_unreduced_probability(
     )
     submission_path = app / "submission.json"
     submission = json.loads(submission_path.read_text())
-    submission["result"]["probability"] = {"num": "10", "den": "16"}
+    submission["result"]["probability"] = {"num": 10, "den": 16}
     _write_json(submission_path, submission)
 
     accepted = _run_verifier(task, app, logs)
@@ -81,7 +81,7 @@ def test_reliability_rejects_oversized_fraction_without_crashing(
     )
     submission_path = app / "submission.json"
     submission = json.loads(submission_path.read_text())
-    submission["result"]["probability"] = {"num": "9" * 5000, "den": "1"}
+    submission["result"]["probability"] = {"num": 10**4000, "den": 1}
     _write_json(submission_path, submission)
 
     rejected = run_verifier_in_child(task=task, app=app, logs=logs)
@@ -131,3 +131,35 @@ def test_public_reproductions_reject_schema_invalid_integer_coercion(
     _write_json(submission_path, submission)
     rejected = _run_verifier(task, app, logs)
     assert rejected.reward == 0.0
+
+
+@pytest.mark.parametrize(
+    ("task_name", "path", "invalid"),
+    (
+        ("reliability-series-path", ("probability", "num"), "1"),
+        ("reliability-single-edge", ("probability", "num"), "1"),
+        ("reliability-triangle-fair", ("probability", "num"), "5"),
+        ("smith-rank-deficient", ("invariant_factors", 0), "2"),
+        ("smith-rectangular", ("invariant_factors", 1), "6"),
+    ),
+)
+def test_exact_numeric_results_reject_string_coercion(
+    tmp_path: Path,
+    task_name: str,
+    path: tuple[str | int, ...],
+    invalid: object,
+) -> None:
+    task, app, logs = _solution_case(tmp_path, "public-reproductions-v1", task_name)
+    assert _run_verifier(task, app, logs).reward == pytest.approx(1.0)
+
+    submission_path = app / "submission.json"
+    submission = json.loads(submission_path.read_text())
+    parent = submission["result"]
+    for part in path[:-1]:
+        parent = parent[part]
+    parent[path[-1]] = invalid
+    _write_json(submission_path, submission)
+
+    rejected = _run_verifier(task, app, logs)
+    assert rejected.details["correctness"] == pytest.approx(0.0)
+    assert rejected.reward == pytest.approx(0.0)


### PR DESCRIPTION
## What changed

- Represent exact reliability probabilities with integer numerator/denominator components.
- Represent Smith normal-form invariant factors as JSON integers.
- Tighten verifier parsing so string-coerced numeric answers fail closed while equivalent typed rational values retain the existing reward semantics.
- Update gold submissions, expected results, generated schemas, verifier checksums, and focused security regressions.

## Why

These correctness-bearing values were exposed as unrestricted strings even though their semantics are exact integers. Typed values let agents submit the mathematical answer directly and let verifiers parse the semantic result before reducing it to scalar reward.

## Validation

- `make harbor-check-task DATASET=public-reproductions-v1 TASKS="reliability-series-path reliability-single-edge reliability-triangle-fair smith-rank-deficient smith-rectangular"`
- `make harbor-validation-tests TESTS="benchmarks/validation/test_verifier_security_regressions.py" PYTEST_ARGS="-k 'exact_numeric_results or reliability or public_reproductions_reject_schema_invalid_integer_coercion'" HARBOR_VALIDATION_WORKERS=0` (10 passed)
- `uv run --locked ruff check` on all changed verifier/test Python files
- `make harbor-plan BASE=origin/main` selects all five changed-task Oracles

The local host has no Docker-compatible runtime, so the five exact task Oracles are left to the PR benchmark workflow.
