### PR TITLE
refactor(benchmarks): type exact analysis benchmark results

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -9,16 +28,16 @@
           "additionalProperties": false,
           "properties": {
             "x": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "xyz": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "y": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "z": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             }
           },
           "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/instruction.md
@@ -3,6 +3,8 @@
 Solve the exact problem in the offline input. Return the integer value of
 `log_z(w)` and the three rational reciprocal-log contributions relative to
 `ln(w)`.
+Represent each exact rational as an integer `numerator` and positive integer
+`denominator`.
 
 Write `submission.json` to the exact agent-visible `submission_schema.json`.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/solution/submission.json
@@ -1,10 +1,10 @@
 {
   "result": {
     "reciprocal_log_contributions": {
-      "x": "1/24",
-      "xyz": "1/12",
-      "y": "1/40",
-      "z": "1/60"
+      "x": {"denominator": 24, "numerator": 1},
+      "xyz": {"denominator": 12, "numerator": 1},
+      "y": {"denominator": 40, "numerator": 1},
+      "z": {"denominator": 60, "numerator": 1}
     },
     "value": 60
   }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 LABEL jacobian.task="jacobian/log-exponent-recovery" \
-      jacobian.checksum="c759a2738aad08c1db4b0352e5c08df30adfd7143ec37b629e63e034e912ee31"
+      jacobian.checksum="dff591a71c90764ccb679e853f021c3619321f201972a98b5624e5bd48f3ab30"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -10,16 +20,16 @@
         "additionalProperties": false,
         "properties": {
           "x": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "xyz": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "y": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "z": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [
@@ -42,6 +52,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -51,16 +72,16 @@
             "additionalProperties": false,
             "properties": {
               "x": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "xyz": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "y": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "z": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               }
             },
             "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/log-exponent-recovery/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -9,7 +8,16 @@ from verifier_support import (
 )
 
 E = Path("/tests")
-RATIONAL_PATTERN = re.compile(r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?")
+
+
+def _fraction(value):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        raise ValueError
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
+        raise ValueError
+    return Fraction(numerator, denominator)
 
 
 def witness_ok(result):
@@ -26,13 +34,7 @@ def witness_ok(result):
     ):
         return False
     try:
-        if any(
-            not isinstance(values[key], str)
-            or RATIONAL_PATTERN.fullmatch(values[key]) is None
-            for key in ("x", "y", "z", "xyz")
-        ):
-            return False
-        x, y, z, xyz = (Fraction(values[key]) for key in ("x", "y", "z", "xyz"))
+        x, y, z, xyz = (_fraction(values[key]) for key in ("x", "y", "z", "xyz"))
     except (TypeError, ValueError, ZeroDivisionError):
         return False
     return (

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -6,31 +25,31 @@
       "additionalProperties": false,
       "properties": {
         "gap_witness": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "jump": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "left_endpoint_value": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "left_limit": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "left_slope": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "offset": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_breakpoint_value": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_endpoint_value": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_slope": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         }
       },
       "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/instruction.md
@@ -5,7 +5,8 @@ function on a compact interval.  Within the declared two-branch rational family,
 construct a strictly increasing function with a jump at zero and certify that its
 image omits a rational point lying strictly between its endpoint values.
 
-Submit canonical rational parameters, the four boundary values listed in the
+Submit canonical rational parameters as integer `numerator`/positive integer
+`denominator` objects in lowest terms, the four boundary values listed in the
 schema, and any canonical rational gap witness.  The witness must lie strictly
 between the left limit and the right value at zero.  This simultaneously refutes
 the claimed interval-image conclusion and the existence of a two-sided inverse

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/solution/submission.json
@@ -1,13 +1,13 @@
 {
   "result": {
-    "gap_witness": "1",
-    "jump": "2",
-    "left_endpoint_value": "-2",
-    "left_limit": "0",
-    "left_slope": "1",
-    "offset": "0",
-    "right_breakpoint_value": "2",
-    "right_endpoint_value": "6",
-    "right_slope": "2"
+    "gap_witness": {"denominator": 1, "numerator": 1},
+    "jump": {"denominator": 1, "numerator": 2},
+    "left_endpoint_value": {"denominator": 1, "numerator": -2},
+    "left_limit": {"denominator": 1, "numerator": 0},
+    "left_slope": {"denominator": 1, "numerator": 1},
+    "offset": {"denominator": 1, "numerator": 0},
+    "right_breakpoint_value": {"denominator": 1, "numerator": 2},
+    "right_endpoint_value": {"denominator": 1, "numerator": 6},
+    "right_slope": {"denominator": 1, "numerator": 2}
   }
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact verifier for a strict-monotonicity missing-continuity audit.
 LABEL jacobian.task="jacobian/monotone-inverse-continuity-audit" \
-      jacobian.checksum="22780c005d4541c7deb31f948aa8b6dceafde6f1accacadecc3e3463472b67e1"
+      jacobian.checksum="8a9e613464affe400c64428ff28cc98900d27ba2c76045bf969593c221354992"
 COPY expected.json input.json public_contract.json test.sh verifier.py verifier_support.py /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/public_contract.json
@@ -1,37 +1,47 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
     "additionalProperties": false,
     "properties": {
       "gap_witness": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "jump": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "left_endpoint_value": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "left_limit": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "left_slope": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "offset": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_breakpoint_value": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_endpoint_value": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_slope": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       }
     },
     "required": [
@@ -49,37 +59,48 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
         "additionalProperties": false,
         "properties": {
           "gap_witness": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "jump": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "left_endpoint_value": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "left_limit": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "left_slope": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "offset": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_breakpoint_value": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_endpoint_value": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_slope": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/monotone-inverse-continuity-audit/tests/verifier.py
@@ -27,6 +27,19 @@ def _fraction(value):
     return parsed
 
 
+def _result_fraction(value):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        raise ValueError
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
+        raise ValueError
+    parsed = Fraction(numerator, denominator)
+    if parsed.numerator != numerator or parsed.denominator != denominator:
+        raise ValueError
+    return parsed
+
+
 def _valid_countermodel(result, source):
     keys = {
         "left_slope",
@@ -42,7 +55,7 @@ def _valid_countermodel(result, source):
     if not isinstance(result, dict) or set(result) != keys:
         return False
     try:
-        value = {key: _fraction(item) for key, item in result.items()}
+        value = {key: _result_fraction(item) for key, item in result.items()}
         bounds = source["parameter_bounds"]
         left = _fraction(source["interval"]["left"])
         right = _fraction(source["interval"]["right"])

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -6,25 +25,25 @@
       "additionalProperties": false,
       "properties": {
         "left_derivative": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "left_slope": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "left_value_at_join": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "peak": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_derivative": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_slope": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "right_value_at_join": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         }
       },
       "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/instruction.md
@@ -5,7 +5,8 @@ attained at `0` but which is not differentiable there. Use the two-branch family
 declared in the input and choose any rational peak and slopes satisfying the
 requirements.
 
-Return exact rational parameters and the branch values at the join. The
+Return exact rational parameters as integer `numerator`/positive integer
+`denominator` objects in lowest terms and the branch values at the join. The
 verifier independently checks continuity at zero, monotonicity toward and away
 from the peak, and the unequal one-sided derivatives. Write `submission.json`
 to the exact `submission_schema.json` contract, Write the task-specific witness to

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/solution/submission.json
@@ -1,12 +1,12 @@
 {
   "result": {
-    "left_derivative": "3",
-    "left_slope": "3",
-    "left_value_at_join": "2",
-    "peak": "2",
-    "right_derivative": "-1/2",
-    "right_slope": "-1/2",
-    "right_value_at_join": "2"
+    "left_derivative": {"denominator": 1, "numerator": 3},
+    "left_slope": {"denominator": 1, "numerator": 3},
+    "left_value_at_join": {"denominator": 1, "numerator": 2},
+    "peak": {"denominator": 1, "numerator": 2},
+    "right_derivative": {"denominator": 2, "numerator": -1},
+    "right_slope": {"denominator": 2, "numerator": -1},
+    "right_value_at_join": {"denominator": 1, "numerator": 2}
   },
   "witness": [
     {

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact rational verifier for a piecewise-linear analysis construction.
 LABEL jacobian.task="jacobian/nondifferentiable-maximum-construction" \
-      jacobian.checksum="0290332451680037fa99a0cf18bc2b66b191d0ec40307a914e96efc689265312"
+      jacobian.checksum="c75c9383dfc95e86041aa03755017c9dadd51f77c9038e95a47c511110513c24"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/public_contract.json
@@ -15,32 +15,42 @@
   "required_witness_filenames": [
     "evidence/answer.txt"
   ],
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
     "additionalProperties": false,
     "properties": {
       "left_derivative": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "left_slope": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "left_value_at_join": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "peak": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_derivative": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_slope": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "right_value_at_join": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       }
     },
     "required": [
@@ -56,31 +66,42 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
         "additionalProperties": false,
         "properties": {
           "left_derivative": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "left_slope": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "left_value_at_join": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "peak": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_derivative": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_slope": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "right_value_at_join": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/nondifferentiable-maximum-construction/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -16,12 +15,14 @@ E = Path("/tests")
 
 
 def _fraction(value):
-    if not isinstance(value, str) or len(value) > 80:
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
         raise ValueError
-    if re.fullmatch(r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?", value) is None:
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         raise ValueError
-    parsed = Fraction(value)
-    if str(parsed) != value:
+    parsed = Fraction(numerator, denominator)
+    if parsed.numerator != numerator or parsed.denominator != denominator:
         raise ValueError
     return parsed
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -54,7 +73,7 @@
           "type": "object"
         },
         "real_part": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "reciprocal_denominator": {
           "maximum": 7,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/instruction.md
@@ -2,6 +2,9 @@
 
 A frozen API defines `F(s)` by `Σ n^{-s}` when the series is summable and returns `0` otherwise. Choose `s=1/q` with `3≤q≤7` and certify nonsummability using all dyadic blocks `2^k≤n<2^(k+1)` for the frozen levels.
 
+Represent the exact real part as an integer `numerator` and positive integer
+`denominator` in lowest terms.
+
 First report the affine exponent of the general q-th-power lower bound as a coefficient of `k` and a constant term. For each frozen block, report its term count and the corresponding integer lower bound obtained from `n<2^(k+1)`. Include the divergence and returned-value classifications in the typed result.
 
 The verifier recomputes the symbolic exponent and all frozen powers and accepts any allowed q. The nine blocks replay instances of the general bound; finite data alone is not treated as a proof of divergence.

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/solution/submission.json
@@ -61,7 +61,7 @@
       "constant": -1,
       "level_coefficient": 2
     },
-    "real_part": "1/3",
+    "real_part": {"denominator": 3, "numerator": 1},
     "reciprocal_denominator": 3,
     "returned_value": 0,
     "summability_status": "DIVERGENT",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact verifier for a series-domain fallback audit.
 LABEL jacobian.task="jacobian/series-domain-junk-zero" \
-      jacobian.checksum="0f7881060f99e87ff6b3be9ba0f13284533da6ec7a51aa74392138cfa02d1a91"
+      jacobian.checksum="5a6d561a9de4bc1c4a5d7d4a46313ef30f5b19287a9a32bade5aceb8b4f19c69"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -55,7 +65,7 @@
         "type": "object"
       },
       "real_part": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "reciprocal_denominator": {
         "maximum": 7,
@@ -86,6 +96,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -140,7 +161,7 @@
             "type": "object"
           },
           "real_part": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "reciprocal_denominator": {
             "maximum": 7,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/series-domain-junk-zero/tests/verifier.py
@@ -28,13 +28,21 @@ def _load_frozen_input():
 
 
 def _canonical_fraction(value):
-    if not isinstance(value, str):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         return None
     try:
-        parsed = Fraction(value)
+        parsed = Fraction(numerator, denominator)
     except (ValueError, ZeroDivisionError):
         return None
-    return parsed if str(parsed) == value else None
+    return (
+        parsed
+        if parsed.numerator == numerator and parsed.denominator == denominator
+        else None
+    )
 
 
 def _valid_blocks(blocks, q, start, end):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -47,10 +66,10 @@
               "additionalProperties": false,
               "properties": {
                 "order_1": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "order_2": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/instruction.md
@@ -10,7 +10,8 @@ Your JSON must:
    0, 4, and 6 from the definition
    `K_j(i)=sum_h (-1)^h (q-1)^(j-h) C(i,h) C(n-i,j-h)`;
 4. give nonnegative rational multipliers for those two Delsarte inequalities
-   whose linear combination is exactly `18 - (1 + A4 + A6) >= 0`.
+   whose linear combination is exactly `18 - (1 + A4 + A6) >= 0`, representing
+   each multiplier as an integer `numerator` and positive integer `denominator`.
 
 The verifier accepts any valid construction and recomputes all finite
 arithmetic. A published value of 18 without the construction and dual

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/solution/submission.json
@@ -28,8 +28,8 @@
     "upper_bound_certificate": {
       "bound": 18,
       "dual_multipliers": {
-        "order_1": "7/12",
-        "order_2": "1/6"
+        "order_1": {"denominator": 12, "numerator": 7},
+        "order_2": {"denominator": 6, "numerator": 1}
       },
       "krawtchouk_rows": [
         {

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="0e8a60d8d501b00fc8241f499e7493a280bc39e944c4e88afcebef1e82a4791b"
+LABEL jacobian.checksum="a669b5568cd2574297543be1fb9d9a065839f2bb99d371982199817de4d09eed"
 COPY verifier.py verifier_support.py input.json expected.json test.sh public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -47,11 +57,11 @@
           "dual_multipliers": {
             "additionalProperties": false,
             "properties": {
-              "order_1": {
-                "type": "string"
+          "order_1": {
+            "$ref": "#/$defs/rational"
               },
-              "order_2": {
-                "type": "string"
+          "order_2": {
+            "$ref": "#/$defs/rational"
               }
             },
             "required": [
@@ -110,6 +120,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -156,11 +177,11 @@
               "dual_multipliers": {
                 "additionalProperties": false,
                 "properties": {
-                  "order_1": {
-                    "type": "string"
+              "order_1": {
+                "$ref": "#/$defs/rational"
                   },
-                  "order_2": {
-                    "type": "string"
+              "order_2": {
+                "$ref": "#/$defs/rational"
                   }
                 },
                 "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ternary-distance-code-optimum/tests/verifier.py
@@ -35,6 +35,19 @@ def _fraction(value: object) -> Fraction | None:
         return None
 
 
+def _result_fraction(value: object) -> Fraction | None:
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
+        return None
+    try:
+        return Fraction(numerator, denominator)
+    except (ValueError, ZeroDivisionError):
+        return None
+
+
 def _krawtchouk(order: int, distance: int, *, q: int = 3, n: int = 6) -> int:
     total = 0
     for h in range(order + 1):
@@ -144,8 +157,8 @@ def _upper_bound(value: object, a4: Fraction, a6: Fraction) -> bool:
     multipliers = value["dual_multipliers"]
     if not isinstance(multipliers, dict) or set(multipliers) != {"order_1", "order_2"}:
         return False
-    m1 = _fraction(multipliers["order_1"])
-    m2 = _fraction(multipliers["order_2"])
+    m1 = _result_fraction(multipliers["order_1"])
+    m2 = _result_fraction(multipliers["order_2"])
     if m1 is None or m2 is None or m1 < 0 or m2 < 0:
         return False
     combined = tuple(

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_monotone_inverse_continuity_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_monotone_inverse_continuity_audit.py
@@ -21,6 +21,15 @@ def test_rejects_wrong_countermodel(tmp_path: Path) -> None:
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
     path = app / "submission.json"
     submission = json.loads(path.read_text())
-    submission["result"]["gap_witness"] = "0"
+    submission["result"]["gap_witness"] = {"numerator": 0, "denominator": 1}
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0
+
+
+def test_rejects_string_coerced_parameter(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "string")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["jump"] = "2"
     _fixtures._write_json(path, submission)
     assert _verifier._run_verifier(task, app, logs).reward == 0.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_nondifferentiable_maximum_construction.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_nondifferentiable_maximum_construction.py
@@ -6,17 +6,17 @@ from pathlib import Path
 import pytest
 from benchmarks.validation.mathematical_benchmarks_v1 import _fixtures, _verifier
 
-TASK = "log-exponent-recovery"
+TASK = "nondifferentiable-maximum-construction"
 
 
-def test_accepts_typed_rational_contributions(tmp_path: Path) -> None:
+def test_accepts_typed_rational_construction(tmp_path: Path) -> None:
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "typed")
     assert _verifier._run_verifier(task, app, logs).reward == pytest.approx(1.0)
 
 
-def test_rejects_string_coerced_contribution(tmp_path: Path) -> None:
+def test_rejects_string_coerced_slope(tmp_path: Path) -> None:
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "string")
     submission = json.loads((app / "submission.json").read_text())
-    submission["result"]["reciprocal_log_contributions"]["x"] = "1/24"
+    submission["result"]["right_slope"] = "-1/2"
     _fixtures._write_json(app / "submission.json", submission)
     assert _verifier._run_verifier(task, app, logs).reward == 0.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_series_domain_junk_zero.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_series_domain_junk_zero.py
@@ -24,7 +24,7 @@ def test_accepts_alternative_denominator(tmp_path: Path) -> None:
     submission = json.loads((app / "submission.json").read_text())
     result = submission["result"]
     result["reciprocal_denominator"] = 5
-    result["real_part"] = "1/5"
+    result["real_part"] = {"numerator": 1, "denominator": 5}
     result["general_block_power_exponent"] = {
         "level_coefficient": 4,
         "constant": -1,
@@ -47,6 +47,14 @@ def test_rejects_corrupted_general_bound(tmp_path: Path) -> None:
     rejected = _verifier._run_verifier(task, app, logs)
     assert rejected.details["correctness"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_rejects_string_coerced_real_part(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["real_part"] = "1/3"
+    _rewrite(app, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0
 
 
 def test_uses_result_only_protocol(tmp_path: Path) -> None:

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_ternary_distance_code_optimum.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_ternary_distance_code_optimum.py
@@ -68,9 +68,10 @@ def test_pair_distance_corruption_is_rejected(tmp_path: Path) -> None:
 
 def test_wrong_dual_multiplier_is_rejected(tmp_path: Path) -> None:
     submission = _submission()
-    submission["result"]["upper_bound_certificate"]["dual_multipliers"]["order_1"] = (
-        "1/2"
-    )
+    submission["result"]["upper_bound_certificate"]["dual_multipliers"]["order_1"] = {
+        "numerator": 1,
+        "denominator": 2,
+    }
     result = _verifier._run_verifier(*_case(tmp_path, submission, label="dual"))
     assert result.details["correctness"] == 0.0
     assert result.reward == 0.0
@@ -81,12 +82,23 @@ def test_noncanonical_rational_is_accepted(tmp_path: Path) -> None:
     the same nonnegative rational value.
     """
     submission = _submission()
-    submission["result"]["upper_bound_certificate"]["dual_multipliers"]["order_2"] = (
-        "2/12"
-    )
+    submission["result"]["upper_bound_certificate"]["dual_multipliers"]["order_2"] = {
+        "numerator": 2,
+        "denominator": 12,
+    }
     result = _verifier._run_verifier(*_case(tmp_path, submission, label="fraction"))
     assert result.details["correctness"] == 1.0
     assert result.reward == pytest.approx(1.0)
+
+
+def test_string_coerced_multiplier_is_rejected(tmp_path: Path) -> None:
+    submission = _submission()
+    submission["result"]["upper_bound_certificate"]["dual_multipliers"]["order_2"] = (
+        "1/6"
+    )
+    result = _verifier._run_verifier(*_case(tmp_path, submission, label="string"))
+    assert result.details["correctness"] == 0.0
+    assert result.reward == 0.0
 
 
 def test_input_tampering_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- Represent exact rational result fields as integer `numerator`/positive-integer `denominator` objects in five analysis and coding-theory tasks.
- Parse typed semantic values before computing correctness reward.
- Preserve prior rational equivalence semantics: log recovery and the Delsarte certificate still accept unreduced equivalents, while tasks that previously required canonical fractions continue to reject them.
- Update instructions, gold submissions, generated schemas, verifier checksums, and focused coercion tests.

## Tasks

- `log-exponent-recovery`
- `monotone-inverse-continuity-audit`
- `nondifferentiable-maximum-construction`
- `series-domain-junk-zero`
- `ternary-distance-code-optimum`

## Validation

- selected-task Harbor static validation passed
- focused host validation: 20 passed
- Ruff passed on all changed verifier/test Python files
- the benchmark planner selects all five changed-task Oracles

The local host has no Docker-compatible runtime, so the exact Oracles are left to the PR benchmark workflow.
