### PR TITLE
refactor(benchmarks): type exact algebra certificate coefficients

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -43,7 +62,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "coefficient": {
-                      "type": "string"
+                      "$ref": "#/$defs/rational"
                     },
                     "x_power": {
                       "maximum": 4,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/instruction.md
@@ -8,7 +8,7 @@ has zero integral around every closed smooth curve in `R2`.
 
 The frozen source solution claims that closedness is `f_y(x,y)=f_x(y,x)`. Audit the chain rule rather than trusting that claim.
 
-Write `/app/submission.json` matching `/app/submission_schema.json`. Submit two independent integer row constraints on the ten coefficients, their rank and the resulting dimension, eight integer coefficient vectors forming a basis of the solution space, and one polynomial potential for each basis vector. A potential `F` must satisfy `F_x=f(x,y)` and `F_y=f(y,x)` exactly. Rational coefficients use canonical strings such as `1/2` or `-3`; combine like terms and omit zero terms.
+Write `/app/submission.json` matching `/app/submission_schema.json`. Submit two independent integer row constraints on the ten coefficients, their rank and the resulting dimension, eight integer coefficient vectors forming a basis of the solution space, and one polynomial potential for each basis vector. A potential `F` must satisfy `F_x=f(x,y)` and `F_y=f(y,x)` exactly. Represent rational coefficients as objects with an integer `numerator` and positive integer `denominator` in lowest terms; combine like terms and omit zero terms.
 
 The verifier independently derives the correctly chained closedness constraints, checks row-space equality rather than a fixed presentation, performs exact rank and nullspace tests, and differentiates every potential.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/solution/submission.json
@@ -129,12 +129,18 @@
       {
         "terms": [
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 1,
             "y_power": 0
           },
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 0,
             "y_power": 1
           }
@@ -143,12 +149,18 @@
       {
         "terms": [
           {
-            "coefficient": "1/2",
+            "coefficient": {
+              "denominator": 2,
+              "numerator": 1
+            },
             "x_power": 2,
             "y_power": 0
           },
           {
-            "coefficient": "1/2",
+            "coefficient": {
+              "denominator": 2,
+              "numerator": 1
+            },
             "x_power": 0,
             "y_power": 2
           }
@@ -157,7 +169,10 @@
       {
         "terms": [
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 1,
             "y_power": 1
           }
@@ -166,12 +181,18 @@
       {
         "terms": [
           {
-            "coefficient": "1/3",
+            "coefficient": {
+              "denominator": 3,
+              "numerator": 1
+            },
             "x_power": 3,
             "y_power": 0
           },
           {
-            "coefficient": "1/3",
+            "coefficient": {
+              "denominator": 3,
+              "numerator": 1
+            },
             "x_power": 0,
             "y_power": 3
           }
@@ -180,12 +201,18 @@
       {
         "terms": [
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 2,
             "y_power": 1
           },
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 1,
             "y_power": 2
           }
@@ -194,12 +221,18 @@
       {
         "terms": [
           {
-            "coefficient": "1/4",
+            "coefficient": {
+              "denominator": 4,
+              "numerator": 1
+            },
             "x_power": 4,
             "y_power": 0
           },
           {
-            "coefficient": "1/4",
+            "coefficient": {
+              "denominator": 4,
+              "numerator": 1
+            },
             "x_power": 0,
             "y_power": 4
           }
@@ -208,7 +241,10 @@
       {
         "terms": [
           {
-            "coefficient": "1/2",
+            "coefficient": {
+              "denominator": 2,
+              "numerator": 1
+            },
             "x_power": 2,
             "y_power": 2
           }
@@ -217,12 +253,18 @@
       {
         "terms": [
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 3,
             "y_power": 1
           },
           {
-            "coefficient": "1",
+            "coefficient": {
+              "denominator": 1,
+              "numerator": 1
+            },
             "x_power": 1,
             "y_power": 3
           }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="157bcbfb36c747a2ead6d7639d21733667f73c51b3b4174a5bffb68fd4065c6b"
+LABEL jacobian.checksum="d5dd9231f6c4e2027ba6997b29f877c5edbd03c0be2d2347473bedf2f078316b"
 WORKDIR /tests
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -43,8 +53,8 @@
               "items": {
                 "additionalProperties": false,
                 "properties": {
-                  "coefficient": {
-                    "type": "string"
+                "coefficient": {
+                  "$ref": "#/$defs/rational"
                   },
                   "x_power": {
                     "maximum": 4,
@@ -91,6 +101,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -133,8 +154,8 @@
                   "items": {
                     "additionalProperties": false,
                     "properties": {
-                      "coefficient": {
-                        "type": "string"
+                    "coefficient": {
+                      "$ref": "#/$defs/rational"
                       },
                       "x_power": {
                         "maximum": 4,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/closed-one-form-polynomial-classification/tests/verifier.py
@@ -19,13 +19,21 @@ def _integer(value):
 
 
 def _canonical_fraction(value):
-    if not isinstance(value, str):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         return None
     try:
-        fraction = Fraction(value)
+        fraction = Fraction(numerator, denominator)
     except (ValueError, ZeroDivisionError):
         return None
-    return fraction if str(fraction) == value else None
+    return (
+        fraction
+        if fraction.numerator == numerator and fraction.denominator == denominator
+        else None
+    )
 
 
 def _valid_vector(vector):
@@ -90,7 +98,9 @@ def rank(matrix):
 def derivative(terms, axis):
     result = {}
     for term in terms:
-        coefficient = Fraction(term["coefficient"])
+        coefficient = _canonical_fraction(term["coefficient"])
+        if coefficient is None:
+            raise ValueError
         x_power, y_power = term["x_power"], term["y_power"]
         power = x_power if axis == 0 else y_power
         if not power:

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/environment/submission_schema.json
@@ -16,6 +16,23 @@
       ],
       "type": "object"
     },
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    },
     "rational_function": {
       "additionalProperties": false,
       "properties": {
@@ -46,7 +63,7 @@
       "additionalProperties": false,
       "properties": {
         "coefficient": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "exponents": {
           "items": {
@@ -94,7 +111,7 @@
         },
         "relation_coefficients": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "maxItems": 3,
           "minItems": 3,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/instruction.md
@@ -5,6 +5,8 @@ the offline input. Return exact coordinates for `O`, `G`, and `H`, together
 with nonzero relation coefficients in the declared point order. The
 coordinates must satisfy every defining identity and the submitted relation
 as rational-function identities under the declared nonzero assumption.
+Represent every submitted coefficient as an integer `numerator` and positive
+integer `denominator`.
 
 Write `submission.json` to the exact agent-visible `submission_schema.json`.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/solution/submission.json
@@ -5,7 +5,10 @@
         "x": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -15,7 +18,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "2/3",
+              "coefficient": {
+                "denominator": 3,
+                "numerator": 2
+              },
               "exponents": [
                 1,
                 0,
@@ -23,7 +29,10 @@
               ]
             },
             {
-              "coefficient": "2/3",
+              "coefficient": {
+                "denominator": 3,
+                "numerator": 2
+              },
               "exponents": [
                 0,
                 1,
@@ -35,7 +44,10 @@
         "y": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -45,7 +57,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "2/3",
+              "coefficient": {
+                "denominator": 3,
+                "numerator": 2
+              },
               "exponents": [
                 0,
                 0,
@@ -59,7 +74,10 @@
         "x": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -69,7 +87,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "2",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 2
+              },
               "exponents": [
                 0,
                 1,
@@ -81,7 +102,10 @@
         "y": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -91,7 +115,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "2",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 2
+              },
               "exponents": [
                 1,
                 1,
@@ -99,7 +126,10 @@
               ]
             },
             {
-              "coefficient": "-2",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": -2
+              },
               "exponents": [
                 0,
                 2,
@@ -113,7 +143,10 @@
         "x": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -123,7 +156,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 1,
                 0,
@@ -135,7 +171,10 @@
         "y": {
           "denominator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -145,7 +184,10 @@
           ],
           "numerator": [
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 2,
@@ -153,7 +195,10 @@
               ]
             },
             {
-              "coefficient": "1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": 1
+              },
               "exponents": [
                 0,
                 0,
@@ -161,7 +206,10 @@
               ]
             },
             {
-              "coefficient": "-1",
+              "coefficient": {
+                "denominator": 1,
+                "numerator": -1
+              },
               "exponents": [
                 1,
                 1,
@@ -173,9 +221,18 @@
       }
     },
     "relation_coefficients": [
-      "2",
-      "-3",
-      "1"
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      }
     ]
   }
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact sparse rational-function identity verifier.
 LABEL jacobian.task="jacobian/euler-line-symbolic-certificate" \
-      jacobian.checksum="bdf8a92a814add22efc64c6b0463854e9303dc3444ca0844b54bacd1c164a76b"
+      jacobian.checksum="e780ae3e852343f688944a15d385051f0f099f3e123ab25977a16d0d1673027b"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/public_contract.json
@@ -17,6 +17,15 @@
       ],
       "type": "object"
     },
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    },
     "rational_function": {
       "additionalProperties": false,
       "properties": {
@@ -47,7 +56,7 @@
       "additionalProperties": false,
       "properties": {
         "coefficient": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "exponents": {
           "items": {
@@ -94,7 +103,7 @@
       },
       "relation_coefficients": {
         "items": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "maxItems": 3,
         "minItems": 3,
@@ -123,6 +132,15 @@
           "x",
           "y"
         ],
+        "type": "object"
+      },
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
         "type": "object"
       },
       "rational_function": {
@@ -154,8 +172,8 @@
       "term": {
         "additionalProperties": false,
         "properties": {
-          "coefficient": {
-            "type": "string"
+            "coefficient": {
+              "$ref": "#/$defs/rational"
           },
           "exponents": {
             "items": {
@@ -203,7 +221,7 @@
           },
           "relation_coefficients": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 3,
             "minItems": 3,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/euler-line-symbolic-certificate/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -15,13 +14,14 @@ ONE = {(0, 0, 0): Fraction(1)}
 
 
 def q(value):
-    if (
-        not isinstance(value, str)
-        or re.fullmatch(r"-?[0-9]{1,20}(?:/[0-9]{1,20})?", value) is None
-    ):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         return None
     try:
-        parsed = Fraction(value)
+        parsed = Fraction(numerator, denominator)
     except (ValueError, TypeError, ZeroDivisionError):
         return None
     return parsed

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -55,7 +74,7 @@
         },
         "h_coefficients": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "maxItems": 2,
           "minItems": 2,
@@ -82,11 +101,11 @@
           "type": "object"
         },
         "parameter_a": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "v_coefficients": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "maxItems": 3,
           "minItems": 3,
@@ -97,7 +116,7 @@
           "properties": {
             "denominator": {
               "items": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "maxItems": 16,
               "minItems": 1,
@@ -105,7 +124,7 @@
             },
             "numerator": {
               "items": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "maxItems": 16,
               "minItems": 2,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/instruction.md
@@ -2,7 +2,7 @@
 
 The frozen packet gives a three-real-Gaussian template and a formal Lagrange-inversion identity. A prior audit checked twelve moments and then claimed the identities for every exponent. That extrapolation is invalid.
 
-Choose any nonzero rational parameter `a` within the declared bounds. Derive the quadratic `v(z)` and rational inverse branch `zeta(t)` satisfying the identities below; both are determined by `a` and the correction-factor identity rather than freely chosen. Submit canonical rational coefficient lists in ascending degree order.
+Choose any nonzero rational parameter `a` within the declared bounds. Derive the quadratic `v(z)` and rational inverse branch `zeta(t)` satisfying the identities below; both are determined by `a` and the correction-factor identity rather than freely chosen. Submit canonical rational coefficient lists in ascending degree order as integer `numerator`/positive integer `denominator` objects in lowest terms.
 
 Your certificate must establish, by exact rational-function identities rather than samples, all of the following:
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/solution/submission.json
@@ -13,28 +13,58 @@
       "square_root_branch": "CONSTANT_TERM_ONE"
     },
     "h_coefficients": [
-      "1",
-      "1"
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      }
     ],
     "moment_conclusion": {
       "mixed": "M_FACTORIAL",
       "ordinary": "ZERO",
       "quantifier": "EVERY_INTEGER_M_AT_LEAST_ONE"
     },
-    "parameter_a": "1",
+    "parameter_a": {
+      "denominator": 1,
+      "numerator": 1
+    },
     "v_coefficients": [
-      "-1",
-      "-3/2",
-      "-1/2"
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 2,
+        "numerator": -3
+      },
+      {
+        "denominator": 2,
+        "numerator": -1
+      }
     ],
     "zeta": {
       "denominator": [
-        "1",
-        "-1"
+        {
+          "denominator": 1,
+          "numerator": 1
+        },
+        {
+          "denominator": 1,
+          "numerator": -1
+        }
       ],
       "numerator": [
-        "0",
-        "1"
+        {
+          "denominator": 1,
+          "numerator": 0
+        },
+        {
+          "denominator": 1,
+          "numerator": 1
+        }
       ]
     }
   }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="3e143e51a586a878337010adf6546ac97e62f19e586c72e97839672adb07be0d"
+LABEL jacobian.checksum="ccc08e48cf6a81287b29fa91d79cba51e2411eb1d7901345a559ef96e6546677"
 LABEL jacobian.task="jacobian/gaussian-moment-generality-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -56,7 +66,7 @@
       },
       "h_coefficients": {
         "items": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "maxItems": 2,
         "minItems": 2,
@@ -83,11 +93,11 @@
         "type": "object"
       },
       "parameter_a": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "v_coefficients": {
         "items": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "maxItems": 3,
         "minItems": 3,
@@ -98,7 +108,7 @@
         "properties": {
           "denominator": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 16,
             "minItems": 1,
@@ -106,7 +116,7 @@
           },
           "numerator": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 16,
             "minItems": 2,
@@ -133,6 +143,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -188,7 +209,7 @@
           },
           "h_coefficients": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 2,
             "minItems": 2,
@@ -215,11 +236,11 @@
             "type": "object"
           },
           "parameter_a": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "v_coefficients": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 3,
             "minItems": 3,
@@ -230,7 +251,7 @@
             "properties": {
               "denominator": {
                 "items": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "maxItems": 16,
                 "minItems": 1,
@@ -238,7 +259,7 @@
               },
               "numerator": {
                 "items": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "maxItems": 16,
                 "minItems": 2,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/gaussian-moment-generality-audit/tests/verifier.py
@@ -82,15 +82,14 @@ ONE_MINUS_T = RationalFunction([Fraction(1), Fraction(-1)], [Fraction(1)])
 
 
 def canonical_fraction(value: object) -> Fraction:
-    if not isinstance(value, str) or not value or value.strip() != value:
-        raise ValueError("non-string rational")
-    parsed = Fraction(value)
-    canonical = (
-        str(parsed.numerator)
-        if parsed.denominator == 1
-        else f"{parsed.numerator}/{parsed.denominator}"
-    )
-    if value != canonical:
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        raise ValueError("invalid rational object")
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
+        raise ValueError("invalid rational components")
+    parsed = Fraction(numerator, denominator)
+    if parsed.numerator != numerator or parsed.denominator != denominator:
         raise ValueError("noncanonical rational")
     return parsed
 

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_closed_one_form_polynomial_classification.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_closed_one_form_polynomial_classification.py
@@ -40,8 +40,16 @@ def test_correct_constraint_rank_and_wrong_published_rank() -> None:
 def test_derivative_replays_potential() -> None:
     v = _module()
     terms = [
-        {"coefficient": "1", "x_power": 2, "y_power": 1},
-        {"coefficient": "1", "x_power": 1, "y_power": 2},
+        {
+            "coefficient": {"numerator": 1, "denominator": 1},
+            "x_power": 2,
+            "y_power": 1,
+        },
+        {
+            "coefficient": {"numerator": 1, "denominator": 1},
+            "x_power": 1,
+            "y_power": 2,
+        },
     ]
     assert v.derivative(terms, 0) == {(1, 1): Fraction(2), (0, 2): Fraction(1)}
     assert v.derivative(terms, 1) == {(2, 0): Fraction(1), (1, 1): Fraction(2)}
@@ -99,3 +107,18 @@ def test_verifier_rejects_boolean_matrix_entries(tmp_path: Path) -> None:
     rejected = _verifier._run_verifier(task, app, logs)
     assert rejected.details["correctness"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_verifier_rejects_string_coerced_coefficient(tmp_path: Path) -> None:
+    from benchmarks.validation.mathematical_benchmarks_v1 import (
+        _fixtures,
+        _verifier,
+    )
+
+    task, app, logs = _fixtures._prepare_case(
+        tmp_path, "closed-one-form-polynomial-classification", "string-coefficient"
+    )
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["potentials"][0]["terms"][0]["coefficient"] = "1"
+    _fixtures._write_json(app / "submission.json", submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_euler_line_symbolic_certificate.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_euler_line_symbolic_certificate.py
@@ -19,8 +19,20 @@ def test_rejects_wrong_symbolic_relation(tmp_path: Path) -> None:
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
     path = app / "submission.json"
     submission = json.loads(path.read_text())
-    submission["result"]["relation_coefficients"][0] = "0"
+    submission["result"]["relation_coefficients"][0] = {
+        "numerator": 0,
+        "denominator": 1,
+    }
     _fixtures._write_json(path, submission)
     rejected = _verifier._run_verifier(task, app, logs)
     assert rejected.details["correctness"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_rejects_string_coerced_polynomial_coefficient(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "string")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["coordinates"]["G"]["x"]["numerator"][0]["coefficient"] = "2/3"
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_gaussian_moment_generality_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_gaussian_moment_generality_audit.py
@@ -14,8 +14,19 @@ TASK = "gaussian-moment-generality-audit"
 def test_rejects_corrupted_coefficient(tmp_path: Path) -> None:
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())
-    submission["result"]["v_coefficients"][2] = "-1/3"
+    submission["result"]["v_coefficients"][2] = {
+        "numerator": -1,
+        "denominator": 3,
+    }
     _fixtures._write_json(app / "submission.json", submission)
     rejected = _verifier._run_verifier(task, app, logs)
     assert rejected.details["correctness"] == 0.0
     assert rejected.reward == 0.0
+
+
+def test_rejects_string_coerced_coefficient(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "string")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["parameter_a"] = "1"
+    _fixtures._write_json(app / "submission.json", submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0


### PR DESCRIPTION
## What changed

- Replace unrestricted rational coefficient strings with typed `numerator`/`denominator` objects in three algebraic certificate tasks.
- Cover potential coefficients, Euler-line rational-function and relation coefficients, and Gaussian formal-identity coefficient lists.
- Parse typed semantic coefficients before correctness scoring while preserving each verifier's prior canonical-versus-equivalent-rational behavior.
- Update instructions, gold submissions, generated contracts, verifier checksums, and coercion regressions.

## Validation

- selected-task Harbor static validation passed
- focused host validation: 12 passed
- Ruff passed on all changed verifier/test Python files
- the benchmark planner selects all three changed-task Oracles

The local host has no Docker-compatible runtime, so the exact Oracles are left to the PR benchmark workflow.
