### PR TITLE
refactor(benchmarks): type exact convergence certificates

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -6,8 +25,7 @@
       "additionalProperties": false,
       "properties": {
         "alpha": {
-          "maxLength": 100,
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "baseline_power": {
           "const": 2
@@ -32,24 +50,19 @@
             "additionalProperties": false,
             "properties": {
               "area": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "center": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "half_width": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "integer_sample": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "left": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "n": {
                 "maximum": 12,
@@ -57,8 +70,7 @@
                 "type": "integer"
               },
               "right": {
-                "maxLength": 100,
-                "type": "string"
+                "$ref": "#/$defs/rational"
               }
             },
             "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/instruction.md
@@ -7,8 +7,8 @@ must be disjoint from every other support and must avoid every integer. The
 spike areas must form a divergent series while the integer samples form a
 convergent series.
 
-Each rational field in the submission must be a canonical reduced fraction
-string of at most 100 characters.
+Represent each rational field as an integer `numerator` and positive integer
+`denominator` in lowest terms.
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->
 ## Submission

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/solution/submission.json
@@ -1,6 +1,9 @@
 {
   "result": {
-    "alpha": "1/4",
+    "alpha": {
+      "denominator": 4,
+      "numerator": 1
+    },
     "baseline_power": 2,
     "integral_classification": {
       "spike_area_series": "alpha*sum(1/n)",
@@ -13,112 +16,328 @@
     "spike_height": "1",
     "spikes": [
       {
-        "area": "1/4",
-        "center": "3/2",
-        "half_width": "1/4",
-        "integer_sample": "1",
-        "left": "5/4",
+        "area": {
+          "denominator": 4,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 3
+        },
+        "half_width": {
+          "denominator": 4,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 1,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 4,
+          "numerator": 5
+        },
         "n": 1,
-        "right": "7/4"
+        "right": {
+          "denominator": 4,
+          "numerator": 7
+        }
       },
       {
-        "area": "1/8",
-        "center": "5/2",
-        "half_width": "1/8",
-        "integer_sample": "1/4",
-        "left": "19/8",
+        "area": {
+          "denominator": 8,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 5
+        },
+        "half_width": {
+          "denominator": 8,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 4,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 8,
+          "numerator": 19
+        },
         "n": 2,
-        "right": "21/8"
+        "right": {
+          "denominator": 8,
+          "numerator": 21
+        }
       },
       {
-        "area": "1/12",
-        "center": "7/2",
-        "half_width": "1/12",
-        "integer_sample": "1/9",
-        "left": "41/12",
+        "area": {
+          "denominator": 12,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 7
+        },
+        "half_width": {
+          "denominator": 12,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 9,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 12,
+          "numerator": 41
+        },
         "n": 3,
-        "right": "43/12"
+        "right": {
+          "denominator": 12,
+          "numerator": 43
+        }
       },
       {
-        "area": "1/16",
-        "center": "9/2",
-        "half_width": "1/16",
-        "integer_sample": "1/16",
-        "left": "71/16",
+        "area": {
+          "denominator": 16,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 9
+        },
+        "half_width": {
+          "denominator": 16,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 16,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 16,
+          "numerator": 71
+        },
         "n": 4,
-        "right": "73/16"
+        "right": {
+          "denominator": 16,
+          "numerator": 73
+        }
       },
       {
-        "area": "1/20",
-        "center": "11/2",
-        "half_width": "1/20",
-        "integer_sample": "1/25",
-        "left": "109/20",
+        "area": {
+          "denominator": 20,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 11
+        },
+        "half_width": {
+          "denominator": 20,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 25,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 20,
+          "numerator": 109
+        },
         "n": 5,
-        "right": "111/20"
+        "right": {
+          "denominator": 20,
+          "numerator": 111
+        }
       },
       {
-        "area": "1/24",
-        "center": "13/2",
-        "half_width": "1/24",
-        "integer_sample": "1/36",
-        "left": "155/24",
+        "area": {
+          "denominator": 24,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 13
+        },
+        "half_width": {
+          "denominator": 24,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 36,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 24,
+          "numerator": 155
+        },
         "n": 6,
-        "right": "157/24"
+        "right": {
+          "denominator": 24,
+          "numerator": 157
+        }
       },
       {
-        "area": "1/28",
-        "center": "15/2",
-        "half_width": "1/28",
-        "integer_sample": "1/49",
-        "left": "209/28",
+        "area": {
+          "denominator": 28,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 15
+        },
+        "half_width": {
+          "denominator": 28,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 49,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 28,
+          "numerator": 209
+        },
         "n": 7,
-        "right": "211/28"
+        "right": {
+          "denominator": 28,
+          "numerator": 211
+        }
       },
       {
-        "area": "1/32",
-        "center": "17/2",
-        "half_width": "1/32",
-        "integer_sample": "1/64",
-        "left": "271/32",
+        "area": {
+          "denominator": 32,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 17
+        },
+        "half_width": {
+          "denominator": 32,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 64,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 32,
+          "numerator": 271
+        },
         "n": 8,
-        "right": "273/32"
+        "right": {
+          "denominator": 32,
+          "numerator": 273
+        }
       },
       {
-        "area": "1/36",
-        "center": "19/2",
-        "half_width": "1/36",
-        "integer_sample": "1/81",
-        "left": "341/36",
+        "area": {
+          "denominator": 36,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 19
+        },
+        "half_width": {
+          "denominator": 36,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 81,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 36,
+          "numerator": 341
+        },
         "n": 9,
-        "right": "343/36"
+        "right": {
+          "denominator": 36,
+          "numerator": 343
+        }
       },
       {
-        "area": "1/40",
-        "center": "21/2",
-        "half_width": "1/40",
-        "integer_sample": "1/100",
-        "left": "419/40",
+        "area": {
+          "denominator": 40,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 21
+        },
+        "half_width": {
+          "denominator": 40,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 100,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 40,
+          "numerator": 419
+        },
         "n": 10,
-        "right": "421/40"
+        "right": {
+          "denominator": 40,
+          "numerator": 421
+        }
       },
       {
-        "area": "1/44",
-        "center": "23/2",
-        "half_width": "1/44",
-        "integer_sample": "1/121",
-        "left": "505/44",
+        "area": {
+          "denominator": 44,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 23
+        },
+        "half_width": {
+          "denominator": 44,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 121,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 44,
+          "numerator": 505
+        },
         "n": 11,
-        "right": "507/44"
+        "right": {
+          "denominator": 44,
+          "numerator": 507
+        }
       },
       {
-        "area": "1/48",
-        "center": "25/2",
-        "half_width": "1/48",
-        "integer_sample": "1/144",
-        "left": "599/48",
+        "area": {
+          "denominator": 48,
+          "numerator": 1
+        },
+        "center": {
+          "denominator": 2,
+          "numerator": 25
+        },
+        "half_width": {
+          "denominator": 48,
+          "numerator": 1
+        },
+        "integer_sample": {
+          "denominator": 144,
+          "numerator": 1
+        },
+        "left": {
+          "denominator": 48,
+          "numerator": 599
+        },
         "n": 12,
-        "right": "601/48"
+        "right": {
+          "denominator": 48,
+          "numerator": 601
+        }
       }
     ]
   }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact verifier for a continuous triangular-spike construction.
 LABEL jacobian.task="jacobian/continuous-spike-integral-separation" \
-      jacobian.checksum="ac14f7504bb2822109b7ab6ee5789d7db828fb75961adc3b28f2d75fd05b8dab"
+      jacobian.checksum="804ea06253cb3655e92ac9b0faf13bfe303d075a85a36c4768c9fab760c5baa9"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && python -c 'import json; assert json.load(open("/tests/expected.json"))["task_id"] == "jacobian/continuous-spike-integral-separation"'

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/public_contract.json
@@ -1,14 +1,23 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
     "additionalProperties": false,
     "properties": {
       "alpha": {
-        "maxLength": 100,
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "baseline_power": {
         "const": 2
@@ -33,24 +42,19 @@
           "additionalProperties": false,
           "properties": {
             "area": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "center": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "half_width": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "integer_sample": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "left": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "n": {
               "maximum": 12,
@@ -58,8 +62,7 @@
               "type": "integer"
             },
             "right": {
-              "maxLength": 100,
-              "type": "string"
+              "$ref": "#/$defs/rational"
             }
           },
           "required": [
@@ -90,14 +93,24 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
         "additionalProperties": false,
         "properties": {
           "alpha": {
-            "maxLength": 100,
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "baseline_power": {
             "const": 2
@@ -122,24 +135,19 @@
               "additionalProperties": false,
               "properties": {
                 "area": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "center": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "half_width": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "integer_sample": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "left": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "n": {
                   "maximum": 12,
@@ -147,8 +155,7 @@
                   "type": "integer"
                 },
                 "right": {
-                  "maxLength": 100,
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/continuous-spike-integral-separation/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from itertools import pairwise
 from pathlib import Path
@@ -10,18 +9,23 @@ from verifier_support import (
 )
 
 W, T = Path("/app"), Path("/tests")
-MAX_RATIONAL_LEN = 100
 
 
 def fraction(value):
-    if not isinstance(value, str) or len(value) > MAX_RATIONAL_LEN:
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
         raise ValueError
-    if re.fullmatch(r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?", value) is None:
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         raise ValueError
-    parsed = Fraction(value)
-    if str(parsed) != value:
+    parsed = Fraction(numerator, denominator)
+    if parsed.numerator != numerator or parsed.denominator != denominator:
         raise ValueError
     return parsed
+
+
+def encoded(value):
+    return {"numerator": value.numerator, "denominator": value.denominator}
 
 
 def expected_spike(n, alpha):
@@ -29,12 +33,12 @@ def expected_spike(n, alpha):
     width = alpha / n
     return {
         "n": n,
-        "center": str(center),
-        "half_width": str(width),
-        "left": str(center - width),
-        "right": str(center + width),
-        "area": str(width),
-        "integer_sample": str(Fraction(1, n * n)),
+        "center": encoded(center),
+        "half_width": encoded(width),
+        "left": encoded(center - width),
+        "right": encoded(center + width),
+        "area": encoded(width),
+        "integer_sample": encoded(Fraction(1, n * n)),
     }
 
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -10,7 +29,7 @@
             "additionalProperties": false,
             "properties": {
               "event_mass": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "index_end": {
                 "type": "integer"
@@ -83,7 +102,7 @@
                 "type": "array"
               },
               "point": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               }
             },
             "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/instruction.md
@@ -2,7 +2,7 @@
 
 On `[0,1)` equipped with Lebesgue measure, consider the dyadic typewriter sequence. At level `k`, enumerate the indicators of all half-open intervals `[j/2^k,(j+1)/2^k)` in order, using sequence index `2^k+j`.
 
-Certify that these indicators converge to zero in probability but not almost surely. Submit exact block summaries for every frozen level and at least three freely chosen canonical rational probe points in `[0,1)`. For each probe, give the unique hit index at every level.
+Certify that these indicators converge to zero in probability but not almost surely. Submit exact block summaries for every frozen level and at least three freely chosen canonical rational probe points in `[0,1)`. Represent rationals as integer `numerator`/positive integer `denominator` objects; probe points must be in lowest terms. For each probe, give the unique hit index at every level.
 
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/solution/submission.json
@@ -2,56 +2,80 @@
   "result": {
     "levels": [
       {
-        "event_mass": "1/2",
+        "event_mass": {
+          "denominator": 2,
+          "numerator": 1
+        },
         "index_end": 3,
         "index_start": 2,
         "interval_count": 2,
         "level": 1
       },
       {
-        "event_mass": "1/4",
+        "event_mass": {
+          "denominator": 4,
+          "numerator": 1
+        },
         "index_end": 7,
         "index_start": 4,
         "interval_count": 4,
         "level": 2
       },
       {
-        "event_mass": "1/8",
+        "event_mass": {
+          "denominator": 8,
+          "numerator": 1
+        },
         "index_end": 15,
         "index_start": 8,
         "interval_count": 8,
         "level": 3
       },
       {
-        "event_mass": "1/16",
+        "event_mass": {
+          "denominator": 16,
+          "numerator": 1
+        },
         "index_end": 31,
         "index_start": 16,
         "interval_count": 16,
         "level": 4
       },
       {
-        "event_mass": "1/32",
+        "event_mass": {
+          "denominator": 32,
+          "numerator": 1
+        },
         "index_end": 63,
         "index_start": 32,
         "interval_count": 32,
         "level": 5
       },
       {
-        "event_mass": "1/64",
+        "event_mass": {
+          "denominator": 64,
+          "numerator": 1
+        },
         "index_end": 127,
         "index_start": 64,
         "interval_count": 64,
         "level": 6
       },
       {
-        "event_mass": "1/128",
+        "event_mass": {
+          "denominator": 128,
+          "numerator": 1
+        },
         "index_end": 255,
         "index_start": 128,
         "interval_count": 128,
         "level": 7
       },
       {
-        "event_mass": "1/256",
+        "event_mass": {
+          "denominator": 256,
+          "numerator": 1
+        },
         "index_end": 511,
         "index_start": 256,
         "interval_count": 256,
@@ -78,7 +102,10 @@
           170,
           341
         ],
-        "point": "1/3"
+        "point": {
+          "denominator": 3,
+          "numerator": 1
+        }
       },
       {
         "hit_indices": [
@@ -91,7 +118,10 @@
           179,
           358
         ],
-        "point": "2/5"
+        "point": {
+          "denominator": 5,
+          "numerator": 2
+        }
       },
       {
         "hit_indices": [
@@ -104,7 +134,10 @@
           240,
           480
         ],
-        "point": "7/8"
+        "point": {
+          "denominator": 8,
+          "numerator": 7
+        }
       }
     ],
     "relationship": "IN_PROBABILITY_NOT_IMPLY_ALMOST_SURE",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca9798
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 # Exact verifier for a dyadic convergence-mode separation certificate.
 LABEL jacobian.task="jacobian/convergence-mode-separation" \
-      jacobian.checksum="2e94fbfe92fb83b1845b14b4896cab0678546fb9d5b4c509c2a21e45d4e3295e"
+      jacobian.checksum="76a9c56ffe78bb6e3539cde2bcd173f7fa1ebcff87b975cbee13b10537fc99d8"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json
 RUN chmod +x /tests/test.sh && \

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/public_contract.json
@@ -1,6 +1,16 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -11,7 +21,7 @@
           "additionalProperties": false,
           "properties": {
             "event_mass": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "index_end": {
               "type": "integer"
@@ -84,7 +94,7 @@
               "type": "array"
             },
             "point": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             }
           },
           "required": [
@@ -129,6 +139,17 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -139,7 +160,7 @@
               "additionalProperties": false,
               "properties": {
                 "event_mass": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "index_end": {
                   "type": "integer"
@@ -212,7 +233,7 @@
                   "type": "array"
                 },
                 "point": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/convergence-mode-separation/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -34,16 +33,22 @@ def _load_bounded_submission():
         return None
 
 
-def _fraction(text, *, canonical=True):
-    if not isinstance(text, str) or len(text) > 128:
+def _fraction(value, *, canonical=True):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
         return None
-    if not re.fullmatch(r"[+-]?(?:\d+(?:/\d+)?|\d+\.\d+)", text):
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         return None
     try:
-        value = Fraction(text)
+        parsed = Fraction(numerator, denominator)
     except (ValueError, ZeroDivisionError, OverflowError):
         return None
-    return value if not canonical or str(value) == text else None
+    if canonical and (
+        parsed.numerator != numerator or parsed.denominator != denominator
+    ):
+        return None
+    return parsed
 
 
 def _valid_levels(levels, start, end):

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/environment/submission_schema.json
@@ -7,13 +7,13 @@
           "type": "integer"
         },
         "excluded_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "excluded_endpoint": {
           "type": "integer"
         },
         "included_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "included_endpoint": {
           "type": "integer"
@@ -31,6 +31,23 @@
         "cumulative_count",
         "included_density",
         "excluded_density"
+      ],
+      "type": "object"
+    },
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
       ],
       "type": "object"
     }
@@ -61,7 +78,7 @@
           "type": "array"
         },
         "lower_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "lower_density_positive": {
           "const": true
@@ -73,7 +90,7 @@
           "const": "FORMALIZED_PREDICATE_STRICTLY_STRONGER"
         },
         "upper_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         }
       },
       "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/instruction.md
@@ -2,7 +2,7 @@
 
 Audit the reported formalization mismatch: “positive lower density” does not require the natural density to exist.
 
-Choose an integer base from 2 through 9 and consider the set formed by the alternating geometric blocks `[b^(2m), b^(2m+1))` for all `m >= 0`. Submit the exact endpoint certificate for levels 0 through 7: the included-block endpoint, the following excluded-block endpoint, the cumulative count below each endpoint, and both reduced density fractions. State the two closed-form subsequential limits and the resulting semantic separation.
+Choose an integer base from 2 through 9 and consider the set formed by the alternating geometric blocks `[b^(2m), b^(2m+1))` for all `m >= 0`. Submit the exact endpoint certificate for levels 0 through 7: the included-block endpoint, the following excluded-block endpoint, the cumulative count below each endpoint, and both reduced density fractions. Represent each rational as an integer `numerator` and positive integer `denominator` in lowest terms. State the two closed-form subsequential limits and the resulting semantic separation.
 
 The verifier recomputes all finite arithmetic and checks the general closed-form fields. The finite levels are instances of the general argument, not a machine proof of the infinite limit. The eight level rows may appear in any order; no prose explanation or duplicate artifact is required.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/solution/solve.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/solution/solve.py
@@ -2,6 +2,11 @@ import json
 from fractions import Fraction
 from pathlib import Path
 
+
+def rational(value: Fraction) -> dict[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
 b = 3
 levels = []
 for m in range(8):
@@ -13,8 +18,8 @@ for m in range(8):
             "included_endpoint": high,
             "excluded_endpoint": low,
             "cumulative_count": count,
-            "included_density": str(Fraction(count, high)),
-            "excluded_density": str(Fraction(count, low)),
+            "included_density": rational(Fraction(count, high)),
+            "excluded_density": rational(Fraction(count, low)),
         }
     )
 result = {
@@ -22,8 +27,8 @@ result = {
     "family": "ALTERNATING_GEOMETRIC_BLOCKS",
     "count_formula": "(b^(2m+2)-1)/(b+1)",
     "levels": levels,
-    "lower_density": str(Fraction(1, b + 1)),
-    "upper_density": str(Fraction(b, b + 1)),
+    "lower_density": rational(Fraction(1, b + 1)),
+    "upper_density": rational(Fraction(b, b + 1)),
     "lower_density_positive": True,
     "natural_density_exists": False,
     "semantic_relation": "FORMALIZED_PREDICATE_STRICTLY_STRONGER",

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/solution/submission.json
@@ -6,73 +6,127 @@
     "levels": [
       {
         "cumulative_count": 2,
-        "excluded_density": "2/9",
+        "excluded_density": {
+          "denominator": 9,
+          "numerator": 2
+        },
         "excluded_endpoint": 9,
-        "included_density": "2/3",
+        "included_density": {
+          "denominator": 3,
+          "numerator": 2
+        },
         "included_endpoint": 3,
         "level": 0
       },
       {
         "cumulative_count": 20,
-        "excluded_density": "20/81",
+        "excluded_density": {
+          "denominator": 81,
+          "numerator": 20
+        },
         "excluded_endpoint": 81,
-        "included_density": "20/27",
+        "included_density": {
+          "denominator": 27,
+          "numerator": 20
+        },
         "included_endpoint": 27,
         "level": 1
       },
       {
         "cumulative_count": 182,
-        "excluded_density": "182/729",
+        "excluded_density": {
+          "denominator": 729,
+          "numerator": 182
+        },
         "excluded_endpoint": 729,
-        "included_density": "182/243",
+        "included_density": {
+          "denominator": 243,
+          "numerator": 182
+        },
         "included_endpoint": 243,
         "level": 2
       },
       {
         "cumulative_count": 1640,
-        "excluded_density": "1640/6561",
+        "excluded_density": {
+          "denominator": 6561,
+          "numerator": 1640
+        },
         "excluded_endpoint": 6561,
-        "included_density": "1640/2187",
+        "included_density": {
+          "denominator": 2187,
+          "numerator": 1640
+        },
         "included_endpoint": 2187,
         "level": 3
       },
       {
         "cumulative_count": 14762,
-        "excluded_density": "14762/59049",
+        "excluded_density": {
+          "denominator": 59049,
+          "numerator": 14762
+        },
         "excluded_endpoint": 59049,
-        "included_density": "14762/19683",
+        "included_density": {
+          "denominator": 19683,
+          "numerator": 14762
+        },
         "included_endpoint": 19683,
         "level": 4
       },
       {
         "cumulative_count": 132860,
-        "excluded_density": "132860/531441",
+        "excluded_density": {
+          "denominator": 531441,
+          "numerator": 132860
+        },
         "excluded_endpoint": 531441,
-        "included_density": "132860/177147",
+        "included_density": {
+          "denominator": 177147,
+          "numerator": 132860
+        },
         "included_endpoint": 177147,
         "level": 5
       },
       {
         "cumulative_count": 1195742,
-        "excluded_density": "1195742/4782969",
+        "excluded_density": {
+          "denominator": 4782969,
+          "numerator": 1195742
+        },
         "excluded_endpoint": 4782969,
-        "included_density": "1195742/1594323",
+        "included_density": {
+          "denominator": 1594323,
+          "numerator": 1195742
+        },
         "included_endpoint": 1594323,
         "level": 6
       },
       {
         "cumulative_count": 10761680,
-        "excluded_density": "10761680/43046721",
+        "excluded_density": {
+          "denominator": 43046721,
+          "numerator": 10761680
+        },
         "excluded_endpoint": 43046721,
-        "included_density": "10761680/14348907",
+        "included_density": {
+          "denominator": 14348907,
+          "numerator": 10761680
+        },
         "included_endpoint": 14348907,
         "level": 7
       }
     ],
-    "lower_density": "1/4",
+    "lower_density": {
+      "denominator": 4,
+      "numerator": 1
+    },
     "lower_density_positive": true,
     "natural_density_exists": false,
     "semantic_relation": "FORMALIZED_PREDICATE_STRICTLY_STRONGER",
-    "upper_density": "3/4"
+    "upper_density": {
+      "denominator": 4,
+      "numerator": 3
+    }
   }
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 # Exact positive-lower-density separation verifier.
 LABEL jacobian.task="jacobian/positive-lower-density-separation" \
-      jacobian.checksum="d0a81b950bbd29be619477f450960e479bcec7dc3551b505fc5357d6f26b4552"
+      jacobian.checksum="0bd6cfd439cc69df5c4316cefad83805d276352115bd49cb488e29ccaa859780"
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json verifier_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/public_contract.json
@@ -1,6 +1,15 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
   "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {"minimum": 1, "type": "integer"},
+        "numerator": {"type": "integer"}
+      },
+      "required": ["numerator", "denominator"],
+      "type": "object"
+    },
     "level": {
       "additionalProperties": false,
       "properties": {
@@ -8,13 +17,13 @@
           "type": "integer"
         },
         "excluded_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "excluded_endpoint": {
           "type": "integer"
         },
         "included_density": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "included_endpoint": {
           "type": "integer"
@@ -61,7 +70,7 @@
         "type": "array"
       },
       "lower_density": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       },
       "lower_density_positive": {
         "const": true
@@ -73,7 +82,7 @@
         "const": "FORMALIZED_PREDICATE_STRICTLY_STRONGER"
       },
       "upper_density": {
-        "type": "string"
+        "$ref": "#/$defs/rational"
       }
     },
     "required": [
@@ -91,6 +100,15 @@
   },
   "submission_schema": {
     "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {"minimum": 1, "type": "integer"},
+          "numerator": {"type": "integer"}
+        },
+        "required": ["numerator", "denominator"],
+        "type": "object"
+      },
       "level": {
         "additionalProperties": false,
         "properties": {
@@ -98,13 +116,13 @@
             "type": "integer"
           },
           "excluded_density": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "excluded_endpoint": {
             "type": "integer"
           },
           "included_density": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "included_endpoint": {
             "type": "integer"
@@ -152,7 +170,7 @@
             "type": "array"
           },
           "lower_density": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "lower_density_positive": {
             "const": true
@@ -164,7 +182,7 @@
             "const": "FORMALIZED_PREDICATE_STRICTLY_STRONGER"
           },
           "upper_density": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/positive-lower-density-separation/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -13,17 +12,26 @@ from verifier_support import (
 T = Path("/tests")
 
 
-def q(text):
-    if (
-        not isinstance(text, str)
-        or re.fullmatch(r"(?:0|1|[1-9][0-9]*/[1-9][0-9]*)", text) is None
-    ):
+def q(value):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator <= 0:
         return None
     try:
-        value = Fraction(text)
+        parsed = Fraction(numerator, denominator)
     except (ValueError, ZeroDivisionError):
         return None
-    return value if str(value) == text else None
+    return (
+        parsed
+        if parsed.numerator == numerator and parsed.denominator == denominator
+        else None
+    )
+
+
+def encoded(value):
+    return {"numerator": value.numerator, "denominator": value.denominator}
 
 
 def valid_result(result):
@@ -57,8 +65,8 @@ def valid_result(result):
                 "included_endpoint": high,
                 "excluded_endpoint": low,
                 "cumulative_count": count,
-                "included_density": str(Fraction(count, high)),
-                "excluded_density": str(Fraction(count, low)),
+                "included_density": encoded(Fraction(count, high)),
+                "excluded_density": encoded(Fraction(count, low)),
             }
         )
     levels = result.get("levels")

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_continuous_spike_integral_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_continuous_spike_integral_separation.py
@@ -30,7 +30,7 @@ def load_verifier():
 def candidate(alpha=Fraction(1, 4)):
     verifier = load_verifier()
     return {
-        "alpha": str(alpha),
+        "alpha": verifier.encoded(alpha),
         "baseline_power": 2,
         "spike_height": "1",
         "spikes": [verifier.expected_spike(n, alpha) for n in range(1, 13)],
@@ -83,10 +83,13 @@ def test_accepts_permuted_spike_order():
     assert verifier.valid_result(good)
 
 
-def test_rejects_rational_exceeding_published_bound():
+def test_rejects_noncanonical_rational_and_string_coercion():
     verifier = load_verifier()
     bad = candidate()
-    bad["alpha"] = "1/" + "0" * 100
+    bad["alpha"] = {"numerator": 2, "denominator": 8}
+    assert not verifier.valid_result(bad)
+    bad = candidate()
+    bad["alpha"] = "1/4"
     assert not verifier.valid_result(bad)
 
 

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_convergence_mode_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_convergence_mode_separation.py
@@ -32,6 +32,37 @@ def _case(tmp_path: Path):
     return TASK, app, logs
 
 
+def test_typed_oracle_and_unreduced_event_mass_pass(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path / "oracle")
+    assert _run_verifier(task, app, logs).reward == pytest.approx(1.0)
+
+    task, app, logs = _case(tmp_path / "unreduced")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["levels"][0]["event_mass"] = {
+        "numerator": 2,
+        "denominator": 4,
+    }
+    _write_json(app / "submission.json", submission)
+    assert _run_verifier(task, app, logs).reward == pytest.approx(1.0)
+
+
+def test_string_or_noncanonical_probe_is_rejected(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path / "string")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["probes"][0]["point"] = "1/3"
+    _write_json(app / "submission.json", submission)
+    assert _run_verifier(task, app, logs).reward == pytest.approx(0.0)
+
+    task, app, logs = _case(tmp_path / "noncanonical")
+    submission = json.loads((app / "submission.json").read_text())
+    submission["result"]["probes"][0]["point"] = {
+        "numerator": 2,
+        "denominator": 6,
+    }
+    _write_json(app / "submission.json", submission)
+    assert _run_verifier(task, app, logs).reward == pytest.approx(0.0)
+
+
 def test_rejects_unbounded_research_status_fact(tmp_path: Path) -> None:
     task, app, logs = _case(tmp_path)
     submission = json.loads((app / "submission.json").read_text())

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_positive_lower_density_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_positive_lower_density_separation.py
@@ -9,6 +9,10 @@ from benchmarks.validation.mathematical_benchmarks_v1 import _fixtures, _verifie
 TASK = "positive-lower-density-separation"
 
 
+def _q(value: Fraction) -> dict[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
 def _run(tmp_path: Path, mutate=None):
     task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
     submission = json.loads((app / "submission.json").read_text())
@@ -29,16 +33,16 @@ def _set_base(submission, base):
                 "included_endpoint": high,
                 "excluded_endpoint": low,
                 "cumulative_count": count,
-                "included_density": str(Fraction(count, high)),
-                "excluded_density": str(Fraction(count, low)),
+                "included_density": _q(Fraction(count, high)),
+                "excluded_density": _q(Fraction(count, low)),
             }
         )
     submission["result"].update(
         {
             "base": base,
             "levels": levels,
-            "lower_density": str(Fraction(1, base + 1)),
-            "upper_density": str(Fraction(base, base + 1)),
+            "lower_density": _q(Fraction(1, base + 1)),
+            "upper_density": _q(Fraction(base, base + 1)),
         }
     )
 
@@ -85,3 +89,13 @@ def test_input_binding_and_type_checks_are_hard_gates(tmp_path: Path) -> None:
     result = _verifier._run_verifier(task, app, logs)
     assert result.details["input_binding"] == 0.0
     assert result.reward == 0.0
+
+
+def test_string_coerced_density_is_rejected(tmp_path: Path) -> None:
+    assert (
+        _run(
+            tmp_path,
+            lambda submission: submission["result"].update(lower_density="1/4"),
+        ).reward
+        == 0.0
+    )

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_positive_lower_density_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_positive_lower_density_separation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import runpy
 from fractions import Fraction
 from pathlib import Path
 
@@ -99,3 +100,27 @@ def test_string_coerced_density_is_rejected(tmp_path: Path) -> None:
         ).reward
         == 0.0
     )
+
+
+def test_oracle_generator_emits_typed_rationals(tmp_path: Path, monkeypatch) -> None:
+    generated: dict[str, str] = {}
+    original_write_text = Path.write_text
+
+    def capture(self: Path, data: str, *args, **kwargs) -> int:
+        assert self == Path("/app/submission.json")
+        generated["submission"] = data
+        return len(data)
+
+    monkeypatch.setattr(Path, "write_text", capture)
+    runpy.run_path(
+        "benchmarks/datasets/mathematical-benchmarks-v1/"
+        "positive-lower-density-separation/solution/solve.py"
+    )
+    monkeypatch.setattr(Path, "write_text", original_write_text)
+
+    submission = json.loads(generated["submission"])
+    assert submission["result"]["lower_density"] == _q(Fraction(1, 4))
+    assert submission["result"]["levels"][0]["included_density"] == _q(Fraction(2, 3))
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "generated-oracle")
+    _fixtures._write_json(app / "submission.json", submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 1.0


### PR DESCRIPTION
## What changed

- Replace unrestricted rational strings with typed `numerator`/`denominator` objects in three convergence and density certificates.
- Parse semantic rational values before correctness scoring.
- Preserve prior semantics: convergence event masses still accept equivalent unreduced values, while canonical probe, spike, and density fields remain lowest-term-only.
- Update instructions, gold submissions, generated contracts, verifier checksums, and focused coercion/canonicality tests.

## Validation

- selected-task Harbor static validation passed
- focused host validation: 15 passed
- Ruff passed on all changed verifier/test Python files
- the benchmark planner selects all three changed-task Oracles

The local host has no Docker-compatible runtime, so the exact Oracles are left to the PR benchmark workflow.
