### PR TITLE
refactor(benchmarks): type cyclic duality rational certificates

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -10,7 +29,7 @@
         },
         "flow": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "maxItems": 60,
           "minItems": 60,
@@ -21,7 +40,7 @@
         },
         "sequence": {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           },
           "maxItems": 60,
           "minItems": 60,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/instruction.md
@@ -2,7 +2,7 @@
 
 Read `/app/input.json`. Maximize the sum at the marked positions over real cyclic sequences satisfying the zero-sum and adjacent-difference constraints.
 
-Write a task-specific JSON witness at `evidence/answer.txt` with `schema_version: "1"`, the task ID, the primal and dual certificates below, and `optimality: "weak_duality_after_median_minimum"`. Give a canonical rational feasible sequence and a canonical rational edge circulation `q`. With indices modulo the frozen cycle size, require `q_i-q_(i-1)=w_i`, where `w_i=1-m/n` at a marked position and `-m/n` otherwise, for cycle size `n` and `m` marked positions. Its `L1` norm is the dual value.
+Write a task-specific JSON witness at `evidence/answer.txt` with `schema_version: "1"`, the task ID, the primal and dual certificates below, and `optimality: "weak_duality_after_median_minimum"`. Give a canonical rational feasible sequence and a canonical rational edge circulation `q`, representing each entry as a `{"numerator": integer, "denominator": positive integer}` object in lowest terms. With indices modulo the frozen cycle size, require `q_i-q_(i-1)=w_i`, where `w_i=1-m/n` at a marked position and `-m/n` otherwise, for cycle size `n` and `m` marked positions. Its `L1` norm is the dual value.
 
 
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/solution/submission.json
@@ -2,129 +2,489 @@
   "result": {
     "dual_value": "15",
     "flow": [
-      "3/8",
-      "7/24",
-      "5/24",
-      "1/8",
-      "1/24",
-      "-1/24",
-      "-1/8",
-      "-5/24",
-      "-7/24",
-      "-3/8",
-      "-11/24",
-      "11/24",
-      "3/8",
-      "7/24",
-      "5/24",
-      "1/8",
-      "1/24",
-      "-1/24",
-      "-1/8",
-      "-5/24",
-      "-7/24",
-      "-3/8",
-      "-11/24",
-      "11/24",
-      "3/8",
-      "7/24",
-      "5/24",
-      "1/8",
-      "1/24",
-      "-1/24",
-      "-1/8",
-      "-5/24",
-      "-7/24",
-      "-3/8",
-      "-11/24",
-      "11/24",
-      "3/8",
-      "7/24",
-      "5/24",
-      "1/8",
-      "1/24",
-      "-1/24",
-      "-1/8",
-      "-5/24",
-      "-7/24",
-      "-3/8",
-      "-11/24",
-      "11/24",
-      "3/8",
-      "7/24",
-      "5/24",
-      "1/8",
-      "1/24",
-      "-1/24",
-      "-1/8",
-      "-5/24",
-      "-7/24",
-      "-3/8",
-      "-11/24",
-      "11/24"
+      {
+        "denominator": 8,
+        "numerator": 3
+      },
+      {
+        "denominator": 24,
+        "numerator": 7
+      },
+      {
+        "denominator": 24,
+        "numerator": 5
+      },
+      {
+        "denominator": 8,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": -1
+      },
+      {
+        "denominator": 8,
+        "numerator": -1
+      },
+      {
+        "denominator": 24,
+        "numerator": -5
+      },
+      {
+        "denominator": 24,
+        "numerator": -7
+      },
+      {
+        "denominator": 8,
+        "numerator": -3
+      },
+      {
+        "denominator": 24,
+        "numerator": -11
+      },
+      {
+        "denominator": 24,
+        "numerator": 11
+      },
+      {
+        "denominator": 8,
+        "numerator": 3
+      },
+      {
+        "denominator": 24,
+        "numerator": 7
+      },
+      {
+        "denominator": 24,
+        "numerator": 5
+      },
+      {
+        "denominator": 8,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": -1
+      },
+      {
+        "denominator": 8,
+        "numerator": -1
+      },
+      {
+        "denominator": 24,
+        "numerator": -5
+      },
+      {
+        "denominator": 24,
+        "numerator": -7
+      },
+      {
+        "denominator": 8,
+        "numerator": -3
+      },
+      {
+        "denominator": 24,
+        "numerator": -11
+      },
+      {
+        "denominator": 24,
+        "numerator": 11
+      },
+      {
+        "denominator": 8,
+        "numerator": 3
+      },
+      {
+        "denominator": 24,
+        "numerator": 7
+      },
+      {
+        "denominator": 24,
+        "numerator": 5
+      },
+      {
+        "denominator": 8,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": -1
+      },
+      {
+        "denominator": 8,
+        "numerator": -1
+      },
+      {
+        "denominator": 24,
+        "numerator": -5
+      },
+      {
+        "denominator": 24,
+        "numerator": -7
+      },
+      {
+        "denominator": 8,
+        "numerator": -3
+      },
+      {
+        "denominator": 24,
+        "numerator": -11
+      },
+      {
+        "denominator": 24,
+        "numerator": 11
+      },
+      {
+        "denominator": 8,
+        "numerator": 3
+      },
+      {
+        "denominator": 24,
+        "numerator": 7
+      },
+      {
+        "denominator": 24,
+        "numerator": 5
+      },
+      {
+        "denominator": 8,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": -1
+      },
+      {
+        "denominator": 8,
+        "numerator": -1
+      },
+      {
+        "denominator": 24,
+        "numerator": -5
+      },
+      {
+        "denominator": 24,
+        "numerator": -7
+      },
+      {
+        "denominator": 8,
+        "numerator": -3
+      },
+      {
+        "denominator": 24,
+        "numerator": -11
+      },
+      {
+        "denominator": 24,
+        "numerator": 11
+      },
+      {
+        "denominator": 8,
+        "numerator": 3
+      },
+      {
+        "denominator": 24,
+        "numerator": 7
+      },
+      {
+        "denominator": 24,
+        "numerator": 5
+      },
+      {
+        "denominator": 8,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": 1
+      },
+      {
+        "denominator": 24,
+        "numerator": -1
+      },
+      {
+        "denominator": 8,
+        "numerator": -1
+      },
+      {
+        "denominator": 24,
+        "numerator": -5
+      },
+      {
+        "denominator": 24,
+        "numerator": -7
+      },
+      {
+        "denominator": 8,
+        "numerator": -3
+      },
+      {
+        "denominator": 24,
+        "numerator": -11
+      },
+      {
+        "denominator": 24,
+        "numerator": 11
+      }
     ],
     "primal_value": "15",
     "sequence": [
-      "2",
-      "1",
-      "0",
-      "-1",
-      "-2",
-      "-3",
-      "-2",
-      "-1",
-      "0",
-      "1",
-      "2",
-      "3",
-      "2",
-      "1",
-      "0",
-      "-1",
-      "-2",
-      "-3",
-      "-2",
-      "-1",
-      "0",
-      "1",
-      "2",
-      "3",
-      "2",
-      "1",
-      "0",
-      "-1",
-      "-2",
-      "-3",
-      "-2",
-      "-1",
-      "0",
-      "1",
-      "2",
-      "3",
-      "2",
-      "1",
-      "0",
-      "-1",
-      "-2",
-      "-3",
-      "-2",
-      "-1",
-      "0",
-      "1",
-      "2",
-      "3",
-      "2",
-      "1",
-      "0",
-      "-1",
-      "-2",
-      "-3",
-      "-2",
-      "-1",
-      "0",
-      "1",
-      "2",
-      "3"
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 3
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 3
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 3
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 3
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -3
+      },
+      {
+        "denominator": 1,
+        "numerator": -2
+      },
+      {
+        "denominator": 1,
+        "numerator": -1
+      },
+      {
+        "denominator": 1,
+        "numerator": 0
+      },
+      {
+        "denominator": 1,
+        "numerator": 1
+      },
+      {
+        "denominator": 1,
+        "numerator": 2
+      },
+      {
+        "denominator": 1,
+        "numerator": 3
+      }
     ]
   },
   "witness": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="48121b835aa861660ba3a5df60aea9d57b47aac72f4b36f80fa8a8d0523ac581"
+LABEL jacobian.checksum="c39e44606538d9ebd4d23bb2544f90f8247132317369f0fd303a5a7475827dc1"
 # Exact cyclic primal-dual optimization verifier.
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="2d578693236a05be67e5399a57ede7a1d114778d88ed8ef31d2e5a35390c348a"
+LABEL jacobian.checksum="48121b835aa861660ba3a5df60aea9d57b47aac72f4b36f80fa8a8d0523ac581"
 # Exact cyclic primal-dual optimization verifier.
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/public_contract.json
@@ -15,7 +15,25 @@
   "required_witness_filenames": [
     "evidence/answer.txt"
   ],
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -26,7 +44,7 @@
       },
       "flow": {
         "items": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "maxItems": 60,
         "minItems": 60,
@@ -37,7 +55,7 @@
       },
       "sequence": {
         "items": {
-          "type": "string"
+          "$ref": "#/$defs/rational"
         },
         "maxItems": 60,
         "minItems": 60,
@@ -54,6 +72,25 @@
   },
   "submission_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "denominator": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "numerator": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "numerator",
+          "denominator"
+        ],
+        "type": "object"
+      }
+    },
     "additionalProperties": false,
     "properties": {
       "result": {
@@ -64,7 +101,7 @@
           },
           "flow": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 60,
             "minItems": 60,
@@ -75,7 +112,7 @@
           },
           "sequence": {
             "items": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "maxItems": 60,
             "minItems": 60,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier.py
@@ -1,5 +1,4 @@
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -10,7 +9,6 @@ from verifier_support import (
 )
 
 FROZEN_INPUT = Path(__file__).with_name("input.json")
-RATIONAL_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?")
 REQUIRED_RESULT_FIELDS = frozenset({"sequence", "flow", "primal_value", "dual_value"})
 
 
@@ -46,14 +44,19 @@ def load_instance(path=FROZEN_INPUT):
     }
 
 
-def fraction(text):
-    if type(text) is not str or len(text) > 128 or RATIONAL_RE.fullmatch(text) is None:
+def fraction(value):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
         return None
-    try:
-        value = Fraction(text)
-    except (ValueError, ZeroDivisionError, TypeError, OverflowError):
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator < 1:
         return None
-    return value if str(value) == text else None
+    result = Fraction(numerator, denominator)
+    return (
+        result
+        if result.numerator == numerator and result.denominator == denominator
+        else None
+    )
 
 
 def minimum_cost(instance=None):
@@ -90,8 +93,6 @@ def valid(result, instance=None):
             or not isinstance(result["flow"], list)
             or len(result["sequence"]) != cycle_size
             or len(result["flow"]) != cycle_size
-            or any(type(value) is not str for value in result["sequence"])
-            or any(type(value) is not str for value in result["flow"])
         ):
             return False
         sequence = [fraction(value) for value in result["sequence"]]
@@ -129,8 +130,8 @@ def result_contract(result, instance):
         and isinstance(result["flow"], list)
         and len(result["sequence"]) == cycle_size
         and len(result["flow"]) == cycle_size
-        and all(type(value) is str for value in result["sequence"])
-        and all(type(value) is str for value in result["flow"])
+        and all(fraction(value) is not None for value in result["sequence"])
+        and all(fraction(value) is not None for value in result["flow"])
         and type(result["primal_value"]) is str
         and type(result["dual_value"]) is str
     )

--- a/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/cyclic-lipschitz-duality/tests/verifier.py
@@ -10,6 +10,9 @@ from verifier_support import (
 
 FROZEN_INPUT = Path(__file__).with_name("input.json")
 REQUIRED_RESULT_FIELDS = frozenset({"sequence", "flow", "primal_value", "dual_value"})
+# Keep the exact sums below bounded-cost arithmetic even for a submission that
+# otherwise fits within the outer JSON-size limit.
+MAX_FRACTION_BITS = 1_024
 
 
 def load_instance(path=FROZEN_INPUT):
@@ -49,7 +52,13 @@ def fraction(value):
         return None
     numerator = value["numerator"]
     denominator = value["denominator"]
-    if type(numerator) is not int or type(denominator) is not int or denominator < 1:
+    if (
+        type(numerator) is not int
+        or type(denominator) is not int
+        or denominator < 1
+        or numerator.bit_length() > MAX_FRACTION_BITS
+        or denominator.bit_length() > MAX_FRACTION_BITS
+    ):
         return None
     result = Fraction(numerator, denominator)
     return (

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
@@ -23,11 +23,12 @@ def test_independent_dual_cost():
 
 
 def test_noncanonical_fraction_rejected():
-    assert module().fraction("2/4") is None
+    assert module().fraction({"numerator": 2, "denominator": 4}) is None
 
 
 def test_fraction_rejects_nonfinite_and_unbounded_values():
     loaded = module()
     assert loaded.fraction(float("inf")) is None
     assert loaded.fraction("1e1000000000") is None
-    assert loaded.fraction("1" * 129) is None
+    assert loaded.fraction({"numerator": True, "denominator": 1}) is None
+    assert loaded.fraction({"numerator": 1, "denominator": 0}) is None

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_cyclic_lipschitz_duality.py
@@ -32,3 +32,4 @@ def test_fraction_rejects_nonfinite_and_unbounded_values():
     assert loaded.fraction("1e1000000000") is None
     assert loaded.fraction({"numerator": True, "denominator": 1}) is None
     assert loaded.fraction({"numerator": 1, "denominator": 0}) is None
+    assert loaded.fraction({"numerator": 1 << 1_024, "denominator": 1}) is None


### PR DESCRIPTION
## Summary
- replace the 120 free-form rational strings in the primal sequence and dual flow with canonical numerator/denominator objects
- parse and validate typed rationals before replaying feasibility, objective, divergence, and dual-cost predicates
- update the public contract, generated schema, gold submission, instructions, verifier checksum, and focused parser tests

The already `const`-constrained primal and dual value strings and the task-specific evidence payload remain unchanged.

## Validation
- selected-task Harbor contract check
- focused host validation (3 passed)
- focused Ruff check
- Harbor planner selects one host test and one Oracle