### PR TITLE
refactor(benchmarks): structure algebraic derivation results

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/environment/submission_schema.json
@@ -124,10 +124,6 @@
         "elimination": {
           "additionalProperties": false,
           "properties": {
-            "hypothesis_factorization": {
-              "minLength": 1,
-              "type": "string"
-            },
             "sum_polynomial": {
               "$ref": "#/$defs/polynomial"
             },

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/instruction.md
@@ -8,8 +8,9 @@ certificate that:
 3. returns both and only the possible target values as quadratic surds; and
 4. certifies that each submitted branch is achievable.
 
-The optional `recurrence` and `hypothesis_factorization` fields describe one
-accepted exact certificate format; they are not required.
+The optional `recurrence` field describes one accepted exact certificate
+format; it is not required. The submitted sum and target polynomials provide
+the elimination identity directly.
 
 The two algebraic branches may appear in either order. Rational numbers must be
 reduced with positive denominators. Write the result to `/app/submission.json`

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/solution/submission.json
@@ -84,7 +84,6 @@
       }
     ],
     "elimination": {
-      "hypothesis_factorization": "A4-2*A3=-(s^2/2)*(s^2-10*s+8)",
       "sum_polynomial": [
         {
           "denominator": 1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="8e1e1e1eb18c3d7b8eed45de1b26f01a9225c8c99ed1939bfc90792807e5f7ad"
+LABEL jacobian.checksum="534ec0f0908b50f454cdacf89f5562ffbc2562c60822db06f13971f554b365a1"
 LABEL jacobian.task="jacobian/complex-power-sum-elimination"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/public_contract.json
@@ -124,10 +124,6 @@
       "elimination": {
         "additionalProperties": false,
         "properties": {
-          "hypothesis_factorization": {
-            "minLength": 1,
-            "type": "string"
-          },
           "sum_polynomial": {
             "$ref": "#/$defs/polynomial"
           },
@@ -323,10 +319,6 @@
           "elimination": {
             "additionalProperties": false,
             "properties": {
-              "hypothesis_factorization": {
-                "minLength": 1,
-                "type": "string"
-              },
               "sum_polynomial": {
                 "$ref": "#/$defs/polynomial"
               },

--- a/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/complex-power-sum-elimination/tests/verifier.py
@@ -202,15 +202,11 @@ def _recurrence_is_valid(value: object, expected_powers: dict[str, Poly]) -> boo
 
 
 def _elimination_is_valid(value: object, expected_powers: dict[str, Poly]) -> bool:
-    if (
-        not isinstance(value, dict)
-        or not {"sum_polynomial", "target_polynomial"} <= set(value)
-        or not set(value)
-        <= {"sum_polynomial", "hypothesis_factorization", "target_polynomial"}
-    ):
+    if not isinstance(value, dict) or set(value) != {
+        "sum_polynomial",
+        "target_polynomial",
+    }:
         return False
-    expected_factorization = "A4-2*A3=-(s^2/2)*(s^2-10*s+8)"
-    factorization = value.get("hypothesis_factorization")
     difference = _padd(
         expected_powers["4"], _pscale(expected_powers["3"], Fraction(-2))
     )
@@ -222,7 +218,6 @@ def _elimination_is_valid(value: object, expected_powers: dict[str, Poly]) -> bo
         _poly(value["sum_polynomial"]) == (Fraction(8), Fraction(-10), Fraction(1))
         and _poly(value["target_polynomial"])
         == (Fraction(32), Fraction(-20), Fraction(1))
-        and factorization in {None, expected_factorization}
         and difference == factorized
     )
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/environment/submission_schema.json
@@ -121,8 +121,20 @@
           "additionalProperties": false,
           "properties": {
             "claimed_partner": {
-              "minLength": 1,
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "denominator": {
+                  "$ref": "#/$defs/poly"
+                },
+                "numerator": {
+                  "$ref": "#/$defs/poly"
+                }
+              },
+              "required": [
+                "numerator",
+                "denominator"
+              ],
+              "type": "object"
             },
             "downstream_recurrence_status": {
               "minLength": 1,
@@ -133,8 +145,7 @@
               "type": "string"
             },
             "k": {
-              "minLength": 1,
-              "type": "string"
+              "$ref": "#/$defs/poly"
             },
             "status_for_d_ge_2": {
               "minLength": 1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/instruction.md
@@ -2,7 +2,12 @@
 
 Audit the frozen Vieta-jumping proof for positive integer pairs satisfying `x^2-xy+y^2 | xy(xy-1)`. Identify the first invalid integrality step, then replace the broken recurrence with one integer-polynomial parameter family proving infinitely many distinct ratios.
 
-The `source_audit` object must use the following exact tokens: `invalid_step` is `"VIETA_PARTNER_INTEGRALITY"`, `k` is `"d^2-1"`, `claimed_partner` is `"d^2/(d^2-1)"`, `status_for_d_ge_2` is `"NONINTEGER"`, and `downstream_recurrence_status` is `"UNSUPPORTED"`.
+The `source_audit` object must use the following exact categorical tokens:
+`invalid_step` is `"VIETA_PARTNER_INTEGRALITY"`, `status_for_d_ge_2` is
+`"NONINTEGER"`, and `downstream_recurrence_status` is `"UNSUPPORTED"`.
+Represent `k=d^2-1` as an ascending coefficient array in `d`, and represent
+the claimed partner `d^2/(d^2-1)` by separate ascending numerator and
+denominator coefficient arrays.
 
 Submit ascending coefficient arrays in the parameter `t` for the reduced variables `a,b,d`, the original pair `x,y`, the norm, both exact identity quotients, the final divisibility quotient, and the ratio polynomial. The verifier binds `x` to `ratio*y` as a polynomial identity, so any valid integer-polynomial parameterization is allowed; do not assume the Oracle's `t^2` parameterization is required.
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/solution/submission.json
@@ -100,10 +100,25 @@
       }
     ],
     "source_audit": {
-      "claimed_partner": "d^2/(d^2-1)",
+      "claimed_partner": {
+        "denominator": [
+          -1,
+          0,
+          1
+        ],
+        "numerator": [
+          0,
+          0,
+          1
+        ]
+      },
       "downstream_recurrence_status": "UNSUPPORTED",
       "invalid_step": "VIETA_PARTNER_INTEGRALITY",
-      "k": "d^2-1",
+      "k": [
+        -1,
+        0,
+        1
+      ],
       "status_for_d_ge_2": "NONINTEGER"
     }
   }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="4ee668ed27e740eb9b9af2260fc17697a699d88744e6968963e7b4c9138c9b5f"
+LABEL jacobian.checksum="cc9df4eab6fdd189ee0e9bc76fe88b6539408dba7566ccd080546c3e5df11623"
 LABEL jacobian.task="jacobian/diophantine-ratio-family-repair"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/public_contract.json
@@ -121,8 +121,20 @@
         "additionalProperties": false,
         "properties": {
           "claimed_partner": {
-            "minLength": 1,
-            "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "numerator": {
+                "$ref": "#/$defs/poly"
+              },
+              "denominator": {
+                "$ref": "#/$defs/poly"
+              }
+            },
+            "required": [
+              "numerator",
+              "denominator"
+            ],
+            "type": "object"
           },
           "downstream_recurrence_status": {
             "minLength": 1,
@@ -133,8 +145,7 @@
             "type": "string"
           },
           "k": {
-            "minLength": 1,
-            "type": "string"
+            "$ref": "#/$defs/poly"
           },
           "status_for_d_ge_2": {
             "minLength": 1,
@@ -282,8 +293,20 @@
             "additionalProperties": false,
             "properties": {
               "claimed_partner": {
-                "minLength": 1,
-                "type": "string"
+                "additionalProperties": false,
+                "properties": {
+                  "numerator": {
+                    "$ref": "#/$defs/poly"
+                  },
+                  "denominator": {
+                    "$ref": "#/$defs/poly"
+                  }
+                },
+                "required": [
+                  "numerator",
+                  "denominator"
+                ],
+                "type": "object"
               },
               "downstream_recurrence_status": {
                 "minLength": 1,
@@ -294,8 +317,7 @@
                 "type": "string"
               },
               "k": {
-                "minLength": 1,
-                "type": "string"
+                "$ref": "#/$defs/poly"
               },
               "status_for_d_ge_2": {
                 "minLength": 1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/diophantine-ratio-family-repair/tests/verifier.py
@@ -169,17 +169,29 @@ def _result_shape_is_valid(result: object) -> bool:
     }:
         return False
     audit = result["source_audit"]
+    if not isinstance(audit, dict) or set(audit) != {
+        "invalid_step",
+        "k",
+        "claimed_partner",
+        "status_for_d_ge_2",
+        "downstream_recurrence_status",
+    }:
+        return False
+    partner = audit["claimed_partner"]
     return bool(
-        isinstance(audit, dict)
-        and set(audit)
-        == {
-            "invalid_step",
-            "k",
-            "claimed_partner",
-            "status_for_d_ge_2",
-            "downstream_recurrence_status",
-        }
-        and all(type(value) is str and value for value in audit.values())
+        all(
+            type(audit[field]) is str and audit[field]
+            for field in (
+                "invalid_step",
+                "status_for_d_ge_2",
+                "downstream_recurrence_status",
+            )
+        )
+        and _poly(audit["k"]) is not None
+        and isinstance(partner, dict)
+        and set(partner) == {"numerator", "denominator"}
+        and _poly(partner["numerator"]) is not None
+        and _poly(partner["denominator"]) is not None
         and _family_shape(result["family"])
         and _probes_shape(result["probes"])
         and type(result["conclusion"]) is str
@@ -280,8 +292,11 @@ def _result_is_valid(result: object, source: dict[str, Any]) -> bool:
     audit = result["source_audit"]
     if not isinstance(audit, dict) or audit != {
         "invalid_step": "VIETA_PARTNER_INTEGRALITY",
-        "k": "d^2-1",
-        "claimed_partner": "d^2/(d^2-1)",
+        "k": [-1, 0, 1],
+        "claimed_partner": {
+            "numerator": [0, 0, 1],
+            "denominator": [-1, 0, 1],
+        },
         "status_for_d_ge_2": "NONINTEGER",
         "downstream_recurrence_status": "UNSUPPORTED",
     }:

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/environment/submission_schema.json
@@ -86,14 +86,34 @@
         "difference_identity": {
           "additionalProperties": false,
           "properties": {
-            "left": {
-              "minLength": 1,
-              "type": "string"
+            "left_function_coefficients": {
+              "items": {
+                "type": "integer"
+              },
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
             },
             "right_factors": {
               "items": {
-                "minLength": 1,
-                "type": "string"
+                "additionalProperties": false,
+                "properties": {
+                  "a_coefficient": {
+                    "type": "integer"
+                  },
+                  "b_coefficient": {
+                    "type": "integer"
+                  },
+                  "constant": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "a_coefficient",
+                  "b_coefficient",
+                  "constant"
+                ],
+                "type": "object"
               },
               "maxItems": 2,
               "minItems": 2,
@@ -101,7 +121,7 @@
             }
           },
           "required": [
-            "left",
+            "left_function_coefficients",
             "right_factors"
           ],
           "type": "object"
@@ -110,12 +130,48 @@
           "additionalProperties": false,
           "properties": {
             "product": {
-              "minLength": 1,
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "P_2n": {
+                  "type": "integer"
+                },
+                "P_n_squared": {
+                  "type": "integer"
+                },
+                "P_n_times_u_n_times_delta": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "P_2n",
+                "P_n_squared",
+                "P_n_times_u_n_times_delta"
+              ],
+              "type": "object"
             },
             "taylor": {
-              "minLength": 1,
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "u_2n": {
+                  "type": "integer"
+                },
+                "u_n": {
+                  "type": "integer"
+                },
+                "u_n_squared_times_K": {
+                  "type": "integer"
+                },
+                "u_n_times_P_n": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "u_2n",
+                "u_n",
+                "u_n_times_P_n",
+                "u_n_squared_times_K"
+              ],
+              "type": "object"
             }
           },
           "required": [
@@ -165,8 +221,22 @@
           "additionalProperties": false,
           "properties": {
             "add_one_reason": {
-              "minLength": 1,
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "conclusion_exact_v2": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "premise_minimum_v2": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "premise_minimum_v2",
+                "conclusion_exact_v2"
+              ],
+              "type": "object"
             },
             "hypotheses": {
               "$ref": "#/$defs/triple"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/instruction.md
@@ -22,6 +22,10 @@ is at least that affine value; `hypotheses`, `successor`, `u_difference`, and
 `b_difference` assert exact valuations. The doubling identities are frozen source premises;
 your certificate must use them to establish the required affine valuation
 relations and strict gaps symbolically, not only for selected values of `k`.
+Encode the difference identity using ascending coefficients of `f` and two
+linear factors in `a,b`. Encode each doubling identity as coefficients of its
+named monomials after moving every term to the left-hand side. Encode the
+add-one valuation implication by its premise lower bound and exact conclusion.
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->
 ## Submission

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/solution/submission.json
@@ -23,15 +23,36 @@
       }
     },
     "difference_identity": {
-      "left": "f(a)-f(b)",
+      "left_function_coefficients": [
+        2,
+        1,
+        1
+      ],
       "right_factors": [
-        "a-b",
-        "a+b+1"
+        {
+          "a_coefficient": 1,
+          "b_coefficient": -1,
+          "constant": 0
+        },
+        {
+          "a_coefficient": 1,
+          "b_coefficient": 1,
+          "constant": 1
+        }
       ]
     },
     "doubling_identities": {
-      "product": "P_2n=P_n*(P_n+2*u_n*Delta)",
-      "taylor": "u_2n-2*u_n=u_n*(P_n-1)+u_n^2*K"
+      "product": {
+        "P_2n": 1,
+        "P_n_squared": -1,
+        "P_n_times_u_n_times_delta": -2
+      },
+      "taylor": {
+        "u_2n": 1,
+        "u_n": -1,
+        "u_n_squared_times_K": -1,
+        "u_n_times_P_n": -1
+      }
     },
     "finite_testing_role": "SANITY_ONLY_NOT_UNIVERSAL_PROOF",
     "target_transfer": {
@@ -64,7 +85,10 @@
       ]
     },
     "valuation_induction": {
-      "add_one_reason": "P_2n_minus_1_divisible_by_8_implies_P_2n_plus_1_has_v2_1",
+      "add_one_reason": {
+        "conclusion_exact_v2": 1,
+        "premise_minimum_v2": 3
+      },
       "hypotheses": [
         [
           1,

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="5b22c5e591bb92a4410dd26354a1c3b47da121082fc8228beca8c8a65e443524"
+LABEL jacobian.checksum="965c18d8eccd8ea3ae96fa341144a1787dc03c1ba9544bea4d271e42b2f5a17a"
 LABEL jacobian.task="jacobian/putnam-2adic-induction-audit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/
 COPY input.json /app/input.json

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/public_contract.json
@@ -86,14 +86,34 @@
       "difference_identity": {
         "additionalProperties": false,
         "properties": {
-          "left": {
-            "minLength": 1,
-            "type": "string"
+          "left_function_coefficients": {
+            "items": {
+              "type": "integer"
+            },
+            "maxItems": 3,
+            "minItems": 3,
+            "type": "array"
           },
           "right_factors": {
             "items": {
-              "minLength": 1,
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "a_coefficient": {
+                  "type": "integer"
+                },
+                "b_coefficient": {
+                  "type": "integer"
+                },
+                "constant": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "a_coefficient",
+                "b_coefficient",
+                "constant"
+              ],
+              "type": "object"
             },
             "maxItems": 2,
             "minItems": 2,
@@ -101,7 +121,7 @@
           }
         },
         "required": [
-          "left",
+          "left_function_coefficients",
           "right_factors"
         ],
         "type": "object"
@@ -109,13 +129,49 @@
       "doubling_identities": {
         "additionalProperties": false,
         "properties": {
-          "product": {
-            "minLength": 1,
-            "type": "string"
-          },
           "taylor": {
-            "minLength": 1,
-            "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "u_2n": {
+                "type": "integer"
+              },
+              "u_n": {
+                "type": "integer"
+              },
+              "u_n_times_P_n": {
+                "type": "integer"
+              },
+              "u_n_squared_times_K": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "u_2n",
+              "u_n",
+              "u_n_times_P_n",
+              "u_n_squared_times_K"
+            ],
+            "type": "object"
+          },
+          "product": {
+            "additionalProperties": false,
+            "properties": {
+              "P_2n": {
+                "type": "integer"
+              },
+              "P_n_squared": {
+                "type": "integer"
+              },
+              "P_n_times_u_n_times_delta": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "P_2n",
+              "P_n_squared",
+              "P_n_times_u_n_times_delta"
+            ],
+            "type": "object"
           }
         },
         "required": [
@@ -165,8 +221,22 @@
         "additionalProperties": false,
         "properties": {
           "add_one_reason": {
-            "minLength": 1,
-            "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "premise_minimum_v2": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "conclusion_exact_v2": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "premise_minimum_v2",
+              "conclusion_exact_v2"
+            ],
+            "type": "object"
           },
           "hypotheses": {
             "$ref": "#/$defs/triple"
@@ -289,14 +359,34 @@
           "difference_identity": {
             "additionalProperties": false,
             "properties": {
-              "left": {
-                "minLength": 1,
-                "type": "string"
+              "left_function_coefficients": {
+                "items": {
+                  "type": "integer"
+                },
+                "maxItems": 3,
+                "minItems": 3,
+                "type": "array"
               },
               "right_factors": {
                 "items": {
-                  "minLength": 1,
-                  "type": "string"
+                  "additionalProperties": false,
+                  "properties": {
+                    "a_coefficient": {
+                      "type": "integer"
+                    },
+                    "b_coefficient": {
+                      "type": "integer"
+                    },
+                    "constant": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "a_coefficient",
+                    "b_coefficient",
+                    "constant"
+                  ],
+                  "type": "object"
                 },
                 "maxItems": 2,
                 "minItems": 2,
@@ -304,7 +394,7 @@
               }
             },
             "required": [
-              "left",
+              "left_function_coefficients",
               "right_factors"
             ],
             "type": "object"
@@ -312,13 +402,49 @@
           "doubling_identities": {
             "additionalProperties": false,
             "properties": {
-              "product": {
-                "minLength": 1,
-                "type": "string"
-              },
               "taylor": {
-                "minLength": 1,
-                "type": "string"
+                "additionalProperties": false,
+                "properties": {
+                  "u_2n": {
+                    "type": "integer"
+                  },
+                  "u_n": {
+                    "type": "integer"
+                  },
+                  "u_n_times_P_n": {
+                    "type": "integer"
+                  },
+                  "u_n_squared_times_K": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "u_2n",
+                  "u_n",
+                  "u_n_times_P_n",
+                  "u_n_squared_times_K"
+                ],
+                "type": "object"
+              },
+              "product": {
+                "additionalProperties": false,
+                "properties": {
+                  "P_2n": {
+                    "type": "integer"
+                  },
+                  "P_n_squared": {
+                    "type": "integer"
+                  },
+                  "P_n_times_u_n_times_delta": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "P_2n",
+                  "P_n_squared",
+                  "P_n_times_u_n_times_delta"
+                ],
+                "type": "object"
               }
             },
             "required": [
@@ -368,8 +494,22 @@
             "additionalProperties": false,
             "properties": {
               "add_one_reason": {
-                "minLength": 1,
-                "type": "string"
+                "additionalProperties": false,
+                "properties": {
+                  "premise_minimum_v2": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "conclusion_exact_v2": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "premise_minimum_v2",
+                  "conclusion_exact_v2"
+                ],
+                "type": "object"
               },
               "hypotheses": {
                 "$ref": "#/$defs/triple"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/putnam-2adic-induction-audit/tests/verifier.py
@@ -93,14 +93,43 @@ def _base_is_valid(base: object) -> bool:
 
 
 def _difference_identity_is_valid(value: object) -> bool:
-    if value != {"left": "f(a)-f(b)", "right_factors": ["a-b", "a+b+1"]}:
+    if not isinstance(value, dict) or set(value) != {
+        "left_function_coefficients",
+        "right_factors",
+    }:
+        return False
+    coefficients = value["left_function_coefficients"]
+    factors = value["right_factors"]
+    if (
+        not isinstance(coefficients, list)
+        or len(coefficients) != 3
+        or not all(type(coefficient) is int for coefficient in coefficients)
+        or not isinstance(factors, list)
+        or len(factors) != 2
+        or any(
+            not isinstance(factor, dict)
+            or set(factor) != {"a_coefficient", "b_coefficient", "constant"}
+            or not all(type(coefficient) is int for coefficient in factor.values())
+            for factor in factors
+        )
+    ):
         return False
     # Both sides have degree at most two in each variable; exact evaluation on
     # this grid independently catches any coefficient mismatch.
     for a in range(-3, 4):
         for b in range(-3, 4):
-            left = (a * a + a + 2) - (b * b + b + 2)
-            if left != (a - b) * (a + b + 1):
+            left = sum(
+                coefficient * (a**power - b**power)
+                for power, coefficient in enumerate(coefficients)
+            )
+            right = 1
+            for factor in factors:
+                right *= (
+                    factor["a_coefficient"] * a
+                    + factor["b_coefficient"] * b
+                    + factor["constant"]
+                )
+            if left != right:
                 return False
     return True
 
@@ -133,7 +162,7 @@ def _induction_is_valid(value: object) -> bool:
         sub_terms == expected_sub
         and _strictly_above(sub_terms[1], sub_terms[0])
         and value["add_one_reason"]
-        == "P_2n_minus_1_divisible_by_8_implies_P_2n_plus_1_has_v2_1"
+        == {"premise_minimum_v2": 3, "conclusion_exact_v2": 1}
         and u_terms == expected_u
         and _strictly_above(u_terms[1], u_terms[0])
         and successor == expected_successor == shifted_hypotheses
@@ -199,8 +228,17 @@ def _result_is_valid(result: object, source: dict[str, Any]) -> bool:
         and _difference_identity_is_valid(result["difference_identity"])
         and identities
         == {
-            "taylor": "u_2n-2*u_n=u_n*(P_n-1)+u_n^2*K",
-            "product": "P_2n=P_n*(P_n+2*u_n*Delta)",
+            "taylor": {
+                "u_2n": 1,
+                "u_n": -1,
+                "u_n_times_P_n": -1,
+                "u_n_squared_times_K": -1,
+            },
+            "product": {
+                "P_2n": 1,
+                "P_n_squared": -1,
+                "P_n_times_u_n_times_delta": -2,
+            },
         }
         and _induction_is_valid(result["valuation_induction"])
         and _target_is_valid(result["target_transfer"])

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_complex_power_sum_elimination.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_complex_power_sum_elimination.py
@@ -84,7 +84,6 @@ def test_does_not_require_prescribed_recurrence(tmp_path: Path) -> None:
     task, app, logs = _case(tmp_path)
     submission = json.loads((app / "submission.json").read_text())
     submission["result"].pop("recurrence")
-    submission["result"]["elimination"].pop("hypothesis_factorization")
     schema = json.loads((TASK / "environment" / "submission_schema.json").read_text())
     Draft202012Validator(schema).validate(submission)
     _rewrite(app, submission)
@@ -92,3 +91,9 @@ def test_does_not_require_prescribed_recurrence(tmp_path: Path) -> None:
     accepted = _run_verifier(task, app, logs)
     assert accepted.details["correctness"] == 1.0
     assert accepted.reward == pytest.approx(1.0)
+
+
+def test_elimination_schema_has_no_redundant_formula_string() -> None:
+    schema = json.loads((TASK / "environment" / "submission_schema.json").read_text())
+    elimination = schema["properties"]["result"]["properties"]["elimination"]
+    assert "hypothesis_factorization" not in elimination["properties"]

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_diophantine_ratio_family_repair.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_diophantine_ratio_family_repair.py
@@ -1,1 +1,21 @@
+from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from benchmarks.validation.mathematical_benchmarks_v1 import _fixtures, _verifier
+
+TASK = "diophantine-ratio-family-repair"
+
+
+def test_result_protocol(tmp_path: Path) -> None:
+    _fixtures.assert_result_witness_protocol(tmp_path, TASK)
+
+
+def test_rejects_formula_strings_in_source_audit(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["source_audit"]["claimed_partner"] = "d^2/(d^2-1)"
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_putnam_2adic_induction_audit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_putnam_2adic_induction_audit.py
@@ -34,6 +34,11 @@ def test_oracle_passes(tmp_path: Path) -> None:
     [
         (("valuation_induction", "sub_one_term_lower_bounds", 1), [1, 2]),
         (("target_transfer", "b_difference"), [2, 3]),
+        (("difference_identity", "left_function_coefficients"), "f(a)-f(b)"),
+        (
+            ("valuation_induction", "add_one_reason"),
+            "P_2n_minus_1_divisible_by_8_implies_P_2n_plus_1_has_v2_1",
+        ),
         (("finite_testing_role",), "FINITE_CASES_PROVE_ALL_K"),
     ],
 )


### PR DESCRIPTION
## Summary
- remove a redundant optional complex-elimination factorization string while retaining independent polynomial replay
- encode the audited Diophantine `k` and claimed partner as polynomial/rational-function coefficient objects
- encode Putnam difference and doubling identities as coefficient structures and the valuation implication as numeric bounds
- preserve categorical audit verdicts and reward semantics

Updates include contracts, generated schemas, gold submissions, instructions, verifier checksums, and focused tests.

## Validation
- selected-task Harbor contract check for all three tasks
- focused host validation (16 passed)
- focused Ruff check
- Harbor planner selects exactly three host tests and three Oracles