### PR TITLE
Type boundary sequence certificates

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/environment/submission_schema.json
@@ -1,4 +1,23 @@
 {
+  "$defs": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -30,16 +49,16 @@
             "additionalProperties": false,
             "properties": {
               "amplitude": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "endpoint_contribution": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "frequency": {
                 "type": "integer"
               },
               "interior_contribution": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               },
               "interior_segments": {
                 "type": "integer"
@@ -49,7 +68,7 @@
                 "type": "integer"
               },
               "total_variation": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               }
             },
             "required": [
@@ -76,7 +95,61 @@
           "type": "integer"
         },
         "sequence": {
-          "type": "string"
+          "additionalProperties": false,
+          "properties": {
+            "argument_exponents": {
+              "additionalProperties": false,
+              "properties": {
+                "n": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "q": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "x": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "q",
+                "n",
+                "x"
+              ],
+              "type": "object"
+            },
+            "denominator_exponents": {
+              "additionalProperties": false,
+              "properties": {
+                "n": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "q": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "q",
+                "n"
+              ],
+              "type": "object"
+            },
+            "function": {
+              "enum": [
+                "SIN"
+              ]
+            }
+          },
+          "required": [
+            "function",
+            "argument_exponents",
+            "denominator_exponents"
+          ],
+          "type": "object"
         },
         "uniform_certificate": {
           "additionalProperties": false,
@@ -111,10 +184,23 @@
               "const": 2
             },
             "interior_segment_count": {
-              "type": "string"
+              "additionalProperties": false,
+              "properties": {
+                "constant": {
+                  "type": "integer"
+                },
+                "frequency_multiplier": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "frequency_multiplier",
+                "constant"
+              ],
+              "type": "object"
             },
             "total_variation": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             }
           },
           "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/instruction.md
@@ -10,6 +10,10 @@ the exact monotone-segment accounting: two endpoint segments and all interior
 segments. Include at least four distinct freely chosen positive indices with
 their frequency, amplitude, segment counts, endpoint contribution, interior
 contribution, and total variation.
+Represent every exact rational as a numerator/positive-denominator object.
+Encode the sequence by the exponents of `q`, `n`, and `x` in the sine argument
+and of `q` and `n` in the denominator. Encode the interior segment count as an
+affine function of the frequency `q*n`.
 In `result.argument`, use the three typed values
 `SUP_NORM_1_OVER_QN_TENDS_TO_ZERO`, `TOTAL_VARIATION_IS_CONSTANTLY_FOUR`,
 and `UNIFORM_CONVERGENCE_DOES_NOT_FORCE_VARIATION_CONVERGENCE` to record the

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/solution/submission.json
@@ -7,45 +7,104 @@
     },
     "checkpoints": [
       {
-        "amplitude": "1/3",
-        "endpoint_contribution": "2/3",
+        "amplitude": {
+          "denominator": 3,
+          "numerator": 1
+        },
+        "endpoint_contribution": {
+          "denominator": 3,
+          "numerator": 2
+        },
         "frequency": 3,
-        "interior_contribution": "10/3",
+        "interior_contribution": {
+          "denominator": 3,
+          "numerator": 10
+        },
         "interior_segments": 5,
         "n": 1,
-        "total_variation": "4"
+        "total_variation": {
+          "denominator": 1,
+          "numerator": 4
+        }
       },
       {
-        "amplitude": "1/6",
-        "endpoint_contribution": "1/3",
+        "amplitude": {
+          "denominator": 6,
+          "numerator": 1
+        },
+        "endpoint_contribution": {
+          "denominator": 3,
+          "numerator": 1
+        },
         "frequency": 6,
-        "interior_contribution": "11/3",
+        "interior_contribution": {
+          "denominator": 3,
+          "numerator": 11
+        },
         "interior_segments": 11,
         "n": 2,
-        "total_variation": "4"
+        "total_variation": {
+          "denominator": 1,
+          "numerator": 4
+        }
       },
       {
-        "amplitude": "1/15",
-        "endpoint_contribution": "2/15",
+        "amplitude": {
+          "denominator": 15,
+          "numerator": 1
+        },
+        "endpoint_contribution": {
+          "denominator": 15,
+          "numerator": 2
+        },
         "frequency": 15,
-        "interior_contribution": "58/15",
+        "interior_contribution": {
+          "denominator": 15,
+          "numerator": 58
+        },
         "interior_segments": 29,
         "n": 5,
-        "total_variation": "4"
+        "total_variation": {
+          "denominator": 1,
+          "numerator": 4
+        }
       },
       {
-        "amplitude": "1/33",
-        "endpoint_contribution": "2/33",
+        "amplitude": {
+          "denominator": 33,
+          "numerator": 1
+        },
+        "endpoint_contribution": {
+          "denominator": 33,
+          "numerator": 2
+        },
         "frequency": 33,
-        "interior_contribution": "130/33",
+        "interior_contribution": {
+          "denominator": 33,
+          "numerator": 130
+        },
         "interior_segments": 65,
         "n": 11,
-        "total_variation": "4"
+        "total_variation": {
+          "denominator": 1,
+          "numerator": 4
+        }
       }
     ],
     "limit_function": "0",
     "scale_q": 3,
-    "sequence": "sin(q*n*x)/(q*n)",
+    "sequence": {
+      "argument_exponents": {
+        "n": 1,
+        "q": 1,
+        "x": 1
+      },
+      "denominator_exponents": {
+        "n": 1,
+        "q": 1
+      },
+      "function": "SIN"
+    },
     "uniform_certificate": {
       "sup_norm_denominator_coefficient": 3,
       "sup_norm_numerator": 1,
@@ -55,8 +114,14 @@
       "endpoint_jump_multiplier": 1,
       "endpoint_segment_count": 2,
       "interior_jump_multiplier": 2,
-      "interior_segment_count": "2*q*n-1",
-      "total_variation": "4"
+      "interior_segment_count": {
+        "constant": -1,
+        "frequency_multiplier": 2
+      },
+      "total_variation": {
+        "denominator": 1,
+        "numerator": 4
+      }
     }
   }
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="51a63ee42cf3c5a199549c957a1af56c5956fa6c91a182e8567402449cc70620"
+LABEL jacobian.checksum="0fa37cb1e27cec7c46c9a85dbf32190080b0f71313a7202863a306a03e0e8fb1"
 # Exact verifier for bounded-variation uniform-limit certificates.
 LABEL jacobian.task="jacobian/bounded-variation-uniform-limit"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/public_contract.json
@@ -1,6 +1,24 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "numerator": {
+          "type": "integer"
+        },
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -31,16 +49,16 @@
           "additionalProperties": false,
           "properties": {
             "amplitude": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "endpoint_contribution": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "frequency": {
               "type": "integer"
             },
             "interior_contribution": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             },
             "interior_segments": {
               "type": "integer"
@@ -50,7 +68,7 @@
               "type": "integer"
             },
             "total_variation": {
-              "type": "string"
+              "$ref": "#/$defs/rational"
             }
           },
           "required": [
@@ -77,7 +95,61 @@
         "type": "integer"
       },
       "sequence": {
-        "type": "string"
+        "additionalProperties": false,
+        "properties": {
+          "function": {
+            "enum": [
+              "SIN"
+            ]
+          },
+          "argument_exponents": {
+            "additionalProperties": false,
+            "properties": {
+              "q": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "n": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "x": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "q",
+              "n",
+              "x"
+            ],
+            "type": "object"
+          },
+          "denominator_exponents": {
+            "additionalProperties": false,
+            "properties": {
+              "q": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "n": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "q",
+              "n"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "function",
+          "argument_exponents",
+          "denominator_exponents"
+        ],
+        "type": "object"
       },
       "uniform_certificate": {
         "additionalProperties": false,
@@ -112,10 +184,23 @@
             "const": 2
           },
           "interior_segment_count": {
-            "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "frequency_multiplier": {
+                "type": "integer"
+              },
+              "constant": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "frequency_multiplier",
+              "constant"
+            ],
+            "type": "object"
           },
           "total_variation": {
-            "type": "string"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [
@@ -171,16 +256,16 @@
               "additionalProperties": false,
               "properties": {
                 "amplitude": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "endpoint_contribution": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "frequency": {
                   "type": "integer"
                 },
                 "interior_contribution": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "interior_segments": {
                   "type": "integer"
@@ -190,7 +275,7 @@
                   "type": "integer"
                 },
                 "total_variation": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [
@@ -217,7 +302,61 @@
             "type": "integer"
           },
           "sequence": {
-            "type": "string"
+            "additionalProperties": false,
+            "properties": {
+              "function": {
+                "enum": [
+                  "SIN"
+                ]
+              },
+              "argument_exponents": {
+                "additionalProperties": false,
+                "properties": {
+                  "q": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "n": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "x": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "q",
+                  "n",
+                  "x"
+                ],
+                "type": "object"
+              },
+              "denominator_exponents": {
+                "additionalProperties": false,
+                "properties": {
+                  "q": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "n": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "q",
+                  "n"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "function",
+              "argument_exponents",
+              "denominator_exponents"
+            ],
+            "type": "object"
           },
           "uniform_certificate": {
             "additionalProperties": false,
@@ -252,10 +391,23 @@
                 "const": 2
               },
               "interior_segment_count": {
-                "type": "string"
+                "additionalProperties": false,
+                "properties": {
+                  "frequency_multiplier": {
+                    "type": "integer"
+                  },
+                  "constant": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "frequency_multiplier",
+                  "constant"
+                ],
+                "type": "object"
               },
               "total_variation": {
-                "type": "string"
+                "$ref": "#/$defs/rational"
               }
             },
             "required": [
@@ -283,7 +435,26 @@
     "required": [
       "result"
     ],
-    "type": "object"
+    "type": "object",
+    "$defs": {
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "numerator": {
+            "type": "integer"
+          },
+          "denominator": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "numerator",
+          "denominator"
+        ],
+        "type": "object"
+      }
+    }
   },
   "task_id": "jacobian/bounded-variation-uniform-limit"
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/bounded-variation-uniform-limit/tests/verifier.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -18,10 +17,6 @@ CONCLUSION = "UNIFORM_CONVERGENCE_DOES_NOT_FORCE_VARIATION_CONVERGENCE"
 SCOPE = "the full sequence on [0,2*pi] and all submitted exact checkpoints"
 LIMITATION = "NO_PROOF_ASSISTANT_VERIFICATION"
 
-# Accept any ordering of q, n, x in the sine argument and q, n in the
-# denominator, with or without explicit multiplication signs.
-_SEQUENCE_RE = re.compile(r"^sin\(([qnx])\*([qnx])\*([qnx])\)/\(([qn])\*([qn])\)$")
-
 
 def _is_int(value: object) -> bool:
     """Accept only true integers, rejecting booleans and floats."""
@@ -30,27 +25,21 @@ def _is_int(value: object) -> bool:
 
 
 def _fraction(value: object) -> Fraction | None:
-    if not isinstance(value, str) or not re.fullmatch(
-        r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?", value
-    ):
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
         return None
-    try:
-        return Fraction(value)
-    except (ValueError, ZeroDivisionError):
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if not _is_int(numerator) or not _is_int(denominator) or denominator < 1:
         return None
+    return Fraction(numerator, denominator)
 
 
 def _valid_sequence(seq: object) -> bool:
-    """Accept equivalent serializations of ``sin(q*n*x)/(q*n)``."""
-
-    if not isinstance(seq, str):
-        return False
-    match = _SEQUENCE_RE.fullmatch(seq.replace(" ", ""))
-    return bool(
-        match
-        and set(match.group(1, 2, 3)) == {"q", "n", "x"}
-        and set(match.group(4, 5)) == {"q", "n"}
-    )
+    return seq == {
+        "function": "SIN",
+        "argument_exponents": {"q": 1, "n": 1, "x": 1},
+        "denominator_exponents": {"q": 1, "n": 1},
+    }
 
 
 def _source_is_bound() -> bool:
@@ -104,14 +93,13 @@ def _variation_formula_ok(value: object) -> bool:
         }
         and _is_int(value.get("endpoint_segment_count"))
         and value.get("endpoint_segment_count") == 2
-        and isinstance(value.get("interior_segment_count"), str)
-        and value.get("interior_segment_count") == "2*q*n-1"
+        and value.get("interior_segment_count")
+        == {"frequency_multiplier": 2, "constant": -1}
         and _is_int(value.get("endpoint_jump_multiplier"))
         and value.get("endpoint_jump_multiplier") == 1
         and _is_int(value.get("interior_jump_multiplier"))
         and value.get("interior_jump_multiplier") == 2
-        and isinstance(value.get("total_variation"), str)
-        and value.get("total_variation") == "4"
+        and _fraction(value.get("total_variation")) == 4
     )
 
 

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/environment/submission_schema.json
@@ -1,4 +1,47 @@
 {
+  "$defs": {
+    "polynomial": {
+      "items": {
+        "type": "integer"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "numerator": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    },
+    "rational_function": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator_coefficients": {
+          "$ref": "#/$defs/polynomial"
+        },
+        "numerator_coefficients": {
+          "$ref": "#/$defs/polynomial"
+        }
+      },
+      "required": [
+        "numerator_coefficients",
+        "denominator_coefficients"
+      ],
+      "type": "object"
+    }
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
@@ -17,10 +60,10 @@
                     "type": "integer"
                   },
                   "partial_sum": {
-                    "type": "string"
+                    "$ref": "#/$defs/rational"
                   },
                   "tail": {
-                    "type": "string"
+                    "$ref": "#/$defs/rational"
                   }
                 },
                 "required": [
@@ -35,16 +78,21 @@
               "type": "array"
             },
             "ratio": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             },
             "ratio_error": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             },
             "telescoping_identity": {
-              "type": "string"
+              "items": {
+                "$ref": "#/$defs/rational_function"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
             },
             "term": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             }
           },
           "required": [
@@ -64,7 +112,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "block_lower_bound": {
-                    "type": "string"
+                    "$ref": "#/$defs/rational"
                   },
                   "count": {
                     "type": "integer"
@@ -79,7 +127,7 @@
                     "type": "integer"
                   },
                   "term_lower_bound": {
-                    "type": "string"
+                    "$ref": "#/$defs/rational"
                   }
                 },
                 "required": [
@@ -97,13 +145,13 @@
               "type": "array"
             },
             "ratio": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             },
             "ratio_error": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             },
             "term": {
-              "type": "string"
+              "$ref": "#/$defs/rational_function"
             }
           },
           "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/environment/submission_schema.json
@@ -163,7 +163,7 @@
           "type": "object"
         },
         "ratio_limit": {
-          "const": "1"
+          "$ref": "#/$defs/rational"
         }
       },
       "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/instruction.md
@@ -8,6 +8,10 @@ the harmonic series diverges while the telescoping series converges.
 Supply the exact ratio and ratio-error identities for each witness, nine
 dyadic lower-bound blocks for the divergent witness, and at least four freely
 chosen partial-sum checkpoints for the convergent witness.
+Represent exact rational values as numerator/positive-denominator objects.
+Represent every term, ratio, and ratio-error formula as ascending numerator
+and denominator coefficient arrays in `n`; represent the telescoping identity
+as its two signed rational-function terms.
 
 The verifier independently evaluates every rational checkpoint and replays the
 submitted symbolic identities. A conclusion label or numerical sampling alone

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/solution/submission.json
@@ -4,108 +4,256 @@
       "checkpoints": [
         {
           "N": 3,
-          "partial_sum": "3/4",
-          "tail": "1/4"
+          "partial_sum": {
+            "denominator": 4,
+            "numerator": 3
+          },
+          "tail": {
+            "denominator": 4,
+            "numerator": 1
+          }
         },
         {
           "N": 7,
-          "partial_sum": "7/8",
-          "tail": "1/8"
+          "partial_sum": {
+            "denominator": 8,
+            "numerator": 7
+          },
+          "tail": {
+            "denominator": 8,
+            "numerator": 1
+          }
         },
         {
           "N": 12,
-          "partial_sum": "12/13",
-          "tail": "1/13"
+          "partial_sum": {
+            "denominator": 13,
+            "numerator": 12
+          },
+          "tail": {
+            "denominator": 13,
+            "numerator": 1
+          }
         },
         {
           "N": 25,
-          "partial_sum": "25/26",
-          "tail": "1/26"
+          "partial_sum": {
+            "denominator": 26,
+            "numerator": 25
+          },
+          "tail": {
+            "denominator": 26,
+            "numerator": 1
+          }
         }
       ],
-      "ratio": "n/(n+2)",
-      "ratio_error": "2/(n+2)",
-      "telescoping_identity": "1/n-1/(n+1)",
-      "term": "1/(n*(n+1))"
+      "ratio": {
+        "denominator_coefficients": [
+          2,
+          1
+        ],
+        "numerator_coefficients": [
+          0,
+          1
+        ]
+      },
+      "ratio_error": {
+        "denominator_coefficients": [
+          2,
+          1
+        ],
+        "numerator_coefficients": [
+          2
+        ]
+      },
+      "telescoping_identity": [
+        {
+          "denominator_coefficients": [
+            0,
+            1
+          ],
+          "numerator_coefficients": [
+            1
+          ]
+        },
+        {
+          "denominator_coefficients": [
+            1,
+            1
+          ],
+          "numerator_coefficients": [
+            -1
+          ]
+        }
+      ],
+      "term": {
+        "denominator_coefficients": [
+          0,
+          1,
+          1
+        ],
+        "numerator_coefficients": [
+          1
+        ]
+      }
     },
     "divergent_witness": {
       "blocks": [
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 4,
           "end": 7,
           "level": 2,
           "start": 4,
-          "term_lower_bound": "1/8"
+          "term_lower_bound": {
+            "denominator": 8,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 8,
           "end": 15,
           "level": 3,
           "start": 8,
-          "term_lower_bound": "1/16"
+          "term_lower_bound": {
+            "denominator": 16,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 16,
           "end": 31,
           "level": 4,
           "start": 16,
-          "term_lower_bound": "1/32"
+          "term_lower_bound": {
+            "denominator": 32,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 32,
           "end": 63,
           "level": 5,
           "start": 32,
-          "term_lower_bound": "1/64"
+          "term_lower_bound": {
+            "denominator": 64,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 64,
           "end": 127,
           "level": 6,
           "start": 64,
-          "term_lower_bound": "1/128"
+          "term_lower_bound": {
+            "denominator": 128,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 128,
           "end": 255,
           "level": 7,
           "start": 128,
-          "term_lower_bound": "1/256"
+          "term_lower_bound": {
+            "denominator": 256,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 256,
           "end": 511,
           "level": 8,
           "start": 256,
-          "term_lower_bound": "1/512"
+          "term_lower_bound": {
+            "denominator": 512,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 512,
           "end": 1023,
           "level": 9,
           "start": 512,
-          "term_lower_bound": "1/1024"
+          "term_lower_bound": {
+            "denominator": 1024,
+            "numerator": 1
+          }
         },
         {
-          "block_lower_bound": "1/2",
+          "block_lower_bound": {
+            "denominator": 2,
+            "numerator": 1
+          },
           "count": 1024,
           "end": 2047,
           "level": 10,
           "start": 1024,
-          "term_lower_bound": "1/2048"
+          "term_lower_bound": {
+            "denominator": 2048,
+            "numerator": 1
+          }
         }
       ],
-      "ratio": "n/(n+1)",
-      "ratio_error": "1/(n+1)",
-      "term": "1/n"
+      "ratio": {
+        "denominator_coefficients": [
+          1,
+          1
+        ],
+        "numerator_coefficients": [
+          0,
+          1
+        ]
+      },
+      "ratio_error": {
+        "denominator_coefficients": [
+          1,
+          1
+        ],
+        "numerator_coefficients": [
+          1
+        ]
+      },
+      "term": {
+        "denominator_coefficients": [
+          0,
+          1
+        ],
+        "numerator_coefficients": [
+          1
+        ]
+      }
     },
     "ratio_limit": "1"
   }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/solution/submission.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/solution/submission.json
@@ -255,6 +255,6 @@
         ]
       }
     },
-    "ratio_limit": "1"
+    "ratio_limit": {"numerator": 1, "denominator": 1}
   }
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="d962590efb10e11575fd069a7b614372e0bbce6cf7890d1e0261c5f27545793f"
+LABEL jacobian.checksum="787961cf44010a5e8b5ae7e3465bcb33fe98c69b868a62d6e1628f6b14b2c4e9"
 # Exact verifier for paired ratio-test boundary certificates.
 LABEL jacobian.task="jacobian/ratio-test-boundary-separation"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/Dockerfile
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.8.4-python3.12-bookworm-slim@sha256:dc7e1d08f8ca979826ec0b68b31c783e0b35b568be6a078d4cbedf38c4cc085e
 RUN python -m pip install --no-cache-dir attrs==26.1.0 jsonschema==4.26.0 jsonschema-specifications==2025.9.1 referencing==0.37.0 rpds-py==2026.6.3 typing-extensions==4.16.0
-LABEL jacobian.checksum="787961cf44010a5e8b5ae7e3465bcb33fe98c69b868a62d6e1628f6b14b2c4e9"
+LABEL jacobian.checksum="cff1f049b400abacde4f818c926c4548283f259ad9a0a9188f9f9e1584532a6b"
 # Exact verifier for paired ratio-test boundary certificates.
 LABEL jacobian.task="jacobian/ratio-test-boundary-separation"
 COPY expected.json input.json test.sh verifier.py verifier_support.py public_contract.json /tests/

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/public_contract.json
@@ -1,6 +1,48 @@
 {
   "public_notes": "The verifier replays the task-specific mathematical predicate from the submitted result.",
-  "schema_definitions": {},
+  "schema_definitions": {
+    "polynomial": {
+      "items": {
+        "type": "integer"
+      },
+      "maxItems": 4,
+      "minItems": 1,
+      "type": "array"
+    },
+    "rational": {
+      "additionalProperties": false,
+      "properties": {
+        "numerator": {
+          "type": "integer"
+        },
+        "denominator": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numerator",
+        "denominator"
+      ],
+      "type": "object"
+    },
+    "rational_function": {
+      "additionalProperties": false,
+      "properties": {
+        "numerator_coefficients": {
+          "$ref": "#/$defs/polynomial"
+        },
+        "denominator_coefficients": {
+          "$ref": "#/$defs/polynomial"
+        }
+      },
+      "required": [
+        "numerator_coefficients",
+        "denominator_coefficients"
+      ],
+      "type": "object"
+    }
+  },
   "schema_version": "1",
   "submission_path": "/app/submission.json",
   "submission_result": {
@@ -18,10 +60,10 @@
                   "type": "integer"
                 },
                 "partial_sum": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "tail": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [
@@ -36,16 +78,21 @@
             "type": "array"
           },
           "ratio": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           },
           "ratio_error": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           },
           "telescoping_identity": {
-            "type": "string"
+            "items": {
+              "$ref": "#/$defs/rational_function"
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
           },
           "term": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           }
         },
         "required": [
@@ -65,7 +112,7 @@
               "additionalProperties": false,
               "properties": {
                 "block_lower_bound": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 },
                 "count": {
                   "type": "integer"
@@ -80,7 +127,7 @@
                   "type": "integer"
                 },
                 "term_lower_bound": {
-                  "type": "string"
+                  "$ref": "#/$defs/rational"
                 }
               },
               "required": [
@@ -98,13 +145,13 @@
             "type": "array"
           },
           "ratio": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           },
           "ratio_error": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           },
           "term": {
-            "type": "string"
+            "$ref": "#/$defs/rational_function"
           }
         },
         "required": [
@@ -145,10 +192,10 @@
                       "type": "integer"
                     },
                     "partial_sum": {
-                      "type": "string"
+                      "$ref": "#/$defs/rational"
                     },
                     "tail": {
-                      "type": "string"
+                      "$ref": "#/$defs/rational"
                     }
                   },
                   "required": [
@@ -163,16 +210,21 @@
                 "type": "array"
               },
               "ratio": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               },
               "ratio_error": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               },
               "telescoping_identity": {
-                "type": "string"
+                "items": {
+                  "$ref": "#/$defs/rational_function"
+                },
+                "maxItems": 2,
+                "minItems": 2,
+                "type": "array"
               },
               "term": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               }
             },
             "required": [
@@ -192,7 +244,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "block_lower_bound": {
-                      "type": "string"
+                      "$ref": "#/$defs/rational"
                     },
                     "count": {
                       "type": "integer"
@@ -207,7 +259,7 @@
                       "type": "integer"
                     },
                     "term_lower_bound": {
-                      "type": "string"
+                      "$ref": "#/$defs/rational"
                     }
                   },
                   "required": [
@@ -225,13 +277,13 @@
                 "type": "array"
               },
               "ratio": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               },
               "ratio_error": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               },
               "term": {
-                "type": "string"
+                "$ref": "#/$defs/rational_function"
               }
             },
             "required": [
@@ -257,7 +309,50 @@
     "required": [
       "result"
     ],
-    "type": "object"
+    "type": "object",
+    "$defs": {
+      "polynomial": {
+        "items": {
+          "type": "integer"
+        },
+        "maxItems": 4,
+        "minItems": 1,
+        "type": "array"
+      },
+      "rational": {
+        "additionalProperties": false,
+        "properties": {
+          "numerator": {
+            "type": "integer"
+          },
+          "denominator": {
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "numerator",
+          "denominator"
+        ],
+        "type": "object"
+      },
+      "rational_function": {
+        "additionalProperties": false,
+        "properties": {
+          "numerator_coefficients": {
+            "$ref": "#/$defs/polynomial"
+          },
+          "denominator_coefficients": {
+            "$ref": "#/$defs/polynomial"
+          }
+        },
+        "required": [
+          "numerator_coefficients",
+          "denominator_coefficients"
+        ],
+        "type": "object"
+      }
+    }
   },
   "task_id": "jacobian/ratio-test-boundary-separation"
 }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/public_contract.json
@@ -163,7 +163,7 @@
         "type": "object"
       },
       "ratio_limit": {
-        "const": "1"
+        "$ref": "#/$defs/rational"
       }
     },
     "required": [
@@ -295,7 +295,7 @@
             "type": "object"
           },
           "ratio_limit": {
-            "const": "1"
+            "$ref": "#/$defs/rational"
           }
         },
         "required": [

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from fractions import Fraction
 from pathlib import Path
 
@@ -15,14 +14,37 @@ TESTS = Path("/tests")
 
 
 def _fraction(value: object) -> Fraction | None:
-    if not isinstance(value, str) or not re.fullmatch(
-        r"-?(?:0|[1-9][0-9]*)(?:/[1-9][0-9]*)?", value
+    if not isinstance(value, dict) or set(value) != {"numerator", "denominator"}:
+        return None
+    numerator = value["numerator"]
+    denominator = value["denominator"]
+    if type(numerator) is not int or type(denominator) is not int or denominator < 1:
+        return None
+    return Fraction(numerator, denominator)
+
+
+def _polynomial(value: object) -> tuple[int, ...] | None:
+    if (
+        not isinstance(value, list)
+        or not 1 <= len(value) <= 4
+        or not all(type(coefficient) is int for coefficient in value)
+        or value[-1] == 0
     ):
         return None
-    try:
-        return Fraction(value)
-    except (ValueError, ZeroDivisionError):
+    return tuple(value)
+
+
+def _rational_function(
+    value: object,
+) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    if not isinstance(value, dict) or set(value) != {
+        "numerator_coefficients",
+        "denominator_coefficients",
+    }:
         return None
+    numerator = _polynomial(value["numerator_coefficients"])
+    denominator = _polynomial(value["denominator_coefficients"])
+    return (numerator, denominator) if numerator is not None and denominator else None
 
 
 def _source_is_bound() -> bool:
@@ -48,10 +70,12 @@ def _divergent(value: object) -> bool:
         "blocks",
     }:
         return False
-    if (value["term"], value["ratio"], value["ratio_error"]) != (
-        "1/n",
-        "n/(n+1)",
-        "1/(n+1)",
+    if tuple(
+        _rational_function(value[field]) for field in ("term", "ratio", "ratio_error")
+    ) != (
+        ((1,), (0, 1)),
+        ((0, 1), (1, 1)),
+        ((1,), (1, 1)),
     ):
         return False
     blocks = value["blocks"]
@@ -88,6 +112,23 @@ def _divergent(value: object) -> bool:
     return True
 
 
+def _convergent_formulas_ok(value: dict) -> bool:
+    telescoping = value["telescoping_identity"]
+    if not isinstance(telescoping, list) or len(telescoping) != 2:
+        return False
+    return (
+        _rational_function(value["term"]),
+        tuple(_rational_function(term) for term in telescoping),
+        _rational_function(value["ratio"]),
+        _rational_function(value["ratio_error"]),
+    ) == (
+        ((1,), (0, 1, 1)),
+        (((1,), (0, 1)), ((-1,), (1, 1))),
+        ((0, 1), (2, 1)),
+        ((2,), (2, 1)),
+    )
+
+
 def _convergent(value: object) -> bool:
     if not isinstance(value, dict) or set(value) != {
         "term",
@@ -97,12 +138,7 @@ def _convergent(value: object) -> bool:
         "checkpoints",
     }:
         return False
-    if (
-        value["term"],
-        value["telescoping_identity"],
-        value["ratio"],
-        value["ratio_error"],
-    ) != ("1/(n*(n+1))", "1/n-1/(n+1)", "n/(n+2)", "2/(n+2)"):
+    if not _convergent_formulas_ok(value):
         return False
     checkpoints = value["checkpoints"]
     if not isinstance(checkpoints, list) or not 4 <= len(checkpoints) <= 12:

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
@@ -28,10 +28,12 @@ def _polynomial(value: object) -> tuple[int, ...] | None:
         not isinstance(value, list)
         or not 1 <= len(value) <= 4
         or not all(type(coefficient) is int for coefficient in value)
-        or value[-1] == 0
     ):
         return None
-    return tuple(value)
+    coefficients = list(value)
+    while len(coefficients) > 1 and coefficients[-1] == 0:
+        coefficients.pop()
+    return tuple(coefficients)
 
 
 def _rational_function(
@@ -44,7 +46,31 @@ def _rational_function(
         return None
     numerator = _polynomial(value["numerator_coefficients"])
     denominator = _polynomial(value["denominator_coefficients"])
-    return (numerator, denominator) if numerator is not None and denominator else None
+    if numerator is None or denominator is None or not any(denominator):
+        return None
+    return numerator, denominator
+
+
+def _multiply_polynomials(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[int, ...]:
+    result = [0] * (len(left) + len(right) - 1)
+    for left_power, left_coefficient in enumerate(left):
+        for right_power, right_coefficient in enumerate(right):
+            result[left_power + right_power] += left_coefficient * right_coefficient
+    while len(result) > 1 and result[-1] == 0:
+        result.pop()
+    return tuple(result)
+
+
+def _rational_functions_equal(
+    left: tuple[tuple[int, ...], tuple[int, ...]] | None,
+    right: tuple[tuple[int, ...], tuple[int, ...]],
+) -> bool:
+    return left is not None and (
+        _multiply_polynomials(left[0], right[1])
+        == _multiply_polynomials(right[0], left[1])
+    )
 
 
 def _source_is_bound() -> bool:
@@ -70,12 +96,14 @@ def _divergent(value: object) -> bool:
         "blocks",
     }:
         return False
-    if tuple(
-        _rational_function(value[field]) for field in ("term", "ratio", "ratio_error")
-    ) != (
+    expected = (
         ((1,), (0, 1)),
         ((0, 1), (1, 1)),
         ((1,), (1, 1)),
+    )
+    if not all(
+        _rational_functions_equal(_rational_function(value[field]), formula)
+        for field, formula in zip(("term", "ratio", "ratio_error"), expected, strict=True)
     ):
         return False
     blocks = value["blocks"]
@@ -116,16 +144,23 @@ def _convergent_formulas_ok(value: dict) -> bool:
     telescoping = value["telescoping_identity"]
     if not isinstance(telescoping, list) or len(telescoping) != 2:
         return False
-    return (
-        _rational_function(value["term"]),
-        tuple(_rational_function(term) for term in telescoping),
-        _rational_function(value["ratio"]),
-        _rational_function(value["ratio_error"]),
-    ) == (
-        ((1,), (0, 1, 1)),
-        (((1,), (0, 1)), ((-1,), (1, 1))),
-        ((0, 1), (2, 1)),
-        ((2,), (2, 1)),
+    term, ratio, ratio_error = (
+        _rational_function(value[field]) for field in ("term", "ratio", "ratio_error")
+    )
+    first, second = (_rational_function(item) for item in telescoping)
+    expected_first, expected_second = ((1,), (0, 1)), ((-1,), (1, 1))
+    telescope_matches = (
+        _rational_functions_equal(first, expected_first)
+        and _rational_functions_equal(second, expected_second)
+    ) or (
+        _rational_functions_equal(first, expected_second)
+        and _rational_functions_equal(second, expected_first)
+    )
+    return bool(
+        _rational_functions_equal(term, ((1,), (0, 1, 1)))
+        and telescope_matches
+        and _rational_functions_equal(ratio, ((0, 1), (2, 1)))
+        and _rational_functions_equal(ratio_error, ((2,), (2, 1)))
     )
 
 
@@ -166,7 +201,7 @@ def _result(value: object) -> bool:
     return bool(
         isinstance(value, dict)
         and set(value) == {"ratio_limit", "divergent_witness", "convergent_witness"}
-        and value["ratio_limit"] == "1"
+        and _fraction(value["ratio_limit"]) == 1
         and _divergent(value["divergent_witness"])
         and _convergent(value["convergent_witness"])
     )

--- a/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/ratio-test-boundary-separation/tests/verifier.py
@@ -103,7 +103,9 @@ def _divergent(value: object) -> bool:
     )
     if not all(
         _rational_functions_equal(_rational_function(value[field]), formula)
-        for field, formula in zip(("term", "ratio", "ratio_error"), expected, strict=True)
+        for field, formula in zip(
+            ("term", "ratio", "ratio_error"), expected, strict=True
+        )
     ):
         return False
     blocks = value["blocks"]

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_bounded_variation_uniform_limit.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_bounded_variation_uniform_limit.py
@@ -11,6 +11,10 @@ from benchmarks.validation.mathematical_benchmarks_v1 import (
 TASK = "bounded-variation-uniform-limit"
 
 
+def _rational(numerator: int, denominator: int = 1) -> dict[str, int]:
+    return {"numerator": numerator, "denominator": denominator}
+
+
 def _case(tmp_path: Path):
     return _fixtures._prepare_case(tmp_path, TASK, "computed")
 
@@ -33,11 +37,11 @@ def test_alternative_scale_and_indices_pass(tmp_path: Path) -> None:
             {
                 "n": n,
                 "frequency": k,
-                "amplitude": f"1/{k}",
+                "amplitude": _rational(1, k),
                 "interior_segments": 2 * k - 1,
-                "endpoint_contribution": f"2/{k}",
-                "interior_contribution": f"{4 * k - 2}/{k}",
-                "total_variation": "4",
+                "endpoint_contribution": _rational(2, k),
+                "interior_contribution": _rational(4 * k - 2, k),
+                "total_variation": _rational(4),
             }
         )
     _fixtures._write_json(path, submission)
@@ -68,7 +72,7 @@ def test_wrong_variation_is_rejected(tmp_path: Path) -> None:
         _mutate(
             tmp_path,
             lambda s: s["result"]["variation_formula"].__setitem__(
-                "total_variation", "0"
+                "total_variation", _rational(0)
             ),
         )
         == 0.0
@@ -121,12 +125,21 @@ def test_bool_in_endpoint_jump_multiplier_is_rejected(tmp_path: Path) -> None:
     assert _mutate(tmp_path, mutate) == 0.0
 
 
-def test_equivalent_sequence_serialization_passes(tmp_path: Path) -> None:
-    """``sin(n*q*x)/(n*q)`` is mathematically identical to ``sin(q*n*x)/(q*n)``."""
-
+def test_legacy_sequence_string_is_rejected(tmp_path: Path) -> None:
     task, app, logs = _case(tmp_path)
     path = app / "submission.json"
     submission = json.loads(path.read_text())
     submission["result"]["sequence"] = "sin(n*q*x)/(n*q)"
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0
+
+
+def test_equivalent_unreduced_rational_passes(tmp_path: Path) -> None:
+    task, app, logs = _case(tmp_path)
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    value = submission["result"]["checkpoints"][0]["amplitude"]
+    value["numerator"] *= 2
+    value["denominator"] *= 2
     _fixtures._write_json(path, submission)
     assert _verifier._run_verifier(task, app, logs).reward == 1.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_ratio_test_boundary_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_ratio_test_boundary_separation.py
@@ -1,5 +1,32 @@
-from ._fixtures import assert_result_witness_protocol
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmarks.validation.mathematical_benchmarks_v1 import _fixtures, _verifier
+
+TASK = "ratio-test-boundary-separation"
 
 
-def test_result_protocol(tmp_path):
-    assert_result_witness_protocol(tmp_path, "ratio-test-boundary-separation")
+def test_result_protocol(tmp_path: Path) -> None:
+    _fixtures.assert_result_witness_protocol(tmp_path, TASK)
+
+
+def test_rejects_formula_string(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    submission["result"]["divergent_witness"]["term"] = "1/n"
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 0.0
+
+
+def test_accepts_equivalent_unreduced_rational(tmp_path: Path) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    value = submission["result"]["divergent_witness"]["blocks"][0]["block_lower_bound"]
+    value["numerator"] *= 2
+    value["denominator"] *= 2
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 1.0

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_ratio_test_boundary_separation.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_ratio_test_boundary_separation.py
@@ -30,3 +30,22 @@ def test_accepts_equivalent_unreduced_rational(tmp_path: Path) -> None:
     value["denominator"] *= 2
     _fixtures._write_json(path, submission)
     assert _verifier._run_verifier(task, app, logs).reward == 1.0
+
+
+def test_accepts_equivalent_rational_functions_and_reordered_telescope(
+    tmp_path: Path,
+) -> None:
+    task, app, logs = _fixtures._prepare_case(tmp_path, TASK, "computed")
+    path = app / "submission.json"
+    submission = json.loads(path.read_text())
+    witness = submission["result"]["divergent_witness"]
+    witness["term"] = {
+        "numerator_coefficients": [2],
+        "denominator_coefficients": [0, 2, 0],
+    }
+    telescope = submission["result"]["convergent_witness"]["telescoping_identity"]
+    submission["result"]["convergent_witness"]["telescoping_identity"] = list(
+        reversed(telescope)
+    )
+    _fixtures._write_json(path, submission)
+    assert _verifier._run_verifier(task, app, logs).reward == 1.0


### PR DESCRIPTION
## Summary
- encode bounded-variation checkpoint rationals as numerator/denominator objects and its sequence/variation formulas as exponent and affine structures
- encode ratio-test boundary terms and identities as rational-function coefficient arrays and all checkpoint bounds as rational objects
- parse typed semantics before replaying convergence/divergence predicates and scalar reward
- preserve acceptance of equivalent unreduced rational representations

Updates include contracts, generated schemas, gold submissions, instructions, verifier checksums, and focused tests.

## Validation
- selected-task Harbor contract check for both tasks
- focused host validation (15 passed)
- focused Ruff check
- Harbor planner selects exactly two host tests and two Oracles