### PR TITLE
fix(discovery): make lattice HNF discoverable in the matrix domain

### DIFF
--- a/src/jacobian/domains/lattices/hnf.py
+++ b/src/jacobian/domains/lattices/hnf.py
@@ -54,6 +54,7 @@ HERMITE_NORMAL_FORM_OPERATION: MathTool[
     run=compute_hermite_normal_form,
     tags=(
         "lattice",
+        "matrix",
         "integer",
         "hermite-normal-form",
     ),

--- a/tests/unit/test_serving_catalog.py
+++ b/tests/unit/test_serving_catalog.py
@@ -105,3 +105,29 @@ def test_search_and_browse_do_not_materialize_descriptors(
 
     assert search.matches
     assert browse.operations
+
+
+def test_search_finds_lattice_hnf_in_matrix_domain() -> None:
+    catalog = ServingCatalog.open()
+
+    result = catalog.search(
+        OperationDiscoveryRequest(
+            query="row Hermite normal form",
+            domain="matrix",
+            limit=10,
+        )
+    )
+
+    assert "lattice.hermite_normal_form.compute" in {
+        match.operation_id for match in result.matches
+    }
+
+
+def test_browse_includes_lattice_hnf_in_matrix_domain() -> None:
+    catalog = ServingCatalog.open()
+
+    result = catalog.browse(domain="matrix", limit=100, cursor=None)
+
+    assert "lattice.hermite_normal_form.compute" in {
+        operation.operation_id for operation in result.operations
+    }


### PR DESCRIPTION
## Summary

- add the existing `matrix` discovery tag to `lattice.hermite_normal_form.compute`
- preserve the operation ID and lattice-domain ownership
- cover both matrix-domain search and browse through the real serving catalog

## Root cause

Domain filtering accepts either the operation-ID namespace or an exact discovery tag. HNF is lattice-owned and had no `matrix` tag, so `domain="matrix"` filtered it out before search ranking and browsing.

Fixes #1617.

## Validation

- `make test-unit TESTS=tests/unit/test_serving_catalog.py PYTEST_ARGS='-n 0'` — 7 passed
- `make check` — 473 passed, 1 skipped because Lean is not installed

## Implementation handoff

- stage: implementation
- status: complete
- capability: `lattice.hermite_normal_form.compute`
- base: `3916ec7fecfe51271c20fc4730d62791cf8509de`
- availability delta: discoverable under `domain="matrix"`; invocation and mathematical output unchanged
- compatibility: additive metadata only
- assurance and proof obligations: unchanged

