### PR TITLE
fix(benchmarks): couple Farkas proof modes to certificate shapes

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/environment/submission_schema.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/environment/submission_schema.json
@@ -1,46 +1,25 @@
 {
   "$defs": {
-    "certificate": {
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "d": {
-              "items": {
-                "$ref": "#/$defs/rat"
-              },
-              "maxItems": 4,
-              "minItems": 4,
-              "type": "array"
-            },
-            "l": {
-              "$ref": "#/$defs/matrix4"
-            }
+    "ldl_certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "d": {
+          "items": {
+            "$ref": "#/$defs/rat"
           },
-          "required": [
-            "l",
-            "d"
-          ],
-          "type": "object"
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
         },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "leading_principal_determinants": {
-              "items": {
-                "$ref": "#/$defs/rat"
-              },
-              "maxItems": 4,
-              "minItems": 4,
-              "type": "array"
-            }
-          },
-          "required": [
-            "leading_principal_determinants"
-          ],
-          "type": "object"
+        "l": {
+          "$ref": "#/$defs/matrix4"
         }
-      ]
+      },
+      "required": [
+        "l",
+        "d"
+      ],
+      "type": "object"
     },
     "matrix4": {
       "items": {
@@ -68,27 +47,48 @@
       "type": "object"
     },
     "result": {
-      "additionalProperties": false,
-      "properties": {
-        "positive_definite_certificate": {
-          "$ref": "#/$defs/certificate"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "positive_definite_certificate": {
+              "$ref": "#/$defs/ldl_certificate"
+            },
+            "proof_mode": {
+              "const": "LDL"
+            },
+            "scalar_replay": {
+              "$ref": "#/$defs/scalar"
+            }
+          },
+          "required": [
+            "proof_mode",
+            "scalar_replay",
+            "positive_definite_certificate"
+          ],
+          "type": "object"
         },
-        "proof_mode": {
-          "enum": [
-            "LDL",
-            "SYLVESTER"
-          ]
-        },
-        "scalar_replay": {
-          "$ref": "#/$defs/scalar"
+        {
+          "additionalProperties": false,
+          "properties": {
+            "positive_definite_certificate": {
+              "$ref": "#/$defs/sylvester_certificate"
+            },
+            "proof_mode": {
+              "const": "SYLVESTER"
+            },
+            "scalar_replay": {
+              "$ref": "#/$defs/scalar"
+            }
+          },
+          "required": [
+            "proof_mode",
+            "scalar_replay",
+            "positive_definite_certificate"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "proof_mode",
-        "scalar_replay",
-        "positive_definite_certificate"
-      ],
-      "type": "object"
+      ]
     },
     "row4": {
       "items": {
@@ -119,6 +119,23 @@
         "c00_y",
         "m00",
         "objective"
+      ],
+      "type": "object"
+    },
+    "sylvester_certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "leading_principal_determinants": {
+          "items": {
+            "$ref": "#/$defs/rat"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        }
+      },
+      "required": [
+        "leading_principal_determinants"
       ],
       "type": "object"
     }

--- a/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/public_contract.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/exact-farkas-ldl-slice/tests/public_contract.json
@@ -16,47 +16,26 @@
     "evidence/farkas-slice-certificate.json"
   ],
   "schema_definitions": {
-    "certificate": {
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "d": {
-              "items": {
-                "$ref": "#/$defs/rat"
-              },
-              "maxItems": 4,
-              "minItems": 4,
-              "type": "array"
-            },
-            "l": {
-              "$ref": "#/$defs/matrix4"
-            }
+    "ldl_certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "d": {
+          "items": {
+            "$ref": "#/$defs/rat"
           },
-          "required": [
-            "l",
-            "d"
-          ],
-          "type": "object"
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
         },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "leading_principal_determinants": {
-              "items": {
-                "$ref": "#/$defs/rat"
-              },
-              "maxItems": 4,
-              "minItems": 4,
-              "type": "array"
-            }
-          },
-          "required": [
-            "leading_principal_determinants"
-          ],
-          "type": "object"
+        "l": {
+          "$ref": "#/$defs/matrix4"
         }
-      ]
+      },
+      "required": [
+        "l",
+        "d"
+      ],
+      "type": "object"
     },
     "matrix4": {
       "items": {
@@ -84,27 +63,48 @@
       "type": "object"
     },
     "result": {
-      "additionalProperties": false,
-      "properties": {
-        "positive_definite_certificate": {
-          "$ref": "#/$defs/certificate"
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "positive_definite_certificate": {
+              "$ref": "#/$defs/ldl_certificate"
+            },
+            "proof_mode": {
+              "const": "LDL"
+            },
+            "scalar_replay": {
+              "$ref": "#/$defs/scalar"
+            }
+          },
+          "required": [
+            "proof_mode",
+            "scalar_replay",
+            "positive_definite_certificate"
+          ],
+          "type": "object"
         },
-        "proof_mode": {
-          "enum": [
-            "LDL",
-            "SYLVESTER"
-          ]
-        },
-        "scalar_replay": {
-          "$ref": "#/$defs/scalar"
+        {
+          "additionalProperties": false,
+          "properties": {
+            "positive_definite_certificate": {
+              "$ref": "#/$defs/sylvester_certificate"
+            },
+            "proof_mode": {
+              "const": "SYLVESTER"
+            },
+            "scalar_replay": {
+              "$ref": "#/$defs/scalar"
+            }
+          },
+          "required": [
+            "proof_mode",
+            "scalar_replay",
+            "positive_definite_certificate"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "proof_mode",
-        "scalar_replay",
-        "positive_definite_certificate"
-      ],
-      "type": "object"
+      ]
     },
     "row4": {
       "items": {
@@ -137,6 +137,23 @@
         "objective"
       ],
       "type": "object"
+    },
+    "sylvester_certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "leading_principal_determinants": {
+          "items": {
+            "$ref": "#/$defs/rat"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        }
+      },
+      "required": [
+        "leading_principal_determinants"
+      ],
+      "type": "object"
     }
   },
   "schema_version": "1",
@@ -146,47 +163,26 @@
   },
   "submission_schema": {
     "$defs": {
-      "certificate": {
-        "oneOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "d": {
-                "items": {
-                  "$ref": "#/$defs/rat"
-                },
-                "maxItems": 4,
-                "minItems": 4,
-                "type": "array"
-              },
-              "l": {
-                "$ref": "#/$defs/matrix4"
-              }
+      "ldl_certificate": {
+        "additionalProperties": false,
+        "properties": {
+          "d": {
+            "items": {
+              "$ref": "#/$defs/rat"
             },
-            "required": [
-              "l",
-              "d"
-            ],
-            "type": "object"
+            "maxItems": 4,
+            "minItems": 4,
+            "type": "array"
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "leading_principal_determinants": {
-                "items": {
-                  "$ref": "#/$defs/rat"
-                },
-                "maxItems": 4,
-                "minItems": 4,
-                "type": "array"
-              }
-            },
-            "required": [
-              "leading_principal_determinants"
-            ],
-            "type": "object"
+          "l": {
+            "$ref": "#/$defs/matrix4"
           }
-        ]
+        },
+        "required": [
+          "l",
+          "d"
+        ],
+        "type": "object"
       },
       "matrix4": {
         "items": {
@@ -214,27 +210,48 @@
         "type": "object"
       },
       "result": {
-        "additionalProperties": false,
-        "properties": {
-          "positive_definite_certificate": {
-            "$ref": "#/$defs/certificate"
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "positive_definite_certificate": {
+                "$ref": "#/$defs/ldl_certificate"
+              },
+              "proof_mode": {
+                "const": "LDL"
+              },
+              "scalar_replay": {
+                "$ref": "#/$defs/scalar"
+              }
+            },
+            "required": [
+              "proof_mode",
+              "scalar_replay",
+              "positive_definite_certificate"
+            ],
+            "type": "object"
           },
-          "proof_mode": {
-            "enum": [
-              "LDL",
-              "SYLVESTER"
-            ]
-          },
-          "scalar_replay": {
-            "$ref": "#/$defs/scalar"
+          {
+            "additionalProperties": false,
+            "properties": {
+              "positive_definite_certificate": {
+                "$ref": "#/$defs/sylvester_certificate"
+              },
+              "proof_mode": {
+                "const": "SYLVESTER"
+              },
+              "scalar_replay": {
+                "$ref": "#/$defs/scalar"
+              }
+            },
+            "required": [
+              "proof_mode",
+              "scalar_replay",
+              "positive_definite_certificate"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "proof_mode",
-          "scalar_replay",
-          "positive_definite_certificate"
-        ],
-        "type": "object"
+        ]
       },
       "row4": {
         "items": {
@@ -265,6 +282,23 @@
           "c00_y",
           "m00",
           "objective"
+        ],
+        "type": "object"
+      },
+      "sylvester_certificate": {
+        "additionalProperties": false,
+        "properties": {
+          "leading_principal_determinants": {
+            "items": {
+              "$ref": "#/$defs/rat"
+            },
+            "maxItems": 4,
+            "minItems": 4,
+            "type": "array"
+          }
+        },
+        "required": [
+          "leading_principal_determinants"
         ],
         "type": "object"
       }

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py
@@ -1,9 +1,56 @@
+import copy
+import json
+from collections.abc import Callable
 from pathlib import Path
 
+import pytest
 from benchmarks.validation.mathematical_benchmarks_v1 import _fixtures
+from jsonschema import Draft202012Validator
 
 TASK = "exact-farkas-ldl-slice"
+TASK_DIR = Path("benchmarks/datasets/mathematical-benchmarks-v1") / TASK
 
 
 def test_result_witness_protocol(tmp_path: Path) -> None:
     _fixtures.assert_result_witness_protocol(tmp_path, TASK)
+
+
+def _rational(value: int = 1) -> dict[str, int]:
+    return {"numerator": value, "denominator": 1}
+
+
+def _ldl_certificate() -> dict[str, object]:
+    return {
+        "l": [
+            [_rational(1 if row == column else 0) for column in range(4)]
+            for row in range(4)
+        ],
+        "d": [_rational() for _ in range(4)],
+    }
+
+
+def _sylvester_certificate() -> dict[str, object]:
+    return {"leading_principal_determinants": [_rational() for _ in range(4)]}
+
+
+@pytest.mark.parametrize(
+    ("proof_mode", "certificate_factory", "is_valid"),
+    [
+        ("LDL", _ldl_certificate, True),
+        ("LDL", _sylvester_certificate, False),
+        ("SYLVESTER", _ldl_certificate, False),
+        ("SYLVESTER", _sylvester_certificate, True),
+    ],
+)
+def test_schema_couples_proof_mode_to_certificate_shape(
+    proof_mode: str,
+    certificate_factory: Callable[[], dict[str, object]],
+    is_valid: bool,
+) -> None:
+    schema = json.loads((TASK_DIR / "environment/submission_schema.json").read_text())
+    submission = json.loads((TASK_DIR / "solution/submission.json").read_text())
+    candidate = copy.deepcopy(submission)
+    candidate["result"]["proof_mode"] = proof_mode
+    candidate["result"]["positive_definite_certificate"] = certificate_factory()
+
+    assert Draft202012Validator(schema).is_valid(candidate) is is_valid


### PR DESCRIPTION
## Summary

- encode `exact-farkas-ldl-slice` as two closed result variants: `LDL` with `{l,d}` and `SYLVESTER` with leading principal determinants
- regenerate the public submission schema from the authoritative task contract
- enumerate all four mode/certificate cross-products and accept only the two licensed pairs
- leave the verifier's defensive dispatch and exact mathematical replay unchanged

This addresses only the `exact-farkas-ldl-slice` leaf of #1618; the other task families remain out of scope.

## Root cause

The public schema exposed `proof_mode` and the certificate `oneOf` independently, admitting two combinations that the verifier could never reward. The task-local discriminated union now rejects those mismatches during JSON Schema validation.

## Validation

- `make harbor-prepare-task DATASET=mathematical-benchmarks-v1 TASKS=exact-farkas-ldl-slice`
- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS=exact-farkas-ldl-slice`
- `make harbor-validation-tests TESTS=benchmarks/validation/mathematical_benchmarks_v1/test_exact_farkas_ldl_slice.py` — 5 passed
- `make harbor-plan BASE=origin/main` — selected the focused host regression and exact task Oracle
- `make check PYTEST_ARGS='-n 0'` — 471 passed, 1 skipped because Lean is not installed

Docker is not installed in the local environment. Draft PR CI passed the selected `Benchmark Oracle (mathematical-benchmarks-v1/exact-farkas-ldl-slice)` job and aggregate `Benchmark Validation` gate.

## Coordination

PR #1599 also changes this task for a broader result-only migration, but its current head retains the uncoupled mode/certificate schema. This focused fix is independently based on latest `main` and may need a mechanical restack if #1599 lands first.
