### PR TITLE
fix(benchmark): remove redundant truth-value from calendar-good-days-audit (#1612)

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/environment/input.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/environment/input.json
@@ -1,14 +1,22 @@
 {
-  "task_id":"jacobian/calendar-good-days-audit",
+  "task_id": "jacobian/calendar-good-days-audit",
   "claim": "Across March, April, and May, exactly 15 dates are good.",
   "definition": "A date in month m with day d is good when the base-10 integer formed by concatenating m and d, with no zero padding, is divisible by both m and d.",
   "months": [
-    {"month": 3, "days": 31},
-    {"month": 4, "days": 30},
-    {"month": 5, "days": 31}
+    {
+      "month": 3,
+      "days": 31
+    },
+    {
+      "month": 4,
+      "days": 30
+    },
+    {
+      "month": 5,
+      "days": 31
+    }
   ],
   "required_output": {
-    "audit_claim": true,
     "list_every_good_date_in_calendar_order": true,
     "include_concatenated_values": true,
     "report_exact_count": true

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/instruction.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/instruction.md
@@ -1,7 +1,7 @@
 # Audit a finite calendar claim
 
 Audit the claim in the offline input by exhaustively checking the declared
-finite date range. Return the truth value, exact count, and every qualifying
+finite date range. Return the exact count and every qualifying
 date in calendar order, including each concatenated integer.
 
 <!-- BEGIN PUBLIC CONTRACT SUBMISSION BLOCK -->

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/task.toml
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/task.toml
@@ -21,7 +21,7 @@ category = "mathematics"
 tags = ["proof-audit", "bounded-verification", "divisibility", "offline"]
 case_version = "mathematical-benchmarks-v1"
 contamination_class = "public-dataset-derived-proof-audit"
-fixture_digest = "sha256:84643e15b984a6f6b9515915a85a8d22e723d35f43b236b1692c0dcc425fc774"
+fixture_digest = "sha256:a6c495e9b951f5416a87bce5858ef1714d0c867af1e0f6f4147c23dfb5665dd8"
 derivation = "Derived from BrokenMath benchmark row 84 with an independently exhaustive oracle."
 
 [agent]

--- a/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/input.json
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/calendar-good-days-audit/tests/input.json
@@ -1,14 +1,22 @@
 {
-  "task_id":"jacobian/calendar-good-days-audit",
+  "task_id": "jacobian/calendar-good-days-audit",
   "claim": "Across March, April, and May, exactly 15 dates are good.",
   "definition": "A date in month m with day d is good when the base-10 integer formed by concatenating m and d, with no zero padding, is divisible by both m and d.",
   "months": [
-    {"month": 3, "days": 31},
-    {"month": 4, "days": 30},
-    {"month": 5, "days": 31}
+    {
+      "month": 3,
+      "days": 31
+    },
+    {
+      "month": 4,
+      "days": 30
+    },
+    {
+      "month": 5,
+      "days": 31
+    }
   ],
   "required_output": {
-    "audit_claim": true,
     "list_every_good_date_in_calendar_order": true,
     "include_concatenated_values": true,
     "report_exact_count": true


### PR DESCRIPTION
The instruction asked the agent to "Return the truth value" alongside the exact count and qualifying dates. The truth value is a deterministic consequence of the submitted count and the public claim — the verifier already derives it (). Asking the agent to repeat it would create a synchronizable label with no independent mathematical role.

Changes:
- Remove "truth value" from the instruction
- Remove  from  in both  copies

Closes #1612