### PR TITLE
test(benchmarks): drop tautological fixture-self assertions in Harbor verifier tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v2.16
     hooks:
       - id: vulture
-        args: ["src", "tests", "--min-confidence=80"]
+        args: ["src", "tests", "--min-confidence=80", "--ignore-names", "patched_root"]
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12

--- a/make/development.mk
+++ b/make/development.mk
@@ -38,7 +38,7 @@ complexity-check: ## Reject new, increased, or stale C901 baseline entries.
 
 lint-full: lint ## Add dependency and dead-code checks.
 	$(UV_RUN) deptry .
-	$(UV_RUN) vulture src tests --min-confidence=80
+	$(UV_RUN) vulture src tests --min-confidence=80 --ignore-names patched_root
 
 security-audit: ## Audit dependencies for known vulnerabilities.
 	$(UV_RUN) pip-audit

--- a/tests/boundary/__init__.py
+++ b/tests/boundary/__init__.py
@@ -1,1 +1,1 @@
-"""Boundary-tier tests for real persistence, processes, transports, providers."""
+"""Boundary-tier tests for real processes, transports, and providers."""

--- a/tests/unit/tooling/test_harbor_verifier_checks.py
+++ b/tests/unit/tooling/test_harbor_verifier_checks.py
@@ -16,7 +16,6 @@ def test_check_verifier_support_allows_task_owned_contents(
     tmp_path: Path, patched_root: Path
 ) -> None:
     suite, task = _make_suite_with_task(tmp_path)
-    assert patched_root == tmp_path
     (task / "tests" / "verifier_support.py").write_text("# task support\n")
     assert check_verifier_support(suite) == []
 
@@ -25,7 +24,6 @@ def test_check_verifier_support_reports_syntax_errors(
     tmp_path: Path, patched_root: Path
 ) -> None:
     suite, task = _make_suite_with_task(tmp_path)
-    assert patched_root == tmp_path
     (task / "tests" / "verifier_support.py").write_text("def broken(:\n")
     failures = check_verifier_support(suite)
     assert any("does not compile" in f for f in failures)
@@ -35,7 +33,6 @@ def test_check_verifier_support_rejects_support_symlink(
     tmp_path: Path, patched_root: Path
 ) -> None:
     suite, task = _make_suite_with_task(tmp_path)
-    assert patched_root == tmp_path
     support = task / "tests" / "verifier_support.py"
     support.unlink()
     support.symlink_to(task / "tests" / "verifier.py")


### PR DESCRIPTION
## Summary

Aggressive audit of all 125 tracked regression test files across `tests/unit/`, `tests/boundary/`, `tests/component/`, `tests/composition/`, `tests/domain/`, `tests/e2e/`, and `tests/fixtures/`. The codebase is remarkably clean — only one real finding, fixed here.

**`test: drop tautological fixture-self assertions`**
- Remove the three `assert patched_root == tmp_path` lines in `tests/unit/tooling/test_harbor_verifier_checks.py`. The `patched_root` fixture (in `tests/unit/tooling/conftest.py`) always returns `tmp_path` by construction, so these assertions can never fail and test nothing about the code under test. The fixture is still requested for its monkeypatching side effect; only the dead assertion is removed.
- Drop a stale "persistence" reference from the `tests/boundary/__init__.py` docstring now that the storage/persistence test subdirectory has been deleted.

## Audit findings (no action needed)

- **Tautological assertions** (`assert True`, `assert x == x`, `assert result is not None` alone) — none found across all 125 files.
- **`pass`/`...` test bodies or no assertions** — none.
- **`@pytest.mark.skip` / `pytest.mark.xfail` / `pytest.skip()` with stale or missing reason** — none. The three `@pytest.mark.skipif` in `test_bounded_process.py` all carry valid POSIX-specific reasons; the one `pytest.skip()` in `test_logic_operations.py` correctly checks for the optional Lean toolchain.
- **Bare `except` / caught exceptions without type/message assertions** — none.
- **Duplicate tests** — none. The two `test_polynomial_conversions.py` files test distinct concerns.
- **Tests for removed features** — none. `test_namespace.py` even asserts that deleted modules raise `ModuleNotFoundError`.
- **Redundant parametrized tests** — none.
- **Storage/durability/recovery/transaction regressions** — none in source. Empty directories (`tests/boundary/storage/`, `tests/unit/persistence/`, `tests/unit/portfolio/`, `tests/unit/research/`, `tests/component/workspaces/`, `tests/component/storage/`, `tests/component/artifacts/`, `tests/e2e/`) contain only untracked `__pycache__` leftovers from deleted test modules; gitignored, no effect on CI.
- **`tests/fixtures/` `spike.py` scripts** — tooling, not tests; not collected by pytest.

## Validation

- `uv run pytest tests/unit/tooling/test_harbor_verifier_checks.py` — 3 passed
- `uv run pytest tests/unit` — 473 passed
- `uv run ruff check tests/unit/tooling/test_harbor_verifier_checks.py tests/boundary/__init__.py` — all checks passed