### PR TITLE
docs: record Harbor protocol cutover rules in skills and authoring docs

### DIFF
--- a/.agents/skills/harbor-benchmarks/SKILL.md
+++ b/.agents/skills/harbor-benchmarks/SKILL.md
@@ -71,7 +71,14 @@ Do not copy these authoring failures into a new or generated task:
 - scoring prose with keywords, length, or negation regexes;
 - publishing a universal certificate `oneOf` for every generated family;
 - requiring a witness that only mirrors, hashes, or paraphrases `result`;
-- leaving instruction, schema, and verifier mutually unsatisfiable.
+- leaving instruction, schema, and verifier mutually unsatisfiable;
+- putting a leaked answer constant or derived conclusion in the public schema
+  (`const` status fields, semantic-relation enums, rationality conclusions,
+  `Claim COMPUTED`, tautological bound certificates);
+- requiring JSON `null` for fields a closed success variant does not declare;
+  omit those fields;
+- excluding Harbor host-verifier tests from unsupported-surface AST or text
+  scans merely because they spawn the verifier subprocess.
 
 The verifier replays the advertised predicate from the frozen input. Keep
 `expected.json` as an Oracle fixture only. Generated families emit the
@@ -80,6 +87,14 @@ instruction and schema are the complete public protocol: required result
 fields, exact types, scope, and any task-specific witness rule. Do not hide a
 validity requirement in a README or task metadata. Keep solution, verifier,
 Oracle, host paths, and caches out of the agent environment.
+
+When a schema shrinks, update the instruction, verifier exact-key set, gold
+submission, public contract, and host tests in the same change. Align a
+mismatch by shrinking the verifier and instruction, never by restoring leaked
+constants. If one submitted object implies a dimension or bound, parse every
+related object at that derived size. After merging `main`, re-read every
+touched `instruction.md`: truncated sentences, leftover contract fragments,
+and `COMPUTED` clauses on result-only schemas are protocol bugs.
 
 Each task is a direct child of its dataset with one authoritative member record:
 
@@ -112,11 +127,15 @@ example, input binding or a witness check); they do not create fractional
 credit. Use non-binary scoring only for an explicitly decomposed task whose
 independent subclaims are each meaningful, replayable mathematical outcomes.
 
-For `input_binding_decoupled` tasks, keep `load_submission()` strict. A bounded
-raw parse may support independent diagnostics, but it never establishes public
-protocol validity or reward eligibility. Store every such exception in that
-task's closed `tests/verifier_contract.json`; never use a global task-name
-registry.
+For `input_binding_decoupled` tasks, keep `load_submission()` the strict
+protocol loader. A bounded raw parse may support independent diagnostics, but
+it never establishes public protocol validity or reward eligibility. Store
+every such exception in that task's closed `tests/verifier_contract.json`;
+never use a global task-name registry. If correctness or witness validity must
+remain observable when `/app/input.json` is replaced, parse with
+`require_input_binding=False`, replay math against the frozen tests input, and
+AND binding only into `reward`. Do not fold binding into `correctness` or
+`witness_validity`.
 
 Bound raw submissions and visible/frozen inputs before parsing. If a task needs
 a witness artifact, publish a finite bound only when its encoding or task
@@ -155,6 +174,11 @@ Treat task-local `tests/verifier_support.py` copies as authoritative because
 Harbor's separate verifier image needs them in its build context. Migrate copies
 explicitly, inspect their diffs, and refresh only their Dockerfile checksum
 labels. Do not silently synchronize all tasks from a global runtime helper.
+`verifier_bundle_checksum()` hashes filenames, NUL separators, and bytes; do
+not concatenate `sha256(verifier.py)` with `sha256(verifier_support.py)`.
+Refresh selected tasks with `make harbor-prepare-task` or scoped
+`tools/sync_harbor_verifier_support.py`. Gold witness descriptors must resolve
+to regular files under a non-symlink `solution/` root.
 
 Create a snapshot only for an intentional evaluation or publication boundary:
 

--- a/.agents/skills/verifier-evaluations/SKILL.md
+++ b/.agents/skills/verifier-evaluations/SKILL.md
@@ -59,6 +59,15 @@ itself the mathematical object being checked. A hard task may deliberately
 expose no operation that solves it today: that is a capability finding, not a
 verifier defect.
 
+The verifier derives conclusions from submitted mathematics. Do not score a
+submitted copy of those conclusions, and do not publish them as schema
+`const` fields. If a review asks to restore leaked constants so the schema and
+verifier match, refuse and shrink the verifier and instruction instead. When
+reducing a schema, update instruction, verifier key set, gold, public
+contract, and host tests together. Closed `oneOf` success variants omit
+inapplicable failure fields; they do not send JSON `null`. If one submitted
+object implies a dimension, parse every related object at that derived size.
+
 ## Implement total predicates
 
 Follow this order:
@@ -79,8 +88,8 @@ Read and bound submissions and visible/frozen inputs before parsing. A witness
 artifact needs a published finite bound only when its encoding or task mechanics
 justify one; do not inherit a universal/default cap or create a redundant
 artifact merely to add one. For declared artifacts, reject traversal, symlinks,
-non-regular files, wrong cardinality, wrong digest, and content that does not
-support the claimed result.
+a symlinked solution root, non-regular files, wrong cardinality, wrong digest,
+and content that does not support the claimed result.
 
 Compute mathematical correctness from the frozen verifier copy. Keep input
 binding, declared witness validity, scope, and independent authorization as
@@ -89,6 +98,10 @@ only when calculating aggregate reward. Default reward is binary: return `1`
 only for a valid replayed mathematical outcome and `0` otherwise. Add partial
 credit only when the public task explicitly contains independent, meaningful,
 replayable mathematical subclaims; diagnostics alone never earn credit.
+`load_submission()` may refuse an unbound workspace input; that must not zero
+`correctness` or `witness_validity` when those diagnostics are independent.
+Parse without requiring binding, replay against frozen tests input, and AND
+binding only into `reward`.
 
 For a deliberate raw/strict split, raw parsing is bounded and diagnostic-only.
 `load_submission()` remains the strict authoritative loader; a raw object never

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -49,7 +49,8 @@ Each task owns its `tests/verifier_support.py` file because Harbor builds the
 separate verifier image from that task's `tests/` directory. The task template
 contains the current generic helper for newly scaffolded tasks; existing tasks
 are not silently rewritten. `make harbor-sync DATASET=<id> TASKS="<ids>"`
-updates only the selected verifier checksum labels. The read-only Harbor gates
+updates only the selected verifier checksum labels. The checksum hashes
+filenames, NUL separators, and bytes. The read-only Harbor gates
 validate local support files and never synchronize unrelated tasks.
 
 `benchmarks/tooling/public_contract.py` is internal repository tooling, not an

--- a/benchmarks/templates/task/README.md
+++ b/benchmarks/templates/task/README.md
@@ -26,9 +26,10 @@ as non-authoritative source material, if it is needed at all.
 
 The verifier must replay the claim from frozen `input.json`. Do not score a
 hidden `tests/expected.json` field, a lowest-terms rendering, a formula
-string, or keyword-bearing prose. Do not default a witness path to
-`evidence/answer.txt`. Do not copy a universal certificate union into a
-generated family; each task's schema admits only the certificate that family
-can reward. Instruction, schema, solver, and verifier must accept the same
-objects. See [authoring a Harbor benchmark task](../../../docs/how-to/author-harbor-benchmark-task.md)
+string, keyword-bearing prose, or a leaked derived conclusion. Do not default
+a witness path to `evidence/answer.txt`. Do not copy a universal certificate
+union into a generated family; each task's schema admits only the certificate
+that family can reward. Instruction, schema, solver, and verifier must accept
+the same objects. Closed success variants omit inapplicable fields. See
+[authoring a Harbor benchmark task](../../../docs/how-to/author-harbor-benchmark-task.md)
 and [benchmark contracts](../../../docs/reference/evaluations/benchmark-contracts.md).

--- a/docs/how-to/author-harbor-benchmark-task.md
+++ b/docs/how-to/author-harbor-benchmark-task.md
@@ -29,6 +29,14 @@ complete rewarded protocol. They must agree with the verifier:
    prose while the verifier constructs `Fraction`.
 4. For a generated family, emit one schema licensed by that task's claim
    family. Do not publish a universal `oneOf` of every certificate kind.
+5. Submit mathematics the verifier can replay. Do not require leaked answer
+   constants, derived status fields, or `Claim COMPUTED` on a result-only
+   schema. Closed success variants omit inapplicable failure fields; they do
+   not send JSON `null`.
+6. When a schema shrinks, update the instruction, verifier, gold, public
+   contract, and host tests together. Align a mismatch by shrinking, never by
+   restoring leaked fields. After merging `main`, re-read every touched
+   `instruction.md` for truncated sentences and leftover contract fragments.
 
 Declare the protocol in `tests/public_contract.json` and generate the marked
 submission block plus schema with `benchmarks.tooling.public_contract`. Do not
@@ -57,7 +65,10 @@ Do not award credit for:
 
 Independent propositions must be derived independently. Do not couple a
 collision, invertibility, or completeness claim to an unrelated corrupted
-field.
+field. If input binding is a separate diagnostic, parse the submission without
+requiring workspace-input equality, replay math against the frozen tests
+input, and AND binding only into `reward`. Gold witness descriptors must
+resolve to regular files under a non-symlink `solution/` root.
 
 ## Validate the exact task
 
@@ -67,11 +78,16 @@ make harbor-validate-task DATASET=<dataset-id> TASKS="<task-id>"
 ```
 
 `harbor-prepare-task` formats selected task Python and refreshes public-contract
-and verifier checksums. `harbor-validate-task` is the source-read-only leaf
-gate: static contracts, host tests, then the exact Oracle. Neither command
-starts a model. Use `make harbor-check` only when changing shared Harbor
-tooling, schemas, registry, or suite policy. Create a snapshot lock only when
-freezing an intentional evaluation or publication set.
+and verifier checksums. The checksum hashes filenames, NUL separators, and
+bytes; do not concatenate `sha256(verifier.py)` with
+`sha256(verifier_support.py)`, and do not rewrite every task-local support
+copy. `harbor-validate-task` is the source-read-only leaf gate: static
+contracts, host tests, then the exact Oracle. Neither command starts a model.
+Use `make harbor-check` only when changing shared Harbor tooling, schemas,
+registry, or suite policy. Do not exclude Harbor host-verifier tests from
+unsupported-surface AST or text scans merely because they spawn a verifier
+subprocess. Create a snapshot lock only when freezing an intentional
+evaluation or publication set.
 
 The task's verifier owns correctness; Jacobian owns neither that verifier nor
 its data lifecycle. Keep the task's score distinct from Jacobian's two-tool

--- a/docs/reference/evaluations/benchmark-contracts.md
+++ b/docs/reference/evaluations/benchmark-contracts.md
@@ -36,8 +36,10 @@ returns `1` only when it can replay a valid submitted result and every declared
 task-specific witness condition; otherwise it returns `0`. Tool calls, prose,
 confidence claims, and diagnostic observations do not earn credit. Report
 input binding, witness validity, tool use, cost, and failure modes separately.
-Use non-binary scoring only for a public task deliberately decomposed into
-independent, meaningful, replayable mathematical subclaims.
+Binding is a hard gate on reward only; it must not zero `correctness` or
+`witness_validity` when those diagnostics are independent. Use non-binary
+scoring only for a public task deliberately decomposed into independent,
+meaningful, replayable mathematical subclaims.
 
 The public submission shape is normally `{ "result": ... }`. Add
 `"witness"` only for a finite task-specific mathematical object that replay
@@ -45,6 +47,8 @@ cannot derive from the frozen input and result; prefer structured certificate
 data in `result`, and never require a duplicate result file or natural-language
 explanation. Generic assurance, scope, completeness, limitation, and
 verification-record fields are not part of ordinary mathematical submissions.
+Do not ask the agent to submit a conclusion the verifier can derive, and do
+not publish that conclusion as a schema `const` or leaked status field.
 
 ### Replay authority
 
@@ -75,8 +79,8 @@ one. Parse and compare the represented value:
   parsing into the actual mathematical type, not as privileged list order;
 - formulas as the smallest task-owned type (coefficients, an AST, an enum),
   not as a scored string literal;
-- conclusions as finite reason/status enums the verifier already derives, not
-  as keyword, length, or negation-regex checks over prose.
+- conclusions the verifier already derives from submitted mathematics, not as
+  extra submitted `const` fields, keyword checks, or prose.
 
 Do not encode an exact rational as one undifferentiated `"2/8"` string. Decimal
 strings are allowed only as bounded components of a structured object when
@@ -97,7 +101,13 @@ checks are boundary validation, not rendering rules.
 The instruction, schema, hidden solver, and verifier must accept the same
 objects. A schema-valid, instruction-conforming submission must be able to
 receive full reward. Do not leave `limitations` required in prose and forbidden
-in the verifier, or declare `text/plain` for a JSON object.
+in the verifier, or declare `text/plain` for a JSON object. When a schema
+shrinks, update the instruction, verifier key set, gold submission, public
+contract, and host tests in the same change. Align a mismatch by shrinking the
+verifier and instruction, never by restoring leaked constants. Closed `oneOf`
+success variants omit inapplicable failure fields; they do not send JSON
+`null`. If one submitted object implies a dimension or bound, parse every
+related object at that derived size.
 
 Generated task families specialize the public schema to the claim family and
 frozen case type. Certificate kind is public protocol, not a hidden answer.
@@ -116,8 +126,10 @@ it must not duplicate the typed result or carry a prose explanation.
 Do not require a witness whose only accepted content is a hash of `result`, a
 JSON envelope equal to `result`, selected copied fields, boilerplate keywords,
 or arbitrary nonempty text. Do not score a digest-bound file the verifier never
-opens. The template helper `witness_list_is_bound` has no default
-`evidence/answer.txt` path; pass an explicit path only for a declared artifact.
+opens. Gold witness descriptors must resolve to regular files under a
+non-symlink `solution/` root. The template helper `witness_list_is_bound` has
+no default `evidence/answer.txt` path; pass an explicit path only for a
+declared artifact.
 
 ## Generated output
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Recent Harbor review threads kept recreating the same protocol bugs: leaked derived conclusions in schemas, schema/verifier/instruction cutovers that did not move together, `COMPUTED` clauses on result-only tasks, binding folded into math diagnostics, and requests to restore leaked constants.

The local Harbor skills already banned assurance wrappers, unsatisfiable protocols, and mass-syncing `verifier_support.py`, but they did not state those cutover rules. The authoring how-to, benchmark contracts, and task template had the same gaps.

## Solution

Record the missing rules in `harbor-benchmarks` and `verifier-evaluations`, then mirror them in the published authoring docs:

- do not publish leaked answer constants or derived conclusions
- shrink verifier and instruction to match a reduced schema; never restore leaked fields
- update instruction, verifier, gold, public contract, and host tests in the same change
- keep input binding out of `correctness` / `witness_validity`
- omit closed-variant failure fields instead of sending `null`
- scoped checksum refresh (filenames, NUL separators, and bytes); reject a symlinked gold `solution/` root
- re-read `instruction.md` after merging `main`
- do not exclude Harbor host-verifier tests from unsupported-surface scans merely because they spawn a subprocess

Left unchanged: `AGENTS.md`, `CONTRIBUTING.md`, and `recent-conjecture-evaluations`.

## Testing

Documentation and skill guidance only. No Harbor task, verifier, or Python surface changed.

```sh
make docs-linkcheck
make check
```

`make docs-linkcheck` passed. `make check` passed (Ruff, mypy, 472 unit tests, 1 skipped Lean).

- Specialist validation run: `make docs-linkcheck`

## Trust & Compatibility Impact

None. Authoring guidance only.

## Architecture Budget

Not an operation change.

## Checklist
- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (`make docs-linkcheck`)
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (if applicable)
- [ ] New ordinary operations fit the documented operation budget (if applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bbf00a6-144c-4a75-af51-6dbaaca51706?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bbf00a6-144c-4a75-af51-6dbaaca51706&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

