### PR TITLE
docs(discovery): expose canonical polynomial input guidance

### DIFF
--- a/.agents/skills/audit-mcp-tool-friction/SKILL.md
+++ b/.agents/skills/audit-mcp-tool-friction/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: audit-mcp-tool-friction
+description: Audit existing MCP tools for execution friction after an agent has reached the tool. Use when reviewing public JSON Schemas, Pydantic validation, operation examples, error recovery, completed agent traces, or benchmark runs to explain malformed calls, retries, or unusable results. Do not use to measure whether agents discover or select a tool; use evaluate-mcp-tool-adoption for that.
+---
+
+# Audit MCP Tool Friction
+
+Audit whether an agent that has chosen a tool can form a valid request, recover
+from a failure, and use the returned value. This is a public-contract audit,
+not a call-count target and not a test of model willingness to use a tool.
+
+## Set the boundary
+
+Record the tool, revision, client, task or trace, and public inputs inspected.
+Keep these questions separate:
+
+- **Adoption:** whether the agent saw, discovered, or selected a tool.
+- **Friction:** whether the selected tool made its contract, valid input, error
+  recovery, and result use clear enough to execute correctly.
+- **Capability:** whether an operation actually covers the requested work.
+
+Do not call a successful Python fallback evidence that a tool contract is easy
+to use. Do not call a single malformed request a product defect without
+checking what the public contract exposed beforehand.
+
+## Inspect the public contract
+
+For each relevant operation, inspect the generated MCP input and output
+schemas, tool description, discovery/inspection result, operation examples,
+and error messages. Trace every non-obvious requirement to its owner:
+
+| Contract element | Check |
+| --- | --- |
+| Input expression | Required values, units, encodings, ordering, and bounds are visible before the call. |
+| Schema projection | Constraints representable in JSON Schema appear there with useful field descriptions and examples. |
+| Semantic validation | Rules enforced only by a model validator have an explicit description and minimal valid example. |
+| Recovery | Errors identify the field and state the smallest concrete correction. |
+| Result use | Result shape, exactness, limits, and reconstruction information let the caller continue without guessing. |
+
+Pydantic does not infer JSON-Schema descriptions or examples from custom model
+validators. Add `Field(description=..., examples=...)` or appropriate
+`json_schema_extra` when a semantic invariant cannot be encoded as a standard
+JSON-Schema constraint. Keep canonical output rules when they support stable
+composition; improve the input guidance before weakening the invariant.
+
+## Read a trace as a recovery journey
+
+Capture the exact operation ID, first payload, typed result or error, retry,
+and final use of the value. Classify the first failure narrowly:
+
+- **Hidden representation rule:** required ordering, encoding, or cross-field
+  relation was not visible in the public contract.
+- **Insufficient example or description:** the rule was technically present
+  but not concrete enough for an ordinary first request.
+- **Unhelpful recovery:** the error lacks a field, cause, or actionable repair.
+- **Tool or transport defect:** a documented valid request fails, result schema
+  is wrong, or the typed result cannot be consumed as declared.
+- **Agent slip:** the contract and recovery path were clear; one isolated
+  malformed call does not establish a product problem.
+
+Compare a direct known-valid execution separately from the trace. A direct pass
+proves the operation works; it does not erase caller friction. A trace with no
+call is out of scope unless availability or adoption is under review.
+
+## Measure benchmark friction
+
+For comparable runs, freeze task, image, server revision, model, client,
+budget, and MCP configuration. Report final verifier outcome separately from:
+
+- first-call validity;
+- operation inspection before execution;
+- validation failures by field and invariant;
+- recovery attempts and whether a retry used the returned error;
+- typed-result use versus manual fallback; and
+- added calls, tokens, and elapsed time.
+
+Use repeated tasks or attempts before claiming a stable rate. A successful
+answer after retries is evidence of recoverability, not evidence of a
+frictionless interface.
+
+## Recommend the smallest repair
+
+Prefer, in order: clearer field metadata and examples; actionable errors;
+schema-level constraints; a narrowly scoped adapter or helper. Normalize input
+only when it preserves the documented mathematical meaning and does not hide
+ambiguity, duplicate terms, or caller mistakes. Preserve bounded operation
+semantics and return values directly.
+
+Report confirmed behavior, the exact public evidence, the affected stage,
+proportionate repair, and what remains untested. State when the evidence only
+supports an agent slip rather than a tool-design finding.

--- a/.agents/skills/audit-mcp-tool-friction/agents/openai.yaml
+++ b/.agents/skills/audit-mcp-tool-friction/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit MCP Tool Friction"
+  short_description: "Audit existing MCP tool usability"
+  default_prompt: "Use $audit-mcp-tool-friction to audit an existing MCP tool contract and trace for agent friction."

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -16,6 +16,14 @@ operation reports mathematical completeness or uncertainty in its own result;
 it does not add a generic assurance, artifact, publication, replay, or
 verification wrapper.
 
+Public request contracts must make their valid representation visible before a
+backend call. Express constraints that JSON Schema can represent in typed field
+metadata. When a domain invariant needs a Pydantic model validator—such as a
+cross-field relation or canonical term ordering—also provide an explicit field
+or model description and a minimal valid example in the exported schema. The
+validator remains authoritative; the metadata lets a caller form a valid first
+request rather than discover the rule only through a rejected call.
+
 Use maintained backends through thin private adapters. Direct bounded results
 compose by being supplied as the next operation's typed
 payload.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -25,6 +25,16 @@ domain), and `inspect` supplies the selected operation's exact input/output
 schemas and valid examples. Reuse relevant fields from each direct `math.run`
 value in the next payload; the agent owns the evolving conjecture and hypothesis.
 
+## Form a payload from an inspected contract
+
+Inspect an operation before constructing an unfamiliar payload. Start from one
+of its valid examples and adapt it to the mathematical input. Field descriptions
+and the input schema state the required representation, including units, bounds,
+and canonical encodings or ordering where they matter. An error from `math.run`
+means the request did not meet that operation's contract; use its diagnostic to
+make the smallest correction before drawing a mathematical
+conclusion from any result.
+
 `browse` is recomputed from immutable declarations on every request. Its cursor is
 only caller-supplied pagination state, so it creates no catalog identity, saved
 session, artifact, value reference, or server-side record. The sole built-in MCP

--- a/src/jacobian/math/polynomials/values.py
+++ b/src/jacobian/math/polynomials/values.py
@@ -40,7 +40,25 @@ class RationalPolynomialTerm(ContractModel):
 
 class SparseRationalPolynomial(ContractModel):
     terms: tuple[RationalPolynomialTerm, ...] = Field(
-        default=(), max_length=MAX_POLYNOMIAL_TERMS
+        default=(),
+        max_length=MAX_POLYNOMIAL_TERMS,
+        description=(
+            "Nonzero monomials in descending lexicographic order of their "
+            "exponent tuples (highest first). For one variable, list [2] "
+            "before [0]."
+        ),
+        examples=[
+            [
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [2],
+                },
+                {
+                    "coefficient": {"num": "-1", "den": "1"},
+                    "exponents": [0],
+                },
+            ]
+        ],
     )
 
     @model_validator(mode="after")

--- a/tests/domain/polynomial/test_polynomial_conversions.py
+++ b/tests/domain/polynomial/test_polynomial_conversions.py
@@ -6,7 +6,10 @@ from jacobian.domains.polynomial.conversions import (
     rational_polynomial_to_sympy,
 )
 from jacobian.domains.polynomial.operations import polynomial_gcd
-from jacobian.math.polynomials.values import RationalPolynomial
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    SparseRationalPolynomial,
+)
 
 
 def _polynomial() -> RationalPolynomial:
@@ -75,3 +78,24 @@ def test_gcd_result_composes_without_reshaping_or_json_round_trip() -> None:
         }
     )
     assert polynomial_gcd(serialized_consumer).gcd == result.gcd
+
+
+def test_sparse_polynomial_schema_explains_canonical_term_order() -> None:
+    terms = SparseRationalPolynomial.model_json_schema()["properties"]["terms"]
+
+    assert terms["description"] == (
+        "Nonzero monomials in descending lexicographic order of their exponent "
+        "tuples (highest first). For one variable, list [2] before [0]."
+    )
+    assert terms["examples"] == [
+        [
+            {
+                "coefficient": {"num": "1", "den": "1"},
+                "exponents": [2],
+            },
+            {
+                "coefficient": {"num": "-1", "den": "1"},
+                "exponents": [0],
+            },
+        ]
+    ]


### PR DESCRIPTION
## Problem

`SparseRationalPolynomial` requires nonzero terms in descending lexicographic
order, but the rule was enforced only by a Pydantic validator. Its generated
field schema exposed an array without a description or valid ordering example,
so a caller inspecting an operation contract could form an invalid first
payload.

## Solution

Publish the ordering rule and a highest-degree-first example on `terms` while
keeping the existing canonical validator unchanged. Add a regression test for
the exported schema, clarify the inspection and payload guidance, and add a
repository skill for auditing this kind of execution friction separately from
tool selection.

## Testing

- `make check` — passed
- `make test-domain TESTS=tests/domain/polynomial/test_polynomial_conversions.py` — 3 passed
- `make test-mcp` — 13 passed
- `make docs-linkcheck` — passed

## Trust & Compatibility Impact

No mathematical semantics or validation rules change. The generated request
schema gains backward-compatible descriptions and examples; no verifier,
artifact, or stored-value contract changes.

## Architecture Budget

Not applicable: this adds no operation, shared abstraction, or publication
binding.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (`make test-mcp`)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] New ordinary operations fit the documented operation budget (not applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable)
