### PR TITLE
feat(mcp): publish valid examples for every operation

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -41,6 +41,14 @@ contract through a failed call, a lengthy ad-hoc script, or trial and error.
 Examples illustrate a valid representation; they do not prescribe a proof
 strategy or restrict how operations may be composed.
 
+Avoid **validator-only public contracts**. Do not introduce a required input
+representation solely through a Pydantic validator and expect callers to infer
+it from an error. When a rule cannot be expressed as an ordinary JSON Schema
+constraint, pair the validator with schema-visible field or model guidance and
+a valid invocation example. Diagnostics remain the recovery path for malformed
+requests; they are not the primary documentation for an operation's wire
+contract.
+
 Use maintained backends through thin private adapters. Direct bounded results
 compose by being supplied as the next operation's typed
 payload.

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -24,6 +24,23 @@ or model description and a minimal valid example in the exported schema. The
 validator remains authoritative; the metadata lets a caller form a valid first
 request rather than discover the rule only through a rejected call.
 
+Every built-in `MathTool` declaration must publish at least one small valid
+invocation example. An example is part of the public contract: it must validate
+against the declaration's request model, use canonical values where required,
+and be executable in Jacobian's supported local environment. Keep it close to
+the operation and adapt it when a request contract changes. The catalog test
+checks every published example at the request boundary; the operation's owning
+tests should exercise any nontrivial example behavior.
+
+Examples help an agent form its first request without guessing. JSON Schema can
+name fields and simple bounds, but it cannot fully communicate validator-owned
+rules such as nested value shape, canonical ordering, coupled fields, or the
+smallest useful composition. On exact inspection, an agent can copy an example
+payload and adapt its mathematical content instead of discovering that wire
+contract through a failed call, a lengthy ad-hoc script, or trial and error.
+Examples illustrate a valid representation; they do not prescribe a proof
+strategy or restrict how operations may be composed.
+
 Use maintained backends through thin private adapters. Direct bounded results
 compose by being supplied as the next operation's typed
 payload.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -28,12 +28,12 @@ value in the next payload; the agent owns the evolving conjecture and hypothesis
 ## Form a payload from an inspected contract
 
 Inspect an operation before constructing an unfamiliar payload. Start from one
-of its valid examples and adapt it to the mathematical input. Field descriptions
-and the input schema state the required representation, including units, bounds,
-and canonical encodings or ordering where they matter. An error from `math.run`
-means the request did not meet that operation's contract; use its diagnostic to
-make the smallest correction before drawing a mathematical
-conclusion from any result.
+of its valid examples, when it has one, and adapt it to the mathematical input.
+Otherwise form the payload from the input schema and field descriptions. They
+state the required representation, including units, bounds, and canonical
+encodings or ordering where they matter. An error from `math.run` means the
+request did not meet that operation's contract; use its diagnostic to make the
+smallest correction before drawing a mathematical conclusion from any result.
 
 `browse` is recomputed from immutable declarations on every request. Its cursor is
 only caller-supplied pagination state, so it creates no catalog identity, saved

--- a/src/jacobian/adapters/mcp/guidance.py
+++ b/src/jacobian/adapters/mcp/guidance.py
@@ -43,9 +43,10 @@ Run one installed math tool by ID with its typed `payload`. A successful call re
 the operation-owned mathematical value in `output`; read its fields to determine what
 the calculation established. MCP reports malformed payloads, unknown IDs, and host
 failures as tool errors, not as mathematical results. If the payload shape is unknown,
-inspect the exact operation with math.find, select one item from `examples`, and copy
-and adapt that item's `input` object as the `payload`. Do not call math.run with an
-empty `payload` merely to discover required fields; inspection is authoritative.
+inspect the exact operation with math.find. When it publishes an `examples` item, copy
+and adapt that item's `input` object as the `payload`; otherwise, form the payload from
+the input schema and its field descriptions. Do not call math.run with an empty
+`payload` merely to discover required fields; inspection is authoritative.
 
 Timeout, incomplete search, and missing witnesses appear only in the concrete domain
 result that owns them; none is a mathematical conclusion by itself.

--- a/src/jacobian/contracts/exact.py
+++ b/src/jacobian/contracts/exact.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from typing import Annotated, Self
 
-from pydantic import StringConstraints, model_validator
+from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.contracts.base import ContractModel
@@ -37,8 +37,23 @@ def require_bounded_rational(
 
 
 class CanonicalRational(ContractModel):
-    num: CanonicalInteger
-    den: CanonicalInteger
+    """A reduced rational whose denominator is positive and whose zero is 0/1."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"examples": [{"num": "1", "den": "2"}]}
+    )
+
+    num: CanonicalInteger = Field(
+        description="Canonical decimal numerator of the reduced rational.",
+        examples=["1"],
+    )
+    den: CanonicalInteger = Field(
+        description=(
+            "Positive canonical decimal denominator; together with num it must be "
+            "reduced, and integers use den='1'."
+        ),
+        examples=["2"],
+    )
 
     @model_validator(mode="after")
     def require_reduced_positive_denominator(self) -> Self:

--- a/src/jacobian/domains/finite_fields/operations.py
+++ b/src/jacobian/domains/finite_fields/operations.py
@@ -1,5 +1,6 @@
 """Finite-field operation declarations over authoritative native values."""
 
+from jacobian.domains._examples import example
 from jacobian.domains.finite_fields.contracts import (
     CollisionRequest,
     DirectionRankLedgerRequest,
@@ -39,6 +40,94 @@ _MAX_FINITE_MAP_ELEMENTS = 4096
 _MAX_FINITE_MAP_WORK = 1_000_000
 _MAX_FINITE_MAP_REPLAY_WORK = 1_000_000
 _MAX_DIRECTION_RANK_WORK = 1_000_000
+
+_FIELD: dict[str, object] = {
+    "characteristic": 2,
+    "modulus_coefficients": [1, 1, 1],
+    "generator": "a",
+    "element_encoding_version": "power-basis-v1",
+}
+_ROWS: dict[str, object] = {"name": "b", "labels": ["b1", "b2"]}
+_IMAGE: dict[str, object] = {"name": "image", "labels": ["y1"]}
+_BASIS_AXIS: dict[str, object] = {"name": "basis", "labels": ["B1"]}
+
+
+def _element(first: int, second: int) -> dict[str, object]:
+    return {"presentation": _FIELD, "coordinates": [first, second]}
+
+
+def _direction(first: tuple[int, int], second: tuple[int, int]) -> dict[str, object]:
+    return {
+        "presentation": _FIELD,
+        "axis": _ROWS,
+        "coordinates": [_element(*first), _element(*second)],
+    }
+
+
+_ZERO = _element(0, 0)
+_ONE = _element(1, 0)
+_SUBSPACE: dict[str, object] = {
+    "presentation": _FIELD,
+    "basis_axis": _BASIS_AXIS,
+    "basis": [
+        {
+            "presentation": _FIELD,
+            "row_axis": _ROWS,
+            "column_axis": _IMAGE,
+            "entries": [[_ONE], [_ZERO]],
+        }
+    ],
+}
+_DIRECTIONS = (
+    _direction((0, 0), (1, 0)),
+    _direction((1, 0), (0, 0)),
+    _direction((1, 0), (1, 0)),
+    _direction((1, 0), (0, 1)),
+    _direction((1, 0), (1, 1)),
+)
+_PROJECTIVE_LINE: dict[str, object] = {
+    "presentation": _FIELD,
+    "axis": _ROWS,
+    "points": list(_DIRECTIONS),
+}
+
+
+def _linear_map(rank: int) -> dict[str, object]:
+    return {
+        "source_axis": _BASIS_AXIS,
+        "target_axis": {"name": "Res(image)", "labels": ["y1:1", "y1:a"]},
+        "matrix": {"prime": 2, "entries": [[rank], [0]], "columns": 1},
+    }
+
+
+_LINEAR_MAPS = tuple(_linear_map(rank) for rank in (0, 1, 1, 1, 1))
+_LEDGER: dict[str, object] = {
+    "subspace": _SUBSPACE,
+    "entries": [
+        {"direction": direction, "linear_map": linear_map, "rank": rank}
+        for direction, linear_map, rank in zip(
+            _DIRECTIONS, _LINEAR_MAPS, (0, 1, 1, 1, 1), strict=True
+        )
+    ],
+}
+_POLYNOMIAL_MAP: dict[str, object] = {
+    "domain": _FIELD,
+    "codomain": _FIELD,
+    "polynomial": {
+        "presentation": _FIELD,
+        "variable": "x",
+        "coefficients": [_ZERO, _ZERO, _ZERO, _ONE],
+    },
+}
+_TABLE: dict[str, object] = {
+    "map": _POLYNOMIAL_MAP,
+    "entries": [
+        [_element(0, 0), _element(0, 0)],
+        [_element(1, 0), _element(1, 0)],
+        [_element(0, 1), _element(1, 0)],
+        [_element(1, 1), _element(1, 0)],
+    ],
+}
 
 
 def _enumerate_projective_line(request: ProjectiveLineRequest) -> ProjectiveLine:
@@ -153,6 +242,13 @@ def finite_field_operations() -> MathTools:
         title="Enumerate an exact finite projective line",
         description="Return every normalized direction in deterministic order.",
         tags=("finite-field", "projective"),
+        examples=(
+            example(
+                "projective_line_over_gf_four",
+                "Enumerate the projective line on a two-coordinate GF(4) axis.",
+                {"presentation": _FIELD, "axis": _ROWS},
+            ),
+        ),
     )
     restrict_operation = MathTool(
         operation_id="finite_field.restrict_scalars.compute",
@@ -163,6 +259,13 @@ def finite_field_operations() -> MathTools:
         title="Restrict a finite-field matrix action to its prime field",
         description="Construct the exact prime-field map B -> B^T b.",
         tags=("finite-field", "linear-map", "restriction-of-scalars"),
+        examples=(
+            example(
+                "one_basis_vector",
+                "Restrict a one-vector GF(4) subspace along one projective direction.",
+                {"subspace": _SUBSPACE, "direction": _DIRECTIONS[0]},
+            ),
+        ),
     )
     rank_operation = MathTool(
         operation_id="finite_field.linear_map.rank.compute",
@@ -173,6 +276,13 @@ def finite_field_operations() -> MathTools:
         title="Compute finite linear-map rank over the prime field",
         description="Return the exact rank bound to its direction and map.",
         tags=("finite-field", "linear-map", "rank", "exact"),
+        examples=(
+            example(
+                "restricted_map_rank",
+                "Compute the rank of a restricted GF(4) map over GF(2).",
+                {"direction": _DIRECTIONS[0], "linear_map": _LINEAR_MAPS[0]},
+            ),
+        ),
     )
     ledger_operation = MathTool(
         operation_id="finite_field.direction_rank_ledger.compute",
@@ -183,6 +293,13 @@ def finite_field_operations() -> MathTools:
         title="Compute ranks for a complete finite projective line",
         description="Return every direction with its restricted map and rank.",
         tags=("finite-field", "rank"),
+        examples=(
+            example(
+                "complete_projective_line",
+                "Compute ranks for every direction on a GF(4) projective line.",
+                {"subspace": _SUBSPACE, "directions": _PROJECTIVE_LINE},
+            ),
+        ),
     )
     orbit_operation = MathTool(
         operation_id="finite_field.orbit_distribution.compute",
@@ -193,6 +310,13 @@ def finite_field_operations() -> MathTools:
         title="Aggregate a complete direction-rank ledger",
         description="Return exact orbit-size counts bound to the full ledger.",
         tags=("finite-field", "orbit"),
+        examples=(
+            example(
+                "complete_rank_ledger",
+                "Aggregate the rank distribution of a complete GF(4) line.",
+                {"ledger": _LEDGER},
+            ),
+        ),
     )
     table_operation = MathTool(
         operation_id="finite_field.polynomial_map.table.compute",
@@ -203,6 +327,13 @@ def finite_field_operations() -> MathTools:
         title="Evaluate a polynomial on its complete finite field",
         description="Return the exact domain-bound map table in canonical order.",
         tags=("finite-field", "polynomial", "map-table", "exact"),
+        examples=(
+            example(
+                "cubic_map_over_gf_four",
+                "Evaluate x³ on every element of GF(4).",
+                {"polynomial_map": _POLYNOMIAL_MAP},
+            ),
+        ),
     )
     fiber_operation = MathTool(
         operation_id="finite_field.polynomial_map.fibers.compute",
@@ -213,6 +344,13 @@ def finite_field_operations() -> MathTools:
         title="Partition a finite polynomial map into fibers",
         description="Return every nonempty fiber bound to the exact map table.",
         tags=("finite-field", "polynomial", "fibers", "exact"),
+        examples=(
+            example(
+                "cubic_map_table",
+                "Partition the table of x³ over GF(4) into nonempty fibers.",
+                {"table": _TABLE},
+            ),
+        ),
     )
     collision_operation = MathTool(
         operation_id="finite_field.polynomial_map.collision.analyze",
@@ -223,6 +361,13 @@ def finite_field_operations() -> MathTools:
         title="Analyze finite polynomial-map collisions",
         description="Return a collision or an exact injectivity result.",
         tags=("finite-field", "polynomial", "collision"),
+        examples=(
+            example(
+                "cubic_map_table",
+                "Find a collision in the table of x³ over GF(4).",
+                {"table": _TABLE},
+            ),
+        ),
     )
     permutation_operation = MathTool(
         operation_id="finite_field.polynomial_map.permutation.analyze",
@@ -233,6 +378,13 @@ def finite_field_operations() -> MathTools:
         title="Analyze a finite polynomial permutation",
         description="Return an inverse table or an exact non-permutation result.",
         tags=("finite-field", "polynomial", "permutation"),
+        examples=(
+            example(
+                "cubic_map_table",
+                "Determine whether x³ permutes GF(4).",
+                {"table": _TABLE},
+            ),
+        ),
     )
     return (
         projective_line_operation,

--- a/src/jacobian/domains/geometry/polygons.py
+++ b/src/jacobian/domains/geometry/polygons.py
@@ -41,6 +41,19 @@ POLYGON_OPERATIONS = (
         "polygon",
         "triangulation",
         "optimization",
+        examples=(
+            example(
+                "unit_square_complete_diagonals",
+                "Triangulate a unit square with one weight for each non-hull diagonal.",
+                {
+                    "polygon": {"points": _UNIT_SQUARE},
+                    "diagonal_weights": [
+                        {"first": 0, "second": 2, "weight": {"num": "1", "den": "1"}},
+                        {"first": 1, "second": 3, "weight": {"num": "2", "den": "1"}},
+                    ],
+                },
+            ),
+        ),
     ),
     geometry_operation(
         "geometry.polygon.compute.signed_area",

--- a/src/jacobian/domains/logic/operations.py
+++ b/src/jacobian/domains/logic/operations.py
@@ -9,7 +9,14 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Literal, Self
 
-from pydantic import Field, StrictBool, StrictInt, field_validator, model_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    field_validator,
+    model_validator,
+)
 
 from jacobian.bounded_process import run_bounded_process
 from jacobian.contracts.base import ContractModel
@@ -28,8 +35,25 @@ _LEAN_TOOLCHAIN = "leanprover/lean4:v4.31.0"
 class CanonicalCnf(ContractModel):
     """A bounded canonical propositional formula value."""
 
-    variables: tuple[str, ...] = Field(max_length=_MAX_VARIABLES)
-    clauses: tuple[tuple[StrictInt, ...], ...] = Field(max_length=_MAX_CLAUSES)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [{"variables": ["a", "b"], "clauses": [[-1, 2], [1]]}]
+        }
+    )
+
+    variables: tuple[str, ...] = Field(
+        max_length=_MAX_VARIABLES,
+        description="Distinct variable names in ascending lexicographic order.",
+        examples=[["a", "b"]],
+    )
+    clauses: tuple[tuple[StrictInt, ...], ...] = Field(
+        max_length=_MAX_CLAUSES,
+        description=(
+            "Unique non-tautological clauses in canonical order. Literals are signed "
+            "one-based indexes into variables and each clause is ordered by variable."
+        ),
+        examples=[[[-1, 2], [1]]],
+    )
 
     @field_validator("variables")
     @classmethod
@@ -216,7 +240,17 @@ def _top_level_smtlib_commands(source: str) -> tuple[tuple[str, ...], ...]:
 
 class SmtSolveRequest(ContractModel):
     logic: SmtLogic
-    smtlib: str = Field(min_length=1, max_length=_MAX_SMTLIB_BYTES)
+    smtlib: str = Field(
+        min_length=1,
+        max_length=_MAX_SMTLIB_BYTES,
+        description=(
+            "ASCII SMT-LIB that declares logic, contains exactly one check-sat command, "
+            "and ends with that command."
+        ),
+        examples=[
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
+        ],
+    )
     timeout_ms: StrictInt = Field(default=1_000, ge=1, le=10_000)
 
     @model_validator(mode="after")
@@ -260,7 +294,12 @@ class LeanDiagnostic(ContractModel):
 class LeanCheckRequest(ContractModel):
     """A source snippet checked in the service image's fixed Lean environment."""
 
-    source: str = Field(min_length=1, max_length=32_000)
+    source: str = Field(
+        min_length=1,
+        max_length=32_000,
+        description="A self-contained Lean source snippet for the fixed service toolchain.",
+        examples=["example : True := by trivial"],
+    )
     timeout_seconds: StrictInt = Field(default=10, ge=1, le=30)
 
 
@@ -504,6 +543,16 @@ LOGIC_OPERATIONS = (
         result_type=SatAssignmentCheckResult,
         run=check_sat_assignment,
         tags=("sat", "cnf", "assignment", "predicate"),
+        examples=(
+            example(
+                "satisfying_assignment",
+                "Check a total assignment against a canonical CNF.",
+                {
+                    "cnf": {"variables": ["a", "b"], "clauses": [[-1, 2], [1]]},
+                    "assignment": [True, True],
+                },
+            ),
+        ),
     ),
     MathTool(
         operation_id="sat.solve",
@@ -514,6 +563,13 @@ LOGIC_OPERATIONS = (
         result_type=SatSolveResult,
         run=solve_sat,
         tags=("sat", "cnf", "solve", "z3"),
+        examples=(
+            example(
+                "two_variable_cnf",
+                "Solve a small canonical CNF.",
+                {"cnf": {"variables": ["a", "b"], "clauses": [[-1, 2], [1]]}},
+            ),
+        ),
     ),
     MathTool(
         operation_id="smt.solve",
@@ -524,6 +580,16 @@ LOGIC_OPERATIONS = (
         result_type=SmtSolveResult,
         run=solve_smt,
         tags=("smt", "solve", "smtlib", "z3"),
+        examples=(
+            example(
+                "positive_integer",
+                "Solve a bounded quantifier-free linear-integer query.",
+                {
+                    "logic": "QF_LIA",
+                    "smtlib": "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+                },
+            ),
+        ),
     ),
     MathTool(
         operation_id="lean.check",
@@ -534,6 +600,13 @@ LOGIC_OPERATIONS = (
         result_type=LeanCheckResult,
         run=check_lean_source,
         tags=("lean", "elaboration", "source", "bounded"),
+        examples=(
+            example(
+                "trivial_proposition",
+                "Elaborate a self-contained proof of True.",
+                {"source": "example : True := by trivial"},
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/domains/polynomial/jacobian_syzygy.py
+++ b/src/jacobian/domains/polynomial/jacobian_syzygy.py
@@ -423,6 +423,34 @@ JACOBIAN_SYZYGY_COEFFICIENT_LEDGER_OPERATION = polynomial_operation(
     "syzygy",
     "coefficient-ledger",
     "evidence",
+    examples=(
+        OperationExample(
+            name="sparse-homogeneous-polynomial",
+            description="Compute sparse coefficient maps for h=x²+y²+z².",
+            input={
+                "polynomial": {
+                    "variables": ["x", "y", "z"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [2, 0, 0],
+                            },
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [0, 2, 0],
+                            },
+                            {
+                                "coefficient": {"num": "1", "den": "1"},
+                                "exponents": [0, 0, 2],
+                            },
+                        ]
+                    },
+                },
+                "max_degree": 0,
+            },
+        ),
+    ),
 )
 
 

--- a/src/jacobian/domains/posets/operations.py
+++ b/src/jacobian/domains/posets/operations.py
@@ -301,6 +301,35 @@ _DIAMOND: dict[str, Any] = {
     "reflexive_pairs": "FORBIDDEN",
 }
 
+_MATERIALIZED_DIAMOND: dict[str, Any] = {
+    "poset_format": "jacobian.finite-poset/v1",
+    "elements": ["0", "1", "a", "b"],
+    "strict_order_pairs": [
+        {"lower": "0", "upper": "1"},
+        {"lower": "0", "upper": "a"},
+        {"lower": "0", "upper": "b"},
+        {"lower": "a", "upper": "1"},
+        {"lower": "b", "upper": "1"},
+    ],
+    "cover_relations": [
+        {"lower": "0", "upper": "a"},
+        {"lower": "0", "upper": "b"},
+        {"lower": "a", "upper": "1"},
+        {"lower": "b", "upper": "1"},
+    ],
+    "incomparable_pairs": [{"left": "a", "right": "b"}],
+    "minimal_elements": ["0"],
+    "maximal_elements": ["1"],
+    "graded": True,
+    "ranks": [
+        {"element": "0", "rank": 0},
+        {"element": "1", "rank": 2},
+        {"element": "a", "rank": 1},
+        {"element": "b", "rank": 1},
+    ],
+    "poset_digest": "sha256:bb8df218b7f750edddcb9259c6aff4ca7128e1d1e73bd092306c350583ab8e96",
+}
+
 FINITE_POSET_OPERATIONS: MathTools = (
     MathTool(
         operation_id="poset.finite.compute",
@@ -351,6 +380,13 @@ FINITE_POSET_OPERATIONS: MathTools = (
             "dilworth",
             "exact",
         ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute the width of the canonical four-element diamond.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
+        ),
     ),
     MathTool(
         operation_id="poset.linear_extensions.count",
@@ -366,6 +402,13 @@ FINITE_POSET_OPERATIONS: MathTools = (
             "exact-count",
             "order-ideal",
             "dynamic-programming",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Count the linear extensions of the canonical diamond.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
         ),
     ),
     MathTool(
@@ -385,6 +428,13 @@ FINITE_POSET_OPERATIONS: MathTools = (
             "incidence-algebra",
             "interval",
             "exact",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute every Möbius value of the canonical diamond.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
         ),
     ),
 )

--- a/src/jacobian/domains/rational_linear/operations.py
+++ b/src/jacobian/domains/rational_linear/operations.py
@@ -135,6 +135,27 @@ def rational_linear_operations() -> MathTools:
             result_type=LinearRationalInconsistencyResult,
             run=compute_rational_inconsistency,
             tags=("linear-algebra", "rational", "inconsistency", "exact"),
+            examples=(
+                example(
+                    "contradictory_one_variable_system",
+                    "Find a witness for x=0 together with x=1.",
+                    {
+                        "system": {
+                            "variables": ["x"],
+                            "coefficients": {
+                                "entries": [
+                                    [{"num": "1", "den": "1"}],
+                                    [{"num": "1", "den": "1"}],
+                                ]
+                            },
+                            "rhs": [
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                        }
+                    },
+                ),
+            ),
         ),
     )
 

--- a/src/jacobian/math/finite_fields/values.py
+++ b/src/jacobian/math/finite_fields/values.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal, Self
 
 import rfc8785
-from pydantic import model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from jacobian.canonical import sha256_digest
 from jacobian.contracts.base import ContractModel
@@ -60,10 +60,39 @@ def _validate_presentation_shape(
 class FiniteFieldPresentation(ContractModel):
     """An exact polynomial presentation with a fixed power-basis encoding."""
 
-    characteristic: int
-    modulus_coefficients: tuple[int, ...]
-    generator: str = "a"
-    element_encoding_version: str = "power-basis-v1"
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "characteristic": 2,
+                    "modulus_coefficients": [1, 1, 1],
+                    "generator": "a",
+                    "element_encoding_version": "power-basis-v1",
+                }
+            ]
+        }
+    )
+
+    characteristic: int = Field(
+        description="Prime p defining the base field GF(p).", examples=[2]
+    )
+    modulus_coefficients: tuple[int, ...] = Field(
+        description=(
+            "Constant-to-leading coefficients of a monic irreducible modulus over "
+            "GF(characteristic); each coefficient is a canonical residue."
+        ),
+        examples=[[1, 1, 1]],
+    )
+    generator: str = Field(
+        default="a",
+        description="Name of the power-basis generator represented by the modulus.",
+        examples=["a"],
+    )
+    element_encoding_version: str = Field(
+        default="power-basis-v1",
+        description="Fixed coordinate encoding for finite-field elements.",
+        examples=["power-basis-v1"],
+    )
 
     @model_validator(mode="after")
     def validate_presentation(self) -> Self:

--- a/tests/unit/contracts/test_public_schema_guidance.py
+++ b/tests/unit/contracts/test_public_schema_guidance.py
@@ -1,0 +1,37 @@
+"""Public JSON Schema guidance for canonical input values."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.domains.logic.operations import CanonicalCnf
+from jacobian.math.finite_fields import FiniteFieldPresentation
+
+
+@pytest.mark.parametrize(
+    ("model", "fields"),
+    (
+        (CanonicalRational, ("num", "den")),
+        (CanonicalCnf, ("variables", "clauses")),
+        (
+            FiniteFieldPresentation,
+            (
+                "characteristic",
+                "modulus_coefficients",
+                "generator",
+                "element_encoding_version",
+            ),
+        ),
+    ),
+)
+def test_canonical_value_schema_exposes_examples_and_field_guidance(
+    model: type[CanonicalRational | CanonicalCnf | FiniteFieldPresentation],
+    fields: tuple[str, ...],
+) -> None:
+    schema = model.model_json_schema()
+
+    assert schema["examples"]
+    for field in fields:
+        assert schema["properties"][field]["description"]
+        assert schema["properties"][field]["examples"]

--- a/tests/unit/test_serving_catalog.py
+++ b/tests/unit/test_serving_catalog.py
@@ -17,6 +17,19 @@ def test_serving_catalog_inspects_determinant_without_sqlite() -> None:
     assert descriptor.operation_id == "matrix.determinant.compute"
 
 
+def test_every_served_operation_publishes_request_valid_examples() -> None:
+    catalog = ServingCatalog.open()
+
+    for descriptor in catalog.snapshot().operations:
+        operation = catalog.operation(descriptor.operation_id)
+        assert operation is not None
+        assert operation.examples, (
+            f"{descriptor.operation_id} must publish an invocation example"
+        )
+        for invocation_example in operation.examples:
+            operation.request_type.model_validate(invocation_example.input)
+
+
 def test_invoke_operation_runs_determinant_without_state() -> None:
     catalog = ServingCatalog.open()
     result = invoke_operation(


### PR DESCRIPTION
## Problem

Agents inspect operation contracts before invoking them, but nineteen installed operations had no invocation example. Several shared canonical input values also kept their decisive representation rules only in Pydantic validators, so an agent could learn the constraint only after a rejected request.

## Solution

- Publish one request-valid invocation example for every served operation, including finite-field, SAT/SMT, Lean, triangulation, syzygy, poset, and rational-linear operations.
- Add Pydantic JSON-Schema descriptions and examples for canonical rationals, canonical CNF, and finite-field presentations.
- Make `math.run` and the tool reference use examples when present and otherwise direct agents to schema field guidance.
- Document why examples are part of the agent-facing contract, and enforce the catalog-wide request-validity invariant in the serving-catalog unit tests.

Validation semantics and mathematical operation behavior are unchanged.

## Testing

- `make check` — 477 passed
- `make test-mcp` — 13 passed
- `make docs-linkcheck`

## Trust & Compatibility Impact

Operation inspection and generated request schemas gain descriptions and examples. Existing operation IDs, request validation, canonicalization rules, and result types are unchanged.

## Architecture Budget

No operations, providers, runtime services, or shared execution abstractions were added. Examples remain static metadata next to their domain-owned operation declarations.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] New ordinary operations fit the documented operation budget (not applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable)