### PR TITLE
docs: add public operation preflight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Read the [documentation home](docs/index.md), the
 [product model](docs/explanation/product-blueprint.md), and the
 [testing strategy](docs/reference/testing-strategy.md).
 Use the installed catalog and current references for present tool membership.
+Before proposing a public operation, follow the
+[operation preflight](docs/reference/domain-operation-library.md#operation-preflight).
 
 ## Contributor quick path
 

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -59,3 +59,24 @@ directly. `smt.solve` accepts one bounded QF SMT-LIB query. `lean.check` accepts
 one bounded source snippet and returns elaboration diagnostics after a one-shot
 process invocation. None of these operations consumes or produces a stored
 reference.
+
+## Operation preflight
+
+Do not add a public operation until its stated mathematical claim has a bounded,
+appropriate backend method. A heuristic or approximation may be useful only when
+its result contract states that limited scope. It must not return a negative
+decision, exact invariant, or optimum that the method cannot establish.
+
+Before declaring the operation, provide tests for:
+
+- a known-answer input and its claimed mathematical result;
+- a boundary or degenerate input, including valid empty, zero, singleton, or
+  identity values where the domain admits them;
+- an adversarial input that distinguishes the stated semantics from a tempting
+  weaker algorithm; and
+- request validation proving schema-valid inputs reach the backend without a
+  representation or shape failure.
+
+If no maintained bounded method can support the public claim, do not expose the
+operation yet. A backend import is not evidence that its result has the desired
+mathematical semantics.


### PR DESCRIPTION
## Problem

A maintained backend import is not enough to justify a public mathematical operation. Recent review findings included approximations presented as exact conclusions, result contracts that omitted valid boundary cases, and schema-valid inputs that reached backend failures.

## Solution

Add a concise operation preflight to the domain-operation reference and link to it from `CONTRIBUTING.md`. It requires an appropriate bounded method and tests for known-answer, boundary, adversarial, and request-to-backend cases before an operation is declared.

## Testing

- `make docs-linkcheck`

## Trust & Compatibility Impact

Documentation only.

## Architecture Budget

No runtime or operation changes.

## Checklist

- [x] `make check` passes (not applicable: documentation-only change)
- [x] Explicitly relevant specialist validation is listed above
- [x] New ordinary operations fit the documented operation budget (not applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable)