### PR TITLE
fix(math): preserve exact contracts in new math operations

### DIFF
--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -84,7 +84,10 @@ Before declaring the operation, provide tests for:
 - a boundary or degenerate input, including valid empty, zero, singleton, or
   identity values where the domain admits them;
 - an adversarial input that distinguishes the stated semantics from a tempting
-  weaker algorithm; and
+  weaker algorithm;
+- a public-operation assertion that the returned value satisfies its defining
+  mathematical invariant or witness, rather than merely parsing or reaching a
+  backend; and
 - request validation proving schema-valid inputs reach the backend without a
   representation or shape failure.
 

--- a/docs/reference/operations/topology/recurrences-and-generating-series.md
+++ b/docs/reference/operations/topology/recurrences-and-generating-series.md
@@ -14,3 +14,8 @@ They calculate finite typed prefixes, terms, and residuals under the operation
 bounds. A finite prefix is not a claim about an infinite series beyond the
 specified scope, and Jacobian does not retain the recurrence or generated
 table.
+
+`sequence.recurrence.closed_form.compute` returns a SymPy expression only for
+characteristic polynomials of degree at most four. For exact bounded terms of a
+higher-order constant-coefficient recurrence, use
+`combinatorics.recurrence.linear.evaluate`.

--- a/src/jacobian/contracts/recurrence_solving.py
+++ b/src/jacobian/contracts/recurrence_solving.py
@@ -26,18 +26,36 @@ class RecurrenceFindRequest(ContractModel):
 
 
 class RecurrenceFindResult(ContractModel):
-    """The minimal linear recurrence coefficients."""
+    """A fitted recurrence or an explicit finite-prefix missing outcome."""
 
     coefficients: tuple[str, ...] = Field(max_length=255)
     order: int = Field(ge=0, le=255)
+    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
     method: Literal["RATIONAL_INTERPOLATION"] = "RATIONAL_INTERPOLATION"
+
+    @model_validator(mode="after")
+    def require_status_consistent_coefficients(self) -> Self:
+        if self.status == "FOUND":
+            if self.order == 0 or len(self.coefficients) != self.order:
+                raise ValueError(
+                    "a found recurrence must have one coefficient per order"
+                )
+        elif self.order != 0 or self.coefficients:
+            raise ValueError(
+                "a missing recurrence must have zero order and no coefficients"
+            )
+        return self
 
 
 class ClosedFormRequest(ContractModel):
-    """Compute the closed-form solution of a linear recurrence."""
+    """Compute a SymPy-expression closed form for a recurrence of degree at most four."""
 
-    characteristic_coefficients: tuple[str, ...] = Field(min_length=1, max_length=64)
-    initial_values: tuple[str, ...] = Field(min_length=1, max_length=64)
+    characteristic_coefficients: tuple[str, ...] = Field(
+        min_length=1,
+        max_length=5,
+        description="Characteristic polynomial coefficients in descending order, with degree at most four.",
+    )
+    initial_values: tuple[str, ...] = Field(min_length=1, max_length=4)
 
     @model_validator(mode="after")
     def require_initial_values_for_order(self) -> Self:

--- a/src/jacobian/contracts/root_isolation.py
+++ b/src/jacobian/contracts/root_isolation.py
@@ -23,7 +23,7 @@ class UnivariatePolynomialRequest(ContractModel):
 
 
 class RootIsolationResult(ContractModel):
-    """Real roots with rational isolating intervals."""
+    """Real roots with rational intervals; rational roots use a singleton."""
 
     roots: tuple[tuple[CanonicalRational, CanonicalRational], ...]
     multiplicities: tuple[int, ...]
@@ -34,9 +34,9 @@ class RootIsolationResult(ContractModel):
         if len(self.roots) != len(self.multiplicities):
             raise ValueError("roots and multiplicities must have the same length")
         if any(
-            lower.as_fraction() >= upper.as_fraction() for lower, upper in self.roots
+            lower.as_fraction() > upper.as_fraction() for lower, upper in self.roots
         ):
-            raise ValueError("isolating intervals must have lower < upper")
+            raise ValueError("isolating intervals must have lower <= upper")
         if any(multiplicity < 1 for multiplicity in self.multiplicities):
             raise ValueError("root multiplicities must be positive")
         return self

--- a/src/jacobian/domains/code_theory/math_tools.py
+++ b/src/jacobian/domains/code_theory/math_tools.py
@@ -64,7 +64,7 @@ CODE_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     ct_operation(
         "code.weight_distribution.compute",
         "Compute the weight distribution of a linear code",
-        "Compute the weight distribution by exact enumeration over a bounded prime field.",
+        "Compute the distribution of distinct codeword weights by exact enumeration over a bounded prime field.",
         LinearCodeRequest,
         WeightDistributionResult,
         compute_weight_dist,

--- a/src/jacobian/domains/markov_chain/math_tools.py
+++ b/src/jacobian/domains/markov_chain/math_tools.py
@@ -70,7 +70,7 @@ MARKOV_CHAIN_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     mc_operation(
         "probability.markov_chain.ergodic.decide",
         "Decide whether a Markov chain is ergodic",
-        "Decide whether a finite Markov chain is ergodic (irreducible and aperiodic) using SymPy.",
+        "Decide whether a finite Markov chain is ergodic (irreducible and aperiodic); aperiodicity is checked in every communicating class.",
         TransitionMatrixRequest,
         ErgodicDecisionResult,
         compute_ergodic_decision,

--- a/src/jacobian/domains/recurrence_solving/math_tools.py
+++ b/src/jacobian/domains/recurrence_solving/math_tools.py
@@ -47,7 +47,7 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     rs_operation(
         "sequence.recurrence.find",
         "Find the minimal linear recurrence of a sequence",
-        "Find the lowest-order homogeneous recurrence that exactly fits the supplied finite rational sequence.",
+        "Find the lowest-order non-vacuous homogeneous recurrence that exactly fits the supplied finite rational sequence, or report NO_FITTING_RECURRENCE.",
         RecurrenceFindRequest,
         RecurrenceFindResult,
         compute_find_recurrence,
@@ -65,7 +65,7 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     rs_operation(
         "sequence.recurrence.closed_form.compute",
         "Compute the closed-form of a linear recurrence",
-        "Compute the closed form from a characteristic polynomial and exactly one initial value per degree, including repeated roots.",
+        "Compute a SymPy-expression closed form for a characteristic polynomial of degree at most four and exactly one initial value per degree, including repeated roots.",
         ClosedFormRequest,
         ClosedFormResult,
         compute_closed_form,

--- a/src/jacobian/domains/recurrence_solving/operations.py
+++ b/src/jacobian/domains/recurrence_solving/operations.py
@@ -16,6 +16,7 @@ def compute_find_recurrence(request: RecurrenceFindRequest) -> RecurrenceFindRes
     return RecurrenceFindResult(
         coefficients=result["coefficients"],
         order=result["order"],
+        status=result["status"],
     )
 
 

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -12,9 +12,13 @@ def _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-def]
 
     n_rows = len(generator_matrix)
     generator = nmod_mat(generator_matrix, field_order)
+    seen = set()
     for coeffs in product(range(field_order), repeat=n_rows):
         coefficient_row = nmod_mat([list(coeffs)], field_order)
-        yield tuple((coefficient_row * generator).tolist()[0])
+        codeword = tuple((coefficient_row * generator).tolist()[0])
+        if codeword not in seen:
+            seen.add(codeword)
+            yield codeword
 
 
 def minimum_distance(generator_matrix, field_order):  # type: ignore[no-untyped-def]

--- a/src/jacobian/math/markov_chain/operations.py
+++ b/src/jacobian/math/markov_chain/operations.py
@@ -38,5 +38,8 @@ def ergodic_properties(matrix):  # type: ignore[no-untyped-def]
         if value["num"] != "0"
     )
     irreducible = nx.is_strongly_connected(graph)
-    aperiodic = irreducible and nx.is_aperiodic(graph)
+    aperiodic = all(
+        nx.is_aperiodic(graph.subgraph(component))
+        for component in nx.strongly_connected_components(graph)
+    )
     return irreducible, aperiodic

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -26,27 +26,33 @@ def find_recurrence(sequence):  # type: ignore[no-untyped-def]
         return {
             "coefficients": tuple(str(value) for value in solution),
             "order": order,
+            "status": "FOUND",
         }
-    return {"coefficients": (), "order": 0}
+    return {
+        "coefficients": (),
+        "order": 0,
+        "status": "NO_FITTING_RECURRENCE",
+    }
 
 
 def closed_form(char_coeffs, initial_values):  # type: ignore[no-untyped-def]
     import sympy
 
     x = sympy.Symbol("x")
-    n = sympy.Symbol("n")
+    n = sympy.Symbol("n", integer=True, nonnegative=True)
     char_poly_coeffs = [sympy.Rational(c) for c in char_coeffs]
     char_poly = sum(
         c * x ** (len(char_poly_coeffs) - 1 - i) for i, c in enumerate(char_poly_coeffs)
     )
-    roots = sympy.roots(char_poly, x)
-    if sum(roots.values()) != len(initial_values):
-        raise ValueError("characteristic polynomial degree must match initial values")
-    basis = [
+    roots = sympy.Poly(char_poly, x).all_roots()
+    zero_root_multiplicity = sum(root == 0 for root in roots)
+    nonzero_roots = list(dict.fromkeys(root for root in roots if root != 0))
+    basis = [sympy.KroneckerDelta(index, n) for index in range(zero_root_multiplicity)]
+    basis.extend(
         n**power * root**n
-        for root, multiplicity in roots.items()
-        for power in range(multiplicity)
-    ]
+        for root in nonzero_roots
+        for power in range(roots.count(root))
+    )
     init = [sympy.Rational(v) for v in initial_values]
     a = sympy.Matrix([[term.subs(n, i) for term in basis] for i in range(len(basis))])
     b = sympy.Matrix(init)

--- a/tests/domain/algebra/test_exact_algebraic_operation_regressions.py
+++ b/tests/domain/algebra/test_exact_algebraic_operation_regressions.py
@@ -46,6 +46,24 @@ def test_root_isolation_returns_intervals_aligned_with_multiplicities() -> None:
     )
 
 
+def test_root_isolation_accepts_sympy_singleton_interval_for_a_rational_root() -> None:
+    result = compute_root_isolation(
+        UnivariatePolynomialRequest.model_validate(
+            {
+                "coefficients_descending": [
+                    {"num": "1", "den": "1"},
+                    {"num": "-1", "den": "1"},
+                ]
+            }
+        )
+    )
+
+    assert tuple(
+        (lower.num, lower.den, upper.num, upper.den) for lower, upper in result.roots
+    ) == (("1", "1", "1", "1"),)
+    assert result.multiplicities == (1,)
+
+
 def test_algebraic_comparison_parses_canonical_interval_endpoints() -> None:
     result = compute_algebraic_compare(
         AlgebraicCompareRequest.model_validate(
@@ -111,6 +129,14 @@ def test_recurrence_finder_solves_for_coefficients() -> None:
     assert result.coefficients == ("2",)
 
 
+def test_recurrence_finder_reports_a_missing_nonvacuous_fit() -> None:
+    result = compute_find_recurrence(RecurrenceFindRequest(sequence=("0", "1")))
+
+    assert result.status == "NO_FITTING_RECURRENCE"
+    assert result.order == 0
+    assert result.coefficients == ()
+
+
 def test_repeated_root_closed_form_preserves_polynomial_factor() -> None:
     result = compute_closed_form(
         ClosedFormRequest(
@@ -120,6 +146,27 @@ def test_repeated_root_closed_form_preserves_polynomial_factor() -> None:
     )
 
     assert result.expression == "3*n + 2"
+
+
+def test_closed_form_handles_repeated_zero_characteristic_roots() -> None:
+    result = compute_closed_form(
+        ClosedFormRequest(
+            characteristic_coefficients=("1", "0", "0"),
+            initial_values=("2", "5"),
+        )
+    )
+
+    assert result.expression == "2*KroneckerDelta(0, n) + 5*KroneckerDelta(1, n)"
+
+
+def test_closed_form_contract_rejects_characteristic_polynomials_above_degree_four() -> (
+    None
+):
+    with pytest.raises(ValidationError):
+        ClosedFormRequest(
+            characteristic_coefficients=("1", "0", "0", "0", "-1", "-1"),
+            initial_values=("0", "0", "0", "0", "0"),
+        )
 
 
 def test_closed_form_contract_requires_every_initial_value() -> None:

--- a/tests/domain/code_theory/test_exact_code_enumeration.py
+++ b/tests/domain/code_theory/test_exact_code_enumeration.py
@@ -17,6 +17,12 @@ def test_prime_field_code_enumeration_uses_the_declared_matrix() -> None:
     assert compute_weight_dist(request).weights == ((0, 1), (2, 1))
 
 
+def test_code_weight_distribution_counts_distinct_words_for_dependent_rows() -> None:
+    request = LinearCodeRequest(field_order=2, generator_matrix=((1,), (1,)))
+
+    assert compute_weight_dist(request).weights == ((0, 1), (1, 1))
+
+
 def test_code_contract_rejects_nonprime_fields_and_unbounded_enumeration() -> None:
     with pytest.raises(ValidationError, match="prime"):
         LinearCodeRequest(field_order=4, generator_matrix=((1,),))

--- a/tests/domain/probability/test_markov_chain_regressions.py
+++ b/tests/domain/probability/test_markov_chain_regressions.py
@@ -37,6 +37,29 @@ def test_ergodicity_uses_irreducibility_and_period_not_square_positivity() -> No
     assert result.is_ergodic is True
 
 
+def test_aperiodicity_is_checked_for_each_communicating_class() -> None:
+    result = compute_ergodic_decision(
+        TransitionMatrixRequest.model_validate(
+            {
+                "matrix": [
+                    [
+                        {"num": "1", "den": "1"},
+                        {"num": "0", "den": "1"},
+                    ],
+                    [
+                        {"num": "0", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                ]
+            }
+        )
+    )
+
+    assert result.is_irreducible is False
+    assert result.is_aperiodic is True
+    assert result.is_ergodic is False
+
+
 @pytest.mark.parametrize(
     "matrix",
     [


### PR DESCRIPTION
## Problem

Follow-up review of #1683 found valid inputs that either failed at the result boundary or overstated the operation claim: rational roots used SymPy singleton intervals; dependent generator rows counted coefficient vectors rather than codewords; recurrence search represented a missing finite-prefix fit as order zero; repeated zero roots could not form a closed expression; generic degree-five characteristic polynomials could not reliably produce the promised SymPy expression; and reducible chains reported aperiodicity only when irreducible.

## Solution

- Accept singleton intervals for rational roots and count distinct generated codewords.
- Return `NO_FITTING_RECURRENCE` when no non-vacuous homogeneous recurrence fits the supplied finite prefix.
- Represent zero-root contributions with finite-prefix Kronecker deltas.
- Limit the expression-string closed-form operation to characteristic polynomials of degree at most four. Generic higher-degree polynomials need not admit a practical symbolic expression even though their roots have exact `CRootOf` representations.
- Evaluate aperiodicity in every communicating class, while ergodicity remains the conjunction of irreducibility and aperiodicity.
- Require operation tests to assert a returned value’s defining invariant or witness, not only parsing or backend execution.

## Testing

- `make check` — 477 passed
- `make test-domain` — 86 passed
- `make test-mcp` — 13 passed
- `make docs-linkcheck` — passed

## Trust & Compatibility Impact

`sequence.recurrence.find` now exposes an explicit missing-result status. `sequence.recurrence.closed_form.compute` rejects characteristic polynomials above degree four; this narrows a previously unreliable expression-string contract. No verification kernel, artifact format, or retained state changes.

## Architecture Budget

No new operation or shared abstraction. The existing domain adapters continue to call maintained SymPy, FLINT, and NetworkX backends.

## Checklist

- [x] `make check` passes
- [x] Explicit specialist validation: `make test-domain`; `make test-mcp`
- [x] No Harbor task or verifier change
- [x] No new ordinary operation or shared abstraction