### PR TITLE
Add bounded graph isomorphism decision with explicit mapping certificate (#1655)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -16,6 +16,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.graph_coloring_ops", "graph_coloring_operations"),
     ("jacobian.domains.graph_spectral", "graph_spectral_operations"),
     ("jacobian.domains.graph_flow", "graph_flow_operations"),
+    ("jacobian.domains.graph_isomorphism", "graph_isomorphism_operations"),
     ("jacobian.domains.root_isolation", "root_isolation_operations"),
     ("jacobian.domains.recurrence_solving", "recurrence_solving_operations"),
     ("jacobian.domains.code_theory", "code_theory_operations"),

--- a/src/jacobian/contracts/graph_isomorphism.py
+++ b/src/jacobian/contracts/graph_isomorphism.py
@@ -1,0 +1,70 @@
+"""Typed wire contracts for graph isomorphism decision operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+
+class UndirectedGraph(ContractModel):
+    """A simple undirected graph given by a vertex count and edge list.
+
+    Vertices are the integers ``0..vertex_count-1``.  Edges are unordered
+    pairs with no self-loops or duplicates.
+    """
+
+    vertex_count: int = Field(ge=1, le=32)
+    edges: tuple[tuple[int, int], ...] = Field(max_length=512)
+
+    @model_validator(mode="after")
+    def require_simple_graph(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for u, v in self.edges:
+            if not (0 <= u < self.vertex_count and 0 <= v < self.vertex_count):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            if u == v:
+                raise ValueError("a simple graph cannot contain self-loops")
+            key = (min(u, v), max(u, v))
+            if key in seen:
+                raise ValueError("a simple graph cannot contain duplicate edges")
+            seen.add(key)
+        return self
+
+
+class GraphIsomorphismRequest(ContractModel):
+    """Two simple undirected graphs to compare for isomorphism."""
+
+    graph_a: UndirectedGraph
+    graph_b: UndirectedGraph
+
+    @model_validator(mode="after")
+    def require_matching_vertex_counts(self) -> Self:
+        if self.graph_a.vertex_count != self.graph_b.vertex_count:
+            raise ValueError(
+                "graph_a and graph_b must have the same vertex count"
+            )
+        return self
+
+
+class GraphIsomorphismResult(ContractModel):
+    """Decision and explicit certificate for a graph isomorphism query.
+
+    When ``decision`` is ``ISOMORPHIC`` the optional ``mapping`` is a vertex
+    bijection from the first graph to the second graph.  When ``decision`` is
+    ``NOT_ISOMORPHIC`` the ``mapping`` is ``None``.
+    """
+
+    decision: Literal["ISOMORPHIC", "NOT_ISOMORPHIC"]
+    mapping: tuple[tuple[int, int], ...] | None = None
+    convention: Literal["NETWORKX_IS_ISOMORPHIC"] = "NETWORKX_IS_ISOMORPHIC"
+
+    @model_validator(mode="after")
+    def require_mapping_when_isomorphic(self) -> Self:
+        if self.decision == "ISOMORPHIC" and self.mapping is None:
+            raise ValueError("an isomorphic decision must carry a mapping")
+        if self.decision == "NOT_ISOMORPHIC" and self.mapping is not None:
+            raise ValueError("a non-isomorphic decision must not carry a mapping")
+        return self

--- a/src/jacobian/domains/graph_isomorphism/__init__.py
+++ b/src/jacobian/domains/graph_isomorphism/__init__.py
@@ -1,0 +1,18 @@
+"""Exact declared graph isomorphism operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["graph_isomorphism_operations"]
+
+
+def graph_isomorphism_operations() -> MathTools:
+    from jacobian.domains.graph_isomorphism.math_tools import (
+        GRAPH_ISOMORPHISM_OPERATIONS,
+    )
+
+    return GRAPH_ISOMORPHISM_OPERATIONS

--- a/src/jacobian/domains/graph_isomorphism/math_tools.py
+++ b/src/jacobian/domains/graph_isomorphism/math_tools.py
@@ -1,0 +1,79 @@
+"""Exact graph isomorphism operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.graph_isomorphism import (
+    GraphIsomorphismRequest,
+    GraphIsomorphismResult,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.graph_isomorphism.operations import (
+    compute_isomorphism_decision,
+)
+from jacobian.math_tools import MathTool
+
+
+def graph_isomorphism_operation[
+    RequestT: ContractModel,
+    ResultT: ContractModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+GRAPH_ISOMORPHISM_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    graph_isomorphism_operation(
+        "graph.isomorphism.decide",
+        "Decide graph isomorphism with explicit mapping certificate",
+        "Decide whether two simple undirected graphs are isomorphic using "
+        "NetworkX. Returns ISOMORPHIC with an explicit vertex mapping "
+        "certificate, or NOT_ISOMORPHIC.",
+        GraphIsomorphismRequest,
+        GraphIsomorphismResult,
+        compute_isomorphism_decision,
+        "graph",
+        "isomorphism",
+        "structure",
+        "compare",
+        "decision",
+        "exact",
+        examples=(
+            example(
+                "path_graph_isomorphic",
+                "Decide isomorphism of two 3-vertex path graphs.",
+                {
+                    "graph_a": {
+                        "vertex_count": 3,
+                        "edges": [[0, 1], [1, 2]],
+                    },
+                    "graph_b": {
+                        "vertex_count": 3,
+                        "edges": [[0, 1], [1, 2]],
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/graph_isomorphism/operations.py
+++ b/src/jacobian/domains/graph_isomorphism/operations.py
@@ -1,0 +1,44 @@
+"""Domain adapter for bounded graph isomorphism decision operations."""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from jacobian.contracts.graph_isomorphism import (
+    GraphIsomorphismRequest,
+    GraphIsomorphismResult,
+)
+
+
+def _build_graph(vertex_count: int, edges: tuple[tuple[int, int], ...]) -> nx.Graph:
+    graph = nx.Graph()
+    graph.add_nodes_from(range(vertex_count))
+    graph.add_edges_from(edges)
+    return graph
+
+
+def compute_isomorphism_decision(
+    request: GraphIsomorphismRequest,
+) -> GraphIsomorphismResult:
+    """Decide graph isomorphism and return an explicit mapping certificate.
+
+    Uses NetworkX's :func:`networkx.is_isomorphic` for the decision and
+    :class:`networkx.algorithms.isomorphism.GraphMatcher` to extract one
+    explicit vertex bijection when the graphs are isomorphic.  The caller
+    can independently verify the returned mapping.
+    """
+    graph_a = _build_graph(request.graph_a.vertex_count, request.graph_a.edges)
+    graph_b = _build_graph(request.graph_b.vertex_count, request.graph_b.edges)
+
+    if not nx.is_isomorphic(graph_a, graph_b):
+        return GraphIsomorphismResult(decision="NOT_ISOMORPHIC")
+
+    matcher = nx.algorithms.isomorphism.GraphMatcher(graph_a, graph_b)
+    # GraphMatcher is lazily evaluated; is_isomorphic runs the search.
+    # When it returns True, mapping() yields at least one mapping.
+    matcher.is_isomorphic()
+    mapping = matcher.mapping
+    mapping_tuple = tuple(
+        sorted((source, target) for source, target in mapping.items())
+    )
+    return GraphIsomorphismResult(decision="ISOMORPHIC", mapping=mapping_tuple)

--- a/tests/domain/graph/test_graph_isomorphism.py
+++ b/tests/domain/graph/test_graph_isomorphism.py
@@ -1,0 +1,235 @@
+"""Tests for the bounded graph isomorphism decision operation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.graph_isomorphism import (
+    GraphIsomorphismRequest,
+    GraphIsomorphismResult,
+)
+from jacobian.domains.graph_isomorphism.operations import (
+    compute_isomorphism_decision,
+)
+from jacobian.domains.graph_isomorphism.math_tools import (
+    GRAPH_ISOMORPHISM_OPERATIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Empty graph on 3 isolated vertices.
+EMPTY_3 = {"vertex_count": 3, "edges": []}
+
+# Path graph P3.
+P3_A = {"vertex_count": 3, "edges": [[0, 1], [1, 2]]}
+# Same path P3 with relabelled vertices.
+P3_B = {"vertex_count": 3, "edges": [[0, 2], [2, 1]]}
+
+# Path graph P4.
+P4_A = {"vertex_count": 4, "edges": [[0, 1], [1, 2], [2, 3]]}
+P4_B = {"vertex_count": 4, "edges": [[0, 3], [3, 1], [1, 2]]}
+
+# Cycle graph C4.
+C4_A = {"vertex_count": 4, "edges": [[0, 1], [1, 2], [2, 3], [3, 0]]}
+C4_B = {"vertex_count": 4, "edges": [[0, 1], [1, 3], [3, 2], [2, 0]]}
+
+# Complete graph K3.
+K3_A = {"vertex_count": 3, "edges": [[0, 1], [0, 2], [1, 2]]}
+K3_B = {"vertex_count": 3, "edges": [[0, 2], [1, 2], [0, 1]]}
+
+# Complete graph K4.
+K4_A = {
+    "vertex_count": 4,
+    "edges": [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
+}
+
+# C6: a single 6-cycle (degree sequence all 2).
+C6 = {
+    "vertex_count": 6,
+    "edges": [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0]],
+}
+
+# 2 x K3: two disjoint triangles (degree sequence all 2, not isomorphic to C6).
+TWO_K3 = {
+    "vertex_count": 6,
+    "edges": [[0, 1], [1, 2], [0, 2], [3, 4], [4, 5], [3, 5]],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _decide(graph_a: dict, graph_b: dict) -> GraphIsomorphismResult:
+    request = GraphIsomorphismRequest.model_validate(
+        {"graph_a": graph_a, "graph_b": graph_b}
+    )
+    return compute_isomorphism_decision(request)
+
+
+def _assert_valid_mapping(
+    result: GraphIsomorphismResult,
+    vertex_count: int,
+) -> None:
+    """Assert the mapping is a valid bijection covering every vertex."""
+    assert result.mapping is not None
+    sources = [pair[0] for pair in result.mapping]
+    targets = [pair[1] for pair in result.mapping]
+    assert sorted(sources) == list(range(vertex_count))
+    assert sorted(targets) == list(range(vertex_count))
+
+
+# ---------------------------------------------------------------------------
+# Decision tests
+# ---------------------------------------------------------------------------
+
+class TestIsomorphismDecision:
+    def test_empty_graphs_are_isomorphic(self) -> None:
+        result = _decide(EMPTY_3, EMPTY_3)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 3)
+
+    def test_path_graph_isomorphic(self) -> None:
+        result = _decide(P3_A, P3_B)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 3)
+
+    def test_path_p4_isomorphic(self) -> None:
+        result = _decide(P4_A, P4_B)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 4)
+
+    def test_cycle_c4_isomorphic(self) -> None:
+        result = _decide(C4_A, C4_B)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 4)
+
+    def test_complete_k3_isomorphic(self) -> None:
+        result = _decide(K3_A, K3_B)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 3)
+
+    def test_complete_k4_isomorphic(self) -> None:
+        result = _decide(K4_A, K4_A)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+        _assert_valid_mapping(result, 4)
+
+
+# ---------------------------------------------------------------------------
+# Non-isomorphic cases
+# ---------------------------------------------------------------------------
+
+class TestNonIsomorphic:
+    def test_empty_vs_path_not_isomorphic(self) -> None:
+        result = _decide(EMPTY_3, P3_A)
+        assert result.decision == "NOT_ISOMORPHIC"
+        assert result.mapping is None
+
+    def test_path_vs_cycle_not_isomorphic(self) -> None:
+        # P4 vs C4 — same vertex count, different edge counts.
+        result = _decide(P4_A, C4_A)
+        assert result.decision == "NOT_ISOMORPHIC"
+        assert result.mapping is None
+
+    def test_same_degree_sequence_non_isomorphic(self) -> None:
+        # C6 (one 6-cycle) vs 2 x K3 (two disjoint triangles) both have
+        # degree sequence (2, 2, 2, 2, 2, 2) but are not isomorphic.
+        result = _decide(C6, TWO_K3)
+        assert result.decision == "NOT_ISOMORPHIC"
+        assert result.mapping is None
+
+
+# ---------------------------------------------------------------------------
+# Certificate correctness
+# ---------------------------------------------------------------------------
+
+class TestCertificateCorrectness:
+    def test_mapping_preserves_edges(self) -> None:
+        """The mapped vertices must preserve adjacency of the source graph."""
+        result = _decide(P4_A, P4_B)
+        assert result.decision == "ISOMORPHIC"
+        assert result.mapping is not None
+
+        mapping = dict(result.mapping)
+        for u, v in P4_A["edges"]:
+            mapped_u, mapped_v = mapping[u], mapping[v]
+            expected = tuple(sorted((mapped_u, mapped_v)))
+            assert expected in P4_B["edges"] or tuple(
+                sorted((mapped_u, mapped_v))
+            ) in [tuple(sorted(e)) for e in P4_B["edges"]]
+
+    def test_mapping_is_a_bijection(self) -> None:
+        result = _decide(C4_A, C4_B)
+        assert result.decision == "ISOMORPHIC"
+        _assert_valid_mapping(result, 4)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed validation
+# ---------------------------------------------------------------------------
+
+class TestFailClosed:
+    def test_mismatched_vertex_counts_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="same vertex count"):
+            GraphIsomorphismRequest.model_validate(
+                {
+                    "graph_a": P3_A,
+                    "graph_b": {"vertex_count": 4, "edges": [[0, 1], [1, 2], [2, 3]]},
+                }
+            )
+
+    def test_self_loop_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="self-loops"):
+            GraphIsomorphismRequest.model_validate(
+                {
+                    "graph_a": {"vertex_count": 3, "edges": [[0, 0], [1, 2]]},
+                    "graph_b": P3_A,
+                }
+            )
+
+    def test_duplicate_edge_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="duplicate edges"):
+            GraphIsomorphismRequest.model_validate(
+                {
+                    "graph_a": {
+                        "vertex_count": 3,
+                        "edges": [[0, 1], [1, 0], [1, 2]],
+                    },
+                    "graph_b": P3_A,
+                }
+            )
+
+    def test_out_of_range_vertex_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="edge vertices must be in"):
+            GraphIsomorphismRequest.model_validate(
+                {
+                    "graph_a": {"vertex_count": 3, "edges": [[0, 3]]},
+                    "graph_b": P3_A,
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Math tool registration and discovery
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_operation_is_registered(self) -> None:
+        op_ids = [op.operation_id for op in GRAPH_ISOMORPHISM_OPERATIONS]
+        assert "graph.isomorphism.decide" in op_ids
+
+    def test_operation_has_tags(self) -> None:
+        op = GRAPH_ISOMORPHISM_OPERATIONS[0]
+        assert "graph" in op.tags
+        assert "isomorphism" in op.tags
+        assert "exact" in op.tags


### PR DESCRIPTION
## Summary

Adds a new atomic composable math operation `graph.isomorphism.decide` that decides whether two bounded simple undirected graphs are isomorphic and returns an explicit vertex-mapping certificate when they are. Closes #1655.

## Implementation

- **Decision:** Uses NetworkX `is_isomorphic` for the isomorphism check — no hand-rolled search.
- **Certificate:** When the graphs are isomorphic, extracts the explicit vertex bijection via NetworkX `GraphMatcher.mapping`. The mapping can be independently verified by the existing `graph.isomorphism.verify` checker.
- **Result:** Returns `ISOMORPHIC` with a `mapping` (tuple of `(source, target)` pairs) or `NOT_ISOMORPHIC` with no mapping. The result model enforces this invariant: an `ISOMORPHIC` decision must carry a mapping and a `NOT_ISOMORPHIC` decision must not.
- **Fail-closed:** Mismatched vertex counts, self-loops, duplicate edges, and out-of-range vertices are rejected at the contract layer.

## Files

| File | Description |
| --- | --- |
| `src/jacobian/contracts/graph_isomorphism.py` | `UndirectedGraph`, `GraphIsomorphismRequest`, `GraphIsomorphismResult` Pydantic models |
| `src/jacobian/domains/graph_isomorphism/__init__.py` | Factory function `graph_isomorphism_operations()` |
| `src/jacobian/domains/graph_isomorphism/operations.py` | `compute_isomorphism_decision` using `nx.is_isomorphic` + `GraphMatcher` |
| `src/jacobian/domains/graph_isomorphism/math_tools.py` | `graph.isomorphism.decide` `MathTool` declaration |
| `src/jacobian/builtin_operation_modules.py` | Registered the new domain |
| `tests/domain/graph/test_graph_isomorphism.py` | 17 tests |

## Tests

17 tests covering:
- **Isomorphic fixtures:** path (P3, P4), cycle (C4), complete (K3, K4), empty graph
- **Non-isomorphic fixtures:** empty-vs-path, path-vs-cycle, same-degree-sequence (C6 vs 2×K3 — both regular degree sequence `(2,2,2,2,2,2)` but not isomorphic)
- **Certificate correctness:** mapping is a bijection, mapping preserves adjacency
- **Fail-closed validation:** mismatched vertex counts, self-loops, duplicate edges, out-of-range vertices

All 17 tests pass. The operation is discoverable via `math.find` (ranks #1 for "graph isomorphism") and executable via `math.run`.