### PR TITLE
feat(math): add bounded exact code covering radius (#1675)

### DIFF
--- a/src/jacobian/contracts/code_theory.py
+++ b/src/jacobian/contracts/code_theory.py
@@ -8,6 +8,72 @@ from pydantic import Field, model_validator
 
 from jacobian.contracts.base import ContractModel
 
+MAX_EXACT_CODEWORDS = 65_536
+MAX_COVERING_RADIUS_STATES = 65_536
+MAX_COVERING_RADIUS_TRANSITIONS = 2_000_000
+
+
+def _validate_prime_field_matrix(
+    field_order: int,
+    generator_matrix: tuple[tuple[int, ...], ...],
+) -> int:
+    from sympy import isprime
+
+    if not isprime(field_order):
+        raise ValueError("field_order must be prime for this prime-field operation")
+    width = len(generator_matrix[0])
+    if width == 0 or width > 256:
+        raise ValueError("generator rows must have between one and 256 entries")
+    if any(len(row) != width for row in generator_matrix):
+        raise ValueError("generator matrix rows must have equal length")
+    if any(
+        not 0 <= entry < field_order
+        for row in generator_matrix
+        for entry in row
+    ):
+        raise ValueError("generator entries must be canonical field residues")
+    return width
+
+
+def _matrix_rank_mod_prime(
+    matrix: tuple[tuple[int, ...], ...],
+    field_order: int,
+) -> int:
+    rows = [list(row) for row in matrix]
+    row_count = len(rows)
+    column_count = len(rows[0])
+    pivot_row = 0
+    for column in range(column_count):
+        pivot = next(
+            (
+                index
+                for index in range(pivot_row, row_count)
+                if rows[index][column] % field_order != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            continue
+        rows[pivot_row], rows[pivot] = rows[pivot], rows[pivot_row]
+        inverse = pow(rows[pivot_row][column] % field_order, -1, field_order)
+        rows[pivot_row] = [
+            value * inverse % field_order for value in rows[pivot_row]
+        ]
+        for index, row in enumerate(rows):
+            if index == pivot_row:
+                continue
+            factor = row[column] % field_order
+            if factor == 0:
+                continue
+            rows[index] = [
+                (left - factor * right) % field_order
+                for left, right in zip(row, rows[pivot_row], strict=True)
+            ]
+        pivot_row += 1
+        if pivot_row == row_count:
+            break
+    return pivot_row
+
 
 class LinearCodeRequest(ContractModel):
     """A linear code given by its generator matrix over one bounded prime field."""
@@ -17,22 +83,8 @@ class LinearCodeRequest(ContractModel):
 
     @model_validator(mode="after")
     def require_bounded_prime_field_matrix(self) -> Self:
-        from sympy import isprime
-
-        if not isprime(self.field_order):
-            raise ValueError("field_order must be prime for this prime-field operation")
-        width = len(self.generator_matrix[0])
-        if width == 0 or width > 256:
-            raise ValueError("generator rows must have between one and 256 entries")
-        if any(len(row) != width for row in self.generator_matrix):
-            raise ValueError("generator matrix rows must have equal length")
-        if any(
-            not 0 <= entry < self.field_order
-            for row in self.generator_matrix
-            for entry in row
-        ):
-            raise ValueError("generator entries must be canonical field residues")
-        if self.field_order ** len(self.generator_matrix) > 65_536:
+        _validate_prime_field_matrix(self.field_order, self.generator_matrix)
+        if self.field_order ** len(self.generator_matrix) > MAX_EXACT_CODEWORDS:
             raise ValueError("generator matrix exceeds the exact enumeration bound")
         return self
 
@@ -45,3 +97,34 @@ class MinimumDistanceResult(ContractModel):
 class WeightDistributionResult(ContractModel):
     weights: tuple[tuple[int, int], ...] = Field(max_length=10000)
     method: Literal["EXACT_ENUMERATION"] = "EXACT_ENUMERATION"
+
+
+class CoveringRadiusRequest(ContractModel):
+    """A linear code whose syndrome graph fits declared exact-work bounds."""
+
+    field_order: int = Field(ge=2, le=251)
+    generator_matrix: tuple[tuple[int, ...], ...] = Field(min_length=1, max_length=8)
+
+    @model_validator(mode="after")
+    def require_bounded_syndrome_graph(self) -> Self:
+        width = _validate_prime_field_matrix(
+            self.field_order,
+            self.generator_matrix,
+        )
+        rank = _matrix_rank_mod_prime(self.generator_matrix, self.field_order)
+        syndrome_dimension = width - rank
+        state_count = self.field_order**syndrome_dimension
+        if state_count > MAX_COVERING_RADIUS_STATES:
+            raise ValueError("syndrome space exceeds the exact state bound")
+        move_count_bound = min(
+            width * (self.field_order - 1),
+            max(state_count - 1, 0),
+        )
+        if state_count * move_count_bound > MAX_COVERING_RADIUS_TRANSITIONS:
+            raise ValueError("syndrome graph exceeds the exact transition bound")
+        return self
+
+
+class CoveringRadiusResult(ContractModel):
+    covering_radius: int = Field(ge=0, le=256)
+    method: Literal["SYNDROME_BFS"] = "SYNDROME_BFS"

--- a/src/jacobian/contracts/code_theory.py
+++ b/src/jacobian/contracts/code_theory.py
@@ -26,11 +26,7 @@ def _validate_prime_field_matrix(
         raise ValueError("generator rows must have between one and 256 entries")
     if any(len(row) != width for row in generator_matrix):
         raise ValueError("generator matrix rows must have equal length")
-    if any(
-        not 0 <= entry < field_order
-        for row in generator_matrix
-        for entry in row
-    ):
+    if any(not 0 <= entry < field_order for row in generator_matrix for entry in row):
         raise ValueError("generator entries must be canonical field residues")
     return width
 
@@ -56,9 +52,7 @@ def _matrix_rank_mod_prime(
             continue
         rows[pivot_row], rows[pivot] = rows[pivot], rows[pivot_row]
         inverse = pow(rows[pivot_row][column] % field_order, -1, field_order)
-        rows[pivot_row] = [
-            value * inverse % field_order for value in rows[pivot_row]
-        ]
+        rows[pivot_row] = [value * inverse % field_order for value in rows[pivot_row]]
         for index, row in enumerate(rows):
             if index == pivot_row:
                 continue

--- a/src/jacobian/domains/code_theory/math_tools.py
+++ b/src/jacobian/domains/code_theory/math_tools.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from jacobian.contracts.base import ContractModel
 from jacobian.contracts.code_theory import (
+    CoveringRadiusRequest,
+    CoveringRadiusResult,
     LinearCodeRequest,
     MinimumDistanceResult,
     WeightDistributionResult,
@@ -12,6 +14,7 @@ from jacobian.contracts.code_theory import (
 from jacobian.contracts.operations import OperationExample
 from jacobian.domains._examples import example
 from jacobian.domains.code_theory.operations import (
+    compute_covering_radius,
     compute_min_distance,
     compute_weight_dist,
 )
@@ -76,6 +79,24 @@ CODE_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "binary_repetition_code",
                 "Weight distribution of the binary repetition code of length two.",
                 {"field_order": 2, "generator_matrix": [[1, 1]]},
+            ),
+        ),
+    ),
+    ct_operation(
+        "code.covering_radius.compute",
+        "Compute the covering radius of a linear code",
+        "Compute the exact covering radius over a bounded prime field by breadth-first search on the syndrome graph.",
+        CoveringRadiusRequest,
+        CoveringRadiusResult,
+        compute_covering_radius,
+        "code",
+        "covering-radius",
+        "exact",
+        examples=(
+            example(
+                "binary_repetition_code",
+                "Covering radius of the binary repetition code of length four.",
+                {"field_order": 2, "generator_matrix": [[1, 1, 1, 1]]},
             ),
         ),
     ),

--- a/src/jacobian/domains/code_theory/operations.py
+++ b/src/jacobian/domains/code_theory/operations.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 from jacobian.contracts.code_theory import (
+    CoveringRadiusRequest,
+    CoveringRadiusResult,
     LinearCodeRequest,
     MinimumDistanceResult,
     WeightDistributionResult,
 )
-from jacobian.math.code_theory import minimum_distance, weight_distribution
+from jacobian.math.code_theory import (
+    covering_radius,
+    minimum_distance,
+    weight_distribution,
+)
 
 
 def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
@@ -18,3 +24,8 @@ def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
 def compute_weight_dist(request: LinearCodeRequest) -> WeightDistributionResult:
     weights = weight_distribution(request.generator_matrix, request.field_order)  # type: ignore[no-untyped-call]
     return WeightDistributionResult(weights=tuple((w, c) for w, c in weights))
+
+
+def compute_covering_radius(request: CoveringRadiusRequest) -> CoveringRadiusResult:
+    radius = covering_radius(request.generator_matrix, request.field_order)  # type: ignore[no-untyped-call]
+    return CoveringRadiusResult(covering_radius=radius)

--- a/src/jacobian/math/code_theory/__init__.py
+++ b/src/jacobian/math/code_theory/__init__.py
@@ -1,5 +1,9 @@
 """Code theory operations."""
 
-from jacobian.math.code_theory.operations import minimum_distance, weight_distribution
+from jacobian.math.code_theory.operations import (
+    covering_radius,
+    minimum_distance,
+    weight_distribution,
+)
 
-__all__ = ["minimum_distance", "weight_distribution"]
+__all__ = ["covering_radius", "minimum_distance", "weight_distribution"]

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import deque
 from itertools import product
 
-__all__ = ["minimum_distance", "weight_distribution"]
+__all__ = ["covering_radius", "minimum_distance", "weight_distribution"]
 
 
 def _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-def]
@@ -40,3 +41,104 @@ def weight_distribution(generator_matrix, field_order):  # type: ignore[no-untyp
         weight = sum(1 for c in codeword if c != 0)
         weights[weight] += 1
     return sorted(weights.items())
+
+
+def _parity_check_matrix(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+    """Return a basis of the generator matrix's right nullspace."""
+    rows = [list(row) for row in generator_matrix]
+    row_count = len(rows)
+    column_count = len(rows[0])
+    pivot_columns: list[int] = []
+    pivot_row = 0
+    for column in range(column_count):
+        pivot = next(
+            (
+                index
+                for index in range(pivot_row, row_count)
+                if rows[index][column] % field_order != 0
+            ),
+            None,
+        )
+        if pivot is None:
+            continue
+        rows[pivot_row], rows[pivot] = rows[pivot], rows[pivot_row]
+        inverse = pow(rows[pivot_row][column] % field_order, -1, field_order)
+        rows[pivot_row] = [
+            value * inverse % field_order for value in rows[pivot_row]
+        ]
+        for index, row in enumerate(rows):
+            if index == pivot_row:
+                continue
+            factor = row[column] % field_order
+            if factor == 0:
+                continue
+            rows[index] = [
+                (left - factor * right) % field_order
+                for left, right in zip(row, rows[pivot_row], strict=True)
+            ]
+        pivot_columns.append(column)
+        pivot_row += 1
+        if pivot_row == row_count:
+            break
+
+    pivot_set = set(pivot_columns)
+    free_columns = [
+        column for column in range(column_count) if column not in pivot_set
+    ]
+    check_rows: list[list[int]] = []
+    for free_column in free_columns:
+        vector = [0] * column_count
+        vector[free_column] = 1
+        for index, pivot_column in enumerate(pivot_columns):
+            vector[pivot_column] = (-rows[index][free_column]) % field_order
+        check_rows.append(vector)
+    return check_rows
+
+
+def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+    """Compute a linear code's covering radius by syndrome-space BFS.
+
+    One graph step adds a nonzero scalar multiple of one parity-check column,
+    exactly corresponding to changing one coordinate of an error vector.
+    Therefore graph distance from the zero syndrome is minimum coset-leader
+    weight, and the maximum distance is the covering radius.
+    """
+    check_rows = _parity_check_matrix(generator_matrix, field_order)
+    if not check_rows:
+        return 0
+
+    syndrome_dimension = len(check_rows)
+    column_count = len(check_rows[0])
+    zero = (0,) * syndrome_dimension
+    move_set = {
+        tuple(
+            scalar * check_rows[row][column] % field_order
+            for row in range(syndrome_dimension)
+        )
+        for column in range(column_count)
+        for scalar in range(1, field_order)
+    }
+    move_set.discard(zero)
+    moves = tuple(sorted(move_set))
+
+    distances = {zero: 0}
+    queue = deque([zero])
+    radius = 0
+    while queue:
+        syndrome = queue.popleft()
+        next_distance = distances[syndrome] + 1
+        for move in moves:
+            neighbor = tuple(
+                (left + right) % field_order
+                for left, right in zip(syndrome, move, strict=True)
+            )
+            if neighbor in distances:
+                continue
+            distances[neighbor] = next_distance
+            radius = max(radius, next_distance)
+            queue.append(neighbor)
+
+    expected_states = field_order**syndrome_dimension
+    if len(distances) != expected_states:
+        raise ArithmeticError("parity-check columns did not span the syndrome space")
+    return radius

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -63,9 +63,7 @@ def _parity_check_matrix(generator_matrix, field_order):  # type: ignore[no-unty
             continue
         rows[pivot_row], rows[pivot] = rows[pivot], rows[pivot_row]
         inverse = pow(rows[pivot_row][column] % field_order, -1, field_order)
-        rows[pivot_row] = [
-            value * inverse % field_order for value in rows[pivot_row]
-        ]
+        rows[pivot_row] = [value * inverse % field_order for value in rows[pivot_row]]
         for index, row in enumerate(rows):
             if index == pivot_row:
                 continue
@@ -82,9 +80,7 @@ def _parity_check_matrix(generator_matrix, field_order):  # type: ignore[no-unty
             break
 
     pivot_set = set(pivot_columns)
-    free_columns = [
-        column for column in range(column_count) if column not in pivot_set
-    ]
+    free_columns = [column for column in range(column_count) if column not in pivot_set]
     check_rows: list[list[int]] = []
     for free_column in free_columns:
         vector = [0] * column_count

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -99,7 +99,10 @@ def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-d
     Therefore graph distance from the zero syndrome is minimum coset-leader
     weight, and the maximum distance is the covering radius.
     """
-    check_rows = _parity_check_matrix(generator_matrix, field_order)
+    check_rows = _parity_check_matrix(  # type: ignore[no-untyped-call]
+        generator_matrix,
+        field_order,
+    )
     if not check_rows:
         return 0
 

--- a/tests/domain/code_theory/test_exact_code_enumeration.py
+++ b/tests/domain/code_theory/test_exact_code_enumeration.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from jacobian.contracts.code_theory import LinearCodeRequest
+from jacobian.contracts.code_theory import (
+    CoveringRadiusRequest,
+    LinearCodeRequest,
+)
 from jacobian.domains.code_theory.operations import (
+    compute_covering_radius,
     compute_min_distance,
     compute_weight_dist,
 )
@@ -28,3 +32,105 @@ def test_code_contract_rejects_nonprime_fields_and_unbounded_enumeration() -> No
         LinearCodeRequest(field_order=4, generator_matrix=((1,),))
     with pytest.raises(ValidationError, match="enumeration"):
         LinearCodeRequest(field_order=251, generator_matrix=((1,), (1,), (1,)))
+
+
+def test_binary_repetition_code_length_three_has_covering_radius_one() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=((1, 1, 1),),
+    )
+
+    result = compute_covering_radius(request)
+
+    assert result.covering_radius == 1
+    assert result.method == "SYNDROME_BFS"
+
+
+def test_binary_repetition_code_length_four_has_covering_radius_two() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=((1, 1, 1, 1),),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 2
+
+
+def test_binary_hamming_code_has_covering_radius_one() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=(
+            (1, 0, 0, 0, 0, 1, 1),
+            (0, 1, 0, 0, 1, 0, 1),
+            (0, 0, 1, 0, 1, 1, 0),
+            (0, 0, 0, 1, 1, 1, 1),
+        ),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 1
+
+
+def test_ternary_repetition_code_has_covering_radius_two() -> None:
+    request = CoveringRadiusRequest(
+        field_order=3,
+        generator_matrix=((1, 1, 1),),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 2
+
+
+def test_dependent_generator_rows_use_rank_not_row_count() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=((1, 1, 1), (1, 1, 1)),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 1
+
+
+def test_full_space_code_has_covering_radius_zero() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=((1, 0, 0), (0, 1, 0), (0, 0, 1)),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 0
+
+
+def test_zero_code_has_covering_radius_equal_to_length() -> None:
+    request = CoveringRadiusRequest(
+        field_order=2,
+        generator_matrix=((0, 0, 0),),
+    )
+
+    assert compute_covering_radius(request).covering_radius == 3
+
+
+def test_covering_radius_contract_rejects_dependent_row_state_space_hole() -> None:
+    repeated_row = (1, 0, 0, 0, 0, 0, 0, 0)
+
+    with pytest.raises(ValidationError, match="syndrome space"):
+        CoveringRadiusRequest(
+            field_order=251,
+            generator_matrix=(repeated_row,) * 8,
+        )
+
+
+def test_covering_radius_contract_rejects_excessive_transition_work() -> None:
+    generator_matrix = tuple(
+        tuple(1 if column == row else 0 for column in range(18))
+        for row in range(8)
+    )
+
+    with pytest.raises(ValidationError, match="transition"):
+        CoveringRadiusRequest(
+            field_order=3,
+            generator_matrix=generator_matrix,
+        )
+
+
+def test_covering_radius_contract_rejects_nonprime_field() -> None:
+    with pytest.raises(ValidationError, match="prime"):
+        CoveringRadiusRequest(
+            field_order=4,
+            generator_matrix=((1, 1),),
+        )

--- a/tests/domain/code_theory/test_exact_code_enumeration.py
+++ b/tests/domain/code_theory/test_exact_code_enumeration.py
@@ -117,8 +117,7 @@ def test_covering_radius_contract_rejects_dependent_row_state_space_hole() -> No
 
 def test_covering_radius_contract_rejects_excessive_transition_work() -> None:
     generator_matrix = tuple(
-        tuple(1 if column == row else 0 for column in range(18))
-        for row in range(8)
+        tuple(1 if column == row else 0 for column in range(18)) for row in range(8)
     )
 
     with pytest.raises(ValidationError, match="transition"):


### PR DESCRIPTION
## Summary

Closes #1675.

Adds the remaining direct coding-theory operation:

- `code.covering_radius.compute`

The branch has been rebuilt on current `main` as a focused six-file patch. It no longer contains unrelated graph-spectral changes.

## Mathematical kernel

For a linear code `C = row_span(G)` over a declared prime field, the kernel:

1. row-reduces `G` exactly modulo `q`;
2. constructs a basis `H` of the right nullspace, so `C = ker(H)`;
3. performs breadth-first search from the zero syndrome;
4. uses every distinct nonzero scalar multiple of a parity-check column as one move.

One move changes one error coordinate. Thus the shortest path to a syndrome is exactly its coset-leader Hamming weight, and the maximum BFS distance is the covering radius.

## Bounded contract

The request computes `rank(G)` over the prime field before execution and bounds the actual syndrome graph:

- states: `q ** (n - rank(G)) <= 65,536`;
- transitions: `states * distinct_move_upper_bound <= 2,000,000`.

This fixes the prior branch's dependent-row hole: `q ** (n - number_of_rows)` can exponentially *underestimate* the coset count when generator rows are dependent.

The result returns the exact radius with method `SYNDROME_BFS`.

## Tests

Coverage includes:

- binary repetition codes of lengths three and four;
- the binary `[7,4,3]` Hamming code;
- a ternary repetition code;
- dependent generator rows;
- full-space and zero codes;
- non-prime-field rejection;
- regression for the dependent-row state-space hole;
- a separate case whose state count fits but transition count exceeds the work bound.
