### PR TITLE
Add bounded constraint-satisfaction object construction and verification

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -13,6 +13,7 @@ type LoadedOperationModule = tuple[str, MathTools]
 BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.boolean", "boolean_operations"),
     ("jacobian.domains.group", "group_operations"),
+    ("jacobian.domains.permutation_group", "permutation_group_operations"),
     ("jacobian.domains.graph_coloring_ops", "graph_coloring_operations"),
     ("jacobian.domains.graph_spectral", "graph_spectral_operations"),
     ("jacobian.domains.graph_flow", "graph_flow_operations"),
@@ -45,6 +46,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
         "jacobian.domains.graph_symmetry",
         "graph_symmetry_operations",
     ),
+    ("jacobian.domains.certified_factoring", "certified_factoring_operations"),
     ("jacobian.domains.certified_snf", "certified_snf_operations"),
     ("jacobian.domains.matrices", "matrix_operations"),
     ("jacobian.domains.symbolic_matrix", "symbolic_matrix_operations"),

--- a/src/jacobian/contracts/candidate_construction.py
+++ b/src/jacobian/contracts/candidate_construction.py
@@ -1,0 +1,90 @@
+"""Typed contracts for bounded constraint-satisfaction object construction."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+
+
+class IntegerLinearConstraint(ContractModel):
+    """One linear constraint over integer variables: sum(a_i * x_i) <= b."""
+
+    coefficients: tuple[StrictInt, ...] = Field(min_length=1, max_length=32)
+    rhs: StrictInt
+    relation: Literal["LE", "EQ", "GE"] = "LE"
+
+
+class IntegerFeasibilityRequest(ContractModel):
+    """Request to find one feasible integer point satisfying all constraints."""
+
+    variable_count: StrictInt = Field(ge=1, le=16)
+    constraints: tuple[IntegerLinearConstraint, ...] = Field(
+        min_length=1, max_length=64
+    )
+    timeout_ms: StrictInt = Field(default=5000, ge=100, le=30000)
+
+    @model_validator(mode="after")
+    def validate_constraint_dimensions(self) -> Self:
+        for i, c in enumerate(self.constraints):
+            if len(c.coefficients) != self.variable_count:
+                raise ValueError(
+                    f"constraint {i} has {len(c.coefficients)} coefficients "
+                    f"but variable_count is {self.variable_count}"
+                )
+        return self
+
+
+class IntegerFeasibilityResult(ContractModel):
+    """Result of a bounded integer feasibility search."""
+
+    status: Literal["FEASIBLE", "INFEASIBLE", "UNKNOWN", "INVALID"]
+    assignment: tuple[StrictInt, ...] | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_status_to_assignment(self) -> Self:
+        if self.status == "FEASIBLE" and self.assignment is None:
+            raise ValueError("a feasible result requires an assignment")
+        if self.status != "FEASIBLE" and self.assignment is not None:
+            raise ValueError("only a feasible result may carry an assignment")
+        return self
+
+
+class IntegerFeasibilityCheckRequest(ContractModel):
+    """Request to independently verify that an assignment satisfies all constraints."""
+
+    variable_count: StrictInt = Field(ge=1, le=16)
+    constraints: tuple[IntegerLinearConstraint, ...] = Field(
+        min_length=1, max_length=64
+    )
+    assignment: tuple[StrictInt, ...] = Field(min_length=1, max_length=16)
+
+    @model_validator(mode="after")
+    def validate_dimensions(self) -> Self:
+        for i, c in enumerate(self.constraints):
+            if len(c.coefficients) != self.variable_count:
+                raise ValueError(
+                    f"constraint {i} has {len(c.coefficients)} coefficients "
+                    f"but variable_count is {self.variable_count}"
+                )
+        if len(self.assignment) != self.variable_count:
+            raise ValueError("assignment length must match variable_count")
+        return self
+
+
+class IntegerFeasibilityCheckResult(ContractModel):
+    """Result of independently verifying an integer feasibility assignment."""
+
+    satisfies: bool
+    first_violated_constraint: StrictInt | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_violation(self) -> Self:
+        if self.satisfies and self.first_violated_constraint is not None:
+            raise ValueError("a satisfying result cannot have a violated constraint")
+        return self

--- a/src/jacobian/domains/candidate_construction/__init__.py
+++ b/src/jacobian/domains/candidate_construction/__init__.py
@@ -1,0 +1,18 @@
+"""Bounded constraint-satisfaction object construction."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["candidate_construction_operations"]
+
+
+def candidate_construction_operations() -> MathTools:
+    from jacobian.domains.candidate_construction.math_tools import (
+        CANDIDATE_CONSTRUCTION_OPERATIONS,
+    )
+
+    return CANDIDATE_CONSTRUCTION_OPERATIONS

--- a/src/jacobian/domains/candidate_construction/math_tools.py
+++ b/src/jacobian/domains/candidate_construction/math_tools.py
@@ -1,0 +1,90 @@
+"""MathTool declarations for constraint-satisfaction construction."""
+
+from __future__ import annotations
+
+from jacobian.contracts.candidate_construction import (
+    IntegerFeasibilityCheckRequest,
+    IntegerFeasibilityCheckResult,
+    IntegerFeasibilityRequest,
+    IntegerFeasibilityResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.candidate_construction.operations import (
+    construct_integer_feasibility,
+    verify_integer_feasibility,
+)
+from jacobian.math_tools import MathTool
+
+
+CANDIDATE_CONSTRUCTION_OPERATIONS: tuple[MathTool, ...] = (
+    MathTool(
+        operation_id="candidate.construct.integer_feasibility",
+        version="1",
+        title="Construct one feasible integer point",
+        description=(
+            "Use Z3 SMT to find one feasible integer point satisfying a set "
+            "of declared linear constraints, or return a bounded infeasible "
+            "result."
+        ),
+        request_type=IntegerFeasibilityRequest,
+        result_type=IntegerFeasibilityResult,
+        run=construct_integer_feasibility,
+        tags=(
+            "optimization",
+            "integer",
+            "feasibility",
+            "z3",
+            "smt",
+            "bounded",
+            "construction",
+        ),
+        examples=(
+            example(
+                "simple_feasible",
+                "Find a feasible point for x + y <= 5, x >= 0, y >= 0.",
+                {
+                    "variable_count": 2,
+                    "constraints": [
+                        {"coefficients": [1, 1], "rhs": 5, "relation": "LE"},
+                        {"coefficients": [-1, 0], "rhs": 0, "relation": "GE"},
+                        {"coefficients": [0, -1], "rhs": 0, "relation": "GE"},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="candidate.verify.integer_feasibility",
+        version="1",
+        title="Independently verify an integer feasibility assignment",
+        description=(
+            "Independently evaluate an integer assignment against a set of "
+            "declared linear constraints and return whether it satisfies all."
+        ),
+        request_type=IntegerFeasibilityCheckRequest,
+        result_type=IntegerFeasibilityCheckResult,
+        run=verify_integer_feasibility,
+        tags=(
+            "optimization",
+            "integer",
+            "feasibility",
+            "verify",
+            "predicate",
+        ),
+        examples=(
+            example(
+                "simple_check",
+                "Check that x=2, y=1 satisfies x + y <= 5.",
+                {
+                    "variable_count": 2,
+                    "constraints": [
+                        {"coefficients": [1, 1], "rhs": 5, "relation": "LE"},
+                    ],
+                    "assignment": [2, 1],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["CANDIDATE_CONSTRUCTION_OPERATIONS"]

--- a/src/jacobian/domains/candidate_construction/operations.py
+++ b/src/jacobian/domains/candidate_construction/operations.py
@@ -1,0 +1,88 @@
+"""Bounded constraint-satisfaction object construction backed by Z3."""
+
+from __future__ import annotations
+
+from jacobian.contracts.candidate_construction import (
+    IntegerFeasibilityCheckRequest,
+    IntegerFeasibilityCheckResult,
+    IntegerFeasibilityRequest,
+    IntegerFeasibilityResult,
+    IntegerLinearConstraint,
+)
+
+
+def construct_integer_feasibility(
+    request: IntegerFeasibilityRequest,
+) -> IntegerFeasibilityResult:
+    """Find one feasible integer point satisfying all declared constraints using Z3."""
+    import z3
+
+    variables = [z3.Int(f"x{i}") for i in range(request.variable_count)]
+    solver = z3.Solver()
+    solver.set("timeout", request.timeout_ms)
+
+    for constraint in request.constraints:
+        terms = []
+        for coeff, var in zip(constraint.coefficients, variables):
+            terms.append(coeff * var)
+        expr = sum(terms)
+        if constraint.relation == "LE":
+            solver.add(expr <= constraint.rhs)
+        elif constraint.relation == "EQ":
+            solver.add(expr == constraint.rhs)
+        else:  # GE
+            solver.add(expr >= constraint.rhs)
+
+    result = solver.check()
+    if result == z3.sat:
+        model = solver.model()
+        assignment = tuple(int(model.eval(var).as_long()) for var in variables)
+        return IntegerFeasibilityResult(
+            status="FEASIBLE",
+            assignment=assignment,
+            detail="Z3 found a feasible integer assignment.",
+        )
+    elif result == z3.unsat:
+        return IntegerFeasibilityResult(
+            status="INFEASIBLE",
+            detail="Z3 proved infeasibility for the declared constraints.",
+        )
+    else:
+        return IntegerFeasibilityResult(
+            status="UNKNOWN",
+            detail="Z3 returned unknown (timeout or resource limit).",
+        )
+
+
+def verify_integer_feasibility(
+    request: IntegerFeasibilityCheckRequest,
+) -> IntegerFeasibilityCheckResult:
+    """Independently verify that an assignment satisfies all constraints."""
+
+    for i, constraint in enumerate(request.constraints):
+        total = sum(
+            coeff * request.assignment[j]
+            for j, coeff in enumerate(constraint.coefficients)
+        )
+        if constraint.relation == "LE" and not (total <= constraint.rhs):
+            return IntegerFeasibilityCheckResult(
+                satisfies=False,
+                first_violated_constraint=i,
+                detail=f"Constraint {i} violated: {total} > {constraint.rhs}.",
+            )
+        elif constraint.relation == "EQ" and not (total == constraint.rhs):
+            return IntegerFeasibilityCheckResult(
+                satisfies=False,
+                first_violated_constraint=i,
+                detail=f"Constraint {i} violated: {total} != {constraint.rhs}.",
+            )
+        elif constraint.relation == "GE" and not (total >= constraint.rhs):
+            return IntegerFeasibilityCheckResult(
+                satisfies=False,
+                first_violated_constraint=i,
+                detail=f"Constraint {i} violated: {total} < {constraint.rhs}.",
+            )
+    return IntegerFeasibilityCheckResult(
+        satisfies=True,
+        detail="All constraints satisfied by the given assignment.",
+    )

--- a/tests/domain/candidate_construction/test_candidate.py
+++ b/tests/domain/candidate_construction/test_candidate.py
@@ -1,0 +1,95 @@
+"""Tests for bounded constraint-satisfaction construction."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.candidate_construction import IntegerFeasibilityRequest
+from jacobian.domains.candidate_construction.operations import (
+    construct_integer_feasibility,
+    verify_integer_feasibility,
+)
+
+
+def test_satisfiable_constraint():
+    """x + y <= 5, x >= 0, y >= 0 should be feasible."""
+    request = IntegerFeasibilityRequest.model_validate({
+        "variable_count": 2,
+        "constraints": [
+            {"coefficients": [1, 1], "rhs": 5, "relation": "LE"},
+            {"coefficients": [-1, 0], "rhs": 0, "relation": "GE"},
+            {"coefficients": [0, -1], "rhs": 0, "relation": "GE"},
+        ],
+    })
+    result = construct_integer_feasibility(request)
+    assert result.status == "FEASIBLE"
+    assert result.assignment is not None
+    assert len(result.assignment) == 2
+
+
+def test_unsatisfiable_constraint():
+    """x <= 0 and x >= 1 is infeasible."""
+    request = IntegerFeasibilityRequest.model_validate({
+        "variable_count": 1,
+        "constraints": [
+            {"coefficients": [1], "rhs": 0, "relation": "LE"},
+            {"coefficients": [1], "rhs": 1, "relation": "GE"},
+        ],
+    })
+    result = construct_integer_feasibility(request)
+    assert result.status == "INFEASIBLE"
+
+
+def test_verify_satisfying_assignment():
+    """Verify that x=2, y=1 satisfies x + y <= 5."""
+    from jacobian.contracts.candidate_construction import IntegerFeasibilityCheckRequest
+
+    request = IntegerFeasibilityCheckRequest.model_validate({
+        "variable_count": 2,
+        "constraints": [
+            {"coefficients": [1, 1], "rhs": 5, "relation": "LE"},
+        ],
+        "assignment": [2, 1],
+    })
+    result = verify_integer_feasibility(request)
+    assert result.satisfies is True
+
+
+def test_verify_violating_assignment():
+    """Verify that x=3, y=3 does NOT satisfy x + y <= 5."""
+    from jacobian.contracts.candidate_construction import IntegerFeasibilityCheckRequest
+
+    request = IntegerFeasibilityCheckRequest.model_validate({
+        "variable_count": 2,
+        "constraints": [
+            {"coefficients": [1, 1], "rhs": 5, "relation": "LE"},
+        ],
+        "assignment": [3, 3],
+    })
+    result = verify_integer_feasibility(request)
+    assert result.satisfies is False
+    assert result.first_violated_constraint == 0
+
+
+def test_constraint_dimension_mismatch():
+    """A constraint with wrong coefficient count should fail."""
+    with pytest.raises(ValidationError, match="variable_count"):
+        IntegerFeasibilityRequest.model_validate({
+            "variable_count": 2,
+            "constraints": [
+                {"coefficients": [1, 2, 3], "rhs": 5, "relation": "LE"},
+            ],
+        })
+
+
+def test_operations_discoverable():
+    """Both operations should be discoverable via the factory."""
+    from jacobian.domains.candidate_construction import (
+        candidate_construction_operations,
+    )
+
+    ops = candidate_construction_operations()
+    op_ids = [op.operation_id for op in ops]
+    assert "candidate.construct.integer_feasibility" in op_ids
+    assert "candidate.verify.integer_feasibility" in op_ids


### PR DESCRIPTION
Closes #1656

Implements `candidate.construct.integer_feasibility` and `candidate.verify.integer_feasibility`: a bounded integer feasibility constructor backed by Z3 SMT and a separate independent verifier.

## What was added
- **Contracts**: `IntegerFeasibilityRequest` / `IntegerFeasibilityResult` / `IntegerFeasibilityCheckRequest` / `IntegerFeasibilityCheckResult` in `candidate_construction.py`
- **Domain**: `candidate_construction/` with construct and verify operations
- **Tests**: 6 tests covering satisfiable/un satisfiable constraints, verification, and validation