### PR TITLE
Add exact rational LP optimality verification

### DIFF
--- a/src/jacobian/contracts/optimality_verification.py
+++ b/src/jacobian/contracts/optimality_verification.py
@@ -1,0 +1,64 @@
+"""Typed contracts for exact optimality verification."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.validated_analysis import (
+    MAX_RATIONAL_DIGITS,
+    StandardFormRationalLinearProgram,
+    require_bounded_rational,
+)
+
+
+class RationalOptimalityVerifyRequest(ContractModel):
+    """Request to verify an exact LP optimum from primal and dual evidence."""
+
+    program: StandardFormRationalLinearProgram
+    claimed_objective: CanonicalRational
+    primal_candidate: tuple[CanonicalRational, ...]
+    dual_candidate: tuple[CanonicalRational, ...]
+
+    @model_validator(mode="after")
+    def validate_dimensions(self) -> Self:
+        n_vars = len(self.program.variables)
+        n_constraints = len(self.program.coefficients)
+        if len(self.primal_candidate) != n_vars:
+            raise ValueError(
+                f"primal candidate has {len(self.primal_candidate)} values but "
+                f"the program has {n_vars} variables"
+            )
+        if len(self.dual_candidate) != n_constraints:
+            raise ValueError(
+                f"dual candidate has {len(self.dual_candidate)} values but "
+                f"the program has {n_constraints} constraints"
+            )
+        require_bounded_rational(
+            self.claimed_objective,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="claimed objective",
+        )
+        return self
+
+
+class RationalOptimalityVerifyResult(ContractModel):
+    """Result of an exact LP optimality verification."""
+
+    status: Literal["VERIFIED", "REJECTED", "INVALID"]
+    primal_objective: CanonicalRational | None = None
+    dual_objective: CanonicalRational | None = None
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_status_to_evidence(self) -> Self:
+        if self.status == "VERIFIED":
+            if self.primal_objective is None or self.dual_objective is None:
+                raise ValueError("a verified result requires both objectives")
+        if self.status != "VERIFIED" and self.primal_objective is not None:
+            if self.dual_objective is not None:
+                pass  # REJECTED can carry evidence showing the mismatch
+        return self

--- a/src/jacobian/domains/optimality_verification/__init__.py
+++ b/src/jacobian/domains/optimality_verification/__init__.py
@@ -1,0 +1,18 @@
+"""Exact optimality verification operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["optimality_verification_operations"]
+
+
+def optimality_verification_operations() -> MathTools:
+    from jacobian.domains.optimality_verification.math_tools import (
+        OPTIMALITY_VERIFICATION_OPERATIONS,
+    )
+
+    return OPTIMALITY_VERIFICATION_OPERATIONS

--- a/src/jacobian/domains/optimality_verification/math_tools.py
+++ b/src/jacobian/domains/optimality_verification/math_tools.py
@@ -1,0 +1,57 @@
+"""MathTool declarations for optimality verification."""
+
+from __future__ import annotations
+
+from jacobian.contracts.optimality_verification import (
+    RationalOptimalityVerifyRequest,
+    RationalOptimalityVerifyResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.optimality_verification.operations import (
+    verify_rational_optimality,
+)
+from jacobian.math_tools import MathTool
+
+
+OPTIMALITY_VERIFICATION_OPERATIONS: tuple[MathTool, ...] = (
+    MathTool(
+        operation_id="optimality.verify.rational_lp",
+        version="1",
+        title="Verify an exact rational LP optimum",
+        description=(
+            "Independently verify a claimed rational LP optimum by "
+            "checking primal feasibility, dual feasibility, and strong "
+            "duality agreement on the objective value."
+        ),
+        request_type=RationalOptimalityVerifyRequest,
+        result_type=RationalOptimalityVerifyResult,
+        run=verify_rational_optimality,
+        tags=(
+            "optimization",
+            "linear",
+            "rational",
+            "verify",
+            "optimality",
+            "certificate",
+        ),
+        examples=(
+            example(
+                "simple_lp_verify",
+                "Verify the optimum of min(x) s.t. x >= 0, x <= 3.",
+                {
+                    "program": {
+                        "variables": ["x"],
+                        "objective": [{"num": "1", "den": "1"}],
+                        "coefficients": [[{"num": "1", "den": "1"}]],
+                        "rhs": [{"num": "3", "den": "1"}],
+                    },
+                    "claimed_objective": {"num": "0", "den": "1"},
+                    "primal_candidate": [{"num": "0", "den": "1"}],
+                    "dual_candidate": [{"num": "0", "den": "1"}],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["OPTIMALITY_VERIFICATION_OPERATIONS"]

--- a/src/jacobian/domains/optimality_verification/operations.py
+++ b/src/jacobian/domains/optimality_verification/operations.py
@@ -1,0 +1,129 @@
+"""Exact optimality verification backed by direct rational arithmetic."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.optimality_verification import (
+    RationalOptimalityVerifyRequest,
+    RationalOptimalityVerifyResult,
+)
+
+
+def _check_primal_feasibility(
+    request: RationalOptimalityVerifyRequest,
+) -> tuple[bool, str]:
+    """Check that the primal candidate satisfies Ax = b and x >= 0."""
+    program = request.program
+    primal = request.primal_candidate
+
+    for var, val in zip(program.variables, primal):
+        if val.as_fraction() < 0:
+            return False, f"primal variable {var} is negative"
+
+    for i, (row, rhs) in enumerate(zip(program.coefficients, program.rhs)):
+        total = sum(
+            coeff.as_fraction() * val.as_fraction()
+            for coeff, val in zip(row, primal)
+        )
+        if total != rhs.as_fraction():
+            return False, f"primal constraint {i} violated: {total} != {rhs.as_fraction()}"
+    return True, ""
+
+
+def _check_dual_feasibility(
+    request: RationalOptimalityVerifyRequest,
+) -> tuple[bool, str]:
+    """Check that the dual candidate satisfies the dual feasibility conditions."""
+    program = request.program
+    dual = request.dual_candidate
+
+    # For standard form min cTx s.t. Ax=b, x>=0:
+    # The dual is max bTy s.t. ATy <= c (where y is the dual)
+    # We check that ATy <= c for each variable
+    n_vars = len(program.variables)
+    n_constraints = len(program.coefficients)
+
+    # AT is n_vars x n_constraints (transpose of coefficients)
+    for j, var in enumerate(program.variables):
+        dual_dot_col = sum(
+            program.coefficients[i][j].as_fraction() * dual[i].as_fraction()
+            for i in range(n_constraints)
+        )
+        objective_j = program.objective[j].as_fraction()
+        if dual_dot_col > objective_j:
+            return False, (
+                f"dual constraint for variable {var} violated: "
+                f"{dual_dot_col} > {objective_j}"
+            )
+    return True, ""
+
+
+def verify_rational_optimality(
+    request: RationalOptimalityVerifyRequest,
+) -> RationalOptimalityVerifyResult:
+    """Verify an exact rational LP optimum from primal and dual evidence."""
+    from jacobian.contracts.exact import CanonicalRational
+
+    # Check primal feasibility
+    primal_ok, primal_msg = _check_primal_feasibility(request)
+    if not primal_ok:
+        return RationalOptimalityVerifyResult(
+            status="REJECTED",
+            detail=f"Primal infeasible: {primal_msg}",
+        )
+
+    # Check dual feasibility
+    dual_ok, dual_msg = _check_dual_feasibility(request)
+    if not dual_ok:
+        return RationalOptimalityVerifyResult(
+            status="REJECTED",
+            detail=f"Dual infeasible: {dual_msg}",
+        )
+
+    # Compute primal objective
+    primal_obj = sum(
+        coeff.as_fraction() * val.as_fraction()
+        for coeff, val in zip(request.program.objective, request.primal_candidate)
+    )
+
+    # Compute dual objective (b^T y)
+    dual_obj = sum(
+        rhs.as_fraction() * dual_val.as_fraction()
+        for rhs, dual_val in zip(request.program.rhs, request.dual_candidate)
+    )
+
+    primal_obj_rational = CanonicalRational.from_fraction(primal_obj)
+    dual_obj_rational = CanonicalRational.from_fraction(dual_obj)
+
+    # Check that the claimed objective matches the primal objective
+    if request.claimed_objective.as_fraction() != primal_obj:
+        return RationalOptimalityVerifyResult(
+            status="REJECTED",
+            primal_objective=primal_obj_rational,
+            dual_objective=dual_obj_rational,
+            detail=(
+                f"Claimed objective {request.claimed_objective.as_fraction()} does not "
+                f"match primal objective {primal_obj}"
+            ),
+        )
+
+    # Check that primal and dual objectives agree (strong duality)
+    if primal_obj != dual_obj:
+        return RationalOptimalityVerifyResult(
+            status="REJECTED",
+            primal_objective=primal_obj_rational,
+            dual_objective=dual_obj_rational,
+            detail=(
+                f"Primal objective {primal_obj} does not match dual objective {dual_obj}; "
+                f"strong duality fails."
+            ),
+        )
+
+    return RationalOptimalityVerifyResult(
+        status="VERIFIED",
+        primal_objective=primal_obj_rational,
+        dual_objective=dual_obj_rational,
+        detail="Primal and dual evidence agree on the exact objective value.",
+    )

--- a/tests/domain/optimality_verification/test_optimality.py
+++ b/tests/domain/optimality_verification/test_optimality.py
@@ -1,0 +1,92 @@
+"""Tests for exact optimality verification."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.optimality_verification import (
+    RationalOptimalityVerifyRequest,
+)
+from jacobian.domains.optimality_verification.operations import (
+    verify_rational_optimality,
+)
+
+
+def _make_lp():
+    """Make a simple LP: min(x) s.t. x = 3, x >= 0."""
+    return {
+        "variables": ["x"],
+        "objective": [{"num": "1", "den": "1"}],
+        "coefficients": [[{"num": "1", "den": "1"}]],
+        "rhs": [{"num": "3", "den": "1"}],
+    }
+
+
+def test_correct_optimum_is_verified():
+    """A correct primal and dual should be verified."""
+    request = RationalOptimalityVerifyRequest.model_validate({
+        "program": _make_lp(),
+        "claimed_objective": {"num": "3", "den": "1"},
+        "primal_candidate": [{"num": "3", "den": "1"}],
+        "dual_candidate": [{"num": "1", "den": "1"}],
+    })
+    result = verify_rational_optimality(request)
+    assert result.status == "VERIFIED"
+
+
+def test_primal_corruption_rejected():
+    """A primal that violates constraints should be rejected."""
+    request = RationalOptimalityVerifyRequest.model_validate({
+        "program": _make_lp(),
+        "claimed_objective": {"num": "3", "den": "1"},
+        "primal_candidate": [{"num": "5", "den": "1"}],
+        "dual_candidate": [{"num": "1", "den": "1"}],
+    })
+    result = verify_rational_optimality(request)
+    assert result.status == "REJECTED"
+
+
+def test_dual_corruption_rejected():
+    """A dual that violates the dual constraint should be rejected."""
+    request = RationalOptimalityVerifyRequest.model_validate({
+        "program": _make_lp(),
+        "claimed_objective": {"num": "3", "den": "1"},
+        "primal_candidate": [{"num": "3", "den": "1"}],
+        "dual_candidate": [{"num": "5", "den": "1"}],
+    })
+    result = verify_rational_optimality(request)
+    assert result.status == "REJECTED"
+
+
+def test_claimed_objective_mismatch_rejected():
+    """A wrong claimed objective should be rejected."""
+    request = RationalOptimalityVerifyRequest.model_validate({
+        "program": _make_lp(),
+        "claimed_objective": {"num": "4", "den": "1"},
+        "primal_candidate": [{"num": "3", "den": "1"}],
+        "dual_candidate": [{"num": "1", "den": "1"}],
+    })
+    result = verify_rational_optimality(request)
+    assert result.status == "REJECTED"
+
+
+def test_dimension_mismatch_rejected():
+    """Mismatched primal/dual dimensions should fail validation."""
+    with pytest.raises(ValidationError, match="primal candidate"):
+        RationalOptimalityVerifyRequest.model_validate({
+            "program": _make_lp(),
+            "claimed_objective": {"num": "3", "den": "1"},
+            "primal_candidate": [{"num": "3", "den": "1"}, {"num": "0", "den": "1"}],
+            "dual_candidate": [{"num": "1", "den": "1"}],
+        })
+
+
+def test_operation_discoverable():
+    """The operation should be discoverable via the factory."""
+    from jacobian.domains.optimality_verification import (
+        optimality_verification_operations,
+    )
+
+    ops = optimality_verification_operations()
+    assert any(op.operation_id == "optimality.verify.rational_lp" for op in ops)


### PR DESCRIPTION
Closes #1657

Implements `optimality.verify.rational_lp`: an exact optimality verifier that checks primal feasibility, dual feasibility, and strong duality agreement on the objective value.

## What was added
- **Contract**: `RationalOptimalityVerifyRequest` / `RationalOptimalityVerifyResult` in `optimality_verification.py`
- **Domain**: `optimality_verification/` with `verify_rational_optimality` kernel
- **Tests**: 6 tests covering correct optimum, primal corruption, dual corruption, claimed objective mismatch, dimension mismatch, and discoverability