### PR TITLE
Add bounded arithmetic function operations: Dirichlet convolution, divisor transform, inverse, and summatory

### DIFF
--- a/src/jacobian/contracts/arithmetic_functions.py
+++ b/src/jacobian/contracts/arithmetic_functions.py
@@ -1,0 +1,83 @@
+"""Typed contracts for arithmetic function operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+
+class ArithmeticFunctionTable(ContractModel):
+    """A bounded finite table of arithmetic function values f(1), ..., f(N)."""
+
+    values: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def validate_table(self) -> Self:
+        return self
+
+
+class DirichletConvolutionRequest(ContractModel):
+    """Request to compute the Dirichlet convolution (f * g)(n) for 1 <= n <= N."""
+
+    left: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+    right: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def validate_same_length(self) -> Self:
+        if len(self.left) != len(self.right):
+            raise ValueError(
+                f"left and right tables must have the same length, got "
+                f"{len(self.left)} and {len(self.right)}"
+            )
+        return self
+
+
+class DirichletConvolutionResult(ContractModel):
+    """Result of a Dirichlet convolution."""
+
+    values: tuple[StrictInt, ...]
+
+
+class MobiusTransformRequest(ContractModel):
+    """Request to compute the Mobius (divisor) transform of a table."""
+
+    values: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+
+
+class MobiusTransformResult(ContractModel):
+    """Result of the Mobius transform."""
+
+    values: tuple[StrictInt, ...]
+
+
+class DirichletInverseRequest(ContractModel):
+    """Request to compute the Dirichlet inverse of a table (with f(1)=1)."""
+
+    values: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def validate_f_one(self) -> Self:
+        if self.values[0] != 1:
+            raise ValueError("Dirichlet inverse requires f(1) = 1")
+        return self
+
+
+class DirichletInverseResult(ContractModel):
+    """Result of the Dirichlet inverse."""
+
+    values: tuple[StrictInt, ...]
+
+
+class SummatoryFunctionRequest(ContractModel):
+    """Request to compute the summatory (prefix sum) of an arithmetic function."""
+
+    values: tuple[StrictInt, ...] = Field(min_length=1, max_length=1024)
+
+
+class SummatoryFunctionResult(ContractModel):
+    """Result of the summatory function."""
+
+    values: tuple[StrictInt, ...]

--- a/src/jacobian/domains/number_theory/__init__.py
+++ b/src/jacobian/domains/number_theory/__init__.py
@@ -11,6 +11,9 @@ __all__ = ["number_theory_operations"]
 
 
 def number_theory_operations() -> MathTools:
+    from jacobian.domains.number_theory.arithmetic_function_math_tools import (
+        ARITHMETIC_FUNCTION_OPERATIONS,
+    )
     from jacobian.domains.number_theory.derived import DERIVED_NUMBER_THEORY_OPERATIONS
     from jacobian.domains.number_theory.divisibility import DIVISIBILITY_OPERATIONS
     from jacobian.domains.number_theory.finite_abelian_groups import (
@@ -29,4 +32,5 @@ def number_theory_operations() -> MathTools:
         *MODULAR_IDENTITY_OPERATIONS,
         *DERIVED_NUMBER_THEORY_OPERATIONS,
         FINITE_ABELIAN_GROUP_FACTORIZATION_OPERATION,
+        *ARITHMETIC_FUNCTION_OPERATIONS,
     )

--- a/src/jacobian/domains/number_theory/arithmetic_function_math_tools.py
+++ b/src/jacobian/domains/number_theory/arithmetic_function_math_tools.py
@@ -1,0 +1,135 @@
+"""MathTool declarations for arithmetic function operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.arithmetic_functions import (
+    DirichletConvolutionRequest,
+    DirichletConvolutionResult,
+    DirichletInverseRequest,
+    DirichletInverseResult,
+    MobiusTransformRequest,
+    MobiusTransformResult,
+    SummatoryFunctionRequest,
+    SummatoryFunctionResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.number_theory.arithmetic_function_operations import (
+    compute_dirichlet_convolution,
+    compute_dirichlet_inverse,
+    compute_mobius_transform,
+    compute_summatory_function,
+)
+from jacobian.math_tools import MathTool
+
+
+ARITHMETIC_FUNCTION_OPERATIONS: tuple[MathTool, ...] = (
+    MathTool(
+        operation_id="number_theory.arithmetic_function.dirichlet_convolution.compute",
+        version="1",
+        title="Compute the Dirichlet convolution of two arithmetic functions",
+        description=(
+            "Compute (f * g)(n) = sum_{d|n} f(d) * g(n/d) for 1 <= n <= N "
+            "from two bounded tables f and g."
+        ),
+        request_type=DirichletConvolutionRequest,
+        result_type=DirichletConvolutionResult,
+        run=compute_dirichlet_convolution,
+        tags=(
+            "number-theory",
+            "arithmetic-function",
+            "dirichlet",
+            "convolution",
+            "exact",
+        ),
+        examples=(
+            example(
+                "id_convolution",
+                "Dirichlet convolution of the identity with itself.",
+                {
+                    "left": [1, 2, 3, 4],
+                    "right": [1, 2, 3, 4],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.arithmetic_function.divisor_transform.compute",
+        version="1",
+        title="Compute the divisor (zeta) transform of an arithmetic function",
+        description=(
+            "Compute g(n) = sum_{d|n} f(d) for 1 <= n <= N, the divisor-sum "
+            "(zeta) transform of a bounded arithmetic function table."
+        ),
+        request_type=MobiusTransformRequest,
+        result_type=MobiusTransformResult,
+        run=compute_mobius_transform,
+        tags=(
+            "number-theory",
+            "arithmetic-function",
+            "divisor-transform",
+            "zeta",
+            "exact",
+        ),
+        examples=(
+            example(
+                "divisor_sum",
+                "Divisor sum of [1,1,1,1] is [1,3,1,7].",
+                {"values": [1, 1, 1, 1]},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.arithmetic_function.dirichlet_inverse.compute",
+        version="1",
+        title="Compute the Dirichlet inverse of an arithmetic function",
+        description=(
+            "Compute the Dirichlet inverse g such that (f * g)(n) = "
+            "epsilon(n), requiring f(1) = 1."
+        ),
+        request_type=DirichletInverseRequest,
+        result_type=DirichletInverseResult,
+        run=compute_dirichlet_inverse,
+        tags=(
+            "number-theory",
+            "arithmetic-function",
+            "dirichlet",
+            "inverse",
+            "exact",
+        ),
+        examples=(
+            example(
+                "identity_inverse",
+                "Dirichlet inverse of the identity function.",
+                {"values": [1, 2, 3, 4, 5]},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="number_theory.arithmetic_function.summatory.compute",
+        version="1",
+        title="Compute the summatory (prefix sum) of an arithmetic function",
+        description=(
+            "Compute S(n) = sum_{k=1}^{n} f(k) for 1 <= n <= N, the "
+            "prefix sum of a bounded arithmetic function table."
+        ),
+        request_type=SummatoryFunctionRequest,
+        result_type=SummatoryFunctionResult,
+        run=compute_summatory_function,
+        tags=(
+            "number-theory",
+            "arithmetic-function",
+            "summatory",
+            "prefix-sum",
+            "exact",
+        ),
+        examples=(
+            example(
+                "prefix_sum",
+                "Summatory function of [1,2,3,4] is [1,3,6,10].",
+                {"values": [1, 2, 3, 4]},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["ARITHMETIC_FUNCTION_OPERATIONS"]

--- a/src/jacobian/domains/number_theory/arithmetic_function_operations.py
+++ b/src/jacobian/domains/number_theory/arithmetic_function_operations.py
@@ -1,0 +1,100 @@
+"""Arithmetic function operations backed by exact integer arithmetic."""
+
+from __future__ import annotations
+
+from jacobian.contracts.arithmetic_functions import (
+    DirichletConvolutionRequest,
+    DirichletConvolutionResult,
+    DirichletInverseRequest,
+    DirichletInverseResult,
+    MobiusTransformRequest,
+    MobiusTransformResult,
+    SummatoryFunctionRequest,
+    SummatoryFunctionResult,
+)
+
+
+def _divisors(n: int) -> list[int]:
+    """Return all positive divisors of n."""
+    divs = []
+    i = 1
+    while i * i <= n:
+        if i * i == n:
+            divs.append(i)
+        elif n % i == 0:
+            divs.append(i)
+            divs.append(n // i)
+        i += 1
+    return sorted(divs)
+
+
+def compute_dirichlet_convolution(
+    request: DirichletConvolutionRequest,
+) -> DirichletConvolutionResult:
+    """Compute (f * g)(n) = sum_{d|n} f(d) * g(n/d) for 1 <= n <= N."""
+    N = len(request.left)
+    result = [0] * N
+    for n in range(1, N + 1):
+        total = 0
+        for d in _divisors(n):
+            total += request.left[d - 1] * request.right[n // d - 1]
+        result[n - 1] = total
+    return DirichletConvolutionResult(values=tuple(result))
+
+
+def compute_mobius_transform(
+    request: MobiusTransformRequest,
+) -> MobiusTransformResult:
+    """Compute the Mobius (divisor) transform: g(n) = sum_{d|n} mu(d) * f(n/d).
+
+    This is equivalent to the Dirichlet convolution with the Mobius function.
+    The inverse transform computes g(n) = sum_{d|n} f(d).
+    """
+    N = len(request.values)
+
+    # Compute Mobius function for 1..N
+    from sympy import mobius
+
+    # Dirichlet transform: g(n) = sum_{d|n} f(d)
+    # This is the divisor-sum (zeta) transform
+    result = [0] * N
+    for n in range(1, N + 1):
+        total = 0
+        for d in _divisors(n):
+            total += request.values[d - 1]
+        result[n - 1] = total
+    return MobiusTransformResult(values=tuple(result))
+
+
+def compute_dirichlet_inverse(
+    request: DirichletInverseRequest,
+) -> DirichletInverseResult:
+    """Compute the Dirichlet inverse of f (given f(1) = 1).
+
+    The inverse g satisfies (f * g)(n) = epsilon(n) where epsilon(1)=1, epsilon(n>1)=0.
+    Computed recursively: g(1) = 1/f(1) = 1, g(n) = -sum_{d|n, d<n} f(n/d) * g(d).
+    """
+    N = len(request.values)
+    result = [0] * N
+    result[0] = 1  # g(1) = 1/f(1) = 1
+
+    for n in range(2, N + 1):
+        total = 0
+        for d in _divisors(n):
+            if d == n:
+                continue
+            total += request.values[n // d - 1] * result[d - 1]
+        result[n - 1] = -total
+    return DirichletInverseResult(values=tuple(result))
+
+
+def compute_summatory_function(
+    request: SummatoryFunctionRequest,
+) -> SummatoryFunctionResult:
+    """Compute the summatory (prefix sum) function S(n) = sum_{k=1}^{n} f(k)."""
+    result = []
+    total = 0
+    for v in request.values:
+        total += v
+        result.append(total)
+    return SummatoryFunctionResult(values=tuple(result))

--- a/tests/domain/number_theory/test_arithmetic_functions.py
+++ b/tests/domain/number_theory/test_arithmetic_functions.py
@@ -1,0 +1,121 @@
+"""Tests for arithmetic function operations."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.arithmetic_functions import (
+    DirichletConvolutionRequest,
+    DirichletInverseRequest,
+    MobiusTransformRequest,
+    SummatoryFunctionRequest,
+)
+from jacobian.domains.number_theory.arithmetic_function_operations import (
+    compute_dirichlet_convolution,
+    compute_dirichlet_inverse,
+    compute_mobius_transform,
+    compute_summatory_function,
+)
+
+
+def test_dirichlet_convolution_identity():
+    """(id * id)(n) = sum_{d|n} d * (n/d) = n * tau(n) where tau is divisor count."""
+    # id = [1, 2, 3, 4, 5, 6]
+    # (id * id)(1) = 1*1 = 1
+    # (id * id)(2) = 1*2 + 2*1 = 4
+    # (id * id)(3) = 1*3 + 3*1 = 6
+    # (id * id)(4) = 1*4 + 2*2 + 4*1 = 12
+    result = compute_dirichlet_convolution(
+        DirichletConvolutionRequest.model_validate({
+            "left": [1, 2, 3, 4],
+            "right": [1, 2, 3, 4],
+        })
+    )
+    assert result.values[0] == 1
+    assert result.values[1] == 4
+    assert result.values[2] == 6
+    assert result.values[3] == 12
+
+
+def test_dirichlet_convolution_euler_totient():
+    """(phi * 1)(n) = n. phi = [1,1,2,2,4,2,6,4]."""
+    # phi(n) for n=1..8: [1,1,2,2,4,2,6,4]
+    # ones = [1,1,1,1,1,1,1,1]
+    # (phi * 1)(n) should give [1, 2, 3, 4, 5, 6, 7, 8]
+    result = compute_dirichlet_convolution(
+        DirichletConvolutionRequest.model_validate({
+            "left": [1, 1, 2, 2, 4, 2, 6, 4],
+            "right": [1, 1, 1, 1, 1, 1, 1, 1],
+        })
+    )
+    assert result.values == (1, 2, 3, 4, 5, 6, 7, 8)
+
+
+def test_divisor_transform():
+    """Divisor sum of [1,1,1,1] is [1, 3, 1, 7]."""
+    result = compute_mobius_transform(
+        MobiusTransformRequest.model_validate({"values": [1, 1, 1, 1]})
+    )
+    # g(1) = f(1) = 1
+    # g(2) = f(1) + f(2) = 2
+    # g(3) = f(1) + f(3) = 2
+    # g(4) = f(1) + f(2) + f(4) = 3
+    assert result.values[0] == 1
+    assert result.values[1] == 2
+    assert result.values[2] == 2
+    assert result.values[3] == 3
+
+
+def test_dirichlet_inverse():
+    """Dirichlet inverse of the constant function 1 is the Mobius function."""
+    # 1 = [1,1,1,1,1,1,1,1]
+    # inverse should give mu(n) = [1,-1,-1,0,-1,1,-1,0]
+    result = compute_dirichlet_inverse(
+        DirichletInverseRequest.model_validate({
+            "values": [1, 1, 1, 1, 1, 1, 1, 1],
+        })
+    )
+    assert result.values[0] == 1  # mu(1) = 1
+    assert result.values[1] == -1  # mu(2) = -1
+    assert result.values[2] == -1  # mu(3) = -1
+    assert result.values[3] == 0  # mu(4) = 0
+    assert result.values[4] == -1  # mu(5) = -1
+    assert result.values[5] == 1  # mu(6) = 1
+    assert result.values[6] == -1  # mu(7) = -1
+    assert result.values[7] == 0  # mu(8) = 0
+
+
+def test_summatory_function():
+    """Summatory function of [1,2,3,4] is [1,3,6,10]."""
+    result = compute_summatory_function(
+        SummatoryFunctionRequest.model_validate({"values": [1, 2, 3, 4]})
+    )
+    assert result.values == (1, 3, 6, 10)
+
+
+def test_dirichlet_inverse_requires_f1_one():
+    """Dirichlet inverse requires f(1) = 1."""
+    with pytest.raises(ValidationError, match="Dirichlet inverse requires"):
+        DirichletInverseRequest.model_validate({"values": [2, 1, 1]})
+
+
+def test_convolution_length_mismatch():
+    """Mismatched lengths should fail."""
+    with pytest.raises(ValidationError, match="same length"):
+        DirichletConvolutionRequest.model_validate({
+            "left": [1, 2, 3],
+            "right": [1, 2],
+        })
+
+
+def test_operations_discoverable():
+    """All four operations should be discoverable."""
+    from jacobian.domains.number_theory import number_theory_operations
+
+    ops = number_theory_operations()
+    op_ids = [op.operation_id for op in ops]
+    assert "number_theory.arithmetic_function.dirichlet_convolution.compute" in op_ids
+    assert "number_theory.arithmetic_function.divisor_transform.compute" in op_ids
+    assert "number_theory.arithmetic_function.dirichlet_inverse.compute" in op_ids
+    assert "number_theory.arithmetic_function.summatory.compute" in op_ids


### PR DESCRIPTION
Closes #1709

Implements four atomic composable math operations for arithmetic functions:
- `number_theory.arithmetic_function.dirichlet_convolution.compute` - Dirichlet convolution (f*g)(n) = sum_{d|n} f(d)g(n/d)
- `number_theory.arithmetic_function.divisor_transform.compute` - divisor (zeta) transform g(n) = sum_{d|n} f(d)
- `number_theory.arithmetic_function.dirichlet_inverse.compute` - Dirichlet inverse (requires f(1)=1)
- `number_theory.arithmetic_function.summatory.compute` - summatory/prefix sum S(n) = sum_{k=1}^n f(k)

Built on exact integer arithmetic with divisor enumeration. No hand-rolled libraries.

## Tests
8 tests covering identity convolution, Euler totient verification, Mobius function as Dirichlet inverse of 1, divisor sums, prefix sums, and contract validation