### PR TITLE
Add exact Boolean analysis: Fourier, multilinear extension, influence, erasure noise

### DIFF
--- a/src/jacobian/contracts/boolean_analysis.py
+++ b/src/jacobian/contracts/boolean_analysis.py
@@ -1,0 +1,105 @@
+"""Typed contracts for Boolean analysis operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+
+class BooleanTruthTable(ContractModel):
+    """A truth table for f: {-1,+1}^n -> {-1,+1}."""
+
+    variable_names: tuple[str, ...] = Field(min_length=1, max_length=16)
+    values: tuple[StrictInt, ...] = Field(min_length=2, max_length=65536)
+
+    @model_validator(mode="after")
+    def validate_truth_table(self) -> Self:
+        n = len(self.variable_names)
+        expected = 2 ** n
+        if len(self.values) != expected:
+            raise ValueError(
+                f"truth table must have 2^{n}={expected} values, got {len(self.values)}"
+            )
+        if any(v not in (-1, 1) for v in self.values):
+            raise ValueError("truth table values must be -1 or +1")
+        if len(set(self.variable_names)) != len(self.variable_names):
+            raise ValueError("variable names must be distinct")
+        return self
+
+
+class BooleanFourierRequest(ContractModel):
+    """Request to compute Walsh-Fourier coefficients."""
+
+    truth_table: BooleanTruthTable
+
+
+class FourierCoefficient(ContractModel):
+    """One Walsh-Fourier coefficient."""
+
+    subset_mask: StrictInt = Field(ge=0)
+    coefficient: StrictInt
+
+
+class BooleanFourierResult(ContractModel):
+    """Result of computing Walsh-Fourier coefficients."""
+
+    coefficients: tuple[FourierCoefficient, ...] = Field(min_length=1)
+    variable_count: StrictInt = Field(ge=1)
+
+
+class BooleanMultilinearExtensionRequest(ContractModel):
+    """Request to evaluate the multilinear extension at a point."""
+
+    truth_table: BooleanTruthTable
+    point: tuple[StrictInt, ...] = Field(min_length=1, max_length=16)
+
+    @model_validator(mode="after")
+    def validate_point(self) -> Self:
+        n = len(self.truth_table.variable_names)
+        if len(self.point) != n:
+            raise ValueError("point dimension must match truth table variable count")
+        return self
+
+
+class BooleanMultilinearExtensionResult(ContractModel):
+    """Result of multilinear extension evaluation."""
+
+    value: StrictInt
+    detail: str = Field(min_length=1, max_length=1024)
+
+
+class BooleanInfluenceRequest(ContractModel):
+    """Request to compute the influence of each variable."""
+
+    truth_table: BooleanTruthTable
+
+
+class BooleanInfluenceResult(ContractModel):
+    """Result of computing variable influences."""
+
+    influences: tuple[StrictInt, ...]
+    total_influence: StrictInt
+
+
+class BooleanErasureNoiseRequest(ContractModel):
+    """Request to compute the exact erasure noise L1 expectation."""
+
+    truth_table: BooleanTruthTable
+    erasure_count: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_erasure(self) -> Self:
+        if self.erasure_count > len(self.truth_table.variable_names):
+            raise ValueError("erasure count cannot exceed variable count")
+        return self
+
+
+class BooleanErasureNoiseResult(ContractModel):
+    """Result of exact erasure noise computation."""
+
+    expected_absolute_value_numerator: StrictInt
+    expected_absolute_value_denominator: StrictInt
+    detail: str = Field(min_length=1, max_length=1024)

--- a/src/jacobian/domains/boolean_analysis/__init__.py
+++ b/src/jacobian/domains/boolean_analysis/__init__.py
@@ -1,0 +1,16 @@
+"""Boolean analysis operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["boolean_analysis_operations"]
+
+
+def boolean_analysis_operations() -> MathTools:
+    from jacobian.domains.boolean_analysis.math_tools import BOOLEAN_ANALYSIS_OPERATIONS
+
+    return BOOLEAN_ANALYSIS_OPERATIONS

--- a/src/jacobian/domains/boolean_analysis/math_tools.py
+++ b/src/jacobian/domains/boolean_analysis/math_tools.py
@@ -1,0 +1,131 @@
+"""MathTool declarations for Boolean analysis operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.boolean_analysis import (
+    BooleanErasureNoiseRequest,
+    BooleanErasureNoiseResult,
+    BooleanFourierRequest,
+    BooleanFourierResult,
+    BooleanInfluenceRequest,
+    BooleanInfluenceResult,
+    BooleanMultilinearExtensionRequest,
+    BooleanMultilinearExtensionResult,
+    BooleanTruthTable,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.boolean_analysis.operations import (
+    compute_boolean_fourier,
+    compute_boolean_influence,
+    compute_erasure_noise,
+    compute_multilinear_extension,
+)
+from jacobian.math_tools import MathTool
+
+
+BOOLEAN_ANALYSIS_OPERATIONS: tuple[MathTool, ...] = (
+    MathTool(
+        operation_id="boolean.fourier.compute",
+        version="1",
+        title="Compute Walsh-Fourier coefficients of a Boolean function",
+        description=(
+            "Compute all Walsh-Fourier coefficients of a Boolean "
+            "function f: {-1,+1}^n -> {-1,+1} from its truth table."
+        ),
+        request_type=BooleanFourierRequest,
+        result_type=BooleanFourierResult,
+        run=compute_boolean_fourier,
+        tags=("boolean", "fourier", "walsh", "analysis", "exact"),
+        examples=(
+            example(
+                "and_function",
+                "Fourier coefficients of AND on 2 variables.",
+                {
+                    "truth_table": {
+                        "variable_names": ["a", "b"],
+                        "values": [-1, -1, -1, 1],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="boolean.multilinear_extension.evaluate",
+        version="1",
+        title="Evaluate the multilinear extension of a Boolean function",
+        description=(
+            "Evaluate the multilinear extension of a Boolean function "
+            "at a point in Z^n."
+        ),
+        request_type=BooleanMultilinearExtensionRequest,
+        result_type=BooleanMultilinearExtensionResult,
+        run=compute_multilinear_extension,
+        tags=("boolean", "multilinear", "extension", "polynomial", "exact"),
+        examples=(
+            example(
+                "and_at_origin",
+                "Evaluate AND(0,0) via multilinear extension.",
+                {
+                    "truth_table": {
+                        "variable_names": ["a", "b"],
+                        "values": [-1, -1, -1, 1],
+                    },
+                    "point": [0, 0],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="boolean.influence.compute",
+        version="1",
+        title="Compute the influence of each variable",
+        description=(
+            "Compute the influence (number of flippable edges) of each "
+            "variable in a Boolean function."
+        ),
+        request_type=BooleanInfluenceRequest,
+        result_type=BooleanInfluenceResult,
+        run=compute_boolean_influence,
+        tags=("boolean", "influence", "analysis", "exact"),
+        examples=(
+            example(
+                "dictator_influence",
+                "Influence of variables in the dictator function.",
+                {
+                    "truth_table": {
+                        "variable_names": ["a", "b"],
+                        "values": [-1, 1, -1, 1],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="boolean.erasure_noise.compute",
+        version="1",
+        title="Compute the exact erasure noise expectation E|f(z)|",
+        description=(
+            "Compute the exact expected absolute value E|f(z)| when k "
+            "randomly chosen variables are erased from the input."
+        ),
+        request_type=BooleanErasureNoiseRequest,
+        result_type=BooleanErasureNoiseResult,
+        run=compute_erasure_noise,
+        tags=("boolean", "erasure", "noise", "analysis", "exact"),
+        examples=(
+            example(
+                "and_1_erasure",
+                "E|f(z)| for AND on 2 variables with 1 erasure.",
+                {
+                    "truth_table": {
+                        "variable_names": ["a", "b"],
+                        "values": [-1, -1, -1, 1],
+                    },
+                    "erasure_count": 1,
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["BOOLEAN_ANALYSIS_OPERATIONS"]

--- a/src/jacobian/domains/boolean_analysis/operations.py
+++ b/src/jacobian/domains/boolean_analysis/operations.py
@@ -1,0 +1,193 @@
+"""Boolean analysis operations backed by exact integer arithmetic."""
+
+from __future__ import annotations
+
+from itertools import combinations, product
+
+from jacobian.contracts.boolean_analysis import (
+    BooleanErasureNoiseRequest,
+    BooleanErasureNoiseResult,
+    BooleanFourierRequest,
+    BooleanFourierResult,
+    BooleanInfluenceRequest,
+    BooleanInfluenceResult,
+    BooleanMultilinearExtensionRequest,
+    BooleanMultilinearExtensionResult,
+    BooleanTruthTable,
+    FourierCoefficient,
+)
+
+
+def _vertex_index(assignment: tuple[int, ...]) -> int:
+    """Convert a {-1,+1}^n assignment to a canonical index."""
+    index = 0
+    for i, v in enumerate(assignment):
+        if v == 1:
+            index |= (1 << i)
+    return index
+
+
+def _vertex_from_index(index: int, n: int) -> tuple[int, ...]:
+    """Convert a canonical index to a {-1,+1}^n assignment."""
+    return tuple(1 if (index >> i) & 1 else -1 for i in range(n))
+
+
+def compute_boolean_fourier(
+    request: BooleanFourierRequest,
+) -> BooleanFourierResult:
+    """Compute all Walsh-Fourier coefficients of a Boolean function.
+
+    For f: {-1,+1}^n -> {-1,+1}, the Walsh-Fourier coefficient is:
+    f_hat(S) = (1/2^n) * sum_{x} f(x) * chi_S(x)
+    where chi_S(x) = prod_{i in S} x_i.
+
+    We return the coefficients as integers (numerator only, denominator = 2^n).
+    """
+    n = len(request.truth_table.variable_names)
+    values = request.truth_table.values
+    total = 2 ** n
+    coefficients = []
+
+    for mask in range(total):
+        coeff = 0
+        for idx in range(total):
+            assignment = _vertex_from_index(idx, n)
+            # chi_S(x) = product of x_i for i in S
+            chi = 1
+            for i in range(n):
+                if mask & (1 << i):
+                    chi *= assignment[i]
+            coeff += values[idx] * chi
+        coefficients.append(
+            FourierCoefficient(subset_mask=mask, coefficient=coeff)
+        )
+
+    return BooleanFourierResult(
+        coefficients=tuple(coefficients),
+        variable_count=n,
+    )
+
+
+def compute_multilinear_extension(
+    request: BooleanMultilinearExtensionRequest,
+) -> BooleanMultilinearExtensionResult:
+    """Evaluate the multilinear extension of f at a point in Z^n.
+
+    The multilinear extension is:
+    f(x_1,...,x_n) = sum_S f_hat(S) * prod_{i in S} (x_i + 1) / 2 * prod_{i not in S} (1 - x_i) / 2
+
+    But since the truth table gives us f directly, we use:
+    f(z) = sum_{x in {-1,+1}^n} f(x) * prod_i (1 + z_i * x_i) / 2
+    """
+    n = len(request.truth_table.variable_names)
+    values = request.truth_table.values
+    point = request.point
+    total = 2 ** n
+
+    result_num = 0
+    result_den = 1
+
+    for idx in range(total):
+        assignment = _vertex_from_index(idx, n)
+        # prod_i (1 + z_i * x_i) / 2
+        num = 1
+        den = 1
+        for i in range(n):
+            # (1 + z_i * x_i) / 2
+            num *= (1 + point[i] * assignment[i])
+            den *= 2
+        result_num = result_num * den + values[idx] * num * result_den
+        result_den = result_den * den
+
+    # Simplify
+    from math import gcd
+    g = gcd(abs(result_num), abs(result_den))
+    if g > 0:
+        result_num //= g
+        result_den //= g
+
+    return BooleanMultilinearExtensionResult(
+        value=result_num // result_den if result_den != 0 else 0,
+        detail=f"Multilinear extension evaluated at {point}: numerator={result_num}, denominator={result_den}.",
+    )
+
+
+def compute_boolean_influence(
+    request: BooleanInfluenceRequest,
+) -> BooleanInfluenceResult:
+    """Compute the influence of each variable.
+
+    The influence of variable i is the number of edges (x, x^i) where f(x) != f(x^i),
+    divided by 2^(n-1). We return the numerator (number of flippable edges).
+    """
+    n = len(request.truth_table.variable_names)
+    values = request.truth_table.values
+    total = 2 ** n
+
+    influences = []
+    for i in range(n):
+        count = 0
+        for idx in range(total):
+            neighbor = idx ^ (1 << i)
+            if values[idx] != values[neighbor]:
+                count += 1
+        influences.append(count)
+
+    return BooleanInfluenceResult(
+        influences=tuple(influences),
+        total_influence=sum(influences),
+    )
+
+
+def compute_erasure_noise(
+    request: BooleanErasureNoiseRequest,
+) -> BooleanErasureNoiseResult:
+    """Compute the exact expected |f(z)| where z is f with some variables erased.
+
+    When k variables are erased, each of the C(n,k) subsets is equally likely.
+    For each erasure set S of size k, we evaluate f at the 2^(n-k) remaining
+    assignments and compute E|f(z)| over all erasures and completions.
+    """
+    n = len(request.truth_table.variable_names)
+    values = request.truth_table.values
+    k = request.erasure_count
+
+    if k == 0:
+        # No erasure: E|f(z)| = sum |f(x)| / 2^n = 1 since f is always +-1
+        return BooleanErasureNoiseResult(
+            expected_absolute_value_numerator=1,
+            expected_absolute_value_denominator=1,
+            detail="No erasure: E|f(z)| = 1.",
+        )
+
+    total_sum = 0
+    total_count = 0
+
+    # For each subset S of size k (erased variables)
+    for erased in combinations(range(n), k):
+        remaining = [i for i in range(n) if i not in erased]
+        # For each assignment of the remaining variables
+        for remaining_vals in product([-1, 1], repeat=len(remaining)):
+            # Average over all assignments of the erased variables
+            for erased_vals in product([-1, 1], repeat=k):
+                # Construct full assignment
+                assignment = [0] * n
+                for j, idx in enumerate(remaining):
+                    assignment[idx] = remaining_vals[j]
+                for j, idx in enumerate(erased):
+                    assignment[idx] = erased_vals[j]
+                # Evaluate f
+                idx = 0
+                for i in range(n):
+                    if assignment[i] == 1:
+                        idx |= (1 << i)
+                total_sum += abs(values[idx])
+                total_count += 1
+
+    from math import gcd
+    g = gcd(total_sum, total_count)
+    return BooleanErasureNoiseResult(
+        expected_absolute_value_numerator=total_sum // g,
+        expected_absolute_value_denominator=total_count // g,
+        detail=f"E|f(z)| = {total_sum}/{total_count} with {k} erasures.",
+    )

--- a/tests/domain/boolean_analysis/test_boolean_analysis.py
+++ b/tests/domain/boolean_analysis/test_boolean_analysis.py
@@ -1,0 +1,133 @@
+"""Tests for Boolean analysis operations."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.boolean_analysis import (
+    BooleanErasureNoiseRequest,
+    BooleanFourierRequest,
+    BooleanInfluenceRequest,
+    BooleanMultilinearExtensionRequest,
+    BooleanTruthTable,
+)
+from jacobian.domains.boolean_analysis.operations import (
+    compute_boolean_fourier,
+    compute_boolean_influence,
+    compute_erasure_noise,
+    compute_multilinear_extension,
+)
+
+
+def test_fourier_of_and():
+    """AND(a,b) = [-1,-1,-1,1] has Fourier coefficients: f_hat(00)=-1, f_hat(01)=-1, f_hat(10)=-1, f_hat(11)=1."""
+    result = compute_boolean_fourier(
+        BooleanFourierRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, -1, -1, 1],
+            },
+        })
+    )
+    coeffs = {c.subset_mask: c.coefficient for c in result.coefficients}
+    # AND has f_hat(0) = -1, f_hat({a}) = -1, f_hat({b}) = -1, f_hat({a,b}) = 1
+    # But these are numerators with denominator 2^2=4
+    # f(x) = sum_S f_hat(S) chi_S(x), so f_hat(S) = (1/2^n) sum_x f(x) chi_S(x)
+    assert coeffs[0] == -2  # f_hat(empty) * 4
+    assert coeffs[3] == 2   # f_hat({a,b}) * 4
+
+
+def test_fourier_of_dictator():
+    """Dictator f(a,b) = a has Fourier coefficient only for {a}."""
+    result = compute_boolean_fourier(
+        BooleanFourierRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, 1, -1, 1],
+            },
+        })
+    )
+    coeffs = {c.subset_mask: c.coefficient for c in result.coefficients}
+    assert coeffs[1] == 4  # f_hat({a}) * 4 = 4
+    assert coeffs[0] == 0
+    assert coeffs[2] == 0
+    assert coeffs[3] == 0
+
+
+def test_influence_of_and():
+    """AND(a,b) has influence 2 for each variable."""
+    result = compute_boolean_influence(
+        BooleanInfluenceRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, -1, -1, 1],
+            },
+        })
+    )
+    assert result.influences == (2, 2)
+    assert result.total_influence == 4
+
+
+def test_influence_of_dictator():
+    """Dictator f(a,b) = a has influence 4 for a, 0 for b."""
+    result = compute_boolean_influence(
+        BooleanInfluenceRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, 1, -1, 1],
+            },
+        })
+    )
+    assert result.influences == (4, 0)
+
+
+def test_erasure_noise_no_erasure():
+    """With 0 erasures, E|f(z)| = 1."""
+    result = compute_erasure_noise(
+        BooleanErasureNoiseRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, -1, -1, 1],
+            },
+            "erasure_count": 0,
+        })
+    )
+    assert result.expected_absolute_value_numerator == 1
+    assert result.expected_absolute_value_denominator == 1
+
+
+def test_erasure_noise_one_erasure():
+    """With 1 erasure on AND, E|f(z)| should be computable."""
+    result = compute_erasure_noise(
+        BooleanErasureNoiseRequest.model_validate({
+            "truth_table": {
+                "variable_names": ["a", "b"],
+                "values": [-1, -1, -1, 1],
+            },
+            "erasure_count": 1,
+        })
+    )
+    assert result.expected_absolute_value_denominator > 0
+    assert result.expected_absolute_value_numerator > 0
+
+
+def test_truth_table_validation():
+    """Invalid truth table length should fail."""
+    with pytest.raises(ValidationError, match="truth table must have"):
+        BooleanTruthTable.model_validate({
+            "variable_names": ["a", "b"],
+            "values": [-1, 1, -1],
+        })
+
+
+def test_operations_discoverable():
+    """All four operations should be discoverable."""
+    from jacobian.domains.boolean_analysis import boolean_analysis_operations
+
+    ops = boolean_analysis_operations()
+    op_ids = [op.operation_id for op in ops]
+    assert "boolean.fourier.compute" in op_ids
+    assert "boolean.multilinear_extension.evaluate" in op_ids
+    assert "boolean.influence.compute" in op_ids
+    assert "boolean.erasure_noise.compute" in op_ids


### PR DESCRIPTION
Closes #1699

Implements four atomic composable math operations for Boolean analysis:
- `boolean.fourier.compute` - Walsh-Fourier coefficients of f: {-1,+1}^n -> {-1,+1}
- `boolean.multilinear_extension.evaluate` - multilinear extension evaluation at a point in Z^n
- `boolean.influence.compute` - variable influences (number of flippable edges)
- `boolean.erasure_noise.compute` - exact expected |f(z)| when k variables are erased

Built on exact integer arithmetic. No hand-rolled libraries.

## Tests
8 tests covering AND function Fourier, dictator function Fourier, influences, erasure noise, and contract validation