### PR TITLE
feat(graphs): add exact maximal independent-set decision (#1668)

### DIFF
--- a/src/jacobian/contracts/graph_coloring_ops.py
+++ b/src/jacobian/contracts/graph_coloring_ops.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -53,3 +53,54 @@ class MaximumIndependentSetRequest(ContractModel):
 class MaximumIndependentSetResult(ContractModel):
     independent_set: tuple[int, ...]
     cardinality: int = Field(ge=0, le=20)
+
+
+class MaximalIndependentSetRequest(ContractModel):
+    """One canonical candidate set in a bounded simple graph."""
+
+    graph: GraphEdgeList
+    candidate_set: tuple[int, ...] = Field(max_length=20)
+
+    @model_validator(mode="after")
+    def require_canonical_candidate_set(self) -> Self:
+        if tuple(sorted(self.candidate_set)) != self.candidate_set:
+            raise ValueError("candidate_set must be strictly increasing")
+        if len(set(self.candidate_set)) != len(self.candidate_set):
+            raise ValueError("candidate_set must not contain duplicate vertices")
+        if any(
+            vertex < 0 or vertex >= self.graph.vertex_count
+            for vertex in self.candidate_set
+        ):
+            raise ValueError("candidate vertices must lie in 0..vertex_count-1")
+        return self
+
+
+class MaximalIndependentSetResult(ContractModel):
+    """A closed decision with a concrete rejection witness when applicable."""
+
+    decision: Literal["MAXIMAL", "NOT_INDEPENDENT", "INDEPENDENT_NOT_MAXIMAL"]
+    blocking_edge: tuple[int, int] | None = None
+    addable_vertex: int | None = None
+
+    @model_validator(mode="after")
+    def bind_witness_to_decision(self) -> Self:
+        if self.decision == "MAXIMAL":
+            if self.blocking_edge is not None or self.addable_vertex is not None:
+                raise ValueError("a maximal result must not carry a rejection witness")
+            return self
+        if self.decision == "NOT_INDEPENDENT":
+            if self.blocking_edge is None or self.addable_vertex is not None:
+                raise ValueError(
+                    "a non-independent result requires exactly one blocking edge"
+                )
+            u, v = self.blocking_edge
+            if u < 0 or v < 0 or u >= v:
+                raise ValueError("blocking_edge must be a canonical pair u < v")
+            return self
+        if self.blocking_edge is not None or self.addable_vertex is None:
+            raise ValueError(
+                "an independent non-maximal result requires exactly one addable vertex"
+            )
+        if self.addable_vertex < 0:
+            raise ValueError("addable_vertex must be nonnegative")
+        return self

--- a/src/jacobian/domains/graph_coloring_ops/math_tools.py
+++ b/src/jacobian/domains/graph_coloring_ops/math_tools.py
@@ -7,6 +7,8 @@ from jacobian.contracts.base import ContractModel
 from jacobian.contracts.graph_coloring_ops import (
     KColorabilityRequest,
     KColorabilityResult,
+    MaximalIndependentSetRequest,
+    MaximalIndependentSetResult,
     MaximumIndependentSetRequest,
     MaximumIndependentSetResult,
 )
@@ -14,6 +16,7 @@ from jacobian.contracts.operations import OperationExample
 from jacobian.domains._examples import example
 from jacobian.domains.graph_coloring_ops.operations import (
     compute_k_colorability,
+    compute_maximal_independent_set_decision,
     compute_maximum_independent_set,
 )
 from jacobian.math_tools import MathTool
@@ -50,7 +53,7 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_coloring_operation(
         "graph.coloring.k_colorability.decide",
         "Decide k-colorability of a graph",
-        "Decide whether a simple undirected graph admits a proper k-coloring and return a coloring if one exists, using NetworkX greedy coloring.",
+        "Decide whether a simple undirected graph admits a proper k-coloring and return a coloring if one exists, using a Z3 SAT encoding.",
         KColorabilityRequest,
         KColorabilityResult,
         compute_k_colorability,
@@ -75,7 +78,7 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_coloring_operation(
         "graph.independent_set.maximum.compute",
         "Compute the maximum independent set of a graph",
-        "Compute the maximum independent set of a simple undirected graph using NetworkX approximation.",
+        "Compute the maximum independent set of a simple undirected graph using a Z3 optimization encoding.",
         MaximumIndependentSetRequest,
         MaximumIndependentSetResult,
         compute_maximum_independent_set,
@@ -91,6 +94,31 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                         "vertex_count": 4,
                         "edges": [[0, 1], [1, 2], [2, 3]],
                     },
+                },
+            ),
+        ),
+    ),
+    graph_coloring_operation(
+        "graph.independent_set.maximal.decide",
+        "Decide whether a candidate set is a maximal independent set",
+        "Decide maximal independence in a bounded simple graph and return a blocking edge or addable vertex when the candidate fails.",
+        MaximalIndependentSetRequest,
+        MaximalIndependentSetResult,
+        compute_maximal_independent_set_decision,
+        "graph",
+        "independent-set",
+        "maximal",
+        "exact",
+        examples=(
+            example(
+                "path_maximal_independent_set",
+                "Decide whether {0, 2} is a maximal independent set of P4.",
+                {
+                    "graph": {
+                        "vertex_count": 4,
+                        "edges": [[0, 1], [1, 2], [2, 3]],
+                    },
+                    "candidate_set": [0, 2],
                 },
             ),
         ),

--- a/src/jacobian/domains/graph_coloring_ops/operations.py
+++ b/src/jacobian/domains/graph_coloring_ops/operations.py
@@ -65,9 +65,7 @@ def compute_maximal_independent_set_decision(
 ) -> MaximalIndependentSetResult:
     """Decide maximal independence and return the first canonical obstruction."""
     candidate = frozenset(request.candidate_set)
-    edges = tuple(
-        sorted((min(u, v), max(u, v)) for u, v in request.graph.edges)
-    )
+    edges = tuple(sorted((min(u, v), max(u, v)) for u, v in request.graph.edges))
     for edge in edges:
         if edge[0] in candidate and edge[1] in candidate:
             return MaximalIndependentSetResult(
@@ -75,9 +73,7 @@ def compute_maximal_independent_set_decision(
                 blocking_edge=edge,
             )
 
-    adjacency: list[set[int]] = [
-        set() for _ in range(request.graph.vertex_count)
-    ]
+    adjacency: list[set[int]] = [set() for _ in range(request.graph.vertex_count)]
     for u, v in edges:
         adjacency[u].add(v)
         adjacency[v].add(u)

--- a/src/jacobian/domains/graph_coloring_ops/operations.py
+++ b/src/jacobian/domains/graph_coloring_ops/operations.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from jacobian.contracts.graph_coloring_ops import (
     KColorabilityRequest,
     KColorabilityResult,
+    MaximalIndependentSetRequest,
+    MaximalIndependentSetResult,
     MaximumIndependentSetRequest,
     MaximumIndependentSetResult,
 )
@@ -56,3 +58,33 @@ def compute_maximum_independent_set(
         independent_set=iset,
         cardinality=len(iset),
     )
+
+
+def compute_maximal_independent_set_decision(
+    request: MaximalIndependentSetRequest,
+) -> MaximalIndependentSetResult:
+    """Decide maximal independence and return the first canonical obstruction."""
+    candidate = frozenset(request.candidate_set)
+    edges = tuple(
+        sorted((min(u, v), max(u, v)) for u, v in request.graph.edges)
+    )
+    for edge in edges:
+        if edge[0] in candidate and edge[1] in candidate:
+            return MaximalIndependentSetResult(
+                decision="NOT_INDEPENDENT",
+                blocking_edge=edge,
+            )
+
+    adjacency: list[set[int]] = [
+        set() for _ in range(request.graph.vertex_count)
+    ]
+    for u, v in edges:
+        adjacency[u].add(v)
+        adjacency[v].add(u)
+    for vertex in range(request.graph.vertex_count):
+        if vertex not in candidate and adjacency[vertex].isdisjoint(candidate):
+            return MaximalIndependentSetResult(
+                decision="INDEPENDENT_NOT_MAXIMAL",
+                addable_vertex=vertex,
+            )
+    return MaximalIndependentSetResult(decision="MAXIMAL")

--- a/tests/domain/graph/test_graph_coloring_1668.py
+++ b/tests/domain/graph/test_graph_coloring_1668.py
@@ -1,0 +1,128 @@
+"""Tests for exact maximal-independent-set decision."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.graph_coloring_ops import (
+    MaximalIndependentSetRequest,
+    MaximalIndependentSetResult,
+)
+from jacobian.domains.graph_coloring_ops.operations import (
+    compute_maximal_independent_set_decision,
+)
+
+
+def _request(
+    *,
+    vertex_count: int,
+    edges: list[list[int]],
+    candidate_set: list[int],
+) -> MaximalIndependentSetRequest:
+    return MaximalIndependentSetRequest.model_validate(
+        {
+            "graph": {"vertex_count": vertex_count, "edges": edges},
+            "candidate_set": candidate_set,
+        }
+    )
+
+
+def test_path_candidate_is_maximal() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(
+            vertex_count=4,
+            edges=[[0, 1], [1, 2], [2, 3]],
+            candidate_set=[0, 2],
+        )
+    )
+
+    assert result == MaximalIndependentSetResult(decision="MAXIMAL")
+
+
+def test_non_independent_candidate_returns_canonical_blocking_edge() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(
+            vertex_count=3,
+            edges=[[1, 0], [1, 2]],
+            candidate_set=[0, 1],
+        )
+    )
+
+    assert result.decision == "NOT_INDEPENDENT"
+    assert result.blocking_edge == (0, 1)
+    assert result.addable_vertex is None
+
+
+def test_nonmaximal_candidate_returns_smallest_addable_vertex() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(
+            vertex_count=4,
+            edges=[[0, 1], [1, 2], [2, 3]],
+            candidate_set=[0],
+        )
+    )
+
+    assert result.decision == "INDEPENDENT_NOT_MAXIMAL"
+    assert result.blocking_edge is None
+    assert result.addable_vertex == 2
+
+
+def test_empty_candidate_in_nonempty_graph_is_not_maximal() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(vertex_count=1, edges=[], candidate_set=[])
+    )
+
+    assert result.decision == "INDEPENDENT_NOT_MAXIMAL"
+    assert result.addable_vertex == 0
+
+
+def test_singleton_in_complete_graph_is_maximal() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(
+            vertex_count=3,
+            edges=[[0, 1], [0, 2], [1, 2]],
+            candidate_set=[1],
+        )
+    )
+
+    assert result.decision == "MAXIMAL"
+
+
+def test_all_vertices_of_empty_graph_form_a_maximal_set() -> None:
+    result = compute_maximal_independent_set_decision(
+        _request(vertex_count=3, edges=[], candidate_set=[0, 1, 2])
+    )
+
+    assert result.decision == "MAXIMAL"
+
+
+@pytest.mark.parametrize(
+    ("candidate_set", "message"),
+    [
+        ([1, 0], "strictly increasing"),
+        ([0, 0], "duplicate"),
+        ([0, 3], "0..vertex_count-1"),
+    ],
+)
+def test_candidate_set_is_canonical_and_in_range(
+    candidate_set: list[int],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        _request(vertex_count=3, edges=[], candidate_set=candidate_set)
+
+
+def test_result_rejects_witness_for_maximal_decision() -> None:
+    with pytest.raises(ValidationError, match="must not carry"):
+        MaximalIndependentSetResult(
+            decision="MAXIMAL",
+            addable_vertex=0,
+        )
+
+
+def test_result_requires_matching_rejection_witness() -> None:
+    with pytest.raises(ValidationError, match="blocking edge"):
+        MaximalIndependentSetResult(decision="NOT_INDEPENDENT")
+    with pytest.raises(ValidationError, match="addable vertex"):
+        MaximalIndependentSetResult(decision="INDEPENDENT_NOT_MAXIMAL")


### PR DESCRIPTION
## Summary

Closes #1668.

Adds the remaining direct operation requested by the issue:

- `graph.independent_set.maximal.decide`

The existing exact k-colorability and maximum-independent-set operations remain unchanged. This branch was rebuilt on the current `main`; it no longer contains the rejected finite-instance-testing domain or unrelated solver-timeout edits.

## Contract

The request accepts one bounded simple graph and one canonical, strictly increasing candidate vertex set.

The result is a closed decision:

- `MAXIMAL`
- `NOT_INDEPENDENT`, with a concrete canonical blocking edge
- `INDEPENDENT_NOT_MAXIMAL`, with the smallest addable vertex

The rejection witnesses make both negative outcomes independently checkable against the request.

## Implementation

The kernel is a direct bounded combinatorial function over the explicit edge list. It normalizes edge orientation, checks independence, builds adjacency once, and then checks whether any outside vertex can be added. It introduces no solver, verifier layer, workflow, storage, or backend abstraction.

The operation declaration also corrects the stale descriptions of the two existing graph operations: both are Z3-backed, not NetworkX approximations.

## Tests

Focused tests cover:

- a maximal independent set of a path;
- a non-independent candidate and its blocking edge;
- an independent non-maximal candidate and its smallest addable vertex;
- empty and complete graph edge cases;
- canonical ordering, duplicate, and range validation;
- result/witness consistency.
