### PR TITLE
Fix graph_flow registration, add formal power series and multivariate polynomial domains

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -53,6 +53,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
         "rational_linear_operations",
     ),
     ("jacobian.domains.lattices", "lattice_operations"),
+    ("jacobian.domains.formal_power_series", "formal_power_series_operations"),
     ("jacobian.domains.polynomial", "polynomial_operations"),
     (
         "jacobian.domains.multivariate_polynomial",

--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -54,6 +54,10 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ),
     ("jacobian.domains.lattices", "lattice_operations"),
     ("jacobian.domains.polynomial", "polynomial_operations"),
+    (
+        "jacobian.domains.multivariate_polynomial",
+        "multivariate_polynomial_operations",
+    ),
     ("jacobian.domains.analysis", "real_analysis_operations"),
     (
         "jacobian.domains.probability",
@@ -72,18 +76,37 @@ def load_builtin_operation_modules() -> tuple[LoadedOperationModule, ...]:
     """Load the fixed built-in inventory for catalog compilation or binding."""
 
     return tuple(
-        load_builtin_operation_module(module_name)
-        for module_name, _factory_name in BUILTIN_OPERATION_MODULES
+        load_builtin_operation_module(module_name, factory_name)
+        for module_name, factory_name in BUILTIN_OPERATION_MODULES
     )
 
 
-def load_builtin_operation_module(module_name: str) -> LoadedOperationModule:
+def load_builtin_operation_module(
+    module_name: str,
+    factory_name: str | None = None,
+) -> LoadedOperationModule:
     """Load one selected module from the fixed built-in inventory."""
 
-    try:
-        factory_name = dict(BUILTIN_OPERATION_MODULES)[module_name]
-    except KeyError as exc:
-        raise ValueError(f"unknown built-in operation module: {module_name}") from exc
+    matching_factories = tuple(
+        factory
+        for configured_module_name, factory in BUILTIN_OPERATION_MODULES
+        if configured_module_name == module_name
+    )
+
+    if factory_name is None:
+        if not matching_factories:
+            raise ValueError(f"unknown built-in operation module: {module_name}")
+        if len(matching_factories) > 1:
+            duplicate_factories = ", ".join(matching_factories)
+            raise ValueError(
+                "ambiguous built-in operation module; specify factory with one of: "
+                f"{duplicate_factories}",
+            )
+        factory_name = matching_factories[0]
+    elif factory_name not in matching_factories:
+        raise ValueError(
+            f"unknown built-in operation module/factory: {module_name}.{factory_name}",
+        )
     module = import_module(module_name)
     factory = getattr(module, factory_name)
     operations = cast(MathTools, factory())

--- a/src/jacobian/contracts/formal_power_series.py
+++ b/src/jacobian/contracts/formal_power_series.py
@@ -1,0 +1,310 @@
+"""Wire contracts for exact truncated formal power series operations."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+
+# ---------------------------------------------------------------------------
+# Public bounds
+# ---------------------------------------------------------------------------
+
+MAX_TRUNCATION_ORDER = 512
+MAX_RATIONAL_DIGITS = 256
+MAX_RESULT_RATIONAL_DIGITS = 4_096
+MAX_RESULT_BYTES = 10 * 1024 * 1024
+MAX_POWER_EXPONENT = 1_000
+
+Variable = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9]*$",
+        max_length=16,
+        strict=True,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared value type
+# ---------------------------------------------------------------------------
+
+
+class TruncatedSeries(ContractModel):
+    """One immutable element of QQ[[x]]/(x^N).
+
+    The coefficient tuple has exactly ``truncation_order`` entries in
+    ascending-power order.  Two series are equal iff they share the same
+    variable, truncation order, and coefficient tuple.
+    """
+
+    variable: Variable = Field(description="The single formal variable.")
+    truncation_order: StrictInt = Field(
+        ge=1,
+        le=MAX_TRUNCATION_ORDER,
+        description="Truncation order N (coefficients a_0..a_{N-1}).",
+    )
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        description="Exactly N rational coefficients in ascending powers.",
+    )
+
+    @model_validator(mode="after")
+    def require_dense_tuple(self) -> Self:
+        if len(self.coefficients) != self.truncation_order:
+            raise ValueError(
+                "coefficient tuple must have exactly truncation_order entries"
+            )
+        for value in self.coefficients:
+            num = value.num
+            den = value.den
+            if len(num.lstrip("-")) > MAX_RATIONAL_DIGITS or len(den) > MAX_RATIONAL_DIGITS:
+                raise ValueError("coefficient exceeds the 256-digit rational bound")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Pair / single-series request helpers
+# ---------------------------------------------------------------------------
+
+
+class _SeriesPairRequest(ContractModel):
+    """Base request with two series that must share variable and order."""
+
+    left: TruncatedSeries
+    right: TruncatedSeries
+
+    @model_validator(mode="after")
+    def require_matching_context(self) -> Self:
+        if self.left.variable != self.right.variable:
+            raise ValueError("operands must share the same variable")
+        if self.left.truncation_order != self.right.truncation_order:
+            raise ValueError("operands must share the same truncation order")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic: add / subtract / multiply / scalar multiply
+# ---------------------------------------------------------------------------
+
+
+class SeriesArithmeticResult(ContractModel):
+    result: TruncatedSeries
+    residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+class SeriesMultiplyResult(ContractModel):
+    result: TruncatedSeries
+    convolution_ledger: tuple[CanonicalRational, ...] = Field(
+        description="Per-degree Cauchy convolution sums c_n = sum_{i=0}^n a_i b_{n-i}.",
+    )
+    residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+class SeriesScalarMultiplyRequest(ContractModel):
+    series: TruncatedSeries
+    scalar: CanonicalRational
+
+
+class SeriesScalarMultiplyResult(ContractModel):
+    result: TruncatedSeries
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Power
+# ---------------------------------------------------------------------------
+
+
+class SeriesPowerRequest(ContractModel):
+    series: TruncatedSeries
+    exponent: StrictInt = Field(ge=0, le=MAX_POWER_EXPONENT)
+
+
+class SeriesPowerResult(ContractModel):
+    result: TruncatedSeries
+    multiplication_count: StrictInt
+    residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Inverse
+# ---------------------------------------------------------------------------
+
+
+class SeriesInverseResult(ContractModel):
+    result: TruncatedSeries
+    residual_congruence: Literal[
+        "PRODUCT_IS_ONE_MOD_X_TO_N"
+    ] = "PRODUCT_IS_ONE_MOD_X_TO_N"
+    residual_coefficients: tuple[CanonicalRational, ...] = Field(
+        description="A(x) * B(x) - 1 coefficients (must all be zero).",
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Divide
+# ---------------------------------------------------------------------------
+
+
+class SeriesDivideResult(ContractModel):
+    quotient: TruncatedSeries
+    residual_congruence: Literal[
+        "DENOMINATOR_TIMES_QUOTIENT_MINUS_NUMERATOR_IS_ZERO_MOD_X_TO_N"
+    ] = "DENOMINATOR_TIMES_QUOTIENT_MINUS_NUMERATOR_IS_ZERO_MOD_X_TO_N"
+    residual_coefficients: tuple[CanonicalRational, ...] = Field(
+        description="B(x) Q(x) - A(x) coefficients (must all be zero).",
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Compose
+# ---------------------------------------------------------------------------
+
+
+class SeriesComposeRequest(ContractModel):
+    outer: TruncatedSeries
+    inner: TruncatedSeries
+
+    @model_validator(mode="after")
+    def require_matching_variable_and_zero_inner_constant(self) -> Self:
+        if self.outer.variable != self.inner.variable:
+            raise ValueError("outer and inner series must share the same variable")
+        if self.outer.truncation_order != self.inner.truncation_order:
+            raise ValueError("outer and inner series must share the same truncation order")
+        if self.inner.coefficients[0].as_fraction() != 0:
+            raise ValueError(
+                "inner series must have zero constant term for composition with a finite prefix"
+            )
+        return self
+
+
+class SeriesComposeResult(ContractModel):
+    result: TruncatedSeries
+    residual_congruence: Literal["EXACT_MOD_X_TO_N"] = "EXACT_MOD_X_TO_N"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Reversion
+# ---------------------------------------------------------------------------
+
+
+class SeriesReversionResult(ContractModel):
+    result: TruncatedSeries
+    left_identity: Literal["F_OF_G_IS_X_MOD_X_TO_N"] = "F_OF_G_IS_X_MOD_X_TO_N"
+    right_identity: Literal["G_OF_F_IS_X_MOD_X_TO_N"] = "G_OF_F_IS_X_MOD_X_TO_N"
+    left_residual: tuple[CanonicalRational, ...]
+    right_residual: tuple[CanonicalRational, ...]
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Derivative / integral
+# ---------------------------------------------------------------------------
+
+
+class SeriesDerivativeResult(ContractModel):
+    result: TruncatedSeries
+    output_order_convention: Literal[
+        "MAX_N_MINUS_1_AT_LEAST_1"
+    ] = "MAX_N_MINUS_1_AT_LEAST_1"
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+class SeriesIntegralRequest(ContractModel):
+    series: TruncatedSeries
+    output_order: StrictInt = Field(ge=1, le=MAX_TRUNCATION_ORDER)
+
+
+class SeriesIntegralResult(ContractModel):
+    result: TruncatedSeries
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Truncate
+# ---------------------------------------------------------------------------
+
+
+class SeriesTruncateRequest(ContractModel):
+    series: TruncatedSeries
+    target_order: StrictInt = Field(ge=1)
+
+    @model_validator(mode="after")
+    def require_target_le_source(self) -> Self:
+        if self.target_order > self.series.truncation_order:
+            raise ValueError("target_order must not exceed source truncation order")
+        if self.target_order > MAX_TRUNCATION_ORDER:
+            raise ValueError("target_order exceeds the public bound")
+        return self
+
+
+class SeriesTruncateResult(ContractModel):
+    result: TruncatedSeries
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Identity check
+# ---------------------------------------------------------------------------
+
+
+class SeriesIdentityCheckResult(ContractModel):
+    status: Literal["EQUAL_MOD_X_TO_N", "NOT_EQUAL"]
+    first_differing_index: StrictInt | None = None
+    exact_difference: CanonicalRational | None = None
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+    @model_validator(mode="after")
+    def require_consistent_diff(self) -> Self:
+        if self.status == "EQUAL_MOD_X_TO_N":
+            if self.first_differing_index is not None or self.exact_difference is not None:
+                raise ValueError("EQUAL must not carry a difference")
+        else:
+            if self.first_differing_index is None or self.exact_difference is None:
+                raise ValueError("NOT_EQUAL must carry a difference")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Polynomial conversions
+# ---------------------------------------------------------------------------
+
+
+class SeriesFromPolynomialRequest(ContractModel):
+    """Convert a dense rational polynomial coefficient prefix into a series."""
+
+    variable: Variable
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_TRUNCATION_ORDER,
+    )
+    truncation_order: StrictInt = Field(ge=1, le=MAX_TRUNCATION_ORDER)
+
+    @model_validator(mode="after")
+    def require_dense_tuple(self) -> Self:
+        if len(self.coefficients) != self.truncation_order:
+            raise ValueError("input coefficients must match truncation_order exactly")
+        return self
+
+
+class SeriesFromPolynomialResult(ContractModel):
+    result: TruncatedSeries
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+class SeriesToPolynomialResult(ContractModel):
+    result: TruncatedSeries
+    polynomial_label: Literal["TRUNCATED_POLYNOMIAL_REPRESENTATIVE"] = (
+        "TRUNCATED_POLYNOMIAL_REPRESENTATIVE"
+    )
+    exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"

--- a/src/jacobian/contracts/graph_flow.py
+++ b/src/jacobian/contracts/graph_flow.py
@@ -58,10 +58,19 @@ class MaxFlowRequest(ContractModel):
         return self
 
 
+class FlowEdgeValue(ContractModel):
+    """The flow assigned to one directed edge."""
+
+    source: int = Field(ge=0, le=63)
+    target: int = Field(ge=0, le=63)
+    flow: CanonicalRational
+
+
 class MaxFlowResult(ContractModel):
     flow_value: CanonicalRational
     source: int = Field(ge=0, le=63)
     sink: int = Field(ge=0, le=63)
+    flow_edges: tuple[FlowEdgeValue, ...] = Field(default=())
     convention: Literal["NETWORKX_MAXIMUM_FLOW"] = "NETWORKX_MAXIMUM_FLOW"
 
 
@@ -86,3 +95,53 @@ class MinCutResult(ContractModel):
     reachable: tuple[int, ...]
     unreachable: tuple[int, ...]
     convention: Literal["NETWORKX_MINIMUM_CUT"] = "NETWORKX_MINIMUM_CUT"
+
+
+class EdgeDisjointPathsGraph(ContractModel):
+    """A simple directed graph for edge-disjoint path computation."""
+
+    vertex_count: int = Field(ge=2, le=64)
+    edges: tuple[tuple[int, int], ...] = Field(min_length=1, max_length=512)
+
+    @model_validator(mode="after")
+    def require_valid_edges(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for source, target in self.edges:
+            if not (
+                0 <= source < self.vertex_count
+                and 0 <= target < self.vertex_count
+            ):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            if source == target:
+                raise ValueError("self-loops are not allowed")
+            endpoint_pair = (source, target)
+            if endpoint_pair in seen:
+                raise ValueError("directed edges must be unique")
+            seen.add(endpoint_pair)
+        return self
+
+
+class EdgeDisjointPathsRequest(ContractModel):
+    graph: EdgeDisjointPathsGraph
+    source: int = Field(ge=0, le=63)
+    sink: int = Field(ge=0, le=63)
+
+    @model_validator(mode="after")
+    def require_valid_terminals(self) -> Self:
+        if not (0 <= self.source < self.graph.vertex_count):
+            raise ValueError("source must be in 0..graph.vertex_count-1")
+        if not (0 <= self.sink < self.graph.vertex_count):
+            raise ValueError("sink must be in 0..graph.vertex_count-1")
+        if self.source == self.sink:
+            raise ValueError("source and sink must be distinct")
+        return self
+
+
+class EdgeDisjointPathsResult(ContractModel):
+    path_count: int = Field(ge=0)
+    paths: tuple[tuple[int, ...], ...] = Field(default=())
+    source: int = Field(ge=0, le=63)
+    sink: int = Field(ge=0, le=63)
+    convention: Literal["NETWORKX_EDGE_DISJOINT_PATHS"] = (
+        "NETWORKX_EDGE_DISJOINT_PATHS"
+    )

--- a/src/jacobian/contracts/multivariate_polynomial.py
+++ b/src/jacobian/contracts/multivariate_polynomial.py
@@ -1,0 +1,170 @@
+"""Contracts for exact multivariate polynomial operations over ``QQ``."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
+    require_polynomial_budget,
+)
+
+_MAX_MULTIVARIATE_TERMS = 512
+_MAX_MULTIVARIATE_EXPONENT = 64
+_MAX_MULTIVARIATE_COEFFICIENT_DIGITS = 256
+_MAX_ELIMINATION_DEGREE_SUM = 64
+
+MonomialOrder = Literal["lex", "grlex", "grevlex"]
+"""Declared monomial order for multivariate polynomial division."""
+
+_MULTIVARIATE_MIN_VARIABLES = 2
+
+
+def _validate_multivariate_pair(
+    left: RationalPolynomial,
+    right: RationalPolynomial,
+) -> None:
+    """Shared validation for two polynomials in the same declared ring."""
+
+    if len(left.variables) < _MULTIVARIATE_MIN_VARIABLES:
+        raise ValueError("multivariate operations require at least two variables")
+    if left.variables != right.variables:
+        raise ValueError("both polynomials must use the same ordered variables")
+
+
+class MultivariateGcdRequest(ContractModel):
+    """Two multivariate polynomials in ``QQ[x_1, ..., x_n]``."""
+
+    left: RationalPolynomial
+    right: RationalPolynomial
+
+    @model_validator(mode="after")
+    def require_multivariate_ring(self) -> Self:
+        _validate_multivariate_pair(self.left, self.right)
+        for polynomial in (self.left, self.right):
+            require_polynomial_budget(
+                polynomial,
+                maximum_terms=_MAX_MULTIVARIATE_TERMS,
+                maximum_exponent=_MAX_MULTIVARIATE_EXPONENT,
+                maximum_coefficient_digits=_MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
+            )
+        return self
+
+
+class MultivariateGcdResult(ContractModel):
+    gcd: RationalPolynomial
+    convention: Literal["MONIC_ASSOCIATE"] = "MONIC_ASSOCIATE"
+
+
+class MultivariateDivisionRequest(ContractModel):
+    """Divide one multivariate polynomial by another under a declared monomial order."""
+
+    left: RationalPolynomial
+    right: RationalPolynomial
+    monomial_order: MonomialOrder = "lex"
+
+    @model_validator(mode="after")
+    def require_multivariate_ring(self) -> Self:
+        _validate_multivariate_pair(self.left, self.right)
+        for polynomial in (self.left, self.right):
+            require_polynomial_budget(
+                polynomial,
+                maximum_terms=_MAX_MULTIVARIATE_TERMS,
+                maximum_exponent=_MAX_MULTIVARIATE_EXPONENT,
+                maximum_coefficient_digits=_MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
+            )
+        return self
+
+
+class MultivariateDivisionResult(ContractModel):
+    quotient: RationalPolynomial
+    remainder: RationalPolynomial
+    monomial_order: MonomialOrder
+    convention: Literal["EXACT_DIVISION_REMAINDER"] = "EXACT_DIVISION_REMAINDER"
+
+
+class MultivariateResultantRequest(ContractModel):
+    """Compute the resultant of two multivariate polynomials w.r.t. one variable."""
+
+    left: RationalPolynomial
+    right: RationalPolynomial
+    elimination_variable: PolynomialVariable
+
+    @model_validator(mode="after")
+    def require_multivariate_ring(self) -> Self:
+        _validate_multivariate_pair(self.left, self.right)
+        if self.elimination_variable not in self.left.variables:
+            raise ValueError(
+                "elimination variable must belong to the declared ring"
+            )
+        for polynomial in (self.left, self.right):
+            require_polynomial_budget(
+                polynomial,
+                maximum_terms=_MAX_MULTIVARIATE_TERMS,
+                maximum_exponent=_MAX_MULTIVARIATE_EXPONENT,
+                maximum_coefficient_digits=_MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
+            )
+        variable_index = self.left.variables.index(self.elimination_variable)
+        for polynomial, label in ((self.left, "left"), (self.right, "right")):
+            degree_in_variable = max(
+                (
+                    term.exponents[variable_index]
+                    for term in polynomial.polynomial.terms
+                ),
+                default=0,
+            )
+            if degree_in_variable == 0:
+                raise ValueError(
+                    f"{label} polynomial has zero degree in the elimination variable"
+                )
+        degree_sum = max(
+            (term.exponents[variable_index] for term in self.left.polynomial.terms),
+            default=0,
+        ) + max(
+            (term.exponents[variable_index] for term in self.right.polynomial.terms),
+            default=0,
+        )
+        if degree_sum > _MAX_ELIMINATION_DEGREE_SUM:
+            raise ValueError("Sylvester degree exceeds the resultant budget")
+        return self
+
+
+class MultivariateScalarValue(ContractModel):
+    kind: Literal["SCALAR"] = "SCALAR"
+    value: CanonicalRational
+
+
+class MultivariatePolynomialValue(ContractModel):
+    kind: Literal["POLYNOMIAL"] = "POLYNOMIAL"
+    value: RationalPolynomial
+
+
+MultivariateInvariantValue = Annotated[
+    MultivariateScalarValue | MultivariatePolynomialValue,
+    Field(discriminator="kind"),
+]
+
+
+class MultivariateResultantResult(ContractModel):
+    elimination_variable: PolynomialVariable
+    resultant: MultivariateInvariantValue
+    convention: Literal["SYLVESTER_DETERMINANT"] = "SYLVESTER_DETERMINANT"
+
+
+__all__ = [
+    "MonomialOrder",
+    "MultivariateDivisionRequest",
+    "MultivariateDivisionResult",
+    "MultivariateGcdRequest",
+    "MultivariateGcdResult",
+    "MultivariateInvariantValue",
+    "MultivariatePolynomialValue",
+    "MultivariateResultantRequest",
+    "MultivariateResultantResult",
+    "MultivariateScalarValue",
+]

--- a/src/jacobian/domains/formal_power_series/__init__.py
+++ b/src/jacobian/domains/formal_power_series/__init__.py
@@ -1,0 +1,18 @@
+"""Exact truncated formal power series operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["formal_power_series_operations"]
+
+
+def formal_power_series_operations() -> MathTools:
+    from jacobian.domains.formal_power_series.math_tools import (
+        FORMAL_POWER_SERIES_OPERATIONS,
+    )
+
+    return FORMAL_POWER_SERIES_OPERATIONS

--- a/src/jacobian/domains/formal_power_series/math_tools.py
+++ b/src/jacobian/domains/formal_power_series/math_tools.py
@@ -1,0 +1,674 @@
+"""MathTool declarations for exact truncated formal power series operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.formal_power_series import (
+    SeriesArithmeticResult,
+    SeriesComposeRequest,
+    SeriesComposeResult,
+    SeriesDerivativeResult,
+    SeriesDivideResult,
+    SeriesFromPolynomialRequest,
+    SeriesFromPolynomialResult,
+    SeriesIdentityCheckResult,
+    SeriesIntegralRequest,
+    SeriesIntegralResult,
+    SeriesInverseResult,
+    SeriesMultiplyResult,
+    SeriesPowerRequest,
+    SeriesPowerResult,
+    SeriesReversionResult,
+    SeriesScalarMultiplyRequest,
+    SeriesScalarMultiplyResult,
+    SeriesToPolynomialResult,
+    SeriesTruncateRequest,
+    SeriesTruncateResult,
+    TruncatedSeries,
+    _SeriesPairRequest,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.formal_power_series.operations import (
+    compute_add,
+    compute_compose,
+    compute_derivative,
+    compute_divide,
+    compute_from_polynomial,
+    compute_identity_check,
+    compute_integral,
+    compute_inverse,
+    compute_multiply,
+    compute_power,
+    compute_scalar_multiply,
+    compute_subtract,
+    compute_to_polynomial,
+    compute_truncate,
+    compute_reversion,
+)
+from jacobian.math_tools import MathTool
+
+
+class _SeriesArithmeticRequest(_SeriesPairRequest):
+    """Request for add/subtract/multiply/divide operations."""
+
+
+class _SeriesIdentityCheckRequest(_SeriesPairRequest):
+    """Request for identity check operation."""
+
+
+FORMAL_POWER_SERIES_OPERATIONS = (
+    MathTool(
+        operation_id="formal_series.rational.add.compute",
+        version="1",
+        title="Add two truncated formal power series",
+        description=(
+            "Compute the exact rational sum of two truncated series in QQ[[x]]/(x^N) "
+            "coefficient-wise.  Both operands must share the same variable and "
+            "truncation order."
+        ),
+        request_type=_SeriesArithmeticRequest,
+        result_type=SeriesArithmeticResult,
+        run=lambda request: compute_add(request.left, request.right),
+        tags=(
+            "formal-series",
+            "power-series",
+            "arithmetic",
+            "addition",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "add_one_plus_x",
+                "Add (1+x) + (1+2x) = 2+3x at order 2.",
+                {
+                    "left": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                    "right": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "2", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.subtract.compute",
+        version="1",
+        title="Subtract two truncated formal power series",
+        description=(
+            "Compute the exact rational difference of two truncated series in "
+            "QQ[[x]]/(x^N) coefficient-wise.  Both operands must share the same "
+            "variable and truncation order."
+        ),
+        request_type=_SeriesArithmeticRequest,
+        result_type=SeriesArithmeticResult,
+        run=lambda request: compute_subtract(request.left, request.right),
+        tags=(
+            "formal-series",
+            "power-series",
+            "arithmetic",
+            "subtraction",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "subtract_1_plus_x",
+                "Subtract (1+x) - (2+x) = -1 at order 2.",
+                {
+                    "left": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                    "right": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "2", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.multiply.compute",
+        version="1",
+        title="Multiply two truncated formal power series",
+        description=(
+            "Compute the exact Cauchy convolution of two truncated series in "
+            "QQ[[x]]/(x^N).  Both operands must share the same variable and "
+            "truncation order."
+        ),
+        request_type=_SeriesArithmeticRequest,
+        result_type=SeriesMultiplyResult,
+        run=lambda request: compute_multiply(request.left, request.right),
+        tags=(
+            "formal-series",
+            "power-series",
+            "arithmetic",
+            "multiplication",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "multiply_1_plus_x",
+                "Multiply (1+x) * (1+x) = 1+2x+x^2 at order 3.",
+                {
+                    "left": {
+                        "variable": "x",
+                        "truncation_order": 3,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    "right": {
+                        "variable": "x",
+                        "truncation_order": 3,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.scalar_multiply.compute",
+        version="1",
+        title="Multiply a series by a rational scalar",
+        description=(
+            "Multiply a truncated formal power series by an exact rational scalar. "
+        ),
+        request_type=SeriesScalarMultiplyRequest,
+        result_type=SeriesScalarMultiplyResult,
+        run=lambda request: compute_scalar_multiply(request.series, request.scalar),
+        tags=(
+            "formal-series",
+            "power-series",
+            "arithmetic",
+            "scalar",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "scalar_multiply_3",
+                "Multiply (1+x) by 3 = 3+3x at order 2.",
+                {
+                    "series": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                    "scalar": {"num": "3", "den": "1"},
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.power.compute",
+        version="1",
+        title="Raise a truncated formal power series to a nonnegative integer power",
+        description=(
+            "Compute the exact power of a truncated series in QQ[[x]]/(x^N) via "
+            "binary exponentiation."
+        ),
+        request_type=SeriesPowerRequest,
+        result_type=SeriesPowerResult,
+        run=lambda request: compute_power(request.series, request.exponent),
+        tags=(
+            "formal-series",
+            "power-series",
+            "arithmetic",
+            "power",
+            "exponentiation",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "power_3_of_1_plus_x",
+                "Compute (1+x)^3 at order 4.",
+                {
+                    "series": {
+                        "variable": "x",
+                        "truncation_order": 4,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    "exponent": 3,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.inverse.compute",
+        version="1",
+        title="Invert a truncated formal power series",
+        description=(
+            "Compute the multiplicative inverse B(x) of A(x) modulo x^N, requiring "
+            "a_0 != 0.  Returns the exact product residual A*B - 1."
+        ),
+        request_type=TruncatedSeries,
+        result_type=SeriesInverseResult,
+        run=lambda request: compute_inverse(request),
+        tags=(
+            "formal-series",
+            "power-series",
+            "inverse",
+            "unit",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "inverse_1_plus_x",
+                "Invert (1+x) at order 4: 1-x+x^2-x^3.",
+                {
+                    "variable": "x",
+                    "truncation_order": 4,
+                    "coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "1", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "0", "den": "1"},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.divide.compute",
+        version="1",
+        title="Divide two truncated formal power series",
+        description=(
+            "Compute the exact quotient Q = A/B modulo x^N, requiring b_0 != 0. "
+            "Returns the exact residual B*Q - A."
+        ),
+        request_type=_SeriesArithmeticRequest,
+        result_type=SeriesDivideResult,
+        run=lambda request: compute_divide(request.left, request.right),
+        tags=(
+            "formal-series",
+            "power-series",
+            "division",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "divide_1_by_1_minus_x",
+                "Divide 1 by (1-x) at order 4: 1+x+x^2+x^3.",
+                {
+                    "left": {
+                        "variable": "x",
+                        "truncation_order": 4,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    "right": {
+                        "variable": "x",
+                        "truncation_order": 4,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "-1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.compose.compute",
+        version="1",
+        title="Compose two truncated formal power series",
+        description=(
+            "Compute the composition F(G(x)) mod x^N.  The inner series G must "
+            "have zero constant term."
+        ),
+        request_type=SeriesComposeRequest,
+        result_type=SeriesComposeResult,
+        run=lambda request: compute_compose(request.outer, request.inner),
+        tags=(
+            "formal-series",
+            "power-series",
+            "composition",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "compose_x_with_x_squared",
+                "Compose (1+x) with (x^2) at order 4: 1+x^2.",
+                {
+                    "outer": {
+                        "variable": "x",
+                        "truncation_order": 4,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    "inner": {
+                        "variable": "x",
+                        "truncation_order": 4,
+                        "coefficients": [
+                            {"num": "0", "den": "1"},
+                            {"num": "0", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.reversion.compute",
+        version="1",
+        title="Compositional inverse of a truncated formal power series",
+        description=(
+            "Compute the compositional inverse G(x) of F(x) mod x^N, requiring "
+            "F(0)=0 and f_1 != 0.  Validates both left and right identities "
+            "exactly."
+        ),
+        request_type=TruncatedSeries,
+        result_type=SeriesReversionResult,
+        run=lambda request: compute_reversion(request),
+        tags=(
+            "formal-series",
+            "power-series",
+            "reversion",
+            "compositional-inverse",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "reversion_of_2x",
+                "Reversion of (2x) at order 4: (1/2)x.",
+                {
+                    "variable": "x",
+                    "truncation_order": 4,
+                    "coefficients": [
+                        {"num": "0", "den": "1"},
+                        {"num": "2", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "0", "den": "1"},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.derivative.compute",
+        version="1",
+        title="Formal derivative of a truncated power series",
+        description=(
+            "Compute the formal derivative of a truncated series in QQ[[x]]/(x^N). "
+            "Output order convention: max(N-1, 1)."
+        ),
+        request_type=TruncatedSeries,
+        result_type=SeriesDerivativeResult,
+        run=lambda request: compute_derivative(request),
+        tags=(
+            "formal-series",
+            "power-series",
+            "derivative",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "derivative_of_1_plus_2x_plus_3x_squared",
+                "Derivative of (1+2x+3x^2) at order 3: 2+6x at order 2.",
+                {
+                    "variable": "x",
+                    "truncation_order": 3,
+                    "coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "2", "den": "1"},
+                        {"num": "3", "den": "1"},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.integral_zero_constant.compute",
+        version="1",
+        title="Zero-constant formal integral of a truncated power series",
+        description=(
+            "Compute the unique formal antiderivative B'(x)=A(x), B(0)=0 of a "
+            "truncated series."
+        ),
+        request_type=SeriesIntegralRequest,
+        result_type=SeriesIntegralResult,
+        run=lambda request: compute_integral(request.series, request.output_order),
+        tags=(
+            "formal-series",
+            "power-series",
+            "integral",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "integral_of_1_plus_2x",
+                "Integral of (1+2x) at order 3: x+x^2 at order 3.",
+                {
+                    "series": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "2", "den": "1"},
+                        ],
+                    },
+                    "output_order": 3,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.truncate.compute",
+        version="1",
+        title="Truncate a formal power series to a smaller order",
+        description=(
+            "Return the same coefficients through M-1 at order M, where M <= N."
+        ),
+        request_type=SeriesTruncateRequest,
+        result_type=SeriesTruncateResult,
+        run=lambda request: compute_truncate(request.series, request.target_order),
+        tags=(
+            "formal-series",
+            "power-series",
+            "truncate",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "truncate_to_2",
+                "Truncate (1+x+x^2) at order 2: (1+x).",
+                {
+                    "series": {
+                        "variable": "x",
+                        "truncation_order": 3,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                    "target_order": 2,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.identity.check",
+        version="1",
+        title="Check whether two truncated formal power series are identical",
+        description=(
+            "Check if two series are equal mod x^N, returning either EQUAL_MOD_X_TO_N "
+            "or the first differing index with the exact difference."
+        ),
+        request_type=_SeriesIdentityCheckRequest,
+        result_type=SeriesIdentityCheckResult,
+        run=lambda request: compute_identity_check(request.left, request.right),
+        tags=(
+            "formal-series",
+            "power-series",
+            "identity",
+            "check",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "identity_1_plus_x",
+                "Check (1+x) = (1+x): EQUAL.",
+                {
+                    "left": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                    "right": {
+                        "variable": "x",
+                        "truncation_order": 2,
+                        "coefficients": [
+                            {"num": "1", "den": "1"},
+                            {"num": "1", "den": "1"},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.from_polynomial.compute",
+        version="1",
+        title="Convert a dense rational polynomial into a truncated series",
+        description=(
+            "Project a dense rational coefficient tuple onto a series value with "
+            "explicit truncation order."
+        ),
+        request_type=SeriesFromPolynomialRequest,
+        result_type=SeriesFromPolynomialResult,
+        run=lambda request: compute_from_polynomial(
+            request.variable, request.coefficients, request.truncation_order
+        ),
+        tags=(
+            "formal-series",
+            "power-series",
+            "polynomial",
+            "conversion",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "from_polynomial_1_plus_x",
+                "Convert (1+x) into a series at order 2.",
+                {
+                    "variable": "x",
+                    "coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "truncation_order": 2,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="formal_series.rational.to_polynomial.compute",
+        version="1",
+        title="Return the canonical truncated polynomial representative",
+        description=(
+            "Return the canonical truncated polynomial containing exactly the "
+            "known coefficients below x^N."
+        ),
+        request_type=TruncatedSeries,
+        result_type=SeriesToPolynomialResult,
+        run=lambda request: compute_to_polynomial(request),
+        tags=(
+            "formal-series",
+            "power-series",
+            "polynomial",
+            "conversion",
+            "rational",
+            "truncated",
+            "exact",
+        ),
+        examples=(
+            example(
+                "to_polynomial_1_plus_x",
+                "Return the truncated polynomial representative of (1+x).",
+                {
+                    "variable": "x",
+                    "truncation_order": 2,
+                    "coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/formal_power_series/operations.py
+++ b/src/jacobian/domains/formal_power_series/operations.py
@@ -1,0 +1,442 @@
+"""Domain-owned exact truncated formal power series operations.
+
+All kernel functions operate on the immutable :class:`TruncatedSeries`
+contract value defined in :mod:`jacobian.contracts.formal_power_series`.
+Arithmetic is exact rational (Python ``Fraction``); no CAS series object
+crosses the boundary.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Sequence
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.formal_power_series import (
+    MAX_TRUNCATION_ORDER,
+    SeriesArithmeticResult,
+    SeriesComposeResult,
+    SeriesDerivativeResult,
+    SeriesDivideResult,
+    SeriesFromPolynomialResult,
+    SeriesIdentityCheckResult,
+    SeriesIntegralResult,
+    SeriesInverseResult,
+    SeriesMultiplyResult,
+    SeriesPowerResult,
+    SeriesReversionResult,
+    SeriesScalarMultiplyResult,
+    SeriesToPolynomialResult,
+    SeriesTruncateResult,
+    TruncatedSeries,
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _wire(value: Fraction) -> CanonicalRational:
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
+
+
+def _series_fractions(series: TruncatedSeries) -> list[Fraction]:
+    return [c.as_fraction() for c in series.coefficients]
+
+
+def _series_result(
+    variable: str, order: int, coeffs: Sequence[Fraction]
+) -> TruncatedSeries:
+    if len(coeffs) != order:
+        raise ValueError("internal coefficient length does not match truncation order")
+    return TruncatedSeries(
+        variable=variable,
+        truncation_order=order,
+        coefficients=tuple(_wire(c) for c in coeffs),
+    )
+
+
+def _cauchy_convolve(
+    a: Sequence[Fraction], b: Sequence[Fraction], n: int
+) -> list[Fraction]:
+    """c_k = sum_{i=0}^{k} a_i * b_{k-i} for 0 <= k < n."""
+    return [sum(a[i] * b[k - i] for i in range(k + 1)) for k in range(n)]
+
+
+def _require_matching(left: TruncatedSeries, right: TruncatedSeries, label: str) -> None:
+    if left.variable != right.variable:
+        raise ValueError(f"{label} must share the same variable")
+    if left.truncation_order != right.truncation_order:
+        raise ValueError(f"{label} must share the same truncation order")
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic: add / subtract / multiply / scalar multiply
+# ---------------------------------------------------------------------------
+
+
+def compute_add(left: TruncatedSeries, right: TruncatedSeries) -> SeriesArithmeticResult:
+    """Add two series coefficientwise modulo x^N."""
+    _require_matching(left, right, "operands")
+    n = left.truncation_order
+    a = _series_fractions(left)
+    b = _series_fractions(right)
+    return SeriesArithmeticResult(
+        result=_series_result(left.variable, n, [a[i] + b[i] for i in range(n)])
+    )
+
+
+def compute_subtract(
+    left: TruncatedSeries, right: TruncatedSeries
+) -> SeriesArithmeticResult:
+    """Subtract two series coefficientwise modulo x^N."""
+    _require_matching(left, right, "operands")
+    n = left.truncation_order
+    a = _series_fractions(left)
+    b = _series_fractions(right)
+    return SeriesArithmeticResult(
+        result=_series_result(left.variable, n, [a[i] - b[i] for i in range(n)])
+    )
+
+
+def compute_multiply(
+    left: TruncatedSeries, right: TruncatedSeries
+) -> SeriesMultiplyResult:
+    """Multiply two series modulo x^N via Cauchy convolution."""
+    _require_matching(left, right, "operands")
+    n = left.truncation_order
+    a = _series_fractions(left)
+    b = _series_fractions(right)
+    result = _cauchy_convolve(a, b, n)
+    return SeriesMultiplyResult(
+        result=_series_result(left.variable, n, result),
+        convolution_ledger=tuple(_wire(c) for c in result),
+    )
+
+
+def compute_scalar_multiply(
+    series: TruncatedSeries, scalar: CanonicalRational
+) -> SeriesScalarMultiplyResult:
+    """Multiply a series by an exact rational scalar."""
+    a = _series_fractions(series)
+    scalar_val = scalar.as_fraction()
+    n = series.truncation_order
+    result = [a[i] * scalar_val for i in range(n)]
+    return SeriesScalarMultiplyResult(
+        result=_series_result(series.variable, n, result)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Power (binary exponentiation)
+# ---------------------------------------------------------------------------
+
+
+def compute_power(series: TruncatedSeries, exponent: int) -> SeriesPowerResult:
+    """Compute series^exponent via binary exponentiation modulo x^N."""
+    if exponent < 0:
+        raise ValueError("negative exponents are not supported in this operation")
+    n = series.truncation_order
+    a = _series_fractions(series)
+
+    result_coeffs = [Fraction(1)] + [Fraction(0)] * (n - 1)
+    base = a[:]
+    multiplications = 0
+    e = exponent
+    while e > 0:
+        if e & 1:
+            result_coeffs = _cauchy_convolve(result_coeffs, base, n)
+            multiplications += 1
+        e >>= 1
+        if e > 0:
+            base = _cauchy_convolve(base, base, n)
+            multiplications += 1
+
+    return SeriesPowerResult(
+        result=_series_result(series.variable, n, result_coeffs),
+        multiplication_count=multiplications,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inverse
+# ---------------------------------------------------------------------------
+
+
+def compute_inverse(series: TruncatedSeries) -> SeriesInverseResult:
+    """Compute the multiplicative inverse of a series modulo x^N.
+
+    Requires a_0 != 0.  Computes B such that A*B = 1 (mod x^N) via the
+    standard recurrence: b_0 = 1/a_0; b_n = -(1/a_0) * sum_{i=1}^{n} a_i b_{n-i}.
+    """
+    n = series.truncation_order
+    a = _series_fractions(series)
+    if a[0] == 0:
+        raise ValueError("series with zero constant term is not a unit")
+    inv = [Fraction(0)] * n
+    inv[0] = Fraction(1) / a[0]
+    for k in range(1, n):
+        s = Fraction(0)
+        for i in range(1, k + 1):
+            s += a[i] * inv[k - i]
+        inv[k] = -inv[0] * s
+    # Compute residual A*B - 1
+    product = _cauchy_convolve(a, inv, n)
+    product[0] -= Fraction(1)
+    return SeriesInverseResult(
+        result=_series_result(series.variable, n, inv),
+        residual_coefficients=tuple(_wire(c) for c in product),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Divide
+# ---------------------------------------------------------------------------
+
+
+def compute_divide(
+    numerator: TruncatedSeries, denominator: TruncatedSeries
+) -> SeriesDivideResult:
+    """Compute Q = A / B mod x^N where b_0 != 0."""
+    _require_matching(numerator, denominator, "operands")
+    if denominator.coefficients[0].as_fraction() == 0:
+        raise ValueError("denominator with zero constant term is not a unit")
+    n = numerator.truncation_order
+    a = _series_fractions(numerator)
+    b = _series_fractions(denominator)
+
+    inv = compute_inverse(denominator)
+    b_inv = _series_fractions(inv.result)
+    q = _cauchy_convolve(a, b_inv, n)
+    bq = _cauchy_convolve(b, q, n)
+    residual = [bq[i] - a[i] for i in range(n)]
+    return SeriesDivideResult(
+        quotient=_series_result(numerator.variable, n, q),
+        residual_coefficients=tuple(_wire(c) for c in residual),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compose
+# ---------------------------------------------------------------------------
+
+
+def compute_compose(
+    outer: TruncatedSeries, inner: TruncatedSeries
+) -> SeriesComposeResult:
+    """Compute F(G(x)) mod x^N where G(0) = 0.
+
+    Composes by iteratively computing G^k (powers) and multiplying by f_k:
+    F(G) = sum_{k=0}^{N-1} f_k * G^k mod x^N.
+    """
+    _require_matching(outer, inner, "outer and inner series")
+    if inner.coefficients[0].as_fraction() != 0:
+        raise ValueError(
+            "inner series must have zero constant term for composition with a finite prefix"
+        )
+    n = outer.truncation_order
+    f = _series_fractions(outer)
+    g = _series_fractions(inner)
+
+    g_power = [Fraction(1)] + [Fraction(0)] * (n - 1)  # G^0 = 1
+    result = [f[0] * g_power[i] for i in range(n)]
+    for k in range(1, n):
+        g_power = _cauchy_convolve(g_power, g, n)  # G^k
+        for i in range(n):
+            result[i] += f[k] * g_power[i]
+    return SeriesComposeResult(
+        result=_series_result(outer.variable, n, result)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reversion (compositional inverse)
+# ---------------------------------------------------------------------------
+
+
+def compute_reversion(series: TruncatedSeries) -> SeriesReversionResult:
+    """Compute the compositional inverse G(x) of F(x) mod x^N.
+
+    Requires F(0) = 0 and F'(0) = f_1 != 0.  Returns G such that:
+      - F(G(x)) = x mod x^N (left identity)
+      - G(F(x)) = x mod x^N (right identity)
+
+    Uses a coefficient-by-coefficient recurrence to determine coefficients
+    of G one at a time.
+    """
+    n = series.truncation_order
+    f = _series_fractions(series)
+    if f[0] != 0:
+        raise ValueError("reversion requires zero constant term")
+    if n < 2:
+        raise ValueError("reversion requires truncation order >= 2")
+    if f[1] == 0:
+        raise ValueError("reversion requires nonzero linear coefficient")
+
+    # G(x) = g_0 + g_1 x + g_2 x^2 + ... such that F(G(x)) = x mod x^N
+    # g_0 = 0, g_1 = 1/f_1
+    g = [Fraction(0)] * n
+    g[1] = Fraction(1) / f[1]
+    # Compute G powers up to N-1 and solve for g_k one at a time
+    for k in range(2, n):
+        target = Fraction(0)
+        # For j = 2 to k:
+        #   compute G^j using g_0..g_{k-1} and read off coefficient of x^k
+        g_powers = [[Fraction(0)] * (k + 1) for _ in range(k + 1)]
+        g_powers[0] = [Fraction(1)] + [Fraction(0)] * k  # G^0 = 1
+        g_powers[1] = list(g[:k]) + [Fraction(0)]
+        for j in range(2, k + 1):
+            g_powers[j] = [
+                sum(g_powers[j - 1][m] * g_powers[1][i - m] for m in range(i + 1))
+                for i in range(k + 1)
+            ]
+        known = Fraction(0)
+        for j in range(2, k + 1):
+            fj = f[j] if j < len(f) else Fraction(0)
+            known += fj * g_powers[j][k]
+        g[k] = (target - known) / f[1]
+
+    # Compute residuals F(G) and G(F)
+    fg = compute_compose(
+        _series_result(series.variable, n, f),
+        _series_result(series.variable, n, g),
+    )
+    fg_coeffs = _series_fractions(fg.result)
+    left_residual = [fg_coeffs[i] - (Fraction(1) if i == 1 else Fraction(0)) for i in range(n)]
+
+    gf = compute_compose(
+        _series_result(series.variable, n, g),
+        _series_result(series.variable, n, f),
+    )
+    gf_coeffs = _series_fractions(gf.result)
+    right_residual = [gf_coeffs[i] - (Fraction(1) if i == 1 else Fraction(0)) for i in range(n)]
+
+    return SeriesReversionResult(
+        result=_series_result(series.variable, n, g),
+        left_residual=tuple(_wire(c) for c in left_residual),
+        right_residual=tuple(_wire(c) for c in right_residual),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivative
+# ---------------------------------------------------------------------------
+
+
+def compute_derivative(series: TruncatedSeries) -> SeriesDerivativeResult:
+    """Formal derivative: b_n = (n+1) * a_{n+1}.
+
+    Output order convention: max(N-1, 1).
+    """
+    n = series.truncation_order
+    a = _series_fractions(series)
+    output_order = max(n - 1, 1)
+    result = [Fraction((i + 1) * a[i + 1]) for i in range(output_order)]
+    return SeriesDerivativeResult(
+        result=_series_result(series.variable, output_order, result)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integral (zero constant)
+# ---------------------------------------------------------------------------
+
+
+def compute_integral(
+    series: TruncatedSeries, output_order: int
+) -> SeriesIntegralResult:
+    """Zero-constant formal antiderivative with output_order coefficients.
+
+    B(x) = sum_{n=1}^{output_order-1} (a_{n-1} / n) x^n + 0
+    (the constant is zero).
+    """
+    n = series.truncation_order
+    a = _series_fractions(series)
+    if output_order > n + 1:
+        raise ValueError("output_order must not exceed source_order + 1")
+    result = [Fraction(0)] * output_order
+    for i in range(1, output_order):
+        if i - 1 < n:
+            result[i] = a[i - 1] / i
+    return SeriesIntegralResult(
+        result=_series_result(series.variable, output_order, result)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Truncate
+# ---------------------------------------------------------------------------
+
+
+def compute_truncate(
+    series: TruncatedSeries, target_order: int
+) -> SeriesTruncateResult:
+    """Truncate a series to a smaller order."""
+    if target_order > series.truncation_order:
+        raise ValueError("target_order must not exceed source truncation order")
+    if target_order > MAX_TRUNCATION_ORDER:
+        raise ValueError("target_order exceeds the public bound")
+    a = _series_fractions(series)
+    result = a[:target_order]
+    return SeriesTruncateResult(
+        result=_series_result(series.variable, target_order, result)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity check
+# ---------------------------------------------------------------------------
+
+
+def compute_identity_check(
+    left: TruncatedSeries, right: TruncatedSeries
+) -> SeriesIdentityCheckResult:
+    """Check if two series are equal mod x^N."""
+    _require_matching(left, right, "operands")
+    a = _series_fractions(left)
+    b = _series_fractions(right)
+    for i in range(left.truncation_order):
+        if a[i] != b[i]:
+            diff = a[i] - b[i]
+            return SeriesIdentityCheckResult(
+                status="NOT_EQUAL",
+                first_differing_index=i,
+                exact_difference=_wire(diff),
+            )
+    return SeriesIdentityCheckResult(status="EQUAL_MOD_X_TO_N")
+
+
+# ---------------------------------------------------------------------------
+# Polynomial conversions
+# ---------------------------------------------------------------------------
+
+
+def compute_from_polynomial(
+    variable: str,
+    coefficients: Sequence[CanonicalRational],
+    truncation_order: int,
+) -> SeriesFromPolynomialResult:
+    """Convert a dense rational coefficient tuple into a truncated series."""
+    from jacobian.contracts.formal_power_series import SeriesFromPolynomialRequest
+
+    request = SeriesFromPolynomialRequest(
+        variable=variable,
+        coefficients=tuple(coefficients),
+        truncation_order=truncation_order,
+    )
+    coeffs = [c.as_fraction() for c in request.coefficients]
+    return SeriesFromPolynomialResult(
+        result=_series_result(request.variable, request.truncation_order, coeffs)
+    )
+
+
+def compute_to_polynomial(series: TruncatedSeries) -> SeriesToPolynomialResult:
+    """Return the canonical truncated polynomial representative of the series."""
+    return SeriesToPolynomialResult(
+        result=series
+    )

--- a/src/jacobian/domains/graph_flow/math_tools.py
+++ b/src/jacobian/domains/graph_flow/math_tools.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from jacobian.contracts.base import ContractModel
 from jacobian.contracts.graph_flow import (
+    EdgeDisjointPathsRequest,
+    EdgeDisjointPathsResult,
     MaxFlowRequest,
     MaxFlowResult,
     MinCutRequest,
@@ -12,7 +14,11 @@ from jacobian.contracts.graph_flow import (
 )
 from jacobian.contracts.operations import OperationExample
 from jacobian.domains._examples import example
-from jacobian.domains.graph_flow.operations import compute_max_flow, compute_min_cut
+from jacobian.domains.graph_flow.operations import (
+    compute_edge_disjoint_paths,
+    compute_max_flow,
+    compute_min_cut,
+)
 from jacobian.math_tools import MathTool
 
 
@@ -47,7 +53,7 @@ GRAPH_FLOW_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_flow_operation(
         "graph.flow.maximum.compute",
         "Compute the maximum flow in a capacitated graph",
-        "Compute the maximum flow value between source and sink in a directed capacitated graph using NetworkX.",
+        "Compute the maximum flow value between source and sink in a directed capacitated graph using NetworkX. Returns the flow value and a per-edge flow decomposition so the caller can independently verify conservation and capacity constraints.",
         MaxFlowRequest,
         MaxFlowResult,
         compute_max_flow,
@@ -63,16 +69,8 @@ GRAPH_FLOW_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "graph": {
                         "vertex_count": 3,
                         "edges": [
-                            {
-                                "source": 0,
-                                "target": 1,
-                                "capacity": {"num": "3", "den": "1"},
-                            },
-                            {
-                                "source": 1,
-                                "target": 2,
-                                "capacity": {"num": "2", "den": "1"},
-                            },
+                            {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                            {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
                         ],
                     },
                     "source": 0,
@@ -86,21 +84,9 @@ GRAPH_FLOW_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "graph": {
                         "vertex_count": 4,
                         "edges": [
-                            {
-                                "source": 0,
-                                "target": 1,
-                                "capacity": {"num": "5", "den": "1"},
-                            },
-                            {
-                                "source": 1,
-                                "target": 2,
-                                "capacity": {"num": "3", "den": "1"},
-                            },
-                            {
-                                "source": 2,
-                                "target": 3,
-                                "capacity": {"num": "4", "den": "1"},
-                            },
+                            {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                            {"source": 1, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                            {"source": 2, "target": 3, "capacity": {"num": "4", "den": "1"}},
                         ],
                     },
                     "source": 0,
@@ -128,16 +114,8 @@ GRAPH_FLOW_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "graph": {
                         "vertex_count": 3,
                         "edges": [
-                            {
-                                "source": 0,
-                                "target": 1,
-                                "capacity": {"num": "3", "den": "1"},
-                            },
-                            {
-                                "source": 1,
-                                "target": 2,
-                                "capacity": {"num": "2", "den": "1"},
-                            },
+                            {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                            {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
                         ],
                     },
                     "source": 0,
@@ -151,21 +129,40 @@ GRAPH_FLOW_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "graph": {
                         "vertex_count": 4,
                         "edges": [
-                            {
-                                "source": 0,
-                                "target": 1,
-                                "capacity": {"num": "5", "den": "1"},
-                            },
-                            {
-                                "source": 1,
-                                "target": 2,
-                                "capacity": {"num": "3", "den": "1"},
-                            },
-                            {
-                                "source": 2,
-                                "target": 3,
-                                "capacity": {"num": "4", "den": "1"},
-                            },
+                            {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                            {"source": 1, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                            {"source": 2, "target": 3, "capacity": {"num": "4", "den": "1"}},
+                        ],
+                    },
+                    "source": 0,
+                    "sink": 3,
+                },
+            ),
+        ),
+    ),
+    graph_flow_operation(
+        "graph.menger.edge_disjoint.compute",
+        "Compute the maximum number of edge-disjoint paths (Menger theorem)",
+        "Compute the maximum number of edge-disjoint directed paths between source and sink in a simple directed graph using NetworkX, along with the explicit paths.",
+        EdgeDisjointPathsRequest,
+        EdgeDisjointPathsResult,
+        compute_edge_disjoint_paths,
+        "graph",
+        "menger",
+        "edge-disjoint",
+        "exact",
+        examples=(
+            example(
+                "two_edge_disjoint_paths",
+                "Compute the maximum number of edge-disjoint paths in a diamond graph.",
+                {
+                    "graph": {
+                        "vertex_count": 4,
+                        "edges": [
+                            [0, 1],
+                            [0, 2],
+                            [1, 3],
+                            [2, 3],
                         ],
                     },
                     "source": 0,

--- a/src/jacobian/domains/graph_flow/operations.py
+++ b/src/jacobian/domains/graph_flow/operations.py
@@ -10,6 +10,9 @@ import networkx as nx
 from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.exact import CanonicalRational
 from jacobian.contracts.graph_flow import (
+    EdgeDisjointPathsRequest,
+    EdgeDisjointPathsResult,
+    FlowEdgeValue,
     FlowGraph,
     MaxFlowRequest,
     MaxFlowResult,
@@ -26,18 +29,39 @@ def _build_digraph(graph: FlowGraph) -> nx.DiGraph[int]:
     return g
 
 
+def _rational(value: Fraction | int) -> CanonicalRational:
+    """Convert an exact Fraction or int to a CanonicalRational."""
+    frac = Fraction(value)
+    return CanonicalRational(
+        num=format_canonical_integer(frac.numerator),
+        den=format_canonical_integer(frac.denominator),
+    )
+
+
 def compute_max_flow(request: MaxFlowRequest) -> MaxFlowResult:
     g = _build_digraph(request.graph)
-    flow_value = nx.maximum_flow_value(g, request.source, request.sink)
+    flow_value, flow_dict = nx.maximum_flow(g, request.source, request.sink)
     if not isinstance(flow_value, (int, Fraction)):
         raise RuntimeError("NetworkX did not preserve the exact flow value")
+
+    # Build a per-edge flow decomposition so the caller can independently
+    # verify conservation and capacity constraints.
+    flow_edges: list[FlowEdgeValue] = []
+    for source_node, targets in flow_dict.items():
+        for target_node, flow_amount in targets.items():
+            if flow_amount != 0:
+                flow_edges.append(
+                    FlowEdgeValue(
+                        source=source_node,
+                        target=target_node,
+                        flow=_rational(flow_amount),
+                    )
+                )
     return MaxFlowResult(
-        flow_value=CanonicalRational(
-            num=format_canonical_integer(flow_value.numerator),
-            den=format_canonical_integer(flow_value.denominator),
-        ),
+        flow_value=_rational(flow_value),
         source=request.source,
         sink=request.sink,
+        flow_edges=tuple(flow_edges),
     )
 
 
@@ -48,10 +72,38 @@ def compute_min_cut(request: MinCutRequest) -> MinCutResult:
         raise RuntimeError("NetworkX did not preserve the exact cut value")
     reachable, unreachable = partition
     return MinCutResult(
-        cut_value=CanonicalRational(
-            num=format_canonical_integer(cut_value.numerator),
-            den=format_canonical_integer(cut_value.denominator),
-        ),
+        cut_value=_rational(cut_value),
         reachable=tuple(sorted(reachable)),
         unreachable=tuple(sorted(unreachable)),
+    )
+
+
+def compute_edge_disjoint_paths(
+    request: EdgeDisjointPathsRequest,
+) -> EdgeDisjointPathsResult:
+    """Compute the maximum number of edge-disjoint paths and the explicit paths.
+
+    Uses NetworkX's ``edge_disjoint_paths`` (which internally computes a
+    maximum flow with unit capacities and extracts the paths).
+    """
+    g: nx.DiGraph[Any] = nx.DiGraph()
+    g.add_nodes_from(range(request.graph.vertex_count))
+    for source, target in request.graph.edges:
+        g.add_edge(source, target)
+
+    try:
+        paths = list(nx.edge_disjoint_paths(g, request.source, request.sink))
+    except nx.NetworkXNoPath:
+        return EdgeDisjointPathsResult(
+            path_count=0,
+            paths=(),
+            source=request.source,
+            sink=request.sink,
+        )
+
+    return EdgeDisjointPathsResult(
+        path_count=len(paths),
+        paths=tuple(tuple(path) for path in paths),
+        source=request.source,
+        sink=request.sink,
     )

--- a/src/jacobian/domains/multivariate_polynomial/__init__.py
+++ b/src/jacobian/domains/multivariate_polynomial/__init__.py
@@ -1,0 +1,18 @@
+"""Exact multivariate polynomial operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["multivariate_polynomial_operations"]
+
+
+def multivariate_polynomial_operations() -> MathTools:
+    from jacobian.domains.multivariate_polynomial.math_tools import (
+        MULTIVARIATE_POLYNOMIAL_OPERATIONS,
+    )
+
+    return MULTIVARIATE_POLYNOMIAL_OPERATIONS

--- a/src/jacobian/domains/multivariate_polynomial/math_tools.py
+++ b/src/jacobian/domains/multivariate_polynomial/math_tools.py
@@ -1,0 +1,239 @@
+"""Exact multivariate polynomial operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.multivariate_polynomial import (
+    MultivariateDivisionRequest,
+    MultivariateDivisionResult,
+    MultivariateGcdRequest,
+    MultivariateGcdResult,
+    MultivariateResultantRequest,
+    MultivariateResultantResult,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.multivariate_polynomial.operations import (
+    compute_multivariate_division,
+    compute_multivariate_gcd,
+    compute_multivariate_resultant,
+)
+from jacobian.domains.multivariate_polynomial.operations import (
+    compute_multivariate_division,
+    compute_multivariate_gcd,
+    compute_multivariate_resultant,
+)
+from jacobian.math_tools import MathTool
+
+
+def multivariate_polynomial_operation[
+    RequestT: ContractModel,
+    ResultT: ContractModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_GCD_EXAMPLE = example(
+    "gcd_xy_minus_one_coprime",
+    "Compute the GCD of two coprime multivariate polynomials.",
+    {
+        "left": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [1, 1],
+                    },
+                    {
+                        "coefficient": {"num": "-1", "den": "1"},
+                        "exponents": [0, 0],
+                    },
+                ]
+            },
+        },
+        "right": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [2, 0],
+                    },
+                    {
+                        "coefficient": {"num": "-1", "den": "1"},
+                        "exponents": [0, 0],
+                    },
+                ]
+            },
+        },
+    },
+)
+
+_DIVISION_EXAMPLE = example(
+    "division_xy_minus_one",
+    "Divide x^2*y + x by x*y - 1 under lex order.",
+    {
+        "left": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [2, 1],
+                    },
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [1, 0],
+                    },
+                ]
+            },
+        },
+        "right": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [1, 1],
+                    },
+                    {
+                        "coefficient": {"num": "-1", "den": "1"},
+                        "exponents": [0, 0],
+                    },
+                ]
+            },
+        },
+        "monomial_order": "lex",
+    },
+)
+
+_RESULTANT_EXAMPLE = example(
+    "resultant_xy_minus_one_x_squared_minus_one",
+    "Compute the resultant of x*y-1 and x^2-1 w.r.t. x.",
+    {
+        "left": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [1, 1],
+                    },
+                    {
+                        "coefficient": {"num": "-1", "den": "1"},
+                        "exponents": [0, 0],
+                    },
+                ]
+            },
+        },
+        "right": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x", "y"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {"num": "1", "den": "1"},
+                        "exponents": [2, 0],
+                    },
+                    {
+                        "coefficient": {"num": "-1", "den": "1"},
+                        "exponents": [0, 0],
+                    },
+                ]
+            },
+        },
+        "elimination_variable": "x",
+    },
+)
+
+
+MULTIVARIATE_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    multivariate_polynomial_operation(
+        "polynomial.multivariate.gcd.compute",
+        "Compute a multivariate polynomial GCD over QQ",
+        (
+            "Compute the monic GCD of two bounded multivariate polynomials over "
+            "QQ[x_1, ..., x_n].  Backed by SymPy's multivariate polynomial GCD."
+        ),
+        MultivariateGcdRequest,
+        MultivariateGcdResult,
+        compute_multivariate_gcd,
+        "polynomial",
+        "gcd",
+        "multivariate",
+        "rational",
+        examples=(_GCD_EXAMPLE,),
+    ),
+    multivariate_polynomial_operation(
+        "polynomial.multivariate.divide.compute",
+        "Divide multivariate polynomials with remainder",
+        (
+            "Compute the quotient and remainder of one multivariate polynomial "
+            "divided by another over QQ[x_1, ..., x_n] under a declared monomial "
+            "order.  Backed by SymPy's multivariate polynomial division."
+        ),
+        MultivariateDivisionRequest,
+        MultivariateDivisionResult,
+        compute_multivariate_division,
+        "polynomial",
+        "division",
+        "multivariate",
+        "rational",
+        examples=(_DIVISION_EXAMPLE,),
+    ),
+    multivariate_polynomial_operation(
+        "polynomial.multivariate.resultant.compute",
+        "Compute a multivariate polynomial resultant over QQ",
+        (
+            "Compute the exact resultant of two multivariate polynomials with "
+            "respect to one declared variable over QQ[x_1, ..., x_n].  The "
+            "resultant lives in the ring over the remaining variables.  Backed "
+            "by SymPy's resultant."
+        ),
+        MultivariateResultantRequest,
+        MultivariateResultantResult,
+        compute_multivariate_resultant,
+        "polynomial",
+        "resultant",
+        "multivariate",
+        "rational",
+        "elimination",
+        examples=(_RESULTANT_EXAMPLE,),
+    ),
+)
+
+
+__all__ = ["MULTIVARIATE_POLYNOMIAL_OPERATIONS"]

--- a/src/jacobian/domains/multivariate_polynomial/operations.py
+++ b/src/jacobian/domains/multivariate_polynomial/operations.py
@@ -1,0 +1,152 @@
+"""Domain-owned multivariate polynomial operations over ``QQ``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.contracts.multivariate_polynomial import (
+    MultivariateDivisionRequest,
+    MultivariateDivisionResult,
+    MultivariateGcdRequest,
+    MultivariateGcdResult,
+    MultivariatePolynomialValue,
+    MultivariateResultantRequest,
+    MultivariateResultantResult,
+    MultivariateScalarValue,
+)
+from jacobian.domains.polynomial.conversions import (
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+
+_MAX_OUTPUT_TERMS = 1024
+
+
+class MultivariateOutputBudgetError(RuntimeError):
+    """A valid computation produced more output than its public contract permits."""
+
+
+def _result_polynomial(
+    poly: Any,
+    variables: tuple[str, ...],
+) -> Any:
+    """Convert a SymPy ``Poly`` to a ``RationalPolynomial``, re-raising budget errors."""
+
+    try:
+        return rational_polynomial_from_sympy(
+            poly,
+            variables,
+            maximum_terms=_MAX_OUTPUT_TERMS,
+        )
+    except ValueError as exc:
+        if "term operation budget" in str(exc):
+            raise MultivariateOutputBudgetError(str(exc)) from exc
+        raise
+
+
+def compute_multivariate_gcd(request: MultivariateGcdRequest) -> MultivariateGcdResult:
+    """Compute the GCD of two multivariate polynomials over ``QQ``."""
+
+    left = rational_polynomial_to_sympy(request.left)
+    right = rational_polynomial_to_sympy(request.right)
+    gcd = left.gcd(right)
+    return MultivariateGcdResult(
+        gcd=_result_polynomial(gcd, request.left.variables),
+    )
+
+
+def compute_multivariate_division(
+    request: MultivariateDivisionRequest,
+) -> MultivariateDivisionResult:
+    """Divide one multivariate polynomial by another with a declared monomial order."""
+
+    variables = request.left.variables
+    symbols = symbols_for_variables(variables)
+
+    # Build a low-level ring with the requested monomial order so that
+    # multivariate division respects the declared term ordering.  The
+    # ``Poly`` API uses the implicit lex order and does not expose the
+    # monomial-order keyword in its constructor.
+    from sympy.polys.rings import ring as sympy_ring
+    from sympy import QQ
+
+    ring_obj = sympy_ring(symbols, QQ, request.monomial_order)[0]
+
+    left_poly = rational_polynomial_to_sympy(request.left)
+    right_poly = rational_polynomial_to_sympy(request.right)
+
+    left_ring = ring_obj.from_dict(
+        {exponents: coeff for exponents, coeff in left_poly.terms()}
+    )
+    right_ring = ring_obj.from_dict(
+        {exponents: coeff for exponents, coeff in right_poly.terms()}
+    )
+
+    quotient_ring, remainder_ring = left_ring.div(right_ring)
+
+    # Convert back to ``Poly`` for the canonical sparse wire contract.
+    quotient_poly = _to_poly(quotient_ring, symbols)
+    remainder_poly = _to_poly(remainder_ring, symbols)
+
+    # Verify the exact reconstruction: left == quotient * right + remainder.
+    reconstruction = quotient_poly * right_poly + remainder_poly
+    if reconstruction != left_poly:
+        raise MultivariateOutputBudgetError(
+            "multivariate division reconstruction failed"
+        )
+
+    return MultivariateDivisionResult(
+        quotient=_result_polynomial(quotient_poly, variables),
+        remainder=_result_polynomial(remainder_poly, variables),
+        monomial_order=request.monomial_order,
+    )
+
+
+def compute_multivariate_resultant(
+    request: MultivariateResultantRequest,
+) -> MultivariateResultantResult:
+    """Compute the resultant of two multivariate polynomials w.r.t. one variable."""
+
+    from sympy import resultant as sympy_resultant, Poly, QQ
+
+    variables = request.left.variables
+    elimination_index = variables.index(request.elimination_variable)
+    generator = symbols_for_variables(variables)[elimination_index]
+
+    left = rational_polynomial_to_sympy(request.left)
+    right = rational_polynomial_to_sympy(request.right)
+    value = sympy_resultant(left.as_expr(), right.as_expr(), generator)
+
+    remaining_variables = tuple(
+        variable
+        for variable in variables
+        if variable != request.elimination_variable
+    )
+    if not remaining_variables:
+        # The resultant is a rational scalar.
+        from jacobian.domains.polynomial.conversions import rational_from_sympy
+
+        return MultivariateResultantResult(
+            elimination_variable=request.elimination_variable,
+            resultant=MultivariateScalarValue(
+                value=rational_from_sympy(value),
+            ),
+        )
+    resultant_poly = Poly(
+        value, *symbols_for_variables(remaining_variables), domain=QQ
+    )
+    return MultivariateResultantResult(
+        elimination_variable=request.elimination_variable,
+        resultant=MultivariatePolynomialValue(
+            value=_result_polynomial(resultant_poly, remaining_variables),
+        ),
+    )
+
+
+def _to_poly(ring_element: Any, symbols: tuple[Any, ...]) -> Any:
+    """Convert a low-level ring element to a SymPy ``Poly`` in ``QQ``."""
+
+    from sympy import Poly, QQ
+
+    return Poly(ring_element.as_expr(), *symbols, domain=QQ)

--- a/tests/domain/graph/test_graph_flow.py
+++ b/tests/domain/graph/test_graph_flow.py
@@ -1,0 +1,500 @@
+"""Tests for graph flow, cut, and edge-disjoint path operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.graph_flow import (
+    EdgeDisjointPathsRequest,
+    EdgeDisjointPathsResult,
+    FlowGraph,
+    MaxFlowRequest,
+    MaxFlowResult,
+    MinCutRequest,
+    MinCutResult,
+)
+from jacobian.domains.graph_flow.operations import (
+    compute_edge_disjoint_paths,
+    compute_max_flow,
+    compute_min_cut,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _max_flow(graph: dict, source: int, sink: int) -> MaxFlowResult:
+    return compute_max_flow(MaxFlowRequest.model_validate({"graph": graph, "source": source, "sink": sink}))
+
+
+def _min_cut(graph: dict, source: int, sink: int) -> MinCutResult:
+    return compute_min_cut(MinCutRequest.model_validate({"graph": graph, "source": source, "sink": sink}))
+
+
+def _edge_disjoint(graph: dict, source: int, sink: int) -> EdgeDisjointPathsResult:
+    return compute_edge_disjoint_paths(EdgeDisjointPathsRequest.model_validate({"graph": graph, "source": source, "sink": sink}))
+
+
+# ---------------------------------------------------------------------------
+# Max-flow
+# ---------------------------------------------------------------------------
+
+
+class TestMaxFlow:
+    def test_simple_path_max_flow(self) -> None:
+        result = _max_flow(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert result.flow_value.num == "2"
+        assert result.flow_value.den == "1"
+
+    def test_flow_decomposition_returns_per_edge_flow(self) -> None:
+        """The flow_edges field should contain per-edge flow values."""
+        result = _max_flow(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert len(result.flow_edges) == 2
+        for edge in result.flow_edges:
+            assert edge.flow.as_fraction() > 0
+
+    def test_flow_decomposition_satisfies_capacity_constraint(self) -> None:
+        """Each edge flow must not exceed its capacity."""
+        graph = {
+            "vertex_count": 4,
+            "edges": [
+                {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                {"source": 0, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                {"source": 1, "target": 3, "capacity": {"num": "4", "den": "1"}},
+                {"source": 2, "target": 3, "capacity": {"num": "6", "den": "1"}},
+            ],
+        }
+        result = _max_flow(graph, 0, 3)
+        capacities = {(0, 1): 5, (0, 2): 3, (1, 3): 4, (2, 3): 6}
+        for edge in result.flow_edges:
+            assert edge.flow.as_fraction() <= capacities[(edge.source, edge.target)]
+
+    def test_flow_value_matches_sum_of_outgoing_source_flows(self) -> None:
+        """Conservation: the flow value equals the total outflow from source."""
+        result = _max_flow(
+            {
+                "vertex_count": 4,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                    {"source": 0, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 3, "capacity": {"num": "4", "den": "1"}},
+                    {"source": 2, "target": 3, "capacity": {"num": "6", "den": "1"}},
+                ],
+            },
+            0,
+            3,
+        )
+        source_outflow = sum(
+            edge.flow.as_fraction()
+            for edge in result.flow_edges
+            if edge.source == result.source
+        )
+        assert source_outflow == result.flow_value.as_fraction()
+
+    def test_direct_edge_max_flow(self) -> None:
+        result = _max_flow(
+            {
+                "vertex_count": 2,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "10", "den": "1"}},
+                ],
+            },
+            0,
+            1,
+        )
+        assert result.flow_value.num == "10"
+        assert result.flow_value.den == "1"
+
+    def test_disconnected_graph_max_flow_is_zero(self) -> None:
+        """When there is no path from source to sink, max flow is 0."""
+        result = _max_flow(
+            {
+                "vertex_count": 4,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                    {"source": 2, "target": 3, "capacity": {"num": "7", "den": "1"}},
+                ],
+            },
+            0,
+            3,
+        )
+        assert result.flow_value.num == "0"
+        assert result.flow_value.den == "1"
+
+    def test_rational_capacities_max_flow(self) -> None:
+        """Max flow with rational (non-integer) capacities."""
+        result = _max_flow(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "1", "den": "2"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "1", "den": "3"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert result.flow_value.as_fraction() == Fraction(1, 3)
+
+    def test_contract_rejects_source_equals_sink(self) -> None:
+        with pytest.raises(ValidationError, match="source and sink must be distinct"):
+            MaxFlowRequest.model_validate({
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [
+                        {"source": 0, "target": 1, "capacity": {"num": "1", "den": "1"}},
+                    ],
+                },
+                "source": 0,
+                "sink": 0,
+            })
+
+    def test_contract_rejects_out_of_range_source(self) -> None:
+        with pytest.raises(ValidationError, match="source must be"):
+            MaxFlowRequest.model_validate({
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [
+                        {"source": 0, "target": 1, "capacity": {"num": "1", "den": "1"}},
+                    ],
+                },
+                "source": 5,
+                "sink": 1,
+            })
+
+
+# ---------------------------------------------------------------------------
+# Min-cut
+# ---------------------------------------------------------------------------
+
+
+class TestMinCut:
+    def test_simple_path_min_cut(self) -> None:
+        result = _min_cut(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert result.cut_value.num == "2"
+        assert result.cut_value.den == "1"
+
+    def test_cut_partition_covers_all_vertices(self) -> None:
+        result = _min_cut(
+            {
+                "vertex_count": 4,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                    {"source": 0, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 3, "capacity": {"num": "4", "den": "1"}},
+                    {"source": 2, "target": 3, "capacity": {"num": "6", "den": "1"}},
+                ],
+            },
+            0,
+            3,
+        )
+        all_vertices = set(result.reachable) | set(result.unreachable)
+        assert all_vertices == {0, 1, 2, 3}
+        assert len(set(result.reachable) & set(result.unreachable)) == 0
+
+    def test_source_in_reachable_sink_in_unreachable(self) -> None:
+        result = _min_cut(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "2", "den": "1"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert 0 in result.reachable
+        assert 2 in result.unreachable
+
+    def test_min_cut_equals_max_flow(self) -> None:
+        """Max-flow min-cut theorem: the max flow equals the min cut."""
+        graph = {
+            "vertex_count": 4,
+            "edges": [
+                {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                {"source": 0, "target": 2, "capacity": {"num": "3", "den": "1"}},
+                {"source": 1, "target": 3, "capacity": {"num": "4", "den": "1"}},
+                {"source": 2, "target": 3, "capacity": {"num": "6", "den": "1"}},
+            ],
+        }
+        flow = _max_flow(graph, 0, 3)
+        cut = _min_cut(graph, 0, 3)
+        assert flow.flow_value.as_fraction() == cut.cut_value.as_fraction()
+
+    def test_disconnected_graph_min_cut_is_zero(self) -> None:
+        result = _min_cut(
+            {
+                "vertex_count": 4,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "5", "den": "1"}},
+                    {"source": 2, "target": 3, "capacity": {"num": "7", "den": "1"}},
+                ],
+            },
+            0,
+            3,
+        )
+        assert result.cut_value.num == "0"
+        assert result.cut_value.den == "1"
+
+    def test_rational_capacities_min_cut(self) -> None:
+        result = _min_cut(
+            {
+                "vertex_count": 3,
+                "edges": [
+                    {"source": 0, "target": 1, "capacity": {"num": "1", "den": "2"}},
+                    {"source": 1, "target": 2, "capacity": {"num": "1", "den": "3"}},
+                ],
+            },
+            0,
+            2,
+        )
+        assert result.cut_value.as_fraction() == Fraction(1, 3)
+
+    def test_contract_rejects_duplicate_edges(self) -> None:
+        with pytest.raises(ValidationError, match="unique"):
+            MinCutRequest.model_validate({
+                "graph": {
+                    "vertex_count": 3,
+                    "edges": [
+                        {"source": 0, "target": 1, "capacity": {"num": "1", "den": "1"}},
+                        {"source": 0, "target": 1, "capacity": {"num": "2", "den": "1"}},
+                    ],
+                },
+                "source": 0,
+                "sink": 2,
+            })
+
+    def test_contract_rejects_negative_capacity(self) -> None:
+        with pytest.raises(ValidationError, match="nonnegative"):
+            MinCutRequest.model_validate({
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [
+                        {"source": 0, "target": 1, "capacity": {"num": "-1", "den": "1"}},
+                    ],
+                },
+                "source": 0,
+                "sink": 1,
+            })
+
+
+# ---------------------------------------------------------------------------
+# Edge-disjoint paths (Menger)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeDisjointPaths:
+    def test_diamond_graph_has_two_edge_disjoint_paths(self) -> None:
+        result = _edge_disjoint(
+            {
+                "vertex_count": 4,
+                "edges": [[0, 1], [0, 2], [1, 3], [2, 3]],
+            },
+            0,
+            3,
+        )
+        assert result.path_count == 2
+        assert len(result.paths) == 2
+        for path in result.paths:
+            assert path[0] == 0
+            assert path[-1] == 3
+
+    def test_single_path_has_one_edge_disjoint_path(self) -> None:
+        result = _edge_disjoint(
+            {
+                "vertex_count": 3,
+                "edges": [[0, 1], [1, 2]],
+            },
+            0,
+            2,
+        )
+        assert result.path_count == 1
+        assert len(result.paths) == 1
+        assert result.paths[0] == (0, 1, 2)
+
+    def test_no_path_returns_zero(self) -> None:
+        result = _edge_disjoint(
+            {
+                "vertex_count": 2,
+                "edges": [[0, 1]],
+            },
+            1,
+            0,
+        )
+        assert result.path_count == 0
+        assert result.paths == ()
+
+    def test_disconnected_graph_returns_zero(self) -> None:
+        result = _edge_disjoint(
+            {
+                "vertex_count": 4,
+                "edges": [[0, 1], [2, 3]],
+            },
+            0,
+            3,
+        )
+        assert result.path_count == 0
+        assert result.paths == ()
+
+    def test_complete_graph_edge_disjoint_paths(self) -> None:
+        """In K_n, there are n-1 edge-disjoint paths from 0 to n-1."""
+        n = 5
+        edges = [[i, j] for i in range(n) for j in range(n) if i != j]
+        result = _edge_disjoint(
+            {"vertex_count": n, "edges": edges},
+            0,
+            n - 1,
+        )
+        assert result.path_count == n - 1
+
+    def test_paths_are_edge_disjoint(self) -> None:
+        """Verify that returned paths share no edges."""
+        result = _edge_disjoint(
+            {
+                "vertex_count": 6,
+                "edges": [
+                    [0, 1], [0, 2], [1, 3], [2, 3], [3, 4], [3, 5], [4, 5],
+                ],
+            },
+            0,
+            5,
+        )
+        used_edges: set[tuple[int, int]] = set()
+        for path in result.paths:
+            for u, v in zip(path[:-1], path[1:]):
+                edge = (u, v)
+                assert edge not in used_edges, f"Edge {edge} used in multiple paths"
+                used_edges.add(edge)
+
+    def test_direct_edge_has_one_path(self) -> None:
+        result = _edge_disjoint(
+            {
+                "vertex_count": 2,
+                "edges": [[0, 1]],
+            },
+            0,
+            1,
+        )
+        assert result.path_count == 1
+        assert result.paths[0] == (0, 1)
+
+    def test_contract_rejects_self_loop(self) -> None:
+        with pytest.raises(ValidationError, match="self-loops"):
+            EdgeDisjointPathsRequest.model_validate({
+                "graph": {
+                    "vertex_count": 3,
+                    "edges": [[0, 0], [0, 1]],
+                },
+                "source": 0,
+                "sink": 1,
+            })
+
+    def test_contract_rejects_duplicate_edges(self) -> None:
+        with pytest.raises(ValidationError, match="unique"):
+            EdgeDisjointPathsRequest.model_validate({
+                "graph": {
+                    "vertex_count": 3,
+                    "edges": [[0, 1], [0, 1]],
+                },
+                "source": 0,
+                "sink": 1,
+            })
+
+    def test_contract_rejects_source_equals_sink(self) -> None:
+        with pytest.raises(ValidationError, match="distinct"):
+            EdgeDisjointPathsRequest.model_validate({
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [[0, 1]],
+                },
+                "source": 0,
+                "sink": 0,
+            })
+
+    def test_contract_rejects_out_of_range_vertex_in_edge(self) -> None:
+        with pytest.raises(ValidationError, match="edge vertices must be"):
+            EdgeDisjointPathsRequest.model_validate({
+                "graph": {
+                    "vertex_count": 2,
+                    "edges": [[0, 3]],
+                },
+                "source": 0,
+                "sink": 1,
+            })
+
+
+# ---------------------------------------------------------------------------
+# Cross-consistency: max-flow vs min-cut vs edge-disjoint
+# ---------------------------------------------------------------------------
+
+
+class TestCrossConsistency:
+    def test_unit_capacity_flow_equals_edge_disjoint_count(self) -> None:
+        """For a unit-capacity graph, max flow = edge-disjoint path count."""
+        vertex_count = 4
+        edges_list = [[0, 1], [0, 2], [1, 3], [2, 3]]
+        # Build a capacitated graph with unit capacities
+        cap_graph = {
+            "vertex_count": vertex_count,
+            "edges": [
+                {"source": s, "target": t, "capacity": {"num": "1", "den": "1"}}
+                for s, t in edges_list
+            ],
+        }
+        uncap_graph = {"vertex_count": vertex_count, "edges": [tuple(e) for e in edges_list]}
+        flow = _max_flow(cap_graph, 0, 3)
+        paths = _edge_disjoint(uncap_graph, 0, 3)
+        assert flow.flow_value.as_fraction() == paths.path_count
+
+    def test_max_flow_min_cut_equality(self) -> None:
+        """Max-flow min-cut theorem."""
+        graph = {
+            "vertex_count": 5,
+            "edges": [
+                {"source": 0, "target": 1, "capacity": {"num": "3", "den": "1"}},
+                {"source": 0, "target": 2, "capacity": {"num": "2", "den": "1"}},
+                {"source": 1, "target": 2, "capacity": {"num": "1", "den": "1"}},
+                {"source": 1, "target": 3, "capacity": {"num": "2", "den": "1"}},
+                {"source": 2, "target": 3, "capacity": {"num": "3", "den": "1"}},
+                {"source": 3, "target": 4, "capacity": {"num": "5", "den": "1"}},
+            ],
+        }
+        flow = _max_flow(graph, 0, 4)
+        cut = _min_cut(graph, 0, 4)
+        assert flow.flow_value.as_fraction() == cut.cut_value.as_fraction()

--- a/tests/domain/multivariate_polynomial/test_multivariate_polynomial.py
+++ b/tests/domain/multivariate_polynomial/test_multivariate_polynomial.py
@@ -1,0 +1,348 @@
+"""Tests for bounded exact multivariate polynomial operations over ``QQ``."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.contracts.multivariate_polynomial import (
+    MultivariateDivisionRequest,
+    MultivariateGcdRequest,
+    MultivariateResultantRequest,
+)
+from jacobian.domains.multivariate_polynomial.operations import (
+    compute_multivariate_division,
+    compute_multivariate_gcd,
+    compute_multivariate_resultant,
+)
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def _poly(
+    variables: tuple[str, ...],
+    terms: tuple[tuple[str, tuple[int, ...]], ...],
+) -> RationalPolynomial:
+    """Build a ``RationalPolynomial`` from ``"num/den", (exponents,)`` tuples."""
+
+    return RationalPolynomial.model_validate(
+        {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": list(variables),
+            "polynomial": {
+                "terms": [
+                    {"coefficient": {"num": num, "den": den}, "exponents": list(exp)}
+                    for coeff, exp in terms
+                    for num, den in [coeff.split("/")]
+                ]
+            },
+        }
+    )
+
+
+def _scalar(
+    variables: tuple[str, ...],
+    value: str,
+) -> RationalPolynomial:
+    """Build a scalar (constant) polynomial for the given variable ring."""
+
+    num, _, den = value.partition("/")
+    if not den:
+        den = "1"
+    return _poly(variables, ((f"{num}/{den}", (0,) * len(variables)),))
+
+
+# --------------------------------------------------------------------------- #
+# Multivariate GCD
+# --------------------------------------------------------------------------- #
+
+
+class TestMultivariateGcd:
+    """Tests for ``polynomial.multivariate.gcd.compute``."""
+
+    def test_gcd_of_non_coprime_pair(self) -> None:
+        """gcd(x^2*y, x*y) = x*y."""
+
+        left = _poly(("x", "y"), (("1/1", (2, 1)),))
+        right = _poly(("x", "y"), (("1/1", (1, 1)),))
+        result = compute_multivariate_gcd(
+            MultivariateGcdRequest(left=left, right=right)
+        )
+        gcd = result.gcd
+        assert gcd.variables == ("x", "y")
+        assert len(gcd.polynomial.terms) == 1
+        term = gcd.polynomial.terms[0]
+        assert term.coefficient.num == "1"
+        assert term.coefficient.den == "1"
+        assert term.exponents == (1, 1)
+
+    def test_gcd_of_coprime_pair(self) -> None:
+        """gcd(x*y - 1, x^2 - 1) = 1 (coprime over QQ[x, y])."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        right = _poly(("x", "y"), (("1/1", (2, 0)), ("-1/1", (0, 0))))
+        result = compute_multivariate_gcd(
+            MultivariateGcdRequest(left=left, right=right)
+        )
+        gcd = result.gcd
+        assert len(gcd.polynomial.terms) == 1
+        term = gcd.polynomial.terms[0]
+        assert term.coefficient.num == "1"
+        assert term.coefficient.den == "1"
+        assert term.exponents == (0, 0)
+
+    def test_gcd_is_monic(self) -> None:
+        """The GCD should be normalized to a monic (leading-coefficient 1) polynomial."""
+
+        # gcd(2*x*y, 3*x*y) = x*y (content stripped, monic associate)
+        left = _poly(("x", "y"), (("2/1", (1, 1)),))
+        right = _poly(("x", "y"), (("3/1", (1, 1)),))
+        result = compute_multivariate_gcd(
+            MultivariateGcdRequest(left=left, right=right)
+        )
+        gcd = result.gcd
+        assert len(gcd.polynomial.terms) == 1
+        term = gcd.polynomial.terms[0]
+        assert term.coefficient.num == "1"
+        assert term.coefficient.den == "1"
+
+    def test_gcd_with_rational_coefficients(self) -> None:
+        """GCD works over QQ with non-integer coefficients."""
+
+        left = _poly(("x", "y"), (("1/2", (2, 1)),))
+        right = _poly(("x", "y"), (("1/3", (1, 1)),))
+        result = compute_multivariate_gcd(
+            MultivariateGcdRequest(left=left, right=right)
+        )
+        gcd = result.gcd
+        # gcd(x^2*y, x*y) = x*y, monic
+        assert len(gcd.polynomial.terms) == 1
+        term = gcd.polynomial.terms[0]
+        assert term.coefficient.num == "1"
+        assert term.coefficient.den == "1"
+
+    def test_gcd_rejects_univariate(self) -> None:
+        """Univariate polynomials are rejected for multivariate operations."""
+
+        left = _poly(("x",), (("1/1", (1,)),))
+        right = _poly(("x",), (("1/1", (0,)),))
+        with pytest.raises(ValueError, match="at least two variables"):
+            MultivariateGcdRequest(left=left, right=right)
+
+    def test_gcd_rejects_mismatched_variables(self) -> None:
+        """Polynomials must share the same ordered variable list."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)),))
+        right = _poly(("x", "z"), (("1/1", (1, 1)),))
+        with pytest.raises(ValueError, match="same ordered variables"):
+            MultivariateGcdRequest(left=left, right=right)
+
+    def test_gcd_rejects_oversized_terms(self) -> None:
+        """Operations fail closed on oversized inputs."""
+
+        # Build >512 unique monomials (i, 0) for i = 599..0 (descending order).
+        terms = tuple((f"{i+1}/1", (i, 0)) for i in range(599, -1, -1))
+        left = _poly(("x", "y"), terms[:600])
+        right = _poly(("x", "y"), (("1/1", (0, 0)),))
+        with pytest.raises(ValueError, match="term operation budget"):
+            MultivariateGcdRequest(left=left, right=right)
+
+
+# --------------------------------------------------------------------------- #
+# Multivariate division
+# --------------------------------------------------------------------------- #
+
+
+class TestMultivariateDivision:
+    """Tests for ``polynomial.multivariate.divide.compute``."""
+
+    def test_division_exact(self) -> None:
+        """x^2*y / (x*y) = x, remainder 0."""
+
+        left = _poly(("x", "y"), (("1/1", (2, 1)),))
+        right = _poly(("x", "y"), (("1/1", (1, 1)),))
+        result = compute_multivariate_division(
+            MultivariateDivisionRequest(left=left, right=right)
+        )
+        assert len(result.remainder.polynomial.terms) == 0
+        quotient = result.quotient
+        assert len(quotient.polynomial.terms) == 1
+        assert quotient.polynomial.terms[0].exponents == (1, 0)
+        assert quotient.polynomial.terms[0].coefficient.num == "1"
+
+    def test_division_with_remainder(self) -> None:
+        """Divide x^2*y + x by x*y - 1: quotient = x, remainder = 2*x."""
+
+        left = _poly(("x", "y"), (("1/1", (2, 1)), ("1/1", (1, 0))))
+        right = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        result = compute_multivariate_division(
+            MultivariateDivisionRequest(left=left, right=right, monomial_order="lex")
+        )
+        quotient = result.quotient
+        remainder = result.remainder
+        assert len(quotient.polynomial.terms) == 1
+        assert quotient.polynomial.terms[0].exponents == (1, 0)
+        assert quotient.polynomial.terms[0].coefficient.num == "1"
+        assert len(remainder.polynomial.terms) == 1
+        assert remainder.polynomial.terms[0].exponents == (1, 0)
+        assert remainder.polynomial.terms[0].coefficient.num == "2"
+
+    def test_division_grlex_order(self) -> None:
+        """Division under grlex order should be a valid reconstruction."""
+
+        left = _poly(
+            ("x", "y"),
+            (("1/1", (2, 1)), ("1/1", (1, 0))),
+        )
+        right = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        result = compute_multivariate_division(
+            MultivariateDivisionRequest(
+                left=left, right=right, monomial_order="grlex"
+            )
+        )
+        assert result.monomial_order == "grlex"
+
+    def test_division_grevlex_order(self) -> None:
+        """Division under grevlex order should be a valid reconstruction."""
+
+        left = _poly(
+            ("x", "y"),
+            (("1/1", (2, 1)), ("1/1", (1, 0))),
+        )
+        right = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        result = compute_multivariate_division(
+            MultivariateDivisionRequest(
+                left=left, right=right, monomial_order="grevlex"
+            )
+        )
+        assert result.monomial_order == "grevlex"
+
+    def test_division_zero_dividend(self) -> None:
+        """Dividing the zero polynomial gives zero quotient and remainder."""
+
+        left = _poly(("x", "y"), ())
+        right = _poly(("x", "y"), (("1/1", (1, 1)),))
+        result = compute_multivariate_division(
+            MultivariateDivisionRequest(left=left, right=right)
+        )
+        assert len(result.quotient.polynomial.terms) == 0
+        assert len(result.remainder.polynomial.terms) == 0
+
+    def test_division_rejects_univariate(self) -> None:
+        """Univariate polynomials are rejected for multivariate operations."""
+
+        left = _poly(("x",), (("1/1", (2,)),))
+        right = _poly(("x",), (("1/1", (1,)),))
+        with pytest.raises(ValueError, match="at least two variables"):
+            MultivariateDivisionRequest(left=left, right=right)
+
+    def test_division_rejects_mismatched_variables(self) -> None:
+        """Polynomials must share the same ordered variable list."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)),))
+        right = _poly(("a", "b"), (("1/1", (1, 1)),))
+        with pytest.raises(ValueError, match="same ordered variables"):
+            MultivariateDivisionRequest(left=left, right=right)
+
+
+# --------------------------------------------------------------------------- #
+# Multivariate resultant
+# --------------------------------------------------------------------------- #
+
+
+class TestMultivariateResultant:
+    """Tests for ``polynomial.multivariate.resultant.compute``."""
+
+    def test_resultant_bivariate(self) -> None:
+        """res(x*y - 1, x^2 - 1, x) = 1 - y^2 (a polynomial in y)."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        right = _poly(("x", "y"), (("1/1", (2, 0)), ("-1/1", (0, 0))))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+        )
+        assert result.elimination_variable == "x"
+        # Resultant should be a polynomial in the remaining variable y.
+        assert result.resultant.kind == "POLYNOMIAL"
+        value = result.resultant.value
+        assert value.variables == ("y",)
+        # The resultant is 1 - y^2, i.e. terms {y^2: -1, y^0: 1}.
+        terms = {t.exponents[0]: (t.coefficient.num, t.coefficient.den) for t in value.polynomial.terms}
+        assert terms.get(2) == ("-1", "1")
+        assert terms.get(0) == ("1", "1")
+
+    def test_resultant_eliminating_different_variable(self) -> None:
+        """res(x*y - 1, y^2 - x, y) = 1 - x^3 (a polynomial in x)."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        right = _poly(("x", "y"), (("-1/1", (1, 0)), ("1/1", (0, 2))))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="y"
+            )
+        )
+        assert result.elimination_variable == "y"
+        assert result.resultant.kind == "POLYNOMIAL"
+        value = result.resultant.value
+        assert value.variables == ("x",)
+
+    def test_resultant_with_three_variables(self) -> None:
+        """res(x^2 - y, x - z, x) = z^2 - y (a polynomial in y, z)."""
+
+        left = _poly(("x", "y", "z"), (("1/1", (2, 0, 0)), ("-1/1", (0, 1, 0))))
+        right = _poly(("x", "y", "z"), (("1/1", (1, 0, 0)), ("-1/1", (0, 0, 1))))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+        )
+        assert result.elimination_variable == "x"
+        assert result.resultant.kind == "POLYNOMIAL"
+        value = result.resultant.value
+        assert value.variables == ("y", "z")
+
+    def test_resultant_rejects_zero_degree(self) -> None:
+        """The elimination variable must appear in both polynomials."""
+
+        # left has zero degree in x; right has zero degree in x
+        left = _poly(("x", "y"), (("1/1", (0, 1)),))
+        right = _poly(("x", "y"), (("1/1", (0, 1)),))
+        with pytest.raises(ValueError, match="zero degree in the elimination variable"):
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+
+    def test_resultant_rejects_univariate(self) -> None:
+        """Univariate polynomials are rejected for multivariate operations."""
+
+        left = _poly(("x",), (("1/1", (2,)), ("-1/1", (0,))))
+        right = _poly(("x",), (("1/1", (1,)), ("-2/1", (0,))))
+        with pytest.raises(ValueError, match="at least two variables"):
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+
+    def test_resultant_rejects_variable_not_in_ring(self) -> None:
+        """The elimination variable must belong to the declared ring."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)),))
+        right = _poly(("x", "y"), (("1/1", (2, 0)),))
+        with pytest.raises(ValueError, match="must belong to the declared ring"):
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="z"
+            )
+
+    def test_resultant_rejects_oversized_degree(self) -> None:
+        """Operations fail closed on oversized inputs."""
+
+        # Build polynomials with degree sum > 64 in the elimination variable.
+        # Terms must be in descending lex order.
+        terms_left = tuple((f"1/1", (i, 0)) for i in range(39, -1, -1))
+        terms_right = tuple((f"1/1", (i, 0)) for i in range(39, -1, -1))
+        left = _poly(("x", "y"), terms_left)
+        right = _poly(("x", "y"), terms_right)
+        with pytest.raises(ValueError, match="Sylvester degree"):
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )


### PR DESCRIPTION
## Summary

Fixes #1753, #1757, adds #1713 (formal power series) and #1678 (multivariate polynomial).

### Graph flow fixes (#1753, #1757)
- Fix `result_type=result_type` → `result_type=result_model` in `graph_flow_operation` factory
- Add `EdgeDisjointPathsRequest`/`EdgeDisjointPathsResult` contracts and `compute_edge_disjoint_paths` operation
- Add per-edge `flow_edges` decomposition to `MaxFlowResult` so callers can independently verify conservation and capacity constraints
- Add tests for max-flow, min-cut, and edge-disjoint paths

### Formal power series (#1713)
15 exact truncated formal power series operations over QQ:
- Arithmetic: add, subtract, multiply, scalar multiply, power
- Inverse, divide with residual certificates
- Composition and compositional inverse (reversion) with dual identity residuals
- Derivative, integral, truncation, identity check
- Polynomial conversion operations

All operations use exact rational arithmetic (Python `Fraction`).

### Multivariate polynomial (#1678)
3 exact multivariate polynomial operations over QQ:
- GCD via SymPy's multivariate polynomial GCD
- Division with declared monomial order (lex, grlex, grevlex) using SymPy's polynomial ring
- Resultant with respect to one declared variable

All backed by SymPy's polynomial ring. Includes 51 tests.

### Testing
- 51 new tests all pass
- All 35 built-in operation modules load correctly after fixes