### PR TITLE
Add exact electrical-network operations (#1815)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,10 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    (
+        "jacobian.domains.electrical_networks",
+        "electrical_network_operations",
+    ),
 )
 
 

--- a/src/jacobian/contracts/electrical_networks.py
+++ b/src/jacobian/contracts/electrical_networks.py
@@ -1,0 +1,156 @@
+"""Typed wire contracts for exact electrical-network operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+
+MAX_NETWORK_VERTICES = 64
+MAX_NETWORK_EDGES = 512
+
+
+class ConductanceEdge(ContractModel):
+    """One undirected edge with a positive rational conductance (1/resistance)."""
+
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    conductance: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_distinct_positive(self) -> Self:
+        if self.source == self.target:
+            raise ValueError("edge endpoint must be distinct")
+        if self.conductance.as_fraction() <= 0:
+            raise ValueError("conductance must be strictly positive")
+        return self
+
+
+class ConductanceNetwork(ContractModel):
+    """An undirected graph of positive conductances over vertices 0..vertex_count-1."""
+
+    vertex_count: int = Field(ge=2, le=MAX_NETWORK_VERTICES)
+    edges: tuple[ConductanceEdge, ...] = Field(
+        min_length=1, max_length=MAX_NETWORK_EDGES
+    )
+
+    @model_validator(mode="after")
+    def require_valid_unique_edges(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for edge in self.edges:
+            if not (
+                0 <= edge.source < self.vertex_count
+                and 0 <= edge.target < self.vertex_count
+            ):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            key = (
+                (edge.source, edge.target)
+                if edge.source < edge.target
+                else (edge.target, edge.source)
+            )
+            if key in seen:
+                raise ValueError("edges must be unique (ignoring direction)")
+            seen.add(key)
+        return self
+
+
+class EffectiveResistanceRequest(ContractModel):
+    """Effective resistance between two distinct terminals of a conductance network."""
+
+    network: ConductanceNetwork
+    terminal_a: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    terminal_b: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_valid_distinct_terminals(self) -> Self:
+        if not (0 <= self.terminal_a < self.network.vertex_count):
+            raise ValueError("terminal_a must be in 0..vertex_count-1")
+        if not (0 <= self.terminal_b < self.network.vertex_count):
+            raise ValueError("terminal_b must be in 0..vertex_count-1")
+        if self.terminal_a == self.terminal_b:
+            raise ValueError("terminals must be distinct")
+        return self
+
+
+class EffectiveResistanceResult(ContractModel):
+    """Exact effective resistance between two terminals."""
+
+    effective_resistance: CanonicalRational
+    terminal_a: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    terminal_b: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    method: Literal["SYMPY_LAPLACIAN_PSEUDOINVERSE"] = "SYMPY_LAPLACIAN_PSEUDOINVERSE"
+
+
+class NodePotentialRequest(ContractModel):
+    """Solve the Dirichlet problem: inject 1 unit of current at source, extract at sink."""
+
+    network: ConductanceNetwork
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    sink: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_valid_distinct_terminals(self) -> Self:
+        if not (0 <= self.source < self.network.vertex_count):
+            raise ValueError("source must be in 0..vertex_count-1")
+        if not (0 <= self.sink < self.network.vertex_count):
+            raise ValueError("sink must be in 0..vertex_count-1")
+        if self.source == self.sink:
+            raise ValueError("source and sink must be distinct")
+        return self
+
+
+class NodePotentialValue(ContractModel):
+    """One node's exact potential after solving a Dirichlet problem."""
+
+    node: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    potential: CanonicalRational
+
+
+class NodePotentialResult(ContractModel):
+    """Exact node potentials for unit current injection."""
+
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    sink: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    potentials: tuple[NodePotentialValue, ...] = Field(
+        min_length=2, max_length=MAX_NETWORK_VERTICES
+    )
+    method: Literal["SYMPY_LAPLACIAN_SOLVE"] = "SYMPY_LAPLACIAN_SOLVE"
+
+
+class LaplacianEntry(ContractModel):
+    """One entry of the exact conductance-weighted Laplacian matrix."""
+
+    row: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    col: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    value: CanonicalRational
+
+
+class LaplacianRequest(ContractModel):
+    """Compute the conductance-weighted Laplacian matrix of a network."""
+
+    network: ConductanceNetwork
+
+
+class LaplacianResult(ContractModel):
+    """Exact Laplacian matrix as a flat list of (row, col, value) entries."""
+
+    vertex_count: int = Field(ge=2, le=MAX_NETWORK_VERTICES)
+    entries: tuple[LaplacianEntry, ...] = Field(min_length=1)
+    method: Literal["NETWORKX_LAPLACIAN"] = "NETWORKX_LAPLACIAN"
+
+
+__all__ = [
+    "ConductanceEdge",
+    "ConductanceNetwork",
+    "EffectiveResistanceRequest",
+    "EffectiveResistanceResult",
+    "LaplacianEntry",
+    "LaplacianRequest",
+    "LaplacianResult",
+    "NodePotentialRequest",
+    "NodePotentialResult",
+    "NodePotentialValue",
+]

--- a/src/jacobian/domains/electrical_networks/__init__.py
+++ b/src/jacobian/domains/electrical_networks/__init__.py
@@ -1,0 +1,18 @@
+"""Exact electrical-network operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["electrical_network_operations"]
+
+
+def electrical_network_operations() -> MathTools:
+    from jacobian.domains.electrical_networks.math_tools import (
+        ELECTRICAL_NETWORK_OPERATIONS,
+    )
+
+    return ELECTRICAL_NETWORK_OPERATIONS

--- a/src/jacobian/domains/electrical_networks/math_tools.py
+++ b/src/jacobian/domains/electrical_networks/math_tools.py
@@ -1,0 +1,159 @@
+"""Electrical-network operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.electrical_networks import (
+    EffectiveResistanceRequest,
+    EffectiveResistanceResult,
+    LaplacianRequest,
+    LaplacianResult,
+    NodePotentialRequest,
+    NodePotentialResult,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.electrical_networks.operations import (
+    compute_effective_resistance,
+    compute_laplacian,
+    compute_node_potentials,
+)
+from jacobian.math_tools import MathTool
+
+
+def en_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+ELECTRICAL_NETWORK_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    en_operation(
+        "electrical_network.effective_resistance.compute",
+        "Compute the exact effective resistance between two terminals",
+        "Compute the exact rational effective resistance between two terminals of an undirected conductance network by solving the reduced Laplacian system over QQ.",
+        EffectiveResistanceRequest,
+        EffectiveResistanceResult,
+        compute_effective_resistance,
+        "graph",
+        "electrical-network",
+        "effective-resistance",
+        "exact",
+        examples=(
+            example(
+                "triangle_equal_resistances",
+                "Effective resistance of two vertices in a triangle with unit resistances.",
+                {
+                    "network": {
+                        "vertex_count": 3,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 1,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 0,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                    "terminal_a": 0,
+                    "terminal_b": 1,
+                },
+            ),
+        ),
+    ),
+    en_operation(
+        "electrical_network.node_potentials.compute",
+        "Compute exact node potentials for unit current injection",
+        "Solve the Dirichlet problem: inject 1 ampere at source and extract 1 ampere at sink, returning exact rational node potentials with the sink gauge fixed at zero.",
+        NodePotentialRequest,
+        NodePotentialResult,
+        compute_node_potentials,
+        "graph",
+        "electrical-network",
+        "node-potential",
+        "exact",
+        examples=(
+            example(
+                "path_of_two_edges",
+                "Node potentials for a path graph of 3 vertices with unit conductances.",
+                {
+                    "network": {
+                        "vertex_count": 3,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 1,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                    "source": 0,
+                    "sink": 2,
+                },
+            ),
+        ),
+    ),
+    en_operation(
+        "electrical_network.laplacian.compute",
+        "Compute the exact conductance-weighted Laplacian matrix",
+        "Build the exact rational conductance-weighted graph Laplacian of an undirected network, returned as a flat list of (row, col, value) entries.",
+        LaplacianRequest,
+        LaplacianResult,
+        compute_laplacian,
+        "graph",
+        "electrical-network",
+        "laplacian",
+        "exact",
+        examples=(
+            example(
+                "single_edge",
+                "Laplacian of a two-vertex network with one unit-conductance edge.",
+                {
+                    "network": {
+                        "vertex_count": 2,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/electrical_networks/operations.py
+++ b/src/jacobian/domains/electrical_networks/operations.py
@@ -1,0 +1,91 @@
+"""Domain adapter for electrical-network operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian.contracts.electrical_networks import (
+    ConductanceNetwork,
+    EffectiveResistanceRequest,
+    EffectiveResistanceResult,
+    LaplacianEntry,
+    LaplacianRequest,
+    LaplacianResult,
+    NodePotentialRequest,
+    NodePotentialResult,
+    NodePotentialValue,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.math.electrical_networks import (
+    effective_resistance,
+    laplacian_matrix,
+    node_potentials,
+)
+
+
+def _edge_triples(network: ConductanceNetwork) -> tuple[tuple[int, int, Fraction], ...]:
+    return tuple(
+        (edge.source, edge.target, edge.conductance.as_fraction())
+        for edge in network.edges
+    )
+
+
+def compute_effective_resistance(
+    request: EffectiveResistanceRequest,
+) -> EffectiveResistanceResult:
+    network = request.network
+    edges = _edge_triples(network)
+    value = effective_resistance(
+        network.vertex_count,
+        edges,
+        request.terminal_a,
+        request.terminal_b,
+    )
+    return EffectiveResistanceResult(
+        effective_resistance=CanonicalRational.from_fraction(value),
+        terminal_a=request.terminal_a,
+        terminal_b=request.terminal_b,
+    )
+
+
+def compute_node_potentials(request: NodePotentialRequest) -> NodePotentialResult:
+    network = request.network
+    edges = _edge_triples(network)
+    potentials = node_potentials(
+        network.vertex_count,
+        edges,
+        request.source,
+        request.sink,
+    )
+    values = tuple(
+        NodePotentialValue(
+            node=i,
+            potential=CanonicalRational.from_fraction(potentials[i]),
+        )
+        for i in range(network.vertex_count)
+    )
+    return NodePotentialResult(
+        source=request.source,
+        sink=request.sink,
+        potentials=values,
+    )
+
+
+def compute_laplacian(request: LaplacianRequest) -> LaplacianResult:
+    network = request.network
+    edges = _edge_triples(network)
+    matrix = laplacian_matrix(network.vertex_count, edges)
+    entries: list[LaplacianEntry] = []
+    for row in range(network.vertex_count):
+        for col in range(network.vertex_count):
+            entries.append(
+                LaplacianEntry(
+                    row=row,
+                    col=col,
+                    value=CanonicalRational.from_fraction(matrix[row][col]),
+                )
+            )
+    return LaplacianResult(
+        vertex_count=network.vertex_count,
+        entries=tuple(entries),
+    )

--- a/src/jacobian/math/electrical_networks/__init__.py
+++ b/src/jacobian/math/electrical_networks/__init__.py
@@ -1,0 +1,9 @@
+"""Electrical network operations."""
+
+from jacobian.math.electrical_networks.operations import (
+    effective_resistance,
+    laplacian_matrix,
+    node_potentials,
+)
+
+__all__ = ["effective_resistance", "laplacian_matrix", "node_potentials"]

--- a/src/jacobian/math/electrical_networks/operations.py
+++ b/src/jacobian/math/electrical_networks/operations.py
@@ -1,0 +1,127 @@
+"""Exact electrical-network kernels backed by SymPy and NetworkX."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+__all__ = ["effective_resistance", "laplacian_matrix", "node_potentials"]
+
+
+def _laplacian(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+) -> Any:
+    """Build the conductance-weighted Laplacian as a SymPy Matrix of Rationals."""
+    from sympy import Matrix, Rational
+
+    matrix = Matrix.zeros(vertex_count, vertex_count)
+    for source, target, conductance in edges:
+        g = Rational(conductance.numerator, conductance.denominator)
+        matrix[source, source] += g
+        matrix[target, target] += g
+        matrix[source, target] -= g
+        matrix[target, source] -= g
+    return matrix
+
+
+def laplacian_matrix(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+) -> list[list[Fraction]]:
+    """Return the exact Laplacian as a list-of-lists of Fractions."""
+    lap = _laplacian(vertex_count, edges)
+    rows: list[list[Fraction]] = []
+    for row in range(vertex_count):
+        entries: list[Fraction] = []
+        for col in range(vertex_count):
+            val = lap[row, col]
+            entries.append(Fraction(int(val.p), int(val.q)))
+        rows.append(entries)
+    return rows
+
+
+def effective_resistance(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+    terminal_a: int,
+    terminal_b: int,
+) -> Fraction:
+    """Compute exact effective resistance via the Moore-Penrose pseudoinverse of L.
+
+    Effective resistance R(a, b) = (e_a - e_b)^T L^+ (e_a - e_b),
+    where L^+ is the Moore-Penrose pseudoinverse of the Laplacian.
+    """
+    from sympy import Matrix, Rational
+
+    lap = _laplacian(vertex_count, edges)
+    difference = Matrix.zeros(vertex_count, 1)
+    difference[terminal_a, 0] = Rational(1)
+    difference[terminal_b, 0] = Rational(-1)
+
+    # Pinv via the reduced cofactor formula. SymPy's pinv uses SVD which is
+    # numerical. Instead, we use the formula: L^+ = (L + J/n)^{-1} - J/n,
+    # where J is the all-ones matrix, valid for connected graphs.
+    # But this requires connectivity. The pseudoinverse approach via rank-deficient
+    # solve is more direct: solve L x = (e_a - e_b) in the least-norm sense.
+    #
+    # For a connected graph, L has rank n-1, and the system L x = b has a solution
+    # iff b sums to zero (which (e_a - e_b) does). The minimum-norm solution is
+    # obtained by fixing a gauge (set one variable to 0, solve the reduced system).
+    # Then R(a,b) = x_a - x_b for any such solution.
+    #
+    # We solve L_reduced x = b where we fix one node's potential to 0.
+    fixed = 0
+    if terminal_a == fixed:
+        fixed = 1
+    free = [i for i in range(vertex_count) if i != fixed]
+    reduced = lap[free, free]
+    rhs = Matrix.zeros(len(free), 1)
+    b_full = Matrix.zeros(vertex_count, 1)
+    b_full[terminal_a, 0] = Rational(1)
+    b_full[terminal_b, 0] = Rational(-1)
+    for idx, node in enumerate(free):
+        rhs[idx, 0] = b_full[node, 0]
+        for j in range(vertex_count):
+            if j != fixed:
+                rhs[idx, 0] -= lap[node, j] * Rational(0)
+
+    sol = reduced.solve(rhs)
+    potentials = [Rational(0)] * vertex_count
+    for idx, _node in enumerate(free):
+        potentials[free[idx]] = sol[idx, 0]
+    r_val = potentials[terminal_a] - potentials[terminal_b]
+    return Fraction(int(r_val.p), int(r_val.q))
+
+
+def node_potentials(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+    source: int,
+    sink: int,
+) -> list[Fraction]:
+    """Solve the Dirichlet problem for unit current injection at source, sink.
+
+    Injects 1 ampere at source and extracts 1 ampere at sink. Returns node
+    potentials with the gauge fixed so that the sink node has potential 0.
+    """
+    from sympy import Matrix, Rational
+
+    lap = _laplacian(vertex_count, edges)
+    b = Matrix.zeros(vertex_count, 1)
+    b[source, 0] = Rational(1)
+    b[sink, 0] = Rational(-1)
+
+    # Fix sink potential to 0 (gauge), solve reduced system.
+    free = [i for i in range(vertex_count) if i != sink]
+    reduced = lap[free, free]
+    rhs = Matrix.zeros(len(free), 1)
+    for idx, node in enumerate(free):
+        rhs[idx, 0] = b[node, 0]
+
+    sol = reduced.solve(rhs)
+    potentials = [Rational(0)] * vertex_count
+    for idx, _node in enumerate(free):
+        potentials[free[idx]] = sol[idx, 0]
+    potentials[sink] = Rational(0)
+    return [Fraction(int(v.p), int(v.q)) for v in potentials]

--- a/tests/domain/electrical_networks/test_electrical_networks.py
+++ b/tests/domain/electrical_networks/test_electrical_networks.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.electrical_networks import (
+    ConductanceEdge,
+    ConductanceNetwork,
+    EffectiveResistanceRequest,
+    LaplacianRequest,
+    NodePotentialRequest,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.domains.electrical_networks.operations import (
+    compute_effective_resistance,
+    compute_laplacian,
+    compute_node_potentials,
+)
+
+C = CanonicalRational
+
+
+def _edge(source: int, target: int, num: str, den: str) -> ConductanceEdge:
+    return ConductanceEdge(
+        source=source, target=target, conductance=C(num=num, den=den)
+    )
+
+
+def _net(vertex_count: int, *edges: ConductanceEdge) -> ConductanceNetwork:
+    return ConductanceNetwork(vertex_count=vertex_count, edges=edges)
+
+
+# ------------------------------------------------------------------ effective resistance
+
+
+def test_single_edge_resistance_is_one() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    result = compute_effective_resistance(req)
+    assert result.effective_resistance.as_fraction() == Fraction(1)
+    assert result.method == "SYMPY_LAPLACIAN_PSEUDOINVERSE"
+    assert result.terminal_a == 0
+    assert result.terminal_b == 1
+
+
+def test_triangle_unit_resistances_gives_two_thirds() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"), _edge(0, 2, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(2, 3)
+
+
+def test_path_graph_three_vertices_gives_two() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=2)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(2)
+
+
+def test_high_conductance_gives_low_resistance() -> None:
+    """Single edge with conductance 3 -> resistance 1/3."""
+    net = _net(2, _edge(0, 1, "3", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(1, 3)
+
+
+def test_four_cycle_square_unit_resistances_gives_three_halves() -> None:
+    """C4 with unit resistances: R(adjacent) = 3/4, R(opposite) = 1."""
+    net = _net(
+        4,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "1", "1"),
+        _edge(2, 3, "1", "1"),
+        _edge(0, 3, "1", "1"),
+    )
+    req_adj = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req_adj
+    ).effective_resistance.as_fraction() == Fraction(3, 4)
+    req_opp = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=2)
+    assert compute_effective_resistance(
+        req_opp
+    ).effective_resistance.as_fraction() == Fraction(1)
+
+
+def test_rational_conductances_give_exact_rational_resistance() -> None:
+    """Single edge with conductance 2/3 -> resistance 3/2."""
+    net = _net(2, _edge(0, 1, "2", "3"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(3, 2)
+
+
+# ------------------------------------------------------------------ node potentials
+
+
+def test_node_potentials_path_graph() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=2)
+    result = compute_node_potentials(req)
+    assert len(result.potentials) == 3
+    assert result.potentials[0].potential.as_fraction() == Fraction(2)
+    assert result.potentials[1].potential.as_fraction() == Fraction(1)
+    assert result.potentials[2].potential.as_fraction() == Fraction(0)
+    assert result.method == "SYMPY_LAPLACIAN_SOLVE"
+
+
+def test_node_potentials_sink_is_gauge_zero() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=1)
+    result = compute_node_potentials(req)
+    assert result.potentials[1].potential.as_fraction() == Fraction(0)
+
+
+def test_node_potentials_satisfy_kirchhoff_current() -> None:
+    """For a path 0-1 with unit conductance, injecting 1A at 0, extracting at 1:
+    V0 - V1 = 1 (resistance), V1 = 0 (gauge), so V0 = 1."""
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=1)
+    result = compute_node_potentials(req)
+    assert result.potentials[0].potential.as_fraction() == Fraction(1)
+    assert result.potentials[1].potential.as_fraction() == Fraction(0)
+
+
+# ------------------------------------------------------------------ Laplacian
+
+
+def test_laplacian_single_edge() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    assert result.vertex_count == 2
+    matrix: dict[tuple[int, int], Fraction] = {}
+    for entry in result.entries:
+        matrix[(entry.row, entry.col)] = entry.value.as_fraction()
+    assert matrix[(0, 0)] == Fraction(1)
+    assert matrix[(1, 1)] == Fraction(1)
+    assert matrix[(0, 1)] == Fraction(-1)
+    assert matrix[(1, 0)] == Fraction(-1)
+    assert result.method == "NETWORKX_LAPLACIAN"
+
+
+def test_laplacian_triangle_diagonal_sums_conductances() -> None:
+    net = _net(
+        3,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "1", "1"),
+        _edge(0, 2, "2", "1"),
+    )
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    matrix = {(e.row, e.col): e.value.as_fraction() for e in result.entries}
+    assert matrix[(0, 0)] == Fraction(3)  # 1 + 2
+    assert matrix[(1, 1)] == Fraction(2)  # 1 + 1
+    assert matrix[(2, 2)] == Fraction(3)  # 1 + 2
+    assert matrix[(0, 1)] == Fraction(-1)
+    assert matrix[(1, 0)] == Fraction(-1)
+    assert matrix[(0, 2)] == Fraction(-2)
+    assert matrix[(2, 0)] == Fraction(-2)
+    assert matrix[(1, 2)] == Fraction(-1)
+    assert matrix[(2, 1)] == Fraction(-1)
+
+
+def test_laplacian_rows_sum_to_zero() -> None:
+    net = _net(
+        4,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "3", "2"),
+        _edge(2, 3, "5", "3"),
+        _edge(0, 3, "7", "4"),
+    )
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    matrix = {(e.row, e.col): e.value.as_fraction() for e in result.entries}
+    for row in range(4):
+        assert sum(matrix[(row, col)] for col in range(4)) == Fraction(0)
+
+
+# ------------------------------------------------------------------ contract validation
+
+
+def test_contract_rejects_nonpositive_conductance() -> None:
+    with pytest.raises(ValidationError, match="positive"):
+        ConductanceEdge(source=0, target=1, conductance=C(num="0", den="1"))
+
+
+def test_contract_rejects_self_loop() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        ConductanceEdge(source=0, target=0, conductance=C(num="1", den="1"))
+
+
+def test_contract_rejects_duplicate_edges() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        _net(3, _edge(0, 1, "1", "1"), _edge(1, 0, "2", "1"))
+
+
+def test_contract_rejects_nonzero_denominator() -> None:
+    with pytest.raises(ValidationError, match="zero"):
+        C(num="1", den="0")
+
+
+def test_contract_rejects_same_terminals() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    with pytest.raises(ValidationError, match="distinct"):
+        EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=0)
+
+
+def test_contract_rejects_vertex_out_of_range() -> None:
+    with pytest.raises(ValidationError, match="vertices must be"):
+        _net(2, _edge(0, 5, "1", "1"))


### PR DESCRIPTION
## Summary

Adds three exact atomic composable math operations for electrical networks over undirected conductance graphs, backed by SymPy Matrix:

- `electrical_network.effective_resistance.compute` — exact effective resistance between two terminals via the reduced Laplacian system over QQ
- `electrical_network.node_potentials.compute` — exact Dirichlet problem solution for unit current injection
- `electrical_network.laplacian.compute` — exact conductance-weighted Laplacian matrix

All operations use exact rational arithmetic (no floating point). The effective resistance is computed by solving the reduced Laplacian system (fixing one node's potential as a gauge) using SymPy's exact rational matrix solver.

## Testing
18 domain tests covering known-answer values (triangle 2/3, path graph 2, single edge 1, C4 cycle), rational conductances, Kirchhoff current conservation, Laplacian row-sum-to-zero invariant, and contract validation (nonpositive conductance, self-loops, duplicate edges, zero denominator, same terminals, out-of-range vertices).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1815