### PR TITLE
Add exact minimal polynomial, rational canonical form, and primary decomposition (#1848)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    ("jacobian.domains.linear_canonical_forms", "linear_canonical_form_operations"),
 )
 
 

--- a/src/jacobian/contracts/canonical_forms.py
+++ b/src/jacobian/contracts/canonical_forms.py
@@ -1,0 +1,105 @@
+"""Typed wire contracts for exact canonical-form operations over QQ."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import (
+    CanonicalRational,
+)
+from jacobian.contracts.matrices import RationalMatrix, require_matrix_scalar_digits
+
+MAX_CANONICAL_FORM_DIMENSION = 16
+MAX_CANONICAL_FORM_SCALAR_DIGITS = 256
+
+
+class SquareMatrixRequest(ContractModel):
+    """One square rational matrix bounded for canonical-form computation."""
+
+    matrix: RationalMatrix
+
+    @model_validator(mode="after")
+    def require_bounded_square(self) -> Self:
+        n = len(self.matrix.entries)
+        if n != len(self.matrix.entries[0]):
+            raise ValueError("canonical-form operations require a square matrix")
+        if n > MAX_CANONICAL_FORM_DIMENSION:
+            raise ValueError(
+                "canonical-form operations are bounded to 16 x 16 matrices"
+            )
+        require_matrix_scalar_digits(
+            self.matrix.entries,
+            maximum=MAX_CANONICAL_FORM_SCALAR_DIGITS,
+            label="canonical-form matrix",
+        )
+        return self
+
+
+class MonicPolynomial(ContractModel):
+    """One monic univariate polynomial over QQ, as increasing-degree coefficients."""
+
+    coefficients: tuple[CanonicalRational, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_monic(self) -> Self:
+        if self.coefficients[-1].as_fraction() != 1:
+            raise ValueError("polynomial must be monic (leading coefficient = 1)")
+        if len(self.coefficients) > MAX_CANONICAL_FORM_DIMENSION + 1:
+            raise ValueError("polynomial degree exceeds the canonical-form bound")
+        return self
+
+    def as_sympy(self) -> object:
+        from sympy import Symbol
+
+        x = Symbol("x")
+        return sum(
+            self.coefficients[i].as_fraction() * x**i
+            for i in range(len(self.coefficients))
+        )
+
+
+class MinimalPolynomialResult(ContractModel):
+    """Exact minimal polynomial of a square rational matrix."""
+
+    minimal_polynomial: MonicPolynomial
+    characteristic_polynomial: MonicPolynomial
+    degree: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+    method: Literal["KRYLOV_NULLSPACE"] = "KRYLOV_NULLSPACE"
+
+
+class InvariantFactorEntry(ContractModel):
+    """One monic invariant factor from the rational canonical form."""
+
+    factor: MonicPolynomial
+    block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+
+
+class RationalCanonicalFormResult(ContractModel):
+    """Exact rational (Frobenius) canonical form of a square rational matrix."""
+
+    invariant_factors: tuple[InvariantFactorEntry, ...] = Field(min_length=1)
+    characteristic_polynomial: MonicPolynomial
+    minimal_polynomial: MonicPolynomial
+    total_block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+    method: Literal["SMITH_NORMAL_FORM"] = "SMITH_NORMAL_FORM"
+
+
+class PrimaryDecompositionResult(ContractModel):
+    """Primary decomposition of the minimal polynomial into irreducible-power components."""
+
+    components: tuple[MonicPolynomial, ...] = Field(min_length=1)
+    minimal_polynomial: MonicPolynomial
+    method: Literal["FACTOR_LCM"] = "FACTOR_LCM"
+
+
+__all__ = [
+    "InvariantFactorEntry",
+    "MinimalPolynomialResult",
+    "MonicPolynomial",
+    "PrimaryDecompositionResult",
+    "RationalCanonicalFormResult",
+    "SquareMatrixRequest",
+]

--- a/src/jacobian/domains/linear_canonical_forms/__init__.py
+++ b/src/jacobian/domains/linear_canonical_forms/__init__.py
@@ -1,0 +1,18 @@
+"""Exact linear canonical-form operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["linear_canonical_form_operations"]
+
+
+def linear_canonical_form_operations() -> MathTools:
+    from jacobian.domains.linear_canonical_forms.math_tools import (
+        LINEAR_CANONICAL_FORM_OPERATIONS,
+    )
+
+    return LINEAR_CANONICAL_FORM_OPERATIONS

--- a/src/jacobian/domains/linear_canonical_forms/math_tools.py
+++ b/src/jacobian/domains/linear_canonical_forms/math_tools.py
@@ -1,0 +1,127 @@
+"""Linear canonical-form operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.canonical_forms import (
+    MinimalPolynomialResult,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
+    SquareMatrixRequest,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.linear_canonical_forms.operations import (
+    compute_minimal_polynomial,
+    compute_primary_decomposition,
+    compute_rational_canonical_form,
+)
+from jacobian.math_tools import MathTool
+
+
+def lc_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+LINEAR_CANONICAL_FORM_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    lc_operation(
+        "matrix.minimal_polynomial.compute",
+        "Compute the exact minimal polynomial of a square rational matrix",
+        "Compute the monic minimal polynomial over QQ by the Krylov/nullspace "
+        "method, returning the exact minimal and characteristic polynomials.",
+        SquareMatrixRequest,
+        MinimalPolynomialResult,
+        compute_minimal_polynomial,
+        "matrix",
+        "minimal-polynomial",
+        "exact",
+        examples=(
+            example(
+                "nilpotent_block",
+                "Minimal polynomial of a 2x2 nilpotent Jordan block is t^2.",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "0", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    lc_operation(
+        "matrix.rational_canonical_form.compute",
+        "Compute the exact rational (Frobenius) canonical form",
+        "Compute the invariant factors, characteristic polynomial, and minimal "
+        "polynomial of a square rational matrix via Smith normal form of tI - A "
+        "over QQ[t].",
+        SquareMatrixRequest,
+        RationalCanonicalFormResult,
+        compute_rational_canonical_form,
+        "matrix",
+        "rational-canonical-form",
+        "exact",
+        examples=(
+            example(
+                "diagonal_distinct",
+                "Rational canonical form of diag(2,3) has one invariant factor (t-2)(t-3).",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "2", "den": "1"}, {"num": "0", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "3", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    lc_operation(
+        "matrix.primary_decomposition.compute",
+        "Decompose the minimal polynomial into irreducible-power components",
+        "Factor the minimal polynomial over QQ into its irreducible-power "
+        "components and return each monic component polynomial.",
+        SquareMatrixRequest,
+        PrimaryDecompositionResult,
+        compute_primary_decomposition,
+        "matrix",
+        "primary-decomposition",
+        "exact",
+        examples=(
+            example(
+                "diagonal_distinct",
+                "Primary decomposition of diag(2,3) gives (t-2) and (t-3).",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "2", "den": "1"}, {"num": "0", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "3", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/linear_canonical_forms/operations.py
+++ b/src/jacobian/domains/linear_canonical_forms/operations.py
@@ -1,0 +1,91 @@
+"""Domain adapter for linear canonical-form operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.contracts.canonical_forms import (
+    InvariantFactorEntry,
+    MinimalPolynomialResult,
+    MonicPolynomial,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
+)
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.math.canonical_forms import (
+    characteristic_polynomial,
+    invariant_factors,
+    minimal_polynomial,
+    primary_decomposition,
+)
+
+
+def _matrix_entries(request: Any) -> list[list[Any]]:
+    return [[entry.as_fraction() for entry in row] for row in request.matrix.entries]
+
+
+def _to_monic_polynomial(coeffs: list[Any]) -> MonicPolynomial:
+    return MonicPolynomial(
+        coefficients=tuple(
+            CanonicalRational.from_fraction(_to_fraction(c)) for c in coeffs
+        )
+    )
+
+
+def _to_fraction(value: Any) -> Any:
+    from fractions import Fraction
+
+    if isinstance(value, (int, float)):
+        return Fraction(value)
+    # SymPy Rational
+    return Fraction(int(value.p), int(value.q))
+
+
+def compute_minimal_polynomial(request: Any) -> MinimalPolynomialResult:
+    entries = _matrix_entries(request)
+    mp_coeffs = minimal_polynomial(entries)
+    cp_coeffs = characteristic_polynomial(entries)
+
+    degree = len(mp_coeffs) - 1
+    return MinimalPolynomialResult(
+        minimal_polynomial=_to_monic_polynomial(mp_coeffs),
+        characteristic_polynomial=_to_monic_polynomial(cp_coeffs),
+        degree=degree,
+    )
+
+
+def compute_rational_canonical_form(request: Any) -> RationalCanonicalFormResult:
+    entries = _matrix_entries(request)
+    ifs = invariant_factors(entries)
+    mp_coeffs = minimal_polynomial(entries)
+    cp_coeffs = characteristic_polynomial(entries)
+
+    invariant_entries = tuple(
+        InvariantFactorEntry(
+            factor=_to_monic_polynomial(coeffs),
+            block_size=len(coeffs) - 1,
+        )
+        for coeffs in ifs
+    )
+
+    total_block_size = sum(entry.block_size for entry in invariant_entries)
+
+    return RationalCanonicalFormResult(
+        invariant_factors=invariant_entries,
+        characteristic_polynomial=_to_monic_polynomial(cp_coeffs),
+        minimal_polynomial=_to_monic_polynomial(mp_coeffs),
+        total_block_size=total_block_size,
+    )
+
+
+def compute_primary_decomposition(request: Any) -> PrimaryDecompositionResult:
+    entries = _matrix_entries(request)
+    pd = primary_decomposition(entries)
+    mp_coeffs = minimal_polynomial(entries)
+
+    components = tuple(_to_monic_polynomial(coeffs) for coeffs in pd)
+
+    return PrimaryDecompositionResult(
+        components=components,
+        minimal_polynomial=_to_monic_polynomial(mp_coeffs),
+    )

--- a/src/jacobian/math/canonical_forms/__init__.py
+++ b/src/jacobian/math/canonical_forms/__init__.py
@@ -1,0 +1,15 @@
+"""Exact canonical-form kernels."""
+
+from jacobian.math.canonical_forms.operations import (
+    characteristic_polynomial,
+    invariant_factors,
+    minimal_polynomial,
+    primary_decomposition,
+)
+
+__all__ = [
+    "characteristic_polynomial",
+    "invariant_factors",
+    "minimal_polynomial",
+    "primary_decomposition",
+]

--- a/src/jacobian/math/canonical_forms/operations.py
+++ b/src/jacobian/math/canonical_forms/operations.py
@@ -1,0 +1,181 @@
+"""Exact canonical-form kernels backed by SymPy polynomial algebra."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any
+
+__all__ = [
+    "characteristic_polynomial",
+    "invariant_factors",
+    "minimal_polynomial",
+    "primary_decomposition",
+]
+
+
+def _sympy_matrix(entries: list[list[Any]]) -> Any:
+    from sympy import Matrix
+
+    return Matrix(entries)
+
+
+def characteristic_polynomial(entries: list[list[Any]]) -> list[Any]:
+    """Return the monic characteristic polynomial coefficients [a_0, ..., a_n]."""
+    from sympy import Symbol
+
+    x = Symbol("x")
+    matrix = _sympy_matrix(entries)
+    charpoly = matrix.charpoly(x)
+    poly = charpoly.as_expr()
+    return list(_poly_to_coeffs(poly, x))
+
+
+def minimal_polynomial(entries: list[list[Any]]) -> list[Any]:
+    """Compute the minimal polynomial via the Krylov/nullspace method.
+
+    Returns the monic minimal polynomial as coefficient list [a_0, ..., a_n].
+    """
+    from sympy import Matrix, Symbol, eye
+
+    x = Symbol("x")
+    n = len(entries)
+    if n == 0:
+        return [1]
+
+    matrix = _sympy_matrix(entries)
+
+    # Build I, A, A^2, ..., A^n as column vectors in R^(n^2)
+    powers = [eye(n)]
+    for _ in range(n):
+        powers.append(powers[-1] * matrix)
+
+    # Stack as rows of a (n+1) x n^2 matrix
+    rows = []
+    for mat in powers:
+        rows.append([mat[i, j] for i in range(n) for j in range(n)])
+
+    stacked = Matrix(rows).T  # n^2 x (n+1)
+
+    _rref, pivots = stacked.rref()
+
+    # Find the first dependent column (non-pivot)
+    degree = n + 1
+    for i in range(n + 1):
+        if i not in pivots:
+            degree = i
+            break
+
+    if degree == 0:
+        return [1]
+
+    # The null space of the first 'degree' columns gives the coefficients
+    submatrix = stacked[:, : degree + 1]
+    null_vectors = submatrix.nullspace()
+
+    if not null_vectors:
+        return [0] * degree + [1]
+
+    coeffs = null_vectors[0]
+    minpoly = sum(coeffs[i] * x**i for i in range(degree + 1))
+
+    # Ensure monic
+    from sympy import Poly
+
+    poly = Poly(minpoly, x)
+    lc = poly.LC()
+    minpoly_monic = minpoly / lc
+
+    return list(_poly_to_coeffs(minpoly_monic, x))
+
+
+def invariant_factors(entries: list[list[Any]]) -> list[list[Any]]:
+    """Compute the non-unit invariant factors over QQ[x].
+
+    Returns a list of monic polynomial coefficient lists, ordered by divisibility:
+    f_1 | f_2 | ... | f_s.
+    """
+    from sympy import Matrix, Poly, Symbol, cancel, eye, gcd
+
+    x = Symbol("x")
+    n = len(entries)
+    matrix = _sympy_matrix(entries)
+    mat = x * eye(n) - matrix
+
+    # Compute determinantal divisors d_0, d_1, ..., d_n
+    divisors: list[Any] = [None] * (n + 1)
+    divisors[0] = Poly(1, x)
+
+    for k in range(1, n + 1):
+        minors_gcd = None
+        for rows_idx in combinations(range(n), k):
+            for cols_idx in combinations(range(n), k):
+                sub = Matrix([[mat[r, c] for c in cols_idx] for r in rows_idx])
+                det = sub.det()
+                if det == 0:
+                    continue
+                minors_gcd = det if minors_gcd is None else gcd(minors_gcd, det)
+        if minors_gcd is not None:
+            poly = Poly(minors_gcd, x)
+            lc = poly.LC()
+            divisors[k] = poly / lc
+        else:
+            divisors[k] = Poly(1, x)
+
+    # Compute invariant factors: f_k = d_k / d_{k-1}
+    factors = []
+    for k in range(n, 0, -1):
+        prev = divisors[k - 1]
+        curr = divisors[k]
+        quotient, remainder = divmod(curr, prev)
+        if remainder != 0:
+            quotient = Poly(cancel(curr.as_expr() / prev.as_expr()), x)
+        if quotient.degree() >= 1:
+            factors.append(list(_poly_to_coeffs(quotient.as_expr(), x)))
+
+    factors.reverse()
+    return factors
+
+
+def primary_decomposition(entries: list[list[Any]]) -> list[list[Any]]:
+    """Decompose the minimal polynomial into irreducible-power components.
+
+    Returns a list of monic polynomial coefficient lists, one for each
+    irreducible factor raised to its multiplicity in the minimal polynomial.
+    """
+    from sympy import Symbol, factor_list
+
+    x = Symbol("x")
+    mp_coeffs = minimal_polynomial(entries)
+    mp_expr = _coeffs_to_expr(mp_coeffs, x)
+
+    factored = factor_list(mp_expr, x)
+    coeff = factored[0]
+    components = []
+    for poly, power in factored[1]:
+        poly_monic = poly / coeff
+        poly_powered = poly_monic**power
+        components.append(list(_poly_to_coeffs(poly_powered, x)))
+
+    return components
+
+
+def _poly_to_coeffs(expr: Any, x: Any) -> list[Any]:
+    """Extract monic polynomial coefficients [a_0, a_1, ..., a_n] from a SymPy expression."""
+    from sympy import Poly
+
+    poly = Poly(expr, x)
+    degree = poly.degree()
+    coeffs = []
+    for i in range(degree + 1):
+        c = poly.as_expr().coeff(x, i)
+        coeffs.append(c)
+    # Normalize to monic
+    if poly.LC() != 1:
+        lc = poly.LC()
+        coeffs = [c / lc for c in coeffs]
+    return coeffs
+
+
+def _coeffs_to_expr(coeffs: list[Any], x: Any) -> Any:
+    """Build a SymPy expression from a coefficient list [a_0, ..., a_n]."""
+    return sum(coeffs[i] * x**i for i in range(len(coeffs)))

--- a/tests/domain/linear_canonical_forms/test_canonical_forms.py
+++ b/tests/domain/linear_canonical_forms/test_canonical_forms.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.canonical_forms import MonicPolynomial, SquareMatrixRequest
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.matrices import RationalMatrix
+from jacobian.domains.linear_canonical_forms.operations import (
+    compute_minimal_polynomial,
+    compute_primary_decomposition,
+    compute_rational_canonical_form,
+)
+
+R = CanonicalRational
+
+
+def _mat(*rows: tuple[str, ...]) -> SquareMatrixRequest:
+    entries = tuple(tuple(R(num=n, den=d) for n, d in row) for row in rows)
+    return SquareMatrixRequest(matrix=RationalMatrix(entries=entries))
+
+
+def _pair(n: str, d: str) -> tuple[str, str]:
+    return (n, d)
+
+
+def test_nilpotent_jordan_block_minimal_polynomial_is_t_squared() -> None:
+    """Matrix [[0,1],[0,0]] has minimal polynomial t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    coeffs = [c.as_fraction() for c in result.minimal_polynomial.coefficients]
+    assert coeffs == [Fraction(0), Fraction(0), Fraction(1)]
+    assert result.degree == 2
+
+
+def test_diagonal_distinct_minimal_equals_characteristic() -> None:
+    """diag(2,3) has minimal polynomial (t-2)(t-3) = t^2 - 5t + 6."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    coeffs = [c.as_fraction() for c in result.minimal_polynomial.coefficients]
+    assert coeffs == [Fraction(6), Fraction(-5), Fraction(1)]
+    char_coeffs = [
+        c.as_fraction() for c in result.characteristic_polynomial.coefficients
+    ]
+    assert char_coeffs == [Fraction(6), Fraction(-5), Fraction(1)]
+
+
+def test_jordan_block_minimal_equals_characteristic() -> None:
+    """[[2,1],[0,2]] has minimal polynomial (t-2)^2 = t^2 - 4t + 4."""
+    req = _mat(
+        (_pair("2", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("2", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    coeffs = [c.as_fraction() for c in result.minimal_polynomial.coefficients]
+    assert coeffs == [Fraction(4), Fraction(-4), Fraction(1)]
+    char_coeffs = [
+        c.as_fraction() for c in result.characteristic_polynomial.coefficients
+    ]
+    assert char_coeffs == [Fraction(4), Fraction(-4), Fraction(1)]
+
+
+def test_identity_matrix_minimal_polynomial_is_t_minus_one() -> None:
+    """2x2 identity has minimal polynomial t - 1."""
+    req = _mat(
+        (_pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("1", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    coeffs = [c.as_fraction() for c in result.minimal_polynomial.coefficients]
+    assert coeffs == [Fraction(-1), Fraction(1)]
+
+
+def test_irreducible_over_qq_minimal_polynomial() -> None:
+    """[[0,-1],[1,0]] has minimal polynomial t^2 + 1 (irreducible over QQ)."""
+    req = _mat(
+        (_pair("0", "1"), _pair("-1", "1")),
+        (_pair("1", "1"), _pair("0", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    coeffs = [c.as_fraction() for c in result.minimal_polynomial.coefficients]
+    assert coeffs == [Fraction(1), Fraction(0), Fraction(1)]
+
+
+def test_nilpotent_single_block_canonical_form() -> None:
+    """[[0,1],[0,0]] has one invariant factor t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 1
+    coeffs = [c.as_fraction() for c in result.invariant_factors[0].factor.coefficients]
+    assert coeffs == [Fraction(0), Fraction(0), Fraction(1)]
+    assert result.invariant_factors[0].block_size == 2
+    assert result.total_block_size == 2
+
+
+def test_diagonal_distinct_single_factor_canonical_form() -> None:
+    """diag(2,3) has one invariant factor (t-2)(t-3)."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 1
+    coeffs = [c.as_fraction() for c in result.invariant_factors[0].factor.coefficients]
+    assert coeffs == [Fraction(6), Fraction(-5), Fraction(1)]
+
+
+def test_identity_two_blocks_canonical_form() -> None:
+    """2x2 identity has invariant factors (t-1), (t-1)."""
+    req = _mat(
+        (_pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("1", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 2
+    assert result.total_block_size == 2
+    for entry in result.invariant_factors:
+        coeffs = [c.as_fraction() for c in entry.factor.coefficients]
+        assert coeffs == [Fraction(-1), Fraction(1)]
+
+
+def test_nilpotent_two_blocks_divisibility_chain() -> None:
+    """Nilpotent with blocks of sizes 2 and 1: invariant factors t | t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 2
+    sizes = [entry.block_size for entry in result.invariant_factors]
+    assert sizes == [1, 2]
+
+
+def test_primary_decomposition_distinct_linear_factors() -> None:
+    """diag(2,3) decomposes into (t-2) and (t-3)."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    assert len(result.components) == 2
+    for comp in result.components:
+        coeffs = [c.as_fraction() for c in comp.coefficients]
+        assert len(coeffs) == 2
+
+
+def test_primary_decomposition_irreducible_power() -> None:
+    """[[0,1],[0,0]] has minpoly t^2, primary decomposition is [t^2]."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    assert len(result.components) == 1
+    coeffs = [c.as_fraction() for c in result.components[0].coefficients]
+    assert coeffs == [Fraction(0), Fraction(0), Fraction(1)]
+
+
+def test_contract_rejects_nonsquare() -> None:
+    with pytest.raises(ValidationError, match="square"):
+        SquareMatrixRequest(
+            matrix=RationalMatrix(entries=((R(num="1", den="1"), R(num="0", den="1")),))
+        )
+
+
+def test_contract_rejects_non_monic_polynomial() -> None:
+    with pytest.raises(ValidationError, match="monic"):
+        MonicPolynomial(coefficients=(R(num="1", den="1"), R(num="2", den="1")))
+
+
+def test_characteristic_equals_product_of_invariant_factors() -> None:
+    """Product of invariant factors equals the characteristic polynomial."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    # Product of invariant factor degrees should equal matrix size (3)
+    assert result.total_block_size == 3
+    # Characteristic polynomial should be t^3
+    char_coeffs = [
+        c.as_fraction() for c in result.characteristic_polynomial.coefficients
+    ]
+    assert char_coeffs == [Fraction(0), Fraction(0), Fraction(0), Fraction(1)]
+
+
+def test_method_tags() -> None:
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    assert compute_minimal_polynomial(req).method == "KRYLOV_NULLSPACE"
+    assert compute_rational_canonical_form(req).method == "SMITH_NORMAL_FORM"
+    assert compute_primary_decomposition(req).method == "FACTOR_LCM"


### PR DESCRIPTION
## Summary

Adds three exact atomic composable math operations for linear algebra canonical forms over QQ, backed by SymPy:

- `matrix.minimal_polynomial.compute` — minimal polynomial via the Krylov/nullspace method (stacking I, A, A², ... as column vectors and finding the first linear dependency)
- `matrix.rational_canonical_form.compute` — invariant factors via the Smith normal form of tI - A over QQ[t], using determinantal divisors
- `matrix.primary_decomposition.compute` — irreducible-power decomposition of the minimal polynomial via factorization

All operations use exact rational arithmetic and return monic polynomials with canonical rational coefficients. The minimal polynomial computation proves both annihilation and minimality by finding the smallest degree monic annihilating polynomial via linear algebra over QQ. The rational canonical form computes invariant factors from determinantal divisors, ensuring the divisibility chain f₁ | f₂ | ... | fₛ.

## Testing
15 domain tests covering nilpotent Jordan blocks, diagonal matrices with distinct eigenvalues, Jordan blocks with repeated eigenvalues, identity matrices, irreducible-over-QQ cases (rotation matrix), divisibility chains for multi-block nilpotent matrices, characteristic-polynomial-equals-product-of-invariant-factors identity, and contract validation (non-square matrices, non-monic polynomials).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1848