### PR TITLE
Add exact Diophantine approximation operations (#1859)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,10 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    (
+        "jacobian.domains.diophantine_approximation",
+        "diophantine_approximation_operations",
+    ),
 )
 
 

--- a/src/jacobian/contracts/diophantine_approximation.py
+++ b/src/jacobian/contracts/diophantine_approximation.py
@@ -1,0 +1,114 @@
+"""Typed wire contracts for exact Diophantine approximation operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+
+class SquarefreeRequest(ContractModel):
+    """One positive squarefree integer D for sqrt(D) operations."""
+
+    discriminant: int = Field(ge=2, le=10000)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        from sympy import factorint
+
+        if all(e == 1 for e in factorint(self.discriminant).values()):
+            return self
+        raise ValueError("discriminant must be squarefree")
+
+
+class ContinuedFractionRequest(ContractModel):
+    """Request the continued fraction expansion of sqrt(D) up to n terms."""
+
+    discriminant: int = Field(ge=2, le=10000)
+    term_count: int = Field(ge=1, le=500)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        from sympy import factorint
+
+        if all(e == 1 for e in factorint(self.discriminant).values()):
+            return self
+        raise ValueError("discriminant must be squarefree")
+
+
+class ContinuedFractionResult(ContractModel):
+    """The continued fraction [a_0; a_1, ...] of sqrt(D)."""
+
+    discriminant: int = Field(ge=2, le=10000)
+    coefficients: tuple[int, ...] = Field(min_length=1, max_length=500)
+    preperiod_length: int = Field(ge=1)
+    period_length: int = Field(ge=1)
+    method: Literal["SYMPY_CONTINUED_FRACTION"] = "SYMPY_CONTINUED_FRACTION"
+
+
+class ConvergentRequest(ContractModel):
+    """Request the first n convergents p_n/q_n of sqrt(D)."""
+
+    discriminant: int = Field(ge=2, le=10000)
+    convergent_count: int = Field(ge=1, le=500)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        from sympy import factorint
+
+        if all(e == 1 for e in factorint(self.discriminant).values()):
+            return self
+        raise ValueError("discriminant must be squarefree")
+
+
+class ConvergentValue(ContractModel):
+    """One convergent p_n/q_n with index n."""
+
+    index: int = Field(ge=0)
+    numerator: int = Field(ge=0)
+    denominator: int = Field(ge=1)
+
+
+class ConvergentResult(ContractModel):
+    """Convergents of sqrt(D)."""
+
+    discriminant: int = Field(ge=2, le=10000)
+    convergents: tuple[ConvergentValue, ...] = Field(min_length=1, max_length=500)
+    method: Literal["CONTINUED_FRACTION_RECURSION"] = "CONTINUED_FRACTION_RECURSION"
+
+
+class PellEquationRequest(ContractModel):
+    """Solve x^2 - D*y^2 = 1 for the fundamental solution."""
+
+    discriminant: int = Field(ge=2, le=10000)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        from sympy import factorint
+
+        if all(e == 1 for e in factorint(self.discriminant).values()):
+            return self
+        raise ValueError("discriminant must be squarefree")
+
+
+class PellEquationResult(ContractModel):
+    """The fundamental solution (x, y) to x^2 - D*y^2 = 1."""
+
+    discriminant: int = Field(ge=2, le=10000)
+    x: int = Field(ge=1)
+    y: int = Field(ge=1)
+    method: Literal["CONTINUED_FRACTION_CONVERGENTS"] = "CONTINUED_FRACTION_CONVERGENTS"
+
+
+__all__ = [
+    "ContinuedFractionRequest",
+    "ContinuedFractionResult",
+    "ConvergentRequest",
+    "ConvergentResult",
+    "ConvergentValue",
+    "PellEquationRequest",
+    "PellEquationResult",
+    "SquarefreeRequest",
+]

--- a/src/jacobian/domains/diophantine_approximation/__init__.py
+++ b/src/jacobian/domains/diophantine_approximation/__init__.py
@@ -1,0 +1,18 @@
+"""Exact Diophantine approximation operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["diophantine_approximation_operations"]
+
+
+def diophantine_approximation_operations() -> MathTools:
+    from jacobian.domains.diophantine_approximation.math_tools import (
+        DIOPHANTINE_APPROXIMATION_OPERATIONS,
+    )
+
+    return DIOPHANTINE_APPROXIMATION_OPERATIONS

--- a/src/jacobian/domains/diophantine_approximation/math_tools.py
+++ b/src/jacobian/domains/diophantine_approximation/math_tools.py
@@ -1,0 +1,109 @@
+"""Diophantine approximation operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.diophantine_approximation import (
+    ContinuedFractionRequest,
+    ContinuedFractionResult,
+    ConvergentRequest,
+    ConvergentResult,
+    PellEquationRequest,
+    PellEquationResult,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.diophantine_approximation.operations import (
+    compute_continued_fraction,
+    compute_convergents,
+    compute_pell_equation,
+)
+from jacobian.math_tools import MathTool
+
+
+def da_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+DIOPHANTINE_APPROXIMATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    da_operation(
+        "diophantine.continued_fraction.compute",
+        "Compute the continued fraction expansion of sqrt(D)",
+        "Compute the exact continued fraction [a_0; a_1, ...] of sqrt(D) "
+        "for a squarefree positive integer D, using SymPy's exact "
+        "continued_fraction_periodic.",
+        ContinuedFractionRequest,
+        ContinuedFractionResult,
+        compute_continued_fraction,
+        "number-theory",
+        "continued-fraction",
+        "exact",
+        examples=(
+            example(
+                "sqrt_2",
+                "Continued fraction of sqrt(2) is [1; 2, 2, 2, ...].",
+                {"discriminant": 2, "term_count": 5},
+            ),
+        ),
+    ),
+    da_operation(
+        "diophantine.convergents.compute",
+        "Compute convergents of sqrt(D)",
+        "Compute the first n convergents p_n/q_n of sqrt(D) by the "
+        "standard recurrence from the continued fraction expansion.",
+        ConvergentRequest,
+        ConvergentResult,
+        compute_convergents,
+        "number-theory",
+        "convergents",
+        "exact",
+        examples=(
+            example(
+                "sqrt_2_convergents",
+                "First 5 convergents of sqrt(2): 1/1, 3/2, 7/5, 17/12, 41/29.",
+                {"discriminant": 2, "convergent_count": 5},
+            ),
+        ),
+    ),
+    da_operation(
+        "diophantine.pell_equation.solve",
+        "Solve the Pell equation x^2 - D*y^2 = 1",
+        "Find the fundamental solution (x, y) to the Pell equation "
+        "x^2 - D*y^2 = 1 by iterating through continued fraction "
+        "convergents of sqrt(D).",
+        PellEquationRequest,
+        PellEquationResult,
+        compute_pell_equation,
+        "number-theory",
+        "pell-equation",
+        "exact",
+        examples=(
+            example(
+                "pell_2",
+                "The fundamental solution to x^2 - 2*y^2 = 1 is (3, 2).",
+                {"discriminant": 2},
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/diophantine_approximation/operations.py
+++ b/src/jacobian/domains/diophantine_approximation/operations.py
@@ -1,0 +1,51 @@
+"""Domain adapter for Diophantine approximation operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.diophantine_approximation import (
+    ContinuedFractionRequest,
+    ContinuedFractionResult,
+    ConvergentRequest,
+    ConvergentResult,
+    ConvergentValue,
+    PellEquationRequest,
+    PellEquationResult,
+)
+from jacobian.math.diophantine_approximation import (
+    continued_fraction,
+    convergents,
+    solve_pell,
+)
+
+
+def compute_continued_fraction(
+    request: ContinuedFractionRequest,
+) -> ContinuedFractionResult:
+    disc = request.discriminant
+    count = request.term_count
+    coeffs, preperiod_len, period_len = continued_fraction(disc, count)
+    return ContinuedFractionResult(
+        discriminant=disc,
+        coefficients=tuple(coeffs),
+        preperiod_length=preperiod_len,
+        period_length=period_len,
+    )
+
+
+def compute_convergents(request: ConvergentRequest) -> ConvergentResult:
+    disc = request.discriminant
+    count = request.convergent_count
+    convs = convergents(disc, count)
+    return ConvergentResult(
+        discriminant=disc,
+        convergents=tuple(
+            ConvergentValue(index=idx, numerator=p, denominator=q)
+            for idx, p, q in convs
+        ),
+    )
+
+
+def compute_pell_equation(request: PellEquationRequest) -> PellEquationResult:
+    disc = request.discriminant
+    x, y = solve_pell(disc)
+    return PellEquationResult(discriminant=disc, x=x, y=y)

--- a/src/jacobian/math/diophantine_approximation/__init__.py
+++ b/src/jacobian/math/diophantine_approximation/__init__.py
@@ -1,0 +1,9 @@
+"""Diophantine approximation operations."""
+
+from jacobian.math.diophantine_approximation.operations import (
+    continued_fraction,
+    convergents,
+    solve_pell,
+)
+
+__all__ = ["continued_fraction", "convergents", "solve_pell"]

--- a/src/jacobian/math/diophantine_approximation/operations.py
+++ b/src/jacobian/math/diophantine_approximation/operations.py
@@ -1,0 +1,72 @@
+"""Exact continued fraction and Pell equation kernels backed by SymPy."""
+
+from __future__ import annotations
+
+__all__ = ["continued_fraction", "convergents", "solve_pell"]
+
+
+def _cf_coefficients(discriminant: int) -> tuple[list[int], list[int]]:
+    """Return (preperiod, period) of the continued fraction of sqrt(D)."""
+    from sympy import continued_fraction_periodic
+
+    cf = continued_fraction_periodic(0, 1, discriminant)
+    preperiod = [cf[0]] if not isinstance(cf[0], list) else cf[0]
+    period = cf[1] if isinstance(cf[1], list) else [cf[1]]
+    return (preperiod, period)
+
+
+def continued_fraction(
+    discriminant: int, term_count: int
+) -> tuple[list[int], int, int]:
+    """Return the continued fraction expansion of sqrt(D).
+
+    Returns (coefficients, preperiod_length, period_length).
+    """
+    preperiod, period = _cf_coefficients(discriminant)
+    full = preperiod + list(period) * ((term_count - len(preperiod)) // len(period) + 2)
+    return (full[:term_count], len(preperiod), len(period))
+
+
+def convergents(discriminant: int, count: int) -> list[tuple[int, int, int]]:
+    """Return the first count convergents (index, p_n, q_n) of sqrt(D)."""
+    preperiod, period = _cf_coefficients(discriminant)
+    cf_coeffs = preperiod + list(period) * 10
+
+    p_prev2, p_prev1 = 1, int(cf_coeffs[0])
+    q_prev2, q_prev1 = 0, 1
+
+    result = [(0, int(p_prev1), int(q_prev1))]
+    for i in range(1, count):
+        a = int(cf_coeffs[i])
+        p_curr = a * p_prev1 + p_prev2
+        q_curr = a * q_prev1 + q_prev2
+        p_prev2, p_prev1 = p_prev1, p_curr
+        q_prev2, q_prev1 = q_prev1, q_curr
+        result.append((i, int(p_prev1), int(q_prev1)))
+
+    return result
+
+
+def solve_pell(discriminant: int, max_convergents: int = 10000) -> tuple[int, int]:
+    """Solve x^2 - D*y^2 = 1 for the fundamental solution (x, y)."""
+    preperiod, period = _cf_coefficients(discriminant)
+    cf_coeffs = preperiod + list(period) * 1000
+
+    p_prev2, p_prev1 = 1, int(cf_coeffs[0])
+    q_prev2, q_prev1 = 0, 1
+
+    if p_prev1**2 - discriminant * q_prev1**2 == 1:
+        return (p_prev1, q_prev1)
+
+    for _i in range(1, max_convergents):
+        a = int(cf_coeffs[_i])
+        p_curr = a * p_prev1 + p_prev2
+        q_curr = a * q_prev1 + q_prev2
+        p_prev2, p_prev1 = p_prev1, p_curr
+        q_prev2, q_prev1 = q_prev1, q_curr
+
+        if p_prev1**2 - discriminant * q_prev1**2 == 1:
+            return (p_prev1, q_prev1)
+
+    msg = f"No Pell solution found within {max_convergents} convergents"
+    raise ValueError(msg)

--- a/tests/domain/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/domain/diophantine_approximation/test_diophantine_approximation.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.diophantine_approximation import (
+    ContinuedFractionRequest,
+    ConvergentRequest,
+    PellEquationRequest,
+)
+from jacobian.domains.diophantine_approximation.operations import (
+    compute_continued_fraction,
+    compute_convergents,
+    compute_pell_equation,
+)
+
+
+def test_continued_fraction_sqrt_2() -> None:
+    """sqrt(2) = [1; 2, 2, 2, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=5)
+    )
+    assert result.coefficients == (1, 2, 2, 2, 2)
+    assert result.preperiod_length == 1
+    assert result.period_length == 1
+    assert result.method == "SYMPY_CONTINUED_FRACTION"
+
+
+def test_continued_fraction_sqrt_3() -> None:
+    """sqrt(3) = [1; 1, 2, 1, 2, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=6)
+    )
+    assert result.coefficients == (1, 1, 2, 1, 2, 1)
+    assert result.preperiod_length == 1
+    assert result.period_length == 2
+
+
+def test_continued_fraction_sqrt_5() -> None:
+    """sqrt(5) = [2; 4, 4, 4, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=5, term_count=5)
+    )
+    assert result.coefficients[0] == 2
+    assert all(c == 4 for c in result.coefficients[1:])
+
+
+def test_convergents_sqrt_2() -> None:
+    """Convergents of sqrt(2): 1/1, 3/2, 7/5, 17/12, 41/29."""
+    result = compute_convergents(ConvergentRequest(discriminant=2, convergent_count=5))
+    assert len(result.convergents) == 5
+    nums = [c.numerator for c in result.convergents]
+    dens = [c.denominator for c in result.convergents]
+    assert nums == [1, 3, 7, 17, 41]
+    assert dens == [1, 2, 5, 12, 29]
+
+
+def test_convergents_are_best_approximations() -> None:
+    """Each convergent p/q satisfies |p^2 - D*q^2| < 2*sqrt(D)."""
+    discriminant = 2
+    result = compute_convergents(
+        ConvergentRequest(discriminant=discriminant, convergent_count=10)
+    )
+    import math
+
+    for conv in result.convergents:
+        val = abs(conv.numerator**2 - discriminant * conv.denominator**2)
+        assert val < 2 * math.sqrt(discriminant)
+
+
+def test_pell_equation_sqrt_2() -> None:
+    """x^2 - 2*y^2 = 1 has fundamental solution (3, 2)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=2))
+    assert result.x == 3
+    assert result.y == 2
+    assert result.x**2 - 2 * result.y**2 == 1
+
+
+def test_pell_equation_sqrt_3() -> None:
+    """x^2 - 3*y^2 = 1 has fundamental solution (2, 1)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=3))
+    assert result.x == 2
+    assert result.y == 1
+    assert result.x**2 - 3 * result.y**2 == 1
+
+
+def test_pell_equation_sqrt_5() -> None:
+    """x^2 - 5*y^2 = 1 has fundamental solution (9, 4)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=5))
+    assert result.x == 9
+    assert result.y == 4
+    assert result.x**2 - 5 * result.y**2 == 1
+
+
+def test_pell_equation_sqrt_13() -> None:
+    """x^2 - 13*y^2 = 1 has fundamental solution (649, 180)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=13))
+    assert result.x == 649
+    assert result.y == 180
+    assert result.x**2 - 13 * result.y**2 == 1
+
+
+def test_pell_equation_all_verified() -> None:
+    """Every Pell solution satisfies x^2 - D*y^2 = 1."""
+    for discriminant in [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]:
+        result = compute_pell_equation(PellEquationRequest(discriminant=discriminant))
+        assert result.x**2 - discriminant * result.y**2 == 1
+
+
+def test_contract_rejects_non_squarefree() -> None:
+    with pytest.raises(ValidationError, match="squarefree"):
+        ContinuedFractionRequest(discriminant=4, term_count=5)
+
+
+def test_contract_rejects_perfect_square() -> None:
+    with pytest.raises(ValidationError, match="squarefree"):
+        ContinuedFractionRequest(discriminant=9, term_count=5)
+
+
+def test_contract_rejects_out_of_range() -> None:
+    with pytest.raises(ValidationError):
+        ContinuedFractionRequest(discriminant=1, term_count=5)


### PR DESCRIPTION
## Summary

Adds three exact atomic composable math operations for Diophantine approximation, backed by SymPy's :

-  — exact continued fraction expansion [a₀; a₁, …] of √D with preperiod and period identification
-  — convergents pₙ/qₙ of √D via the standard recurrence from CF coefficients
-  — fundamental solution (x, y) to x² − Dy² = 1 via iterating convergents

All operations use exact integer arithmetic. The Pell equation solver iterates through convergents until finding the fundamental solution where p² − Dq² = 1.

## Testing
13 domain tests: known-answer continued fractions (√2=[1;2,2,2,…], √3=[1;1,2,1,2,…], √5=[2;4,4,4,…]), convergent sequences (√2: 1/1, 3/2, 7/5, 17/12, 41/29), best-approximation property verification, Pell equation solutions verified for 10 discriminants (2,3,5,7,11,13,17,19,23,29), contract validation (non-squarefree, perfect square, out-of-range).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1859