### PR TITLE
Add exact regular language DFA operations (#1854)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    ("jacobian.domains.regular_languages", "regular_language_operations"),
 )
 
 

--- a/src/jacobian/contracts/regular_languages.py
+++ b/src/jacobian/contracts/regular_languages.py
@@ -1,0 +1,121 @@
+"""Typed wire contracts for exact regular language operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+MAX_DFA_STATES = 64
+MAX_DFA_ALPHABET = 32
+MAX_DFA_TRANSITIONS = 4096
+MAX_WORD_LENGTH = 1000
+
+
+class DFATransition(ContractModel):
+    """One transition: from state on symbol to next state."""
+
+    source: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    symbol: int = Field(ge=0, le=MAX_DFA_ALPHABET - 1)
+    target: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+
+
+class DFA(ContractModel):
+    """One deterministic finite automaton."""
+
+    state_count: int = Field(ge=1, le=MAX_DFA_STATES)
+    alphabet_size: int = Field(ge=1, le=MAX_DFA_ALPHABET)
+    transitions: tuple[DFATransition, ...] = Field(
+        min_length=0, max_length=MAX_DFA_TRANSITIONS
+    )
+    initial_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    accepting_states: tuple[int, ...] = Field(min_length=0, max_length=MAX_DFA_STATES)
+
+    @model_validator(mode="after")
+    def require_valid_dfa(self) -> Self:
+        if not (0 <= self.initial_state < self.state_count):
+            raise ValueError("initial_state must be in 0..state_count-1")
+        for state in self.accepting_states:
+            if not (0 <= state < self.state_count):
+                raise ValueError("accepting states must be in 0..state_count-1")
+        if len(set(self.accepting_states)) != len(self.accepting_states):
+            raise ValueError("accepting states must be unique")
+        seen: set[tuple[int, int]] = set()
+        for tr in self.transitions:
+            if not (0 <= tr.source < self.state_count):
+                raise ValueError("transition source must be in 0..state_count-1")
+            if not (0 <= tr.target < self.state_count):
+                raise ValueError("transition target must be in 0..state_count-1")
+            if not (0 <= tr.symbol < self.alphabet_size):
+                raise ValueError("transition symbol must be in 0..alphabet_size-1")
+            key = (tr.source, tr.symbol)
+            if key in seen:
+                raise ValueError(
+                    "DFA must be deterministic (no duplicate source/symbol)"
+                )
+            seen.add(key)
+        return self
+
+
+class RunRequest(ContractModel):
+    """Check if a word is accepted by a DFA."""
+
+    dfa: DFA
+    word: tuple[int, ...] = Field(max_length=MAX_WORD_LENGTH)
+
+    @model_validator(mode="after")
+    def require_valid_word(self) -> Self:
+        for symbol in self.word:
+            if not (0 <= symbol < self.dfa.alphabet_size):
+                raise ValueError("word symbols must be in 0..alphabet_size-1")
+        return self
+
+
+class CountRequest(ContractModel):
+    """Count accepted words of a given length."""
+
+    dfa: DFA
+    word_length: int = Field(ge=0, le=200)
+
+
+class ComplementRequest(ContractModel):
+    """Compute the complement of a DFA's language."""
+
+    dfa: DFA
+
+
+class RunResult(ContractModel):
+    """Whether a word was accepted."""
+
+    accepted: bool
+    final_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    method: Literal["DFA_SIMULATION"] = "DFA_SIMULATION"
+
+
+class CountResult(ContractModel):
+    """Count of accepted words of a given length."""
+
+    count: int = Field(ge=0)
+    word_length: int = Field(ge=0, le=200)
+    method: Literal["MATRIX_POWERING"] = "MATRIX_POWERING"
+
+
+class ComplementResult(ContractModel):
+    """The complement DFA."""
+
+    dfa: DFA
+    method: Literal["ACCEPTING_FLIP"] = "ACCEPTING_FLIP"
+
+
+__all__ = [
+    "DFA",
+    "ComplementRequest",
+    "ComplementResult",
+    "CountRequest",
+    "CountResult",
+    "DFATransition",
+    "RunRequest",
+    "RunResult",
+]

--- a/src/jacobian/contracts/regular_languages.py
+++ b/src/jacobian/contracts/regular_languages.py
@@ -1,4 +1,9 @@
-"""Typed wire contracts for exact regular language operations."""
+"""Typed wire contracts for exact regular language operations.
+
+Domain-owned models (``DFA``, ``DFATransition``) live in
+``jacobian.domains.regular_languages.contracts``; this module re-exports
+them alongside the request/result contracts for wire-level consumers.
+"""
 
 from __future__ import annotations
 
@@ -7,56 +12,12 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian.contracts.base import ContractModel
-
-MAX_DFA_STATES = 64
-MAX_DFA_ALPHABET = 32
-MAX_DFA_TRANSITIONS = 4096
-MAX_WORD_LENGTH = 1000
-
-
-class DFATransition(ContractModel):
-    """One transition: from state on symbol to next state."""
-
-    source: int = Field(ge=0, le=MAX_DFA_STATES - 1)
-    symbol: int = Field(ge=0, le=MAX_DFA_ALPHABET - 1)
-    target: int = Field(ge=0, le=MAX_DFA_STATES - 1)
-
-
-class DFA(ContractModel):
-    """One deterministic finite automaton."""
-
-    state_count: int = Field(ge=1, le=MAX_DFA_STATES)
-    alphabet_size: int = Field(ge=1, le=MAX_DFA_ALPHABET)
-    transitions: tuple[DFATransition, ...] = Field(
-        min_length=0, max_length=MAX_DFA_TRANSITIONS
-    )
-    initial_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
-    accepting_states: tuple[int, ...] = Field(min_length=0, max_length=MAX_DFA_STATES)
-
-    @model_validator(mode="after")
-    def require_valid_dfa(self) -> Self:
-        if not (0 <= self.initial_state < self.state_count):
-            raise ValueError("initial_state must be in 0..state_count-1")
-        for state in self.accepting_states:
-            if not (0 <= state < self.state_count):
-                raise ValueError("accepting states must be in 0..state_count-1")
-        if len(set(self.accepting_states)) != len(self.accepting_states):
-            raise ValueError("accepting states must be unique")
-        seen: set[tuple[int, int]] = set()
-        for tr in self.transitions:
-            if not (0 <= tr.source < self.state_count):
-                raise ValueError("transition source must be in 0..state_count-1")
-            if not (0 <= tr.target < self.state_count):
-                raise ValueError("transition target must be in 0..state_count-1")
-            if not (0 <= tr.symbol < self.alphabet_size):
-                raise ValueError("transition symbol must be in 0..alphabet_size-1")
-            key = (tr.source, tr.symbol)
-            if key in seen:
-                raise ValueError(
-                    "DFA must be deterministic (no duplicate source/symbol)"
-                )
-            seen.add(key)
-        return self
+from jacobian.domains.regular_languages.contracts import (
+    DFA,
+    MAX_DFA_STATES,
+    MAX_WORD_LENGTH,
+    DFATransition,
+)
 
 
 class RunRequest(ContractModel):

--- a/src/jacobian/domains/regular_languages/__init__.py
+++ b/src/jacobian/domains/regular_languages/__init__.py
@@ -1,0 +1,18 @@
+"""Exact regular language operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["regular_language_operations"]
+
+
+def regular_language_operations() -> MathTools:
+    from jacobian.domains.regular_languages.math_tools import (
+        REGULAR_LANGUAGE_OPERATIONS,
+    )
+
+    return REGULAR_LANGUAGE_OPERATIONS

--- a/src/jacobian/domains/regular_languages/contracts.py
+++ b/src/jacobian/domains/regular_languages/contracts.py
@@ -1,0 +1,76 @@
+"""Domain-owned contract models for exact regular language operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+MAX_DFA_STATES = 64
+MAX_DFA_ALPHABET = 32
+MAX_DFA_TRANSITIONS = 4096
+MAX_WORD_LENGTH = 1000
+
+
+class DFATransition(ContractModel):
+    """One transition: from state on symbol to next state."""
+
+    source: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    symbol: int = Field(ge=0, le=MAX_DFA_ALPHABET - 1)
+    target: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+
+
+class DFA(ContractModel):
+    """One deterministic finite automaton.
+
+    A valid DFA must have a transition for every (state, symbol) pair so that
+    the automaton is total (no missing transitions).
+    """
+
+    state_count: int = Field(ge=1, le=MAX_DFA_STATES)
+    alphabet_size: int = Field(ge=1, le=MAX_DFA_ALPHABET)
+    transitions: tuple[DFATransition, ...] = Field(
+        min_length=0, max_length=MAX_DFA_TRANSITIONS
+    )
+    initial_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    accepting_states: tuple[int, ...] = Field(min_length=0, max_length=MAX_DFA_STATES)
+
+    @model_validator(mode="after")
+    def require_valid_dfa(self) -> Self:
+        self._validate_states()
+        self._validate_transitions()
+        return self
+
+    def _validate_states(self) -> None:
+        if not (0 <= self.initial_state < self.state_count):
+            raise ValueError("initial_state must be in 0..state_count-1")
+        for state in self.accepting_states:
+            if not (0 <= state < self.state_count):
+                raise ValueError("accepting states must be in 0..state_count-1")
+        if len(set(self.accepting_states)) != len(self.accepting_states):
+            raise ValueError("accepting states must be unique")
+
+    def _validate_transitions(self) -> None:
+        seen: set[tuple[int, int]] = set()
+        for tr in self.transitions:
+            if not (0 <= tr.source < self.state_count):
+                raise ValueError("transition source must be in 0..state_count-1")
+            if not (0 <= tr.target < self.state_count):
+                raise ValueError("transition target must be in 0..state_count-1")
+            if not (0 <= tr.symbol < self.alphabet_size):
+                raise ValueError("transition symbol must be in 0..alphabet_size-1")
+            key = (tr.source, tr.symbol)
+            if key in seen:
+                raise ValueError(
+                    "DFA must be deterministic (no duplicate source/symbol)"
+                )
+            seen.add(key)
+        expected = self.state_count * self.alphabet_size
+        if len(seen) != expected:
+            raise ValueError(
+                f"DFA must be total: expected {expected} transitions for "
+                f"{self.state_count} states x {self.alphabet_size} symbols, "
+                f"got {len(seen)}"
+            )

--- a/src/jacobian/domains/regular_languages/math_tools.py
+++ b/src/jacobian/domains/regular_languages/math_tools.py
@@ -1,0 +1,122 @@
+"""Regular language operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.operations import OperationExample
+from jacobian.contracts.regular_languages import (
+    ComplementRequest,
+    ComplementResult,
+    CountRequest,
+    CountResult,
+    RunRequest,
+    RunResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.regular_languages.operations import (
+    compute_complement,
+    compute_count,
+    compute_run,
+)
+from jacobian.math_tools import MathTool
+
+
+def rl_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_DFA_EXAMPLE = {
+    "dfa": {
+        "state_count": 2,
+        "alphabet_size": 2,
+        "transitions": [
+            {"source": 0, "symbol": 0, "target": 0},
+            {"source": 0, "symbol": 1, "target": 1},
+            {"source": 1, "symbol": 0, "target": 0},
+            {"source": 1, "symbol": 1, "target": 1},
+        ],
+        "initial_state": 0,
+        "accepting_states": [1],
+    },
+}
+
+
+REGULAR_LANGUAGE_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    rl_operation(
+        "regular_language.run.check",
+        "Check if a word is accepted by a DFA",
+        "Simulate a deterministic finite automaton on a word and return "
+        "whether it is accepted and the final state reached.",
+        RunRequest,
+        RunResult,
+        compute_run,
+        "automata",
+        "dfa",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "DFA accepting binary strings ending in 1, word [1,0,1] accepted.",
+                {"dfa": _DFA_EXAMPLE["dfa"], "word": [1, 0, 1]},
+            ),
+        ),
+    ),
+    rl_operation(
+        "regular_language.count_words.compute",
+        "Count accepted words of a given length",
+        "Count the number of words of exact length accepted by a DFA "
+        "using exact integer matrix powering of the transition matrix.",
+        CountRequest,
+        CountResult,
+        compute_count,
+        "automata",
+        "counting",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "Count binary strings of length 3 ending in 1: 4 words.",
+                {"dfa": _DFA_EXAMPLE["dfa"], "word_length": 3},
+            ),
+        ),
+    ),
+    rl_operation(
+        "regular_language.complement.compute",
+        "Compute the complement of a DFA's language",
+        "Compute the complement DFA by flipping the set of accepting states.",
+        ComplementRequest,
+        ComplementResult,
+        compute_complement,
+        "automata",
+        "complement",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "Complement of DFA accepting strings ending in 1.",
+                {"dfa": _DFA_EXAMPLE["dfa"]},
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/regular_languages/operations.py
+++ b/src/jacobian/domains/regular_languages/operations.py
@@ -1,0 +1,32 @@
+"""Domain adapter for regular language operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.regular_languages import (
+    ComplementRequest,
+    ComplementResult,
+    CountRequest,
+    CountResult,
+    RunRequest,
+    RunResult,
+)
+from jacobian.math.regular_languages import (
+    count_accepted_words,
+    dfa_complement,
+    dfa_run,
+)
+
+
+def compute_run(request: RunRequest) -> RunResult:
+    accepted, final_state = dfa_run(request.dfa, request.word)
+    return RunResult(accepted=accepted, final_state=final_state)
+
+
+def compute_count(request: CountRequest) -> CountResult:
+    count = count_accepted_words(request.dfa, request.word_length)
+    return CountResult(count=count, word_length=request.word_length)
+
+
+def compute_complement(request: ComplementRequest) -> ComplementResult:
+    result = dfa_complement(request.dfa)
+    return ComplementResult(dfa=result)

--- a/src/jacobian/math/regular_languages/__init__.py
+++ b/src/jacobian/math/regular_languages/__init__.py
@@ -1,0 +1,9 @@
+"""Regular language operations."""
+
+from jacobian.math.regular_languages.operations import (
+    count_accepted_words,
+    dfa_complement,
+    dfa_run,
+)
+
+__all__ = ["count_accepted_words", "dfa_complement", "dfa_run"]

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -1,4 +1,4 @@
-"""Exact DFA kernels backed by integer matrix powering."""
+"""Exact DFA kernels backed by integer matrix powering via SymPy."""
 
 from __future__ import annotations
 
@@ -11,41 +11,23 @@ def _transition_map(dfa: Any) -> dict[tuple[int, int], int]:
     return {(tr.source, tr.symbol): tr.target for tr in dfa.transitions}
 
 
-def _mat_mul(a: list[list[int]], b: list[list[int]], n: int) -> list[list[int]]:
-    result = [[0] * n for _ in range(n)]
-    for i in range(n):
-        for j in range(n):
-            for k in range(n):
-                result[i][j] += a[i][k] * b[k][j]
-    return result
+def _build_matrix(dfa: Any, n: int):
+    """Build the adjacency matrix of the DFA transition graph."""
+    import sympy
 
-
-def _mat_pow(m: list[list[int]], p: int, n: int) -> list[list[int]]:
-    if p == 0:
-        return [[1 if i == j else 0 for j in range(n)] for i in range(n)]
-    if p == 1:
-        return m
-    half = _mat_pow(m, p // 2, n)
-    result = _mat_mul(half, half, n)
-    if p % 2 == 1:
-        result = _mat_mul(result, m, n)
-    return result
-
-
-def _build_matrix(dfa: Any, n: int) -> list[list[int]]:
     trans = _transition_map(dfa)
-    matrix = [[0] * n for _ in range(n)]
+    matrix = sympy.zeros(n, n)
     for (src, _symbol), dst in trans.items():
-        matrix[src][dst] += 1
+        matrix[src, dst] += 1
     return matrix
 
 
-def _count_from_powered(powered: list[list[int]], dfa: Any, n: int) -> int:
+def _count_from_powered(powered, dfa: Any, n: int) -> int:
     count = 0
     accepting = set(dfa.accepting_states)
     for target in range(n):
         if target in accepting:
-            count += powered[dfa.initial_state][target]
+            count += int(powered[dfa.initial_state, target])
     return count
 
 
@@ -60,19 +42,19 @@ def dfa_run(dfa: Any, word: tuple[int, ...]) -> tuple[bool, int]:
 
 
 def count_accepted_words(dfa: Any, word_length: int) -> int:
-    """Count accepted words of exact length via matrix powering."""
+    """Count accepted words of exact length via SymPy matrix powering."""
     n = dfa.state_count
     accepting = set(dfa.accepting_states)
     if word_length == 0:
         return 1 if dfa.initial_state in accepting else 0
     matrix = _build_matrix(dfa, n)
-    powered = _mat_pow(matrix, word_length, n)
+    powered = matrix**word_length
     return _count_from_powered(powered, dfa, n)
 
 
 def dfa_complement(dfa: Any) -> Any:
     """Compute the complement DFA by flipping accepting states."""
-    from jacobian.contracts.regular_languages import DFA
+    from jacobian.domains.regular_languages.contracts import DFA
 
     all_states = set(range(dfa.state_count))
     new_accepting = tuple(sorted(all_states - set(dfa.accepting_states)))

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -1,0 +1,85 @@
+"""Exact DFA kernels backed by integer matrix powering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["count_accepted_words", "dfa_complement", "dfa_run"]
+
+
+def _transition_map(dfa: Any) -> dict[tuple[int, int], int]:
+    return {(tr.source, tr.symbol): tr.target for tr in dfa.transitions}
+
+
+def _mat_mul(a: list[list[int]], b: list[list[int]], n: int) -> list[list[int]]:
+    result = [[0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                result[i][j] += a[i][k] * b[k][j]
+    return result
+
+
+def _mat_pow(m: list[list[int]], p: int, n: int) -> list[list[int]]:
+    if p == 0:
+        return [[1 if i == j else 0 for j in range(n)] for i in range(n)]
+    if p == 1:
+        return m
+    half = _mat_pow(m, p // 2, n)
+    result = _mat_mul(half, half, n)
+    if p % 2 == 1:
+        result = _mat_mul(result, m, n)
+    return result
+
+
+def _build_matrix(dfa: Any, n: int) -> list[list[int]]:
+    trans = _transition_map(dfa)
+    matrix = [[0] * n for _ in range(n)]
+    for (src, _symbol), dst in trans.items():
+        matrix[src][dst] += 1
+    return matrix
+
+
+def _count_from_powered(powered: list[list[int]], dfa: Any, n: int) -> int:
+    count = 0
+    accepting = set(dfa.accepting_states)
+    for target in range(n):
+        if target in accepting:
+            count += powered[dfa.initial_state][target]
+    return count
+
+
+def dfa_run(dfa: Any, word: tuple[int, ...]) -> tuple[bool, int]:
+    """Simulate a DFA on a word; return (accepted, final_state)."""
+    trans = _transition_map(dfa)
+    state = dfa.initial_state
+    for symbol in word:
+        state = trans.get((state, symbol), state)
+    accepted = state in set(dfa.accepting_states)
+    return (accepted, state)
+
+
+def count_accepted_words(dfa: Any, word_length: int) -> int:
+    """Count accepted words of exact length via matrix powering."""
+    n = dfa.state_count
+    accepting = set(dfa.accepting_states)
+    if word_length == 0:
+        return 1 if dfa.initial_state in accepting else 0
+    matrix = _build_matrix(dfa, n)
+    powered = _mat_pow(matrix, word_length, n)
+    return _count_from_powered(powered, dfa, n)
+
+
+def dfa_complement(dfa: Any) -> Any:
+    """Compute the complement DFA by flipping accepting states."""
+    from jacobian.contracts.regular_languages import DFA
+
+    all_states = set(range(dfa.state_count))
+    new_accepting = tuple(sorted(all_states - set(dfa.accepting_states)))
+    return DFA(
+        state_count=dfa.state_count,
+        alphabet_size=dfa.alphabet_size,
+        transitions=dfa.transitions,
+        initial_state=dfa.initial_state,
+        accepting_states=new_accepting,
+    )

--- a/tests/domain/regular_languages/test_regular_languages.py
+++ b/tests/domain/regular_languages/test_regular_languages.py
@@ -152,7 +152,12 @@ def test_contract_rejects_invalid_accepting_states() -> None:
         DFA(
             state_count=2,
             alphabet_size=2,
-            transitions=(),
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=1, target=0),
+                DFATransition(source=1, symbol=0, target=0),
+                DFATransition(source=1, symbol=1, target=0),
+            ),
             initial_state=0,
             accepting_states=(5,),  # out of range
         )
@@ -162,3 +167,20 @@ def test_contract_rejects_out_of_range_word_symbol() -> None:
     dfa = _dfa_ends_in_1()
     with pytest.raises(ValidationError, match="word symbols"):
         RunRequest(dfa=dfa, word=(5,))  # symbol 5 is out of range for alphabet_size=2
+
+
+def test_contract_rejects_non_total_dfa() -> None:
+    """A DFA missing a transition for some (state, symbol) pair must be rejected."""
+    with pytest.raises(ValidationError, match="total"):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=1, target=1),
+                DFATransition(source=1, symbol=0, target=0),
+                # missing (1, symbol=1)
+            ),
+            initial_state=0,
+            accepting_states=(1,),
+        )

--- a/tests/domain/regular_languages/test_regular_languages.py
+++ b/tests/domain/regular_languages/test_regular_languages.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.regular_languages import (
+    DFA,
+    ComplementRequest,
+    CountRequest,
+    DFATransition,
+    RunRequest,
+)
+from jacobian.domains.regular_languages.operations import (
+    compute_complement,
+    compute_count,
+    compute_run,
+)
+
+
+def _dfa_ends_in_1() -> DFA:
+    return DFA(
+        state_count=2,
+        alphabet_size=2,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=0),
+            DFATransition(source=0, symbol=1, target=1),
+            DFATransition(source=1, symbol=0, target=0),
+            DFATransition(source=1, symbol=1, target=1),
+        ),
+        initial_state=0,
+        accepting_states=(1,),
+    )
+
+
+def _dfa_even_zeros() -> DFA:
+    """Accepts binary strings with an even number of 0s."""
+    return DFA(
+        state_count=2,
+        alphabet_size=2,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=1),
+            DFATransition(source=0, symbol=1, target=0),
+            DFATransition(source=1, symbol=0, target=0),
+            DFATransition(source=1, symbol=1, target=1),
+        ),
+        initial_state=0,
+        accepting_states=(0,),
+    )
+
+
+def test_run_accepts_word_ending_in_1() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=(1, 0, 1)))
+    assert result.accepted is True
+    assert result.final_state == 1
+
+
+def test_run_rejects_word_ending_in_0() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=(1, 0, 0)))
+    assert result.accepted is False
+    assert result.final_state == 0
+
+
+def test_run_accepts_empty_word_if_initial_is_accepting() -> None:
+    dfa = _dfa_even_zeros()
+    result = compute_run(RunRequest(dfa=dfa, word=()))
+    assert result.accepted is True
+    assert result.final_state == 0
+
+
+def test_run_rejects_empty_word_if_initial_not_accepting() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=()))
+    assert result.accepted is False
+    assert result.final_state == 0
+
+
+def test_count_binary_strings_ending_in_1() -> None:
+    """Length 3 binary strings ending in 1: 4 (001, 011, 101, 111)."""
+    dfa = _dfa_ends_in_1()
+    result = compute_count(CountRequest(dfa=dfa, word_length=3))
+    assert result.count == 4
+
+
+def test_count_length_zero() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_count(CountRequest(dfa=dfa, word_length=0))
+    assert result.count == 0  # initial state 0 is not accepting
+
+
+def test_count_length_zero_accepting() -> None:
+    dfa = _dfa_even_zeros()
+    result = compute_count(CountRequest(dfa=dfa, word_length=0))
+    assert result.count == 1  # initial state 0 is accepting
+
+
+def test_count_even_zeros_length_3() -> None:
+    """Length 3 binary strings with even number of 0s: 4 (111, 100, 010, 001)."""
+    dfa = _dfa_even_zeros()
+    result = compute_count(CountRequest(dfa=dfa, word_length=3))
+    assert result.count == 4
+
+
+def test_count_matches_brute_force() -> None:
+    """Count via matrix powering matches brute-force enumeration."""
+    from itertools import product
+
+    dfa = _dfa_ends_in_1()
+    for length in range(8):
+        result = compute_count(CountRequest(dfa=dfa, word_length=length))
+        brute = 0
+        for word in product(range(2), repeat=length):
+            res = compute_run(RunRequest(dfa=dfa, word=tuple(word)))
+            if res.accepted:
+                brute += 1
+        assert result.count == brute, f"Length {length}: {result.count} != {brute}"
+
+
+def test_complement_flips_acceptance() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_complement(ComplementRequest(dfa=dfa))
+    assert result.dfa.accepting_states == (0,)
+    # Word ending in 0 should now be accepted
+    run = compute_run(RunRequest(dfa=result.dfa, word=(0,)))
+    assert run.accepted is True
+
+
+def test_complement_double_complement_is_identity() -> None:
+    dfa = _dfa_ends_in_1()
+    result1 = compute_complement(ComplementRequest(dfa=dfa))
+    result2 = compute_complement(ComplementRequest(dfa=result1.dfa))
+    assert result2.dfa.accepting_states == dfa.accepting_states
+
+
+def test_contract_rejects_duplicate_transitions() -> None:
+    with pytest.raises(ValidationError, match="deterministic"):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=0, target=1),  # duplicate
+            ),
+            initial_state=0,
+            accepting_states=(1,),
+        )
+
+
+def test_contract_rejects_invalid_accepting_states() -> None:
+    with pytest.raises(ValidationError):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(),
+            initial_state=0,
+            accepting_states=(5,),  # out of range
+        )
+
+
+def test_contract_rejects_out_of_range_word_symbol() -> None:
+    dfa = _dfa_ends_in_1()
+    with pytest.raises(ValidationError, match="word symbols"):
+        RunRequest(dfa=dfa, word=(5,))  # symbol 5 is out of range for alphabet_size=2


### PR DESCRIPTION
## Summary

Adds three exact atomic composable math operations for regular languages over deterministic finite automata (DFAs):

- `regular_language.run.check` — DFA simulation: check if a word is accepted
- `regular_language.count_words.compute` — count accepted words of exact length via integer matrix powering of the transition matrix
- `regular_language.complement.compute` — complement DFA by flipping accepting states

All operations use exact integer arithmetic. The word counting uses fast matrix exponentiation (O(n³ log L) for n states and word length L).

## Testing
14 domain tests: known-answer DFA simulation (binary strings ending in 1, even-number-of-zeros), empty word acceptance, word counting verification against brute-force enumeration for lengths 0-7, complement double-complement-is-identity, contract validation (duplicate transitions, invalid accepting states, out-of-range symbols).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1854