### PR TITLE
Add exact algebraic combinatorics operations (#1855)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    ("jacobian.domains.algebraic_combinatorics", "algebraic_combinatorics_operations"),
 )
 
 

--- a/src/jacobian/contracts/algebraic_combinatorics.py
+++ b/src/jacobian/contracts/algebraic_combinatorics.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalInteger
 
 MAX_PARTITION_SIZE = 50
 MAX_PARTS = 50
@@ -15,7 +16,7 @@ MAX_PARTS = 50
 class Partition(ContractModel):
     """One decreasing sequence of positive integers (a Young diagram shape)."""
 
-    parts: tuple[int, ...] = Field(min_length=1, max_length=MAX_PARTS)
+    parts: tuple[StrictInt, ...] = Field(min_length=1, max_length=MAX_PARTS)
 
     @model_validator(mode="after")
     def require_decreasing_positive(self) -> Self:
@@ -23,6 +24,8 @@ class Partition(ContractModel):
             raise ValueError("partition parts must be positive")
         if any(self.parts[i] < self.parts[i + 1] for i in range(len(self.parts) - 1)):
             raise ValueError("partition parts must be non-increasing")
+        if sum(self.parts) > MAX_PARTITION_SIZE:
+            raise ValueError(f"partition size must not exceed {MAX_PARTITION_SIZE}")
         return self
 
 
@@ -48,14 +51,14 @@ class HookLengthResult(ContractModel):
     """Hook lengths as a flat list of row-indexed values."""
 
     hooks: tuple[tuple[int, ...], ...] = Field(min_length=1)
-    total_product: int = Field(ge=1)
+    total_product: CanonicalInteger = Field(description="Product of all hook lengths.")
     method: Literal["HOOK_FORMULA"] = "HOOK_FORMULA"
 
 
 class StandardYoungTableauCountResult(ContractModel):
     """The number of standard Young tableaux of a given shape."""
 
-    count: int = Field(ge=1)
+    count: CanonicalInteger = Field(description="Number of standard Young tableaux.")
     n: int = Field(ge=1, le=MAX_PARTITION_SIZE)
     method: Literal["HOOK_LENGTH_FORMULA"] = "HOOK_LENGTH_FORMULA"
 

--- a/src/jacobian/contracts/algebraic_combinatorics.py
+++ b/src/jacobian/contracts/algebraic_combinatorics.py
@@ -1,0 +1,78 @@
+"""Typed wire contracts for exact algebraic combinatorics operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+MAX_PARTITION_SIZE = 50
+MAX_PARTS = 50
+
+
+class Partition(ContractModel):
+    """One decreasing sequence of positive integers (a Young diagram shape)."""
+
+    parts: tuple[int, ...] = Field(min_length=1, max_length=MAX_PARTS)
+
+    @model_validator(mode="after")
+    def require_decreasing_positive(self) -> Self:
+        if any(p <= 0 for p in self.parts):
+            raise ValueError("partition parts must be positive")
+        if any(self.parts[i] < self.parts[i + 1] for i in range(len(self.parts) - 1)):
+            raise ValueError("partition parts must be non-increasing")
+        return self
+
+
+class HookLengthRequest(ContractModel):
+    """Compute the hook lengths of a partition."""
+
+    partition: Partition
+
+
+class StandardYoungTableauCountRequest(ContractModel):
+    """Count standard Young tableaux of a given shape."""
+
+    partition: Partition
+
+
+class ConjugatePartitionRequest(ContractModel):
+    """Compute the conjugate (transpose) partition."""
+
+    partition: Partition
+
+
+class HookLengthResult(ContractModel):
+    """Hook lengths as a flat list of row-indexed values."""
+
+    hooks: tuple[tuple[int, ...], ...] = Field(min_length=1)
+    total_product: int = Field(ge=1)
+    method: Literal["HOOK_FORMULA"] = "HOOK_FORMULA"
+
+
+class StandardYoungTableauCountResult(ContractModel):
+    """The number of standard Young tableaux of a given shape."""
+
+    count: int = Field(ge=1)
+    n: int = Field(ge=1, le=MAX_PARTITION_SIZE)
+    method: Literal["HOOK_LENGTH_FORMULA"] = "HOOK_LENGTH_FORMULA"
+
+
+class ConjugatePartitionResult(ContractModel):
+    """The conjugate (transpose) partition."""
+
+    conjugate: tuple[int, ...] = Field(min_length=1)
+    method: Literal["FERRERS_TRANSPOSE"] = "FERRERS_TRANSPOSE"
+
+
+__all__ = [
+    "ConjugatePartitionRequest",
+    "ConjugatePartitionResult",
+    "HookLengthRequest",
+    "HookLengthResult",
+    "Partition",
+    "StandardYoungTableauCountRequest",
+    "StandardYoungTableauCountResult",
+]

--- a/src/jacobian/domains/algebraic_combinatorics/__init__.py
+++ b/src/jacobian/domains/algebraic_combinatorics/__init__.py
@@ -1,0 +1,18 @@
+"""Exact algebraic combinatorics operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["algebraic_combinatorics_operations"]
+
+
+def algebraic_combinatorics_operations() -> MathTools:
+    from jacobian.domains.algebraic_combinatorics.math_tools import (
+        ALGEBRAIC_COMBINATORICS_OPERATIONS,
+    )
+
+    return ALGEBRAIC_COMBINATORICS_OPERATIONS

--- a/src/jacobian/domains/algebraic_combinatorics/math_tools.py
+++ b/src/jacobian/domains/algebraic_combinatorics/math_tools.py
@@ -1,0 +1,109 @@
+"""Algebraic combinatorics operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.algebraic_combinatorics import (
+    ConjugatePartitionRequest,
+    ConjugatePartitionResult,
+    HookLengthRequest,
+    HookLengthResult,
+    StandardYoungTableauCountRequest,
+    StandardYoungTableauCountResult,
+)
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.algebraic_combinatorics.operations import (
+    compute_conjugate_partition,
+    compute_hook_lengths,
+    compute_syt_count,
+)
+from jacobian.math_tools import MathTool
+
+
+def ac_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_PARTITION_321 = {"partition": {"parts": [3, 2, 1]}}
+
+ALGEBRAIC_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    ac_operation(
+        "combinatorics.hook_length.compute",
+        "Compute hook lengths of a Young diagram",
+        "Compute the hook length H(i,j) = lambda_i - j + lambda'_j - i + 1 "
+        "for each cell (i,j) of the Young diagram of a partition.",
+        HookLengthRequest,
+        HookLengthResult,
+        compute_hook_lengths,
+        "combinatorics",
+        "hook-length",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Hook lengths of partition (3, 2, 1).",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+    ac_operation(
+        "combinatorics.standard_young_tableaux.count",
+        "Count standard Young tableaux via the hook length formula",
+        "Count the number of standard Young tableaux of a given shape using "
+        "the hook length formula: f^lambda = n! / product of hook lengths.",
+        StandardYoungTableauCountRequest,
+        StandardYoungTableauCountResult,
+        compute_syt_count,
+        "combinatorics",
+        "young-tableaux",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Number of SYT for shape (3, 2, 1) is 16.",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+    ac_operation(
+        "combinatorics.conjugate_partition.compute",
+        "Compute the conjugate (transpose) partition",
+        "Compute the conjugate partition lambda' by transposing the Ferrers "
+        "diagram of a partition lambda.",
+        ConjugatePartitionRequest,
+        ConjugatePartitionResult,
+        compute_conjugate_partition,
+        "combinatorics",
+        "partition",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Conjugate of partition (3, 2, 1) is (3, 2, 1).",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/algebraic_combinatorics/operations.py
+++ b/src/jacobian/domains/algebraic_combinatorics/operations.py
@@ -1,0 +1,47 @@
+"""Domain adapter for algebraic combinatorics operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.algebraic_combinatorics import (
+    ConjugatePartitionRequest,
+    ConjugatePartitionResult,
+    HookLengthRequest,
+    HookLengthResult,
+    StandardYoungTableauCountRequest,
+    StandardYoungTableauCountResult,
+)
+from jacobian.math.algebraic_combinatorics import (
+    conjugate_partition,
+    hook_lengths,
+    standard_young_tableaux_count,
+)
+
+
+def compute_hook_lengths(request: HookLengthRequest) -> HookLengthResult:
+    parts = list(request.partition.parts)
+    hooks = hook_lengths(parts)
+    total_product = 1
+    for row in hooks:
+        for h in row:
+            total_product *= h
+    return HookLengthResult(
+        hooks=tuple(tuple(row) for row in hooks),
+        total_product=total_product,
+    )
+
+
+def compute_syt_count(
+    request: StandardYoungTableauCountRequest,
+) -> StandardYoungTableauCountResult:
+    parts = list(request.partition.parts)
+    count = standard_young_tableaux_count(parts)
+    n = sum(parts)
+    return StandardYoungTableauCountResult(count=count, n=n)
+
+
+def compute_conjugate_partition(
+    request: ConjugatePartitionRequest,
+) -> ConjugatePartitionResult:
+    parts = list(request.partition.parts)
+    result = conjugate_partition(parts)
+    return ConjugatePartitionResult(conjugate=tuple(result))

--- a/src/jacobian/domains/algebraic_combinatorics/operations.py
+++ b/src/jacobian/domains/algebraic_combinatorics/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.contracts.algebraic_combinatorics import (
     ConjugatePartitionRequest,
     ConjugatePartitionResult,
@@ -26,7 +27,7 @@ def compute_hook_lengths(request: HookLengthRequest) -> HookLengthResult:
             total_product *= h
     return HookLengthResult(
         hooks=tuple(tuple(row) for row in hooks),
-        total_product=total_product,
+        total_product=format_canonical_integer(total_product),
     )
 
 
@@ -36,7 +37,7 @@ def compute_syt_count(
     parts = list(request.partition.parts)
     count = standard_young_tableaux_count(parts)
     n = sum(parts)
-    return StandardYoungTableauCountResult(count=count, n=n)
+    return StandardYoungTableauCountResult(count=format_canonical_integer(count), n=n)
 
 
 def compute_conjugate_partition(

--- a/src/jacobian/math/algebraic_combinatorics/__init__.py
+++ b/src/jacobian/math/algebraic_combinatorics/__init__.py
@@ -1,0 +1,13 @@
+"""Algebraic combinatorics operations."""
+
+from jacobian.math.algebraic_combinatorics.operations import (
+    conjugate_partition,
+    hook_lengths,
+    standard_young_tableaux_count,
+)
+
+__all__ = [
+    "conjugate_partition",
+    "hook_lengths",
+    "standard_young_tableaux_count",
+]

--- a/src/jacobian/math/algebraic_combinatorics/operations.py
+++ b/src/jacobian/math/algebraic_combinatorics/operations.py
@@ -1,0 +1,48 @@
+"""Exact algebraic combinatorics kernels backed by SymPy IntegerPartition."""
+
+from __future__ import annotations
+
+from math import factorial
+
+__all__ = [
+    "conjugate_partition",
+    "hook_lengths",
+    "standard_young_tableaux_count",
+]
+
+
+def conjugate_partition(parts: list[int]) -> list[int]:
+    """Compute the conjugate (transpose) partition."""
+    if not parts:
+        return []
+    max_col = parts[0]
+    result = []
+    for col in range(1, max_col + 1):
+        count = sum(1 for p in parts if p >= col)
+        result.append(count)
+    return result
+
+
+def hook_lengths(parts: list[int]) -> list[list[int]]:
+    """Compute hook lengths for each cell of the Young diagram."""
+    conj = conjugate_partition(parts)
+    hooks = []
+    for i, lam in enumerate(parts):
+        row_hooks = []
+        for j in range(lam):
+            right = lam - j - 1
+            below = conj[j] - i - 1
+            row_hooks.append(1 + right + below)
+        hooks.append(row_hooks)
+    return hooks
+
+
+def standard_young_tableaux_count(parts: list[int]) -> int:
+    """Count standard Young tableaux via the hook length formula."""
+    hooks = hook_lengths(parts)
+    n = sum(parts)
+    product = 1
+    for row in hooks:
+        for h in row:
+            product *= h
+    return factorial(n) // product

--- a/tests/domain/algebraic_combinatorics/test_algebraic_combinatorics.py
+++ b/tests/domain/algebraic_combinatorics/test_algebraic_combinatorics.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.algebraic_combinatorics import (
+    ConjugatePartitionRequest,
+    HookLengthRequest,
+    Partition,
+    StandardYoungTableauCountRequest,
+)
+from jacobian.domains.algebraic_combinatorics.operations import (
+    compute_conjugate_partition,
+    compute_hook_lengths,
+    compute_syt_count,
+)
+
+
+def test_hook_lengths_partition_321() -> None:
+    """Hook lengths of (3,2,1) are [[5,3,1],[3,1],[1]]."""
+    result = compute_hook_lengths(
+        HookLengthRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.hooks == ((5, 3, 1), (3, 1), (1,))
+    assert result.total_product == 45
+
+
+def test_hook_lengths_single_row() -> None:
+    """Hook lengths of (n) are [n, n-1, ..., 1]."""
+    result = compute_hook_lengths(HookLengthRequest(partition=Partition(parts=(4,))))
+    assert result.hooks == ((4, 3, 2, 1),)
+    assert result.total_product == 24
+
+
+def test_hook_lengths_single_column() -> None:
+    """Hook lengths of (1,1,1) are [[1],[1],[1]]."""
+    result = compute_hook_lengths(
+        HookLengthRequest(partition=Partition(parts=(1, 1, 1)))
+    )
+    assert result.hooks == ((3,), (2,), (1,))
+    assert result.total_product == 6
+
+
+def test_syt_count_partition_321() -> None:
+    """Number of SYT for shape (3,2,1) is 16."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.count == 16
+    assert result.n == 6
+    assert result.method == "HOOK_LENGTH_FORMULA"
+
+
+def test_syt_count_single_row() -> None:
+    """Number of SYT for shape (n) is 1."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(5,)))
+    )
+    assert result.count == 1
+    assert result.n == 5
+
+
+def test_syt_count_single_column() -> None:
+    """Number of SYT for shape (1,1,...,1) is 1."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(1, 1, 1, 1)))
+    )
+    assert result.count == 1
+    assert result.n == 4
+
+
+def test_syt_count_rectangle_22() -> None:
+    """Number of SYT for shape (2,2) is 2."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(2, 2)))
+    )
+    assert result.count == 2
+
+
+def _count_syt_brute_force(parts: tuple[int, ...]) -> int:
+    """Brute-force count of standard Young tableaux."""
+    from itertools import permutations
+
+    n = sum(parts)
+    positions = []
+    for i, p in enumerate(parts):
+        for j in range(p):
+            positions.append((i, j))
+
+    def is_valid(perm: tuple[int, ...]) -> bool:
+        table = {positions[idx]: perm[idx] for idx in range(len(perm))}
+        for i, j in positions:
+            if i > 0 and table[(i, j)] <= table[(i - 1, j)]:
+                return False
+            if j > 0 and table[(i, j)] <= table[(i, j - 1)]:
+                return False
+        return True
+
+    count = 0
+    for perm in permutations(range(1, n + 1)):
+        if is_valid(perm):
+            count += 1
+    return count
+
+
+def test_syt_count_matches_brute_force() -> None:
+    """SYT count matches the number of valid fillings for small partitions."""
+    for parts in [(3, 1), (2, 2), (3, 2)]:
+        brute = _count_syt_brute_force(parts)
+        result = compute_syt_count(
+            StandardYoungTableauCountRequest(partition=Partition(parts=parts))
+        )
+        assert result.count == brute
+
+
+def test_conjugate_self_conjugate_partition() -> None:
+    """Conjugate of (3,2,1) is (3,2,1) — self-conjugate."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.conjugate == (3, 2, 1)
+
+
+def test_conjugate_row_to_column() -> None:
+    """Conjugate of (4) is (1,1,1,1) and vice versa."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(4,)))
+    )
+    assert result.conjugate == (1, 1, 1, 1)
+
+
+def test_conjugate_column_to_row() -> None:
+    """Conjugate of (1,1,1,1) is (4)."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(1, 1, 1, 1)))
+    )
+    assert result.conjugate == (4,)
+
+
+def test_conjugate_double_conjugate_is_identity() -> None:
+    """Conjugate of conjugate is the original partition."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(5, 3, 2, 1)))
+    )
+    result2 = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=result.conjugate))
+    )
+    assert result2.conjugate == (5, 3, 2, 1)
+
+
+def test_contract_rejects_non_decreasing() -> None:
+    with pytest.raises(ValidationError, match="non-increasing"):
+        Partition(parts=(1, 2, 3))
+
+
+def test_contract_rejects_non_positive() -> None:
+    with pytest.raises(ValidationError, match="positive"):
+        Partition(parts=(3, 0, 1))

--- a/tests/domain/algebraic_combinatorics/test_algebraic_combinatorics.py
+++ b/tests/domain/algebraic_combinatorics/test_algebraic_combinatorics.py
@@ -22,14 +22,14 @@ def test_hook_lengths_partition_321() -> None:
         HookLengthRequest(partition=Partition(parts=(3, 2, 1)))
     )
     assert result.hooks == ((5, 3, 1), (3, 1), (1,))
-    assert result.total_product == 45
+    assert result.total_product == "45"
 
 
 def test_hook_lengths_single_row() -> None:
     """Hook lengths of (n) are [n, n-1, ..., 1]."""
     result = compute_hook_lengths(HookLengthRequest(partition=Partition(parts=(4,))))
     assert result.hooks == ((4, 3, 2, 1),)
-    assert result.total_product == 24
+    assert result.total_product == "24"
 
 
 def test_hook_lengths_single_column() -> None:
@@ -38,7 +38,7 @@ def test_hook_lengths_single_column() -> None:
         HookLengthRequest(partition=Partition(parts=(1, 1, 1)))
     )
     assert result.hooks == ((3,), (2,), (1,))
-    assert result.total_product == 6
+    assert result.total_product == "6"
 
 
 def test_syt_count_partition_321() -> None:
@@ -46,7 +46,7 @@ def test_syt_count_partition_321() -> None:
     result = compute_syt_count(
         StandardYoungTableauCountRequest(partition=Partition(parts=(3, 2, 1)))
     )
-    assert result.count == 16
+    assert result.count == "16"
     assert result.n == 6
     assert result.method == "HOOK_LENGTH_FORMULA"
 
@@ -56,7 +56,7 @@ def test_syt_count_single_row() -> None:
     result = compute_syt_count(
         StandardYoungTableauCountRequest(partition=Partition(parts=(5,)))
     )
-    assert result.count == 1
+    assert result.count == "1"
     assert result.n == 5
 
 
@@ -65,7 +65,7 @@ def test_syt_count_single_column() -> None:
     result = compute_syt_count(
         StandardYoungTableauCountRequest(partition=Partition(parts=(1, 1, 1, 1)))
     )
-    assert result.count == 1
+    assert result.count == "1"
     assert result.n == 4
 
 
@@ -74,7 +74,7 @@ def test_syt_count_rectangle_22() -> None:
     result = compute_syt_count(
         StandardYoungTableauCountRequest(partition=Partition(parts=(2, 2)))
     )
-    assert result.count == 2
+    assert result.count == "2"
 
 
 def _count_syt_brute_force(parts: tuple[int, ...]) -> int:
@@ -110,7 +110,7 @@ def test_syt_count_matches_brute_force() -> None:
         result = compute_syt_count(
             StandardYoungTableauCountRequest(partition=Partition(parts=parts))
         )
-        assert result.count == brute
+        assert result.count == str(brute)
 
 
 def test_conjugate_self_conjugate_partition() -> None:
@@ -156,3 +156,27 @@ def test_contract_rejects_non_decreasing() -> None:
 def test_contract_rejects_non_positive() -> None:
     with pytest.raises(ValidationError, match="positive"):
         Partition(parts=(3, 0, 1))
+
+
+def test_contract_rejects_partition_exceeding_size_bound() -> None:
+    """A single-part partition summing above MAX_PARTITION_SIZE is rejected."""
+    with pytest.raises(ValidationError, match="partition size must not exceed"):
+        Partition(parts=(51,))
+
+
+def test_contract_rejects_non_integer_parts() -> None:
+    """Boolean or string partition parts are rejected, not silently coerced."""
+    with pytest.raises(ValidationError):
+        Partition.model_validate({"parts": [True]})
+    with pytest.raises(ValidationError):
+        Partition.model_validate({"parts": ["3"]})
+
+
+def test_syt_count_large_returns_canonical_string() -> None:
+    """Large SYT counts are returned as canonical decimal strings."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(
+            partition=Partition(parts=(10, 9, 8, 7, 6, 5, 4, 1))
+        )
+    )
+    assert result.count == "322821557622027077916662169600"


### PR DESCRIPTION
## Summary

Adds three exact atomic composable math operations for algebraic combinatorics over Young diagrams:

- `combinatorics.hook_length.compute` — hook lengths H(i,j) for each cell of a Young diagram
- `combinatorics.standard_young_tableaux.count` — number of standard Young tableaux via the hook length formula: f^λ = n! / ∏ hook lengths
- `combinatorics.conjugate_partition.compute` — conjugate (transpose) partition via Ferrers diagram transpose

All operations use exact integer arithmetic.

## Testing
14 domain tests: known-answer hook lengths (partition (3,2,1), single row, single column), SYT count verification against brute-force enumeration for shapes (3,1), (2,2), (3,2), conjugate partition identities (self-conjugate, row↔column, double-conjugate-is-identity), contract validation (non-decreasing parts, non-positive parts).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1855