### PR TITLE
Add exact Sturm chain and interval root counting operations (#1872)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    ("jacobian.domains.real_algebra", "real_algebra_operations"),
 )
 
 

--- a/src/jacobian/contracts/real_algebra.py
+++ b/src/jacobian/contracts/real_algebra.py
@@ -1,0 +1,84 @@
+"""Typed wire contracts for exact real algebra operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.exact import CanonicalRational
+
+MAX_POLYNOMIAL_DEGREE = 32
+MAX_POLYNOMIAL_TERMS = 33
+
+
+class PolynomialTerm(ContractModel):
+    """One term: coefficient times x^exponent."""
+
+    coefficient: CanonicalRational
+    exponent: int = Field(ge=0, le=MAX_POLYNOMIAL_DEGREE)
+
+
+class UnivariatePolynomial(ContractModel):
+    """A univariate polynomial over QQ as sparse nonzero terms."""
+
+    terms: tuple[PolynomialTerm, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_TERMS
+    )
+
+    @model_validator(mode="after")
+    def require_unique_exponents(self) -> Self:
+        exponents = [t.exponent for t in self.terms]
+        if len(set(exponents)) != len(exponents):
+            raise ValueError("polynomial exponents must be unique")
+        if any(t.coefficient.as_fraction() == 0 for t in self.terms):
+            raise ValueError("zero polynomial terms must be omitted")
+        return self
+
+
+class SturmChainRequest(ContractModel):
+    """Compute the Sturm chain of a univariate polynomial."""
+
+    polynomial: UnivariatePolynomial
+
+
+class RootCountRequest(ContractModel):
+    """Count real roots of a polynomial in an interval [a, b]."""
+
+    polynomial: UnivariatePolynomial
+    lower: CanonicalRational
+    upper: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_lower_leq_upper(self) -> Self:
+        if self.lower.as_fraction() > self.upper.as_fraction():
+            raise ValueError("lower bound must not exceed upper bound")
+        return self
+
+
+class SturmChainResult(ContractModel):
+    """The Sturm chain as a list of polynomials."""
+
+    chain: tuple[UnivariatePolynomial, ...] = Field(min_length=1)
+    degree: int = Field(ge=1, le=MAX_POLYNOMIAL_DEGREE)
+    method: Literal["SYMPY_STURM"] = "SYMPY_STURM"
+
+
+class RootCountResult(ContractModel):
+    """Count of real roots in an interval."""
+
+    root_count: int = Field(ge=0)
+    lower: CanonicalRational
+    upper: CanonicalRational
+    method: Literal["STURM_THEOREM"] = "STURM_THEOREM"
+
+
+__all__ = [
+    "PolynomialTerm",
+    "RootCountRequest",
+    "RootCountResult",
+    "SturmChainRequest",
+    "SturmChainResult",
+    "UnivariatePolynomial",
+]

--- a/src/jacobian/contracts/real_algebra.py
+++ b/src/jacobian/contracts/real_algebra.py
@@ -7,10 +7,14 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian.contracts.base import ContractModel
-from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.exact import (
+    CanonicalRational,
+    require_bounded_rational,
+)
 
 MAX_POLYNOMIAL_DEGREE = 32
 MAX_POLYNOMIAL_TERMS = 33
+MAX_COEFFICIENT_DIGITS = 256
 
 
 class PolynomialTerm(ContractModel):
@@ -34,6 +38,12 @@ class UnivariatePolynomial(ContractModel):
             raise ValueError("polynomial exponents must be unique")
         if any(t.coefficient.as_fraction() == 0 for t in self.terms):
             raise ValueError("zero polynomial terms must be omitted")
+        for term in self.terms:
+            require_bounded_rational(
+                term.coefficient,
+                max_digits=MAX_COEFFICIENT_DIGITS,
+                label="polynomial coefficient",
+            )
         return self
 
 
@@ -41,6 +51,12 @@ class SturmChainRequest(ContractModel):
     """Compute the Sturm chain of a univariate polynomial."""
 
     polynomial: UnivariatePolynomial
+
+    @model_validator(mode="after")
+    def require_nonconstant_polynomial(self) -> Self:
+        if max(t.exponent for t in self.polynomial.terms) < 1:
+            raise ValueError("Sturm chain requires a non-constant polynomial")
+        return self
 
 
 class RootCountRequest(ContractModel):

--- a/src/jacobian/domains/real_algebra/__init__.py
+++ b/src/jacobian/domains/real_algebra/__init__.py
@@ -1,0 +1,16 @@
+"""Exact real algebra operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["real_algebra_operations"]
+
+
+def real_algebra_operations() -> MathTools:
+    from jacobian.domains.real_algebra.math_tools import REAL_ALGEBRA_OPERATIONS
+
+    return REAL_ALGEBRA_OPERATIONS

--- a/src/jacobian/domains/real_algebra/math_tools.py
+++ b/src/jacobian/domains/real_algebra/math_tools.py
@@ -1,0 +1,105 @@
+"""Real algebra operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.operations import OperationExample
+from jacobian.contracts.real_algebra import (
+    RootCountRequest,
+    RootCountResult,
+    SturmChainRequest,
+    SturmChainResult,
+)
+from jacobian.domains._examples import example
+from jacobian.domains.real_algebra.operations import (
+    compute_root_count,
+    compute_sturm_chain,
+)
+from jacobian.math_tools import MathTool
+
+
+def ra_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+REAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    ra_operation(
+        "polynomial.sturm_chain.compute",
+        "Compute the Sturm chain of a univariate polynomial",
+        "Compute the exact Sturm subresultant chain of a univariate "
+        "polynomial over QQ using SymPy's sturm function.",
+        SturmChainRequest,
+        SturmChainResult,
+        compute_sturm_chain,
+        "polynomial",
+        "sturm-chain",
+        "exact",
+        examples=(
+            example(
+                "cubic",
+                "Sturm chain of x^3 - 2x^2 + x - 3.",
+                {
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 3},
+                            {"coefficient": {"num": "-2", "den": "1"}, "exponent": 2},
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 1},
+                            {"coefficient": {"num": "-3", "den": "1"}, "exponent": 0},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    ra_operation(
+        "polynomial.root_count.compute",
+        "Count real roots in an interval via Sturm's theorem",
+        "Count the exact number of real roots of a univariate polynomial "
+        "in the closed interval [lower, upper] using the Sturm theorem.",
+        RootCountRequest,
+        RootCountResult,
+        compute_root_count,
+        "polynomial",
+        "root-count",
+        "exact",
+        examples=(
+            example(
+                "cubic",
+                "Count roots of x^3 - 2x^2 + x - 3 in [-10, 10].",
+                {
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 3},
+                            {"coefficient": {"num": "-2", "den": "1"}, "exponent": 2},
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 1},
+                            {"coefficient": {"num": "-3", "den": "1"}, "exponent": 0},
+                        ],
+                    },
+                    "lower": {"num": "-10", "den": "1"},
+                    "upper": {"num": "10", "den": "1"},
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/real_algebra/operations.py
+++ b/src/jacobian/domains/real_algebra/operations.py
@@ -1,0 +1,57 @@
+"""Domain adapter for real algebra operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.real_algebra import (
+    PolynomialTerm,
+    RootCountRequest,
+    RootCountResult,
+    SturmChainRequest,
+    SturmChainResult,
+    UnivariatePolynomial,
+)
+from jacobian.math.real_algebra import root_count, sturm_chain
+
+
+def _poly_to_terms(poly: UnivariatePolynomial) -> list[tuple[Fraction, int]]:
+    return [(t.coefficient.as_fraction(), t.exponent) for t in poly.terms]
+
+
+def _terms_to_poly(terms: list[tuple[Fraction, int]]) -> UnivariatePolynomial:
+    return UnivariatePolynomial(
+        terms=tuple(
+            PolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coeff),
+                exponent=exp,
+            )
+            for coeff, exp in terms
+            if coeff != 0
+        )
+    )
+
+
+def compute_sturm_chain(request: SturmChainRequest) -> SturmChainResult:
+    poly = request.polynomial
+    terms = _poly_to_terms(poly)
+    chain = sturm_chain(terms)
+    degree = max(t.exponent for t in poly.terms)
+    return SturmChainResult(
+        chain=tuple(_terms_to_poly(c) for c in chain),
+        degree=degree,
+    )
+
+
+def compute_root_count(request: RootCountRequest) -> RootCountResult:
+    poly = request.polynomial
+    terms = _poly_to_terms(poly)
+    lower = request.lower.as_fraction()
+    upper = request.upper.as_fraction()
+    count = root_count(terms, lower, upper)
+    return RootCountResult(
+        root_count=count,
+        lower=request.lower,
+        upper=request.upper,
+    )

--- a/src/jacobian/math/real_algebra/__init__.py
+++ b/src/jacobian/math/real_algebra/__init__.py
@@ -1,0 +1,5 @@
+"""Real algebra operations."""
+
+from jacobian.math.real_algebra.operations import root_count, sturm_chain
+
+__all__ = ["root_count", "sturm_chain"]

--- a/src/jacobian/math/real_algebra/operations.py
+++ b/src/jacobian/math/real_algebra/operations.py
@@ -1,0 +1,85 @@
+"""Exact Sturm chain and root counting kernels backed by SymPy."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+__all__ = ["root_count", "sturm_chain"]
+
+
+def _to_sympy_poly(terms: list[tuple[Fraction, int]]) -> Any:
+    from sympy import Poly, Rational, Symbol
+
+    x = Symbol("x")
+    poly_dict = {exp: Rational(val.numerator, val.denominator) for val, exp in terms}
+    return Poly(poly_dict, x, domain="QQ")
+
+
+def sturm_chain(terms: list[tuple[Fraction, int]]) -> list[list[tuple[Fraction, int]]]:
+    """Compute the Sturm chain of a univariate polynomial."""
+    from sympy import sturm
+
+    poly = _to_sympy_poly(terms)
+    chain = sturm(poly)
+    result = []
+    for p in chain:
+        result.append(_sympy_poly_to_terms(p))
+    return result
+
+
+def root_count(
+    terms: list[tuple[Fraction, int]],
+    lower: Fraction,
+    upper: Fraction,
+) -> int:
+    """Count real roots in [lower, upper] using the Sturm theorem."""
+    from sympy import Rational
+
+    poly = _to_sympy_poly(terms)
+    chain = _build_sturm_chain(poly)
+
+    a = Rational(lower.numerator, lower.denominator)
+    b = Rational(upper.numerator, upper.denominator)
+
+    sign_changes_a = _sign_changes(chain, a)
+    sign_changes_b = _sign_changes(chain, b)
+
+    return sign_changes_a - sign_changes_b
+
+
+def _build_sturm_chain(poly: Any) -> list[Any]:
+    from sympy import sturm
+
+    return list(sturm(poly))
+
+
+def _sign_changes(chain: list[Any], point: Any) -> int:
+
+    if len(chain) == 0:
+        return 0
+    signs = []
+    for poly in chain:
+        val = poly.as_expr().subs(poly.gen, point)
+        if val != 0:
+            signs.append(1 if val > 0 else -1)
+    count = 0
+    for i in range(1, len(signs)):
+        if signs[i] != signs[i - 1]:
+            count += 1
+    return count
+
+
+def _sympy_poly_to_terms(poly: Any) -> list[tuple[Fraction, int]]:
+    from fractions import Fraction
+
+    result = []
+    for exps, coeff in poly.as_dict().items():
+        if coeff == 0:
+            continue
+        if hasattr(coeff, "p") and hasattr(coeff, "q"):
+            frac = Fraction(int(coeff.p), int(coeff.q))
+        else:
+            frac = Fraction(coeff)
+        result.append((frac, exps[0]))
+    return result

--- a/tests/domain/real_algebra/test_real_algebra.py
+++ b/tests/domain/real_algebra/test_real_algebra.py
@@ -156,3 +156,24 @@ def test_contract_rejects_zero_coefficient() -> None:
         UnivariatePolynomial(
             terms=(PolynomialTerm(coefficient=R(num="0", den="1"), exponent=2),)
         )
+
+
+def test_contract_rejects_oversized_coefficient_digits() -> None:
+    """A coefficient at the 32,768-digit wire limit is rejected by the
+    operation-specific 256-digit polynomial budget."""
+    big_num = "9" * 257
+    with pytest.raises(ValidationError, match="256-digit bound"):
+        UnivariatePolynomial(
+            terms=(
+                PolynomialTerm(coefficient=R(num=big_num, den="1"), exponent=2),
+                PolynomialTerm(coefficient=R(num="-2", den="1"), exponent=0),
+            )
+        )
+
+
+def test_sturm_rejects_constant_polynomial() -> None:
+    """A degree-0 polynomial is rejected before execution."""
+    with pytest.raises(ValidationError, match="non-constant"):
+        SturmChainRequest(
+            polynomial=_poly(("5", "1", 0)),
+        )

--- a/tests/domain/real_algebra/test_real_algebra.py
+++ b/tests/domain/real_algebra/test_real_algebra.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.exact import CanonicalRational
+from jacobian.contracts.real_algebra import (
+    PolynomialTerm,
+    RootCountRequest,
+    SturmChainRequest,
+    UnivariatePolynomial,
+)
+from jacobian.domains.real_algebra.operations import (
+    compute_root_count,
+    compute_sturm_chain,
+)
+
+R = CanonicalRational
+
+
+def _poly(*terms: tuple[str, str, int]) -> UnivariatePolynomial:
+    return UnivariatePolynomial(
+        terms=tuple(
+            PolynomialTerm(coefficient=R(num=num, den=den), exponent=exp)
+            for num, den, exp in terms
+        )
+    )
+
+
+def test_sturm_chain_cubic() -> None:
+    """x^3 - 2x^2 + x - 3 has a Sturm chain of length 4."""
+    poly = _poly(("1", "1", 3), ("-2", "1", 2), ("1", "1", 1), ("-3", "1", 0))
+    result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
+    assert len(result.chain) == 4
+    assert result.degree == 3
+    assert result.method == "SYMPY_STURM"
+
+
+def test_sturm_chain_quadratic() -> None:
+    """x^2 - 2 has a Sturm chain of length 3."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
+    assert len(result.chain) == 3
+    assert result.degree == 2
+
+
+def test_root_count_cubic_has_one_real_root() -> None:
+    """x^3 - 2x^2 + x - 3 has exactly 1 real root in [-10, 10]."""
+    poly = _poly(("1", "1", 3), ("-2", "1", 2), ("1", "1", 1), ("-3", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 1
+
+
+def test_root_count_x_squared_minus_2() -> None:
+    """x^2 - 2 has 2 real roots in [-10, 10] but 0 in [0, 10]... wait sqrt(2) ~1.41.
+    Actually x^2-2 has roots at +-sqrt(2). So 2 roots in [-10,10], 1 in [0,10]."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 2
+
+    result_pos = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="2", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result_pos.root_count == 0
+
+
+def test_root_count_no_real_roots() -> None:
+    """x^2 + 1 has no real roots."""
+    poly = _poly(("1", "1", 2), ("1", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 0
+
+
+def test_root_count_linear() -> None:
+    """x - 5 has one root at x=5."""
+    poly = _poly(("1", "1", 1), ("-5", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 1
+
+
+def test_root_count_quartic_two_roots() -> None:
+    """x^4 - 5x^2 + 4 = (x-1)(x+1)(x-2)(x+2) has 4 roots in [-10, 10]."""
+    poly = _poly(("1", "1", 4), ("-5", "1", 2), ("4", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 4
+
+
+def test_root_count_empty_interval() -> None:
+    """An empty interval has 0 roots."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="0", den="1"),
+        )
+    )
+    assert result.root_count == 0
+
+
+def test_contract_rejects_lower_gt_upper() -> None:
+    with pytest.raises(ValidationError, match="lower bound"):
+        RootCountRequest(
+            polynomial=_poly(("1", "1", 1)),
+            lower=R(num="10", den="1"),
+            upper=R(num="0", den="1"),
+        )
+
+
+def test_contract_rejects_duplicate_exponents() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        UnivariatePolynomial(
+            terms=(
+                PolynomialTerm(coefficient=R(num="1", den="1"), exponent=2),
+                PolynomialTerm(coefficient=R(num="1", den="1"), exponent=2),
+            )
+        )
+
+
+def test_contract_rejects_zero_coefficient() -> None:
+    with pytest.raises(ValidationError, match="zero"):
+        UnivariatePolynomial(
+            terms=(PolynomialTerm(coefficient=R(num="0", den="1"), exponent=2),)
+        )


### PR DESCRIPTION
## Summary

Adds two exact atomic composable math operations for real algebra over QQ, backed by SymPy's  function:

- `polynomial.sturm_chain.compute` — exact Sturm subresultant chain of a univariate polynomial
- `polynomial.root_count.compute` — count real roots in [lower, upper] using Sturm's theorem (sign change count difference)

## Testing
11 domain tests: known-answer Sturm chains (cubic, quadratic), root counting (cubic with 1 root, quadratic with 2 roots, no real roots, linear, quartic with 4 roots), empty interval, contract validation (lower > upper, duplicate exponents, zero coefficients).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1872