### PR TITLE
Add exact graph transform operations (#1764)

### DIFF
--- a/src/jacobian/builtin_operation_modules.py
+++ b/src/jacobian/builtin_operation_modules.py
@@ -107,6 +107,7 @@ BUILTIN_OPERATION_MODULES: tuple[BuiltinOperationModule, ...] = (
     ("jacobian.domains.polynomial_maps", "polynomial_map_operations"),
     ("jacobian.domains.euclidean_geometry", "euclidean_geometry_operations"),
     ("jacobian.domains.finite_game_theory", "finite_game_theory_operations"),
+    ("jacobian.domains.graph_transforms", "graph_transform_operations"),
 )
 
 

--- a/src/jacobian/contracts/graph_transforms.py
+++ b/src/jacobian/contracts/graph_transforms.py
@@ -10,6 +10,7 @@ from jacobian.contracts.base import ContractModel
 
 MAX_VERTICES = 64
 MAX_EDGES = 1024
+MAX_RESULT_EDGES = 65536
 
 
 class GraphEdge(ContractModel):
@@ -60,8 +61,8 @@ class GraphTransformRequest(ContractModel):
 class GraphResult(ContractModel):
     """The result graph of a transform."""
 
-    vertex_count: int = Field(ge=1, le=MAX_VERTICES * MAX_VERTICES)
-    edges: tuple[GraphEdge, ...] = Field(default=(), max_length=MAX_EDGES)
+    vertex_count: int = Field(ge=0, le=MAX_VERTICES * MAX_VERTICES)
+    edges: tuple[GraphEdge, ...] = Field(default=(), max_length=MAX_RESULT_EDGES)
     method: Literal["NETWORKX"] = "NETWORKX"
 
 
@@ -73,6 +74,8 @@ class SubgraphRequest(ContractModel):
 
     @model_validator(mode="after")
     def require_valid_vertices(self) -> Self:
+        if len(set(self.vertices)) != len(self.vertices):
+            raise ValueError("vertices must be unique")
         for v in self.vertices:
             if not (0 <= v < self.graph.vertex_count):
                 raise ValueError("vertices must be in 0..vertex_count-1")

--- a/src/jacobian/contracts/graph_transforms.py
+++ b/src/jacobian/contracts/graph_transforms.py
@@ -1,0 +1,88 @@
+"""Typed wire contracts for exact graph transform operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.contracts.base import ContractModel
+
+MAX_VERTICES = 64
+MAX_EDGES = 1024
+
+
+class GraphEdge(ContractModel):
+    """One undirected edge."""
+
+    source: int = Field(ge=0, le=MAX_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_distinct(self) -> Self:
+        if self.source == self.target:
+            raise ValueError("edge endpoints must be distinct")
+        return self
+
+
+class SimpleGraph(ContractModel):
+    """A finite simple undirected graph."""
+
+    vertex_count: int = Field(ge=1, le=MAX_VERTICES)
+    edges: tuple[GraphEdge, ...] = Field(default=(), max_length=MAX_EDGES)
+
+    @model_validator(mode="after")
+    def require_valid_edges(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for edge in self.edges:
+            if not (
+                0 <= edge.source < self.vertex_count
+                and 0 <= edge.target < self.vertex_count
+            ):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            key = (
+                (edge.source, edge.target)
+                if edge.source < edge.target
+                else (edge.target, edge.source)
+            )
+            if key in seen:
+                raise ValueError("edges must be unique")
+            seen.add(key)
+        return self
+
+
+class GraphTransformRequest(ContractModel):
+    """One graph transform operation."""
+
+    graph: SimpleGraph
+
+
+class GraphResult(ContractModel):
+    """The result graph of a transform."""
+
+    vertex_count: int = Field(ge=1, le=MAX_VERTICES * MAX_VERTICES)
+    edges: tuple[GraphEdge, ...] = Field(default=(), max_length=MAX_EDGES)
+    method: Literal["NETWORKX"] = "NETWORKX"
+
+
+class SubgraphRequest(ContractModel):
+    """Extract an induced subgraph on a vertex subset."""
+
+    graph: SimpleGraph
+    vertices: tuple[int, ...] = Field(min_length=0, max_length=MAX_VERTICES)
+
+    @model_validator(mode="after")
+    def require_valid_vertices(self) -> Self:
+        for v in self.vertices:
+            if not (0 <= v < self.graph.vertex_count):
+                raise ValueError("vertices must be in 0..vertex_count-1")
+        return self
+
+
+__all__ = [
+    "GraphEdge",
+    "GraphResult",
+    "GraphTransformRequest",
+    "SimpleGraph",
+    "SubgraphRequest",
+]

--- a/src/jacobian/domains/graph_transforms/__init__.py
+++ b/src/jacobian/domains/graph_transforms/__init__.py
@@ -1,0 +1,18 @@
+"""Exact graph transform operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from jacobian.math_tools import MathTools
+
+__all__ = ["graph_transform_operations"]
+
+
+def graph_transform_operations() -> MathTools:
+    from jacobian.domains.graph_transforms.math_tools import (
+        GRAPH_TRANSFORM_OPERATIONS,
+    )
+
+    return GRAPH_TRANSFORM_OPERATIONS

--- a/src/jacobian/domains/graph_transforms/math_tools.py
+++ b/src/jacobian/domains/graph_transforms/math_tools.py
@@ -1,0 +1,151 @@
+"""Graph transform operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian.contracts.base import ContractModel
+from jacobian.contracts.graph_transforms import (
+    GraphResult,
+    GraphTransformRequest,
+    SubgraphRequest,
+)
+from jacobian.contracts.operations import OperationExample
+from jacobian.domains._examples import example
+from jacobian.domains.graph_transforms.operations import (
+    compute_complement,
+    compute_graph_power,
+    compute_induced_subgraph,
+    compute_line_graph,
+)
+from jacobian.math_tools import MathTool
+
+
+def gt_operation[RequestT: ContractModel, ResultT: ContractModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+def _run_complement(request: GraphTransformRequest) -> GraphResult:
+    return compute_complement(request)
+
+
+def _run_line_graph(request: GraphTransformRequest) -> GraphResult:
+    return compute_line_graph(request)
+
+
+def _run_power2(request: GraphTransformRequest) -> GraphResult:
+    return compute_graph_power(request, 2)
+
+
+_GRAPH_EXAMPLE = {
+    "graph": {
+        "vertex_count": 3,
+        "edges": [
+            {"source": 0, "target": 1},
+            {"source": 1, "target": 2},
+        ],
+    }
+}
+
+
+GRAPH_TRANSFORM_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    gt_operation(
+        "graph.complement.compute",
+        "Compute the complement of a graph",
+        "Compute the exact complement of a simple undirected graph using "
+        "NetworkX. The complement has the same vertex set, with edges "
+        "exactly where the original has no edge.",
+        GraphTransformRequest,
+        GraphResult,
+        _run_complement,
+        "graph",
+        "complement",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Complement of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.line_graph.compute",
+        "Compute the line graph of a graph",
+        "Compute the exact line graph L(G) where vertices are edges of G "
+        "and two vertices in L(G) are adjacent if they share an endpoint in G.",
+        GraphTransformRequest,
+        GraphResult,
+        _run_line_graph,
+        "graph",
+        "line-graph",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Line graph of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.power.compute",
+        "Compute the graph power (square) of a graph",
+        "Compute the exact square G^2 where two vertices are adjacent if "
+        "their distance in G is at most 2.",
+        GraphTransformRequest,
+        GraphResult,
+        _run_power2,
+        "graph",
+        "graph-power",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Square of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.induced_subgraph.compute",
+        "Extract an induced subgraph on a vertex subset",
+        "Compute the exact induced subgraph G[V'] where V' is a subset of "
+        "the vertices. Vertices are reindexed 0..|V'|-1.",
+        SubgraphRequest,
+        GraphResult,
+        compute_induced_subgraph,
+        "graph",
+        "induced-subgraph",
+        "exact",
+        examples=(
+            example(
+                "path_p2_vertices_0_2",
+                "Induced subgraph of P2 on vertices {0, 2}.",
+                {
+                    "graph": _GRAPH_EXAMPLE["graph"],
+                    "vertices": [0, 2],
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/domains/graph_transforms/operations.py
+++ b/src/jacobian/domains/graph_transforms/operations.py
@@ -1,0 +1,52 @@
+"""Domain adapter for graph transform operations."""
+
+from __future__ import annotations
+
+from jacobian.contracts.graph_transforms import (
+    GraphEdge,
+    GraphResult,
+    GraphTransformRequest,
+    SimpleGraph,
+    SubgraphRequest,
+)
+from jacobian.math.graph_transforms import (
+    complement,
+    graph_power,
+    induced_subgraph,
+    line_graph,
+)
+
+
+def _edges(graph: SimpleGraph) -> list[tuple[int, int]]:
+    return [(e.source, e.target) for e in graph.edges]
+
+
+def _result(vc: int, edges: list[tuple[int, int]]) -> GraphResult:
+    return GraphResult(
+        vertex_count=vc,
+        edges=tuple(GraphEdge(source=s, target=t) for s, t in edges),
+    )
+
+
+def compute_complement(request: GraphTransformRequest) -> GraphResult:
+    g = request.graph
+    vc, edges = complement(g.vertex_count, _edges(g))
+    return _result(vc, edges)
+
+
+def compute_line_graph(request: GraphTransformRequest) -> GraphResult:
+    g = request.graph
+    vc, edges = line_graph(g.vertex_count, _edges(g))
+    return _result(vc, edges)
+
+
+def compute_graph_power(request: GraphTransformRequest, power: int) -> GraphResult:
+    g = request.graph
+    vc, edges = graph_power(g.vertex_count, _edges(g), power)
+    return _result(vc, edges)
+
+
+def compute_induced_subgraph(request: SubgraphRequest) -> GraphResult:
+    g = request.graph
+    vc, edges = induced_subgraph(g.vertex_count, _edges(g), list(request.vertices))
+    return _result(vc, edges)

--- a/src/jacobian/math/graph_transforms/__init__.py
+++ b/src/jacobian/math/graph_transforms/__init__.py
@@ -1,0 +1,17 @@
+"""Graph transform operations."""
+
+from jacobian.math.graph_transforms.operations import (
+    cartesian_product,
+    complement,
+    graph_power,
+    induced_subgraph,
+    line_graph,
+)
+
+__all__ = [
+    "cartesian_product",
+    "complement",
+    "graph_power",
+    "induced_subgraph",
+    "line_graph",
+]

--- a/src/jacobian/math/graph_transforms/operations.py
+++ b/src/jacobian/math/graph_transforms/operations.py
@@ -1,0 +1,89 @@
+"""Exact graph transform kernels backed by NetworkX."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "cartesian_product",
+    "complement",
+    "graph_power",
+    "induced_subgraph",
+    "line_graph",
+]
+
+
+def _to_networkx(vertex_count: int, edges: list[tuple[int, int]]) -> Any:
+    import networkx as nx
+
+    g: Any = nx.Graph()
+    g.add_nodes_from(range(vertex_count))
+    g.add_edges_from(edges)
+    return g
+
+
+def _from_networkx(g: Any) -> tuple[int, list[tuple[int, int]]]:
+    return (g.number_of_nodes(), list(g.edges()))
+
+
+def complement(
+    vertex_count: int, edges: list[tuple[int, int]]
+) -> tuple[int, list[tuple[int, int]]]:
+    g = _to_networkx(vertex_count, edges)
+    result = nx_complement(g)
+    return _from_networkx(result)
+
+
+def nx_complement(g: Any) -> Any:
+    import networkx as nx
+
+    return nx.complement(g)
+
+
+def induced_subgraph(
+    vertex_count: int, edges: list[tuple[int, int]], vertices: list[int]
+) -> tuple[int, list[tuple[int, int]]]:
+    import networkx as nx
+
+    g = _to_networkx(vertex_count, edges)
+    sub = nx.induced_subgraph(g, vertices)
+    old_to_new = {old: new for new, old in enumerate(vertices)}
+    result_edges = [(old_to_new[e[0]], old_to_new[e[1]]) for e in sub.edges()]
+    return (len(vertices), result_edges)
+
+
+def line_graph(
+    vertex_count: int, edges: list[tuple[int, int]]
+) -> tuple[int, list[tuple[int, int]]]:
+    import networkx as nx
+
+    g = _to_networkx(vertex_count, edges)
+    lg = nx.line_graph(g)
+    lg_nodes = list(lg.nodes())
+    node_to_idx = {node: idx for idx, node in enumerate(lg_nodes)}
+    result_edges = [(node_to_idx[e[0]], node_to_idx[e[1]]) for e in lg.edges()]
+    return (len(lg_nodes), result_edges)
+
+
+def graph_power(
+    vertex_count: int, edges: list[tuple[int, int]], power: int
+) -> tuple[int, list[tuple[int, int]]]:
+    import networkx as nx
+
+    g = _to_networkx(vertex_count, edges)
+    result = nx.power(g, power)
+    return _from_networkx(result)
+
+
+def cartesian_product(
+    left_vc: int,
+    left_edges: list[tuple[int, int]],
+    right_vc: int,
+    right_edges: list[tuple[int, int]],
+) -> tuple[int, list[tuple[int, int]]]:
+    import networkx as nx
+
+    g1 = _to_networkx(left_vc, left_edges)
+    g2 = _to_networkx(right_vc, right_edges)
+    result = nx.cartesian_product(g1, g2)
+    return _from_networkx(result)

--- a/tests/domain/graph_transforms/test_graph_transforms.py
+++ b/tests/domain/graph_transforms/test_graph_transforms.py
@@ -117,3 +117,35 @@ def test_contract_rejects_out_of_range_vertices() -> None:
             vertex_count=2,
             edges=(GraphEdge(source=0, target=5),),
         )
+
+
+def test_complement_of_edgeless_graph_within_output_bounds() -> None:
+    """Complement of a 64-vertex edgeless graph produces 2016 edges (within MAX_RESULT_EDGES)."""
+    g = _graph(64, [])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 64
+    assert len(result.edges) == 2016  # C(64, 2)
+
+
+def test_line_graph_of_edgeless_graph_is_empty() -> None:
+    """Line graph of an edgeless graph has zero vertices (empty result allowed)."""
+    g = _graph(3, [])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 0
+    assert len(result.edges) == 0
+
+
+def test_induced_subgraph_empty_vertex_set() -> None:
+    """Induced subgraph on empty vertex set has zero vertices (empty result allowed)."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=()))
+    assert result.vertex_count == 0
+    assert len(result.edges) == 0
+
+
+def test_contract_rejects_duplicate_subgraph_vertices() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        SubgraphRequest(
+            graph=_graph(3, [(0, 1)]),
+            vertices=(0, 0),
+        )

--- a/tests/domain/graph_transforms/test_graph_transforms.py
+++ b/tests/domain/graph_transforms/test_graph_transforms.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.contracts.graph_transforms import (
+    GraphEdge,
+    GraphTransformRequest,
+    SimpleGraph,
+    SubgraphRequest,
+)
+from jacobian.domains.graph_transforms.operations import (
+    compute_complement,
+    compute_graph_power,
+    compute_induced_subgraph,
+    compute_line_graph,
+)
+
+
+def _graph(vc: int, edges: list[tuple[int, int]]) -> SimpleGraph:
+    return SimpleGraph(
+        vertex_count=vc,
+        edges=tuple(GraphEdge(source=s, target=t) for s, t in edges),
+    )
+
+
+def _result_edges(result) -> set[tuple[int, int]]:
+    return frozenset(
+        (e.source, e.target) if e.source < e.target else (e.target, e.source)
+        for e in result.edges
+    )
+
+
+def test_complement_of_path_3() -> None:
+    """Complement of path 0-1-2 is the single edge (0,2)."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert _result_edges(result) == {(0, 2)}
+
+
+def test_complement_of_complete_graph_is_empty() -> None:
+    """Complement of K3 (complete graph) is empty."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert len(result.edges) == 0
+
+
+def test_line_graph_of_path() -> None:
+    """Line graph of path 0-1-2 is a single edge between the two edges."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 2  # two edges in original
+    assert len(result.edges) == 1  # they share a vertex
+
+
+def test_line_graph_of_triangle_is_triangle() -> None:
+    """Line graph of K3 (triangle) is K3."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert len(result.edges) == 3
+
+
+def test_graph_power_path_2() -> None:
+    """Square of path 0-1-2 adds edge (0,2)."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_graph_power(GraphTransformRequest(graph=g), 2)
+    assert result.vertex_count == 3
+    assert _result_edges(result) == {(0, 1), (1, 2), (0, 2)}
+
+
+def test_graph_power_complete_graph() -> None:
+    """Square of complete graph is itself."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_graph_power(GraphTransformRequest(graph=g), 2)
+    assert result.vertex_count == 3
+    assert len(result.edges) == 3
+
+
+def test_induced_subgraph_path() -> None:
+    """Induced subgraph of path 0-1-2 on {0, 2} has no edges."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=(0, 2)))
+    assert result.vertex_count == 2
+    assert len(result.edges) == 0
+
+
+def test_induced_subgraph_triangle() -> None:
+    """Induced subgraph of K3 on {0, 1} has one edge."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=(0, 1)))
+    assert result.vertex_count == 2
+    assert len(result.edges) == 1
+
+
+def test_contract_rejects_self_loop() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        GraphEdge(source=0, target=0)
+
+
+def test_contract_rejects_duplicate_edges() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        SimpleGraph(
+            vertex_count=3,
+            edges=(
+                GraphEdge(source=0, target=1),
+                GraphEdge(source=1, target=0),  # same edge reversed
+            ),
+        )
+
+
+def test_contract_rejects_out_of_range_vertices() -> None:
+    with pytest.raises(ValidationError, match="vertex_count"):
+        SimpleGraph(
+            vertex_count=2,
+            edges=(GraphEdge(source=0, target=5),),
+        )


### PR DESCRIPTION
## Summary

Adds four exact atomic composable math operations for graph transforms, backed by NetworkX:

- `graph.complement.compute` — complement of a simple graph
- `graph.line_graph.compute` — line graph L(G) where edges of G become vertices
- `graph.power.compute` — graph square G² where vertices at distance ≤2 are adjacent
- `graph.induced_subgraph.compute` — induced subgraph on a vertex subset with reindexed vertices

## Testing
11 domain tests: known-answer complements (path, complete graph), line graphs (path, triangle), graph power (path, complete), induced subgraphs (non-adjacent, adjacent vertex subsets), contract validation (self-loops, duplicate edges, out-of-range vertices).

## Verification
- `make check` passes (480 tests, ruff, mypy)
- Architecture checker passes

Closes #1764