### PR TITLE
feat(math): extract 8 closed math PRs with review-thread root-cause fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ root_package = "jacobian"
 name = "The public math library does not depend on product layers"
 type = "forbidden"
 source_modules = [
+    "jacobian.math.algebraic_combinatorics.operations",
     "jacobian.math.arithmetic.operations",
     "jacobian.math.boolean.operations",
     "jacobian.math.certified_snf.operations",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ source_modules = [
     "jacobian.math.projective_geometry.values",
     "jacobian.math.real_quadratic",
     "jacobian.math.recurrence_solving.operations",
+    "jacobian.math.regular_languages.operations",
+    "jacobian.math.regular_languages.values",
     "jacobian.math.root_isolation.operations",
     "jacobian.math.symbolic_matrix.operations",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ type = "forbidden"
 source_modules = [
     "jacobian.math.arithmetic.operations",
     "jacobian.math.boolean.operations",
+    "jacobian.math.canonical_forms.operations",
     "jacobian.math.certified_snf.operations",
     "jacobian.math.certified_snf.values",
     "jacobian.math.code_theory.operations",

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -36,6 +36,7 @@ from jacobian.math.graph_polynomials._tools import TOOLS as GRAPH_POLYNOMIALS_TO
 from jacobian.math.graph_realization._tools import TOOLS as GRAPH_REALIZATION_TOOLS
 from jacobian.math.graph_spectral._tools import TOOLS as GRAPH_SPECTRAL_TOOLS
 from jacobian.math.graph_symmetry._tools import TOOLS as GRAPH_SYMMETRY_TOOLS
+from jacobian.math.graph_transforms._tools import TOOLS as GRAPH_TRANSFORMS_TOOLS
 from jacobian.math.graphs._tools import TOOLS as GRAPHS_TOOLS
 from jacobian.math.group._tools import TOOLS as GROUP_TOOLS
 from jacobian.math.lattices._tools import TOOLS as LATTICES_TOOLS
@@ -91,6 +92,7 @@ BUILTIN_TOOLS: MathTools = (
     *GRAPH_OPTIMIZATION_TOOLS,
     *GRAPHS_TOOLS,
     *GRAPH_SYMMETRY_TOOLS,
+    *GRAPH_TRANSFORMS_TOOLS,
     *CERTIFIED_SNF_TOOLS,
     *MATRICES_TOOLS,
     *SYMBOLIC_MATRIX_TOOLS,

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -20,6 +20,9 @@ from jacobian.math.combinatorics._tools import TOOLS as COMBINATORICS_TOOLS
 from jacobian.math.convex_analysis._tools import TOOLS as CONVEX_ANALYSIS_TOOLS
 from jacobian.math.directed_graph._tools import TOOLS as DIRECTED_GRAPH_TOOLS
 from jacobian.math.discrepancy_theory._tools import TOOLS as DISCREPANCY_THEORY_TOOLS
+from jacobian.math.electrical_networks._tools import (
+    TOOLS as ELECTRICAL_NETWORKS_TOOLS,
+)
 from jacobian.math.euclidean_geometry._tools import TOOLS as EUCLIDEAN_GEOMETRY_TOOLS
 from jacobian.math.exact_geometry._tools import TOOLS as EXACT_GEOMETRY_TOOLS
 from jacobian.math.finite_fields._tools import TOOLS as FINITE_FIELDS_TOOLS
@@ -121,6 +124,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *ELECTRICAL_NETWORKS_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -14,6 +14,7 @@ from jacobian.math.arithmetic_functions._tools import (
 )
 from jacobian.math.boolean._tools import TOOLS as BOOLEAN_TOOLS
 from jacobian.math.boolean_analysis._tools import TOOLS as BOOLEAN_ANALYSIS_TOOLS
+from jacobian.math.canonical_forms._tools import TOOLS as CANONICAL_FORMS_TOOLS
 from jacobian.math.certified_snf._tools import TOOLS as CERTIFIED_SNF_TOOLS
 from jacobian.math.code_theory._tools import TOOLS as CODE_THEORY_TOOLS
 from jacobian.math.combinatorics._tools import TOOLS as COMBINATORICS_TOOLS
@@ -93,6 +94,7 @@ BUILTIN_TOOLS: MathTools = (
     *GRAPH_SYMMETRY_TOOLS,
     *CERTIFIED_SNF_TOOLS,
     *MATRICES_TOOLS,
+    *CANONICAL_FORMS_TOOLS,
     *SYMBOLIC_MATRIX_TOOLS,
     *RATIONAL_LINEAR_TOOLS,
     *LATTICES_TOOLS,

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -60,6 +60,7 @@ from jacobian.math.probability._tools import TOOLS as PROBABILITY_TOOLS
 from jacobian.math.projective_geometry._tools import TOOLS as PROJECTIVE_GEOMETRY_TOOLS
 from jacobian.math.rational_linear._tools import TOOLS as RATIONAL_LINEAR_TOOLS
 from jacobian.math.recurrence_solving._tools import TOOLS as RECURRENCE_SOLVING_TOOLS
+from jacobian.math.regular_languages._tools import TOOLS as REGULAR_LANGUAGES_TOOLS
 from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
@@ -121,6 +122,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *REGULAR_LANGUAGES_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -24,6 +24,9 @@ from jacobian.math.euclidean_geometry._tools import TOOLS as EUCLIDEAN_GEOMETRY_
 from jacobian.math.exact_geometry._tools import TOOLS as EXACT_GEOMETRY_TOOLS
 from jacobian.math.finite_fields._tools import TOOLS as FINITE_FIELDS_TOOLS
 from jacobian.math.finite_game_theory._tools import TOOLS as FINITE_GAME_THEORY_TOOLS
+from jacobian.math.finite_metric_spaces._tools import (
+    TOOLS as FINITE_METRIC_SPACES_TOOLS,
+)
 from jacobian.math.finite_sets._tools import TOOLS as FINITE_SETS_TOOLS
 from jacobian.math.formal_power_series._tools import TOOLS as FORMAL_POWER_SERIES_TOOLS
 from jacobian.math.geometry._tools import TOOLS as GEOMETRY_TOOLS
@@ -121,6 +124,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *FINITE_METRIC_SPACES_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -6,6 +6,9 @@ from jacobian.catalog.models import MathTools
 from jacobian.math.additive_combinatorics._tools import (
     TOOLS as ADDITIVE_COMBINATORICS_TOOLS,
 )
+from jacobian.math.algebraic_combinatorics._tools import (
+    TOOLS as ALGEBRAIC_COMBINATORICS_TOOLS,
+)
 from jacobian.math.analysis._tools import TOOLS as ANALYSIS_TOOLS
 from jacobian.math.arithmetic._tools import TOOLS as ARITHMETIC_TOOLS
 from jacobian.math.arithmetic_counting._tools import TOOLS as ARITHMETIC_COUNTING_TOOLS
@@ -121,6 +124,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *ALGEBRAIC_COMBINATORICS_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -18,6 +18,9 @@ from jacobian.math.certified_snf._tools import TOOLS as CERTIFIED_SNF_TOOLS
 from jacobian.math.code_theory._tools import TOOLS as CODE_THEORY_TOOLS
 from jacobian.math.combinatorics._tools import TOOLS as COMBINATORICS_TOOLS
 from jacobian.math.convex_analysis._tools import TOOLS as CONVEX_ANALYSIS_TOOLS
+from jacobian.math.diophantine_approximation._tools import (
+    TOOLS as DIOPHANTINE_APPROXIMATION_TOOLS,
+)
 from jacobian.math.directed_graph._tools import TOOLS as DIRECTED_GRAPH_TOOLS
 from jacobian.math.discrepancy_theory._tools import TOOLS as DISCREPANCY_THEORY_TOOLS
 from jacobian.math.euclidean_geometry._tools import TOOLS as EUCLIDEAN_GEOMETRY_TOOLS
@@ -81,6 +84,7 @@ BUILTIN_TOOLS: MathTools = (
     *MARKOV_CHAIN_TOOLS,
     *ARITHMETIC_TOOLS,
     *NUMBER_THEORY_TOOLS,
+    *DIOPHANTINE_APPROXIMATION_TOOLS,
     *COMBINATORICS_TOOLS,
     *FINITE_SETS_TOOLS,
     *FINITE_FIELDS_TOOLS,

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -59,6 +59,7 @@ from jacobian.math.posets._tools import TOOLS as POSETS_TOOLS
 from jacobian.math.probability._tools import TOOLS as PROBABILITY_TOOLS
 from jacobian.math.projective_geometry._tools import TOOLS as PROJECTIVE_GEOMETRY_TOOLS
 from jacobian.math.rational_linear._tools import TOOLS as RATIONAL_LINEAR_TOOLS
+from jacobian.math.real_algebra._tools import TOOLS as REAL_ALGEBRA_TOOLS
 from jacobian.math.recurrence_solving._tools import TOOLS as RECURRENCE_SOLVING_TOOLS
 from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
@@ -121,6 +122,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *REAL_ALGEBRA_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/math/algebraic_combinatorics/__init__.py
+++ b/src/jacobian/math/algebraic_combinatorics/__init__.py
@@ -1,0 +1,13 @@
+"""Algebraic combinatorics operations."""
+
+from jacobian.math.algebraic_combinatorics.operations import (
+    conjugate_partition,
+    hook_lengths,
+    standard_young_tableaux_count,
+)
+
+__all__ = [
+    "conjugate_partition",
+    "hook_lengths",
+    "standard_young_tableaux_count",
+]

--- a/src/jacobian/math/algebraic_combinatorics/_models.py
+++ b/src/jacobian/math/algebraic_combinatorics/_models.py
@@ -1,0 +1,81 @@
+"""Typed wire contracts for exact algebraic combinatorics operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+
+MAX_PARTITION_SIZE = 50
+MAX_PARTS = 50
+
+
+class Partition(StrictModel):
+    """One decreasing sequence of positive integers (a Young diagram shape)."""
+
+    parts: tuple[StrictInt, ...] = Field(min_length=1, max_length=MAX_PARTS)
+
+    @model_validator(mode="after")
+    def require_decreasing_positive(self) -> Self:
+        if any(part <= 0 for part in self.parts):
+            raise ValueError("partition parts must be positive")
+        if any(self.parts[i] < self.parts[i + 1] for i in range(len(self.parts) - 1)):
+            raise ValueError("partition parts must be non-increasing")
+        if sum(self.parts) > MAX_PARTITION_SIZE:
+            raise ValueError(f"partition size must not exceed {MAX_PARTITION_SIZE}")
+        return self
+
+
+class HookLengthRequest(StrictModel):
+    """Compute the hook lengths of a partition."""
+
+    partition: Partition
+
+
+class StandardYoungTableauCountRequest(StrictModel):
+    """Count standard Young tableaux of a given shape."""
+
+    partition: Partition
+
+
+class ConjugatePartitionRequest(StrictModel):
+    """Compute the conjugate (transpose) partition."""
+
+    partition: Partition
+
+
+class HookLengthResult(StrictModel):
+    """Hook lengths as a flat list of row-indexed values."""
+
+    hooks: tuple[tuple[int, ...], ...] = Field(min_length=1)
+    total_product: CanonicalInteger = Field(description="Product of all hook lengths.")
+    method: Literal["HOOK_FORMULA"] = "HOOK_FORMULA"
+
+
+class StandardYoungTableauCountResult(StrictModel):
+    """The number of standard Young tableaux of a given shape."""
+
+    count: CanonicalInteger = Field(description="Number of standard Young tableaux.")
+    n: int = Field(ge=1, le=MAX_PARTITION_SIZE)
+    method: Literal["HOOK_LENGTH_FORMULA"] = "HOOK_LENGTH_FORMULA"
+
+
+class ConjugatePartitionResult(StrictModel):
+    """The conjugate (transpose) partition."""
+
+    conjugate: tuple[int, ...] = Field(min_length=1)
+    method: Literal["FERRERS_TRANSPOSE"] = "FERRERS_TRANSPOSE"
+
+
+__all__ = [
+    "ConjugatePartitionRequest",
+    "ConjugatePartitionResult",
+    "HookLengthRequest",
+    "HookLengthResult",
+    "Partition",
+    "StandardYoungTableauCountRequest",
+    "StandardYoungTableauCountResult",
+]

--- a/src/jacobian/math/algebraic_combinatorics/_operations.py
+++ b/src/jacobian/math/algebraic_combinatorics/_operations.py
@@ -1,0 +1,48 @@
+"""Domain-owned algebraic combinatorics operation adapters."""
+
+from __future__ import annotations
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.algebraic_combinatorics import (
+    conjugate_partition,
+    hook_lengths,
+    standard_young_tableaux_count,
+)
+from jacobian.math.algebraic_combinatorics._models import (
+    ConjugatePartitionRequest,
+    ConjugatePartitionResult,
+    HookLengthRequest,
+    HookLengthResult,
+    StandardYoungTableauCountRequest,
+    StandardYoungTableauCountResult,
+)
+
+
+def compute_hook_lengths(request: HookLengthRequest) -> HookLengthResult:
+    parts = list(request.partition.parts)
+    hooks = hook_lengths(parts)
+    total_product = 1
+    for row in hooks:
+        for hook in row:
+            total_product *= hook
+    return HookLengthResult(
+        hooks=tuple(tuple(row) for row in hooks),
+        total_product=format_canonical_integer(total_product),
+    )
+
+
+def compute_syt_count(
+    request: StandardYoungTableauCountRequest,
+) -> StandardYoungTableauCountResult:
+    parts = list(request.partition.parts)
+    count = standard_young_tableaux_count(parts)
+    n = sum(parts)
+    return StandardYoungTableauCountResult(count=format_canonical_integer(count), n=n)
+
+
+def compute_conjugate_partition(
+    request: ConjugatePartitionRequest,
+) -> ConjugatePartitionResult:
+    parts = list(request.partition.parts)
+    result = conjugate_partition(parts)
+    return ConjugatePartitionResult(conjugate=tuple(result))

--- a/src/jacobian/math/algebraic_combinatorics/_tools.py
+++ b/src/jacobian/math/algebraic_combinatorics/_tools.py
@@ -1,0 +1,112 @@
+"""Algebraic combinatorics operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.algebraic_combinatorics._models import (
+    ConjugatePartitionRequest,
+    ConjugatePartitionResult,
+    HookLengthRequest,
+    HookLengthResult,
+    StandardYoungTableauCountRequest,
+    StandardYoungTableauCountResult,
+)
+from jacobian.math.algebraic_combinatorics._operations import (
+    compute_conjugate_partition,
+    compute_hook_lengths,
+    compute_syt_count,
+)
+
+
+def ac_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_PARTITION_321 = {"partition": {"parts": [3, 2, 1]}}
+
+ALGEBRAIC_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    ac_operation(
+        "combinatorics.hook_length.compute",
+        "Compute hook lengths of a Young diagram",
+        "Compute the hook length H(i,j) = lambda_i - j + lambda'_j - i + 1 "
+        "for each cell (i,j) of the Young diagram of a partition.",
+        HookLengthRequest,
+        HookLengthResult,
+        compute_hook_lengths,
+        "combinatorics",
+        "hook-length",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Hook lengths of partition (3, 2, 1).",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+    ac_operation(
+        "combinatorics.standard_young_tableaux.count",
+        "Count standard Young tableaux via the hook length formula",
+        "Count the number of standard Young tableaux of a given shape using "
+        "the hook length formula: f^lambda = n! / product of hook lengths.",
+        StandardYoungTableauCountRequest,
+        StandardYoungTableauCountResult,
+        compute_syt_count,
+        "combinatorics",
+        "young-tableaux",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Number of SYT for shape (3, 2, 1) is 16.",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+    ac_operation(
+        "combinatorics.conjugate_partition.compute",
+        "Compute the conjugate (transpose) partition",
+        "Compute the conjugate partition lambda' by transposing the Ferrers "
+        "diagram of a partition lambda.",
+        ConjugatePartitionRequest,
+        ConjugatePartitionResult,
+        compute_conjugate_partition,
+        "combinatorics",
+        "partition",
+        "exact",
+        examples=(
+            example(
+                "partition_321",
+                "Conjugate of partition (3, 2, 1) is (3, 2, 1).",
+                _PARTITION_321,
+            ),
+        ),
+    ),
+)
+
+TOOLS = ALGEBRAIC_COMBINATORICS_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/algebraic_combinatorics/operations.py
+++ b/src/jacobian/math/algebraic_combinatorics/operations.py
@@ -1,0 +1,67 @@
+"""Exact algebraic combinatorics kernels over Young diagrams.
+
+The kernels operate on a partition ``lambda`` represented as a non-increasing
+tuple/list of positive integers.  They use only exact integer arithmetic and
+are private implementation details of the public operations.
+"""
+
+from __future__ import annotations
+
+from math import factorial
+
+__all__ = [
+    "conjugate_partition",
+    "hook_lengths",
+    "standard_young_tableaux_count",
+]
+
+
+def conjugate_partition(parts: list[int]) -> list[int]:
+    """Compute the conjugate (transpose) partition.
+
+    The conjugate ``lambda'`` has ``lambda'_j`` equal to the number of parts of
+    ``lambda`` that are at least ``j``, i.e. the column heights of the Ferrers
+    diagram.
+    """
+    if not parts:
+        return []
+    max_column = parts[0]
+    return [
+        sum(1 for part in parts if part >= column)
+        for column in range(1, max_column + 1)
+    ]
+
+
+def hook_lengths(parts: list[int]) -> list[list[int]]:
+    """Compute the hook length of every cell of the Young diagram.
+
+    The hook length of cell ``(i, j)`` (0-indexed) is
+    ``lambda_i - j + lambda'_j - i - 1``: one arm step plus the cell itself
+    plus the number of cells below it in its column.
+    """
+    conjugate = conjugate_partition(parts)
+    hooks: list[list[int]] = []
+    for row, length in enumerate(parts):
+        row_hooks: list[int] = []
+        for column in range(length):
+            right = length - column - 1
+            below = conjugate[column] - row - 1
+            row_hooks.append(right + below + 1)
+        hooks.append(row_hooks)
+    return hooks
+
+
+def standard_young_tableaux_count(parts: list[int]) -> int:
+    """Count standard Young tableaux via the hook length formula.
+
+    The number of standard Young tableaux of shape ``lambda`` is
+    ``n! / prod_{(i,j) in lambda} h(i,j)`` where ``n = |lambda|`` and
+    ``h(i,j)`` is the cell's hook length.
+    """
+    hooks = hook_lengths(parts)
+    n = sum(parts)
+    product = 1
+    for row in hooks:
+        for hook in row:
+            product *= hook
+    return factorial(n) // product

--- a/src/jacobian/math/canonical_forms/__init__.py
+++ b/src/jacobian/math/canonical_forms/__init__.py
@@ -1,0 +1,29 @@
+"""Exact canonical-form kernels and typed contracts over QQ."""
+
+from jacobian.math.canonical_forms._models import (
+    InvariantFactorEntry,
+    MinimalPolynomialResult,
+    MonicPolynomial,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
+    SquareMatrixRequest,
+)
+from jacobian.math.canonical_forms.operations import (
+    characteristic_polynomial,
+    invariant_factors,
+    minimal_polynomial,
+    primary_decomposition,
+)
+
+__all__ = [
+    "InvariantFactorEntry",
+    "MinimalPolynomialResult",
+    "MonicPolynomial",
+    "PrimaryDecompositionResult",
+    "RationalCanonicalFormResult",
+    "SquareMatrixRequest",
+    "characteristic_polynomial",
+    "invariant_factors",
+    "minimal_polynomial",
+    "primary_decomposition",
+]

--- a/src/jacobian/math/canonical_forms/_models.py
+++ b/src/jacobian/math/canonical_forms/_models.py
@@ -1,0 +1,98 @@
+"""Typed wire contracts for exact canonical-form operations over QQ."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.matrices.values import RationalMatrix, require_matrix_scalar_digits
+
+MAX_CANONICAL_FORM_DIMENSION = 16
+MAX_CANONICAL_FORM_SCALAR_DIGITS = 256
+
+
+class SquareMatrixRequest(StrictModel):
+    """One square rational matrix bounded for canonical-form computation."""
+
+    matrix: RationalMatrix
+
+    @model_validator(mode="after")
+    def require_bounded_square(self) -> Self:
+        rows = len(self.matrix.entries)
+        columns = len(self.matrix.entries[0])
+        if rows != columns:
+            raise ValueError("canonical-form operations require a square matrix")
+        if rows > MAX_CANONICAL_FORM_DIMENSION:
+            raise ValueError(
+                "canonical-form operations are bounded to 16 x 16 matrices"
+            )
+        require_matrix_scalar_digits(
+            self.matrix.entries,
+            maximum=MAX_CANONICAL_FORM_SCALAR_DIGITS,
+            label="canonical-form matrix",
+        )
+        return self
+
+
+class MonicPolynomial(StrictModel):
+    """One monic univariate polynomial over QQ, as increasing-degree coefficients."""
+
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_CANONICAL_FORM_DIMENSION + 1,
+    )
+
+    @model_validator(mode="after")
+    def require_monic(self) -> Self:
+        if self.coefficients[-1].as_fraction() != 1:
+            raise ValueError("polynomial must be monic (leading coefficient = 1)")
+        return self
+
+
+class MinimalPolynomialResult(StrictModel):
+    """Exact minimal polynomial of a square rational matrix."""
+
+    minimal_polynomial: MonicPolynomial
+    characteristic_polynomial: MonicPolynomial
+    degree: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+    method: Literal["KRYLOV_NULLSPACE"] = "KRYLOV_NULLSPACE"
+
+
+class InvariantFactorEntry(StrictModel):
+    """One monic invariant factor from the rational canonical form."""
+
+    factor: MonicPolynomial
+    block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+
+
+class RationalCanonicalFormResult(StrictModel):
+    """Exact rational (Frobenius) canonical form of a square rational matrix."""
+
+    invariant_factors: tuple[InvariantFactorEntry, ...] = Field(min_length=1)
+    characteristic_polynomial: MonicPolynomial
+    minimal_polynomial: MonicPolynomial
+    total_block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
+    method: Literal["SMITH_NORMAL_FORM"] = "SMITH_NORMAL_FORM"
+
+
+class PrimaryDecompositionResult(StrictModel):
+    """Primary decomposition of the minimal polynomial into irreducible-power components."""
+
+    components: tuple[MonicPolynomial, ...] = Field(min_length=1)
+    minimal_polynomial: MonicPolynomial
+    method: Literal["FACTOR_LCM"] = "FACTOR_LCM"
+
+
+__all__ = [
+    "MAX_CANONICAL_FORM_DIMENSION",
+    "MAX_CANONICAL_FORM_SCALAR_DIGITS",
+    "InvariantFactorEntry",
+    "MinimalPolynomialResult",
+    "MonicPolynomial",
+    "PrimaryDecompositionResult",
+    "RationalCanonicalFormResult",
+    "SquareMatrixRequest",
+]

--- a/src/jacobian/math/canonical_forms/_operations.py
+++ b/src/jacobian/math/canonical_forms/_operations.py
@@ -1,0 +1,89 @@
+"""Domain adapter for exact canonical-form operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.canonical_forms import (
+    characteristic_polynomial,
+    invariant_factors,
+    minimal_polynomial,
+    primary_decomposition,
+)
+from jacobian.math.canonical_forms._models import (
+    InvariantFactorEntry,
+    MinimalPolynomialResult,
+    MonicPolynomial,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
+    SquareMatrixRequest,
+)
+
+
+def _matrix_entries(
+    request: SquareMatrixRequest,
+) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(
+        tuple(value.as_fraction() for value in row) for row in request.matrix.entries
+    )
+
+
+def _to_monic_polynomial(coefficients: Sequence[Fraction]) -> MonicPolynomial:
+    return MonicPolynomial(
+        coefficients=tuple(
+            CanonicalRational.from_fraction(coefficient) for coefficient in coefficients
+        )
+    )
+
+
+def compute_minimal_polynomial(
+    request: SquareMatrixRequest,
+) -> MinimalPolynomialResult:
+    entries = _matrix_entries(request)
+    minimal = minimal_polynomial(entries)
+    characteristic = characteristic_polynomial(entries)
+    return MinimalPolynomialResult(
+        minimal_polynomial=_to_monic_polynomial(minimal),
+        characteristic_polynomial=_to_monic_polynomial(characteristic),
+        degree=len(minimal) - 1,
+    )
+
+
+def compute_rational_canonical_form(
+    request: SquareMatrixRequest,
+) -> RationalCanonicalFormResult:
+    entries = _matrix_entries(request)
+    factors = invariant_factors(entries)
+    minimal = minimal_polynomial(entries)
+    characteristic = characteristic_polynomial(entries)
+
+    invariant_entries = tuple(
+        InvariantFactorEntry(
+            factor=_to_monic_polynomial(coefficients),
+            block_size=len(coefficients) - 1,
+        )
+        for coefficients in factors
+    )
+
+    return RationalCanonicalFormResult(
+        invariant_factors=invariant_entries,
+        characteristic_polynomial=_to_monic_polynomial(characteristic),
+        minimal_polynomial=_to_monic_polynomial(minimal),
+        total_block_size=sum(entry.block_size for entry in invariant_entries),
+    )
+
+
+def compute_primary_decomposition(
+    request: SquareMatrixRequest,
+) -> PrimaryDecompositionResult:
+    entries = _matrix_entries(request)
+    components = primary_decomposition(entries)
+    minimal = minimal_polynomial(entries)
+    return PrimaryDecompositionResult(
+        components=tuple(
+            _to_monic_polynomial(coefficient) for coefficient in components
+        ),
+        minimal_polynomial=_to_monic_polynomial(minimal),
+    )

--- a/src/jacobian/math/canonical_forms/_tools.py
+++ b/src/jacobian/math/canonical_forms/_tools.py
@@ -1,0 +1,130 @@
+"""Exact canonical-form operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.canonical_forms._models import (
+    MinimalPolynomialResult,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
+    SquareMatrixRequest,
+)
+from jacobian.math.canonical_forms._operations import (
+    compute_minimal_polynomial,
+    compute_primary_decomposition,
+    compute_rational_canonical_form,
+)
+
+
+def canonical_form_operation[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+TOOLS: MathTools = (
+    canonical_form_operation(
+        "matrix.minimal_polynomial.compute",
+        "Compute the exact minimal polynomial of a square rational matrix",
+        "Compute the monic minimal polynomial over QQ by the Krylov/nullspace "
+        "method, returning the exact minimal and characteristic polynomials.",
+        SquareMatrixRequest,
+        MinimalPolynomialResult,
+        compute_minimal_polynomial,
+        "matrix",
+        "minimal-polynomial",
+        "exact",
+        examples=(
+            example(
+                "nilpotent_block",
+                "Minimal polynomial of a 2x2 nilpotent Jordan block is t^2.",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "0", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    canonical_form_operation(
+        "matrix.rational_canonical_form.compute",
+        "Compute the exact rational (Frobenius) canonical form",
+        "Compute the invariant factors, characteristic polynomial, and minimal "
+        "polynomial of a square rational matrix via Smith normal form of tI - A "
+        "over QQ[t].",
+        SquareMatrixRequest,
+        RationalCanonicalFormResult,
+        compute_rational_canonical_form,
+        "matrix",
+        "rational-canonical-form",
+        "exact",
+        examples=(
+            example(
+                "diagonal_distinct",
+                "Rational canonical form of diag(2,3) has one invariant factor (t-2)(t-3).",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "2", "den": "1"}, {"num": "0", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "3", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    canonical_form_operation(
+        "matrix.primary_decomposition.compute",
+        "Decompose the minimal polynomial into irreducible-power components",
+        "Factor the minimal polynomial over QQ into its irreducible-power "
+        "components and return each monic component polynomial.",
+        SquareMatrixRequest,
+        PrimaryDecompositionResult,
+        compute_primary_decomposition,
+        "matrix",
+        "primary-decomposition",
+        "exact",
+        examples=(
+            example(
+                "diagonal_distinct",
+                "Primary decomposition of diag(2,3) gives (t-2) and (t-3).",
+                {
+                    "matrix": {
+                        "entries": [
+                            [{"num": "2", "den": "1"}, {"num": "0", "den": "1"}],
+                            [{"num": "0", "den": "1"}, {"num": "3", "den": "1"}],
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/canonical_forms/operations.py
+++ b/src/jacobian/math/canonical_forms/operations.py
@@ -1,0 +1,155 @@
+"""Exact canonical-form kernels backed by SymPy polynomial algebra."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from fractions import Fraction
+from typing import Any
+
+__all__ = [
+    "characteristic_polynomial",
+    "invariant_factors",
+    "minimal_polynomial",
+    "primary_decomposition",
+]
+
+RationalEntries = Sequence[Sequence[Fraction]]
+CoefficientList = tuple[Fraction, ...]
+
+
+def _square_dimension(entries: RationalEntries) -> int:
+    """Return the shared side length of a nonempty square entry matrix."""
+
+    dimension = len(entries)
+    if dimension == 0:
+        raise ValueError("canonical-form operations require a nonempty square matrix")
+    if any(len(row) != dimension for row in entries):
+        raise ValueError("canonical-form operations require a square matrix")
+    return dimension
+
+
+def _sympy_matrix(entries: RationalEntries) -> Any:
+    from sympy import Matrix, Rational
+
+    return Matrix(
+        [
+            [Rational(entry.numerator, entry.denominator) for entry in row]
+            for row in entries
+        ]
+    )
+
+
+def _to_fraction(value: Any) -> Fraction:
+    from sympy import Rational
+
+    if not isinstance(value, Rational):
+        raise ValueError("canonical-form backend returned a non-rational value")
+    return Fraction(int(value.p), int(value.q))
+
+
+def _coefficients(poly: Any) -> CoefficientList:
+    """Return a monic polynomial's increasing-degree rational coefficients."""
+
+    return tuple(
+        _to_fraction(coefficient) for coefficient in reversed(poly.all_coeffs())
+    )
+
+
+def characteristic_polynomial(entries: RationalEntries) -> CoefficientList:
+    """Return the monic characteristic polynomial coefficients [a_0, ..., a_n]."""
+
+    from sympy import Poly, Symbol
+
+    x = Symbol("x")
+    _square_dimension(entries)
+    matrix = _sympy_matrix(entries)
+    charpoly = matrix.charpoly(x)
+    return _coefficients(Poly(charpoly.as_expr(), x))
+
+
+def minimal_polynomial(entries: RationalEntries) -> CoefficientList:
+    """Compute the minimal polynomial via the Krylov/nullspace method.
+
+    Returns the monic minimal polynomial as coefficient list [a_0, ..., a_n].
+    """
+
+    from sympy import Matrix, Poly, Symbol, eye
+
+    x = Symbol("x")
+    n = _square_dimension(entries)
+    matrix = _sympy_matrix(entries)
+
+    powers = [eye(n)]
+    for _ in range(n):
+        powers.append(powers[-1] * matrix)
+
+    rows = [[mat[i, j] for i in range(n) for j in range(n)] for mat in powers]
+    stacked = Matrix(rows).T
+
+    _reduced, pivots = stacked.rref()
+    degree = next((index for index in range(n + 1) if index not in pivots), None)
+    if degree is None:
+        raise ArithmeticError("Krylov subspace exceeded the Cayley-Hamilton bound")
+    if degree == 0:
+        return (Fraction(1),)
+
+    submatrix = stacked[:, : degree + 1]
+    null_vectors = submatrix.nullspace()
+    if not null_vectors:
+        raise ArithmeticError(
+            "Krylov subspace produced no minimal polynomial dependency"
+        )
+
+    coefficients = null_vectors[0]
+    dependency = sum(coefficients[index] * x**index for index in range(degree + 1))
+    return _coefficients(Poly(dependency, x).monic())
+
+
+def invariant_factors(entries: RationalEntries) -> tuple[CoefficientList, ...]:
+    """Compute the non-unit invariant factors over QQ[x].
+
+    Returns a list of monic polynomial coefficient lists, ordered by divisibility:
+    f_1 | f_2 | ... | f_s.
+    """
+
+    from sympy import QQ, Poly, Symbol, eye
+    from sympy.matrices.normalforms import smith_normal_form
+
+    x = Symbol("x")
+    n = _square_dimension(entries)
+    matrix = _sympy_matrix(entries)
+    characteristic_matrix = x * eye(n) - matrix
+    smith = smith_normal_form(characteristic_matrix, domain=QQ[x])
+
+    factors: list[CoefficientList] = []
+    for index in range(n):
+        diagonal = smith[index, index]
+        if diagonal == 0:
+            continue
+        factor = Poly(diagonal, x).monic()
+        if factor.degree() >= 1:
+            factors.append(_coefficients(factor))
+    return tuple(factors)
+
+
+def primary_decomposition(entries: RationalEntries) -> tuple[CoefficientList, ...]:
+    """Decompose the minimal polynomial into irreducible-power components.
+
+    Returns a list of monic polynomial coefficient lists, one for each
+    irreducible factor raised to its multiplicity in the minimal polynomial.
+    """
+
+    from sympy import Poly, Symbol, factor_list
+
+    x = Symbol("x")
+    minimal_coefficients = minimal_polynomial(entries)
+    minimal_expression = sum(
+        coefficient * x**index for index, coefficient in enumerate(minimal_coefficients)
+    )
+    _constant, factors = factor_list(minimal_expression, x)
+
+    components: list[CoefficientList] = []
+    for factor, power in factors:
+        monic = Poly(factor, x).monic()
+        components.append(_coefficients(monic**power))
+    return tuple(components)

--- a/src/jacobian/math/diophantine_approximation/__init__.py
+++ b/src/jacobian/math/diophantine_approximation/__init__.py
@@ -1,0 +1,9 @@
+"""Exact Diophantine approximation operations."""
+
+from jacobian.math.diophantine_approximation.operations import (
+    continued_fraction,
+    convergents,
+    solve_pell,
+)
+
+__all__ = ["continued_fraction", "convergents", "solve_pell"]

--- a/src/jacobian/math/diophantine_approximation/_models.py
+++ b/src/jacobian/math/diophantine_approximation/_models.py
@@ -1,0 +1,117 @@
+"""Typed wire contracts for exact Diophantine approximation operations."""
+
+from __future__ import annotations
+
+from math import isqrt
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+
+_MAX_DISCRIMINANT = 10_000
+_MAX_TERMS = 500
+
+
+def _is_square_free(value: int) -> bool:
+    return all(value % (divisor * divisor) for divisor in range(2, isqrt(value) + 1))
+
+
+class SquarefreeRequest(StrictModel):
+    """One positive squarefree integer D for sqrt(D) operations."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
+
+
+class ContinuedFractionRequest(StrictModel):
+    """Request the continued fraction expansion of sqrt(D) up to n terms."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    term_count: StrictInt = Field(ge=1, le=_MAX_TERMS)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
+
+
+class ContinuedFractionResult(StrictModel):
+    """The continued fraction [a_0; a_1, ...] of sqrt(D)."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    coefficients: tuple[StrictInt, ...] = Field(min_length=1, max_length=_MAX_TERMS)
+    preperiod_length: StrictInt = Field(ge=1)
+    period_length: StrictInt = Field(ge=1)
+    method: Literal["SYMPY_CONTINUED_FRACTION"] = "SYMPY_CONTINUED_FRACTION"
+
+
+class ConvergentRequest(StrictModel):
+    """Request the first n convergents p_n/q_n of sqrt(D)."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    convergent_count: StrictInt = Field(ge=1, le=_MAX_TERMS)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
+
+
+class ConvergentValue(StrictModel):
+    """One convergent p_n/q_n with index n."""
+
+    index: StrictInt = Field(ge=0)
+    numerator: CanonicalInteger
+    denominator: CanonicalInteger
+
+
+class ConvergentResult(StrictModel):
+    """Convergents of sqrt(D)."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    convergents: tuple[ConvergentValue, ...] = Field(
+        min_length=1, max_length=_MAX_TERMS
+    )
+    method: Literal["CONTINUED_FRACTION_RECURSION"] = "CONTINUED_FRACTION_RECURSION"
+
+
+class PellEquationRequest(StrictModel):
+    """Solve x^2 - D*y^2 = 1 for the fundamental solution."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
+
+
+class PellEquationResult(StrictModel):
+    """The fundamental solution (x, y) to x^2 - D*y^2 = 1."""
+
+    discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    x: CanonicalInteger
+    y: CanonicalInteger
+    method: Literal["CONTINUED_FRACTION_CONVERGENTS"] = "CONTINUED_FRACTION_CONVERGENTS"
+
+
+__all__ = [
+    "ContinuedFractionRequest",
+    "ContinuedFractionResult",
+    "ConvergentRequest",
+    "ConvergentResult",
+    "ConvergentValue",
+    "PellEquationRequest",
+    "PellEquationResult",
+    "SquarefreeRequest",
+]

--- a/src/jacobian/math/diophantine_approximation/_operations.py
+++ b/src/jacobian/math/diophantine_approximation/_operations.py
@@ -1,0 +1,57 @@
+"""Domain-owned Diophantine approximation operations."""
+
+from __future__ import annotations
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.diophantine_approximation import (
+    continued_fraction,
+    convergents,
+    solve_pell,
+)
+from jacobian.math.diophantine_approximation._models import (
+    ContinuedFractionRequest,
+    ContinuedFractionResult,
+    ConvergentRequest,
+    ConvergentResult,
+    ConvergentValue,
+    PellEquationRequest,
+    PellEquationResult,
+)
+
+
+def compute_continued_fraction(
+    request: ContinuedFractionRequest,
+) -> ContinuedFractionResult:
+    coefficients, preperiod_length, period_length = continued_fraction(
+        request.discriminant, request.term_count
+    )
+    return ContinuedFractionResult(
+        discriminant=request.discriminant,
+        coefficients=tuple(coefficients),
+        preperiod_length=preperiod_length,
+        period_length=period_length,
+    )
+
+
+def compute_convergents(request: ConvergentRequest) -> ConvergentResult:
+    values = convergents(request.discriminant, request.convergent_count)
+    return ConvergentResult(
+        discriminant=request.discriminant,
+        convergents=tuple(
+            ConvergentValue(
+                index=index,
+                numerator=format_canonical_integer(numerator),
+                denominator=format_canonical_integer(denominator),
+            )
+            for index, numerator, denominator in values
+        ),
+    )
+
+
+def compute_pell_equation(request: PellEquationRequest) -> PellEquationResult:
+    x, y = solve_pell(request.discriminant)
+    return PellEquationResult(
+        discriminant=request.discriminant,
+        x=format_canonical_integer(x),
+        y=format_canonical_integer(y),
+    )

--- a/src/jacobian/math/diophantine_approximation/_tools.py
+++ b/src/jacobian/math/diophantine_approximation/_tools.py
@@ -1,0 +1,112 @@
+"""Diophantine approximation operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.diophantine_approximation._models import (
+    ContinuedFractionRequest,
+    ContinuedFractionResult,
+    ConvergentRequest,
+    ConvergentResult,
+    PellEquationRequest,
+    PellEquationResult,
+)
+from jacobian.math.diophantine_approximation._operations import (
+    compute_continued_fraction,
+    compute_convergents,
+    compute_pell_equation,
+)
+
+
+def da_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+DIOPHANTINE_APPROXIMATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    da_operation(
+        "diophantine.continued_fraction.compute",
+        "Compute the continued fraction expansion of sqrt(D)",
+        "Compute the exact continued fraction [a_0; a_1, ...] of sqrt(D) "
+        "for a squarefree positive integer D, using SymPy's exact "
+        "continued_fraction_periodic.",
+        ContinuedFractionRequest,
+        ContinuedFractionResult,
+        compute_continued_fraction,
+        "number-theory",
+        "continued-fraction",
+        "exact",
+        examples=(
+            example(
+                "sqrt_2",
+                "Continued fraction of sqrt(2) is [1; 2, 2, 2, ...].",
+                {"discriminant": 2, "term_count": 5},
+            ),
+        ),
+    ),
+    da_operation(
+        "diophantine.convergents.compute",
+        "Compute convergents of sqrt(D)",
+        "Compute the first n convergents p_n/q_n of sqrt(D) by the "
+        "standard recurrence from the continued fraction expansion.",
+        ConvergentRequest,
+        ConvergentResult,
+        compute_convergents,
+        "number-theory",
+        "convergents",
+        "exact",
+        examples=(
+            example(
+                "sqrt_2_convergents",
+                "First 5 convergents of sqrt(2): 1/1, 3/2, 7/5, 17/12, 41/29.",
+                {"discriminant": 2, "convergent_count": 5},
+            ),
+        ),
+    ),
+    da_operation(
+        "diophantine.pell_equation.solve",
+        "Solve the Pell equation x^2 - D*y^2 = 1",
+        "Find the fundamental solution (x, y) to the Pell equation "
+        "x^2 - D*y^2 = 1 by iterating through continued fraction "
+        "convergents of sqrt(D).",
+        PellEquationRequest,
+        PellEquationResult,
+        compute_pell_equation,
+        "number-theory",
+        "pell-equation",
+        "exact",
+        examples=(
+            example(
+                "pell_2",
+                "The fundamental solution to x^2 - 2*y^2 = 1 is (3, 2).",
+                {"discriminant": 2},
+            ),
+        ),
+    ),
+)
+
+TOOLS = DIOPHANTINE_APPROXIMATION_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/diophantine_approximation/operations.py
+++ b/src/jacobian/math/diophantine_approximation/operations.py
@@ -1,0 +1,122 @@
+"""Exact continued fraction and Pell equation kernels backed by SymPy."""
+
+from __future__ import annotations
+
+from math import isqrt
+
+__all__ = ["continued_fraction", "convergents", "solve_pell"]
+
+
+def _require_periodic_discriminant(discriminant: int) -> None:
+    """Reject discriminants whose sqrt is not a periodic quadratic surd."""
+    if discriminant < 2:
+        raise ValueError("discriminant must be at least 2")
+    root = isqrt(discriminant)
+    if root * root == discriminant:
+        raise ValueError("discriminant must not be a perfect square")
+
+
+def _cf_coefficients(discriminant: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return (preperiod, period) of the continued fraction of sqrt(D)."""
+    from sympy import continued_fraction_periodic
+
+    _require_periodic_discriminant(discriminant)
+
+    expansion = continued_fraction_periodic(0, 1, discriminant)
+    head = expansion[0]
+    preperiod = (
+        tuple(int(item) for item in head) if isinstance(head, list) else (int(head),)
+    )
+    tail = expansion[1]
+    period = (
+        tuple(int(item) for item in tail) if isinstance(tail, list) else (int(tail),)
+    )
+    return preperiod, period
+
+
+def _coefficients(
+    preperiod: tuple[int, ...],
+    period: tuple[int, ...],
+    count: int,
+) -> list[int]:
+    """Return exactly count terms by repeating the period after the preperiod."""
+    coefficients: list[int] = []
+    for index in range(count):
+        coefficients.append(
+            preperiod[index]
+            if index < len(preperiod)
+            else period[(index - len(preperiod)) % len(period)]
+        )
+    return coefficients
+
+
+def continued_fraction(
+    discriminant: int,
+    term_count: int,
+) -> tuple[list[int], int, int]:
+    """Return the continued fraction expansion of sqrt(D) up to term_count terms.
+
+    Returns (coefficients, preperiod_length, period_length).
+    """
+    if term_count < 1:
+        raise ValueError("term_count must be at least 1")
+    preperiod, period = _cf_coefficients(discriminant)
+    return (
+        _coefficients(preperiod, period, term_count),
+        len(preperiod),
+        len(period),
+    )
+
+
+def convergents(discriminant: int, count: int) -> list[tuple[int, int, int]]:
+    """Return the first count convergents (index, p_n, q_n) of sqrt(D)."""
+    if count < 1:
+        raise ValueError("count must be at least 1")
+    preperiod, period = _cf_coefficients(discriminant)
+    coefficients = _coefficients(preperiod, period, count)
+
+    p_prev2, p_prev1 = 1, coefficients[0]
+    q_prev2, q_prev1 = 0, 1
+
+    result = [(0, p_prev1, q_prev1)]
+    for index in range(1, count):
+        coefficient = coefficients[index]
+        p_current = coefficient * p_prev1 + p_prev2
+        q_current = coefficient * q_prev1 + q_prev2
+        p_prev2, p_prev1 = p_prev1, p_current
+        q_prev2, q_prev1 = q_prev1, q_current
+        result.append((index, p_prev1, q_prev1))
+
+    return result
+
+
+def solve_pell(discriminant: int) -> tuple[int, int]:
+    """Return the fundamental solution (x, y) to x^2 - D*y^2 = 1.
+
+    For a non-square positive integer D the continued fraction of sqrt(D) has
+    period length r, and the fundamental solution is p_{r-1}/q_{r-1} when r is
+    even and p_{2r-1}/q_{2r-1} when r is odd. Iterating the first 2r
+    convergents therefore always reaches the first solution.
+    """
+    preperiod, period = _cf_coefficients(discriminant)
+    period_length = len(period)
+    convergents_needed = 2 * period_length
+
+    coefficients = _coefficients(preperiod, period, convergents_needed)
+    p_prev2, p_prev1 = 1, coefficients[0]
+    q_prev2, q_prev1 = 0, 1
+
+    if p_prev1**2 - discriminant * q_prev1**2 == 1:
+        return (p_prev1, q_prev1)
+
+    for index in range(1, convergents_needed):
+        coefficient = coefficients[index]
+        p_current = coefficient * p_prev1 + p_prev2
+        q_current = coefficient * q_prev1 + q_prev2
+        p_prev2, p_prev1 = p_prev1, p_current
+        q_prev2, q_prev1 = q_prev1, q_current
+
+        if p_prev1**2 - discriminant * q_prev1**2 == 1:
+            return (p_prev1, q_prev1)
+
+    raise ArithmeticError("Pell solution was not reached within the period bound")

--- a/src/jacobian/math/electrical_networks/__init__.py
+++ b/src/jacobian/math/electrical_networks/__init__.py
@@ -1,0 +1,9 @@
+"""Electrical network operations."""
+
+from jacobian.math.electrical_networks.operations import (
+    effective_resistance,
+    laplacian_matrix,
+    node_potentials,
+)
+
+__all__ = ["effective_resistance", "laplacian_matrix", "node_potentials"]

--- a/src/jacobian/math/electrical_networks/_models.py
+++ b/src/jacobian/math/electrical_networks/_models.py
@@ -1,0 +1,202 @@
+"""Typed wire contracts for exact electrical-network operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+
+MAX_NETWORK_VERTICES = 64
+MAX_NETWORK_EDGES = 512
+
+# Each conductance is reduced and has numerator and denominator at most this many
+# decimal digits. Results (effective resistance, node potentials, Laplacian
+# entries) are ratios of degree-at-most-63 weighted spanning-forest/tree
+# polynomials: after clearing the common denominator, each component is bounded
+# by MAX_NETWORK_EDGES * MAX_CONDUCTANCE_DIGITS + log10(64**62) digits
+# (512 * 50 + 112 = 25,712), comfortably inside the canonical 32,768-digit
+# rational ceiling.
+MAX_CONDUCTANCE_DIGITS = 50
+
+
+class ConductanceEdge(StrictModel):
+    """One undirected edge with a positive rational conductance (1/resistance)."""
+
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    conductance: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_distinct_positive(self) -> Self:
+        if self.source == self.target:
+            raise ValueError("edge endpoint must be distinct")
+        if self.conductance.as_fraction() <= 0:
+            raise ValueError("conductance must be strictly positive")
+        require_bounded_rational(
+            self.conductance,
+            max_digits=MAX_CONDUCTANCE_DIGITS,
+            label="conductance",
+        )
+        return self
+
+
+class ConductanceNetwork(StrictModel):
+    """An undirected graph of positive conductances over vertices 0..vertex_count-1."""
+
+    vertex_count: int = Field(ge=2, le=MAX_NETWORK_VERTICES)
+    edges: tuple[ConductanceEdge, ...] = Field(
+        min_length=1, max_length=MAX_NETWORK_EDGES
+    )
+
+    @model_validator(mode="after")
+    def require_valid_unique_edges(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for edge in self.edges:
+            if not (
+                0 <= edge.source < self.vertex_count
+                and 0 <= edge.target < self.vertex_count
+            ):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            key = (
+                (edge.source, edge.target)
+                if edge.source < edge.target
+                else (edge.target, edge.source)
+            )
+            if key in seen:
+                raise ValueError("edges must be unique (ignoring direction)")
+            seen.add(key)
+        return self
+
+
+def _require_connected(network: ConductanceNetwork) -> None:
+    """Reject networks whose reduced Laplacian solve is singular."""
+
+    adjacency: list[list[int]] = [[] for _ in range(network.vertex_count)]
+    for edge in network.edges:
+        adjacency[edge.source].append(edge.target)
+        adjacency[edge.target].append(edge.source)
+
+    seen: list[bool] = [False] * network.vertex_count
+    seen[0] = True
+    stack = [0]
+    while stack:
+        node = stack.pop()
+        for neighbor in adjacency[node]:
+            if not seen[neighbor]:
+                seen[neighbor] = True
+                stack.append(neighbor)
+
+    if not all(seen):
+        raise ValueError("network must be connected")
+
+
+class EffectiveResistanceRequest(StrictModel):
+    """Effective resistance between two distinct terminals of a conductance network."""
+
+    network: ConductanceNetwork
+    terminal_a: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    terminal_b: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_valid_distinct_terminals(self) -> Self:
+        if not (0 <= self.terminal_a < self.network.vertex_count):
+            raise ValueError("terminal_a must be in 0..vertex_count-1")
+        if not (0 <= self.terminal_b < self.network.vertex_count):
+            raise ValueError("terminal_b must be in 0..vertex_count-1")
+        if self.terminal_a == self.terminal_b:
+            raise ValueError("terminals must be distinct")
+        return self
+
+    @model_validator(mode="after")
+    def require_connected_network(self) -> Self:
+        _require_connected(self.network)
+        return self
+
+
+class EffectiveResistanceResult(StrictModel):
+    """Exact effective resistance between two terminals."""
+
+    effective_resistance: CanonicalRational
+    terminal_a: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    terminal_b: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    method: Literal["SYMPY_REDUCED_LAPLACIAN_SOLVE"] = "SYMPY_REDUCED_LAPLACIAN_SOLVE"
+
+
+class NodePotentialRequest(StrictModel):
+    """Solve the Dirichlet problem: inject 1 unit of current at source, extract at sink."""
+
+    network: ConductanceNetwork
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    sink: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_valid_distinct_terminals(self) -> Self:
+        if not (0 <= self.source < self.network.vertex_count):
+            raise ValueError("source must be in 0..vertex_count-1")
+        if not (0 <= self.sink < self.network.vertex_count):
+            raise ValueError("sink must be in 0..vertex_count-1")
+        if self.source == self.sink:
+            raise ValueError("source and sink must be distinct")
+        return self
+
+    @model_validator(mode="after")
+    def require_connected_network(self) -> Self:
+        _require_connected(self.network)
+        return self
+
+
+class NodePotentialValue(StrictModel):
+    """One node's exact potential after solving a Dirichlet problem."""
+
+    node: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    potential: CanonicalRational
+
+
+class NodePotentialResult(StrictModel):
+    """Exact node potentials for unit current injection."""
+
+    source: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    sink: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    potentials: tuple[NodePotentialValue, ...] = Field(
+        min_length=2, max_length=MAX_NETWORK_VERTICES
+    )
+    method: Literal["SYMPY_LAPLACIAN_SOLVE"] = "SYMPY_LAPLACIAN_SOLVE"
+
+
+class LaplacianEntry(StrictModel):
+    """One entry of the exact conductance-weighted Laplacian matrix."""
+
+    row: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    col: int = Field(ge=0, le=MAX_NETWORK_VERTICES - 1)
+    value: CanonicalRational
+
+
+class LaplacianRequest(StrictModel):
+    """Compute the conductance-weighted Laplacian matrix of a network."""
+
+    network: ConductanceNetwork
+
+
+class LaplacianResult(StrictModel):
+    """Exact Laplacian matrix as a flat list of (row, col, value) entries."""
+
+    vertex_count: int = Field(ge=2, le=MAX_NETWORK_VERTICES)
+    entries: tuple[LaplacianEntry, ...] = Field(min_length=1)
+    method: Literal["SYMPY_LAPLACIAN"] = "SYMPY_LAPLACIAN"
+
+
+__all__ = [
+    "ConductanceEdge",
+    "ConductanceNetwork",
+    "EffectiveResistanceRequest",
+    "EffectiveResistanceResult",
+    "LaplacianEntry",
+    "LaplacianRequest",
+    "LaplacianResult",
+    "NodePotentialRequest",
+    "NodePotentialResult",
+    "NodePotentialValue",
+]

--- a/src/jacobian/math/electrical_networks/_operations.py
+++ b/src/jacobian/math/electrical_networks/_operations.py
@@ -1,0 +1,97 @@
+"""Domain-owned electrical-network operation adapters."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.electrical_networks import (
+    effective_resistance,
+    laplacian_matrix,
+    node_potentials,
+)
+from jacobian.math.electrical_networks._models import (
+    ConductanceNetwork,
+    EffectiveResistanceRequest,
+    EffectiveResistanceResult,
+    LaplacianEntry,
+    LaplacianRequest,
+    LaplacianResult,
+    NodePotentialRequest,
+    NodePotentialResult,
+    NodePotentialValue,
+)
+
+
+def _edge_triples(
+    network: ConductanceNetwork,
+) -> tuple[tuple[int, int, Fraction], ...]:
+    return tuple(
+        (edge.source, edge.target, edge.conductance.as_fraction())
+        for edge in network.edges
+    )
+
+
+def compute_effective_resistance(
+    request: EffectiveResistanceRequest,
+) -> EffectiveResistanceResult:
+    network = request.network
+    value = effective_resistance(
+        network.vertex_count,
+        _edge_triples(network),
+        request.terminal_a,
+        request.terminal_b,
+    )
+    return EffectiveResistanceResult(
+        effective_resistance=CanonicalRational.from_fraction(value),
+        terminal_a=request.terminal_a,
+        terminal_b=request.terminal_b,
+    )
+
+
+def compute_node_potentials(request: NodePotentialRequest) -> NodePotentialResult:
+    network = request.network
+    potentials = node_potentials(
+        network.vertex_count,
+        _edge_triples(network),
+        request.source,
+        request.sink,
+    )
+    values = tuple(
+        NodePotentialValue(
+            node=i,
+            potential=CanonicalRational.from_fraction(potentials[i]),
+        )
+        for i in range(network.vertex_count)
+    )
+    return NodePotentialResult(
+        source=request.source,
+        sink=request.sink,
+        potentials=values,
+    )
+
+
+def compute_laplacian(request: LaplacianRequest) -> LaplacianResult:
+    network = request.network
+    matrix = laplacian_matrix(network.vertex_count, _edge_triples(network))
+    entries: list[LaplacianEntry] = []
+    for row in range(network.vertex_count):
+        for col in range(network.vertex_count):
+            entries.append(
+                LaplacianEntry(
+                    row=row,
+                    col=col,
+                    value=CanonicalRational.from_fraction(matrix[row][col]),
+                )
+            )
+    return LaplacianResult(
+        vertex_count=network.vertex_count,
+        entries=tuple(entries),
+    )
+
+
+__all__ = [
+    "compute_effective_resistance",
+    "compute_laplacian",
+    "compute_node_potentials",
+]

--- a/src/jacobian/math/electrical_networks/_tools.py
+++ b/src/jacobian/math/electrical_networks/_tools.py
@@ -1,0 +1,162 @@
+"""Electrical-network operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.electrical_networks._models import (
+    EffectiveResistanceRequest,
+    EffectiveResistanceResult,
+    LaplacianRequest,
+    LaplacianResult,
+    NodePotentialRequest,
+    NodePotentialResult,
+)
+from jacobian.math.electrical_networks._operations import (
+    compute_effective_resistance,
+    compute_laplacian,
+    compute_node_potentials,
+)
+
+
+def en_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+ELECTRICAL_NETWORK_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    en_operation(
+        "electrical_network.effective_resistance.compute",
+        "Compute the exact effective resistance between two terminals",
+        "Compute the exact rational effective resistance between two terminals of an undirected conductance network by solving the reduced Laplacian system over QQ.",
+        EffectiveResistanceRequest,
+        EffectiveResistanceResult,
+        compute_effective_resistance,
+        "graph",
+        "electrical-network",
+        "effective-resistance",
+        "exact",
+        examples=(
+            example(
+                "triangle_equal_resistances",
+                "Effective resistance of two vertices in a triangle with unit resistances.",
+                {
+                    "network": {
+                        "vertex_count": 3,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 1,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 0,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                    "terminal_a": 0,
+                    "terminal_b": 1,
+                },
+            ),
+        ),
+    ),
+    en_operation(
+        "electrical_network.node_potentials.compute",
+        "Compute exact node potentials for unit current injection",
+        "Solve the Dirichlet problem: inject 1 ampere at source and extract 1 ampere at sink, returning exact rational node potentials with the sink gauge fixed at zero.",
+        NodePotentialRequest,
+        NodePotentialResult,
+        compute_node_potentials,
+        "graph",
+        "electrical-network",
+        "node-potential",
+        "exact",
+        examples=(
+            example(
+                "path_of_two_edges",
+                "Node potentials for a path graph of 3 vertices with unit conductances.",
+                {
+                    "network": {
+                        "vertex_count": 3,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "source": 1,
+                                "target": 2,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                    "source": 0,
+                    "sink": 2,
+                },
+            ),
+        ),
+    ),
+    en_operation(
+        "electrical_network.laplacian.compute",
+        "Compute the exact conductance-weighted Laplacian matrix",
+        "Build the exact rational conductance-weighted graph Laplacian of an undirected network, returned as a flat list of (row, col, value) entries.",
+        LaplacianRequest,
+        LaplacianResult,
+        compute_laplacian,
+        "graph",
+        "electrical-network",
+        "laplacian",
+        "exact",
+        examples=(
+            example(
+                "single_edge",
+                "Laplacian of a two-vertex network with one unit-conductance edge.",
+                {
+                    "network": {
+                        "vertex_count": 2,
+                        "edges": [
+                            {
+                                "source": 0,
+                                "target": 1,
+                                "conductance": {"num": "1", "den": "1"},
+                            },
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+TOOLS = ELECTRICAL_NETWORK_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/electrical_networks/operations.py
+++ b/src/jacobian/math/electrical_networks/operations.py
@@ -1,0 +1,109 @@
+"""Exact electrical-network kernels backed by SymPy."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+__all__ = ["effective_resistance", "laplacian_matrix", "node_potentials"]
+
+
+def _laplacian(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+) -> Any:
+    """Build the conductance-weighted Laplacian as a SymPy Matrix of rationals."""
+
+    from sympy import Matrix, Rational
+
+    matrix = Matrix.zeros(vertex_count, vertex_count)
+    for source, target, conductance in edges:
+        g = Rational(conductance.numerator, conductance.denominator)
+        matrix[source, source] += g
+        matrix[target, target] += g
+        matrix[source, target] -= g
+        matrix[target, source] -= g
+    return matrix
+
+
+def laplacian_matrix(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+) -> list[list[Fraction]]:
+    """Return the exact Laplacian as a list-of-lists of Fractions."""
+
+    lap = _laplacian(vertex_count, edges)
+    rows: list[list[Fraction]] = []
+    for row in range(vertex_count):
+        entries: list[Fraction] = []
+        for col in range(vertex_count):
+            val = lap[row, col]
+            entries.append(Fraction(int(val.p), int(val.q)))
+        rows.append(entries)
+    return rows
+
+
+def effective_resistance(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+    terminal_a: int,
+    terminal_b: int,
+) -> Fraction:
+    """Compute exact effective resistance by solving the reduced Laplacian system.
+
+    Fix one node's potential as a gauge, solve the invertible reduced system
+    ``L_reduced x = e_a - e_b`` over QQ, and return ``x_a - x_b``. For a
+    connected graph this difference is gauge-invariant and equals the effective
+    resistance.
+    """
+
+    from sympy import Matrix, Rational
+
+    lap = _laplacian(vertex_count, edges)
+    fixed = 0
+    free = [node for node in range(vertex_count) if node != fixed]
+    reduced = lap[free, free]
+    rhs = Matrix.zeros(len(free), 1)
+    for idx, node in enumerate(free):
+        if node == terminal_a:
+            rhs[idx, 0] += Rational(1)
+        if node == terminal_b:
+            rhs[idx, 0] -= Rational(1)
+
+    sol = reduced.solve(rhs)
+    potentials = [Rational(0)] * vertex_count
+    for idx, node in enumerate(free):
+        potentials[node] = sol[idx, 0]
+
+    value = potentials[terminal_a] - potentials[terminal_b]
+    return Fraction(int(value.p), int(value.q))
+
+
+def node_potentials(
+    vertex_count: int,
+    edges: tuple[tuple[int, int, Fraction], ...],
+    source: int,
+    sink: int,
+) -> list[Fraction]:
+    """Solve the Dirichlet problem for unit current injection at source, sink.
+
+    Inject one ampere at ``source`` and extract one ampere at ``sink``, with the
+    sink gauge fixed to zero, returning exact rational node potentials.
+    """
+
+    from sympy import Matrix, Rational
+
+    lap = _laplacian(vertex_count, edges)
+    free = [node for node in range(vertex_count) if node != sink]
+    reduced = lap[free, free]
+    rhs = Matrix.zeros(len(free), 1)
+    for idx, node in enumerate(free):
+        if node == source:
+            rhs[idx, 0] += Rational(1)
+
+    sol = reduced.solve(rhs)
+    potentials = [Rational(0)] * vertex_count
+    for idx, node in enumerate(free):
+        potentials[node] = sol[idx, 0]
+    potentials[sink] = Rational(0)
+    return [Fraction(int(value.p), int(value.q)) for value in potentials]

--- a/src/jacobian/math/finite_metric_spaces/__init__.py
+++ b/src/jacobian/math/finite_metric_spaces/__init__.py
@@ -1,0 +1,9 @@
+"""Finite metric space operations."""
+
+from jacobian.math.finite_metric_spaces.operations import (
+    ball,
+    gromov_hyperbolicity,
+    metric_profile,
+)
+
+__all__ = ["ball", "gromov_hyperbolicity", "metric_profile"]

--- a/src/jacobian/math/finite_metric_spaces/_models.py
+++ b/src/jacobian/math/finite_metric_spaces/_models.py
@@ -1,0 +1,123 @@
+"""Typed wire contracts for exact finite metric space operations."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+
+MAX_POINTS = 64
+MAX_DISTANCE = (1 << 53) - 1
+
+DistanceValue = Annotated[int, Field(ge=0, le=MAX_DISTANCE)]
+
+
+class FiniteMetricSpace(StrictModel):
+    """A finite metric space given by its complete distance matrix."""
+
+    point_count: int = Field(ge=2, le=MAX_POINTS)
+    distances: tuple[tuple[DistanceValue, ...], ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_distances(self) -> Self:
+        self._require_square()
+        self._require_metric_properties()
+        return self
+
+    def _require_square(self) -> None:
+        if len(self.distances) != self.point_count:
+            raise ValueError("distance matrix row count must match point_count")
+        for row in self.distances:
+            if len(row) != self.point_count:
+                raise ValueError("distance matrix must be square")
+
+    def _require_metric_properties(self) -> None:
+        for i in range(self.point_count):
+            if self.distances[i][i] != 0:
+                raise ValueError("diagonal distances must be zero")
+            for j in range(self.point_count):
+                if self.distances[i][j] != self.distances[j][i]:
+                    raise ValueError("distance matrix must be symmetric")
+        self._require_positive_separation()
+        self._require_triangle_inequality()
+
+    def _require_positive_separation(self) -> None:
+        for i in range(self.point_count):
+            for j in range(self.point_count):
+                if i != j and self.distances[i][j] == 0:
+                    raise ValueError("distinct points must have positive distance")
+
+    def _require_triangle_inequality(self) -> None:
+        for i in range(self.point_count):
+            for j in range(self.point_count):
+                for k in range(self.point_count):
+                    if (
+                        self.distances[i][j]
+                        > self.distances[i][k] + self.distances[k][j]
+                    ):
+                        raise ValueError(
+                            "distances must satisfy the triangle inequality"
+                        )
+
+
+class MetricProfileRequest(StrictModel):
+    """Compute distance profile, radius, diameter, centers, periphery."""
+
+    metric_space: FiniteMetricSpace
+
+
+class EccentricityResult(StrictModel):
+    """One point's eccentricity."""
+
+    point: int = Field(ge=0, le=MAX_POINTS - 1)
+    eccentricity: int = Field(ge=0, le=MAX_DISTANCE)
+
+
+class MetricProfileResult(StrictModel):
+    """Profile of a finite metric space."""
+
+    diameter: int = Field(ge=0, le=MAX_DISTANCE)
+    radius: int = Field(ge=0, le=MAX_DISTANCE)
+    eccentricities: tuple[EccentricityResult, ...] = Field(min_length=2)
+    centers: tuple[int, ...] = Field(min_length=1)
+    periphery: tuple[int, ...] = Field(min_length=0)
+    method: Literal["FLOYD_WARSHALL"] = "FLOYD_WARSHALL"
+
+
+class BallRequest(StrictModel):
+    """Compute the ball of given radius centered at a point."""
+
+    metric_space: FiniteMetricSpace
+    center: int = Field(ge=0, le=MAX_POINTS - 1)
+    radius: int = Field(ge=0, le=10000)
+
+    @model_validator(mode="after")
+    def require_center_in_range(self) -> Self:
+        if self.center >= self.metric_space.point_count:
+            raise ValueError("ball center index must be within the metric space")
+        return self
+
+
+class BallResult(StrictModel):
+    """The ball (set of points within radius of center)."""
+
+    center: int = Field(ge=0, le=MAX_POINTS - 1)
+    radius: int = Field(ge=0, le=10000)
+    points: tuple[int, ...] = Field(min_length=1)
+    method: Literal["DIRECT_SCAN"] = "DIRECT_SCAN"
+
+
+class GromovHyperbolicityRequest(StrictModel):
+    """Compute the four-point Gromov hyperbolicity of a metric space."""
+
+    metric_space: FiniteMetricSpace
+
+
+class GromovHyperbolicityResult(StrictModel):
+    """The four-point Gromov hyperbolicity (max delta over all quadruples)."""
+
+    hyperbolicity: CanonicalRational
+    method: Literal["FOUR_POINT_BRUTE_FORCE"] = "FOUR_POINT_BRUTE_FORCE"

--- a/src/jacobian/math/finite_metric_spaces/_operations.py
+++ b/src/jacobian/math/finite_metric_spaces/_operations.py
@@ -1,0 +1,60 @@
+"""Domain-owned finite metric space operations."""
+
+from __future__ import annotations
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.finite_metric_spaces import (
+    ball,
+    gromov_hyperbolicity,
+    metric_profile,
+)
+from jacobian.math.finite_metric_spaces._models import (
+    BallRequest,
+    BallResult,
+    EccentricityResult,
+    FiniteMetricSpace,
+    GromovHyperbolicityRequest,
+    GromovHyperbolicityResult,
+    MetricProfileRequest,
+    MetricProfileResult,
+)
+
+
+def _distance_matrix(metric_space: FiniteMetricSpace) -> list[list[int]]:
+    return [list(row) for row in metric_space.distances]
+
+
+def compute_metric_profile(request: MetricProfileRequest) -> MetricProfileResult:
+    distances = _distance_matrix(request.metric_space)
+    profile = metric_profile(distances)
+    n = len(distances)
+    return MetricProfileResult(
+        diameter=profile["diameter"],
+        radius=profile["radius"],
+        eccentricities=tuple(
+            EccentricityResult(point=i, eccentricity=profile["eccentricities"][i])
+            for i in range(n)
+        ),
+        centers=profile["centers"],
+        periphery=profile["periphery"],
+    )
+
+
+def compute_ball(request: BallRequest) -> BallResult:
+    distances = _distance_matrix(request.metric_space)
+    points = ball(distances, request.center, request.radius)
+    return BallResult(
+        center=request.center,
+        radius=request.radius,
+        points=tuple(points),
+    )
+
+
+def compute_gromov_hyperbolicity(
+    request: GromovHyperbolicityRequest,
+) -> GromovHyperbolicityResult:
+    distances = _distance_matrix(request.metric_space)
+    result = gromov_hyperbolicity(distances)
+    return GromovHyperbolicityResult(
+        hyperbolicity=CanonicalRational.from_fraction(result)
+    )

--- a/src/jacobian/math/finite_metric_spaces/_tools.py
+++ b/src/jacobian/math/finite_metric_spaces/_tools.py
@@ -1,0 +1,123 @@
+"""Finite metric space operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.finite_metric_spaces._models import (
+    BallRequest,
+    BallResult,
+    GromovHyperbolicityRequest,
+    GromovHyperbolicityResult,
+    MetricProfileRequest,
+    MetricProfileResult,
+)
+from jacobian.math.finite_metric_spaces._operations import (
+    compute_ball,
+    compute_gromov_hyperbolicity,
+    compute_metric_profile,
+)
+
+
+def fms_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_METRIC_SPACE = {
+    "metric_space": {
+        "point_count": 3,
+        "distances": [[0, 1, 2], [1, 0, 1], [2, 1, 0]],
+    }
+}
+
+
+FINITE_METRIC_SPACE_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    fms_operation(
+        "metric_space.profile.compute",
+        "Compute diameter, radius, eccentricities, centers, and periphery",
+        "Compute the exact metric profile of a finite metric space: "
+        "diameter (max eccentricity), radius (min eccentricity), "
+        "eccentricities for all points, centers, and periphery.",
+        MetricProfileRequest,
+        MetricProfileResult,
+        compute_metric_profile,
+        "metric",
+        "profile",
+        "exact",
+        examples=(
+            example(
+                "path_graph",
+                "Profile of a path metric space with 3 points.",
+                _METRIC_SPACE,
+            ),
+        ),
+    ),
+    fms_operation(
+        "metric_space.ball.compute",
+        "Compute the ball of a given radius centered at a point",
+        "Return the set of all points within the given radius of a "
+        "specified center point in a finite metric space.",
+        BallRequest,
+        BallResult,
+        compute_ball,
+        "metric",
+        "ball",
+        "exact",
+        examples=(
+            example(
+                "ball_1",
+                "Ball of radius 1 centered at point 0 in a 3-point space.",
+                {
+                    "metric_space": _METRIC_SPACE["metric_space"],
+                    "center": 0,
+                    "radius": 1,
+                },
+            ),
+        ),
+    ),
+    fms_operation(
+        "metric_space.gromov_hyperbolicity.compute",
+        "Compute the four-point Gromov hyperbolicity",
+        "Compute the exact four-point Gromov hyperbolicity of a finite "
+        "metric space by brute-force enumeration over all quadruples.",
+        GromovHyperbolicityRequest,
+        GromovHyperbolicityResult,
+        compute_gromov_hyperbolicity,
+        "metric",
+        "hyperbolicity",
+        "exact",
+        examples=(
+            example(
+                "path_graph",
+                "Gromov hyperbolicity of a 3-point path metric.",
+                _METRIC_SPACE,
+            ),
+        ),
+    ),
+)
+
+TOOLS = FINITE_METRIC_SPACE_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/finite_metric_spaces/operations.py
+++ b/src/jacobian/math/finite_metric_spaces/operations.py
@@ -1,0 +1,58 @@
+"""Exact finite metric space kernels."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+__all__ = ["ball", "gromov_hyperbolicity", "metric_profile"]
+
+
+def metric_profile(
+    distances: list[list[int]],
+) -> dict[str, Any]:
+    """Compute diameter, radius, eccentricities, centers, and periphery."""
+    n = len(distances)
+    eccentricities = [max(distances[i]) for i in range(n)]
+    diameter = max(eccentricities)
+    radius = min(eccentricities)
+    centers = tuple(i for i, e in enumerate(eccentricities) if e == radius)
+    periphery = tuple(i for i, e in enumerate(eccentricities) if e == diameter)
+    return {
+        "diameter": diameter,
+        "radius": radius,
+        "eccentricities": eccentricities,
+        "centers": centers,
+        "periphery": periphery,
+    }
+
+
+def ball(distances: list[list[int]], center: int, radius: int) -> list[int]:
+    """Return the list of points within radius of center."""
+    n = len(distances)
+    return [i for i in range(n) if distances[center][i] <= radius]
+
+
+def gromov_hyperbolicity(distances: list[list[int]]) -> Fraction:
+    """Compute the four-point Gromov hyperbolicity (max over all quadruples).
+
+    For four points i, j, k, l, define the three pairing sums
+    s1 = d(i,j)+d(k,l), s2 = d(i,k)+d(j,l), s3 = d(i,l)+d(j,k).
+    The four-point delta is half the gap between the two largest sums, and
+    the hyperbolicity is the maximum delta over all quadruples. Since that
+    gap can be odd, the result is an exact ``Fraction`` (possibly half-integer).
+    """
+    n = len(distances)
+    max_delta = Fraction(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            for k in range(j + 1, n):
+                for m in range(k + 1, n):
+                    s1 = distances[i][j] + distances[k][m]
+                    s2 = distances[i][k] + distances[j][m]
+                    s3 = distances[i][m] + distances[j][k]
+                    second, largest = sorted((s1, s2, s3))[1:]
+                    delta = Fraction(largest - second, 2)
+                    if delta > max_delta:
+                        max_delta = delta
+    return max_delta

--- a/src/jacobian/math/graph_transforms/__init__.py
+++ b/src/jacobian/math/graph_transforms/__init__.py
@@ -1,0 +1,10 @@
+"""Graph transform operations."""
+
+from jacobian.math.graph_transforms.operations import (
+    complement,
+    graph_power,
+    induced_subgraph,
+    line_graph,
+)
+
+__all__ = ["complement", "graph_power", "induced_subgraph", "line_graph"]

--- a/src/jacobian/math/graph_transforms/_models.py
+++ b/src/jacobian/math/graph_transforms/_models.py
@@ -1,0 +1,116 @@
+"""Typed wire contracts for exact graph transform operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+# Input graph bounds.
+MAX_VERTICES = 64
+MAX_EDGES = 1024
+
+# Result bounds derived from the worst-case transforms over the accepted
+# input domain. A line graph reindexes one vertex per input edge, so its
+# vertices reach the input edge bound (0..MAX_EDGES-1) rather than the input
+# vertex bound; every other transform keeps the input vertex set and stays
+# within MAX_VERTICES.
+MAX_RESULT_VERTICES = MAX_EDGES
+MAX_RESULT_EDGE_ENDPOINT = MAX_EDGES - 1
+
+# |E(L(G))| = sum_v C(deg(v), 2) <= (max_deg - 1) * |E(G)|
+#           <= (MAX_VERTICES - 2) * MAX_EDGES.
+# Complement, square, and induced subgraph produce at most C(MAX_VERTICES, 2)
+# = 2016 edges, so this line-graph bound covers every transform result.
+MAX_RESULT_EDGES = MAX_EDGES * (MAX_VERTICES - 2)
+
+
+class GraphEdge(StrictModel):
+    """One undirected edge of an input graph."""
+
+    source: int = Field(ge=0, le=MAX_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_VERTICES - 1)
+
+    @model_validator(mode="after")
+    def require_distinct(self) -> Self:
+        if self.source == self.target:
+            raise ValueError("edge endpoints must be distinct")
+        return self
+
+
+class ResultGraphEdge(StrictModel):
+    """One undirected edge of a transformed graph.
+
+    Line graph vertices are reindexed input edges, so result endpoints may
+    reach the input edge bound, not just the input vertex bound.
+    """
+
+    source: int = Field(ge=0, le=MAX_RESULT_EDGE_ENDPOINT)
+    target: int = Field(ge=0, le=MAX_RESULT_EDGE_ENDPOINT)
+
+    @model_validator(mode="after")
+    def require_distinct(self) -> Self:
+        if self.source == self.target:
+            raise ValueError("edge endpoints must be distinct")
+        return self
+
+
+class SimpleGraph(StrictModel):
+    """A finite simple undirected graph."""
+
+    vertex_count: int = Field(ge=1, le=MAX_VERTICES)
+    edges: tuple[GraphEdge, ...] = Field(default=(), max_length=MAX_EDGES)
+
+    @model_validator(mode="after")
+    def require_valid_edges(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for edge in self.edges:
+            if not (
+                0 <= edge.source < self.vertex_count
+                and 0 <= edge.target < self.vertex_count
+            ):
+                raise ValueError("edge vertices must be in 0..vertex_count-1")
+            key = (
+                (edge.source, edge.target)
+                if edge.source < edge.target
+                else (edge.target, edge.source)
+            )
+            if key in seen:
+                raise ValueError("edges must be unique")
+            seen.add(key)
+        return self
+
+
+class GraphTransformRequest(StrictModel):
+    """One graph transform operation."""
+
+    graph: SimpleGraph
+
+
+class GraphResult(StrictModel):
+    """The result graph of a transform."""
+
+    vertex_count: int = Field(ge=0, le=MAX_RESULT_VERTICES)
+    edges: tuple[ResultGraphEdge, ...] = Field(
+        default=(),
+        max_length=MAX_RESULT_EDGES,
+    )
+    method: Literal["NETWORKX"] = "NETWORKX"
+
+
+class SubgraphRequest(StrictModel):
+    """Extract an induced subgraph on a vertex subset."""
+
+    graph: SimpleGraph
+    vertices: tuple[int, ...] = Field(min_length=0, max_length=MAX_VERTICES)
+
+    @model_validator(mode="after")
+    def require_valid_vertices(self) -> Self:
+        if len(set(self.vertices)) != len(self.vertices):
+            raise ValueError("vertices must be unique")
+        for v in self.vertices:
+            if not (0 <= v < self.graph.vertex_count):
+                raise ValueError("vertices must be in 0..vertex_count-1")
+        return self

--- a/src/jacobian/math/graph_transforms/_operations.py
+++ b/src/jacobian/math/graph_transforms/_operations.py
@@ -1,0 +1,64 @@
+"""Domain-owned graph transform operations."""
+
+from __future__ import annotations
+
+from jacobian.math.graph_transforms import (
+    complement,
+    graph_power,
+    induced_subgraph,
+    line_graph,
+)
+from jacobian.math.graph_transforms._models import (
+    GraphResult,
+    GraphTransformRequest,
+    ResultGraphEdge,
+    SimpleGraph,
+    SubgraphRequest,
+)
+
+SQUARE_POWER = 2
+
+
+def _edges(graph: SimpleGraph) -> list[tuple[int, int]]:
+    return [(edge.source, edge.target) for edge in graph.edges]
+
+
+def _result(vertex_count: int, edges: list[tuple[int, int]]) -> GraphResult:
+    return GraphResult(
+        vertex_count=vertex_count,
+        edges=tuple(
+            ResultGraphEdge(source=source, target=target) for source, target in edges
+        ),
+    )
+
+
+def compute_complement(request: GraphTransformRequest) -> GraphResult:
+    graph = request.graph
+    vertex_count, edges = complement(graph.vertex_count, _edges(graph))
+    return _result(vertex_count, edges)
+
+
+def compute_line_graph(request: GraphTransformRequest) -> GraphResult:
+    graph = request.graph
+    vertex_count, edges = line_graph(graph.vertex_count, _edges(graph))
+    return _result(vertex_count, edges)
+
+
+def compute_graph_power(request: GraphTransformRequest) -> GraphResult:
+    graph = request.graph
+    vertex_count, edges = graph_power(
+        graph.vertex_count,
+        _edges(graph),
+        SQUARE_POWER,
+    )
+    return _result(vertex_count, edges)
+
+
+def compute_induced_subgraph(request: SubgraphRequest) -> GraphResult:
+    graph = request.graph
+    vertex_count, edges = induced_subgraph(
+        graph.vertex_count,
+        _edges(graph),
+        list(request.vertices),
+    )
+    return _result(vertex_count, edges)

--- a/src/jacobian/math/graph_transforms/_tools.py
+++ b/src/jacobian/math/graph_transforms/_tools.py
@@ -1,0 +1,139 @@
+"""Graph transform operation declarations."""
+
+from collections.abc import Callable
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools, OperationExample
+from jacobian.math.graph_transforms._models import (
+    GraphResult,
+    GraphTransformRequest,
+    SubgraphRequest,
+)
+from jacobian.math.graph_transforms._operations import (
+    compute_complement,
+    compute_graph_power,
+    compute_induced_subgraph,
+    compute_line_graph,
+)
+
+
+def gt_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_GRAPH_EXAMPLE = {
+    "graph": {
+        "vertex_count": 3,
+        "edges": [
+            {"source": 0, "target": 1},
+            {"source": 1, "target": 2},
+        ],
+    }
+}
+
+
+TOOLS: MathTools = (
+    gt_operation(
+        "graph.complement.compute",
+        "Compute the complement of a graph",
+        "Compute the exact complement of a simple undirected graph using "
+        "NetworkX. The complement has the same vertex set, with edges "
+        "exactly where the original has no edge.",
+        GraphTransformRequest,
+        GraphResult,
+        compute_complement,
+        "graph",
+        "complement",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Complement of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.line_graph.compute",
+        "Compute the line graph of a graph",
+        "Compute the exact line graph L(G) where vertices are edges of G "
+        "and two vertices in L(G) are adjacent if they share an endpoint in G.",
+        GraphTransformRequest,
+        GraphResult,
+        compute_line_graph,
+        "graph",
+        "line-graph",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Line graph of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.power.compute",
+        "Compute the graph power (square) of a graph",
+        "Compute the exact square G^2 where two vertices are adjacent if "
+        "their distance in G is at most 2.",
+        GraphTransformRequest,
+        GraphResult,
+        compute_graph_power,
+        "graph",
+        "graph-power",
+        "exact",
+        examples=(
+            example(
+                "path_p2",
+                "Square of a path graph P2.",
+                _GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    gt_operation(
+        "graph.induced_subgraph.compute",
+        "Extract an induced subgraph on a vertex subset",
+        "Compute the exact induced subgraph G[V'] where V' is a subset of "
+        "the vertices. Vertices are reindexed 0..|V'|-1.",
+        SubgraphRequest,
+        GraphResult,
+        compute_induced_subgraph,
+        "graph",
+        "induced-subgraph",
+        "exact",
+        examples=(
+            example(
+                "path_p2_vertices_0_2",
+                "Induced subgraph of P2 on vertices {0, 2}.",
+                {
+                    "graph": _GRAPH_EXAMPLE["graph"],
+                    "vertices": [0, 2],
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graph_transforms/operations.py
+++ b/src/jacobian/math/graph_transforms/operations.py
@@ -1,0 +1,75 @@
+"""Exact graph transform kernels backed by NetworkX."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["complement", "graph_power", "induced_subgraph", "line_graph"]
+
+
+def _to_networkx(vertex_count: int, edges: list[tuple[int, int]]) -> Any:
+    import networkx as nx
+
+    graph: Any = nx.Graph()
+    graph.add_nodes_from(range(vertex_count))
+    graph.add_edges_from(edges)
+    return graph
+
+
+def _from_networkx(graph: Any) -> tuple[int, list[tuple[int, int]]]:
+    return (graph.number_of_nodes(), list(graph.edges()))
+
+
+def complement(
+    vertex_count: int, edges: list[tuple[int, int]]
+) -> tuple[int, list[tuple[int, int]]]:
+    """Return the complement of a simple graph on vertices 0..vertex_count-1."""
+
+    import networkx as nx
+
+    graph = _to_networkx(vertex_count, edges)
+    return _from_networkx(nx.complement(graph))
+
+
+def induced_subgraph(
+    vertex_count: int, edges: list[tuple[int, int]], vertices: list[int]
+) -> tuple[int, list[tuple[int, int]]]:
+    """Return the induced subgraph on ``vertices``, reindexed 0..len-1."""
+
+    import networkx as nx
+
+    graph = _to_networkx(vertex_count, edges)
+    subgraph = nx.induced_subgraph(graph, vertices)
+    old_to_new = {old: new for new, old in enumerate(vertices)}
+    result_edges = [
+        (old_to_new[source], old_to_new[target]) for source, target in subgraph.edges()
+    ]
+    return (len(vertices), result_edges)
+
+
+def line_graph(
+    vertex_count: int, edges: list[tuple[int, int]]
+) -> tuple[int, list[tuple[int, int]]]:
+    """Return the line graph with vertices reindexed 0..|E(G)|-1."""
+
+    import networkx as nx
+
+    graph = _to_networkx(vertex_count, edges)
+    transformed = nx.line_graph(graph)
+    node_to_index = {node: index for index, node in enumerate(transformed.nodes())}
+    result_edges = [
+        (node_to_index[source], node_to_index[target])
+        for source, target in transformed.edges()
+    ]
+    return (len(transformed.nodes()), result_edges)
+
+
+def graph_power(
+    vertex_count: int, edges: list[tuple[int, int]], power: int
+) -> tuple[int, list[tuple[int, int]]]:
+    """Return the ``power``-th power of a simple graph."""
+
+    import networkx as nx
+
+    graph = _to_networkx(vertex_count, edges)
+    return _from_networkx(nx.power(graph, power))

--- a/src/jacobian/math/real_algebra/__init__.py
+++ b/src/jacobian/math/real_algebra/__init__.py
@@ -1,0 +1,5 @@
+"""Exact real algebra operations."""
+
+from jacobian.math.real_algebra.operations import root_count, sturm_chain
+
+__all__ = ["root_count", "sturm_chain"]

--- a/src/jacobian/math/real_algebra/_models.py
+++ b/src/jacobian/math/real_algebra/_models.py
@@ -1,0 +1,115 @@
+"""Typed wire contracts for exact real algebra operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+
+MAX_POLYNOMIAL_DEGREE = 32
+MAX_POLYNOMIAL_TERMS = 33
+
+# SymPy's ``sturm`` builds the exact Euclidean remainder sequence over QQ. For
+# an integer-coefficient polynomial of degree ``n`` with ``d``-digit
+# coefficients the chain coefficients grow like ``d * n^2`` decimal digits
+# (verified adversarially), so a degree-32 input with 16-digit coefficients
+# produces Sturm-chain coefficients of at most about 16,000 digits, comfortably
+# inside the canonical 32,768-digit wire bound. Rational coefficients are
+# rejected because a 16-digit numerator/denominator drives the plain QQ
+# remainder sequence to roughly 200,000 digits, which cannot be represented.
+MAX_COEFFICIENT_DIGITS = 16
+
+
+class PolynomialTerm(StrictModel):
+    """One term: coefficient times x^exponent."""
+
+    coefficient: CanonicalRational
+    exponent: int = Field(ge=0, le=MAX_POLYNOMIAL_DEGREE)
+
+
+class UnivariatePolynomial(StrictModel):
+    """A univariate polynomial over QQ as sparse nonzero terms."""
+
+    terms: tuple[PolynomialTerm, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_TERMS
+    )
+
+    @model_validator(mode="after")
+    def require_unique_exponents(self) -> Self:
+        exponents = [t.exponent for t in self.terms]
+        if len(set(exponents)) != len(exponents):
+            raise ValueError("polynomial exponents must be unique")
+        if any(t.coefficient.as_fraction() == 0 for t in self.terms):
+            raise ValueError("zero polynomial terms must be omitted")
+        return self
+
+
+def _require_bounded_integer_coefficients(polynomial: UnivariatePolynomial) -> None:
+    """Reject non-integer or oversized coefficients before Sturm construction."""
+
+    for term in polynomial.terms:
+        if term.coefficient.den != "1":
+            raise ValueError("polynomial coefficients must be integers")
+        require_bounded_rational(
+            term.coefficient,
+            max_digits=MAX_COEFFICIENT_DIGITS,
+            label="polynomial coefficient",
+        )
+
+
+class SturmChainRequest(StrictModel):
+    """Compute the Sturm chain of a univariate polynomial."""
+
+    polynomial: UnivariatePolynomial
+
+    @model_validator(mode="after")
+    def require_nonconstant_polynomial(self) -> Self:
+        if max(t.exponent for t in self.polynomial.terms) < 1:
+            raise ValueError("Sturm chain requires a non-constant polynomial")
+        _require_bounded_integer_coefficients(self.polynomial)
+        return self
+
+
+class RootCountRequest(StrictModel):
+    """Count real roots of a polynomial in an interval [lower, upper]."""
+
+    polynomial: UnivariatePolynomial
+    lower: CanonicalRational
+    upper: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_ordered_bounded_interval(self) -> Self:
+        if self.lower.as_fraction() > self.upper.as_fraction():
+            raise ValueError("lower bound must not exceed upper bound")
+        _require_bounded_integer_coefficients(self.polynomial)
+        return self
+
+
+class SturmChainResult(StrictModel):
+    """The Sturm chain as a list of polynomials."""
+
+    chain: tuple[UnivariatePolynomial, ...] = Field(min_length=1)
+    degree: int = Field(ge=1, le=MAX_POLYNOMIAL_DEGREE)
+    method: Literal["SYMPY_STURM"] = "SYMPY_STURM"
+
+
+class RootCountResult(StrictModel):
+    """Count of real roots in an interval."""
+
+    root_count: int = Field(ge=0)
+    lower: CanonicalRational
+    upper: CanonicalRational
+    method: Literal["STURM_THEOREM"] = "STURM_THEOREM"
+
+
+__all__ = [
+    "PolynomialTerm",
+    "RootCountRequest",
+    "RootCountResult",
+    "SturmChainRequest",
+    "SturmChainResult",
+    "UnivariatePolynomial",
+]

--- a/src/jacobian/math/real_algebra/_operations.py
+++ b/src/jacobian/math/real_algebra/_operations.py
@@ -1,0 +1,56 @@
+"""Domain-owned real algebra operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.real_algebra import root_count, sturm_chain
+from jacobian.math.real_algebra._models import (
+    PolynomialTerm,
+    RootCountRequest,
+    RootCountResult,
+    SturmChainRequest,
+    SturmChainResult,
+    UnivariatePolynomial,
+)
+
+
+def _poly_to_terms(poly: UnivariatePolynomial) -> list[tuple[Fraction, int]]:
+    return [(t.coefficient.as_fraction(), t.exponent) for t in poly.terms]
+
+
+def _terms_to_poly(terms: list[tuple[Fraction, int]]) -> UnivariatePolynomial:
+    return UnivariatePolynomial(
+        terms=tuple(
+            PolynomialTerm(
+                coefficient=CanonicalRational.from_fraction(coeff),
+                exponent=exp,
+            )
+            for coeff, exp in terms
+            if coeff != 0
+        )
+    )
+
+
+def compute_sturm_chain(request: SturmChainRequest) -> SturmChainResult:
+    poly = request.polynomial
+    terms = _poly_to_terms(poly)
+    chain = sturm_chain(terms)
+    degree = max(t.exponent for t in poly.terms)
+    return SturmChainResult(
+        chain=tuple(_terms_to_poly(c) for c in chain),
+        degree=degree,
+    )
+
+
+def compute_root_count(request: RootCountRequest) -> RootCountResult:
+    terms = _poly_to_terms(request.polynomial)
+    lower = request.lower.as_fraction()
+    upper = request.upper.as_fraction()
+    count = root_count(terms, lower, upper)
+    return RootCountResult(
+        root_count=count,
+        lower=request.lower,
+        upper=request.upper,
+    )

--- a/src/jacobian/math/real_algebra/_tools.py
+++ b/src/jacobian/math/real_algebra/_tools.py
@@ -1,0 +1,108 @@
+"""Real algebra operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.real_algebra._models import (
+    RootCountRequest,
+    RootCountResult,
+    SturmChainRequest,
+    SturmChainResult,
+)
+from jacobian.math.real_algebra._operations import (
+    compute_root_count,
+    compute_sturm_chain,
+)
+
+
+def ra_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+REAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    ra_operation(
+        "polynomial.sturm_chain.compute",
+        "Compute the Sturm chain of a univariate polynomial",
+        "Compute the exact Sturm subresultant chain of a univariate "
+        "polynomial over QQ using SymPy's sturm function.",
+        SturmChainRequest,
+        SturmChainResult,
+        compute_sturm_chain,
+        "polynomial",
+        "sturm-chain",
+        "exact",
+        examples=(
+            example(
+                "cubic",
+                "Sturm chain of x^3 - 2x^2 + x - 3.",
+                {
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 3},
+                            {"coefficient": {"num": "-2", "den": "1"}, "exponent": 2},
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 1},
+                            {"coefficient": {"num": "-3", "den": "1"}, "exponent": 0},
+                        ],
+                    },
+                },
+            ),
+        ),
+    ),
+    ra_operation(
+        "polynomial.root_count.compute",
+        "Count real roots in an interval via Sturm's theorem",
+        "Count the exact number of real roots of a univariate polynomial "
+        "in the closed interval [lower, upper] using the Sturm theorem.",
+        RootCountRequest,
+        RootCountResult,
+        compute_root_count,
+        "polynomial",
+        "root-count",
+        "exact",
+        examples=(
+            example(
+                "cubic",
+                "Count roots of x^3 - 2x^2 + x - 3 in [-10, 10].",
+                {
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 3},
+                            {"coefficient": {"num": "-2", "den": "1"}, "exponent": 2},
+                            {"coefficient": {"num": "1", "den": "1"}, "exponent": 1},
+                            {"coefficient": {"num": "-3", "den": "1"}, "exponent": 0},
+                        ],
+                    },
+                    "lower": {"num": "-10", "den": "1"},
+                    "upper": {"num": "10", "den": "1"},
+                },
+            ),
+        ),
+    ),
+)
+
+TOOLS = REAL_ALGEBRA_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/real_algebra/operations.py
+++ b/src/jacobian/math/real_algebra/operations.py
@@ -1,0 +1,89 @@
+"""Exact Sturm chain and root counting kernels backed by SymPy."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+__all__ = ["root_count", "sturm_chain"]
+
+
+def _to_sympy_poly(terms: list[tuple[Fraction, int]]) -> Any:
+    from sympy import Poly, Rational, Symbol
+
+    x = Symbol("x")
+    poly_dict = {exp: Rational(val.numerator, val.denominator) for val, exp in terms}
+    return Poly(poly_dict, x, domain="QQ")
+
+
+def sturm_chain(terms: list[tuple[Fraction, int]]) -> list[list[tuple[Fraction, int]]]:
+    """Compute the exact Sturm subresultant chain of a univariate polynomial."""
+
+    from sympy import sturm
+
+    poly = _to_sympy_poly(terms)
+    chain = sturm(poly)
+    return [_sympy_poly_to_terms(p) for p in chain]
+
+
+def root_count(
+    terms: list[tuple[Fraction, int]],
+    lower: Fraction,
+    upper: Fraction,
+) -> int:
+    """Count distinct real roots in the closed interval [lower, upper]."""
+
+    from sympy import Rational
+
+    poly = _to_sympy_poly(terms)
+    chain = _build_sturm_chain(poly)
+
+    a = Rational(lower.numerator, lower.denominator)
+    b = Rational(upper.numerator, upper.denominator)
+
+    sign_changes_a = _sign_changes(chain, a)
+    sign_changes_b = _sign_changes(chain, b)
+    root_at_lower = _evaluates_to_zero(poly, a)
+
+    # The zero-skipping variation is right-continuous, so the difference counts
+    # the half-open interval (lower, upper]. Add the root exactly at ``lower``
+    # back to obtain the advertised closed interval.
+    return sign_changes_a - sign_changes_b + (1 if root_at_lower else 0)
+
+
+def _build_sturm_chain(poly: Any) -> list[Any]:
+    from sympy import sturm
+
+    return list(sturm(poly))
+
+
+def _sign_changes(chain: list[Any], point: Any) -> int:
+    if len(chain) == 0:
+        return 0
+    signs: list[int] = []
+    for poly in chain:
+        value = poly.as_expr().subs(poly.gen, point)
+        if value != 0:
+            signs.append(1 if value > 0 else -1)
+    count = 0
+    for index in range(1, len(signs)):
+        if signs[index] != signs[index - 1]:
+            count += 1
+    return count
+
+
+def _evaluates_to_zero(poly: Any, point: Any) -> bool:
+    return bool(poly.as_expr().subs(poly.gen, point) == 0)
+
+
+def _sympy_poly_to_terms(poly: Any) -> list[tuple[Fraction, int]]:
+    result: list[tuple[Fraction, int]] = []
+    for exps, coeff in poly.as_dict().items():
+        if coeff == 0:
+            continue
+        if hasattr(coeff, "p") and hasattr(coeff, "q"):
+            fraction = Fraction(int(coeff.p), int(coeff.q))
+        else:
+            fraction = Fraction(coeff)
+        result.append((fraction, int(exps[0])))
+    return result

--- a/src/jacobian/math/regular_languages/__init__.py
+++ b/src/jacobian/math/regular_languages/__init__.py
@@ -1,0 +1,16 @@
+"""Exact regular language operations."""
+
+from jacobian.math.regular_languages.operations import (
+    count_accepted_words,
+    dfa_complement,
+    dfa_run,
+)
+from jacobian.math.regular_languages.values import DFA, DFATransition
+
+__all__ = [
+    "DFA",
+    "DFATransition",
+    "count_accepted_words",
+    "dfa_complement",
+    "dfa_run",
+]

--- a/src/jacobian/math/regular_languages/_models.py
+++ b/src/jacobian/math/regular_languages/_models.py
@@ -1,0 +1,76 @@
+"""Typed wire contracts for exact regular language operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.math.regular_languages.values import (
+    DFA,
+    MAX_COUNT_WORD_LENGTH,
+    MAX_DFA_STATES,
+    MAX_WORD_LENGTH,
+)
+
+
+class RunRequest(StrictModel):
+    """Check if a word is accepted by a DFA."""
+
+    dfa: DFA
+    word: tuple[int, ...] = Field(max_length=MAX_WORD_LENGTH)
+
+    @model_validator(mode="after")
+    def require_valid_word(self) -> Self:
+        for symbol in self.word:
+            if not 0 <= symbol < self.dfa.alphabet_size:
+                raise ValueError("word symbols must be in 0..alphabet_size-1")
+        return self
+
+
+class CountRequest(StrictModel):
+    """Count accepted words of a given length."""
+
+    dfa: DFA
+    word_length: int = Field(ge=0, le=MAX_COUNT_WORD_LENGTH)
+
+
+class ComplementRequest(StrictModel):
+    """Compute the complement of a DFA's language."""
+
+    dfa: DFA
+
+
+class RunResult(StrictModel):
+    """Whether a word was accepted and the final state reached."""
+
+    accepted: bool
+    final_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    method: Literal["DFA_SIMULATION"] = "DFA_SIMULATION"
+
+
+class CountResult(StrictModel):
+    """Exact count of accepted words of a given length."""
+
+    count: CanonicalInteger
+    word_length: int = Field(ge=0, le=MAX_COUNT_WORD_LENGTH)
+    method: Literal["MATRIX_POWERING"] = "MATRIX_POWERING"
+
+
+class ComplementResult(StrictModel):
+    """The complement DFA."""
+
+    dfa: DFA
+    method: Literal["ACCEPTING_FLIP"] = "ACCEPTING_FLIP"
+
+
+__all__ = [
+    "ComplementRequest",
+    "ComplementResult",
+    "CountRequest",
+    "CountResult",
+    "RunRequest",
+    "RunResult",
+]

--- a/src/jacobian/math/regular_languages/_operations.py
+++ b/src/jacobian/math/regular_languages/_operations.py
@@ -1,0 +1,38 @@
+"""Domain adapter for regular language operations."""
+
+from __future__ import annotations
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.regular_languages import (
+    count_accepted_words,
+    dfa_complement,
+    dfa_run,
+)
+from jacobian.math.regular_languages._models import (
+    ComplementRequest,
+    ComplementResult,
+    CountRequest,
+    CountResult,
+    RunRequest,
+    RunResult,
+)
+
+
+def compute_run(request: RunRequest) -> RunResult:
+    accepted, final_state = dfa_run(request.dfa, request.word)
+    return RunResult(accepted=accepted, final_state=final_state)
+
+
+def compute_count(request: CountRequest) -> CountResult:
+    count = count_accepted_words(request.dfa, request.word_length)
+    return CountResult(
+        count=format_canonical_integer(count),
+        word_length=request.word_length,
+    )
+
+
+def compute_complement(request: ComplementRequest) -> ComplementResult:
+    return ComplementResult(dfa=dfa_complement(request.dfa))
+
+
+__all__ = ["compute_complement", "compute_count", "compute_run"]

--- a/src/jacobian/math/regular_languages/_tools.py
+++ b/src/jacobian/math/regular_languages/_tools.py
@@ -1,0 +1,125 @@
+"""Regular language operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.regular_languages._models import (
+    ComplementRequest,
+    ComplementResult,
+    CountRequest,
+    CountResult,
+    RunRequest,
+    RunResult,
+)
+from jacobian.math.regular_languages._operations import (
+    compute_complement,
+    compute_count,
+    compute_run,
+)
+
+
+def rl_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_DFA_EXAMPLE = {
+    "dfa": {
+        "state_count": 2,
+        "alphabet_size": 2,
+        "transitions": [
+            {"source": 0, "symbol": 0, "target": 0},
+            {"source": 0, "symbol": 1, "target": 1},
+            {"source": 1, "symbol": 0, "target": 0},
+            {"source": 1, "symbol": 1, "target": 1},
+        ],
+        "initial_state": 0,
+        "accepting_states": [1],
+    },
+}
+
+
+REGULAR_LANGUAGE_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    rl_operation(
+        "regular_language.run.check",
+        "Check if a word is accepted by a DFA",
+        "Simulate a deterministic finite automaton on a word and return "
+        "whether it is accepted and the final state reached.",
+        RunRequest,
+        RunResult,
+        compute_run,
+        "automata",
+        "dfa",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "DFA accepting binary strings ending in 1, word [1,0,1] accepted.",
+                {"dfa": _DFA_EXAMPLE["dfa"], "word": [1, 0, 1]},
+            ),
+        ),
+    ),
+    rl_operation(
+        "regular_language.count_words.compute",
+        "Count accepted words of a given length",
+        "Count the number of words of exact length accepted by a DFA "
+        "using exact integer matrix powering of the transition matrix.",
+        CountRequest,
+        CountResult,
+        compute_count,
+        "automata",
+        "counting",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "Count binary strings of length 3 ending in 1: 4 words.",
+                {"dfa": _DFA_EXAMPLE["dfa"], "word_length": 3},
+            ),
+        ),
+    ),
+    rl_operation(
+        "regular_language.complement.compute",
+        "Compute the complement of a DFA's language",
+        "Compute the complement DFA by flipping the set of accepting states.",
+        ComplementRequest,
+        ComplementResult,
+        compute_complement,
+        "automata",
+        "complement",
+        "exact",
+        examples=(
+            example(
+                "binary_ends_in_1",
+                "Complement of DFA accepting strings ending in 1.",
+                {"dfa": _DFA_EXAMPLE["dfa"]},
+            ),
+        ),
+    ),
+)
+
+TOOLS = REGULAR_LANGUAGE_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -1,0 +1,52 @@
+"""Exact regular language kernels backed by SymPy matrix powering."""
+
+from __future__ import annotations
+
+from jacobian.math.regular_languages.values import DFA
+
+__all__ = ["count_accepted_words", "dfa_complement", "dfa_run"]
+
+
+def _transition_map(dfa: DFA) -> dict[tuple[int, int], int]:
+    return {(tr.source, tr.symbol): tr.target for tr in dfa.transitions}
+
+
+def dfa_run(dfa: DFA, word: tuple[int, ...]) -> tuple[bool, int]:
+    """Simulate a total DFA on a word; return ``(accepted, final_state)``."""
+
+    transitions = _transition_map(dfa)
+    state = dfa.initial_state
+    for symbol in word:
+        state = transitions[(state, symbol)]
+    return (state in dfa.accepting_states, state)
+
+
+def count_accepted_words(dfa: DFA, word_length: int) -> int:
+    """Count accepted words of exact length via exact integer matrix powering."""
+
+    import sympy
+
+    state_count = dfa.state_count
+    if word_length == 0:
+        return 1 if dfa.initial_state in dfa.accepting_states else 0
+    matrix = sympy.zeros(state_count, state_count)
+    for (source, _symbol), target in _transition_map(dfa).items():
+        matrix[source, target] += 1
+    powered = matrix**word_length
+    total = 0
+    for target in dfa.accepting_states:
+        total += int(powered[dfa.initial_state, target])
+    return total
+
+
+def dfa_complement(dfa: DFA) -> DFA:
+    """Compute the complement DFA by flipping the accepting states."""
+
+    accepting = set(dfa.accepting_states)
+    return DFA(
+        state_count=dfa.state_count,
+        alphabet_size=dfa.alphabet_size,
+        transitions=dfa.transitions,
+        initial_state=dfa.initial_state,
+        accepting_states=tuple(sorted(set(range(dfa.state_count)) - accepting)),
+    )

--- a/src/jacobian/math/regular_languages/values.py
+++ b/src/jacobian/math/regular_languages/values.py
@@ -1,0 +1,76 @@
+"""Provider-independent values for exact regular languages over finite DFAs."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_DFA_STATES = 64
+MAX_DFA_ALPHABET = 32
+MAX_DFA_TRANSITIONS = 4096
+MAX_WORD_LENGTH = 1000
+MAX_COUNT_WORD_LENGTH = 200
+
+
+class DFATransition(StrictModel):
+    """One transition: from ``source`` on ``symbol`` to ``target``."""
+
+    source: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    symbol: int = Field(ge=0, le=MAX_DFA_ALPHABET - 1)
+    target: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+
+
+class DFA(StrictModel):
+    """One total deterministic finite automaton over an integer alphabet.
+
+    A valid DFA declares exactly one transition for every ``(state, symbol)``
+    pair so that simulation and word counting share one consistent semantics.
+    """
+
+    state_count: int = Field(ge=1, le=MAX_DFA_STATES)
+    alphabet_size: int = Field(ge=1, le=MAX_DFA_ALPHABET)
+    transitions: tuple[DFATransition, ...] = Field(
+        min_length=0,
+        max_length=MAX_DFA_TRANSITIONS,
+    )
+    initial_state: int = Field(ge=0, le=MAX_DFA_STATES - 1)
+    accepting_states: tuple[int, ...] = Field(
+        min_length=0,
+        max_length=MAX_DFA_STATES,
+    )
+
+    @model_validator(mode="after")
+    def require_total_deterministic_dfa(self) -> Self:
+        if not 0 <= self.initial_state < self.state_count:
+            raise ValueError("initial_state must be in 0..state_count-1")
+        if any(not 0 <= state < self.state_count for state in self.accepting_states):
+            raise ValueError("accepting states must be in 0..state_count-1")
+        if len(set(self.accepting_states)) != len(self.accepting_states):
+            raise ValueError("accepting states must be unique")
+        seen: set[tuple[int, int]] = set()
+        for transition in self.transitions:
+            if not 0 <= transition.source < self.state_count:
+                raise ValueError("transition source must be in 0..state_count-1")
+            if not 0 <= transition.target < self.state_count:
+                raise ValueError("transition target must be in 0..state_count-1")
+            if not 0 <= transition.symbol < self.alphabet_size:
+                raise ValueError("transition symbol must be in 0..alphabet_size-1")
+            key = (transition.source, transition.symbol)
+            if key in seen:
+                raise ValueError(
+                    "DFA must be deterministic (no duplicate source/symbol)"
+                )
+            seen.add(key)
+        expected = self.state_count * self.alphabet_size
+        if len(seen) != expected:
+            raise ValueError(
+                "DFA must be total: expected one transition for every "
+                f"state-symbol pair ({expected}), got {len(seen)}"
+            )
+        return self
+
+
+__all__ = ["DFA", "DFATransition"]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -209,6 +209,18 @@
       "input_schema": "sha256:8ae7dad21581c69dc3c14a0e890365a00579b11c0cee1d08b255ada0201e7bbd",
       "output_schema": "sha256:2aa9830a8fcb7554a1242bbe80a70320d93998ad56eab19698a7e03815e1368f"
     },
+    "electrical_network.effective_resistance.compute": {
+      "input_schema": "sha256:f7fc49bf5faddbba755a6bdc7945636893cf22802b83e7543f0d3cf35287fbf4",
+      "output_schema": "sha256:80a4bd01eba24d01e9f6b3da4971428d1713e8ab1fb65572c49d684dbf5b3d1e"
+    },
+    "electrical_network.laplacian.compute": {
+      "input_schema": "sha256:98bafdb82ba37fb001d89f5c776d67089a6a5058358f6cf0825f1422d5c39e2a",
+      "output_schema": "sha256:87f5dd35ede9a6bb886388c91474fad61b5c03ad62e11e791142cc5aff5f4ed5"
+    },
+    "electrical_network.node_potentials.compute": {
+      "input_schema": "sha256:6b351b506287744d0ea6b664737bc25830bf026d4d25499b93c0cabd730e0272",
+      "output_schema": "sha256:5bf0322fde491950f1e37a1eddcb68552e47c0d08fd9a620f7b9dbd5773b5436"
+    },
     "finite_abelian_group.exact_factorization.compute": {
       "input_schema": "sha256:1c1af27397f6e871b042146827f184be128cfe6c824877fa796ad191826ffed9",
       "output_schema": "sha256:b5fedde2179445bed43a1bd76b1a295befe124648fbeab54e3fe79dab77a8042"

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -853,6 +853,10 @@
       "input_schema": "sha256:b93588a14714787066232fc9d5c38d8b74dab2777d8c2ffb33782552fe48d818",
       "output_schema": "sha256:a8f803f08d5bec3577b0f1c438d3c95e7d50712c72a69bc664a3d1ec7ab37d20"
     },
+    "matrix.minimal_polynomial.compute": {
+      "input_schema": "sha256:cdba93aafda683f36484b99b9112445a6642b23f7afec202f77323c27f5cee63",
+      "output_schema": "sha256:50f14eefd5fedc087ce384f60d17fc09ee234d96e13def06603528bf2f4f5194"
+    },
     "matrix.multiply.compute": {
       "input_schema": "sha256:6d367846847b9fee425918a14d69384ef2b4dbae2407450b9cfa0ec21319bf3d",
       "output_schema": "sha256:f4e32cbfca35bf4b487db039ee6d46e9f34d7681f5339461eb3be7a7bac24d13"
@@ -881,9 +885,17 @@
       "input_schema": "sha256:04eaecca92f61d8a6abfab1f2274ef8e062bf0f6a50aef0ea8c3e9ed0971d62c",
       "output_schema": "sha256:4cd93ed5352ea6c517bafe03ecb7329a5783969e3d7c5f10eeb750e180ec2411"
     },
+    "matrix.primary_decomposition.compute": {
+      "input_schema": "sha256:cdba93aafda683f36484b99b9112445a6642b23f7afec202f77323c27f5cee63",
+      "output_schema": "sha256:aea76bdefd8866a4590d4080b551bdf38d71aec24628928161c55bb90d892635"
+    },
     "matrix.rank.compute": {
       "input_schema": "sha256:9399c1bb101d7546b140f4c47ed4d1c1ca4b3c6ed441f902cf2c127e50e6f4f8",
       "output_schema": "sha256:203e83a904c2bc4fa5e46b8326763fedd0609c08c7f60bc3c8e25088a0019063"
+    },
+    "matrix.rational_canonical_form.compute": {
+      "input_schema": "sha256:cdba93aafda683f36484b99b9112445a6642b23f7afec202f77323c27f5cee63",
+      "output_schema": "sha256:38e8dfeb665530af389e56988258c5efcf7089e55e476d6b5c277fe6c08957a8"
     },
     "matrix.rational_linear_system.solve": {
       "input_schema": "sha256:9b80937cd45ba3845521f275a762565ccdf701954d9ff8e5ec0c1e8122b5f270",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -201,6 +201,18 @@
       "input_schema": "sha256:93e2f363ed4f25f0483b99ee796101f5a8545fdbeaae764d1da9bac739c95675",
       "output_schema": "sha256:c03266ff0970b09dc6368730fedab88f02cd33f762b2b1d9ac35a4026d5a0256"
     },
+    "diophantine.continued_fraction.compute": {
+      "input_schema": "sha256:8db83f972791f0607634aacfca7eee107b3b5b5129ef561673233067d7e22dc5",
+      "output_schema": "sha256:c59425c803170d2984be0f70de24300271b8ee603fa344768706cd9ccd9947b8"
+    },
+    "diophantine.convergents.compute": {
+      "input_schema": "sha256:06c8ad7e3329030d938d71ee8950c2fafca74f9967e40a14916c0873aff41680",
+      "output_schema": "sha256:c2c5e7afdb0e66f468216a4165f145aaa473f947074181d3934e0073fbe69fde"
+    },
+    "diophantine.pell_equation.solve": {
+      "input_schema": "sha256:26381c0326d0b4afd7e450273f12e4c1cc574ca4b6839cd2f9832a520b299172",
+      "output_schema": "sha256:c3a0316d05ca68913a3a27dc5b416abfe099001fc8ba2f8586abc329e25458b2"
+    },
     "discrepancy.theory.eval.compute": {
       "input_schema": "sha256:e47d0ef803e121163a71578e0b3033921d572bf86f45f644e30573c3b920fab6",
       "output_schema": "sha256:d1dcd725fd5d5db850ead660a13140d3dc6da6635210e76c30068f9e9929619b"

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -149,6 +149,10 @@
       "input_schema": "sha256:3e7574bec1081f0ce6c524384915d281cfc6b455296c89216896ed091fb6e5fb",
       "output_schema": "sha256:8fc351368b45bfb6d2fc5d710a52d94c114df1270c6de4a4d777244558e6bf43"
     },
+    "combinatorics.conjugate_partition.compute": {
+      "input_schema": "sha256:309b1f18edaa3657ee05f8281d694c692ce522fe4052fdebba599034d2b49b3d",
+      "output_schema": "sha256:975a46d7ce1443a9d1de10a28c4814019acc7a8a8b83931385244a72ab18103b"
+    },
     "combinatorics.cyclic_difference_set.extension.decide": {
       "input_schema": "sha256:8124611617ad72bfc7cc562342e6d53710204c37578a72961b581cf21371ba42",
       "output_schema": "sha256:ee605a9c59dab292119148b78e032c235cae224ebc3591a2215acc2ab222928e"
@@ -164,6 +168,10 @@
     "combinatorics.generating_function.coefficients.compute": {
       "input_schema": "sha256:8772b24c32bedea9a382758e2538de463362830a494b9bbefba6dab64f1ed34f",
       "output_schema": "sha256:8c7fcd8984beb56307a91bb9e7068b34856f097280b8a2d9d51f3c79f859dc9d"
+    },
+    "combinatorics.hook_length.compute": {
+      "input_schema": "sha256:5383bea70824c336b88da0f0270507bc73ecf08689861690781dc3c73fb3a1e0",
+      "output_schema": "sha256:90e01a73b40c2527d276be011200fe052fd3e2bf1aecb76aec4cd18b4efb2f36"
     },
     "combinatorics.integer_set.sidon.decide": {
       "input_schema": "sha256:892525fd272560090e34f7babb2cd9b5fd477acd714dd3cecfbc4212a88ac225",
@@ -192,6 +200,10 @@
     "combinatorics.set_function.submodularity": {
       "input_schema": "sha256:22754dbe168296d6e6e0d5dd6359079873209a397de4d3bd6e51db14f265f806",
       "output_schema": "sha256:89e59456f49d01b61d8629fde714f6818db8e0eeb338e7a762ed638e30950272"
+    },
+    "combinatorics.standard_young_tableaux.count": {
+      "input_schema": "sha256:dbc5bbccc227278f0c3a90a252cd673ab54a2e4b40989e9242a9f694630079b0",
+      "output_schema": "sha256:f409575292c996f2bea47897510f606f7c947742c3ecea1e89c01a248686607c"
     },
     "convex.max_affine.evaluate": {
       "input_schema": "sha256:f23a9850b08779f60b74d9b30b5bc07840ae2dae95b95fce130df4f4af06d306",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -909,6 +909,18 @@
       "input_schema": "sha256:cd706bed75accaf880ade826fee22200b3bdfdc6011333364641abee165b65a2",
       "output_schema": "sha256:525174a77eb2639f36effd36e7c71216bdd13f22d415fb4da730f36e899aa9c8"
     },
+    "metric_space.ball.compute": {
+      "input_schema": "sha256:f4365e2d9efae53503147e142219bb82890a47f425200854f5ec5d5da27b0dfd",
+      "output_schema": "sha256:7b53aff04dba2c5e6ab51b066824af6a98a6c7c628086833cd4b55035eaf311a"
+    },
+    "metric_space.gromov_hyperbolicity.compute": {
+      "input_schema": "sha256:26c721a71a36d00553baeb7168b75922b8df8d71088b3e39e2ea9a74b1147215",
+      "output_schema": "sha256:ffb220874a13afb2ad00b366af830306289ae98cc86ca4070cb75fa04461844c"
+    },
+    "metric_space.profile.compute": {
+      "input_schema": "sha256:93b80ed8bfdb1cace84bf2eb7ac60c5ce7d58be373eae0273c39a56f81bec0f3",
+      "output_schema": "sha256:d9c6f9576cedc747e9af8789359b371a2ac5fac2b83101c354ead3c119cf8452"
+    },
     "modular.compute.discrete_logarithm": {
       "input_schema": "sha256:83b89e6c101376613c6ecbc2552572b1f42397ddffd4c6eab2700ba362be9469",
       "output_schema": "sha256:3d7e704bad1ccec1910bc0f650c3a41e9266d897a97d13790325a8c8d88aa995"

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1065,9 +1065,17 @@
       "input_schema": "sha256:b38cc7030dd1046da9fc1313b61be395121c6102ab221dfab7f99a7ced97dda8",
       "output_schema": "sha256:725c10c9920836da6168e644b9c15565221678640249f81eef16afb59b91c047"
     },
+    "polynomial.root_count.compute": {
+      "input_schema": "sha256:a6d64ccc1da7ad368136c2381a83eb69b951ba43ad258cb1402606428464e652",
+      "output_schema": "sha256:cb3bdf34db4b813334a21cc07672b4405d82e888d02baecd94ae1fa2fe507209"
+    },
     "polynomial.roots.isolate": {
       "input_schema": "sha256:1bb055763d969d462cd7b989502b816716ba40339663d489f33db34e20d438d5",
       "output_schema": "sha256:ebbabea1bc3985b058f77e9fd3da9b0748b70c8ad42d3fbed6980126a9bce861"
+    },
+    "polynomial.sturm_chain.compute": {
+      "input_schema": "sha256:2b40338042028e9a6e477838b179c012662fcd374322c1b0451039f9fc4b7f6e",
+      "output_schema": "sha256:ca8d93197a2ccaa55fce3e8eab6cb1de174742a4a9463606807c4877054865df"
     },
     "poset.finite.compute": {
       "input_schema": "sha256:73c1738f192a084128ea68cc954c524bed9c6b65898f7a47498b9d5e516b94b2",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1189,6 +1189,18 @@
       "input_schema": "sha256:ba6423e4cce44197eb98f3a6ae2839cce5c89d8f3c67938f8702b682e19c0985",
       "output_schema": "sha256:460d45024087160fd1cc757f952e363d3fd18b48dd0dec9d4a7b0bf104c7bf8c"
     },
+    "regular_language.complement.compute": {
+      "input_schema": "sha256:bf36e2409b31e359054b83d9b0fe28fddb1e1105b4c82e0fbb219cf1751e240e",
+      "output_schema": "sha256:bc6fdc4fb8bf39d7d8fcf7f0d65e32cd232b8efb06265929a031b508c46d1141"
+    },
+    "regular_language.count_words.compute": {
+      "input_schema": "sha256:c84d11d1becee2c0672dc97dbaa1659e3a540ee77cae7651e70eabf6c65c042e",
+      "output_schema": "sha256:32f5f0ff90051b9e5d438dd1815e8fdadbcaf33ec7582fff2422beb9d484d433"
+    },
+    "regular_language.run.check": {
+      "input_schema": "sha256:3366f388ed26f9f15a00fad35a14332b418f1752db02507c15404c59ec41ad55",
+      "output_schema": "sha256:77e39238312939b8450b419e53fb4dbaef1ee4c238e939c683dfb3f92f77f475"
+    },
     "sat.assignment.check": {
       "input_schema": "sha256:043d67beebbde52080df34632b3c9f5cef0deeee54aa868cf9475d970251a8b0",
       "output_schema": "sha256:dcba46f01160ac35cc05556235610b8e4a47300ff329b29b69c5efb629bdad3a"

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -457,6 +457,10 @@
       "input_schema": "sha256:0046a0d3920b79f0849d444d74edcb68e73b4a3efee3f679372e22e5abd0f2c9",
       "output_schema": "sha256:818097102f36a887171bb0bc850a12e894f8b46df20f559777ee721f19a929eb"
     },
+    "graph.complement.compute": {
+      "input_schema": "sha256:f5e22b2b4e7927018cce90aaf9763f6ff6bda2cb8d7871cc5e2b46478a78d516",
+      "output_schema": "sha256:34cca77e162ad804dd5eb93f56bfbb5fda4e5fe088078d24ef987ea72b8cf1f2"
+    },
     "graph.cut.minimum_st.compute": {
       "input_schema": "sha256:dd40f3a37c1098d8caeb05b125bb7f7684b44e5e3b5a8dffc1d9a09119196261",
       "output_schema": "sha256:137a06454af2fdfb0bed4d877d654c7f595872855a29b28c96ad88e3f7ffbb41"
@@ -529,6 +533,10 @@
       "input_schema": "sha256:c5325fe91eaf07a82ed42666b0691144b4db1d369a1dfca9a42b73f190c88919",
       "output_schema": "sha256:1fac8ffd2e1fc4fbc22e312eb3074cb50fb7c5c997b9e2bf53c7f6334083084c"
     },
+    "graph.induced_subgraph.compute": {
+      "input_schema": "sha256:e6c76fafeb1389bd5e31bae10167461767b8e075272429168712ad551918d8e7",
+      "output_schema": "sha256:34cca77e162ad804dd5eb93f56bfbb5fda4e5fe088078d24ef987ea72b8cf1f2"
+    },
     "graph.induced_tree.maximum.compute": {
       "input_schema": "sha256:c5325fe91eaf07a82ed42666b0691144b4db1d369a1dfca9a42b73f190c88919",
       "output_schema": "sha256:587db12c617a12f32d9dcdb6dfe121ebc757d17d087d90f33e57e6564826ab16"
@@ -589,6 +597,10 @@
       "input_schema": "sha256:0b54d65dec3be9d6e6e5793895ed1809de84d2163d6acacad775f86b5d64da12",
       "output_schema": "sha256:438e31ef5edc071cdade852520ebb140e8ede3d08626a50750fe7d586109a433"
     },
+    "graph.line_graph.compute": {
+      "input_schema": "sha256:f5e22b2b4e7927018cce90aaf9763f6ff6bda2cb8d7871cc5e2b46478a78d516",
+      "output_schema": "sha256:34cca77e162ad804dd5eb93f56bfbb5fda4e5fe088078d24ef987ea72b8cf1f2"
+    },
     "graph.matching.maximal.minimum.compute": {
       "input_schema": "sha256:c5325fe91eaf07a82ed42666b0691144b4db1d369a1dfca9a42b73f190c88919",
       "output_schema": "sha256:ddec0da6730145fbe5c0071fa9a253d479968ffe23490cab069a6561dbe513ff"
@@ -612,6 +624,10 @@
     "graph.polynomial.tutte.compute": {
       "input_schema": "sha256:49a6e8ab1943a47b36ac70014d3bbbe27a7a8e644b512d866a49b01a426523f3",
       "output_schema": "sha256:20679c5cc5d1aade8396de44af8767150e012aab464b7a5e9ca7dc921e3f9fe6"
+    },
+    "graph.power.compute": {
+      "input_schema": "sha256:f5e22b2b4e7927018cce90aaf9763f6ff6bda2cb8d7871cc5e2b46478a78d516",
+      "output_schema": "sha256:34cca77e162ad804dd5eb93f56bfbb5fda4e5fe088078d24ef987ea72b8cf1f2"
     },
     "graph.realization.check.compute": {
       "input_schema": "sha256:3766ae7e6a99e94254cdf1067f85bd971e5927f976f789a5aaae9f9d429b2026",

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 336
+    assert len(actual) == 338
     assert actual == expected["operations"]
 
 

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 339
+    assert len(actual) == 360
     assert actual == expected["operations"]
 
 
@@ -98,9 +98,9 @@ def test_representative_search_browse_and_inspect_results_are_stable() -> None:
         "electrical_network.laplacian.compute",
         "electrical_network.node_potentials.compute",
         "graph.coloring.k_colorability.decide",
-        "graph.cut.minimum_st.compute",
+        "graph.complement.compute",
     ]
-    assert browse.total_operations == 51
+    assert browse.total_operations == 55
     assert inspected is not None
     assert inspected.operation_id == "integer.compute.gcd"
     assert inspected.version == "2"

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 336
+    assert len(actual) == 339
     assert actual == expected["operations"]
 
 
@@ -94,13 +94,13 @@ def test_representative_search_browse_and_inspect_results_are_stable() -> None:
         "finite_field.direction_rank_ledger.compute",
     ]
     assert [operation.operation_id for operation in browse.operations] == [
+        "electrical_network.effective_resistance.compute",
+        "electrical_network.laplacian.compute",
+        "electrical_network.node_potentials.compute",
         "graph.coloring.k_colorability.decide",
         "graph.cut.minimum_st.compute",
-        "graph.decomposition.biconnected_components.compute",
-        "graph.decomposition.block_cut_tree.compute",
-        "graph.decomposition.bridge_block_tree.compute",
     ]
-    assert browse.total_operations == 48
+    assert browse.total_operations == 51
     assert inspected is not None
     assert inspected.operation_id == "integer.compute.gcd"
     assert inspected.version == "2"

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 336
+    assert len(actual) == 339
     assert actual == expected["operations"]
 
 

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 336
+    assert len(actual) == 340
     assert actual == expected["operations"]
 
 
@@ -95,12 +95,12 @@ def test_representative_search_browse_and_inspect_results_are_stable() -> None:
     ]
     assert [operation.operation_id for operation in browse.operations] == [
         "graph.coloring.k_colorability.decide",
+        "graph.complement.compute",
         "graph.cut.minimum_st.compute",
         "graph.decomposition.biconnected_components.compute",
         "graph.decomposition.block_cut_tree.compute",
-        "graph.decomposition.bridge_block_tree.compute",
     ]
-    assert browse.total_operations == 48
+    assert browse.total_operations == 52
     assert inspected is not None
     assert inspected.operation_id == "integer.compute.gcd"
     assert inspected.version == "2"

--- a/tests/math/algebraic_combinatorics/test_algebraic_combinatorics.py
+++ b/tests/math/algebraic_combinatorics/test_algebraic_combinatorics.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from itertools import permutations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.algebraic_combinatorics._models import (
+    ConjugatePartitionRequest,
+    HookLengthRequest,
+    Partition,
+    StandardYoungTableauCountRequest,
+)
+from jacobian.math.algebraic_combinatorics._operations import (
+    compute_conjugate_partition,
+    compute_hook_lengths,
+    compute_syt_count,
+)
+
+
+def test_hook_lengths_partition_321() -> None:
+    """Hook lengths of (3,2,1) are [[5,3,1],[3,1],[1]]."""
+    result = compute_hook_lengths(
+        HookLengthRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.hooks == ((5, 3, 1), (3, 1), (1,))
+    assert result.total_product == "45"
+
+
+def test_hook_lengths_single_row() -> None:
+    """Hook lengths of (n) are [n, n-1, ..., 1]."""
+    result = compute_hook_lengths(HookLengthRequest(partition=Partition(parts=(4,))))
+    assert result.hooks == ((4, 3, 2, 1),)
+    assert result.total_product == "24"
+
+
+def test_hook_lengths_single_column() -> None:
+    """Hook lengths of (1,1,1) are [[1],[1],[1]]."""
+    result = compute_hook_lengths(
+        HookLengthRequest(partition=Partition(parts=(1, 1, 1)))
+    )
+    assert result.hooks == ((3,), (2,), (1,))
+    assert result.total_product == "6"
+
+
+def test_syt_count_partition_321() -> None:
+    """Number of SYT for shape (3,2,1) is 16."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.count == "16"
+    assert result.n == 6
+    assert result.method == "HOOK_LENGTH_FORMULA"
+
+
+def test_syt_count_single_row() -> None:
+    """Number of SYT for shape (n) is 1."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(5,)))
+    )
+    assert result.count == "1"
+    assert result.n == 5
+
+
+def test_syt_count_single_column() -> None:
+    """Number of SYT for shape (1,1,...,1) is 1."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(1, 1, 1, 1)))
+    )
+    assert result.count == "1"
+    assert result.n == 4
+
+
+def test_syt_count_rectangle_22() -> None:
+    """Number of SYT for shape (2,2) is 2."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(partition=Partition(parts=(2, 2)))
+    )
+    assert result.count == "2"
+
+
+def _count_syt_brute_force(parts: tuple[int, ...]) -> int:
+    """Brute-force count of standard Young tableaux."""
+    n = sum(parts)
+    positions = []
+    for row, length in enumerate(parts):
+        for column in range(length):
+            positions.append((row, column))
+
+    def is_valid(perm: tuple[int, ...]) -> bool:
+        table = {positions[idx]: perm[idx] for idx in range(len(perm))}
+        for row, column in positions:
+            if row > 0 and table[(row, column)] <= table[(row - 1, column)]:
+                return False
+            if column > 0 and table[(row, column)] <= table[(row, column - 1)]:
+                return False
+        return True
+
+    return sum(1 for perm in permutations(range(1, n + 1)) if is_valid(perm))
+
+
+def test_syt_count_matches_brute_force() -> None:
+    """SYT count matches the number of valid fillings for small partitions."""
+    for parts in [(3, 1), (2, 2), (3, 2)]:
+        brute = _count_syt_brute_force(parts)
+        result = compute_syt_count(
+            StandardYoungTableauCountRequest(partition=Partition(parts=parts))
+        )
+        assert result.count == str(brute)
+
+
+def test_conjugate_self_conjugate_partition() -> None:
+    """Conjugate of (3,2,1) is (3,2,1) — self-conjugate."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(3, 2, 1)))
+    )
+    assert result.conjugate == (3, 2, 1)
+
+
+def test_conjugate_row_to_column() -> None:
+    """Conjugate of (4) is (1,1,1,1) and vice versa."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(4,)))
+    )
+    assert result.conjugate == (1, 1, 1, 1)
+
+
+def test_conjugate_column_to_row() -> None:
+    """Conjugate of (1,1,1,1) is (4)."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(1, 1, 1, 1)))
+    )
+    assert result.conjugate == (4,)
+
+
+def test_conjugate_double_conjugate_is_identity() -> None:
+    """Conjugate of conjugate is the original partition."""
+    result = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=(5, 3, 2, 1)))
+    )
+    result2 = compute_conjugate_partition(
+        ConjugatePartitionRequest(partition=Partition(parts=result.conjugate))
+    )
+    assert result2.conjugate == (5, 3, 2, 1)
+
+
+def test_contract_rejects_non_decreasing() -> None:
+    with pytest.raises(ValidationError, match="non-increasing"):
+        Partition(parts=(1, 2, 3))
+
+
+def test_contract_rejects_non_positive() -> None:
+    with pytest.raises(ValidationError, match="positive"):
+        Partition(parts=(3, 0, 1))
+
+
+def test_contract_rejects_partition_exceeding_size_bound() -> None:
+    """A single-part partition summing above MAX_PARTITION_SIZE is rejected."""
+    with pytest.raises(ValidationError, match="partition size must not exceed"):
+        Partition(parts=(51,))
+
+
+def test_contract_rejects_non_integer_parts() -> None:
+    """Boolean or string partition parts are rejected, not silently coerced."""
+    with pytest.raises(ValidationError):
+        Partition.model_validate({"parts": [True]})
+    with pytest.raises(ValidationError):
+        Partition.model_validate({"parts": ["3"]})
+
+
+def test_syt_count_large_returns_canonical_string() -> None:
+    """Large SYT counts are returned as canonical decimal strings."""
+    result = compute_syt_count(
+        StandardYoungTableauCountRequest(
+            partition=Partition(parts=(10, 9, 8, 7, 6, 5, 4, 1))
+        )
+    )
+    assert result.count == "322821557622027077916662169600"

--- a/tests/math/canonical_forms/test_canonical_forms.py
+++ b/tests/math/canonical_forms/test_canonical_forms.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.canonical_forms import (
+    invariant_factors,
+    minimal_polynomial,
+    primary_decomposition,
+)
+from jacobian.math.canonical_forms._models import MonicPolynomial, SquareMatrixRequest
+from jacobian.math.canonical_forms._operations import (
+    compute_minimal_polynomial,
+    compute_primary_decomposition,
+    compute_rational_canonical_form,
+)
+from jacobian.math.matrices.values import RationalMatrix
+
+R = CanonicalRational
+
+
+def _mat(*rows: tuple[tuple[str, str], ...]) -> SquareMatrixRequest:
+    entries = tuple(tuple(R(num=num, den=den) for num, den in row) for row in rows)
+    return SquareMatrixRequest(matrix=RationalMatrix(entries=entries))
+
+
+def _coeffs(poly: MonicPolynomial) -> list[Fraction]:
+    return [coefficient.as_fraction() for coefficient in poly.coefficients]
+
+
+def _pair(num: str, den: str) -> tuple[str, str]:
+    return (num, den)
+
+
+def _diagonal(*values: str) -> SquareMatrixRequest:
+    entries = tuple(
+        tuple(
+            R(num=value if row == column else "0", den="1")
+            for column, value in enumerate(values)
+        )
+        for row in range(len(values))
+    )
+    return SquareMatrixRequest(matrix=RationalMatrix(entries=entries))
+
+
+def test_nilpotent_jordan_block_minimal_polynomial_is_t_squared() -> None:
+    """Matrix [[0,1],[0,0]] has minimal polynomial t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    assert _coeffs(result.minimal_polynomial) == [Fraction(0), Fraction(0), Fraction(1)]
+    assert result.degree == 2
+
+
+def test_diagonal_distinct_minimal_equals_characteristic() -> None:
+    """diag(2,3) has minimal polynomial (t-2)(t-3) = t^2 - 5t + 6."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    assert _coeffs(result.minimal_polynomial) == [
+        Fraction(6),
+        Fraction(-5),
+        Fraction(1),
+    ]
+    assert _coeffs(result.characteristic_polynomial) == [
+        Fraction(6),
+        Fraction(-5),
+        Fraction(1),
+    ]
+
+
+def test_jordan_block_minimal_equals_characteristic() -> None:
+    """[[2,1],[0,2]] has minimal polynomial (t-2)^2 = t^2 - 4t + 4."""
+    req = _mat(
+        (_pair("2", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("2", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    assert _coeffs(result.minimal_polynomial) == [
+        Fraction(4),
+        Fraction(-4),
+        Fraction(1),
+    ]
+    assert _coeffs(result.characteristic_polynomial) == [
+        Fraction(4),
+        Fraction(-4),
+        Fraction(1),
+    ]
+
+
+def test_identity_matrix_minimal_polynomial_is_t_minus_one() -> None:
+    """2x2 identity has minimal polynomial t - 1."""
+    req = _mat(
+        (_pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("1", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    assert _coeffs(result.minimal_polynomial) == [Fraction(-1), Fraction(1)]
+
+
+def test_irreducible_over_qq_minimal_polynomial() -> None:
+    """[[0,-1],[1,0]] has minimal polynomial t^2 + 1 (irreducible over QQ)."""
+    req = _mat(
+        (_pair("0", "1"), _pair("-1", "1")),
+        (_pair("1", "1"), _pair("0", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    assert _coeffs(result.minimal_polynomial) == [Fraction(1), Fraction(0), Fraction(1)]
+
+
+def test_nilpotent_single_block_canonical_form() -> None:
+    """[[0,1],[0,0]] has one invariant factor t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 1
+    assert _coeffs(result.invariant_factors[0].factor) == [
+        Fraction(0),
+        Fraction(0),
+        Fraction(1),
+    ]
+    assert result.invariant_factors[0].block_size == 2
+    assert result.total_block_size == 2
+
+
+def test_diagonal_distinct_single_factor_canonical_form() -> None:
+    """diag(2,3) has one invariant factor (t-2)(t-3)."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 1
+    assert _coeffs(result.invariant_factors[0].factor) == [
+        Fraction(6),
+        Fraction(-5),
+        Fraction(1),
+    ]
+
+
+def test_identity_two_blocks_canonical_form() -> None:
+    """2x2 identity has invariant factors (t-1), (t-1)."""
+    req = _mat(
+        (_pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("1", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 2
+    assert result.total_block_size == 2
+    for entry in result.invariant_factors:
+        assert _coeffs(entry.factor) == [Fraction(-1), Fraction(1)]
+
+
+def test_nilpotent_two_blocks_divisibility_chain() -> None:
+    """Nilpotent with blocks of sizes 2 and 1: invariant factors t | t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 2
+    sizes = [entry.block_size for entry in result.invariant_factors]
+    assert sizes == [1, 2]
+
+
+def test_primary_decomposition_distinct_linear_factors() -> None:
+    """diag(2,3) decomposes into (t-2) and (t-3)."""
+    req = _mat(
+        (_pair("2", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("3", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    assert len(result.components) == 2
+    for component in result.components:
+        assert len(_coeffs(component)) == 2
+
+
+def test_primary_decomposition_irreducible_power() -> None:
+    """[[0,1],[0,0]] has minpoly t^2, primary decomposition is [t^2]."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    assert len(result.components) == 1
+    assert _coeffs(result.components[0]) == [Fraction(0), Fraction(0), Fraction(1)]
+
+
+def test_primary_decomposition_normalizes_rational_root_factors() -> None:
+    """diag(1/2, 1/3) decomposes into the monic factors (t-1/2) and (t-1/3)."""
+    req = _mat(
+        (_pair("1", "2"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("1", "3")),
+    )
+    result = compute_primary_decomposition(req)
+    assert sorted(_coeffs(component) for component in result.components) == [
+        [Fraction(-1, 2), Fraction(1)],
+        [Fraction(-1, 3), Fraction(1)],
+    ]
+
+
+def test_contract_rejects_nonsquare() -> None:
+    with pytest.raises(ValidationError, match="square"):
+        SquareMatrixRequest(
+            matrix=RationalMatrix(entries=((R(num="1", den="1"), R(num="0", den="1")),))
+        )
+
+
+def test_contract_rejects_non_monic_polynomial() -> None:
+    with pytest.raises(ValidationError, match="monic"):
+        MonicPolynomial(coefficients=(R(num="1", den="1"), R(num="2", den="1")))
+
+
+def test_characteristic_equals_product_of_invariant_factors() -> None:
+    """Product of invariant factors equals the characteristic polynomial."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+        (_pair("0", "1"), _pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_rational_canonical_form(req)
+    assert result.total_block_size == 3
+    assert _coeffs(result.characteristic_polynomial) == [
+        Fraction(0),
+        Fraction(0),
+        Fraction(0),
+        Fraction(1),
+    ]
+
+
+def test_method_tags() -> None:
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    assert compute_minimal_polynomial(req).method == "KRYLOV_NULLSPACE"
+    assert compute_rational_canonical_form(req).method == "SMITH_NORMAL_FORM"
+    assert compute_primary_decomposition(req).method == "FACTOR_LCM"
+
+
+def test_smith_normal_form_path_handles_larger_matrices() -> None:
+    """A 6x6 diagonal matrix uses the maintained Smith form, not minor enumeration."""
+    req = _diagonal("2", "3", "5", "7", "11", "13")
+    result = compute_rational_canonical_form(req)
+    assert len(result.invariant_factors) == 1
+    assert result.invariant_factors[0].block_size == 6
+    assert result.total_block_size == 6
+    characteristic = _coeffs(result.characteristic_polynomial)
+    assert len(characteristic) == 7
+    assert characteristic[-1] == Fraction(1)
+    assert characteristic[0] == Fraction(2 * 3 * 5 * 7 * 11 * 13)
+    assert characteristic[-2] == Fraction(-(2 + 3 + 5 + 7 + 11 + 13))
+    assert _coeffs(result.minimal_polynomial) == characteristic
+
+
+def test_single_entry_matrix_canonical_forms() -> None:
+    req = _mat((_pair("2", "1"),))
+    assert _coeffs(compute_minimal_polynomial(req).minimal_polynomial) == [
+        Fraction(-2),
+        Fraction(1),
+    ]
+
+    rcf = compute_rational_canonical_form(req)
+    assert len(rcf.invariant_factors) == 1
+    assert rcf.invariant_factors[0].block_size == 1
+    assert rcf.total_block_size == 1
+    assert _coeffs(rcf.invariant_factors[0].factor) == [Fraction(-2), Fraction(1)]
+
+    decomposition = compute_primary_decomposition(req)
+    assert len(decomposition.components) == 1
+    assert _coeffs(decomposition.components[0]) == [Fraction(-2), Fraction(1)]
+
+
+def test_contract_rejects_oversized_and_wide_scalar_matrices() -> None:
+    identity_17 = tuple(
+        tuple(R(num="1" if row == column else "0", den="1") for column in range(17))
+        for row in range(17)
+    )
+    with pytest.raises(ValidationError, match="16 x 16"):
+        SquareMatrixRequest(matrix=RationalMatrix(entries=identity_17))
+
+    wide_scalar = ((R(num="1" + "0" * 256, den="1"),),)
+    with pytest.raises(ValidationError, match="256 decimal digits"):
+        SquareMatrixRequest(matrix=RationalMatrix(entries=wide_scalar))
+
+
+def test_public_kernels_return_monic_coefficient_lists() -> None:
+    entries = (
+        (Fraction(0), Fraction(1)),
+        (Fraction(0), Fraction(0)),
+    )
+    assert minimal_polynomial(entries) == (Fraction(0), Fraction(0), Fraction(1))
+    assert invariant_factors(entries) == ((Fraction(0), Fraction(0), Fraction(1)),)
+    assert primary_decomposition(entries) == ((Fraction(0), Fraction(0), Fraction(1)),)

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -1,0 +1,232 @@
+"""Domain tests for exact Diophantine approximation operations."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.diophantine_approximation import (
+    continued_fraction,
+    convergents,
+    solve_pell,
+)
+from jacobian.math.diophantine_approximation._models import (
+    ContinuedFractionRequest,
+    ConvergentRequest,
+    PellEquationRequest,
+)
+from jacobian.math.diophantine_approximation._operations import (
+    compute_continued_fraction,
+    compute_convergents,
+    compute_pell_equation,
+)
+
+
+def test_continued_fraction_sqrt_2() -> None:
+    """sqrt(2) = [1; 2, 2, 2, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=5)
+    )
+    assert result.coefficients == (1, 2, 2, 2, 2)
+    assert result.preperiod_length == 1
+    assert result.period_length == 1
+    assert result.method == "SYMPY_CONTINUED_FRACTION"
+
+
+def test_continued_fraction_sqrt_3() -> None:
+    """sqrt(3) = [1; 1, 2, 1, 2, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=6)
+    )
+    assert result.coefficients == (1, 1, 2, 1, 2, 1)
+    assert result.preperiod_length == 1
+    assert result.period_length == 2
+
+
+def test_continued_fraction_sqrt_5() -> None:
+    """sqrt(5) = [2; 4, 4, 4, ...]"""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=5, term_count=5)
+    )
+    assert result.coefficients[0] == 2
+    assert all(c == 4 for c in result.coefficients[1:])
+
+
+def test_continued_fraction_expands_period_to_max_terms() -> None:
+    """A one-term period still produces every requested coefficient."""
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=500)
+    )
+    assert len(result.coefficients) == 500
+    assert result.coefficients[0] == 1
+    assert all(c == 2 for c in result.coefficients[1:])
+
+
+def test_convergents_sqrt_2() -> None:
+    """Convergents of sqrt(2): 1/1, 3/2, 7/5, 17/12, 41/29."""
+    result = compute_convergents(ConvergentRequest(discriminant=2, convergent_count=5))
+    assert len(result.convergents) == 5
+    nums = [c.numerator for c in result.convergents]
+    dens = [c.denominator for c in result.convergents]
+    assert nums == ["1", "3", "7", "17", "41"]
+    assert dens == ["1", "2", "5", "12", "29"]
+
+
+def test_convergents_repeat_period_beyond_fixed_window() -> None:
+    """Regression: a period of length one must expand for any convergent count."""
+    result = compute_convergents(ConvergentRequest(discriminant=2, convergent_count=12))
+    assert [c.index for c in result.convergents] == list(range(12))
+    assert [c.numerator for c in result.convergents] == [
+        "1",
+        "3",
+        "7",
+        "17",
+        "41",
+        "99",
+        "239",
+        "577",
+        "1393",
+        "3363",
+        "8119",
+        "19601",
+    ]
+    assert [c.denominator for c in result.convergents] == [
+        "1",
+        "2",
+        "5",
+        "12",
+        "29",
+        "70",
+        "169",
+        "408",
+        "985",
+        "2378",
+        "5741",
+        "13860",
+    ]
+
+
+def test_convergents_expand_to_max_count() -> None:
+    result = compute_convergents(
+        ConvergentRequest(discriminant=2, convergent_count=500)
+    )
+    assert len(result.convergents) == 500
+    assert [c.index for c in result.convergents] == list(range(500))
+
+
+def test_convergents_are_best_approximations() -> None:
+    """Each convergent p/q satisfies |p^2 - D*q^2| < 2*sqrt(D)."""
+    discriminant = 2
+    result = compute_convergents(
+        ConvergentRequest(discriminant=discriminant, convergent_count=10)
+    )
+    for conv in result.convergents:
+        p = parse_canonical_integer(conv.numerator)
+        q = parse_canonical_integer(conv.denominator)
+        assert abs(p**2 - discriminant * q**2) < 2 * math.sqrt(discriminant)
+
+
+def test_pell_equation_sqrt_2() -> None:
+    """x^2 - 2*y^2 = 1 has fundamental solution (3, 2)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=2))
+    assert result.x == "3"
+    assert result.y == "2"
+    assert (
+        parse_canonical_integer(result.x) ** 2
+        - 2 * parse_canonical_integer(result.y) ** 2
+        == 1
+    )
+
+
+def test_pell_equation_sqrt_3() -> None:
+    """x^2 - 3*y^2 = 1 has fundamental solution (2, 1)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=3))
+    assert result.x == "2"
+    assert result.y == "1"
+    assert (
+        parse_canonical_integer(result.x) ** 2
+        - 3 * parse_canonical_integer(result.y) ** 2
+        == 1
+    )
+
+
+def test_pell_equation_sqrt_5() -> None:
+    """x^2 - 5*y^2 = 1 has fundamental solution (9, 4)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=5))
+    assert result.x == "9"
+    assert result.y == "4"
+    assert (
+        parse_canonical_integer(result.x) ** 2
+        - 5 * parse_canonical_integer(result.y) ** 2
+        == 1
+    )
+
+
+def test_pell_equation_sqrt_13() -> None:
+    """x^2 - 13*y^2 = 1 has fundamental solution (649, 180)."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=13))
+    assert result.x == "649"
+    assert result.y == "180"
+    assert (
+        parse_canonical_integer(result.x) ** 2
+        - 13 * parse_canonical_integer(result.y) ** 2
+        == 1
+    )
+
+
+def test_pell_equation_all_verified() -> None:
+    """Every Pell solution satisfies x^2 - D*y^2 = 1."""
+    for discriminant in [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]:
+        result = compute_pell_equation(PellEquationRequest(discriminant=discriminant))
+        x = parse_canonical_integer(result.x)
+        y = parse_canonical_integer(result.y)
+        assert x**2 - discriminant * y**2 == 1
+
+
+def test_pell_equation_large_discriminant() -> None:
+    """The derived period bound reaches a large fundamental solution exactly."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=991))
+    x = parse_canonical_integer(result.x)
+    y = parse_canonical_integer(result.y)
+    assert x**2 - 991 * y**2 == 1
+
+
+def test_pell_equation_long_period() -> None:
+    """The longest period below the bound still reaches the fundamental solution."""
+    result = compute_pell_equation(PellEquationRequest(discriminant=9949))
+    x = parse_canonical_integer(result.x)
+    y = parse_canonical_integer(result.y)
+    assert x**2 - 9949 * y**2 == 1
+
+
+def test_contract_rejects_non_squarefree() -> None:
+    with pytest.raises(ValidationError, match="squarefree"):
+        ContinuedFractionRequest(discriminant=4, term_count=5)
+
+
+def test_contract_rejects_perfect_square() -> None:
+    with pytest.raises(ValidationError, match="squarefree"):
+        ContinuedFractionRequest(discriminant=9, term_count=5)
+
+
+def test_contract_rejects_out_of_range() -> None:
+    with pytest.raises(ValidationError):
+        ContinuedFractionRequest(discriminant=1, term_count=5)
+
+
+def test_public_kernels_reject_perfect_square() -> None:
+    with pytest.raises(ValueError, match="perfect square"):
+        continued_fraction(4, 5)
+    with pytest.raises(ValueError, match="perfect square"):
+        convergents(9, 3)
+    with pytest.raises(ValueError, match="perfect square"):
+        solve_pell(16)
+
+
+def test_public_kernels_return_typed_values() -> None:
+    assert continued_fraction(2, 3) == ([1, 2, 2], 1, 1)
+    assert convergents(2, 3) == [(0, 1, 1), (1, 3, 2), (2, 7, 5)]
+    assert solve_pell(2) == (3, 2)

--- a/tests/math/electrical_networks/test_electrical_networks.py
+++ b/tests/math/electrical_networks/test_electrical_networks.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.electrical_networks._models import (
+    ConductanceEdge,
+    ConductanceNetwork,
+    EffectiveResistanceRequest,
+    LaplacianRequest,
+    NodePotentialRequest,
+)
+from jacobian.math.electrical_networks._operations import (
+    compute_effective_resistance,
+    compute_laplacian,
+    compute_node_potentials,
+)
+
+C = CanonicalRational
+
+
+def _edge(source: int, target: int, num: str, den: str) -> ConductanceEdge:
+    return ConductanceEdge(
+        source=source, target=target, conductance=C(num=num, den=den)
+    )
+
+
+def _net(vertex_count: int, *edges: ConductanceEdge) -> ConductanceNetwork:
+    return ConductanceNetwork(vertex_count=vertex_count, edges=edges)
+
+
+# ------------------------------------------------------------------ effective resistance
+
+
+def test_single_edge_resistance_is_one() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    result = compute_effective_resistance(req)
+    assert result.effective_resistance.as_fraction() == Fraction(1)
+    assert result.method == "SYMPY_REDUCED_LAPLACIAN_SOLVE"
+    assert result.terminal_a == 0
+    assert result.terminal_b == 1
+
+
+def test_triangle_unit_resistances_gives_two_thirds() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"), _edge(0, 2, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(2, 3)
+
+
+def test_path_graph_three_vertices_gives_two() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=2)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(2)
+
+
+def test_high_conductance_gives_low_resistance() -> None:
+    """Single edge with conductance 3 -> resistance 1/3."""
+    net = _net(2, _edge(0, 1, "3", "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(1, 3)
+
+
+def test_four_cycle_square_unit_resistances_gives_expected_values() -> None:
+    """C4 with unit resistances: R(adjacent) = 3/4, R(opposite) = 1."""
+    net = _net(
+        4,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "1", "1"),
+        _edge(2, 3, "1", "1"),
+        _edge(0, 3, "1", "1"),
+    )
+    req_adj = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req_adj
+    ).effective_resistance.as_fraction() == Fraction(3, 4)
+    req_opp = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=2)
+    assert compute_effective_resistance(
+        req_opp
+    ).effective_resistance.as_fraction() == Fraction(1)
+
+
+def test_rational_conductances_give_exact_rational_resistance() -> None:
+    """Single edge with conductance 2/3 -> resistance 3/2."""
+    net = _net(2, _edge(0, 1, "2", "3"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    assert compute_effective_resistance(
+        req
+    ).effective_resistance.as_fraction() == Fraction(3, 2)
+
+
+# ------------------------------------------------------------------ node potentials
+
+
+def test_node_potentials_path_graph() -> None:
+    net = _net(3, _edge(0, 1, "1", "1"), _edge(1, 2, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=2)
+    result = compute_node_potentials(req)
+    assert len(result.potentials) == 3
+    assert result.potentials[0].potential.as_fraction() == Fraction(2)
+    assert result.potentials[1].potential.as_fraction() == Fraction(1)
+    assert result.potentials[2].potential.as_fraction() == Fraction(0)
+    assert result.method == "SYMPY_LAPLACIAN_SOLVE"
+
+
+def test_node_potentials_sink_is_gauge_zero() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=1)
+    result = compute_node_potentials(req)
+    assert result.potentials[1].potential.as_fraction() == Fraction(0)
+
+
+def test_node_potentials_satisfy_kirchhoff_current() -> None:
+    """For a path 0-1 with unit conductance, injecting 1A at 0, extracting at 1:
+    V0 - V1 = 1 (resistance), V1 = 0 (gauge), so V0 = 1."""
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = NodePotentialRequest(network=net, source=0, sink=1)
+    result = compute_node_potentials(req)
+    assert result.potentials[0].potential.as_fraction() == Fraction(1)
+    assert result.potentials[1].potential.as_fraction() == Fraction(0)
+
+
+# ------------------------------------------------------------------ Laplacian
+
+
+def test_laplacian_single_edge() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    assert result.vertex_count == 2
+    matrix: dict[tuple[int, int], Fraction] = {}
+    for entry in result.entries:
+        matrix[(entry.row, entry.col)] = entry.value.as_fraction()
+    assert matrix[(0, 0)] == Fraction(1)
+    assert matrix[(1, 1)] == Fraction(1)
+    assert matrix[(0, 1)] == Fraction(-1)
+    assert matrix[(1, 0)] == Fraction(-1)
+    assert result.method == "SYMPY_LAPLACIAN"
+
+
+def test_laplacian_triangle_diagonal_sums_conductances() -> None:
+    net = _net(
+        3,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "1", "1"),
+        _edge(0, 2, "2", "1"),
+    )
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    matrix = {(e.row, e.col): e.value.as_fraction() for e in result.entries}
+    assert matrix[(0, 0)] == Fraction(3)  # 1 + 2
+    assert matrix[(1, 1)] == Fraction(2)  # 1 + 1
+    assert matrix[(2, 2)] == Fraction(3)  # 1 + 2
+    assert matrix[(0, 1)] == Fraction(-1)
+    assert matrix[(1, 0)] == Fraction(-1)
+    assert matrix[(0, 2)] == Fraction(-2)
+    assert matrix[(2, 0)] == Fraction(-2)
+    assert matrix[(1, 2)] == Fraction(-1)
+    assert matrix[(2, 1)] == Fraction(-1)
+
+
+def test_laplacian_rows_sum_to_zero() -> None:
+    net = _net(
+        4,
+        _edge(0, 1, "1", "1"),
+        _edge(1, 2, "3", "2"),
+        _edge(2, 3, "5", "3"),
+        _edge(0, 3, "7", "4"),
+    )
+    req = LaplacianRequest(network=net)
+    result = compute_laplacian(req)
+    matrix = {(e.row, e.col): e.value.as_fraction() for e in result.entries}
+    for row in range(4):
+        assert sum(matrix[(row, col)] for col in range(4)) == Fraction(0)
+
+
+def test_laplacian_accepts_disconnected_network() -> None:
+    """The Laplacian is well-defined without connectivity."""
+    net = _net(4, _edge(0, 1, "1", "1"), _edge(2, 3, "1", "1"))
+    result = compute_laplacian(LaplacianRequest(network=net))
+    assert result.vertex_count == 4
+    assert len(result.entries) == 16
+
+
+# ------------------------------------------------------------------ contract validation
+
+
+def test_contract_rejects_nonpositive_conductance() -> None:
+    with pytest.raises(ValidationError, match="positive"):
+        ConductanceEdge(source=0, target=1, conductance=C(num="0", den="1"))
+
+
+def test_contract_rejects_self_loop() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        ConductanceEdge(source=0, target=0, conductance=C(num="1", den="1"))
+
+
+def test_contract_rejects_duplicate_edges() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        _net(3, _edge(0, 1, "1", "1"), _edge(1, 0, "2", "1"))
+
+
+def test_contract_rejects_nonzero_denominator() -> None:
+    with pytest.raises(ValidationError, match="zero"):
+        C(num="1", den="0")
+
+
+def test_contract_rejects_same_terminals() -> None:
+    net = _net(2, _edge(0, 1, "1", "1"))
+    with pytest.raises(ValidationError, match="distinct"):
+        EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=0)
+
+
+def test_contract_rejects_vertex_out_of_range() -> None:
+    with pytest.raises(ValidationError, match="vertices must be"):
+        _net(2, _edge(0, 5, "1", "1"))
+
+
+# ------------------------------------------------------------------ review root-cause fixes
+
+
+def test_contract_rejects_disconnected_effective_resistance() -> None:
+    """Deleting one Laplacian row/column still leaves a singular component."""
+    net = _net(4, _edge(0, 1, "1", "1"), _edge(2, 3, "1", "1"))
+    with pytest.raises(ValidationError, match="connected"):
+        EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+
+
+def test_contract_rejects_disconnected_node_potentials() -> None:
+    net = _net(4, _edge(0, 1, "1", "1"), _edge(2, 3, "1", "1"))
+    with pytest.raises(ValidationError, match="connected"):
+        NodePotentialRequest(network=net, source=0, sink=1)
+
+
+def test_contract_rejects_isolated_vertex() -> None:
+    net = _net(4, _edge(1, 2, "1", "1"))
+    with pytest.raises(ValidationError, match="connected"):
+        EffectiveResistanceRequest(network=net, terminal_a=1, terminal_b=2)
+
+
+def test_contract_rejects_oversized_conductance() -> None:
+    with pytest.raises(ValidationError, match="50-digit bound"):
+        ConductanceEdge(
+            source=0,
+            target=1,
+            conductance=C(num="9" * 51, den="1"),
+        )
+
+
+def test_contract_accepts_boundary_conductance() -> None:
+    """A 50-digit conductance is the declared maximum and must be accepted."""
+    numerator = "9" * 50
+    net = _net(2, _edge(0, 1, numerator, "1"))
+    req = EffectiveResistanceRequest(network=net, terminal_a=0, terminal_b=1)
+    result = compute_effective_resistance(req)
+    assert result.effective_resistance.as_fraction() == Fraction(1, int(numerator))

--- a/tests/math/finite_metric_spaces/test_finite_metric_spaces.py
+++ b/tests/math/finite_metric_spaces/test_finite_metric_spaces.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.finite_metric_spaces._models import (
+    MAX_DISTANCE,
+    BallRequest,
+    FiniteMetricSpace,
+    GromovHyperbolicityRequest,
+    MetricProfileRequest,
+)
+from jacobian.math.finite_metric_spaces._operations import (
+    compute_ball,
+    compute_gromov_hyperbolicity,
+    compute_metric_profile,
+)
+
+
+def _ms(distances: list[list[int]]) -> FiniteMetricSpace:
+    return FiniteMetricSpace(
+        point_count=len(distances), distances=tuple(tuple(r) for r in distances)
+    )
+
+
+def test_profile_path_graph() -> None:
+    """Path graph 0-1-2: diameter=2, radius=1, center=1."""
+    ms = _ms([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+    result = compute_metric_profile(MetricProfileRequest(metric_space=ms))
+    assert result.diameter == 2
+    assert result.radius == 1
+    assert result.centers == (1,)
+    assert result.periphery == (0, 2)
+
+
+def test_profile_complete_graph() -> None:
+    """Complete graph K3: all eccentricities = 1, diameter = radius = 1."""
+    ms = _ms([[0, 1, 1], [1, 0, 1], [1, 1, 0]])
+    result = compute_metric_profile(MetricProfileRequest(metric_space=ms))
+    assert result.diameter == 1
+    assert result.radius == 1
+    assert set(result.centers) == {0, 1, 2}
+
+
+def test_profile_star_graph_center_has_min_eccentricity() -> None:
+    ms = _ms([[0, 1, 1, 1], [1, 0, 2, 2], [1, 2, 0, 2], [1, 2, 2, 0]])
+    result = compute_metric_profile(MetricProfileRequest(metric_space=ms))
+    assert result.centers == (0,)
+    assert result.radius == 1
+    assert result.diameter == 2
+
+
+def test_ball_radius_0() -> None:
+    """Ball of radius 0 contains only the center."""
+    ms = _ms([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+    result = compute_ball(BallRequest(metric_space=ms, center=1, radius=0))
+    assert result.points == (1,)
+
+
+def test_ball_radius_1_path() -> None:
+    """Ball of radius 1 at point 1 in a path: {0, 1, 2}."""
+    ms = _ms([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+    result = compute_ball(BallRequest(metric_space=ms, center=1, radius=1))
+    assert set(result.points) == {0, 1, 2}
+
+
+def test_ball_radius_1_at_endpoint() -> None:
+    """Ball of radius 1 at point 0 in a path: {0, 1}."""
+    ms = _ms([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+    result = compute_ball(BallRequest(metric_space=ms, center=0, radius=1))
+    assert set(result.points) == {0, 1}
+
+
+def test_gromov_hyperbolicity_path_graph() -> None:
+    """Path graph 0-1-2-3: Gromov hyperbolicity is 0 (tree)."""
+    ms = _ms([[0, 1, 2, 3], [1, 0, 1, 2], [2, 1, 0, 1], [3, 2, 1, 0]])
+    result = compute_gromov_hyperbolicity(GromovHyperbolicityRequest(metric_space=ms))
+    assert result.hyperbolicity.as_fraction() == Fraction(0, 1)
+
+
+def test_gromov_hyperbolicity_cycle_c4() -> None:
+    """C4 (cycle on 4 points): Gromov hyperbolicity is 1 (integer)."""
+    ms = _ms([[0, 1, 2, 1], [1, 0, 1, 2], [2, 1, 0, 1], [1, 2, 1, 0]])
+    result = compute_gromov_hyperbolicity(GromovHyperbolicityRequest(metric_space=ms))
+    assert result.hyperbolicity.as_fraction() == Fraction(1, 1)
+
+
+def test_gromov_hyperbolicity_cycle_c5_half_integer() -> None:
+    """C5 (cycle on 5 points): Gromov hyperbolicity is 1/2 (half-integer)."""
+    ms = _ms(
+        [
+            [0, 1, 2, 2, 1],
+            [1, 0, 1, 2, 2],
+            [2, 1, 0, 1, 2],
+            [2, 2, 1, 0, 1],
+            [1, 2, 2, 1, 0],
+        ]
+    )
+    result = compute_gromov_hyperbolicity(GromovHyperbolicityRequest(metric_space=ms))
+    assert result.hyperbolicity.as_fraction() == Fraction(1, 2)
+
+
+def test_contract_rejects_nonsymmetric() -> None:
+    with pytest.raises(ValidationError, match="symmetric"):
+        FiniteMetricSpace(
+            point_count=2,
+            distances=((0, 1), (2, 0)),
+        )
+
+
+def test_contract_rejects_nonzero_diagonal() -> None:
+    with pytest.raises(ValidationError, match="zero"):
+        FiniteMetricSpace(
+            point_count=2,
+            distances=((1, 1), (1, 0)),
+        )
+
+
+def test_contract_rejects_triangle_inequality() -> None:
+    with pytest.raises(ValidationError, match="triangle inequality"):
+        FiniteMetricSpace(
+            point_count=3,
+            distances=((0, 1, 3), (1, 0, 1), (3, 1, 0)),
+        )
+
+
+def test_contract_rejects_zero_distance() -> None:
+    with pytest.raises(ValidationError, match="positive distance"):
+        FiniteMetricSpace(
+            point_count=3,
+            distances=((0, 0, 1), (0, 0, 1), (1, 1, 0)),
+        )
+
+
+def test_contract_rejects_oversized_distance() -> None:
+    with pytest.raises(ValidationError, match="less than or equal to"):
+        FiniteMetricSpace(
+            point_count=2,
+            distances=((0, MAX_DISTANCE + 1), (MAX_DISTANCE + 1, 0)),
+        )
+
+
+def test_ball_rejects_center_out_of_range() -> None:
+    ms = _ms([[0, 1, 2], [1, 0, 1], [2, 1, 0]])
+    with pytest.raises(ValidationError, match="within the metric space"):
+        BallRequest(metric_space=ms, center=3, radius=1)

--- a/tests/math/graph_transforms/test_graph_transforms.py
+++ b/tests/math/graph_transforms/test_graph_transforms.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graph_transforms._models import (
+    GraphEdge,
+    GraphTransformRequest,
+    ResultGraphEdge,
+    SimpleGraph,
+    SubgraphRequest,
+)
+from jacobian.math.graph_transforms._operations import (
+    compute_complement,
+    compute_graph_power,
+    compute_induced_subgraph,
+    compute_line_graph,
+)
+
+
+def _graph(vc: int, edges: list[tuple[int, int]]) -> SimpleGraph:
+    return SimpleGraph(
+        vertex_count=vc,
+        edges=tuple(GraphEdge(source=s, target=t) for s, t in edges),
+    )
+
+
+def _result_edges(result) -> frozenset[tuple[int, int]]:
+    return frozenset(
+        (e.source, e.target) if e.source < e.target else (e.target, e.source)
+        for e in result.edges
+    )
+
+
+def test_complement_of_path_3() -> None:
+    """Complement of path 0-1-2 is the single edge (0,2)."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert _result_edges(result) == {(0, 2)}
+
+
+def test_complement_of_complete_graph_is_empty() -> None:
+    """Complement of K3 (complete graph) is empty."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert len(result.edges) == 0
+
+
+def test_line_graph_of_path() -> None:
+    """Line graph of path 0-1-2 is a single edge between the two edges."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 2  # two edges in original
+    assert len(result.edges) == 1  # they share a vertex
+
+
+def test_line_graph_of_triangle_is_triangle() -> None:
+    """Line graph of K3 (triangle) is K3."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert len(result.edges) == 3
+
+
+def test_graph_power_path_2() -> None:
+    """Square of path 0-1-2 adds edge (0,2)."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_graph_power(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert _result_edges(result) == {(0, 1), (1, 2), (0, 2)}
+
+
+def test_graph_power_complete_graph() -> None:
+    """Square of complete graph is itself."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_graph_power(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 3
+    assert len(result.edges) == 3
+
+
+def test_induced_subgraph_path() -> None:
+    """Induced subgraph of path 0-1-2 on {0, 2} has no edges."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=(0, 2)))
+    assert result.vertex_count == 2
+    assert len(result.edges) == 0
+
+
+def test_induced_subgraph_triangle() -> None:
+    """Induced subgraph of K3 on {0, 1} has one edge."""
+    g = _graph(3, [(0, 1), (1, 2), (0, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=(0, 1)))
+    assert result.vertex_count == 2
+    assert len(result.edges) == 1
+
+
+def test_contract_rejects_self_loop() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        GraphEdge(source=0, target=0)
+
+
+def test_contract_rejects_duplicate_edges() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        SimpleGraph(
+            vertex_count=3,
+            edges=(
+                GraphEdge(source=0, target=1),
+                GraphEdge(source=1, target=0),  # same edge reversed
+            ),
+        )
+
+
+def test_contract_rejects_out_of_range_vertices() -> None:
+    with pytest.raises(ValidationError, match="vertex_count"):
+        SimpleGraph(
+            vertex_count=2,
+            edges=(GraphEdge(source=0, target=5),),
+        )
+
+
+def test_complement_of_edgeless_graph_within_output_bounds() -> None:
+    """Complement of a 64-vertex edgeless graph produces 2016 edges."""
+    g = _graph(64, [])
+    result = compute_complement(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 64
+    assert len(result.edges) == 2016  # C(64, 2)
+
+
+def test_line_graph_of_edgeless_graph_is_empty() -> None:
+    """Line graph of an edgeless graph has zero vertices (empty result allowed)."""
+    g = _graph(3, [])
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 0
+    assert len(result.edges) == 0
+
+
+def test_induced_subgraph_empty_vertex_set() -> None:
+    """Induced subgraph on empty vertex set has zero vertices."""
+    g = _graph(3, [(0, 1), (1, 2)])
+    result = compute_induced_subgraph(SubgraphRequest(graph=g, vertices=()))
+    assert result.vertex_count == 0
+    assert len(result.edges) == 0
+
+
+def test_contract_rejects_duplicate_subgraph_vertices() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        SubgraphRequest(
+            graph=_graph(3, [(0, 1)]),
+            vertices=(0, 0),
+        )
+
+
+def test_line_graph_reindexes_endpoints_above_input_vertex_bound() -> None:
+    """A line graph of more than 64 input edges reindexes endpoints above 63."""
+    edges = [(0, i) for i in range(1, 64)] + [(1, 2), (1, 3)]
+    g = _graph(64, edges)
+    result = compute_line_graph(GraphTransformRequest(graph=g))
+    assert result.vertex_count == 65
+    endpoints = {
+        endpoint for edge in result.edges for endpoint in (edge.source, edge.target)
+    }
+    assert max(endpoints) >= 64
+
+
+def test_input_edge_rejects_endpoint_at_or_above_vertex_bound() -> None:
+    with pytest.raises(ValidationError):
+        GraphEdge(source=0, target=64)
+
+
+def test_result_edge_allows_endpoint_up_to_input_edge_bound() -> None:
+    edge = ResultGraphEdge(source=1023, target=1022)
+    assert edge.source == 1023
+    assert edge.target == 1022
+
+
+def test_result_edge_rejects_endpoint_above_input_edge_bound() -> None:
+    with pytest.raises(ValidationError):
+        ResultGraphEdge(source=1024, target=0)

--- a/tests/math/real_algebra/test_real_algebra.py
+++ b/tests/math/real_algebra/test_real_algebra.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.real_algebra._models import (
+    PolynomialTerm,
+    RootCountRequest,
+    SturmChainRequest,
+    UnivariatePolynomial,
+)
+from jacobian.math.real_algebra._operations import (
+    compute_root_count,
+    compute_sturm_chain,
+)
+
+R = CanonicalRational
+
+
+def _poly(*terms: tuple[str, str, int]) -> UnivariatePolynomial:
+    return UnivariatePolynomial(
+        terms=tuple(
+            PolynomialTerm(coefficient=R(num=num, den=den), exponent=exp)
+            for num, den, exp in terms
+        )
+    )
+
+
+def _coefficient_map(poly: UnivariatePolynomial) -> dict[int, Fraction]:
+    return {term.exponent: term.coefficient.as_fraction() for term in poly.terms}
+
+
+def test_sturm_chain_cubic_known_answer() -> None:
+    """x^3 - 2x^2 + x - 3 has SymPy's documented four-term Sturm chain."""
+    poly = _poly(("1", "1", 3), ("-2", "1", 2), ("1", "1", 1), ("-3", "1", 0))
+    result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
+
+    assert result.degree == 3
+    assert result.method == "SYMPY_STURM"
+    assert [_coefficient_map(p) for p in result.chain] == [
+        {3: Fraction(1), 2: Fraction(-2), 1: Fraction(1), 0: Fraction(-3)},
+        {2: Fraction(3), 1: Fraction(-4), 0: Fraction(1)},
+        {1: Fraction(2, 9), 0: Fraction(25, 9)},
+        {0: Fraction(-2079, 4)},
+    ]
+
+
+def test_sturm_chain_quadratic() -> None:
+    """x^2 - 2 has a three-term Sturm chain."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
+    assert len(result.chain) == 3
+    assert result.degree == 2
+
+
+def test_root_count_cubic_has_one_real_root() -> None:
+    """x^3 - 2x^2 + x - 3 has exactly 1 real root in [-10, 10]."""
+    poly = _poly(("1", "1", 3), ("-2", "1", 2), ("1", "1", 1), ("-3", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 1
+    assert result.method == "STURM_THEOREM"
+
+
+def test_root_count_x_squared_minus_2() -> None:
+    """x^2 - 2 has 2 roots in [-10, 10] and 0 in [2, 10]."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 2
+
+    result_pos = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="2", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result_pos.root_count == 0
+
+
+def test_root_count_no_real_roots() -> None:
+    """x^2 + 1 has no real roots."""
+    poly = _poly(("1", "1", 2), ("1", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 0
+
+
+def test_root_count_linear() -> None:
+    """x - 5 has one root at x=5."""
+    poly = _poly(("1", "1", 1), ("-5", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 1
+
+
+def test_root_count_quartic_four_roots() -> None:
+    """x^4 - 5x^2 + 4 = (x-1)(x+1)(x-2)(x+2) has 4 roots in [-10, 10]."""
+    poly = _poly(("1", "1", 4), ("-5", "1", 2), ("4", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    )
+    assert result.root_count == 4
+
+
+def test_root_count_rational_endpoints() -> None:
+    """Root counting supports rational interval endpoints exactly."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="3", den="2"),
+        )
+    )
+    assert result.root_count == 1  # sqrt(2) in [0, 1.5], -sqrt(2) excluded
+
+
+def test_root_count_repeated_roots_are_distinct() -> None:
+    """(x-1)^2 counts its single distinct real root once."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 1), ("1", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="2", den="1"),
+        )
+    )
+    assert result.root_count == 1
+
+
+def test_root_count_counts_lower_endpoint_root() -> None:
+    """Review fix: a root exactly at the lower endpoint belongs to [lower, upper]."""
+    poly = _poly(("1", "1", 1))
+
+    full = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="1", den="1"),
+        )
+    )
+    assert full.root_count == 1
+
+    singleton = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="0", den="1"),
+        )
+    )
+    assert singleton.root_count == 1
+
+
+def test_root_count_counts_both_endpoint_roots() -> None:
+    """x^2 - 1 has roots at both endpoints of [-1, 1]."""
+    poly = _poly(("1", "1", 2), ("-1", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-1", den="1"),
+            upper=R(num="1", den="1"),
+        )
+    )
+    assert result.root_count == 2
+
+
+def test_root_count_empty_interval() -> None:
+    """A non-root singleton interval has 0 roots."""
+    poly = _poly(("1", "1", 2), ("-2", "1", 0))
+    result = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="0", den="1"),
+            upper=R(num="0", den="1"),
+        )
+    )
+    assert result.root_count == 0
+
+
+def test_contract_rejects_lower_gt_upper() -> None:
+    with pytest.raises(ValidationError, match="lower bound"):
+        RootCountRequest(
+            polynomial=_poly(("1", "1", 1)),
+            lower=R(num="10", den="1"),
+            upper=R(num="0", den="1"),
+        )
+
+
+def test_contract_rejects_duplicate_exponents() -> None:
+    with pytest.raises(ValidationError, match="unique"):
+        UnivariatePolynomial(
+            terms=(
+                PolynomialTerm(coefficient=R(num="1", den="1"), exponent=2),
+                PolynomialTerm(coefficient=R(num="1", den="1"), exponent=2),
+            )
+        )
+
+
+def test_contract_rejects_zero_coefficient() -> None:
+    with pytest.raises(ValidationError, match="zero"):
+        UnivariatePolynomial(
+            terms=(PolynomialTerm(coefficient=R(num="0", den="1"), exponent=2),)
+        )
+
+
+def test_contract_rejects_oversized_coefficient_digits() -> None:
+    """Review fix: a 17-digit coefficient exceeds the 16-digit input budget."""
+    big_num = "9" * 17
+    poly = _poly((big_num, "1", 2), ("-2", "1", 0))
+    with pytest.raises(ValidationError, match="16-digit bound"):
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+
+
+def test_contract_rejects_non_integer_coefficients() -> None:
+    """Review fix: rational coefficients would blow up SymPy's plain QQ chain."""
+    with pytest.raises(ValidationError, match="must be integers"):
+        RootCountRequest(
+            polynomial=_poly(("1", "2", 2), ("-2", "1", 0)),
+            lower=R(num="-10", den="1"),
+            upper=R(num="10", den="1"),
+        )
+    with pytest.raises(ValidationError, match="must be integers"):
+        SturmChainRequest(polynomial=_poly(("1", "2", 2), ("-2", "1", 0)))
+
+
+def test_sturm_rejects_constant_polynomial() -> None:
+    """Review fix: a degree-0 polynomial is rejected before execution."""
+    with pytest.raises(ValidationError, match="non-constant"):
+        SturmChainRequest(
+            polynomial=_poly(("5", "1", 0)),
+        )
+
+
+def test_sturm_chain_boundary_sixteen_digit_coefficient() -> None:
+    """Review fix: the largest accepted coefficient stays representable.
+
+    For x^2 + N*x + 1 with N = 10^16 - 1, SymPy's chain constant is
+    (N^2 - 4)/4, which has about 32 digits -- far below the 32,768-digit wire
+    bound that the unbounded request would have blown through.
+    """
+    n = 10**16 - 1
+    poly = _poly(("1", "1", 2), (str(n), "1", 1), ("1", "1", 0))
+    result = compute_sturm_chain(SturmChainRequest(polynomial=poly))
+
+    assert result.degree == 2
+    assert _coefficient_map(result.chain[-1]) == {0: Fraction(n * n - 4, 4)}
+
+    count = compute_root_count(
+        RootCountRequest(
+            polynomial=poly,
+            lower=R(num=str(-(n + 1)), den="1"),
+            upper=R(num=str(n + 1), den="1"),
+        )
+    )
+    assert count.root_count == 2

--- a/tests/math/regular_languages/test_regular_languages.py
+++ b/tests/math/regular_languages/test_regular_languages.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from itertools import product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.regular_languages._models import (
+    ComplementRequest,
+    CountRequest,
+    RunRequest,
+)
+from jacobian.math.regular_languages._operations import (
+    compute_complement,
+    compute_count,
+    compute_run,
+)
+from jacobian.math.regular_languages.operations import (
+    count_accepted_words,
+    dfa_complement,
+    dfa_run,
+)
+from jacobian.math.regular_languages.values import DFA, DFATransition
+
+
+def _dfa_ends_in_1() -> DFA:
+    return DFA(
+        state_count=2,
+        alphabet_size=2,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=0),
+            DFATransition(source=0, symbol=1, target=1),
+            DFATransition(source=1, symbol=0, target=0),
+            DFATransition(source=1, symbol=1, target=1),
+        ),
+        initial_state=0,
+        accepting_states=(1,),
+    )
+
+
+def _dfa_even_zeros() -> DFA:
+    """Accepts binary strings with an even number of 0s."""
+
+    return DFA(
+        state_count=2,
+        alphabet_size=2,
+        transitions=(
+            DFATransition(source=0, symbol=0, target=1),
+            DFATransition(source=0, symbol=1, target=0),
+            DFATransition(source=1, symbol=0, target=0),
+            DFATransition(source=1, symbol=1, target=1),
+        ),
+        initial_state=0,
+        accepting_states=(0,),
+    )
+
+
+def _dfa_full_alphabet_accepting() -> DFA:
+    """One accepting state looping on all 32 symbols."""
+
+    return DFA(
+        state_count=1,
+        alphabet_size=32,
+        transitions=tuple(
+            DFATransition(source=0, symbol=symbol, target=0) for symbol in range(32)
+        ),
+        initial_state=0,
+        accepting_states=(0,),
+    )
+
+
+def test_run_accepts_word_ending_in_1() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=(1, 0, 1)))
+    assert result.accepted is True
+    assert result.final_state == 1
+    assert result.method == "DFA_SIMULATION"
+
+
+def test_run_rejects_word_ending_in_0() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=(1, 0, 0)))
+    assert result.accepted is False
+    assert result.final_state == 0
+
+
+def test_run_accepts_empty_word_if_initial_is_accepting() -> None:
+    dfa = _dfa_even_zeros()
+    result = compute_run(RunRequest(dfa=dfa, word=()))
+    assert result.accepted is True
+    assert result.final_state == 0
+
+
+def test_run_rejects_empty_word_if_initial_not_accepting() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_run(RunRequest(dfa=dfa, word=()))
+    assert result.accepted is False
+    assert result.final_state == 0
+
+
+def test_count_binary_strings_ending_in_1() -> None:
+    """Length 3 binary strings ending in 1: 4 (001, 011, 101, 111)."""
+
+    dfa = _dfa_ends_in_1()
+    result = compute_count(CountRequest(dfa=dfa, word_length=3))
+    assert result.count == "4"
+    assert result.method == "MATRIX_POWERING"
+
+
+def test_count_length_zero() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_count(CountRequest(dfa=dfa, word_length=0))
+    assert result.count == "0"  # initial state 0 is not accepting
+
+
+def test_count_length_zero_accepting() -> None:
+    dfa = _dfa_even_zeros()
+    result = compute_count(CountRequest(dfa=dfa, word_length=0))
+    assert result.count == "1"  # initial state 0 is accepting
+
+
+def test_count_even_zeros_length_3() -> None:
+    """Length 3 binary strings with even number of 0s: 4 (111, 100, 010, 001)."""
+
+    dfa = _dfa_even_zeros()
+    result = compute_count(CountRequest(dfa=dfa, word_length=3))
+    assert result.count == "4"
+
+
+def test_count_matches_brute_force() -> None:
+    """Count via matrix powering matches brute-force enumeration."""
+
+    dfa = _dfa_ends_in_1()
+    for length in range(8):
+        result = compute_count(CountRequest(dfa=dfa, word_length=length))
+        brute = 0
+        for word in product(range(2), repeat=length):
+            run = compute_run(RunRequest(dfa=dfa, word=word))
+            if run.accepted:
+                brute += 1
+        assert result.count == str(brute), f"Length {length}: {result.count} != {brute}"
+
+
+def test_count_exact_matrix_powering_known_answer() -> None:
+    """Binary strings of length 10 ending in 1: 2**9 = 512."""
+
+    dfa = _dfa_ends_in_1()
+    result = compute_count(CountRequest(dfa=dfa, word_length=10))
+    assert result.count == "512"
+
+
+def test_count_large_value_uses_canonical_string() -> None:
+    """A 32-symbol one-state DFA accepts all 32**200 words of length 200."""
+
+    dfa = _dfa_full_alphabet_accepting()
+    result = compute_count(CountRequest(dfa=dfa, word_length=200))
+    assert result.count == str(32**200)
+
+
+def test_native_kernels_are_typed_and_consistent() -> None:
+    """Public kernels compose directly on DFA values without wire adapters."""
+
+    dfa = _dfa_ends_in_1()
+    assert dfa_run(dfa, (1, 0, 1)) == (True, 1)
+    assert count_accepted_words(dfa, 3) == 4
+    complemented = dfa_complement(dfa)
+    assert isinstance(complemented, DFA)
+    assert complemented.accepting_states == (0,)
+    assert dfa_run(complemented, (0,))[0] is True
+
+
+def test_complement_flips_acceptance() -> None:
+    dfa = _dfa_ends_in_1()
+    result = compute_complement(ComplementRequest(dfa=dfa))
+    assert result.dfa.accepting_states == (0,)
+    assert result.method == "ACCEPTING_FLIP"
+    # Word ending in 0 should now be accepted
+    run = compute_run(RunRequest(dfa=result.dfa, word=(0,)))
+    assert run.accepted is True
+
+
+def test_complement_double_complement_is_identity() -> None:
+    dfa = _dfa_ends_in_1()
+    result1 = compute_complement(ComplementRequest(dfa=dfa))
+    result2 = compute_complement(ComplementRequest(dfa=result1.dfa))
+    assert result2.dfa.accepting_states == dfa.accepting_states
+
+
+def test_contract_rejects_duplicate_transitions() -> None:
+    with pytest.raises(ValidationError, match="deterministic"):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=0, target=1),  # duplicate
+            ),
+            initial_state=0,
+            accepting_states=(1,),
+        )
+
+
+def test_contract_rejects_invalid_accepting_states() -> None:
+    with pytest.raises(ValidationError, match="accepting"):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=1, target=0),
+                DFATransition(source=1, symbol=0, target=0),
+                DFATransition(source=1, symbol=1, target=0),
+            ),
+            initial_state=0,
+            accepting_states=(5,),  # out of range
+        )
+
+
+def test_contract_rejects_out_of_range_word_symbol() -> None:
+    dfa = _dfa_ends_in_1()
+    with pytest.raises(ValidationError, match="word symbols"):
+        RunRequest(dfa=dfa, word=(5,))  # symbol 5 is out of range for alphabet_size=2
+
+
+def test_contract_rejects_non_total_dfa() -> None:
+    """A DFA missing a transition for some (state, symbol) pair must be rejected."""
+
+    with pytest.raises(ValidationError, match="total"):
+        DFA(
+            state_count=2,
+            alphabet_size=2,
+            transitions=(
+                DFATransition(source=0, symbol=0, target=0),
+                DFATransition(source=0, symbol=1, target=1),
+                DFATransition(source=1, symbol=0, target=0),
+                # missing (1, symbol=1)
+            ),
+            initial_state=0,
+            accepting_states=(1,),
+        )
+
+
+def test_contract_rejects_review_missing_edge_example() -> None:
+    """The reviewed one-state example must fail validation, not self-loop."""
+
+    with pytest.raises(ValidationError, match="total"):
+        DFA(
+            state_count=1,
+            alphabet_size=1,
+            transitions=(),
+            initial_state=0,
+            accepting_states=(0,),
+        )


### PR DESCRIPTION
## Summary

Extracts eight closed math-domain PRs into the current owner-first layout under `src/jacobian/math/`, adding **24 atomic operations**. Each port fixes the root causes raised in the original PR's review threads, not just a mechanical migration.

Closes #1764
Closes #1815
Closes #1848
Closes #1854
Closes #1855
Closes #1859
Closes #1860
Closes #1872

## Domains and operations

| Original PR | Issue | Domain | Operations |
|-------------|-------|--------|------------|
| #1913 | #1815 | `electrical_networks` | `electrical_network.effective_resistance.compute`, `.node_potentials.compute`, `.laplacian.compute` |
| #1914 | #1848 | `canonical_forms` | `matrix.minimal_polynomial.compute`, `matrix.rational_canonical_form.compute`, `matrix.primary_decomposition.compute` |
| #1923 | #1859 | `diophantine_approximation` | `diophantine.continued_fraction.compute`, `.convergents.compute`, `.pell_equation.solve` |
| #1924 | #1854 | `regular_languages` | `regular_language.run.check`, `.count_words.compute`, `.complement.compute` |
| #1925 | #1855 | `algebraic_combinatorics` | `combinatorics.hook_length.compute`, `combinatorics.standard_young_tableaux.count`, `combinatorics.conjugate_partition.compute` |
| #1926 | #1872 | `real_algebra` | `polynomial.sturm_chain.compute`, `polynomial.root_count.compute` |
| #1927 | #1860 | `finite_metric_spaces` | `metric_space.profile.compute`, `.ball.compute`, `.gromov_hyperbolicity.compute` |
| #1928 | #1764 | `graph_transforms` | `graph.complement.compute`, `.line_graph.compute`, `.power.compute`, `.induced_subgraph.compute` |

## Review-thread root causes fixed

- **#1913** — disconnected networks rejected (no singular reduced solve); conductance digit bound; Laplacian `method` relabeled to the actual SymPy backend.
- **#1914** — determinantal divisors kept as `Poly`; exhaustive ~601M-minor enumeration replaced with SymPy `smith_normal_form`; latent primary-decomposition normalization bug fixed.
- **#1923** — convergent coefficient generation repeats the period instead of indexing past it (`IndexError`); Pell magic bounds replaced with a derived `2·period` bound; perfect-square / non-squarefree discriminants validated before the backend.
- **#1924** — DFA transition totality enforced (deterministic + complete); semantic automaton values moved to the native domain; handwritten matrix powering replaced with SymPy.
- **#1925** — total partition-size bound enforced before execution; unbounded exact counts encoded as canonical integer strings; strict-integer partition parts.
- **#1926** — roots at the interval lower endpoint counted; coefficient digit bound before Sturm-chain expansion; constant Sturm requests rejected.
- **#1927** — four-point delta formula corrected (half-integer hyperbolicity preserved as `CanonicalRational`); triangle inequality / positive separation enforced; ball center bound; per-distance bound.
- **#1928** — separate result-edge bound for line-graph reindexing (endpoints up to 1023); empty results allowed; duplicate induced-subgraph vertices rejected.

Each fix has a regression test.

## Validation

- `make check` green: ruff, mypy (384 source files), `977 passed`.
- Catalog snapshot regenerated to **360 operations** (was 336).
- Each source domain was first validated independently on its own branch.

## Notes

- This branch merges the eight per-PR extraction branches (`agent/extract-*-<issue>`) and reconciles the shared catalog snapshot and `graph` browse assertion.
- `pyproject.toml` import-linter entries were added for three domains by the extraction; the list is a curated subset, so the remaining public modules were left as-is.
