### PR TITLE
Add impartial combinatorial game operations (#1907)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -29,6 +29,7 @@ from jacobian.math.electrical_networks._tools import (
 )
 from jacobian.math.finite_fields._tools import TOOLS as FINITE_FIELDS_TOOLS
 from jacobian.math.finite_game_theory._tools import TOOLS as FINITE_GAME_THEORY_TOOLS
+from jacobian.math.impartial_games._tools import TOOLS as IMPARTIAL_GAMES_TOOLS
 from jacobian.math.finite_metric_spaces._tools import (
     TOOLS as FINITE_METRIC_SPACES_TOOLS,
 )
@@ -140,6 +141,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *IMPARTIAL_GAMES_TOOLS,
     *ELECTRICAL_NETWORKS_TOOLS,
     *REGULAR_LANGUAGES_TOOLS,
     *ALGEBRAIC_COMBINATORICS_TOOLS,

--- a/src/jacobian/math/impartial_games/__init__.py
+++ b/src/jacobian/math/impartial_games/__init__.py
@@ -1,0 +1,3 @@
+"""Impartial combinatorial game operations."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -1,0 +1,345 @@
+"""Typed wire contracts for impartial combinatorial game operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_POSITIONS = 500
+MAX_MOVES = 2_000
+MAX_LABEL_LEN = 64
+MAX_HEAPS = 50
+MAX_HEAP_SIZE = 10_000
+MAX_SUBTRACTION_VALUE = 500
+MAX_HEAP_BOUND = 5_000
+
+
+class GameMove(StrictModel):
+    """One directed edge ``source -> target`` in the game DAG."""
+
+    source: str = Field(min_length=1, max_length=MAX_LABEL_LEN)
+    target: str = Field(min_length=1, max_length=MAX_LABEL_LEN)
+
+
+class ImpartialGameDAGRequest(StrictModel):
+    """A finite impartial game specified as a complete move relation."""
+
+    positions: tuple[str, ...] = Field(min_length=1, max_length=MAX_POSITIONS)
+    moves: tuple[GameMove, ...] = Field(max_length=MAX_MOVES)
+
+    @model_validator(mode="after")
+    def validate_dag(self) -> Self:
+        labels = set(self.positions)
+        if len(labels) != len(self.positions):
+            raise ValueError("position labels must be unique")
+        seen: set[tuple[str, str]] = set()
+        for move in self.moves:
+            if move.source not in labels:
+                raise ValueError(
+                    f"move source {move.source!r} is not a declared position"
+                )
+            if move.target not in labels:
+                raise ValueError(
+                    f"move target {move.target!r} is not a declared position"
+                )
+            if move.source == move.target:
+                raise ValueError("self-loops are not allowed")
+            key = (move.source, move.target)
+            if key in seen:
+                raise ValueError(f"duplicate move {key}")
+            seen.add(key)
+        return self
+
+
+class GrundyTableRequest(StrictModel):
+    """Compute the Grundy table of a finite impartial game DAG."""
+
+    game: ImpartialGameDAGRequest
+
+
+class PositionGrundyRequest(StrictModel):
+    """Compute the Grundy value of a single position."""
+
+    game: ImpartialGameDAGRequest
+    position: str = Field(min_length=1, max_length=MAX_LABEL_LEN)
+
+    @model_validator(mode="after")
+    def validate_position(self) -> Self:
+        if self.position not in set(self.game.positions):
+            raise ValueError(f"position {self.position!r} is not in the game")
+        return self
+
+
+class OutcomeProfileRequest(StrictModel):
+    """Compute the P/N partition of a finite impartial game."""
+
+    game: ImpartialGameDAGRequest
+
+
+class NimEquivalentRequest(StrictModel):
+    """Find the canonical Nim heap equivalent to one position."""
+
+    game: ImpartialGameDAGRequest
+    position: str = Field(min_length=1, max_length=MAX_LABEL_LEN)
+
+    @model_validator(mode="after")
+    def validate_position(self) -> Self:
+        if self.position not in set(self.game.positions):
+            raise ValueError(f"position {self.position!r} is not in the game")
+        return self
+
+
+class GrundyClassesRequest(StrictModel):
+    """Partition positions by equal Grundy value."""
+
+    game: ImpartialGameDAGRequest
+
+
+class BirthdayRequest(StrictModel):
+    """Compute birthdays (DAG heights) of all positions."""
+
+    game: ImpartialGameDAGRequest
+
+
+# -- Results ----------------------------------------------------------------
+
+
+class GrundyEntry(StrictModel):
+    """One position with its Grundy value and option Grundy set."""
+
+    position: str
+    grundy: int = Field(ge=0)
+    option_grundy_set: tuple[int, ...] = Field(default_factory=tuple)
+
+
+class GrundyTableResult(StrictModel):
+    """Complete Grundy table of a finite impartial game."""
+
+    entry_map: tuple[GrundyEntry, ...]
+    max_grundy: int = Field(ge=0)
+    histogram: tuple[int, ...]
+    topological_order: tuple[str, ...]
+
+
+class PositionGrundyResult(StrictModel):
+    """Grundy value of a single position with its dependency sub-DAG."""
+
+    position: str
+    grundy: int = Field(ge=0)
+    reachable_positions: tuple[str, ...]
+    topological_order: tuple[str, ...]
+    option_grundy_set: tuple[int, ...] = Field(default_factory=tuple)
+
+
+class OutcomeProfileResult(StrictModel):
+    """P/N partition of a finite impartial game."""
+
+    p_positions: tuple[str, ...]
+    n_positions: tuple[str, ...]
+    terminal_positions: tuple[str, ...]
+    grundy_map: tuple[tuple[str, int], ...]
+
+
+class NimEquivalentResult(StrictModel):
+    """Canonical Nim heap equivalent to one position."""
+
+    position: str
+    heap_size: int = Field(ge=0)
+
+
+class GrundyClassEntry(StrictModel):
+    """One equivalence class of positions with the same Grundy value."""
+
+    grundy: int = Field(ge=0)
+    positions: tuple[str, ...]
+
+
+class GrundyClassesResult(StrictModel):
+    """Partition of positions by equal Grundy value."""
+
+    classes: tuple[GrundyClassEntry, ...]
+    histogram: tuple[int, ...]
+
+
+class BirthdayResult(StrictModel):
+    """Birthday (DAG height) of every position."""
+
+    birthdays: tuple[tuple[str, int], ...]
+
+
+# -- Nim --------------------------------------------------------------------
+
+
+class NimSumRequest(StrictModel):
+    """Compute the nim-sum (bitwise xor) of heap sizes."""
+
+    heaps: tuple[int, ...] = Field(min_length=1, max_length=MAX_HEAPS)
+
+    @model_validator(mode="after")
+    def validate_heaps(self) -> Self:
+        for heap in self.heaps:
+            if heap < 0:
+                raise ValueError("heap sizes must be non-negative")
+            if heap > MAX_HEAP_SIZE:
+                raise ValueError(f"heap sizes must be at most {MAX_HEAP_SIZE}")
+        return self
+
+
+class NimSumResult(StrictModel):
+    """Result of a nim-sum computation."""
+
+    heaps: tuple[int, ...]
+    nim_sum: int = Field(ge=0)
+    is_p_position: bool
+
+
+class NimOptionsRequest(StrictModel):
+    """Enumerate all legal options of a Nim position."""
+
+    heaps: tuple[int, ...] = Field(min_length=1, max_length=MAX_HEAPS)
+
+    @model_validator(mode="after")
+    def validate_heaps(self) -> Self:
+        for heap in self.heaps:
+            if heap < 0:
+                raise ValueError("heap sizes must be non-negative")
+            if heap > MAX_HEAP_SIZE:
+                raise ValueError(f"heap sizes must be at most {MAX_HEAP_SIZE}")
+        return self
+
+
+class NimOption(StrictModel):
+    """One legal move in Nim: reduce one heap."""
+
+    heap_index: int = Field(ge=0)
+    old_size: int = Field(ge=0)
+    new_size: int = Field(ge=0)
+    resulting_heaps: tuple[int, ...]
+
+
+class NimOptionsResult(StrictModel):
+    """All legal options of a Nim position."""
+
+    options: tuple[NimOption, ...]
+
+
+# -- Subtraction games -----------------------------------------------------
+
+
+class SubtractionDAGRequest(StrictModel):
+    """Build the game DAG for a bounded subtraction game."""
+
+    subtraction_set: tuple[int, ...] = Field(min_length=1)
+    max_heap: int = Field(ge=0, le=MAX_HEAP_BOUND)
+
+    @model_validator(mode="after")
+    def validate_subtraction_set(self) -> Self:
+        seen: set[int] = set()
+        for value in self.subtraction_set:
+            if value <= 0:
+                raise ValueError("subtraction set values must be positive")
+            if value > MAX_SUBTRACTION_VALUE:
+                raise ValueError(
+                    f"subtraction set values must be at most {MAX_SUBTRACTION_VALUE}"
+                )
+            if value in seen:
+                raise ValueError("subtraction set values must be unique")
+            seen.add(value)
+        return self
+
+
+class SubtractionDAGResult(StrictModel):
+    """Game DAG for a bounded subtraction game."""
+
+    positions: tuple[str, ...]
+    moves: tuple[GameMove, ...]
+    terminal_positions: tuple[str, ...]
+
+
+class SubtractionGrundyPrefixRequest(StrictModel):
+    """Compute the Grundy prefix of a bounded subtraction game."""
+
+    subtraction_set: tuple[int, ...] = Field(min_length=1)
+    max_heap: int = Field(ge=0, le=MAX_HEAP_BOUND)
+
+    @model_validator(mode="after")
+    def validate_subtraction_set(self) -> Self:
+        seen: set[int] = set()
+        for value in self.subtraction_set:
+            if value <= 0:
+                raise ValueError("subtraction set values must be positive")
+            if value > MAX_SUBTRACTION_VALUE:
+                raise ValueError(
+                    f"subtraction set values must be at most {MAX_SUBTRACTION_VALUE}"
+                )
+            if value in seen:
+                raise ValueError("subtraction set values must be unique")
+            seen.add(value)
+        return self
+
+
+class SubtractionGrundyPrefixResult(StrictModel):
+    """Grundy prefix of a bounded subtraction game."""
+
+    grundy_values: tuple[int, ...]
+    option_sets: tuple[tuple[int, ...], ...]
+    p_positions: tuple[int, ...]
+    n_positions: tuple[int, ...]
+
+
+# -- Mex --------------------------------------------------------------------
+
+
+class MexRequest(StrictModel):
+    """Compute the mex (minimum excluded value) of a bounded finite set."""
+
+    values: tuple[int, ...] = Field(max_length=MAX_POSITIONS)
+
+    @model_validator(mode="after")
+    def validate_values(self) -> Self:
+        for value in self.values:
+            if value < 0:
+                raise ValueError("mex values must be non-negative")
+        return self
+
+
+class MexResult(StrictModel):
+    """Result of a mex computation."""
+
+    mex: int = Field(ge=0)
+    membership_prefix: tuple[int, ...]
+    first_gap: int = Field(ge=0)
+
+
+__all__ = [
+    "BirthdayRequest",
+    "BirthdayResult",
+    "GameMove",
+    "GrundyClassEntry",
+    "GrundyClassesRequest",
+    "GrundyClassesResult",
+    "GrundyEntry",
+    "GrundyTableRequest",
+    "GrundyTableResult",
+    "ImpartialGameDAGRequest",
+    "MexRequest",
+    "MexResult",
+    "NimEquivalentRequest",
+    "NimEquivalentResult",
+    "NimOption",
+    "NimOptionsRequest",
+    "NimOptionsResult",
+    "NimSumRequest",
+    "NimSumResult",
+    "OutcomeProfileRequest",
+    "OutcomeProfileResult",
+    "PositionGrundyRequest",
+    "PositionGrundyResult",
+    "SubtractionDAGRequest",
+    "SubtractionDAGResult",
+    "SubtractionGrundyPrefixRequest",
+    "SubtractionGrundyPrefixResult",
+]

--- a/src/jacobian/math/impartial_games/_operations.py
+++ b/src/jacobian/math/impartial_games/_operations.py
@@ -1,0 +1,360 @@
+"""Domain-owned impartial combinatorial game operations."""
+
+from __future__ import annotations
+
+from functools import reduce
+from operator import xor
+
+import networkx as nx
+
+from jacobian.math.impartial_games._models import (
+    BirthdayRequest,
+    BirthdayResult,
+    GameMove,
+    GrundyClassEntry,
+    GrundyClassesRequest,
+    GrundyClassesResult,
+    GrundyEntry,
+    GrundyTableRequest,
+    GrundyTableResult,
+    ImpartialGameDAGRequest,
+    MexRequest,
+    MexResult,
+    NimEquivalentRequest,
+    NimEquivalentResult,
+    NimOption,
+    NimOptionsRequest,
+    NimOptionsResult,
+    NimSumRequest,
+    NimSumResult,
+    OutcomeProfileRequest,
+    OutcomeProfileResult,
+    PositionGrundyRequest,
+    PositionGrundyResult,
+    SubtractionDAGRequest,
+    SubtractionDAGResult,
+    SubtractionGrundyPrefixRequest,
+    SubtractionGrundyPrefixResult,
+)
+
+
+def _build_digraph(game: ImpartialGameDAGRequest) -> nx.DiGraph:
+    """Build a NetworkX digraph from the game DAG request."""
+    graph = nx.DiGraph()
+    graph.add_nodes_from(game.positions)
+    for move in game.moves:
+        graph.add_edge(move.source, move.target)
+    return graph
+
+
+def _check_acyclic(graph: nx.DiGraph) -> None:
+    """Reject cyclic game DAGs."""
+    if not nx.is_directed_acyclic_graph(graph):
+        raise ValueError("game DAG must be acyclic; cycles are not allowed")
+
+
+def _topological_order(graph: nx.DiGraph) -> list[str]:
+    """Return a deterministic topological order of the graph nodes."""
+    return list(nx.topological_sort(graph))
+
+
+def _compute_grundy_table(
+    graph: nx.DiGraph,
+) -> tuple[dict[str, int], dict[str, tuple[int, ...]], list[str]]:
+    """Compute Grundy values for all positions in reverse topological order.
+
+    Terminal positions (no successors) have Grundy value 0.  For each
+    non-terminal position, the Grundy value is the mex of its successors'
+    Grundy values.  Processing in reverse topological order ensures
+    all successors are computed before the position itself.
+
+    Returns (grundy_map, option_grundy_sets, topo_order).
+    """
+    topo = _topological_order(graph)
+    # Reverse: process terminal positions first
+    grundy: dict[str, int] = {}
+    option_sets: dict[str, tuple[int, ...]] = {}
+
+    for pos in reversed(topo):
+        successors = list(graph.successors(pos))
+        opt_values = sorted(grundy[s] for s in successors)
+        option_sets[pos] = tuple(opt_values)
+        grundy[pos] = _mex_of_set(opt_values)
+
+    return grundy, option_sets, topo
+
+
+def _mex_of_set(values: list[int]) -> int:
+    """Compute the mex of a sorted list of non-negative integers."""
+    mex = 0
+    for v in values:
+        if v == mex:
+            mex += 1
+        elif v > mex:
+            break
+    return mex
+
+
+def compute_mex(request: MexRequest) -> MexResult:
+    """Compute the minimum excluded value of a bounded finite set."""
+    values = sorted(set(request.values))
+    mex = 0
+    membership = []
+    for v in values:
+        if v == mex:
+            membership.append(mex)
+            mex += 1
+        elif v > mex:
+            break
+    return MexResult(
+        mex=mex,
+        membership_prefix=tuple(membership),
+        first_gap=mex,
+    )
+
+
+def compute_grundy_table(request: GrundyTableRequest) -> GrundyTableResult:
+    """Compute the complete Grundy table of a finite impartial game DAG."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    grundy, option_sets, topo = _compute_grundy_table(graph)
+
+    max_g = max(grundy.values()) if grundy else 0
+    histogram = [0] * (max_g + 1)
+    for v in grundy.values():
+        histogram[v] += 1
+
+    entries = tuple(
+        GrundyEntry(
+            position=pos,
+            grundy=grundy[pos],
+            option_grundy_set=option_sets[pos],
+        )
+        for pos in request.game.positions
+    )
+
+    return GrundyTableResult(
+        entry_map=entries,
+        max_grundy=max_g,
+        histogram=tuple(histogram),
+        topological_order=tuple(topo),
+    )
+
+
+def compute_position_grundy(request: PositionGrundyRequest) -> PositionGrundyResult:
+    """Compute the Grundy value of a single position."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    target = request.position
+    reachable = set(nx.descendants(graph, target))
+    reachable.add(target)
+    subgraph = graph.subgraph(reachable)
+    topo = _topological_order(subgraph)
+
+    grundy: dict[str, int] = {}
+    for pos in reversed(topo):
+        successors = list(subgraph.successors(pos))
+        opt_values = sorted(grundy[s] for s in successors)
+        grundy[pos] = _mex_of_set(opt_values)
+
+    opt_grundy_set = sorted(
+        grundy[s] for s in subgraph.successors(target)
+    )
+
+    return PositionGrundyResult(
+        position=target,
+        grundy=grundy[target],
+        reachable_positions=tuple(topo),
+        topological_order=tuple(topo),
+        option_grundy_set=tuple(opt_grundy_set),
+    )
+
+
+def compute_outcome_profile(request: OutcomeProfileRequest) -> OutcomeProfileResult:
+    """Compute the P/N partition of a finite impartial game."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    grundy, _, _ = _compute_grundy_table(graph)
+
+    p_positions = tuple(p for p in request.game.positions if grundy[p] == 0)
+    n_positions = tuple(p for p in request.game.positions if grundy[p] > 0)
+    terminal = tuple(
+        p for p in request.game.positions if graph.out_degree(p) == 0
+    )
+
+    grundy_map = tuple(
+        (p, grundy[p]) for p in request.game.positions
+    )
+
+    return OutcomeProfileResult(
+        p_positions=p_positions,
+        n_positions=n_positions,
+        terminal_positions=terminal,
+        grundy_map=grundy_map,
+    )
+
+
+def compute_nim_equivalent(request: NimEquivalentRequest) -> NimEquivalentResult:
+    """Find the canonical Nim heap equivalent to one position."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    grundy, _, _ = _compute_grundy_table(graph)
+
+    return NimEquivalentResult(
+        position=request.position,
+        heap_size=grundy[request.position],
+    )
+
+
+def compute_grundy_classes(request: GrundyClassesRequest) -> GrundyClassesResult:
+    """Partition positions by equal Grundy value."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    grundy, _, _ = _compute_grundy_table(graph)
+
+    classes: dict[int, list[str]] = {}
+    for pos in request.game.positions:
+        g = grundy[pos]
+        classes.setdefault(g, []).append(pos)
+
+    max_g = max(grundy.values()) if grundy else 0
+    histogram = [0] * (max_g + 1)
+    for v in grundy.values():
+        histogram[v] += 1
+
+    sorted_classes = sorted(classes.items())
+    return GrundyClassesResult(
+        classes=tuple(
+            GrundyClassEntry(grundy=g, positions=tuple(sorted(positions)))
+            for g, positions in sorted_classes
+        ),
+        histogram=tuple(histogram),
+    )
+
+
+def compute_birthday(request: BirthdayRequest) -> BirthdayResult:
+    """Compute the birthday (DAG height) of every position."""
+    graph = _build_digraph(request.game)
+    _check_acyclic(graph)
+
+    topo = _topological_order(graph)
+    birthday: dict[str, int] = {}
+
+    for pos in reversed(topo):
+        successors = list(graph.successors(pos))
+        if not successors:
+            birthday[pos] = 0
+        else:
+            birthday[pos] = 1 + max(birthday[s] for s in successors)
+
+    return BirthdayResult(
+        birthdays=tuple((p, birthday[p]) for p in request.game.positions)
+    )
+
+
+# -- Nim operations ---------------------------------------------------------
+
+
+def compute_nim_sum(request: NimSumRequest) -> NimSumResult:
+    """Compute the nim-sum (bitwise xor) of heap sizes."""
+    total = reduce(xor, request.heaps, 0)
+    return NimSumResult(
+        heaps=request.heaps,
+        nim_sum=total,
+        is_p_position=(total == 0),
+    )
+
+
+def compute_nim_options(request: NimOptionsRequest) -> NimOptionsResult:
+    """Enumerate all legal options of a Nim position."""
+    heaps = request.heaps
+    options: list[NimOption] = []
+    for i, size in enumerate(heaps):
+        for new_size in range(size):
+            resulting = list(heaps)
+            resulting[i] = new_size
+            options.append(
+                NimOption(
+                    heap_index=i,
+                    old_size=size,
+                    new_size=new_size,
+                    resulting_heaps=tuple(resulting),
+                )
+            )
+    return NimOptionsResult(options=tuple(options))
+
+
+# -- Subtraction games ------------------------------------------------------
+
+
+def compute_subtraction_dag(request: SubtractionDAGRequest) -> SubtractionDAGResult:
+    """Build the game DAG for a bounded subtraction game."""
+    s = sorted(request.subtraction_set)
+    n = request.max_heap
+    positions = tuple(str(i) for i in range(n + 1))
+    moves: list[GameMove] = []
+    for pos in range(n + 1):
+        for sub in s:
+            target = pos - sub
+            if target >= 0:
+                moves.append(
+                    GameMove(source=str(pos), target=str(target))
+                )
+    terminal = tuple(
+        str(i) for i in range(n + 1) if not any(i >= s for s in request.subtraction_set)
+    )
+    return SubtractionDAGResult(
+        positions=positions,
+        moves=tuple(moves),
+        terminal_positions=terminal,
+    )
+
+
+def compute_subtraction_grundy_prefix(
+    request: SubtractionGrundyPrefixRequest,
+) -> SubtractionGrundyPrefixResult:
+    """Compute the Grundy prefix of a bounded subtraction game."""
+    s = sorted(request.subtraction_set)
+    n = request.max_heap
+    grundy = [0] * (n + 1)
+    option_sets_list: list[tuple[int, ...]] = [()] * (n + 1)
+
+    for pos in range(n + 1):
+        opt_grundy: list[int] = []
+        for sub in s:
+            target = pos - sub
+            if target >= 0:
+                opt_grundy.append(grundy[target])
+        opt_grundy.sort()
+        option_sets_list[pos] = tuple(opt_grundy)
+        grundy[pos] = _mex_of_set(opt_grundy)
+
+    p_positions = tuple(i for i in range(n + 1) if grundy[i] == 0)
+    n_positions = tuple(i for i in range(n + 1) if grundy[i] > 0)
+
+    return SubtractionGrundyPrefixResult(
+        grundy_values=tuple(grundy),
+        option_sets=tuple(option_sets_list),
+        p_positions=p_positions,
+        n_positions=n_positions,
+    )
+
+
+__all__ = [
+    "compute_birthday",
+    "compute_grundy_classes",
+    "compute_grundy_table",
+    "compute_mex",
+    "compute_nim_equivalent",
+    "compute_nim_options",
+    "compute_nim_sum",
+    "compute_outcome_profile",
+    "compute_position_grundy",
+    "compute_subtraction_dag",
+    "compute_subtraction_grundy_prefix",
+]

--- a/src/jacobian/math/impartial_games/_tools.py
+++ b/src/jacobian/math/impartial_games/_tools.py
@@ -1,0 +1,320 @@
+"""Impartial combinatorial game operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.impartial_games._models import (
+    BirthdayRequest,
+    BirthdayResult,
+    GrundyClassesRequest,
+    GrundyClassesResult,
+    GrundyTableRequest,
+    GrundyTableResult,
+    MexRequest,
+    MexResult,
+    NimEquivalentRequest,
+    NimEquivalentResult,
+    NimOptionsRequest,
+    NimOptionsResult,
+    NimSumRequest,
+    NimSumResult,
+    OutcomeProfileRequest,
+    OutcomeProfileResult,
+    PositionGrundyRequest,
+    PositionGrundyResult,
+    SubtractionDAGRequest,
+    SubtractionDAGResult,
+    SubtractionGrundyPrefixRequest,
+    SubtractionGrundyPrefixResult,
+)
+from jacobian.math.impartial_games._operations import (
+    compute_birthday,
+    compute_grundy_classes,
+    compute_grundy_table,
+    compute_mex,
+    compute_nim_equivalent,
+    compute_nim_options,
+    compute_nim_sum,
+    compute_outcome_profile,
+    compute_position_grundy,
+    compute_subtraction_dag,
+    compute_subtraction_grundy_prefix,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_SIMPLE_GAME = {
+    "game": {
+        "positions": ["0", "1", "2", "3"],
+        "moves": [
+            {"source": "3", "target": "2"},
+            {"source": "3", "target": "1"},
+            {"source": "2", "target": "1"},
+            {"source": "2", "target": "0"},
+            {"source": "1", "target": "0"},
+        ],
+    },
+}
+
+IMPARTIAL_GAME_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "game.impartial.grundy_table.compute",
+        "Compute Grundy table of an impartial game",
+        "Given a finite impartial game DAG, compute the complete Grundy "
+        "table with mex per position, max Grundy value, histogram, and "
+        "topological evaluation order.",
+        GrundyTableRequest,
+        GrundyTableResult,
+        compute_grundy_table,
+        "game-theory",
+        "impartial",
+        "grundy",
+        "exact",
+        examples=(
+            example(
+                "chain_3",
+                "Grundy values for a 4-position chain game; the game DAG "
+                "must be acyclic.",
+                _SIMPLE_GAME,
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.position.grundy.compute",
+        "Compute Grundy value of one position",
+        "Compute the Grundy value of a single position and its reachable "
+        "dependency sub-DAG in topological order.",
+        PositionGrundyRequest,
+        PositionGrundyResult,
+        compute_position_grundy,
+        "game-theory",
+        "impartial",
+        "grundy",
+        "exact",
+        examples=(
+            example(
+                "chain_3_position",
+                "Grundy value of position 3 in a 4-position chain game; "
+                "the position must be in the game.",
+                {"game": _SIMPLE_GAME["game"], "position": "3"},
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.outcome_profile.compute",
+        "Compute P/N partition of an impartial game",
+        "Partition positions into P-positions (Grundy 0) and N-positions "
+        "(Grundy > 0), with terminal positions and the complete Grundy map.",
+        OutcomeProfileRequest,
+        OutcomeProfileResult,
+        compute_outcome_profile,
+        "game-theory",
+        "impartial",
+        "outcome",
+        "exact",
+        examples=(
+            example(
+                "chain_3_outcome",
+                "P/N partition of a 4-position chain game; the game DAG "
+                "must be acyclic.",
+                _SIMPLE_GAME,
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.nim_equivalent.compute",
+        "Compute Nim-heap equivalence of a position",
+        "Find the canonical Nim heap size equivalent to one position under "
+        "normal-play disjunctive sum, given the complete game DAG.",
+        NimEquivalentRequest,
+        NimEquivalentResult,
+        compute_nim_equivalent,
+        "game-theory",
+        "impartial",
+        "nim",
+        "exact",
+        examples=(
+            example(
+                "chain_3_nim_equiv",
+                "Nim heap equivalent to position 3 in a 4-position chain; "
+                "the position must be in the game.",
+                {"game": _SIMPLE_GAME["game"], "position": "3"},
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.grundy_classes.compute",
+        "Partition positions by Grundy value",
+        "Partition positions into equivalence classes by equal Grundy "
+        "value, with class histograms.",
+        GrundyClassesRequest,
+        GrundyClassesResult,
+        compute_grundy_classes,
+        "game-theory",
+        "impartial",
+        "grundy",
+        "exact",
+        examples=(
+            example(
+                "chain_3_classes",
+                "Grundy equivalence classes of a 4-position chain game; "
+                "the game DAG must be acyclic.",
+                _SIMPLE_GAME,
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.birthday.compute",
+        "Compute birthdays of all positions",
+        "Compute the birthday (DAG height) of every position: 0 for "
+        "terminals, 1 + max of successors otherwise.",
+        BirthdayRequest,
+        BirthdayResult,
+        compute_birthday,
+        "game-theory",
+        "impartial",
+        "birthday",
+        "exact",
+        examples=(
+            example(
+                "chain_3_birthday",
+                "Birthdays of a 4-position chain game; the game DAG must "
+                "be acyclic.",
+                _SIMPLE_GAME,
+            ),
+        ),
+    ),
+    _op(
+        "game.nim.nim_sum.compute",
+        "Compute nim-sum of heap sizes",
+        "Compute the bitwise xor (nim-sum) of a finite tuple of "
+        "non-negative heap sizes and determine P/N status.",
+        NimSumRequest,
+        NimSumResult,
+        compute_nim_sum,
+        "game-theory",
+        "nim",
+        "exact",
+        examples=(
+            example(
+                "simple_nim_sum",
+                "Nim-sum of heaps [3, 4, 5]; heaps must be non-negative.",
+                {"heaps": [3, 4, 5]},
+            ),
+        ),
+    ),
+    _op(
+        "game.nim.options.compute",
+        "Enumerate all legal Nim options",
+        "Enumerate every distinct legal option of a Nim position obtained "
+        "by reducing exactly one heap.",
+        NimOptionsRequest,
+        NimOptionsResult,
+        compute_nim_options,
+        "game-theory",
+        "nim",
+        "exact",
+        examples=(
+            example(
+                "nim_2_2_options",
+                "All options of Nim position [2, 2]; heaps must be "
+                "non-negative.",
+                {"heaps": [2, 2]},
+            ),
+        ),
+    ),
+    _op(
+        "game.subtraction.dag.compute",
+        "Build game DAG for a subtraction game",
+        "Construct the exact game DAG for a bounded subtraction game "
+        "with a given subtraction set and maximum heap.",
+        SubtractionDAGRequest,
+        SubtractionDAGResult,
+        compute_subtraction_dag,
+        "game-theory",
+        "subtraction",
+        "exact",
+        examples=(
+            example(
+                "sub_1_3_dag",
+                "DAG for subtraction set {1, 3} with max heap 5; "
+                "subtraction set values must be positive.",
+                {"subtraction_set": [1, 3], "max_heap": 5},
+            ),
+        ),
+    ),
+    _op(
+        "game.subtraction.grundy_prefix.compute",
+        "Compute Grundy prefix of a subtraction game",
+        "Compute g(0),...,g(N), option-value sets, and P/N heap sets "
+        "for a bounded subtraction game.",
+        SubtractionGrundyPrefixRequest,
+        SubtractionGrundyPrefixResult,
+        compute_subtraction_grundy_prefix,
+        "game-theory",
+        "subtraction",
+        "grundy",
+        "exact",
+        examples=(
+            example(
+                "sub_1_3_grundy",
+                "Grundy prefix for subtraction set {1, 3} with max heap 5; "
+                "subtraction set values must be positive.",
+                {"subtraction_set": [1, 3], "max_heap": 5},
+            ),
+        ),
+    ),
+    _op(
+        "combinatorics.mex.compute",
+        "Compute minimum excluded value",
+        "Compute the mex (minimum excluded non-negative integer) of a "
+        "bounded finite set, with the membership prefix and first gap.",
+        MexRequest,
+        MexResult,
+        compute_mex,
+        "combinatorics",
+        "mex",
+        "exact",
+        examples=(
+            example(
+                "mex_example",
+                "Mex of {0, 1, 3, 4}; values must be non-negative.",
+                {"values": [0, 1, 3, 4]},
+            ),
+        ),
+    ),
+)
+
+
+TOOLS = IMPARTIAL_GAME_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -177,6 +177,10 @@
       "input_schema": "sha256:892525fd272560090e34f7babb2cd9b5fd477acd714dd3cecfbc4212a88ac225",
       "output_schema": "sha256:03dd1f3fd2c5d21d50ec9d815d3f5f254066a92111d864bc88ef5646e0222a14"
     },
+    "combinatorics.mex.compute": {
+      "input_schema": "sha256:a7dfb9fdc7e0f31651503ab0c7e1cb3278481f0bb324db08b0d120826acc2c6c",
+      "output_schema": "sha256:df0b9035d273c2d3f2b0cd226f5dcf66906d2402500f2d2be5e93c9a1e3055c3"
+    },
     "combinatorics.recurrence.linear.evaluate": {
       "input_schema": "sha256:aa0c112bc3c99aecd7881933223352b4969d99ad3b3bfd71cc8c773509405e3c",
       "output_schema": "sha256:043a742a3be82ac62dee396df8ba508653025bd700b3c2bbca3eaf41b3586305"
@@ -388,6 +392,46 @@
     "formal_series.rational.truncate.compute": {
       "input_schema": "sha256:bc7dcfe7176d471f8517297a8b4668a9aa1da2b878734baeb582b416ae8d9bff",
       "output_schema": "sha256:f4e431dd60ee3d88d100f0e178b4f638955403da360bc104261319b6e0aeb302"
+    },
+    "game.impartial.birthday.compute": {
+      "input_schema": "sha256:a2a1cc9fab4ae0a39f4e6e9f143570b7e269d48b1c95adde1bae81c28bff8cda",
+      "output_schema": "sha256:0a1b514435cdcf91de65645f3b626660ee56d5df0c313fb21cd5d07812e810e8"
+    },
+    "game.impartial.grundy_classes.compute": {
+      "input_schema": "sha256:c21c4f85cbc43f92e7dccc59d13542817e8610cf4bd94f8fbee9b7a05659d0c6",
+      "output_schema": "sha256:a7344181c78c3f25abbd8d290d78b8fa7c44c1e1873780b106421eea39a30765"
+    },
+    "game.impartial.grundy_table.compute": {
+      "input_schema": "sha256:e1a7a2f5010f80a2288c1c06d26a19f1bce29b96b8bd41701f6625bbd9647d87",
+      "output_schema": "sha256:9e587083e10d40c364f6a916c3309d47b33bcc4af0051648557a55331789eb40"
+    },
+    "game.impartial.nim_equivalent.compute": {
+      "input_schema": "sha256:fdaa162f9f5186fd01a7daa39516ad7329f5e358924dc3fc06a62518ac7db00b",
+      "output_schema": "sha256:40b40ade8b16cc6f97bd935031542e2359b3d77e6fe8bc251699c45c1291e925"
+    },
+    "game.impartial.outcome_profile.compute": {
+      "input_schema": "sha256:ab158b6dfb067f8e793f91b719fc8454b83e9a43db386f57683d8271cd49f97a",
+      "output_schema": "sha256:4d1233b07420e17042dd78e4e9bfdb5b5ee40c4d41a612debbd89f5943b70123"
+    },
+    "game.impartial.position.grundy.compute": {
+      "input_schema": "sha256:f2144fadcdccc40d258bdcf61a6ca1658bd38661758579a42520009a2b8deb5e",
+      "output_schema": "sha256:eec4f65d90a377fc230a2216afa24e3f8f7f4b34f51d656ade427e1be78308e4"
+    },
+    "game.nim.nim_sum.compute": {
+      "input_schema": "sha256:ddfe39ff030ad61ed9554ff4739aa7351e908eeca5a2facf4abedbf436231955",
+      "output_schema": "sha256:c4055c055d0863a4d31c1118688f6d539a8addb56b2c5a99bfd4f5af27d070bb"
+    },
+    "game.nim.options.compute": {
+      "input_schema": "sha256:44bbdcd380fb3151d4df9cf495e4b50e03aff0569d4d0565662b33a7ffb52c92",
+      "output_schema": "sha256:0901e2fb932c278728c3365a9fcdb5d74d72241ea275e4fe182585bea95b4912"
+    },
+    "game.subtraction.dag.compute": {
+      "input_schema": "sha256:284aebd95d4e634381eb7d6038691547aa8c99f7b3fcc70833e5cdc90c6f0cf8",
+      "output_schema": "sha256:4d6f616c346b0c1e0257e0bcef4ae10d69e527b5ac06f7c86c5db6c5365686ba"
+    },
+    "game.subtraction.grundy_prefix.compute": {
+      "input_schema": "sha256:0ef1be8c3ad5cf636af16c4782e40a2624161a9770166491be9f540204c93897",
+      "output_schema": "sha256:4ae654a0b0f5ed425baa77abed3d8c4de8151cd29e6d6a03348f4f188a5d2a92"
     },
     "game_theory.best_response.compute": {
       "input_schema": "sha256:fd3bbd5d7284ea00acb0389777e444d5b79922dcd6ca059c21c857431896a543",

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 371
     assert actual == expected["operations"]
 
 

--- a/tests/math/impartial_games/test_impartial_games.py
+++ b/tests/math/impartial_games/test_impartial_games.py
@@ -1,0 +1,374 @@
+"""Tests for impartial combinatorial game operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.impartial_games._models import (
+    BirthdayRequest,
+    GameMove,
+    GrundyClassesRequest,
+    GrundyTableRequest,
+    ImpartialGameDAGRequest,
+    MexRequest,
+    NimEquivalentRequest,
+    NimOptionsRequest,
+    NimSumRequest,
+    OutcomeProfileRequest,
+    PositionGrundyRequest,
+    SubtractionDAGRequest,
+    SubtractionGrundyPrefixRequest,
+)
+from jacobian.math.impartial_games._operations import (
+    compute_birthday,
+    compute_grundy_classes,
+    compute_grundy_table,
+    compute_mex,
+    compute_nim_equivalent,
+    compute_nim_options,
+    compute_nim_sum,
+    compute_outcome_profile,
+    compute_position_grundy,
+    compute_subtraction_dag,
+    compute_subtraction_grundy_prefix,
+)
+
+
+def _chain_game() -> ImpartialGameDAGRequest:
+    """A simple chain: 3->2, 3->1, 2->1, 2->0, 1->0.
+
+    Grundy values: 0->0, 1->1, 2->2, 3->mex(1,2)=0.
+    """
+    return ImpartialGameDAGRequest(
+        positions=("0", "1", "2", "3"),
+        moves=(
+            GameMove(source="3", target="2"),
+            GameMove(source="3", target="1"),
+            GameMove(source="2", target="1"),
+            GameMove(source="2", target="0"),
+            GameMove(source="1", target="0"),
+        ),
+    )
+
+
+def _pure_chain() -> ImpartialGameDAGRequest:
+    """Pure chain: 3->2->1->0. Grundy values: 0,1,2,3."""
+    return ImpartialGameDAGRequest(
+        positions=("0", "1", "2", "3"),
+        moves=(
+            GameMove(source="3", target="2"),
+            GameMove(source="2", target="1"),
+            GameMove(source="1", target="0"),
+        ),
+    )
+
+
+class TestMex:
+    def test_simple(self):
+        req = MexRequest(values=[0, 1, 3, 4])
+        result = compute_mex(req)
+        assert result.mex == 2
+        assert result.membership_prefix == (0, 1)
+        assert result.first_gap == 2
+
+    def test_empty(self):
+        req = MexRequest(values=[])
+        result = compute_mex(req)
+        assert result.mex == 0
+
+    def test_contiguous(self):
+        req = MexRequest(values=[0, 1, 2, 3])
+        result = compute_mex(req)
+        assert result.mex == 4
+
+    def test_with_duplicates(self):
+        req = MexRequest(values=[0, 0, 1, 1, 3])
+        result = compute_mex(req)
+        assert result.mex == 2
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValidationError, match="non-negative"):
+            MexRequest(values=[-1])
+
+
+class TestGrundyTable:
+    def test_pure_chain(self):
+        """A pure chain 3->2->1->0 has Grundy values [0, 1, 0, 1] (alternating)."""
+        req = GrundyTableRequest(game=_pure_chain())
+        result = compute_grundy_table(req)
+        grundy_map = {e.position: e.grundy for e in result.entry_map}
+        assert grundy_map["0"] == 0
+        assert grundy_map["1"] == 1
+        assert grundy_map["2"] == 0
+        assert grundy_map["3"] == 1
+        assert result.max_grundy == 1
+
+    def test_chain_with_branch(self):
+        """Chain with branch: 3->2, 3->1, 2->1, 2->0, 1->0.
+        Grundy(0)=0, Grundy(1)=1, Grundy(2)=mex(1,0)=2, Grundy(3)=mex(2,1)=0."""
+        req = GrundyTableRequest(game=_chain_game())
+        result = compute_grundy_table(req)
+        grundy_map = {e.position: e.grundy for e in result.entry_map}
+        assert grundy_map["0"] == 0
+        assert grundy_map["1"] == 1
+        assert grundy_map["2"] == 2
+        assert grundy_map["3"] == 0
+        assert result.max_grundy == 2
+
+    def test_terminal_positions(self):
+        """Terminal positions have Grundy value 0."""
+        req = GrundyTableRequest(game=_chain_game())
+        result = compute_grundy_table(req)
+        assert result.entry_map[0].grundy == 0  # position "0"
+        assert result.entry_map[0].option_grundy_set == ()
+
+        # Find position "3" entry
+        pos3 = next(e for e in result.entry_map if e.position == "3")
+        assert set(pos3.option_grundy_set) == {1, 2}
+
+    def test_histogram(self):
+        req = GrundyTableRequest(game=_chain_game())
+        result = compute_grundy_table(req)
+        # values are 0, 1, 2, 0 -> histogram = [2, 1, 1]
+        assert result.histogram == (2, 1, 1)
+
+    def test_topological_order(self):
+        req = GrundyTableRequest(game=_chain_game())
+        result = compute_grundy_table(req)
+        # In topological order, "0" (terminal) should come last
+        order = result.topological_order
+        # topo sort goes from source to sink
+        assert order.index("0") > order.index("1")
+        assert order.index("1") > order.index("2")
+
+    def test_diamond_game(self):
+        """Diamond: 3->2, 3->1, 2->0, 1->0. Grundy(0)=0, Grundy(1)=1,
+        Grundy(2)=1, Grundy(3)=mex(1,1)=0."""
+        moves = (
+            GameMove(source="3", target="2"),
+            GameMove(source="3", target="1"),
+            GameMove(source="2", target="0"),
+            GameMove(source="1", target="0"),
+        )
+        req = GrundyTableRequest(
+            game=ImpartialGameDAGRequest(
+                positions=("0", "1", "2", "3"), moves=moves
+            )
+        )
+        result = compute_grundy_table(req)
+        grundy_map = {e.position: e.grundy for e in result.entry_map}
+        assert grundy_map["0"] == 0
+        assert grundy_map["1"] == 1
+        assert grundy_map["2"] == 1
+        assert grundy_map["3"] == 0
+
+    def test_rejects_cycle(self):
+        moves = (
+            GameMove(source="a", target="b"),
+            GameMove(source="b", target="a"),
+        )
+        req = GrundyTableRequest(
+            game=ImpartialGameDAGRequest(positions=("a", "b"), moves=moves)
+        )
+        with pytest.raises(ValueError, match="acyclic"):
+            compute_grundy_table(req)
+
+
+class TestPositionGrundy:
+    def test_single_position(self):
+        req = PositionGrundyRequest(game=_pure_chain(), position="3")
+        result = compute_position_grundy(req)
+        assert result.grundy == 1
+        assert "3" in result.reachable_positions
+
+    def test_terminal(self):
+        req = PositionGrundyRequest(game=_chain_game(), position="0")
+        result = compute_position_grundy(req)
+        assert result.grundy == 0
+
+
+class TestOutcomeProfile:
+    def test_chain_partition(self):
+        """Chain game: positions 0 and 3 are P (Grundy 0), 1 and 2 are N."""
+        req = OutcomeProfileRequest(game=_chain_game())
+        result = compute_outcome_profile(req)
+        assert "0" in result.p_positions
+        assert "3" in result.p_positions
+        assert "1" in result.n_positions
+        assert "2" in result.n_positions
+        assert "0" in result.terminal_positions
+
+
+class TestNimEquivalent:
+    def test_pure_chain(self):
+        req = NimEquivalentRequest(game=_pure_chain(), position="3")
+        result = compute_nim_equivalent(req)
+        assert result.heap_size == 1
+        assert result.position == "3"
+
+
+class TestGrundyClasses:
+    def test_pure_chain(self):
+        req = GrundyClassesRequest(game=_pure_chain())
+        result = compute_grundy_classes(req)
+        # Pure chain has 2 classes: {0,2} with grundy 0, {1,3} with grundy 1
+        assert len(result.classes) == 2
+        grundy_0 = next(c for c in result.classes if c.grundy == 0)
+        assert set(grundy_0.positions) == {"0", "2"}
+        grundy_1 = next(c for c in result.classes if c.grundy == 1)
+        assert set(grundy_1.positions) == {"1", "3"}
+
+    def test_chain_with_branch(self):
+        """Chain game: positions 0 and 3 have Grundy 0."""
+        req = GrundyClassesRequest(game=_chain_game())
+        result = compute_grundy_classes(req)
+        # Should have 3 classes: {0, 3} with grundy 0, {1} with grundy 1, {2} with grundy 2
+        grundy_0 = next(c for c in result.classes if c.grundy == 0)
+        assert set(grundy_0.positions) == {"0", "3"}
+
+
+class TestBirthday:
+    def test_pure_chain(self):
+        req = BirthdayRequest(game=_pure_chain())
+        result = compute_birthday(req)
+        bdays = dict(result.birthdays)
+        assert bdays["0"] == 0
+        assert bdays["1"] == 1
+        assert bdays["2"] == 2
+        assert bdays["3"] == 3
+
+
+class TestNimSum:
+    def test_simple(self):
+        req = NimSumRequest(heaps=(3, 4, 5))
+        result = compute_nim_sum(req)
+        assert result.nim_sum == 3 ^ 4 ^ 5
+        assert result.is_p_position is False
+
+    def test_p_position(self):
+        req = NimSumRequest(heaps=(1, 1))
+        result = compute_nim_sum(req)
+        assert result.nim_sum == 0
+        assert result.is_p_position is True
+
+    def test_single_heap(self):
+        req = NimSumRequest(heaps=(7,))
+        result = compute_nim_sum(req)
+        assert result.nim_sum == 7
+
+    def test_zero_heaps(self):
+        req = NimSumRequest(heaps=(0, 0))
+        result = compute_nim_sum(req)
+        assert result.nim_sum == 0
+        assert result.is_p_position is True
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValidationError, match="non-negative"):
+            NimSumRequest(heaps=(-1,))
+
+
+class TestNimOptions:
+    def test_simple(self):
+        req = NimOptionsRequest(heaps=(2, 1))
+        result = compute_nim_options(req)
+        # heap 0: can go to 0 or 1; heap 1: can go to 0
+        # heap 0 -> 0: (0, 1)
+        # heap 0 -> 1: (1, 1)
+        # heap 1 -> 0: (2, 0)
+        assert len(result.options) == 3
+
+    def test_zero_heap(self):
+        req = NimOptionsRequest(heaps=(0,))
+        result = compute_nim_options(req)
+        assert len(result.options) == 0
+
+    def test_option_correctness(self):
+        req = NimOptionsRequest(heaps=(3, 2))
+        result = compute_nim_options(req)
+        for opt in result.options:
+            assert opt.new_size < opt.old_size
+            assert opt.resulting_heaps[opt.heap_index] == opt.new_size
+
+
+class TestSubtractionDAG:
+    def test_simple(self):
+        req = SubtractionDAGRequest(subtraction_set=(1, 3), max_heap=5)
+        result = compute_subtraction_dag(req)
+        assert len(result.positions) == 6
+        # Position 0 has no moves (can't subtract 1 or 3)
+        assert "0" in result.terminal_positions
+
+    def test_moves(self):
+        req = SubtractionDAGRequest(subtraction_set=(1, 3), max_heap=5)
+        result = compute_subtraction_dag(req)
+        # From position 3: can go to 2 (subtract 1) and 0 (subtract 3)
+        sources = [m.source for m in result.moves if m.source == "3"]
+        assert set(sources) == {"3"}
+        targets_3 = {m.target for m in result.moves if m.source == "3"}
+        assert targets_3 == {"2", "0"}
+
+
+class TestSubtractionGrundyPrefix:
+    def test_sub_1(self):
+        """Subtraction set {1}: g(i) = i mod 2."""
+        req = SubtractionGrundyPrefixRequest(subtraction_set=(1,), max_heap=10)
+        result = compute_subtraction_grundy_prefix(req)
+        for i in range(11):
+            assert result.grundy_values[i] == i % 2
+
+    def test_sub_1_3(self):
+        """Subtraction set {1, 3}: known sequence g = 0, 1, 0, 1, 0, 1, ..."""
+        req = SubtractionGrundyPrefixRequest(subtraction_set=(1, 3), max_heap=10)
+        result = compute_subtraction_grundy_prefix(req)
+        for i in range(11):
+            assert result.grundy_values[i] in (0, 1)
+
+    def test_sub_2_3(self):
+        """Subtraction set {2, 3}: g = 0, 0, 1, 1, 2, 0, 3, ..."""
+        req = SubtractionGrundyPrefixRequest(subtraction_set=(2, 3), max_heap=10)
+        result = compute_subtraction_grundy_prefix(req)
+        assert result.grundy_values[0] == 0
+        assert result.grundy_values[1] == 0
+        assert result.grundy_values[2] == 1
+        assert result.grundy_values[3] == 1
+
+    def test_p_n_positions(self):
+        req = SubtractionGrundyPrefixRequest(subtraction_set=(1,), max_heap=5)
+        result = compute_subtraction_grundy_prefix(req)
+        for p in result.p_positions:
+            assert result.grundy_values[p] == 0
+        for n in result.n_positions:
+            assert result.grundy_values[n] > 0
+
+
+class TestValidation:
+    def test_duplicate_positions(self):
+        with pytest.raises(ValidationError, match="unique"):
+            ImpartialGameDAGRequest(positions=("a", "a"), moves=())
+
+    def test_self_loop(self):
+        with pytest.raises(ValidationError, match="self-loops"):
+            ImpartialGameDAGRequest(
+                positions=("a", "b"),
+                moves=(GameMove(source="a", target="a"),),
+            )
+
+    def test_duplicate_move(self):
+        with pytest.raises(ValidationError, match="duplicate"):
+            ImpartialGameDAGRequest(
+                positions=("a", "b"),
+                moves=(
+                    GameMove(source="a", target="b"),
+                    GameMove(source="a", target="b"),
+                ),
+            )
+
+    def test_undeclared_target(self):
+        with pytest.raises(ValidationError, match="target"):
+            ImpartialGameDAGRequest(
+                positions=("a",),
+                moves=(GameMove(source="a", target="b"),),
+            )
+
+    def test_position_not_in_game(self):
+        with pytest.raises(ValidationError, match="not in the game"):
+            PositionGrundyRequest(game=_chain_game(), position="99")


### PR DESCRIPTION
## Summary

Implements issue #1907: finite impartial normal-play acyclic games with Sprague–Grundy theory.

Closes #1907.

## Design

All operations build on **NetworkX** for DAG construction, cycle detection, and topological sorting. No hand-rolled graph algorithms — the Sprague–Grundy mex computation is a thin typed adapter over NetworkX's topological sort.

### 11 atomic operations

| Operation ID | Description |
|---|---|
| `game.impartial.grundy_table.compute` | Complete Grundy table with mex per position |
| `game.impartial.position.grundy.compute` | Single-position Grundy value with dependency sub-DAG |
| `game.impartial.outcome_profile.compute` | P/N partition with terminals and Grundy map |
| `game.impartial.nim_equivalent.compute` | Canonical Nim heap equivalent to one position |
| `game.impartial.grundy_classes.compute` | Partition positions by equal Grundy value |
| `game.impartial.birthday.compute` | Birthday (DAG height) of every position |
| `game.nim.nim_sum.compute` | Bitwise xor of heap sizes |
| `game.nim.options.compute` | Enumerate all legal Nim options |
| `game.subtraction.dag.compute` | Build subtraction game DAG |
| `game.subtraction.grundy_prefix.compute` | Grundy prefix of a bounded subtraction game |
| `combinatorics.mex.compute` | Minimum excluded value (reusable atomic) |

### Library choices

- **NetworkX**: DAG construction, `is_directed_acyclic_graph`, `topological_sort`, `descendants`, `subgraph`, `out_degree`. These are mature, well-tested operations.
- **Standard library `functools.reduce` / `operator.xor`**: nim-sum is a single bitwise xor reduction.
- **No hand-rolled graph algorithms**: the mex computation is a simple loop over a sorted list, not a graph traversal.

### Key design decisions

1. **Acyclicity is enforced**: self-loops and cycles are rejected at model validation and operation execution time. The game DAG must be a finite DAG.
2. **Reverse topological order**: Grundy values are computed in reverse topological order (terminals first) using NetworkX's `topological_sort`.
3. **Subtraction games are bounded**: the `max_heap` parameter explicitly bounds the finite prefix. No claim of eventual periodicity.
4. **Nim options are complete**: every distinct option from reducing exactly one heap is enumerated.
5. **Mex is domain-independent**: it lives under `combinatorics.mex` as a reusable atomic operation.

### Tests

38 unit tests covering:
- Known-answer cases (chain games, diamond games, subtraction games)
- Boundary cases (empty mex, zero heaps, terminal positions)
- Adversarial cases (cycle rejection, self-loop rejection)
- Validation cases (duplicate positions, undeclared targets, position not in game)

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/00eb776c-d897-4adb-bf28-61ce15c3d4e8)