### PR TITLE
Add arithmetic dynamics operations (#1918)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -29,6 +29,7 @@ from jacobian.math.electrical_networks._tools import (
 )
 from jacobian.math.finite_fields._tools import TOOLS as FINITE_FIELDS_TOOLS
 from jacobian.math.finite_game_theory._tools import TOOLS as FINITE_GAME_THEORY_TOOLS
+from jacobian.math.arithmetic_dynamics._tools import TOOLS as ARITHMETIC_DYNAMICS_TOOLS
 from jacobian.math.finite_metric_spaces._tools import (
     TOOLS as FINITE_METRIC_SPACES_TOOLS,
 )
@@ -140,6 +141,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *ARITHMETIC_DYNAMICS_TOOLS,
     *ELECTRICAL_NETWORKS_TOOLS,
     *REGULAR_LANGUAGES_TOOLS,
     *ALGEBRAIC_COMBINATORICS_TOOLS,

--- a/src/jacobian/math/arithmetic_dynamics/__init__.py
+++ b/src/jacobian/math/arithmetic_dynamics/__init__.py
@@ -1,0 +1,3 @@
+"""Arithmetic dynamics operation ownership."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -1,0 +1,168 @@
+"""Typed wire contracts for arithmetic dynamics operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_COEFF = 10_000
+MAX_DEGREE = 30
+MAX_ITERATE = 20
+MAX_ORBIT = 1_000
+MAX_FIELD_PRIME = 10_000
+
+
+class PolynomialMapRequest(StrictModel):
+    """A polynomial dynamical system f: A^1 -> A^1 over QQ."""
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+
+    @model_validator(mode="after")
+    def validate_coefficients(self) -> Self:
+        for coeff in self.coefficients:
+            value = int(coeff)
+            if abs(value) > MAX_COEFF:
+                raise ValueError(f"coefficients must be at most {MAX_COEFF} in absolute value")
+        return self
+
+
+class MapIterateRequest(StrictModel):
+    """Compute the n-th iterate of a polynomial map by composition."""
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    n: int = Field(ge=0, le=MAX_ITERATE)
+
+
+class OrbitPrefixRequest(StrictModel):
+    """Compute the orbit prefix of a point under a polynomial map."""
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    start: str
+    length: int = Field(ge=0, le=MAX_ORBIT)
+
+
+class FixedPointEquationRequest(StrictModel):
+    """Compute the fixed-point equation of the n-th iterate."""
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    n: int = Field(ge=1, le=MAX_ITERATE)
+
+
+class DynatomicPolynomialRequest(StrictModel):
+    """Compute the n-th dynatomic polynomial of a polynomial map."""
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    n: int = Field(ge=1, le=MAX_ITERATE)
+
+
+class CycleMultiplierRequest(StrictModel):
+    """Compute the multiplier of a periodic cycle.
+
+    The cycle is given as a list of exact rational points (as strings)
+    forming one orbit under the map. The multiplier is the product of
+    the derivative at each cycle point.
+    """
+
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    cycle: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT)
+
+
+class FiniteFieldMapRequest(StrictModel):
+    """A polynomial map over a finite field GF(p)."""
+
+    prime: int = Field(ge=2, le=MAX_FIELD_PRIME)
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+
+    @model_validator(mode="after")
+    def validate(self) -> Self:
+        if not _is_prime(self.prime):
+            raise ValueError("prime must be a prime number")
+        for coeff in self.coefficients:
+            int(coeff)
+        return self
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n < 4:
+        return True
+    if n % 2 == 0 or n % 3 == 0:
+        return False
+    i = 5
+    while i * i <= n:
+        if n % i == 0 or n % (i + 2) == 0:
+            return False
+        i += 6
+    return True
+
+
+# -- Results -----------------------------------------------------------------
+
+
+class MapIterateResult(StrictModel):
+    """Result of computing the n-th iterate."""
+
+    n: int = Field(ge=0)
+    coefficients: tuple[str, ...]
+    degree: int = Field(ge=0)
+
+
+class OrbitPrefixResult(StrictModel):
+    """Orbit prefix of a point."""
+
+    orbit: tuple[str, ...]
+    length: int = Field(ge=0)
+    first_repeat_index: int | None = None
+    first_repeat_match: int | None = None
+
+
+class FixedPointEquationResult(StrictModel):
+    """Fixed-point equation f^n(x) - x as a polynomial."""
+
+    coefficients: tuple[str, ...]
+    degree: int = Field(ge=0)
+
+
+class DynatomicPolynomialResult(StrictModel):
+    """The n-th dynatomic polynomial."""
+
+    coefficients: tuple[str, ...]
+    degree: int = Field(ge=0)
+    n: int = Field(ge=1)
+
+
+class CycleMultiplierResult(StrictModel):
+    """The multiplier of a periodic cycle."""
+
+    multiplier: str
+    cycle: tuple[str, ...]
+
+
+class FiniteFieldMapResult(StrictModel):
+    """Functional graph of a polynomial map over a finite field."""
+
+    prime: int = Field(ge=2)
+    edges: tuple[tuple[int, int], ...]
+    cycles: tuple[tuple[int, ...], ...]
+    tail_lengths: tuple[int, ...]
+
+
+__all__ = [
+    "CycleMultiplierRequest",
+    "CycleMultiplierResult",
+    "DynatomicPolynomialRequest",
+    "DynatomicPolynomialResult",
+    "FiniteFieldMapRequest",
+    "FiniteFieldMapResult",
+    "FixedPointEquationRequest",
+    "FixedPointEquationResult",
+    "MapIterateRequest",
+    "MapIterateResult",
+    "OrbitPrefixRequest",
+    "OrbitPrefixResult",
+    "PolynomialMapRequest",
+]

--- a/src/jacobian/math/arithmetic_dynamics/_operations.py
+++ b/src/jacobian/math/arithmetic_dynamics/_operations.py
@@ -1,0 +1,282 @@
+"""Domain-owned arithmetic dynamics operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from functools import reduce
+from math import gcd
+from typing import Any
+
+import sympy
+
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    CycleMultiplierResult,
+    DynatomicPolynomialRequest,
+    DynatomicPolynomialResult,
+    FiniteFieldMapRequest,
+    FiniteFieldMapResult,
+    FixedPointEquationRequest,
+    FixedPointEquationResult,
+    MapIterateRequest,
+    MapIterateResult,
+    OrbitPrefixRequest,
+    OrbitPrefixResult,
+    PolynomialMapRequest,
+)
+
+_x = sympy.Symbol("x")
+
+
+def _coeffs_to_poly(coefficients: tuple[str, ...]) -> sympy.Poly:
+    """Convert coefficient tuple (low to high) to a sympy Poly."""
+    coeffs = [Fraction(c) for c in coefficients]
+    poly = sum(c * _x**i for i, c in enumerate(coeffs))
+    return sympy.Poly(poly, _x, domain=sympy.QQ)
+
+
+def _poly_to_coeffs(poly: sympy.Poly) -> tuple[str, ...]:
+    """Convert a sympy Poly to a coefficient tuple (low to high)."""
+    if poly.is_zero:
+        return ("0",)
+    degree = poly.degree()
+    coeffs = []
+    for i in range(degree + 1):
+        coeff = poly.all_coeffs()[degree - i] if i <= degree else 0
+        if coeff == 0 and i > degree:
+            coeffs.append("0")
+        else:
+            coeffs.append(str(Fraction(coeff)))
+    return tuple(coeffs)
+
+
+def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
+    """Compute the n-th iterate of a polynomial map by composition."""
+    f = _coeffs_to_poly(request.coefficients)
+    x = sympy.Symbol("x")
+    result = x
+    for _ in range(request.n):
+        result = f.as_expr().subs(x, result)
+    result_poly = sympy.Poly(result, x, domain=sympy.QQ)
+    degree = result_poly.degree() if not result_poly.is_zero else 0
+    return MapIterateResult(
+        n=request.n,
+        coefficients=_poly_to_coeffs(result_poly),
+        degree=degree,
+    )
+
+
+def compute_orbit_prefix(request: OrbitPrefixRequest) -> OrbitPrefixResult:
+    """Compute the orbit prefix of a point under a polynomial map."""
+    f = _coeffs_to_poly(request.coefficients)
+    expr = f.as_expr()
+    start = Fraction(request.start)
+    orbit: list[Fraction] = [start]
+    first_repeat_index: int | None = None
+    first_repeat_match: int | None = None
+
+    x = sympy.Symbol("x")
+    current = start
+    for i in range(request.length):
+        current = Fraction(sympy.simplify(expr.subs(x, sympy.Rational(current.numerator, current.denominator))))
+        orbit.append(current)
+        # Check for repeat
+        for j, prev in enumerate(orbit[:-1]):
+            if prev == current:
+                first_repeat_index = i + 1
+                first_repeat_match = j
+                break
+        if first_repeat_index is not None:
+            break
+
+    return OrbitPrefixResult(
+        orbit=tuple(str(f) for f in orbit),
+        length=len(orbit) - 1,
+        first_repeat_index=first_repeat_index,
+        first_repeat_match=first_repeat_match,
+    )
+
+
+def compute_fixed_point_equation(
+    request: FixedPointEquationRequest,
+) -> FixedPointEquationResult:
+    """Compute f^n(x) - x as a polynomial."""
+    f = _coeffs_to_poly(request.coefficients)
+    x = sympy.Symbol("x")
+    result = x
+    for _ in range(request.n):
+        result = f.as_expr().subs(x, result)
+    result_poly = sympy.Poly(result - x, x, domain=sympy.QQ)
+    degree = result_poly.degree() if not result_poly.is_zero else 0
+    return FixedPointEquationResult(
+        coefficients=_poly_to_coeffs(result_poly),
+        degree=degree,
+    )
+
+
+def _mobius_mu(n: int) -> int:
+    """Mobius function mu(n)."""
+    if n == 1:
+        return 1
+    if n == 0:
+        return 0
+    factors = set()
+    d = n
+    p = 2
+    while p * p <= d:
+        if d % p == 0:
+            if p in factors:
+                return 0
+            factors.add(p)
+            d //= p
+            while d % p == 0:
+                d //= p
+                if d % p == 0:
+                    return 0
+            p = 2
+        else:
+            p += 1
+    if d > 1:
+        if d in factors:
+            return 0
+        factors.add(d)
+    return (-1) ** len(factors)
+
+
+def _divisors(n: int) -> list[int]:
+    """Return all positive divisors of n."""
+    divs = []
+    for i in range(1, n + 1):
+        if n % i == 0:
+            divs.append(i)
+    return divs
+
+
+def compute_dynatomic_polynomial(
+    request: DynatomicPolynomialRequest,
+) -> DynatomicPolynomialResult:
+    """Compute the n-th dynatomic polynomial.
+
+    Phi*_n(x) = product_{d|n} (f^d(x) - x)^{mu(n/d)}
+    """
+    f = _coeffs_to_poly(request.coefficients)
+    n = request.n
+    x = sympy.Symbol("x")
+
+    # Compute iterates
+    iterates: dict[int, sympy.Expr] = {}
+    for d in _divisors(n):
+        expr = x
+        for _ in range(d):
+            expr = f.as_expr().subs(x, expr)
+        iterates[d] = expr - x
+
+    # Compute product
+    result: sympy.Expr = sympy.Integer(1)
+    for d in _divisors(n):
+        mu = _mobius_mu(n // d)
+        if mu > 0:
+            result *= iterates[d]
+        elif mu < 0:
+            result /= iterates[d]
+
+    result_poly = sympy.Poly(result, x, domain=sympy.QQ)
+    degree = result_poly.degree() if not result_poly.is_zero else 0
+    return DynatomicPolynomialResult(
+        coefficients=_poly_to_coeffs(result_poly),
+        degree=degree,
+        n=n,
+    )
+
+
+def compute_cycle_multiplier(
+    request: CycleMultiplierRequest,
+) -> CycleMultiplierResult:
+    """Compute the multiplier of a periodic cycle.
+
+    The multiplier is the product of f'(P_i) over all cycle points.
+    """
+    f = _coeffs_to_poly(request.coefficients)
+    f_deriv = sympy.Poly(sympy.diff(f.as_expr(), sympy.Symbol("x")), sympy.Symbol("x"), domain=sympy.QQ)
+    x = sympy.Symbol("x")
+
+    multiplier = Fraction(1)
+    for point_str in request.cycle:
+        point = Fraction(point_str)
+        deriv_val = f_deriv.as_expr().subs(x, sympy.Rational(point.numerator, point.denominator))
+        multiplier *= Fraction(deriv_val)
+
+    return CycleMultiplierResult(
+        multiplier=str(multiplier),
+        cycle=request.cycle,
+    )
+
+
+def compute_finite_field_map(request: FiniteFieldMapRequest) -> FiniteFieldMapResult:
+    """Compute the functional graph of a polynomial map over GF(p)."""
+    p = request.prime
+    coeffs = [int(c) % p for c in request.coefficients]
+
+    def f(x: int) -> int:
+        result = 0
+        power = 1
+        for coeff in coeffs:
+            result = (result + coeff * power) % p
+            power = (power * x) % p
+        return result
+
+    # Compute functional graph
+    edges: list[tuple[int, int]] = []
+    for x in range(p):
+        edges.append((x, f(x)))
+
+    # Find cycles and tail lengths
+    visited: set[int] = set()
+    cycles: list[tuple[int, ...]] = []
+    tail_lengths: list[int] = [0] * p
+
+    for start in range(p):
+        if start in visited:
+            continue
+        path: list[int] = [start]
+        path_pos: dict[int, int] = {start: 0}
+        current = start
+        while True:
+            nxt = f(current)
+            if nxt in path_pos:
+                # Found a cycle
+                cycle_start = path_pos[nxt]
+                cycle = tuple(path[cycle_start:])
+                if cycle not in cycles and len(cycle) > 0:
+                    cycles.append(cycle)
+                # Tail lengths
+                for i, node in enumerate(path):
+                    if i < cycle_start:
+                        tail_lengths[node] = cycle_start - i
+                    visited.add(node)
+                break
+            if nxt in visited:
+                for i, node in enumerate(path):
+                    tail_lengths[node] = len(path) - i + tail_lengths[nxt]
+                    visited.add(node)
+                break
+            path.append(nxt)
+            path_pos[nxt] = len(path) - 1
+            current = nxt
+
+    return FiniteFieldMapResult(
+        prime=p,
+        edges=tuple(edges),
+        cycles=tuple(cycles),
+        tail_lengths=tuple(tail_lengths),
+    )
+
+
+__all__ = [
+    "compute_cycle_multiplier",
+    "compute_dynatomic_polynomial",
+    "compute_finite_field_map",
+    "compute_fixed_point_equation",
+    "compute_map_iterate",
+    "compute_orbit_prefix",
+]

--- a/src/jacobian/math/arithmetic_dynamics/_tools.py
+++ b/src/jacobian/math/arithmetic_dynamics/_tools.py
@@ -1,0 +1,188 @@
+"""Arithmetic dynamics operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    CycleMultiplierResult,
+    DynatomicPolynomialRequest,
+    DynatomicPolynomialResult,
+    FiniteFieldMapRequest,
+    FiniteFieldMapResult,
+    FixedPointEquationRequest,
+    FixedPointEquationResult,
+    MapIterateRequest,
+    MapIterateResult,
+    OrbitPrefixRequest,
+    OrbitPrefixResult,
+    PolynomialMapRequest,
+)
+from jacobian.math.arithmetic_dynamics._operations import (
+    compute_cycle_multiplier,
+    compute_dynatomic_polynomial,
+    compute_finite_field_map,
+    compute_fixed_point_equation,
+    compute_map_iterate,
+    compute_orbit_prefix,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "arithmetic_dynamics.map.iterate.compute",
+        "Compute the n-th iterate of a polynomial map",
+        "Compute phi^n by exact polynomial composition. "
+        "Phi^0 is the identity; coefficients are low-to-high.",
+        MapIterateRequest,
+        MapIterateResult,
+        compute_map_iterate,
+        "arithmetic-dynamics",
+        "polynomial",
+        "exact",
+        examples=(
+            example(
+                "f_x_squared_plus_1_iterate_2",
+                "Compute f^2 for f(x)=x^2+1; n must be non-negative.",
+                {"coefficients": ["1", "0", "1"], "n": 2},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.point.orbit.compute",
+        "Compute orbit prefix of a point",
+        "Compute P, f(P), ..., f^N(P) for a polynomial map and detect "
+        "the first repeat if one occurs within the prefix.",
+        OrbitPrefixRequest,
+        OrbitPrefixResult,
+        compute_orbit_prefix,
+        "arithmetic-dynamics",
+        "orbit",
+        "exact",
+        examples=(
+            example(
+                "orbit_of_0_under_x2",
+                "Orbit of 0 under f(x)=x^2 for 5 steps; "
+                "start must be a rational number.",
+                {"coefficients": ["0", "0", "1"], "start": "0", "length": 5},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.fixed_point_equation.compute",
+        "Compute f^n(x) - x as a polynomial",
+        "Return the fixed-point equation of the n-th iterate as an "
+        "exact polynomial f^n(x) - x.",
+        FixedPointEquationRequest,
+        FixedPointEquationResult,
+        compute_fixed_point_equation,
+        "arithmetic-dynamics",
+        "fixed-point",
+        "exact",
+        examples=(
+            example(
+                "f_x_squared_1_fixed_1",
+                "Fixed-point equation of f(x)=x^2+1 for n=1; "
+                "n must be at least 1.",
+                {"coefficients": ["1", "0", "1"], "n": 1},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.dynatomic_polynomial.compute",
+        "Compute the n-th dynatomic polynomial",
+        "Compute the Mobius-normalized formal-period polynomial "
+        "Phi*_n(x) = product_{d|n} (f^d(x)-x)^{mu(n/d)}.",
+        DynatomicPolynomialRequest,
+        DynatomicPolynomialResult,
+        compute_dynatomic_polynomial,
+        "arithmetic-dynamics",
+        "dynatomic",
+        "exact",
+        examples=(
+            example(
+                "dynatomic_n1_x2",
+                "Dynatomic polynomial for n=1 of f(x)=x^2; "
+                "n must be at least 1.",
+                {"coefficients": ["0", "0", "1"], "n": 1},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.cycle.multiplier.compute",
+        "Compute the multiplier of a periodic cycle",
+        "Compute the product of f'(P_i) over all cycle points, "
+        "giving the exact multiplier of a periodic cycle.",
+        CycleMultiplierRequest,
+        CycleMultiplierResult,
+        compute_cycle_multiplier,
+        "arithmetic-dynamics",
+        "cycle",
+        "multiplier",
+        "exact",
+        examples=(
+            example(
+                "multiplier_fixed_0_x2",
+                "Multiplier of the fixed point 0 under f(x)=x^2; "
+                "cycle points must be rational.",
+                {"coefficients": ["0", "0", "1"], "cycle": ["0"]},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.finite_field.functional_graph.compute",
+        "Compute functional graph of a polynomial map over GF(p)",
+        "Compute the complete functional graph of a polynomial map "
+        "over a finite field, including cycles, tail lengths, and "
+        "all edges.",
+        FiniteFieldMapRequest,
+        FiniteFieldMapResult,
+        compute_finite_field_map,
+        "arithmetic-dynamics",
+        "finite-field",
+        "exact",
+        examples=(
+            example(
+                "x2_mod_5",
+                "Functional graph of x^2 over GF(5); "
+                "prime must be a prime number.",
+                {"prime": 5, "coefficients": ["0", "0", "1"]},
+            ),
+        ),
+    ),
+)
+
+
+TOOLS = ARITHMETIC_DYNAMICS_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -93,10 +93,359 @@ class SemigroupMembershipResult(StrictModel):
     value: CanonicalInteger
     in_semigroup: bool
 
+# ---------------------------------------------------------------------------
+# Extended operations: factorization, elasticity, catenary degree, etc.
+# ---------------------------------------------------------------------------
+
+
+class FactorizationComputeRequest(StrictModel):
+    """Compute the complete factorization family Z(s) for one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationComputeResult(StrictModel):
+    """Complete factorization family Z(s) for one element."""
+
+    value: CanonicalInteger
+    minimal_generators: tuple[CanonicalInteger, ...]
+    factorizations: tuple[tuple[int, ...], ...]
+
+
+class FactorizationLengthsComputeRequest(StrictModel):
+    """Compute the complete sorted length set of one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationLengthsComputeResult(StrictModel):
+    """Sorted length set of one element."""
+
+    value: CanonicalInteger
+    lengths: tuple[int, ...]
+
+
+class FactorizationDistanceRequest(StrictModel):
+    """Distance between two factorizations of the same element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+    first: tuple[int, ...] = Field(min_length=1)
+    second: tuple[int, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_request(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        if len(self.first) != len(self.second):
+            raise ValueError("factorizations must have equal coordinate length")
+        if any(c < 0 for c in self.first) or any(c < 0 for c in self.second):
+            raise ValueError("factorization coordinates must be non-negative")
+        return self
+
+
+class FactorizationDistanceResult(StrictModel):
+    """Distance between two factorizations."""
+
+    value: CanonicalInteger
+    distance: int = Field(ge=0)
+    first_length: int = Field(ge=0)
+    second_length: int = Field(ge=0)
+
+
+class FactorizationGraphComputeRequest(StrictModel):
+    """Compute the standard factorization graph of one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationGraphComputeResult(StrictModel):
+    """Standard factorization graph with connected components."""
+
+    value: CanonicalInteger
+    minimal_generators: tuple[CanonicalInteger, ...]
+    factorizations: tuple[tuple[int, ...], ...]
+    edges: tuple[tuple[int, int], ...]
+    connected_components: tuple[tuple[int, ...], ...]
+    is_connected: bool
+
+
+class ElementDeltaSetRequest(StrictModel):
+    """Delta set of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementDeltaSetResult(StrictModel):
+    """Delta set of one element."""
+
+    value: CanonicalInteger
+    delta_set: tuple[int, ...]
+
+
+class ElementElasticityRequest(StrictModel):
+    """Elasticity of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementElasticityResult(StrictModel):
+    """Elasticity of one element."""
+
+    value: CanonicalInteger
+    elasticity: str
+
+
+class ElementCatenaryDegreeRequest(StrictModel):
+    """Catenary degree of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementCatenaryDegreeResult(StrictModel):
+    """Catenary degree of one element."""
+
+    value: CanonicalInteger
+    catenary_degree: int = Field(ge=0)
+
+
+class BettiElementsRequest(StrictModel):
+    """Betti elements of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class BettiElementsResult(StrictModel):
+    """Betti elements of a semigroup."""
+
+    betti_elements: tuple[CanonicalInteger, ...]
+
+
+class MinimalPresentationRequest(StrictModel):
+    """One minimal presentation of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class MinimalPresentationRelation(StrictModel):
+    """One relation (pair of distinct factorizations) in a presentation."""
+
+    first: tuple[int, ...]
+    second: tuple[int, ...]
+
+
+class MinimalPresentationResult(StrictModel):
+    """One minimal presentation of the semigroup."""
+
+    minimal_generators: tuple[CanonicalInteger, ...]
+    betti_elements: tuple[CanonicalInteger, ...]
+    relations: tuple[MinimalPresentationRelation, ...]
+
+
+class PresentationBinomialsRequest(StrictModel):
+    """Convert a minimal presentation to sparse binomial form."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    relations: tuple[MinimalPresentationRelation, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class PresentationBinomial(StrictModel):
+    """One sparse binomial (aX - bX) arising from a presentation relation."""
+
+    left_coefficient: str
+    left_exponents: tuple[int, ...]
+    right_coefficient: str
+    right_exponents: tuple[int, ...]
+
+
+class PresentationBinomialsResult(StrictModel):
+    """Presentation converted to sparse binomials."""
+
+    minimal_generators: tuple[CanonicalInteger, ...]
+    binomials: tuple[PresentationBinomial, ...]
+
+
+class DeltaSetRequest(StrictModel):
+    """Global delta set of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class DeltaSetResult(StrictModel):
+    """Global delta set of the semigroup."""
+
+    delta_set: tuple[int, ...]
+
+
+class ElasticityRequest(StrictModel):
+    """Global elasticity of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class ElasticityResult(StrictModel):
+    """Global elasticity of the semigroup."""
+
+    elasticity: str
+
+
+class CatenaryDegreeRequest(StrictModel):
+    """Global catenary degree of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class CatenaryDegreeResult(StrictModel):
+    """Global catenary degree of the semigroup."""
+
+    catenary_degree: int = Field(ge=0)
+
 
 __all__ = [
     "NumericalSemigroupSummaryRequest",
     "NumericalSemigroupSummaryResult",
     "SemigroupMembershipRequest",
     "SemigroupMembershipResult",
+    # Factorization family
+    "FactorizationComputeRequest",
+    "FactorizationComputeResult",
+    # Factorization lengths
+    "FactorizationLengthsComputeRequest",
+    "FactorizationLengthsComputeResult",
+    # Distance
+    "FactorizationDistanceRequest",
+    "FactorizationDistanceResult",
+    # Factorization graph
+    "FactorizationGraphComputeRequest",
+    "FactorizationGraphComputeResult",
+    # Element-level
+    "ElementDeltaSetRequest",
+    "ElementDeltaSetResult",
+    "ElementElasticityRequest",
+    "ElementElasticityResult",
+    "ElementCatenaryDegreeRequest",
+    "ElementCatenaryDegreeResult",
+    # Betti
+    "BettiElementsRequest",
+    "BettiElementsResult",
+    # Minimal presentation
+    "MinimalPresentationRequest",
+    "MinimalPresentationRelation",
+    "MinimalPresentationResult",
+    "PresentationBinomialsRequest",
+    "PresentationBinomial",
+    "PresentationBinomialsResult",
+    # Global
+    "DeltaSetRequest",
+    "DeltaSetResult",
+    "ElasticityRequest",
+    "ElasticityResult",
+    "CatenaryDegreeRequest",
+    "CatenaryDegreeResult",
 ]
+

--- a/src/jacobian/math/numerical_semigroups/_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_operations.py
@@ -108,4 +108,522 @@ def compute_membership(
     )
 
 
-__all__ = ["compute_membership", "compute_summary"]
+# __all__ defined at end
+
+
+
+# ---------------------------------------------------------------------------
+# Extended operations: factorization, elasticity, catenary degree, etc.
+# ---------------------------------------------------------------------------
+
+import networkx as _nx
+
+from jacobian.math.numerical_semigroups._models import (
+    BettiElementsRequest,
+    BettiElementsResult,
+    CatenaryDegreeRequest,
+    CatenaryDegreeResult,
+    DeltaSetRequest,
+    DeltaSetResult,
+    ElasticityRequest,
+    ElasticityResult,
+    ElementCatenaryDegreeRequest,
+    ElementCatenaryDegreeResult,
+    ElementDeltaSetRequest,
+    ElementDeltaSetResult,
+    ElementElasticityRequest,
+    ElementElasticityResult,
+    FactorizationComputeRequest,
+    FactorizationComputeResult,
+    FactorizationDistanceRequest,
+    FactorizationDistanceResult,
+    FactorizationGraphComputeRequest,
+    FactorizationGraphComputeResult,
+    FactorizationLengthsComputeRequest,
+    FactorizationLengthsComputeResult,
+    MinimalPresentationRequest,
+    MinimalPresentationRelation,
+    MinimalPresentationResult,
+    PresentationBinomial,
+    PresentationBinomialsRequest,
+    PresentationBinomialsResult,
+)
+
+
+def _minimal_generators_list(gens: tuple[str, ...]) -> list[int]:
+    """Return the sorted minimal generating set as a list of ints."""
+    raw = sorted({parse_canonical_integer(g) for g in gens})
+    if not raw:
+        return []
+    if raw[0] == 1:
+        return [1]
+    result = []
+    for generator in raw:
+        others = [other for other in raw if other != generator]
+        if not others:
+            result.append(generator)
+            continue
+        can_reach = [False] * (generator + 1)
+        can_reach[0] = True
+        for value in range(1, generator + 1):
+            can_reach[value] = any(
+                value >= other and can_reach[value - other] for other in others
+            )
+        if not can_reach[generator]:
+            result.append(generator)
+    return result
+
+
+def _enumerate_factorizations(
+    atoms: list[int], target: int
+) -> list[tuple[int, ...]]:
+    """Enumerate all factorizations of *target* using *atoms* (minimal generators).
+
+    Uses bounded dynamic programming.  Returns a list of tuples, each of length
+    ``len(atoms)``, representing one factorization.
+    """
+    if target == 0:
+        return [tuple([0] * len(atoms))]
+    if not atoms:
+        return []
+    max_per_value = MAX_FACTOR_SEARCH * MAX_FACTOR_SEARCH
+    dp: list[list[tuple[int, ...]]] = [[] for _ in range(target + 1)]
+    dp[0] = [tuple([0] * len(atoms))]
+    for v in range(1, target + 1):
+        facts: list[tuple[int, ...]] = []
+        for idx, atom in enumerate(atoms):
+            if atom > v:
+                continue
+            for fact in dp[v - atom]:
+                new_fact = list(fact)
+                new_fact[idx] += 1
+                facts.append(tuple(new_fact))
+            if len(facts) > max_per_value:
+                break
+        seen: set[tuple[int, ...]] = set()
+        unique: list[tuple[int, ...]] = []
+        for f in facts:
+            if f not in seen:
+                seen.add(f)
+                unique.append(f)
+        dp[v] = unique
+    return dp[target]
+
+
+def _factorizations(atoms: list[int], target: int) -> list[tuple[int, ...]]:
+    """Wrapper for the enumeration routine."""
+    return _enumerate_factorizations(atoms, target)
+
+
+def _length(fact: tuple[int, ...]) -> int:
+    """Length (norm) of a factorization = sum of coordinates."""
+    return sum(fact)
+
+
+def _gcd_factor(
+    f1: tuple[int, ...], f2: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Coordinate-wise minimum of two factorizations."""
+    return tuple(min(a, b) for a, b in zip(f1, f2, strict=True))
+
+
+def _distance(f1: tuple[int, ...], f2: tuple[int, ...]) -> int:
+    """Distance d(z, z') = max(|z - gcd|, |z' - gcd|) where gcd is coordinatewise min."""
+    if not f1 or not f2:
+        return 0
+    g = _gcd_factor(f1, f2)
+    l1 = sum(f1)
+    l2 = sum(f2)
+    lg = sum(g)
+    return max(abs(l1 - lg), abs(l2 - lg))
+
+
+def _build_factorization_graph(
+    factorizations: list[tuple[int, ...]],
+) -> tuple[list[tuple[int, int]], list[list[int]], bool]:
+    """Build the standard factorization graph.
+
+    Two factorizations are connected if their coordinatewise gcd is nonzero
+    (they share a common atom).  Returns ``(edges, connected_components, is_connected)``.
+    """
+    n = len(factorizations)
+    if n == 0:
+        return [], [], True
+    graph = _nx.Graph()
+    for i in range(n):
+        graph.add_node(i)
+    edges = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            if sum(_gcd_factor(factorizations[i], factorizations[j])) > 0:
+                graph.add_edge(i, j)
+                edges.append((i, j))
+    components = [list(comp) for comp in _nx.connected_components(graph)]
+    is_connected = len(components) <= 1
+    return edges, components, is_connected
+
+
+def _catenary_degree_of(atoms: list[int], target: int) -> int:
+    """Catenary degree of one element.
+
+    For every pair (z, z') of factorizations of *target*, the catenary degree is
+    the minimum value *c* such that there exists a chain z -> z₁ -> ... -> z' with
+    all consecutive distances ≤ *c*.  Equivalently, it is the maximum over all
+    pairs (z, z') of the minimax path weight in the distance-weighted graph.
+    """
+    facts = _factorizations(atoms, target)
+    if len(facts) <= 1:
+        return 0
+
+    n = len(facts)
+    _, components, _ = _build_factorization_graph(facts)
+    if len(components) <= 1:
+        return 0
+
+    # Build a complete distance-weighted graph.
+    dist_graph = _nx.Graph()
+    for i in range(n):
+        dist_graph.add_node(i)
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = _distance(facts[i], facts[j])
+            dist_graph.add_edge(i, j, weight=d)
+
+    # Minimax path via MST.
+    mst = _nx.minimum_spanning_tree(dist_graph)
+    catenary = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            try:
+                path = _nx.shortest_path(mst, i, j, weight="weight")
+            except _nx.NetworkXNoPath:
+                continue
+            if len(path) < 2:
+                continue
+            path_max = 0
+            for k in range(len(path) - 1):
+                edge_weight = mst[path[k]][path[k + 1]]["weight"]
+                path_max = max(path_max, edge_weight)
+            catenary = max(catenary, path_max)
+    return catenary
+
+
+def _delta_set_of(atoms: list[int], target: int) -> list[int]:
+    """Delta set of one element = successive differences of the sorted length set."""
+    facts = _factorizations(atoms, target)
+    if len(facts) <= 1:
+        return []
+    lengths = sorted({sum(f) for f in facts})
+    if len(lengths) <= 1:
+        return []
+    return [lengths[i + 1] - lengths[i] for i in range(len(lengths) - 1)]
+
+
+def _betti_elements(atoms: list[int]) -> list[int]:
+    """Betti elements = elements where the factorization graph is disconnected."""
+    # The search space is bounded: Betti elements are at most lcm of pairs of
+    # atoms times some small factor.  We search up to the Frobenius-like bound.
+    if not atoms or atoms[0] == 1:
+        return []
+    max_atom = atoms[-1]
+    # Betti elements are bounded by the Frobenius number + 1, but we use a
+    # generous bound.  The conductor is at most (m-1)*max_atom where m is
+    # the multiplicity (smallest generator).
+    multiplicity = atoms[0]
+    bound = (multiplicity - 1) * max_atom
+    betti: list[int] = []
+    for n in range(1, bound + 1):
+        facts = _factorizations(atoms, n)
+        if len(facts) <= 1:
+            continue
+        _, _, connected = _build_factorization_graph(facts)
+        if not connected:
+            betti.append(n)
+    return betti
+
+
+# ---------------------------------------------------------------------------
+# Public operation functions
+# ---------------------------------------------------------------------------
+
+
+def compute_factorizations(
+    request: FactorizationComputeRequest,
+) -> FactorizationComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationComputeResult(
+            value=request.value,
+            minimal_generators=tuple(
+                format_canonical_integer(a) for a in atoms
+            ),
+            factorizations=(),
+        )
+    facts = _factorizations(atoms, value)
+    return FactorizationComputeResult(
+        value=request.value,
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        factorizations=tuple(facts),
+    )
+
+
+def compute_factorization_lengths(
+    request: FactorizationLengthsComputeRequest,
+) -> FactorizationLengthsComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationLengthsComputeResult(value=request.value, lengths=())
+    facts = _factorizations(atoms, value)
+    lengths = sorted({sum(f) for f in facts})
+    return FactorizationLengthsComputeResult(
+        value=request.value,
+        lengths=tuple(lengths),
+    )
+
+
+def compute_factorization_distance(
+    request: FactorizationDistanceRequest,
+) -> FactorizationDistanceResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    f1 = tuple(request.first)
+    f2 = tuple(request.second)
+    d = _distance(f1, f2)
+    return FactorizationDistanceResult(
+        value=request.value,
+        distance=d,
+        first_length=sum(f1),
+        second_length=sum(f2),
+    )
+
+
+def compute_factorization_graph(
+    request: FactorizationGraphComputeRequest,
+) -> FactorizationGraphComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationGraphComputeResult(
+            value=request.value,
+            minimal_generators=tuple(
+                format_canonical_integer(a) for a in atoms
+            ),
+            factorizations=(),
+            edges=(),
+            connected_components=(),
+            is_connected=True,
+        )
+    facts = _factorizations(atoms, value)
+    edges, components, connected = _build_factorization_graph(facts)
+    return FactorizationGraphComputeResult(
+        value=request.value,
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        factorizations=tuple(facts),
+        edges=tuple((i, j) for i, j in edges),
+        connected_components=tuple(
+            tuple(sorted(comp)) for comp in components
+        ),
+        is_connected=connected,
+    )
+
+
+def compute_element_delta_set(
+    request: ElementDeltaSetRequest,
+) -> ElementDeltaSetResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementDeltaSetResult(value=request.value, delta_set=())
+    deltas = _delta_set_of(atoms, value)
+    return ElementDeltaSetResult(
+        value=request.value,
+        delta_set=tuple(deltas),
+    )
+
+
+def compute_element_elasticity(
+    request: ElementElasticityRequest,
+) -> ElementElasticityResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    facts = _factorizations(atoms, value)
+    if not facts:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    lengths = [sum(f) for f in facts]
+    min_len = min(lengths)
+    max_len = max(lengths)
+    if min_len == 0:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    frac = Fraction(max_len, min_len)
+    return ElementElasticityResult(
+        value=request.value,
+        elasticity=f"{frac.numerator}/{frac.denominator}"
+        if frac.denominator != 1
+        else f"{frac.numerator}",
+    )
+
+
+def compute_element_catenary_degree(
+    request: ElementCatenaryDegreeRequest,
+) -> ElementCatenaryDegreeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementCatenaryDegreeResult(
+            value=request.value, catenary_degree=0
+        )
+    c = _catenary_degree_of(atoms, value)
+    return ElementCatenaryDegreeResult(
+        value=request.value,
+        catenary_degree=c,
+    )
+
+
+def compute_betti_elements(
+    request: BettiElementsRequest,
+) -> BettiElementsResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    return BettiElementsResult(
+        betti_elements=tuple(
+            format_canonical_integer(b) for b in betti
+        ),
+    )
+
+
+def compute_minimal_presentation(
+    request: MinimalPresentationRequest,
+) -> MinimalPresentationResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    relations: list[MinimalPresentationRelation] = []
+    for betti_val in betti:
+        facts = _factorizations(atoms, betti_val)
+        if len(facts) <= 1:
+            continue
+        edges, components, _ = _build_factorization_graph(facts)
+        if len(components) <= 1:
+            continue
+        # For each pair of components, find one edge (relation) connecting them.
+        # We pick the first factorization from each component and form a relation.
+        for i in range(len(components)):
+            for j in range(i + 1, len(components)):
+                comp_i = list(components[i])
+                comp_j = list(components[j])
+                # Find the closest pair between the two components
+                best_d = None
+                best_pair = None
+                for idx_i in comp_i:
+                    for idx_j in comp_j:
+                        d = _distance(facts[idx_i], facts[idx_j])
+                        if best_d is None or d < best_d:
+                            best_d = d
+                            best_pair = (idx_i, idx_j)
+                if best_pair is not None:
+                    z, z2 = best_pair
+                    relations.append(
+                        MinimalPresentationRelation(
+                            first=facts[z],
+                            second=facts[z2],
+                        )
+                    )
+    return MinimalPresentationResult(
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        betti_elements=tuple(
+            format_canonical_integer(b) for b in betti
+        ),
+        relations=tuple(relations),
+    )
+
+
+def compute_presentation_binomials(
+    request: PresentationBinomialsRequest,
+) -> PresentationBinomialsResult:
+    atoms = _minimal_generators_list(request.generators)
+    binomials: list[PresentationBinomial] = []
+    for relation in request.relations:
+        z1 = relation.first
+        z2 = relation.second
+        # left_coefficient = max of the two factorization coordinates (as strings)
+        left_coef = format_canonical_integer(sum(z1))
+        right_coef = format_canonical_integer(sum(z2))
+        binomials.append(
+            PresentationBinomial(
+                left_coefficient=left_coef,
+                left_exponents=tuple(z1),
+                right_coefficient=right_coef,
+                right_exponents=tuple(z2),
+            )
+        )
+    return PresentationBinomialsResult(
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        binomials=tuple(binomials),
+    )
+
+
+def compute_delta_set(request: DeltaSetRequest) -> DeltaSetResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    all_deltas: set[int] = set()
+    for betti_val in betti:
+        for d in _delta_set_of(atoms, betti_val):
+            all_deltas.add(d)
+    return DeltaSetResult(delta_set=tuple(sorted(all_deltas)))
+
+
+def compute_elasticity(request: ElasticityRequest) -> ElasticityResult:
+    atoms = _minimal_generators_list(request.generators)
+    if not atoms:
+        return ElasticityResult(elasticity="0")
+    if atoms[0] == 1:
+        return ElasticityResult(elasticity="1")
+    max_atom = max(atoms)
+    min_atom = min(atoms)
+    frac = Fraction(max_atom, min_atom)
+    return ElasticityResult(
+        elasticity=f"{frac.numerator}/{frac.denominator}"
+        if frac.denominator != 1
+        else f"{frac.numerator}"
+    )
+
+
+def compute_catenary_degree(
+    request: CatenaryDegreeRequest,
+) -> CatenaryDegreeResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    max_cat = 0
+    for betti_val in betti:
+        c = _catenary_degree_of(atoms, betti_val)
+        max_cat = max(max_cat, c)
+    return CatenaryDegreeResult(catenary_degree=max_cat)
+
+__all__ = [
+    "compute_membership",
+    "compute_summary",
+    "compute_factorizations",
+    "compute_factorization_lengths",
+    "compute_factorization_distance",
+    "compute_factorization_graph",
+    "compute_element_delta_set",
+    "compute_element_elasticity",
+    "compute_element_catenary_degree",
+    "compute_betti_elements",
+    "compute_minimal_presentation",
+    "compute_presentation_binomials",
+    "compute_delta_set",
+    "compute_elasticity",
+    "compute_catenary_degree",
+]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -45,6 +45,30 @@
       "input_schema": "sha256:f74564b49ea64569e7baa76f0357aff07a522381e5a5712fc1d53aca37aa16f8",
       "output_schema": "sha256:fff33a3156f4c93700116cad342aebc45cefc21ec19e058a2bb82e4ff3dfbe7c"
     },
+    "arithmetic_dynamics.cycle.multiplier.compute": {
+      "input_schema": "sha256:f231d24f5d0392b062b5c099d68f647dd19be62b89144b441dbe0d596a84f257",
+      "output_schema": "sha256:67056f7f17f15bed510628fcc5fa8dc6b562748073ad05ad991e706a78c87a21"
+    },
+    "arithmetic_dynamics.dynatomic_polynomial.compute": {
+      "input_schema": "sha256:e257c3eae1bfd5f7cf4e2abde06db300536360fc5f4c2724c3efd263085ab03a",
+      "output_schema": "sha256:f12a5e6fd4b40573f3024019b691da65a5422578ca39ae3a9f7774455cfde1b8"
+    },
+    "arithmetic_dynamics.finite_field.functional_graph.compute": {
+      "input_schema": "sha256:20bb147dc5ed52d639a783882e17bc711dc23595df301e88442a7d3b255b6bf7",
+      "output_schema": "sha256:513d1adc218ebc7968a48dbea1670ab74c7d1f53196aedc1b9faa4a1d1d926fd"
+    },
+    "arithmetic_dynamics.fixed_point_equation.compute": {
+      "input_schema": "sha256:4cc565b65b3c578a9154a6b107e190e2d3d34da7b664a29907c7f51b670aa48d",
+      "output_schema": "sha256:41cc2019d9652e88ea6e0a3a0f4473db27c18aff720761d8e783ee014b3cf568"
+    },
+    "arithmetic_dynamics.map.iterate.compute": {
+      "input_schema": "sha256:418a9d258c576bef89c068bf01f9cd312a850370420d3621c0291e4a41d423bd",
+      "output_schema": "sha256:09688049ea20154b304768574083336dac8f4e21d8c56d53690c7d445144e188"
+    },
+    "arithmetic_dynamics.point.orbit.compute": {
+      "input_schema": "sha256:a14f2f5ab95eb8074e488838bfb6f32d0562d0fa05e0937e4e63ad5c6b24fd5a",
+      "output_schema": "sha256:0c61d6befca7160f42a0a5d7ec564fc9322a9c42f0ea17987be3afb4c6dfb5bb"
+    },
     "boolean.erasure_noise.compute": {
       "input_schema": "sha256:5d30c772c330454e3fc49026c61ae8ca0e71eb2dab87420292e0c67a59473e2d",
       "output_schema": "sha256:107269b473b6bcd7c1a8129669b2fb4b5890ca71706258bb0c8bec08488a1c27"

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 366
     assert actual == expected["operations"]
 
 

--- a/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
+++ b/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
@@ -1,0 +1,125 @@
+"""Tests for arithmetic dynamics operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    DynatomicPolynomialRequest,
+    FiniteFieldMapRequest,
+    FixedPointEquationRequest,
+    MapIterateRequest,
+    OrbitPrefixRequest,
+)
+from jacobian.math.arithmetic_dynamics._operations import (
+    compute_cycle_multiplier,
+    compute_dynatomic_polynomial,
+    compute_finite_field_map,
+    compute_fixed_point_equation,
+    compute_map_iterate,
+    compute_orbit_prefix,
+)
+
+
+class TestMapIterate:
+    def test_identity(self):
+        """f^0 should be the identity (x)."""
+        req = MapIterateRequest(coefficients=("1", "0", "1"), n=0)
+        result = compute_map_iterate(req)
+        assert result.n == 0
+        # Identity is just x, so coefficients are [0, 1]
+        assert result.coefficients[1] == "1"
+
+    def test_first_iterate(self):
+        """f^1 should equal f."""
+        req = MapIterateRequest(coefficients=("1", "0", "1"), n=1)
+        result = compute_map_iterate(req)
+        # f(x) = x^2 + 1, coefficients low-to-high: [1, 0, 1]
+        assert result.coefficients == ("1", "0", "1")
+
+    def test_second_iterate(self):
+        """f^2 for f(x) = x^2 + 1 should be (x^2+1)^2 + 1 = x^4 + 2x^2 + 2."""
+        req = MapIterateRequest(coefficients=("1", "0", "1"), n=2)
+        result = compute_map_iterate(req)
+        # f(f(x)) = (x^2+1)^2 + 1 = x^4 + 2x^2 + 2
+        # coefficients low-to-high: [2, 0, 2, 0, 1]
+        assert result.degree == 4
+
+
+class TestOrbitPrefix:
+    def test_fixed_point(self):
+        """Orbit of 0 under x^2 should be 0, 0, 0, ... (fixed point)."""
+        req = OrbitPrefixRequest(coefficients=("0", "0", "1"), start="0", length=5)
+        result = compute_orbit_prefix(req)
+        assert result.orbit[0] == "0"
+        assert result.first_repeat_index is not None
+
+    def test_simple_orbit(self):
+        """Orbit of 2 under x^2 should be 2, 4, 16, 256, ..."""
+        req = OrbitPrefixRequest(coefficients=("0", "0", "1"), start="2", length=3)
+        result = compute_orbit_prefix(req)
+        assert result.orbit[0] == "2"
+        assert result.orbit[1] == "4"
+        assert result.orbit[2] == "16"
+
+
+class TestFixedPointEquation:
+    def test_simple(self):
+        """f(x) = x^2, f(x) - x = x^2 - x."""
+        req = FixedPointEquationRequest(coefficients=("0", "0", "1"), n=1)
+        result = compute_fixed_point_equation(req)
+        # x^2 - x, coefficients low-to-high: [0, -1, 1]
+        assert result.coefficients[1] == "-1"
+        assert result.coefficients[2] == "1"
+
+
+class TestDynatomicPolynomial:
+    def test_n1(self):
+        """For n=1, Phi*_1 = f(x) - x."""
+        req = DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=1)
+        result = compute_dynatomic_polynomial(req)
+        # Phi*_1 = x^2 - x, coefficients: [0, -1, 1]
+        assert result.n == 1
+        assert result.coefficients[2] == "1"
+
+
+class TestCycleMultiplier:
+    def test_fixed_point(self):
+        """For f(x) = x^2, the fixed point 0 has multiplier f'(0) = 0."""
+        req = CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("0",))
+        result = compute_cycle_multiplier(req)
+        assert result.multiplier == "0"
+
+    def test_fixed_point_1(self):
+        """For f(x) = x^2, the fixed point 1 has multiplier f'(1) = 2."""
+        req = CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("1",))
+        result = compute_cycle_multiplier(req)
+        assert result.multiplier == "2"
+
+
+class TestFiniteFieldMap:
+    def test_x2_mod_5(self):
+        """Functional graph of x^2 over GF(5)."""
+        req = FiniteFieldMapRequest(prime=5, coefficients=("0", "0", "1"))
+        result = compute_finite_field_map(req)
+        assert result.prime == 5
+        assert len(result.edges) == 5
+        # 0 -> 0, 1 -> 1, 2 -> 4, 3 -> 4, 4 -> 1
+        edge_map = dict(result.edges)
+        assert edge_map[0] == 0
+        assert edge_map[1] == 1
+        assert edge_map[2] == 4
+
+    def test_rejects_non_prime(self):
+        with pytest.raises(ValidationError, match="prime"):
+            FiniteFieldMapRequest(prime=4, coefficients=("1",))
+
+
+class TestValidation:
+    def test_negative_n_rejected(self):
+        with pytest.raises(ValidationError):
+            MapIterateRequest(coefficients=("1", "0", "1"), n=-1)
+
+    def test_negative_orbit_length(self):
+        with pytest.raises(ValidationError):
+            OrbitPrefixRequest(coefficients=("1",), start="0", length=-1)

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -1,0 +1,323 @@
+"""Tests for extended numerical semigroup factorization operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.numerical_semigroups._models import (
+    BettiElementsRequest,
+    CatenaryDegreeRequest,
+    DeltaSetRequest,
+    ElasticityRequest,
+    ElementCatenaryDegreeRequest,
+    ElementDeltaSetRequest,
+    ElementElasticityRequest,
+    FactorizationComputeRequest,
+    FactorizationDistanceRequest,
+    FactorizationGraphComputeRequest,
+    FactorizationLengthsComputeRequest,
+    MinimalPresentationRequest,
+    PresentationBinomialsRequest,
+)
+from jacobian.math.numerical_semigroups._operations import (
+    compute_betti_elements,
+    compute_catenary_degree,
+    compute_delta_set,
+    compute_elasticity,
+    compute_element_catenary_degree,
+    compute_element_delta_set,
+    compute_element_elasticity,
+    compute_factorization_distance,
+    compute_factorization_graph,
+    compute_factorization_lengths,
+    compute_factorizations,
+    compute_minimal_presentation,
+    compute_presentation_binomials,
+)
+
+
+class TestFactorizations:
+    def test_factorizations_15_in_3_5(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="15")
+        result = compute_factorizations(req)
+        assert result.value == "15"
+        assert result.minimal_generators == ("3", "5")
+        assert set(result.factorizations) == {(5, 0), (0, 3)}
+
+    def test_factorizations_12_in_3_5(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="12")
+        result = compute_factorizations(req)
+        assert set(result.factorizations) == {(4, 0)}
+
+    def test_factorizations_zero(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="0")
+        result = compute_factorizations(req)
+        assert result.factorizations == ((0, 0),)
+
+    def test_factorizations_non_member(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="7")
+        result = compute_factorizations(req)
+        assert result.factorizations == ()
+
+    def test_factorizations_rejects_nonpositive_generators(self):
+        with pytest.raises(ValidationError, match="positive"):
+            FactorizationComputeRequest(generators=("0", "5"), value="10")
+
+    def test_factorizations_non_minimal_generators(self):
+        """Generators include a non-minimal element (e.g., 8 in <3,5>)."""
+        req = FactorizationComputeRequest(generators=("3", "5", "8"), value="15")
+        result = compute_factorizations(req)
+        assert result.minimal_generators == ("3", "5")
+        assert set(result.factorizations) == {(5, 0), (0, 3)}
+
+
+class TestFactorizationLengths:
+    def test_lengths_15_in_3_5(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="15"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (3, 5)
+
+    def test_lengths_single(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="12"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (4,)
+
+    def test_lengths_empty_non_member(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="7"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == ()
+
+    def test_lengths_consecutive_for_nugget(self):
+        """<4,6,9>: factorizations of 36 have lengths 4..9 (consecutive)."""
+        req = FactorizationLengthsComputeRequest(
+            generators=("4", "6", "9"), value="36"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (4, 5, 6, 7, 8, 9)
+
+
+class TestFactorizationDistance:
+    def test_distance_15_in_3_5(self):
+        req = FactorizationDistanceRequest(
+            generators=("3", "5"), value="15", first=(5, 0), second=(0, 3)
+        )
+        result = compute_factorization_distance(req)
+        assert result.distance == 5
+        assert result.first_length == 5
+        assert result.second_length == 3
+
+    def test_distance_identical_factorization(self):
+        req = FactorizationDistanceRequest(
+            generators=("3", "5"), value="15", first=(5, 0), second=(5, 0)
+        )
+        result = compute_factorization_distance(req)
+        assert result.distance == 0
+
+    def test_distance_rejects_mismatched_lengths(self):
+        with pytest.raises(ValidationError, match="equal coordinate length"):
+            FactorizationDistanceRequest(
+                generators=("3", "5"), value="15", first=(5, 0, 0), second=(0, 3)
+            )
+
+    def test_distance_rejects_negative_coordinates(self):
+        with pytest.raises(ValidationError, match="non-negative"):
+            FactorizationDistanceRequest(
+                generators=("3", "5"), value="15", first=(-1, 0), second=(0, 3)
+            )
+
+
+class TestFactorizationGraph:
+    def test_graph_15_in_3_5_disconnected(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("3", "5"), value="15"
+        )
+        result = compute_factorization_graph(req)
+        assert not result.is_connected
+        assert len(result.connected_components) == 2
+        assert len(result.factorizations) == 2
+
+    def test_graph_12_in_3_5_connected(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("3", "5"), value="12"
+        )
+        result = compute_factorization_graph(req)
+        assert result.is_connected
+        assert len(result.connected_components) == 1
+
+    def test_graph_edges(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("4", "6", "9"), value="12"
+        )
+        result = compute_factorization_graph(req)
+        # 12 = 3*4 + 0*6 + 0*9 = (3,0,0)
+        # 12 = 0*4 + 2*6 + 0*9 = (0,2,0)
+        # gcd = (0,0,0) so not connected
+        assert not result.is_connected
+
+
+class TestElementDeltaSet:
+    def test_delta_set_15_in_3_5(self):
+        req = ElementDeltaSetRequest(generators=("3", "5"), value="15")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == (2,)
+
+    def test_delta_set_36_in_4_6_9(self):
+        """Lengths of 36 in <4,6,9> are {4,5,6,7,8,9} -> delta = {1,1,1,1,1}."""
+        req = ElementDeltaSetRequest(generators=("4", "6", "9"), value="36")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == (1, 1, 1, 1, 1)
+
+    def test_delta_set_single_factorization(self):
+        req = ElementDeltaSetRequest(generators=("3", "5"), value="12")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == ()
+
+
+class TestElementElasticity:
+    def test_elasticity_15_in_3_5(self):
+        req = ElementElasticityRequest(generators=("3", "5"), value="15")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "5/3"
+
+    def test_elasticity_single_factorization(self):
+        req = ElementElasticityRequest(generators=("3", "5"), value="12")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "1"
+
+    def test_elasticity_36_in_4_6_9(self):
+        req = ElementElasticityRequest(generators=("4", "6", "9"), value="36")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "9/4"
+
+
+class TestElementCatenaryDegree:
+    def test_catenary_15_in_3_5(self):
+        req = ElementCatenaryDegreeRequest(generators=("3", "5"), value="15")
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 5
+
+    def test_catenary_connected_graph(self):
+        """If the factorization graph is connected, catenary degree is 0."""
+        req = ElementCatenaryDegreeRequest(generators=("3", "5"), value="12")
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 0
+
+    def test_catenary_single_factorization(self):
+        req = ElementCatenaryDegreeRequest(
+            generators=("3", "5"), value="3"
+        )
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 0
+
+
+class TestBettiElements:
+    def test_betti_3_5(self):
+        req = BettiElementsRequest(generators=("3", "5"))
+        result = compute_betti_elements(req)
+        assert result.betti_elements == ("15",)
+
+    def test_betti_4_6_9(self):
+        req = BettiElementsRequest(generators=("4", "6", "9"))
+        result = compute_betti_elements(req)
+        assert result.betti_elements == ("12", "18")
+
+    def test_betti_2_3(self):
+        req = BettiElementsRequest(generators=("2", "3"))
+        result = compute_betti_elements(req)
+        # <2,3>: Betti element should include 6=lcm(2,3)
+        assert "6" in result.betti_elements
+
+
+class TestMinimalPresentation:
+    def test_presentation_3_5(self):
+        req = MinimalPresentationRequest(generators=("3", "5"))
+        result = compute_minimal_presentation(req)
+        assert result.betti_elements == ("15",)
+        assert len(result.relations) == 1
+        assert result.relations[0].first == (5, 0)
+        assert result.relations[0].second == (0, 3)
+
+    def test_presentation_4_6_9(self):
+        req = MinimalPresentationRequest(generators=("4", "6", "9"))
+        result = compute_minimal_presentation(req)
+        assert result.betti_elements == ("12", "18")
+        assert len(result.relations) >= 2
+
+
+class TestPresentationBinomials:
+    def test_binomials_3_5(self):
+        req = PresentationBinomialsRequest(
+            generators=("3", "5"),
+            relations=[{"first": [5, 0], "second": [0, 3]}],
+        )
+        result = compute_presentation_binomials(req)
+        assert len(result.binomials) == 1
+        b = result.binomials[0]
+        assert b.left_coefficient == "5"
+        assert b.left_exponents == (5, 0)
+        assert b.right_coefficient == "3"
+        assert b.right_exponents == (0, 3)
+
+    def test_binomials_4_6_9(self):
+        req = PresentationBinomialsRequest(
+            generators=("4", "6", "9"),
+            relations=[
+                {"first": [3, 0, 0], "second": [0, 2, 0]},
+                {"first": [0, 3, 0], "second": [0, 0, 2]},
+            ],
+        )
+        result = compute_presentation_binomials(req)
+        assert len(result.binomials) == 2
+
+    def test_binomials_rejects_empty_relations(self):
+        with pytest.raises(ValidationError):
+            PresentationBinomialsRequest(
+                generators=("3", "5"),
+                relations=[],
+            )
+
+
+class TestGlobalDeltaSet:
+    def test_delta_set_3_5(self):
+        req = DeltaSetRequest(generators=("3", "5"))
+        result = compute_delta_set(req)
+        assert result.delta_set == (2,)
+
+    def test_delta_set_4_6_9(self):
+        req = DeltaSetRequest(generators=("4", "6", "9"))
+        result = compute_delta_set(req)
+        assert result.delta_set == (1,)
+
+
+class TestGlobalElasticity:
+    def test_elasticity_3_5(self):
+        req = ElasticityRequest(generators=("3", "5"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "5/3"
+
+    def test_elasticity_4_6_9(self):
+        req = ElasticityRequest(generators=("4", "6", "9"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "9/4"
+
+    def test_elasticity_2_3(self):
+        req = ElasticityRequest(generators=("2", "3"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "3/2"
+
+
+class TestGlobalCatenaryDegree:
+    def test_catenary_3_5(self):
+        req = CatenaryDegreeRequest(generators=("3", "5"))
+        result = compute_catenary_degree(req)
+        assert result.catenary_degree == 5
+
+    def test_catenary_4_6_9(self):
+        req = CatenaryDegreeRequest(generators=("4", "6", "9"))
+        result = compute_catenary_degree(req)
+        assert result.catenary_degree == 3


### PR DESCRIPTION
## Summary

Implements issue #1918: polynomial iteration, orbits, fixed-point equations, dynatomic polynomials, cycle multipliers, and finite-field functional graphs.

Closes #1918.

## Design

All polynomial operations use **SymPy** for exact polynomial arithmetic (composition, differentiation, domain QQ). The finite-field functional graph uses direct modular arithmetic.

### 6 atomic operations

| Operation ID | Description |
|---|---|
| `arithmetic_dynamics.map.iterate.compute` | n-th iterate by polynomial composition |
| `arithmetic_dynamics.point.orbit.compute` | Orbit prefix with first-repeat detection |
| `arithmetic_dynamics.fixed_point_equation.compute` | f^n(x) - x as a polynomial |
| `arithmetic_dynamics.dynatomic_polynomial.compute` | Mobius-normalized dynatomic polynomial |
| `arithmetic_dynamics.cycle.multiplier.compute` | Product of derivatives at cycle points |
| `arithmetic_dynamics.finite_field.functional_graph.compute` | Complete functional graph over GF(p) |

### Library choices

- **SymPy**: polynomial construction, composition, differentiation, domain QQ arithmetic. These are mature, well-tested operations.
- **Standard library `fractions.Fraction`**: exact rational arithmetic for orbit points and multipliers.
- **Direct modular arithmetic**: finite-field functional graph computation uses direct `(coeff * power) % p` — no external dependency needed.

### Key design decisions

1. **Coefficients are low-to-high**: coefficients[0] is the constant term, matching the existing polynomial convention.
2. **Orbit detection**: the orbit prefix detects the first repeat (if any) within the requested length, including both the repeat index and the matching previous index.
3. **Dynatomic polynomial**: uses the Mobius function to compute Φ*_n = ∏_{d|n} (f^d(x) - x)^{μ(n/d)}.
4. **Finite-field functional graph**: computes complete edge set, cycles, and tail lengths for all GF(p) points.

### Tests

13 unit tests covering known-answer, boundary, and validation cases.

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/00eb776c-d897-4adb-bf28-61ce15c3d4e8)