### PR TITLE
Add extended numerical semigroup factorization operations (#1906)

### DIFF
--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -93,10 +93,359 @@ class SemigroupMembershipResult(StrictModel):
     value: CanonicalInteger
     in_semigroup: bool
 
+# ---------------------------------------------------------------------------
+# Extended operations: factorization, elasticity, catenary degree, etc.
+# ---------------------------------------------------------------------------
+
+
+class FactorizationComputeRequest(StrictModel):
+    """Compute the complete factorization family Z(s) for one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationComputeResult(StrictModel):
+    """Complete factorization family Z(s) for one element."""
+
+    value: CanonicalInteger
+    minimal_generators: tuple[CanonicalInteger, ...]
+    factorizations: tuple[tuple[int, ...], ...]
+
+
+class FactorizationLengthsComputeRequest(StrictModel):
+    """Compute the complete sorted length set of one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationLengthsComputeResult(StrictModel):
+    """Sorted length set of one element."""
+
+    value: CanonicalInteger
+    lengths: tuple[int, ...]
+
+
+class FactorizationDistanceRequest(StrictModel):
+    """Distance between two factorizations of the same element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+    first: tuple[int, ...] = Field(min_length=1)
+    second: tuple[int, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_request(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        if len(self.first) != len(self.second):
+            raise ValueError("factorizations must have equal coordinate length")
+        if any(c < 0 for c in self.first) or any(c < 0 for c in self.second):
+            raise ValueError("factorization coordinates must be non-negative")
+        return self
+
+
+class FactorizationDistanceResult(StrictModel):
+    """Distance between two factorizations."""
+
+    value: CanonicalInteger
+    distance: int = Field(ge=0)
+    first_length: int = Field(ge=0)
+    second_length: int = Field(ge=0)
+
+
+class FactorizationGraphComputeRequest(StrictModel):
+    """Compute the standard factorization graph of one element."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class FactorizationGraphComputeResult(StrictModel):
+    """Standard factorization graph with connected components."""
+
+    value: CanonicalInteger
+    minimal_generators: tuple[CanonicalInteger, ...]
+    factorizations: tuple[tuple[int, ...], ...]
+    edges: tuple[tuple[int, int], ...]
+    connected_components: tuple[tuple[int, ...], ...]
+    is_connected: bool
+
+
+class ElementDeltaSetRequest(StrictModel):
+    """Delta set of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementDeltaSetResult(StrictModel):
+    """Delta set of one element."""
+
+    value: CanonicalInteger
+    delta_set: tuple[int, ...]
+
+
+class ElementElasticityRequest(StrictModel):
+    """Elasticity of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementElasticityResult(StrictModel):
+    """Elasticity of one element."""
+
+    value: CanonicalInteger
+    elasticity: str
+
+
+class ElementCatenaryDegreeRequest(StrictModel):
+    """Catenary degree of one element in a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    value: CanonicalInteger
+
+    @model_validator(mode="after")
+    def require_positive_generators_and_bounded_value(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        if parse_canonical_integer(self.value) > MAX_ELEMENT:
+            raise ValueError(f"value must be at most {MAX_ELEMENT}")
+        return self
+
+
+class ElementCatenaryDegreeResult(StrictModel):
+    """Catenary degree of one element."""
+
+    value: CanonicalInteger
+    catenary_degree: int = Field(ge=0)
+
+
+class BettiElementsRequest(StrictModel):
+    """Betti elements of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class BettiElementsResult(StrictModel):
+    """Betti elements of a semigroup."""
+
+    betti_elements: tuple[CanonicalInteger, ...]
+
+
+class MinimalPresentationRequest(StrictModel):
+    """One minimal presentation of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class MinimalPresentationRelation(StrictModel):
+    """One relation (pair of distinct factorizations) in a presentation."""
+
+    first: tuple[int, ...]
+    second: tuple[int, ...]
+
+
+class MinimalPresentationResult(StrictModel):
+    """One minimal presentation of the semigroup."""
+
+    minimal_generators: tuple[CanonicalInteger, ...]
+    betti_elements: tuple[CanonicalInteger, ...]
+    relations: tuple[MinimalPresentationRelation, ...]
+
+
+class PresentationBinomialsRequest(StrictModel):
+    """Convert a minimal presentation to sparse binomial form."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+    relations: tuple[MinimalPresentationRelation, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class PresentationBinomial(StrictModel):
+    """One sparse binomial (aX - bX) arising from a presentation relation."""
+
+    left_coefficient: str
+    left_exponents: tuple[int, ...]
+    right_coefficient: str
+    right_exponents: tuple[int, ...]
+
+
+class PresentationBinomialsResult(StrictModel):
+    """Presentation converted to sparse binomials."""
+
+    minimal_generators: tuple[CanonicalInteger, ...]
+    binomials: tuple[PresentationBinomial, ...]
+
+
+class DeltaSetRequest(StrictModel):
+    """Global delta set of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class DeltaSetResult(StrictModel):
+    """Global delta set of the semigroup."""
+
+    delta_set: tuple[int, ...]
+
+
+class ElasticityRequest(StrictModel):
+    """Global elasticity of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class ElasticityResult(StrictModel):
+    """Global elasticity of the semigroup."""
+
+    elasticity: str
+
+
+class CatenaryDegreeRequest(StrictModel):
+    """Global catenary degree of a numerical semigroup."""
+
+    generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
+
+    @model_validator(mode="after")
+    def require_positive_generators(self) -> Self:
+        _require_positive_bounded_generators(self.generators)
+        return self
+
+
+class CatenaryDegreeResult(StrictModel):
+    """Global catenary degree of the semigroup."""
+
+    catenary_degree: int = Field(ge=0)
+
 
 __all__ = [
     "NumericalSemigroupSummaryRequest",
     "NumericalSemigroupSummaryResult",
     "SemigroupMembershipRequest",
     "SemigroupMembershipResult",
+    # Factorization family
+    "FactorizationComputeRequest",
+    "FactorizationComputeResult",
+    # Factorization lengths
+    "FactorizationLengthsComputeRequest",
+    "FactorizationLengthsComputeResult",
+    # Distance
+    "FactorizationDistanceRequest",
+    "FactorizationDistanceResult",
+    # Factorization graph
+    "FactorizationGraphComputeRequest",
+    "FactorizationGraphComputeResult",
+    # Element-level
+    "ElementDeltaSetRequest",
+    "ElementDeltaSetResult",
+    "ElementElasticityRequest",
+    "ElementElasticityResult",
+    "ElementCatenaryDegreeRequest",
+    "ElementCatenaryDegreeResult",
+    # Betti
+    "BettiElementsRequest",
+    "BettiElementsResult",
+    # Minimal presentation
+    "MinimalPresentationRequest",
+    "MinimalPresentationRelation",
+    "MinimalPresentationResult",
+    "PresentationBinomialsRequest",
+    "PresentationBinomial",
+    "PresentationBinomialsResult",
+    # Global
+    "DeltaSetRequest",
+    "DeltaSetResult",
+    "ElasticityRequest",
+    "ElasticityResult",
+    "CatenaryDegreeRequest",
+    "CatenaryDegreeResult",
 ]
+

--- a/src/jacobian/math/numerical_semigroups/_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_operations.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.numerical_semigroups._models import (
+    MAX_ELEMENT,
+    MAX_FACTOR_SEARCH,
     NumericalSemigroupSummaryRequest,
     NumericalSemigroupSummaryResult,
     SemigroupMembershipRequest,
@@ -108,4 +112,524 @@ def compute_membership(
     )
 
 
-__all__ = ["compute_membership", "compute_summary"]
+# __all__ defined at end
+
+
+# ---------------------------------------------------------------------------
+# Extended operations: factorization, elasticity, catenary degree, etc.
+# ---------------------------------------------------------------------------
+
+import networkx as _nx
+
+from jacobian.math.numerical_semigroups._models import (
+    BettiElementsRequest,
+    BettiElementsResult,
+    CatenaryDegreeRequest,
+    CatenaryDegreeResult,
+    DeltaSetRequest,
+    DeltaSetResult,
+    ElasticityRequest,
+    ElasticityResult,
+    ElementCatenaryDegreeRequest,
+    ElementCatenaryDegreeResult,
+    ElementDeltaSetRequest,
+    ElementDeltaSetResult,
+    ElementElasticityRequest,
+    ElementElasticityResult,
+    FactorizationComputeRequest,
+    FactorizationComputeResult,
+    FactorizationDistanceRequest,
+    FactorizationDistanceResult,
+    FactorizationGraphComputeRequest,
+    FactorizationGraphComputeResult,
+    FactorizationLengthsComputeRequest,
+    FactorizationLengthsComputeResult,
+    MinimalPresentationRequest,
+    MinimalPresentationRelation,
+    MinimalPresentationResult,
+    PresentationBinomial,
+    PresentationBinomialsRequest,
+    PresentationBinomialsResult,
+)
+
+
+def _minimal_generators_list(gens: tuple[str, ...]) -> list[int]:
+    """Return the sorted minimal generating set as a list of ints."""
+    raw = sorted({parse_canonical_integer(g) for g in gens})
+    if not raw:
+        return []
+    if raw[0] == 1:
+        return [1]
+    result = []
+    for generator in raw:
+        others = [other for other in raw if other != generator]
+        if not others:
+            result.append(generator)
+            continue
+        can_reach = [False] * (generator + 1)
+        can_reach[0] = True
+        for value in range(1, generator + 1):
+            can_reach[value] = any(
+                value >= other and can_reach[value - other] for other in others
+            )
+        if not can_reach[generator]:
+            result.append(generator)
+    return result
+
+
+def _enumerate_factorizations(
+    atoms: list[int], target: int
+) -> list[tuple[int, ...]]:
+    """Enumerate all factorizations of *target* using *atoms* (minimal generators).
+
+    Uses bounded dynamic programming.  Returns a list of tuples, each of length
+    ``len(atoms)``, representing one factorization.
+    """
+    if target == 0:
+        return [tuple([0] * len(atoms))]
+    if not atoms:
+        return []
+    max_per_value = MAX_FACTOR_SEARCH * MAX_FACTOR_SEARCH
+    dp: list[list[tuple[int, ...]]] = [[] for _ in range(target + 1)]
+    dp[0] = [tuple([0] * len(atoms))]
+    for v in range(1, target + 1):
+        facts: list[tuple[int, ...]] = []
+        for idx, atom in enumerate(atoms):
+            if atom > v:
+                continue
+            for fact in dp[v - atom]:
+                new_fact = list(fact)
+                new_fact[idx] += 1
+                facts.append(tuple(new_fact))
+            if len(facts) > max_per_value:
+                break
+        seen: set[tuple[int, ...]] = set()
+        unique: list[tuple[int, ...]] = []
+        for f in facts:
+            if f not in seen:
+                seen.add(f)
+                unique.append(f)
+        dp[v] = unique
+    return dp[target]
+
+
+def _factorizations(atoms: list[int], target: int) -> list[tuple[int, ...]]:
+    """Wrapper for the enumeration routine."""
+    return _enumerate_factorizations(atoms, target)
+
+
+def _length(fact: tuple[int, ...]) -> int:
+    """Length (norm) of a factorization = sum of coordinates."""
+    return sum(fact)
+
+
+def _gcd_factor(
+    f1: tuple[int, ...], f2: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Coordinate-wise minimum of two factorizations."""
+    return tuple(min(a, b) for a, b in zip(f1, f2, strict=True))
+
+
+def _distance(f1: tuple[int, ...], f2: tuple[int, ...]) -> int:
+    """Distance d(z, z') = max(|z - gcd|, |z' - gcd|) where gcd is coordinatewise min."""
+    if not f1 or not f2:
+        return 0
+    g = _gcd_factor(f1, f2)
+    l1 = sum(f1)
+    l2 = sum(f2)
+    lg = sum(g)
+    return max(abs(l1 - lg), abs(l2 - lg))
+
+
+def _build_factorization_graph(
+    factorizations: list[tuple[int, ...]],
+) -> tuple[list[tuple[int, int]], list[list[int]], bool]:
+    """Build the standard factorization graph.
+
+    Two factorizations are connected if their coordinatewise gcd is nonzero
+    (they share a common atom).  Returns ``(edges, connected_components, is_connected)``.
+    """
+    n = len(factorizations)
+    if n == 0:
+        return [], [], True
+    graph = _nx.Graph()
+    for i in range(n):
+        graph.add_node(i)
+    edges = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            if sum(_gcd_factor(factorizations[i], factorizations[j])) > 0:
+                graph.add_edge(i, j)
+                edges.append((i, j))
+    components = [list(comp) for comp in _nx.connected_components(graph)]
+    is_connected = len(components) <= 1
+    return edges, components, is_connected
+
+
+def _catenary_degree_of(atoms: list[int], target: int) -> int:
+    """Catenary degree of one element.
+
+    For every pair (z, z') of factorizations of *target*, the catenary degree is
+    the minimum value *c* such that there exists a chain z -> z₁ -> ... -> z' with
+    all consecutive distances ≤ *c*.  Equivalently, it is the maximum over all
+    pairs (z, z') of the minimax path weight in the distance-weighted graph.
+    """
+    facts = _factorizations(atoms, target)
+    if len(facts) <= 1:
+        return 0
+
+    n = len(facts)
+    _, components, _ = _build_factorization_graph(facts)
+    if len(components) <= 1:
+        return 0
+
+    # Build a complete distance-weighted graph.
+    dist_graph = _nx.Graph()
+    for i in range(n):
+        dist_graph.add_node(i)
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = _distance(facts[i], facts[j])
+            dist_graph.add_edge(i, j, weight=d)
+
+    # Minimax path via MST.
+    mst = _nx.minimum_spanning_tree(dist_graph)
+    catenary = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            try:
+                path = _nx.shortest_path(mst, i, j, weight="weight")
+            except _nx.NetworkXNoPath:
+                continue
+            if len(path) < 2:
+                continue
+            path_max = 0
+            for k in range(len(path) - 1):
+                edge_weight = mst[path[k]][path[k + 1]]["weight"]
+                path_max = max(path_max, edge_weight)
+            catenary = max(catenary, path_max)
+    return catenary
+
+
+def _delta_set_of(atoms: list[int], target: int) -> list[int]:
+    """Delta set of one element = successive differences of the sorted length set."""
+    facts = _factorizations(atoms, target)
+    if len(facts) <= 1:
+        return []
+    lengths = sorted({sum(f) for f in facts})
+    if len(lengths) <= 1:
+        return []
+    return [lengths[i + 1] - lengths[i] for i in range(len(lengths) - 1)]
+
+
+def _betti_elements(atoms: list[int]) -> list[int]:
+    """Betti elements = elements where the factorization graph is disconnected."""
+    # The search space is bounded: Betti elements are at most lcm of pairs of
+    # atoms times some small factor.  We search up to the Frobenius-like bound.
+    if not atoms or atoms[0] == 1:
+        return []
+    max_atom = atoms[-1]
+    # Betti elements are bounded by the Frobenius number + 1, but we use a
+    # generous bound.  The conductor is at most (m-1)*max_atom where m is
+    # the multiplicity (smallest generator).
+    multiplicity = atoms[0]
+    conductor_bound = (multiplicity - 1) * max_atom
+    bound = conductor_bound * multiplicity
+    if bound > MAX_ELEMENT:
+        bound = MAX_ELEMENT
+    betti: list[int] = []
+    for n in range(1, bound + 1):
+        facts = _factorizations(atoms, n)
+        if len(facts) <= 1:
+            continue
+        _, _, connected = _build_factorization_graph(facts)
+        if not connected:
+            betti.append(n)
+    return betti
+
+
+# ---------------------------------------------------------------------------
+# Public operation functions
+# ---------------------------------------------------------------------------
+
+
+def compute_factorizations(
+    request: FactorizationComputeRequest,
+) -> FactorizationComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationComputeResult(
+            value=request.value,
+            minimal_generators=tuple(
+                format_canonical_integer(a) for a in atoms
+            ),
+            factorizations=(),
+        )
+    facts = _factorizations(atoms, value)
+    return FactorizationComputeResult(
+        value=request.value,
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        factorizations=tuple(facts),
+    )
+
+
+def compute_factorization_lengths(
+    request: FactorizationLengthsComputeRequest,
+) -> FactorizationLengthsComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationLengthsComputeResult(value=request.value, lengths=())
+    facts = _factorizations(atoms, value)
+    lengths = sorted({sum(f) for f in facts})
+    return FactorizationLengthsComputeResult(
+        value=request.value,
+        lengths=tuple(lengths),
+    )
+
+
+def compute_factorization_distance(
+    request: FactorizationDistanceRequest,
+) -> FactorizationDistanceResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    f1 = tuple(request.first)
+    f2 = tuple(request.second)
+    d = _distance(f1, f2)
+    return FactorizationDistanceResult(
+        value=request.value,
+        distance=d,
+        first_length=sum(f1),
+        second_length=sum(f2),
+    )
+
+
+def compute_factorization_graph(
+    request: FactorizationGraphComputeRequest,
+) -> FactorizationGraphComputeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return FactorizationGraphComputeResult(
+            value=request.value,
+            minimal_generators=tuple(
+                format_canonical_integer(a) for a in atoms
+            ),
+            factorizations=(),
+            edges=(),
+            connected_components=(),
+            is_connected=True,
+        )
+    facts = _factorizations(atoms, value)
+    edges, components, connected = _build_factorization_graph(facts)
+    return FactorizationGraphComputeResult(
+        value=request.value,
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        factorizations=tuple(facts),
+        edges=tuple((i, j) for i, j in edges),
+        connected_components=tuple(
+            tuple(sorted(comp)) for comp in components
+        ),
+        is_connected=connected,
+    )
+
+
+def compute_element_delta_set(
+    request: ElementDeltaSetRequest,
+) -> ElementDeltaSetResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementDeltaSetResult(value=request.value, delta_set=())
+    deltas = _delta_set_of(atoms, value)
+    return ElementDeltaSetResult(
+        value=request.value,
+        delta_set=tuple(deltas),
+    )
+
+
+def compute_element_elasticity(
+    request: ElementElasticityRequest,
+) -> ElementElasticityResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    facts = _factorizations(atoms, value)
+    if not facts:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    lengths = [sum(f) for f in facts]
+    min_len = min(lengths)
+    max_len = max(lengths)
+    if min_len == 0:
+        return ElementElasticityResult(value=request.value, elasticity="0")
+    frac = Fraction(max_len, min_len)
+    return ElementElasticityResult(
+        value=request.value,
+        elasticity=f"{frac.numerator}/{frac.denominator}"
+        if frac.denominator != 1
+        else f"{frac.numerator}",
+    )
+
+
+def compute_element_catenary_degree(
+    request: ElementCatenaryDegreeRequest,
+) -> ElementCatenaryDegreeResult:
+    atoms = _minimal_generators_list(request.generators)
+    value = parse_canonical_integer(request.value)
+    if value < 0:
+        return ElementCatenaryDegreeResult(
+            value=request.value, catenary_degree=0
+        )
+    c = _catenary_degree_of(atoms, value)
+    return ElementCatenaryDegreeResult(
+        value=request.value,
+        catenary_degree=c,
+    )
+
+
+def compute_betti_elements(
+    request: BettiElementsRequest,
+) -> BettiElementsResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    return BettiElementsResult(
+        betti_elements=tuple(
+            format_canonical_integer(b) for b in betti
+        ),
+    )
+
+
+def compute_minimal_presentation(
+    request: MinimalPresentationRequest,
+) -> MinimalPresentationResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    relations: list[MinimalPresentationRelation] = []
+    for betti_val in betti:
+        facts = _factorizations(atoms, betti_val)
+        if len(facts) <= 1:
+            continue
+        edges, components, _ = _build_factorization_graph(facts)
+        if len(components) <= 1:
+            continue
+        # For each pair of components, find one edge (relation) connecting them.
+        # We pick the first factorization from each component and form a relation.
+        for i in range(len(components)):
+            for j in range(i + 1, len(components)):
+                comp_i = list(components[i])
+                comp_j = list(components[j])
+                # Find the closest pair between the two components
+                best_d = None
+                best_pair = None
+                for idx_i in comp_i:
+                    for idx_j in comp_j:
+                        d = _distance(facts[idx_i], facts[idx_j])
+                        if best_d is None or d < best_d:
+                            best_d = d
+                            best_pair = (idx_i, idx_j)
+                if best_pair is not None:
+                    z, z2 = best_pair
+                    relations.append(
+                        MinimalPresentationRelation(
+                            first=facts[z],
+                            second=facts[z2],
+                        )
+                    )
+    return MinimalPresentationResult(
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        betti_elements=tuple(
+            format_canonical_integer(b) for b in betti
+        ),
+        relations=tuple(relations),
+    )
+
+
+def compute_presentation_binomials(
+    request: PresentationBinomialsRequest,
+) -> PresentationBinomialsResult:
+    atoms = _minimal_generators_list(request.generators)
+    binomials: list[PresentationBinomial] = []
+    for relation in request.relations:
+        z1 = relation.first
+        z2 = relation.second
+        # left_coefficient = max of the two factorization coordinates (as strings)
+        left_coef = format_canonical_integer(sum(z1))
+        right_coef = format_canonical_integer(sum(z2))
+        binomials.append(
+            PresentationBinomial(
+                left_coefficient=left_coef,
+                left_exponents=tuple(z1),
+                right_coefficient=right_coef,
+                right_exponents=tuple(z2),
+            )
+        )
+    return PresentationBinomialsResult(
+        minimal_generators=tuple(
+            format_canonical_integer(a) for a in atoms
+        ),
+        binomials=tuple(binomials),
+    )
+
+
+def compute_delta_set(request: DeltaSetRequest) -> DeltaSetResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    all_deltas: set[int] = set()
+    for betti_val in betti:
+        for d in _delta_set_of(atoms, betti_val):
+            all_deltas.add(d)
+    return DeltaSetResult(delta_set=tuple(sorted(all_deltas)))
+
+
+def compute_elasticity(request: ElasticityRequest) -> ElasticityResult:
+    atoms = _minimal_generators_list(request.generators)
+    if not atoms:
+        return ElasticityResult(elasticity="0")
+    if atoms[0] == 1:
+        return ElasticityResult(elasticity="1")
+    max_atom = max(atoms)
+    min_atom = min(atoms)
+    frac = Fraction(max_atom, min_atom)
+    return ElasticityResult(
+        elasticity=f"{frac.numerator}/{frac.denominator}"
+        if frac.denominator != 1
+        else f"{frac.numerator}"
+    )
+
+
+def compute_catenary_degree(
+    request: CatenaryDegreeRequest,
+) -> CatenaryDegreeResult:
+    atoms = _minimal_generators_list(request.generators)
+    betti = _betti_elements(atoms)
+    max_cat = 0
+    for betti_val in betti:
+        c = _catenary_degree_of(atoms, betti_val)
+        max_cat = max(max_cat, c)
+    return CatenaryDegreeResult(catenary_degree=max_cat)
+
+__all__ = [
+    "compute_membership",
+    "compute_summary",
+    "compute_factorizations",
+    "compute_factorization_lengths",
+    "compute_factorization_distance",
+    "compute_factorization_graph",
+    "compute_element_delta_set",
+    "compute_element_elasticity",
+    "compute_element_catenary_degree",
+    "compute_betti_elements",
+    "compute_minimal_presentation",
+    "compute_presentation_binomials",
+    "compute_delta_set",
+    "compute_elasticity",
+    "compute_catenary_degree",
+]

--- a/src/jacobian/math/numerical_semigroups/_tools.py
+++ b/src/jacobian/math/numerical_semigroups/_tools.py
@@ -7,13 +7,52 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.numerical_semigroups._models import (
+    BettiElementsRequest,
+    BettiElementsResult,
+    CatenaryDegreeRequest,
+    CatenaryDegreeResult,
+    DeltaSetRequest,
+    DeltaSetResult,
+    ElasticityRequest,
+    ElasticityResult,
+    ElementCatenaryDegreeRequest,
+    ElementCatenaryDegreeResult,
+    ElementDeltaSetRequest,
+    ElementDeltaSetResult,
+    ElementElasticityRequest,
+    ElementElasticityResult,
+    FactorizationComputeRequest,
+    FactorizationComputeResult,
+    FactorizationDistanceRequest,
+    FactorizationDistanceResult,
+    FactorizationGraphComputeRequest,
+    FactorizationGraphComputeResult,
+    FactorizationLengthsComputeRequest,
+    FactorizationLengthsComputeResult,
+    MinimalPresentationRequest,
+    MinimalPresentationResult,
     NumericalSemigroupSummaryRequest,
     NumericalSemigroupSummaryResult,
+    PresentationBinomialsRequest,
+    PresentationBinomialsResult,
     SemigroupMembershipRequest,
     SemigroupMembershipResult,
 )
 from jacobian.math.numerical_semigroups._operations import (
+    compute_betti_elements,
+    compute_catenary_degree,
+    compute_delta_set,
+    compute_element_catenary_degree,
+    compute_element_delta_set,
+    compute_element_elasticity,
+    compute_elasticity,
+    compute_factorization_distance,
+    compute_factorization_graph,
+    compute_factorization_lengths,
+    compute_factorizations,
     compute_membership,
+    compute_minimal_presentation,
+    compute_presentation_binomials,
     compute_summary,
 )
 
@@ -82,6 +121,274 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "membership_8_in_3_5",
                 "Check if 8 is in <3,5>.",
                 {"generators": ["3", "5"], "value": "8"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.factorizations.compute",
+        "Compute complete factorization family Z(s)",
+        "Given a numerical semigroup and an element, compute the complete "
+        "factorization family Z(s) - all factorizations expressed as tuples "
+        "of minimal-generator multiplicities.",
+        FactorizationComputeRequest,
+        FactorizationComputeResult,
+        compute_factorizations,
+        "number-theory",
+        "numerical-semigroup",
+        "factorization",
+        "exact",
+        examples=(
+            example(
+                "factorizations_15_in_3_5",
+                "Factorizations of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.factorization_lengths.compute",
+        "Compute sorted factorization length set",
+        "Given a numerical semigroup and an element, compute the complete "
+        "sorted set of factorization lengths.",
+        FactorizationLengthsComputeRequest,
+        FactorizationLengthsComputeResult,
+        compute_factorization_lengths,
+        "number-theory",
+        "numerical-semigroup",
+        "factorization",
+        "exact",
+        examples=(
+            example(
+                "lengths_15_in_3_5",
+                "Lengths of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.factorization_distance.compute",
+        "Compute distance between two factorizations",
+        "Compute the standard distance d(z,z') = max(|z-gcd|,|z'-gcd|) "
+        "between two factorizations of the same element, where gcd is "
+        "the coordinatewise minimum.",
+        FactorizationDistanceRequest,
+        FactorizationDistanceResult,
+        compute_factorization_distance,
+        "number-theory",
+        "numerical-semigroup",
+        "factorization",
+        "exact",
+        examples=(
+            example(
+                "distance_15_in_3_5",
+                "Distance between (5,0) and (0,3) for 15 in <3,5>.",
+                {
+                    "generators": ["3", "5"],
+                    "value": "15",
+                    "first": [5, 0],
+                    "second": [0, 3],
+                },
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.factorization_graph.compute",
+        "Compute factorization graph with connected components",
+        "Build the standard factorization graph where two factorizations "
+        "are connected if they share a common atom (coordinatewise gcd is "
+        "nonzero). Returns edges and connected components.",
+        FactorizationGraphComputeRequest,
+        FactorizationGraphComputeResult,
+        compute_factorization_graph,
+        "number-theory",
+        "numerical-semigroup",
+        "factorization",
+        "exact",
+        examples=(
+            example(
+                "graph_15_in_3_5",
+                "Factorization graph of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.element.delta_set.compute",
+        "Compute delta set of one element",
+        "Compute the delta set (set of successive length differences) of "
+        "one element in a numerical semigroup.",
+        ElementDeltaSetRequest,
+        ElementDeltaSetResult,
+        compute_element_delta_set,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "delta_15_in_3_5",
+                "Delta set of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.element.elasticity.compute",
+        "Compute elasticity of one element",
+        "Compute the elasticity (ratio of maximum to minimum factorization "
+        "length) of one element in a numerical semigroup.",
+        ElementElasticityRequest,
+        ElementElasticityResult,
+        compute_element_elasticity,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "elasticity_15_in_3_5",
+                "Elasticity of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.element.catenary_degree.compute",
+        "Compute catenary degree of one element",
+        "Compute the catenary degree of one element in a numerical "
+        "semigroup, defined as the minimum chain-max distance over all "
+        "pairs of factorizations.",
+        ElementCatenaryDegreeRequest,
+        ElementCatenaryDegreeResult,
+        compute_element_catenary_degree,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "catenary_15_in_3_5",
+                "Catenary degree of 15 in <3,5>.",
+                {"generators": ["3", "5"], "value": "15"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.betti_elements.compute",
+        "Compute Betti elements of a numerical semigroup",
+        "Compute the Betti elements of a numerical semigroup - elements "
+        "whose factorization graph is disconnected.",
+        BettiElementsRequest,
+        BettiElementsResult,
+        compute_betti_elements,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "betti_3_5",
+                "Betti elements of <3,5>.",
+                {"generators": ["3", "5"]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.minimal_presentation.compute",
+        "Compute a minimal presentation",
+        "Compute one minimal presentation of a numerical semigroup, "
+        "returning one relation per pair of connected components of the "
+        "factorization graph at each Betti element.",
+        MinimalPresentationRequest,
+        MinimalPresentationResult,
+        compute_minimal_presentation,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "presentation_3_5",
+                "Minimal presentation of <3,5>.",
+                {"generators": ["3", "5"]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.presentation_binomials.compute",
+        "Convert presentation to sparse binomials",
+        "Convert a minimal presentation into sparse binomial form, where "
+        "each relation becomes a binomial with coefficient and exponent "
+        "vectors.",
+        PresentationBinomialsRequest,
+        PresentationBinomialsResult,
+        compute_presentation_binomials,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "binomials_3_5",
+                "Sparse binomials of <3,5>.",
+                {
+                    "generators": ["3", "5"],
+                    "relations": [
+                        {"first": [5, 0], "second": [0, 3]},
+                    ],
+                },
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.delta_set.compute",
+        "Compute global delta set",
+        "Compute the global delta set of a numerical semigroup - the "
+        "union of delta set over all Betti elements (finite theorem).",
+        DeltaSetRequest,
+        DeltaSetResult,
+        compute_delta_set,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "global_delta_3_5",
+                "Global delta set of <3,5>.",
+                {"generators": ["3", "5"]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.elasticity.compute",
+        "Compute global elasticity",
+        "Compute the global elasticity of a numerical semigroup, defined "
+        "as the ratio of the largest to the smallest minimal generator.",
+        ElasticityRequest,
+        ElasticityResult,
+        compute_elasticity,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "global_elasticity_3_5",
+                "Global elasticity of <3,5>.",
+                {"generators": ["3", "5"]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.numerical_semigroup.catenary_degree.compute",
+        "Compute global catenary degree",
+        "Compute the global catenary degree of a numerical semigroup - "
+        "the maximum catenary degree over all Betti elements (finite "
+        "theorem).",
+        CatenaryDegreeRequest,
+        CatenaryDegreeResult,
+        compute_catenary_degree,
+        "number-theory",
+        "numerical-semigroup",
+        "exact",
+        examples=(
+            example(
+                "global_catenary_3_5",
+                "Global catenary degree of <3,5>.",
+                {"generators": ["3", "5"]},
             ),
         ),
     ),

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1033,9 +1033,61 @@
       "input_schema": "sha256:eca1fbc54c3d5c72d4711197aae16587172e4c4686055e9ca64222481fa5275a",
       "output_schema": "sha256:7297a74c4f3c5ac3de2f6c77dd3d44fa8690f14affdc3745a09e52dd49bcda60"
     },
+    "number_theory.numerical_semigroup.betti_elements.compute": {
+      "input_schema": "sha256:be456ffbca1d5991b1f6d71da7d9f95af266bf0d6b7353fa31b269683ddd296b",
+      "output_schema": "sha256:8aecb728b51d36eaf0e4879f9173c50e556d18282602b5a2a128068d3d43c53e"
+    },
+    "number_theory.numerical_semigroup.catenary_degree.compute": {
+      "input_schema": "sha256:856d4fe5bc8ca0d87e72f5c11d7ba428e0718fa57326681ba07d00683c5e6af5",
+      "output_schema": "sha256:7afa712fdb7d345393c77b50503f9c1b2301d811fb20f6e10940259046814cfc"
+    },
+    "number_theory.numerical_semigroup.delta_set.compute": {
+      "input_schema": "sha256:6c06ade9881834813f6206e6cccb9964fdd5d453f508126271ad3882223027a4",
+      "output_schema": "sha256:80b45e07e52c8986e8dd25931806771e79bbe13abf7f3da652627f13b0864002"
+    },
+    "number_theory.numerical_semigroup.elasticity.compute": {
+      "input_schema": "sha256:653c1407c35c4c0d956310620254ebfe6f9d96a322ba8b3db00d512a8959c9b4",
+      "output_schema": "sha256:4e563abda37d86d83485422c40f02e9616000939d50c5bcf650eb3d04436ee67"
+    },
+    "number_theory.numerical_semigroup.element.catenary_degree.compute": {
+      "input_schema": "sha256:111f5e0edc9f95d6e32124ea84e7717d945b395218bd71b66c8025ed68bda726",
+      "output_schema": "sha256:5c6c58a6798aa1833e49de3c5ff49f682716a0b606fcd12391d4ffb22cbe29b6"
+    },
+    "number_theory.numerical_semigroup.element.delta_set.compute": {
+      "input_schema": "sha256:a87d2f995825a0b052bfdb8952d0a20b48cbc9975fc029ce1b077fc9ef415225",
+      "output_schema": "sha256:a34ce33186c2b5206d2ec6f3d0bcb5719d9d2a8d02cce8257a1b8077690684ec"
+    },
+    "number_theory.numerical_semigroup.element.elasticity.compute": {
+      "input_schema": "sha256:52c878622b15a8714b31997f240e1de21bb7f588a84270ed829b6a598b6b6ade",
+      "output_schema": "sha256:69fdd50262af4080d6703fded1ab303f3742389e8c6440fe9ed87691af6b01bf"
+    },
+    "number_theory.numerical_semigroup.factorization_distance.compute": {
+      "input_schema": "sha256:41824a63b2eb0a0fd49e0551941fdb01f521ae611d14812ab3f29a5f1f4d68dc",
+      "output_schema": "sha256:ef48a70f43bcfe40191de6fb39edafdc731a28a5585329b5a74e73dd410f3e9b"
+    },
+    "number_theory.numerical_semigroup.factorization_graph.compute": {
+      "input_schema": "sha256:05bbb230aeda5586efcd8f16ca080b649049435ea4071addd571fb7a73061333",
+      "output_schema": "sha256:a9c775b4cd01c0cadccc3a8199c6859fdcb9dd2a3e5c9ba62bb949a5bfb3e75f"
+    },
+    "number_theory.numerical_semigroup.factorization_lengths.compute": {
+      "input_schema": "sha256:2503062ef5da7835fc6987af937e0896e33842391de63819e3f449313f4f07eb",
+      "output_schema": "sha256:f3cbcdcba0875bd04dca1cebf9a1753a0d7b08f1ab1e85b58c1f4b39eb1c2017"
+    },
+    "number_theory.numerical_semigroup.factorizations.compute": {
+      "input_schema": "sha256:c8e61f5287124813f89c50444fce3308c4d682e8235a5f9e8dc0d4657ebc880e",
+      "output_schema": "sha256:18a834e8204c375903d4c64e4c35486486b6abc428a244f1449ec2f008948416"
+    },
     "number_theory.numerical_semigroup.membership.compute": {
       "input_schema": "sha256:994409947c1647431e8aaac86516c11d1b17f31f5aaf635b14094f4130591ccc",
       "output_schema": "sha256:ea2ccebf9418464b7974ab4af6d63b82a8217ab7c1fe34658cfa0b27e868e5b5"
+    },
+    "number_theory.numerical_semigroup.minimal_presentation.compute": {
+      "input_schema": "sha256:7250a5e807ac6735e054ab4a0269a4843fa0f21886be4dca00d75faa9a3c2d90",
+      "output_schema": "sha256:00f0c9060d793c839c1d65f20670d2305e30cacfca67fa368bcb7f4fc5030184"
+    },
+    "number_theory.numerical_semigroup.presentation_binomials.compute": {
+      "input_schema": "sha256:2d865404e71ab43cf2d9f04126cee845fcc9ecd794f2663e26de1fde7d93c043",
+      "output_schema": "sha256:a4404e31a2ab63597bb34b2282d720f6b813718aff67b85eabb0089d25947c85"
     },
     "number_theory.numerical_semigroup.summary.compute": {
       "input_schema": "sha256:a96330f2cbf2fa44aa4ee06fa965ca37fa86281b96ab336eae54554a779888ea",

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 373
     assert actual == expected["operations"]
 
 

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -1,0 +1,323 @@
+"""Tests for extended numerical semigroup factorization operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.numerical_semigroups._models import (
+    BettiElementsRequest,
+    CatenaryDegreeRequest,
+    DeltaSetRequest,
+    ElasticityRequest,
+    ElementCatenaryDegreeRequest,
+    ElementDeltaSetRequest,
+    ElementElasticityRequest,
+    FactorizationComputeRequest,
+    FactorizationDistanceRequest,
+    FactorizationGraphComputeRequest,
+    FactorizationLengthsComputeRequest,
+    MinimalPresentationRequest,
+    PresentationBinomialsRequest,
+)
+from jacobian.math.numerical_semigroups._operations import (
+    compute_betti_elements,
+    compute_catenary_degree,
+    compute_delta_set,
+    compute_elasticity,
+    compute_element_catenary_degree,
+    compute_element_delta_set,
+    compute_element_elasticity,
+    compute_factorization_distance,
+    compute_factorization_graph,
+    compute_factorization_lengths,
+    compute_factorizations,
+    compute_minimal_presentation,
+    compute_presentation_binomials,
+)
+
+
+class TestFactorizations:
+    def test_factorizations_15_in_3_5(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="15")
+        result = compute_factorizations(req)
+        assert result.value == "15"
+        assert result.minimal_generators == ("3", "5")
+        assert set(result.factorizations) == {(5, 0), (0, 3)}
+
+    def test_factorizations_12_in_3_5(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="12")
+        result = compute_factorizations(req)
+        assert set(result.factorizations) == {(4, 0)}
+
+    def test_factorizations_zero(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="0")
+        result = compute_factorizations(req)
+        assert result.factorizations == ((0, 0),)
+
+    def test_factorizations_non_member(self):
+        req = FactorizationComputeRequest(generators=("3", "5"), value="7")
+        result = compute_factorizations(req)
+        assert result.factorizations == ()
+
+    def test_factorizations_rejects_nonpositive_generators(self):
+        with pytest.raises(ValidationError, match="positive"):
+            FactorizationComputeRequest(generators=("0", "5"), value="10")
+
+    def test_factorizations_non_minimal_generators(self):
+        """Generators include a non-minimal element (e.g., 8 in <3,5>)."""
+        req = FactorizationComputeRequest(generators=("3", "5", "8"), value="15")
+        result = compute_factorizations(req)
+        assert result.minimal_generators == ("3", "5")
+        assert set(result.factorizations) == {(5, 0), (0, 3)}
+
+
+class TestFactorizationLengths:
+    def test_lengths_15_in_3_5(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="15"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (3, 5)
+
+    def test_lengths_single(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="12"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (4,)
+
+    def test_lengths_empty_non_member(self):
+        req = FactorizationLengthsComputeRequest(
+            generators=("3", "5"), value="7"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == ()
+
+    def test_lengths_consecutive_for_nugget(self):
+        """<4,6,9>: factorizations of 36 have lengths 4..9 (consecutive)."""
+        req = FactorizationLengthsComputeRequest(
+            generators=("4", "6", "9"), value="36"
+        )
+        result = compute_factorization_lengths(req)
+        assert result.lengths == (4, 5, 6, 7, 8, 9)
+
+
+class TestFactorizationDistance:
+    def test_distance_15_in_3_5(self):
+        req = FactorizationDistanceRequest(
+            generators=("3", "5"), value="15", first=(5, 0), second=(0, 3)
+        )
+        result = compute_factorization_distance(req)
+        assert result.distance == 5
+        assert result.first_length == 5
+        assert result.second_length == 3
+
+    def test_distance_identical_factorization(self):
+        req = FactorizationDistanceRequest(
+            generators=("3", "5"), value="15", first=(5, 0), second=(5, 0)
+        )
+        result = compute_factorization_distance(req)
+        assert result.distance == 0
+
+    def test_distance_rejects_mismatched_lengths(self):
+        with pytest.raises(ValidationError, match="equal coordinate length"):
+            FactorizationDistanceRequest(
+                generators=("3", "5"), value="15", first=(5, 0, 0), second=(0, 3)
+            )
+
+    def test_distance_rejects_negative_coordinates(self):
+        with pytest.raises(ValidationError, match="non-negative"):
+            FactorizationDistanceRequest(
+                generators=("3", "5"), value="15", first=(-1, 0), second=(0, 3)
+            )
+
+
+class TestFactorizationGraph:
+    def test_graph_15_in_3_5_disconnected(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("3", "5"), value="15"
+        )
+        result = compute_factorization_graph(req)
+        assert not result.is_connected
+        assert len(result.connected_components) == 2
+        assert len(result.factorizations) == 2
+
+    def test_graph_12_in_3_5_connected(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("3", "5"), value="12"
+        )
+        result = compute_factorization_graph(req)
+        assert result.is_connected
+        assert len(result.connected_components) == 1
+
+    def test_graph_edges(self):
+        req = FactorizationGraphComputeRequest(
+            generators=("4", "6", "9"), value="12"
+        )
+        result = compute_factorization_graph(req)
+        # 12 = 3*4 + 0*6 + 0*9 = (3,0,0)
+        # 12 = 0*4 + 2*6 + 0*9 = (0,2,0)
+        # gcd = (0,0,0) so not connected
+        assert not result.is_connected
+
+
+class TestElementDeltaSet:
+    def test_delta_set_15_in_3_5(self):
+        req = ElementDeltaSetRequest(generators=("3", "5"), value="15")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == (2,)
+
+    def test_delta_set_36_in_4_6_9(self):
+        """Lengths of 36 in <4,6,9> are {4,5,6,7,8,9} -> delta = {1,1,1,1,1}."""
+        req = ElementDeltaSetRequest(generators=("4", "6", "9"), value="36")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == (1, 1, 1, 1, 1)
+
+    def test_delta_set_single_factorization(self):
+        req = ElementDeltaSetRequest(generators=("3", "5"), value="12")
+        result = compute_element_delta_set(req)
+        assert result.delta_set == ()
+
+
+class TestElementElasticity:
+    def test_elasticity_15_in_3_5(self):
+        req = ElementElasticityRequest(generators=("3", "5"), value="15")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "5/3"
+
+    def test_elasticity_single_factorization(self):
+        req = ElementElasticityRequest(generators=("3", "5"), value="12")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "1"
+
+    def test_elasticity_36_in_4_6_9(self):
+        req = ElementElasticityRequest(generators=("4", "6", "9"), value="36")
+        result = compute_element_elasticity(req)
+        assert result.elasticity == "9/4"
+
+
+class TestElementCatenaryDegree:
+    def test_catenary_15_in_3_5(self):
+        req = ElementCatenaryDegreeRequest(generators=("3", "5"), value="15")
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 5
+
+    def test_catenary_connected_graph(self):
+        """If the factorization graph is connected, catenary degree is 0."""
+        req = ElementCatenaryDegreeRequest(generators=("3", "5"), value="12")
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 0
+
+    def test_catenary_single_factorization(self):
+        req = ElementCatenaryDegreeRequest(
+            generators=("3", "5"), value="3"
+        )
+        result = compute_element_catenary_degree(req)
+        assert result.catenary_degree == 0
+
+
+class TestBettiElements:
+    def test_betti_3_5(self):
+        req = BettiElementsRequest(generators=("3", "5"))
+        result = compute_betti_elements(req)
+        assert result.betti_elements == ("15",)
+
+    def test_betti_4_6_9(self):
+        req = BettiElementsRequest(generators=("4", "6", "9"))
+        result = compute_betti_elements(req)
+        assert result.betti_elements == ("12", "18")
+
+    def test_betti_2_3(self):
+        req = BettiElementsRequest(generators=("2", "3"))
+        result = compute_betti_elements(req)
+        # <2,3>: Betti element should include 6=lcm(2,3)
+        assert "6" in result.betti_elements
+
+
+class TestMinimalPresentation:
+    def test_presentation_3_5(self):
+        req = MinimalPresentationRequest(generators=("3", "5"))
+        result = compute_minimal_presentation(req)
+        assert result.betti_elements == ("15",)
+        assert len(result.relations) == 1
+        assert result.relations[0].first == (5, 0)
+        assert result.relations[0].second == (0, 3)
+
+    def test_presentation_4_6_9(self):
+        req = MinimalPresentationRequest(generators=("4", "6", "9"))
+        result = compute_minimal_presentation(req)
+        assert result.betti_elements == ("12", "18")
+        assert len(result.relations) >= 2
+
+
+class TestPresentationBinomials:
+    def test_binomials_3_5(self):
+        req = PresentationBinomialsRequest(
+            generators=("3", "5"),
+            relations=[{"first": [5, 0], "second": [0, 3]}],
+        )
+        result = compute_presentation_binomials(req)
+        assert len(result.binomials) == 1
+        b = result.binomials[0]
+        assert b.left_coefficient == "5"
+        assert b.left_exponents == (5, 0)
+        assert b.right_coefficient == "3"
+        assert b.right_exponents == (0, 3)
+
+    def test_binomials_4_6_9(self):
+        req = PresentationBinomialsRequest(
+            generators=("4", "6", "9"),
+            relations=[
+                {"first": [3, 0, 0], "second": [0, 2, 0]},
+                {"first": [0, 3, 0], "second": [0, 0, 2]},
+            ],
+        )
+        result = compute_presentation_binomials(req)
+        assert len(result.binomials) == 2
+
+    def test_binomials_rejects_empty_relations(self):
+        with pytest.raises(ValidationError):
+            PresentationBinomialsRequest(
+                generators=("3", "5"),
+                relations=[],
+            )
+
+
+class TestGlobalDeltaSet:
+    def test_delta_set_3_5(self):
+        req = DeltaSetRequest(generators=("3", "5"))
+        result = compute_delta_set(req)
+        assert result.delta_set == (2,)
+
+    def test_delta_set_4_6_9(self):
+        req = DeltaSetRequest(generators=("4", "6", "9"))
+        result = compute_delta_set(req)
+        assert result.delta_set == (1,)
+
+
+class TestGlobalElasticity:
+    def test_elasticity_3_5(self):
+        req = ElasticityRequest(generators=("3", "5"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "5/3"
+
+    def test_elasticity_4_6_9(self):
+        req = ElasticityRequest(generators=("4", "6", "9"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "9/4"
+
+    def test_elasticity_2_3(self):
+        req = ElasticityRequest(generators=("2", "3"))
+        result = compute_elasticity(req)
+        assert result.elasticity == "3/2"
+
+
+class TestGlobalCatenaryDegree:
+    def test_catenary_3_5(self):
+        req = CatenaryDegreeRequest(generators=("3", "5"))
+        result = compute_catenary_degree(req)
+        assert result.catenary_degree == 5
+
+    def test_catenary_4_6_9(self):
+        req = CatenaryDegreeRequest(generators=("4", "6", "9"))
+        result = compute_catenary_degree(req)
+        assert result.catenary_degree == 3


### PR DESCRIPTION
## Summary

Implements issue #1906: extended numerical semigroup factorization invariants including factorizations, Betti elements, presentations, delta sets, elasticity, and catenary degrees.

Closes #1906.

## Design

All factorization graph operations use **NetworkX** for connected components and shortest paths (catenary degree via MST). Factorization enumeration uses bounded dynamic programming. Coordinates use the minimal generator axis (atoms).

### 13 atomic operations

| Operation ID | Description |
|---|---|
| `number_theory.numerical_semigroup.factorizations.compute` | Complete factorization family Z(s) |
| `number_theory.numerical_semigroup.factorization_lengths.compute` | Complete sorted length set |
| `number_theory.numerical_semigroup.factorization_distance.compute` | Distance between two factorizations |
| `number_theory.numerical_semigroup.factorization_graph.compute` | Factorization graph with connected components |
| `number_theory.numerical_semigroup.element.delta_set.compute` | Delta set of one element |
| `number_theory.numerical_semigroup.element.elasticity.compute` | Elasticity of one element |
| `number_theory.numerical_semigroup.element.catenary_degree.compute` | Catenary degree of one element |
| `number_theory.numerical_semigroup.betti_elements.compute` | Betti elements of the semigroup |
| `number_theory.numerical_semigroup.minimal_presentation.compute` | One minimal presentation |
| `number_theory.numerical_semigroup.presentation_binomials.compute` | Convert presentation to sparse binomials |
| `number_theory.numerical_semigroup.delta_set.compute` | Global delta set |
| `number_theory.numerical_semigroup.elasticity.compute` | Global elasticity |
| `number_theory.numerical_semigroup.catenary_degree.compute` | Global catenary degree |

### Library choices

- **NetworkX**: factorization graph construction, connected components, shortest paths for catenary degree
- **Standard library**: bounded dynamic programming for factorization enumeration, coordinatewise gcd/min for distances

### Tests

41 unit tests covering known-answer, boundary, and validation cases.

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/00eb776c-d897-4adb-bf28-61ce15c3d4e8)