### PR TITLE
Add finite-state transducer operations (#1909)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -82,6 +82,10 @@ from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
 from jacobian.math.topology._tools import TOOLS as TOPOLOGY_TOOLS
 
+from jacobian.math.finite_state_transducers._tools import (
+    TOOLS as FINITE_STATE_TRANSDUCER_TOOLS,
+)
+
 BUILTIN_TOOLS: MathTools = (
     *BOOLEAN_TOOLS,
     *GROUP_TOOLS,
@@ -145,6 +149,7 @@ BUILTIN_TOOLS: MathTools = (
     *ALGEBRAIC_COMBINATORICS_TOOLS,
     *REAL_ALGEBRA_TOOLS,
     *FINITE_METRIC_SPACES_TOOLS,
+    *FINITE_STATE_TRANSDUCER_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/math/finite_state_transducers/__init__.py
+++ b/src/jacobian/math/finite_state_transducers/__init__.py
@@ -1,0 +1,3 @@
+"""Finite-state transducer operation ownership."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/finite_state_transducers/_models.py
+++ b/src/jacobian/math/finite_state_transducers/_models.py
@@ -1,0 +1,165 @@
+"""Typed wire contracts for finite-state transducer operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.finite_state_transducers.values import (
+    MAX_FST_ALPHABET,
+    MAX_FST_STATES,
+    MAX_FST_WORD_LENGTH,
+    RationalTransducer,
+    SubsequentialTransducer,
+)
+
+# ---------------------------------------------------------------------------
+# Subsequential run
+# ---------------------------------------------------------------------------
+
+
+class SubseqRunRequest(StrictModel):
+    """Run a subsequential transducer on an input word."""
+
+    transducer: SubsequentialTransducer
+    word: tuple[int, ...] = Field(max_length=MAX_FST_WORD_LENGTH)
+
+    @model_validator(mode="after")
+    def require_valid_word(self) -> Self:
+        for symbol in self.word:
+            if not 0 <= symbol < self.transducer.input_alphabet_size:
+                raise ValueError("word symbols must be in 0..input_alphabet_size-1")
+        return self
+
+
+class SubseqRunResult(StrictModel):
+    """Result of a subsequential run.
+
+    ``status`` is ``OUTPUT`` when the function is defined on the word;
+    ``UNDEFINED_TRANSITION`` when a transition is missing;
+    ``NONFINAL_DOMAIN_STATE`` when the final state lacks a final output.
+    """
+
+    status: Literal["OUTPUT", "UNDEFINED_TRANSITION", "NONFINAL_DOMAIN_STATE"]
+    output: tuple[int, ...] = Field(default=())
+    final_state: int = Field(ge=0, le=MAX_FST_STATES - 1)
+    undefined_position: int | None = None
+    partial_output: tuple[int, ...] = Field(default=())
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+class IdentityRequest(StrictModel):
+    """Construct the identity subsequential transducer on one alphabet."""
+
+    alphabet_size: int = Field(ge=1, le=MAX_FST_ALPHABET)
+
+
+class IdentityResult(StrictModel):
+    """The identity transducer."""
+
+    transducer: SubsequentialTransducer
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+class ComposeRequest(StrictModel):
+    """Compose T: A* -> B* followed by U: B* -> C*."""
+
+    first: SubsequentialTransducer
+    second: SubsequentialTransducer
+
+    @model_validator(mode="after")
+    def require_compatible_alphabets(self) -> Self:
+        if self.first.output_alphabet_size != self.second.input_alphabet_size:
+            raise ValueError(
+                "first output alphabet must match second input alphabet"
+            )
+        return self
+
+
+class ComposeResult(StrictModel):
+    """The composite subsequential transducer."""
+
+    transducer: SubsequentialTransducer
+
+
+# ---------------------------------------------------------------------------
+# Trim
+# ---------------------------------------------------------------------------
+
+
+class TrimRequest(StrictModel):
+    """Trim a subsequential transducer to reachable + coaccessible states."""
+
+    transducer: SubsequentialTransducer
+
+
+class TrimResult(StrictModel):
+    """The trimmed transducer and state mapping."""
+
+    transducer: SubsequentialTransducer
+    state_map: dict[int, int] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Rational relation inverse
+# ---------------------------------------------------------------------------
+
+
+class RelationInverseRequest(StrictModel):
+    """Invert a rational transducer."""
+
+    transducer: RationalTransducer
+
+
+class RelationInverseResult(StrictModel):
+    """The inverted transducer."""
+
+    transducer: RationalTransducer
+
+
+# ---------------------------------------------------------------------------
+# Rational relation path replay
+# ---------------------------------------------------------------------------
+
+
+class RelationPathReplayRequest(StrictModel):
+    """Replay a candidate edge path and check it is an valid accepting path."""
+
+    transducer: RationalTransducer
+    edge_path: tuple[int, ...] = Field(max_length=MAX_FST_WORD_LENGTH)
+
+
+class RelationPathReplayResult(StrictModel):
+    """Result of replaying one edge path."""
+
+    status: Literal["ACCEPTING_PAIR", "INVALID_PATH"]
+    input_word: tuple[int, ...] = Field(default=())
+    output_word: tuple[int, ...] = Field(default=())
+    state_trace: tuple[int, ...] = Field(default=())
+    error: str | None = None
+
+
+__all__ = [
+    "ComposeRequest",
+    "ComposeResult",
+    "IdentityRequest",
+    "IdentityResult",
+    "RelationInverseRequest",
+    "RelationInverseResult",
+    "RelationPathReplayRequest",
+    "RelationPathReplayResult",
+    "SubseqRunRequest",
+    "SubseqRunResult",
+    "TrimRequest",
+    "TrimResult",
+]

--- a/src/jacobian/math/finite_state_transducers/_operations.py
+++ b/src/jacobian/math/finite_state_transducers/_operations.py
@@ -1,0 +1,108 @@
+"""Domain adapter for finite-state transducer operations."""
+
+from __future__ import annotations
+
+from jacobian.math.finite_state_transducers._models import (
+    ComposeRequest,
+    ComposeResult,
+    IdentityRequest,
+    IdentityResult,
+    RelationInverseRequest,
+    RelationInverseResult,
+    RelationPathReplayRequest,
+    RelationPathReplayResult,
+    SubseqRunRequest,
+    SubseqRunResult,
+    TrimRequest,
+    TrimResult,
+)
+from jacobian.math.finite_state_transducers.operations import (
+    compose_subsequential,
+    identity_transducer,
+    invert_rational,
+    replay_rational_path,
+    run_subsequential,
+    trim_subsequential,
+)
+
+__all__ = [
+    "compute_compose",
+    "compute_identity",
+    "compute_relation_inverse",
+    "compute_relation_path_replay",
+    "compute_run",
+    "compute_trim",
+]
+
+
+def compute_run(request: SubseqRunRequest) -> SubseqRunResult:
+    status, output, final_state, undef_pos, partial = run_subsequential(
+        request.transducer, request.word
+    )
+    if status == "OUTPUT":
+        return SubseqRunResult(
+            status="OUTPUT",
+            output=output,
+            final_state=final_state,
+            undefined_position=None,
+            partial_output=(),
+        )
+    if status == "UNDEFINED_TRANSITION":
+        return SubseqRunResult(
+            status="UNDEFINED_TRANSITION",
+            output=(),
+            final_state=final_state,
+            undefined_position=undef_pos,
+            partial_output=partial,
+        )
+    return SubseqRunResult(
+        status="NONFINAL_DOMAIN_STATE",
+        output=(),
+        final_state=final_state,
+        undefined_position=None,
+        partial_output=partial,
+    )
+
+
+def compute_identity(request: IdentityRequest) -> IdentityResult:
+    return IdentityResult(transducer=identity_transducer(request.alphabet_size))
+
+
+def compute_compose(request: ComposeRequest) -> ComposeResult:
+    return ComposeResult(
+        transducer=compose_subsequential(request.first, request.second)
+    )
+
+
+def compute_trim(request: TrimRequest) -> TrimResult:
+    transducer, state_map = trim_subsequential(request.transducer)
+    return TrimResult(transducer=transducer, state_map=state_map)
+
+
+def compute_relation_inverse(
+    request: RelationInverseRequest,
+) -> RelationInverseResult:
+    return RelationInverseResult(transducer=invert_rational(request.transducer))
+
+
+def compute_relation_path_replay(
+    request: RelationPathReplayRequest,
+) -> RelationPathReplayResult:
+    status, input_word, output_word, state_trace, error = replay_rational_path(
+        request.transducer, request.edge_path
+    )
+    if status == "ACCEPTING_PAIR":
+        return RelationPathReplayResult(
+            status="ACCEPTING_PAIR",
+            input_word=input_word,
+            output_word=output_word,
+            state_trace=state_trace,
+            error=None,
+        )
+    return RelationPathReplayResult(
+        status="INVALID_PATH",
+        input_word=input_word,
+        output_word=output_word,
+        state_trace=state_trace,
+        error=error,
+    )

--- a/src/jacobian/math/finite_state_transducers/_tools.py
+++ b/src/jacobian/math/finite_state_transducers/_tools.py
@@ -1,0 +1,266 @@
+"""Finite-state transducer operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.finite_state_transducers._models import (
+    ComposeRequest,
+    ComposeResult,
+    IdentityRequest,
+    IdentityResult,
+    RelationInverseRequest,
+    RelationInverseResult,
+    RelationPathReplayRequest,
+    RelationPathReplayResult,
+    SubseqRunRequest,
+    SubseqRunResult,
+    TrimRequest,
+    TrimResult,
+)
+from jacobian.math.finite_state_transducers._operations import (
+    compute_compose,
+    compute_identity,
+    compute_relation_inverse,
+    compute_relation_path_replay,
+    compute_run,
+    compute_trim,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_TRANS1 = {
+    "source": 0,
+    "input_symbol": 0,
+    "target": 0,
+    "output": [1],
+}
+_TRANS2 = {
+    "source": 0,
+    "input_symbol": 1,
+    "target": 1,
+    "output": [0],
+}
+_TRANS3 = {
+    "source": 1,
+    "input_symbol": 0,
+    "target": 0,
+    "output": [0],
+}
+_TRANS4 = {
+    "source": 1,
+    "input_symbol": 1,
+    "target": 1,
+    "output": [1],
+}
+
+_RUN_EXAMPLE = {
+    "transducer": {
+        "input_alphabet_size": 2,
+        "output_alphabet_size": 2,
+        "state_count": 2,
+        "initial_state": 0,
+        "transitions": [_TRANS1, _TRANS2, _TRANS3, _TRANS4],
+        "final_outputs": [{"state": 0, "output": []}, {"state": 1, "output": []}],
+    },
+    "word": [0, 1, 0],
+}
+
+_IDENTITY_EXAMPLE = {"alphabet_size": 2}
+
+_TRIM_EXAMPLE = {"transducer": _RUN_EXAMPLE["transducer"]}
+
+_INVERT_EXAMPLE = {
+    "transducer": {
+        "input_alphabet_size": 2,
+        "output_alphabet_size": 2,
+        "state_count": 1,
+        "initial_states": [0],
+        "accepting_states": [0],
+        "edges": [
+            {"source": 0, "target": 0, "input_label": [0], "output_label": [1]},
+            {"source": 0, "target": 0, "input_label": [1], "output_label": [0]},
+        ],
+    },
+}
+
+_REPLAY_EXAMPLE = _INVERT_EXAMPLE.copy()
+
+
+FINITE_STATE_TRANSDUCER_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "transducer.subsequential.run.compute",
+        "Run a subsequential transducer on a word",
+        "Execute a deterministic subsequential transducer and return the exact "
+        "output, distinguishing undefined transitions, nonfinal domain states, "
+        "and successful output.",
+        SubseqRunRequest,
+        SubseqRunResult,
+        compute_run,
+        "transducer",
+        "subsequential",
+        "exact",
+        examples=(
+            example(
+                "binary_id_run",
+                "Run a 2-symbol identity-like transducer on word [0,1,0].",
+                _RUN_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "transducer.subsequential.identity.compute",
+        "Construct the identity subsequential transducer",
+        "Return the one-state subsequential transducer that outputs each "
+        "consumed input symbol unchanged with an empty final output.",
+        IdentityRequest,
+        IdentityResult,
+        compute_identity,
+        "transducer",
+        "subsequential",
+        "identity",
+        "exact",
+        examples=(
+            example(
+                "binary_identity",
+                "Identity transducer on a 2-symbol alphabet.",
+                _IDENTITY_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "transducer.subsequential.compose.compute",
+        "Compose two subsequential transducers",
+        "Return the subsequential transducer computing U∘T where T:A*->B* and "
+        "U:B*->C*. The composition simulates U over each T transition output.",
+        ComposeRequest,
+        ComposeResult,
+        compute_compose,
+        "transducer",
+        "subsequential",
+        "composition",
+        "exact",
+        examples=(
+            example(
+                "compose_identity_flip",
+                "Compose identity with bit-flip transducer.",
+                {
+                    "first": {
+                        "input_alphabet_size": 2,
+                        "output_alphabet_size": 2,
+                        "state_count": 1,
+                        "initial_state": 0,
+                        "transitions": [
+                            {"source": 0, "input_symbol": 0, "target": 0, "output": [0]},
+                            {"source": 0, "input_symbol": 1, "target": 0, "output": [1]},
+                        ],
+                        "final_outputs": [{"state": 0, "output": []}],
+                    },
+                    "second": {
+                        "input_alphabet_size": 2,
+                        "output_alphabet_size": 2,
+                        "state_count": 1,
+                        "initial_state": 0,
+                        "transitions": [
+                            {"source": 0, "input_symbol": 0, "target": 0, "output": [1]},
+                            {"source": 0, "input_symbol": 1, "target": 0, "output": [0]},
+                        ],
+                        "final_outputs": [{"state": 0, "output": []}],
+                    },
+                },
+            ),
+        ),
+    ),
+    _op(
+        "transducer.subsequential.trim.compute",
+        "Trim a subsequential transducer to reachable and coaccessible states",
+        "Restrict a subsequential transducer to states that are both reachable "
+        "from the initial state and can reach a final-output state.",
+        TrimRequest,
+        TrimResult,
+        compute_trim,
+        "transducer",
+        "subsequential",
+        "trim",
+        "exact",
+        examples=(
+            example(
+                "trim_dead_states",
+                "Trim a transducer with dead states.",
+                _TRIM_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "transducer.relation.inverse.compute",
+        "Invert a rational transducer",
+        "Swap input and output alphabets and every edge label pair of a "
+        "rational transducer, producing the inverse relation R^{-1}.",
+        RelationInverseRequest,
+        RelationInverseResult,
+        compute_relation_inverse,
+        "transducer",
+        "rational",
+        "inverse",
+        "exact",
+        examples=(
+            example(
+                "bit_flip_inverse",
+                "Invert a bit-flip rational transducer.",
+                _INVERT_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "transducer.relation.path.replay.compute",
+        "Replay a candidate edge path of a rational transducer",
+        "Replay a given edge path through a rational transducer and return the "
+        "concatenated input/output words, state trace, and acceptance status.",
+        RelationPathReplayRequest,
+        RelationPathReplayResult,
+        compute_relation_path_replay,
+        "transducer",
+        "rational",
+        "path-replay",
+        "exact",
+        examples=(
+            example(
+                "replay_simple_path",
+                "Replay a simple edge path.",
+                {"transducer": _REPLAY_EXAMPLE["transducer"], "edge_path": [0, 0]},
+            ),
+        ),
+    ),
+)
+
+TOOLS = FINITE_STATE_TRANSDUCER_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/finite_state_transducers/operations.py
+++ b/src/jacobian/math/finite_state_transducers/operations.py
@@ -1,0 +1,390 @@
+"""Domain-owned finite-state transducer kernels."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from jacobian.math.finite_state_transducers.values import (
+    RationalEdge,
+    RationalTransducer,
+    SubseqFinalOutput,
+    SubseqTransition,
+    SubsequentialTransducer,
+)
+
+__all__ = [
+    "coaccessible_states",
+    "compose_subsequential",
+    "identity_transducer",
+    "invert_rational",
+    "reachable_states",
+    "replay_rational_path",
+    "run_subsequential",
+    "trim_subsequential",
+]
+
+
+def _transition_map(
+    transducer: SubsequentialTransducer,
+) -> dict[tuple[int, int], tuple[int, tuple[int, ...]]]:
+    return {
+        (tr.source, tr.input_symbol): (tr.target, tr.output)
+        for tr in transducer.transitions
+    }
+
+
+def _final_output_map(
+    transducer: SubsequentialTransducer,
+) -> dict[int, tuple[int, ...]]:
+    return {fo.state: fo.output for fo in transducer.final_outputs}
+
+
+def run_subsequential(
+    transducer: SubsequentialTransducer,
+    word: tuple[int, ...],
+) -> tuple[str, tuple[int, ...], int, int | None, tuple[int, ...]]:
+    """Run a subsequential transducer on ``word``.
+
+    Returns ``(status, output, final_state, undefined_position, partial_output)``.
+
+    ``status`` is one of ``"OUTPUT"``, ``"UNDEFINED_TRANSITION"``, or
+    ``"NONFINAL_DOMAIN_STATE"``.
+    """
+    transitions = _transition_map(transducer)
+    finals = _final_output_map(transducer)
+    state = transducer.initial_state
+    accumulated: list[int] = []
+    for pos, symbol in enumerate(word):
+        key = (state, symbol)
+        if key not in transitions:
+            return (
+                "UNDEFINED_TRANSITION",
+                (),
+                state,
+                pos,
+                tuple(accumulated),
+            )
+        target, output = transitions[key]
+        accumulated.extend(output)
+        state = target
+    if state not in finals:
+        return (
+            "NONFINAL_DOMAIN_STATE",
+            (),
+            state,
+            None,
+            tuple(accumulated),
+        )
+    final_word = finals[state]
+    accumulated.extend(final_word)
+    return ("OUTPUT", tuple(accumulated), state, None, ())
+
+
+def identity_transducer(alphabet_size: int) -> SubsequentialTransducer:
+    """Return the identity subsequential transducer on one alphabet."""
+
+    transitions = tuple(
+        SubseqTransition(
+            source=0,
+            input_symbol=sym,
+            target=0,
+            output=(sym,),
+        )
+        for sym in range(alphabet_size)
+    )
+    return SubsequentialTransducer(
+        input_alphabet_size=alphabet_size,
+        output_alphabet_size=alphabet_size,
+        state_count=1,
+        initial_state=0,
+        transitions=transitions,
+        final_outputs=(SubseqFinalOutput(state=0, output=()),),
+    )
+
+
+def reachable_states(
+    transducer: SubsequentialTransducer,
+) -> set[int]:
+    """Return states reachable from the initial state by defined transitions."""
+
+    visited: set[int] = set()
+    queue: deque[int] = deque([transducer.initial_state])
+    visited.add(transducer.initial_state)
+    adj: dict[int, list[tuple[int, int]]] = {}
+    for tr in transducer.transitions:
+        adj.setdefault(tr.source, []).append((tr.input_symbol, tr.target))
+    while queue:
+        current = queue.popleft()
+        for _sym, target in adj.get(current, []):
+            if target not in visited:
+                visited.add(target)
+                queue.append(target)
+    return visited
+
+
+def coaccessible_states(
+    transducer: SubsequentialTransducer,
+) -> set[int]:
+    """Return states from which some final-output state is reachable."""
+
+    finals = {fo.state for fo in transducer.final_outputs}
+    reverse_adj: dict[int, list[int]] = {}
+    for tr in transducer.transitions:
+        reverse_adj.setdefault(tr.target, []).append(tr.source)
+    visited: set[int] = set()
+    queue: deque[int] = deque(finals)
+    visited.update(finals)
+    while queue:
+        current = queue.popleft()
+        for source in reverse_adj.get(current, []):
+            if source not in visited:
+                visited.add(source)
+                queue.append(source)
+    return visited
+
+
+def trim_subsequential(
+    transducer: SubsequentialTransducer,
+) -> tuple[SubsequentialTransducer, dict[int, int]]:
+    """Restrict a transducer to reachable and coaccessible states.
+
+    Returns the trimmed transducer and an old-state -> new-state map.
+    """
+    reachable = reachable_states(transducer)
+    coaccessible = coaccessible_states(transducer)
+    keep = reachable & coaccessible
+    if not keep:
+        return (
+            SubsequentialTransducer(
+                input_alphabet_size=transducer.input_alphabet_size,
+                output_alphabet_size=transducer.output_alphabet_size,
+                state_count=1,
+                initial_state=0,
+                transitions=(),
+                final_outputs=(),
+            ),
+            {},
+        )
+    old_to_new = {old: new for new, old in enumerate(sorted(keep))}
+    new_transitions = tuple(
+        SubseqTransition(
+            source=old_to_new[tr.source],
+            input_symbol=tr.input_symbol,
+            target=old_to_new[tr.target],
+            output=tr.output,
+        )
+        for tr in transducer.transitions
+        if tr.source in keep and tr.target in keep
+    )
+    new_finals = tuple(
+        SubseqFinalOutput(
+            state=old_to_new[fo.state],
+            output=fo.output,
+        )
+        for fo in transducer.final_outputs
+        if fo.state in keep
+    )
+    return (
+        SubsequentialTransducer(
+            input_alphabet_size=transducer.input_alphabet_size,
+            output_alphabet_size=transducer.output_alphabet_size,
+            state_count=len(keep),
+            initial_state=old_to_new[transducer.initial_state],
+            transitions=new_transitions,
+            final_outputs=new_finals,
+        ),
+        old_to_new,
+    )
+
+
+def _run_u_on_word(
+    u_map: dict[tuple[int, int], tuple[int, tuple[int, ...]]],
+    u_state: int,
+    word: tuple[int, ...],
+) -> tuple[int, list[int]] | None:
+    """Run U over a finite word starting from u_state.
+
+    Returns ``(final_u_state, output)`` or ``None`` if U is undefined.
+    """
+    u_current = u_state
+    all_output: list[int] = []
+    for out_sym in word:
+        u_key = (u_current, out_sym)
+        if u_key not in u_map:
+            return None
+        u_next, u_output = u_map[u_key]
+        all_output.extend(u_output)
+        u_current = u_next
+    return (u_current, all_output)
+
+
+def compose_subsequential(
+    first: SubsequentialTransducer,
+    second: SubsequentialTransducer,
+) -> SubsequentialTransducer:
+    """Compose two subsequential transducers, computing U o T.
+
+    The result computes ``second(first(word))`` whenever both are defined.
+    """
+    t_map = {
+        (tr.source, tr.input_symbol): (tr.target, tr.output)
+        for tr in first.transitions
+    }
+    t_finals = {fo.state: fo.output for fo in first.final_outputs}
+    u_map = {
+        (tr.source, tr.input_symbol): (tr.target, tr.output)
+        for tr in second.transitions
+    }
+    u_finals = {fo.state: fo.output for fo in second.final_outputs}
+
+    start_pair = (first.initial_state, second.initial_state)
+    state_pairs: dict[tuple[int, int], int] = {start_pair: 0}
+    queue: deque[tuple[int, int]] = deque([start_pair])
+    new_transitions: list[SubseqTransition] = []
+
+    while queue:
+        t_state, u_state = queue.popleft()
+        new_state = state_pairs[(t_state, u_state)]
+        for sym in range(first.input_alphabet_size):
+            key = (t_state, sym)
+            if key not in t_map:
+                continue
+            t_next, t_output = t_map[key]
+            result = _run_u_on_word(u_map, u_state, t_output)
+            if result is None:
+                continue
+            u_next_final, all_output = result
+            pair_next = (t_next, u_next_final)
+            if pair_next not in state_pairs:
+                state_pairs[pair_next] = len(state_pairs)
+                queue.append(pair_next)
+            new_state_next = state_pairs[pair_next]
+            new_transitions.append(
+                SubseqTransition(
+                    source=new_state,
+                    input_symbol=sym,
+                    target=new_state_next,
+                    output=tuple(all_output),
+                )
+            )
+
+    new_finals: list[SubseqFinalOutput] = []
+    for (t_state, u_state), new_state in state_pairs.items():
+        if t_state not in t_finals:
+            continue
+        t_final_word = t_finals[t_state]
+        result = _run_u_on_word(u_map, u_state, t_final_word)
+        if result is None:
+            continue
+        u_final_state, composite_output = result
+        if u_final_state in u_finals:
+            composite_output.extend(u_finals[u_final_state])
+        new_finals.append(
+            SubseqFinalOutput(state=new_state, output=tuple(composite_output))
+        )
+
+    return SubsequentialTransducer(
+        input_alphabet_size=first.input_alphabet_size,
+        output_alphabet_size=second.output_alphabet_size,
+        state_count=len(state_pairs),
+        initial_state=0,
+        transitions=tuple(new_transitions),
+        final_outputs=tuple(new_finals),
+    )
+
+
+def invert_rational(
+    transducer: RationalTransducer,
+) -> RationalTransducer:
+    """Invert a rational transducer by swapping input/output labels and alphabets."""
+
+    return RationalTransducer(
+        input_alphabet_size=transducer.output_alphabet_size,
+        output_alphabet_size=transducer.input_alphabet_size,
+        state_count=transducer.state_count,
+        initial_states=transducer.initial_states,
+        accepting_states=transducer.accepting_states,
+        edges=tuple(
+            RationalEdge(
+                source=e.source,
+                target=e.target,
+                input_label=e.output_label,
+                output_label=e.input_label,
+            )
+            for e in transducer.edges
+        ),
+    )
+
+
+def replay_rational_path(  # noqa: C901
+    transducer: RationalTransducer,
+    edge_path: tuple[int, ...],
+) -> tuple[str, tuple[int, ...], tuple[int, ...], tuple[int, ...], str | None]:
+    """Replay an edge path and check it is a valid accepting path.
+
+    Returns ``(status, input_word, output_word, state_trace, error)``.
+    """
+    if not edge_path:
+        if not transducer.initial_states:
+            return ("INVALID_PATH", (), (), (), "no initial states")
+        return (
+            "ACCEPTING_PAIR" if transducer.initial_states[0] in set(
+                transducer.accepting_states
+            )
+            else "INVALID_PATH",
+            (),
+            (),
+            (transducer.initial_states[0],),
+            None if transducer.initial_states[0] in set(
+                transducer.accepting_states
+            )
+            else "start state not accepting",
+        )
+    edges = transducer.edges
+    state_trace: list[int] = []
+    input_word: list[int] = []
+    output_word: list[int] = []
+    for idx in edge_path:
+        if idx < 0 or idx >= len(edges):
+            return ("INVALID_PATH", (), (), (), f"edge index {idx} out of range")
+        if not state_trace:
+            if edges[edge_path[0]].source not in set(transducer.initial_states):
+                return (
+                    "INVALID_PATH",
+                    (),
+                    (),
+                    (),
+                    "first edge source is not an initial state",
+                )
+            state_trace.append(edges[edge_path[0]].source)
+    for i, idx in enumerate(edge_path):
+        edge = edges[idx]
+        if i > 0:
+            prev_target = edges[edge_path[i - 1]].target
+            if edge.source != prev_target:
+                return (
+                    "INVALID_PATH",
+                    (),
+                    (),
+                    (),
+                    f"edge {idx} source {edge.source} != prev target {prev_target}",
+                )
+        input_word.extend(edge.input_label)
+        output_word.extend(edge.output_label)
+        state_trace.append(edge.target)
+    last_state = state_trace[-1]
+    if last_state not in set(transducer.accepting_states):
+        return (
+            "INVALID_PATH",
+            tuple(input_word),
+            tuple(output_word),
+            tuple(state_trace),
+            "final state not accepting",
+        )
+    return (
+        "ACCEPTING_PAIR",
+        tuple(input_word),
+        tuple(output_word),
+        tuple(state_trace),
+        None,
+    )

--- a/src/jacobian/math/finite_state_transducers/values.py
+++ b/src/jacobian/math/finite_state_transducers/values.py
@@ -1,0 +1,194 @@
+"""Provider-independent values for exact finite-state transducers."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_FST_STATES = 64
+MAX_FST_ALPHABET = 32
+MAX_FST_WORD_LENGTH = 512
+MAX_FST_EDGES = 4096
+
+
+class SubseqTransition(StrictModel):
+    """One deterministic transition of a subsequential transducer.
+
+    Maps ``(source, input_symbol)`` to ``(target, output_word)`` where
+    ``output_word`` is a sequence of output-alphabet symbols.
+    """
+
+    source: int = Field(ge=0)
+    input_symbol: int = Field(ge=0)
+    target: int = Field(ge=0)
+    output: tuple[int, ...] = Field(default=())
+
+
+class SubseqFinalOutput(StrictModel):
+    """One final-output word associated with a state."""
+
+    state: int = Field(ge=0)
+    output: tuple[int, ...] = Field(default=())
+
+
+def _check_subseq_transitions(
+    transitions: tuple[SubseqTransition, ...],
+    state_count: int,
+    input_size: int,
+    output_size: int,
+) -> None:
+    seen_pairs: set[tuple[int, int]] = set()
+    for tr in transitions:
+        if not 0 <= tr.source < state_count:
+            raise ValueError("transition source out of range")
+        if not 0 <= tr.target < state_count:
+            raise ValueError("transition target out of range")
+        if not 0 <= tr.input_symbol < input_size:
+            raise ValueError("transition input_symbol out of range")
+        key = (tr.source, tr.input_symbol)
+        if key in seen_pairs:
+            raise ValueError("duplicate (source, input_symbol) transition")
+        seen_pairs.add(key)
+        if any(not 0 <= sym < output_size for sym in tr.output):
+            raise ValueError("transition output symbol out of range")
+        if len(tr.output) > MAX_FST_WORD_LENGTH:
+            raise ValueError("transition output word too long")
+
+
+def _check_subseq_finals(
+    final_outputs: tuple[SubseqFinalOutput, ...],
+    state_count: int,
+    output_size: int,
+) -> None:
+    seen_finals: set[int] = set()
+    for fo in final_outputs:
+        if not 0 <= fo.state < state_count:
+            raise ValueError("final output state out of range")
+        if fo.state in seen_finals:
+            raise ValueError("duplicate final output state")
+        seen_finals.add(fo.state)
+        if any(not 0 <= sym < output_size for sym in fo.output):
+            raise ValueError("final output symbol out of range")
+
+
+class SubsequentialTransducer(StrictModel):
+    """A deterministic subsequential transducer computing a partial function f: A* -> B*.
+
+    The transition map is partial (sparse omission means undefined, not
+    empty output). A word is in the domain exactly when every input transition
+    is defined along the path and the final state has a final output.
+    """
+
+    input_alphabet_size: int = Field(ge=1, le=MAX_FST_ALPHABET)
+    output_alphabet_size: int = Field(ge=1, le=MAX_FST_ALPHABET)
+    state_count: int = Field(ge=1, le=MAX_FST_STATES)
+    initial_state: int = Field(ge=0)
+    transitions: tuple[SubseqTransition, ...] = Field(
+        min_length=0, max_length=MAX_FST_EDGES
+    )
+    final_outputs: tuple[SubseqFinalOutput, ...] = Field(
+        min_length=0, max_length=MAX_FST_STATES
+    )
+
+    @model_validator(mode="after")
+    def require_valid_transducer(self) -> Self:
+        if not 0 <= self.initial_state < self.state_count:
+            raise ValueError("initial_state must be in 0..state_count-1")
+        _check_subseq_transitions(
+            self.transitions,
+            self.state_count,
+            self.input_alphabet_size,
+            self.output_alphabet_size,
+        )
+        _check_subseq_finals(
+            self.final_outputs,
+            self.state_count,
+            self.output_alphabet_size,
+        )
+        return self
+
+
+class RationalEdge(StrictModel):
+    """One edge of a nondeterministic rational transducer.
+
+    Carries finite input and output label words over separate alphabets.
+    ``(input, output)`` must not both be empty.
+    """
+
+    source: int = Field(ge=0)
+    target: int = Field(ge=0)
+    input_label: tuple[int, ...] = Field(default=())
+    output_label: tuple[int, ...] = Field(default=())
+
+
+def _check_rational_edges(
+    edges: tuple[RationalEdge, ...],
+    state_count: int,
+    input_size: int,
+    output_size: int,
+) -> None:
+    for edge in edges:
+        if not 0 <= edge.source < state_count:
+            raise ValueError("edge source out of range")
+        if not 0 <= edge.target < state_count:
+            raise ValueError("edge target out of range")
+        for sym in edge.input_label:
+            if not 0 <= sym < input_size:
+                raise ValueError("edge input label out of range")
+        for sym in edge.output_label:
+            if not 0 <= sym < output_size:
+                raise ValueError("edge output label out of range")
+        if not edge.input_label and not edge.output_label:
+            raise ValueError("edge with both labels empty is forbidden")
+        if (
+            len(edge.input_label) > MAX_FST_WORD_LENGTH
+            or len(edge.output_label) > MAX_FST_WORD_LENGTH
+        ):
+            raise ValueError("edge label too long")
+
+
+class RationalTransducer(StrictModel):
+    """A finite-state transducer defining a rational relation R subseteq A* x B*.
+
+    Edges are a multigraph (parallel edges preserved by identity). Each edge
+    has finite input and output label words; ``(u, v)`` both empty is forbidden.
+    """
+
+    input_alphabet_size: int = Field(ge=1, le=MAX_FST_ALPHABET)
+    output_alphabet_size: int = Field(ge=1, le=MAX_FST_ALPHABET)
+    state_count: int = Field(ge=1, le=MAX_FST_STATES)
+    initial_states: tuple[int, ...] = Field(min_length=1)
+    accepting_states: tuple[int, ...] = Field(min_length=0)
+    edges: tuple[RationalEdge, ...] = Field(
+        min_length=0, max_length=MAX_FST_EDGES
+    )
+
+    @model_validator(mode="after")
+    def require_valid_relation(self) -> Self:
+        if any(not 0 <= s < self.state_count for s in self.initial_states):
+            raise ValueError("initial state out of range")
+        if any(not 0 <= s < self.state_count for s in self.accepting_states):
+            raise ValueError("accepting state out of range")
+        _check_rational_edges(
+            self.edges,
+            self.state_count,
+            self.input_alphabet_size,
+            self.output_alphabet_size,
+        )
+        return self
+
+
+__all__ = [
+    "MAX_FST_ALPHABET",
+    "MAX_FST_EDGES",
+    "MAX_FST_STATES",
+    "MAX_FST_WORD_LENGTH",
+    "RationalEdge",
+    "RationalTransducer",
+    "SubseqFinalOutput",
+    "SubseqTransition",
+    "SubsequentialTransducer",
+]

--- a/src/jacobian/math/posets/_models.py
+++ b/src/jacobian/math/posets/_models.py
@@ -581,6 +581,137 @@ class MobiusFunctionResult(PosetExactResult):
         return self
 
 
+
+
+# ---------------------------------------------------------------------------
+# Issue #1746: Closures, duals, zeta transforms, antichain profiles
+# ---------------------------------------------------------------------------
+
+
+class PosetSubset(StrictModel):
+    """A subset of poset elements for closure operations."""
+
+    elements: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
+
+class PosetClosureRequest(StrictModel):
+    """Request lower/upper closure of a subset in a poset."""
+
+    poset: FinitePoset
+    subset: PosetSubset
+    closure_type: Literal["LOWER", "UPPER"] = "LOWER"
+
+    @model_validator(mode="after")
+    def require_subset_in_carrier(self) -> Self:
+        carrier = set(self.poset.elements)
+        for element in self.subset.elements:
+            if element not in carrier:
+                raise ValueError("subset elements must be poset elements")
+        return self
+
+
+class PosetClosureResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    closure_type: Literal["LOWER", "UPPER"]
+    closure: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+    generated_element: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
+
+class PosetDualRequest(StrictModel):
+    """Request the dual (opposite) of a poset."""
+
+    poset: FinitePoset
+
+
+class PosetDualResult(PosetExactResult):
+    poset: FinitePoset
+
+
+class ZetaTransformRequest(StrictModel):
+    """Compute the zeta transform of a function on the poset."""
+
+    poset: FinitePoset
+    function_values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+    @model_validator(mode="after")
+    def require_function_domain_covers(self) -> Self:
+        pairs = {v.lower + "|" + v.upper for v in self.function_values}
+        if len(pairs) != len(self.function_values):
+            raise ValueError("function values must have unique intervals")
+        carrier = set(self.poset.elements)
+        comparable = {(p.lower, p.upper) for p in self.poset.strict_order_pairs}
+        for v in self.function_values:
+            if v.lower not in carrier or v.upper not in carrier:
+                raise ValueError("function value endpoints must be poset elements")
+            if v.lower != v.upper and (v.lower, v.upper) not in comparable:
+                raise ValueError("function value must satisfy lower <= upper")
+        return self
+
+
+class ZetaTransformResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    transform: Literal["ZETA"] = "ZETA"
+    values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+
+class IncidenceConvolutionRequest(StrictModel):
+    """Incidence-algebra convolution of two functions on the poset."""
+
+    poset: FinitePoset
+    first: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+    second: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+    @model_validator(mode="after")
+    def require_unique_values(self) -> Self:
+        for label, values in (("first", self.first), ("second", self.second)):
+            pairs = {v.lower + "|" + v.upper for v in values}
+            if len(pairs) != len(values):
+                raise ValueError(f"{label} values must have unique intervals")
+            carrier = set(self.poset.elements)
+            comparable = {(p.lower, p.upper) for p in self.poset.strict_order_pairs}
+            for v in values:
+                if v.lower not in carrier or v.upper not in carrier:
+                    raise ValueError(f"{label} value endpoints must be poset elements")
+                if v.lower != v.upper and (v.lower, v.upper) not in comparable:
+                    raise ValueError(f"{label} value must satisfy lower <= upper")
+        return self
+
+
+class IncidenceConvolutionResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+
+class AntichainProfileRequest(StrictModel):
+    """Request the antichain profile (maximal antichains)."""
+
+    poset: FinitePoset
+
+
+class AntichainProfileResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    maximum_antichain_size: StrictInt = Field(ge=0, le=MAX_POSET_ELEMENTS)
+    antichain_count: StrictInt = Field(ge=1)
+    maximum_antichains: tuple[tuple[ElementLabel, ...], ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
 __all__ = [
     "MAX_LINEAR_EXTENSION_ELEMENTS",
     "MAX_POSET_ELEMENTS",
@@ -609,4 +740,15 @@ __all__ = [
     "RelationInterpretation",
     "canonical_poset_ranks",
     "finite_poset_digest",
+    "AntichainProfileResult",
+    "AntichainProfileRequest",
+    "IncidenceConvolutionResult",
+    "IncidenceConvolutionRequest",
+    "PosetClosureResult",
+    "PosetClosureRequest",
+    "PosetDualResult",
+    "PosetDualRequest",
+    "PosetSubset",
+    "ZetaTransformResult",
+    "ZetaTransformRequest",
 ]

--- a/src/jacobian/math/posets/_operations.py
+++ b/src/jacobian/math/posets/_operations.py
@@ -26,6 +26,16 @@ from jacobian.math.posets._models import (
     PosetRequest,
     PosetWidthResult,
     RelationInterpretation,
+    AntichainProfileRequest,
+    AntichainProfileResult,
+    IncidenceConvolutionRequest,
+    IncidenceConvolutionResult,
+    PosetClosureRequest,
+    PosetClosureResult,
+    PosetDualRequest,
+    PosetDualResult,
+    ZetaTransformRequest,
+    ZetaTransformResult,
     canonical_poset_ranks,
     finite_poset_digest,
 )
@@ -330,6 +340,166 @@ _MATERIALIZED_DIAMOND: dict[str, Any] = {
     "poset_digest": "sha256:bb8df218b7f750edddcb9259c6aff4ca7128e1d1e73bd092306c350583ab8e96",
 }
 
+
+def _closure(request: PosetClosureRequest) -> PosetClosureResult:
+    poset = request.poset
+    elements = set(poset.elements)
+    order_pairs = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    order_set = order_pairs | {(e, e) for e in elements}
+    if request.closure_type == "LOWER":
+        result = set()
+        for target in request.subset.elements:
+            for (lo, hi) in order_set:
+                if hi == target:
+                    result.add(lo)
+        result |= set(request.subset.elements)
+    else:
+        result = set()
+        for target in request.subset.elements:
+            for (lo, hi) in order_set:
+                if lo == target:
+                    result.add(hi)
+        result |= set(request.subset.elements)
+    return PosetClosureResult(
+        poset_digest=poset.poset_digest,
+        closure_type=request.closure_type,
+        closure=tuple(sorted(result)),
+        generated_element=tuple(sorted(result - set(request.subset.elements))),
+    )
+
+
+def _dual(request: PosetDualRequest) -> PosetDualResult:
+    poset = request.poset
+    elements = poset.elements
+    reversed_pairs = tuple(
+        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.strict_order_pairs
+    )
+    reversed_covers = tuple(
+        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.cover_relations
+    )
+    sorted_pairs = tuple(sorted((p.lower, p.upper) for p in reversed_pairs))
+    sorted_covers = tuple(sorted((p.lower, p.upper) for p in reversed_covers))
+    order_pairs_obj = tuple(
+        OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_pairs
+    )
+    cover_pairs_obj = tuple(
+        OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_covers
+    )
+    new_digest = finite_poset_digest(
+        elements=elements,
+        strict_order_pairs=order_pairs_obj,
+        cover_relations=cover_pairs_obj,
+        incomparable_pairs=poset.incomparable_pairs,
+        minimal_elements=tuple(sorted(poset.maximal_elements)),
+        maximal_elements=tuple(sorted(poset.minimal_elements)),
+        graded=poset.graded,
+        ranks=(
+            tuple(sorted(poset.ranks, key=lambda r: r.element))
+            if poset.ranks
+            else None
+        ),
+    )
+    new_poset = FinitePoset(
+        poset_format="jacobian.finite-poset/v1",
+        elements=elements,
+        strict_order_pairs=order_pairs_obj,
+        cover_relations=cover_pairs_obj,
+        incomparable_pairs=poset.incomparable_pairs,
+        minimal_elements=tuple(sorted(poset.maximal_elements)),
+        maximal_elements=tuple(sorted(poset.minimal_elements)),
+        graded=poset.graded,
+        ranks=(
+            tuple(sorted(poset.ranks, key=lambda r: r.element))
+            if poset.ranks
+            else None
+        ),
+        poset_digest=new_digest,
+    )
+    return PosetDualResult(poset=new_poset)
+
+
+def _zeta_transform(request: ZetaTransformRequest) -> ZetaTransformResult:
+    poset = request.poset
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    func_lookup = {(v.lower, v.upper): v.value for v in request.function_values}
+    all_intervals = []
+    for a in poset.elements:
+        for c in poset.elements:
+            if a == c or (a, c) in comparable:
+                all_intervals.append((a, c))
+    results = []
+    for (a, c) in all_intervals:
+        total = 0
+        for b in poset.elements:
+            if (b == a or (a, b) in comparable) and (b == c or (b, c) in comparable):
+                total += func_lookup.get((a, b), 0)
+        results.append(MobiusValue(lower=a, upper=c, value=total))
+    return ZetaTransformResult(
+        poset_digest=poset.poset_digest,
+        values=tuple(results),
+    )
+
+
+def _incidence_convolution(
+    request: IncidenceConvolutionRequest,
+) -> IncidenceConvolutionResult:
+    poset = request.poset
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    first_lookup = {(v.lower, v.upper): v.value for v in request.first}
+    second_lookup = {(v.lower, v.upper): v.value for v in request.second}
+    all_intervals = []
+    for a in poset.elements:
+        for c in poset.elements:
+            if a == c or (a, c) in comparable:
+                all_intervals.append((a, c))
+    results = []
+    for (a, c) in all_intervals:
+        total = 0
+        for b in poset.elements:
+            if (b == a or (a, b) in comparable) and (b == c or (b, c) in comparable):
+                total += first_lookup.get((a, b), 0) * second_lookup.get((b, c), 0)
+        results.append(MobiusValue(lower=a, upper=c, value=total))
+    return IncidenceConvolutionResult(
+        poset_digest=poset.poset_digest,
+        values=tuple(results),
+    )
+
+
+def _antichain_profile(
+    request: AntichainProfileRequest,
+) -> AntichainProfileResult:
+    poset = request.poset
+    elements = poset.elements
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+
+    def is_antichain(subset: tuple[str, ...]) -> bool:
+        for i, a in enumerate(subset):
+            for b in subset[i + 1:]:
+                if (a, b) in comparable or (b, a) in comparable:
+                    return False
+        return True
+
+    n = len(elements)
+    max_size = 0
+    max_antichains: list[tuple[str, ...]] = []
+    antichain_count = 1
+    for mask in range(1, 1 << n):
+        subset = tuple(sorted(elements[i] for i in range(n) if mask & (1 << i)))
+        if is_antichain(subset):
+            antichain_count += 1
+            if len(subset) > max_size:
+                max_size = len(subset)
+                max_antichains = [subset]
+            elif len(subset) == max_size:
+                max_antichains.append(subset)
+    return AntichainProfileResult(
+        poset_digest=poset.poset_digest,
+        maximum_antichain_size=max_size,
+        antichain_count=antichain_count,
+        maximum_antichains=tuple(max_antichains),
+    )
+
+
 FINITE_POSET_OPERATIONS: MathTools = (
     MathTool(
         operation_id="poset.finite.compute",
@@ -467,6 +637,167 @@ FINITE_POSET_OPERATIONS: MathTools = (
             ),
         ),
     ),
+
+    MathTool(
+        operation_id="poset.closure.compute",
+        version="1",
+        title="Compute ideal or filter closure of a subset",
+        description=(
+            "Return the lower (ideal) or upper (filter) closure of a given "
+            "subset in a finite poset."
+        ),
+        request_type=PosetClosureRequest,
+        result_type=PosetClosureResult,
+        run=_closure,
+        tags=(
+            "poset",
+            "ideal",
+            "filter",
+            "closure",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_lower_closure",
+                "Compute the lower closure of {1} in the diamond poset.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "subset": {"elements": ["1"]},
+                    "closure_type": "LOWER",
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.dual.compute",
+        version="1",
+        title="Compute the dual (opposite) of a finite poset",
+        description="Return the dual poset where all order relations are reversed.",
+        request_type=PosetDualRequest,
+        result_type=PosetDualResult,
+        run=_dual,
+        tags=(
+            "poset",
+            "dual",
+            "opposite",
+            "exact",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute the dual of the canonical diamond poset.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.zeta_transform.compute",
+        version="1",
+        title="Compute the zeta transform of a function on a poset",
+        description=(
+            "Apply the incidence-algebra zeta transform to a function "
+            "defined on intervals of a finite poset."
+        ),
+        request_type=ZetaTransformRequest,
+        result_type=ZetaTransformResult,
+        run=_zeta_transform,
+        tags=(
+            "poset",
+            "zeta-transform",
+            "incidence-algebra",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_zeta",
+                "Compute the zeta transform of a constant function on the diamond.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "function_values": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.incidence_convolution.compute",
+        version="1",
+        title="Convolve two incidence-algebra functions on a poset",
+        description=(
+            "Compute the incidence-algebra convolution of two functions "
+            "defined on intervals of a finite poset."
+        ),
+        request_type=IncidenceConvolutionRequest,
+        result_type=IncidenceConvolutionResult,
+        run=_incidence_convolution,
+        tags=(
+            "poset",
+            "incidence-algebra",
+            "convolution",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_convolution",
+                "Convolve the zeta function with itself on the diamond.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "first": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "0", "upper": "a", "value": 1},
+                        {"lower": "0", "upper": "b", "value": 1},
+                        {"lower": "0", "upper": "1", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "a", "upper": "1", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "b", "upper": "1", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                    "second": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "0", "upper": "a", "value": 1},
+                        {"lower": "0", "upper": "b", "value": 1},
+                        {"lower": "0", "upper": "1", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "a", "upper": "1", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "b", "upper": "1", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.antichain_profile.compute",
+        version="1",
+        title="Compute the antichain profile of a finite poset",
+        description=(
+            "Return the maximum antichain size, total antichain count, and "
+            "all maximum antichains of a finite poset."
+        ),
+        request_type=AntichainProfileRequest,
+        result_type=AntichainProfileResult,
+        run=_antichain_profile,
+        tags=(
+            "poset",
+            "antichain",
+            "profile",
+            "exact",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute the antichain profile of the canonical diamond.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
+        ),
+    ),
+
 )
 
 __all__ = ["FINITE_POSET_OPERATIONS"]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1153,9 +1153,25 @@
       "input_schema": "sha256:2b40338042028e9a6e477838b179c012662fcd374322c1b0451039f9fc4b7f6e",
       "output_schema": "sha256:ca8d93197a2ccaa55fce3e8eab6cb1de174742a4a9463606807c4877054865df"
     },
+    "poset.antichain_profile.compute": {
+      "input_schema": "sha256:f5f976c7fadcf196d9c99702758c469b9aa33d5ed9d92cd9fd39a4a6c46d8504",
+      "output_schema": "sha256:baa54525e476bbc4081ce06a64a0ca7285c765f6dd1275c7ef389aa7485a19d4"
+    },
+    "poset.closure.compute": {
+      "input_schema": "sha256:8c523de94c4518ce16efd219de63311b779e2cbb40e983f26f3e1da0816e98bf",
+      "output_schema": "sha256:716b58d26859656f7553292f757370e3367d8c747b9d74691d38f5df62ac01f1"
+    },
+    "poset.dual.compute": {
+      "input_schema": "sha256:279cb415a127e29fdb74087665e97d999f32dddf03654dad57c839656edb277b",
+      "output_schema": "sha256:d546dec3c632f9a42f1ec2d278d8897d40763358af57fc542e0d8e023659f2f2"
+    },
     "poset.finite.compute": {
       "input_schema": "sha256:73c1738f192a084128ea68cc954c524bed9c6b65898f7a47498b9d5e516b94b2",
       "output_schema": "sha256:d5021ca8f1a5bfc3ab3612f4e80db9c447089aa82f7845d8dda8594bc39753f1"
+    },
+    "poset.incidence_convolution.compute": {
+      "input_schema": "sha256:fc69337f0a5f3d21570924a1e94dc76023b5cf9b3ad33586f9bc9d2684746d62",
+      "output_schema": "sha256:339070992c99f3989c7c00e1443507e1f33c2528a7363ccedc629e1d9c7e58cb"
     },
     "poset.linear_extensions.count": {
       "input_schema": "sha256:e1db5dfa1a85945ba8d8da52ad863146f51d1146f20bc295e2a27419ff89d713",
@@ -1168,6 +1184,10 @@
     "poset.width.compute": {
       "input_schema": "sha256:ff2a448f4335d1fac63825191d2d16991a33f31bfa7f7175c49b69495984ff0d",
       "output_schema": "sha256:58722ae468c6000b997cf340f9b7cc29f5aa8b466cee2242227d40d75208f8e1"
+    },
+    "poset.zeta_transform.compute": {
+      "input_schema": "sha256:868970b3a99028c903476fe0b1606462906625eee5182c0eb065b318debe78b2",
+      "output_schema": "sha256:fb22b106f8b8ce3794fc1a49aa1dbafcb3c0d6afc09db58a7c82c8ba35cc2cbb"
     },
     "probability.bh_step_up.compute": {
       "input_schema": "sha256:b51f86a304afd50af235612492073289c041418e8d45c4f517acf774df308fa9",
@@ -1440,6 +1460,30 @@
     "topology.simplicial_homology.integral.compute": {
       "input_schema": "sha256:ae5513f34822ee0e5602f3a67701a3de98a4f3595422d2ae8d8d53e45b3cf60b",
       "output_schema": "sha256:0b9ca74c0cd26174705d7dff455d0513a03c8f9bd5d62148fefd675632b3f5dc"
+    },
+    "transducer.relation.inverse.compute": {
+      "input_schema": "sha256:42ae00ded91013be51b4129d7bd0e9837914b471fe4d72d10510a8ec14571e5b",
+      "output_schema": "sha256:9e74c8574ff44e287defe87e50536967d22cf63ac6ef9bfbb8301b7697ba5217"
+    },
+    "transducer.relation.path.replay.compute": {
+      "input_schema": "sha256:079a5a7ee2a9788ed5b04e0c1529f2a9e68564985c822df17452d2eb9756d1e0",
+      "output_schema": "sha256:251274b8846b1076a1e92cf5fb2d7054d99f1ce03353580ee0fa87acf06e1ba2"
+    },
+    "transducer.subsequential.compose.compute": {
+      "input_schema": "sha256:4293a90969b04204b0a8e295fc9cfd6d3e92b8bec4213b6f9c2704cd5d7cb97f",
+      "output_schema": "sha256:667e3c75dfb267c859289b6e316511b27c263cd9be768e8554c97a2863fe5239"
+    },
+    "transducer.subsequential.identity.compute": {
+      "input_schema": "sha256:249b996e14f308f17198f96159df32687f1254549ee9c90c8949d43003732040",
+      "output_schema": "sha256:841f8bd40ce59b31d49ec96b0270801df3d462dc1d515e06e366e7f137af5b6a"
+    },
+    "transducer.subsequential.run.compute": {
+      "input_schema": "sha256:72fa8158f5c0bd2c673923ce61b8daa801ad2afee0b746199b8808ca455ca533",
+      "output_schema": "sha256:ecfa06d3f59254d64e197a28d736fc7f85352ab59795f97e771fc8748b437001"
+    },
+    "transducer.subsequential.trim.compute": {
+      "input_schema": "sha256:c1f9f9e0c307187200ed8e9f614f36483ce30d502fc360c07f74b751177c7d83",
+      "output_schema": "sha256:2968ddf18e5c0ba7bf33c1929ae9b59445ca5ec9f1eea074ffe42ae6b3c2cba5"
     }
   }
 }

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 371
     assert actual == expected["operations"]
 
 

--- a/tests/math/finite_state_transducers/test_finite_state_transducers.py
+++ b/tests/math/finite_state_transducers/test_finite_state_transducers.py
@@ -1,0 +1,330 @@
+"""Tests for finite-state transducer operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.finite_state_transducers._models import (
+    ComposeRequest,
+    IdentityRequest,
+    RelationInverseRequest,
+    RelationPathReplayRequest,
+)
+from jacobian.math.finite_state_transducers._operations import (
+    compute_compose,
+    compute_identity,
+    compute_relation_inverse,
+    compute_relation_path_replay,
+)
+from jacobian.math.finite_state_transducers.operations import (
+    compose_subsequential,
+    identity_transducer,
+    run_subsequential,
+    trim_subsequential,
+)
+from jacobian.math.finite_state_transducers.values import (
+    RationalEdge,
+    RationalTransducer,
+    SubseqFinalOutput,
+    SubseqTransition,
+    SubsequentialTransducer,
+)
+
+
+def _bit_flip_transducer() -> SubsequentialTransducer:
+    return SubsequentialTransducer(
+        input_alphabet_size=2,
+        output_alphabet_size=2,
+        state_count=1,
+        initial_state=0,
+        transitions=(
+            SubseqTransition(source=0, input_symbol=0, target=0, output=(1,)),
+            SubseqTransition(source=0, input_symbol=1, target=0, output=(0,)),
+        ),
+        final_outputs=(SubseqFinalOutput(state=0, output=()),),
+    )
+
+
+def _partial_transducer() -> SubsequentialTransducer:
+    return SubsequentialTransducer(
+        input_alphabet_size=2,
+        output_alphabet_size=2,
+        state_count=2,
+        initial_state=0,
+        transitions=(
+            SubseqTransition(source=0, input_symbol=0, target=1, output=(0,)),
+            SubseqTransition(source=1, input_symbol=0, target=1, output=(0,)),
+            SubseqTransition(source=1, input_symbol=1, target=1, output=(1,)),
+        ),
+        final_outputs=(SubseqFinalOutput(state=1, output=()),),
+    )
+
+
+class TestSubseqRun:
+    def test_identity_run(self):
+        transducer = identity_transducer(2)
+        result = run_subsequential(transducer, (0, 1, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (0, 1, 0)
+        assert result[2] == 0
+
+    def test_bit_flip_run(self):
+        transducer = _bit_flip_transducer()
+        result = run_subsequential(transducer, (0, 1, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (1, 0, 1)
+
+    def test_undefined_transition(self):
+        transducer = _partial_transducer()
+        result = run_subsequential(transducer, (1,))
+        assert result[0] == "UNDEFINED_TRANSITION"
+        assert result[3] == 0
+        assert result[4] == ()
+
+    def test_nonfinal_domain_state(self):
+        transducer = SubsequentialTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=0, output=()),
+                SubseqTransition(source=0, input_symbol=1, target=0, output=()),
+            ),
+            final_outputs=(),
+        )
+        result = run_subsequential(transducer, (0,))
+        assert result[0] == "NONFINAL_DOMAIN_STATE"
+        assert result[2] == 0
+
+    def test_empty_output_distinct_from_undefined(self):
+        transducer = SubsequentialTransducer(
+            input_alphabet_size=1,
+            output_alphabet_size=1,
+            state_count=1,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=0, output=()),
+            ),
+            final_outputs=(SubseqFinalOutput(state=0, output=()),),
+        )
+        result = run_subsequential(transducer, (0, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == ()
+
+    def test_final_output_appended(self):
+        transducer = SubsequentialTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=0, output=(0,)),
+            ),
+            final_outputs=(SubseqFinalOutput(state=0, output=(1,)),),
+        )
+        result = run_subsequential(transducer, (0, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (0, 0, 1)
+
+
+class TestIdentity:
+    def test_identity_2(self):
+        transducer = identity_transducer(2)
+        assert transducer.state_count == 1
+        assert transducer.input_alphabet_size == 2
+        assert len(transducer.transitions) == 2
+        result = run_subsequential(transducer, (0, 1))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (0, 1)
+
+    def test_identity_via_request(self):
+        result = compute_identity(IdentityRequest(alphabet_size=3))
+        transducer = result.transducer
+        run_result = run_subsequential(transducer, (0, 1, 2))
+        assert run_result[0] == "OUTPUT"
+        assert run_result[1] == (0, 1, 2)
+
+
+class TestComposition:
+    def test_compose_identity_with_bit_flip(self):
+        identity = identity_transducer(2)
+        flip = _bit_flip_transducer()
+        composed = compose_subsequential(identity, flip)
+        result = run_subsequential(composed, (0, 1, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (1, 0, 1)
+
+    def test_compose_flip_with_flip_is_identity(self):
+        flip = _bit_flip_transducer()
+        composed = compose_subsequential(flip, flip)
+        result = run_subsequential(composed, (0, 1, 0))
+        assert result[0] == "OUTPUT"
+        assert result[1] == (0, 1, 0)
+
+    def test_compose_shrinks_domain(self):
+        t = SubsequentialTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=0, output=(0,)),
+                SubseqTransition(source=0, input_symbol=1, target=0, output=(1,)),
+            ),
+            final_outputs=(SubseqFinalOutput(state=0, output=()),),
+        )
+        u = SubsequentialTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=0, output=(0,)),
+            ),
+            final_outputs=(SubseqFinalOutput(state=0, output=()),),
+        )
+        composed = compose_subsequential(t, u)
+        result0 = run_subsequential(composed, (0,))
+        assert result0[0] == "OUTPUT"
+        assert result0[1] == (0,)
+        result1 = run_subsequential(composed, (1,))
+        assert result1[0] == "UNDEFINED_TRANSITION"
+
+    def test_compose_via_request(self):
+        identity = identity_transducer(2)
+        flip = _bit_flip_transducer()
+        result = compute_compose(ComposeRequest(first=identity, second=flip))
+        run = run_subsequential(result.transducer, (0, 1))
+        assert run[0] == "OUTPUT"
+        assert run[1] == (1, 0)
+
+
+class TestTrim:
+    def test_trim_removes_dead_states(self):
+        transducer = SubsequentialTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=3,
+            initial_state=0,
+            transitions=(
+                SubseqTransition(source=0, input_symbol=0, target=1, output=(0,)),
+                SubseqTransition(source=0, input_symbol=1, target=0, output=(1,)),
+                SubseqTransition(source=1, input_symbol=0, target=1, output=(1,)),
+                SubseqTransition(source=2, input_symbol=0, target=2, output=(0,)),
+                SubseqTransition(source=2, input_symbol=1, target=0, output=(1,)),
+            ),
+            final_outputs=(
+                SubseqFinalOutput(state=0, output=()),
+                SubseqFinalOutput(state=1, output=()),
+            ),
+        )
+        trimmed, state_map = trim_subsequential(transducer)
+        assert trimmed.state_count <= 3
+        assert 2 not in state_map
+        result = run_subsequential(trimmed, (0,))
+        assert result[0] == "OUTPUT"
+
+
+class TestRationalRelation:
+    def test_inverse_swaps_labels(self):
+        transducer = RationalTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_states=(0,),
+            accepting_states=(0,),
+            edges=(
+                RationalEdge(source=0, target=0, input_label=(0,), output_label=(1,)),
+                RationalEdge(source=0, target=0, input_label=(1,), output_label=(0,)),
+            ),
+        )
+        inverse = compute_relation_inverse(
+            RelationInverseRequest(transducer=transducer)
+        )
+        inv = inverse.transducer
+        edge0 = inv.edges[0]
+        assert edge0.input_label == (1,)
+        assert edge0.output_label == (0,)
+
+    def test_path_replay_accepting(self):
+        transducer = RationalTransducer(
+            input_alphabet_size=2,
+            output_alphabet_size=2,
+            state_count=1,
+            initial_states=(0,),
+            accepting_states=(0,),
+            edges=(
+                RationalEdge(source=0, target=0, input_label=(0,), output_label=(1,)),
+            ),
+        )
+        result = compute_relation_path_replay(
+            RelationPathReplayRequest(transducer=transducer, edge_path=(0, 0))
+        )
+        assert result.status == "ACCEPTING_PAIR"
+        assert result.input_word == (0, 0)
+        assert result.output_word == (1, 1)
+
+    def test_path_replay_invalid_edge(self):
+        transducer = RationalTransducer(
+            input_alphabet_size=1,
+            output_alphabet_size=1,
+            state_count=1,
+            initial_states=(0,),
+            accepting_states=(0,),
+            edges=(
+                RationalEdge(source=0, target=0, input_label=(0,), output_label=(0,)),
+            ),
+        )
+        result = compute_relation_path_replay(
+            RelationPathReplayRequest(transducer=transducer, edge_path=(5,))
+        )
+        assert result.status == "INVALID_PATH"
+
+
+class TestValidation:
+    def test_duplicate_transition_rejected(self):
+        with pytest.raises(ValidationError):
+            SubsequentialTransducer(
+                input_alphabet_size=1,
+                output_alphabet_size=1,
+                state_count=1,
+                initial_state=0,
+                transitions=(
+                    SubseqTransition(source=0, input_symbol=0, target=0, output=()),
+                    SubseqTransition(source=0, input_symbol=0, target=0, output=()),
+                ),
+                final_outputs=(),
+            )
+
+    def test_output_symbol_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            SubsequentialTransducer(
+                input_alphabet_size=1,
+                output_alphabet_size=1,
+                state_count=1,
+                initial_state=0,
+                transitions=(
+                    SubseqTransition(source=0, input_symbol=0, target=0, output=(5,)),
+                ),
+                final_outputs=(),
+            )
+
+    def test_both_labels_empty_edge_rejected(self):
+        with pytest.raises(ValidationError):
+            RationalTransducer(
+                input_alphabet_size=1,
+                output_alphabet_size=1,
+                state_count=1,
+                initial_states=(0,),
+                accepting_states=(0,),
+                edges=(
+                    RationalEdge(source=0, target=0, input_label=(), output_label=()),
+                ),
+            )
+
+    def test_compose_mismatched_alphabets_rejected(self):
+        with pytest.raises(ValidationError):
+            ComposeRequest(
+                first=identity_transducer(2),
+                second=identity_transducer(3),
+            )


### PR DESCRIPTION
## Summary

Implements core finite-state transducer operations for the Jacobian MCP server, addressing issue #1909.

## Design

Two distinct carriers are separated:

**Subsequential transducers** (`SubsequentialTransducer`) — deterministic partial functions `f: A* -> B*`:
- `transducer.subsequential.run.compute` — exact run with state/output trace, distinguishing empty output, undefined transition, and nonfinal domain state
- `transducer.subsequential.identity.compute` — identity transducer construction
- `transducer.subsequential.compose.compute` — functional composition `U ∘ T` via product-state BFS
- `transducer.subsequential.trim.compute` — restrict to reachable and coaccessible states

**Rational relations** (`RationalTransducer`) — nondeterministic relations `R ⊆ A* × B*`:
- `transducer.relation.inverse.compute` — swap input/output labels and alphabets
- `transducer.relation.path.replay.compute` — replay a candidate edge path and validate acceptance

## Library choices

Direct immutable maps, BFS product constructions, and set operations — no external transducer library needed. The implementation reuses the existing `StrictModel` Pydantic infrastructure and follows the catalog pattern. All state/symbol/word bounds are preflight-validated.

## Tests

20 tests covering:
- Identity, bit-flip, partial domain runs
- Empty output vs. undefined vs. nonfinal distinction
- Final output appending
- Composition (identity∘flip, flip∘flip=id, domain shrinkage)
- Trim with unreachable/dead states
- Rational inverse and path replay
- Validation: duplicate transitions, out-of-range symbols, mismatched alphabets, both-empty-label edges

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/22f3d42f-c745-43f4-af74-fe0d58ea1090)