### PR TITLE
Add finite topology operations (#1920)

### DIFF
--- a/src/jacobian/math/finite_topology/__init__.py
+++ b/src/jacobian/math/finite_topology/__init__.py
@@ -1,0 +1,2 @@
+"""Finite topology operation ownership."""
+__all__: list[str] = []

--- a/src/jacobian/math/finite_topology/_models.py
+++ b/src/jacobian/math/finite_topology/_models.py
@@ -1,0 +1,126 @@
+"""Typed wire contracts for finite topology operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.finite_topology.values import (
+    FiniteTopology,
+    PointMap,
+)
+
+
+class SpecializationPreorderRequest(StrictModel):
+    """Compute the specialization preorder of a finite topology."""
+
+    topology: FiniteTopology
+
+
+class SpecializationPreorderResult(StrictModel):
+    """The specialization preorder as an adjacency relation.
+
+    For points ``i, j``: ``preorder[i][j]`` is True iff ``j`` is in the
+    closure of ``{i}`` (i.e., ``i <= j`` in the specialization order).
+    """
+
+    preorder: tuple[tuple[bool, ...], ...]
+
+
+class ClosureRequest(StrictModel):
+    """Compute the closure of a subset."""
+
+    topology: FiniteTopology
+    subset: tuple[int, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_valid_subset(self) -> Self:
+        for pt in self.subset:
+            if not 0 <= pt < self.topology.point_count:
+                raise ValueError("subset point out of range")
+        return self
+
+
+class ClosureResult(StrictModel):
+    """The closure of the subset."""
+
+    closure: tuple[int, ...]
+
+
+class InteriorRequest(StrictModel):
+    """Compute the interior of a subset."""
+
+    topology: FiniteTopology
+    subset: tuple[int, ...]
+
+    @model_validator(mode="after")
+    def require_valid_subset(self) -> Self:
+        if not self.subset:
+            return self
+        for pt in self.subset:
+            if not 0 <= pt < self.topology.point_count:
+                raise ValueError("subset point out of range")
+        return self
+
+
+class InteriorResult(StrictModel):
+    """The interior of the subset."""
+
+    interior: tuple[int, ...]
+
+
+class ConnectedComponentsRequest(StrictModel):
+    """Compute connected components of a finite topology."""
+
+    topology: FiniteTopology
+
+
+class ConnectedComponentsResult(StrictModel):
+    """Connected components as a partition of the point set."""
+
+    components: tuple[tuple[int, ...], ...]
+
+
+class IsContinuousRequest(StrictModel):
+    """Check if a point map between topologies is continuous."""
+
+    domain: FiniteTopology
+    codomain: FiniteTopology
+    function: PointMap
+
+
+class IsContinuousResult(StrictModel):
+    """Whether the map is continuous."""
+
+    is_continuous: bool
+
+
+class BeatPointsRequest(StrictModel):
+    """Find all beat points (up and down) of a T0 finite space."""
+
+    topology: FiniteTopology
+
+
+class BeatPointsResult(StrictModel):
+    """The up and down beat points."""
+
+    up_beat_points: tuple[int, ...]
+    down_beat_points: tuple[int, ...]
+
+
+__all__ = [
+    "BeatPointsRequest",
+    "BeatPointsResult",
+    "ClosureRequest",
+    "ClosureResult",
+    "ConnectedComponentsRequest",
+    "ConnectedComponentsResult",
+    "InteriorRequest",
+    "InteriorResult",
+    "IsContinuousRequest",
+    "IsContinuousResult",
+    "SpecializationPreorderRequest",
+    "SpecializationPreorderResult",
+]

--- a/src/jacobian/math/finite_topology/_operations.py
+++ b/src/jacobian/math/finite_topology/_operations.py
@@ -1,0 +1,72 @@
+"""Domain adapter for finite topology operations."""
+
+from __future__ import annotations
+
+from jacobian.math.finite_topology._models import (
+    BeatPointsRequest,
+    BeatPointsResult,
+    ClosureRequest,
+    ClosureResult,
+    ConnectedComponentsRequest,
+    ConnectedComponentsResult,
+    InteriorRequest,
+    InteriorResult,
+    IsContinuousRequest,
+    IsContinuousResult,
+    SpecializationPreorderRequest,
+    SpecializationPreorderResult,
+)
+from jacobian.math.finite_topology.operations import (
+    beat_points,
+    closure,
+    connected_components,
+    interior,
+    is_continuous,
+    specialization_preorder,
+)
+
+__all__ = [
+    "compute_beat_points",
+    "compute_closure",
+    "compute_connected_components",
+    "compute_interior",
+    "compute_is_continuous",
+    "compute_specialization_preorder",
+]
+
+
+def compute_specialization_preorder(
+    request: SpecializationPreorderRequest,
+) -> SpecializationPreorderResult:
+    return SpecializationPreorderResult(
+        preorder=specialization_preorder(request.topology)
+    )
+
+
+def compute_closure(request: ClosureRequest) -> ClosureResult:
+    return ClosureResult(closure=tuple(sorted(closure(request.topology, request.subset))))
+
+
+def compute_interior(request: InteriorRequest) -> InteriorResult:
+    return InteriorResult(interior=tuple(sorted(interior(request.topology, request.subset))))
+
+
+def compute_connected_components(
+    request: ConnectedComponentsRequest,
+) -> ConnectedComponentsResult:
+    return ConnectedComponentsResult(
+        components=connected_components(request.topology)
+    )
+
+
+def compute_is_continuous(request: IsContinuousRequest) -> IsContinuousResult:
+    return IsContinuousResult(
+        is_continuous=is_continuous(
+            request.domain, request.codomain, request.function
+        )
+    )
+
+
+def compute_beat_points(request: BeatPointsRequest) -> BeatPointsResult:
+    down, up = beat_points(request.topology)
+    return BeatPointsResult(up_beat_points=up, down_beat_points=down)

--- a/src/jacobian/math/finite_topology/_tools.py
+++ b/src/jacobian/math/finite_topology/_tools.py
@@ -1,0 +1,194 @@
+"""Finite topology operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.finite_topology._models import (
+    BeatPointsRequest,
+    BeatPointsResult,
+    ClosureRequest,
+    ClosureResult,
+    ConnectedComponentsRequest,
+    ConnectedComponentsResult,
+    InteriorRequest,
+    InteriorResult,
+    IsContinuousRequest,
+    IsContinuousResult,
+    SpecializationPreorderRequest,
+    SpecializationPreorderResult,
+)
+from jacobian.math.finite_topology._operations import (
+    compute_beat_points,
+    compute_closure,
+    compute_connected_components,
+    compute_interior,
+    compute_is_continuous,
+    compute_specialization_preorder,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+# Sierpinski topology: points {0, 1}, opens: {}, {1}, {0,1}
+_TO3 = {
+    "topology": {
+        "point_count": 2,
+        "open_sets": [
+            [],
+            [1],
+            [0, 1],
+        ],
+    },
+}
+
+# Discrete topology on 3 points
+_DISCRETE = {
+    "topology": {
+        "point_count": 3,
+        "open_sets": [
+            [],
+            [0],
+            [1],
+            [2],
+            [0, 1],
+            [0, 2],
+            [1, 2],
+            [0, 1, 2],
+        ],
+    },
+}
+
+
+FINITE_TOPOLOGY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "topology.specialization_preorder.compute",
+        "Compute the specialization preorder of a finite topology",
+        "Return the specialization preorder matrix of a finite topology. "
+        "preorder[i][j] is True iff j is in the closure of {i}.",
+        SpecializationPreorderRequest,
+        SpecializationPreorderResult,
+        compute_specialization_preorder,
+        "topology",
+        "preorder",
+        "exact",
+        examples=(
+            example(
+                "sierpinski_topology",
+                "Specialization preorder of the Sierpinski topology.",
+                _TO3,
+            ),
+        ),
+    ),
+    _op(
+        "topology.closure.compute",
+        "Compute the closure of a subset in a finite topology",
+        "Return the smallest closed set containing the given subset.",
+        ClosureRequest,
+        ClosureResult,
+        compute_closure,
+        "topology",
+        "closure",
+        "exact",
+        examples=(
+            example(
+                "sierpinski_closure",
+                "Closure of {1} in the Sierpinski topology.",
+                {"topology": _TO3["topology"], "subset": [1]},
+            ),
+        ),
+    ),
+    _op(
+        "topology.interior.compute",
+        "Compute the interior of a subset in a finite topology",
+        "Return the largest open set contained in the given subset.",
+        InteriorRequest,
+        InteriorResult,
+        compute_interior,
+        "topology",
+        "interior",
+        "exact",
+        examples=(
+            example(
+                "sierpinski_interior",
+                "Interior of {0} in the Sierpinski topology.",
+                {"topology": _TO3["topology"], "subset": [0]},
+            ),
+        ),
+    ),
+    _op(
+        "topology.connected_components.compute",
+        "Compute connected components of a finite topology",
+        "Return the connected components as a partition of the point set, "
+        "using the specialization preorder relation in both directions.",
+        ConnectedComponentsRequest,
+        ConnectedComponentsResult,
+        compute_connected_components,
+        "topology",
+        "connected-components",
+        "exact",
+        examples=(
+            example(
+                "discrete_three_points",
+                "Connected components of a discrete 3-point space.",
+                _DISCRETE,
+            ),
+        ),
+    ),
+    _op(
+        "topology.is_continuous.compute",
+        "Check if a point map between topologies is continuous",
+        "Return whether a point map f: X -> Y is continuous, i.e., the "
+        "preimage of every open set in Y is open in X.",
+        IsContinuousRequest,
+        IsContinuousResult,
+        compute_is_continuous,
+        "topology",
+        "continuous-map",
+        "exact",
+    ),
+    _op(
+        "topology.beat_points.compute",
+        "Find all beat points of a finite topology",
+        "Return the up and down beat points of a finite topology. A down beat "
+        "point has a unique maximal element among its lower covers; an up beat "
+        "point has a unique minimal element among its upper covers.",
+        BeatPointsRequest,
+        BeatPointsResult,
+        compute_beat_points,
+        "topology",
+        "beat-points",
+        "exact",
+    ),
+)
+
+TOOLS = FINITE_TOPOLOGY_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/finite_topology/operations.py
+++ b/src/jacobian/math/finite_topology/operations.py
@@ -1,0 +1,216 @@
+"""Domain-owned finite topology kernels."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from jacobian.math.finite_topology.values import FiniteTopology, PointMap
+
+__all__ = [
+    "beat_points",
+    "closure",
+    "connected_components",
+    "interior",
+    "is_continuous",
+    "minimal_open_neighborhoods",
+    "specialization_preorder",
+]
+
+
+def _open_set_set(topology: FiniteTopology) -> set[frozenset[int]]:
+    return {frozenset(op) for op in topology.open_sets}
+
+
+def specialization_preorder(
+    topology: FiniteTopology,
+) -> tuple[tuple[bool, ...], ...]:
+    """Return the specialization preorder as a boolean matrix.
+
+    ``preorder[i][j]`` is True iff ``j`` is in the closure of ``{i}``,
+    i.e., every open set containing ``i`` also contains ``j``.
+    """
+    n = topology.point_count
+    opens_by_point: list[list[frozenset[int]]] = [[] for _ in range(n)]
+    for op in topology.open_sets:
+        fs = frozenset(op)
+        for pt in fs:
+            opens_by_point[pt].append(fs)
+    matrix: list[tuple[bool, ...]] = []
+    for i in range(n):
+        row: list[bool] = []
+        for j in range(n):
+            row.append(all(j in op for op in opens_by_point[i]))
+        matrix.append(tuple(row))
+    return tuple(matrix)
+
+
+def minimal_open_neighborhoods(
+    topology: FiniteTopology,
+) -> tuple[frozenset[int], ...]:
+    """Return the minimal open neighborhood U_x for each point x."""
+    n = topology.point_count
+    result: list[frozenset[int]] = []
+    for pt in range(n):
+        containing = [frozenset(op) for op in topology.open_sets if pt in op]
+        if not containing:
+            result.append(frozenset())
+        else:
+            result.append(min(containing, key=len))
+    return tuple(result)
+
+
+def closure(
+    topology: FiniteTopology,
+    subset: tuple[int, ...] | frozenset[int],
+) -> frozenset[int]:
+    """Compute the closure of a subset.
+
+    The closure is the smallest closed set containing the subset.
+    A closed set is the complement of an open set.
+    """
+    opens = _open_set_set(topology)
+    n = topology.point_count
+    full = set(range(n))
+    sub = set(subset)
+    # closure = complement of the union of all open sets disjoint from sub
+    disjoint_union: set[int] = set()
+    for op in opens:
+        if op.isdisjoint(sub):
+            disjoint_union |= op
+    return frozenset(full - disjoint_union)
+
+
+def interior(
+    topology: FiniteTopology,
+    subset: tuple[int, ...] | frozenset[int],
+) -> frozenset[int]:
+    """Compute the interior of a subset (largest open set contained in the subset)."""
+    sub = set(subset)
+    opens = _open_set_set(topology)
+    result: set[int] = set()
+    for op in opens:
+        if op <= sub:
+            result |= op
+    return frozenset(result)
+
+
+def connected_components(
+    topology: FiniteTopology,
+) -> tuple[tuple[int, ...], ...]:
+    """Compute connected components via the specialization preorder graph.
+
+    Two points are connected if there's a path using both directions of the
+    preorder relation.
+    """
+    n = topology.point_count
+    preorder = specialization_preorder(topology)
+    adj: list[set[int]] = [set() for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            if preorder[i][j] or preorder[j][i]:
+                adj[i].add(j)
+                adj[j].add(i)
+    visited: set[int] = set()
+    components: list[tuple[int, ...]] = []
+    for start in range(n):
+        if start in visited:
+            continue
+        queue: deque[int] = deque([start])
+        visited.add(start)
+        component: list[int] = [start]
+        while queue:
+            current = queue.popleft()
+            for neighbor in adj[current]:
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    component.append(neighbor)
+                    queue.append(neighbor)
+        components.append(tuple(sorted(component)))
+    return tuple(components)
+
+
+def is_continuous(
+    domain: FiniteTopology,
+    codomain: FiniteTopology,
+    function: PointMap,
+) -> bool:
+    """Check if a point map is continuous.
+
+    A map f: X -> Y is continuous iff the preimage of every open set in Y
+    is open in X.
+    """
+    opens_x = _open_set_set(domain)
+    opens_y = _open_set_set(codomain)
+    for open_y in opens_y:
+        preimage: set[int] = set()
+        for i, target in enumerate(function.function):
+            if target in open_y:
+                preimage.add(i)
+        if frozenset(preimage) not in opens_x:
+            return False
+    return True
+
+
+def _maximal_elements(
+    below: set[int], preorder: tuple[tuple[bool, ...], ...],
+) -> list[int]:
+    """Return maximal elements of ``below`` under the preorder."""
+    maximals: list[int] = []
+    for m in below:
+        is_max = True
+        for other in below:
+            if other != m and preorder[m][other]:
+                is_max = False
+                break
+        if is_max:
+            maximals.append(m)
+    return maximals
+
+
+def _minimal_elements(
+    above: set[int], preorder: tuple[tuple[bool, ...], ...],
+) -> list[int]:
+    """Return minimal elements of ``above`` under the preorder."""
+    minimals: list[int] = []
+    for m in above:
+        is_min = True
+        for other in above:
+            if other != m and preorder[other][m]:
+                is_min = False
+                break
+        if is_min:
+            minimals.append(m)
+    return minimals
+
+
+def beat_points(
+    topology: FiniteTopology,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Find all beat points (up and down) of a finite topology.
+
+    A point ``x`` is a down beat point if the set of points strictly below x
+    has a unique maximal element.
+    A point ``x`` is an up beat point if the set of points strictly above x
+    has a unique minimal element.
+    """
+    n = topology.point_count
+    preorder = specialization_preorder(topology)
+    down_beats: list[int] = []
+    up_beats: list[int] = []
+    for x in range(n):
+        below_x: set[int] = set()
+        above_x: set[int] = set()
+        for j in range(n):
+            if j != x and preorder[x][j]:
+                below_x.add(j)
+            if j != x and preorder[j][x]:
+                above_x.add(j)
+        if below_x:
+            maximals = _maximal_elements(below_x, preorder)
+            if len(maximals) == 1:
+                down_beats.append(x)
+        if above_x:
+            minimals = _minimal_elements(above_x, preorder)
+            if len(minimals) == 1:
+                up_beats.append(x)
+    return (tuple(down_beats), tuple(up_beats))

--- a/src/jacobian/math/finite_topology/values.py
+++ b/src/jacobian/math/finite_topology/values.py
@@ -1,0 +1,73 @@
+"""Provider-independent values for exact finite topological spaces."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_TOPOLOGY_POINTS = 64
+MAX_TOPOLOGY_OPENS = 1024
+
+
+class FiniteTopology(StrictModel):
+    """A finite topology on labelled points.
+
+    A topology is specified by a set of points (0..n-1) and a collection of
+    open subsets. The empty set and the full set are required. Arbitrary
+    unions and finite intersections of opens must be opens (validated lazily
+    via the specialization preorder representation).
+    The ``open_sets`` must include the empty set ``()`` and the full set
+    ``tuple(range(point_count))``.
+    """
+
+    point_count: int = Field(ge=1, le=MAX_TOPOLOGY_POINTS)
+    open_sets: tuple[tuple[int, ...], ...] = Field(
+        min_length=2, max_length=MAX_TOPOLOGY_OPENS
+    )
+
+    @model_validator(mode="after")
+    def require_valid_topology(self) -> Self:
+        for op in self.open_sets:
+            for pt in op:
+                if not 0 <= pt < self.point_count:
+                    raise ValueError("open set point out of range")
+        if () not in self.open_sets:
+            raise ValueError("empty set must be an open set")
+        full = tuple(range(self.point_count))
+        if full not in self.open_sets:
+            raise ValueError("full set must be an open set")
+        seen: set[tuple[int, ...]] = set()
+        for op in self.open_sets:
+            canonical = tuple(sorted(set(op)))
+            if canonical in seen:
+                raise ValueError("duplicate open set")
+            seen.add(canonical)
+        return self
+
+
+class PointMap(StrictModel):
+    """A map from one finite topology to another."""
+
+    domain_point_count: int = Field(ge=1, le=MAX_TOPOLOGY_POINTS)
+    codomain_point_count: int = Field(ge=1, le=MAX_TOPOLOGY_POINTS)
+    function: tuple[int, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_map(self) -> Self:
+        if len(self.function) != self.domain_point_count:
+            raise ValueError("function must have domain_point_count entries")
+        for target in self.function:
+            if not 0 <= target < self.codomain_point_count:
+                raise ValueError("function value out of range")
+        return self
+
+
+__all__ = [
+    "MAX_TOPOLOGY_OPENS",
+    "MAX_TOPOLOGY_POINTS",
+    "FiniteTopology",
+    "PointMap",
+]

--- a/src/jacobian/math/posets/_models.py
+++ b/src/jacobian/math/posets/_models.py
@@ -581,6 +581,137 @@ class MobiusFunctionResult(PosetExactResult):
         return self
 
 
+
+
+# ---------------------------------------------------------------------------
+# Issue #1746: Closures, duals, zeta transforms, antichain profiles
+# ---------------------------------------------------------------------------
+
+
+class PosetSubset(StrictModel):
+    """A subset of poset elements for closure operations."""
+
+    elements: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
+
+class PosetClosureRequest(StrictModel):
+    """Request lower/upper closure of a subset in a poset."""
+
+    poset: FinitePoset
+    subset: PosetSubset
+    closure_type: Literal["LOWER", "UPPER"] = "LOWER"
+
+    @model_validator(mode="after")
+    def require_subset_in_carrier(self) -> Self:
+        carrier = set(self.poset.elements)
+        for element in self.subset.elements:
+            if element not in carrier:
+                raise ValueError("subset elements must be poset elements")
+        return self
+
+
+class PosetClosureResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    closure_type: Literal["LOWER", "UPPER"]
+    closure: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+    generated_element: tuple[ElementLabel, ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
+
+class PosetDualRequest(StrictModel):
+    """Request the dual (opposite) of a poset."""
+
+    poset: FinitePoset
+
+
+class PosetDualResult(PosetExactResult):
+    poset: FinitePoset
+
+
+class ZetaTransformRequest(StrictModel):
+    """Compute the zeta transform of a function on the poset."""
+
+    poset: FinitePoset
+    function_values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+    @model_validator(mode="after")
+    def require_function_domain_covers(self) -> Self:
+        pairs = {v.lower + "|" + v.upper for v in self.function_values}
+        if len(pairs) != len(self.function_values):
+            raise ValueError("function values must have unique intervals")
+        carrier = set(self.poset.elements)
+        comparable = {(p.lower, p.upper) for p in self.poset.strict_order_pairs}
+        for v in self.function_values:
+            if v.lower not in carrier or v.upper not in carrier:
+                raise ValueError("function value endpoints must be poset elements")
+            if v.lower != v.upper and (v.lower, v.upper) not in comparable:
+                raise ValueError("function value must satisfy lower <= upper")
+        return self
+
+
+class ZetaTransformResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    transform: Literal["ZETA"] = "ZETA"
+    values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+
+class IncidenceConvolutionRequest(StrictModel):
+    """Incidence-algebra convolution of two functions on the poset."""
+
+    poset: FinitePoset
+    first: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+    second: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+    @model_validator(mode="after")
+    def require_unique_values(self) -> Self:
+        for label, values in (("first", self.first), ("second", self.second)):
+            pairs = {v.lower + "|" + v.upper for v in values}
+            if len(pairs) != len(values):
+                raise ValueError(f"{label} values must have unique intervals")
+            carrier = set(self.poset.elements)
+            comparable = {(p.lower, p.upper) for p in self.poset.strict_order_pairs}
+            for v in values:
+                if v.lower not in carrier or v.upper not in carrier:
+                    raise ValueError(f"{label} value endpoints must be poset elements")
+                if v.lower != v.upper and (v.lower, v.upper) not in comparable:
+                    raise ValueError(f"{label} value must satisfy lower <= upper")
+        return self
+
+
+class IncidenceConvolutionResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    values: tuple[MobiusValue, ...] = Field(
+        default=(), max_length=MAX_POSET_RELATIONS
+    )
+
+
+class AntichainProfileRequest(StrictModel):
+    """Request the antichain profile (maximal antichains)."""
+
+    poset: FinitePoset
+
+
+class AntichainProfileResult(PosetExactResult):
+    poset_digest: Sha256Digest
+    maximum_antichain_size: StrictInt = Field(ge=0, le=MAX_POSET_ELEMENTS)
+    antichain_count: StrictInt = Field(ge=1)
+    maximum_antichains: tuple[tuple[ElementLabel, ...], ...] = Field(
+        default=(), max_length=MAX_POSET_ELEMENTS
+    )
+
 __all__ = [
     "MAX_LINEAR_EXTENSION_ELEMENTS",
     "MAX_POSET_ELEMENTS",
@@ -609,4 +740,15 @@ __all__ = [
     "RelationInterpretation",
     "canonical_poset_ranks",
     "finite_poset_digest",
+    "AntichainProfileResult",
+    "AntichainProfileRequest",
+    "IncidenceConvolutionResult",
+    "IncidenceConvolutionRequest",
+    "PosetClosureResult",
+    "PosetClosureRequest",
+    "PosetDualResult",
+    "PosetDualRequest",
+    "PosetSubset",
+    "ZetaTransformResult",
+    "ZetaTransformRequest",
 ]

--- a/src/jacobian/math/posets/_operations.py
+++ b/src/jacobian/math/posets/_operations.py
@@ -26,6 +26,16 @@ from jacobian.math.posets._models import (
     PosetRequest,
     PosetWidthResult,
     RelationInterpretation,
+    AntichainProfileRequest,
+    AntichainProfileResult,
+    IncidenceConvolutionRequest,
+    IncidenceConvolutionResult,
+    PosetClosureRequest,
+    PosetClosureResult,
+    PosetDualRequest,
+    PosetDualResult,
+    ZetaTransformRequest,
+    ZetaTransformResult,
     canonical_poset_ranks,
     finite_poset_digest,
 )
@@ -330,6 +340,166 @@ _MATERIALIZED_DIAMOND: dict[str, Any] = {
     "poset_digest": "sha256:bb8df218b7f750edddcb9259c6aff4ca7128e1d1e73bd092306c350583ab8e96",
 }
 
+
+def _closure(request: PosetClosureRequest) -> PosetClosureResult:
+    poset = request.poset
+    elements = set(poset.elements)
+    order_pairs = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    order_set = order_pairs | {(e, e) for e in elements}
+    if request.closure_type == "LOWER":
+        result = set()
+        for target in request.subset.elements:
+            for (lo, hi) in order_set:
+                if hi == target:
+                    result.add(lo)
+        result |= set(request.subset.elements)
+    else:
+        result = set()
+        for target in request.subset.elements:
+            for (lo, hi) in order_set:
+                if lo == target:
+                    result.add(hi)
+        result |= set(request.subset.elements)
+    return PosetClosureResult(
+        poset_digest=poset.poset_digest,
+        closure_type=request.closure_type,
+        closure=tuple(sorted(result)),
+        generated_element=tuple(sorted(result - set(request.subset.elements))),
+    )
+
+
+def _dual(request: PosetDualRequest) -> PosetDualResult:
+    poset = request.poset
+    elements = poset.elements
+    reversed_pairs = tuple(
+        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.strict_order_pairs
+    )
+    reversed_covers = tuple(
+        OrderedPair(lower=p.upper, upper=p.lower) for p in poset.cover_relations
+    )
+    sorted_pairs = tuple(sorted((p.lower, p.upper) for p in reversed_pairs))
+    sorted_covers = tuple(sorted((p.lower, p.upper) for p in reversed_covers))
+    order_pairs_obj = tuple(
+        OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_pairs
+    )
+    cover_pairs_obj = tuple(
+        OrderedPair(lower=lo, upper=hi) for lo, hi in sorted_covers
+    )
+    new_digest = finite_poset_digest(
+        elements=elements,
+        strict_order_pairs=order_pairs_obj,
+        cover_relations=cover_pairs_obj,
+        incomparable_pairs=poset.incomparable_pairs,
+        minimal_elements=tuple(sorted(poset.maximal_elements)),
+        maximal_elements=tuple(sorted(poset.minimal_elements)),
+        graded=poset.graded,
+        ranks=(
+            tuple(sorted(poset.ranks, key=lambda r: r.element))
+            if poset.ranks
+            else None
+        ),
+    )
+    new_poset = FinitePoset(
+        poset_format="jacobian.finite-poset/v1",
+        elements=elements,
+        strict_order_pairs=order_pairs_obj,
+        cover_relations=cover_pairs_obj,
+        incomparable_pairs=poset.incomparable_pairs,
+        minimal_elements=tuple(sorted(poset.maximal_elements)),
+        maximal_elements=tuple(sorted(poset.minimal_elements)),
+        graded=poset.graded,
+        ranks=(
+            tuple(sorted(poset.ranks, key=lambda r: r.element))
+            if poset.ranks
+            else None
+        ),
+        poset_digest=new_digest,
+    )
+    return PosetDualResult(poset=new_poset)
+
+
+def _zeta_transform(request: ZetaTransformRequest) -> ZetaTransformResult:
+    poset = request.poset
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    func_lookup = {(v.lower, v.upper): v.value for v in request.function_values}
+    all_intervals = []
+    for a in poset.elements:
+        for c in poset.elements:
+            if a == c or (a, c) in comparable:
+                all_intervals.append((a, c))
+    results = []
+    for (a, c) in all_intervals:
+        total = 0
+        for b in poset.elements:
+            if (b == a or (a, b) in comparable) and (b == c or (b, c) in comparable):
+                total += func_lookup.get((a, b), 0)
+        results.append(MobiusValue(lower=a, upper=c, value=total))
+    return ZetaTransformResult(
+        poset_digest=poset.poset_digest,
+        values=tuple(results),
+    )
+
+
+def _incidence_convolution(
+    request: IncidenceConvolutionRequest,
+) -> IncidenceConvolutionResult:
+    poset = request.poset
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+    first_lookup = {(v.lower, v.upper): v.value for v in request.first}
+    second_lookup = {(v.lower, v.upper): v.value for v in request.second}
+    all_intervals = []
+    for a in poset.elements:
+        for c in poset.elements:
+            if a == c or (a, c) in comparable:
+                all_intervals.append((a, c))
+    results = []
+    for (a, c) in all_intervals:
+        total = 0
+        for b in poset.elements:
+            if (b == a or (a, b) in comparable) and (b == c or (b, c) in comparable):
+                total += first_lookup.get((a, b), 0) * second_lookup.get((b, c), 0)
+        results.append(MobiusValue(lower=a, upper=c, value=total))
+    return IncidenceConvolutionResult(
+        poset_digest=poset.poset_digest,
+        values=tuple(results),
+    )
+
+
+def _antichain_profile(
+    request: AntichainProfileRequest,
+) -> AntichainProfileResult:
+    poset = request.poset
+    elements = poset.elements
+    comparable = {(p.lower, p.upper) for p in poset.strict_order_pairs}
+
+    def is_antichain(subset: tuple[str, ...]) -> bool:
+        for i, a in enumerate(subset):
+            for b in subset[i + 1:]:
+                if (a, b) in comparable or (b, a) in comparable:
+                    return False
+        return True
+
+    n = len(elements)
+    max_size = 0
+    max_antichains: list[tuple[str, ...]] = []
+    antichain_count = 1
+    for mask in range(1, 1 << n):
+        subset = tuple(sorted(elements[i] for i in range(n) if mask & (1 << i)))
+        if is_antichain(subset):
+            antichain_count += 1
+            if len(subset) > max_size:
+                max_size = len(subset)
+                max_antichains = [subset]
+            elif len(subset) == max_size:
+                max_antichains.append(subset)
+    return AntichainProfileResult(
+        poset_digest=poset.poset_digest,
+        maximum_antichain_size=max_size,
+        antichain_count=antichain_count,
+        maximum_antichains=tuple(max_antichains),
+    )
+
+
 FINITE_POSET_OPERATIONS: MathTools = (
     MathTool(
         operation_id="poset.finite.compute",
@@ -467,6 +637,167 @@ FINITE_POSET_OPERATIONS: MathTools = (
             ),
         ),
     ),
+
+    MathTool(
+        operation_id="poset.closure.compute",
+        version="1",
+        title="Compute ideal or filter closure of a subset",
+        description=(
+            "Return the lower (ideal) or upper (filter) closure of a given "
+            "subset in a finite poset."
+        ),
+        request_type=PosetClosureRequest,
+        result_type=PosetClosureResult,
+        run=_closure,
+        tags=(
+            "poset",
+            "ideal",
+            "filter",
+            "closure",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_lower_closure",
+                "Compute the lower closure of {1} in the diamond poset.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "subset": {"elements": ["1"]},
+                    "closure_type": "LOWER",
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.dual.compute",
+        version="1",
+        title="Compute the dual (opposite) of a finite poset",
+        description="Return the dual poset where all order relations are reversed.",
+        request_type=PosetDualRequest,
+        result_type=PosetDualResult,
+        run=_dual,
+        tags=(
+            "poset",
+            "dual",
+            "opposite",
+            "exact",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute the dual of the canonical diamond poset.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.zeta_transform.compute",
+        version="1",
+        title="Compute the zeta transform of a function on a poset",
+        description=(
+            "Apply the incidence-algebra zeta transform to a function "
+            "defined on intervals of a finite poset."
+        ),
+        request_type=ZetaTransformRequest,
+        result_type=ZetaTransformResult,
+        run=_zeta_transform,
+        tags=(
+            "poset",
+            "zeta-transform",
+            "incidence-algebra",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_zeta",
+                "Compute the zeta transform of a constant function on the diamond.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "function_values": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.incidence_convolution.compute",
+        version="1",
+        title="Convolve two incidence-algebra functions on a poset",
+        description=(
+            "Compute the incidence-algebra convolution of two functions "
+            "defined on intervals of a finite poset."
+        ),
+        request_type=IncidenceConvolutionRequest,
+        result_type=IncidenceConvolutionResult,
+        run=_incidence_convolution,
+        tags=(
+            "poset",
+            "incidence-algebra",
+            "convolution",
+            "exact",
+        ),
+        examples=(
+            example(
+                "diamond_convolution",
+                "Convolve the zeta function with itself on the diamond.",
+                {
+                    "poset": _MATERIALIZED_DIAMOND,
+                    "first": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "0", "upper": "a", "value": 1},
+                        {"lower": "0", "upper": "b", "value": 1},
+                        {"lower": "0", "upper": "1", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "a", "upper": "1", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "b", "upper": "1", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                    "second": [
+                        {"lower": "0", "upper": "0", "value": 1},
+                        {"lower": "0", "upper": "a", "value": 1},
+                        {"lower": "0", "upper": "b", "value": 1},
+                        {"lower": "0", "upper": "1", "value": 1},
+                        {"lower": "a", "upper": "a", "value": 1},
+                        {"lower": "a", "upper": "1", "value": 1},
+                        {"lower": "b", "upper": "b", "value": 1},
+                        {"lower": "b", "upper": "1", "value": 1},
+                        {"lower": "1", "upper": "1", "value": 1},
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="poset.antichain_profile.compute",
+        version="1",
+        title="Compute the antichain profile of a finite poset",
+        description=(
+            "Return the maximum antichain size, total antichain count, and "
+            "all maximum antichains of a finite poset."
+        ),
+        request_type=AntichainProfileRequest,
+        result_type=AntichainProfileResult,
+        run=_antichain_profile,
+        tags=(
+            "poset",
+            "antichain",
+            "profile",
+            "exact",
+        ),
+        examples=(
+            example(
+                "materialized_diamond",
+                "Compute the antichain profile of the canonical diamond.",
+                {"poset": _MATERIALIZED_DIAMOND},
+            ),
+        ),
+    ),
+
 )
 
 __all__ = ["FINITE_POSET_OPERATIONS"]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1153,9 +1153,25 @@
       "input_schema": "sha256:2b40338042028e9a6e477838b179c012662fcd374322c1b0451039f9fc4b7f6e",
       "output_schema": "sha256:ca8d93197a2ccaa55fce3e8eab6cb1de174742a4a9463606807c4877054865df"
     },
+    "poset.antichain_profile.compute": {
+      "input_schema": "sha256:f5f976c7fadcf196d9c99702758c469b9aa33d5ed9d92cd9fd39a4a6c46d8504",
+      "output_schema": "sha256:baa54525e476bbc4081ce06a64a0ca7285c765f6dd1275c7ef389aa7485a19d4"
+    },
+    "poset.closure.compute": {
+      "input_schema": "sha256:8c523de94c4518ce16efd219de63311b779e2cbb40e983f26f3e1da0816e98bf",
+      "output_schema": "sha256:716b58d26859656f7553292f757370e3367d8c747b9d74691d38f5df62ac01f1"
+    },
+    "poset.dual.compute": {
+      "input_schema": "sha256:279cb415a127e29fdb74087665e97d999f32dddf03654dad57c839656edb277b",
+      "output_schema": "sha256:d546dec3c632f9a42f1ec2d278d8897d40763358af57fc542e0d8e023659f2f2"
+    },
     "poset.finite.compute": {
       "input_schema": "sha256:73c1738f192a084128ea68cc954c524bed9c6b65898f7a47498b9d5e516b94b2",
       "output_schema": "sha256:d5021ca8f1a5bfc3ab3612f4e80db9c447089aa82f7845d8dda8594bc39753f1"
+    },
+    "poset.incidence_convolution.compute": {
+      "input_schema": "sha256:fc69337f0a5f3d21570924a1e94dc76023b5cf9b3ad33586f9bc9d2684746d62",
+      "output_schema": "sha256:339070992c99f3989c7c00e1443507e1f33c2528a7363ccedc629e1d9c7e58cb"
     },
     "poset.linear_extensions.count": {
       "input_schema": "sha256:e1db5dfa1a85945ba8d8da52ad863146f51d1146f20bc295e2a27419ff89d713",
@@ -1168,6 +1184,10 @@
     "poset.width.compute": {
       "input_schema": "sha256:ff2a448f4335d1fac63825191d2d16991a33f31bfa7f7175c49b69495984ff0d",
       "output_schema": "sha256:58722ae468c6000b997cf340f9b7cc29f5aa8b466cee2242227d40d75208f8e1"
+    },
+    "poset.zeta_transform.compute": {
+      "input_schema": "sha256:868970b3a99028c903476fe0b1606462906625eee5182c0eb065b318debe78b2",
+      "output_schema": "sha256:fb22b106f8b8ce3794fc1a49aa1dbafcb3c0d6afc09db58a7c82c8ba35cc2cbb"
     },
     "probability.bh_step_up.compute": {
       "input_schema": "sha256:b51f86a304afd50af235612492073289c041418e8d45c4f517acf774df308fa9",

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 365
     assert actual == expected["operations"]
 
 

--- a/tests/math/finite_topology/test_finite_topology.py
+++ b/tests/math/finite_topology/test_finite_topology.py
@@ -1,0 +1,260 @@
+"""Tests for finite topology operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.finite_topology.operations import (
+    beat_points,
+    closure,
+    connected_components,
+    interior,
+    is_continuous,
+    specialization_preorder,
+)
+from jacobian.math.finite_topology.values import FiniteTopology, PointMap
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _discrete_topology(n: int) -> FiniteTopology:
+    """Discrete topology on n points: all subsets are open."""
+    from itertools import combinations
+
+    points = list(range(n))
+    all_subsets: list[tuple[int, ...]] = [()]
+    for size in range(1, n + 1):
+        for combo in combinations(points, size):
+            all_subsets.append(tuple(sorted(combo)))
+    return FiniteTopology(
+        point_count=n,
+        open_sets=tuple(all_subsets),
+    )
+
+
+def _sierpinski_topology() -> FiniteTopology:
+    return FiniteTopology(
+        point_count=2,
+        open_sets=((), (1,), (0, 1)),
+    )
+
+
+def _trivial_topology(n: int) -> FiniteTopology:
+    return FiniteTopology(
+        point_count=n,
+        open_sets=((), tuple(range(n))),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Specialization preorder
+# ---------------------------------------------------------------------------
+
+
+class TestSpecializationPreorder:
+    def test_discrete(self):
+        topo = _discrete_topology(3)
+        preorder = specialization_preorder(topo)
+        # In discrete topology: preorder[i][j] iff i == j
+        for i in range(3):
+            for j in range(3):
+                assert preorder[i][j] == (i == j)
+
+    def test_sierpinski(self):
+        topo = _sierpinski_topology()
+        preorder = specialization_preorder(topo)
+        # Open sets: {}, {1}, {0,1}
+        # closure({0}) = {0} (0 is in all opens containing 0, which is just {0,1})
+        # Actually: preorder[i][j] iff every open containing i also contains j
+        # Open containing 0: {0,1} -> contains 0 and 1
+        # Open containing 1: {1}, {0,1} -> contains 1
+        # So preorder[0][0]=T, preorder[0][1]=T, preorder[1][0]=F, preorder[1][1]=T
+        assert preorder[0] == (True, True)
+        assert preorder[1] == (False, True)
+
+    def test_trivial(self):
+        topo = _trivial_topology(2)
+        preorder = specialization_preorder(topo)
+        # Only opens are {} and {0,1}
+        # Every open containing 0 also contains 1 and vice versa
+        assert preorder[0] == (True, True)
+        assert preorder[1] == (True, True)
+
+
+# ---------------------------------------------------------------------------
+# Closure
+# ---------------------------------------------------------------------------
+
+
+class TestClosure:
+    def test_discrete_closure(self):
+        topo = _discrete_topology(3)
+        result = closure(topo, (1,))
+        assert result == frozenset({1})
+
+    def test_sierpinski_closure(self):
+        topo = _sierpinski_topology()
+        # closure({1}) = complement of union of opens disjoint from {1}
+        # Opens disjoint from {1}: {} -> empty union
+        # So closure({1}) = {0,1} - {} = {0,1}
+        # Wait: opens are {}, {1}, {0,1}
+        # Opens disjoint from {1}: {} only (since {1} contains 1, {0,1} contains 1)
+        # So closure({1}) = {0,1} - {} = {0,1}
+        result = closure(topo, (1,))
+        assert result == frozenset({0, 1})
+
+    def test_sierpinski_closure_0(self):
+        topo = _sierpinski_topology()
+        # closure({0}): opens disjoint from {0}: {} and {1}
+        # Union = {1}
+        # closure = {0,1} - {1} = {0}
+        result = closure(topo, (0,))
+        assert result == frozenset({0})
+
+
+# ---------------------------------------------------------------------------
+# Interior
+# ---------------------------------------------------------------------------
+
+
+class TestInterior:
+    def test_discrete_interior(self):
+        topo = _discrete_topology(3)
+        result = interior(topo, (0, 1))
+        assert result == frozenset({0, 1})
+
+    def test_sierpinski_interior(self):
+        topo = _sierpinski_topology()
+        # interior({0}) = largest open subset of {0} = {} (since {0} is not open)
+        result = interior(topo, (0,))
+        assert result == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Connected components
+# ---------------------------------------------------------------------------
+
+
+class TestConnectedComponents:
+    def test_discrete_connected(self):
+        topo = _discrete_topology(3)
+        result = connected_components(topo)
+        assert len(result) == 3
+        # Each point is its own component
+        for comp in result:
+            assert len(comp) == 1
+
+    def test_trivial_connected(self):
+        topo = _trivial_topology(3)
+        result = connected_components(topo)
+        assert len(result) == 1
+        assert set(result[0]) == {0, 1, 2}
+
+    def test_sierpinski_connected(self):
+        topo = _sierpinski_topology()
+        result = connected_components(topo)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Continuity
+# ---------------------------------------------------------------------------
+
+
+class TestIsContinuous:
+    def test_identity_is_continuous(self):
+        topo = _discrete_topology(2)
+        identity = PointMap(
+            domain_point_count=2,
+            codomain_point_count=2,
+            function=(0, 1),
+        )
+        assert is_continuous(topo, topo, identity)
+
+    def test_constant_map_continuous(self):
+        domain = _discrete_topology(3)
+        codomain = _trivial_topology(2)
+        constant = PointMap(
+            domain_point_count=3,
+            codomain_point_count=2,
+            function=(0, 0, 0),
+        )
+        # Preimage of any open in codomain is either empty or full set
+        # In discrete topology both are open
+        assert is_continuous(domain, codomain, constant)
+
+    def test_non_continuous(self):
+        domain = _trivial_topology(2)
+        codomain = _discrete_topology(2)
+        identity = PointMap(
+            domain_point_count=2,
+            codomain_point_count=2,
+            function=(0, 1),
+        )
+        # Preimage of {0} = {0}, which is not open in trivial topology
+        assert not is_continuous(domain, codomain, identity)
+
+
+# ---------------------------------------------------------------------------
+# Beat points
+# ---------------------------------------------------------------------------
+
+
+class TestBeatPoints:
+    def test_discrete_no_beat_points(self):
+        topo = _discrete_topology(3)
+        down, up = beat_points(topo)
+        # In discrete topology: no beat points
+        assert len(down) == 0
+        assert len(up) == 0
+
+    def test_trivial_has_beat_points(self):
+        topo = _trivial_topology(2)
+        down, up = beat_points(topo)
+        assert 0 in down
+        assert 0 in up
+
+    def test_sierpinski_beat_points(self):
+        topo = _sierpinski_topology()
+        down, up = beat_points(topo)
+        # In Sierpinski: preorder[0]=(T,T), preorder[1]=(F,T)
+        # below 0 = {1}, maximals of {1} = {1} -> unique -> 0 is down beat
+        # above 1 = {0}, minimals of {0} = {0} -> unique -> 1 is up beat
+        assert 0 in down
+        assert 1 in up
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_missing_empty_set_rejected(self):
+        with pytest.raises(ValidationError):
+            FiniteTopology(
+                point_count=2,
+                open_sets=((1,), (0, 1)),
+            )
+
+    def test_missing_full_set_rejected(self):
+        with pytest.raises(ValidationError):
+            FiniteTopology(
+                point_count=2,
+                open_sets=((), (1,)),
+            )
+
+    def test_point_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            FiniteTopology(
+                point_count=2,
+                open_sets=((), (0, 5)),
+            )
+
+    def test_duplicate_open_set_rejected(self):
+        with pytest.raises(ValidationError):
+            FiniteTopology(
+                point_count=2,
+                open_sets=((), (0, 1), (0, 1)),
+            )


### PR DESCRIPTION
## Summary

Implements core finite topological space operations for the Jacobian MCP server, addressing issue #1920.

## Design

Every finite topology is Alexandrov and equivalent to a specialization preorder. Operations work directly on open sets and their derived structure:

- `topology.specialization_preorder.compute` — specialization preorder matrix
- `topology.closure.compute` — smallest closed set containing a subset
- `topology.interior.compute` — largest open set contained in a subset
- `topology.connected_components.compute` — partition via preorder graph
- `topology.is_continuous.compute` — preimage-of-open-set check for point maps
- `topology.beat_points.compute` — up/down beat point detection

## Library choices

Direct set operations and BFS — no external topology library needed. The implementation follows the existing `StrictModel` Pydantic pattern and reuses set/frozenset for open/closed set computation.

## Tests

21 tests covering:
- Discrete, trivial, and Sierpinski topologies
- Specialization preorder for each topology type
- Closure and interior with known-answer verification
- Connected components in connected and disconnected spaces
- Continuity (identity, constant, non-continuous maps)
- Beat point detection for Sierpinski and trivial topologies
- Validation: missing empty/full sets, out-of-range points, duplicate open sets

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/22f3d42f-c745-43f4-af74-fe0d58ea1090)