### PR TITLE
Make term rewrite choices explicit and complete (#1921)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -32,6 +32,9 @@ from jacobian.math.finite_game_theory._tools import TOOLS as FINITE_GAME_THEORY_
 from jacobian.math.finite_metric_spaces._tools import (
     TOOLS as FINITE_METRIC_SPACES_TOOLS,
 )
+from jacobian.math.term_rewriting._tools import (
+    TOOLS as TERM_REWRITING_TOOLS,
+)
 from jacobian.math.finite_sets._tools import TOOLS as FINITE_SETS_TOOLS
 from jacobian.math.formal_power_series._tools import TOOLS as FORMAL_POWER_SERIES_TOOLS
 from jacobian.math.geometry._tools import TOOLS as GEOMETRY_TOOLS
@@ -145,6 +148,7 @@ BUILTIN_TOOLS: MathTools = (
     *ALGEBRAIC_COMBINATORICS_TOOLS,
     *REAL_ALGEBRA_TOOLS,
     *FINITE_METRIC_SPACES_TOOLS,
+    *TERM_REWRITING_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -32,9 +32,6 @@ from jacobian.math.finite_game_theory._tools import TOOLS as FINITE_GAME_THEORY_
 from jacobian.math.finite_metric_spaces._tools import (
     TOOLS as FINITE_METRIC_SPACES_TOOLS,
 )
-from jacobian.math.term_rewriting._tools import (
-    TOOLS as TERM_REWRITING_TOOLS,
-)
 from jacobian.math.finite_sets._tools import TOOLS as FINITE_SETS_TOOLS
 from jacobian.math.formal_power_series._tools import TOOLS as FORMAL_POWER_SERIES_TOOLS
 from jacobian.math.geometry._tools import TOOLS as GEOMETRY_TOOLS
@@ -83,6 +80,7 @@ from jacobian.math.regular_languages._tools import TOOLS as REGULAR_LANGUAGES_TO
 from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
+from jacobian.math.term_rewriting._tools import TOOLS as TERM_REWRITING_TOOLS
 from jacobian.math.topology._tools import TOOLS as TOPOLOGY_TOOLS
 
 BUILTIN_TOOLS: MathTools = (

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -9,6 +9,7 @@ from jacobian.math import (
     polynomials,
     prime_field_linear_algebra,
     probability,
+    term_rewriting,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "polynomials",
     "prime_field_linear_algebra",
     "probability",
+    "term_rewriting",
 ]

--- a/src/jacobian/math/term_rewriting/__init__.py
+++ b/src/jacobian/math/term_rewriting/__init__.py
@@ -1,0 +1,2 @@
+"""Term rewriting operation ownership."""
+__all__: list[str] = []

--- a/src/jacobian/math/term_rewriting/__init__.py
+++ b/src/jacobian/math/term_rewriting/__init__.py
@@ -1,2 +1,3 @@
 """Term rewriting operation ownership."""
+
 __all__: list[str] = []

--- a/src/jacobian/math/term_rewriting/__init__.py
+++ b/src/jacobian/math/term_rewriting/__init__.py
@@ -1,3 +1,25 @@
-"""Term rewriting operation ownership."""
+"""Supported native first-order term-rewriting API."""
 
-__all__: list[str] = []
+from jacobian.math.term_rewriting.operations import (
+    apply_substitution,
+    match,
+    normal_form,
+    rewrite_steps,
+    selected_rewrite_step,
+    term_at_position,
+    unify,
+)
+from jacobian.math.term_rewriting.values import RewriteApplication, RewriteRule, Term
+
+__all__ = [
+    "RewriteApplication",
+    "RewriteRule",
+    "Term",
+    "apply_substitution",
+    "match",
+    "normal_form",
+    "rewrite_steps",
+    "selected_rewrite_step",
+    "term_at_position",
+    "unify",
+]

--- a/src/jacobian/math/term_rewriting/_models.py
+++ b/src/jacobian/math/term_rewriting/_models.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
-from jacobian.math.term_rewriting.values import RewriteRule, Substitution, Term
+from jacobian.math.term_rewriting.operations import (
+    normal_form,
+    rewrite_steps,
+    selected_rewrite_step,
+    term_at_position,
+    unify,
+)
+from jacobian.math.term_rewriting.values import (
+    MAX_RULES,
+    RewriteApplication,
+    RewriteRule,
+    Substitution,
+    Term,
+)
 
 
 class SubstitutionRequest(StrictModel):
@@ -45,38 +60,116 @@ class UnificationRequest(StrictModel):
 class UnificationResult(StrictModel):
     """Result of unification."""
 
+    left: Term
+    right: Term
     unified: bool
     substitution: dict[int, Term] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def require_exact_unifier(self) -> Self:
+        expected = unify(self.left, self.right)
+        if expected is None:
+            if self.unified or self.substitution:
+                raise ValueError("failed unification must not claim a substitution")
+        elif not self.unified or self.substitution != expected:
+            raise ValueError("substitution must be the computed idempotent MGU")
+        return self
+
+
+class RewriteStepSelection(StrictModel):
+    """An agent-selected redex and rule for one rewrite derivation."""
+
+    position: tuple[int, ...]
+    rule_index: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_nonnegative_position(self) -> Self:
+        if any(child_index < 0 for child_index in self.position):
+            raise ValueError("rewrite position indices must be non-negative")
+        return self
+
 
 class RewriteStepRequest(StrictModel):
-    """Apply one rewrite step to a term."""
+    """Enumerate every step, or apply one explicitly selected redex and rule."""
 
     term: Term
-    rules: tuple[RewriteRule, ...] = Field(min_length=1)
+    rules: tuple[RewriteRule, ...] = Field(min_length=1, max_length=MAX_RULES)
+    selection: RewriteStepSelection | None = None
+
+    @model_validator(mode="after")
+    def require_valid_selection(self) -> Self:
+        if self.selection is None:
+            return self
+        if self.selection.rule_index >= len(self.rules):
+            raise ValueError("selected rule_index is out of range")
+        term_at_position(self.term, self.selection.position)
+        return self
 
 
 class RewriteStepResult(StrictModel):
-    """Result of one rewrite step."""
+    """All applicable derivations or the declared selected derivation."""
 
-    rewritten: bool
-    term: Term
+    source_term: Term
+    rules: tuple[RewriteRule, ...]
+    selection: RewriteStepSelection | None
+    scope: Literal["ALL_APPLICABLE_STEPS", "SELECTED_STEP"]
+    applications: tuple[RewriteApplication, ...]
+
+    @model_validator(mode="after")
+    def require_exact_applications(self) -> Self:
+        if self.selection is None:
+            expected = rewrite_steps(self.source_term, self.rules)
+            expected_scope = "ALL_APPLICABLE_STEPS"
+        else:
+            application = selected_rewrite_step(
+                self.source_term,
+                self.rules,
+                self.selection.position,
+                self.selection.rule_index,
+            )
+            expected = () if application is None else (application,)
+            expected_scope = "SELECTED_STEP"
+        if self.scope != expected_scope:
+            raise ValueError("scope must agree with selection")
+        if self.applications != expected:
+            raise ValueError("applications do not match the declared rewrite scope")
+        return self
 
 
 class NormalFormRequest(StrictModel):
-    """Compute the normal form of a term under a set of rules."""
+    """Run an explicit bounded normalization strategy."""
 
     term: Term
-    rules: tuple[RewriteRule, ...] = Field(min_length=1)
-    max_steps: int = Field(default=1000, ge=1, le=100000)
+    rules: tuple[RewriteRule, ...] = Field(min_length=1, max_length=MAX_RULES)
+    strategy: Literal["LEFTMOST_OUTERMOST_RULE_ORDER"]
+    max_steps: int = Field(default=1000, ge=1, le=1000)
 
 
 class NormalFormResult(StrictModel):
-    """The normal form (or last term if max_steps reached)."""
+    """A proved normal form or a bounded prefix with an explicit next step."""
 
+    source_term: Term
+    rules: tuple[RewriteRule, ...]
+    strategy: Literal["LEFTMOST_OUTERMOST_RULE_ORDER"]
+    max_steps: int = Field(ge=1, le=1000)
     term: Term
-    converged: bool
-    steps: int
+    status: Literal["NORMAL_FORM", "STEP_LIMIT"]
+    steps: int = Field(ge=0)
+    next_step: RewriteApplication | None
+
+    @model_validator(mode="after")
+    def require_exact_bounded_run(self) -> Self:
+        term, status, steps, next_step = normal_form(
+            self.source_term, self.rules, self.max_steps
+        )
+        if (self.term, self.status, self.steps, self.next_step) != (
+            term,
+            status,
+            steps,
+            next_step,
+        ):
+            raise ValueError("normal-form result does not replay exactly")
+        return self
 
 
 __all__ = [
@@ -86,6 +179,7 @@ __all__ = [
     "NormalFormResult",
     "RewriteStepRequest",
     "RewriteStepResult",
+    "RewriteStepSelection",
     "SubstitutionRequest",
     "SubstitutionResult",
     "UnificationRequest",

--- a/src/jacobian/math/term_rewriting/_models.py
+++ b/src/jacobian/math/term_rewriting/_models.py
@@ -1,0 +1,93 @@
+"""Typed wire contracts for first-order term rewriting operations."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+from jacobian.math.term_rewriting.values import RewriteRule, Substitution, Term
+
+
+class SubstitutionRequest(StrictModel):
+    """Apply a substitution to a term."""
+
+    term: Term
+    substitution: Substitution
+
+
+class SubstitutionResult(StrictModel):
+    """The term after substitution."""
+
+    term: Term
+
+
+class MatchingRequest(StrictModel):
+    """Match a pattern against a subject term (one-way matching)."""
+
+    pattern: Term
+    subject: Term
+
+
+class MatchingResult(StrictModel):
+    """Result of one-way matching."""
+
+    matched: bool
+    substitution: dict[int, Term] = Field(default_factory=dict)
+
+
+class UnificationRequest(StrictModel):
+    """Unify two terms."""
+
+    left: Term
+    right: Term
+
+
+class UnificationResult(StrictModel):
+    """Result of unification."""
+
+    unified: bool
+    substitution: dict[int, Term] = Field(default_factory=dict)
+
+
+class RewriteStepRequest(StrictModel):
+    """Apply one rewrite step to a term."""
+
+    term: Term
+    rules: tuple[RewriteRule, ...] = Field(min_length=1)
+
+
+class RewriteStepResult(StrictModel):
+    """Result of one rewrite step."""
+
+    rewritten: bool
+    term: Term
+
+
+class NormalFormRequest(StrictModel):
+    """Compute the normal form of a term under a set of rules."""
+
+    term: Term
+    rules: tuple[RewriteRule, ...] = Field(min_length=1)
+    max_steps: int = Field(default=1000, ge=1, le=100000)
+
+
+class NormalFormResult(StrictModel):
+    """The normal form (or last term if max_steps reached)."""
+
+    term: Term
+    converged: bool
+    steps: int
+
+
+__all__ = [
+    "MatchingRequest",
+    "MatchingResult",
+    "NormalFormRequest",
+    "NormalFormResult",
+    "RewriteStepRequest",
+    "RewriteStepResult",
+    "SubstitutionRequest",
+    "SubstitutionResult",
+    "UnificationRequest",
+    "UnificationResult",
+]

--- a/src/jacobian/math/term_rewriting/_operations.py
+++ b/src/jacobian/math/term_rewriting/_operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from jacobian.math.term_rewriting._models import (
     MatchingRequest,
     MatchingResult,
@@ -18,7 +20,8 @@ from jacobian.math.term_rewriting.operations import (
     apply_substitution,
     match,
     normal_form,
-    rewrite_step,
+    rewrite_steps,
+    selected_rewrite_step,
     unify,
 )
 
@@ -47,17 +50,54 @@ def compute_matching(request: MatchingRequest) -> MatchingResult:
 def compute_unification(request: UnificationRequest) -> UnificationResult:
     result = unify(request.left, request.right)
     if result is None:
-        return UnificationResult(unified=False, substitution={})
-    return UnificationResult(unified=True, substitution=result)
+        return UnificationResult(
+            left=request.left,
+            right=request.right,
+            unified=False,
+            substitution={},
+        )
+    return UnificationResult(
+        left=request.left,
+        right=request.right,
+        unified=True,
+        substitution=result,
+    )
 
 
 def compute_rewrite_step(request: RewriteStepRequest) -> RewriteStepResult:
-    rewritten, term = rewrite_step(request.term, list(request.rules))
-    return RewriteStepResult(rewritten=rewritten, term=term)
+    scope: Literal["ALL_APPLICABLE_STEPS", "SELECTED_STEP"]
+    if request.selection is None:
+        applications = rewrite_steps(request.term, request.rules)
+        scope = "ALL_APPLICABLE_STEPS"
+    else:
+        application = selected_rewrite_step(
+            request.term,
+            request.rules,
+            request.selection.position,
+            request.selection.rule_index,
+        )
+        applications = () if application is None else (application,)
+        scope = "SELECTED_STEP"
+    return RewriteStepResult(
+        source_term=request.term,
+        rules=request.rules,
+        selection=request.selection,
+        scope=scope,
+        applications=applications,
+    )
 
 
 def compute_normal_form(request: NormalFormRequest) -> NormalFormResult:
-    term, converged, steps = normal_form(
-        request.term, list(request.rules), request.max_steps,
+    term, status, steps, next_step = normal_form(
+        request.term, request.rules, request.max_steps
     )
-    return NormalFormResult(term=term, converged=converged, steps=steps)
+    return NormalFormResult(
+        source_term=request.term,
+        rules=request.rules,
+        strategy=request.strategy,
+        max_steps=request.max_steps,
+        term=term,
+        status=status,
+        steps=steps,
+        next_step=next_step,
+    )

--- a/src/jacobian/math/term_rewriting/_operations.py
+++ b/src/jacobian/math/term_rewriting/_operations.py
@@ -1,0 +1,63 @@
+"""Domain adapter for term rewriting operations."""
+
+from __future__ import annotations
+
+from jacobian.math.term_rewriting._models import (
+    MatchingRequest,
+    MatchingResult,
+    NormalFormRequest,
+    NormalFormResult,
+    RewriteStepRequest,
+    RewriteStepResult,
+    SubstitutionRequest,
+    SubstitutionResult,
+    UnificationRequest,
+    UnificationResult,
+)
+from jacobian.math.term_rewriting.operations import (
+    apply_substitution,
+    match,
+    normal_form,
+    rewrite_step,
+    unify,
+)
+
+__all__ = [
+    "compute_matching",
+    "compute_normal_form",
+    "compute_rewrite_step",
+    "compute_substitution",
+    "compute_unification",
+]
+
+
+def compute_substitution(request: SubstitutionRequest) -> SubstitutionResult:
+    return SubstitutionResult(
+        term=apply_substitution(request.term, request.substitution.mapping)
+    )
+
+
+def compute_matching(request: MatchingRequest) -> MatchingResult:
+    result = match(request.pattern, request.subject)
+    if result is None:
+        return MatchingResult(matched=False, substitution={})
+    return MatchingResult(matched=True, substitution=result)
+
+
+def compute_unification(request: UnificationRequest) -> UnificationResult:
+    result = unify(request.left, request.right)
+    if result is None:
+        return UnificationResult(unified=False, substitution={})
+    return UnificationResult(unified=True, substitution=result)
+
+
+def compute_rewrite_step(request: RewriteStepRequest) -> RewriteStepResult:
+    rewritten, term = rewrite_step(request.term, list(request.rules))
+    return RewriteStepResult(rewritten=rewritten, term=term)
+
+
+def compute_normal_form(request: NormalFormRequest) -> NormalFormResult:
+    term, converged, steps = normal_form(
+        request.term, list(request.rules), request.max_steps,
+    )
+    return NormalFormResult(term=term, converged=converged, steps=steps)

--- a/src/jacobian/math/term_rewriting/_tools.py
+++ b/src/jacobian/math/term_rewriting/_tools.py
@@ -171,9 +171,10 @@ _TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     ),
     _op(
         "term_rewriting.rewrite_step.compute",
-        "Apply one rewrite step to a term",
-        "Apply the leftmost-outermost matching rewrite rule to a term "
-        "and return the rewritten term.",
+        "Enumerate or select one-step term rewrites",
+        "Return every applicable one-step derivation, or apply one agent-selected "
+        "rule at one agent-selected position. Each result includes its position, "
+        "rule index, matching substitution, and rewritten term.",
         RewriteStepRequest,
         RewriteStepResult,
         compute_rewrite_step,
@@ -216,9 +217,10 @@ _TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     ),
     _op(
         "term_rewriting.normal_form.compute",
-        "Compute the normal form of a term",
-        "Iteratively apply rewrite rules until no rule applies or the "
-        "step limit is reached, returning the normal form (or last term).",
+        "Run an explicit bounded term-normalization strategy",
+        "Apply the explicitly declared leftmost-outermost, rule-order strategy. "
+        "Return NORMAL_FORM only when no rewrite applies; otherwise return "
+        "STEP_LIMIT with the exact next-step witness.",
         NormalFormRequest,
         NormalFormResult,
         compute_normal_form,
@@ -259,6 +261,7 @@ _TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                             },
                         }
                     ],
+                    "strategy": "LEFTMOST_OUTERMOST_RULE_ORDER",
                     "max_steps": 100,
                 },
             ),

--- a/src/jacobian/math/term_rewriting/_tools.py
+++ b/src/jacobian/math/term_rewriting/_tools.py
@@ -1,0 +1,271 @@
+"""First-order term rewriting operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.term_rewriting._models import (
+    MatchingRequest,
+    MatchingResult,
+    NormalFormRequest,
+    NormalFormResult,
+    RewriteStepRequest,
+    RewriteStepResult,
+    SubstitutionRequest,
+    SubstitutionResult,
+    UnificationRequest,
+    UnificationResult,
+)
+from jacobian.math.term_rewriting._operations import (
+    compute_matching,
+    compute_normal_form,
+    compute_rewrite_step,
+    compute_substitution,
+    compute_unification,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_SUBST_EXAMPLE = {
+    "term": {
+        "is_variable": False,
+        "symbol": 0,
+        "children": [
+            {"is_variable": True, "symbol": 0, "children": []},
+            {"is_variable": False, "symbol": 1, "children": []},
+        ],
+    },
+    "substitution": {
+        "mapping": {
+            "0": {
+                "is_variable": False,
+                "symbol": 2,
+                "children": [],
+            },
+        },
+    },
+}
+
+_MATCH_EXAMPLE = {
+    "pattern": {
+        "is_variable": False,
+        "symbol": 0,
+        "children": [
+            {"is_variable": True, "symbol": 0, "children": []},
+            {"is_variable": True, "symbol": 1, "children": []},
+        ],
+    },
+    "subject": {
+        "is_variable": False,
+        "symbol": 0,
+        "children": [
+            {"is_variable": False, "symbol": 1, "children": []},
+            {"is_variable": False, "symbol": 2, "children": []},
+        ],
+    },
+}
+
+_UNIFY_EXAMPLE = {
+    "left": {
+        "is_variable": False,
+        "symbol": 0,
+        "children": [
+            {"is_variable": True, "symbol": 0, "children": []},
+            {"is_variable": False, "symbol": 1, "children": []},
+        ],
+    },
+    "right": {
+        "is_variable": False,
+        "symbol": 0,
+        "children": [
+            {"is_variable": False, "symbol": 2, "children": []},
+            {"is_variable": False, "symbol": 1, "children": []},
+        ],
+    },
+}
+
+_TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "term_rewriting.substitution.compute",
+        "Apply a substitution to a term",
+        "Apply a variable-to-term substitution to a first-order term, "
+        "replacing each variable with its binding.",
+        SubstitutionRequest,
+        SubstitutionResult,
+        compute_substitution,
+        "term-rewriting",
+        "substitution",
+        "exact",
+        examples=(
+            example(
+                "simple_substitution",
+                "Substitute a function symbol for a variable.",
+                _SUBST_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "term_rewriting.matching.compute",
+        "Match a pattern against a subject term",
+        "One-way matching: find a substitution that makes a pattern "
+        "(with variables) structurally equal to a ground subject term.",
+        MatchingRequest,
+        MatchingResult,
+        compute_matching,
+        "term-rewriting",
+        "matching",
+        "exact",
+        examples=(
+            example(
+                "match_pattern",
+                "Match f(x, y) against f(g, h).",
+                _MATCH_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "term_rewriting.unification.compute",
+        "Unify two terms",
+        "Compute the most general unifier (MGU) of two first-order terms.",
+        UnificationRequest,
+        UnificationResult,
+        compute_unification,
+        "term-rewriting",
+        "unification",
+        "exact",
+        examples=(
+            example(
+                "unify_two_terms",
+                "Unify f(x, c) with f(d, c).",
+                _UNIFY_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "term_rewriting.rewrite_step.compute",
+        "Apply one rewrite step to a term",
+        "Apply the leftmost-outermost matching rewrite rule to a term "
+        "and return the rewritten term.",
+        RewriteStepRequest,
+        RewriteStepResult,
+        compute_rewrite_step,
+        "term-rewriting",
+        "rewrite-step",
+        "exact",
+        examples=(
+            example(
+                "rewrite_f_to_g",
+                "Rewrite f(x) to g(x) in a simple term.",
+                {
+                    "term": {
+                        "is_variable": False,
+                        "symbol": 0,
+                        "children": [
+                            {"is_variable": False, "symbol": 1, "children": []},
+                        ],
+                    },
+                    "rules": [
+                        {
+                            "lhs": {
+                                "is_variable": False,
+                                "symbol": 0,
+                                "children": [
+                                    {"is_variable": True, "symbol": 0, "children": []},
+                                ],
+                            },
+                            "rhs": {
+                                "is_variable": False,
+                                "symbol": 1,
+                                "children": [
+                                    {"is_variable": True, "symbol": 0, "children": []},
+                                ],
+                            },
+                        }
+                    ],
+                },
+            ),
+        ),
+    ),
+    _op(
+        "term_rewriting.normal_form.compute",
+        "Compute the normal form of a term",
+        "Iteratively apply rewrite rules until no rule applies or the "
+        "step limit is reached, returning the normal form (or last term).",
+        NormalFormRequest,
+        NormalFormResult,
+        compute_normal_form,
+        "term-rewriting",
+        "normal-form",
+        "exact",
+        examples=(
+            example(
+                "strip_f_layers",
+                "Strip f layers from f(f(a)) using rule f(x) -> x.",
+                {
+                    "term": {
+                        "is_variable": False,
+                        "symbol": 0,
+                        "children": [
+                            {
+                                "is_variable": False,
+                                "symbol": 0,
+                                "children": [
+                                    {"is_variable": False, "symbol": 1, "children": []},
+                                ],
+                            },
+                        ],
+                    },
+                    "rules": [
+                        {
+                            "lhs": {
+                                "is_variable": False,
+                                "symbol": 0,
+                                "children": [
+                                    {"is_variable": True, "symbol": 0, "children": []},
+                                ],
+                            },
+                            "rhs": {
+                                "is_variable": True,
+                                "symbol": 0,
+                                "children": [],
+                            },
+                        }
+                    ],
+                    "max_steps": 100,
+                },
+            ),
+        ),
+    ),
+)
+
+TOOLS = _TERM_REWRITING_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/term_rewriting/_tools.py
+++ b/src/jacobian/math/term_rewriting/_tools.py
@@ -9,20 +9,14 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.term_rewriting._models import (
     MatchingRequest,
     MatchingResult,
-    NormalFormRequest,
-    NormalFormResult,
     RewriteStepRequest,
     RewriteStepResult,
-    SubstitutionRequest,
-    SubstitutionResult,
     UnificationRequest,
     UnificationResult,
 )
 from jacobian.math.term_rewriting._operations import (
     compute_matching,
-    compute_normal_form,
     compute_rewrite_step,
-    compute_substitution,
     compute_unification,
 )
 
@@ -53,26 +47,6 @@ def _op[
         examples=examples,
     )
 
-
-_SUBST_EXAMPLE = {
-    "term": {
-        "is_variable": False,
-        "symbol": 0,
-        "children": [
-            {"is_variable": True, "symbol": 0, "children": []},
-            {"is_variable": False, "symbol": 1, "children": []},
-        ],
-    },
-    "substitution": {
-        "mapping": {
-            "0": {
-                "is_variable": False,
-                "symbol": 2,
-                "children": [],
-            },
-        },
-    },
-}
 
 _MATCH_EXAMPLE = {
     "pattern": {
@@ -113,25 +87,6 @@ _UNIFY_EXAMPLE = {
 }
 
 _TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
-    _op(
-        "term_rewriting.substitution.compute",
-        "Apply a substitution to a term",
-        "Apply a variable-to-term substitution to a first-order term, "
-        "replacing each variable with its binding.",
-        SubstitutionRequest,
-        SubstitutionResult,
-        compute_substitution,
-        "term-rewriting",
-        "substitution",
-        "exact",
-        examples=(
-            example(
-                "simple_substitution",
-                "Substitute a function symbol for a variable.",
-                _SUBST_EXAMPLE,
-            ),
-        ),
-    ),
     _op(
         "term_rewriting.matching.compute",
         "Match a pattern against a subject term",
@@ -211,58 +166,6 @@ _TERM_REWRITING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                             },
                         }
                     ],
-                },
-            ),
-        ),
-    ),
-    _op(
-        "term_rewriting.normal_form.compute",
-        "Run an explicit bounded term-normalization strategy",
-        "Apply the explicitly declared leftmost-outermost, rule-order strategy. "
-        "Return NORMAL_FORM only when no rewrite applies; otherwise return "
-        "STEP_LIMIT with the exact next-step witness.",
-        NormalFormRequest,
-        NormalFormResult,
-        compute_normal_form,
-        "term-rewriting",
-        "normal-form",
-        "exact",
-        examples=(
-            example(
-                "strip_f_layers",
-                "Strip f layers from f(f(a)) using rule f(x) -> x.",
-                {
-                    "term": {
-                        "is_variable": False,
-                        "symbol": 0,
-                        "children": [
-                            {
-                                "is_variable": False,
-                                "symbol": 0,
-                                "children": [
-                                    {"is_variable": False, "symbol": 1, "children": []},
-                                ],
-                            },
-                        ],
-                    },
-                    "rules": [
-                        {
-                            "lhs": {
-                                "is_variable": False,
-                                "symbol": 0,
-                                "children": [
-                                    {"is_variable": True, "symbol": 0, "children": []},
-                                ],
-                            },
-                            "rhs": {
-                                "is_variable": True,
-                                "symbol": 0,
-                                "children": [],
-                            },
-                        }
-                    ],
-                    "strategy": "LEFTMOST_OUTERMOST_RULE_ORDER",
-                    "max_steps": 100,
                 },
             ),
         ),

--- a/src/jacobian/math/term_rewriting/operations.py
+++ b/src/jacobian/math/term_rewriting/operations.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from jacobian.math.term_rewriting.values import RewriteRule, Term
+from typing import Literal
+
+from jacobian.math.term_rewriting.values import RewriteApplication, RewriteRule, Term
 
 __all__ = [
     "apply_substitution",
     "match",
     "normal_form",
-    "rewrite_step",
+    "rewrite_steps",
+    "selected_rewrite_step",
+    "term_at_position",
     "unify",
 ]
 
@@ -33,7 +37,7 @@ def apply_substitution(term: Term, subst: dict[int, Term]) -> Term:
 
 
 def match(pattern: Term, subject: Term) -> dict[int, Term] | None:
-    """One-way matching: match a pattern (with variables) against a ground subject."""
+    """One-way matching: instantiate pattern variables to obtain the subject."""
     if pattern.is_variable:
         return {pattern.symbol: subject}
     if subject.is_variable:
@@ -54,86 +58,143 @@ def match(pattern: Term, subject: Term) -> dict[int, Term] | None:
     return result
 
 
-def _unify(
-    left: Term, right: Term, subst: dict[int, Term],
-) -> dict[int, Term] | None:
-    """Recursive unification with substitution accumulation."""
-    left = _resolve(left, subst)
-    right = _resolve(right, subst)
-    if left.is_variable and right.is_variable and left.symbol == right.symbol:
-        return subst
-    if left.is_variable:
-        if left.symbol in _variables(right):
-            return None
-        new_subst = dict(subst)
-        new_subst[left.symbol] = right
-        return new_subst
-    if right.is_variable:
-        if right.symbol in _variables(left):
-            return None
-        new_subst = dict(subst)
-        new_subst[right.symbol] = left
-        return new_subst
-    if left.symbol != right.symbol or len(left.children) != len(right.children):
-        return None
-    new_subst = dict(subst)
-    for l_child, r_child in zip(left.children, right.children, strict=False):
-        result = _unify(l_child, r_child, new_subst)
-        if result is None:
-            return None
-        new_subst = result
-    return new_subst
-
-
-def _resolve(term: Term, subst: dict[int, Term]) -> Term:
+def _apply_recursive_substitution(term: Term, subst: dict[int, Term]) -> Term:
     if term.is_variable and term.symbol in subst:
-        return _resolve(subst[term.symbol], subst)
-    return term
+        return _apply_recursive_substitution(subst[term.symbol], subst)
+    if term.is_variable:
+        return term
+    return Term(
+        is_variable=False,
+        symbol=term.symbol,
+        children=tuple(
+            _apply_recursive_substitution(child, subst) for child in term.children
+        ),
+    )
 
 
 def unify(left: Term, right: Term) -> dict[int, Term] | None:
-    """Unify two terms, returning a substitution or None."""
-    return _unify(left, right, {})
+    """Unify two terms, returning an idempotent most-general unifier."""
+    equations = [(left, right)]
+    substitution: dict[int, Term] = {}
+    while equations:
+        equation_left, equation_right = equations.pop()
+        equation_left = _apply_recursive_substitution(equation_left, substitution)
+        equation_right = _apply_recursive_substitution(equation_right, substitution)
+        if equation_left == equation_right:
+            continue
+        if equation_right.is_variable:
+            equation_left, equation_right = equation_right, equation_left
+        if equation_left.is_variable:
+            if equation_left.symbol in _variables(equation_right):
+                return None
+            binding = {equation_left.symbol: equation_right}
+            substitution = {
+                variable: _apply_recursive_substitution(term, binding)
+                for variable, term in substitution.items()
+            }
+            substitution[equation_left.symbol] = equation_right
+            continue
+        if (
+            equation_right.is_variable
+            or equation_left.symbol != equation_right.symbol
+            or len(equation_left.children) != len(equation_right.children)
+        ):
+            return None
+        equations.extend(
+            zip(equation_left.children, equation_right.children, strict=True)
+        )
+    return substitution
 
 
-def _rewrite_at_root(term: Term, rules: list[RewriteRule]) -> Term | None:
-    for rule in rules:
-        subst = match(rule.lhs, term)
-        if subst is not None:
-            return apply_substitution(rule.rhs, subst)
-    return None
+def term_at_position(term: Term, position: tuple[int, ...]) -> Term:
+    """Return the subterm at a child-index path, raising for an invalid path."""
+    current = term
+    for child_index in position:
+        if not 0 <= child_index < len(current.children):
+            raise ValueError("rewrite position is outside the source term")
+        current = current.children[child_index]
+    return current
 
 
-def rewrite_step(term: Term, rules: list[RewriteRule]) -> tuple[bool, Term]:
-    """Apply one rewrite step at the leftmost-outermost redex.
+def _replace_at_position(
+    term: Term, position: tuple[int, ...], replacement: Term
+) -> Term:
+    if not position:
+        return replacement
+    child_index = position[0]
+    children = list(term.children)
+    children[child_index] = _replace_at_position(
+        children[child_index], position[1:], replacement
+    )
+    return Term(is_variable=False, symbol=term.symbol, children=tuple(children))
 
-    Returns (rewritten, new_term).
-    """
-    result = _rewrite_at_root(term, rules)
-    if result is not None:
-        return (True, result)
-    for i, child in enumerate(term.children):
-        rewritten, new_child = rewrite_step(child, rules)
-        if rewritten:
-            new_children = list(term.children)
-            new_children[i] = new_child
-            return (True, Term(is_variable=False, symbol=term.symbol, children=tuple(new_children)))
-    return (False, term)
+
+def _positions(term: Term, prefix: tuple[int, ...] = ()) -> tuple[tuple[int, ...], ...]:
+    return (
+        prefix,
+        *(
+            position
+            for child_index, child in enumerate(term.children)
+            for position in _positions(child, (*prefix, child_index))
+        ),
+    )
+
+
+def selected_rewrite_step(
+    term: Term,
+    rules: tuple[RewriteRule, ...],
+    position: tuple[int, ...],
+    rule_index: int,
+) -> RewriteApplication | None:
+    """Apply exactly the declared rule at exactly the declared position."""
+    redex = term_at_position(term, position)
+    substitution = match(rules[rule_index].lhs, redex)
+    if substitution is None:
+        return None
+    replacement = apply_substitution(rules[rule_index].rhs, substitution)
+    return RewriteApplication(
+        position=position,
+        rule_index=rule_index,
+        substitution=substitution,
+        term=_replace_at_position(term, position, replacement),
+    )
+
+
+def rewrite_steps(
+    term: Term, rules: tuple[RewriteRule, ...]
+) -> tuple[RewriteApplication, ...]:
+    """Return every applicable one-step derivation, including its witness."""
+    return tuple(
+        application
+        for position in _positions(term)
+        for rule_index in range(len(rules))
+        if (application := selected_rewrite_step(term, rules, position, rule_index))
+        is not None
+    )
 
 
 def normal_form(
-    term: Term, rules: list[RewriteRule], max_steps: int = 1000,
-) -> tuple[Term, bool, int]:
-    """Compute the normal form of a term.
+    term: Term, rules: tuple[RewriteRule, ...], max_steps: int = 1000
+) -> tuple[
+    Term,
+    Literal["NORMAL_FORM", "STEP_LIMIT"],
+    int,
+    RewriteApplication | None,
+]:
+    """Run the explicit leftmost-outermost, rule-order strategy.
 
-    Returns (term, converged, steps).
+    Returns (term, status, steps, next_step). ``next_step`` is the open
+    obligation when the declared step bound is exhausted.
     """
     steps = 0
     current = term
     while steps < max_steps:
-        rewritten, new_term = rewrite_step(current, rules)
-        if not rewritten:
-            return (current, True, steps)
-        current = new_term
+        applications = rewrite_steps(current, rules)
+        if not applications:
+            return (current, "NORMAL_FORM", steps, None)
+        current = applications[0].term
         steps += 1
-    return (current, False, steps)
+    applications = rewrite_steps(current, rules)
+    if not applications:
+        return (current, "NORMAL_FORM", steps, None)
+    return (current, "STEP_LIMIT", steps, applications[0])

--- a/src/jacobian/math/term_rewriting/operations.py
+++ b/src/jacobian/math/term_rewriting/operations.py
@@ -147,6 +147,8 @@ def selected_rewrite_step(
     rule_index: int,
 ) -> RewriteApplication | None:
     """Apply exactly the declared rule at exactly the declared position."""
+    if not 0 <= rule_index < len(rules):
+        raise ValueError("rule_index is out of range")
     redex = term_at_position(term, position)
     substitution = match(rules[rule_index].lhs, redex)
     if substitution is None:
@@ -186,6 +188,8 @@ def normal_form(
     Returns (term, status, steps, next_step). ``next_step`` is the open
     obligation when the declared step bound is exhausted.
     """
+    if max_steps < 0:
+        raise ValueError("max_steps must be nonnegative")
     steps = 0
     current = term
     while steps < max_steps:

--- a/src/jacobian/math/term_rewriting/operations.py
+++ b/src/jacobian/math/term_rewriting/operations.py
@@ -1,0 +1,139 @@
+"""Domain-owned first-order term rewriting kernels."""
+
+from __future__ import annotations
+
+from jacobian.math.term_rewriting.values import RewriteRule, Term
+
+__all__ = [
+    "apply_substitution",
+    "match",
+    "normal_form",
+    "rewrite_step",
+    "unify",
+]
+
+
+def _variables(term: Term) -> set[int]:
+    if term.is_variable:
+        return {term.symbol}
+    result: set[int] = set()
+    for child in term.children:
+        result |= _variables(child)
+    return result
+
+
+def apply_substitution(term: Term, subst: dict[int, Term]) -> Term:
+    """Apply a substitution to a term, replacing variables with their bindings."""
+    if term.is_variable:
+        if term.symbol in subst:
+            return subst[term.symbol]
+        return term
+    new_children = tuple(apply_substitution(c, subst) for c in term.children)
+    return Term(is_variable=False, symbol=term.symbol, children=new_children)
+
+
+def match(pattern: Term, subject: Term) -> dict[int, Term] | None:
+    """One-way matching: match a pattern (with variables) against a ground subject."""
+    if pattern.is_variable:
+        return {pattern.symbol: subject}
+    if subject.is_variable:
+        return None
+    if pattern.symbol != subject.symbol:
+        return None
+    if len(pattern.children) != len(subject.children):
+        return None
+    result: dict[int, Term] = {}
+    for p_child, s_child in zip(pattern.children, subject.children, strict=False):
+        sub_result = match(p_child, s_child)
+        if sub_result is None:
+            return None
+        for var, val in sub_result.items():
+            if var in result and result[var] != val:
+                return None
+            result[var] = val
+    return result
+
+
+def _unify(
+    left: Term, right: Term, subst: dict[int, Term],
+) -> dict[int, Term] | None:
+    """Recursive unification with substitution accumulation."""
+    left = _resolve(left, subst)
+    right = _resolve(right, subst)
+    if left.is_variable and right.is_variable and left.symbol == right.symbol:
+        return subst
+    if left.is_variable:
+        if left.symbol in _variables(right):
+            return None
+        new_subst = dict(subst)
+        new_subst[left.symbol] = right
+        return new_subst
+    if right.is_variable:
+        if right.symbol in _variables(left):
+            return None
+        new_subst = dict(subst)
+        new_subst[right.symbol] = left
+        return new_subst
+    if left.symbol != right.symbol or len(left.children) != len(right.children):
+        return None
+    new_subst = dict(subst)
+    for l_child, r_child in zip(left.children, right.children, strict=False):
+        result = _unify(l_child, r_child, new_subst)
+        if result is None:
+            return None
+        new_subst = result
+    return new_subst
+
+
+def _resolve(term: Term, subst: dict[int, Term]) -> Term:
+    if term.is_variable and term.symbol in subst:
+        return _resolve(subst[term.symbol], subst)
+    return term
+
+
+def unify(left: Term, right: Term) -> dict[int, Term] | None:
+    """Unify two terms, returning a substitution or None."""
+    return _unify(left, right, {})
+
+
+def _rewrite_at_root(term: Term, rules: list[RewriteRule]) -> Term | None:
+    for rule in rules:
+        subst = match(rule.lhs, term)
+        if subst is not None:
+            return apply_substitution(rule.rhs, subst)
+    return None
+
+
+def rewrite_step(term: Term, rules: list[RewriteRule]) -> tuple[bool, Term]:
+    """Apply one rewrite step at the leftmost-outermost redex.
+
+    Returns (rewritten, new_term).
+    """
+    result = _rewrite_at_root(term, rules)
+    if result is not None:
+        return (True, result)
+    for i, child in enumerate(term.children):
+        rewritten, new_child = rewrite_step(child, rules)
+        if rewritten:
+            new_children = list(term.children)
+            new_children[i] = new_child
+            return (True, Term(is_variable=False, symbol=term.symbol, children=tuple(new_children)))
+    return (False, term)
+
+
+def normal_form(
+    term: Term, rules: list[RewriteRule], max_steps: int = 1000,
+) -> tuple[Term, bool, int]:
+    """Compute the normal form of a term.
+
+    Returns (term, converged, steps).
+    """
+    steps = 0
+    current = term
+    while steps < max_steps:
+        rewritten, new_term = rewrite_step(current, rules)
+        if not rewritten:
+            return (current, True, steps)
+        current = new_term
+        steps += 1
+    return (current, False, steps)

--- a/src/jacobian/math/term_rewriting/values.py
+++ b/src/jacobian/math/term_rewriting/values.py
@@ -1,0 +1,70 @@
+"""Provider-independent values for first-order term rewriting."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_TERMS = 32
+MAX_SYMBOLS = 64
+MAX_ARITY = 16
+MAX_RULES = 64
+
+
+class Term(StrictModel):
+    """A first-order term represented as a tree.
+
+    A term is either a variable (``is_variable=True``) or a function
+    application (``symbol`` applied to ``children``, which are themselves
+    terms).
+    """
+
+    is_variable: bool = False
+    symbol: int = Field(ge=0)
+    children: tuple[Term, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_valid_term(self) -> Self:
+        if self.is_variable and self.children:
+            raise ValueError("a variable cannot have children")
+        if not self.is_variable and self.symbol < 0:
+            raise ValueError("function symbol must be non-negative")
+        if len(self.children) > MAX_ARITY:
+            raise ValueError("too many children (arity exceeds bound)")
+        return self
+
+
+class RewriteRule(StrictModel):
+    """A rewrite rule: left-hand side rewrites to right-hand side."""
+
+    lhs: Term
+    rhs: Term
+
+    @model_validator(mode="after")
+    def require_valid_rule(self) -> Self:
+        if self.lhs.is_variable:
+            raise ValueError("LHS must be a function application, not a variable")
+        return self
+
+
+Term.model_rebuild()
+
+
+class Substitution(StrictModel):
+    """A variable substitution mapping variable IDs to terms."""
+
+    mapping: dict[int, Term] = Field(default_factory=dict)
+
+
+__all__ = [
+    "MAX_ARITY",
+    "MAX_RULES",
+    "MAX_SYMBOLS",
+    "MAX_TERMS",
+    "RewriteRule",
+    "Substitution",
+    "Term",
+]

--- a/src/jacobian/math/term_rewriting/values.py
+++ b/src/jacobian/math/term_rewriting/values.py
@@ -14,6 +14,12 @@ MAX_ARITY = 16
 MAX_RULES = 64
 
 
+def _variable_symbols(term: Term) -> set[int]:
+    if term.is_variable:
+        return {term.symbol}
+    return set().union(*(_variable_symbols(child) for child in term.children))
+
+
 class Term(StrictModel):
     """A first-order term represented as a tree.
 
@@ -47,7 +53,19 @@ class RewriteRule(StrictModel):
     def require_valid_rule(self) -> Self:
         if self.lhs.is_variable:
             raise ValueError("LHS must be a function application, not a variable")
+        extra_variables = _variable_symbols(self.rhs) - _variable_symbols(self.lhs)
+        if extra_variables:
+            raise ValueError("RHS variables must occur in the LHS")
         return self
+
+
+class RewriteApplication(StrictModel):
+    """One fully witnessed one-step rewrite derivation."""
+
+    position: tuple[int, ...]
+    rule_index: int = Field(ge=0)
+    substitution: dict[int, Term]
+    term: Term
 
 
 Term.model_rebuild()
@@ -64,6 +82,7 @@ __all__ = [
     "MAX_RULES",
     "MAX_SYMBOLS",
     "MAX_TERMS",
+    "RewriteApplication",
     "RewriteRule",
     "Substitution",
     "Term",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1153,25 +1153,9 @@
       "input_schema": "sha256:2b40338042028e9a6e477838b179c012662fcd374322c1b0451039f9fc4b7f6e",
       "output_schema": "sha256:ca8d93197a2ccaa55fce3e8eab6cb1de174742a4a9463606807c4877054865df"
     },
-    "poset.antichain_profile.compute": {
-      "input_schema": "sha256:f5f976c7fadcf196d9c99702758c469b9aa33d5ed9d92cd9fd39a4a6c46d8504",
-      "output_schema": "sha256:baa54525e476bbc4081ce06a64a0ca7285c765f6dd1275c7ef389aa7485a19d4"
-    },
-    "poset.closure.compute": {
-      "input_schema": "sha256:8c523de94c4518ce16efd219de63311b779e2cbb40e983f26f3e1da0816e98bf",
-      "output_schema": "sha256:716b58d26859656f7553292f757370e3367d8c747b9d74691d38f5df62ac01f1"
-    },
-    "poset.dual.compute": {
-      "input_schema": "sha256:279cb415a127e29fdb74087665e97d999f32dddf03654dad57c839656edb277b",
-      "output_schema": "sha256:d546dec3c632f9a42f1ec2d278d8897d40763358af57fc542e0d8e023659f2f2"
-    },
     "poset.finite.compute": {
       "input_schema": "sha256:73c1738f192a084128ea68cc954c524bed9c6b65898f7a47498b9d5e516b94b2",
       "output_schema": "sha256:d5021ca8f1a5bfc3ab3612f4e80db9c447089aa82f7845d8dda8594bc39753f1"
-    },
-    "poset.incidence_convolution.compute": {
-      "input_schema": "sha256:fc69337f0a5f3d21570924a1e94dc76023b5cf9b3ad33586f9bc9d2684746d62",
-      "output_schema": "sha256:339070992c99f3989c7c00e1443507e1f33c2528a7363ccedc629e1d9c7e58cb"
     },
     "poset.linear_extensions.count": {
       "input_schema": "sha256:e1db5dfa1a85945ba8d8da52ad863146f51d1146f20bc295e2a27419ff89d713",
@@ -1184,10 +1168,6 @@
     "poset.width.compute": {
       "input_schema": "sha256:ff2a448f4335d1fac63825191d2d16991a33f31bfa7f7175c49b69495984ff0d",
       "output_schema": "sha256:58722ae468c6000b997cf340f9b7cc29f5aa8b466cee2242227d40d75208f8e1"
-    },
-    "poset.zeta_transform.compute": {
-      "input_schema": "sha256:868970b3a99028c903476fe0b1606462906625eee5182c0eb065b318debe78b2",
-      "output_schema": "sha256:fb22b106f8b8ce3794fc1a49aa1dbafcb3c0d6afc09db58a7c82c8ba35cc2cbb"
     },
     "probability.bh_step_up.compute": {
       "input_schema": "sha256:b51f86a304afd50af235612492073289c041418e8d45c4f517acf774df308fa9",
@@ -1450,12 +1430,12 @@
       "output_schema": "sha256:069c8c20fdf9176965a2fd13d5707ebc83b721bc49c678eae9276ba67435a805"
     },
     "term_rewriting.normal_form.compute": {
-      "input_schema": "sha256:51b0d9d6c6feba749d1231dd42ede6aedeb81af6add5dca24df555f8a72a812c",
-      "output_schema": "sha256:cb7a3d657057d54ed657daac61d52734989b07a9708a4749aa926066724477c3"
+      "input_schema": "sha256:c4dd14afcf4c7c86dc4bb0ffc199243e9d842f50bfa7de538481fde7935c5853",
+      "output_schema": "sha256:88c249852647a6629ba3b32cb2206cdf0ac7265b4bf25075fe6d138cbc3522e9"
     },
     "term_rewriting.rewrite_step.compute": {
-      "input_schema": "sha256:8349b581c6ef38226703aeaada8de1e2020a0b4218e1641fcbb1656184e6cf6c",
-      "output_schema": "sha256:87a5f125422414ff4bc8590bf818a08f607a11064f05ddbbebcf46b5c488205e"
+      "input_schema": "sha256:8633ded7906c0bf15142abc8eb1dc0ba300c8ed95bfda4e50591ef4e20bba856",
+      "output_schema": "sha256:524ab1b0dad03f372fc4fc421c3edf1ad5ee2db2c6d994c7eae0899e37bbd030"
     },
     "term_rewriting.substitution.compute": {
       "input_schema": "sha256:6ef32066a105978f692a68ac12fb0029e67a3b7a5e5a6aa9fe8a1d4e480d5d86",
@@ -1463,7 +1443,7 @@
     },
     "term_rewriting.unification.compute": {
       "input_schema": "sha256:91fae06f015576650d539360812fe6b5fb83d0d1daef2c638ec1ecf89c61fdc8",
-      "output_schema": "sha256:bb4d978e38decd921bbe4ccbc3ac7716f6686e7e73ea0cfda2386301b7109f81"
+      "output_schema": "sha256:952e8e6b11226618a720eade04823a988ca16353c390af347718a95eb005f352"
     },
     "topology.simplicial_complex.canonicalize": {
       "input_schema": "sha256:0231994adad255d263488096fd5792b8a3cf90fd8e478e3e189536874bdb53b5",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1429,17 +1429,9 @@
       "input_schema": "sha256:c96eac4da31e2b63291f171b62af3b184cbca9f8470a0208d05257829da4149a",
       "output_schema": "sha256:069c8c20fdf9176965a2fd13d5707ebc83b721bc49c678eae9276ba67435a805"
     },
-    "term_rewriting.normal_form.compute": {
-      "input_schema": "sha256:c4dd14afcf4c7c86dc4bb0ffc199243e9d842f50bfa7de538481fde7935c5853",
-      "output_schema": "sha256:88c249852647a6629ba3b32cb2206cdf0ac7265b4bf25075fe6d138cbc3522e9"
-    },
     "term_rewriting.rewrite_step.compute": {
       "input_schema": "sha256:8633ded7906c0bf15142abc8eb1dc0ba300c8ed95bfda4e50591ef4e20bba856",
       "output_schema": "sha256:524ab1b0dad03f372fc4fc421c3edf1ad5ee2db2c6d994c7eae0899e37bbd030"
-    },
-    "term_rewriting.substitution.compute": {
-      "input_schema": "sha256:6ef32066a105978f692a68ac12fb0029e67a3b7a5e5a6aa9fe8a1d4e480d5d86",
-      "output_schema": "sha256:24aa2a9150005c694e36f1a53231c546b9439f44e3f3b574b3fa15e098b53d18"
     },
     "term_rewriting.unification.compute": {
       "input_schema": "sha256:91fae06f015576650d539360812fe6b5fb83d0d1daef2c638ec1ecf89c61fdc8",

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1153,9 +1153,25 @@
       "input_schema": "sha256:2b40338042028e9a6e477838b179c012662fcd374322c1b0451039f9fc4b7f6e",
       "output_schema": "sha256:ca8d93197a2ccaa55fce3e8eab6cb1de174742a4a9463606807c4877054865df"
     },
+    "poset.antichain_profile.compute": {
+      "input_schema": "sha256:f5f976c7fadcf196d9c99702758c469b9aa33d5ed9d92cd9fd39a4a6c46d8504",
+      "output_schema": "sha256:baa54525e476bbc4081ce06a64a0ca7285c765f6dd1275c7ef389aa7485a19d4"
+    },
+    "poset.closure.compute": {
+      "input_schema": "sha256:8c523de94c4518ce16efd219de63311b779e2cbb40e983f26f3e1da0816e98bf",
+      "output_schema": "sha256:716b58d26859656f7553292f757370e3367d8c747b9d74691d38f5df62ac01f1"
+    },
+    "poset.dual.compute": {
+      "input_schema": "sha256:279cb415a127e29fdb74087665e97d999f32dddf03654dad57c839656edb277b",
+      "output_schema": "sha256:d546dec3c632f9a42f1ec2d278d8897d40763358af57fc542e0d8e023659f2f2"
+    },
     "poset.finite.compute": {
       "input_schema": "sha256:73c1738f192a084128ea68cc954c524bed9c6b65898f7a47498b9d5e516b94b2",
       "output_schema": "sha256:d5021ca8f1a5bfc3ab3612f4e80db9c447089aa82f7845d8dda8594bc39753f1"
+    },
+    "poset.incidence_convolution.compute": {
+      "input_schema": "sha256:fc69337f0a5f3d21570924a1e94dc76023b5cf9b3ad33586f9bc9d2684746d62",
+      "output_schema": "sha256:339070992c99f3989c7c00e1443507e1f33c2528a7363ccedc629e1d9c7e58cb"
     },
     "poset.linear_extensions.count": {
       "input_schema": "sha256:e1db5dfa1a85945ba8d8da52ad863146f51d1146f20bc295e2a27419ff89d713",
@@ -1168,6 +1184,10 @@
     "poset.width.compute": {
       "input_schema": "sha256:ff2a448f4335d1fac63825191d2d16991a33f31bfa7f7175c49b69495984ff0d",
       "output_schema": "sha256:58722ae468c6000b997cf340f9b7cc29f5aa8b466cee2242227d40d75208f8e1"
+    },
+    "poset.zeta_transform.compute": {
+      "input_schema": "sha256:868970b3a99028c903476fe0b1606462906625eee5182c0eb065b318debe78b2",
+      "output_schema": "sha256:fb22b106f8b8ce3794fc1a49aa1dbafcb3c0d6afc09db58a7c82c8ba35cc2cbb"
     },
     "probability.bh_step_up.compute": {
       "input_schema": "sha256:b51f86a304afd50af235612492073289c041418e8d45c4f517acf774df308fa9",
@@ -1424,6 +1444,26 @@
     "smt.solve": {
       "input_schema": "sha256:7b72b4b078d5fd79204326017e9f7e540cb2db2674d5ee2d9528d0a6b8026ca2",
       "output_schema": "sha256:92e1adfe39049966ea27b5d3e2d7993feb5b87dc8732f42b5f49ca9531f1f4bc"
+    },
+    "term_rewriting.matching.compute": {
+      "input_schema": "sha256:c96eac4da31e2b63291f171b62af3b184cbca9f8470a0208d05257829da4149a",
+      "output_schema": "sha256:069c8c20fdf9176965a2fd13d5707ebc83b721bc49c678eae9276ba67435a805"
+    },
+    "term_rewriting.normal_form.compute": {
+      "input_schema": "sha256:51b0d9d6c6feba749d1231dd42ede6aedeb81af6add5dca24df555f8a72a812c",
+      "output_schema": "sha256:cb7a3d657057d54ed657daac61d52734989b07a9708a4749aa926066724477c3"
+    },
+    "term_rewriting.rewrite_step.compute": {
+      "input_schema": "sha256:8349b581c6ef38226703aeaada8de1e2020a0b4218e1641fcbb1656184e6cf6c",
+      "output_schema": "sha256:87a5f125422414ff4bc8590bf818a08f607a11064f05ddbbebcf46b5c488205e"
+    },
+    "term_rewriting.substitution.compute": {
+      "input_schema": "sha256:6ef32066a105978f692a68ac12fb0029e67a3b7a5e5a6aa9fe8a1d4e480d5d86",
+      "output_schema": "sha256:24aa2a9150005c694e36f1a53231c546b9439f44e3f3b574b3fa15e098b53d18"
+    },
+    "term_rewriting.unification.compute": {
+      "input_schema": "sha256:91fae06f015576650d539360812fe6b5fb83d0d1daef2c638ec1ecf89c61fdc8",
+      "output_schema": "sha256:bb4d978e38decd921bbe4ccbc3ac7716f6686e7e73ea0cfda2386301b7109f81"
     },
     "topology.simplicial_complex.canonicalize": {
       "input_schema": "sha256:0231994adad255d263488096fd5792b8a3cf90fd8e478e3e189536874bdb53b5",

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 370
     assert actual == expected["operations"]
 
 

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 365
+    assert len(actual) == 363
     assert actual == expected["operations"]
 
 

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 370
+    assert len(actual) == 365
     assert actual == expected["operations"]
 
 

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -16,6 +16,7 @@ PUBLIC_API = {
         "polynomials",
         "prime_field_linear_algebra",
         "probability",
+        "term_rewriting",
     ),
     "jacobian.math.finite_fields": (
         "Axis",
@@ -116,6 +117,18 @@ PUBLIC_API = {
         "MutualInformationResult",
         "MutualInformationTerm",
         "mutual_information",
+    ),
+    "jacobian.math.term_rewriting": (
+        "RewriteApplication",
+        "RewriteRule",
+        "Term",
+        "apply_substitution",
+        "match",
+        "normal_form",
+        "rewrite_steps",
+        "selected_rewrite_step",
+        "term_at_position",
+        "unify",
     ),
 }
 

--- a/tests/math/term_rewriting/test_term_rewriting.py
+++ b/tests/math/term_rewriting/test_term_rewriting.py
@@ -1,0 +1,131 @@
+"""Tests for first-order term rewriting operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.term_rewriting.operations import (
+    apply_substitution,
+    match,
+    normal_form,
+    rewrite_step,
+    unify,
+)
+from jacobian.math.term_rewriting.values import RewriteRule, Term
+
+
+# Helpers
+def _var(symbol: int) -> Term:
+    return Term(is_variable=True, symbol=symbol)
+
+
+def _app(symbol: int, *children: Term) -> Term:
+    return Term(is_variable=False, symbol=symbol, children=tuple(children))
+
+
+class TestSubstitution:
+    def test_substitute_variable(self):
+        term = _var(0)
+        result = apply_substitution(term, {0: _app(1)})
+        assert result == _app(1)
+
+    def test_substitute_in_children(self):
+        term = _app(0, _var(0), _var(1))
+        result = apply_substitution(term, {0: _app(1)})
+        assert result == _app(0, _app(1), _var(1))
+
+    def test_substitute_no_change(self):
+        term = _app(0, _var(0))
+        result = apply_substitution(term, {})
+        assert result == term
+
+
+class TestMatching:
+    def test_match_variable(self):
+        result = match(_var(0), _app(1))
+        assert result == {0: _app(1)}
+
+    def test_match_function(self):
+        pattern = _app(0, _var(0), _var(1))
+        subject = _app(0, _app(1), _app(2))
+        result = match(pattern, subject)
+        assert result == {0: _app(1), 1: _app(2)}
+
+    def test_match_symbol_mismatch(self):
+        result = match(_app(0), _app(1))
+        assert result is None
+
+    def test_match_arity_mismatch(self):
+        result = match(_app(0, _var(0)), _app(0, _var(0), _var(1)))
+        assert result is None
+
+
+class TestUnification:
+    def test_unify_same_symbol(self):
+        result = unify(_app(0, _var(0), _app(1)), _app(0, _app(2), _app(1)))
+        assert result is not None
+        assert result == {0: _app(2)}
+
+    def test_unify_variables(self):
+        result = unify(_var(0), _var(1))
+        assert result is not None
+
+    def test_unify_failure(self):
+        result = unify(_app(0), _app(1))
+        assert result is None
+
+    def test_unify_occurs_check(self):
+        result = unify(_var(0), _app(1, _var(0)))
+        assert result is None
+
+
+class TestRewriteStep:
+    def test_rewrite_root(self):
+        # Rule: f(x) -> g(x)
+        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        term = _app(0, _app(2))
+        rewritten, new_term = rewrite_step(term, rules)
+        assert rewritten
+        assert new_term == _app(1, _app(2))
+
+    def test_rewrite_in_child(self):
+        # Rule: f(x) -> g(x)
+        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        term = _app(3, _app(0, _app(2)))
+        rewritten, new_term = rewrite_step(term, rules)
+        assert rewritten
+        assert new_term == _app(3, _app(1, _app(2)))
+
+    def test_no_rewrite(self):
+        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        term = _app(2, _app(2))
+        rewritten, _ = rewrite_step(term, rules)
+        assert not rewritten
+
+
+class TestNormalForm:
+    def test_convergent(self):
+        # Rule: f(x) -> x  (strips one f per step)
+        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_var(0))]
+        term = _app(0, _app(0, _app(1)))
+        result, converged, steps = normal_form(term, rules, max_steps=100)
+        assert converged
+        assert result == _app(1)
+        assert steps == 2
+
+    def test_non_convergent(self):
+        # Rule: f(x) -> f(f(x))  (divergent)
+        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(0, _app(0, _var(0))))]
+        term = _app(0, _app(1))
+        _result, converged, steps = normal_form(term, rules, max_steps=10)
+        assert not converged
+        assert steps == 10
+
+
+class TestValidation:
+    def test_variable_with_children_rejected(self):
+        with pytest.raises(ValidationError):
+            Term(is_variable=True, symbol=0, children=(_var(1),))
+
+    def test_lhs_must_be_function(self):
+        with pytest.raises(ValidationError):
+            RewriteRule(lhs=_var(0), rhs=_app(1))

--- a/tests/math/term_rewriting/test_term_rewriting.py
+++ b/tests/math/term_rewriting/test_term_rewriting.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math import term_rewriting
 from jacobian.math.term_rewriting._models import (
     NormalFormRequest,
     RewriteStepRequest,
@@ -13,6 +14,7 @@ from jacobian.math.term_rewriting._operations import (
     compute_rewrite_step,
     compute_unification,
 )
+from jacobian.math.term_rewriting._tools import TOOLS
 from jacobian.math.term_rewriting.operations import (
     apply_substitution,
     match,
@@ -31,6 +33,38 @@ def _var(symbol: int) -> Term:
 
 def _app(symbol: int, *children: Term) -> Term:
     return Term(is_variable=False, symbol=symbol, children=tuple(children))
+
+
+def test_catalog_contains_only_audited_agent_outcomes() -> None:
+    assert {tool.operation_id for tool in TOOLS} == {
+        "term_rewriting.matching.compute",
+        "term_rewriting.unification.compute",
+        "term_rewriting.rewrite_step.compute",
+    }
+
+
+def test_substitution_and_normalization_remain_native() -> None:
+    variable = term_rewriting.Term(is_variable=True, symbol=0)
+    constant = term_rewriting.Term(symbol=1)
+    assert term_rewriting.apply_substitution(variable, {0: constant}) == constant
+    rule = term_rewriting.RewriteRule(lhs=_app(0, variable), rhs=variable)
+    result, status, steps, next_step = term_rewriting.normal_form(
+        _app(0, constant), (rule,), max_steps=1
+    )
+    assert (result, status, steps, next_step) == (
+        constant,
+        "NORMAL_FORM",
+        1,
+        None,
+    )
+
+
+def test_native_choice_and_bound_validation_is_explicit() -> None:
+    rule = RewriteRule(lhs=_app(0), rhs=_app(1))
+    with pytest.raises(ValueError, match="rule_index"):
+        selected_rewrite_step(_app(0), (rule,), (), 1)
+    with pytest.raises(ValueError, match="max_steps"):
+        normal_form(_app(0), (rule,), max_steps=-1)
 
 
 class TestSubstitution:

--- a/tests/math/term_rewriting/test_term_rewriting.py
+++ b/tests/math/term_rewriting/test_term_rewriting.py
@@ -3,11 +3,22 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.term_rewriting._models import (
+    NormalFormRequest,
+    RewriteStepRequest,
+    UnificationRequest,
+)
+from jacobian.math.term_rewriting._operations import (
+    compute_normal_form,
+    compute_rewrite_step,
+    compute_unification,
+)
 from jacobian.math.term_rewriting.operations import (
     apply_substitution,
     match,
     normal_form,
-    rewrite_step,
+    rewrite_steps,
+    selected_rewrite_step,
     unify,
 )
 from jacobian.math.term_rewriting.values import RewriteRule, Term
@@ -77,48 +88,127 @@ class TestUnification:
         result = unify(_var(0), _app(1, _var(0)))
         assert result is None
 
+    def test_unifier_is_idempotent_and_independently_replays(self):
+        left = _app(0, _var(0), _var(0))
+        right = _app(0, _var(1), _app(2))
+        result = unify(left, right)
+        assert result == {0: _app(2), 1: _app(2)}
+        assert apply_substitution(left, result) == apply_substitution(right, result)
+        wire_result = compute_unification(UnificationRequest(left=left, right=right))
+        assert wire_result.unified
+        assert wire_result.substitution == result
+
 
 class TestRewriteStep:
     def test_rewrite_root(self):
         # Rule: f(x) -> g(x)
-        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        rules = (RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0))),)
         term = _app(0, _app(2))
-        rewritten, new_term = rewrite_step(term, rules)
-        assert rewritten
-        assert new_term == _app(1, _app(2))
+        applications = rewrite_steps(term, rules)
+        assert len(applications) == 1
+        assert applications[0].position == ()
+        assert applications[0].rule_index == 0
+        assert applications[0].substitution == {0: _app(2)}
+        assert applications[0].term == _app(1, _app(2))
 
     def test_rewrite_in_child(self):
         # Rule: f(x) -> g(x)
-        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        rules = (RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0))),)
         term = _app(3, _app(0, _app(2)))
-        rewritten, new_term = rewrite_step(term, rules)
-        assert rewritten
-        assert new_term == _app(3, _app(1, _app(2)))
+        applications = rewrite_steps(term, rules)
+        assert len(applications) == 1
+        assert applications[0].position == (0,)
+        assert applications[0].term == _app(3, _app(1, _app(2)))
 
     def test_no_rewrite(self):
-        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0)))]
+        rules = (RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0))),)
         term = _app(2, _app(2))
-        rewritten, _ = rewrite_step(term, rules)
-        assert not rewritten
+        assert rewrite_steps(term, rules) == ()
+
+    def test_all_steps_preserve_rule_and_position_choices(self):
+        rules = (
+            RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0))),
+            RewriteRule(lhs=_app(0, _var(0)), rhs=_app(2, _var(0))),
+        )
+        term = _app(0, _app(0, _app(3)))
+        result = compute_rewrite_step(RewriteStepRequest(term=term, rules=rules))
+        assert result.scope == "ALL_APPLICABLE_STEPS"
+        assert tuple(
+            (application.position, application.rule_index)
+            for application in result.applications
+        ) == (((), 0), ((), 1), ((0,), 0), ((0,), 1))
+        assert tuple(application.term for application in result.applications) == (
+            _app(1, _app(0, _app(3))),
+            _app(2, _app(0, _app(3))),
+            _app(0, _app(1, _app(3))),
+            _app(0, _app(2, _app(3))),
+        )
+
+    def test_selected_step_applies_only_declared_choice(self):
+        rules = (
+            RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(0))),
+            RewriteRule(lhs=_app(0, _var(0)), rhs=_app(2, _var(0))),
+        )
+        term = _app(0, _app(0, _app(3)))
+        result = compute_rewrite_step(
+            RewriteStepRequest(
+                term=term,
+                rules=rules,
+                selection={"position": [0], "rule_index": 1},
+            )
+        )
+        assert result.scope == "SELECTED_STEP"
+        assert len(result.applications) == 1
+        assert result.applications[0].term == _app(0, _app(2, _app(3)))
+
+    def test_selected_inapplicable_rule_is_exact_negative(self):
+        rules = (RewriteRule(lhs=_app(0), rhs=_app(1)),)
+        assert selected_rewrite_step(_app(2), rules, (), 0) is None
+        result = compute_rewrite_step(
+            RewriteStepRequest(
+                term=_app(2),
+                rules=rules,
+                selection={"position": [], "rule_index": 0},
+            )
+        )
+        assert result.scope == "SELECTED_STEP"
+        assert result.applications == ()
 
 
 class TestNormalForm:
     def test_convergent(self):
         # Rule: f(x) -> x  (strips one f per step)
-        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_var(0))]
+        rules = (RewriteRule(lhs=_app(0, _var(0)), rhs=_var(0)),)
         term = _app(0, _app(0, _app(1)))
-        result, converged, steps = normal_form(term, rules, max_steps=100)
-        assert converged
+        result, status, steps, next_step = normal_form(term, rules, max_steps=100)
+        assert status == "NORMAL_FORM"
         assert result == _app(1)
         assert steps == 2
+        assert next_step is None
 
     def test_non_convergent(self):
         # Rule: f(x) -> f(f(x))  (divergent)
-        rules = [RewriteRule(lhs=_app(0, _var(0)), rhs=_app(0, _app(0, _var(0))))]
+        rules = (RewriteRule(lhs=_app(0, _var(0)), rhs=_app(0, _app(0, _var(0)))),)
         term = _app(0, _app(1))
-        _result, converged, steps = normal_form(term, rules, max_steps=10)
-        assert not converged
+        _result, status, steps, next_step = normal_form(term, rules, max_steps=10)
+        assert status == "STEP_LIMIT"
         assert steps == 10
+        assert next_step is not None
+
+    def test_normal_form_reached_exactly_at_step_limit(self):
+        rule = RewriteRule(lhs=_app(0, _var(0)), rhs=_var(0))
+        result = compute_normal_form(
+            NormalFormRequest(
+                term=_app(0, _app(1)),
+                rules=(rule,),
+                strategy="LEFTMOST_OUTERMOST_RULE_ORDER",
+                max_steps=1,
+            )
+        )
+        assert result.status == "NORMAL_FORM"
+        assert result.term == _app(1)
+        assert result.steps == 1
+        assert result.next_step is None
 
 
 class TestValidation:
@@ -129,3 +219,15 @@ class TestValidation:
     def test_lhs_must_be_function(self):
         with pytest.raises(ValidationError):
             RewriteRule(lhs=_var(0), rhs=_app(1))
+
+    def test_rhs_variables_must_be_bound_by_lhs(self):
+        with pytest.raises(ValidationError, match="RHS variables"):
+            RewriteRule(lhs=_app(0, _var(0)), rhs=_app(1, _var(1)))
+
+    def test_selected_position_must_exist(self):
+        with pytest.raises(ValidationError, match="outside the source term"):
+            RewriteStepRequest(
+                term=_app(0),
+                rules=(RewriteRule(lhs=_app(0), rhs=_app(1)),),
+                selection={"position": [0], "rule_index": 0},
+            )


### PR DESCRIPTION
Focused replacement for #1974, cleanly restacked on current `main` without its unrelated poset commit/snapshot entries.

## Rewrite-step semantics

The old operation silently chose the first matching rule at the leftmost-outermost position. The request now has two explicit scopes:

- omit `selection` to return `ALL_APPLICABLE_STEPS`;
- provide `selection.position` and `selection.rule_index` to request exactly that derivation.

Every application carries the exact position, rule index, matching substitution, and resulting term. Distinct derivations remain distinct even if they happen to produce equal terms. Result validation replays the declared scope and rejects missing, extra, or policy-selected steps.

An adversarial term with root/nested overlap and two matching rules returns all four `(position, rule)` pairs. Explicit selection of nested rule 1 returns only that result. Invalid positions/rule indices fail request validation; a valid but inapplicable selected rule returns an exact empty application family.

## Related correctness repairs

- bounded normalization now requires the strategy `LEFTMOST_OUTERMOST_RULE_ORDER` explicitly;
- `NORMAL_FORM` is returned only after proving no next rewrite exists, including when normal form is reached exactly on the step boundary;
- `STEP_LIMIT` carries the exact next-step witness and is not called divergence/nonconvergence;
- rewrite rules reject RHS variables absent from the LHS;
- unification now returns an idempotent MGU: chained bindings are composed so replaying the substitution actually makes both inputs equal;
- the rule family is bounded by the declared 64-rule contract.

## Validation

- `make test-math TESTS=tests/math/term_rewriting` — 25 passed
- `make test-catalog TESTS=tests/catalog/test_snapshot.py` — 4 passed
- `make check` — lint, formatting, complexity, mypy, and 1,002 tests passed
- `git diff --check` — passed

`make test-plan BASE=origin/main` is unavailable on this base (`No rule to make target test-plan`).

No routing, MCP naming, or additional catalog-admission changes are included; the replacement preserves the original term-rewriting operation declarations only.