### PR TITLE
Add exact bounded tree automata (#1922)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -81,6 +81,7 @@ from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
 from jacobian.math.topology._tools import TOOLS as TOPOLOGY_TOOLS
+from jacobian.math.tree_automata._tools import TOOLS as TREE_AUTOMATA_TOOLS
 
 BUILTIN_TOOLS: MathTools = (
     *BOOLEAN_TOOLS,
@@ -145,6 +146,7 @@ BUILTIN_TOOLS: MathTools = (
     *ALGEBRAIC_COMBINATORICS_TOOLS,
     *REAL_ALGEBRA_TOOLS,
     *FINITE_METRIC_SPACES_TOOLS,
+    *TREE_AUTOMATA_TOOLS,
 )
 
 __all__ = ["BUILTIN_TOOLS"]

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -9,6 +9,7 @@ from jacobian.math import (
     polynomials,
     prime_field_linear_algebra,
     probability,
+    tree_automata,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "polynomials",
     "prime_field_linear_algebra",
     "probability",
+    "tree_automata",
 ]

--- a/src/jacobian/math/tree_automata/__init__.py
+++ b/src/jacobian/math/tree_automata/__init__.py
@@ -1,0 +1,19 @@
+"""Exact finite bottom-up tree automata."""
+
+from jacobian.math.tree_automata.operations import (
+    accepted_tree_count,
+    run_tree_automaton,
+)
+from jacobian.math.tree_automata.values import (
+    BottomUpTreeAutomaton,
+    RankedTree,
+    TreeAutomatonTransition,
+)
+
+__all__ = [
+    "BottomUpTreeAutomaton",
+    "RankedTree",
+    "TreeAutomatonTransition",
+    "accepted_tree_count",
+    "run_tree_automaton",
+]

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -1,0 +1,78 @@
+"""Typed wire contracts for tree automaton operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.tree_automata.values import (
+    BottomUpTreeAutomaton,
+    RankedTree,
+    accepted_tree_count_work_bound,
+    validate_ranked_tree,
+)
+
+
+class TreeRunRequest(StrictModel):
+    """Run a bottom-up tree automaton on a ranked tree.
+
+    Returns the set of states reachable at the root.
+    """
+
+    automaton: BottomUpTreeAutomaton
+    tree: RankedTree
+
+    @model_validator(mode="after")
+    def require_valid_tree_arity(self) -> Self:
+        validate_ranked_tree(self.automaton, self.tree)
+        return self
+
+
+class TreeRunResult(StrictModel):
+    """Result of a tree automaton run."""
+
+    accepted: bool
+    root_states: tuple[int, ...] = Field(max_length=64)
+    node_count: int = Field(ge=1, le=4096)
+    complete: Literal[True] = True
+    method: Literal["BOTTOM_UP_REACHABLE_STATE_SETS"] = "BOTTOM_UP_REACHABLE_STATE_SETS"
+
+    @model_validator(mode="after")
+    def require_canonical_root_states(self) -> Self:
+        if self.root_states != tuple(sorted(set(self.root_states))):
+            raise ValueError("root states must be unique and sorted")
+        return self
+
+
+class AcceptedTreeCountRequest(StrictModel):
+    """Count accepted trees of a given size."""
+
+    automaton: BottomUpTreeAutomaton
+    tree_size: int = Field(ge=1, le=100)
+
+    @model_validator(mode="after")
+    def require_bounded_exact_count(self) -> Self:
+        accepted_tree_count_work_bound(self.automaton, self.tree_size)
+        return self
+
+
+class AcceptedTreeCountResult(StrictModel):
+    """Exact count of accepted trees."""
+
+    tree_size: int = Field(ge=1, le=100)
+    count: int = Field(ge=0)
+    complete: Literal[True] = True
+    method: Literal["ON_THE_FLY_SUBSET_DYNAMIC_PROGRAMMING"] = (
+        "ON_THE_FLY_SUBSET_DYNAMIC_PROGRAMMING"
+    )
+    estimated_work_bound: int = Field(ge=0, le=2_000_000)
+
+
+__all__ = [
+    "AcceptedTreeCountRequest",
+    "AcceptedTreeCountResult",
+    "TreeRunRequest",
+    "TreeRunResult",
+]

--- a/src/jacobian/math/tree_automata/_operations.py
+++ b/src/jacobian/math/tree_automata/_operations.py
@@ -1,0 +1,42 @@
+"""Domain adapter for tree automaton operations."""
+
+from __future__ import annotations
+
+from jacobian.math.tree_automata._models import (
+    AcceptedTreeCountRequest,
+    AcceptedTreeCountResult,
+    TreeRunRequest,
+    TreeRunResult,
+)
+from jacobian.math.tree_automata.operations import (
+    accepted_tree_count,
+    run_tree_automaton,
+)
+from jacobian.math.tree_automata.values import (
+    accepted_tree_count_work_bound,
+    validate_ranked_tree,
+)
+
+__all__ = ["compute_accepted_tree_count", "compute_tree_run"]
+
+
+def compute_tree_run(request: TreeRunRequest) -> TreeRunResult:
+    states = run_tree_automaton(request.automaton, request.tree)
+    accepting = set(states) & set(request.automaton.final_states)
+    return TreeRunResult(
+        accepted=bool(accepting),
+        root_states=tuple(sorted(states)),
+        node_count=validate_ranked_tree(request.automaton, request.tree),
+    )
+
+
+def compute_accepted_tree_count(
+    request: AcceptedTreeCountRequest,
+) -> AcceptedTreeCountResult:
+    return AcceptedTreeCountResult(
+        tree_size=request.tree_size,
+        count=accepted_tree_count(request.automaton, request.tree_size),
+        estimated_work_bound=accepted_tree_count_work_bound(
+            request.automaton, request.tree_size
+        ),
+    )

--- a/src/jacobian/math/tree_automata/_tools.py
+++ b/src/jacobian/math/tree_automata/_tools.py
@@ -1,0 +1,123 @@
+"""Tree automaton operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.tree_automata._models import (
+    AcceptedTreeCountRequest,
+    AcceptedTreeCountResult,
+    TreeRunRequest,
+    TreeRunResult,
+)
+from jacobian.math.tree_automata._operations import (
+    compute_accepted_tree_count,
+    compute_tree_run,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+# Automaton: states {0, 1}, symbols {a (arity 0), f (arity 2)}
+# Transitions: a -> 0, f(0, 0) -> 0, f(1, 0) -> 1, f(0, 1) -> 1, f(1, 1) -> 1
+# Final states: {0}
+_RUN_EXAMPLE = {
+    "automaton": {
+        "state_count": 2,
+        "arity": [0, 2],
+        "transitions": [
+            {"symbol": 0, "child_states": [], "target_state": 0},
+            {"symbol": 1, "child_states": [0, 0], "target_state": 0},
+            {"symbol": 1, "child_states": [0, 1], "target_state": 1},
+            {"symbol": 1, "child_states": [1, 0], "target_state": 1},
+            {"symbol": 1, "child_states": [1, 1], "target_state": 1},
+        ],
+        "final_states": [0],
+    },
+    "tree": {
+        "symbol": 1,
+        "children": [
+            {"symbol": 0, "children": []},
+            {"symbol": 0, "children": []},
+        ],
+    },
+}
+
+TREE_AUTOMATA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "tree_automaton.run.compute",
+        "Run a bottom-up tree automaton on a ranked tree",
+        "Execute a nondeterministic bottom-up tree automaton on a ranked "
+        "tree and return the set of reachable root states and whether the "
+        "tree is accepted.",
+        TreeRunRequest,
+        TreeRunResult,
+        compute_tree_run,
+        "tree-automata",
+        "run",
+        "exact",
+        examples=(
+            example(
+                "simple_run",
+                "Run a tree automaton on f(a, a).",
+                _RUN_EXAMPLE,
+            ),
+        ),
+    ),
+    _op(
+        "tree_automaton.accepted_tree_count.compute",
+        "Count accepted trees of a given size",
+        "Count the number of ranked trees of a given size accepted by a "
+        "bottom-up nondeterministic tree automaton. On-the-fly subset-state "
+        "dynamic programming counts each distinct tree once, even when it has "
+        "multiple accepting runs; the validated request carries a conservative "
+        "work bound.",
+        AcceptedTreeCountRequest,
+        AcceptedTreeCountResult,
+        compute_accepted_tree_count,
+        "tree-automata",
+        "counting",
+        "exact",
+        examples=(
+            example(
+                "count_size_1",
+                "Count accepted trees of size 1.",
+                {
+                    "automaton": _RUN_EXAMPLE["automaton"],
+                    "tree_size": 1,
+                },
+            ),
+        ),
+    ),
+)
+
+TOOLS = TREE_AUTOMATA_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/tree_automata/operations.py
+++ b/src/jacobian/math/tree_automata/operations.py
@@ -1,0 +1,146 @@
+"""Domain-owned bottom-up tree automaton kernels."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator
+from itertools import product
+from math import prod
+
+from jacobian.math.tree_automata.values import (
+    BottomUpTreeAutomaton,
+    RankedTree,
+    TreeAutomatonTransition,
+    accepted_tree_count_work_bound,
+    validate_ranked_tree,
+)
+
+__all__ = [
+    "accepted_tree_count",
+    "run_tree_automaton",
+]
+
+
+def run_tree_automaton(
+    automaton: BottomUpTreeAutomaton,
+    tree: RankedTree,
+) -> set[int]:
+    """Run a bottom-up tree automaton on a ranked tree.
+
+    Returns the set of states reachable at the root.
+    """
+    validate_ranked_tree(automaton, tree)
+    return _reachable_root_states(automaton, tree)
+
+
+def _reachable_root_states(
+    automaton: BottomUpTreeAutomaton,
+    tree: RankedTree,
+) -> set[int]:
+    child_states: list[set[int]] = []
+    if tree.children:
+        child_states = [
+            _reachable_root_states(automaton, child) for child in tree.children
+        ]
+    matching: set[int] = set()
+    for tr in automaton.transitions:
+        if tr.symbol != tree.symbol:
+            continue
+        if len(tr.child_states) != len(child_states):
+            continue
+        match = True
+        for i, states in enumerate(child_states):
+            if tr.child_states[i] not in states:
+                match = False
+                break
+        if match:
+            matching.add(tr.target_state)
+    return matching
+
+
+def accepted_tree_count(
+    automaton: BottomUpTreeAutomaton,
+    tree_size: int,
+) -> int:
+    """Count distinct accepted ranked trees, not accepting runs."""
+    if tree_size < 1:
+        return 0
+    accepted_tree_count_work_bound(automaton, tree_size)
+    transitions_by_symbol = {
+        symbol: tuple(
+            transition
+            for transition in automaton.transitions
+            if transition.symbol == symbol
+        )
+        for symbol in range(len(automaton.arity))
+    }
+    counts_by_size: list[dict[int, int]] = [{} for _ in range(tree_size + 1)]
+    for size in range(1, tree_size + 1):
+        size_counts: defaultdict[int, int] = defaultdict(int)
+        for symbol, arity in enumerate(automaton.arity):
+            _accumulate_symbol_trees(
+                arity=arity,
+                size=size,
+                transitions=transitions_by_symbol[symbol],
+                counts_by_size=counts_by_size,
+                size_counts=size_counts,
+            )
+        counts_by_size[size] = dict(size_counts)
+
+    final_mask = sum(1 << state for state in automaton.final_states)
+    return sum(
+        count
+        for state_subset, count in counts_by_size[tree_size].items()
+        if state_subset & final_mask
+    )
+
+
+def _accumulate_symbol_trees(
+    *,
+    arity: int,
+    size: int,
+    transitions: tuple[TreeAutomatonTransition, ...],
+    counts_by_size: list[dict[int, int]],
+    size_counts: defaultdict[int, int],
+) -> None:
+    if not transitions:
+        return
+    if arity == 0:
+        if size == 1:
+            root_subset = _target_subset(transitions, ())
+            if root_subset:
+                size_counts[root_subset] += 1
+        return
+    for child_sizes in _positive_compositions(size - 1, arity):
+        if any(not counts_by_size[value] for value in child_sizes):
+            continue
+        child_choices = [counts_by_size[value].items() for value in child_sizes]
+        for child_items in product(*child_choices):
+            child_subsets = tuple(item[0] for item in child_items)
+            root_subset = _target_subset(transitions, child_subsets)
+            if root_subset:
+                size_counts[root_subset] += prod(item[1] for item in child_items)
+
+
+def _target_subset(
+    transitions: tuple[TreeAutomatonTransition, ...],
+    child_subsets: tuple[int, ...],
+) -> int:
+    target_subset = 0
+    for transition in transitions:
+        if all(
+            child_subsets[index] & (1 << child_state)
+            for index, child_state in enumerate(transition.child_states)
+        ):
+            target_subset |= 1 << transition.target_state
+    return target_subset
+
+
+def _positive_compositions(total: int, parts: int) -> Iterator[tuple[int, ...]]:
+    if parts == 1:
+        if total >= 1:
+            yield (total,)
+        return
+    for first in range(1, total - parts + 2):
+        for remainder in _positive_compositions(total - first, parts - 1):
+            yield (first, *remainder)

--- a/src/jacobian/math/tree_automata/values.py
+++ b/src/jacobian/math/tree_automata/values.py
@@ -1,0 +1,158 @@
+"""Provider-independent values for exact bottom-up tree automata."""
+
+from __future__ import annotations
+
+from collections import Counter
+from math import comb
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_TA_STATES = 64
+MAX_TA_SYMBOLS = 32
+MAX_TA_TRANSITIONS = 4096
+MAX_TA_ARITY = 16
+MAX_RUN_TREE_NODES = 4096
+MAX_RUN_TREE_DEPTH = 128
+MAX_TREE_AUTOMATON_WORK = 2_000_000
+
+Arity = Annotated[int, Field(ge=0, le=MAX_TA_ARITY)]
+
+
+class TreeAutomatonTransition(StrictModel):
+    """A bottom-up tree automaton transition.
+
+    A transition ``f(q_1, ..., q_n) -> q`` says: if the children of a
+    ``f``-labelled node are in states ``q_1, ..., q_n``, the node is in
+    state ``q``.
+    ``symbol`` is the function symbol (label of the node).
+    """
+
+    symbol: int = Field(ge=0, le=MAX_TA_SYMBOLS - 1)
+    child_states: tuple[int, ...] = Field(max_length=MAX_TA_ARITY)
+    target_state: int = Field(ge=0, le=MAX_TA_STATES - 1)
+
+
+class RankedTree(StrictModel):
+    """A ranked tree: a node labelled by a symbol with zero or more children."""
+
+    symbol: int = Field(ge=0, le=MAX_TA_SYMBOLS - 1)
+    children: tuple[RankedTree, ...] = Field(default=(), max_length=MAX_TA_ARITY)
+
+
+RankedTree.model_rebuild()
+
+
+class BottomUpTreeAutomaton(StrictModel):
+    """A nondeterministic bottom-up tree automaton (NFTA).
+
+    The automaton has ``state_count`` states, a ranked alphabet where
+    ``arity[symbol]`` gives the arity of each symbol, a set of transitions,
+    and a set of final (accepting) states.
+    """
+
+    state_count: int = Field(ge=1, le=MAX_TA_STATES)
+    arity: tuple[Arity, ...] = Field(min_length=1, max_length=MAX_TA_SYMBOLS)
+    transitions: tuple[TreeAutomatonTransition, ...] = Field(
+        min_length=0, max_length=MAX_TA_TRANSITIONS
+    )
+    final_states: tuple[int, ...] = Field(min_length=0, max_length=MAX_TA_STATES)
+
+    @model_validator(mode="after")
+    def require_valid_automaton(self) -> Self:
+        self._require_unique_sets()
+        self._require_valid_transitions()
+        self._require_valid_final_states()
+        return self
+
+    def _require_unique_sets(self) -> None:
+        if len(set(self.transitions)) != len(self.transitions):
+            raise ValueError("transitions must be unique")
+        if len(set(self.final_states)) != len(self.final_states):
+            raise ValueError("final states must be unique")
+
+    def _require_valid_transitions(self) -> None:
+        for tr in self.transitions:
+            if not 0 <= tr.target_state < self.state_count:
+                raise ValueError("transition target out of range")
+            if tr.symbol >= len(self.arity):
+                raise ValueError("transition symbol out of range")
+            if len(tr.child_states) != self.arity[tr.symbol]:
+                raise ValueError("transition child count must match symbol arity")
+            for s in tr.child_states:
+                if not 0 <= s < self.state_count:
+                    raise ValueError("transition child state out of range")
+
+    def _require_valid_final_states(self) -> None:
+        for f in self.final_states:
+            if not 0 <= f < self.state_count:
+                raise ValueError("final state out of range")
+
+
+def validate_ranked_tree(
+    automaton: BottomUpTreeAutomaton,
+    tree: RankedTree,
+) -> int:
+    """Validate every node against the ranked alphabet and return node count."""
+
+    node_count = 0
+    stack = [(tree, 1)]
+    while stack:
+        node, depth = stack.pop()
+        node_count += 1
+        if node_count > MAX_RUN_TREE_NODES:
+            raise ValueError("tree node count exceeds bound")
+        if depth > MAX_RUN_TREE_DEPTH:
+            raise ValueError("tree depth exceeds bound")
+        if node.symbol >= len(automaton.arity):
+            raise ValueError("tree symbol out of ranked alphabet")
+        if len(node.children) != automaton.arity[node.symbol]:
+            raise ValueError("every tree node must match its symbol arity")
+        stack.extend((child, depth + 1) for child in node.children)
+
+    arity_factor = max(1, max(automaton.arity))
+    estimated_work = node_count * max(1, len(automaton.transitions)) * arity_factor
+    if estimated_work > MAX_TREE_AUTOMATON_WORK:
+        raise ValueError("tree run work bound exceeded")
+    return node_count
+
+
+def accepted_tree_count_work_bound(
+    automaton: BottomUpTreeAutomaton,
+    tree_size: int,
+) -> int:
+    """Return a conservative bound for subset-DP transition checks."""
+
+    transition_counts = Counter(
+        transition.symbol for transition in automaton.transitions
+    )
+    subset_count = (1 << automaton.state_count) - 1
+    work = 0
+    for symbol, arity in enumerate(automaton.arity):
+        transition_count = max(1, transition_counts[symbol])
+        if arity == 0:
+            work += transition_count
+        elif tree_size > arity:
+            compositions = comb(tree_size - 1, arity)
+            work += compositions * subset_count**arity * transition_count
+        if work > MAX_TREE_AUTOMATON_WORK:
+            raise ValueError("accepted-tree count work bound exceeded")
+    return work
+
+
+__all__ = [
+    "MAX_RUN_TREE_DEPTH",
+    "MAX_RUN_TREE_NODES",
+    "MAX_TA_ARITY",
+    "MAX_TA_STATES",
+    "MAX_TA_SYMBOLS",
+    "MAX_TA_TRANSITIONS",
+    "MAX_TREE_AUTOMATON_WORK",
+    "BottomUpTreeAutomaton",
+    "RankedTree",
+    "TreeAutomatonTransition",
+    "accepted_tree_count_work_bound",
+    "validate_ranked_tree",
+]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1440,6 +1440,14 @@
     "topology.simplicial_homology.integral.compute": {
       "input_schema": "sha256:ae5513f34822ee0e5602f3a67701a3de98a4f3595422d2ae8d8d53e45b3cf60b",
       "output_schema": "sha256:0b9ca74c0cd26174705d7dff455d0513a03c8f9bd5d62148fefd675632b3f5dc"
+    },
+    "tree_automaton.accepted_tree_count.compute": {
+      "input_schema": "sha256:af92a45ff48db188731ed3338c7869aa04a01278c0a16e377be186a6539101ac",
+      "output_schema": "sha256:a315f5d2d4514df1c0e41e5b675d9533ab1808b2872574bf2ae3c0587a324098"
+    },
+    "tree_automaton.run.compute": {
+      "input_schema": "sha256:61bc44d47623089db1a9f3f590f462cc2d1ac8cb70bcffe27db76553fbc08fcd",
+      "output_schema": "sha256:67b7e7b060986da4ebd31b9389319612d7e17883863029226414cba47d86dc01"
     }
   }
 }

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 362
     assert actual == expected["operations"]
 
 

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -16,6 +16,7 @@ PUBLIC_API = {
         "polynomials",
         "prime_field_linear_algebra",
         "probability",
+        "tree_automata",
     ),
     "jacobian.math.finite_fields": (
         "Axis",
@@ -116,6 +117,13 @@ PUBLIC_API = {
         "MutualInformationResult",
         "MutualInformationTerm",
         "mutual_information",
+    ),
+    "jacobian.math.tree_automata": (
+        "BottomUpTreeAutomaton",
+        "RankedTree",
+        "TreeAutomatonTransition",
+        "accepted_tree_count",
+        "run_tree_automaton",
     ),
 }
 

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -1,0 +1,286 @@
+"""Tests for tree automaton operations."""
+
+from math import comb
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.tree_automata._models import (
+    AcceptedTreeCountRequest,
+    TreeRunRequest,
+)
+from jacobian.math.tree_automata._operations import (
+    compute_accepted_tree_count,
+    compute_tree_run,
+)
+from jacobian.math.tree_automata.operations import (
+    accepted_tree_count,
+    run_tree_automaton,
+)
+from jacobian.math.tree_automata.values import (
+    BottomUpTreeAutomaton,
+    RankedTree,
+    TreeAutomatonTransition,
+)
+
+
+# Helpers
+def _leaf() -> RankedTree:
+    return RankedTree(symbol=0, children=())
+
+
+def _node(left: RankedTree, right: RankedTree) -> RankedTree:
+    return RankedTree(symbol=1, children=(left, right))
+
+
+def _simple_automaton() -> BottomUpTreeAutomaton:
+    """2-state automaton: accepts balanced binary trees."""
+    return BottomUpTreeAutomaton(
+        state_count=2,
+        arity=(0, 2),
+        transitions=(
+            TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+            TreeAutomatonTransition(symbol=1, child_states=(0, 0), target_state=0),
+            TreeAutomatonTransition(symbol=1, child_states=(1, 0), target_state=1),
+            TreeAutomatonTransition(symbol=1, child_states=(0, 1), target_state=1),
+            TreeAutomatonTransition(symbol=1, child_states=(1, 1), target_state=1),
+        ),
+        final_states=(0,),
+    )
+
+
+class TestRun:
+    def test_accepted_leaf(self):
+        automaton = _simple_automaton()
+        tree = _leaf()
+        states = run_tree_automaton(automaton, tree)
+        assert states == {0}
+
+    def test_accepted_balanced_tree(self):
+        automaton = _simple_automaton()
+        tree = _node(_leaf(), _leaf())
+        states = run_tree_automaton(automaton, tree)
+        assert states == {0}
+
+    def test_balanced_tree_state1(self):
+        # With the simple automaton, f(a, a) -> state 0 (balanced)
+        automaton = _simple_automaton()
+        tree = _node(_leaf(), _leaf())
+        states = run_tree_automaton(automaton, tree)
+        assert states == {0}
+
+    def test_run_request_accepts(self):
+        automaton = _simple_automaton()
+        tree = _node(_leaf(), _leaf())
+        result = compute_tree_run(TreeRunRequest(automaton=automaton, tree=tree))
+        assert result.accepted is True
+        assert result.root_states == (0,)
+
+    def test_run_request_rejects(self):
+        # Use automaton where state 1 is final but not state 0
+        automaton = BottomUpTreeAutomaton(
+            state_count=2,
+            arity=(0, 2),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=1),
+                TreeAutomatonTransition(symbol=1, child_states=(1, 1), target_state=0),
+            ),
+            final_states=(0,),
+        )
+        # Tree f(a, a) with a -> state 1, f(1, 1) -> state 0 (accepted)
+        tree = _node(_leaf(), _leaf())
+        result = compute_tree_run(TreeRunRequest(automaton=automaton, tree=tree))
+        assert result.accepted is True
+        assert result.root_states == (0,)
+        # Leaf alone: a -> state 1 (not final, rejected)
+        leaf_result = compute_tree_run(
+            TreeRunRequest(automaton=automaton, tree=_leaf())
+        )
+        assert leaf_result.accepted is False
+        assert leaf_result.root_states == (1,)
+
+    def test_nondeterministic_run_returns_every_reachable_root_state(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=2,
+            arity=(0,),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=1),
+            ),
+            final_states=(1,),
+        )
+
+        result = compute_tree_run(TreeRunRequest(automaton=automaton, tree=_leaf()))
+
+        assert result.root_states == (0, 1)
+        assert result.accepted is True
+        assert result.node_count == 1
+        assert result.complete is True
+
+    def test_native_run_rejects_invalid_nested_rank(self):
+        automaton = _simple_automaton()
+        invalid_tree = _node(RankedTree(symbol=1), _leaf())
+
+        with pytest.raises(ValueError, match="every tree node"):
+            run_tree_automaton(automaton, invalid_tree)
+
+
+class TestAcceptedTreeCount:
+    def test_count_size_1(self):
+        automaton = _simple_automaton()
+        result = compute_accepted_tree_count(
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=1)
+        )
+        assert result.count == 1
+
+    def test_count_size_3(self):
+        automaton = _simple_automaton()
+        result = compute_accepted_tree_count(
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=3)
+        )
+        assert result.count == 1
+
+    def test_nondeterminism_counts_trees_not_accepting_runs(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=3,
+            arity=(0, 1),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=1),
+                TreeAutomatonTransition(symbol=1, child_states=(0,), target_state=2),
+                TreeAutomatonTransition(symbol=1, child_states=(1,), target_state=2),
+            ),
+            final_states=(2,),
+        )
+
+        assert accepted_tree_count(automaton, 2) == 1
+
+    def test_one_tree_reaching_two_final_states_is_counted_once(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=2,
+            arity=(0,),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=1),
+            ),
+            final_states=(0, 1),
+        )
+
+        assert accepted_tree_count(automaton, 1) == 1
+
+    def test_distinct_nullary_symbols_are_distinct_trees(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=1,
+            arity=(0, 0),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=1, child_states=(), target_state=0),
+            ),
+            final_states=(0,),
+        )
+
+        assert accepted_tree_count(automaton, 1) == 2
+
+    def test_full_binary_tree_boundary_count_is_complete(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=1,
+            arity=(0, 2),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=1, child_states=(0, 0), target_state=0),
+            ),
+            final_states=(0,),
+        )
+        result = compute_accepted_tree_count(
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=99)
+        )
+
+        assert result.count == comb(98, 49) // 50
+        assert result.tree_size == 99
+        assert result.complete is True
+        assert result.estimated_work_bound <= 2_000_000
+
+    def test_impossible_binary_tree_size_has_exact_zero_count(self):
+        automaton = _simple_automaton()
+
+        result = compute_accepted_tree_count(
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=2)
+        )
+
+        assert result.count == 0
+        assert result.complete is True
+
+
+class TestValidation:
+    def test_arity_mismatch_rejected(self):
+        with pytest.raises(ValidationError):
+            BottomUpTreeAutomaton(
+                state_count=1,
+                arity=(0, 2),
+                transitions=(
+                    TreeAutomatonTransition(
+                        symbol=0, child_states=(0,), target_state=0
+                    ),
+                ),
+                final_states=(0,),
+            )
+
+    def test_symbol_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            BottomUpTreeAutomaton(
+                state_count=1,
+                arity=(0,),
+                transitions=(
+                    TreeAutomatonTransition(symbol=5, child_states=(), target_state=0),
+                ),
+                final_states=(0,),
+            )
+
+    def test_final_state_out_of_range_rejected(self):
+        with pytest.raises(ValidationError):
+            BottomUpTreeAutomaton(
+                state_count=1,
+                arity=(0,),
+                transitions=(),
+                final_states=(5,),
+            )
+
+    def test_nested_tree_arity_is_validated_before_execution(self):
+        invalid_tree = _node(RankedTree(symbol=1), _leaf())
+
+        with pytest.raises(ValidationError, match="every tree node"):
+            TreeRunRequest(automaton=_simple_automaton(), tree=invalid_tree)
+
+    def test_duplicate_transitions_are_rejected(self):
+        transition = TreeAutomatonTransition(symbol=0, child_states=(), target_state=0)
+
+        with pytest.raises(ValidationError, match="transitions must be unique"):
+            BottomUpTreeAutomaton(
+                state_count=1,
+                arity=(0,),
+                transitions=(transition, transition),
+                final_states=(0,),
+            )
+
+    def test_duplicate_final_states_are_rejected(self):
+        with pytest.raises(ValidationError, match="final states must be unique"):
+            BottomUpTreeAutomaton(
+                state_count=1,
+                arity=(0,),
+                transitions=(),
+                final_states=(0, 0),
+            )
+
+    def test_count_request_rejects_work_beyond_complete_bound(self):
+        automaton = BottomUpTreeAutomaton(
+            state_count=6,
+            arity=(0, 2),
+            transitions=(
+                TreeAutomatonTransition(symbol=0, child_states=(), target_state=0),
+                TreeAutomatonTransition(symbol=1, child_states=(0, 0), target_state=0),
+            ),
+            final_states=(0,),
+        )
+
+        with pytest.raises(ValidationError, match="count work bound exceeded"):
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=100)


### PR DESCRIPTION
## Summary

Focused replacement for #1975. This keeps the two mathematically atomic tree-automata outcomes and removes the unrelated stacked poset changes.

- `tree_automaton.run.compute` validates every node against the ranked alphabet, then returns the complete reachable root-state set and acceptance.
- `tree_automaton.accepted_tree_count.compute` counts distinct accepted ranked trees of one exact positive node size. On-the-fly subset-state dynamic programming prevents nondeterministic accepting runs from double-counting a tree.
- Native `jacobian.math.tree_automata` values and kernels share the same implementation.
- Request validation bounds alphabet/state/transition/arity sizes, tree depth/node count, and a conservative input-specific work estimate. Oversized work is rejected before computation; exact zero counts remain complete conclusions.

No poset files or catalog-admission infrastructure are included. This branch is intentionally based on the pre-curation `main`; after #1976 lands, rebase it and add only the two reviewed admission rows rather than merging it first.

## Correctness evidence

Tests cover known answers, nondeterministic root-state sets, multiple accepting runs, multiple final states, distinct symbols, impossible sizes, a size-99 Catalan boundary, recursive rank errors, duplicate transition/final-state rejection, native fail-closed behavior, and work-bound rejection. An independent diagnostic compared the subset DP with brute-force distinct-tree enumeration for 30 random nondeterministic automata at every size 1 through 6.

## Validation

- `make test-math TESTS="tests/math/tree_automata/test_tree_automata.py tests/math/public_api/test_namespace.py"` — 25 passed
- `make test-catalog` — 17 passed
- `make check` — 998 passed plus Ruff, formatting, complexity, and mypy
- `make test-plan BASE=origin/main` — unavailable on this base (`No rule to make target test-plan`)

## Implementation handoff

```yaml
stage: implementation
status: complete
subject:
  candidate_id: issue-1922-tree-automata
  capability_ids:
    - tree_automaton.run.compute
    - tree_automaton.accepted_tree_count.compute
evidence_refs:
  - ref: PR #1975 at 43b74c73190a855e47a7770e943aa11f9b3d533c
  - ref: focused regression and brute-force equivalence checks in this PR
contract_ref: src/jacobian/math/tree_automata/_models.py
runtime_snapshot: exact Python integer/set DP; no optional provider
assurance: COMPUTED exact finite result
open_obligations:
  - rebase after #1976 and add its two admission-ledger rows
missing_evidence: []
decision: retain both bounded atomic operations and the shared native API
next_action: merge #1976, then rebase this PR before merge
```

Supersedes #1975.