### PR TITLE
feat(math): add bounded arithmetic dynamics

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -12,6 +12,9 @@ from jacobian.math.algebraic_combinatorics._tools import (
 from jacobian.math.analysis._tools import TOOLS as ANALYSIS_TOOLS
 from jacobian.math.arithmetic._tools import TOOLS as ARITHMETIC_TOOLS
 from jacobian.math.arithmetic_counting._tools import TOOLS as ARITHMETIC_COUNTING_TOOLS
+from jacobian.math.arithmetic_dynamics._tools import (
+    TOOLS as ARITHMETIC_DYNAMICS_TOOLS,
+)
 from jacobian.math.arithmetic_functions._tools import (
     TOOLS as ARITHMETIC_FUNCTIONS_TOOLS,
 )
@@ -96,6 +99,7 @@ BUILTIN_TOOLS: MathTools = (
     *NUMBER_FIELD_TOOLS,
     *MARKOV_CHAIN_TOOLS,
     *ARITHMETIC_TOOLS,
+    *ARITHMETIC_DYNAMICS_TOOLS,
     *NUMBER_THEORY_TOOLS,
     *DIOPHANTINE_APPROXIMATION_TOOLS,
     *COMBINATORICS_TOOLS,

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -2,6 +2,7 @@
 
 from jacobian.math import (
     arithmetic,
+    arithmetic_dynamics,
     finite_abelian_groups,
     finite_fields,
     graphs,
@@ -13,6 +14,7 @@ from jacobian.math import (
 
 __all__ = [
     "arithmetic",
+    "arithmetic_dynamics",
     "finite_abelian_groups",
     "finite_fields",
     "graphs",

--- a/src/jacobian/math/arithmetic_dynamics/__init__.py
+++ b/src/jacobian/math/arithmetic_dynamics/__init__.py
@@ -1,0 +1,31 @@
+"""Exact bounded arithmetic dynamics."""
+
+from jacobian.math.arithmetic_dynamics.operations import (
+    FunctionalGraph,
+    OrbitComputation,
+    RepeatEvidence,
+    cycle_multiplier,
+    dynatomic_polynomial,
+    finite_field_functional_graph,
+    fixed_point_equation,
+    iterate_polynomial,
+    orbit_prefix,
+    polynomial_coefficients,
+    polynomial_from_coefficients,
+    validate_cycle,
+)
+
+__all__ = [
+    "FunctionalGraph",
+    "OrbitComputation",
+    "RepeatEvidence",
+    "cycle_multiplier",
+    "dynatomic_polynomial",
+    "finite_field_functional_graph",
+    "fixed_point_equation",
+    "iterate_polynomial",
+    "orbit_prefix",
+    "polynomial_coefficients",
+    "polynomial_from_coefficients",
+    "validate_cycle",
+]

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -1,0 +1,432 @@
+"""Typed wire contracts for exact bounded arithmetic dynamics."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import pairwise
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_COEFFICIENT_DIGITS = 128
+MAX_DEGREE = 30
+MAX_ITERATE = 20
+MAX_ITERATE_DEGREE = 1024
+MAX_DYNATOMIC_DEGREE = 512
+MAX_ORBIT_STEPS = 1_000
+MAX_ORBIT_VALUE_DIGITS = 2_048
+MAX_POLYNOMIAL_OUTPUT_DIGITS = 32_768
+MAX_FIELD_PRIME = 10_000
+
+
+def parse_canonical_rational(value: str, *, label: str) -> Fraction:
+    if len(value) > 2 * MAX_COEFFICIENT_DIGITS + 2:
+        raise ValueError(f"{label} exceeds the rational digit bound")
+    try:
+        parsed = Fraction(value)
+    except (ValueError, ZeroDivisionError):
+        raise ValueError(f"{label} must be a canonical rational") from None
+    if str(parsed) != value:
+        raise ValueError(f"{label} must be a reduced canonical rational")
+    if (
+        len(str(abs(parsed.numerator))) > MAX_COEFFICIENT_DIGITS
+        or len(str(parsed.denominator)) > MAX_COEFFICIENT_DIGITS
+    ):
+        raise ValueError(f"{label} exceeds the rational digit bound")
+    return parsed
+
+
+def parse_polynomial_coefficients(values: tuple[str, ...]) -> tuple[Fraction, ...]:
+    coefficients = tuple(
+        parse_canonical_rational(value, label="coefficient") for value in values
+    )
+    if len(coefficients) > 1 and coefficients[-1] == 0:
+        raise ValueError("polynomial coefficients must omit trailing zeros")
+    return coefficients
+
+
+class PolynomialCoefficientRequest(StrictModel):
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+
+    @model_validator(mode="after")
+    def require_canonical_coefficients(self) -> Self:
+        parse_polynomial_coefficients(self.coefficients)
+        return self
+
+    def coefficient_values(self) -> tuple[Fraction, ...]:
+        return parse_polynomial_coefficients(self.coefficients)
+
+    def polynomial_degree(self) -> int:
+        values = self.coefficient_values()
+        return 0 if values == (Fraction(0),) else len(values) - 1
+
+
+class MapIterateRequest(PolynomialCoefficientRequest):
+    """Compute one exact polynomial iterate within an output-degree bound."""
+
+    n: int = Field(ge=0, le=MAX_ITERATE)
+
+    @model_validator(mode="after")
+    def require_bounded_iterate_degree(self) -> Self:
+        degree = self.polynomial_degree()
+        output_degree = 1 if self.n == 0 else degree**self.n
+        if output_degree > MAX_ITERATE_DEGREE:
+            raise ValueError("iterate output degree exceeds bound")
+        return self
+
+
+class OrbitPrefixRequest(PolynomialCoefficientRequest):
+    """Compute until a first repeat or an explicit finite/output bound."""
+
+    start: str
+    max_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
+
+    @model_validator(mode="after")
+    def require_canonical_start(self) -> Self:
+        parse_canonical_rational(self.start, label="start")
+        return self
+
+
+class DynatomicPolynomialRequest(PolynomialCoefficientRequest):
+    """Compute the n-th dynatomic polynomial of a degree-at-least-two map."""
+
+    n: int = Field(ge=1, le=MAX_ITERATE)
+
+    @model_validator(mode="after")
+    def require_bounded_dynatomic_degree(self) -> Self:
+        degree = self.polynomial_degree()
+        if degree < 2:
+            raise ValueError("dynatomic polynomial requires map degree at least two")
+        if degree**self.n > MAX_DYNATOMIC_DEGREE:
+            raise ValueError("dynatomic output degree exceeds bound")
+        return self
+
+
+class CycleMultiplierRequest(PolynomialCoefficientRequest):
+    """Compute the multiplier of a supplied, validated exact rational cycle."""
+
+    cycle: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS)
+
+    @model_validator(mode="after")
+    def require_exact_cycle(self) -> Self:
+        points = tuple(
+            parse_canonical_rational(value, label="cycle point") for value in self.cycle
+        )
+        if len(set(points)) != len(points):
+            raise ValueError("cycle points must be distinct")
+        coefficients = self.coefficient_values()
+        for index, point in enumerate(points):
+            expected = points[(index + 1) % len(points)]
+            if _evaluate(coefficients, point) != expected:
+                raise ValueError("cycle points must follow the polynomial map in order")
+        return self
+
+
+class FiniteFieldMapRequest(StrictModel):
+    """A canonical polynomial map over the prime field GF(p)."""
+
+    prime: int = Field(ge=2, le=MAX_FIELD_PRIME)
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+
+    @model_validator(mode="after")
+    def require_canonical_prime_field_map(self) -> Self:
+        if not _is_prime(self.prime):
+            raise ValueError("prime must be a prime number")
+        values = tuple(_parse_canonical_integer(value) for value in self.coefficients)
+        if len(values) > 1 and values[-1] % self.prime == 0:
+            raise ValueError("coefficients must omit trailing zeros modulo the prime")
+        return self
+
+
+class MapIterateResult(StrictModel):
+    source_coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_DEGREE + 1
+    )
+    n: int = Field(ge=0, le=MAX_ITERATE)
+    coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_ITERATE_DEGREE + 1
+    )
+    degree: int = Field(ge=0, le=MAX_ITERATE_DEGREE)
+    complete: Literal[True] = True
+    method: Literal["EXACT_POLYNOMIAL_COMPOSITION"] = "EXACT_POLYNOMIAL_COMPOSITION"
+
+    @model_validator(mode="after")
+    def bind_degree_and_coefficients(self) -> Self:
+        parse_polynomial_coefficients(self.source_coefficients)
+        values = tuple(Fraction(value) for value in self.coefficients)
+        if any(
+            str(Fraction(value)) != value
+            or len(value) > MAX_POLYNOMIAL_OUTPUT_DIGITS * 2 + 2
+            for value in self.coefficients
+        ):
+            raise ValueError("iterate coefficients must be bounded and canonical")
+        expected_degree = 0 if values == (Fraction(0),) else len(values) - 1
+        if self.degree != expected_degree:
+            raise ValueError("degree must match the canonical coefficient tuple")
+        return self
+
+
+class OrbitRepeatEvidence(StrictModel):
+    first_seen_index: int = Field(ge=0)
+    repeated_at_index: int = Field(ge=1)
+    preperiod: int = Field(ge=0)
+    period: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def bind_indices(self) -> Self:
+        if self.preperiod != self.first_seen_index:
+            raise ValueError("preperiod must equal first-seen index")
+        if self.period != self.repeated_at_index - self.first_seen_index:
+            raise ValueError("period must equal the repeat-index difference")
+        return self
+
+
+class OrbitPrefixResult(StrictModel):
+    source_coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_DEGREE + 1
+    )
+    start: str
+    orbit: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS + 1)
+    requested_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
+    computed_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
+    termination: Literal["REPEAT_FOUND", "STEP_BOUND_REACHED", "OUTPUT_BOUND_REACHED"]
+    repeat: OrbitRepeatEvidence | None = None
+    eventual_behavior_complete: bool
+    truncated: bool
+
+    @model_validator(mode="after")
+    def bind_termination_evidence(self) -> Self:
+        _require_bound_orbit(self.source_coefficients, self.start, self.orbit)
+        if len(self.orbit) != self.computed_steps + 1:
+            raise ValueError("orbit length must equal computed steps plus one")
+        if self.computed_steps > self.requested_steps:
+            raise ValueError("computed steps cannot exceed the request bound")
+        if self.termination == "REPEAT_FOUND":
+            if (
+                self.repeat is None
+                or not self.eventual_behavior_complete
+                or self.truncated
+            ):
+                raise ValueError("repeat termination requires complete repeat evidence")
+            if self.repeat.repeated_at_index != self.computed_steps:
+                raise ValueError("repeat evidence must bind the final orbit value")
+            if self.orbit[self.repeat.first_seen_index] != self.orbit[-1]:
+                raise ValueError("repeat evidence must bind equal orbit values")
+        elif (
+            self.repeat is not None
+            or self.eventual_behavior_complete
+            or not self.truncated
+        ):
+            raise ValueError("bounded termination cannot imply eventual behavior")
+        if self.termination == "STEP_BOUND_REACHED" and (
+            self.computed_steps != self.requested_steps
+        ):
+            raise ValueError("step-bound termination must exhaust the requested prefix")
+        return self
+
+
+class DynatomicPolynomialResult(StrictModel):
+    source_coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_DEGREE + 1
+    )
+    coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_DYNATOMIC_DEGREE + 1
+    )
+    degree: int = Field(ge=0, le=MAX_DYNATOMIC_DEGREE)
+    n: int = Field(ge=1, le=MAX_ITERATE)
+    complete: Literal[True] = True
+    method: Literal["MOBIUS_EXACT_POLYNOMIAL_DIVISION"] = (
+        "MOBIUS_EXACT_POLYNOMIAL_DIVISION"
+    )
+
+    @model_validator(mode="after")
+    def bind_degree_and_coefficients(self) -> Self:
+        parse_polynomial_coefficients(self.source_coefficients)
+        values = tuple(Fraction(value) for value in self.coefficients)
+        if any(
+            str(Fraction(value)) != value
+            or len(value) > MAX_POLYNOMIAL_OUTPUT_DIGITS * 2 + 2
+            for value in self.coefficients
+        ):
+            raise ValueError("dynatomic coefficients must be bounded and canonical")
+        expected_degree = 0 if values == (Fraction(0),) else len(values) - 1
+        if self.degree != expected_degree:
+            raise ValueError("degree must match the canonical coefficient tuple")
+        return self
+
+
+class CycleMultiplierResult(StrictModel):
+    source_coefficients: tuple[str, ...] = Field(
+        min_length=1, max_length=MAX_DEGREE + 1
+    )
+    multiplier: str
+    cycle: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS)
+    period: int = Field(ge=1, le=MAX_ORBIT_STEPS)
+    validated_cycle: Literal[True] = True
+    complete: Literal[True] = True
+
+    @model_validator(mode="after")
+    def bind_period_and_multiplier(self) -> Self:
+        source = parse_polynomial_coefficients(self.source_coefficients)
+        points = tuple(
+            parse_canonical_rational(value, label="cycle point") for value in self.cycle
+        )
+        if len(set(points)) != len(points) or any(
+            _evaluate(source, point) != points[(index + 1) % len(points)]
+            for index, point in enumerate(points)
+        ):
+            raise ValueError("cycle must be a distinct ordered cycle of the bound map")
+        if self.period != len(self.cycle):
+            raise ValueError("period must match cycle length")
+        value = Fraction(self.multiplier)
+        if (
+            str(value) != self.multiplier
+            or len(str(abs(value.numerator))) > MAX_POLYNOMIAL_OUTPUT_DIGITS
+            or len(str(value.denominator)) > MAX_POLYNOMIAL_OUTPUT_DIGITS
+        ):
+            raise ValueError("multiplier must be a bounded canonical rational")
+        return self
+
+
+class FiniteFieldMapResult(StrictModel):
+    prime: int = Field(ge=2, le=MAX_FIELD_PRIME)
+    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    edges: tuple[tuple[int, int], ...]
+    cycles: tuple[tuple[int, ...], ...]
+    tail_lengths: tuple[int, ...]
+    complete: Literal[True] = True
+    method: Literal["COMPLETE_FUNCTIONAL_GRAPH_ENUMERATION"] = (
+        "COMPLETE_FUNCTIONAL_GRAPH_ENUMERATION"
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_graph(self) -> Self:
+        if not _is_prime(self.prime):
+            raise ValueError("prime must be a prime number")
+        coefficients = tuple(
+            _parse_canonical_integer(value) for value in self.coefficients
+        )
+        if len(coefficients) > 1 and coefficients[-1] % self.prime == 0:
+            raise ValueError("coefficients must omit trailing zeros modulo the prime")
+        self._require_complete_edges()
+        if any(
+            target != _evaluate_mod_prime(coefficients, source, self.prime)
+            for source, target in self.edges
+        ):
+            raise ValueError(
+                "functional graph edges must evaluate the bound polynomial"
+            )
+        cycle_set = self._require_canonical_cycles()
+        self._require_tail_evidence(cycle_set)
+        return self
+
+    def _require_complete_edges(self) -> None:
+        if len(self.edges) != self.prime or len(self.tail_lengths) != self.prime:
+            raise ValueError("functional graph must cover every field element")
+        if tuple(source for source, _ in self.edges) != tuple(range(self.prime)):
+            raise ValueError("functional graph edges must be source ordered")
+        if any(not 0 <= target < self.prime for _, target in self.edges):
+            raise ValueError("functional graph edge target out of range")
+        if any(length < 0 for length in self.tail_lengths):
+            raise ValueError("tail lengths must be nonnegative")
+
+    def _require_canonical_cycles(self) -> set[int]:
+        if self.cycles != tuple(sorted(self.cycles)):
+            raise ValueError("cycles must be canonical and sorted")
+        if any(not cycle or cycle[0] != min(cycle) for cycle in self.cycles):
+            raise ValueError("each cycle must start at its least element")
+        cycle_nodes = [node for cycle in self.cycles for node in cycle]
+        if len(cycle_nodes) != len(set(cycle_nodes)):
+            raise ValueError("functional graph cycles must be disjoint")
+        targets = tuple(target for _, target in self.edges)
+        for cycle in self.cycles:
+            for index, node in enumerate(cycle):
+                if targets[node] != cycle[(index + 1) % len(cycle)]:
+                    raise ValueError("cycle must follow functional graph edges")
+        return set(cycle_nodes)
+
+    def _require_tail_evidence(self, cycle_set: set[int]) -> None:
+        if cycle_set != {
+            node for node, length in enumerate(self.tail_lengths) if length == 0
+        }:
+            raise ValueError("zero tail lengths must identify exactly the cycle nodes")
+        if any(
+            self.tail_lengths[source] != self.tail_lengths[target] + 1
+            for source, target in self.edges
+            if source not in cycle_set
+        ):
+            raise ValueError("tail lengths must decrease by one along every tail edge")
+
+
+def _evaluate(coefficients: tuple[Fraction, ...], point: Fraction) -> Fraction:
+    value = Fraction(0)
+    for coefficient in reversed(coefficients):
+        value = value * point + coefficient
+    return value
+
+
+def _require_bound_orbit(
+    source_coefficients: tuple[str, ...],
+    start: str,
+    orbit_values: tuple[str, ...],
+) -> None:
+    source = parse_polynomial_coefficients(source_coefficients)
+    initial = parse_canonical_rational(start, label="start")
+    orbit = tuple(
+        parse_canonical_rational(value, label="orbit value") for value in orbit_values
+    )
+    if orbit[0] != initial:
+        raise ValueError("orbit must begin at the bound start point")
+    if any(_evaluate(source, point) != target for point, target in pairwise(orbit)):
+        raise ValueError("orbit values must follow the bound polynomial map")
+
+
+def _evaluate_mod_prime(coefficients: tuple[int, ...], point: int, prime: int) -> int:
+    value = 0
+    for coefficient in reversed(coefficients):
+        value = (value * point + coefficient) % prime
+    return value
+
+
+def _parse_canonical_integer(value: str) -> int:
+    if len(value) > MAX_COEFFICIENT_DIGITS + 1:
+        raise ValueError("coefficient exceeds the integer digit bound")
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise ValueError("coefficient must be a canonical integer") from None
+    if str(parsed) != value:
+        raise ValueError("coefficient must be a canonical integer")
+    return parsed
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n < 4:
+        return True
+    if n % 2 == 0 or n % 3 == 0:
+        return False
+    i = 5
+    while i * i <= n:
+        if n % i == 0 or n % (i + 2) == 0:
+            return False
+        i += 6
+    return True
+
+
+__all__ = [
+    "CycleMultiplierRequest",
+    "CycleMultiplierResult",
+    "DynatomicPolynomialRequest",
+    "DynatomicPolynomialResult",
+    "FiniteFieldMapRequest",
+    "FiniteFieldMapResult",
+    "MapIterateRequest",
+    "MapIterateResult",
+    "OrbitPrefixRequest",
+    "OrbitPrefixResult",
+    "OrbitRepeatEvidence",
+]

--- a/src/jacobian/math/arithmetic_dynamics/_operations.py
+++ b/src/jacobian/math/arithmetic_dynamics/_operations.py
@@ -1,0 +1,128 @@
+"""Wire adapters for exact bounded arithmetic dynamics."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Any
+
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    CycleMultiplierResult,
+    DynatomicPolynomialRequest,
+    DynatomicPolynomialResult,
+    FiniteFieldMapRequest,
+    FiniteFieldMapResult,
+    MapIterateRequest,
+    MapIterateResult,
+    OrbitPrefixRequest,
+    OrbitPrefixResult,
+    OrbitRepeatEvidence,
+    PolynomialCoefficientRequest,
+)
+from jacobian.math.arithmetic_dynamics.operations import (
+    cycle_multiplier,
+    dynatomic_polynomial,
+    finite_field_functional_graph,
+    iterate_polynomial,
+    orbit_prefix,
+    polynomial_coefficients,
+    polynomial_from_coefficients,
+)
+
+
+def _polynomial(request: PolynomialCoefficientRequest) -> Any:
+    return polynomial_from_coefficients(request.coefficient_values())
+
+
+def _format_coefficients(polynomial: Any) -> tuple[str, ...]:
+    values = tuple(str(value) for value in polynomial_coefficients(polynomial))
+    if any(len(value) > 65_538 for value in values):
+        raise ValueError("polynomial coefficient output exceeds digit bound")
+    return values
+
+
+def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
+    result = iterate_polynomial(_polynomial(request), request.n)
+    return MapIterateResult(
+        source_coefficients=request.coefficients,
+        n=request.n,
+        coefficients=_format_coefficients(result),
+        degree=0 if result.is_zero else int(result.degree()),
+    )
+
+
+def compute_orbit_prefix(request: OrbitPrefixRequest) -> OrbitPrefixResult:
+    result = orbit_prefix(
+        _polynomial(request),
+        Fraction(request.start),
+        request.max_steps,
+    )
+    repeat = (
+        None
+        if result.repeat is None
+        else OrbitRepeatEvidence(
+            first_seen_index=result.repeat.first_seen_index,
+            repeated_at_index=result.repeat.repeated_at_index,
+            preperiod=result.repeat.preperiod,
+            period=result.repeat.period,
+        )
+    )
+    found_repeat = result.termination == "REPEAT_FOUND"
+    return OrbitPrefixResult(
+        source_coefficients=request.coefficients,
+        start=request.start,
+        orbit=tuple(str(value) for value in result.orbit),
+        requested_steps=request.max_steps,
+        computed_steps=len(result.orbit) - 1,
+        termination=result.termination,
+        repeat=repeat,
+        eventual_behavior_complete=found_repeat,
+        truncated=not found_repeat,
+    )
+
+
+def compute_dynatomic_polynomial(
+    request: DynatomicPolynomialRequest,
+) -> DynatomicPolynomialResult:
+    result = dynatomic_polynomial(_polynomial(request), request.n)
+    return DynatomicPolynomialResult(
+        source_coefficients=request.coefficients,
+        coefficients=_format_coefficients(result),
+        degree=0 if result.is_zero else int(result.degree()),
+        n=request.n,
+    )
+
+
+def compute_cycle_multiplier(
+    request: CycleMultiplierRequest,
+) -> CycleMultiplierResult:
+    points = tuple(Fraction(value) for value in request.cycle)
+    return CycleMultiplierResult(
+        source_coefficients=request.coefficients,
+        multiplier=str(cycle_multiplier(_polynomial(request), points)),
+        cycle=request.cycle,
+        period=len(points),
+    )
+
+
+def compute_finite_field_map(request: FiniteFieldMapRequest) -> FiniteFieldMapResult:
+    graph = finite_field_functional_graph(
+        tuple(int(value) for value in request.coefficients),
+        request.prime,
+    )
+    return FiniteFieldMapResult(
+        prime=request.prime,
+        coefficients=request.coefficients,
+        edges=graph.edges,
+        cycles=graph.cycles,
+        tail_lengths=graph.tail_lengths,
+    )
+
+
+__all__ = [
+    "compute_cycle_multiplier",
+    "compute_dynatomic_polynomial",
+    "compute_finite_field_map",
+    "compute_map_iterate",
+    "compute_orbit_prefix",
+]

--- a/src/jacobian/math/arithmetic_dynamics/_tools.py
+++ b/src/jacobian/math/arithmetic_dynamics/_tools.py
@@ -1,0 +1,166 @@
+"""Arithmetic dynamics operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    CycleMultiplierResult,
+    DynatomicPolynomialRequest,
+    DynatomicPolynomialResult,
+    FiniteFieldMapRequest,
+    FiniteFieldMapResult,
+    MapIterateRequest,
+    MapIterateResult,
+    OrbitPrefixRequest,
+    OrbitPrefixResult,
+)
+from jacobian.math.arithmetic_dynamics._operations import (
+    compute_cycle_multiplier,
+    compute_dynatomic_polynomial,
+    compute_finite_field_map,
+    compute_map_iterate,
+    compute_orbit_prefix,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+    version: str = "1",
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version=version,
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "arithmetic_dynamics.map.iterate.compute",
+        "Compute the n-th iterate of a polynomial map",
+        "Compute phi^n by exact polynomial composition. "
+        "Phi^0 is the identity; coefficients are low-to-high.",
+        MapIterateRequest,
+        MapIterateResult,
+        compute_map_iterate,
+        "arithmetic-dynamics",
+        "polynomial",
+        "exact",
+        examples=(
+            example(
+                "f_x_squared_plus_1_iterate_2",
+                "Compute f^2 for f(x)=x^2+1; n must be non-negative.",
+                {"coefficients": ["1", "0", "1"], "n": 2},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.point.orbit.compute",
+        "Compute orbit prefix of a point",
+        "Compute P, f(P), ..., f^N(P) for a polynomial map and detect "
+        "the first repeat if one occurs within the prefix. A repeat includes "
+        "typed preperiod/period evidence; exhausting a step or output bound is "
+        "explicitly truncated and makes no eventual-behavior claim.",
+        OrbitPrefixRequest,
+        OrbitPrefixResult,
+        compute_orbit_prefix,
+        "arithmetic-dynamics",
+        "orbit",
+        "exact",
+        examples=(
+            example(
+                "orbit_of_0_under_x2",
+                "Orbit of 0 under f(x)=x^2 for 5 steps; "
+                "start must be a rational number.",
+                {"coefficients": ["0", "0", "1"], "start": "0", "max_steps": 5},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.dynatomic_polynomial.compute",
+        "Compute the n-th dynatomic polynomial",
+        "Compute the Mobius-normalized formal-period polynomial "
+        "Phi*_n(x) = product_{d|n} (f^d(x)-x)^{mu(n/d)} for a "
+        "degree-at-least-two map, using exact polynomial division.",
+        DynatomicPolynomialRequest,
+        DynatomicPolynomialResult,
+        compute_dynatomic_polynomial,
+        "arithmetic-dynamics",
+        "dynatomic",
+        "exact",
+        examples=(
+            example(
+                "dynatomic_n1_x2",
+                "Dynatomic polynomial for n=1 of f(x)=x^2; n must be at least 1.",
+                {"coefficients": ["0", "0", "1"], "n": 1},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.cycle.multiplier.compute",
+        "Compute the multiplier of a periodic cycle",
+        "Compute the product of f'(P_i) over all cycle points, "
+        "giving the exact multiplier of a periodic cycle. The request is "
+        "accepted only when the distinct points follow the map in order.",
+        CycleMultiplierRequest,
+        CycleMultiplierResult,
+        compute_cycle_multiplier,
+        "arithmetic-dynamics",
+        "cycle",
+        "multiplier",
+        "exact",
+        examples=(
+            example(
+                "multiplier_fixed_0_x2",
+                "Multiplier of the fixed point 0 under f(x)=x^2; "
+                "cycle points must be rational.",
+                {"coefficients": ["0", "0", "1"], "cycle": ["0"]},
+            ),
+        ),
+    ),
+    _op(
+        "arithmetic_dynamics.finite_field.functional_graph.compute",
+        "Compute functional graph of a polynomial map over GF(p)",
+        "Compute the complete functional graph of a polynomial map "
+        "over a finite field, including cycles, tail lengths, and "
+        "all edges.",
+        FiniteFieldMapRequest,
+        FiniteFieldMapResult,
+        compute_finite_field_map,
+        "arithmetic-dynamics",
+        "finite-field",
+        "exact",
+        examples=(
+            example(
+                "x2_mod_5",
+                "Functional graph of x^2 over GF(5); prime must be a prime number.",
+                {"prime": 5, "coefficients": ["0", "0", "1"]},
+            ),
+        ),
+    ),
+)
+
+
+TOOLS = ARITHMETIC_DYNAMICS_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/arithmetic_dynamics/operations.py
+++ b/src/jacobian/math/arithmetic_dynamics/operations.py
@@ -1,0 +1,344 @@
+"""Exact bounded native arithmetic-dynamics kernels."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Sequence
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Any, Literal
+
+_MAX_INPUT_DEGREE = 30
+_MAX_INPUT_DIGITS = 128
+_MAX_ITERATE_DEGREE = 1_024
+_MAX_DYNATOMIC_DEGREE = 512
+_MAX_ORBIT_STEPS = 1_000
+_MAX_FIELD_PRIME = 10_000
+_MAX_OUTPUT_DIGITS = 32_768
+
+
+@dataclass(frozen=True, slots=True)
+class RepeatEvidence:
+    first_seen_index: int
+    repeated_at_index: int
+    preperiod: int
+    period: int
+
+
+@dataclass(frozen=True, slots=True)
+class OrbitComputation:
+    orbit: tuple[Fraction, ...]
+    requested_steps: int
+    termination: Literal["REPEAT_FOUND", "STEP_BOUND_REACHED", "OUTPUT_BOUND_REACHED"]
+    repeat: RepeatEvidence | None
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionalGraph:
+    edges: tuple[tuple[int, int], ...]
+    cycles: tuple[tuple[int, ...], ...]
+    tail_lengths: tuple[int, ...]
+
+
+def polynomial_from_coefficients(coefficients: Sequence[Fraction | int]) -> Any:
+    """Build a canonical univariate ``QQ`` polynomial from low-to-high values."""
+
+    import sympy
+
+    values = tuple(Fraction(value) for value in coefficients)
+    if not 1 <= len(values) <= _MAX_INPUT_DEGREE + 1:
+        raise ValueError("polynomial must have between 1 and 31 coefficients")
+    if any(_fraction_digits(value) > _MAX_INPUT_DIGITS for value in values):
+        raise ValueError("polynomial coefficient exceeds the input digit bound")
+    if len(values) > 1 and values[-1] == 0:
+        raise ValueError("polynomial coefficients must omit trailing zeros")
+    x = sympy.Symbol("x")
+    expression = sum(
+        sympy.Rational(value.numerator, value.denominator) * x**i
+        for i, value in enumerate(values)
+    )
+    return sympy.Poly(expression, x, domain=sympy.QQ)
+
+
+def polynomial_coefficients(polynomial: Any) -> tuple[Fraction, ...]:
+    """Return low-to-high exact coefficients of a univariate ``QQ`` polynomial."""
+
+    source = _require_polynomial(polynomial)
+    if not source.is_zero and source.degree() > _MAX_ITERATE_DEGREE:
+        raise ValueError("polynomial degree exceeds the extraction bound")
+    _require_bounded_output_coefficients(source)
+    if source.is_zero:
+        return (Fraction(0),)
+    return tuple(Fraction(source.nth(index)) for index in range(source.degree() + 1))
+
+
+def iterate_polynomial(polynomial: Any, n: int) -> Any:
+    """Return the exact n-th compositional iterate, with iterate zero the identity."""
+
+    import sympy
+
+    source = _require_input_polynomial(polynomial)
+    if not 0 <= n <= 20:
+        raise ValueError("iterate count must be between 0 and 20")
+    source_degree = 0 if source.is_zero else max(0, int(source.degree()))
+    output_degree = 1 if n == 0 else source_degree**n
+    if output_degree > _MAX_ITERATE_DEGREE:
+        raise ValueError("iterate output degree exceeds bound")
+    result = sympy.Poly(source.gens[0], source.gens[0], domain=sympy.QQ)
+    for _ in range(n):
+        result = source.compose(result)
+        _require_bounded_output_coefficients(result)
+    return result
+
+
+def fixed_point_equation(polynomial: Any, n: int) -> Any:
+    """Return ``f^n(x) - x`` as a native polynomial projection."""
+
+    import sympy
+
+    source = _require_input_polynomial(polynomial)
+    if n < 1:
+        raise ValueError("fixed-point iterate must be positive")
+    identity = sympy.Poly(source.gens[0], source.gens[0], domain=sympy.QQ)
+    return iterate_polynomial(source, n) - identity
+
+
+def dynatomic_polynomial(polynomial: Any, n: int) -> Any:
+    """Return the exact n-th Möbius-normalized formal-period polynomial."""
+
+    import sympy
+
+    source = _require_input_polynomial(polynomial)
+    if source.degree() < 2:
+        raise ValueError("dynatomic polynomial requires degree at least two")
+    if n < 1:
+        raise ValueError("dynatomic index must be positive")
+    if int(source.degree()) ** n > _MAX_DYNATOMIC_DEGREE:
+        raise ValueError("dynatomic output degree exceeds bound")
+    numerator = sympy.Poly(1, source.gens[0], domain=sympy.QQ)
+    denominator = sympy.Poly(1, source.gens[0], domain=sympy.QQ)
+    for divisor in sympy.divisors(n):
+        term = fixed_point_equation(source, int(divisor))
+        mobius = int(sympy.mobius(n // divisor))
+        if mobius == 1:
+            numerator *= term
+            _require_bounded_output_coefficients(numerator)
+        elif mobius == -1:
+            denominator *= term
+            _require_bounded_output_coefficients(denominator)
+    quotient, remainder = numerator.div(denominator)
+    if not remainder.is_zero:
+        raise RuntimeError("dynatomic quotient was not an exact polynomial")
+    _require_bounded_output_coefficients(quotient)
+    return quotient
+
+
+def orbit_prefix(
+    polynomial: Any,
+    start: Fraction,
+    max_steps: int,
+    *,
+    max_value_digits: int = 2_048,
+) -> OrbitComputation:
+    """Iterate until a first repeat or an explicit step/output bound."""
+
+    source = _require_input_polynomial(polynomial)
+    if not 0 <= max_steps <= _MAX_ORBIT_STEPS:
+        raise ValueError("orbit step bound must be between 0 and 1000")
+    if max_value_digits < 1:
+        raise ValueError("orbit value digit bound must be positive")
+    initial = Fraction(start)
+    if _fraction_digits(initial) > _MAX_INPUT_DIGITS:
+        raise ValueError("orbit start exceeds the input digit bound")
+    values = [initial]
+    seen = {values[0]: 0}
+    for step in range(1, max_steps + 1):
+        next_value = Fraction(source.eval(values[-1]))
+        if _fraction_digits(next_value) > max_value_digits:
+            return OrbitComputation(
+                orbit=tuple(values),
+                requested_steps=max_steps,
+                termination="OUTPUT_BOUND_REACHED",
+                repeat=None,
+            )
+        values.append(next_value)
+        if next_value in seen:
+            first_seen = seen[next_value]
+            return OrbitComputation(
+                orbit=tuple(values),
+                requested_steps=max_steps,
+                termination="REPEAT_FOUND",
+                repeat=RepeatEvidence(
+                    first_seen_index=first_seen,
+                    repeated_at_index=step,
+                    preperiod=first_seen,
+                    period=step - first_seen,
+                ),
+            )
+        seen[next_value] = step
+    return OrbitComputation(
+        orbit=tuple(values),
+        requested_steps=max_steps,
+        termination="STEP_BOUND_REACHED",
+        repeat=None,
+    )
+
+
+def validate_cycle(polynomial: Any, cycle: Sequence[Fraction]) -> None:
+    """Reject a sequence that is not one exact ordered periodic cycle."""
+
+    source = _require_input_polynomial(polynomial)
+    points = tuple(Fraction(point) for point in cycle)
+    if not 1 <= len(points) <= _MAX_ORBIT_STEPS:
+        raise ValueError("cycle must contain between 1 and 1000 points")
+    if any(_fraction_digits(point) > _MAX_INPUT_DIGITS for point in points):
+        raise ValueError("cycle point exceeds the input digit bound")
+    if len(set(points)) != len(points):
+        raise ValueError("cycle must contain distinct points")
+    for index, point in enumerate(points):
+        if Fraction(source.eval(point)) != points[(index + 1) % len(points)]:
+            raise ValueError("cycle points do not follow the polynomial map")
+
+
+def cycle_multiplier(polynomial: Any, cycle: Sequence[Fraction]) -> Fraction:
+    """Return the exact derivative product around a validated periodic cycle."""
+
+    source = _require_input_polynomial(polynomial)
+    points = tuple(Fraction(point) for point in cycle)
+    validate_cycle(source, points)
+    derivative = source.diff()
+    multiplier = Fraction(1)
+    for point in points:
+        multiplier *= Fraction(derivative.eval(point))
+        if _fraction_digits(multiplier) > _MAX_OUTPUT_DIGITS:
+            raise ValueError("cycle multiplier exceeds the output digit bound")
+    return multiplier
+
+
+def finite_field_functional_graph(
+    coefficients: Sequence[int],
+    prime: int,
+) -> FunctionalGraph:
+    """Enumerate the complete functional graph of a polynomial over ``GF(p)``."""
+
+    import sympy
+
+    if not 2 <= prime <= _MAX_FIELD_PRIME or not sympy.isprime(prime):
+        raise ValueError("prime must be a prime number between 2 and 10000")
+    values = tuple(int(value) for value in coefficients)
+    if not 1 <= len(values) <= _MAX_INPUT_DEGREE + 1:
+        raise ValueError("polynomial must have between 1 and 31 coefficients")
+    if any(len(str(abs(value))) > _MAX_INPUT_DIGITS for value in values):
+        raise ValueError("polynomial coefficient exceeds the input digit bound")
+    normalized = tuple(value % prime for value in values)
+    if len(normalized) > 1 and normalized[-1] == 0:
+        raise ValueError("polynomial coefficients must omit trailing zeros modulo p")
+
+    def evaluate(point: int) -> int:
+        value = 0
+        for coefficient in reversed(normalized):
+            value = (value * point + coefficient) % prime
+        return value
+
+    targets = tuple(evaluate(source) for source in range(prime))
+    cycles = _functional_graph_cycles(targets)
+    tail_lengths = _tail_lengths(targets, cycles)
+    return FunctionalGraph(
+        edges=tuple(enumerate(targets)),
+        cycles=cycles,
+        tail_lengths=tail_lengths,
+    )
+
+
+def _functional_graph_cycles(targets: tuple[int, ...]) -> tuple[tuple[int, ...], ...]:
+    processed: set[int] = set()
+    cycles: list[tuple[int, ...]] = []
+    for start in range(len(targets)):
+        if start in processed:
+            continue
+        path: list[int] = []
+        path_positions: dict[int, int] = {}
+        current = start
+        while current not in processed and current not in path_positions:
+            path_positions[current] = len(path)
+            path.append(current)
+            current = targets[current]
+        if current in path_positions:
+            cycle = path[path_positions[current] :]
+            least_index = cycle.index(min(cycle))
+            cycles.append(tuple(cycle[least_index:] + cycle[:least_index]))
+        processed.update(path)
+    return tuple(sorted(cycles))
+
+
+def _tail_lengths(
+    targets: tuple[int, ...],
+    cycles: tuple[tuple[int, ...], ...],
+) -> tuple[int, ...]:
+    reverse_edges: list[list[int]] = [[] for _ in targets]
+    for source, target in enumerate(targets):
+        reverse_edges[target].append(source)
+    distances = [-1] * len(targets)
+    queue: deque[int] = deque()
+    for node in (node for cycle in cycles for node in cycle):
+        distances[node] = 0
+        queue.append(node)
+    while queue:
+        target = queue.popleft()
+        for source in reverse_edges[target]:
+            if distances[source] < 0:
+                distances[source] = distances[target] + 1
+                queue.append(source)
+    if any(distance < 0 for distance in distances):
+        raise RuntimeError("functional graph traversal did not reach every vertex")
+    return tuple(distances)
+
+
+def _require_polynomial(polynomial: Any) -> Any:
+    import sympy
+
+    if not isinstance(polynomial, sympy.Poly):
+        raise TypeError("polynomial must be a SymPy Poly")
+    if len(polynomial.gens) != 1 or not polynomial.domain.is_QQ:
+        raise ValueError("polynomial must be univariate over QQ")
+    return polynomial
+
+
+def _require_input_polynomial(polynomial: Any) -> Any:
+    source = _require_polynomial(polynomial)
+    if not source.is_zero and source.degree() > _MAX_INPUT_DEGREE:
+        raise ValueError("polynomial degree exceeds the input bound")
+    if any(
+        _fraction_digits(Fraction(coefficient)) > _MAX_INPUT_DIGITS
+        for coefficient in source.all_coeffs()
+    ):
+        raise ValueError("polynomial coefficient exceeds the input digit bound")
+    return source
+
+
+def _fraction_digits(value: Fraction) -> int:
+    return max(len(str(abs(value.numerator))), len(str(value.denominator)))
+
+
+def _require_bounded_output_coefficients(polynomial: Any) -> None:
+    if any(
+        _fraction_digits(Fraction(coefficient)) > _MAX_OUTPUT_DIGITS
+        for coefficient in polynomial.all_coeffs()
+    ):
+        raise ValueError("polynomial coefficient exceeds the output digit bound")
+
+
+__all__ = [
+    "FunctionalGraph",
+    "OrbitComputation",
+    "RepeatEvidence",
+    "cycle_multiplier",
+    "dynatomic_polynomial",
+    "finite_field_functional_graph",
+    "fixed_point_equation",
+    "iterate_polynomial",
+    "orbit_prefix",
+    "polynomial_coefficients",
+    "polynomial_from_coefficients",
+    "validate_cycle",
+]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -45,6 +45,26 @@
       "input_schema": "sha256:f74564b49ea64569e7baa76f0357aff07a522381e5a5712fc1d53aca37aa16f8",
       "output_schema": "sha256:fff33a3156f4c93700116cad342aebc45cefc21ec19e058a2bb82e4ff3dfbe7c"
     },
+    "arithmetic_dynamics.cycle.multiplier.compute": {
+      "input_schema": "sha256:57816446c877b77427a93e85b7706779c39e1fbc608f2c3dc437197d762e572d",
+      "output_schema": "sha256:310ee652220022b42fdfdef8e0053c74225ea0146c4b622d89a065a72b83cd82"
+    },
+    "arithmetic_dynamics.dynatomic_polynomial.compute": {
+      "input_schema": "sha256:6e528491f4836c8182c3d7f1cdd18d2f790a1754e8c9dea1651d519d56b057f6",
+      "output_schema": "sha256:bead2c6a536038fa3001f70167f1bfce25d4fe1850411bc53f265d51bc3073f1"
+    },
+    "arithmetic_dynamics.finite_field.functional_graph.compute": {
+      "input_schema": "sha256:80e02af4cfd7c6222079b1d29b5c0069f57532a3347b189fd25354e454a06e67",
+      "output_schema": "sha256:ba8460d032367b942f6d03bba5ccc0924f8072d3a01fd3b319a4b0f0a535ebb4"
+    },
+    "arithmetic_dynamics.map.iterate.compute": {
+      "input_schema": "sha256:7f590a1c0d824db49cb0854574817bbe7a35c4f4f5df67e70fa3110e532b8a55",
+      "output_schema": "sha256:a81024bfccf9f824e658fd6a67a2c983468ee1bd7220889ecb175f35cf2e4849"
+    },
+    "arithmetic_dynamics.point.orbit.compute": {
+      "input_schema": "sha256:84af2c23c824cbffa52f44f1455773d08256cd7c881e5431e65a6b2e5a7e9224",
+      "output_schema": "sha256:e90d983727267c2701cdc1fc179fb24f2bfceb93c1e55393f3136980de66f9e3"
+    },
     "boolean.erasure_noise.compute": {
       "input_schema": "sha256:5d30c772c330454e3fc49026c61ae8ca0e71eb2dab87420292e0c67a59473e2d",
       "output_schema": "sha256:107269b473b6bcd7c1a8129669b2fb4b5890ca71706258bb0c8bec08488a1c27"

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 365
     assert actual == expected["operations"]
 
 

--- a/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
+++ b/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
@@ -1,0 +1,327 @@
+"""Known-answer and adversarial tests for arithmetic dynamics."""
+
+from fractions import Fraction
+
+import pytest
+import sympy
+from pydantic import ValidationError
+
+from jacobian.math.arithmetic_dynamics import (
+    finite_field_functional_graph,
+    fixed_point_equation,
+    iterate_polynomial,
+    polynomial_coefficients,
+    polynomial_from_coefficients,
+)
+from jacobian.math.arithmetic_dynamics._models import (
+    CycleMultiplierRequest,
+    DynatomicPolynomialRequest,
+    FiniteFieldMapRequest,
+    FiniteFieldMapResult,
+    MapIterateRequest,
+    OrbitPrefixRequest,
+    OrbitPrefixResult,
+)
+from jacobian.math.arithmetic_dynamics._operations import (
+    compute_cycle_multiplier,
+    compute_dynatomic_polynomial,
+    compute_finite_field_map,
+    compute_map_iterate,
+    compute_orbit_prefix,
+)
+from jacobian.math.arithmetic_dynamics._tools import TOOLS
+
+
+class TestMapIterate:
+    def test_zero_iterate_is_identity(self) -> None:
+        result = compute_map_iterate(
+            MapIterateRequest(coefficients=("1", "0", "1"), n=0)
+        )
+
+        assert result.coefficients == ("0", "1")
+        assert result.degree == 1
+        assert result.complete is True
+
+    def test_second_iterate_is_exact(self) -> None:
+        result = compute_map_iterate(
+            MapIterateRequest(coefficients=("1", "0", "1"), n=2)
+        )
+
+        assert result.coefficients == ("2", "0", "2", "0", "1")
+        assert result.degree == 4
+
+    def test_zero_polynomial_iterates_without_backend_degree_coercion(self) -> None:
+        result = compute_map_iterate(MapIterateRequest(coefficients=("0",), n=3))
+
+        assert result.coefficients == ("0",)
+        assert result.degree == 0
+
+    def test_degree_growth_beyond_output_bound_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="iterate output degree"):
+            MapIterateRequest(coefficients=("1", "0", "0", "0", "0", "1"), n=5)
+
+
+class TestOrbitPrefix:
+    def test_repeat_proves_preperiod_and_period(self) -> None:
+        result = compute_orbit_prefix(
+            OrbitPrefixRequest(coefficients=("0", "0", "1"), start="0", max_steps=5)
+        )
+
+        assert result.orbit == ("0", "0")
+        assert result.termination == "REPEAT_FOUND"
+        assert result.repeat is not None
+        assert result.repeat.preperiod == 0
+        assert result.repeat.period == 1
+        assert result.eventual_behavior_complete is True
+        assert result.truncated is False
+
+    def test_finite_nonrepeating_prefix_does_not_imply_eventual_behavior(self) -> None:
+        result = compute_orbit_prefix(
+            OrbitPrefixRequest(coefficients=("1", "1"), start="0", max_steps=3)
+        )
+
+        assert result.orbit == ("0", "1", "2", "3")
+        assert result.termination == "STEP_BOUND_REACHED"
+        assert result.repeat is None
+        assert result.eventual_behavior_complete is False
+        assert result.truncated is True
+
+    def test_zero_step_request_is_an_explicit_truncated_prefix(self) -> None:
+        result = compute_orbit_prefix(
+            OrbitPrefixRequest(coefficients=("1", "1"), start="0", max_steps=0)
+        )
+
+        assert result.orbit == ("0",)
+        assert result.computed_steps == 0
+        assert result.termination == "STEP_BOUND_REACHED"
+        assert result.truncated is True
+
+    def test_output_growth_stops_with_nonconcluding_typed_boundary(self) -> None:
+        degree_thirty = ("0",) * 30 + ("1",)
+        result = compute_orbit_prefix(
+            OrbitPrefixRequest(
+                coefficients=degree_thirty,
+                start="1" + "0" * 127,
+                max_steps=2,
+            )
+        )
+
+        assert result.termination == "OUTPUT_BOUND_REACHED"
+        assert result.computed_steps < result.requested_steps
+        assert result.repeat is None
+        assert result.eventual_behavior_complete is False
+        assert result.truncated is True
+
+    def test_result_model_rejects_completion_without_repeat_evidence(self) -> None:
+        with pytest.raises(ValidationError, match="cannot imply eventual behavior"):
+            OrbitPrefixResult(
+                source_coefficients=("1", "1"),
+                start="0",
+                orbit=("0", "1"),
+                requested_steps=1,
+                computed_steps=1,
+                termination="STEP_BOUND_REACHED",
+                repeat=None,
+                eventual_behavior_complete=True,
+                truncated=False,
+            )
+
+    def test_result_model_rejects_orbit_not_bound_to_source_map(self) -> None:
+        with pytest.raises(ValidationError, match="bound polynomial map"):
+            OrbitPrefixResult(
+                source_coefficients=("1", "1"),
+                start="0",
+                orbit=("0", "2"),
+                requested_steps=1,
+                computed_steps=1,
+                termination="STEP_BOUND_REACHED",
+                repeat=None,
+                eventual_behavior_complete=False,
+                truncated=True,
+            )
+
+
+class TestDynatomicPolynomial:
+    def test_first_dynatomic_polynomial(self) -> None:
+        result = compute_dynatomic_polynomial(
+            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=1)
+        )
+
+        assert result.coefficients == ("0", "-1", "1")
+
+    def test_square_factor_mobius_case_and_divisor_product_identity(self) -> None:
+        source = polynomial_from_coefficients((0, 0, 1))
+        phi_1 = compute_dynatomic_polynomial(
+            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=1)
+        )
+        phi_2 = compute_dynatomic_polynomial(
+            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=2)
+        )
+        phi_4 = compute_dynatomic_polynomial(
+            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=4)
+        )
+        product = polynomial_from_coefficients(tuple(map(Fraction, phi_1.coefficients)))
+        product *= polynomial_from_coefficients(
+            tuple(map(Fraction, phi_2.coefficients))
+        )
+        product *= polynomial_from_coefficients(
+            tuple(map(Fraction, phi_4.coefficients))
+        )
+
+        assert phi_4.coefficients == (
+            "1",
+            "0",
+            "0",
+            "1",
+            "0",
+            "0",
+            "1",
+            "0",
+            "0",
+            "1",
+            "0",
+            "0",
+            "1",
+        )
+        assert product == fixed_point_equation(source, 4)
+
+    def test_linear_map_is_outside_dynatomic_contract(self) -> None:
+        with pytest.raises(ValidationError, match="degree at least two"):
+            DynatomicPolynomialRequest(coefficients=("1", "1"), n=2)
+
+
+class TestCycleMultiplier:
+    def test_validated_two_cycle_multiplier(self) -> None:
+        result = compute_cycle_multiplier(
+            CycleMultiplierRequest(coefficients=("1", "-1"), cycle=("0", "1"))
+        )
+
+        assert result.multiplier == "1"
+        assert result.period == 2
+        assert result.validated_cycle is True
+
+    def test_arbitrary_points_cannot_be_labeled_a_cycle(self) -> None:
+        with pytest.raises(ValidationError, match="follow the polynomial map"):
+            CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("0", "1"))
+
+    def test_repeated_cycle_points_are_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="distinct"):
+            CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("0", "0"))
+
+
+class TestFiniteFieldFunctionalGraph:
+    def test_x_squared_mod_five_has_complete_canonical_graph(self) -> None:
+        result = compute_finite_field_map(
+            FiniteFieldMapRequest(prime=5, coefficients=("0", "0", "1"))
+        )
+
+        assert result.edges == ((0, 0), (1, 1), (2, 4), (3, 4), (4, 1))
+        assert result.cycles == ((0,), (1,))
+        assert result.tail_lengths == (0, 0, 2, 2, 1)
+        assert result.complete is True
+
+    @pytest.mark.parametrize(
+        ("prime", "coefficients"),
+        [(2, (1, 1, 1)), (3, (2, 0, 1)), (5, (1, 1)), (7, (3, 2, 1))],
+    )
+    def test_edges_cycles_and_tail_lengths_replay(
+        self, prime: int, coefficients: tuple[int, ...]
+    ) -> None:
+        result = compute_finite_field_map(
+            FiniteFieldMapRequest(
+                prime=prime, coefficients=tuple(str(value) for value in coefficients)
+            )
+        )
+        targets = dict(result.edges)
+        cycle_nodes = {node for cycle in result.cycles for node in cycle}
+
+        assert targets == {
+            point: sum(
+                coefficient * pow(point, exponent, prime)
+                for exponent, coefficient in enumerate(coefficients)
+            )
+            % prime
+            for point in range(prime)
+        }
+        for cycle in result.cycles:
+            assert cycle[0] == min(cycle)
+            assert all(
+                targets[node] == cycle[(index + 1) % len(cycle)]
+                for index, node in enumerate(cycle)
+            )
+        assert cycle_nodes == {
+            node for node, length in enumerate(result.tail_lengths) if length == 0
+        }
+        assert all(
+            result.tail_lengths[source] == result.tail_lengths[target] + 1
+            for source, target in result.edges
+            if source not in cycle_nodes
+        )
+
+    def test_result_contract_rejects_false_tail_evidence(self) -> None:
+        with pytest.raises(ValidationError, match="tail lengths"):
+            FiniteFieldMapResult(
+                prime=2,
+                coefficients=("0",),
+                edges=((0, 0), (1, 0)),
+                cycles=((0,),),
+                tail_lengths=(0, 0),
+            )
+
+    def test_result_contract_rejects_edges_not_bound_to_polynomial(self) -> None:
+        with pytest.raises(ValidationError, match="bound polynomial"):
+            FiniteFieldMapResult(
+                prime=3,
+                coefficients=("0", "0", "1"),
+                edges=((0, 0), (1, 2), (2, 1)),
+                cycles=((0,), (1, 2)),
+                tail_lengths=(0, 0, 0),
+            )
+
+    def test_nonprime_modulus_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="prime"):
+            FiniteFieldMapRequest(prime=4, coefficients=("1",))
+
+    def test_trailing_zero_mod_prime_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="trailing zeros"):
+            FiniteFieldMapRequest(prime=5, coefficients=("1", "5"))
+
+
+class TestCanonicalAndPortfolioContracts:
+    @pytest.mark.parametrize("coefficient", ["01", "+1", "2/4", "1.0"])
+    def test_noncanonical_rational_coefficients_are_rejected(
+        self, coefficient: str
+    ) -> None:
+        with pytest.raises(ValidationError, match="canonical"):
+            MapIterateRequest(coefficients=(coefficient,), n=1)
+
+    def test_trailing_zero_coefficients_are_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="trailing zeros"):
+            MapIterateRequest(coefficients=("1", "0"), n=1)
+
+    def test_fixed_point_equation_is_native_not_a_catalog_slot(self) -> None:
+        operation_ids = {tool.operation_id for tool in TOOLS}
+        source = polynomial_from_coefficients((0, 0, 1))
+
+        assert "arithmetic_dynamics.fixed_point_equation.compute" not in operation_ids
+        assert polynomial_coefficients(fixed_point_equation(source, 1)) == (
+            Fraction(0),
+            Fraction(-1),
+            Fraction(1),
+        )
+
+    def test_native_polynomial_rejects_non_qq_domain(self) -> None:
+        x = sympy.Symbol("x")
+
+        with pytest.raises(ValueError, match="over QQ"):
+            fixed_point_equation(sympy.Poly(x**2 + 1, x, modulus=5), 1)
+
+    def test_native_iterate_enforces_output_degree_bound(self) -> None:
+        source = polynomial_from_coefficients((1,) + (0,) * 4 + (1,))
+
+        with pytest.raises(ValueError, match="output degree"):
+            iterate_polynomial(source, 5)
+
+    def test_native_finite_field_graph_rejects_composite_modulus(self) -> None:
+        with pytest.raises(ValueError, match="prime number"):
+            finite_field_functional_graph((1,), 4)

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -9,6 +9,7 @@ import jacobian
 PUBLIC_API = {
     "jacobian.math": (
         "arithmetic",
+        "arithmetic_dynamics",
         "finite_abelian_groups",
         "finite_fields",
         "graphs",
@@ -59,6 +60,20 @@ PUBLIC_API = {
         "reciprocal",
         "sign",
         "sum_rationals",
+    ),
+    "jacobian.math.arithmetic_dynamics": (
+        "FunctionalGraph",
+        "OrbitComputation",
+        "RepeatEvidence",
+        "cycle_multiplier",
+        "dynatomic_polynomial",
+        "finite_field_functional_graph",
+        "fixed_point_equation",
+        "iterate_polynomial",
+        "orbit_prefix",
+        "polynomial_coefficients",
+        "polynomial_from_coefficients",
+        "validate_cycle",
     ),
     "jacobian.math.graphs": (
         "GraphCompositionInput",


### PR DESCRIPTION
## Summary

Focused replacement for #1967. This preserves the mathematically correct arithmetic-dynamics functionality and removes the unrelated stacked numerical-semigroup changes.

- Five public atomic operations cover exact polynomial iteration, bounded rational orbit prefixes, dynatomic polynomials, validated cycle multipliers, and complete prime-field functional graphs.
- Native `jacobian.math.arithmetic_dynamics` kernels share the exact implementation; `fixed_point_equation` remains a useful native projection but does not consume a public catalog slot.
- All requests validate canonical coefficients and explicit degree, iterate, step, digit, field-size, and output-growth bounds before durable output.
- Results bind the source polynomial and relevant point/cycle data. Orbit truncation is a typed non-conclusion; repeat evidence binds preperiod and period. Functional-graph results bind every edge to the source map and validate canonical cycles and tail distances.
- Dynatomic construction uses the actual Möbius function and exact division, including square-factor cases.

The adjacent `finite_field.polynomial_map.table.compute` capability supplies a reusable complete edge-table outcome; this capability remains distinct because it returns the functional-graph decomposition into canonical cycles and certified tail distances.

No numerical-semigroup files or catalog-admission infrastructure are included. This branch is intentionally based on the pre-curation `main`; after #1976 lands, rebase it and add only the five reviewed admission rows rather than merging it first.

## Correctness evidence

Tests cover exact iterates including the zero polynomial, degree-growth rejection, repeat and bounded orbit semantics, output truncation, the n=4 square-factor Möbius case and divisor-product identity, exact cycle validation, complete functional-graph replay, false result evidence, canonical inputs, native bounds, and the native-only fixed-point projection.

An independent diagnostic checked 50 random polynomial iterates against repeated point evaluation, 30 dynatomic divisor-product identities for quadratic maps, and 72 prime-field functional graphs by replaying every edge, cycle, and tail distance.

## Validation

- Focused math/public API/catalog lane — 55 passed
- `make check` — 1,011 passed plus Ruff, formatting, complexity, and mypy
- `make test-plan BASE=origin/main` — unavailable on this base (`No rule to make target test-plan`)

## Implementation handoff

```yaml
stage: implementation
status: complete
subject:
  candidate_id: issue-1923-arithmetic-dynamics
  capability_ids:
    - arithmetic_dynamics.map.iterate.compute
    - arithmetic_dynamics.point.orbit.compute
    - arithmetic_dynamics.dynatomic_polynomial.compute
    - arithmetic_dynamics.cycle.multiplier.compute
    - arithmetic_dynamics.finite_field.functional_graph.compute
evidence_refs:
  - ref: PR #1967 at 122ebf4a
  - ref: focused regression and independent replay checks in this PR
contract_ref: src/jacobian/math/arithmetic_dynamics/_models.py
git_commit: bf449aac571d0c0c9967fb2114b6db735c946195
git_tree: a8be7ca3154a5525050aa0795f2c7f7b60452269
catalog_digest: sha256:bae4bbd727145dbea00b92e03652833c93a9563a3d2fdfd92df471b6db8c9641
policy_digest: unavailable on pre-#1976 main
runtime_snapshot: SymPy exact QQ kernels and bounded Python finite enumeration; no optional provider
model_prompt_settings: not applicable; deterministic implementation validation
raw_trace_location: GitHub Actions and the validation transcript summarized above
assurance: COMPUTED exact bounded results; no checker self-authorization
open_obligations:
  - rebase after #1976 and add its five admission-ledger rows
missing_evidence: []
decision: retain five bounded atomic operations and the shared native API
next_action: merge #1976, then rebase this PR before merge
```

Supersedes #1967.