### PR TITLE
Add exact combinatorics on words capabilities

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -81,6 +81,7 @@ from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
 from jacobian.math.topology._tools import TOOLS as TOPOLOGY_TOOLS
+from jacobian.math.words._tools import TOOLS as WORDS_TOOLS
 
 BUILTIN_TOOLS: MathTools = (
     *BOOLEAN_TOOLS,
@@ -140,6 +141,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *WORDS_TOOLS,
     *ELECTRICAL_NETWORKS_TOOLS,
     *REGULAR_LANGUAGES_TOOLS,
     *ALGEBRAIC_COMBINATORICS_TOOLS,

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -9,6 +9,7 @@ from jacobian.math import (
     polynomials,
     prime_field_linear_algebra,
     probability,
+    words,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "polynomials",
     "prime_field_linear_algebra",
     "probability",
+    "words",
 ]

--- a/src/jacobian/math/words/__init__.py
+++ b/src/jacobian/math/words/__init__.py
@@ -1,0 +1,34 @@
+"""Supported native combinatorics-on-words API."""
+
+from jacobian.math.words.operations import (
+    FactorAnalysis,
+    PeriodAnalysis,
+    apply_morphism,
+    compose_morphisms,
+    conjugates,
+    factor_occurrences,
+    factors_of_length,
+    incidence_matrix,
+    parikh_vector,
+    periods,
+    prefix_function,
+    primitive_root,
+)
+from jacobian.math.words.values import FiniteWord, WordMorphism
+
+__all__ = [
+    "FactorAnalysis",
+    "FiniteWord",
+    "PeriodAnalysis",
+    "WordMorphism",
+    "apply_morphism",
+    "compose_morphisms",
+    "conjugates",
+    "factor_occurrences",
+    "factors_of_length",
+    "incidence_matrix",
+    "parikh_vector",
+    "periods",
+    "prefix_function",
+    "primitive_root",
+]

--- a/src/jacobian/math/words/_models.py
+++ b/src/jacobian/math/words/_models.py
@@ -1,0 +1,121 @@
+"""Typed wire contracts for exact combinatorics-on-words operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.words.operations import factors_of_length, incidence_matrix, periods
+from jacobian.math.words.values import FiniteWord, WordMorphism
+
+
+class FactorsLengthRequest(StrictModel):
+    """Enumerate all distinct factors of one valid length."""
+
+    word: FiniteWord
+    factor_length: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_bounded_factor_length(self) -> Self:
+        if self.factor_length > len(self.word.letters):
+            raise ValueError("factor_length must not exceed the word length")
+        return self
+
+
+class FactorsLengthResult(FactorsLengthRequest):
+    """Complete factor enumeration, ordered by first occurrence."""
+
+    factors: tuple[tuple[str, ...], ...]
+    occurrences: tuple[tuple[int, ...], ...]
+    multiplicities: tuple[int, ...]
+    first_occurrence: tuple[int, ...]
+    distinct_count: int = Field(ge=0)
+    complete: Literal[True] = True
+    scope: Literal["ALL_CONTIGUOUS_FACTORS_OF_REQUESTED_LENGTH"] = (
+        "ALL_CONTIGUOUS_FACTORS_OF_REQUESTED_LENGTH"
+    )
+    method: Literal["EXACT_SLIDING_WINDOW_ENUMERATION"] = (
+        "EXACT_SLIDING_WINDOW_ENUMERATION"
+    )
+
+    @model_validator(mode="after")
+    def bind_exact_factor_enumeration(self) -> Self:
+        expected = factors_of_length(self.word, self.factor_length)
+        expected_occurrences = expected.occurrences
+        if (
+            self.factors != expected.factors
+            or self.occurrences != expected_occurrences
+            or self.multiplicities
+            != tuple(len(indices) for indices in expected_occurrences)
+            or self.first_occurrence
+            != tuple(indices[0] for indices in expected_occurrences)
+            or self.distinct_count != len(expected.factors)
+        ):
+            raise ValueError("factor result is not bound to the requested word")
+        return self
+
+
+class PeriodsRequest(StrictModel):
+    """Compute all overlap periods of a finite word."""
+
+    word: FiniteWord
+
+
+class PeriodsResult(PeriodsRequest):
+    """Complete overlap-period profile and proper-power primitivity."""
+
+    periods: tuple[int, ...]
+    least_period: int = Field(ge=0)
+    is_primitive: bool
+    complete: Literal[True] = True
+    method: Literal["EXACT_OVERLAP_COMPARISON"] = "EXACT_OVERLAP_COMPARISON"
+    primitive_convention: Literal["NOT_A_NONTRIVIAL_INTEGER_POWER"] = (
+        "NOT_A_NONTRIVIAL_INTEGER_POWER"
+    )
+    empty_word_convention: Literal["NO_POSITIVE_PERIOD_AND_NOT_PRIMITIVE"] = (
+        "NO_POSITIVE_PERIOD_AND_NOT_PRIMITIVE"
+    )
+
+    @model_validator(mode="after")
+    def bind_exact_period_profile(self) -> Self:
+        expected = periods(self.word)
+        if (
+            self.periods != expected.periods
+            or self.least_period != expected.least_period
+            or self.is_primitive != expected.primitive
+        ):
+            raise ValueError("period result is not bound to the requested word")
+        return self
+
+
+class IncidenceMatrixRequest(StrictModel):
+    """Compute the incidence matrix of a finite word morphism."""
+
+    morphism: WordMorphism
+
+
+class IncidenceMatrixResult(IncidenceMatrixRequest):
+    """Exact target-by-source incidence matrix."""
+
+    matrix: tuple[tuple[int, ...], ...]
+    complete: Literal[True] = True
+    method: Literal["EXACT_SYMBOL_COUNTING"] = "EXACT_SYMBOL_COUNTING"
+    orientation: Literal["ROWS_TARGET_COLUMNS_SOURCE"] = "ROWS_TARGET_COLUMNS_SOURCE"
+
+    @model_validator(mode="after")
+    def bind_exact_incidence_matrix(self) -> Self:
+        if self.matrix != incidence_matrix(self.morphism):
+            raise ValueError("incidence matrix is not bound to the requested morphism")
+        return self
+
+
+__all__ = [
+    "FactorsLengthRequest",
+    "FactorsLengthResult",
+    "IncidenceMatrixRequest",
+    "IncidenceMatrixResult",
+    "PeriodsRequest",
+    "PeriodsResult",
+]

--- a/src/jacobian/math/words/_operations.py
+++ b/src/jacobian/math/words/_operations.py
@@ -1,0 +1,48 @@
+"""Wire adapters for public combinatorics-on-words operations."""
+
+from __future__ import annotations
+
+from jacobian.math.words._models import (
+    FactorsLengthRequest,
+    FactorsLengthResult,
+    IncidenceMatrixRequest,
+    IncidenceMatrixResult,
+    PeriodsRequest,
+    PeriodsResult,
+)
+from jacobian.math.words.operations import factors_of_length, incidence_matrix, periods
+
+
+def compute_factors_length(request: FactorsLengthRequest) -> FactorsLengthResult:
+    analysis = factors_of_length(request.word, request.factor_length)
+    occurrences = analysis.occurrences
+    return FactorsLengthResult(
+        **request.model_dump(),
+        factors=analysis.factors,
+        occurrences=occurrences,
+        multiplicities=tuple(len(indices) for indices in occurrences),
+        first_occurrence=tuple(indices[0] for indices in occurrences),
+        distinct_count=len(analysis.factors),
+    )
+
+
+def compute_periods(request: PeriodsRequest) -> PeriodsResult:
+    analysis = periods(request.word)
+    return PeriodsResult(
+        **request.model_dump(),
+        periods=analysis.periods,
+        least_period=analysis.least_period,
+        is_primitive=analysis.primitive,
+    )
+
+
+def compute_incidence_matrix(
+    request: IncidenceMatrixRequest,
+) -> IncidenceMatrixResult:
+    return IncidenceMatrixResult(
+        **request.model_dump(),
+        matrix=incidence_matrix(request.morphism),
+    )
+
+
+__all__ = ["compute_factors_length", "compute_incidence_matrix", "compute_periods"]

--- a/src/jacobian/math/words/_tools.py
+++ b/src/jacobian/math/words/_tools.py
@@ -1,0 +1,104 @@
+"""Public combinatorics-on-words operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.words._models import (
+    FactorsLengthRequest,
+    FactorsLengthResult,
+    IncidenceMatrixRequest,
+    IncidenceMatrixResult,
+    PeriodsRequest,
+    PeriodsResult,
+)
+from jacobian.math.words._operations import (
+    compute_factors_length,
+    compute_incidence_matrix,
+    compute_periods,
+)
+
+WORDS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="word.factors.length.compute",
+        version="1",
+        title="Compute all factors of one length",
+        description=(
+            "Enumerate every distinct contiguous factor of the requested length, "
+            "in first-occurrence order, with all zero-based occurrence positions."
+        ),
+        request_type=FactorsLengthRequest,
+        result_type=FactorsLengthResult,
+        run=compute_factors_length,
+        tags=("combinatorics", "words", "factors", "exact", "complete"),
+        examples=(
+            example(
+                "abaab_factors_2",
+                "Enumerate all length-two factors of abaab.",
+                {
+                    "word": {
+                        "alphabet": ["a", "b"],
+                        "letters": ["a", "b", "a", "a", "b"],
+                    },
+                    "factor_length": 2,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="word.periods.compute",
+        version="1",
+        title="Compute all periods of a word",
+        description=(
+            "Return every positive overlap period and decide whether the word is "
+            "a nontrivial integer power. An empty word has no positive periods and "
+            "is not primitive."
+        ),
+        request_type=PeriodsRequest,
+        result_type=PeriodsResult,
+        run=compute_periods,
+        tags=("combinatorics", "words", "periods", "exact", "complete"),
+        examples=(
+            example(
+                "ababab_periods",
+                "Compute the complete period profile of ababab.",
+                {
+                    "word": {
+                        "alphabet": ["a", "b"],
+                        "letters": ["a", "b", "a", "b", "a", "b"],
+                    }
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="word_morphism.incidence_matrix.compute",
+        version="1",
+        title="Compute a word-morphism incidence matrix",
+        description=(
+            "Compute the exact matrix whose target-symbol rows and source-symbol "
+            "columns count symbols in each morphism image."
+        ),
+        request_type=IncidenceMatrixRequest,
+        result_type=IncidenceMatrixResult,
+        run=compute_incidence_matrix,
+        tags=("combinatorics", "words", "morphism", "matrix", "exact"),
+        examples=(
+            example(
+                "fibonacci_matrix",
+                "Compute the incidence matrix of a->ab and b->a.",
+                {
+                    "morphism": {
+                        "source_alphabet": ["a", "b"],
+                        "target_alphabet": ["a", "b"],
+                        "images": [["a", "b"], ["a"]],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+TOOLS = WORDS_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/words/operations.py
+++ b/src/jacobian/math/words/operations.py
@@ -1,0 +1,164 @@
+"""Exact bounded native kernels for combinatorics on words."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jacobian.math.words.values import (
+    MAX_MORPHISM_OUTPUT_LENGTH,
+    FiniteWord,
+    WordMorphism,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FactorAnalysis:
+    factor_length: int
+    factors: tuple[tuple[str, ...], ...]
+    occurrences: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PeriodAnalysis:
+    periods: tuple[int, ...]
+    least_period: int
+    primitive: bool
+
+
+def factors_of_length(word: FiniteWord, factor_length: int) -> FactorAnalysis:
+    if not 0 <= factor_length <= len(word.letters):
+        raise ValueError("factor length must be between zero and the word length")
+    positions: dict[tuple[str, ...], list[int]] = {}
+    for start in range(len(word.letters) - factor_length + 1):
+        factor = word.letters[start : start + factor_length]
+        positions.setdefault(factor, []).append(start)
+    factors = tuple(positions)
+    return FactorAnalysis(
+        factor_length=factor_length,
+        factors=factors,
+        occurrences=tuple(tuple(positions[factor]) for factor in factors),
+    )
+
+
+def factor_occurrences(word: FiniteWord, pattern: tuple[str, ...]) -> tuple[int, ...]:
+    if any(letter not in word.alphabet for letter in pattern):
+        raise ValueError("pattern letter is outside the declared alphabet")
+    if not pattern:
+        return tuple(range(len(word.letters) + 1))
+    return tuple(
+        start
+        for start in range(len(word.letters) - len(pattern) + 1)
+        if word.letters[start : start + len(pattern)] == pattern
+    )
+
+
+def periods(word: FiniteWord) -> PeriodAnalysis:
+    length = len(word.letters)
+    if length == 0:
+        return PeriodAnalysis(periods=(), least_period=0, primitive=False)
+    values = tuple(
+        period
+        for period in range(1, length + 1)
+        if all(
+            word.letters[index] == word.letters[index + period]
+            for index in range(length - period)
+        )
+    )
+    _, exponent = primitive_root(word)
+    return PeriodAnalysis(
+        periods=values,
+        least_period=values[0],
+        primitive=exponent == 1,
+    )
+
+
+def primitive_root(word: FiniteWord) -> tuple[tuple[str, ...], int]:
+    length = len(word.letters)
+    if length == 0:
+        return ((), 1)
+    for root_length in range(1, length + 1):
+        if length % root_length == 0:
+            root = word.letters[:root_length]
+            if root * (length // root_length) == word.letters:
+                return (root, length // root_length)
+    raise RuntimeError("finite word did not admit itself as a primitive root")
+
+
+def conjugates(word: FiniteWord) -> tuple[tuple[str, ...], ...]:
+    if not word.letters:
+        return ((),)
+    rotations = {
+        word.letters[index:] + word.letters[:index]
+        for index in range(len(word.letters))
+    }
+    rank = {symbol: index for index, symbol in enumerate(word.alphabet)}
+    return tuple(
+        sorted(rotations, key=lambda value: tuple(rank[item] for item in value))
+    )
+
+
+def parikh_vector(word: FiniteWord) -> tuple[int, ...]:
+    return tuple(word.letters.count(symbol) for symbol in word.alphabet)
+
+
+def prefix_function(word: FiniteWord) -> tuple[int, ...]:
+    result = [0] * len(word.letters)
+    for index in range(1, len(word.letters)):
+        border = result[index - 1]
+        while border and word.letters[index] != word.letters[border]:
+            border = result[border - 1]
+        if word.letters[index] == word.letters[border]:
+            border += 1
+        result[index] = border
+    return tuple(result)
+
+
+def apply_morphism(morphism: WordMorphism, word: FiniteWord) -> FiniteWord:
+    if word.alphabet != morphism.source_alphabet:
+        raise ValueError("word alphabet must equal the morphism source alphabet")
+    image_map = dict(zip(morphism.source_alphabet, morphism.images, strict=True))
+    output_length = sum(len(image_map[letter]) for letter in word.letters)
+    if output_length > MAX_MORPHISM_OUTPUT_LENGTH:
+        raise ValueError("morphism output exceeds the length bound")
+    letters = tuple(output for letter in word.letters for output in image_map[letter])
+    return FiniteWord(alphabet=morphism.target_alphabet, letters=letters)
+
+
+def compose_morphisms(first: WordMorphism, second: WordMorphism) -> WordMorphism:
+    if first.target_alphabet != second.source_alphabet:
+        raise ValueError("first target alphabet must equal second source alphabet")
+    second_map = dict(zip(second.source_alphabet, second.images, strict=True))
+    images = tuple(
+        tuple(output for letter in image for output in second_map[letter])
+        for image in first.images
+    )
+    if any(len(image) > MAX_MORPHISM_OUTPUT_LENGTH for image in images):
+        raise ValueError("composed morphism image exceeds the length bound")
+    return WordMorphism(
+        source_alphabet=first.source_alphabet,
+        target_alphabet=second.target_alphabet,
+        images=images,
+    )
+
+
+def incidence_matrix(morphism: WordMorphism) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(image.count(target) for image in morphism.images)
+        for target in morphism.target_alphabet
+    )
+
+
+__all__ = [
+    "FactorAnalysis",
+    "PeriodAnalysis",
+    "apply_morphism",
+    "compose_morphisms",
+    "conjugates",
+    "factor_occurrences",
+    "factors_of_length",
+    "incidence_matrix",
+    "parikh_vector",
+    "periods",
+    "prefix_function",
+    "primitive_root",
+]

--- a/src/jacobian/math/words/values.py
+++ b/src/jacobian/math/words/values.py
@@ -1,0 +1,72 @@
+"""Provider-independent values for bounded combinatorics on words."""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_WORD_LENGTH = 500
+MAX_ALPHABET_SIZE = 50
+MAX_SYMBOL_LENGTH = 64
+MAX_MORPHISM_IMAGE_LENGTH = 10_000
+MAX_MORPHISM_OUTPUT_LENGTH = MAX_WORD_LENGTH
+
+Symbol = Annotated[str, Field(min_length=1, max_length=MAX_SYMBOL_LENGTH)]
+
+
+class FiniteWord(StrictModel):
+    alphabet: tuple[Symbol, ...] = Field(min_length=1, max_length=MAX_ALPHABET_SIZE)
+    letters: tuple[str, ...] = Field(max_length=MAX_WORD_LENGTH)
+
+    @model_validator(mode="after")
+    def require_word_over_ordered_alphabet(self) -> Self:
+        if len(set(self.alphabet)) != len(self.alphabet):
+            raise ValueError("alphabet symbols must be distinct")
+        if any(letter not in self.alphabet for letter in self.letters):
+            raise ValueError("word letter is outside the declared alphabet")
+        return self
+
+
+class WordMorphism(StrictModel):
+    source_alphabet: tuple[Symbol, ...] = Field(
+        min_length=1, max_length=MAX_ALPHABET_SIZE
+    )
+    target_alphabet: tuple[Symbol, ...] = Field(
+        min_length=1, max_length=MAX_ALPHABET_SIZE
+    )
+    images: tuple[tuple[str, ...], ...] = Field(
+        min_length=1, max_length=MAX_ALPHABET_SIZE
+    )
+
+    @model_validator(mode="after")
+    def require_total_bounded_morphism(self) -> Self:
+        if len(set(self.source_alphabet)) != len(self.source_alphabet):
+            raise ValueError("source alphabet symbols must be distinct")
+        if len(set(self.target_alphabet)) != len(self.target_alphabet):
+            raise ValueError("target alphabet symbols must be distinct")
+        if len(self.images) != len(self.source_alphabet):
+            raise ValueError("morphism must have one image per source symbol")
+        if any(len(image) > MAX_MORPHISM_IMAGE_LENGTH for image in self.images):
+            raise ValueError("morphism image exceeds the length bound")
+        if any(
+            letter not in self.target_alphabet
+            for image in self.images
+            for letter in image
+        ):
+            raise ValueError("morphism image uses a symbol outside the target alphabet")
+        return self
+
+
+__all__ = [
+    "MAX_ALPHABET_SIZE",
+    "MAX_MORPHISM_IMAGE_LENGTH",
+    "MAX_MORPHISM_OUTPUT_LENGTH",
+    "MAX_SYMBOL_LENGTH",
+    "MAX_WORD_LENGTH",
+    "FiniteWord",
+    "Symbol",
+    "WordMorphism",
+]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1440,6 +1440,18 @@
     "topology.simplicial_homology.integral.compute": {
       "input_schema": "sha256:ae5513f34822ee0e5602f3a67701a3de98a4f3595422d2ae8d8d53e45b3cf60b",
       "output_schema": "sha256:0b9ca74c0cd26174705d7dff455d0513a03c8f9bd5d62148fefd675632b3f5dc"
+    },
+    "word.factors.length.compute": {
+      "input_schema": "sha256:83a5e15f179ea6db06c71db515052fa0ba1989c236774d02dd66c93b2fb6f499",
+      "output_schema": "sha256:35a29bd2500aca39630759902ee22dea83c9e0fe292b7bbf971d17dc9cc6b025"
+    },
+    "word.periods.compute": {
+      "input_schema": "sha256:fd433607162771e58a57f2f7945c766408d40b2a2836938f30c26aa87044a4bb",
+      "output_schema": "sha256:f907920fe270f4c1e163a28875e68e081ee58f1f3348879dce1c764b306b838f"
+    },
+    "word_morphism.incidence_matrix.compute": {
+      "input_schema": "sha256:697d1e446d014e9d9c94a9df525f32d9570c340e108e8c3f16262dc7e37cccb5",
+      "output_schema": "sha256:c48bd3fca2c875b8419489adf84e2bb67f323d035c3f78906e0350b064511dcc"
     }
   }
 }

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 363
     assert actual == expected["operations"]
 
 

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -16,6 +16,7 @@ PUBLIC_API = {
         "polynomials",
         "prime_field_linear_algebra",
         "probability",
+        "words",
     ),
     "jacobian.math.finite_fields": (
         "Axis",
@@ -116,6 +117,22 @@ PUBLIC_API = {
         "MutualInformationResult",
         "MutualInformationTerm",
         "mutual_information",
+    ),
+    "jacobian.math.words": (
+        "FactorAnalysis",
+        "FiniteWord",
+        "PeriodAnalysis",
+        "WordMorphism",
+        "apply_morphism",
+        "compose_morphisms",
+        "conjugates",
+        "factor_occurrences",
+        "factors_of_length",
+        "incidence_matrix",
+        "parikh_vector",
+        "periods",
+        "prefix_function",
+        "primitive_root",
     ),
 }
 

--- a/tests/math/words/test_words.py
+++ b/tests/math/words/test_words.py
@@ -1,0 +1,226 @@
+"""Correctness and contract tests for bounded combinatorics on words."""
+
+from __future__ import annotations
+
+import itertools
+import random
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.words import (
+    FiniteWord,
+    WordMorphism,
+    apply_morphism,
+    compose_morphisms,
+    conjugates,
+    factor_occurrences,
+    factors_of_length,
+    incidence_matrix,
+    parikh_vector,
+    periods,
+    prefix_function,
+    primitive_root,
+)
+from jacobian.math.words._models import (
+    FactorsLengthRequest,
+    FactorsLengthResult,
+    IncidenceMatrixRequest,
+    IncidenceMatrixResult,
+    PeriodsRequest,
+    PeriodsResult,
+)
+from jacobian.math.words._operations import (
+    compute_factors_length,
+    compute_incidence_matrix,
+    compute_periods,
+)
+from jacobian.math.words._tools import TOOLS
+
+
+def _word(letters: str, alphabet: tuple[str, ...] = ("a", "b")) -> FiniteWord:
+    return FiniteWord(alphabet=alphabet, letters=tuple(letters))
+
+
+def test_public_catalog_surface_is_the_audited_three_operations() -> None:
+    assert tuple(tool.operation_id for tool in TOOLS) == (
+        "word.factors.length.compute",
+        "word.periods.compute",
+        "word_morphism.incidence_matrix.compute",
+    )
+
+
+def test_factor_result_is_complete_and_bound_to_the_request() -> None:
+    request = FactorsLengthRequest(word=_word("abaab"), factor_length=2)
+    result = compute_factors_length(request)
+    assert result.factors == (("a", "b"), ("b", "a"), ("a", "a"))
+    assert result.occurrences == ((0, 3), (1,), (2,))
+    assert result.multiplicities == (2, 1, 1)
+    assert result.first_occurrence == (0, 1, 2)
+    assert result.distinct_count == 3
+    assert result.complete is True
+
+    payload = result.model_dump()
+    payload["distinct_count"] = 2
+    with pytest.raises(ValidationError, match="not bound"):
+        FactorsLengthResult.model_validate(payload)
+
+
+def test_empty_factor_occurs_at_every_boundary() -> None:
+    result = compute_factors_length(
+        FactorsLengthRequest(word=_word("aa", ("a",)), factor_length=0)
+    )
+    assert result.factors == ((),)
+    assert result.occurrences == ((0, 1, 2),)
+
+
+def test_factor_length_is_validated_before_computation() -> None:
+    with pytest.raises(ValidationError, match="must not exceed"):
+        FactorsLengthRequest(word=_word("aa", ("a",)), factor_length=3)
+
+
+def test_periods_distinguish_overlap_period_from_proper_power() -> None:
+    repeated = compute_periods(PeriodsRequest(word=_word("ababab")))
+    assert repeated.periods == (2, 4, 6)
+    assert repeated.least_period == 2
+    assert repeated.is_primitive is False
+
+    bordered_but_primitive = compute_periods(PeriodsRequest(word=_word("ababa")))
+    assert bordered_but_primitive.periods == (2, 4, 5)
+    assert bordered_but_primitive.least_period == 2
+    assert bordered_but_primitive.is_primitive is True
+
+
+def test_empty_period_convention_and_result_binding() -> None:
+    result = compute_periods(PeriodsRequest(word=_word("", ("a",))))
+    assert result.periods == ()
+    assert result.least_period == 0
+    assert result.is_primitive is False
+
+    payload = result.model_dump()
+    payload["is_primitive"] = True
+    with pytest.raises(ValidationError, match="not bound"):
+        PeriodsResult.model_validate(payload)
+
+
+def test_fibonacci_incidence_matrix_and_binding() -> None:
+    morphism = WordMorphism(
+        source_alphabet=("a", "b"),
+        target_alphabet=("a", "b"),
+        images=(("a", "b"), ("a",)),
+    )
+    result = compute_incidence_matrix(IncidenceMatrixRequest(morphism=morphism))
+    assert result.matrix == ((1, 1), (1, 0))
+    assert result.orientation == "ROWS_TARGET_COLUMNS_SOURCE"
+
+    payload = result.model_dump()
+    payload["matrix"] = ((1, 0), (1, 1))
+    with pytest.raises(ValidationError, match="not bound"):
+        IncidenceMatrixResult.model_validate(payload)
+
+
+def test_native_word_operations_are_exact_and_use_declared_order() -> None:
+    word = _word("aaa", ("a",))
+    assert factor_occurrences(word, ("a", "a")) == (0, 1)
+    assert factor_occurrences(word, ()) == (0, 1, 2, 3)
+    assert primitive_root(_word("abcabc", ("a", "b", "c"))) == (
+        ("a", "b", "c"),
+        2,
+    )
+    assert conjugates(_word("abb", ("b", "a"))) == (
+        ("b", "b", "a"),
+        ("b", "a", "b"),
+        ("a", "b", "b"),
+    )
+    assert parikh_vector(_word("abaab")) == (3, 2)
+    assert prefix_function(_word("aabaab")) == (0, 1, 0, 1, 2, 3)
+
+
+def test_native_morphism_application_and_composition() -> None:
+    fibonacci = WordMorphism(
+        source_alphabet=("a", "b"),
+        target_alphabet=("a", "b"),
+        images=(("a", "b"), ("a",)),
+    )
+    swap = WordMorphism(
+        source_alphabet=("a", "b"),
+        target_alphabet=("x", "y"),
+        images=(("y",), ("x",)),
+    )
+    assert apply_morphism(fibonacci, _word("ab")).letters == ("a", "b", "a")
+    composed = compose_morphisms(fibonacci, swap)
+    assert composed.images == (("y", "x"), ("y",))
+    assert incidence_matrix(composed) == ((1, 0), (1, 1))
+
+
+def test_value_models_reject_ambiguous_or_unbounded_inputs() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        FiniteWord(alphabet=("a", "a"), letters=("a",))
+    with pytest.raises(ValidationError, match="outside"):
+        FiniteWord(alphabet=("a",), letters=("b",))
+
+    expanding = WordMorphism(
+        source_alphabet=("a",),
+        target_alphabet=("a",),
+        images=(("a",) * 2,),
+    )
+    with pytest.raises(ValueError, match="output exceeds"):
+        apply_morphism(
+            expanding,
+            FiniteWord(alphabet=("a",), letters=("a",) * 500),
+        )
+
+
+def test_random_words_match_independent_factor_and_period_oracles() -> None:
+    random_source = random.Random(1966)
+    for length in range(9):
+        for _ in range(40):
+            letters = tuple(random_source.choice(("a", "b")) for _ in range(length))
+            word = FiniteWord(alphabet=("a", "b"), letters=letters)
+            for factor_length in range(length + 1):
+                analysis = factors_of_length(word, factor_length)
+                windows = tuple(
+                    letters[index : index + factor_length]
+                    for index in range(length - factor_length + 1)
+                )
+                expected_factors = tuple(dict.fromkeys(windows))
+                expected_positions = tuple(
+                    tuple(
+                        index
+                        for index, window in enumerate(windows)
+                        if window == factor
+                    )
+                    for factor in expected_factors
+                )
+                assert analysis.factors == expected_factors
+                assert analysis.occurrences == expected_positions
+
+            analysis = periods(word)
+            expected_periods = tuple(
+                period
+                for period in range(1, length + 1)
+                if letters[:-period] == letters[period:]
+            )
+            proper_power = any(
+                length % root_length == 0
+                and letters[:root_length] * (length // root_length) == letters
+                for root_length in range(1, length)
+            )
+            assert analysis.periods == expected_periods
+            assert analysis.primitive is (length > 0 and not proper_power)
+
+
+def test_incidence_matrix_matches_independent_count_oracle() -> None:
+    alphabet = ("a", "b")
+    images = tuple(itertools.product(alphabet, repeat=2))
+    for left in images:
+        for right in images:
+            morphism = WordMorphism(
+                source_alphabet=alphabet,
+                target_alphabet=alphabet,
+                images=(left, right),
+            )
+            assert incidence_matrix(morphism) == tuple(
+                tuple(image.count(target) for image in (left, right))
+                for target in alphabet
+            )


### PR DESCRIPTION
Replacement for #1966 after the maintainer audit classified that PR as SPLIT.

This PR rebuilds the combinatorics-on-words work from current `main` and deliberately exposes only the audited atomic public operations:

- `word.factors.length.compute`
- `word.periods.compute`
- `word_morphism.incidence_matrix.compute`

The remaining useful functionality stays in the supported native `jacobian.math.words` API: occurrences, primitive root, conjugates, Parikh vector, prefix function, and morphism application/composition.

Correctness changes relative to #1966:

- validates distinct ordered alphabets and all cross-field membership constraints before computation;
- rejects factor lengths beyond the word rather than treating invalid input as an empty result;
- distinguishes overlap period from proper-power primitivity, including the `ababa` regression;
- defines an explicit empty-word period/primitivity convention;
- orders conjugates by the declared alphabet;
- bounds morphism images and actual expanded outputs;
- binds all public results to the exact request through replay validation;
- records completeness, method, scope, and matrix orientation explicitly;
- removes the unrelated numerical-semigroup stack pollution.

Validation:

- focused words, public API, import isolation, and catalog snapshot: 26 passed;
- independent tests cover random factor enumerations, random period profiles/proper-power decisions, and morphism incidence counts;
- `make check`: lint, format, complexity, mypy, and 989 tests passed;
- `make test-plan BASE=origin/main`: unavailable because this checkout has no `test-plan` Make target.

This is a draft and should not merge ahead of #1976. Rebase it after #1976 lands so the final contract can align with the capability-evidence infrastructure without duplicating it.

Supersedes #1966.
