### PR TITLE
Add exact symbolic dynamics capabilities

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -80,6 +80,7 @@ from jacobian.math.regular_languages._tools import TOOLS as REGULAR_LANGUAGES_TO
 from jacobian.math.root_isolation._tools import TOOLS as ROOT_ISOLATION_TOOLS
 from jacobian.math.sequences._tools import TOOLS as SEQUENCES_TOOLS
 from jacobian.math.submodular_opt._tools import TOOLS as SUBMODULAR_OPT_TOOLS
+from jacobian.math.symbolic_dynamics._tools import TOOLS as SYMBOLIC_DYNAMICS_TOOLS
 from jacobian.math.topology._tools import TOOLS as TOPOLOGY_TOOLS
 
 BUILTIN_TOOLS: MathTools = (
@@ -140,6 +141,7 @@ BUILTIN_TOOLS: MathTools = (
     *POLYNOMIAL_MAPS_TOOLS,
     *EUCLIDEAN_GEOMETRY_TOOLS,
     *FINITE_GAME_THEORY_TOOLS,
+    *SYMBOLIC_DYNAMICS_TOOLS,
     *ELECTRICAL_NETWORKS_TOOLS,
     *REGULAR_LANGUAGES_TOOLS,
     *ALGEBRAIC_COMBINATORICS_TOOLS,

--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -9,6 +9,7 @@ from jacobian.math import (
     polynomials,
     prime_field_linear_algebra,
     probability,
+    symbolic_dynamics,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "polynomials",
     "prime_field_linear_algebra",
     "probability",
+    "symbolic_dynamics",
 ]

--- a/src/jacobian/math/symbolic_dynamics/__init__.py
+++ b/src/jacobian/math/symbolic_dynamics/__init__.py
@@ -1,0 +1,29 @@
+"""Supported native symbolic dynamics API."""
+
+from jacobian.math.symbolic_dynamics.operations import (
+    adjacency_shift,
+    block_language,
+    finite_type_presentation,
+    higher_block_presentation,
+    normalize_forbidden_blocks,
+    periodic_point_profile,
+)
+from jacobian.math.symbolic_dynamics.values import (
+    AdjacencyShift,
+    BlockPresentation,
+    ForbiddenBlockShift,
+    LabeledTransition,
+)
+
+__all__ = [
+    "AdjacencyShift",
+    "BlockPresentation",
+    "ForbiddenBlockShift",
+    "LabeledTransition",
+    "adjacency_shift",
+    "block_language",
+    "finite_type_presentation",
+    "higher_block_presentation",
+    "normalize_forbidden_blocks",
+    "periodic_point_profile",
+]

--- a/src/jacobian/math/symbolic_dynamics/_models.py
+++ b/src/jacobian/math/symbolic_dynamics/_models.py
@@ -1,0 +1,154 @@
+"""Typed wire contracts for exact bounded symbolic dynamics operations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.symbolic_dynamics.operations import (
+    block_language,
+    enumeration_size,
+    finite_type_presentation,
+    higher_block_presentation,
+    normalize_forbidden_blocks,
+    periodic_point_profile,
+)
+from jacobian.math.symbolic_dynamics.values import (
+    MAX_FORBIDDEN_BLOCK_LENGTH,
+    MAX_PERIOD,
+    AdjacencyShift,
+    BlockPresentation,
+    ForbiddenBlockShift,
+)
+
+
+class FiniteTypeShiftRequest(StrictModel):
+    shift: ForbiddenBlockShift
+
+    @model_validator(mode="after")
+    def require_bounded_presentation(self) -> Self:
+        forbidden = normalize_forbidden_blocks(self.shift)
+        memory = max(0, max((len(block) - 1 for block in forbidden), default=0))
+        enumeration_size(len(self.shift.alphabet), memory + 1)
+        return self
+
+
+class FiniteTypeShiftResult(FiniteTypeShiftRequest):
+    presentation: BlockPresentation
+    normalized_forbidden_blocks: tuple[tuple[str, ...], ...]
+    complete: Literal[True] = True
+    method: Literal["EXACT_DE_BRUIJN_PRESENTATION"] = "EXACT_DE_BRUIJN_PRESENTATION"
+
+    @model_validator(mode="after")
+    def bind_presentation(self) -> Self:
+        if self.presentation != finite_type_presentation(
+            self.shift
+        ) or self.normalized_forbidden_blocks != normalize_forbidden_blocks(self.shift):
+            raise ValueError("finite-type presentation is not bound to the request")
+        return self
+
+
+class BlockLanguageRequest(StrictModel):
+    shift: ForbiddenBlockShift
+    block_length: int = Field(ge=0, le=MAX_FORBIDDEN_BLOCK_LENGTH)
+
+    @model_validator(mode="after")
+    def require_bounded_enumeration(self) -> Self:
+        enumeration_size(len(self.shift.alphabet), self.block_length)
+        return self
+
+
+class BlockLanguageResult(BlockLanguageRequest):
+    allowed_blocks: tuple[tuple[str, ...], ...]
+    count: int = Field(ge=0)
+    complete: Literal[True] = True
+    scope: Literal["ALL_LOCALLY_ALLOWED_BLOCKS_OF_REQUESTED_LENGTH"] = (
+        "ALL_LOCALLY_ALLOWED_BLOCKS_OF_REQUESTED_LENGTH"
+    )
+    method: Literal["EXACT_LEXICOGRAPHIC_ENUMERATION"] = (
+        "EXACT_LEXICOGRAPHIC_ENUMERATION"
+    )
+
+    @model_validator(mode="after")
+    def bind_language(self) -> Self:
+        expected = block_language(self.shift, self.block_length)
+        if self.allowed_blocks != expected or self.count != len(expected):
+            raise ValueError("block language is not bound to the request")
+        return self
+
+
+class PeriodicPointProfileRequest(StrictModel):
+    shift: AdjacencyShift
+    max_period: int = Field(ge=1, le=MAX_PERIOD)
+
+
+class PeriodicPointProfileResult(PeriodicPointProfileRequest):
+    periods: tuple[int, ...]
+    fixed_point_counts: tuple[int, ...]
+    least_period_point_counts: tuple[int, ...]
+    primitive_orbit_counts: tuple[int, ...]
+    complete_through_period: int = Field(ge=1, le=MAX_PERIOD)
+    method: Literal["EXACT_MATRIX_TRACES_AND_MOBIUS_INVERSION"] = (
+        "EXACT_MATRIX_TRACES_AND_MOBIUS_INVERSION"
+    )
+
+    @model_validator(mode="after")
+    def bind_profile(self) -> Self:
+        fixed, exact, orbits = periodic_point_profile(self.shift, self.max_period)
+        if (
+            self.periods != tuple(range(1, self.max_period + 1))
+            or self.fixed_point_counts != fixed
+            or self.least_period_point_counts != exact
+            or self.primitive_orbit_counts != orbits
+            or self.complete_through_period != self.max_period
+        ):
+            raise ValueError("periodic-point profile is not bound to the request")
+        return self
+
+
+class HigherBlockRequest(StrictModel):
+    shift: ForbiddenBlockShift
+    block_length: int = Field(ge=1, le=MAX_FORBIDDEN_BLOCK_LENGTH)
+
+    @model_validator(mode="after")
+    def require_exact_bounded_presentation(self) -> Self:
+        forbidden = normalize_forbidden_blocks(self.shift)
+        required_memory = max(
+            0, max((len(block) - 1 for block in forbidden), default=0)
+        )
+        if self.block_length < required_memory:
+            raise ValueError(
+                "block_length must be at least the SFT presentation memory"
+            )
+        enumeration_size(len(self.shift.alphabet), self.block_length + 1)
+        return self
+
+
+class HigherBlockResult(HigherBlockRequest):
+    presentation: BlockPresentation
+    complete: Literal[True] = True
+    method: Literal["EXACT_ALLOWED_OVERLAP_PRESENTATION"] = (
+        "EXACT_ALLOWED_OVERLAP_PRESENTATION"
+    )
+
+    @model_validator(mode="after")
+    def bind_higher_block_presentation(self) -> Self:
+        if self.presentation != higher_block_presentation(
+            self.shift, self.block_length
+        ):
+            raise ValueError("higher-block presentation is not bound to the request")
+        return self
+
+
+__all__ = [
+    "BlockLanguageRequest",
+    "BlockLanguageResult",
+    "FiniteTypeShiftRequest",
+    "FiniteTypeShiftResult",
+    "HigherBlockRequest",
+    "HigherBlockResult",
+    "PeriodicPointProfileRequest",
+    "PeriodicPointProfileResult",
+]

--- a/src/jacobian/math/symbolic_dynamics/_operations.py
+++ b/src/jacobian/math/symbolic_dynamics/_operations.py
@@ -1,0 +1,67 @@
+"""Wire adapters for public symbolic dynamics operations."""
+
+from __future__ import annotations
+
+from jacobian.math.symbolic_dynamics._models import (
+    BlockLanguageRequest,
+    BlockLanguageResult,
+    FiniteTypeShiftRequest,
+    FiniteTypeShiftResult,
+    HigherBlockRequest,
+    HigherBlockResult,
+    PeriodicPointProfileRequest,
+    PeriodicPointProfileResult,
+)
+from jacobian.math.symbolic_dynamics.operations import (
+    block_language,
+    finite_type_presentation,
+    higher_block_presentation,
+    normalize_forbidden_blocks,
+    periodic_point_profile,
+)
+
+
+def construct_finite_type_shift(
+    request: FiniteTypeShiftRequest,
+) -> FiniteTypeShiftResult:
+    return FiniteTypeShiftResult(
+        **request.model_dump(),
+        presentation=finite_type_presentation(request.shift),
+        normalized_forbidden_blocks=normalize_forbidden_blocks(request.shift),
+    )
+
+
+def compute_block_language(request: BlockLanguageRequest) -> BlockLanguageResult:
+    allowed = block_language(request.shift, request.block_length)
+    return BlockLanguageResult(
+        **request.model_dump(), allowed_blocks=allowed, count=len(allowed)
+    )
+
+
+def compute_periodic_point_profile(
+    request: PeriodicPointProfileRequest,
+) -> PeriodicPointProfileResult:
+    fixed, exact, orbits = periodic_point_profile(request.shift, request.max_period)
+    return PeriodicPointProfileResult(
+        **request.model_dump(),
+        periods=tuple(range(1, request.max_period + 1)),
+        fixed_point_counts=fixed,
+        least_period_point_counts=exact,
+        primitive_orbit_counts=orbits,
+        complete_through_period=request.max_period,
+    )
+
+
+def compute_higher_block(request: HigherBlockRequest) -> HigherBlockResult:
+    return HigherBlockResult(
+        **request.model_dump(),
+        presentation=higher_block_presentation(request.shift, request.block_length),
+    )
+
+
+__all__ = [
+    "compute_block_language",
+    "compute_higher_block",
+    "compute_periodic_point_profile",
+    "construct_finite_type_shift",
+]

--- a/src/jacobian/math/symbolic_dynamics/_tools.py
+++ b/src/jacobian/math/symbolic_dynamics/_tools.py
@@ -1,0 +1,118 @@
+"""Public symbolic dynamics operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.symbolic_dynamics._models import (
+    BlockLanguageRequest,
+    BlockLanguageResult,
+    FiniteTypeShiftRequest,
+    FiniteTypeShiftResult,
+    HigherBlockRequest,
+    HigherBlockResult,
+    PeriodicPointProfileRequest,
+    PeriodicPointProfileResult,
+)
+from jacobian.math.symbolic_dynamics._operations import (
+    compute_block_language,
+    compute_higher_block,
+    compute_periodic_point_profile,
+    construct_finite_type_shift,
+)
+
+_GOLDEN_MEAN = {
+    "alphabet": ["0", "1"],
+    "forbidden_blocks": [["1", "1"]],
+    "two_sided": True,
+}
+
+SYMBOLIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="symbolic_dynamics.finite_type_shift.construct",
+        version="1",
+        title="Construct a finite-type shift presentation",
+        description=(
+            "Construct the complete finite labeled De Bruijn presentation induced "
+            "by a bounded forbidden-block specification."
+        ),
+        request_type=FiniteTypeShiftRequest,
+        result_type=FiniteTypeShiftResult,
+        run=construct_finite_type_shift,
+        tags=("symbolic-dynamics", "shift-of-finite-type", "presentation", "exact"),
+        examples=(
+            example(
+                "golden_mean_presentation",
+                "Construct the presentation forbidding the block 11.",
+                {"shift": _GOLDEN_MEAN},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="symbolic_dynamics.block_language.compute",
+        version="1",
+        title="Compute a bounded block language",
+        description=(
+            "Enumerate every locally allowed block of one requested length. "
+            "Oversized enumerations are rejected before computation, never truncated."
+        ),
+        request_type=BlockLanguageRequest,
+        result_type=BlockLanguageResult,
+        run=compute_block_language,
+        tags=("symbolic-dynamics", "block-language", "exact", "complete"),
+        examples=(
+            example(
+                "golden_mean_blocks_3",
+                "Enumerate every allowed length-three block.",
+                {"shift": _GOLDEN_MEAN, "block_length": 3},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="symbolic_dynamics.periodic_point_profile.compute",
+        version="1",
+        title="Compute a periodic-point profile",
+        description=(
+            "Compute fixed-point, least-period-point, and primitive-orbit counts "
+            "through a declared period by exact traces and Möbius inversion."
+        ),
+        request_type=PeriodicPointProfileRequest,
+        result_type=PeriodicPointProfileResult,
+        run=compute_periodic_point_profile,
+        tags=("symbolic-dynamics", "periodic-points", "mobius-inversion", "exact"),
+        examples=(
+            example(
+                "golden_mean_periodic_points",
+                "Compute the profile through period five.",
+                {
+                    "shift": {"matrix": [[1, 1], [1, 0]], "two_sided": True},
+                    "max_period": 5,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="symbolic_dynamics.higher_block.compute",
+        version="1",
+        title="Construct a higher-block presentation",
+        description=(
+            "Construct the exact overlap presentation on all allowed blocks of a "
+            "declared length at least the forbidden-block presentation memory."
+        ),
+        request_type=HigherBlockRequest,
+        result_type=HigherBlockResult,
+        run=compute_higher_block,
+        tags=("symbolic-dynamics", "higher-block", "presentation", "exact"),
+        examples=(
+            example(
+                "golden_mean_two_block",
+                "Construct the two-block presentation of the Golden Mean shift.",
+                {"shift": _GOLDEN_MEAN, "block_length": 2},
+            ),
+        ),
+    ),
+)
+
+TOOLS = SYMBOLIC_DYNAMICS_OPERATIONS
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/symbolic_dynamics/operations.py
+++ b/src/jacobian/math/symbolic_dynamics/operations.py
@@ -1,0 +1,200 @@
+"""Exact bounded native kernels for symbolic dynamics."""
+
+from __future__ import annotations
+
+import itertools
+
+from jacobian.math.symbolic_dynamics.values import (
+    MAX_ENUMERATED_BLOCKS,
+    AdjacencyShift,
+    BlockPresentation,
+    ForbiddenBlockShift,
+    LabeledTransition,
+)
+
+
+def _contains(word: tuple[str, ...], factor: tuple[str, ...]) -> bool:
+    return any(
+        word[start : start + len(factor)] == factor
+        for start in range(len(word) - len(factor) + 1)
+    )
+
+
+def enumeration_size(alphabet_size: int, block_length: int) -> int:
+    if block_length < 0:
+        raise ValueError("block length must be nonnegative")
+    size = 1
+    for _ in range(block_length):
+        size *= alphabet_size
+        if size > MAX_ENUMERATED_BLOCKS:
+            raise ValueError("requested block enumeration exceeds the work bound")
+    return size
+
+
+def normalize_forbidden_blocks(
+    shift: ForbiddenBlockShift,
+) -> tuple[tuple[str, ...], ...]:
+    rank = {symbol: index for index, symbol in enumerate(shift.alphabet)}
+    ordered = sorted(
+        set(shift.forbidden_blocks),
+        key=lambda block: (len(block), tuple(rank[symbol] for symbol in block)),
+    )
+    minimal: list[tuple[str, ...]] = []
+    for block in ordered:
+        if not any(_contains(block, forbidden) for forbidden in minimal):
+            minimal.append(block)
+    return tuple(minimal)
+
+
+def block_language(
+    shift: ForbiddenBlockShift, block_length: int
+) -> tuple[tuple[str, ...], ...]:
+    if block_length < 0:
+        raise ValueError("block length must be nonnegative")
+    enumeration_size(len(shift.alphabet), block_length)
+    forbidden = normalize_forbidden_blocks(shift)
+    return tuple(
+        block
+        for block in itertools.product(shift.alphabet, repeat=block_length)
+        if not any(_contains(block, excluded) for excluded in forbidden)
+    )
+
+
+def _presentation_from_states_and_words(
+    shift: ForbiddenBlockShift,
+    memory: int,
+    states: tuple[tuple[str, ...], ...],
+    extension_words: tuple[tuple[str, ...], ...],
+) -> BlockPresentation:
+    state_index = {state: index for index, state in enumerate(states)}
+    transitions: list[LabeledTransition] = []
+    for word in extension_words:
+        source_block = word[:memory] if memory else ()
+        target_block = word[-memory:] if memory else ()
+        source = state_index.get(source_block)
+        target = state_index.get(target_block)
+        if source is not None and target is not None:
+            transitions.append(
+                LabeledTransition(
+                    source=source,
+                    target=target,
+                    appended_symbol=word[-1],
+                )
+            )
+    size = len(states)
+    adjacency = [[0] * size for _ in range(size)]
+    for transition in transitions:
+        adjacency[transition.source][transition.target] += 1
+    return BlockPresentation(
+        alphabet=shift.alphabet,
+        memory=memory,
+        state_blocks=states,
+        transitions=tuple(transitions),
+        adjacency_matrix=tuple(tuple(row) for row in adjacency),
+        two_sided=shift.two_sided,
+    )
+
+
+def finite_type_presentation(shift: ForbiddenBlockShift) -> BlockPresentation:
+    forbidden = normalize_forbidden_blocks(shift)
+    memory = max(0, max((len(block) - 1 for block in forbidden), default=0))
+    enumeration_size(len(shift.alphabet), memory + 1)
+    states = block_language(shift, memory)
+    extensions = block_language(shift, memory + 1)
+    return _presentation_from_states_and_words(shift, memory, states, extensions)
+
+
+def higher_block_presentation(
+    shift: ForbiddenBlockShift, block_length: int
+) -> BlockPresentation:
+    if block_length < 1:
+        raise ValueError("higher-block length must be positive")
+    required_memory = max(
+        0,
+        max(
+            (len(block) - 1 for block in normalize_forbidden_blocks(shift)),
+            default=0,
+        ),
+    )
+    if block_length < required_memory:
+        raise ValueError("higher-block length is below the presentation memory")
+    enumeration_size(len(shift.alphabet), block_length + 1)
+    states = block_language(shift, block_length)
+    extensions = block_language(shift, block_length + 1)
+    return _presentation_from_states_and_words(shift, block_length, states, extensions)
+
+
+def adjacency_shift(
+    matrix: tuple[tuple[int, ...], ...], *, two_sided: bool = True
+) -> AdjacencyShift:
+    return AdjacencyShift(matrix=matrix, two_sided=two_sided)
+
+
+def _matrix_product(
+    left: tuple[tuple[int, ...], ...], right: tuple[tuple[int, ...], ...]
+) -> tuple[tuple[int, ...], ...]:
+    size = len(left)
+    return tuple(
+        tuple(
+            sum(left[row][inner] * right[inner][column] for inner in range(size))
+            for column in range(size)
+        )
+        for row in range(size)
+    )
+
+
+def _mobius(value: int) -> int:
+    remaining = value
+    prime = 2
+    distinct_factors = 0
+    while prime * prime <= remaining:
+        if remaining % prime:
+            prime += 1
+            continue
+        remaining //= prime
+        distinct_factors += 1
+        if remaining % prime == 0:
+            return 0
+        while remaining % prime == 0:
+            remaining //= prime
+        prime += 1
+    if remaining > 1:
+        distinct_factors += 1
+    return -1 if distinct_factors % 2 else 1
+
+
+def periodic_point_profile(
+    shift: AdjacencyShift, max_period: int
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    if not 1 <= max_period <= 50:
+        raise ValueError("max period is outside the supported bounds")
+    matrix = shift.matrix
+    power = matrix
+    fixed: list[int] = []
+    for period in range(1, max_period + 1):
+        fixed.append(sum(power[index][index] for index in range(len(matrix))))
+        if period < max_period:
+            power = _matrix_product(power, matrix)
+    exact = tuple(
+        sum(
+            _mobius(divisor) * fixed[period // divisor - 1]
+            for divisor in range(1, period + 1)
+            if period % divisor == 0
+        )
+        for period in range(1, max_period + 1)
+    )
+    if any(count < 0 or count % period for period, count in enumerate(exact, 1)):
+        raise RuntimeError("periodic-point inversion violated orbit integrality")
+    orbits = tuple(count // period for period, count in enumerate(exact, 1))
+    return tuple(fixed), exact, orbits
+
+
+__all__ = [
+    "adjacency_shift",
+    "block_language",
+    "enumeration_size",
+    "finite_type_presentation",
+    "higher_block_presentation",
+    "normalize_forbidden_blocks",
+    "periodic_point_profile",
+]

--- a/src/jacobian/math/symbolic_dynamics/values.py
+++ b/src/jacobian/math/symbolic_dynamics/values.py
@@ -1,0 +1,120 @@
+"""Provider-independent bounded values for symbolic dynamics."""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_ALPHABET_SIZE = 16
+MAX_SYMBOL_LENGTH = 64
+MAX_FORBIDDEN_BLOCKS = 100
+MAX_FORBIDDEN_BLOCK_LENGTH = 20
+MAX_ADJACENCY_STATES = 50
+MAX_ADJACENCY_ENTRY = 1_000_000
+MAX_ENUMERATED_BLOCKS = 100_000
+MAX_PERIOD = 50
+
+Symbol = Annotated[str, Field(min_length=1, max_length=MAX_SYMBOL_LENGTH)]
+
+
+class ForbiddenBlockShift(StrictModel):
+    """A finite-alphabet shift specified by forbidden contiguous blocks."""
+
+    alphabet: tuple[Symbol, ...] = Field(min_length=1, max_length=MAX_ALPHABET_SIZE)
+    forbidden_blocks: tuple[tuple[str, ...], ...] = Field(
+        max_length=MAX_FORBIDDEN_BLOCKS
+    )
+    two_sided: bool = True
+
+    @model_validator(mode="after")
+    def require_bounded_words_over_distinct_alphabet(self) -> Self:
+        if len(set(self.alphabet)) != len(self.alphabet):
+            raise ValueError("alphabet symbols must be distinct")
+        for block in self.forbidden_blocks:
+            if len(block) > MAX_FORBIDDEN_BLOCK_LENGTH:
+                raise ValueError("forbidden block exceeds the length bound")
+            if any(symbol not in self.alphabet for symbol in block):
+                raise ValueError("forbidden block uses a symbol outside the alphabet")
+        return self
+
+
+class AdjacencyShift(StrictModel):
+    """An edge-shift carrier with nonnegative edge multiplicities."""
+
+    matrix: tuple[tuple[int, ...], ...] = Field(
+        min_length=1, max_length=MAX_ADJACENCY_STATES
+    )
+    two_sided: bool = True
+
+    @model_validator(mode="after")
+    def require_square_nonnegative_bounded_matrix(self) -> Self:
+        size = len(self.matrix)
+        if any(len(row) != size for row in self.matrix):
+            raise ValueError("adjacency matrix must be square")
+        if any(
+            entry < 0 or entry > MAX_ADJACENCY_ENTRY
+            for row in self.matrix
+            for entry in row
+        ):
+            raise ValueError("adjacency entries must be within the supported bounds")
+        return self
+
+
+class LabeledTransition(StrictModel):
+    source: int = Field(ge=0)
+    target: int = Field(ge=0)
+    appended_symbol: str
+
+
+class BlockPresentation(StrictModel):
+    """A finite labeled overlap presentation."""
+
+    alphabet: tuple[str, ...]
+    memory: int = Field(ge=0)
+    state_blocks: tuple[tuple[str, ...], ...]
+    transitions: tuple[LabeledTransition, ...]
+    adjacency_matrix: tuple[tuple[int, ...], ...]
+    two_sided: bool
+
+    @model_validator(mode="after")
+    def require_bound_presentation(self) -> Self:
+        size = len(self.state_blocks)
+        if len(self.adjacency_matrix) != size or any(
+            len(row) != size for row in self.adjacency_matrix
+        ):
+            raise ValueError("presentation adjacency must match its state blocks")
+        if any(len(block) != self.memory for block in self.state_blocks):
+            raise ValueError("presentation state blocks must match its memory")
+        if any(
+            transition.source >= size
+            or transition.target >= size
+            or transition.appended_symbol not in self.alphabet
+            for transition in self.transitions
+        ):
+            raise ValueError("presentation transition is outside its carrier")
+        counts = [[0] * size for _ in range(size)]
+        for transition in self.transitions:
+            counts[transition.source][transition.target] += 1
+        if self.adjacency_matrix != tuple(tuple(row) for row in counts):
+            raise ValueError("presentation adjacency does not count its transitions")
+        return self
+
+
+__all__ = [
+    "MAX_ADJACENCY_ENTRY",
+    "MAX_ADJACENCY_STATES",
+    "MAX_ALPHABET_SIZE",
+    "MAX_ENUMERATED_BLOCKS",
+    "MAX_FORBIDDEN_BLOCKS",
+    "MAX_FORBIDDEN_BLOCK_LENGTH",
+    "MAX_PERIOD",
+    "MAX_SYMBOL_LENGTH",
+    "AdjacencyShift",
+    "BlockPresentation",
+    "ForbiddenBlockShift",
+    "LabeledTransition",
+    "Symbol",
+]

--- a/tests/catalog/operation-schema-snapshot.json
+++ b/tests/catalog/operation-schema-snapshot.json
@@ -1425,6 +1425,22 @@
       "input_schema": "sha256:7b72b4b078d5fd79204326017e9f7e540cb2db2674d5ee2d9528d0a6b8026ca2",
       "output_schema": "sha256:92e1adfe39049966ea27b5d3e2d7993feb5b87dc8732f42b5f49ca9531f1f4bc"
     },
+    "symbolic_dynamics.block_language.compute": {
+      "input_schema": "sha256:4edfe17c558e8d68d6712c87044d79575f8ed79211caaa11780b0155a2e04486",
+      "output_schema": "sha256:9fade77cd353c1419034544a4535aa34a06751903461e95822061e049a229fbe"
+    },
+    "symbolic_dynamics.finite_type_shift.construct": {
+      "input_schema": "sha256:9fbbad09c68b17a4f6f6b73fee76df05ba68728c5bc8b7b321c56db38cf93f6c",
+      "output_schema": "sha256:a6a8c36608de2ce71310be70a83eeafea57e4ae44f3007c9e14207d6a0bd92dc"
+    },
+    "symbolic_dynamics.higher_block.compute": {
+      "input_schema": "sha256:3f7401291970feda3cd82ea59d2f1a61dc0be77a027eb675f5dd2d5eb0ebb3f0",
+      "output_schema": "sha256:8491aee08f8b27d36cff8602dae5ef796d6668437728aaa2d2a418f057d3bccf"
+    },
+    "symbolic_dynamics.periodic_point_profile.compute": {
+      "input_schema": "sha256:6fe2dad3e326ae6f9346acf2a3132556f39486d0dcd0797243c43db268f5dfbb",
+      "output_schema": "sha256:c56aef92368f3913b4905ed910924166f6bfb6569d11a3a4a1447bce0b41eee3"
+    },
     "topology.simplicial_complex.canonicalize": {
       "input_schema": "sha256:0231994adad255d263488096fd5792b8a3cf90fd8e478e3e189536874bdb53b5",
       "output_schema": "sha256:8a552aeb19d458d766bcfab00a59087018214ac376e021c2236ab1aa380972f1"

--- a/tests/catalog/test_snapshot.py
+++ b/tests/catalog/test_snapshot.py
@@ -41,7 +41,7 @@ def test_operation_ids_and_request_result_schemas_match_snapshot() -> None:
     }
 
     assert snapshot.catalog_version == expected["catalog_version"]
-    assert len(actual) == 360
+    assert len(actual) == 364
     assert actual == expected["operations"]
 
 

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -16,6 +16,7 @@ PUBLIC_API = {
         "polynomials",
         "prime_field_linear_algebra",
         "probability",
+        "symbolic_dynamics",
     ),
     "jacobian.math.finite_fields": (
         "Axis",
@@ -116,6 +117,18 @@ PUBLIC_API = {
         "MutualInformationResult",
         "MutualInformationTerm",
         "mutual_information",
+    ),
+    "jacobian.math.symbolic_dynamics": (
+        "AdjacencyShift",
+        "BlockPresentation",
+        "ForbiddenBlockShift",
+        "LabeledTransition",
+        "adjacency_shift",
+        "block_language",
+        "finite_type_presentation",
+        "higher_block_presentation",
+        "normalize_forbidden_blocks",
+        "periodic_point_profile",
     ),
 }
 

--- a/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
+++ b/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
@@ -1,0 +1,252 @@
+"""Correctness and contract tests for exact symbolic dynamics operations."""
+
+from __future__ import annotations
+
+import itertools
+import random
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.symbolic_dynamics import (
+    AdjacencyShift,
+    ForbiddenBlockShift,
+    adjacency_shift,
+    block_language,
+    finite_type_presentation,
+    normalize_forbidden_blocks,
+    periodic_point_profile,
+)
+from jacobian.math.symbolic_dynamics._models import (
+    BlockLanguageRequest,
+    BlockLanguageResult,
+    FiniteTypeShiftRequest,
+    FiniteTypeShiftResult,
+    HigherBlockRequest,
+    HigherBlockResult,
+    PeriodicPointProfileRequest,
+    PeriodicPointProfileResult,
+)
+from jacobian.math.symbolic_dynamics._operations import (
+    compute_block_language,
+    compute_higher_block,
+    compute_periodic_point_profile,
+    construct_finite_type_shift,
+)
+from jacobian.math.symbolic_dynamics._tools import TOOLS
+
+
+def _golden_mean() -> ForbiddenBlockShift:
+    return ForbiddenBlockShift(alphabet=("0", "1"), forbidden_blocks=(("1", "1"),))
+
+
+def test_public_surface_excludes_adjacency_carrier_invariants() -> None:
+    assert tuple(tool.operation_id for tool in TOOLS) == (
+        "symbolic_dynamics.finite_type_shift.construct",
+        "symbolic_dynamics.block_language.compute",
+        "symbolic_dynamics.periodic_point_profile.compute",
+        "symbolic_dynamics.higher_block.compute",
+    )
+    carrier = adjacency_shift(((1, 1), (1, 0)))
+    assert carrier == AdjacencyShift(matrix=((1, 1), (1, 0)))
+    assert not hasattr(carrier, "is_mixing")
+
+
+def test_golden_mean_finite_type_presentation_is_exact() -> None:
+    result = construct_finite_type_shift(FiniteTypeShiftRequest(shift=_golden_mean()))
+    assert result.presentation.memory == 1
+    assert result.presentation.state_blocks == (("0",), ("1",))
+    assert result.presentation.adjacency_matrix == ((1, 1), (1, 0))
+    assert tuple(
+        (edge.source, edge.target, edge.appended_symbol)
+        for edge in result.presentation.transitions
+    ) == ((0, 0, "0"), (0, 1, "1"), (1, 0, "0"))
+    assert result.complete is True
+
+    payload = result.model_dump()
+    payload["presentation"]["adjacency_matrix"] = ((1, 0), (1, 1))
+    with pytest.raises(ValidationError):
+        FiniteTypeShiftResult.model_validate(payload)
+
+
+def test_shorter_forbidden_factors_are_enforced_in_long_memory_presentation() -> None:
+    shift = ForbiddenBlockShift(
+        alphabet=("0", "1"),
+        forbidden_blocks=(("0",), ("1", "1")),
+    )
+    presentation = finite_type_presentation(shift)
+    assert presentation.state_blocks == (("1",),)
+    assert presentation.transitions == ()
+    assert presentation.adjacency_matrix == ((0,),)
+
+
+def test_forbidden_family_normalization_and_empty_block() -> None:
+    redundant = ForbiddenBlockShift(
+        alphabet=("0", "1"),
+        forbidden_blocks=(("1", "1"), ("1",), ("1",), ("0", "1", "0")),
+    )
+    assert normalize_forbidden_blocks(redundant) == (("1",),)
+    empty = ForbiddenBlockShift(alphabet=("0",), forbidden_blocks=((),))
+    assert finite_type_presentation(empty).state_blocks == ()
+    assert block_language(empty, 0) == ()
+
+
+def test_complete_block_language_includes_empty_word_convention() -> None:
+    result = compute_block_language(
+        BlockLanguageRequest(shift=_golden_mean(), block_length=3)
+    )
+    assert result.allowed_blocks == (
+        ("0", "0", "0"),
+        ("0", "0", "1"),
+        ("0", "1", "0"),
+        ("1", "0", "0"),
+        ("1", "0", "1"),
+    )
+    assert result.count == 5
+    empty_word = compute_block_language(
+        BlockLanguageRequest(shift=_golden_mean(), block_length=0)
+    )
+    assert empty_word.allowed_blocks == ((),)
+
+    payload = result.model_dump()
+    payload["count"] = 4
+    with pytest.raises(ValidationError, match="not bound"):
+        BlockLanguageResult.model_validate(payload)
+
+
+def test_oversized_enumerations_fail_before_computation() -> None:
+    alphabet = tuple(chr(ord("a") + index) for index in range(16))
+    shift = ForbiddenBlockShift(alphabet=alphabet, forbidden_blocks=())
+    with pytest.raises(ValidationError, match="work bound"):
+        BlockLanguageRequest(shift=shift, block_length=5)
+    with pytest.raises(ValidationError, match="work bound"):
+        FiniteTypeShiftRequest(
+            shift=ForbiddenBlockShift(
+                alphabet=alphabet,
+                forbidden_blocks=(("a", "a", "a", "a", "a"),),
+            )
+        )
+
+
+def test_higher_block_presentation_uses_allowed_overlap_edges() -> None:
+    result = compute_higher_block(
+        HigherBlockRequest(shift=_golden_mean(), block_length=2)
+    )
+    assert result.presentation.state_blocks == (
+        ("0", "0"),
+        ("0", "1"),
+        ("1", "0"),
+    )
+    assert result.presentation.adjacency_matrix == (
+        (1, 1, 0),
+        (0, 0, 1),
+        (1, 1, 0),
+    )
+    assert len(result.presentation.transitions) == 5
+
+    payload = result.model_dump()
+    payload["presentation"]["transitions"] = ()
+    with pytest.raises(ValidationError):
+        HigherBlockResult.model_validate(payload)
+
+
+def test_higher_block_requires_enough_memory_for_exact_sft_presentation() -> None:
+    shift = ForbiddenBlockShift(
+        alphabet=("0", "1"), forbidden_blocks=(("1", "0", "1", "0"),)
+    )
+    with pytest.raises(ValidationError, match="at least"):
+        HigherBlockRequest(shift=shift, block_length=2)
+
+
+def test_periodic_profile_handles_square_mobius_factor() -> None:
+    request = PeriodicPointProfileRequest(
+        shift=AdjacencyShift(matrix=((2,),)), max_period=4
+    )
+    result = compute_periodic_point_profile(request)
+    assert result.fixed_point_counts == (2, 4, 8, 16)
+    assert result.least_period_point_counts == (2, 2, 6, 12)
+    assert result.primitive_orbit_counts == (2, 1, 2, 3)
+    assert result.complete_through_period == 4
+
+    payload = result.model_dump()
+    payload["primitive_orbit_counts"] = (2, 1, 2, 4)
+    with pytest.raises(ValidationError, match="not bound"):
+        PeriodicPointProfileResult.model_validate(payload)
+
+
+def test_value_models_reject_ambiguous_and_invalid_carriers() -> None:
+    with pytest.raises(ValidationError, match="distinct"):
+        ForbiddenBlockShift(alphabet=("0", "0"), forbidden_blocks=())
+    with pytest.raises(ValidationError, match="outside"):
+        ForbiddenBlockShift(alphabet=("0",), forbidden_blocks=(("1",),))
+    with pytest.raises(ValidationError, match="square"):
+        AdjacencyShift(matrix=((1, 0), (1,)))
+    with pytest.raises(ValidationError, match="supported bounds"):
+        AdjacencyShift(matrix=((-1,),))
+
+
+def test_random_block_languages_match_independent_filter_oracle() -> None:
+    random_source = random.Random(1968)
+    alphabet = ("0", "1")
+    candidate_forbidden = tuple(
+        itertools.chain(
+            itertools.product(alphabet, repeat=1),
+            itertools.product(alphabet, repeat=2),
+            itertools.product(alphabet, repeat=3),
+        )
+    )
+    for _ in range(120):
+        forbidden = tuple(
+            block for block in candidate_forbidden if random_source.random() < 0.18
+        )
+        shift = ForbiddenBlockShift(alphabet=alphabet, forbidden_blocks=forbidden)
+        for length in range(5):
+            expected = tuple(
+                word
+                for word in itertools.product(alphabet, repeat=length)
+                if all(
+                    not any(
+                        word[start : start + len(block)] == block
+                        for start in range(len(word) - len(block) + 1)
+                    )
+                    for block in forbidden
+                )
+            )
+            assert block_language(shift, length) == expected
+
+
+def test_periodic_profiles_match_closed_walk_and_divisor_oracles() -> None:
+    matrices = (
+        ((0,),),
+        ((3,),),
+        ((0, 1), (1, 0)),
+        ((1, 1), (1, 0)),
+        ((1, 2), (0, 1)),
+    )
+    for matrix in matrices:
+        fixed, exact, orbits = periodic_point_profile(AdjacencyShift(matrix=matrix), 6)
+        size = len(matrix)
+        expected_fixed = []
+        for period in range(1, 7):
+            count = 0
+            for walk in itertools.product(range(size), repeat=period):
+                weight = 1
+                for index in range(period):
+                    weight *= matrix[walk[index]][walk[(index + 1) % period]]
+                count += weight
+            expected_fixed.append(count)
+        expected_exact: list[int] = []
+        for period, count in enumerate(expected_fixed, 1):
+            expected_exact.append(
+                count
+                - sum(
+                    expected_exact[divisor - 1]
+                    for divisor in range(1, period)
+                    if period % divisor == 0
+                )
+            )
+        assert fixed == tuple(expected_fixed)
+        assert exact == tuple(expected_exact)
+        assert orbits == tuple(
+            count // period for period, count in enumerate(expected_exact, 1)
+        )


### PR DESCRIPTION
Replacement for #1968 after the maintainer audit classified that PR as SPLIT.

This PR rebuilds symbolic dynamics from current `main` and exposes only four distinct audited outcomes:

- `symbolic_dynamics.finite_type_shift.construct`
- `symbolic_dynamics.block_language.compute`
- `symbolic_dynamics.periodic_point_profile.compute`
- `symbolic_dynamics.higher_block.compute`

The adjacency shift remains a native carrier in `jacobian.math.symbolic_dynamics`; it does not bundle essentiality, irreducibility, period, or mixing claims into a public construction operation.

Correctness changes relative to #1968:

- enforces every forbidden factor, including shorter factors when the presentation memory comes from a longer block;
- normalizes duplicate and factor-redundant forbidden families;
- builds labeled De Bruijn carriers with explicit state blocks, transitions, and transition-count adjacency matrices;
- constructs genuine higher-block overlap presentations from allowed blocks and allowed one-symbol extensions;
- requires enough higher-block memory to present the supplied finite-type shift exactly;
- fixes Möbius inversion at square factors such as 4 and checks orbit integrality;
- removes unsupported zeta numerator/denominator placeholders;
- rejects exponential enumerations before computation instead of truncating;
- binds every public result to its exact request by replay;
- removes all numerical-semigroup stack pollution, including frozen catalog entries.

Validation:

- focused symbolic dynamics, public API, import isolation, and catalog snapshot: 26 passed;
- independent tests compare random forbidden-block languages with a direct filter oracle and periodic profiles with closed-walk enumeration plus divisor subtraction;
- `make check`: lint, format, complexity, mypy, and 989 tests passed;
- `make test-plan BASE=origin/main`: unavailable because this checkout has no `test-plan` Make target.

This is a draft and should not merge ahead of #1976. Rebase it after #1976 lands so its exact contracts can align with the capability-evidence infrastructure without duplicating it.

Supersedes #1968.
