### PR TITLE
fix(math): bind distance-matrix rows to labelled vertices (#930)

### DIFF
--- a/docs/reference/operations/graphs/graph-distance-matrix.md
+++ b/docs/reference/operations/graphs/graph-distance-matrix.md
@@ -3,8 +3,16 @@
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
 Jacobian exposes the complete bounded distance matrix of a typed finite graph.
-`graph.distance_matrix.compute` returns all pairwise distances or a typed
-non-applicability outcome for a disconnected graph.
+`graph.distance_matrix.compute` returns every exact unweighted shortest-path
+distance between ordered vertex pairs in canonical lexicographic vertex order.
+
+Rows are labelled: every row names its source vertex, and its cells are the
+distances from that source to the result `vertices` in their declared order.
+Because each row carries its own label, the dense positional matrix stays
+bound to the authoritative vertex axis and cannot be silently presented under
+a different ordering — numeric-looking labels such as `"2"` and `"10"` remain
+lexicographic and unambiguous. Unreachable pairs use `null`; a disconnected
+input is a typed result with `connected` false rather than a failure.
 
 Radius and diameter are cheap projections of the complete matrix, so they are
 retained as `jacobian.math.graphs.radius` and

--- a/src/jacobian/math/graphs/optimization/_distance_matrix.py
+++ b/src/jacobian/math/graphs/optimization/_distance_matrix.py
@@ -9,6 +9,7 @@ from jacobian.catalog.models import MathTool
 from jacobian.math.graphs.optimization._distance_models import (
     GraphDistanceMatrixRequest,
     GraphDistanceMatrixResult,
+    GraphDistanceRow,
 )
 from jacobian.math.graphs.optimization._operations import build_simple_graph
 
@@ -16,7 +17,11 @@ from jacobian.math.graphs.optimization._operations import build_simple_graph
 def compute_distance_matrix(
     request: GraphDistanceMatrixRequest,
 ) -> GraphDistanceMatrixResult:
-    """Compute every exact unweighted distance in canonical vertex order."""
+    """Compute every exact unweighted distance in canonical vertex order.
+
+    Rows are labelled with their source vertex so the dense positional
+    matrix stays bound to the authoritative lexicographic vertex axis.
+    """
 
     import networkx as nx
 
@@ -26,20 +31,23 @@ def compute_distance_matrix(
         source: nx.single_source_shortest_path_length(graph, source)
         for source in vertices
     }
-    distances = tuple(
-        tuple(shortest_paths[source].get(target) for target in vertices)
+    rows = tuple(
+        GraphDistanceRow(
+            source=source,
+            distances=tuple(shortest_paths[source].get(target) for target in vertices),
+        )
         for source in vertices
     )
     connected = bool(vertices) and all(
-        distance is not None for row in distances for distance in row
+        distance is not None for row in rows for distance in row.distances
     )
     return GraphDistanceMatrixResult(
-        semantics_version="unweighted-shortest-path-distance-matrix.v1",
+        semantics_version="unweighted-shortest-path-distance-matrix.v2",
         vertex_ordering="LEXICOGRAPHIC_ASCENDING",
         pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
         unreachable_representation="JSON_NULL",
         vertices=vertices,
-        distances=distances,
+        rows=rows,
         connected=connected,
     )
 

--- a/src/jacobian/math/graphs/optimization/_distance_models.py
+++ b/src/jacobian/math/graphs/optimization/_distance_models.py
@@ -41,54 +41,77 @@ GraphDistance = (
     ]
     | None
 )
-GraphDistanceRow = Annotated[
-    tuple[GraphDistance, ...],
-    Field(max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER),
-]
+
+
+class GraphDistanceRow(StrictModel):
+    """One labelled row of the canonical vertex-ordered distance matrix.
+
+    ``source`` names the row's vertex and the ``distances`` cells are the
+    distances from ``source`` to the result ``vertices`` in their declared
+    order. Binding the label into every row keeps a dense matrix attached to
+    its authoritative vertex axis, so numeric-looking identifiers such as
+    ``"2"`` and ``"10"`` cannot be silently presented under a different
+    natural-number ordering.
+    """
+
+    source: GraphVertex
+    distances: tuple[GraphDistance, ...] = Field(
+        max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
+    )
 
 
 def _validate_distance_matrix_shape(
     vertices: tuple[GraphVertex, ...],
-    distances: tuple[GraphDistanceRow, ...],
+    rows: tuple[GraphDistanceRow, ...],
 ) -> int:
     order = len(vertices)
     if tuple(sorted(vertices)) != vertices or len(set(vertices)) != order:
         raise ValueError("distance-matrix vertices must be unique and sorted")
-    if len(distances) != order or any(len(row) != order for row in distances):
-        raise ValueError("distance matrix must be square on the declared vertices")
+    if len(rows) != order:
+        raise ValueError("distance matrix must declare one labelled row per vertex")
+    for index, row in enumerate(rows):
+        if row.source != vertices[index]:
+            raise ValueError(
+                "every distance-matrix row must carry the canonical vertex "
+                "label at its position"
+            )
+        if len(row.distances) != order:
+            raise ValueError("distance matrix must be square on the declared vertices")
     return order
 
 
 def _validate_distance_matrix_diagonal_and_symmetry(
-    distances: tuple[GraphDistanceRow, ...],
+    rows: tuple[GraphDistanceRow, ...],
     order: int,
 ) -> None:
     for source in range(order):
+        row = rows[source].distances
         for target in range(order):
-            distance = distances[source][target]
+            distance = row[target]
             if source == target:
                 if distance != 0:
                     raise ValueError("distance-matrix diagonal must be zero")
             elif distance == 0:
                 raise ValueError("off-diagonal distances must be positive or null")
-            if distance != distances[target][source]:
+            if distance != rows[target].distances[source]:
                 raise ValueError("undirected distance matrix must be symmetric")
 
 
 def _validate_distance_matrix_triangle_inequality(
-    distances: tuple[GraphDistanceRow, ...],
+    rows: tuple[GraphDistanceRow, ...],
     order: int,
 ) -> None:
+    matrix = tuple(row.distances for row in rows)
     for source in range(order):
         for intermediate in range(order):
-            left = distances[source][intermediate]
+            left = matrix[source][intermediate]
             if left is None:
                 continue
             for target in range(order):
-                right = distances[intermediate][target]
+                right = matrix[intermediate][target]
                 if right is None:
                     continue
-                direct = distances[source][target]
+                direct = matrix[source][target]
                 if direct is None or direct > left + right:
                     raise ValueError(
                         "finite distances must satisfy component closure and "
@@ -97,27 +120,32 @@ def _validate_distance_matrix_triangle_inequality(
 
 
 class GraphDistanceMatrixResult(StrictModel):
-    """All exact unweighted shortest-path distances in canonical vertex order."""
+    """All exact unweighted shortest-path distances in canonical vertex order.
 
-    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v1"]
+    ``vertices`` declares the canonical column axis and every row carries its
+    own ``source`` label, so the dense positional matrix stays bound to the
+    authoritative vertex sequence.
+    """
+
+    semantics_version: Literal["unweighted-shortest-path-distance-matrix.v2"]
     vertex_ordering: Literal["LEXICOGRAPHIC_ASCENDING"]
     pair_coverage: Literal["ALL_ORDERED_VERTEX_PAIRS"]
     unreachable_representation: Literal["JSON_NULL"]
     vertices: tuple[GraphVertex, ...] = Field(
         max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
     )
-    distances: tuple[GraphDistanceRow, ...] = Field(
+    rows: tuple[GraphDistanceRow, ...] = Field(
         max_length=MAX_GRAPH_DISTANCE_MATRIX_ORDER
     )
     connected: StrictBool
 
     @model_validator(mode="after")
     def bind_complete_metric(self) -> Self:
-        order = _validate_distance_matrix_shape(self.vertices, self.distances)
-        _validate_distance_matrix_diagonal_and_symmetry(self.distances, order)
-        _validate_distance_matrix_triangle_inequality(self.distances, order)
+        order = _validate_distance_matrix_shape(self.vertices, self.rows)
+        _validate_distance_matrix_diagonal_and_symmetry(self.rows, order)
+        _validate_distance_matrix_triangle_inequality(self.rows, order)
         expected_connected = order > 0 and all(
-            distance is not None for row in self.distances for distance in row
+            distance is not None for row in self.rows for distance in row.distances
         )
         if self.connected != expected_connected:
             raise ValueError("connected must match all-pairs finite reachability")

--- a/tests/catalog/operation_schema_snapshots/graphs.json
+++ b/tests/catalog/operation_schema_snapshots/graphs.json
@@ -36,7 +36,7 @@
     },
     "graph.distance_matrix.compute": {
       "input_schema": "sha256:9e0287b0e71d3c1894e4231f80122cb09cd2b47de2b22f2709d3046dcc5d1882",
-      "output_schema": "sha256:6546ad7d98bc8d60eaeede9886ace10320cc32ffb1e1bc55d946844544cafe5f"
+      "output_schema": "sha256:de0bd3bc61798f76b0343f457b650d63ed3ea390310e614ce0374a5c7d158a4a"
     },
     "graph.domination.minimum.compute": {
       "input_schema": "sha256:c5325fe91eaf07a82ed42666b0691144b4db1d369a1dfca9a42b73f190c88919",

--- a/tests/math/graphs/test_graph_distance_matrix.py
+++ b/tests/math/graphs/test_graph_distance_matrix.py
@@ -1,0 +1,291 @@
+"""Focused tests for the exact graph distance-matrix operation.
+
+Covers the labelled-row result contract: numeric-looking string identifiers
+stay lexicographically canonical while every row carries its own source
+label, so a dense matrix cannot be detached from the authoritative vertex
+axis and relabelled.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.optimization._distance_matrix import (
+    DISTANCE_MATRIX_OPERATION,
+    compute_distance_matrix,
+)
+from jacobian.math.graphs.optimization._distance_models import (
+    GraphDistanceMatrixRequest,
+    GraphDistanceMatrixResult,
+    GraphDistanceRow,
+)
+
+
+def _request(vertices: list[str], edges: list[list[str]]) -> GraphDistanceMatrixRequest:
+    return GraphDistanceMatrixRequest.model_validate(
+        {"graph": {"vertices": vertices, "edges": edges}}
+    )
+
+
+def _row(source: str, distances: list[int | None]) -> GraphDistanceRow:
+    return GraphDistanceRow(source=source, distances=tuple(distances))
+
+
+def _complete_rows(vertices: list[str]) -> list[GraphDistanceRow]:
+    return [
+        _row(
+            source,
+            [0 if target == source else 1 for target in vertices],
+        )
+        for source in vertices
+    ]
+
+
+def test_numeric_looking_labels_stay_lexicographic_and_bound_to_rows() -> None:
+    result = compute_distance_matrix(
+        _request(["1", "2", "10"], [["1", "2"], ["2", "10"]])
+    )
+
+    assert result.semantics_version == "unweighted-shortest-path-distance-matrix.v2"
+    assert result.vertex_ordering == "LEXICOGRAPHIC_ASCENDING"
+    assert result.vertices == ("1", "10", "2")
+    assert [row.source for row in result.rows] == list(result.vertices)
+    assert result.connected is True
+    assert result.rows == (
+        _row("1", [0, 2, 1]),
+        _row("10", [2, 0, 1]),
+        _row("2", [1, 1, 0]),
+    )
+
+
+def test_numeric_looking_label_set_locks_lexicographic_order() -> None:
+    vertices = ["0", "1", "2", "10", "11", "16"]
+    result = compute_distance_matrix(_request(vertices, []))
+
+    assert result.vertices == ("0", "1", "10", "11", "16", "2")
+    assert [row.source for row in result.rows] == list(result.vertices)
+    assert all(
+        row.distances[index] == 0
+        and all(
+            distance is None
+            for column, distance in enumerate(row.distances)
+            if column != index
+        )
+        for index, row in enumerate(result.rows)
+    )
+    assert result.connected is False
+
+
+def test_known_answer_path_with_unsorted_string_labels() -> None:
+    result = compute_distance_matrix(
+        _request(["c", "a", "b"], [["a", "b"], ["b", "c"]])
+    )
+
+    assert result.vertices == ("a", "b", "c")
+    assert result.rows == (
+        _row("a", [0, 1, 2]),
+        _row("b", [1, 0, 1]),
+        _row("c", [2, 1, 0]),
+    )
+    assert result.connected is True
+
+
+def test_disconnected_graph_uses_null_for_unreachable_pairs() -> None:
+    result = compute_distance_matrix(_request(["a", "b", "c"], [["a", "b"]]))
+
+    assert result.vertices == ("a", "b", "c")
+    assert result.connected is False
+    assert result.rows[0].distances == (0, 1, None)
+    assert result.rows[2].distances == (None, None, 0)
+
+
+def test_empty_graph_returns_empty_labelled_matrix() -> None:
+    result = compute_distance_matrix(_request([], []))
+
+    assert result.vertices == ()
+    assert result.rows == ()
+    assert result.connected is False
+
+
+def test_arbitrary_string_identifiers_remain_deterministic() -> None:
+    result = compute_distance_matrix(
+        _request(["root", "leaf-2", "10", "1"], [["1", "10"]])
+    )
+
+    assert result.vertices == ("1", "10", "leaf-2", "root")
+    assert [row.source for row in result.rows] == list(result.vertices)
+
+
+def test_operation_example_runs_through_the_catalog_wrapper() -> None:
+    example_input = DISTANCE_MATRIX_OPERATION.examples[0].input
+    request = DISTANCE_MATRIX_OPERATION.request_type.model_validate(example_input)
+    result = DISTANCE_MATRIX_OPERATION.run(request)
+
+    assert isinstance(result, DISTANCE_MATRIX_OPERATION.result_type)
+    assert result.vertices == ("a", "b", "c")
+    assert [row.source for row in result.rows] == list(result.vertices)
+
+
+def test_producer_payload_revalidates_with_rows_bound_to_the_same_order() -> None:
+    result = compute_distance_matrix(
+        _request(["1", "2", "10"], [["1", "2"], ["2", "10"]])
+    )
+    rebound = GraphDistanceMatrixResult.model_validate(result.model_dump())
+
+    assert rebound == result
+
+
+def test_result_rejects_rows_reordered_away_from_the_canonical_axis() -> None:
+    # Natural-order rows ("1", "2", "10") over the lexicographic vertex axis
+    # ("1", "10", "2") must not look schema-correct: row labels are bound.
+    with pytest.raises(ValidationError, match="canonical vertex label"):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=("1", "10", "2"),
+            rows=(
+                _row("1", [0, 1, 1]),
+                _row("2", [1, 0, 1]),
+                _row("10", [1, 1, 0]),
+            ),
+            connected=True,
+        )
+
+
+def test_result_rejects_relabelled_rows_over_the_same_positions() -> None:
+    # Swapping row labels without touching the matrix cells must also fail:
+    # every row must carry the canonical vertex label at its position.
+    with pytest.raises(ValidationError, match="canonical vertex label"):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=("1", "10", "2"),
+            rows=(
+                _row("10", [0, 1, 1]),
+                _row("1", [1, 0, 1]),
+                _row("2", [1, 1, 0]),
+            ),
+            connected=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("vertices", "message"),
+    [
+        (("2", "10", "1"), "unique and sorted"),
+        (("1", "1", "2"), "unique and sorted"),
+    ],
+)
+def test_result_rejects_unsorted_or_duplicate_vertices(
+    vertices: tuple[str, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=vertices,
+            rows=_complete_rows(list(vertices)),
+            connected=True,
+        )
+
+
+def test_result_rejects_missing_rows_and_nonsquare_rows() -> None:
+    vertices = ("1", "10", "2")
+    with pytest.raises(ValidationError, match="one labelled row per vertex"):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=vertices,
+            rows=_complete_rows(list(vertices))[:2],
+            connected=True,
+        )
+    with pytest.raises(ValidationError, match="must be square"):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=vertices,
+            rows=(
+                _row("1", [0, 1]),
+                _row("10", [1, 0]),
+                _row("2", [0, 1]),
+            ),
+            connected=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("rows", "message"),
+    [
+        (
+            (
+                _row("1", [1, 1, 1]),
+                _row("10", [1, 0, 1]),
+                _row("2", [1, 1, 0]),
+            ),
+            "diagonal must be zero",
+        ),
+        (
+            (
+                _row("1", [0, 0, 1]),
+                _row("10", [0, 0, 1]),
+                _row("2", [1, 1, 0]),
+            ),
+            "positive or null",
+        ),
+        (
+            (
+                _row("1", [0, 1, 1]),
+                _row("10", [2, 0, 1]),
+                _row("2", [1, 1, 0]),
+            ),
+            "must be symmetric",
+        ),
+        (
+            (
+                _row("1", [0, 1, 3]),
+                _row("10", [1, 0, 1]),
+                _row("2", [3, 1, 0]),
+            ),
+            "triangle inequality",
+        ),
+    ],
+)
+def test_result_rejects_broken_metric_invariants(
+    rows: tuple[GraphDistanceRow, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=("1", "10", "2"),
+            rows=rows,
+            connected=True,
+        )
+
+
+def test_result_rejects_connected_mismatch() -> None:
+    with pytest.raises(ValidationError, match="connected must match"):
+        GraphDistanceMatrixResult(
+            semantics_version="unweighted-shortest-path-distance-matrix.v2",
+            vertex_ordering="LEXICOGRAPHIC_ASCENDING",
+            pair_coverage="ALL_ORDERED_VERTEX_PAIRS",
+            unreachable_representation="JSON_NULL",
+            vertices=("1", "10", "2"),
+            rows=_complete_rows(["1", "10", "2"]),
+            connected=False,
+        )


### PR DESCRIPTION
Closes #930

## Problem

`graph.distance_matrix.compute` returns a mathematically correct matrix, but the result contract exposed a bare dense positional `distances` array beside the authoritative `vertices` list. With numeric-looking string labels (`"0","1","10","2",...`) the `LEXICOGRAPHIC_ASCENDING` ordering is valid but surprising, and a dense positional matrix is easy to detach from its vertex axis and present under natural numeric labels while still looking schema-correct.

## Fix

Keep lexicographic canonicalization and bind row identity into the result model, per the issue's maintainer direction (labelled rows, no inferred numeric semantics, no axis registry):

- `GraphDistanceMatrixResult.distances` (bare positional rows) is replaced by `rows`, where each row is a labelled `GraphDistanceRow` carrying its `source` vertex and its positional `distances` over the canonical `vertices` axis.
- The result validator rejects any row whose label does not match the canonical vertex axis at its position, so reordered or relabelled rows cannot appear schema-correct; producer and checker bind exactly the same vertex order.
- `semantics_version` is bumped to `unweighted-shortest-path-distance-matrix.v2` for the shape change. Request and graph contracts are unchanged.

## Tests

New `tests/math/graphs/test_graph_distance_matrix.py` (18 tests):

- numeric-looking labels with `"2"` and `"10"` stay lexicographic and bound to labelled rows;
- reordered and relabelled rows, unsorted/duplicate vertices, non-square rows, broken metric invariants, and `connected` mismatches are rejected;
- the producer payload round-trips through the result model unchanged;
- empty, disconnected, arbitrary string-identifier, and catalog-wrapper example cases.

## Validation

- `make lint` and `make typecheck`: green
- `make test-fast`: 1308 passed
- Catalog schema snapshot for `graph.distance_matrix.compute` regenerated (input hash unchanged)
- CLI smoke: labelled rows serialize end-to-end under `vertices: ["1","10","2"]`
