### PR TITLE
docs: explain Jacobian's executable math vocabulary hypothesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,19 +14,9 @@ discovering, running, and combining typed computations to investigate
 conjectures, build examples, calculate invariants, and check bounded claims.
 
 **Jacobian's hypothesis is that mathematical reasoning benefits from an
-executable vocabulary of small, exact operations.** Rather than exposing large
-domain solvers or precomposed workflows, Jacobian exposes mathematical
-primitives that agents can search for and compose into solutions beyond what
-any individual operation was designed to solve.
-
-This is why atomicity and composability are product requirements, not merely
-code-organization preferences. Jacobian supplies trustworthy mathematical
-moves; the reasoning model owns the search over those moves: what to
-investigate, which results to feed into later operations, how to cross domain
-boundaries, and when to stop. Prefer primitives that enlarge this reusable
-vocabulary over tools that bake in a proof strategy, domain workflow, or final
-solution. As models improve, the library should provide better mathematical
-building blocks rather than increasingly prescriptive solvers.
+executable vocabulary of small, exact operations.** Prefer reusable
+mathematical primitives over large solvers or workflows: Jacobian supplies the
+mathematical moves; the model decides how to compose them into larger solutions.
 
 It is a **stateless MCP server for atomic, composable mathematics** with two
 tools:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,21 @@ Jacobian gives agents atomic, composable tools for higher mathematics:
 discovering, running, and combining typed computations to investigate
 conjectures, build examples, calculate invariants, and check bounded claims.
 
+**Jacobian's hypothesis is that mathematical reasoning benefits from an
+executable vocabulary of small, exact operations.** Rather than exposing large
+domain solvers or precomposed workflows, Jacobian exposes mathematical
+primitives that agents can search for and compose into solutions beyond what
+any individual operation was designed to solve.
+
+This is why atomicity and composability are product requirements, not merely
+code-organization preferences. Jacobian supplies trustworthy mathematical
+moves; the reasoning model owns the search over those moves: what to
+investigate, which results to feed into later operations, how to cross domain
+boundaries, and when to stop. Prefer primitives that enlarge this reusable
+vocabulary over tools that bake in a proof strategy, domain workflow, or final
+solution. As models improve, the library should provide better mathematical
+building blocks rather than increasingly prescriptive solvers.
+
 It is a **stateless MCP server for atomic, composable mathematics** with two
 tools:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ exact computation: a typed request in, a typed mathematical value out, with
 no workflow, state, or intermediate runtime between them. The same
 mathematical library is also available through a CLI and native Python API.
 
+**Jacobian's hypothesis is that mathematical reasoning benefits from an
+executable vocabulary of small, exact operations.** Rather than exposing large
+domain solvers or precomposed workflows, Jacobian exposes mathematical
+primitives that agents can search for and compose into solutions beyond what
+any individual operation was designed to solve. The library supplies
+trustworthy mathematical moves; the reasoning model decides which moves to
+make, how to combine their results, and when to stop. Keeping the operations
+small and domain-owned preserves that search space instead of baking one proof
+strategy or workflow into the tools themselves.
+
 ## Quickstart
 
 Run the canonical Python MCP command without installing Jacobian globally:


### PR DESCRIPTION
## Summary

Make the reason for Jacobian's atomic operation model explicit in both the public README and the agent-facing repository guidance.

- state the core hypothesis: reasoning models benefit from an executable vocabulary of small, exact mathematical operations
- explain why Jacobian prefers primitives over large domain solvers and precomposed workflows
- clarify that atomicity/composability are product requirements, not merely code-organization preferences
- make the ownership split explicit: Jacobian supplies trustworthy mathematical moves; the reasoning model searches over and composes them

This is documentation-only and preserves the existing product/runtime contract.