### PR TITLE
feat(math): add finite categories domain with profile and opposite (#1733)

### DIFF
--- a/src/jacobian/catalog/builtins.py
+++ b/src/jacobian/catalog/builtins.py
@@ -76,6 +76,10 @@ from jacobian.math.electrical_networks._admission import (
 from jacobian.math.electrical_networks._tools import (
     TOOLS as ELECTRICAL_NETWORKS_TOOLS,
 )
+from jacobian.math.finite_categories._admission import (
+    ADMISSIONS as FINITE_CATEGORIES_ADMISSIONS,
+)
+from jacobian.math.finite_categories._tools import TOOLS as FINITE_CATEGORIES_TOOLS
 from jacobian.math.finite_fields._admission import (
     ADMISSIONS as FINITE_FIELDS_ADMISSIONS,
 )
@@ -280,6 +284,7 @@ from jacobian.math.words._admission import ADMISSIONS as WORDS_ADMISSIONS
 from jacobian.math.words._tools import TOOLS as WORDS_TOOLS
 
 _BUILTIN_CANDIDATES: MathTools = (
+    *FINITE_CATEGORIES_TOOLS,
     *BOOLEAN_TOOLS,
     *GROUP_TOOLS,
     *GRAPH_COLORING_OPS_TOOLS,
@@ -372,6 +377,7 @@ _RAW_ADMISSIONS: tuple[OperationAdmission, ...] = (
     *DIOPHANTINE_APPROXIMATION_ADMISSIONS,
     *DISCREPANCY_THEORY_ADMISSIONS,
     *ELECTRICAL_NETWORKS_ADMISSIONS,
+    *FINITE_CATEGORIES_ADMISSIONS,
     *FINITE_FIELDS_ADMISSIONS,
     *FINITE_GAME_THEORY_ADMISSIONS,
     *FINITE_METRIC_SPACES_ADMISSIONS,

--- a/src/jacobian/math/finite_categories/__init__.py
+++ b/src/jacobian/math/finite_categories/__init__.py
@@ -1,0 +1,3 @@
+"""Finite category operations."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/finite_categories/_admission.py
+++ b/src/jacobian/math/finite_categories/_admission.py
@@ -1,0 +1,16 @@
+"""Owner-local admission decisions for built-in math operations."""
+
+from jacobian.catalog.admission import AdmissionDecision, OperationAdmission
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "finite_category.profile.compute",
+        AdmissionDecision.KEEP,
+        "exact hom-set, endomorphism, and identity profiles for a finite category",
+    ),
+    OperationAdmission(
+        "finite_category.opposite.compute",
+        AdmissionDecision.KEEP,
+        "exact opposite category with reversed morphism directions",
+    ),
+)

--- a/src/jacobian/math/finite_categories/_models.py
+++ b/src/jacobian/math/finite_categories/_models.py
@@ -1,0 +1,60 @@
+"""Typed wire contracts for finite category operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_OBJECTS = 20
+MAX_MORPHISMS = 100
+
+
+class MorphismSpec(StrictModel):
+    """One morphism: source and target objects, plus a unique ID."""
+
+    morphism_id: str
+    source: str
+    target: str
+
+
+class FiniteCategoryRequest(StrictModel):
+    """A finite category presented extensionally."""
+
+    objects: tuple[str, ...] = Field(min_length=1, max_length=MAX_OBJECTS)
+    morphisms: tuple[MorphismSpec, ...] = Field(max_length=MAX_MORPHISMS)
+
+    @model_validator(mode="after")
+    def require_valid_category(self) -> Self:
+        obj_set = set(self.objects)
+        if len(obj_set) != len(self.objects):
+            raise ValueError("object labels must be distinct")
+        morph_ids = [m.morphism_id for m in self.morphisms]
+        if len(set(morph_ids)) != len(morph_ids):
+            raise ValueError("morphism IDs must be distinct")
+        for m in self.morphisms:
+            if m.source not in obj_set or m.target not in obj_set:
+                raise ValueError(
+                    "every morphism source/target must be a declared object"
+                )
+        return self
+
+
+class CategoryProfileResult(StrictModel):
+    """Profile of a finite category: hom-sets, endomorphisms, isomorphisms."""
+
+    objects: tuple[str, ...]
+    num_objects: int
+    num_morphisms: int
+    hom_sets: tuple[tuple[str, int], ...]
+    endomorphisms: tuple[tuple[str, int], ...]
+    identity_morphisms: tuple[tuple[str, str], ...]
+
+
+class OppositeCategoryResult(StrictModel):
+    """The opposite category with reversed morphisms."""
+
+    objects: tuple[str, ...]
+    morphisms: tuple[MorphismSpec, ...]

--- a/src/jacobian/math/finite_categories/_models.py
+++ b/src/jacobian/math/finite_categories/_models.py
@@ -10,6 +10,7 @@ from jacobian._models import StrictModel
 
 MAX_OBJECTS = 20
 MAX_MORPHISMS = 100
+MAX_COMPOSITIONS = 1000
 
 
 class MorphismSpec(StrictModel):
@@ -20,41 +21,168 @@ class MorphismSpec(StrictModel):
     target: str
 
 
+def _morphism_index(
+    objects: tuple[str, ...], morphisms: tuple[MorphismSpec, ...]
+) -> dict[str, MorphismSpec]:
+    obj_set = set(objects)
+    if len(obj_set) != len(objects):
+        raise ValueError("object labels must be distinct")
+    by_id = {m.morphism_id: m for m in morphisms}
+    if len(by_id) != len(morphisms):
+        raise ValueError("morphism IDs must be distinct")
+    for m in morphisms:
+        if m.source not in obj_set or m.target not in obj_set:
+            raise ValueError("every morphism source/target must be a declared object")
+    return by_id
+
+
+def _identity_map(
+    objects: tuple[str, ...],
+    by_id: dict[str, MorphismSpec],
+    identities: tuple[tuple[str, str], ...],
+) -> dict[str, str]:
+    obj_set = set(objects)
+    id_map: dict[str, str] = {}
+    for obj, morph_id in identities:
+        if obj not in obj_set:
+            raise ValueError("identity objects must be declared objects")
+        if obj in id_map:
+            raise ValueError("each object has exactly one identity")
+        m = by_id.get(morph_id)
+        if m is None:
+            raise ValueError("an identity must name a declared morphism")
+        if m.source != obj or m.target != obj:
+            raise ValueError("an identity must be an endomorphism of its object")
+        id_map[obj] = morph_id
+    if set(id_map) != obj_set:
+        raise ValueError("every object must have exactly one identity")
+    return id_map
+
+
+def _composition_table(
+    morphisms: tuple[MorphismSpec, ...],
+    by_id: dict[str, MorphismSpec],
+    composition: tuple[tuple[str, str, str], ...],
+) -> dict[tuple[str, str], str]:
+    comp: dict[tuple[str, str], str] = {}
+    for g, f, result in composition:
+        if g not in by_id or f not in by_id or result not in by_id:
+            raise ValueError("composition must name declared morphisms")
+        ff = by_id[f]
+        gf = by_id[g]
+        rf = by_id[result]
+        if ff.target != gf.source:
+            raise ValueError("composition requires target(f) == source(g)")
+        if rf.source != ff.source or rf.target != gf.target:
+            raise ValueError("composition result must have source(f) and target(g)")
+        if (g, f) in comp:
+            raise ValueError("composition must be total and single-valued")
+        comp[(g, f)] = result
+
+    composable = {
+        (g.morphism_id, f.morphism_id)
+        for f in morphisms
+        for g in morphisms
+        if f.target == g.source
+    }
+    if set(comp) != composable:
+        raise ValueError(
+            "composition table domain must be exactly the composable pairs"
+        )
+    return comp
+
+
+def _check_unit_laws(
+    morphisms: tuple[MorphismSpec, ...],
+    id_map: dict[str, str],
+    comp: dict[tuple[str, str], str],
+) -> None:
+    for m in morphisms:
+        id_target = id_map[m.target]
+        id_source = id_map[m.source]
+        if comp[(id_target, m.morphism_id)] != m.morphism_id:
+            raise ValueError("left identity law violated")
+        if comp[(m.morphism_id, id_source)] != m.morphism_id:
+            raise ValueError("right identity law violated")
+
+
+def _check_associativity(
+    morphisms: tuple[MorphismSpec, ...], comp: dict[tuple[str, str], str]
+) -> None:
+    for h in morphisms:
+        for g in morphisms:
+            for f in morphisms:
+                if f.target == g.source and g.target == h.source:
+                    hg = comp[(h.morphism_id, g.morphism_id)]
+                    gf = comp[(g.morphism_id, f.morphism_id)]
+                    if comp[(hg, f.morphism_id)] != comp[(h.morphism_id, gf)]:
+                        raise ValueError("associativity violated")
+
+
+def _check_category(
+    objects: tuple[str, ...],
+    morphisms: tuple[MorphismSpec, ...],
+    identities: tuple[tuple[str, str], ...],
+    composition: tuple[tuple[str, str, str], ...],
+) -> None:
+    """Validate the defining category data and laws, raising on violation.
+
+    A finite category is presented extensionally by its objects, morphisms,
+    a designated identity per object, and a total composition table.  This
+    enforces that the input is a genuine category: distinct labels, closed
+    source/target domains, exactly one typed identity per object, a
+    composition table whose domain is exactly the composable pairs, correct
+    result typing, both unit laws, and associativity on every composable
+    triple.  ``composition`` entries are ``(g, f, result)`` with ``g . f``.
+    """
+
+    by_id = _morphism_index(objects, morphisms)
+    id_map = _identity_map(objects, by_id, identities)
+    comp = _composition_table(morphisms, by_id, composition)
+    _check_unit_laws(morphisms, id_map, comp)
+    _check_associativity(morphisms, comp)
+
+
 class FiniteCategoryRequest(StrictModel):
-    """A finite category presented extensionally."""
+    """A finite category presented extensionally.
+
+    ``identities`` pairs each object with its designated identity morphism;
+    ``composition`` carries a total result for every composable pair as
+    ``(g, f, result)`` meaning ``g . f = result``.  The complete category
+    laws are enforced once at the value boundary.
+    """
 
     objects: tuple[str, ...] = Field(min_length=1, max_length=MAX_OBJECTS)
     morphisms: tuple[MorphismSpec, ...] = Field(max_length=MAX_MORPHISMS)
+    identities: tuple[tuple[str, str], ...] = Field(max_length=MAX_OBJECTS)
+    composition: tuple[tuple[str, str, str], ...] = Field(max_length=MAX_COMPOSITIONS)
 
     @model_validator(mode="after")
     def require_valid_category(self) -> Self:
-        obj_set = set(self.objects)
-        if len(obj_set) != len(self.objects):
-            raise ValueError("object labels must be distinct")
-        morph_ids = [m.morphism_id for m in self.morphisms]
-        if len(set(morph_ids)) != len(morph_ids):
-            raise ValueError("morphism IDs must be distinct")
-        for m in self.morphisms:
-            if m.source not in obj_set or m.target not in obj_set:
-                raise ValueError(
-                    "every morphism source/target must be a declared object"
-                )
+        _check_category(self.objects, self.morphisms, self.identities, self.composition)
         return self
 
 
 class CategoryProfileResult(StrictModel):
-    """Profile of a finite category: hom-sets, endomorphisms, isomorphisms."""
+    """Profile of a finite category: hom-sets, endomorphisms, identities."""
 
     objects: tuple[str, ...]
     num_objects: int
     num_morphisms: int
-    hom_sets: tuple[tuple[str, int], ...]
+    hom_sets: tuple[tuple[str, str, int], ...]
     endomorphisms: tuple[tuple[str, int], ...]
     identity_morphisms: tuple[tuple[str, str], ...]
 
 
 class OppositeCategoryResult(StrictModel):
-    """The opposite category with reversed morphisms."""
+    """The opposite category: reversed morphisms and reversed composition."""
 
     objects: tuple[str, ...]
     morphisms: tuple[MorphismSpec, ...]
+    identities: tuple[tuple[str, str], ...]
+    composition: tuple[tuple[str, str, str], ...]
+
+    @model_validator(mode="after")
+    def require_valid_opposite(self) -> Self:
+        _check_category(self.objects, self.morphisms, self.identities, self.composition)
+        return self

--- a/src/jacobian/math/finite_categories/_operations.py
+++ b/src/jacobian/math/finite_categories/_operations.py
@@ -13,20 +13,20 @@ def compute_category_profile(request: FiniteCategoryRequest) -> CategoryProfileR
     objects = request.objects
     morphisms = request.morphisms
 
-    # Build hom-sets: Hom(a,b) = count of morphisms from a to b
+    # Build hom-sets: Hom(a,b) = count of morphisms from a to b.
     hom_counts: dict[tuple[str, str], int] = {}
     for m in morphisms:
         key = (m.source, m.target)
         hom_counts[key] = hom_counts.get(key, 0) + 1
 
-    hom_list = []
+    hom_list: list[tuple[str, str, int]] = []
     for a in objects:
         for b in objects:
             count = hom_counts.get((a, b), 0)
             if count > 0:
-                hom_list.append((f"{a}->{b}", count))
+                hom_list.append((a, b, count))
 
-    # Endomorphisms: morphisms where source == target
+    # Endomorphisms: morphisms where source == target.
     endo_counts: dict[str, int] = {}
     for m in morphisms:
         if m.source == m.target:
@@ -35,13 +35,8 @@ def compute_category_profile(request: FiniteCategoryRequest) -> CategoryProfileR
         (obj, endo_counts.get(obj, 0)) for obj in objects if obj in endo_counts
     ]
 
-    # Identity morphisms (one per object, if present)
-    identities = []
-    for obj in objects:
-        for m in morphisms:
-            if m.source == obj and m.target == obj:
-                identities.append((obj, m.morphism_id))
-                break
+    # Designated identity morphisms (one per object, from the value).
+    identities = tuple(request.identities)
 
     return CategoryProfileResult(
         objects=objects,
@@ -49,12 +44,17 @@ def compute_category_profile(request: FiniteCategoryRequest) -> CategoryProfileR
         num_morphisms=len(morphisms),
         hom_sets=tuple(hom_list),
         endomorphisms=tuple(endo_list),
-        identity_morphisms=tuple(identities),
+        identity_morphisms=identities,
     )
 
 
 def compute_opposite_category(request: FiniteCategoryRequest) -> OppositeCategoryResult:
-    """Compute the opposite category with reversed morphisms."""
+    """Compute the opposite category.
+
+    Morphism directions are reversed and composition order is reversed: a
+    composition ``(g, f, r)`` in the source category becomes ``(f, g, r)``
+    in the opposite, so that ``f^op . g^op = r^op``.
+    """
     opposite_morphisms = tuple(
         MorphismSpec(
             morphism_id=m.morphism_id,
@@ -63,7 +63,12 @@ def compute_opposite_category(request: FiniteCategoryRequest) -> OppositeCategor
         )
         for m in request.morphisms
     )
+    opposite_composition = tuple(
+        (f, g, result) for (g, f, result) in request.composition
+    )
     return OppositeCategoryResult(
         objects=request.objects,
         morphisms=opposite_morphisms,
+        identities=request.identities,
+        composition=opposite_composition,
     )

--- a/src/jacobian/math/finite_categories/_operations.py
+++ b/src/jacobian/math/finite_categories/_operations.py
@@ -1,0 +1,69 @@
+"""Exact finite category operations."""
+
+from jacobian.math.finite_categories._models import (
+    CategoryProfileResult,
+    FiniteCategoryRequest,
+    MorphismSpec,
+    OppositeCategoryResult,
+)
+
+
+def compute_category_profile(request: FiniteCategoryRequest) -> CategoryProfileResult:
+    """Compute the profile of a finite category."""
+    objects = request.objects
+    morphisms = request.morphisms
+
+    # Build hom-sets: Hom(a,b) = count of morphisms from a to b
+    hom_counts: dict[tuple[str, str], int] = {}
+    for m in morphisms:
+        key = (m.source, m.target)
+        hom_counts[key] = hom_counts.get(key, 0) + 1
+
+    hom_list = []
+    for a in objects:
+        for b in objects:
+            count = hom_counts.get((a, b), 0)
+            if count > 0:
+                hom_list.append((f"{a}->{b}", count))
+
+    # Endomorphisms: morphisms where source == target
+    endo_counts: dict[str, int] = {}
+    for m in morphisms:
+        if m.source == m.target:
+            endo_counts[m.source] = endo_counts.get(m.source, 0) + 1
+    endo_list = [
+        (obj, endo_counts.get(obj, 0)) for obj in objects if obj in endo_counts
+    ]
+
+    # Identity morphisms (one per object, if present)
+    identities = []
+    for obj in objects:
+        for m in morphisms:
+            if m.source == obj and m.target == obj:
+                identities.append((obj, m.morphism_id))
+                break
+
+    return CategoryProfileResult(
+        objects=objects,
+        num_objects=len(objects),
+        num_morphisms=len(morphisms),
+        hom_sets=tuple(hom_list),
+        endomorphisms=tuple(endo_list),
+        identity_morphisms=tuple(identities),
+    )
+
+
+def compute_opposite_category(request: FiniteCategoryRequest) -> OppositeCategoryResult:
+    """Compute the opposite category with reversed morphisms."""
+    opposite_morphisms = tuple(
+        MorphismSpec(
+            morphism_id=m.morphism_id,
+            source=m.target,
+            target=m.source,
+        )
+        for m in request.morphisms
+    )
+    return OppositeCategoryResult(
+        objects=request.objects,
+        morphisms=opposite_morphisms,
+    )

--- a/src/jacobian/math/finite_categories/_tools.py
+++ b/src/jacobian/math/finite_categories/_tools.py
@@ -1,0 +1,95 @@
+"""Finite category operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.finite_categories._models import (
+    CategoryProfileResult,
+    FiniteCategoryRequest,
+    OppositeCategoryResult,
+)
+from jacobian.math.finite_categories._operations import (
+    compute_category_profile,
+    compute_opposite_category,
+)
+
+
+def _op[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version="1",
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_CATEGORY = {
+    "objects": ["A", "B"],
+    "morphisms": [
+        {"morphism_id": "id_A", "source": "A", "target": "A"},
+        {"morphism_id": "id_B", "source": "B", "target": "B"},
+        {"morphism_id": "f", "source": "A", "target": "B"},
+    ],
+}
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "finite_category.profile.compute",
+        "Compute the profile of a finite category",
+        "Compute hom-set counts, endomorphism counts, and identity "
+        "morphisms for a finite category presented extensionally.",
+        FiniteCategoryRequest,
+        CategoryProfileResult,
+        compute_category_profile,
+        "algebra",
+        "category",
+        "exact",
+        examples=(
+            example(
+                "two_object_category",
+                "Profile a 2-object, 3-morphism category; "
+                "every morphism source/target must be a declared object.",
+                {"objects": _CATEGORY["objects"], "morphisms": _CATEGORY["morphisms"]},
+            ),
+        ),
+    ),
+    _op(
+        "finite_category.opposite.compute",
+        "Compute the opposite category",
+        "Compute the opposite category with all morphism directions "
+        "reversed (source and target swapped).",
+        FiniteCategoryRequest,
+        OppositeCategoryResult,
+        compute_opposite_category,
+        "algebra",
+        "category",
+        "exact",
+        examples=(
+            example(
+                "opposite_of_two_object",
+                "Compute the opposite of a 2-object category; "
+                "every morphism source/target must be a declared object.",
+                {"objects": _CATEGORY["objects"], "morphisms": _CATEGORY["morphisms"]},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/finite_categories/_tools.py
+++ b/src/jacobian/math/finite_categories/_tools.py
@@ -47,14 +47,23 @@ _CATEGORY = {
         {"morphism_id": "id_B", "source": "B", "target": "B"},
         {"morphism_id": "f", "source": "A", "target": "B"},
     ],
+    "identities": [["A", "id_A"], ["B", "id_B"]],
+    "composition": [
+        ["id_A", "id_A", "id_A"],
+        ["f", "id_A", "f"],
+        ["id_B", "id_B", "id_B"],
+        ["id_B", "f", "f"],
+    ],
 }
 
 TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "finite_category.profile.compute",
         "Compute the profile of a finite category",
-        "Compute hom-set counts, endomorphism counts, and identity "
-        "morphisms for a finite category presented extensionally.",
+        "Compute hom-set cardinalities, endomorphism counts, and the "
+        "designated identity morphism for each object of a finite category "
+        "presented extensionally with identities and a total composition "
+        "table.",
         FiniteCategoryRequest,
         CategoryProfileResult,
         compute_category_profile,
@@ -64,17 +73,23 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "two_object_category",
-                "Profile a 2-object, 3-morphism category; "
-                "every morphism source/target must be a declared object.",
-                {"objects": _CATEGORY["objects"], "morphisms": _CATEGORY["morphisms"]},
+                "Profile a 2-object, 3-morphism category; every morphism "
+                "source/target must be a declared object and the category "
+                "laws must hold.",
+                {
+                    "objects": _CATEGORY["objects"],
+                    "morphisms": _CATEGORY["morphisms"],
+                    "identities": _CATEGORY["identities"],
+                    "composition": _CATEGORY["composition"],
+                },
             ),
         ),
     ),
     _op(
         "finite_category.opposite.compute",
         "Compute the opposite category",
-        "Compute the opposite category with all morphism directions "
-        "reversed (source and target swapped).",
+        "Compute the opposite category with all morphism directions reversed "
+        "(source and target swapped) and composition order reversed.",
         FiniteCategoryRequest,
         OppositeCategoryResult,
         compute_opposite_category,
@@ -84,9 +99,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "opposite_of_two_object",
-                "Compute the opposite of a 2-object category; "
-                "every morphism source/target must be a declared object.",
-                {"objects": _CATEGORY["objects"], "morphisms": _CATEGORY["morphisms"]},
+                "Compute the opposite of a 2-object category; every morphism "
+                "source/target must be a declared object and the category "
+                "laws must hold.",
+                {
+                    "objects": _CATEGORY["objects"],
+                    "morphisms": _CATEGORY["morphisms"],
+                    "identities": _CATEGORY["identities"],
+                    "composition": _CATEGORY["composition"],
+                },
             ),
         ),
     ),

--- a/tests/catalog/operation_schema_snapshots/finite_categories.json
+++ b/tests/catalog/operation_schema_snapshots/finite_categories.json
@@ -1,14 +1,14 @@
 {
-  "catalog_version": "1",
-  "domain": "finite_categories",
-  "operations": {
-    "finite_category.opposite.compute": {
-      "input_schema": "sha256:d5a8542256b66f448e8fbb3eabfdb4bb0cd65c3afcdbca73360462d10ea8a657",
-      "output_schema": "sha256:21a457ad0ecfd642d7284ef4bcbad2b38ed8f3824eca6164475dc7d8a49c73d3"
-    },
-    "finite_category.profile.compute": {
-      "input_schema": "sha256:d5a8542256b66f448e8fbb3eabfdb4bb0cd65c3afcdbca73360462d10ea8a657",
-      "output_schema": "sha256:051f6ee7a190dcd52aec01f282100506a784c1bad8b25aaa331e3d6a13171d73"
+    "catalog_version": "1",
+    "domain": "finite_categories",
+    "operations": {
+        "finite_category.opposite.compute": {
+            "input_schema": "sha256:4d596bd56dd058f4cfc6b4b48c2b842b82843cf683151b96f121eea49ac6587e",
+            "output_schema": "sha256:3fa21dc6680106a7a74f90f814e7496652d0d10488adb152d3103f3020bc12ab"
+        },
+        "finite_category.profile.compute": {
+            "input_schema": "sha256:4d596bd56dd058f4cfc6b4b48c2b842b82843cf683151b96f121eea49ac6587e",
+            "output_schema": "sha256:f0ea25aa6dc650e0847b8a3bea372e6f5ff29dcfdb43bb35d831d4e71d5d27fc"
+        }
     }
-  }
 }

--- a/tests/catalog/operation_schema_snapshots/finite_categories.json
+++ b/tests/catalog/operation_schema_snapshots/finite_categories.json
@@ -1,0 +1,14 @@
+{
+  "catalog_version": "1",
+  "domain": "finite_categories",
+  "operations": {
+    "finite_category.opposite.compute": {
+      "input_schema": "sha256:d5a8542256b66f448e8fbb3eabfdb4bb0cd65c3afcdbca73360462d10ea8a657",
+      "output_schema": "sha256:21a457ad0ecfd642d7284ef4bcbad2b38ed8f3824eca6164475dc7d8a49c73d3"
+    },
+    "finite_category.profile.compute": {
+      "input_schema": "sha256:d5a8542256b66f448e8fbb3eabfdb4bb0cd65c3afcdbca73360462d10ea8a657",
+      "output_schema": "sha256:051f6ee7a190dcd52aec01f282100506a784c1bad8b25aaa331e3d6a13171d73"
+    }
+  }
+}

--- a/tests/catalog/test_admission.py
+++ b/tests/catalog/test_admission.py
@@ -27,12 +27,12 @@ def test_every_frozen_candidate_has_exactly_one_admission_decision() -> None:
     reviewed_ids = [record.operation_id for record in OPERATION_ADMISSIONS]
 
     assert REVIEWED_BASE_REVISION == "61589543bbbff546edbc51d34a07887982fa4ad6"
-    assert len(candidate_ids) == len(set(candidate_ids)) == 406
+    assert len(candidate_ids) == len(set(candidate_ids)) == 408
     assert reviewed_ids == sorted(reviewed_ids)
     assert set(reviewed_ids) == set(candidate_ids)
     assert all(record.rationale.strip() for record in OPERATION_ADMISSIONS)
     assert Counter(record.decision for record in OPERATION_ADMISSIONS) == {
-        AdmissionDecision.KEEP: 246,
+        AdmissionDecision.KEEP: 248,
         AdmissionDecision.NATIVE_ONLY: 56,
         AdmissionDecision.DROP: 104,
     }
@@ -46,7 +46,7 @@ def test_public_catalog_contains_only_admitted_atomic_operations() -> None:
     }
 
     assert {tool.operation_id for tool in BUILTIN_TOOLS} == expected
-    assert len(BUILTIN_TOOLS) == 246
+    assert len(BUILTIN_TOOLS) == 248
 
 
 def test_catalog_construction_fails_closed_on_duplicate_candidates() -> None:

--- a/tests/math/finite_categories/test_finite_categories.py
+++ b/tests/math/finite_categories/test_finite_categories.py
@@ -16,6 +16,13 @@ CATEGORY = {
         {"morphism_id": "id_B", "source": "B", "target": "B"},
         {"morphism_id": "f", "source": "A", "target": "B"},
     ],
+    "identities": [["A", "id_A"], ["B", "id_B"]],
+    "composition": [
+        ["id_A", "id_A", "id_A"],
+        ["f", "id_A", "f"],
+        ["id_B", "id_B", "id_B"],
+        ["id_B", "f", "f"],
+    ],
 }
 
 
@@ -25,12 +32,9 @@ class TestProfile:
         assert result.num_objects == 2
         assert result.num_morphisms == 3
 
-    def test_hom_sets(self) -> None:
+    def test_hom_sets_are_structural(self) -> None:
         result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
-        hom = dict(result.hom_sets)
-        assert hom.get("A->A") == 1
-        assert hom.get("A->B") == 1
-        assert hom.get("B->B") == 1
+        assert set(result.hom_sets) == {("A", "A", 1), ("A", "B", 1), ("B", "B", 1)}
 
     def test_endomorphisms(self) -> None:
         result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
@@ -54,15 +58,102 @@ class TestOpposite:
         assert morph_map["id_A"].source == "A"
         assert morph_map["id_A"].target == "A"
 
+    def test_reverses_composition(self) -> None:
+        result = compute_opposite_category(FiniteCategoryRequest(**CATEGORY))
+        comp = {(g, f): r for (g, f, r) in result.composition}
+        # f∘f is not composable, but id_B∘f = f in the source becomes
+        # f∘id_B = f in the opposite.
+        assert comp[("f", "id_B")] == "f"
+        assert comp[("id_A", "f")] == "f"
+
+    def test_opposite_is_a_valid_category(self) -> None:
+        result = compute_opposite_category(FiniteCategoryRequest(**CATEGORY))
+        # The opposite value must itself satisfy the category laws.
+        assert set(result.objects) == set(CATEGORY["objects"])
+        assert len(result.morphisms) == 3
+
 
 class TestValidation:
     def test_duplicate_objects(self) -> None:
         with pytest.raises(ValidationError, match="distinct"):
-            FiniteCategoryRequest(objects=["A", "A"], morphisms=[])
+            FiniteCategoryRequest(
+                objects=["A", "A"], morphisms=[], identities=[], composition=[]
+            )
 
     def test_invalid_morphism_target(self) -> None:
         with pytest.raises(ValidationError, match="declared object"):
             FiniteCategoryRequest(
                 objects=["A"],
                 morphisms=[{"morphism_id": "f", "source": "A", "target": "B"}],
+                identities=[],
+                composition=[],
+            )
+
+    def test_missing_identity_rejected(self) -> None:
+        # No designated identity for object A.
+        with pytest.raises(ValidationError, match="exactly one identity"):
+            FiniteCategoryRequest(
+                objects=["A"],
+                morphisms=[{"morphism_id": "id_A", "source": "A", "target": "A"}],
+                identities=[],
+                composition=[["id_A", "id_A", "id_A"]],
+            )
+
+    def test_non_endomorphism_identity_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="endomorphism"):
+            FiniteCategoryRequest(
+                objects=["A", "B"],
+                morphisms=[
+                    {"morphism_id": "id_A", "source": "A", "target": "A"},
+                    {"morphism_id": "id_B", "source": "B", "target": "B"},
+                    {"morphism_id": "f", "source": "A", "target": "B"},
+                ],
+                identities=[["A", "f"], ["B", "id_B"]],
+                composition=[
+                    ["id_A", "id_A", "id_A"],
+                    ["f", "id_A", "f"],
+                    ["id_B", "id_B", "id_B"],
+                    ["id_B", "f", "f"],
+                ],
+            )
+
+    def test_incomplete_composition_rejected(self) -> None:
+        # Missing the (f, id_A) composition entry.
+        with pytest.raises(ValidationError, match="composable pairs"):
+            FiniteCategoryRequest(
+                objects=["A", "B"],
+                morphisms=[
+                    {"morphism_id": "id_A", "source": "A", "target": "A"},
+                    {"morphism_id": "id_B", "source": "B", "target": "B"},
+                    {"morphism_id": "f", "source": "A", "target": "B"},
+                ],
+                identities=[["A", "id_A"], ["B", "id_B"]],
+                composition=[
+                    ["id_A", "id_A", "id_A"],
+                    ["id_B", "id_B", "id_B"],
+                    ["id_B", "f", "f"],
+                ],
+            )
+
+    def test_identity_law_violation_rejected(self) -> None:
+        # id_B∘g is declared to be f (both A→B), breaking the left identity
+        # law id_B∘g = g.
+        with pytest.raises(ValidationError, match="left identity law"):
+            FiniteCategoryRequest(
+                objects=["A", "B"],
+                morphisms=[
+                    {"morphism_id": "id_A", "source": "A", "target": "A"},
+                    {"morphism_id": "id_B", "source": "B", "target": "B"},
+                    {"morphism_id": "f", "source": "A", "target": "B"},
+                    {"morphism_id": "g", "source": "A", "target": "B"},
+                ],
+                identities=[["A", "id_A"], ["B", "id_B"]],
+                composition=[
+                    ["id_A", "id_A", "id_A"],
+                    ["f", "id_A", "f"],
+                    ["g", "id_A", "g"],
+                    ["id_B", "id_B", "id_B"],
+                    ["id_B", "f", "f"],
+                    ["id_B", "g", "f"],
+                ],
             )

--- a/tests/math/finite_categories/test_finite_categories.py
+++ b/tests/math/finite_categories/test_finite_categories.py
@@ -1,0 +1,68 @@
+"""Tests for finite category operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.finite_categories._models import FiniteCategoryRequest
+from jacobian.math.finite_categories._operations import (
+    compute_category_profile,
+    compute_opposite_category,
+)
+
+CATEGORY = {
+    "objects": ["A", "B"],
+    "morphisms": [
+        {"morphism_id": "id_A", "source": "A", "target": "A"},
+        {"morphism_id": "id_B", "source": "B", "target": "B"},
+        {"morphism_id": "f", "source": "A", "target": "B"},
+    ],
+}
+
+
+class TestProfile:
+    def test_counts(self) -> None:
+        result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
+        assert result.num_objects == 2
+        assert result.num_morphisms == 3
+
+    def test_hom_sets(self) -> None:
+        result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
+        hom = dict(result.hom_sets)
+        assert hom.get("A->A") == 1
+        assert hom.get("A->B") == 1
+        assert hom.get("B->B") == 1
+
+    def test_endomorphisms(self) -> None:
+        result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
+        endo = dict(result.endomorphisms)
+        assert endo.get("A") == 1
+        assert endo.get("B") == 1
+
+    def test_identity_morphisms(self) -> None:
+        result = compute_category_profile(FiniteCategoryRequest(**CATEGORY))
+        ids = dict(result.identity_morphisms)
+        assert ids.get("A") == "id_A"
+        assert ids.get("B") == "id_B"
+
+
+class TestOpposite:
+    def test_reverses_morphisms(self) -> None:
+        result = compute_opposite_category(FiniteCategoryRequest(**CATEGORY))
+        morph_map = {m.morphism_id: m for m in result.morphisms}
+        assert morph_map["f"].source == "B"
+        assert morph_map["f"].target == "A"
+        assert morph_map["id_A"].source == "A"
+        assert morph_map["id_A"].target == "A"
+
+
+class TestValidation:
+    def test_duplicate_objects(self) -> None:
+        with pytest.raises(ValidationError, match="distinct"):
+            FiniteCategoryRequest(objects=["A", "A"], morphisms=[])
+
+    def test_invalid_morphism_target(self) -> None:
+        with pytest.raises(ValidationError, match="declared object"):
+            FiniteCategoryRequest(
+                objects=["A"],
+                morphisms=[{"morphism_id": "f", "source": "A", "target": "B"}],
+            )


### PR DESCRIPTION
## Summary

Create the `finite_categories` domain with two operations, partially addressing #1733.

## Operations

- **`finite_category.profile.compute`** — Compute hom-set counts, endomorphism counts, and identity morphisms for a finite category presented extensionally.
- **`finite_category.opposite.compute`** — Compute the opposite category with all morphism directions reversed (source and target swapped).

## Tests

7 known-answer and adversarial tests covering:
- Object/morphism counts, hom-set verification, endomorphism counting
- Identity morphism identification
- Opposite category morphism reversal verification
- Duplicate object rejection, invalid morphism target rejection

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/c82c2624-a326-4714-a7ce-97ed6419d074)