### PR TITLE
docs: fix references to the moved agent evaluation guide

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/README.md
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/README.md
@@ -57,7 +57,7 @@ All Jacobian treatments reach the local sidecar through
 to both jobs; only the treatment adds the Jacobian sidecar and MCP config. This
 paired setup is for workflow comparison; the public dataset is not held-out
 evidence. For a fresh task-image pull behind a proxy, follow the opt-in Buildx
-builder setup in [Run agent observations](../../../docs/how-to/run-agent-evaluations.md).
+builder setup in [Run agent observations](../../docs/run-agent-evaluations.md).
 
 To evaluate the canonical `math.find` and `math.run` surface, keep each model,
 task set, and prompt condition in a separate result root:

--- a/tests/tooling/test_harbor_egress.py
+++ b/tests/tooling/test_harbor_egress.py
@@ -101,7 +101,7 @@ def test_agent_eval_forwards_web_search_setting_to_harbor() -> None:
 
 
 def test_agent_eval_docs_exclude_host_codex_from_the_control_protocol() -> None:
-    guide = (ROOT / "docs" / "how-to" / "run-agent-evaluations.md").read_text(
+    guide = (ROOT / "benchmarks" / "docs" / "run-agent-evaluations.md").read_text(
         encoding="utf-8"
     )
 


### PR DESCRIPTION
## Problem

Merged PR #2019 moved the agent-evaluation guide from `docs/how-to/` to `benchmarks/docs/`, but two consumers retained the old path:

- `tests/tooling/test_harbor_egress.py` raised `FileNotFoundError`, making current-main `make check` fail.
- the mathematical benchmark README linked to the removed location.

## Solution

Point both consumers at the canonical moved guide under `benchmarks/docs/`.

This is a path-only follow-up. It does not change Harbor behavior, network policy, benchmark contracts, or evaluation semantics.

## Validation

- Exact previously failing test: `1 passed`.
- `make check`: `1308 passed`; Ruff, formatting, complexity, and mypy passed.
- Documentation command validation passed.
- Full Markdown link checker could not run locally because `npx` is not installed; the corrected relative target exists in this tree.

## Overlap

- Direct follow-up to merged PR #2019.
- No open issue or PR was found owning these stale paths.
