### PR TITLE
fix(benchmarks): align oracle generators with result-only contracts

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/solution/generate.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/disjoint-closed-distance-scope-audit/solution/generate.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import shutil
@@ -39,23 +38,7 @@ def main():
         "formal_conclusion": "POSITIVE_DISTANCE",
         "corrected_conclusion": "SEPARATED_BUT_DISTANCE_INFIMUM_ZERO",
     }
-    evidence = {
-        "schema_version": "1",
-        "task_id": "jacobian/disjoint-closed-distance-scope-audit",
-        "result": result,
-    }
-    ep = app / "evidence/disjoint-closed-distance-audit.json"
-    ep.parent.mkdir(parents=True, exist_ok=True)
-    ep.write_text(json.dumps(evidence, separators=(",", ":")))
-    submission = {
-        "result": result,
-        "witness": [
-            {
-                "path": "evidence/disjoint-closed-distance-audit.json",
-                "sha256": "sha256:" + hashlib.sha256(ep.read_bytes()).hexdigest(),
-            }
-        ],
-    }
+    submission = {"result": result}
     (app / "submission.json").write_text(json.dumps(submission, indent=2))
     (app / "answer.txt").write_text(
         "Exact countermodel certificate generated; see submission.json.\n"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/solution/generate.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/solution/generate.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import shutil
 from pathlib import Path
@@ -22,25 +21,7 @@ result = {
     ],
     "formal_status": "UNBOUNDED_BELOW",
 }
-limitations = ["LEAN_ELABORATION_NOT_ASSESSED", "INFORMAL_MINIMUM_NOT_REPROVED"]
-evidence = {
-    "schema_version": "1",
-    "task_id": "jacobian/polynomial-precedence-unboundedness-audit",
-    "result": result,
-    "limitations": limitations,
-}
-epath = Path("/app/evidence/precedence-audit.json")
-epath.parent.mkdir(parents=True, exist_ok=True)
-epath.write_text(json.dumps(evidence, separators=(",", ":")))
-submission = {
-    "result": result,
-    "witness": [
-        {
-            "path": "evidence/precedence-audit.json",
-            "sha256": "sha256:" + hashlib.sha256(epath.read_bytes()).hexdigest(),
-        }
-    ],
-}
+submission = {"result": result}
 Path("/app/submission.json").write_text(json.dumps(submission, indent=2) + "\n")
 Path("/app/answer.txt").write_text(
     "The formal expression is unbounded below along the submitted exact rational polynomial family.\n"

--- a/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/solution/generate.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/product-hausdorff-nonempty-scope-audit/solution/generate.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import shutil
@@ -20,26 +19,7 @@ def main():
         "bad_factor_is_hausdorff": False,
         "missing_assumption": "ALL_FACTORS_NONEMPTY",
     }
-    limitations = ["FINITE_TOPOLOGIES_ONLY", "LEAN_ELABORATION_NOT_ASSESSED"]
-    task_id = "jacobian/product-hausdorff-nonempty-scope-audit"
-    evidence = {
-        "schema_version": "1",
-        "task_id": task_id,
-        "result": result,
-        "limitations": limitations,
-    }
-    ep = app / "evidence/product-hausdorff-audit.json"
-    ep.parent.mkdir(parents=True, exist_ok=True)
-    ep.write_text(json.dumps(evidence, separators=(",", ":")))
-    submission = {
-        "result": result,
-        "witness": [
-            {
-                "path": "evidence/product-hausdorff-audit.json",
-                "sha256": "sha256:" + hashlib.sha256(ep.read_bytes()).hexdigest(),
-            }
-        ],
-    }
+    submission = {"result": result}
     (app / "submission.json").write_text(json.dumps(submission, indent=2))
     (app / "answer.txt").write_text(
         "Finite topology countermodel generated; see submission.json.\n"


### PR DESCRIPTION
The result-only contract migration (#1599, #1647) updated verifiers, contracts, and checked-in solution submissions but left three oracle generators emitting a stale `witness` key. Harbor's oracle runs execute the generators, so the produced submission failed the derived public schema (additionalProperties: false) and scored reward 0.

Tasks fixed:
- product-hausdorff-nonempty-scope-audit
- disjoint-closed-distance-scope-audit
- polynomial-precedence-unboundedness-audit

This is the root cause of the failing Benchmark Oracle shards (01, 03, 04) and Benchmark Validation on main and on all open PRs that include these tasks.