### PR TITLE
fix(benchmarks): stop polynomial-precedence oracle from crashing on missing input

### DIFF
--- a/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/solution/generate.py
+++ b/benchmarks/datasets/mathematical-benchmarks-v1/polynomial-precedence-unboundedness-audit/solution/generate.py
@@ -2,7 +2,11 @@ import json
 import shutil
 from pathlib import Path
 
-shutil.copyfile("/solution/input.json", "/app/input.json")
+# The frozen input is provided by the agent environment Dockerfile at
+# /app/input.json; copy a generated /solution/input.json only when present.
+frozen = Path("/solution/input.json")
+if frozen.exists():
+    shutil.copyfile(frozen, "/app/input.json")
 
 
 def r(n, d=1):


### PR DESCRIPTION
## Summary

The benchmark Oracle for `polynomial-precedence-unboundedness-audit` was failing CI with `reward must be full reward` (trial result 24, shard mathematical-benchmarks-v1/03-of-04).

## Root cause

`solution/generate.py` called `shutil.copyfile("/solution/input.json", "/app/input.json")` unconditionally. This task has no `solution/input.json` (the frozen input is supplied by the agent `environment/Dockerfile` as `COPY input.json /app/`), so the copy raised `FileNotFoundError`, the oracle wrote no `/app/submission.json`, and the verifier scored the trial 0.

The sibling generators `disjoint-closed-distance-scope-audit` and `product-hausdorff-nonempty-scope-audit` already guard this copy with `if frozen.exists()`; this PR aligns `polynomial-precedence` with that pattern.

## Validation

- `make harbor-check-task DATASET=mathematical-benchmarks-v1 TASKS=polynomial-precedence-unboundedness-audit` passes (contracts match).
- `benchmarks/validation/mathematical_benchmarks_v1/test_polynomial_precedence_unboundedness_audit.py` passes.
- `check_benchmark_adapters.py` passes.

This is a main-branch benchmark fixture bug that was surfacing on PRs #2030/#2023/#2011 (and any other PR running the benchmark Oracle).