### PR TITLE
test(catalog): drop hardcoded admission counts and base revision

### DIFF
--- a/src/jacobian/catalog/admission.py
+++ b/src/jacobian/catalog/admission.py
@@ -32,9 +32,6 @@ class OperationAdmission:
     native_symbol: str | None = None
 
 
-REVIEWED_BASE_REVISION = "61589543bbbff546edbc51d34a07887982fa4ad6"
-
-
 def curate_public_tools(
     candidates: MathTools, admissions: tuple[OperationAdmission, ...]
 ) -> MathTools:
@@ -68,7 +65,6 @@ def admission_by_id(
 
 
 __all__ = [
-    "REVIEWED_BASE_REVISION",
     "AdmissionDecision",
     "OperationAdmission",
     "admission_by_id",

--- a/tests/catalog/test_admission.py
+++ b/tests/catalog/test_admission.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import importlib
-from collections import Counter
 from pathlib import Path
 
 import pytest
 
 from jacobian.catalog.admission import (
-    REVIEWED_BASE_REVISION,
     AdmissionDecision,
     curate_public_tools,
 )
@@ -22,20 +20,14 @@ from jacobian.catalog.builtins import (
 OPERATION_ADMISSIONS = _ALL_ADMISSIONS
 
 
-def test_every_frozen_candidate_has_exactly_one_admission_decision() -> None:
+def test_every_candidate_has_exactly_one_admission_decision() -> None:
     candidate_ids = [tool.operation_id for tool in _BUILTIN_CANDIDATES]
     reviewed_ids = [record.operation_id for record in OPERATION_ADMISSIONS]
 
-    assert REVIEWED_BASE_REVISION == "61589543bbbff546edbc51d34a07887982fa4ad6"
-    assert len(candidate_ids) == len(set(candidate_ids)) == 408
+    assert len(candidate_ids) == len(set(candidate_ids))
     assert reviewed_ids == sorted(reviewed_ids)
     assert set(reviewed_ids) == set(candidate_ids)
     assert all(record.rationale.strip() for record in OPERATION_ADMISSIONS)
-    assert Counter(record.decision for record in OPERATION_ADMISSIONS) == {
-        AdmissionDecision.KEEP: 248,
-        AdmissionDecision.NATIVE_ONLY: 56,
-        AdmissionDecision.DROP: 104,
-    }
 
 
 def test_public_catalog_contains_only_admitted_atomic_operations() -> None:
@@ -46,7 +38,6 @@ def test_public_catalog_contains_only_admitted_atomic_operations() -> None:
     }
 
     assert {tool.operation_id for tool in BUILTIN_TOOLS} == expected
-    assert len(BUILTIN_TOOLS) == 248
 
 
 def test_catalog_construction_fails_closed_on_duplicate_candidates() -> None:


### PR DESCRIPTION
## Summary

Removes the frozen candidate/KEEP counts and the `REVIEWED_BASE_REVISION` pin from the admission test and module.

## Why

The hardcoded counts (`len(candidate_ids) == 408`, `Counter(...) == {KEEP: 248, ...}`, `len(BUILTIN_TOOLS) == 248`) and the base-revision SHA were a manual ratchet: every operation-adding PR had to bump the same three lines, so concurrent catalog-changing PRs (#2030, #2023, #2011) collided in `tests/catalog/test_admission.py` and required manual conflict resolution on every merge.

The fail-closed contract is already enforced structurally by `curate_public_tools` (which raises unless the candidate inventory and decision ledger match exactly) and by the remaining invariants:
- every candidate has a unique ID,
- the ledger is sorted and covers exactly the candidate set,
- every decision row carries a rationale,
- the public catalog is exactly the `KEEP` set,
- `NATIVE_ONLY`/non-public decisions never leak into discovery or docs.

## Validation

- `tests/catalog`, `tests/math`, `tests/dispatch`, `tests/cli`, `tests/tooling` pass (1367).
- ruff + mypy pass.