### PR TITLE
docs: explain semantic atomicity and vocabulary growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ moves to make, how to combine their results, and when to stop. Keeping the
 operations semantically narrow and domain-owned preserves that search space
 instead of baking one proof strategy or workflow into the tools themselves.
 
+See [Executable mathematical vocabulary](docs/explanation/executable-mathematical-vocabulary.md)
+for what semantic atomicity means and how the operation vocabulary grows.
+
 ## Quickstart
 
 Run the canonical Python MCP command without installing Jacobian globally:

--- a/docs/explanation/executable-mathematical-vocabulary.md
+++ b/docs/explanation/executable-mathematical-vocabulary.md
@@ -1,0 +1,137 @@
+# Executable mathematical vocabulary
+
+Jacobian is a demand-driven executable mathematical vocabulary. It exposes
+stable, typed mathematical operations that agents can discover and compose. It
+does not attempt to enumerate all mathematical knowledge, mirror every backend
+API, or encode proof strategies.
+
+The caller owns problem representation, decomposition, sequencing, strategy,
+interpretation, and stopping. Jacobian owns the public mathematical contracts,
+typed values, execution bounds, and honest result semantics around each move.
+
+## Semantic atomicity
+
+**Atomic means one stable, reusable mathematical postcondition, not a small or
+simple implementation.**
+
+A useful mental model is:
+
+```text
+given mathematical input X,
+return mathematical output Y such that P(X, Y)
+```
+
+`X`, `Y`, and `P` should make sense independently of the algorithm, backend,
+benchmark, theorem, or surrounding reasoning workflow.
+
+A candidate is near the right semantic boundary when:
+
+1. **It has a mathematical identity.** The contract can be defined without
+   mentioning Jacobian, a particular backend, or the motivating problem.
+2. **It establishes one postcondition.** The result is one map, predicate,
+   invariant, construction, search result, witness, or certificate.
+3. **It is strategy-independent.** The result can participate in different
+   reasoning strategies and does not prescribe the next operation.
+4. **Further splitting loses semantic value.** Smaller pieces would mostly
+   expose algorithm state or cheap deterministic projections.
+
+Examples:
+
+| Candidate | Fit | Reason |
+| --- | --- | --- |
+| Smith normal form | Atomic | One canonical mathematical form. |
+| Polynomial factorization | Atomic | One standard mathematical decomposition. |
+| Maximum matching | Atomic | One optimization result with a reusable witness. |
+| Subgraph embedding | Atomic | One well-defined search relation and witness. |
+| Root isolation | Atomic | One mathematical result with explicit enclosure semantics. |
+| DFS frontier update | Too low-level | Exposes an implementation step. |
+| Extract the first matrix row | Usually too low-level | Cheap projection with little independent leverage. |
+| Solve a named conjecture | Too high-level | Encodes the motivating problem and strategy. |
+| Analyze a graph and choose the next theorem | Too high-level | Bundles conclusions with planning. |
+
+Algorithmic complexity is not the test. A sophisticated algorithm may implement
+one atomic operation, while a tiny helper may still be an implementation detail.
+
+## Discover vocabulary gaps from mathematical work
+
+Grow the vocabulary from observed composition failures rather than from a
+top-down inventory of mathematical fields or backend methods:
+
+```text
+real mathematical task
+  -> composition failure or bespoke-code escape
+  -> diagnose the kind of gap
+  -> identify the missing mathematical postcondition
+  -> test reuse or independent canonicality
+  -> consider a public operation
+```
+
+When an agent falls back to custom Python, SymPy, FLINT, NetworkX, Z3, or
+another system, ask what mathematical fact or object it needed rather than which
+helper function it called. Work backward from that result to the stable
+mathematical boundary.
+
+For example, bespoke enumeration of simple cycles of a fixed length may expose
+a need for a fixed-length-cycle witness. Inspection may reveal a deeper reusable
+relation such as finite subgraph embedding. The deeper abstraction is not
+automatically better: both may deserve distinct public operations only when they
+have distinct discovery intent and useful leverage.
+
+## Diagnose the gap before adding an operation
+
+Not every failed attempt reveals a missing operation.
+
+| Gap | Meaning | Typical response |
+| --- | --- | --- |
+| Representation | The mathematical object cannot be expressed cleanly. | Improve or add a typed value. |
+| Interoperability | Existing operations use incompatible mathematical representations. | Align types or add a domain-owned conversion. |
+| Discovery | The operation exists but `math.find` does not surface it. | Improve discovery metadata or examples. |
+| Contract | The operation exists but omits needed semantics, witnesses, or evidence. | Repair its request/result contract. |
+| Scale/backend | The operation exists but its implementation or bounds are inadequate. | Improve the bounded implementation or backend. |
+| Operation | No clean existing composition produces the required mathematical result. | Consider a new public operation. |
+| Reasoning | The necessary operations exist but the model does not find the strategy. | Improve reasoning or evaluation rather than the catalog. |
+
+Only a genuine operation gap normally motivates a new public operation.
+
+## What tends to be useful
+
+Useful operations usually turn substantial computation or mathematical
+subtlety into typed state that several later moves can consume. Common high-value
+shapes include:
+
+- canonical forms and normalizations;
+- decompositions and factorizations;
+- nontrivial invariants;
+- witness-producing searches;
+- complete or explicitly bounded enumeration;
+- structure-preserving transformations; and
+- certified symbolic or numerical computations with explicit guarantees.
+
+Strong candidate signals include repeated bespoke-code escapes, the same
+mathematical move recurring in unrelated problems, established concepts in
+mature libraries or formalizations, intermediate values that unlock several
+downstream compositions, and one narrow contract replacing substantial repeated
+custom code.
+
+A backend API is only a source of candidate ideas. Jacobian's public operation
+should be stated in mathematical terms and remain meaningful if its private
+implementation changes.
+
+## Admission and evaluation
+
+This page explains how candidates are discovered; the
+[public operation admission](../reference/public-operation-admission.md)
+contract decides whether a candidate belongs in the agent-visible catalog.
+Implementation correctness and boundedness are owned by the
+[domain operation library](../reference/domain-operation-library.md).
+
+A useful review heuristic is the deletion test: would the operation still
+clearly deserve to exist if the motivating benchmark, paper, or conjecture
+disappeared? When the answer is unclear, test the candidate on unrelated
+mathematical tasks and compare it with existing compositions. Useful evidence
+includes cross-problem reuse, fewer bespoke-code escapes, better typed handoffs,
+and reliable intermediate witnesses.
+
+No fixed operation count, domain-coverage target, or number of backend wrappers
+is a project goal. The vocabulary should grow only when mathematical work
+reveals a reusable move that is genuinely missing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,10 @@ caller composes the returned mathematical values.
 
 ## Start here
 
-- [Product model](explanation/product-blueprint.md) — what Jacobian is and why
-  operations are atomic and composable.
+- [Executable mathematical vocabulary](explanation/executable-mathematical-vocabulary.md) —
+  why operations are semantically atomic and how vocabulary gaps are discovered.
+- [Product model](explanation/product-blueprint.md) — caller/server ownership and
+  public contract boundaries.
 - [Architecture](explanation/architecture.md) — package structure and execution
   boundaries.
 - [Discover and invoke operations](how-to/invoke-domain-operations.md) — use

--- a/docs/reference/public-operation-admission.md
+++ b/docs/reference/public-operation-admission.md
@@ -18,7 +18,9 @@ public operations and shared mathematical values do not cleanly provide the
 required result, and why the proposed postcondition is independently canonical
 or reusable beyond the motivating workflow. A discovery, representation,
 interoperability, contract, backend, scale, or reasoning failure is not by
-itself evidence for a new public operation.
+itself evidence for a new public operation. See
+[Executable mathematical vocabulary](../explanation/executable-mathematical-vocabulary.md)
+for the semantic-atomicity test and gap-diagnosis methodology.
 
 ## Admission gates
 


### PR DESCRIPTION
## Problem

Jacobian now states that atomicity is semantic and that public operations should fill reusable gaps, but the documentation does not yet have one canonical explanation of how to recognize the semantic boundary, diagnose composition failures, or discover useful new operations. The docs index also points readers to the product blueprint for the “why,” even though that file primarily owns caller/server boundaries.

## Solution

- add `docs/explanation/executable-mathematical-vocabulary.md` as the single explanation owner for semantic atomicity and demand-driven vocabulary growth
- define a practical semantic-cut test and examples of too-low, right-level, and too-high abstractions
- document the representation/interoperability/discovery/contract/scale/operation/reasoning gap taxonomy
- describe how to extract candidate operations from real mathematical tasks and bespoke-code escapes
- identify common high-value operation shapes without turning backend APIs or domain coverage into a checklist
- route `docs/index.md`, the README, and public-operation admission to the explanation page without duplicating admission or implementation policy

## Documentation ownership

- vocabulary explanation: why atomicity works and how gaps are discovered
- public operation admission: whether a candidate belongs in the catalog
- domain operation library: boundedness, contract correctness, and implementation preflight
- product blueprint: caller/server ownership

## Testing

- compared the branch against current `main`: four intended documentation files changed
- documentation-only CI and link checks are left to the repository workflow

## Public contract impact

None. Documentation only.

## Related

#2073 tracks the separate cleanup to trim `AGENTS.md` to high-signal repository invariants; this PR intentionally does not perform that trim.