### PR TITLE
fix(boolean): compute Walsh spectrum from the Boolean sign function

### DIFF
--- a/src/jacobian/math/boolean/_tools.py
+++ b/src/jacobian/math/boolean/_tools.py
@@ -68,6 +68,7 @@ BOOLEAN_OPERATIONS = (
                 {"truth_table": [0, 1]},
             ),
         ),
+        version="2",
     ),
 )
 

--- a/tests/math/boolean/test_walsh_transform.py
+++ b/tests/math/boolean/test_walsh_transform.py
@@ -15,6 +15,18 @@ def _request(truth_table: list[int]) -> BooleanTruthTableRequest:
     return BooleanTruthTableRequest(truth_table=tuple(truth_table))
 
 
+def _character_sum_spectrum(truth_table: list[int]) -> tuple[int, ...]:
+    """Compute the Walsh spectrum directly from its defining character sum."""
+
+    return tuple(
+        sum(
+            (-1) ** (truth_table[x] + ((u & x).bit_count() & 1))
+            for x in range(len(truth_table))
+        )
+        for u in range(len(truth_table))
+    )
+
+
 def test_walsh_transform_of_constant_zero_on_one_bit() -> None:
     # f=[0,0] -> sign=[1,1] -> spectrum=[2,0]
     result = compute_walsh_hadamard_transform(_request([0, 0]))
@@ -94,13 +106,29 @@ def test_walsh_constant_one_spectrum() -> None:
 
 def test_walsh_affine_has_one_nonzero() -> None:
     """Affine functions have exactly one nonzero spectral coefficient of magnitude 2^n."""
-    # f(x) = x_0 (linear) on 2 variables: truth table [0,0,1,1] (index 0->0, 1->0, 2->1, 3->1)
-    # Actually for f(x) = x_0: f(0)=0, f(1)=0, f(2)=1, f(3)=1 in natural order where x=(x0,x1), index=x0+2*x1
-    # Wait, let's use f(x)=x0 on 1 variable: [0,1] -> sign=[1,-1] -> [0,2]
+    # Use f(x)=x_0 on one variable: [0,1] -> sign=[1,-1] -> [0,2].
     result = compute_walsh_hadamard_transform(_request([0, 1]))
     nonzero = [int(v) for v in result.spectrum if int(v) != 0]
     assert len(nonzero) == 1
     assert abs(nonzero[0]) == 2
+
+
+@pytest.mark.parametrize(
+    "truth_table",
+    (
+        [0],
+        [0, 1],
+        [1, 0, 1, 1],
+        [0, 1, 1, 0, 1, 0, 0, 1],
+    ),
+)
+def test_walsh_transform_agrees_with_direct_character_sum(
+    truth_table: list[int],
+) -> None:
+    result = compute_walsh_hadamard_transform(_request(truth_table))
+    assert tuple(int(value) for value in result.spectrum) == _character_sum_spectrum(
+        truth_table
+    )
 
 
 def test_walsh_transform_rejects_non_power_of_two_length() -> None:

--- a/tests/math/boolean/test_walsh_transform.py
+++ b/tests/math/boolean/test_walsh_transform.py
@@ -72,7 +72,7 @@ def test_walsh_complement_identity() -> None:
         r1 = compute_walsh_hadamard_transform(_request(truth))
         complement = [1 - b for b in truth]
         r2 = compute_walsh_hadamard_transform(_request(complement))
-        for v1, v2 in zip(r1.spectrum, r2.spectrum, strict=False):
+        for v1, v2 in zip(r1.spectrum, r2.spectrum, strict=True):
             assert int(v1) == -int(v2), f"Complement identity failed for {truth}"
 
 


### PR DESCRIPTION
Fix #2063: The Walsh-Hadamard transform was applied directly to the 0/1 truth table instead of the sign vector (-1)^f = 1 - 2f. This produced spectra that violated Parseval's identity and disagreed with the mathematical definition of the Boolean Walsh transform.

Changes:
- Map truth values to sign vectors (1 - 2f) before the FWHT
- Update result convention field to BOOLEAN_SIGN
- Add Parseval, complement-identity, constant-function, and affine-spectrum invariant tests
- Update operation description and examples to document the sign convention

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/c7d03893-59c8-4d80-b38e-3d94088f8a20)