### PR TITLE
fix(math): resolve remaining algebraic comparison and linear solve contract gaps

### DIFF
--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -177,6 +177,8 @@ class SquareIntegerMatrixRequest(StrictModel):
 
 
 class RationalLinearSolveRequest(StrictModel):
+    """A square rational system whose coefficient matrix is nonsingular."""
+
     matrix: RationalMatrix
     rhs: tuple[CanonicalRational, ...] = Field(
         min_length=1,
@@ -194,6 +196,16 @@ class RationalLinearSolveRequest(StrictModel):
         for value in self.rhs:
             _check_integer_digits(value.num)
             _check_integer_digits(value.den)
+        from sympy import Matrix, Rational
+
+        raw = Matrix(
+            [
+                [Rational(*value.as_integer_ratio()) for value in row]
+                for row in self.matrix.entries
+            ]
+        )
+        if raw.det() == 0:
+            raise ValueError("matrix is singular; unique solution does not exist")
         return self
 
 

--- a/src/jacobian/math/root_isolation/_models.py
+++ b/src/jacobian/math/root_isolation/_models.py
@@ -63,20 +63,14 @@ class AlgebraicNumberInput(StrictModel):
         x = symbols("x")
         polynomial = Poly(
             sum(
-                Rational(coefficient.num, coefficient.den)
+                Rational(*coefficient.as_integer_ratio())
                 * x ** (len(self.polynomial) - 1 - index)
                 for index, coefficient in enumerate(self.polynomial)
             ),
             x,
         )
-        lower = Rational(
-            self.isolating_interval_lower.num,
-            self.isolating_interval_lower.den,
-        )
-        upper = Rational(
-            self.isolating_interval_upper.num,
-            self.isolating_interval_upper.den,
-        )
+        lower = Rational(*self.isolating_interval_lower.as_integer_ratio())
+        upper = Rational(*self.isolating_interval_upper.as_integer_ratio())
         roots = {
             root
             for root in polynomial.all_roots()

--- a/tests/catalog/operation_schema_snapshots/matrices.json
+++ b/tests/catalog/operation_schema_snapshots/matrices.json
@@ -71,7 +71,7 @@
       "output_schema": "sha256:38e8dfeb665530af389e56988258c5efcf7089e55e476d6b5c277fe6c08957a8"
     },
     "matrix.rational_linear_system.solve": {
-      "input_schema": "sha256:9b80937cd45ba3845521f275a762565ccdf701954d9ff8e5ec0c1e8122b5f270",
+      "input_schema": "sha256:bdb3789f228378263dfc131d259e3c715df4345900b46c4fa02a3473c54c490b",
       "output_schema": "sha256:b0064eded4a3a9d3e9dfc573396b1abe8c7a04c87a6237d2da825d36fb94eee5"
     },
     "matrix.symbolic.characteristic_polynomial.compute": {

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -85,6 +85,34 @@ def test_algebraic_comparison_parses_canonical_interval_endpoints() -> None:
     assert result.order == "LT"
 
 
+def test_algebraic_comparison_accepts_coefficients_above_python_digit_limit() -> None:
+    oversized_coefficient = "1" + "0" * 5_000
+    result = compute_algebraic_compare(
+        AlgebraicCompareRequest.model_validate(
+            {
+                "left": {
+                    "polynomial": [
+                        {"num": oversized_coefficient, "den": "1"},
+                        {"num": "0", "den": "1"},
+                    ],
+                    "isolating_interval_lower": {"num": "-1", "den": "1"},
+                    "isolating_interval_upper": {"num": "1", "den": "1"},
+                },
+                "right": {
+                    "polynomial": [
+                        {"num": "1", "den": "1"},
+                        {"num": "0", "den": "1"},
+                    ],
+                    "isolating_interval_lower": {"num": "-1", "den": "1"},
+                    "isolating_interval_upper": {"num": "1", "den": "1"},
+                },
+            }
+        )
+    )
+
+    assert result.order == "EQ"
+
+
 def test_algebraic_comparison_contract_rejects_a_nonisolating_interval() -> None:
     with pytest.raises(ValidationError, match="exactly one real root"):
         AlgebraicCompareRequest.model_validate(

--- a/tests/math/matrices/test_linear_solve.py
+++ b/tests/math/matrices/test_linear_solve.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.models import MathTool
+from jacobian.math.matrices._operation_models import RationalLinearSolveResult
+from jacobian.math.matrices._tools import TOOLS
+
+
+def _operation() -> MathTool:
+    return next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id == "matrix.rational_linear_system.solve"
+    )
+
+
+def _request(rhs: tuple[str, str]) -> dict[str, object]:
+    def rational(value: str) -> dict[str, str]:
+        return {"num": value, "den": "1"}
+
+    return {
+        "matrix": {
+            "entries": [
+                [rational("1"), rational("1")],
+                [rational("1"), rational("1")],
+            ]
+        },
+        "rhs": [rational(value) for value in rhs],
+    }
+
+
+@pytest.mark.parametrize("rhs", [("0", "1"), ("1", "1")])
+def test_unique_linear_solve_rejects_singular_systems(
+    rhs: tuple[str, str],
+) -> None:
+    with pytest.raises(ValidationError, match="singular"):
+        _operation().request_type.model_validate(_request(rhs))
+
+
+def test_unique_linear_solve_returns_exact_solution() -> None:
+    operation = _operation()
+    request = operation.request_type.model_validate(
+        {
+            "matrix": {
+                "entries": [
+                    [
+                        {"num": "1", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    [
+                        {"num": "1", "den": "1"},
+                        {"num": "-1", "den": "1"},
+                    ],
+                ]
+            },
+            "rhs": [
+                {"num": "3", "den": "1"},
+                {"num": "1", "den": "1"},
+            ],
+        }
+    )
+
+    result = operation.run(request)
+
+    assert isinstance(result, RationalLinearSolveResult)
+    assert tuple(value.as_fraction() for value in result.solution) == (2, 1)


### PR DESCRIPTION
## Problem

Two verified math-operation gaps remain after the earlier audit fixes.

`algebraic_number.compare` accepts canonical rational components up to 32,768 digits, but its request validator passed decimal strings directly to SymPy. Python rejects integer-string conversion above 4,300 digits by default, so a valid 5,001-digit polynomial coefficient escaped as a host exception. This completes the remaining case identified in #1935.

`matrix.rational_linear_system.solve` advertises the unique solution of a square system but still accepted singular coefficient matrices. Both inconsistent and non-unique systems therefore failed during execution instead of at the request boundary.

Fixes #1940.

## Solution

Parse algebraic polynomial coefficients and interval endpoints through `CanonicalRational.as_integer_ratio()` before constructing SymPy rationals. This preserves the public canonical-scalar bound without relying on Python integer-string conversion.

Require the rational linear solve coefficient matrix to have a nonzero exact determinant after the existing shape and scalar-budget checks. Singular systems are now rejected by request validation, while nonsingular systems continue to return exact rational solutions.

## Testing

The regressions were first confirmed against the unchanged branch: the oversized algebraic request raised SymPy `TypeError`, and both singular linear systems validated successfully.

Final-tree validation:

- `make test-integration TESTS=tests/integration/algebra/test_exact_operations.py`
- `make test-math TESTS=tests/math/matrices/test_linear_solve.py`
- `make check`
- structured exact-diff review: no actionable findings

## Public contract impact

`algebraic_number.compare` now fulfills its existing canonical rational input contract for coefficients above Python’s default integer-string conversion limit.

`matrix.rational_linear_system.solve` narrows accepted requests to nonsingular square coefficient matrices, matching its documented unique-solution semantics. Its operation ID and result shape are unchanged; the request schema description and digest are updated.

## Public operation admission

Not applicable; no operation is added or materially expanded.

## Closure matrix

None.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant named validation is listed above
- [x] Harbor task or verifier validation is not applicable
- [x] Public operation admission is not applicable
- [x] Exact result semantics are preserved
- [x] No new shared abstraction is needed for these owner-local fixes