### PR TITLE
feat(markov-chain): add exact bounded mixing time

### DIFF
--- a/src/jacobian/math/markov_chain/__init__.py
+++ b/src/jacobian/math/markov_chain/__init__.py
@@ -1,13 +1,17 @@
 """Markov chain operations."""
 
 from jacobian.math.markov_chain.operations import (
+    MixingTimeSearchResult,
     ergodic_properties,
+    mixing_time,
     stationary_distribution,
     stationary_distribution_extremes,
 )
 
 __all__ = [
+    "MixingTimeSearchResult",
     "ergodic_properties",
+    "mixing_time",
     "stationary_distribution",
     "stationary_distribution_extremes",
 ]

--- a/src/jacobian/math/markov_chain/_admission.py
+++ b/src/jacobian/math/markov_chain/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.markov_chain._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "probability.markov_chain.mixing_time.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded invariant with an explicit incomplete search outcome",
+    ),
+    OperationAdmission(
         "probability.markov_chain.ergodic.decide",
         AdmissionDecision.KEEP,
         "distinct exact bounded predicate or candidate check with typed semantics",

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from math import factorial
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
@@ -111,3 +111,70 @@ class ErgodicDecisionResult(StrictModel):
     is_ergodic: bool
     is_irreducible: bool
     is_aperiodic: bool
+
+
+class MixingTimeRequest(TransitionMatrixRequest):
+    """A bounded exact search for worst-case total-variation mixing time."""
+
+    epsilon: CanonicalRational
+    max_steps: StrictInt = Field(default=64, ge=1, le=256)
+
+    @model_validator(mode="after")
+    def require_bounded_search(self) -> Self:
+        if len(self.matrix) > 8:
+            raise ValueError("mixing-time search supports at most 8 states")
+        if not 0 < self.epsilon.as_fraction() <= 1:
+            raise ValueError("epsilon must lie in (0, 1]")
+        for value in (self.epsilon, *(item for row in self.matrix for item in row)):
+            if max(len(value.num.lstrip("-")), len(value.den)) > 32:
+                raise ValueError(
+                    "mixing-time rational components support at most 32 digits"
+                )
+        return self
+
+
+class MixingTimeResult(StrictModel):
+    status: Literal["FOUND", "NOT_ERGODIC", "BOUND_EXCEEDED"]
+    epsilon: CanonicalRational
+    max_steps: StrictInt = Field(ge=1, le=256)
+    steps_examined: StrictInt = Field(ge=0, le=256)
+    mixing_time: StrictInt | None = Field(default=None, ge=0, le=256)
+    max_total_variation_distance: CanonicalRational | None = None
+    method: Literal["SYMPY_EXACT_MATRIX_POWERS"] = "SYMPY_EXACT_MATRIX_POWERS"
+
+    @model_validator(mode="after")
+    def bind_search_result(self) -> Self:
+        distance = (
+            None
+            if self.max_total_variation_distance is None
+            else self.max_total_variation_distance.as_fraction()
+        )
+        if distance is not None and not 0 <= distance <= 1:
+            raise ValueError("total-variation distance must lie in [0, 1]")
+        if self.status == "FOUND":
+            if (
+                self.mixing_time is None
+                or distance is None
+                or distance > self.epsilon.as_fraction()
+                or self.steps_examined != self.mixing_time
+            ):
+                raise ValueError(
+                    "a found result requires its first satisfactory step and distance"
+                )
+        elif self.status == "BOUND_EXCEEDED":
+            if (
+                self.mixing_time is not None
+                or distance is None
+                or distance <= self.epsilon.as_fraction()
+                or self.steps_examined != self.max_steps
+            ):
+                raise ValueError(
+                    "a bound-exceeded result requires the terminal unsatisfactory distance"
+                )
+        elif (
+            self.mixing_time is not None
+            or distance is not None
+            or self.steps_examined != 0
+        ):
+            raise ValueError("a non-ergodic result has no mixing-time search value")
+        return self

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -130,6 +130,23 @@ class MixingTimeRequest(TransitionMatrixRequest):
                 raise ValueError(
                     "mixing-time rational components support at most 32 digits"
                 )
+        matrix_digits = max(
+            max(len(value.num.lstrip("-")), len(value.den))
+            for row in self.matrix
+            for value in row
+        )
+        state_count = len(self.matrix)
+        # A common denominator for the transition matrix has at most n**2 * d
+        # digits. Exact powers contribute one such denominator per step, while
+        # Cramer's rule bounds the stationary denominator by n times that size.
+        rational_height_digits = matrix_digits * (
+            state_count**3 + self.max_steps * state_count**2
+        )
+        if rational_height_digits > MAX_CANONICAL_RATIONAL_DIGITS - 1_024:
+            raise ValueError(
+                "mixing-time matrix height and max_steps can exceed the exact "
+                "rational result bound"
+            )
         return self
 
 
@@ -137,7 +154,7 @@ class MixingTimeResult(StrictModel):
     status: Literal["FOUND", "NOT_ERGODIC", "BOUND_EXCEEDED"]
     epsilon: CanonicalRational
     max_steps: StrictInt = Field(ge=1, le=256)
-    steps_examined: StrictInt = Field(ge=0, le=256)
+    steps_examined: StrictInt = Field(ge=0, le=257)
     mixing_time: StrictInt | None = Field(default=None, ge=0, le=256)
     max_total_variation_distance: CanonicalRational | None = None
     method: Literal["SYMPY_EXACT_MATRIX_POWERS"] = "SYMPY_EXACT_MATRIX_POWERS"
@@ -156,7 +173,7 @@ class MixingTimeResult(StrictModel):
                 self.mixing_time is None
                 or distance is None
                 or distance > self.epsilon.as_fraction()
-                or self.steps_examined != self.mixing_time
+                or self.steps_examined != self.mixing_time + 1
             ):
                 raise ValueError(
                     "a found result requires its first satisfactory step and distance"
@@ -166,7 +183,7 @@ class MixingTimeResult(StrictModel):
                 self.mixing_time is not None
                 or distance is None
                 or distance <= self.epsilon.as_fraction()
-                or self.steps_examined != self.max_steps
+                or self.steps_examined != self.max_steps + 1
             ):
                 raise ValueError(
                     "a bound-exceeded result requires the terminal unsatisfactory distance"

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -2,17 +2,57 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
+
 from jacobian._exact import CanonicalRational
 from jacobian.math.markov_chain import (
     ergodic_properties,
+    mixing_time,
     stationary_distribution_extremes,
 )
 from jacobian.math.markov_chain._models import (
     ErgodicDecisionResult,
     ExtremeStationaryDistribution,
+    MixingTimeRequest,
+    MixingTimeResult,
     StationaryDistributionResult,
     TransitionMatrixRequest,
 )
+
+
+def compute_mixing_time(request: MixingTimeRequest) -> MixingTimeResult:
+    matrix = tuple(
+        tuple(value.as_fraction() for value in row) for row in request.matrix
+    )
+    irreducible, aperiodic = ergodic_properties(
+        [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
+    )  # type: ignore[no-untyped-call]
+    if not (irreducible and aperiodic):
+        return MixingTimeResult(
+            status="NOT_ERGODIC",
+            epsilon=request.epsilon,
+            max_steps=request.max_steps,
+            steps_examined=0,
+        )
+    extremes = stationary_distribution_extremes(
+        [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
+    )  # type: ignore[no-untyped-call]
+    stationary = tuple(Fraction(int(value.p), int(value.q)) for value in extremes[0][1])
+    outcome = mixing_time(
+        matrix, stationary, request.epsilon.as_fraction(), request.max_steps
+    )
+    distance = CanonicalRational.from_integer_ratio(
+        outcome.max_total_variation_distance.numerator,
+        outcome.max_total_variation_distance.denominator,
+    )
+    return MixingTimeResult(
+        status="FOUND" if outcome.mixing_time is not None else "BOUND_EXCEEDED",
+        epsilon=request.epsilon,
+        max_steps=request.max_steps,
+        steps_examined=outcome.steps_examined,
+        mixing_time=outcome.mixing_time,
+        max_total_variation_distance=distance,
+    )
 
 
 def compute_stationary_distribution(

--- a/src/jacobian/math/markov_chain/_tools.py
+++ b/src/jacobian/math/markov_chain/_tools.py
@@ -8,12 +8,15 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.markov_chain._models import (
     ErgodicDecisionResult,
+    MixingTimeRequest,
+    MixingTimeResult,
     StationaryDistributionRequest,
     StationaryDistributionResult,
     TransitionMatrixRequest,
 )
 from jacobian.math.markov_chain._operations import (
     compute_ergodic_decision,
+    compute_mixing_time,
     compute_stationary_distribution,
 )
 
@@ -43,6 +46,34 @@ def mc_operation[RequestT: StrictModel, ResultT: StrictModel](
 
 
 MARKOV_CHAIN_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    mc_operation(
+        "probability.markov_chain.mixing_time.compute",
+        "Compute an exact bounded Markov-chain mixing time",
+        "Search exact rational matrix powers for the first step whose worst-case total-variation distance is at most epsilon; the chain must have at most eight states.",
+        MixingTimeRequest,
+        MixingTimeResult,
+        compute_mixing_time,
+        "probability",
+        "markov-chain",
+        "mixing-time",
+        "total-variation",
+        "exact",
+        "bounded",
+        examples=(
+            example(
+                "two_state_chain",
+                "Compute the 1/100 mixing time of a two-state ergodic chain; max_steps bounds the exact search.",
+                {
+                    "matrix": [
+                        [{"num": "1", "den": "2"}, {"num": "1", "den": "2"}],
+                        [{"num": "1", "den": "4"}, {"num": "3", "den": "4"}],
+                    ],
+                    "epsilon": {"num": "1", "den": "100"},
+                    "max_steps": 8,
+                },
+            ),
+        ),
+    ),
     mc_operation(
         "probability.markov_chain.stationary_distribution.compute",
         "Compute the stationary-distribution family of a Markov chain",

--- a/src/jacobian/math/markov_chain/_tools.py
+++ b/src/jacobian/math/markov_chain/_tools.py
@@ -73,6 +73,7 @@ MARKOV_CHAIN_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     mc_operation(
         "probability.markov_chain.stationary_distribution.compute",

--- a/src/jacobian/math/markov_chain/operations.py
+++ b/src/jacobian/math/markov_chain/operations.py
@@ -50,10 +50,11 @@ def mixing_time(
         )
         distance = Fraction(int(terminal.p), int(terminal.q))
         if terminal <= threshold:
-            return MixingTimeSearchResult(step, step, distance)
-        power *= transition
+            return MixingTimeSearchResult(step, step + 1, distance)
+        if step < max_steps:
+            power *= transition
     return MixingTimeSearchResult(
-        None, max_steps, Fraction(int(terminal.p), int(terminal.q))
+        None, max_steps + 1, Fraction(int(terminal.p), int(terminal.q))
     )
 
 

--- a/src/jacobian/math/markov_chain/operations.py
+++ b/src/jacobian/math/markov_chain/operations.py
@@ -2,13 +2,59 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from fractions import Fraction
+
 from jacobian.canonical import parse_canonical_integer
 
 __all__ = [
+    "MixingTimeSearchResult",
     "ergodic_properties",
+    "mixing_time",
     "stationary_distribution",
     "stationary_distribution_extremes",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class MixingTimeSearchResult:
+    mixing_time: int | None
+    steps_examined: int
+    max_total_variation_distance: Fraction
+
+
+def mixing_time(
+    matrix: tuple[tuple[Fraction, ...], ...],
+    stationary: tuple[Fraction, ...],
+    epsilon: Fraction,
+    max_steps: int,
+) -> MixingTimeSearchResult:
+    """Return the first exact worst-case epsilon-mixing step within the bound."""
+    import sympy
+
+    transition = sympy.Matrix(
+        [[sympy.Rational(v.numerator, v.denominator) for v in row] for row in matrix]
+    )
+    target = tuple(sympy.Rational(v.numerator, v.denominator) for v in stationary)
+    threshold = sympy.Rational(epsilon.numerator, epsilon.denominator)
+    power = sympy.eye(len(matrix))
+    terminal = sympy.S.One
+    for step in range(max_steps + 1):
+        terminal = max(
+            sum(
+                abs(power[source, target_index] - target[target_index])
+                for target_index in range(len(matrix))
+            )
+            / 2
+            for source in range(len(matrix))
+        )
+        distance = Fraction(int(terminal.p), int(terminal.q))
+        if terminal <= threshold:
+            return MixingTimeSearchResult(step, step, distance)
+        power *= transition
+    return MixingTimeSearchResult(
+        None, max_steps, Fraction(int(terminal.p), int(terminal.q))
+    )
 
 
 def stationary_distribution_extremes(matrix):  # type: ignore[no-untyped-def]

--- a/tests/math/markov_chain/test_mixing_time.py
+++ b/tests/math/markov_chain/test_mixing_time.py
@@ -32,14 +32,18 @@ def test_exact_two_state_mixing_time_and_distance() -> None:
     assert result.mixing_time == 4
     assert result.max_total_variation_distance is not None
     assert result.max_total_variation_distance.as_fraction() == Fraction(1, 384)
+    assert result.steps_examined == 5
 
 
 def test_search_checks_time_zero_and_boundary_equality() -> None:
-    assert compute_mixing_time(_request(epsilon=(1, 1))).mixing_time == 0
+    time_zero = compute_mixing_time(_request(epsilon=(1, 1)))
+    assert time_zero.mixing_time == 0
+    assert time_zero.steps_examined == 1
     equality = compute_mixing_time(_request(epsilon=(1, 6)))
     assert equality.mixing_time == 1
     assert equality.max_total_variation_distance is not None
     assert equality.max_total_variation_distance.as_fraction() == Fraction(1, 6)
+    assert equality.steps_examined == 2
 
 
 def test_bound_exceeded_returns_terminal_exact_distance() -> None:
@@ -47,6 +51,16 @@ def test_bound_exceeded_returns_terminal_exact_distance() -> None:
     assert result.status == "BOUND_EXCEEDED"
     assert result.max_total_variation_distance is not None
     assert result.max_total_variation_distance.as_fraction() == Fraction(1, 96)
+    assert result.steps_examined == 4
+
+
+def test_found_mixing_time_is_the_first_satisfactory_step() -> None:
+    result = compute_mixing_time(_request())
+    assert result.mixing_time is not None and result.mixing_time > 0
+    previous = compute_mixing_time(_request(max_steps=result.mixing_time - 1))
+    assert previous.status == "BOUND_EXCEEDED"
+    assert previous.max_total_variation_distance is not None
+    assert previous.max_total_variation_distance.as_fraction() > Fraction(1, 100)
 
 
 @pytest.mark.parametrize(
@@ -74,3 +88,22 @@ def test_search_bounds_reject_before_exact_matrix_powers() -> None:
         )
     with pytest.raises(ValidationError, match=r"\(0, 1\]"):
         _request(epsilon=(0, 1))
+
+
+def test_search_rejects_a_rational_height_that_cannot_fit_the_result() -> None:
+    denominator = 10**31
+    matrix = [
+        [
+            _r(denominator - 1, denominator)
+            if row == column
+            else _r(1, denominator)
+            if column == (row + 1) % 8
+            else _r(0)
+            for column in range(8)
+        ]
+        for row in range(8)
+    ]
+    with pytest.raises(ValidationError, match="exact rational result bound"):
+        MixingTimeRequest.model_validate(
+            {"matrix": matrix, "epsilon": _r(1, 10), "max_steps": 256}
+        )

--- a/tests/math/markov_chain/test_mixing_time.py
+++ b/tests/math/markov_chain/test_mixing_time.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.markov_chain._models import MixingTimeRequest
+from jacobian.math.markov_chain._operations import compute_mixing_time
+
+
+def _r(num: int, den: int = 1) -> dict[str, str]:
+    return {"num": str(num), "den": str(den)}
+
+
+def _request(
+    *, epsilon: tuple[int, int] = (1, 100), max_steps: int = 8
+) -> MixingTimeRequest:
+    return MixingTimeRequest.model_validate(
+        {
+            "matrix": [[_r(1, 2), _r(1, 2)], [_r(1, 4), _r(3, 4)]],
+            "epsilon": _r(*epsilon),
+            "max_steps": max_steps,
+        }
+    )
+
+
+def test_exact_two_state_mixing_time_and_distance() -> None:
+    result = compute_mixing_time(_request())
+
+    assert result.status == "FOUND"
+    assert result.mixing_time == 4
+    assert result.max_total_variation_distance is not None
+    assert result.max_total_variation_distance.as_fraction() == Fraction(1, 384)
+
+
+def test_search_checks_time_zero_and_boundary_equality() -> None:
+    assert compute_mixing_time(_request(epsilon=(1, 1))).mixing_time == 0
+    equality = compute_mixing_time(_request(epsilon=(1, 6)))
+    assert equality.mixing_time == 1
+    assert equality.max_total_variation_distance is not None
+    assert equality.max_total_variation_distance.as_fraction() == Fraction(1, 6)
+
+
+def test_bound_exceeded_returns_terminal_exact_distance() -> None:
+    result = compute_mixing_time(_request(max_steps=3))
+    assert result.status == "BOUND_EXCEEDED"
+    assert result.max_total_variation_distance is not None
+    assert result.max_total_variation_distance.as_fraction() == Fraction(1, 96)
+
+
+@pytest.mark.parametrize(
+    "matrix", [[[_r(0), _r(1)], [_r(1), _r(0)]], [[_r(1), _r(0)], [_r(0), _r(1)]]]
+)
+def test_nonergodic_chains_return_typed_outcome(
+    matrix: list[list[dict[str, str]]],
+) -> None:
+    request = MixingTimeRequest.model_validate(
+        {"matrix": matrix, "epsilon": _r(1, 10), "max_steps": 4}
+    )
+    assert compute_mixing_time(request).status == "NOT_ERGODIC"
+
+
+def test_search_bounds_reject_before_exact_matrix_powers() -> None:
+    with pytest.raises(ValidationError, match="at most 8 states"):
+        MixingTimeRequest.model_validate(
+            {
+                "matrix": [
+                    [_r(1 if i == j else 0) for j in range(9)] for i in range(9)
+                ],
+                "epsilon": _r(1, 10),
+                "max_steps": 4,
+            }
+        )
+    with pytest.raises(ValidationError, match=r"\(0, 1\]"):
+        _request(epsilon=(0, 1))


### PR DESCRIPTION
Fixes #1674.

## Problem

Jacobian already computes exact stationary-distribution families and decides ergodicity, but the remaining issue delta - mixing time - has no atomic operation. Numerical simulation would weaken the requested exact total-variation semantics.

## Solution

Add `probability.markov_chain.mixing_time.compute`. For an ergodic rational chain, the operation computes the exact stationary distribution and searches successive exact SymPy matrix powers for the first step whose worst-case total-variation distance is at most epsilon.

The request bounds the chain to eight states, rational components to 32 digits, and the search to 256 steps. Results distinguish `FOUND`, `BOUND_EXCEEDED`, and `NOT_ERGODIC`, preserving the exact terminal distance for bounded searches.

## Testing

- Known two-state chain with mixing time 4 and exact distance 1/384
- Time-zero and threshold-equality boundaries
- Bound exhaustion with exact terminal distance 1/96
- Periodic and reducible typed outcomes
- Dimension and epsilon preflight rejection
- `make check` - Ruff, formatting, complexity, mypy, and 1,451 tests passed

## Public contract impact

Adds `probability.markov_chain.mixing_time.compute` version 1, a typed native exact-search function, and the Markov-chain schema snapshot. Existing stationary-distribution and ergodicity contracts are unchanged.

## Public operation admission

KEEP: exact bounded mixing time is a distinct Markov-chain invariant with an explicit incomplete search outcome.

## Closure matrix

- Exact stationary distribution: already present on main
- Exact ergodicity decision: already present on main
- Exact bounded mixing time: complete in this PR
- Typed non-ergodic and bound-exceeded outcomes: complete

## Checklist

- [x] Focused operation, tests, admission decision, executable example, native API, and schema snapshot
- [x] No simulation, verifier framework, persistence, or workflow surface added