### PR TITLE
fix(math): validate exact rational growth before execution

### DIFF
--- a/src/jacobian/math/_rational_height.py
+++ b/src/jacobian/math/_rational_height.py
@@ -1,0 +1,59 @@
+"""Conservative decimal-height propagation for bounded exact rational arithmetic."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from jacobian._exact import CanonicalRational
+
+
+@dataclass(frozen=True)
+class RationalHeight:
+    """Upper bounds for reduced numerator and denominator decimal digits."""
+
+    numerator_digits: int
+    denominator_digits: int
+
+    @classmethod
+    def from_canonical(cls, value: CanonicalRational) -> RationalHeight:
+        return cls(len(value.num.lstrip("-")), len(value.den))
+
+    def product(self, other: RationalHeight) -> RationalHeight:
+        return RationalHeight(
+            self.numerator_digits + other.numerator_digits,
+            self.denominator_digits + other.denominator_digits,
+        )
+
+    def quotient(self, other: RationalHeight) -> RationalHeight:
+        return RationalHeight(
+            self.numerator_digits + other.denominator_digits,
+            self.denominator_digits + other.numerator_digits,
+        )
+
+    def exceeds(self, max_digits: int) -> bool:
+        return (
+            self.numerator_digits > max_digits or self.denominator_digits > max_digits
+        )
+
+
+def sum_heights(values: Iterable[RationalHeight]) -> RationalHeight:
+    """Bound a rational sum using a product common denominator.
+
+    Reduction can only decrease either component.  For ``m`` summands, the
+    product denominator has at most the sum of denominator digit bounds.  Each
+    lifted numerator has its own numerator bound plus every other denominator
+    bound, and adding ``m`` such integers costs at most ``digits(m)`` more.
+    """
+    items = tuple(values)
+    if not items:
+        return RationalHeight(1, 1)
+    denominator_digits = sum(item.denominator_digits for item in items)
+    numerator_digits = max(
+        item.numerator_digits + denominator_digits - item.denominator_digits
+        for item in items
+    ) + len(str(len(items)))
+    return RationalHeight(numerator_digits, denominator_digits)
+
+
+__all__ = ["RationalHeight", "sum_heights"]

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -9,6 +9,7 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math._rational_height import RationalHeight, sum_heights
 
 MAX_COEFFICIENT_DIGITS = 128
 MAX_DEGREE = 30
@@ -19,6 +20,130 @@ MAX_ORBIT_STEPS = 1_000
 MAX_ORBIT_VALUE_DIGITS = 2_048
 MAX_POLYNOMIAL_OUTPUT_DIGITS = 32_768
 MAX_FIELD_PRIME = 10_000
+
+CoefficientHeight = RationalHeight | None
+
+
+def _fraction_height(value: Fraction) -> CoefficientHeight:
+    if value == 0:
+        return None
+    return RationalHeight(len(str(abs(value.numerator))), len(str(value.denominator)))
+
+
+def _add_heights(
+    left: CoefficientHeight, right: CoefficientHeight
+) -> CoefficientHeight:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return sum_heights((left, right))
+
+
+def _multiply_height_polynomials(
+    left: tuple[CoefficientHeight, ...], right: tuple[CoefficientHeight, ...]
+) -> tuple[CoefficientHeight, ...]:
+    result: list[CoefficientHeight] = [None] * (len(left) + len(right) - 1)
+    for left_index, left_height in enumerate(left):
+        if left_height is None:
+            continue
+        for right_index, right_height in enumerate(right):
+            if right_height is None:
+                continue
+            index = left_index + right_index
+            result[index] = _add_heights(
+                result[index], left_height.product(right_height)
+            )
+    return _trim_heights(tuple(result))
+
+
+def _compose_height_polynomials(
+    outer: tuple[CoefficientHeight, ...], inner: tuple[CoefficientHeight, ...]
+) -> tuple[CoefficientHeight, ...]:
+    result: tuple[CoefficientHeight, ...] = (None,)
+    for coefficient in reversed(outer):
+        result = _multiply_height_polynomials(result, inner)
+        result = (_add_heights(result[0], coefficient), *result[1:])
+    return result
+
+
+def _require_polynomial_height(
+    coefficients: tuple[CoefficientHeight, ...], operation: str
+) -> None:
+    if any(
+        height is not None and height.exceeds(MAX_POLYNOMIAL_OUTPUT_DIGITS)
+        for height in coefficients
+    ):
+        raise ValueError(
+            f"{operation} coefficient growth exceeds the "
+            f"{MAX_POLYNOMIAL_OUTPUT_DIGITS}-digit output bound"
+        )
+
+
+def _iterate_heights(
+    source: tuple[CoefficientHeight, ...], count: int
+) -> tuple[CoefficientHeight, ...]:
+    result: tuple[CoefficientHeight, ...] = (None, RationalHeight(1, 1))
+    for _ in range(count):
+        result = _compose_height_polynomials(source, result)
+        _require_polynomial_height(result, "iterate")
+    return result
+
+
+def _trim_heights(
+    coefficients: tuple[CoefficientHeight, ...],
+) -> tuple[CoefficientHeight, ...]:
+    end = len(coefficients)
+    while end > 1 and coefficients[end - 1] is None:
+        end -= 1
+    return coefficients[:end]
+
+
+def _divide_height_polynomials(
+    numerator: tuple[CoefficientHeight, ...],
+    denominator: tuple[CoefficientHeight, ...],
+) -> tuple[CoefficientHeight, ...]:
+    remainder = list(_trim_heights(numerator))
+    divisor = _trim_heights(denominator)
+    divisor_degree = len(divisor) - 1
+    divisor_lead = divisor[-1]
+    if divisor_lead is None:
+        raise RuntimeError("height preflight received a zero polynomial divisor")
+    quotient: list[CoefficientHeight] = [None] * max(1, len(remainder) - divisor_degree)
+    while len(remainder) - 1 >= divisor_degree and remainder[-1] is not None:
+        offset = len(remainder) - 1 - divisor_degree
+        coefficient = remainder[-1].quotient(divisor_lead)
+        quotient[offset] = coefficient
+        _require_polynomial_height((coefficient,), "dynatomic quotient")
+        for index, divisor_height in enumerate(divisor):
+            if divisor_height is None:
+                continue
+            target = offset + index
+            remainder[target] = _add_heights(
+                remainder[target], coefficient.product(divisor_height)
+            )
+        remainder[-1] = None  # exact leading-term cancellation
+        remainder = list(_trim_heights(tuple(remainder)))
+        _require_polynomial_height(tuple(remainder), "dynatomic division")
+    return _trim_heights(tuple(quotient))
+
+
+def _mobius(value: int) -> int:
+    factors = 0
+    candidate = 2
+    remaining = value
+    while candidate * candidate <= remaining:
+        if remaining % candidate == 0:
+            remaining //= candidate
+            factors += 1
+            if remaining % candidate == 0:
+                return 0
+            while remaining % candidate == 0:
+                remaining //= candidate
+        candidate += 1
+    if remaining > 1:
+        factors += 1
+    return -1 if factors % 2 else 1
 
 
 def parse_canonical_rational(value: str, *, label: str) -> Fraction:
@@ -74,6 +199,8 @@ class MapIterateRequest(PolynomialCoefficientRequest):
         output_degree = 1 if self.n == 0 else degree**self.n
         if output_degree > MAX_ITERATE_DEGREE:
             raise ValueError("iterate output degree exceeds bound")
+        source = tuple(_fraction_height(value) for value in self.coefficient_values())
+        _iterate_heights(source, self.n)
         return self
 
 
@@ -101,6 +228,25 @@ class DynatomicPolynomialRequest(PolynomialCoefficientRequest):
             raise ValueError("dynatomic polynomial requires map degree at least two")
         if degree**self.n > MAX_DYNATOMIC_DEGREE:
             raise ValueError("dynatomic output degree exceeds bound")
+        source = tuple(_fraction_height(value) for value in self.coefficient_values())
+        numerator: tuple[CoefficientHeight, ...] = (RationalHeight(1, 1),)
+        denominator: tuple[CoefficientHeight, ...] = (RationalHeight(1, 1),)
+        for divisor in range(1, self.n + 1):
+            if self.n % divisor != 0:
+                continue
+            term = list(_iterate_heights(source, divisor))
+            if len(term) < 2:
+                term.extend([None] * (2 - len(term)))
+            term[1] = _add_heights(term[1], RationalHeight(1, 1))
+            mobius = _mobius(self.n // divisor)
+            if mobius == 1:
+                numerator = _multiply_height_polynomials(numerator, tuple(term))
+                _require_polynomial_height(numerator, "dynatomic numerator")
+            elif mobius == -1:
+                denominator = _multiply_height_polynomials(denominator, tuple(term))
+                _require_polynomial_height(denominator, "dynatomic denominator")
+        quotient = _divide_height_polynomials(numerator, denominator)
+        _require_polynomial_height(quotient, "dynatomic quotient")
         return self
 
 

--- a/src/jacobian/math/arithmetic_functions/_models.py
+++ b/src/jacobian/math/arithmetic_functions/_models.py
@@ -6,12 +6,38 @@ from typing import Literal, Self
 
 from pydantic import model_validator
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math._rational_height import RationalHeight, sum_heights
 
 # Bounds shared by every arithmetic-function operation.
 _MIN_LENGTH = 1
 _MAX_LENGTH = 10_000
+
+
+def _heights(values: tuple[CanonicalRational, ...]) -> tuple[RationalHeight, ...]:
+    return tuple(RationalHeight.from_canonical(value) for value in values)
+
+
+def _divisors(value: int) -> tuple[int, ...]:
+    small: list[int] = []
+    large: list[int] = []
+    candidate = 1
+    while candidate * candidate <= value:
+        if value % candidate == 0:
+            small.append(candidate)
+            if candidate != value // candidate:
+                large.append(value // candidate)
+        candidate += 1
+    return (*small, *reversed(large))
+
+
+def _require_result_height(height: RationalHeight, operation: str) -> None:
+    if height.exceeds(MAX_CANONICAL_RATIONAL_DIGITS):
+        raise ValueError(
+            f"{operation} rational height exceeds the "
+            f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit result bound"
+        )
 
 
 class DirichletConvolutionRequest(StrictModel):
@@ -35,6 +61,18 @@ class DirichletConvolutionRequest(StrictModel):
             raise ValueError("f and g must have the same length")
         return self
 
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        left = _heights(self.f)
+        right = _heights(self.g)
+        for index in range(1, len(left) + 1):
+            terms = (
+                left[divisor - 1].product(right[index // divisor - 1])
+                for divisor in _divisors(index)
+            )
+            _require_result_height(sum_heights(terms), "Dirichlet convolution")
+        return self
+
 
 class DirichletConvolutionResult(StrictModel):
     """Result: the Dirichlet convolution ``(f*g)(1)..(f*g)(n)``."""
@@ -44,6 +82,12 @@ class DirichletConvolutionResult(StrictModel):
     convention: Literal["JACOBIAN_DIRICHLET_CONVOLUTION"] = (
         "JACOBIAN_DIRICHLET_CONVOLUTION"
     )
+
+    @model_validator(mode="after")
+    def bind_length(self) -> Self:
+        if self.length != len(self.values):
+            raise ValueError("length must match the number of values")
+        return self
 
 
 class MobiusTransformRequest(StrictModel):
@@ -66,6 +110,14 @@ class MobiusTransformRequest(StrictModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        heights = _heights(self.values)
+        for index in range(1, len(heights) + 1):
+            terms = (heights[index // divisor - 1] for divisor in _divisors(index))
+            _require_result_height(sum_heights(terms), "Möbius transform")
+        return self
+
 
 class MobiusTransformResult(StrictModel):
     """Result: the (inverse) Möbius transform at indices 1..n."""
@@ -74,6 +126,12 @@ class MobiusTransformResult(StrictModel):
     length: int
     inverse: bool
     convention: Literal["JACOBIAN_MOBIUS_TRANSFORM"] = "JACOBIAN_MOBIUS_TRANSFORM"
+
+    @model_validator(mode="after")
+    def bind_length(self) -> Self:
+        if self.length != len(self.values):
+            raise ValueError("length must match the number of values")
+        return self
 
 
 class SummatoryFunctionRequest(StrictModel):
@@ -89,6 +147,11 @@ class SummatoryFunctionRequest(StrictModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        _require_result_height(sum_heights(_heights(self.values)), "summatory function")
+        return self
+
 
 class SummatoryFunctionResult(StrictModel):
     """Result: the partial sums ``S(1)..S(n)``."""
@@ -96,6 +159,12 @@ class SummatoryFunctionResult(StrictModel):
     values: tuple[CanonicalRational, ...]
     length: int
     convention: Literal["JACOBIAN_SUMMATORY_FUNCTION"] = "JACOBIAN_SUMMATORY_FUNCTION"
+
+    @model_validator(mode="after")
+    def bind_length(self) -> Self:
+        if self.length != len(self.values):
+            raise ValueError("length must match the number of values")
+        return self
 
 
 class DirichletInverseRequest(StrictModel):
@@ -116,6 +185,22 @@ class DirichletInverseRequest(StrictModel):
             raise ValueError("f(1) must be nonzero")
         return self
 
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        source = _heights(self.values)
+        inverse = [RationalHeight(1, 1).quotient(source[0])]
+        _require_result_height(inverse[0], "Dirichlet inverse")
+        for index in range(2, len(source) + 1):
+            terms = (
+                source[divisor - 1].product(inverse[index // divisor - 1])
+                for divisor in _divisors(index)
+                if divisor > 1
+            )
+            height = sum_heights(terms).quotient(source[0])
+            _require_result_height(height, "Dirichlet inverse")
+            inverse.append(height)
+        return self
+
 
 class DirichletInverseResult(StrictModel):
     """Result: the Dirichlet inverse at indices 1..n."""
@@ -123,6 +208,12 @@ class DirichletInverseResult(StrictModel):
     values: tuple[CanonicalRational, ...]
     length: int
     convention: Literal["JACOBIAN_DIRICHLET_INVERSE"] = "JACOBIAN_DIRICHLET_INVERSE"
+
+    @model_validator(mode="after")
+    def bind_length(self) -> Self:
+        if self.length != len(self.values):
+            raise ValueError("length must match the number of values")
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/formal_power_series/_models.py
+++ b/src/jacobian/math/formal_power_series/_models.py
@@ -20,9 +20,89 @@ MAX_RESULT_RATIONAL_DIGITS = 4_096
 MAX_RESULT_BYTES = 10 * 1024 * 1024
 MAX_POWER_EXPONENT = 1_000
 
+CoefficientHeight = RationalHeight | None
+
 
 def _height(value: CanonicalRational) -> RationalHeight:
     return RationalHeight.from_canonical(value)
+
+
+def _coefficient_height(value: CanonicalRational) -> CoefficientHeight:
+    return None if value.num == "0" else _height(value)
+
+
+def _add_height(left: CoefficientHeight, right: CoefficientHeight) -> CoefficientHeight:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return sum_heights((left, right))
+
+
+def _height_vector(
+    coefficients: tuple[CanonicalRational, ...],
+) -> tuple[CoefficientHeight, ...]:
+    return tuple(_coefficient_height(value) for value in coefficients)
+
+
+def _require_height_vector(
+    coefficients: tuple[CoefficientHeight, ...], operation: str
+) -> None:
+    if any(
+        height is not None and height.exceeds(MAX_RESULT_RATIONAL_DIGITS)
+        for height in coefficients
+    ):
+        raise ValueError(
+            f"{operation} coefficient growth exceeds the "
+            f"{MAX_RESULT_RATIONAL_DIGITS}-digit result bound"
+        )
+
+
+def _convolve_height_vectors(
+    left: tuple[CoefficientHeight, ...],
+    right: tuple[CoefficientHeight, ...],
+    order: int,
+    operation: str,
+) -> tuple[CoefficientHeight, ...]:
+    result: list[CoefficientHeight] = []
+    for degree in range(order):
+        terms: list[RationalHeight] = []
+        for index in range(degree + 1):
+            if index >= len(left) or degree - index >= len(right):
+                continue
+            left_height = left[index]
+            right_height = right[degree - index]
+            if left_height is not None and right_height is not None:
+                terms.append(left_height.product(right_height))
+        result.append(sum_heights(terms) if terms else None)
+    coefficients = tuple(result)
+    _require_height_vector(coefficients, operation)
+    return coefficients
+
+
+def _composition_height_vector(
+    outer: tuple[CoefficientHeight, ...],
+    inner: tuple[CoefficientHeight, ...],
+    order: int,
+    operation: str,
+) -> tuple[CoefficientHeight, ...]:
+    powers: tuple[CoefficientHeight, ...] = (
+        RationalHeight(1, 1),
+        *([None] * (order - 1)),
+    )
+    result: list[CoefficientHeight] = [None] * order
+    for outer_degree in range(order):
+        coefficient = outer[outer_degree]
+        if coefficient is not None:
+            for degree, power in enumerate(powers):
+                if power is not None:
+                    result[degree] = _add_height(
+                        result[degree], coefficient.product(power)
+                    )
+            _require_height_vector(tuple(result), operation)
+        if outer_degree + 1 < order:
+            powers = _convolve_height_vectors(powers, inner, order, operation)
+    return tuple(result)
 
 
 def _max_height(values: tuple[CanonicalRational, ...]) -> RationalHeight:
@@ -383,9 +463,12 @@ class SeriesComposeRequest(StrictModel):
             raise ValueError(
                 "inner series must have zero constant term for composition with a finite prefix"
             )
-        outer = _max_height(self.outer.coefficients)
-        inner = _max_height(self.inner.coefficients)
-        _composition_height(outer, inner, self.outer.truncation_order, "composition")
+        _composition_height_vector(
+            _height_vector(self.outer.coefficients),
+            _height_vector(self.inner.coefficients),
+            self.outer.truncation_order,
+            "composition",
+        )
         return self
 
 
@@ -418,22 +501,34 @@ class SeriesReversionRequest(StrictModel):
             raise ValueError("reversion requires zero constant term")
         if series.coefficients[1].as_fraction() == 0:
             raise ValueError("reversion requires nonzero linear coefficient")
-        source = _max_height(series.coefficients)
+        source = _height_vector(series.coefficients)
         linear = _height(series.coefficients[1])
-        result = RationalHeight(1, 1).quotient(linear)
-        _require_height(result, "reversion")
+        result: list[CoefficientHeight] = [
+            None,
+            RationalHeight(1, 1).quotient(linear),
+        ]
+        _require_height_vector(tuple(result), "reversion")
         for degree in range(2, self.truncation_order):
-            powers: list[RationalHeight] = []
-            power = result
-            for _ in range(2, degree + 1):
-                power = _convolution_height(power, result, degree + 1)
-                powers.append(power)
-            known = sum_heights(source.product(power) for power in powers)
+            padded = (*result, None)
+            power = padded
+            terms: list[RationalHeight] = []
+            for source_degree in range(2, degree + 1):
+                power = _convolve_height_vectors(power, padded, degree + 1, "reversion")
+                source_height = source[source_degree]
+                power_height = power[degree]
+                if source_height is not None and power_height is not None:
+                    terms.append(source_height.product(power_height))
+            known = sum_heights(terms)
             coefficient = known.quotient(linear)
             _require_height(coefficient, "reversion")
-            result = _merge_max(result, coefficient)
-        _composition_height(source, result, self.truncation_order, "reversion residual")
-        _composition_height(result, source, self.truncation_order, "reversion residual")
+            result.append(coefficient)
+        result_vector = tuple(result)
+        _composition_height_vector(
+            source, result_vector, self.truncation_order, "reversion residual"
+        )
+        _composition_height_vector(
+            result_vector, source, self.truncation_order, "reversion residual"
+        )
         return self
 
     def as_series(self) -> InputTruncatedSeries:

--- a/src/jacobian/math/formal_power_series/_models.py
+++ b/src/jacobian/math/formal_power_series/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, StrictInt, StringConstraints, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math._rational_height import RationalHeight, sum_heights
 
 # ---------------------------------------------------------------------------
 # Public bounds
@@ -18,6 +19,67 @@ MAX_RATIONAL_DIGITS = 256
 MAX_RESULT_RATIONAL_DIGITS = 4_096
 MAX_RESULT_BYTES = 10 * 1024 * 1024
 MAX_POWER_EXPONENT = 1_000
+
+
+def _height(value: CanonicalRational) -> RationalHeight:
+    return RationalHeight.from_canonical(value)
+
+
+def _max_height(values: tuple[CanonicalRational, ...]) -> RationalHeight:
+    heights = tuple(_height(value) for value in values)
+    return RationalHeight(
+        max(value.numerator_digits for value in heights),
+        max(value.denominator_digits for value in heights),
+    )
+
+
+def _merge_max(left: RationalHeight, right: RationalHeight) -> RationalHeight:
+    return RationalHeight(
+        max(left.numerator_digits, right.numerator_digits),
+        max(left.denominator_digits, right.denominator_digits),
+    )
+
+
+def _convolution_height(
+    left: RationalHeight, right: RationalHeight, term_count: int
+) -> RationalHeight:
+    term = left.product(right)
+    return sum_heights(term for _ in range(term_count))
+
+
+def _require_height(height: RationalHeight, operation: str) -> None:
+    if height.exceeds(MAX_RESULT_RATIONAL_DIGITS):
+        raise ValueError(
+            f"{operation} coefficient growth exceeds the "
+            f"{MAX_RESULT_RATIONAL_DIGITS}-digit result bound"
+        )
+
+
+def _inverse_height(series: InputTruncatedSeries) -> RationalHeight:
+    source = _max_height(series.coefficients)
+    reciprocal = RationalHeight(1, 1).quotient(_height(series.coefficients[0]))
+    _require_height(reciprocal, "inverse")
+    result = reciprocal
+    for degree in range(1, series.truncation_order):
+        recurrence_sum = sum_heights(source.product(result) for _ in range(degree))
+        coefficient = reciprocal.product(recurrence_sum)
+        _require_height(coefficient, "inverse")
+        result = _merge_max(result, coefficient)
+    return result
+
+
+def _composition_height(
+    outer: RationalHeight, inner: RationalHeight, order: int, operation: str
+) -> RationalHeight:
+    power = RationalHeight(1, 1)
+    result = outer.product(power)
+    for _ in range(1, order):
+        power = _convolution_height(power, inner, order)
+        _require_height(power, operation)
+        result = sum_heights((result, outer.product(power)))
+        _require_height(result, operation)
+    return result
+
 
 Variable = Annotated[
     str,
@@ -101,6 +163,32 @@ class _SeriesPairRequest(StrictModel):
         return self
 
 
+class _SeriesAddSubtractRequest(_SeriesPairRequest):
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        for left, right in zip(
+            self.left.coefficients, self.right.coefficients, strict=True
+        ):
+            _require_height(sum_heights((_height(left), _height(right))), "sum")
+        return self
+
+
+class _SeriesMultiplyRequest(_SeriesPairRequest):
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        left = _max_height(self.left.coefficients)
+        right = _max_height(self.right.coefficients)
+        _require_height(
+            _convolution_height(left, right, self.left.truncation_order),
+            "multiplication",
+        )
+        return self
+
+
+class _SeriesIdentityCheckRequest(_SeriesMultiplyRequest):
+    pass
+
+
 class SeriesDivideRequest(_SeriesPairRequest):
     """Divide two series when the denominator is a unit."""
 
@@ -108,6 +196,26 @@ class SeriesDivideRequest(_SeriesPairRequest):
     def require_unit_denominator(self) -> Self:
         if self.right.coefficients[0].as_fraction() == 0:
             raise ValueError("denominator must have a nonzero constant term")
+        return self
+
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        inverse = _inverse_height(self.right)
+        quotient = _convolution_height(
+            _max_height(self.left.coefficients),
+            inverse,
+            self.left.truncation_order,
+        )
+        _require_height(quotient, "division")
+        residual = _convolution_height(
+            _max_height(self.right.coefficients),
+            quotient,
+            self.left.truncation_order,
+        )
+        _require_height(
+            sum_heights((residual, _max_height(self.left.coefficients))),
+            "division residual",
+        )
         return self
 
 
@@ -135,6 +243,14 @@ class SeriesScalarMultiplyRequest(StrictModel):
     series: InputTruncatedSeries
     scalar: CanonicalRational
 
+    @model_validator(mode="after")
+    def require_bounded_result_height(self) -> Self:
+        _require_height(
+            _max_height(self.series.coefficients).product(_height(self.scalar)),
+            "scalar multiplication",
+        )
+        return self
+
 
 class SeriesScalarMultiplyResult(StrictModel):
     result: TruncatedSeries
@@ -152,14 +268,18 @@ class SeriesPowerRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_result_digit_budget(self) -> Self:
-        if self.exponent == 0:
-            return self
-        for coefficient in self.series.coefficients:
-            digits = max(len(coefficient.num.lstrip("-")), len(coefficient.den))
-            if digits * self.exponent > MAX_RESULT_RATIONAL_DIGITS:
-                raise ValueError(
-                    "power would exceed the 4096-digit result coefficient bound"
-                )
+        order = self.series.truncation_order
+        result = RationalHeight(1, 1)
+        base = _max_height(self.series.coefficients)
+        exponent = self.exponent
+        while exponent > 0:
+            if exponent & 1:
+                result = _convolution_height(result, base, order)
+                _require_height(result, "power")
+            exponent >>= 1
+            if exponent:
+                base = _convolution_height(base, base, order)
+                _require_height(base, "power")
         return self
 
 
@@ -200,21 +320,11 @@ class SeriesInverseRequest(StrictModel):
         )
         if series.coefficients[0].as_fraction() == 0:
             raise ValueError("inverse requires a nonzero constant term")
-        # In the recurrence b_n = -a_0^-1 * sum(a_i * b_{n-i}), each path
-        # contributes at most one reciprocal and one input coefficient per
-        # degree.  Two input digit widths cover numerator and denominator
-        # growth; one extra digit per degree covers the recurrence sum.
-        maximum_input_digits = max(
-            max(len(coefficient.num.lstrip("-")), len(coefficient.den))
-            for coefficient in series.coefficients
+        inverse = _inverse_height(series)
+        residual = _convolution_height(
+            _max_height(series.coefficients), inverse, self.truncation_order
         )
-        if (2 * maximum_input_digits + 1) * self.truncation_order > (
-            MAX_RESULT_RATIONAL_DIGITS
-        ):
-            raise ValueError(
-                "inverse coefficient growth would exceed the "
-                f"{MAX_RESULT_RATIONAL_DIGITS}-digit result bound"
-            )
+        _require_height(residual, "inverse residual")
         return self
 
     def as_series(self) -> InputTruncatedSeries:
@@ -273,6 +383,9 @@ class SeriesComposeRequest(StrictModel):
             raise ValueError(
                 "inner series must have zero constant term for composition with a finite prefix"
             )
+        outer = _max_height(self.outer.coefficients)
+        inner = _max_height(self.inner.coefficients)
+        _composition_height(outer, inner, self.outer.truncation_order, "composition")
         return self
 
 
@@ -305,6 +418,22 @@ class SeriesReversionRequest(StrictModel):
             raise ValueError("reversion requires zero constant term")
         if series.coefficients[1].as_fraction() == 0:
             raise ValueError("reversion requires nonzero linear coefficient")
+        source = _max_height(series.coefficients)
+        linear = _height(series.coefficients[1])
+        result = RationalHeight(1, 1).quotient(linear)
+        _require_height(result, "reversion")
+        for degree in range(2, self.truncation_order):
+            powers: list[RationalHeight] = []
+            power = result
+            for _ in range(2, degree + 1):
+                power = _convolution_height(power, result, degree + 1)
+                powers.append(power)
+            known = sum_heights(source.product(power) for power in powers)
+            coefficient = known.quotient(linear)
+            _require_height(coefficient, "reversion")
+            result = _merge_max(result, coefficient)
+        _composition_height(source, result, self.truncation_order, "reversion residual")
+        _composition_height(result, source, self.truncation_order, "reversion residual")
         return self
 
     def as_series(self) -> InputTruncatedSeries:
@@ -345,6 +474,10 @@ class SeriesIntegralRequest(StrictModel):
     def require_output_order_in_range(self) -> Self:
         if self.output_order > self.series.truncation_order + 1:
             raise ValueError("output_order must not exceed source_order + 1")
+        integer = RationalHeight(len(str(max(1, self.output_order - 1))), 1)
+        _require_height(
+            _max_height(self.series.coefficients).quotient(integer), "integration"
+        )
         return self
 
 

--- a/src/jacobian/math/formal_power_series/_tools.py
+++ b/src/jacobian/math/formal_power_series/_tools.py
@@ -29,7 +29,9 @@ from jacobian.math.formal_power_series._models import (
     SeriesToPolynomialResult,
     SeriesTruncateRequest,
     SeriesTruncateResult,
-    _SeriesPairRequest,
+    _SeriesAddSubtractRequest,
+    _SeriesIdentityCheckRequest,
+    _SeriesMultiplyRequest,
 )
 from jacobian.math.formal_power_series._operations import (
     compute_add,
@@ -49,15 +51,6 @@ from jacobian.math.formal_power_series._operations import (
     compute_truncate,
 )
 
-
-class _SeriesArithmeticRequest(_SeriesPairRequest):
-    """Request for add/subtract/multiply/divide operations."""
-
-
-class _SeriesIdentityCheckRequest(_SeriesPairRequest):
-    """Request for identity check operation."""
-
-
 FORMAL_POWER_SERIES_OPERATIONS = (
     MathTool(
         operation_id="formal_series.rational.add.compute",
@@ -68,7 +61,7 @@ FORMAL_POWER_SERIES_OPERATIONS = (
             "coefficient-wise.  Both operands must share the same variable and "
             "truncation order."
         ),
-        request_type=_SeriesArithmeticRequest,
+        request_type=_SeriesAddSubtractRequest,
         result_type=SeriesArithmeticResult,
         run=lambda request: compute_add(request.left, request.right),
         tags=(
@@ -114,7 +107,7 @@ FORMAL_POWER_SERIES_OPERATIONS = (
             "QQ[[x]]/(x^N) coefficient-wise.  Both operands must share the same "
             "variable and truncation order."
         ),
-        request_type=_SeriesArithmeticRequest,
+        request_type=_SeriesAddSubtractRequest,
         result_type=SeriesArithmeticResult,
         run=lambda request: compute_subtract(request.left, request.right),
         tags=(
@@ -160,7 +153,7 @@ FORMAL_POWER_SERIES_OPERATIONS = (
             "QQ[[x]]/(x^N).  Both operands must share the same variable and "
             "truncation order."
         ),
-        request_type=_SeriesArithmeticRequest,
+        request_type=_SeriesMultiplyRequest,
         result_type=SeriesMultiplyResult,
         run=lambda request: compute_multiply(request.left, request.right),
         tags=(

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from math import factorial
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
 
 
@@ -28,6 +29,39 @@ class TransitionMatrixRequest(StrictModel):
                 raise ValueError("transition probabilities must be nonnegative")
             if sum(values) != 1:
                 raise ValueError("each transition row must sum to one")
+        return self
+
+
+class StationaryDistributionRequest(TransitionMatrixRequest):
+    """A transition matrix whose exact stationary solutions fit the wire contract."""
+
+    @model_validator(mode="after")
+    def require_bounded_stationary_height(self) -> Self:
+        dimension = len(self.matrix)
+        cleared_row_bounds: list[int] = []
+        for column in range(dimension - 1):
+            entries = tuple(self.matrix[row][column] for row in range(dimension))
+            denominator_digits = sum(len(value.den) for value in entries)
+            cleared_row_bounds.append(
+                max(
+                    max(len(value.num.lstrip("-")), len(value.den))
+                    + 1
+                    + denominator_digits
+                    - len(value.den)
+                    for value in entries
+                )
+            )
+        cleared_row_bounds.append(1)  # normalization: sum(pi_i) = 1
+
+        # Leibniz bounds both det(A) and every Cramer numerator: each term is
+        # a product with one cleared integer from every row, and there are at
+        # most dimension! terms. Reduction can only decrease coordinate height.
+        determinant_digits = sum(cleared_row_bounds) + len(str(factorial(dimension)))
+        if determinant_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+            raise ValueError(
+                "stationary distribution rational height exceeds the "
+                f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit result bound"
+            )
         return self
 
 

--- a/src/jacobian/math/markov_chain/_tools.py
+++ b/src/jacobian/math/markov_chain/_tools.py
@@ -8,6 +8,7 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.markov_chain._models import (
     ErgodicDecisionResult,
+    StationaryDistributionRequest,
     StationaryDistributionResult,
     TransitionMatrixRequest,
 )
@@ -47,7 +48,7 @@ MARKOV_CHAIN_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Compute the stationary-distribution family of a Markov chain",
         "Compute the canonical extreme stationary distribution on every closed "
         "communicating class; their convex hull is the complete stationary family.",
-        TransitionMatrixRequest,
+        StationaryDistributionRequest,
         StationaryDistributionResult,
         compute_stationary_distribution,
         "probability",

--- a/tests/math/arithmetic_dynamics/test_iterate_height.py
+++ b/tests/math/arithmetic_dynamics/test_iterate_height.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.arithmetic_dynamics._models import (
+    DynatomicPolynomialRequest,
+    MapIterateRequest,
+)
+
+
+def test_monomial_counterexample_is_rejected_by_request_validation() -> None:
+    coefficient = "1" + "0" * 127
+    with pytest.raises(ValidationError, match="iterate coefficient growth"):
+        MapIterateRequest(coefficients=("0", "0", coefficient), n=10)
+
+
+def test_near_boundary_monomial_remains_admitted() -> None:
+    coefficient = "1" + "0" * 30
+    request = MapIterateRequest(coefficients=("0", "0", coefficient), n=10)
+
+    assert request.n == 10
+
+
+def test_dense_polynomial_additive_growth_is_propagated() -> None:
+    coefficient = "1" + "0" * 127
+    with pytest.raises(ValidationError, match="iterate coefficient growth"):
+        MapIterateRequest(coefficients=(coefficient, coefficient, coefficient), n=9)
+
+
+def test_dynatomic_request_checks_each_required_iterate() -> None:
+    coefficient = "1" + "0" * 127
+    with pytest.raises(ValidationError, match="iterate coefficient growth"):
+        DynatomicPolynomialRequest(coefficients=("0", "0", coefficient), n=9)

--- a/tests/math/arithmetic_functions/test_result_height.py
+++ b/tests/math/arithmetic_functions/test_result_height.py
@@ -1,0 +1,71 @@
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.arithmetic_functions._models import (
+    DirichletConvolutionRequest,
+    DirichletInverseRequest,
+    MobiusTransformRequest,
+    SummatoryFunctionRequest,
+)
+
+
+def _rational(num: str, den: str = "1") -> dict[str, str]:
+    return {"num": num, "den": den}
+
+
+def test_summatory_rejects_cross_denominator_growth() -> None:
+    power = 32_768
+    with pytest.raises(ValidationError, match="summatory function rational height"):
+        SummatoryFunctionRequest.model_validate(
+            {
+                "values": [
+                    _rational("1", format_canonical_integer(2**power)),
+                    _rational("1", format_canonical_integer(5**power)),
+                ]
+            }
+        )
+
+
+def test_convolution_accounts_for_numerator_products() -> None:
+    large = "1" + "0" * 20_000
+    with pytest.raises(ValidationError, match="Dirichlet convolution rational height"):
+        DirichletConvolutionRequest.model_validate(
+            {"f": [_rational(large)], "g": [_rational(large)]}
+        )
+
+
+def test_mobius_transform_accounts_for_signed_sums() -> None:
+    power = 32_768
+    with pytest.raises(ValidationError, match="Möbius transform rational height"):
+        MobiusTransformRequest.model_validate(
+            {
+                "values": [
+                    _rational("1", format_canonical_integer(2**power)),
+                    _rational("1", format_canonical_integer(5**power)),
+                ]
+            }
+        )
+
+
+def test_dirichlet_inverse_propagates_its_recurrence() -> None:
+    denominator = "1" + "0" * 20_000
+    with pytest.raises(ValidationError, match="Dirichlet inverse rational height"):
+        DirichletInverseRequest.model_validate(
+            {"values": [_rational("1", denominator), _rational("1")]}
+        )
+
+
+@pytest.mark.parametrize(
+    "parsed_request",
+    [
+        SummatoryFunctionRequest.model_validate({"values": [_rational("1", "2")]}),
+        MobiusTransformRequest.model_validate({"values": [_rational("1", "2")]}),
+        DirichletInverseRequest.model_validate({"values": [_rational("1", "2")]}),
+        DirichletConvolutionRequest.model_validate(
+            {"f": [_rational("1", "2")], "g": [_rational("1", "3")]}
+        ),
+    ],
+)
+def test_ordinary_requests_remain_admitted(parsed_request: object) -> None:
+    assert parsed_request is not None

--- a/tests/math/formal_power_series/test_result_height.py
+++ b/tests/math/formal_power_series/test_result_height.py
@@ -1,0 +1,80 @@
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.formal_power_series._models import (
+    InputTruncatedSeries,
+    SeriesComposeRequest,
+    SeriesDivideRequest,
+    SeriesPowerRequest,
+    SeriesReversionRequest,
+    _SeriesAddSubtractRequest,
+    _SeriesMultiplyRequest,
+)
+
+
+def _coefficient(num: str = "1", den: str = "1") -> dict[str, str]:
+    return {"num": num, "den": den}
+
+
+def _series(order: int, coefficients: list[dict[str, str]]) -> dict[str, object]:
+    return {"variable": "x", "truncation_order": order, "coefficients": coefficients}
+
+
+def test_multiplication_bound_does_not_reject_coefficientwise_addition() -> None:
+    order = 20
+    coefficients = [_coefficient(den=str(2**800)) for _ in range(order)]
+    payload = {
+        "left": _series(order, coefficients),
+        "right": _series(order, coefficients),
+    }
+
+    assert _SeriesAddSubtractRequest.model_validate(payload)
+    with pytest.raises(ValidationError, match="multiplication coefficient growth"):
+        _SeriesMultiplyRequest.model_validate(payload)
+
+
+def test_power_propagates_binary_convolution_growth() -> None:
+    order = 8
+    coefficients = [_coefficient(den=str(3**500)) for _ in range(order)]
+    with pytest.raises(ValidationError, match="power coefficient growth"):
+        SeriesPowerRequest.model_validate(
+            {"series": _series(order, coefficients), "exponent": 16}
+        )
+
+
+def test_division_propagates_inverse_and_residual_growth() -> None:
+    order = 8
+    numerator = [_coefficient() for _ in range(order)]
+    denominator = [_coefficient(den=str(2**700)), *[_coefficient()] * (order - 1)]
+    with pytest.raises(ValidationError, match="inverse coefficient growth"):
+        SeriesDivideRequest.model_validate(
+            {"left": _series(order, numerator), "right": _series(order, denominator)}
+        )
+
+
+def test_composition_propagates_inner_power_growth() -> None:
+    order = 8
+    outer = [_coefficient() for _ in range(order)]
+    inner = [_coefficient("0"), *[_coefficient(den=str(5**300))] * (order - 1)]
+    with pytest.raises(ValidationError, match="composition coefficient growth"):
+        SeriesComposeRequest.model_validate(
+            {"outer": _series(order, outer), "inner": _series(order, inner)}
+        )
+
+
+def test_reversion_propagates_linear_coefficient_division() -> None:
+    order = 8
+    coefficients = [
+        _coefficient("0"),
+        _coefficient(den=str(7**250)),
+        *[_coefficient()] * (order - 2),
+    ]
+    with pytest.raises(ValidationError, match="reversion coefficient growth"):
+        SeriesReversionRequest.model_validate(_series(order, coefficients))
+
+
+def test_small_requests_remain_admitted() -> None:
+    series = InputTruncatedSeries.model_validate(
+        _series(2, [_coefficient("1"), _coefficient("1")])
+    )
+    assert SeriesPowerRequest(series=series, exponent=3)

--- a/tests/math/formal_power_series/test_result_height.py
+++ b/tests/math/formal_power_series/test_result_height.py
@@ -73,6 +73,22 @@ def test_reversion_propagates_linear_coefficient_division() -> None:
         SeriesReversionRequest.model_validate(_series(order, coefficients))
 
 
+def test_sparse_linear_reversion_remains_admitted() -> None:
+    request = SeriesReversionRequest.model_validate(
+        _series(
+            4,
+            [
+                _coefficient("0"),
+                _coefficient("2"),
+                _coefficient("0"),
+                _coefficient("0"),
+            ],
+        )
+    )
+
+    assert request.coefficients[1].num == "2"
+
+
 def test_small_requests_remain_admitted() -> None:
     series = InputTruncatedSeries.model_validate(
         _series(2, [_coefficient("1"), _coefficient("1")])

--- a/tests/math/markov_chain/test_stationary_height.py
+++ b/tests/math/markov_chain/test_stationary_height.py
@@ -1,0 +1,56 @@
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.markov_chain._models import (
+    StationaryDistributionRequest,
+    TransitionMatrixRequest,
+)
+
+
+def _two_state_counterexample(exponent: int) -> dict[str, object]:
+    two = 2**exponent
+    three = 3**exponent
+    p = (three - 1) // 2
+    return {
+        "matrix": [
+            [
+                {
+                    "num": format_canonical_integer(two - 1),
+                    "den": format_canonical_integer(two),
+                },
+                {"num": "1", "den": format_canonical_integer(two)},
+            ],
+            [
+                {
+                    "num": format_canonical_integer(p),
+                    "den": format_canonical_integer(three),
+                },
+                {
+                    "num": format_canonical_integer(three - p),
+                    "den": format_canonical_integer(three),
+                },
+            ],
+        ]
+    }
+
+
+def test_stationary_request_rejects_exact_two_state_height_counterexample() -> None:
+    with pytest.raises(
+        ValidationError, match="stationary distribution rational height"
+    ):
+        StationaryDistributionRequest.model_validate(_two_state_counterexample(45_000))
+
+
+def test_stationary_bound_does_not_narrow_ergodic_decision_request() -> None:
+    request = TransitionMatrixRequest.model_validate(_two_state_counterexample(45_000))
+
+    assert len(request.matrix) == 2
+
+
+def test_useful_near_boundary_stationary_request_remains_admitted() -> None:
+    request = StationaryDistributionRequest.model_validate(
+        _two_state_counterexample(4_000)
+    )
+
+    assert len(request.matrix) == 2

--- a/tests/math/test_rational_height.py
+++ b/tests/math/test_rational_height.py
@@ -1,0 +1,20 @@
+from jacobian._exact import CanonicalRational
+from jacobian.math._rational_height import RationalHeight, sum_heights
+
+
+def _height(num: str, den: str) -> RationalHeight:
+    return RationalHeight.from_canonical(CanonicalRational(num=num, den=den))
+
+
+def test_product_and_quotient_cover_unreduced_component_growth() -> None:
+    left = _height("999", "97")
+    right = _height("103", "9999")
+
+    assert left.product(right) == RationalHeight(6, 6)
+    assert left.quotient(right) == RationalHeight(7, 5)
+
+
+def test_sum_uses_a_product_common_denominator_bound() -> None:
+    result = sum_heights((_height("1", "32"), _height("1", "125")))
+
+    assert result == RationalHeight(5, 5)


### PR DESCRIPTION
## Problem

Schema-valid exact computations can exceed their bounded rational result contracts only after expensive composition, recurrence, aggregation, or linear solving. That turns an accepted request into a late result-model or host failure.

This affects polynomial iteration and dynatomic expansion, arithmetic-function aggregation, formal power-series recurrences, and exact stationary-distribution solving. The existing proposed fixes use unrelated shared request types or incomplete scalar heuristics, so they either reject operations that do not need the bound or fail to prove closure of the accepted domain.

Fixes #2064.
Fixes #2065.
Fixes #2066.
Fixes #2067.

## Solution

Add private decimal-height propagation for exact rational sums, products, and quotients, then apply it through operation-owned request validation:

- polynomial bounds mirror Horner composition, dynatomic products, and exact polynomial division coefficient by coefficient;
- arithmetic-function bounds follow each divisor-indexed sum and the Dirichlet-inverse recurrence;
- formal-series bounds follow Cauchy products, binary powers, inverse/division, composition, reversion, and residual construction;
- stationary distributions use a stationary-only request type and a cleared-integer-system determinant bound, leaving `ergodic.decide` unchanged.

The guards run before the corresponding exact computation. They conservatively narrow accepted requests rather than truncating results, changing exact semantics, or relying on post-hoc result validation. Arithmetic-function result lengths are also bound to their returned value tuples.

## Testing

- `uv run pytest tests/math/arithmetic_dynamics tests/math/arithmetic_functions tests/math/formal_power_series tests/math/markov_chain tests/math/test_rational_height.py -q` — 99 passed
- `make check` — Ruff, formatting, complexity, mypy, and 1,867 tests passed

- Specialist validation run (if any): none; these are domain-owned Python request and operation contracts

## Public contract impact

The affected request schemas now reject exact inputs whose operation-specific arithmetic growth cannot be proven to fit the existing result contracts. Operation IDs, result shapes, and exact mathematical semantics are unchanged. Stationary-distribution validation is separated from the shared transition-matrix request so unrelated ergodicity decisions retain their existing domain.

## Public operation admission

No operations are added or removed; existing owner-local admission decisions are unchanged.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Polynomial iterate and dynatomic coefficient growth | delivered | Existing arithmetic-dynamics operations |
| Arithmetic-function rational growth | delivered | Existing convolution, Möbius, summatory, and inverse operations |
| Formal-series recurrence growth | delivered | Existing rational formal-series operations |
| Stationary-distribution solve height | delivered | `probability.markov_chain.stationary_distribution.compute` |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Result semantics remain exact and bounded
- [x] New shared abstraction replaces duplication across multiple surviving production paths
