### PR TITLE
refactor(core): make execution boundaries explicit and fully typed

### DIFF
--- a/benchmarks/tooling/providers/__init__.py
+++ b/benchmarks/tooling/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Executable provider-feasibility spikes owned by benchmark tooling."""

--- a/benchmarks/tooling/providers/cddlib.py
+++ b/benchmarks/tooling/providers/cddlib.py
@@ -13,17 +13,22 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
-from benchmarks.tooling.spike_utils import (
-    canonical_json,
-    default_runner,
-    sha256_bytes,
-)
 from tools.command_runner import (
+    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
 )
 
-PIN_PATH = Path(__file__).with_name("pin.json")
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    owned_fixture_path,
+    sha256_bytes,
+)
+
+PIN_PATH = owned_fixture_path(
+    __file__, "tests/fixtures/providers/cddlib/pin.json", "pin.json"
+)
 ADAPTER_SOURCE = Path(__file__)
 # Worker re-exec replaces the process environment; keep the image PYTHONPATH so
 # `tools.command_runner` remains importable inside --worker mode.
@@ -40,7 +45,7 @@ _KIND_ORDER = {
     "RAY": 3,
     "LINEALITY": 4,
 }
-ProcessRunner = Callable[..., ToolCommandResult]
+ProcessRunner = Callable[[ToolCommandRequest], ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
@@ -105,11 +110,9 @@ def _load_pin(path: Path) -> dict[str, Any]:
         and isinstance(scope.get("covers"), list)
         and all(isinstance(item, str) for item in scope["covers"])
     )
-    sources_valid = isinstance(sources, dict) and set(sources) == {
-        "cddlib",
-        "pycddlib",
-    }
-    if sources_valid:
+    sources_valid = False
+    if isinstance(sources, dict) and set(sources) == {"cddlib", "pycddlib"}:
+        sources_valid = True
         for source in sources.values():
             if (
                 not isinstance(source, dict)
@@ -350,8 +353,8 @@ def _integer_normalize(row: Sequence[Fraction], *, sign_free: bool) -> list[Frac
         value.numerator * (denominator_lcm // value.denominator) for value in row
     ]
     divisor = 0
-    for value in integers:
-        divisor = math.gcd(divisor, abs(value))
+    for integer in integers:
+        divisor = math.gcd(divisor, abs(integer))
     if divisor == 0:
         return [Fraction(0) for _ in row]
     integers = [value // divisor for value in integers]
@@ -689,15 +692,20 @@ def _run_checked(
     runner: ProcessRunner,
     command: Sequence[str],
     *,
+    cwd: Path,
     timeout_seconds: float,
 ) -> bytes:
     completed = runner(
-        command,
-        input_bytes=b"",
-        timeout_seconds=timeout_seconds,
-        environment=_ENVIRONMENT,
-        stdout_limit=128 * 1024,
-        stderr_limit=16 * 1024,
+        ToolCommandRequest(
+            executable=command[0],
+            arguments=tuple(command[1:]),
+            stdin_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            cwd=str(cwd.resolve(strict=True)),
+            stdout_limit_bytes=128 * 1024,
+            stderr_limit_bytes=16 * 1024,
+        )
     )
     if completed.status is ToolCommandStatus.START_FAILED:
         raise CddlibSpikeError(
@@ -803,6 +811,7 @@ def run_spike(
     python_executable: Path,
     cddlib_source_archive: Path,
     pycddlib_source_archive: Path,
+    cwd: Path,
     timeout_seconds: float = 10,
     runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
@@ -841,6 +850,7 @@ def run_spike(
                 str(pin_path.resolve()),
             ],
             timeout_seconds=timeout_seconds,
+            cwd=cwd,
         )
         provider_output = _parse_provider_output(output, pin)
         by_id = {case["case_id"]: case for case in cases}
@@ -922,9 +932,10 @@ def _worker(pin_path: Path) -> int:
     pin = _load_pin(pin_path)
     cases = _validate_cases(pin)
     try:
+        import importlib
         import importlib.metadata
 
-        import cdd.gmp as cdd
+        cdd = importlib.import_module("cdd.gmp")
     except ImportError as exc:
         raise CddlibSpikeError(
             "UNAVAILABLE",
@@ -1006,11 +1017,16 @@ def _worker(pin_path: Path) -> int:
         rep_type=cdd.RepType.INEQUALITY,
     )
     exact_probe = probe_matrix.array[0][0]
-    gmp_module = Path(cdd.__file__).resolve()
+    module_file = getattr(cdd, "__file__", None)
+    if not isinstance(module_file, str):
+        raise CddlibSpikeError(
+            "UNAVAILABLE", "PROVIDER_IMPORT_ERROR", "cdd.gmp has no module file."
+        )
+    gmp_module = Path(module_file).resolve()
     distribution = importlib.metadata.distribution("pycddlib")
     record_path = next(
         (
-            Path(distribution.locate_file(item))
+            Path(str(distribution.locate_file(item)))
             for item in distribution.files or ()
             if item.name == "RECORD"
         ),
@@ -1052,6 +1068,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--cddlib-source-archive", type=Path)
     parser.add_argument("--pycddlib-source-archive", type=Path)
     parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--cwd", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--worker", action="store_true")
     args = parser.parse_args(argv)
@@ -1070,16 +1087,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.python_executable is None
         or args.cddlib_source_archive is None
         or args.pycddlib_source_archive is None
+        or args.cwd is None
         or args.output is None
     ):
         parser.error(
             "--python-executable, --cddlib-source-archive, "
-            "--pycddlib-source-archive, and --output are required"
+            "--pycddlib-source-archive, --cwd, and --output are required"
         )
     report = run_spike(
         python_executable=args.python_executable,
         cddlib_source_archive=args.cddlib_source_archive,
         pycddlib_source_archive=args.pycddlib_source_archive,
+        cwd=args.cwd,
         pin_path=args.pin,
     )
     args.output.write_text(

--- a/benchmarks/tooling/providers/cddlib.py
+++ b/benchmarks/tooling/providers/cddlib.py
@@ -702,7 +702,7 @@ def _run_checked(
             stdin_bytes=b"",
             timeout_seconds=timeout_seconds,
             environment=_ENVIRONMENT,
-            cwd=str(cwd.resolve(strict=True)),
+            cwd=str(cwd.resolve()),
             stdout_limit_bytes=128 * 1024,
             stderr_limit_bytes=16 * 1024,
         )

--- a/benchmarks/tooling/providers/cgal.py
+++ b/benchmarks/tooling/providers/cgal.py
@@ -204,7 +204,7 @@ def _run_checked(
             stdin_bytes=b"",
             timeout_seconds=timeout_seconds,
             environment=_ENVIRONMENT,
-            cwd=str(cwd.resolve(strict=True)),
+            cwd=str(cwd.resolve()),
             stdout_limit_bytes=32_768,
             stderr_limit_bytes=16_384,
         )

--- a/benchmarks/tooling/providers/cgal.py
+++ b/benchmarks/tooling/providers/cgal.py
@@ -13,23 +13,34 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from benchmarks.tooling.spike_utils import (
-    default_runner,
-    sha256_bytes,
-)
 from tools.command_runner import (
+    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
 )
 
-PIN_PATH = Path(__file__).with_name("cgal_delaunay_pin.json")
-ADAPTER_SOURCE = Path(__file__).with_name("cgal_delaunay_spike.cpp")
+from benchmarks.tooling.spike_utils import (
+    default_runner,
+    owned_fixture_path,
+    sha256_bytes,
+)
+
+PIN_PATH = owned_fixture_path(
+    __file__,
+    "tests/fixtures/providers/cgal/cgal_delaunay_pin.json",
+    "cgal_delaunay_pin.json",
+)
+ADAPTER_SOURCE = owned_fixture_path(
+    __file__,
+    "tests/fixtures/providers/cgal/cgal_delaunay_spike.cpp",
+    "cgal_delaunay_spike.cpp",
+)
 _SOURCE_MEMBERS = (
     "CGAL-6.2/include/CGAL/version.h",
     "CGAL-6.2/include/CGAL/Delaunay_triangulation_2.h",
 )
 _ENVIRONMENT = {"LANG": "C", "LC_ALL": "C", "TZ": "UTC"}
-ProcessRunner = Callable[..., ToolCommandResult]
+ProcessRunner = Callable[[ToolCommandRequest], ToolCommandResult]
 
 
 class CgalSpikeError(RuntimeError):
@@ -183,15 +194,20 @@ def _run_checked(
     runner: ProcessRunner,
     command: Sequence[str],
     *,
+    cwd: Path,
     timeout_seconds: float,
 ) -> bytes:
     completed = runner(
-        command,
-        input_bytes=b"",
-        timeout_seconds=timeout_seconds,
-        environment=_ENVIRONMENT,
-        stdout_limit=32_768,
-        stderr_limit=16_384,
+        ToolCommandRequest(
+            executable=command[0],
+            arguments=tuple(command[1:]),
+            stdin_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            cwd=str(cwd.resolve(strict=True)),
+            stdout_limit_bytes=32_768,
+            stderr_limit_bytes=16_384,
+        )
     )
     if completed.status is ToolCommandStatus.START_FAILED:
         raise CgalSpikeError(
@@ -254,6 +270,7 @@ def run_spike(
     *,
     executable: Path,
     source_archive: Path,
+    cwd: Path,
     timeout_seconds: float = 5,
     runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
@@ -279,6 +296,7 @@ def run_spike(
             _run_checked(
                 runner,
                 [str(resolved), "--version"],
+                cwd=cwd,
                 timeout_seconds=timeout_seconds,
             ),
             pin,
@@ -289,6 +307,7 @@ def run_spike(
             output = _run_checked(
                 runner,
                 [str(resolved), *case["command"]],
+                cwd=cwd,
                 timeout_seconds=timeout_seconds,
             )
             try:
@@ -387,12 +406,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--executable", type=Path, required=True)
     parser.add_argument("--source-archive", type=Path, required=True)
+    parser.add_argument("--cwd", type=Path, required=True)
     parser.add_argument("--timeout-seconds", type=float, default=5)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args(argv)
     report = run_spike(
         executable=args.executable,
         source_archive=args.source_archive,
+        cwd=args.cwd,
         timeout_seconds=args.timeout_seconds,
     )
     encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/benchmarks/tooling/providers/gudhi.py
+++ b/benchmarks/tooling/providers/gudhi.py
@@ -354,7 +354,7 @@ def _run_checked(
             stdin_bytes=b"",
             timeout_seconds=timeout_seconds,
             environment=_ENVIRONMENT,
-            cwd=str(cwd.resolve(strict=True)),
+            cwd=str(cwd.resolve()),
             stdout_limit_bytes=64 * 1024,
             stderr_limit_bytes=16 * 1024,
         )

--- a/benchmarks/tooling/providers/gudhi.py
+++ b/benchmarks/tooling/providers/gudhi.py
@@ -15,17 +15,22 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
-from benchmarks.tooling.spike_utils import (
-    canonical_json,
-    default_runner,
-    sha256_bytes,
-)
 from tools.command_runner import (
+    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
 )
 
-PIN_PATH = Path(__file__).with_name("pin.json")
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    owned_fixture_path,
+    sha256_bytes,
+)
+
+PIN_PATH = owned_fixture_path(
+    __file__, "tests/fixtures/providers/gudhi/pin.json", "pin.json"
+)
 ADAPTER_SOURCE = Path(__file__)
 _SOURCE_ROOT = "gudhi-devel-tags-gudhi-release-3.13.0"
 _SOURCE_MEMBERS = {
@@ -43,7 +48,7 @@ _ENVIRONMENT = {
     "TZ": "UTC",
     "PYTHONPATH": "/opt",
 }
-ProcessRunner = Callable[..., ToolCommandResult]
+ProcessRunner = Callable[[ToolCommandRequest], ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
@@ -339,15 +344,20 @@ def _run_checked(
     runner: ProcessRunner,
     command: Sequence[str],
     *,
+    cwd: Path,
     timeout_seconds: float,
 ) -> bytes:
     completed = runner(
-        command,
-        input_bytes=b"",
-        timeout_seconds=timeout_seconds,
-        environment=_ENVIRONMENT,
-        stdout_limit=64 * 1024,
-        stderr_limit=16 * 1024,
+        ToolCommandRequest(
+            executable=command[0],
+            arguments=tuple(command[1:]),
+            stdin_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            cwd=str(cwd.resolve(strict=True)),
+            stdout_limit_bytes=64 * 1024,
+            stderr_limit_bytes=16 * 1024,
+        )
     )
     if completed.status is ToolCommandStatus.START_FAILED:
         raise GudhiSpikeError(
@@ -476,15 +486,17 @@ def _reduce_columns(
                     column[row] = updated
                 else:
                     column.pop(row, None)
-        pivot = max(column) if column else None
-        if pivot is not None:
-            pivot_to_column[pivot] = column_index
+        column_pivot: int | None = max(column) if column else None
+        if column_pivot is not None:
+            pivot_to_column[column_pivot] = column_index
         reduced_columns.append(column)
         ledger.append(
             {
                 "column_simplex_id": item["simplex_id"],
                 "pivot_simplex_id": (
-                    simplices[pivot]["simplex_id"] if pivot is not None else None
+                    simplices[column_pivot]["simplex_id"]
+                    if column_pivot is not None
+                    else None
                 ),
                 "reduced_entries": [
                     {
@@ -558,6 +570,7 @@ def run_spike(
     python_executable: Path,
     wheel: Path,
     source_archive: Path,
+    cwd: Path,
     timeout_seconds: float = 10,
     runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
@@ -594,6 +607,7 @@ def run_spike(
                 str(pin_path.resolve()),
             ],
             timeout_seconds=timeout_seconds,
+            cwd=cwd,
         )
         provider_output = _parse_provider_output(output, pin)
         mathematical_output = {
@@ -675,7 +689,9 @@ def _worker(pin_path: Path) -> int:
     pin = _load_pin(pin_path)
     simplices = _validate_reproduction(pin)
     try:
-        import gudhi
+        import importlib
+
+        gudhi = importlib.import_module("gudhi")
         import numpy
     except ImportError as exc:
         raise GudhiSpikeError(
@@ -697,11 +713,11 @@ def _worker(pin_path: Path) -> int:
     by_vertices = {tuple(item["vertices"]): item for item in simplices}
     for vertices, rank_as_float in tree.get_filtration():
         canonical = tuple(sorted(vertices))
-        item = by_vertices.get(canonical)
+        observed_item = by_vertices.get(canonical)
         if (
-            item is None
+            observed_item is None
             or not rank_as_float.is_integer()
-            or int(rank_as_float) != item["rank"]
+            or int(rank_as_float) != observed_item["rank"]
         ):
             raise GudhiSpikeError(
                 "REJECTED",
@@ -764,6 +780,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--wheel", type=Path)
     parser.add_argument("--source-archive", type=Path)
     parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--cwd", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--worker", action="store_true")
     args = parser.parse_args(argv)
@@ -782,15 +799,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.python_executable is None
         or args.wheel is None
         or args.source_archive is None
+        or args.cwd is None
         or args.output is None
     ):
         parser.error(
-            "--python-executable, --wheel, --source-archive, and --output are required"
+            "--python-executable, --wheel, --source-archive, --cwd, and --output are required"
         )
     report = run_spike(
         python_executable=args.python_executable,
         wheel=args.wheel,
         source_archive=args.source_archive,
+        cwd=args.cwd,
         pin_path=args.pin,
     )
     args.output.write_text(

--- a/benchmarks/tooling/providers/nauty.py
+++ b/benchmarks/tooling/providers/nauty.py
@@ -278,7 +278,7 @@ def _run_checked(
             stdin_bytes=input_bytes,
             timeout_seconds=timeout_seconds,
             environment=_ENVIRONMENT,
-            cwd=str(cwd.resolve(strict=True)),
+            cwd=str(cwd.resolve()),
             stdout_limit_bytes=stdout_limit,
             stderr_limit_bytes=16_384,
         )

--- a/benchmarks/tooling/providers/nauty.py
+++ b/benchmarks/tooling/providers/nauty.py
@@ -11,16 +11,23 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from benchmarks.tooling.spike_utils import (
-    default_runner,
-    sha256_bytes,
-)
 from tools.command_runner import (
+    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
 )
 
-PIN_PATH = Path(__file__).with_name("nauty_provider_pin.json")
+from benchmarks.tooling.spike_utils import (
+    default_runner,
+    owned_fixture_path,
+    sha256_bytes,
+)
+
+PIN_PATH = owned_fixture_path(
+    __file__,
+    "tests/fixtures/providers/nauty/nauty_provider_pin.json",
+    "nauty_provider_pin.json",
+)
 _HELP_MARKERS = {
     "geng": (
         b"Usage: geng ",
@@ -43,7 +50,7 @@ _SOURCE_MEMBERS = (
     "nauty2_9_3/gtools.h",
 )
 
-ProcessRunner = Callable[..., ToolCommandResult]
+ProcessRunner = Callable[[ToolCommandRequest], ToolCommandResult]
 
 
 class NautySpikeError(RuntimeError):
@@ -259,17 +266,22 @@ def _run_checked(
     runner: ProcessRunner,
     command: Sequence[str],
     *,
+    cwd: Path,
     input_bytes: bytes,
     timeout_seconds: float,
     stdout_limit: int,
 ) -> bytes:
     completed = runner(
-        command,
-        input_bytes=input_bytes,
-        timeout_seconds=timeout_seconds,
-        environment=_ENVIRONMENT,
-        stdout_limit=stdout_limit,
-        stderr_limit=16_384,
+        ToolCommandRequest(
+            executable=command[0],
+            arguments=tuple(command[1:]),
+            stdin_bytes=input_bytes,
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            cwd=str(cwd.resolve(strict=True)),
+            stdout_limit_bytes=stdout_limit,
+            stderr_limit_bytes=16_384,
+        )
     )
     if completed.status is ToolCommandStatus.START_FAILED:
         raise NautySpikeError(
@@ -338,11 +350,13 @@ def _probe_help(
     executable: Path,
     *,
     tool: str,
+    cwd: Path,
     timeout_seconds: float,
 ) -> None:
     output = _run_checked(
         runner,
         [str(executable), "-help"],
+        cwd=cwd,
         input_bytes=b"",
         timeout_seconds=timeout_seconds,
         stdout_limit=16_384,
@@ -463,6 +477,7 @@ def run_spike(
     geng: Path,
     labelg: Path,
     source_archive: Path,
+    cwd: Path,
     timeout_seconds: float = 5,
     runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
@@ -485,18 +500,21 @@ def run_spike(
             runner,
             resolved_geng,
             tool="geng",
+            cwd=cwd,
             timeout_seconds=timeout_seconds,
         )
         _probe_help(
             runner,
             resolved_labelg,
             tool="labelg",
+            cwd=cwd,
             timeout_seconds=timeout_seconds,
         )
 
         generated = _run_checked(
             runner,
             [str(resolved_geng), *pin["reproduction"]["command"][1:]],
+            cwd=cwd,
             input_bytes=b"",
             timeout_seconds=timeout_seconds,
             stdout_limit=4096,
@@ -519,6 +537,7 @@ def run_spike(
         canonicalized = _run_checked(
             runner,
             [str(resolved_labelg), *pin["canonicalization"]["command"][1:]],
+            cwd=cwd,
             input_bytes=canonical_input,
             timeout_seconds=timeout_seconds,
             stdout_limit=4096,
@@ -564,6 +583,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--geng", type=Path, required=True)
     parser.add_argument("--labelg", type=Path, required=True)
     parser.add_argument("--source-archive", type=Path, required=True)
+    parser.add_argument("--cwd", type=Path, required=True)
     parser.add_argument("--timeout-seconds", type=float, default=5)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args(argv)
@@ -571,6 +591,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         geng=args.geng,
         labelg=args.labelg,
         source_archive=args.source_archive,
+        cwd=args.cwd,
         timeout_seconds=args.timeout_seconds,
     )
     encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/benchmarks/tooling/providers/regina.py
+++ b/benchmarks/tooling/providers/regina.py
@@ -348,7 +348,7 @@ def _run_checked(
             stdin_bytes=b"",
             timeout_seconds=timeout_seconds,
             environment=_ENVIRONMENT,
-            cwd=str(cwd.resolve(strict=True)),
+            cwd=str(cwd.resolve()),
             stdout_limit_bytes=256 * 1024,
             stderr_limit_bytes=32 * 1024,
         )

--- a/benchmarks/tooling/providers/regina.py
+++ b/benchmarks/tooling/providers/regina.py
@@ -15,19 +15,24 @@ import zlib
 from collections.abc import Callable, Mapping, Sequence
 from itertools import combinations
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
-from benchmarks.tooling.spike_utils import (
-    canonical_json,
-    default_runner,
-    sha256_bytes,
-)
 from tools.command_runner import (
+    ToolCommandRequest,
     ToolCommandResult,
     ToolCommandStatus,
 )
 
-PIN_PATH = Path(__file__).with_name("pin.json")
+from benchmarks.tooling.spike_utils import (
+    canonical_json,
+    default_runner,
+    owned_fixture_path,
+    sha256_bytes,
+)
+
+PIN_PATH = owned_fixture_path(
+    __file__, "tests/fixtures/providers/regina/pin.json", "pin.json"
+)
 ADAPTER_SOURCE = Path(__file__)
 _SOURCE_ROOT = "regina-7.4.1"
 _SOURCE_MEMBERS = {
@@ -45,7 +50,7 @@ _ENVIRONMENT = {
     "PYTHONPATH": "/opt",
 }
 _INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
-ProcessRunner = Callable[..., ToolCommandResult]
+ProcessRunner = Callable[[ToolCommandRequest], ToolCommandResult]
 _WORKER_ERROR_PREFIX = b"JACOBIAN_SPIKE_ERROR "
 
 
@@ -333,15 +338,20 @@ def _run_checked(
     runner: ProcessRunner,
     command: Sequence[str],
     *,
+    cwd: Path,
     timeout_seconds: float,
 ) -> bytes:
     completed = runner(
-        command,
-        input_bytes=b"",
-        timeout_seconds=timeout_seconds,
-        environment=_ENVIRONMENT,
-        stdout_limit=256 * 1024,
-        stderr_limit=32 * 1024,
+        ToolCommandRequest(
+            executable=command[0],
+            arguments=tuple(command[1:]),
+            stdin_bytes=b"",
+            timeout_seconds=timeout_seconds,
+            environment=_ENVIRONMENT,
+            cwd=str(cwd.resolve(strict=True)),
+            stdout_limit_bytes=256 * 1024,
+            stderr_limit_bytes=32 * 1024,
+        )
     )
     if completed.status is ToolCommandStatus.START_FAILED:
         raise ReginaSpikeError(
@@ -491,12 +501,12 @@ def _gluing_out_of_scope(
 
 
 def _gluing_not_reciprocal(
-    gluings: list,
+    gluings: list[list[Any]],
     source: int,
     facet: int,
     target: int,
     target_facet: int,
-    permutation: list,
+    permutation: list[int],
 ) -> bool:
     reverse = gluings[target][target_facet]
     return (
@@ -510,7 +520,7 @@ def _gluing_not_reciprocal(
     )
 
 
-def _validate_facet_gluings(gluings: list, tetrahedra: int) -> None:
+def _validate_facet_gluings(gluings: list[list[Any]], tetrahedra: int) -> None:
     for source, row in enumerate(gluings):
         for facet, gluing in enumerate(row):
             if gluing is None:
@@ -542,7 +552,7 @@ def _validate_facet_gluings(gluings: list, tetrahedra: int) -> None:
                 )
 
 
-def _compute_f_vector(gluings: list, tetrahedra: int) -> list[int]:
+def _compute_f_vector(gluings: list[list[Any]], tetrahedra: int) -> list[int]:
     nodes = [
         (tetrahedron, dimension, vertices)
         for tetrahedron in range(tetrahedra)
@@ -578,8 +588,10 @@ def _replay_triangulation(case: Mapping[str, Any]) -> dict[str, Any]:
     tetrahedra = case.get("tetrahedra")
     gluings = case.get("facet_gluings")
     _validate_gluing_shape(tetrahedra, gluings)
-    _validate_facet_gluings(gluings, tetrahedra)
-    f_vector = _compute_f_vector(gluings, tetrahedra)
+    checked_tetrahedra = cast(int, tetrahedra)
+    checked_gluings = cast(list[list[Any]], gluings)
+    _validate_facet_gluings(checked_gluings, checked_tetrahedra)
+    f_vector = _compute_f_vector(checked_gluings, checked_tetrahedra)
     if case.get("f_vector") != f_vector:
         raise ReginaSpikeError(
             "REJECTED",
@@ -703,6 +715,7 @@ def run_spike(
     python_executable: Path,
     wheel: Path,
     source_archive: Path,
+    cwd: Path,
     timeout_seconds: float = 20,
     runner: ProcessRunner = default_runner,
     pin_path: Path = PIN_PATH,
@@ -735,6 +748,7 @@ def run_spike(
                 wheel_identity["path"],
             ],
             timeout_seconds=timeout_seconds,
+            cwd=cwd,
         )
         provider_output = _parse_provider_output(output, pin)
         mathematical = {
@@ -857,7 +871,7 @@ def _gluing_payload(triangulation: Any) -> list[list[dict[str, Any] | None]]:
 def _verify_installed_runtime(wheel_path: Path) -> int:
     distribution = importlib.metadata.distribution("regina")
     installed = {
-        str(item).replace("\\", "/"): Path(distribution.locate_file(item))
+        str(item).replace("\\", "/"): Path(str(distribution.locate_file(item)))
         for item in distribution.files or ()
     }
     verified = 0
@@ -902,7 +916,9 @@ def _worker(pin_path: Path, wheel_path: Path) -> int:
     pin = _load_pin(pin_path)
     cases = _validate_reproduction(pin)
     try:
-        import regina
+        import importlib
+
+        regina = importlib.import_module("regina")
     except ImportError as exc:
         raise ReginaSpikeError(
             "UNAVAILABLE", "PROVIDER_IMPORT_ERROR", "Regina is unavailable."
@@ -952,7 +968,7 @@ def _worker(pin_path: Path, wheel_path: Path) -> int:
     )
     surfaces = []
     for surface in normal_list:
-        coordinates = []
+        coordinates: list[str] = []
         for tetrahedron in range(normal_triangulation.size()):
             coordinates.extend(
                 str(surface.triangles(tetrahedron, vertex)) for vertex in range(4)
@@ -1002,6 +1018,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--wheel", type=Path)
     parser.add_argument("--source-archive", type=Path)
     parser.add_argument("--pin", type=Path, default=PIN_PATH)
+    parser.add_argument("--cwd", type=Path)
     parser.add_argument("--output", type=Path)
     parser.add_argument("--worker", action="store_true")
     args = parser.parse_args(argv)
@@ -1022,15 +1039,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.python_executable is None
         or args.wheel is None
         or args.source_archive is None
+        or args.cwd is None
         or args.output is None
     ):
         parser.error(
-            "--python-executable, --wheel, --source-archive, and --output are required"
+            "--python-executable, --wheel, --source-archive, --cwd, and --output are required"
         )
     report = run_spike(
         python_executable=args.python_executable,
         wheel=args.wheel,
         source_archive=args.source_archive,
+        cwd=args.cwd,
         pin_path=args.pin,
     )
     args.output.write_text(

--- a/benchmarks/tooling/spike_utils.py
+++ b/benchmarks/tooling/spike_utils.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from tools.command_runner import (
@@ -22,30 +21,28 @@ from tools.command_runner import (
 __all__ = [
     "canonical_json",
     "default_runner",
+    "owned_fixture_path",
     "sha256_bytes",
 ]
 
 
 def default_runner(
-    command: Sequence[str],
-    *,
-    input_bytes: bytes,
-    timeout_seconds: float,
-    environment: Mapping[str, str],
-    stdout_limit: int,
-    stderr_limit: int,
+    request: ToolCommandRequest,
 ) -> ToolCommandResult:
-    request = ToolCommandRequest(
-        executable=command[0],
-        arguments=tuple(command[1:]),
-        environment=environment,
-        cwd=str(Path.cwd()),
-        timeout_seconds=timeout_seconds,
-        stdin_bytes=input_bytes,
-        stdout_limit_bytes=stdout_limit,
-        stderr_limit_bytes=stderr_limit,
-    )
     return run_tool_command(request)
+
+
+def owned_fixture_path(
+    module_file: str, repository_relative: str, container_name: str
+) -> Path:
+    """Select a passive fixture in a checkout or beside a copied container script."""
+
+    module_path = Path(module_file).resolve()
+    if len(module_path.parents) > 3:
+        checkout_candidate = module_path.parents[3] / repository_relative
+        if checkout_candidate.is_file():
+            return checkout_candidate
+    return module_path.with_name(container_name)
 
 
 def sha256_bytes(payload: bytes) -> str:

--- a/src/jacobian/math/code_theory/__init__.py
+++ b/src/jacobian/math/code_theory/__init__.py
@@ -1,9 +1,15 @@
 """Code theory operations."""
 
 from jacobian.math.code_theory.operations import (
+    GeneratorMatrix,
     covering_radius,
     minimum_distance,
     weight_distribution,
 )
 
-__all__ = ["covering_radius", "minimum_distance", "weight_distribution"]
+__all__ = [
+    "GeneratorMatrix",
+    "covering_radius",
+    "minimum_distance",
+    "weight_distribution",
+]

--- a/src/jacobian/math/code_theory/_operations.py
+++ b/src/jacobian/math/code_theory/_operations.py
@@ -17,15 +17,15 @@ from jacobian.math.code_theory._models import (
 
 
 def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
-    dist = minimum_distance(request.generator_matrix, request.field_order)  # type: ignore[no-untyped-call]
+    dist = minimum_distance(request.generator_matrix, request.field_order)
     return MinimumDistanceResult(minimum_distance=dist)
 
 
 def compute_weight_dist(request: LinearCodeRequest) -> WeightDistributionResult:
-    weights = weight_distribution(request.generator_matrix, request.field_order)  # type: ignore[no-untyped-call]
+    weights = weight_distribution(request.generator_matrix, request.field_order)
     return WeightDistributionResult(weights=tuple((w, c) for w, c in weights))
 
 
 def compute_covering_radius(request: CoveringRadiusRequest) -> CoveringRadiusResult:
-    radius = covering_radius(request.generator_matrix, request.field_order)  # type: ignore[no-untyped-call]
+    radius = covering_radius(request.generator_matrix, request.field_order)
     return CoveringRadiusResult(covering_radius=radius)

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterator
 from itertools import product
 
-__all__ = ["covering_radius", "minimum_distance", "weight_distribution"]
+__all__ = [
+    "GeneratorMatrix",
+    "covering_radius",
+    "minimum_distance",
+    "weight_distribution",
+]
 
 
-def _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+GeneratorMatrix = tuple[tuple[int, ...], ...]
+
+
+def _codewords(
+    generator_matrix: GeneratorMatrix, field_order: int
+) -> Iterator[tuple[int, ...]]:
     from flint import nmod_mat
 
     n_rows = len(generator_matrix)
@@ -16,34 +27,49 @@ def _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-def]
     seen = set()
     for coeffs in product(range(field_order), repeat=n_rows):
         coefficient_row = nmod_mat([list(coeffs)], field_order)
-        codeword = tuple((coefficient_row * generator).tolist()[0])
+        codeword = tuple(
+            int(value) for value in (coefficient_row * generator).tolist()[0]
+        )
         if codeword not in seen:
             seen.add(codeword)
             yield codeword
 
 
-def minimum_distance(generator_matrix, field_order):  # type: ignore[no-untyped-def]
-    if field_order < 2:
-        raise ValueError("field_order must be at least 2")
+def minimum_distance(generator_matrix: GeneratorMatrix, field_order: int) -> int:
+    from jacobian.math.code_theory._models import LinearCodeRequest
+
+    request = LinearCodeRequest(
+        generator_matrix=generator_matrix, field_order=field_order
+    )
     min_dist = float("inf")
-    for codeword in _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-call]
+    for codeword in _codewords(request.generator_matrix, request.field_order):
         weight = sum(1 for c in codeword if c != 0)
         if weight > 0 and weight < min_dist:
             min_dist = weight
     return int(min_dist) if min_dist != float("inf") else 0
 
 
-def weight_distribution(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+def weight_distribution(
+    generator_matrix: GeneratorMatrix, field_order: int
+) -> list[tuple[int, int]]:
     from collections import Counter
 
+    from jacobian.math.code_theory._models import LinearCodeRequest
+
+    request = LinearCodeRequest(
+        generator_matrix=generator_matrix, field_order=field_order
+    )
+
     weights: Counter[int] = Counter()
-    for codeword in _codewords(generator_matrix, field_order):  # type: ignore[no-untyped-call]
+    for codeword in _codewords(request.generator_matrix, request.field_order):
         weight = sum(1 for c in codeword if c != 0)
         weights[weight] += 1
     return sorted(weights.items())
 
 
-def _parity_check_matrix(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+def _parity_check_matrix(
+    generator_matrix: GeneratorMatrix, field_order: int
+) -> list[list[int]]:
     """Return a basis of the generator matrix's right nullspace."""
     rows = [list(row) for row in generator_matrix]
     row_count = len(rows)
@@ -91,7 +117,7 @@ def _parity_check_matrix(generator_matrix, field_order):  # type: ignore[no-unty
     return check_rows
 
 
-def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-def]
+def covering_radius(generator_matrix: GeneratorMatrix, field_order: int) -> int:
     """Compute a linear code's covering radius by syndrome-space BFS.
 
     One graph step adds a nonzero scalar multiple of one parity-check column,
@@ -99,9 +125,14 @@ def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-d
     Therefore graph distance from the zero syndrome is minimum coset-leader
     weight, and the maximum distance is the covering radius.
     """
-    check_rows = _parity_check_matrix(  # type: ignore[no-untyped-call]
-        generator_matrix,
-        field_order,
+    from jacobian.math.code_theory._models import CoveringRadiusRequest
+
+    request = CoveringRadiusRequest(
+        generator_matrix=generator_matrix, field_order=field_order
+    )
+    check_rows = _parity_check_matrix(
+        request.generator_matrix,
+        request.field_order,
     )
     if not check_rows:
         return 0
@@ -111,11 +142,11 @@ def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-d
     zero = (0,) * syndrome_dimension
     move_set = {
         tuple(
-            scalar * check_rows[row][column] % field_order
+            scalar * check_rows[row][column] % request.field_order
             for row in range(syndrome_dimension)
         )
         for column in range(column_count)
-        for scalar in range(1, field_order)
+        for scalar in range(1, request.field_order)
     }
     move_set.discard(zero)
     moves = tuple(sorted(move_set))
@@ -128,7 +159,7 @@ def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-d
         next_distance = distances[syndrome] + 1
         for move in moves:
             neighbor = tuple(
-                (left + right) % field_order
+                (left + right) % request.field_order
                 for left, right in zip(syndrome, move, strict=True)
             )
             if neighbor in distances:
@@ -137,7 +168,7 @@ def covering_radius(generator_matrix, field_order):  # type: ignore[no-untyped-d
             radius = max(radius, next_distance)
             queue.append(neighbor)
 
-    expected_states = field_order**syndrome_dimension
+    expected_states = request.field_order**syndrome_dimension
     if len(distances) != expected_states:
         raise ArithmeticError("parity-check columns did not span the syndrome space")
     return radius

--- a/src/jacobian/math/graphs/_independence_z3.py
+++ b/src/jacobian/math/graphs/_independence_z3.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import time
 from typing import Literal
 
-import networkx as nx
 import z3  # type: ignore[import-untyped]
 
-from jacobian.math.graphs import _networkx
 from jacobian.math.graphs.independence import (
     IndependenceNumberRequest,
     IndependenceNumberResult,
@@ -24,7 +22,7 @@ def solve_independence_number(
 ) -> IndependenceNumberResult:
     """Run one wall-clock-bounded exact maximum independent-set optimization."""
 
-    graph = _networkx.graph_from_value(request.graph)
+    started = time.monotonic()
     vertices = request.graph.vertices
     order = len(vertices)
     if not vertices:
@@ -40,8 +38,7 @@ def solve_independence_number(
             detail="the empty graph has independence number zero",
         )
 
-    started = time.monotonic()
-    incumbent = tuple(sorted(nx.approximation.maximum_independent_set(graph)))
+    incumbent: tuple[str, ...] = (min(vertices),)
     remaining_ms = int(
         (request.resource_budget.wall_seconds - (time.monotonic() - started)) * 1000
     )

--- a/src/jacobian/math/graphs/optimization/_chromatic_number.py
+++ b/src/jacobian/math/graphs/optimization/_chromatic_number.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.graphs.optimization._coloring_models import (
@@ -19,12 +21,14 @@ def _search_chromatic_number(
 ) -> GraphChromaticNumberOutput:
     """Run bounded k-colorability decisions until exactness or timeout."""
 
+    started = time.monotonic()
     networkx_graph = build_simple_graph(request.graph)
     output = solve_chromatic_number(
         networkx_graph,
         graph=request.graph,
         vertices=request.graph.vertices,
         wall_seconds=request.resource_budget.wall_seconds,
+        started=started,
     )
 
     return output

--- a/src/jacobian/math/graphs/optimization/_exact_search.py
+++ b/src/jacobian/math/graphs/optimization/_exact_search.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -53,6 +52,7 @@ def _search_thresholds[WitnessT: (VertexWitness, EdgeWitness)](
     incumbent: WitnessT,
     budget: GraphOptimizationBudget,
     solve: Callable[[int, int], tuple[object, WitnessT]],
+    started: float,
 ) -> _SearchResult[WitnessT]:
     import z3  # type: ignore[import-untyped]
 
@@ -64,8 +64,16 @@ def _search_thresholds[WitnessT: (VertexWitness, EdgeWitness)](
         else range(upper_bound, incumbent_value, -1)
     )
     tested: list[OptimizationSearchStep] = []
-    started = time.monotonic()
-
+    if _remaining_ms(started, budget.wall_seconds) <= 0:
+        return _SearchResult(
+            False,
+            incumbent,
+            incumbent_value,
+            lower_bound,
+            upper_bound,
+            (),
+            "WALL_TIME",
+        )
     for bound in thresholds:
         if len(tested) >= budget.max_solver_calls:
             return _SearchResult(
@@ -169,9 +177,8 @@ def solve_domination(
     graph: Any,
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
+    started: float,
 ) -> GraphDominationMinimumOutput:
-    import networkx as nx
-
     vertices = tuple(source.vertices)
     if not vertices:
         return GraphDominationMinimumOutput(
@@ -186,7 +193,7 @@ def solve_domination(
             termination_reason="SPECIAL_CASE",
             detail="the empty graph is dominated by the empty set",
         )
-    incumbent = tuple(sorted(nx.dominating_set(graph)))
+    incumbent = tuple(sorted(vertices))
 
     def solve(bound: int, timeout_ms: int) -> tuple[object, VertexWitness]:
         import z3
@@ -216,6 +223,7 @@ def solve_domination(
         incumbent=incumbent,
         budget=budget,
         solve=solve,
+        started=started,
     )
     return GraphDominationMinimumOutput(
         status="EXACT" if result.exact else "UNKNOWN",
@@ -235,14 +243,10 @@ def solve_minimum_maximal_matching(
     graph: Any,
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
+    started: float,
 ) -> GraphMinimumMaximalMatchingOutput:
-    import networkx as nx
-
     vertices = tuple(source.vertices)
     edges = _canonical_edges(graph)
-    incumbent = tuple(
-        sorted(tuple(sorted(edge)) for edge in nx.maximal_matching(graph))
-    )
     if not edges:
         return GraphMinimumMaximalMatchingOutput(
             status="EXACT",
@@ -256,6 +260,13 @@ def solve_minimum_maximal_matching(
             termination_reason="SPECIAL_CASE",
             detail="an edgeless graph has the empty maximal matching",
         )
+    used: set[str] = set()
+    greedy_edges: list[tuple[str, str]] = []
+    for edge in edges:
+        if edge[0] not in used and edge[1] not in used:
+            greedy_edges.append(edge)
+            used.update(edge)
+    incumbent = tuple(greedy_edges)
 
     def solve(bound: int, timeout_ms: int) -> tuple[object, EdgeWitness]:
         import z3
@@ -296,6 +307,7 @@ def solve_minimum_maximal_matching(
         incumbent=incumbent,
         budget=budget,
         solve=solve,
+        started=started,
     )
     return GraphMinimumMaximalMatchingOutput(
         status="EXACT" if result.exact else "UNKNOWN",
@@ -317,12 +329,24 @@ def _maximum_vertex_search(
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
     kind: Literal["FOREST", "TREE", "BIPARTITE"],
+    started: float,
 ) -> _SearchResult[VertexWitness]:
     import networkx as nx
 
     vertices = tuple(source.vertices)
     if not vertices:
         return _SearchResult(True, (), 0, 0, 0, (), "SPECIAL_CASE")
+    incumbent: VertexWitness = (min(vertices),)
+    if _remaining_ms(started, budget.wall_seconds) <= 0:
+        return _SearchResult(
+            False,
+            incumbent,
+            1,
+            1,
+            len(vertices),
+            (),
+            "WALL_TIME",
+        )
     whole_valid = (
         nx.is_forest(graph)
         if kind == "FOREST"
@@ -341,7 +365,6 @@ def _maximum_vertex_search(
             (),
             "SPECIAL_CASE",
         )
-    incumbent: VertexWitness = (min(vertices),)
     edges = _canonical_edges(graph)
 
     def solve(bound: int, timeout_ms: int) -> tuple[object, VertexWitness]:
@@ -406,6 +429,7 @@ def _maximum_vertex_search(
         incumbent=incumbent,
         budget=budget,
         solve=solve,
+        started=started,
     )
 
 
@@ -413,9 +437,10 @@ def solve_induced_forest(
     graph: Any,
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
+    started: float,
 ) -> GraphInducedForestMaximumOutput:
     result = _maximum_vertex_search(
-        graph=graph, source=source, budget=budget, kind="FOREST"
+        graph=graph, source=source, budget=budget, kind="FOREST", started=started
     )
     return GraphInducedForestMaximumOutput(
         status="EXACT" if result.exact else "UNKNOWN",
@@ -435,9 +460,10 @@ def solve_induced_tree(
     graph: Any,
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
+    started: float,
 ) -> GraphInducedTreeMaximumOutput:
     result = _maximum_vertex_search(
-        graph=graph, source=source, budget=budget, kind="TREE"
+        graph=graph, source=source, budget=budget, kind="TREE", started=started
     )
     return GraphInducedTreeMaximumOutput(
         status="EXACT" if result.exact else "UNKNOWN",
@@ -457,9 +483,14 @@ def solve_induced_bipartite(
     graph: Any,
     source: ChromaticGraph,
     budget: GraphOptimizationBudget,
+    started: float,
 ) -> GraphInducedBipartiteMaximumOutput:
     result = _maximum_vertex_search(
-        graph=graph, source=source, budget=budget, kind="BIPARTITE"
+        graph=graph,
+        source=source,
+        budget=budget,
+        kind="BIPARTITE",
+        started=started,
     )
     return GraphInducedBipartiteMaximumOutput(
         status="EXACT" if result.exact else "UNKNOWN",

--- a/src/jacobian/math/graphs/optimization/_finite_optimization.py
+++ b/src/jacobian/math/graphs/optimization/_finite_optimization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -104,12 +105,13 @@ def _valid_witness(graph: Any, result: StrictModel) -> bool:
 def _execute[ResultT: StrictModel](
     request: GraphOptimizationRequest,
     solve: Callable[
-        [Any, ChromaticGraph, GraphOptimizationBudget],
+        [Any, ChromaticGraph, GraphOptimizationBudget, float],
         ResultT,
     ],
 ) -> ResultT:
+    started = time.monotonic()
     graph = cast(Any, build_simple_graph(request.graph))
-    result = solve(graph, request.graph, request.resource_budget)
+    result = solve(graph, request.graph, request.resource_budget, started)
     if not _valid_witness(graph, result):
         raise RuntimeError("graph optimization backend returned an invalid witness")
     return result
@@ -120,7 +122,7 @@ def _operation[ResultT: StrictModel](
     title: str,
     description: str,
     result_type: type[ResultT],
-    solve: Callable[[Any, ChromaticGraph, GraphOptimizationBudget], ResultT],
+    solve: Callable[[Any, ChromaticGraph, GraphOptimizationBudget, float], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
 ) -> MathTool[GraphOptimizationRequest, ResultT]:
@@ -142,7 +144,9 @@ DOMINATION_MINIMUM_OPERATION = _operation(
     "Minimum dominating set",
     "Compute the domination number and an attaining set within explicit budgets.",
     GraphDominationMinimumOutput,
-    lambda graph, contract, budget: solve_domination(graph, contract, budget),
+    lambda graph, contract, budget, started: solve_domination(
+        graph, contract, budget, started
+    ),
     "domination",
     "minimum",
     examples=(
@@ -165,8 +169,8 @@ MINIMUM_MAXIMAL_MATCHING_OPERATION = _operation(
     "Minimum maximal matching",
     "Compute the saturation number and an attaining maximal matching within explicit budgets.",
     GraphMinimumMaximalMatchingOutput,
-    lambda graph, contract, budget: solve_minimum_maximal_matching(
-        graph, contract, budget
+    lambda graph, contract, budget, started: solve_minimum_maximal_matching(
+        graph, contract, budget, started
     ),
     "matching",
     "saturation_number",
@@ -191,7 +195,9 @@ INDUCED_FOREST_MAXIMUM_OPERATION = _operation(
     "Maximum induced forest",
     "Compute a maximum-order induced forest and vertex witness within explicit budgets.",
     GraphInducedForestMaximumOutput,
-    lambda graph, contract, budget: solve_induced_forest(graph, contract, budget),
+    lambda graph, contract, budget, started: solve_induced_forest(
+        graph, contract, budget, started
+    ),
     "induced_forest",
     "maximum",
     examples=(
@@ -214,7 +220,9 @@ INDUCED_TREE_MAXIMUM_OPERATION = _operation(
     "Maximum induced tree",
     "Compute a maximum-order induced tree and vertex witness within explicit budgets.",
     GraphInducedTreeMaximumOutput,
-    lambda graph, contract, budget: solve_induced_tree(graph, contract, budget),
+    lambda graph, contract, budget, started: solve_induced_tree(
+        graph, contract, budget, started
+    ),
     "induced_tree",
     "maximum",
     examples=(
@@ -237,7 +245,9 @@ INDUCED_BIPARTITE_MAXIMUM_OPERATION = _operation(
     "Maximum induced bipartite subgraph",
     "Compute a maximum-order induced bipartite subgraph within explicit budgets.",
     GraphInducedBipartiteMaximumOutput,
-    lambda graph, contract, budget: solve_induced_bipartite(graph, contract, budget),
+    lambda graph, contract, budget, started: solve_induced_bipartite(
+        graph, contract, budget, started
+    ),
     "induced_bipartite",
     "maximum",
     examples=(

--- a/src/jacobian/math/graphs/optimization/_invariants.py
+++ b/src/jacobian/math/graphs/optimization/_invariants.py
@@ -243,9 +243,9 @@ def _clique_execute(
 ) -> GraphCliqueNumberResult:
     """Compute the clique number via bounded Z3 threshold search."""
 
-    import networkx as nx
     import z3  # type: ignore[import-untyped]
 
+    started = time.monotonic()
     graph = cast(Any, build_simple_graph(request.graph))
     vertices = tuple(request.graph.vertices)
     if not vertices:
@@ -262,9 +262,8 @@ def _clique_execute(
             detail="the empty graph has optimum zero",
         )
 
-    incumbent = tuple(sorted(nx.approximation.max_clique(graph)))
+    incumbent: tuple[str, ...] = (min(vertices),)
     tested: list[OptimizationSearchStep] = []
-    started = time.monotonic()
     termination: OptimizationTermination = "BOUND_CONVERGENCE"
     upper_bound = len(vertices)
     exact = False

--- a/src/jacobian/math/graphs/optimization/_operations.py
+++ b/src/jacobian/math/graphs/optimization/_operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from typing import Any
 
 from jacobian.math.graphs.optimization._budget import remaining_ms as _remaining_ms
@@ -83,6 +82,7 @@ def solve_chromatic_number(
     graph: ChromaticGraph,
     vertices: tuple[str, ...],
     wall_seconds: int,
+    started: float,
 ) -> GraphChromaticNumberOutput:
     """Bounded Z3 k-colorability search returning EXACT or UNKNOWN.
 
@@ -92,7 +92,6 @@ def solve_chromatic_number(
     tested k-colorability trace; it is never a negative conclusion.
     """
 
-    import networkx as nx
     import z3  # type: ignore[import-untyped]
 
     n = len(vertices)
@@ -110,12 +109,18 @@ def solve_chromatic_number(
             detail="the empty graph requires zero colors",
         )
 
-    greedy = nx.coloring.greedy_color(
-        networkx_graph,
-        strategy="saturation_largest_first",
-    )
-    upper_bound = max(greedy.values(), default=-1) + 1
+    greedy = {vertex: color for color, vertex in enumerate(vertices)}
+    upper_bound = n
     lower_bound = 2 if networkx_graph.number_of_edges() else 1
+    if _remaining_ms(started, wall_seconds) <= 0:
+        return _unknown_chromatic_result(
+            vertices=vertices,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            coloring=greedy,
+            tested=[],
+            detail="the chromatic-number wall-clock budget expired",
+        )
     if upper_bound == lower_bound:
         return GraphChromaticNumberOutput(
             status="EXACT",
@@ -130,7 +135,6 @@ def solve_chromatic_number(
             detail="a maintained greedy coloring and graph edge bound coincide",
         )
 
-    started = time.monotonic()
     tested: list[ChromaticSearchStep] = []
     encoded_graph = canonical_graph(graph)
     for colors in range(lower_bound, upper_bound + 1):

--- a/src/jacobian/math/graphs/spectral/__init__.py
+++ b/src/jacobian/math/graphs/spectral/__init__.py
@@ -1,8 +1,9 @@
 """Supported exact graph spectral API."""
 
+from jacobian.math.graphs.spectral._models import GraphEdgeList
 from jacobian.math.graphs.spectral.operations import (
     adjacency_spectrum,
     laplacian_spectrum,
 )
 
-__all__ = ["adjacency_spectrum", "laplacian_spectrum"]
+__all__ = ["GraphEdgeList", "adjacency_spectrum", "laplacian_spectrum"]

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -10,10 +10,7 @@ from jacobian.math.graphs.spectral._models import (
 
 
 def compute_adjacency_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumResult:
-    result = adjacency_spectrum(  # type: ignore[no-untyped-call]
-        request.graph.vertex_count,
-        [list(e) for e in request.graph.edges],
-    )
+    result = adjacency_spectrum(request.graph)
     return GraphSpectrumResult(
         eigenvalues=tuple(v for v, _ in result),
         multiplicities=tuple(m for _, m in result),
@@ -21,10 +18,7 @@ def compute_adjacency_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
 
 
 def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumResult:
-    result = laplacian_spectrum(  # type: ignore[no-untyped-call]
-        request.graph.vertex_count,
-        [list(e) for e in request.graph.edges],
-    )
+    result = laplacian_spectrum(request.graph)
     return GraphSpectrumResult(
         eigenvalues=tuple(v for v, _ in result),
         multiplicities=tuple(m for _, m in result),

--- a/src/jacobian/math/graphs/spectral/operations.py
+++ b/src/jacobian/math/graphs/spectral/operations.py
@@ -2,34 +2,34 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 __all__ = ["adjacency_spectrum", "laplacian_spectrum"]
 
+from jacobian.math.graphs.spectral._models import GraphEdgeList
 
-def _adjacency_matrix(vertex_count, edges):  # type: ignore[no-untyped-def]
+
+def _adjacency_matrix(graph: GraphEdgeList) -> Any:
     import sympy
 
-    mat = sympy.zeros(vertex_count)
-    for u, v in edges:
+    mat = sympy.zeros(graph.vertex_count)
+    for u, v in graph.edges:
         mat[u, v] = 1
         mat[v, u] = 1
     return mat
 
 
-def adjacency_spectrum(vertex_count, edges):  # type: ignore[no-untyped-def]
-    if not 1 <= vertex_count <= 32:
-        raise ValueError("graph vertex count must be between 1 and 32")
-    mat = _adjacency_matrix(vertex_count, edges)  # type: ignore[no-untyped-call]
+def adjacency_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
+    mat = _adjacency_matrix(graph)
     eigenvals = mat.eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]
 
 
-def laplacian_spectrum(vertex_count, edges):  # type: ignore[no-untyped-def]
+def laplacian_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
     import sympy
 
-    if not 1 <= vertex_count <= 32:
-        raise ValueError("graph vertex count must be between 1 and 32")
-    adj = _adjacency_matrix(vertex_count, edges)  # type: ignore[no-untyped-call]
-    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(vertex_count)))
+    adj = _adjacency_matrix(graph)
+    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(graph.vertex_count)))
     lap = degree - adj
     eigenvals = lap.eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]

--- a/src/jacobian/math/markov_chain/__init__.py
+++ b/src/jacobian/math/markov_chain/__init__.py
@@ -1,5 +1,9 @@
 """Markov chain operations."""
 
+from jacobian.math.markov_chain._models import (
+    StationaryDistributionRequest,
+    TransitionMatrixRequest,
+)
 from jacobian.math.markov_chain.operations import (
     MixingTimeSearchResult,
     ergodic_properties,
@@ -10,6 +14,8 @@ from jacobian.math.markov_chain.operations import (
 
 __all__ = [
     "MixingTimeSearchResult",
+    "StationaryDistributionRequest",
+    "TransitionMatrixRequest",
     "ergodic_properties",
     "mixing_time",
     "stationary_distribution",

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -2,31 +2,28 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
-
 from jacobian._exact import CanonicalRational
 from jacobian.math.markov_chain import (
     ergodic_properties,
     mixing_time,
-    stationary_distribution_extremes,
 )
 from jacobian.math.markov_chain._models import (
     ErgodicDecisionResult,
     ExtremeStationaryDistribution,
     MixingTimeRequest,
     MixingTimeResult,
+    StationaryDistributionRequest,
     StationaryDistributionResult,
     TransitionMatrixRequest,
 )
+from jacobian.math.markov_chain.operations import _stationary_distribution_extremes
 
 
 def compute_mixing_time(request: MixingTimeRequest) -> MixingTimeResult:
     matrix = tuple(
         tuple(value.as_fraction() for value in row) for row in request.matrix
     )
-    irreducible, aperiodic = ergodic_properties(
-        [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
-    )  # type: ignore[no-untyped-call]
+    irreducible, aperiodic = ergodic_properties(request)
     if not (irreducible and aperiodic):
         return MixingTimeResult(
             status="NOT_ERGODIC",
@@ -34,10 +31,8 @@ def compute_mixing_time(request: MixingTimeRequest) -> MixingTimeResult:
             max_steps=request.max_steps,
             steps_examined=0,
         )
-    extremes = stationary_distribution_extremes(
-        [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
-    )  # type: ignore[no-untyped-call]
-    stationary = tuple(Fraction(int(value.p), int(value.q)) for value in extremes[0][1])
+    extremes = _stationary_distribution_extremes(request)
+    stationary = extremes[0][1]
     outcome = mixing_time(
         matrix, stationary, request.epsilon.as_fraction(), request.max_steps
     )
@@ -56,16 +51,17 @@ def compute_mixing_time(request: MixingTimeRequest) -> MixingTimeResult:
 
 
 def compute_stationary_distribution(
-    request: TransitionMatrixRequest,
+    request: StationaryDistributionRequest,
 ) -> StationaryDistributionResult:
-    matrix = [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
-    extremes = stationary_distribution_extremes(matrix)  # type: ignore[no-untyped-call]
+    extremes = _stationary_distribution_extremes(request)
     return StationaryDistributionResult(
         extreme_distributions=tuple(
             ExtremeStationaryDistribution(
                 closed_class=closed_class,
                 distribution=tuple(
-                    CanonicalRational.from_integer_ratio(int(value.p), int(value.q))
+                    CanonicalRational.from_integer_ratio(
+                        value.numerator, value.denominator
+                    )
                     for value in distribution
                 ),
             )
@@ -76,8 +72,7 @@ def compute_stationary_distribution(
 
 
 def compute_ergodic_decision(request: TransitionMatrixRequest) -> ErgodicDecisionResult:
-    matrix = [[{"num": c.num, "den": c.den} for c in row] for row in request.matrix]
-    irreducible, aperiodic = ergodic_properties(matrix)  # type: ignore[no-untyped-call]
+    irreducible, aperiodic = ergodic_properties(request)
     return ErgodicDecisionResult(
         is_ergodic=irreducible and aperiodic,
         is_irreducible=irreducible,

--- a/src/jacobian/math/markov_chain/operations.py
+++ b/src/jacobian/math/markov_chain/operations.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 from fractions import Fraction
 
 from jacobian.canonical import parse_canonical_integer
+from jacobian.math.markov_chain._models import (
+    StationaryDistributionRequest,
+    TransitionMatrixRequest,
+)
 
 __all__ = [
     "MixingTimeSearchResult",
@@ -58,19 +62,22 @@ def mixing_time(
     )
 
 
-def stationary_distribution_extremes(matrix):  # type: ignore[no-untyped-def]
+def _stationary_distribution_extremes(
+    request: TransitionMatrixRequest,
+) -> list[tuple[tuple[int, ...], tuple[Fraction, ...]]]:
     """Return one normalized stationary vector for every closed class."""
 
     import networkx as nx
     import sympy
 
+    matrix = request.matrix
     n = len(matrix)
     p = sympy.Matrix(
         [
             [
                 sympy.Rational(
-                    parse_canonical_integer(matrix[i][j]["num"]),
-                    parse_canonical_integer(matrix[i][j]["den"]),
+                    parse_canonical_integer(matrix[i][j].num),
+                    parse_canonical_integer(matrix[i][j].den),
                 )
                 for j in range(n)
             ]
@@ -83,7 +90,7 @@ def stationary_distribution_extremes(matrix):  # type: ignore[no-untyped-def]
         (source, target)
         for source, row in enumerate(matrix)
         for target, value in enumerate(row)
-        if value["num"] != "0"
+        if value.as_fraction() != 0
     )
     closed_classes = sorted(
         (
@@ -97,7 +104,7 @@ def stationary_distribution_extremes(matrix):  # type: ignore[no-untyped-def]
         ),
         key=lambda component: component,
     )
-    extremes = []
+    extremes: list[tuple[tuple[int, ...], tuple[Fraction, ...]]] = []
     for closed_class in closed_classes:
         submatrix = p.extract(closed_class, closed_class)
         equations = submatrix.T - sympy.eye(len(closed_class))
@@ -108,14 +115,29 @@ def stationary_distribution_extremes(matrix):  # type: ignore[no-untyped-def]
         distribution = [sympy.S.Zero] * n
         for index, state in enumerate(closed_class):
             distribution[state] = local[index]
-        extremes.append((closed_class, distribution))
+        extremes.append(
+            (
+                closed_class,
+                tuple(Fraction(int(value.p), int(value.q)) for value in distribution),
+            )
+        )
     return extremes
 
 
-def stationary_distribution(matrix):  # type: ignore[no-untyped-def]
+def stationary_distribution_extremes(
+    request: StationaryDistributionRequest,
+) -> list[tuple[tuple[int, ...], tuple[Fraction, ...]]]:
+    """Return one normalized stationary vector for every closed class."""
+
+    return _stationary_distribution_extremes(request)
+
+
+def stationary_distribution(
+    request: StationaryDistributionRequest,
+) -> tuple[Fraction, ...]:
     """Return the unique stationary distribution, rejecting non-unique chains."""
 
-    extremes = stationary_distribution_extremes(matrix)  # type: ignore[no-untyped-call]
+    extremes = _stationary_distribution_extremes(request)
     if len(extremes) != 1:
         raise ValueError(
             "the Markov chain does not have a unique stationary distribution"
@@ -123,16 +145,17 @@ def stationary_distribution(matrix):  # type: ignore[no-untyped-def]
     return extremes[0][1]
 
 
-def ergodic_properties(matrix):  # type: ignore[no-untyped-def]
+def ergodic_properties(request: TransitionMatrixRequest) -> tuple[bool, bool]:
     import networkx as nx
 
     graph: nx.DiGraph[int] = nx.DiGraph()
+    matrix = request.matrix
     graph.add_nodes_from(range(len(matrix)))
     graph.add_edges_from(
         (source, target)
         for source, row in enumerate(matrix)
         for target, value in enumerate(row)
-        if value["num"] != "0"
+        if value.as_fraction() != 0
     )
     irreducible = nx.is_strongly_connected(graph)
     aperiodic = all(

--- a/src/jacobian/math/recurrence_solving/__init__.py
+++ b/src/jacobian/math/recurrence_solving/__init__.py
@@ -1,5 +1,10 @@
 """Recurrence solving operations."""
 
-from jacobian.math.recurrence_solving.operations import closed_form, find_recurrence
+from jacobian.math.recurrence_solving.operations import (
+    ClosedForm,
+    Recurrence,
+    closed_form,
+    find_recurrence,
+)
 
-__all__ = ["closed_form", "find_recurrence"]
+__all__ = ["ClosedForm", "Recurrence", "closed_form", "find_recurrence"]

--- a/src/jacobian/math/recurrence_solving/_operations.py
+++ b/src/jacobian/math/recurrence_solving/_operations.py
@@ -12,17 +12,17 @@ from jacobian.math.recurrence_solving._models import (
 
 
 def compute_find_recurrence(request: RecurrenceFindRequest) -> RecurrenceFindResult:
-    result = find_recurrence(list(request.sequence))  # type: ignore[no-untyped-call]
+    result = find_recurrence(request.sequence)
     return RecurrenceFindResult(
-        coefficients=result["coefficients"],
-        order=result["order"],
-        status=result["status"],
+        coefficients=result.coefficients,
+        order=result.order,
+        status=result.status,
     )
 
 
 def compute_closed_form(request: ClosedFormRequest) -> ClosedFormResult:
-    result = closed_form(  # type: ignore[no-untyped-call]
-        list(request.characteristic_coefficients),
-        list(request.initial_values),
+    result = closed_form(
+        request.characteristic_coefficients,
+        request.initial_values,
     )
-    return ClosedFormResult(expression=result["expression"])
+    return ClosedFormResult(expression=result.expression)

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -2,15 +2,36 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
+
 from jacobian.canonical import parse_canonical_integer
 
-__all__ = ["closed_form", "find_recurrence"]
+__all__ = ["ClosedForm", "Recurrence", "closed_form", "find_recurrence"]
 
 
-def find_recurrence(sequence):  # type: ignore[no-untyped-def]
+@dataclass(frozen=True, slots=True)
+class Recurrence:
+    coefficients: tuple[str, ...]
+    order: int
+    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+
+
+@dataclass(frozen=True, slots=True)
+class ClosedForm:
+    expression: str
+
+
+def find_recurrence(sequence: tuple[str, ...]) -> Recurrence:
     import sympy
 
-    values = [sympy.Rational(parse_canonical_integer(value)) for value in sequence]
+    from jacobian.math.recurrence_solving._models import RecurrenceFindRequest
+
+    request = RecurrenceFindRequest(sequence=sequence)
+
+    values = [
+        sympy.Rational(parse_canonical_integer(value)) for value in request.sequence
+    ]
     for order in range(1, len(values)):
         coefficient_matrix = sympy.Matrix(
             [
@@ -25,24 +46,32 @@ def find_recurrence(sequence):  # type: ignore[no-untyped-def]
             continue
         if parameters:
             solution = solution.subs(dict.fromkeys(parameters, 0))
-        return {
-            "coefficients": tuple(str(value) for value in solution),
-            "order": order,
-            "status": "FOUND",
-        }
-    return {
-        "coefficients": (),
-        "order": 0,
-        "status": "NO_FITTING_RECURRENCE",
-    }
+        return Recurrence(
+            coefficients=tuple(str(value) for value in solution),
+            order=order,
+            status="FOUND",
+        )
+    return Recurrence(coefficients=(), order=0, status="NO_FITTING_RECURRENCE")
 
 
-def closed_form(char_coeffs, initial_values):  # type: ignore[no-untyped-def]
+def closed_form(
+    char_coeffs: tuple[str, ...], initial_values: tuple[str, ...]
+) -> ClosedForm:
     import sympy
+
+    from jacobian.math.recurrence_solving._models import ClosedFormRequest
+
+    request = ClosedFormRequest(
+        characteristic_coefficients=char_coeffs,
+        initial_values=initial_values,
+    )
 
     x = sympy.Symbol("x")
     n = sympy.Symbol("n", integer=True, nonnegative=True)
-    char_poly_coeffs = [sympy.Rational(parse_canonical_integer(c)) for c in char_coeffs]
+    char_poly_coeffs = [
+        sympy.Rational(parse_canonical_integer(c))
+        for c in request.characteristic_coefficients
+    ]
     char_poly = sum(
         c * x ** (len(char_poly_coeffs) - 1 - i) for i, c in enumerate(char_poly_coeffs)
     )
@@ -55,9 +84,9 @@ def closed_form(char_coeffs, initial_values):  # type: ignore[no-untyped-def]
         for root in nonzero_roots
         for power in range(roots.count(root))
     )
-    init = [sympy.Rational(parse_canonical_integer(v)) for v in initial_values]
+    init = [sympy.Rational(parse_canonical_integer(v)) for v in request.initial_values]
     a = sympy.Matrix([[term.subs(n, i) for term in basis] for i in range(len(basis))])
     b = sympy.Matrix(init)
     consts = a.solve(b)
     expr = sum(c * term for c, term in zip(consts, basis, strict=True))
-    return {"expression": str(sympy.simplify(expr))}
+    return ClosedForm(expression=str(sympy.simplify(expr)))

--- a/tests/fixtures/providers/cddlib/Dockerfile
+++ b/tests/fixtures/providers/cddlib/Dockerfile
@@ -15,8 +15,9 @@ RUN tar -xzf /opt/provider/cddlib.tar.gz -C /opt/provider && \
 WORKDIR /app
 COPY benchmarks/__init__.py /opt/benchmarks/__init__.py
 COPY benchmarks/tooling/__init__.py /opt/benchmarks/tooling/__init__.py
-COPY benchmarks/tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tools/command_runner.py /opt/tools/command_runner.py
 COPY benchmarks/tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
-COPY tests/fixtures/providers/cddlib/input.json tests/fixtures/providers/cddlib/pin.json tests/fixtures/providers/cddlib/spike.py /app/
+COPY tests/fixtures/providers/cddlib/input.json tests/fixtures/providers/cddlib/pin.json /app/
+COPY benchmarks/tooling/providers/cddlib.py /app/spike.py
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/tests/fixtures/providers/cddlib/pin.json
+++ b/tests/fixtures/providers/cddlib/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:ddbf25b188f6fd5ca6aca2fb0ac6f64c514cb76cc00a4cb504fd660baf343d38",
+  "adapter_source_sha256": "sha256:cbf3c2d666505d6d118c0a668743de9d5bc6335f7b40493a01593c06164348a3",
   "contract": "jacobian.cddlib-hv-spike/v1",
   "provider": "cddlib/pycddlib",
   "reproduction": {

--- a/tests/fixtures/providers/cddlib/pin.json
+++ b/tests/fixtures/providers/cddlib/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:cbf3c2d666505d6d118c0a668743de9d5bc6335f7b40493a01593c06164348a3",
+  "adapter_source_sha256": "sha256:5537efbe3b7ad4de528d679a93de1f42ee1101f68820f2c7caa12ca60b800ccc",
   "contract": "jacobian.cddlib-hv-spike/v1",
   "provider": "cddlib/pycddlib",
   "reproduction": {

--- a/tests/fixtures/providers/cgal/Dockerfile
+++ b/tests/fixtures/providers/cgal/Dockerfile
@@ -9,9 +9,10 @@ RUN mkdir -p /opt/provider && \
 WORKDIR /app
 COPY benchmarks/__init__.py /opt/benchmarks/__init__.py
 COPY benchmarks/tooling/__init__.py /opt/benchmarks/tooling/__init__.py
-COPY benchmarks/tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tools/command_runner.py /opt/tools/command_runner.py
 COPY benchmarks/tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
-COPY tests/fixtures/providers/cgal/cgal_delaunay_spike.cpp tests/fixtures/providers/cgal/input.json tests/fixtures/providers/cgal/cgal_delaunay_pin.json tests/fixtures/providers/cgal/spike.py /app/
+COPY tests/fixtures/providers/cgal/cgal_delaunay_spike.cpp tests/fixtures/providers/cgal/input.json tests/fixtures/providers/cgal/cgal_delaunay_pin.json /app/
+COPY benchmarks/tooling/providers/cgal.py /app/spike.py
 RUN g++ -std=c++17 -O2 -I/opt/provider/CGAL-6.2/include /app/cgal_delaunay_spike.cpp -lgmp -lmpfr -o /opt/provider/cgal-spike
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/tests/fixtures/providers/gudhi/Dockerfile
+++ b/tests/fixtures/providers/gudhi/Dockerfile
@@ -9,8 +9,9 @@ RUN mkdir -p /opt/provider && \
 WORKDIR /app
 COPY benchmarks/__init__.py /opt/benchmarks/__init__.py
 COPY benchmarks/tooling/__init__.py /opt/benchmarks/tooling/__init__.py
-COPY benchmarks/tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tools/command_runner.py /opt/tools/command_runner.py
 COPY benchmarks/tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
-COPY tests/fixtures/providers/gudhi/input.json tests/fixtures/providers/gudhi/pin.json tests/fixtures/providers/gudhi/spike.py /app/
+COPY tests/fixtures/providers/gudhi/input.json tests/fixtures/providers/gudhi/pin.json /app/
+COPY benchmarks/tooling/providers/gudhi.py /app/spike.py
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/tests/fixtures/providers/gudhi/pin.json
+++ b/tests/fixtures/providers/gudhi/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:2406f703ceafb0bff19cda9210358f75670f9ae2a08f7688f7cf168a8975eb4a",
+  "adapter_source_sha256": "sha256:61717cf9ed7c8a4bd1ee001637bc906fc2b04ae840157207af63995c6e72c594",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/tests/fixtures/providers/gudhi/pin.json
+++ b/tests/fixtures/providers/gudhi/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:61717cf9ed7c8a4bd1ee001637bc906fc2b04ae840157207af63995c6e72c594",
+  "adapter_source_sha256": "sha256:203a7d79ad3c9114aa65bc9e14a65856bd6807f9e42335ea0ede909909651ddb",
   "contract": "jacobian.gudhi-persistence-spike/v1",
   "documentation_url": "https://gudhi.inria.fr/python/3.13.0/simplex_tree_ref.html",
   "licensing_url": "https://gudhi.inria.fr/licensing/",

--- a/tests/fixtures/providers/nauty/Dockerfile
+++ b/tests/fixtures/providers/nauty/Dockerfile
@@ -10,8 +10,9 @@ RUN mkdir -p /opt/provider && \
 WORKDIR /app
 COPY benchmarks/__init__.py /opt/benchmarks/__init__.py
 COPY benchmarks/tooling/__init__.py /opt/benchmarks/tooling/__init__.py
-COPY benchmarks/tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tools/command_runner.py /opt/tools/command_runner.py
 COPY benchmarks/tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
-COPY tests/fixtures/providers/nauty/input.json tests/fixtures/providers/nauty/nauty_provider_pin.json tests/fixtures/providers/nauty/spike.py /app/
+COPY tests/fixtures/providers/nauty/input.json tests/fixtures/providers/nauty/nauty_provider_pin.json /app/
+COPY benchmarks/tooling/providers/nauty.py /app/spike.py
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/tests/fixtures/providers/regina/Dockerfile
+++ b/tests/fixtures/providers/regina/Dockerfile
@@ -9,8 +9,9 @@ RUN mkdir -p /opt/provider && \
 WORKDIR /app
 COPY benchmarks/__init__.py /opt/benchmarks/__init__.py
 COPY benchmarks/tooling/__init__.py /opt/benchmarks/tooling/__init__.py
-COPY benchmarks/tooling/command_runner.py /opt/benchmarks/tooling/command_runner.py
+COPY tools/command_runner.py /opt/tools/command_runner.py
 COPY benchmarks/tooling/spike_utils.py /opt/benchmarks/tooling/spike_utils.py
-COPY tests/fixtures/providers/regina/input.json tests/fixtures/providers/regina/pin.json tests/fixtures/providers/regina/spike.py /app/
+COPY tests/fixtures/providers/regina/input.json tests/fixtures/providers/regina/pin.json /app/
+COPY benchmarks/tooling/providers/regina.py /app/spike.py
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/opt

--- a/tests/fixtures/providers/regina/pin.json
+++ b/tests/fixtures/providers/regina/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:2c269ed7abb4b9f31815855533e77017b56fd6821d6ba406af353d2c91b7a574",
+  "adapter_source_sha256": "sha256:ec185067a9d5f3068084fe1dfeeac2ef8329acdd57c8ae9a37b08a95df5febca",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/tests/fixtures/providers/regina/pin.json
+++ b/tests/fixtures/providers/regina/pin.json
@@ -1,5 +1,5 @@
 {
-  "adapter_source_sha256": "sha256:ec185067a9d5f3068084fe1dfeeac2ef8329acdd57c8ae9a37b08a95df5febca",
+  "adapter_source_sha256": "sha256:5a135c82a0e40d0a1dcdc28594f4ad77d6737926f29f4f10df52eb22c299efaf",
   "contract": "jacobian.regina-outcomes-spike/v1",
   "distribution_version": "7.4.1",
   "documentation_url": "https://regina-normal.github.io/engine-docs/",

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -157,6 +157,21 @@ def test_recurrence_finder_solves_for_coefficients() -> None:
     assert result.coefficients == ("2",)
 
 
+def test_native_recurrence_api_enforces_the_sequence_contract() -> None:
+    from jacobian.math.recurrence_solving import closed_form, find_recurrence
+
+    recurrence = find_recurrence(("3", "6", "12", "24"))
+    assert recurrence.status == "FOUND"
+    assert recurrence.coefficients == ("2",)
+    assert closed_form(("1", "-2"), ("3",)).expression == "3*2**n"
+
+    with pytest.raises(ValidationError, match="at least 2"):
+        find_recurrence(("1",))
+
+    with pytest.raises(ValidationError, match="initial value count"):
+        closed_form(("1", "-1", "-1"), ("1",))
+
+
 def test_recurrence_finder_reports_a_missing_nonvacuous_fit() -> None:
     result = compute_find_recurrence(RecurrenceFindRequest(sequence=("0", "1")))
 

--- a/tests/integration/graphs/test_exact_operations.py
+++ b/tests/integration/graphs/test_exact_operations.py
@@ -104,6 +104,20 @@ def test_spectral_contract_rejects_non_simple_graphs() -> None:
         )
 
 
+def test_native_spectral_api_requires_a_validated_simple_graph() -> None:
+    from jacobian.math.graphs.spectral import (
+        GraphEdgeList,
+        adjacency_spectrum,
+        laplacian_spectrum,
+    )
+
+    graph = GraphEdgeList(vertex_count=2, edges=((0, 1),))
+    assert dict(laplacian_spectrum(graph)) == {"0": 1, "2": 1}
+
+    with pytest.raises(ValidationError, match="self-loops"):
+        adjacency_spectrum(GraphEdgeList(vertex_count=2, edges=((0, 0),)))
+
+
 def test_laplacian_spectrum_uses_normalized_simple_graph_degree() -> None:
     result = compute_laplacian_spectrum(
         GraphSpectrumRequest.model_validate(

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.code_theory import minimum_distance
 from jacobian.math.code_theory._models import (
     CoveringRadiusRequest,
     LinearCodeRequest,
@@ -32,6 +33,21 @@ def test_code_contract_rejects_nonprime_fields_and_unbounded_enumeration() -> No
         LinearCodeRequest(field_order=4, generator_matrix=((1,),))
     with pytest.raises(ValidationError, match="enumeration"):
         LinearCodeRequest(field_order=251, generator_matrix=((1,), (1,), (1,)))
+
+
+def test_native_code_api_enforces_the_prime_field_contract() -> None:
+    assert minimum_distance(((1, 1),), 2) == 2
+
+    with pytest.raises(ValidationError, match="prime"):
+        minimum_distance(((1,),), 4)
+
+
+@pytest.mark.parametrize("generator_matrix", [(), ((1, 0), (1,))])
+def test_native_code_api_rejects_invalid_generator_shapes(
+    generator_matrix: tuple[tuple[int, ...], ...],
+) -> None:
+    with pytest.raises(ValidationError, match=r"at least 1|equal length"):
+        minimum_distance(generator_matrix, 2)
 
 
 def test_binary_repetition_code_length_three_has_covering_radius_one() -> None:

--- a/tests/math/graphs/test_optimization_wall_budget.py
+++ b/tests/math/graphs/test_optimization_wall_budget.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from jacobian.math.graphs import _independence_z3
+from jacobian.math.graphs.independence import (
+    IndependenceNumberBudget,
+    IndependenceNumberRequest,
+)
+from jacobian.math.graphs.optimization import (
+    _chromatic_number,
+    _finite_optimization,
+    _invariants,
+)
+from jacobian.math.graphs.optimization._coloring_models import (
+    ChromaticGraph,
+    GraphChromaticNumberRequest,
+)
+from jacobian.math.graphs.optimization._models import (
+    GraphOptimizationBudget,
+    GraphOptimizationRequest,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph() -> ChromaticGraph:
+    return ChromaticGraph(vertices=("a", "b", "c"), edges=(("a", "b"), ("b", "c")))
+
+
+def _expired(monkeypatch: pytest.MonkeyPatch, entry_module: object) -> None:
+    clock = iter((0.0, 2.0))
+    monkeypatch.setattr(entry_module.time, "monotonic", lambda: next(clock, 2.0))
+
+
+def test_clique_budget_starts_before_incumbent_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _expired(monkeypatch, _invariants)
+    monkeypatch.setattr(
+        nx.approximation,
+        "max_clique",
+        lambda _graph: (_ for _ in ()).throw(
+            AssertionError("uninterruptible clique seed must not run")
+        ),
+    )
+    request = GraphOptimizationRequest(
+        graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=1)
+    )
+
+    result = _invariants._clique_execute(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.termination_reason == "WALL_TIME"
+    assert result.tested == ()
+
+
+def test_chromatic_budget_starts_before_graph_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _expired(monkeypatch, _chromatic_number)
+    monkeypatch.setattr(
+        nx.coloring,
+        "greedy_color",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("uninterruptible coloring seed must not run")
+        ),
+    )
+    request = GraphChromaticNumberRequest.model_validate(
+        {"graph": _graph().model_dump(), "resource_budget": {"wall_seconds": 1}}
+    )
+
+    result = _chromatic_number._search_chromatic_number(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.solver_status == "UNKNOWN"
+    assert "wall-clock budget expired" in result.detail
+    assert result.tested == ()
+
+
+@pytest.mark.parametrize(
+    ("operation", "seed_name"),
+    [
+        (_finite_optimization.DOMINATION_MINIMUM_OPERATION, "dominating_set"),
+        (
+            _finite_optimization.MINIMUM_MAXIMAL_MATCHING_OPERATION,
+            "maximal_matching",
+        ),
+    ],
+)
+def test_finite_searches_do_not_reset_the_operation_timer(
+    monkeypatch: pytest.MonkeyPatch, operation: object, seed_name: str
+) -> None:
+    _expired(monkeypatch, _finite_optimization)
+    monkeypatch.setattr(
+        nx,
+        seed_name,
+        lambda _graph: (_ for _ in ()).throw(
+            AssertionError(f"uninterruptible {seed_name} seed must not run")
+        ),
+    )
+    request = GraphOptimizationRequest(
+        graph=_graph(), resource_budget=GraphOptimizationBudget(wall_seconds=1)
+    )
+
+    result = operation.run(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.termination_reason == "WALL_TIME"
+    assert result.tested == ()
+
+
+def test_independence_does_not_enter_z3_after_seed_budget_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = iter((0.0, 2.0))
+    monkeypatch.setattr(_independence_z3.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(
+        nx.approximation,
+        "maximum_independent_set",
+        lambda _graph: (_ for _ in ()).throw(
+            AssertionError("uninterruptible independence seed must not run")
+        ),
+    )
+
+    class ForbiddenOptimizer:
+        def __init__(self) -> None:
+            raise AssertionError("Z3 must not start after the operation deadline")
+
+    monkeypatch.setattr(_independence_z3.z3, "Optimize", ForbiddenOptimizer)
+    request = IndependenceNumberRequest(
+        graph=SimpleUndirectedGraph(
+            vertices=("a", "b", "c"), edges=(("a", "b"), ("b", "c"))
+        ),
+        resource_budget=IndependenceNumberBudget(wall_seconds=1),
+    )
+
+    result = _independence_z3.solve_independence_number(request)
+
+    assert result.status == "UNKNOWN"
+    assert result.termination_reason == "WALL_TIME"
+    assert result.witness_vertices == ("a",)

--- a/tests/math/markov_chain/test_regressions.py
+++ b/tests/math/markov_chain/test_regressions.py
@@ -5,8 +5,12 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
-from jacobian.math.markov_chain import stationary_distribution
-from jacobian.math.markov_chain._models import TransitionMatrixRequest
+from jacobian.math.markov_chain import (
+    StationaryDistributionRequest,
+    TransitionMatrixRequest,
+    ergodic_properties,
+    stationary_distribution,
+)
 from jacobian.math.markov_chain._operations import (
     compute_ergodic_decision,
     compute_stationary_distribution,
@@ -67,7 +71,7 @@ def test_aperiodicity_is_checked_for_each_communicating_class() -> None:
 
 
 def test_stationary_family_exposes_every_closed_class() -> None:
-    request = TransitionMatrixRequest.model_validate(
+    request = StationaryDistributionRequest.model_validate(
         {
             "matrix": [
                 [
@@ -100,13 +104,31 @@ def test_stationary_family_exposes_every_closed_class() -> None:
 
 
 def test_native_singular_stationary_helper_rejects_nonunique_chain() -> None:
-    matrix = [
-        [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}],
-        [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
-    ]
+    request = StationaryDistributionRequest.model_validate(
+        {
+            "matrix": [
+                [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}],
+                [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+            ]
+        }
+    )
 
     with pytest.raises(ValueError, match="does not have a unique"):
-        stationary_distribution(matrix)
+        stationary_distribution(request)
+
+
+def test_native_markov_api_accepts_public_validated_requests() -> None:
+    request = StationaryDistributionRequest.model_validate(
+        {
+            "matrix": [
+                [{"num": "1", "den": "2"}, {"num": "1", "den": "2"}],
+                [{"num": "1", "den": "2"}, {"num": "1", "den": "2"}],
+            ]
+        }
+    )
+
+    assert stationary_distribution(request) == (Fraction(1, 2), Fraction(1, 2))
+    assert ergodic_properties(request) == (True, True)
 
 
 def test_stationary_family_solves_each_nonsingleton_closed_class_exactly() -> None:

--- a/tests/process/providers/_spike_support.py
+++ b/tests/process/providers/_spike_support.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
-from tools.command_runner import ToolCommandResult, ToolCommandStatus
+from tools.command_runner import (
+    ToolCommandRequest,
+    ToolCommandResult,
+    ToolCommandStatus,
+)
 
 
 def _sha256(payload: bytes) -> str:
@@ -44,12 +51,81 @@ def _result(
     )
 
 
-def _runner(
-    outcomes: Sequence[ToolCommandResult],
-) -> Callable[..., ToolCommandResult]:
-    remaining = iter(outcomes)
+@dataclass(slots=True)
+class _ExpectedRunner:
+    outcomes: tuple[ToolCommandResult, ...]
+    requests: list[ToolCommandRequest]
+    expected_requests: tuple[ToolCommandRequest, ...] = ()
+    on_call: Callable[[int, ToolCommandRequest], None] | None = None
+    _index: int = 0
 
-    def run(*_args: object, **_kwargs: object) -> ToolCommandResult:
-        return next(remaining)
+    def __call__(self, request: ToolCommandRequest) -> ToolCommandResult:
+        if not isinstance(request, ToolCommandRequest):
+            raise AssertionError("provider spike must submit one ToolCommandRequest")
+        if self._index >= len(self.outcomes):
+            raise AssertionError(f"unexpected provider command: {request!r}")
+        if not self.expected_requests:
+            raise AssertionError("strict runner expectations were not configured")
+        expected = self.expected_requests[self._index]
+        if request != expected:
+            raise AssertionError(
+                f"provider command {self._index + 1} mismatch:\n"
+                f"expected {expected!r}\nactual   {request!r}"
+            )
+        self.requests.append(request)
+        outcome = self.outcomes[self._index]
+        self._index += 1
+        if self.on_call is not None:
+            self.on_call(self._index, request)
+        return outcome
 
-    return run
+    def assert_finished(self) -> None:
+        remaining = len(self.outcomes) - self._index
+        if remaining:
+            raise AssertionError(
+                f"{remaining} expected provider command(s) were not run"
+            )
+
+    def expect(self, requests: Sequence[ToolCommandRequest]) -> None:
+        expected = tuple(requests)
+        if len(expected) != len(self.outcomes):
+            raise AssertionError("request and outcome expectation counts must match")
+        self.expected_requests = expected
+
+
+def _runner(outcomes: Sequence[ToolCommandResult]) -> _ExpectedRunner:
+    return _ExpectedRunner(tuple(outcomes), [])
+
+
+def _request(
+    executable: Path,
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path,
+    timeout_seconds: float,
+    stdin_bytes: bytes = b"",
+    stdout_limit_bytes: int,
+    stderr_limit_bytes: int,
+) -> ToolCommandRequest:
+    return ToolCommandRequest(
+        executable=str(executable.resolve(strict=True)),
+        arguments=tuple(arguments),
+        environment=environment,
+        cwd=str(cwd.resolve(strict=True)),
+        timeout_seconds=timeout_seconds,
+        stdin_bytes=stdin_bytes,
+        stdout_limit_bytes=stdout_limit_bytes,
+        stderr_limit_bytes=stderr_limit_bytes,
+    )
+
+
+def _run_expected(
+    run: Callable[[], dict[str, Any]],
+    runner: _ExpectedRunner,
+    requests: Sequence[ToolCommandRequest],
+) -> dict[str, Any]:
+    runner.expect(tuple(requests)[: len(runner.outcomes)])
+    result = run()
+    runner.assert_finished()
+    return result

--- a/tests/process/providers/_spike_support.py
+++ b/tests/process/providers/_spike_support.py
@@ -112,7 +112,7 @@ def _request(
         executable=str(executable.resolve(strict=True)),
         arguments=tuple(arguments),
         environment=environment,
-        cwd=str(cwd.resolve(strict=True)),
+        cwd=str(cwd.resolve()),
         timeout_seconds=timeout_seconds,
         stdin_bytes=stdin_bytes,
         stdout_limit_bytes=stdout_limit_bytes,

--- a/tests/process/providers/test_cddlib_hv_spike.py
+++ b/tests/process/providers/test_cddlib_hv_spike.py
@@ -6,26 +6,50 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from tests.fixtures.providers.cddlib.spike import _expected_mathematical, run_spike
+from benchmarks.tooling.providers.cddlib import _expected_mathematical, run_spike
 from tests.process.providers._spike_support import (
     _canonical,
+    _ExpectedRunner,
+    _request,
     _result,
+    _run_expected,
     _runner,
     _sha256,
 )
 from tools.command_runner import ToolCommandResult
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-BASE_PIN = json.loads(
-    (
-        PROJECT_ROOT / "tests" / "fixtures" / "providers" / "cddlib" / "pin.json"
-    ).read_text(encoding="utf-8")
-)
-
-EXPECTED_MATHEMATICAL = _expected_mathematical(BASE_PIN)
 
 
-RUN_SPIKE = run_spike
+def _base_pin() -> dict[str, Any]:
+    path = PROJECT_ROOT / "tests/fixtures/providers/cddlib/pin.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
+    runner = kwargs.get("runner")
+    if not isinstance(runner, _ExpectedRunner):
+        return run_spike(cwd=PROJECT_ROOT, **kwargs)
+    python = Path(kwargs["python_executable"])
+    adapter = Path(
+        kwargs.get(
+            "adapter_source", PROJECT_ROOT / "benchmarks/tooling/providers/cddlib.py"
+        )
+    )
+    pin = Path(kwargs["pin_path"])
+    timeout = float(kwargs.get("timeout_seconds", 10))
+    expected = _request(
+        python,
+        (str(adapter.resolve()), "--worker", "--pin", str(pin.resolve())),
+        environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC", "PYTHONPATH": "/opt"},
+        cwd=PROJECT_ROOT,
+        timeout_seconds=timeout,
+        stdout_limit_bytes=128 * 1024,
+        stderr_limit_bytes=16 * 1024,
+    )
+    return _run_expected(
+        lambda: run_spike(cwd=PROJECT_ROOT, **kwargs), runner, (expected,)
+    )
 
 
 def _provider_output(
@@ -35,7 +59,7 @@ def _provider_output(
     pycddlib_version: str = "3.0.2",
 ) -> bytes:
     payload = {
-        **(mathematical or EXPECTED_MATHEMATICAL),
+        **(mathematical or _expected_mathematical(_base_pin())),
         "runtime": {
             "distribution_record_sha256": "sha256:" + "1" * 64,
             "gmp_module_sha256": "sha256:" + "2" * 64,
@@ -65,11 +89,13 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
 
     cdd_members = {
         name: "\n".join(expected["required_ascii_markers"]).encode("ascii")
-        for name, expected in BASE_PIN["sources"]["cddlib"]["identity_members"].items()
+        for name, expected in _base_pin()["sources"]["cddlib"][
+            "identity_members"
+        ].items()
     }
     pycdd_members = {
         name: "\n".join(expected["required_ascii_markers"]).encode("ascii")
-        for name, expected in BASE_PIN["sources"]["pycddlib"][
+        for name, expected in _base_pin()["sources"]["pycddlib"][
             "identity_members"
         ].items()
     }
@@ -79,26 +105,26 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
     _archive(pycdd_source, pycdd_members)
 
     pin = {
-        **BASE_PIN,
+        **_base_pin(),
         "adapter_source_sha256": _sha256(adapter.read_bytes()),
         "sources": {
             "cddlib": {
-                **BASE_PIN["sources"]["cddlib"],
+                **_base_pin()["sources"]["cddlib"],
                 "archive_sha256": _sha256(cdd_source.read_bytes()),
                 "identity_members": {
                     name: {
-                        **BASE_PIN["sources"]["cddlib"]["identity_members"][name],
+                        **_base_pin()["sources"]["cddlib"]["identity_members"][name],
                         "sha256": _sha256(payload),
                     }
                     for name, payload in cdd_members.items()
                 },
             },
             "pycddlib": {
-                **BASE_PIN["sources"]["pycddlib"],
+                **_base_pin()["sources"]["pycddlib"],
                 "archive_sha256": _sha256(pycdd_source.read_bytes()),
                 "identity_members": {
                     name: {
-                        **BASE_PIN["sources"]["pycddlib"]["identity_members"][name],
+                        **_base_pin()["sources"]["pycddlib"]["identity_members"][name],
                         "sha256": _sha256(payload),
                     }
                     for name, payload in pycdd_members.items()
@@ -195,7 +221,7 @@ def test_protocol_runtime_and_malformed_output_fail_closed(tmp_path: Path) -> No
 
     malformed = RUN_SPIKE(runner=_runner([_result(stdout=b"not-json")]), **common)
     wrong_version = {
-        **EXPECTED_MATHEMATICAL,
+        **_expected_mathematical(_base_pin()),
         "versions": {"cddlib": "0.94n", "pycddlib": "9.9.9"},
     }
     version = RUN_SPIKE(

--- a/tests/process/providers/test_cgal_delaunay_spike.py
+++ b/tests/process/providers/test_cgal_delaunay_spike.py
@@ -6,25 +6,53 @@ import lzma
 import tarfile
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
-from tests.fixtures.providers.cgal.spike import run_spike
-from tests.process.providers._spike_support import _result, _runner
+from benchmarks.tooling.providers.cgal import run_spike
+from tests.process.providers._spike_support import (
+    _ExpectedRunner,
+    _request,
+    _result,
+    _run_expected,
+    _runner,
+)
 from tools.command_runner import ToolCommandResult
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-BASE_PIN = json.loads(
-    (
-        PROJECT_ROOT
-        / "tests"
-        / "fixtures"
-        / "providers"
-        / "cgal"
-        / "cgal_delaunay_pin.json"
-    ).read_text(encoding="utf-8")
-)
 
 
-RUN_SPIKE = run_spike
+def _base_pin() -> dict[str, object]:
+    path = PROJECT_ROOT / "tests/fixtures/providers/cgal/cgal_delaunay_pin.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
+    runner = kwargs.get("runner")
+    if not isinstance(runner, _ExpectedRunner):
+        return run_spike(cwd=PROJECT_ROOT, **kwargs)
+    executable = Path(kwargs["executable"])
+    pin = json.loads(Path(kwargs["pin_path"]).read_text(encoding="utf-8"))
+    timeout = float(kwargs.get("timeout_seconds", 5))
+    commands = [
+        ("--version",),
+        tuple(pin["reproductions"]["unique"]["command"]),
+        tuple(pin["reproductions"]["cocircular"]["command"]),
+    ]
+    expected = tuple(
+        _request(
+            executable,
+            arguments,
+            environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC"},
+            cwd=PROJECT_ROOT,
+            timeout_seconds=timeout,
+            stdout_limit_bytes=32_768,
+            stderr_limit_bytes=16_384,
+        )
+        for arguments in commands
+    )
+    return _run_expected(
+        lambda: run_spike(cwd=PROJECT_ROOT, **kwargs), runner, expected
+    )
 
 
 def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
@@ -53,7 +81,7 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
             info.mtime = 0
             bundle.addfile(info, BytesIO(payload))
     pin = {
-        **BASE_PIN,
+        **_base_pin(),
         "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
         "adapter_source_sha256": (
             "sha256:" + hashlib.sha256(adapter.read_bytes()).hexdigest()
@@ -73,9 +101,13 @@ def _successes() -> list[ToolCommandResult]:
                 b"boost 1_79\n"
             )
         ),
-        _result(stdout=BASE_PIN["reproductions"]["unique"]["expected_output"].encode()),
         _result(
-            stdout=BASE_PIN["reproductions"]["cocircular"]["expected_output"].encode()
+            stdout=_base_pin()["reproductions"]["unique"]["expected_output"].encode()
+        ),
+        _result(
+            stdout=_base_pin()["reproductions"]["cocircular"][
+                "expected_output"
+            ].encode()
         ),
     ]
 
@@ -199,7 +231,7 @@ def test_malformed_xz_archive_does_not_escape_as_an_exception(
     adapter.touch()
     archive.write_bytes(lzma.compress(b"not a tar archive"))
     pin = {
-        **BASE_PIN,
+        **_base_pin(),
         "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
     }
     pin_path = tmp_path / "pin.json"

--- a/tests/process/providers/test_gudhi_persistence_spike.py
+++ b/tests/process/providers/test_gudhi_persistence_spike.py
@@ -7,23 +7,48 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from tests.fixtures.providers.gudhi.spike import run_spike
+from benchmarks.tooling.providers.gudhi import run_spike
 from tests.process.providers._spike_support import (
     _canonical,
+    _ExpectedRunner,
+    _request,
     _result,
+    _run_expected,
     _runner,
     _sha256,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-BASE_PIN = json.loads(
-    (
-        PROJECT_ROOT / "tests" / "fixtures" / "providers" / "gudhi" / "pin.json"
-    ).read_text(encoding="utf-8")
-)
 
 
-RUN_SPIKE = run_spike
+def _base_pin() -> dict[str, Any]:
+    path = PROJECT_ROOT / "tests/fixtures/providers/gudhi/pin.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
+    runner = kwargs.get("runner")
+    if not isinstance(runner, _ExpectedRunner):
+        return run_spike(cwd=PROJECT_ROOT, **kwargs)
+    python = Path(kwargs["python_executable"])
+    adapter = Path(
+        kwargs.get(
+            "adapter_source", PROJECT_ROOT / "benchmarks/tooling/providers/gudhi.py"
+        )
+    )
+    pin = Path(kwargs["pin_path"])
+    expected = _request(
+        python,
+        (str(adapter.resolve()), "--worker", "--pin", str(pin.resolve())),
+        environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC", "PYTHONPATH": "/opt"},
+        cwd=PROJECT_ROOT,
+        timeout_seconds=float(kwargs.get("timeout_seconds", 10)),
+        stdout_limit_bytes=64 * 1024,
+        stderr_limit_bytes=16 * 1024,
+    )
+    return _run_expected(
+        lambda: run_spike(cwd=PROJECT_ROOT, **kwargs), runner, (expected,)
+    )
 
 
 def _provider_output(
@@ -33,7 +58,7 @@ def _provider_output(
     python_version: str = "3.12.13",
 ) -> bytes:
     payload = {
-        **(mathematical or BASE_PIN["reproduction"]["expected_provider_output"]),
+        **(mathematical or _base_pin()["reproduction"]["expected_provider_output"]),
         "runtime": {
             "gudhi": gudhi_version,
             "numpy": "2.4.1",
@@ -70,16 +95,16 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
 
     license_payload = b"MIT License\nfixture\n"
     metadata = b"Name: gudhi\nVersion: 3.13.0\nRequires-Python: >=3.10\n"
-    wheel = tmp_path / BASE_PIN["wheel"]["filename"]
+    wheel = tmp_path / _base_pin()["wheel"]["filename"]
     with zipfile.ZipFile(wheel, mode="w") as archive:
-        archive.writestr(BASE_PIN["wheel"]["license_member"], license_payload)
-        archive.writestr(BASE_PIN["wheel"]["metadata_member"], metadata)
+        archive.writestr(_base_pin()["wheel"]["license_member"], license_payload)
+        archive.writestr(_base_pin()["wheel"]["metadata_member"], metadata)
 
     pin = {
-        **BASE_PIN,
+        **_base_pin(),
         "adapter_source_sha256": _sha256(adapter.read_bytes()),
         "source": {
-            **BASE_PIN["source"],
+            **_base_pin()["source"],
             "archive_sha256": _sha256(source.read_bytes()),
             "module_licenses": {
                 "simplex_tree": {
@@ -108,7 +133,7 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
             },
         },
         "wheel": {
-            **BASE_PIN["wheel"],
+            **_base_pin()["wheel"],
             "sha256": _sha256(wheel.read_bytes()),
             "license_sha256": _sha256(license_payload),
         },
@@ -197,7 +222,7 @@ def test_source_and_wheel_mismatch_fail_before_execution(tmp_path: Path) -> None
 def test_protocol_runtime_and_malformed_output_fail_closed(tmp_path: Path) -> None:
     python, wheel, source, adapter, pin = _fixture(tmp_path)
     wrong_protocol = {
-        **BASE_PIN["reproduction"]["expected_provider_output"],
+        **_base_pin()["reproduction"]["expected_provider_output"],
         "version": "3.12.0",
     }
     version_report = RUN_SPIKE(

--- a/tests/process/providers/test_nauty_provider_spike.py
+++ b/tests/process/providers/test_nauty_provider_spike.py
@@ -4,28 +4,28 @@ import hashlib
 import json
 import math
 import tarfile
-from collections.abc import Sequence
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 import pytest
-from tests.fixtures.providers.nauty.spike import run_spike
-from tests.process.providers._spike_support import _result, _runner
-from tools.command_runner import ToolCommandResult
+from benchmarks.tooling.providers.nauty import run_spike
+from tests.process.providers._spike_support import (
+    _ExpectedRunner,
+    _request,
+    _result,
+    _run_expected,
+    _runner,
+)
+from tools.command_runner import ToolCommandRequest, ToolCommandResult
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-PIN = json.loads(
-    (
-        PROJECT_ROOT
-        / "tests"
-        / "fixtures"
-        / "providers"
-        / "nauty"
-        / "nauty_provider_pin.json"
-    ).read_text(encoding="utf-8")
-)
+
+
+def _base_pin() -> dict[str, Any]:
+    path = PROJECT_ROOT / "tests/fixtures/providers/nauty/nauty_provider_pin.json"
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 GENG_HELP = (
@@ -38,13 +38,71 @@ LABELG_HELP = (
     b"Canonically label a file of graphs or digraphs.\n"
     b"-q  suppress auxiliary information\n"
 )
-GENG_OUTPUT = ("\n".join(PIN["reproduction"]["expected_graph6"]) + "\n").encode()
-LABELG_OUTPUT = (
-    "\n".join(PIN["canonicalization"]["expected_output_graph6"]) + "\n"
-).encode()
 
 
-RUN_SPIKE = run_spike
+def _geng_output() -> bytes:
+    return ("\n".join(_base_pin()["reproduction"]["expected_graph6"]) + "\n").encode()
+
+
+def _labelg_output() -> bytes:
+    return (
+        "\n".join(_base_pin()["canonicalization"]["expected_output_graph6"]) + "\n"
+    ).encode()
+
+
+def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
+    runner = kwargs.get("runner")
+    if not isinstance(runner, _ExpectedRunner):
+        return run_spike(cwd=PROJECT_ROOT, **kwargs)
+    pin = json.loads(Path(kwargs["pin_path"]).read_text(encoding="utf-8"))
+    geng = Path(kwargs["geng"])
+    labelg = Path(kwargs["labelg"])
+    timeout = float(kwargs.get("timeout_seconds", 5))
+    canonical_input = (
+        "\n".join(pin["canonicalization"]["input_graph6"]) + "\n"
+    ).encode("ascii")
+    requests = (
+        _request(
+            geng,
+            ("-help",),
+            environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC"},
+            cwd=PROJECT_ROOT,
+            timeout_seconds=timeout,
+            stdout_limit_bytes=16_384,
+            stderr_limit_bytes=16_384,
+        ),
+        _request(
+            labelg,
+            ("-help",),
+            environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC"},
+            cwd=PROJECT_ROOT,
+            timeout_seconds=timeout,
+            stdout_limit_bytes=16_384,
+            stderr_limit_bytes=16_384,
+        ),
+        _request(
+            geng,
+            tuple(pin["reproduction"]["command"][1:]),
+            environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC"},
+            cwd=PROJECT_ROOT,
+            timeout_seconds=timeout,
+            stdout_limit_bytes=4096,
+            stderr_limit_bytes=16_384,
+        ),
+        _request(
+            labelg,
+            tuple(pin["canonicalization"]["command"][1:]),
+            environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC"},
+            cwd=PROJECT_ROOT,
+            timeout_seconds=timeout,
+            stdin_bytes=canonical_input,
+            stdout_limit_bytes=4096,
+            stderr_limit_bytes=16_384,
+        ),
+    )
+    return _run_expected(
+        lambda: run_spike(cwd=PROJECT_ROOT, **kwargs), runner, requests
+    )
 
 
 def _source_archive(tmp_path: Path, *, pin_digest: bool = True) -> Path:
@@ -60,9 +118,6 @@ def _source_archive(tmp_path: Path, *, pin_digest: bool = True) -> Path:
             info.size = len(payload)
             info.mtime = 0
             archive.addfile(info, BytesIO(payload))
-    if pin_digest:
-        digest = "sha256:" + hashlib.sha256(archive_path.read_bytes()).hexdigest()
-        PIN["archive_sha256"] = digest
     return archive_path
 
 
@@ -76,7 +131,13 @@ def _files(tmp_path: Path) -> tuple[Path, Path]:
 
 def _pin_file(tmp_path: Path, pin: dict[str, Any] | None = None) -> Path:
     path = tmp_path / "pin.json"
-    path.write_text(json.dumps(PIN if pin is None else pin), encoding="utf-8")
+    payload = _base_pin() if pin is None else pin
+    archive = tmp_path / "nauty2_9_3.tar.gz"
+    if pin is None and archive.exists():
+        payload["archive_sha256"] = (
+            "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest()
+        )
+    path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
 
@@ -84,8 +145,8 @@ def _successful_outcomes() -> list[ToolCommandResult]:
     return [
         _result(stdout=GENG_HELP),
         _result(stdout=LABELG_HELP),
-        _result(stdout=GENG_OUTPUT),
-        _result(stdout=LABELG_OUTPUT),
+        _result(stdout=_geng_output()),
+        _result(stdout=_labelg_output()),
     ]
 
 
@@ -190,7 +251,7 @@ def test_nonfinite_timeout_fails_before_provider_inspection(
 
 
 def test_malformed_nested_pin_fails_as_json_safe_non_conclusion(tmp_path: Path) -> None:
-    pin = deepcopy(PIN)
+    pin = deepcopy(_base_pin())
     pin["reproduction"] = {"command": ["geng", "-q", "4"]}
 
     report = RUN_SPIKE(
@@ -208,14 +269,10 @@ def test_malformed_nested_pin_fails_as_json_safe_non_conclusion(tmp_path: Path) 
 def test_spike_executes_the_command_profile_recorded_by_the_pin(tmp_path: Path) -> None:
     archive = _source_archive(tmp_path)
     geng, labelg = _files(tmp_path)
-    pin = deepcopy(PIN)
+    pin = deepcopy(_base_pin())
+    pin["archive_sha256"] = "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest()
     pin["reproduction"]["command"] = ["geng", "--frozen-profile", "4"]
-    commands: list[list[str]] = []
-    outcomes = iter(_successful_outcomes())
-
-    def runner(command: Sequence[str], **_kwargs: object) -> ToolCommandResult:
-        commands.append(list(command))
-        return next(outcomes)
+    runner = _runner(_successful_outcomes())
 
     report = RUN_SPIKE(
         geng=geng,
@@ -226,22 +283,23 @@ def test_spike_executes_the_command_profile_recorded_by_the_pin(tmp_path: Path) 
     )
 
     assert report["status"] == "COMPLETED"
-    assert commands[2] == [str(geng.resolve()), "--frozen-profile", "4"]
+    assert [runner.requests[2].executable, *runner.requests[2].arguments] == [
+        str(geng.resolve()),
+        "--frozen-profile",
+        "4",
+    ]
 
 
 def test_changed_executable_digest_rejects_the_success_report(tmp_path: Path) -> None:
     archive = _source_archive(tmp_path)
     geng, labelg = _files(tmp_path)
-    outcomes = iter(_successful_outcomes())
-    call_count = 0
+    runner = _runner(_successful_outcomes())
 
-    def runner(_command: Sequence[str], **_kwargs: object) -> ToolCommandResult:
-        nonlocal call_count
-        result = next(outcomes)
-        call_count += 1
+    def mutate_after_last_call(call_count: int, _request: ToolCommandRequest) -> None:
         if call_count == 4:
             labelg.write_bytes(b"replaced after execution")
-        return result
+
+    runner.on_call = mutate_after_last_call
 
     report = RUN_SPIKE(
         geng=geng,

--- a/tests/process/providers/test_nauty_provider_spike.py
+++ b/tests/process/providers/test_nauty_provider_spike.py
@@ -105,7 +105,7 @@ def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
     )
 
 
-def _source_archive(tmp_path: Path, *, pin_digest: bool = True) -> Path:
+def _source_archive(tmp_path: Path) -> Path:
     archive_path = tmp_path / "nauty2_9_3.tar.gz"
     copyright_notice = b"Licensed under the Apache License, Version 2.0 (the License)\n"
     version_header = b"/* nauty version 2.9.3 */\n"
@@ -206,7 +206,7 @@ def test_absent_explicit_executable_is_an_isolated_non_conclusion(
 def test_source_version_mismatch_fails_closed_before_execution(
     tmp_path: Path,
 ) -> None:
-    archive = _source_archive(tmp_path, pin_digest=False)
+    archive = _source_archive(tmp_path)
     geng, labelg = _files(tmp_path)
 
     report = RUN_SPIKE(

--- a/tests/process/providers/test_regina_outcomes_spike.py
+++ b/tests/process/providers/test_regina_outcomes_spike.py
@@ -8,23 +8,56 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 
-from tests.fixtures.providers.regina.spike import run_spike
+from benchmarks.tooling.providers.regina import run_spike
 from tests.process.providers._spike_support import (
     _canonical,
+    _ExpectedRunner,
+    _request,
     _result,
+    _run_expected,
     _runner,
     _sha256,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-BASE_PIN = json.loads(
-    (
-        PROJECT_ROOT / "tests" / "fixtures" / "providers" / "regina" / "pin.json"
-    ).read_text(encoding="utf-8")
-)
 
 
-RUN_SPIKE = run_spike
+def _base_pin() -> dict[str, Any]:
+    path = PROJECT_ROOT / "tests/fixtures/providers/regina/pin.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def RUN_SPIKE(**kwargs: Any) -> dict[str, Any]:  # noqa: N802
+    runner = kwargs.get("runner")
+    if not isinstance(runner, _ExpectedRunner):
+        return run_spike(cwd=PROJECT_ROOT, **kwargs)
+    python = Path(kwargs["python_executable"])
+    adapter = Path(
+        kwargs.get(
+            "adapter_source", PROJECT_ROOT / "benchmarks/tooling/providers/regina.py"
+        )
+    )
+    pin = Path(kwargs["pin_path"])
+    wheel = Path(kwargs["wheel"])
+    expected = _request(
+        python,
+        (
+            str(adapter.resolve()),
+            "--worker",
+            "--pin",
+            str(pin.resolve()),
+            "--wheel",
+            str(wheel.resolve()),
+        ),
+        environment={"LANG": "C", "LC_ALL": "C", "TZ": "UTC", "PYTHONPATH": "/opt"},
+        cwd=PROJECT_ROOT,
+        timeout_seconds=float(kwargs.get("timeout_seconds", 20)),
+        stdout_limit_bytes=256 * 1024,
+        stderr_limit_bytes=32 * 1024,
+    )
+    return _run_expected(
+        lambda: run_spike(cwd=PROJECT_ROOT, **kwargs), runner, (expected,)
+    )
 
 
 def _provider_output(
@@ -36,12 +69,12 @@ def _provider_output(
     wheel_sha256: str | None = None,
 ) -> bytes:
     payload = {
-        **(mathematical or BASE_PIN["reproduction"]["expected_provider_output"]),
+        **(mathematical or _base_pin()["reproduction"]["expected_provider_output"]),
         "runtime": {
             "distribution": distribution_version,
             "engine": engine_version,
             "python": python_version,
-            "wheel_sha256": wheel_sha256 or BASE_PIN["wheel"]["sha256"],
+            "wheel_sha256": wheel_sha256 or _base_pin()["wheel"]["sha256"],
             "verified_runtime_files": 1,
         },
     }
@@ -80,16 +113,16 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
         b"Name: regina\nVersion: 7.4.1\nLicense: GPLv2+\nRequires-Python: >=3.6\n"
     )
     wheel_metadata = b"Wheel-Version: 1.0\nTag: cp312-cp312-manylinux_2_28_x86_64\n"
-    wheel = tmp_path / BASE_PIN["wheel"]["filename"]
+    wheel = tmp_path / _base_pin()["wheel"]["filename"]
     with zipfile.ZipFile(wheel, mode="w") as archive:
-        archive.writestr(BASE_PIN["wheel"]["metadata_member"], metadata)
-        archive.writestr(BASE_PIN["wheel"]["wheel_member"], wheel_metadata)
+        archive.writestr(_base_pin()["wheel"]["metadata_member"], metadata)
+        archive.writestr(_base_pin()["wheel"]["wheel_member"], wheel_metadata)
 
     pin = {
-        **BASE_PIN,
+        **_base_pin(),
         "adapter_source_sha256": _sha256(adapter.read_bytes()),
         "source": {
-            **BASE_PIN["source"],
+            **_base_pin()["source"],
             "archive_sha256": _sha256(source.read_bytes()),
             "members": {
                 role: {
@@ -100,7 +133,7 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
             },
         },
         "wheel": {
-            **BASE_PIN["wheel"],
+            **_base_pin()["wheel"],
             "sha256": _sha256(wheel.read_bytes()),
             "metadata_sha256": _sha256(metadata),
             "wheel_sha256": _sha256(wheel_metadata),
@@ -293,7 +326,9 @@ def test_independent_replay_rejects_a_reciprocal_gluing_forgery(
     tmp_path: Path,
 ) -> None:
     python, wheel, source, adapter, pin_path = _fixture(tmp_path)
-    mathematical = copy.deepcopy(BASE_PIN["reproduction"]["expected_provider_output"])
+    mathematical = copy.deepcopy(
+        _base_pin()["reproduction"]["expected_provider_output"]
+    )
     mathematical["cases"][0]["facet_gluings"][0][0]["tetrahedron"] = 0
     pin = json.loads(pin_path.read_text(encoding="utf-8"))
     pin["reproduction"]["expected_provider_output"] = mathematical

--- a/tests/process/providers/test_spike_support.py
+++ b/tests/process/providers/test_spike_support.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from tests.process.providers._spike_support import _request, _result, _runner
+
+
+def _expected(tmp_path: Path):
+    executable = tmp_path / "provider"
+    executable.touch()
+    return _request(
+        executable,
+        ("--probe", "value"),
+        environment={"LANG": "C", "TZ": "UTC"},
+        cwd=tmp_path,
+        timeout_seconds=5,
+        stdin_bytes=b"input",
+        stdout_limit_bytes=1024,
+        stderr_limit_bytes=512,
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda request, tmp_path: replace(request, arguments=("--wrong",)),
+        lambda request, tmp_path: replace(request, environment={"LANG": "en_US"}),
+        lambda request, tmp_path: replace(request, cwd=str(tmp_path.parent)),
+        lambda request, tmp_path: replace(request, timeout_seconds=6),
+        lambda request, tmp_path: replace(request, stdout_limit_bytes=2048),
+    ],
+)
+def test_strict_runner_rejects_mutated_request_fields(tmp_path: Path, mutation) -> None:
+    expected = _expected(tmp_path)
+    runner = _runner([_result()])
+    runner.expect((expected,))
+
+    with pytest.raises(AssertionError, match="provider command 1 mismatch"):
+        runner(mutation(expected, tmp_path))
+
+
+def test_strict_runner_rejects_reordered_and_extra_commands(tmp_path: Path) -> None:
+    first = _expected(tmp_path)
+    second = replace(first, arguments=("--second",))
+    runner = _runner([_result(), _result()])
+    runner.expect((first, second))
+
+    with pytest.raises(AssertionError, match="provider command 1 mismatch"):
+        runner(second)
+
+    runner = _runner([_result()])
+    runner.expect((first,))
+    assert runner(first) == _result()
+    with pytest.raises(AssertionError, match="unexpected provider command"):
+        runner(second)
+
+
+def test_strict_runner_rejects_unconsumed_expectations(tmp_path: Path) -> None:
+    runner = _runner([_result(), _result()])
+    runner.expect((_expected(tmp_path), replace(_expected(tmp_path), arguments=("x",))))
+    runner(_expected(tmp_path))
+
+    with pytest.raises(AssertionError, match="1 expected provider command"):
+        runner.assert_finished()

--- a/tests/process/providers/test_spike_support.py
+++ b/tests/process/providers/test_spike_support.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import replace
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+from benchmarks.tooling.providers import cddlib, cgal, gudhi, nauty, regina
+from benchmarks.tooling.spike_utils import default_runner
 from tests.process.providers._spike_support import _request, _result, _runner
 
 
@@ -64,3 +68,33 @@ def test_strict_runner_rejects_unconsumed_expectations(tmp_path: Path) -> None:
 
     with pytest.raises(AssertionError, match="1 expected provider command"):
         runner.assert_finished()
+
+
+@pytest.mark.parametrize(
+    ("module", "error_type", "extra_arguments"),
+    [
+        (cddlib, cddlib.CddlibSpikeError, {}),
+        (cgal, cgal.CgalSpikeError, {}),
+        (gudhi, gudhi.GudhiSpikeError, {}),
+        (nauty, nauty.NautySpikeError, {"input_bytes": b"", "stdout_limit": 4096}),
+        (regina, regina.ReginaSpikeError, {}),
+    ],
+)
+def test_provider_runner_translates_an_absent_working_directory(
+    tmp_path: Path,
+    module: Any,
+    error_type: type[Exception],
+    extra_arguments: dict[str, Any],
+) -> None:
+    absent_cwd = tmp_path / "absent"
+
+    with pytest.raises(error_type) as caught:
+        module._run_checked(
+            default_runner,
+            (sys.executable, "-c", "pass"),
+            cwd=absent_cwd,
+            timeout_seconds=1,
+            **extra_arguments,
+        )
+
+    assert cast(Any, caught.value).code == "PROVIDER_LAUNCH_ERROR"

--- a/tests/tooling/test_spike_utils.py
+++ b/tests/tooling/test_spike_utils.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
 from benchmarks.tooling.spike_utils import (
     canonical_json,
+    owned_fixture_path,
     sha256_bytes,
 )
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_sha256_bytes_uses_prefixed_sha256() -> None:
@@ -18,3 +25,29 @@ def test_canonical_json_produces_stable_ascii_wire_bytes() -> None:
     assert canonical_json({"z": {"key": "\u00e9"}, "a": [3, 2, 1]}) == (
         b'{"a":[3,2,1],"z":{"key":"\\u00e9"}}\n'
     )
+
+
+@pytest.mark.parametrize("provider", ["cddlib", "gudhi", "regina"])
+def test_checked_in_pin_binds_the_moved_spike_source(provider: str) -> None:
+    source = ROOT / "benchmarks/tooling/providers" / f"{provider}.py"
+    pin_path = ROOT / "tests/fixtures/providers" / provider / "pin.json"
+    pin = json.loads(pin_path.read_text(encoding="utf-8"))
+
+    assert pin["adapter_source_sha256"] == sha256_bytes(source.read_bytes())
+
+
+def test_owned_fixture_path_falls_back_beside_a_copied_script(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "spike.py"
+    script.touch()
+
+    assert owned_fixture_path(script.as_posix(), "missing/pin.json", "pin.json") == (
+        tmp_path / "pin.json"
+    )
+
+
+def test_owned_fixture_path_handles_the_shallow_container_module_path() -> None:
+    assert owned_fixture_path(
+        "/app/spike.py", "tests/fixtures/providers/cddlib", "pin.json"
+    ) == Path("/app/pin.json")


### PR DESCRIPTION
Fixes #2075.
Fixes #2078.
Fixes #2080.

## Problem

Three execution boundaries were weaker than their contracts implied:

- provider tests kept executable spike programs under passive fixtures, read pin files during collection, and accepted variadic runners that did not prove the exact subprocess request;
- graph optimization started wall-clock accounting after preprocessing or synchronous seed heuristics, so those operations could exceed their advertised budget before entering the bounded solver;
- the code theory, graph spectral, Markov chain, and recurrence native APIs used raw wire-shaped values behind `no-untyped-def` and `no-untyped-call` suppressions.

## Solution

- Move provider programs to `benchmarks/tooling/providers`, leave only passive fixture data under `tests/fixtures/providers`, and require an explicit working directory at the executable boundary.
- Pass one complete `ToolCommandRequest` through provider runners. The process tests now compare executable, arguments, environment, working directory, timeout, stdin, and output limits, and reject reordered, extra, or unconsumed calls.
- Start one monotonic deadline before graph construction and carry it through incumbent construction and every threshold search. Replace the synchronous NetworkX seed heuristics with deterministic constant- or linear-work valid incumbents.
- Give all four native math owners explicit parameter and result types, validate inputs through their domain models, and remove the targeted mypy suppressions.

The MCP operation IDs and request/result schemas are unchanged.

Suggested review order: graph deadline propagation and its fake-clock regressions; provider request matching and fixture relocation; typed native math boundaries.

## Testing

- `make check` — Ruff, formatting, mypy, and 1,971 tests passed.
- `make test-process` — 117 tests passed.
- Focused provider, graph, code theory, Markov chain, spectral, and recurrence suite — 359 tests passed.
- `uv run python tools/check_benchmark_static.py` — passed.
- `git diff --check` — passed.

- Specialist validation run: `make test-process`

## Public contract impact

The native Python APIs for code theory, graph spectral operations, Markov chains, and recurrence solving now accept exported typed domain values or validated request models and return typed values. This intentionally replaces their previous raw list/dictionary shapes while Jacobian is pre-stable. MCP operation IDs, wire schemas, and mathematical semantics are unchanged.

## Public operation admission

Not applicable; this PR adds no public operations and does not broaden an admitted mathematical contract.

## Closure matrix

None; each linked issue has one focused acceptance surface and is fully addressed here.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Public operation changes include an owner-local admission decision (not applicable)
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] New shared abstractions replace duplication in at least two surviving production paths (the exact provider request runner covers all five provider spikes)
