### PR TITLE
feat(hypergraphs): add finite hypergraph operations (#1742)

### DIFF
--- a/src/jacobian/math/hypergraphs/__init__.py
+++ b/src/jacobian/math/hypergraphs/__init__.py
@@ -1,0 +1,3 @@
+"""Hypergraph operations."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/hypergraphs/_admission.py
+++ b/src/jacobian/math/hypergraphs/_admission.py
@@ -1,0 +1,40 @@
+"""Owner-local admission decisions for built-in math operations."""
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.hypergraphs._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "hypergraph.parameters.compute",
+        AdmissionDecision.KEEP,
+        "exact vertex count, edge count, rank, corank, uniform size, and "
+        "total incidences of a finite hypergraph",
+    ),
+    OperationAdmission(
+        "hypergraph.vertex_degrees.compute",
+        AdmissionDecision.KEEP,
+        "exact vertex-degree map and degree histogram of a finite hypergraph",
+    ),
+    OperationAdmission(
+        "hypergraph.dual.compute",
+        AdmissionDecision.KEEP,
+        "exact dual hypergraph transposing vertices and edges",
+    ),
+    OperationAdmission(
+        "hypergraph.incidence_graph.compute",
+        AdmissionDecision.KEEP,
+        "exact bipartite incidence graph (Levi graph) of a finite hypergraph",
+    ),
+    OperationAdmission(
+        "hypergraph.clique_expansion.compute",
+        AdmissionDecision.KEEP,
+        "exact 2-section graph where vertices are adjacent if they share a "
+        "hyperedge",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/hypergraphs/_admission.py
+++ b/src/jacobian/math/hypergraphs/_admission.py
@@ -32,8 +32,7 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "hypergraph.clique_expansion.compute",
         AdmissionDecision.KEEP,
-        "exact 2-section graph where vertices are adjacent if they share a "
-        "hyperedge",
+        "exact 2-section graph where vertices are adjacent if they share a hyperedge",
     ),
 )
 

--- a/src/jacobian/math/hypergraphs/_models.py
+++ b/src/jacobian/math/hypergraphs/_models.py
@@ -1,0 +1,250 @@
+"""Typed wire contracts for finite hypergraph operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_VERTICES = 100
+MAX_EDGES = 100
+MAX_LABEL_LENGTH = 64
+
+
+class FiniteHypergraph(StrictModel):
+    """A finite hypergraph: a finite set of vertices and named hyperedges.
+
+    ``vertices`` is a tuple of unique string labels.  ``edges`` is a tuple
+    of ``(edge_id, vertex_subset)`` pairs where ``vertex_subset`` is a tuple
+    of vertex labels.  Edge member order is irrelevant and is canonicalized
+    to sorted order on construction, so two hypergraphs with the same
+    members in different orders compare equal.  Every edge member must be a
+    declared vertex.
+    """
+
+    vertices: tuple[str, ...] = Field(max_length=MAX_VERTICES)
+    edges: tuple[tuple[str, tuple[str, ...]], ...] = Field(
+        max_length=MAX_EDGES
+    )
+
+    @model_validator(mode="after")
+    def require_valid_hypergraph(self) -> Self:
+        labels = set(self.vertices)
+        if len(labels) != len(self.vertices):
+            raise ValueError("vertex labels must be distinct")
+        for label in self.vertices:
+            if len(label) > MAX_LABEL_LENGTH:
+                raise ValueError("vertex label exceeds the bounded length budget")
+        edge_ids: set[str] = set()
+        canonical_edges: list[tuple[str, tuple[str, ...]]] = []
+        for edge_id, members in self.edges:
+            if len(edge_id) > MAX_LABEL_LENGTH:
+                raise ValueError("edge id exceeds the bounded length budget")
+            if edge_id in edge_ids:
+                raise ValueError("edge ids must be distinct")
+            edge_ids.add(edge_id)
+            member_set = set(members)
+            if len(member_set) != len(members):
+                raise ValueError("edge members must be distinct")
+            unknown = member_set - labels
+            if unknown:
+                raise ValueError("every edge member must be a declared vertex")
+            canonical_edges.append((edge_id, tuple(sorted(members))))
+        object.__setattr__(self, "edges", tuple(canonical_edges))
+        return self
+
+
+class ParametersRequest(StrictModel):
+    """Request the basic parameters of a finite hypergraph."""
+
+    hypergraph: FiniteHypergraph
+
+
+class ParametersResult(StrictModel):
+    """The basic parameters of a finite hypergraph.
+
+    ``vertex_count`` and ``edge_count`` are the number of vertices and edges.
+    ``rank`` is the size of the largest edge, ``corank`` the size of the
+    smallest edge, and ``uniform_size`` is that common edge size when every
+    edge has the same cardinality (``None`` otherwise).
+    ``total_incidences`` is the sum of all edge cardinalities.
+    """
+
+    hypergraph: FiniteHypergraph
+    vertex_count: int = Field(ge=0)
+    edge_count: int = Field(ge=0)
+    rank: int = Field(ge=0)
+    corank: int = Field(ge=0)
+    uniform_size: int | None = None
+    total_incidences: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def bind_parameters(self) -> Self:
+        from jacobian.math.hypergraphs._operations import _parameters_data
+
+        (
+            vertex_count,
+            edge_count,
+            rank,
+            corank,
+            uniform_size,
+            total_incidences,
+        ) = _parameters_data(self.hypergraph)
+        if self.vertex_count != vertex_count:
+            raise ValueError("vertex_count must be the exact number of vertices")
+        if self.edge_count != edge_count:
+            raise ValueError("edge_count must be the exact number of edges")
+        if self.rank != rank:
+            raise ValueError("rank must be the exact maximum edge size")
+        if self.corank != corank:
+            raise ValueError("corank must be the exact minimum edge size")
+        if self.uniform_size != uniform_size:
+            raise ValueError("uniform_size must match the exact uniformity")
+        if self.total_incidences != total_incidences:
+            raise ValueError("total_incidences must be the exact incidence count")
+        return self
+
+
+class VertexDegreesRequest(StrictModel):
+    """Request the vertex-degree map of a finite hypergraph."""
+
+    hypergraph: FiniteHypergraph
+
+
+class VertexDegreesResult(StrictModel):
+    """The vertex-degree map and degree histogram of a finite hypergraph.
+
+    ``degrees`` maps each vertex label to its degree (the number of edges
+    containing it), in declared vertex order.  ``histogram`` maps each
+    degree value to the number of vertices with that degree, sorted by
+    degree ascending.
+    """
+
+    hypergraph: FiniteHypergraph
+    degrees: tuple[tuple[str, int], ...]
+    histogram: tuple[tuple[int, int], ...]
+
+    @model_validator(mode="after")
+    def bind_vertex_degrees(self) -> Self:
+        from jacobian.math.hypergraphs._operations import _vertex_degrees_data
+
+        degrees, histogram = _vertex_degrees_data(self.hypergraph)
+        if self.degrees != degrees:
+            raise ValueError(
+                "degrees must be the exact vertex-degree map of the hypergraph"
+            )
+        if self.histogram != histogram:
+            raise ValueError(
+                "histogram must be the exact degree histogram of the hypergraph"
+            )
+        return self
+
+
+class DualRequest(StrictModel):
+    """Request the dual of a finite hypergraph."""
+
+    hypergraph: FiniteHypergraph
+
+
+class DualResult(StrictModel):
+    """The dual of a finite hypergraph.
+
+    The dual hypergraph transposes vertices and edges: the original edges
+    become vertices and the original vertices become edges, where vertex
+    ``v`` becomes the edge containing one dual vertex ``e`` for each original
+    edge containing ``v``.
+    """
+
+    hypergraph: FiniteHypergraph
+    dual: FiniteHypergraph
+
+    @model_validator(mode="after")
+    def bind_dual(self) -> Self:
+        from jacobian.math.hypergraphs._operations import _dual_data
+
+        dual = _dual_data(self.hypergraph)
+        if self.dual != dual:
+            raise ValueError("dual must be the exact dual hypergraph")
+        return self
+
+
+class IncidenceGraphRequest(StrictModel):
+    """Request the bipartite incidence graph (Levi graph) of a hypergraph."""
+
+    hypergraph: FiniteHypergraph
+
+
+class IncidenceGraphResult(StrictModel):
+    """The bipartite incidence graph (Levi graph) of a finite hypergraph.
+
+    ``vertex_incidence`` maps each vertex label to the tuple of edge ids
+    containing it, in declared edge order.  ``edge_incidence`` maps each
+    edge id to the tuple of vertex labels it contains, in sorted member
+    order (the canonical edge order).  ``edges`` lists the
+    ``(vertex, edge_id)`` incidence pairs, sorted by vertex in declared
+    order then by edge id.
+    """
+
+    hypergraph: FiniteHypergraph
+    vertex_incidence: tuple[tuple[str, tuple[str, ...]], ...]
+    edge_incidence: tuple[tuple[str, tuple[str, ...]], ...]
+    edges: tuple[tuple[str, str], ...]
+
+    @model_validator(mode="after")
+    def bind_incidence_graph(self) -> Self:
+        from jacobian.math.hypergraphs._operations import _incidence_graph_data
+
+        vertex_incidence, edge_incidence, edges = _incidence_graph_data(
+            self.hypergraph
+        )
+        if self.vertex_incidence != vertex_incidence:
+            raise ValueError(
+                "vertex_incidence must be the exact vertex-to-edges map"
+            )
+        if self.edge_incidence != edge_incidence:
+            raise ValueError(
+                "edge_incidence must be the exact edge-to-vertices map"
+            )
+        if self.edges != edges:
+            raise ValueError("edges must be the exact incidence pairs")
+        return self
+
+
+class CliqueExpansionRequest(StrictModel):
+    """Request the clique expansion (2-section) of a hypergraph."""
+
+    hypergraph: FiniteHypergraph
+
+
+class CliqueExpansionResult(StrictModel):
+    """The primal/2-section graph of a finite hypergraph.
+
+    Two distinct vertices are adjacent in the 2-section if and only if they
+    share at least one hyperedge.  ``vertices`` lists the vertices in
+    declared order; ``adjacency`` maps each vertex to the tuple of its
+    neighbours in declared vertex order; ``edges`` lists each unordered
+    adjacency pair ``(u, v)`` with ``u`` before ``v`` in declared order,
+    sorted by the first component then the second.
+    """
+
+    hypergraph: FiniteHypergraph
+    vertices: tuple[str, ...]
+    adjacency: tuple[tuple[str, tuple[str, ...]], ...]
+    edges: tuple[tuple[str, str], ...]
+
+    @model_validator(mode="after")
+    def bind_clique_expansion(self) -> Self:
+        from jacobian.math.hypergraphs._operations import _clique_expansion_data
+
+        vertices, adjacency, edges = _clique_expansion_data(self.hypergraph)
+        if self.vertices != vertices:
+            raise ValueError("vertices must be the declared vertex list")
+        if self.adjacency != adjacency:
+            raise ValueError(
+                "adjacency must be the exact neighbour map of the 2-section"
+            )
+        if self.edges != edges:
+            raise ValueError("edges must be the exact 2-section edge list")
+        return self

--- a/src/jacobian/math/hypergraphs/_models.py
+++ b/src/jacobian/math/hypergraphs/_models.py
@@ -25,9 +25,7 @@ class FiniteHypergraph(StrictModel):
     """
 
     vertices: tuple[str, ...] = Field(max_length=MAX_VERTICES)
-    edges: tuple[tuple[str, tuple[str, ...]], ...] = Field(
-        max_length=MAX_EDGES
-    )
+    edges: tuple[tuple[str, tuple[str, ...]], ...] = Field(max_length=MAX_EDGES)
 
     @model_validator(mode="after")
     def require_valid_hypergraph(self) -> Self:
@@ -196,17 +194,11 @@ class IncidenceGraphResult(StrictModel):
     def bind_incidence_graph(self) -> Self:
         from jacobian.math.hypergraphs._operations import _incidence_graph_data
 
-        vertex_incidence, edge_incidence, edges = _incidence_graph_data(
-            self.hypergraph
-        )
+        vertex_incidence, edge_incidence, edges = _incidence_graph_data(self.hypergraph)
         if self.vertex_incidence != vertex_incidence:
-            raise ValueError(
-                "vertex_incidence must be the exact vertex-to-edges map"
-            )
+            raise ValueError("vertex_incidence must be the exact vertex-to-edges map")
         if self.edge_incidence != edge_incidence:
-            raise ValueError(
-                "edge_incidence must be the exact edge-to-vertices map"
-            )
+            raise ValueError("edge_incidence must be the exact edge-to-vertices map")
         if self.edges != edges:
             raise ValueError("edges must be the exact incidence pairs")
         return self

--- a/src/jacobian/math/hypergraphs/_operations.py
+++ b/src/jacobian/math/hypergraphs/_operations.py
@@ -5,6 +5,7 @@ from jacobian.math.hypergraphs._models import (
     CliqueExpansionResult,
     DualRequest,
     DualResult,
+    FiniteHypergraph,
     IncidenceGraphRequest,
     IncidenceGraphResult,
     ParametersRequest,
@@ -12,7 +13,6 @@ from jacobian.math.hypergraphs._models import (
     VertexDegreesRequest,
     VertexDegreesResult,
 )
-from jacobian.math.hypergraphs._models import FiniteHypergraph
 
 
 def _canonical_edges(
@@ -43,10 +43,7 @@ def _parameters_data(
         rank = max(sizes)
         corank = min(sizes)
         total = sum(sizes)
-        if all(size == sizes[0] for size in sizes):
-            uniform_size = sizes[0]
-        else:
-            uniform_size = None
+        uniform_size = sizes[0] if all(size == sizes[0] for size in sizes) else None
     return vertex_count, edge_count, rank, corank, uniform_size, total
 
 
@@ -60,13 +57,11 @@ def _vertex_degrees_data(
     sorted by degree ascending.
     """
 
-    degrees: dict[str, int] = {vertex: 0 for vertex in hypergraph.vertices}
+    degrees: dict[str, int] = dict.fromkeys(hypergraph.vertices, 0)
     for _, members in _canonical_edges(hypergraph):
         for member in members:
             degrees[member] += 1
-    degree_map = tuple(
-        (vertex, degrees[vertex]) for vertex in hypergraph.vertices
-    )
+    degree_map = tuple((vertex, degrees[vertex]) for vertex in hypergraph.vertices)
     histogram_map: dict[int, int] = {}
     for count in degrees.values():
         histogram_map[count] = histogram_map.get(count, 0) + 1
@@ -83,15 +78,12 @@ def _dual_data(hypergraph: FiniteHypergraph) -> FiniteHypergraph:
     """
 
     dual_vertices = tuple(edge_id for edge_id, _ in _canonical_edges(hypergraph))
-    membership: dict[str, list[str]] = {
-        vertex: [] for vertex in hypergraph.vertices
-    }
+    membership: dict[str, list[str]] = {vertex: [] for vertex in hypergraph.vertices}
     for edge_id, members in _canonical_edges(hypergraph):
         for member in members:
             membership[member].append(edge_id)
     dual_edges = tuple(
-        (vertex, tuple(sorted(membership[vertex])))
-        for vertex in hypergraph.vertices
+        (vertex, tuple(sorted(membership[vertex]))) for vertex in hypergraph.vertices
     )
     return FiniteHypergraph(vertices=dual_vertices, edges=dual_edges)
 
@@ -119,12 +111,9 @@ def _incidence_graph_data(
         for member in members:
             vertex_incidence[member].append(edge_id)
     vertex_incidence_pairs = tuple(
-        (vertex, tuple(vertex_incidence[vertex]))
-        for vertex in hypergraph.vertices
+        (vertex, tuple(vertex_incidence[vertex])) for vertex in hypergraph.vertices
     )
-    edge_incidence_pairs = tuple(
-        (edge_id, members) for edge_id, members in edges
-    )
+    edge_incidence_pairs = tuple((edge_id, members) for edge_id, members in edges)
     incidence_edges = tuple(
         (vertex, edge_id)
         for vertex, members in vertex_incidence_pairs
@@ -135,7 +124,11 @@ def _incidence_graph_data(
 
 def _clique_expansion_data(
     hypergraph: FiniteHypergraph,
-) -> tuple[tuple[str, ...], tuple[tuple[str, tuple[str, ...]], ...], tuple[tuple[str, str], ...]]:
+) -> tuple[
+    tuple[str, ...],
+    tuple[tuple[str, tuple[str, ...]], ...],
+    tuple[tuple[str, str], ...],
+]:
     """Compute the 2-section (primal/clique expansion) graph.
 
     Two distinct vertices are adjacent if they share at least one hyperedge.
@@ -223,9 +216,7 @@ def compute_incidence_graph(
 ) -> IncidenceGraphResult:
     """Compute the bipartite incidence graph (Levi graph) of a hypergraph."""
 
-    vertex_incidence, edge_incidence, edges = _incidence_graph_data(
-        request.hypergraph
-    )
+    vertex_incidence, edge_incidence, edges = _incidence_graph_data(request.hypergraph)
     return IncidenceGraphResult(
         hypergraph=request.hypergraph,
         vertex_incidence=vertex_incidence,

--- a/src/jacobian/math/hypergraphs/_operations.py
+++ b/src/jacobian/math/hypergraphs/_operations.py
@@ -1,0 +1,248 @@
+"""Exact bounded finite hypergraph operations."""
+
+from jacobian.math.hypergraphs._models import (
+    CliqueExpansionRequest,
+    CliqueExpansionResult,
+    DualRequest,
+    DualResult,
+    IncidenceGraphRequest,
+    IncidenceGraphResult,
+    ParametersRequest,
+    ParametersResult,
+    VertexDegreesRequest,
+    VertexDegreesResult,
+)
+from jacobian.math.hypergraphs._models import FiniteHypergraph
+
+
+def _canonical_edges(
+    hypergraph: FiniteHypergraph,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return the edges with member labels in sorted canonical order."""
+
+    return tuple(
+        (edge_id, tuple(sorted(members))) for edge_id, members in hypergraph.edges
+    )
+
+
+def _parameters_data(
+    hypergraph: FiniteHypergraph,
+) -> tuple[int, int, int, int, int | None, int]:
+    """Compute ``(vertex_count, edge_count, rank, corank, uniform_size, total)``."""
+
+    edges = _canonical_edges(hypergraph)
+    vertex_count = len(hypergraph.vertices)
+    edge_count = len(edges)
+    if edge_count == 0:
+        rank = 0
+        corank = 0
+        uniform_size: int | None = None
+        total = 0
+    else:
+        sizes = [len(members) for _, members in edges]
+        rank = max(sizes)
+        corank = min(sizes)
+        total = sum(sizes)
+        if all(size == sizes[0] for size in sizes):
+            uniform_size = sizes[0]
+        else:
+            uniform_size = None
+    return vertex_count, edge_count, rank, corank, uniform_size, total
+
+
+def _vertex_degrees_data(
+    hypergraph: FiniteHypergraph,
+) -> tuple[tuple[tuple[str, int], ...], tuple[tuple[int, int], ...]]:
+    """Compute the vertex-degree map and degree histogram.
+
+    ``degrees`` is a tuple of ``(vertex_label, degree)`` pairs in declared
+    vertex order.  ``histogram`` is a tuple of ``(degree, count)`` pairs
+    sorted by degree ascending.
+    """
+
+    degrees: dict[str, int] = {vertex: 0 for vertex in hypergraph.vertices}
+    for _, members in _canonical_edges(hypergraph):
+        for member in members:
+            degrees[member] += 1
+    degree_map = tuple(
+        (vertex, degrees[vertex]) for vertex in hypergraph.vertices
+    )
+    histogram_map: dict[int, int] = {}
+    for count in degrees.values():
+        histogram_map[count] = histogram_map.get(count, 0) + 1
+    histogram = tuple(sorted(histogram_map.items()))
+    return degree_map, histogram
+
+
+def _dual_data(hypergraph: FiniteHypergraph) -> FiniteHypergraph:
+    """Compute the dual hypergraph.
+
+    The dual transposes vertices and edges: the original edge ids become the
+    dual vertices, and each original vertex becomes a dual edge containing
+    the original edges it belongs to.
+    """
+
+    dual_vertices = tuple(edge_id for edge_id, _ in _canonical_edges(hypergraph))
+    membership: dict[str, list[str]] = {
+        vertex: [] for vertex in hypergraph.vertices
+    }
+    for edge_id, members in _canonical_edges(hypergraph):
+        for member in members:
+            membership[member].append(edge_id)
+    dual_edges = tuple(
+        (vertex, tuple(sorted(membership[vertex])))
+        for vertex in hypergraph.vertices
+    )
+    return FiniteHypergraph(vertices=dual_vertices, edges=dual_edges)
+
+
+def _incidence_graph_data(
+    hypergraph: FiniteHypergraph,
+) -> tuple[
+    tuple[tuple[str, tuple[str, ...]], ...],
+    tuple[tuple[str, tuple[str, ...]], ...],
+    tuple[tuple[str, str], ...],
+]:
+    """Compute the bipartite incidence graph (Levi graph).
+
+    ``vertex_incidence`` maps each vertex to the edge ids containing it in
+    declared edge order.  ``edge_incidence`` maps each edge id to the
+    vertices it contains in declared vertex order.  ``edges`` is the list of
+    ``(vertex, edge_id)`` incidence pairs sorted by vertex then edge id.
+    """
+
+    edges = _canonical_edges(hypergraph)
+    vertex_incidence: dict[str, list[str]] = {
+        vertex: [] for vertex in hypergraph.vertices
+    }
+    for edge_id, members in edges:
+        for member in members:
+            vertex_incidence[member].append(edge_id)
+    vertex_incidence_pairs = tuple(
+        (vertex, tuple(vertex_incidence[vertex]))
+        for vertex in hypergraph.vertices
+    )
+    edge_incidence_pairs = tuple(
+        (edge_id, members) for edge_id, members in edges
+    )
+    incidence_edges = tuple(
+        (vertex, edge_id)
+        for vertex, members in vertex_incidence_pairs
+        for edge_id in members
+    )
+    return vertex_incidence_pairs, edge_incidence_pairs, incidence_edges
+
+
+def _clique_expansion_data(
+    hypergraph: FiniteHypergraph,
+) -> tuple[tuple[str, ...], tuple[tuple[str, tuple[str, ...]], ...], tuple[tuple[str, str], ...]]:
+    """Compute the 2-section (primal/clique expansion) graph.
+
+    Two distinct vertices are adjacent if they share at least one hyperedge.
+    ``adjacency`` maps each vertex to its neighbours in declared vertex order.
+    ``edges`` lists each adjacency pair ``(u, v)`` with ``u`` before ``v`` in
+    declared order, sorted by the first component then the second.
+    """
+
+    edges = _canonical_edges(hypergraph)
+    index = {vertex: i for i, vertex in enumerate(hypergraph.vertices)}
+    adjacent: list[set[str]] = [set() for _ in hypergraph.vertices]
+    for _, members in edges:
+        n = len(members)
+        for i in range(n):
+            for j in range(i + 1, n):
+                u, v = members[i], members[j]
+                if u == v:
+                    continue
+                adjacent[index[u]].add(v)
+                adjacent[index[v]].add(u)
+    vertices = hypergraph.vertices
+    adjacency = tuple(
+        (
+            vertex,
+            tuple(
+                neighbour
+                for neighbour in hypergraph.vertices
+                if neighbour in adjacent[index[vertex]]
+            ),
+        )
+        for vertex in hypergraph.vertices
+    )
+    edge_list: list[tuple[str, str]] = []
+    for i, vertex in enumerate(hypergraph.vertices):
+        for neighbour in adjacent[i]:
+            j = index[neighbour]
+            if j > i:
+                edge_list.append((vertex, neighbour))
+    edge_list.sort(key=lambda pair: (index[pair[0]], index[pair[1]]))
+    return vertices, adjacency, tuple(edge_list)
+
+
+def compute_parameters(request: ParametersRequest) -> ParametersResult:
+    """Compute the basic parameters of a finite hypergraph."""
+
+    (
+        vertex_count,
+        edge_count,
+        rank,
+        corank,
+        uniform_size,
+        total_incidences,
+    ) = _parameters_data(request.hypergraph)
+    return ParametersResult(
+        hypergraph=request.hypergraph,
+        vertex_count=vertex_count,
+        edge_count=edge_count,
+        rank=rank,
+        corank=corank,
+        uniform_size=uniform_size,
+        total_incidences=total_incidences,
+    )
+
+
+def compute_vertex_degrees(request: VertexDegreesRequest) -> VertexDegreesResult:
+    """Compute the vertex-degree map of a finite hypergraph."""
+
+    degrees, histogram = _vertex_degrees_data(request.hypergraph)
+    return VertexDegreesResult(
+        hypergraph=request.hypergraph,
+        degrees=degrees,
+        histogram=histogram,
+    )
+
+
+def compute_dual(request: DualRequest) -> DualResult:
+    """Compute the dual of a finite hypergraph."""
+
+    dual = _dual_data(request.hypergraph)
+    return DualResult(hypergraph=request.hypergraph, dual=dual)
+
+
+def compute_incidence_graph(
+    request: IncidenceGraphRequest,
+) -> IncidenceGraphResult:
+    """Compute the bipartite incidence graph (Levi graph) of a hypergraph."""
+
+    vertex_incidence, edge_incidence, edges = _incidence_graph_data(
+        request.hypergraph
+    )
+    return IncidenceGraphResult(
+        hypergraph=request.hypergraph,
+        vertex_incidence=vertex_incidence,
+        edge_incidence=edge_incidence,
+        edges=edges,
+    )
+
+
+def compute_clique_expansion(
+    request: CliqueExpansionRequest,
+) -> CliqueExpansionResult:
+    """Compute the 2-section (primal/clique expansion) of a hypergraph."""
+
+    vertices, adjacency, edges = _clique_expansion_data(request.hypergraph)
+    return CliqueExpansionResult(
+        hypergraph=request.hypergraph,
+        vertices=vertices,
+        adjacency=adjacency,
+        edges=edges,
+    )

--- a/src/jacobian/math/hypergraphs/_tools.py
+++ b/src/jacobian/math/hypergraphs/_tools.py
@@ -1,0 +1,166 @@
+"""Finite hypergraph operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.hypergraphs._models import (
+    CliqueExpansionRequest,
+    CliqueExpansionResult,
+    DualRequest,
+    DualResult,
+    IncidenceGraphRequest,
+    IncidenceGraphResult,
+    ParametersRequest,
+    ParametersResult,
+    VertexDegreesRequest,
+    VertexDegreesResult,
+)
+from jacobian.math.hypergraphs._operations import (
+    compute_clique_expansion,
+    compute_dual,
+    compute_incidence_graph,
+    compute_parameters,
+    compute_vertex_degrees,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version="1",
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+# The Fano-plane-like hypergraph: four vertices and three hyperedges.
+_HYPERGRAPH = {
+    "vertices": ["a", "b", "c", "d"],
+    "edges": [
+        ["e1", ["a", "b", "c"]],
+        ["e2", ["b", "c", "d"]],
+        ["e3", ["a", "d"]],
+    ],
+}
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "hypergraph.parameters.compute",
+        "Compute the basic parameters of a finite hypergraph",
+        "Compute the vertex count, edge count, rank, corank, uniform "
+        "size, and total incidences of a finite hypergraph.",
+        ParametersRequest,
+        ParametersResult,
+        compute_parameters,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "parameters_of_4_vertex_hypergraph",
+                "Compute the parameters of a 4-vertex, 3-edge hypergraph.",
+                {"hypergraph": _HYPERGRAPH},
+            ),
+        ),
+    ),
+    _op(
+        "hypergraph.vertex_degrees.compute",
+        "Compute the vertex degrees of a finite hypergraph",
+        "Compute the degree of each vertex and a degree histogram of a "
+        "finite hypergraph.",
+        VertexDegreesRequest,
+        VertexDegreesResult,
+        compute_vertex_degrees,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "vertex_degrees_of_4_vertex_hypergraph",
+                "Compute the vertex-degree map of a 4-vertex hypergraph.",
+                {"hypergraph": _HYPERGRAPH},
+            ),
+        ),
+    ),
+    _op(
+        "hypergraph.dual.compute",
+        "Compute the dual of a finite hypergraph",
+        "Compute the dual hypergraph, transposing vertices and edges so "
+        "that the original edges become vertices and the original "
+        "vertices become edges.",
+        DualRequest,
+        DualResult,
+        compute_dual,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "dual_of_4_vertex_hypergraph",
+                "Compute the dual of a 4-vertex, 3-edge hypergraph.",
+                {"hypergraph": _HYPERGRAPH},
+            ),
+        ),
+    ),
+    _op(
+        "hypergraph.incidence_graph.compute",
+        "Compute the bipartite incidence graph of a hypergraph",
+        "Compute the bipartite incidence graph (Levi graph) of a finite "
+        "hypergraph, giving vertex-to-edge and edge-to-vertex incidence.",
+        IncidenceGraphRequest,
+        IncidenceGraphResult,
+        compute_incidence_graph,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "incidence_graph_of_4_vertex_hypergraph",
+                "Compute the Levi graph of a 4-vertex, 3-edge hypergraph.",
+                {"hypergraph": _HYPERGRAPH},
+            ),
+        ),
+    ),
+    _op(
+        "hypergraph.clique_expansion.compute",
+        "Compute the 2-section (clique expansion) of a hypergraph",
+        "Compute the primal/2-section graph where two vertices are "
+        "adjacent if and only if they share a hyperedge.",
+        CliqueExpansionRequest,
+        CliqueExpansionResult,
+        compute_clique_expansion,
+        "combinatorics",
+        "hypergraph",
+        "exact",
+        examples=(
+            example(
+                "clique_expansion_of_4_vertex_hypergraph",
+                "Compute the 2-section of a 4-vertex, 3-edge hypergraph.",
+                {"hypergraph": _HYPERGRAPH},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/tests/math/hypergraphs/test_hypergraphs.py
+++ b/tests/math/hypergraphs/test_hypergraphs.py
@@ -19,7 +19,6 @@ from jacobian.math.hypergraphs._operations import (
     compute_vertex_degrees,
 )
 
-
 # ---- Fixtures ----------------------------------------------------------------
 
 HYPERGRAPH = {
@@ -72,9 +71,7 @@ class TestFiniteHypergraph:
 
     def test_undeclared_member_rejected(self) -> None:
         with pytest.raises(ValidationError, match="every edge member"):
-            FiniteHypergraph(
-                vertices=["a", "b"], edges=[["e", ["a", "z"]]]
-            )
+            FiniteHypergraph(vertices=["a", "b"], edges=[["e", ["a", "z"]]])
 
     def test_duplicate_edge_ids_rejected(self) -> None:
         with pytest.raises(ValidationError, match="edge ids must be distinct"):
@@ -85,9 +82,7 @@ class TestFiniteHypergraph:
 
     def test_duplicate_members_in_edge_rejected(self) -> None:
         with pytest.raises(ValidationError, match="edge members must be distinct"):
-            FiniteHypergraph(
-                vertices=["a", "b"], edges=[["e", ["a", "a"]]]
-            )
+            FiniteHypergraph(vertices=["a", "b"], edges=[["e", ["a", "a"]]])
 
 
 class TestParameters:
@@ -211,9 +206,7 @@ class TestDual:
 
 class TestIncidenceGraph:
     def test_incidence(self) -> None:
-        r = compute_incidence_graph(
-            IncidenceGraphRequest(hypergraph=HYPERGRAPH)
-        )
+        r = compute_incidence_graph(IncidenceGraphRequest(hypergraph=HYPERGRAPH))
         vi = dict(r.vertex_incidence)
         assert vi["a"] == ("e1", "e3")
         assert vi["b"] == ("e1", "e2")
@@ -224,16 +217,18 @@ class TestIncidenceGraph:
         assert ei["e2"] == ("b", "c", "d")
         assert ei["e3"] == ("a", "d")
         assert set(r.edges) == {
-            ("a", "e1"), ("a", "e3"),
-            ("b", "e1"), ("b", "e2"),
-            ("c", "e1"), ("c", "e2"),
-            ("d", "e2"), ("d", "e3"),
+            ("a", "e1"),
+            ("a", "e3"),
+            ("b", "e1"),
+            ("b", "e2"),
+            ("c", "e1"),
+            ("c", "e2"),
+            ("d", "e2"),
+            ("d", "e3"),
         }
 
     def test_no_edges(self) -> None:
-        r = compute_incidence_graph(
-            IncidenceGraphRequest(hypergraph=NO_EDGES)
-        )
+        r = compute_incidence_graph(IncidenceGraphRequest(hypergraph=NO_EDGES))
         assert dict(r.vertex_incidence) == {"a": (), "b": ()}
         assert r.edge_incidence == ()
         assert r.edges == ()
@@ -261,9 +256,7 @@ class TestIncidenceGraph:
 
 class TestCliqueExpansion:
     def test_basic(self) -> None:
-        r = compute_clique_expansion(
-            CliqueExpansionRequest(hypergraph=HYPERGRAPH)
-        )
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=HYPERGRAPH))
         assert r.vertices == ("a", "b", "c", "d")
         adj = dict(r.adjacency)
         assert adj["a"] == ("b", "c", "d")
@@ -272,12 +265,13 @@ class TestCliqueExpansion:
         assert adj["d"] == ("a", "b", "c")
 
     def test_edges(self) -> None:
-        r = compute_clique_expansion(
-            CliqueExpansionRequest(hypergraph=HYPERGRAPH)
-        )
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=HYPERGRAPH))
         assert set(r.edges) == {
-            ("a", "b"), ("a", "c"), ("a", "d"),
-            ("b", "c"), ("b", "d"),
+            ("a", "b"),
+            ("a", "c"),
+            ("a", "d"),
+            ("b", "c"),
+            ("b", "d"),
             ("c", "d"),
         }
 
@@ -298,16 +292,12 @@ class TestCliqueExpansion:
         assert set(r.edges) == {("a", "b"), ("c", "d")}
 
     def test_no_edges_no_adjacency(self) -> None:
-        r = compute_clique_expansion(
-            CliqueExpansionRequest(hypergraph=NO_EDGES)
-        )
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=NO_EDGES))
         assert dict(r.adjacency) == {"a": (), "b": ()}
         assert r.edges == ()
 
     def test_singleton(self) -> None:
-        r = compute_clique_expansion(
-            CliqueExpansionRequest(hypergraph=SINGLETON)
-        )
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=SINGLETON))
         assert dict(r.adjacency) == {"v": ()}
         assert r.edges == ()
 
@@ -378,7 +368,11 @@ class TestBindingSafety:
                     ("d", ("a", "b", "c")),
                 ),
                 edges=(
-                    ("a", "b"), ("a", "c"), ("a", "d"),
-                    ("b", "c"), ("b", "d"), ("c", "d"),
+                    ("a", "b"),
+                    ("a", "c"),
+                    ("a", "d"),
+                    ("b", "c"),
+                    ("b", "d"),
+                    ("c", "d"),
                 ),
             )

--- a/tests/math/hypergraphs/test_hypergraphs.py
+++ b/tests/math/hypergraphs/test_hypergraphs.py
@@ -1,0 +1,384 @@
+"""Known-answer and adversarial tests for finite hypergraph operations."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.hypergraphs._models import (
+    CliqueExpansionRequest,
+    DualRequest,
+    FiniteHypergraph,
+    IncidenceGraphRequest,
+    ParametersRequest,
+    VertexDegreesRequest,
+)
+from jacobian.math.hypergraphs._operations import (
+    compute_clique_expansion,
+    compute_dual,
+    compute_incidence_graph,
+    compute_parameters,
+    compute_vertex_degrees,
+)
+
+
+# ---- Fixtures ----------------------------------------------------------------
+
+HYPERGRAPH = {
+    "vertices": ["a", "b", "c", "d"],
+    "edges": [
+        ["e1", ["a", "b", "c"]],
+        ["e2", ["b", "c", "d"]],
+        ["e3", ["a", "d"]],
+    ],
+}
+
+# Uniform hypergraph: every edge has 2 vertices.
+UNIFORM = {
+    "vertices": ["x", "y", "z"],
+    "edges": [
+        ["p", ["x", "y"]],
+        ["q", ["y", "z"]],
+        ["r", ["x", "z"]],
+    ],
+}
+
+# Hypergraph with no edges.
+NO_EDGES = {
+    "vertices": ["a", "b"],
+    "edges": [],
+}
+
+# Singleton vertex with one edge.
+SINGLETON = {
+    "vertices": ["v"],
+    "edges": [["e", ["v"]]],
+}
+
+
+class TestFiniteHypergraph:
+    def test_construct(self) -> None:
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        assert hg.vertices == ("a", "b", "c", "d")
+        assert hg.edges[0] == ("e1", ("a", "b", "c"))
+
+    def test_member_order_canonicalized(self) -> None:
+        hg = FiniteHypergraph(vertices=["a", "b"], edges=[["e", ["b", "a"]]])
+        assert hg.edges == (("e", ("a", "b")),)
+        hg2 = FiniteHypergraph(vertices=["a", "b"], edges=[["e", ["a", "b"]]])
+        assert hg == hg2
+
+    def test_duplicate_vertices_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="vertex labels must be distinct"):
+            FiniteHypergraph(vertices=["a", "a"], edges=[])
+
+    def test_undeclared_member_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="every edge member"):
+            FiniteHypergraph(
+                vertices=["a", "b"], edges=[["e", ["a", "z"]]]
+            )
+
+    def test_duplicate_edge_ids_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="edge ids must be distinct"):
+            FiniteHypergraph(
+                vertices=["a", "b"],
+                edges=[["e", ["a"]], ["e", ["b"]]],
+            )
+
+    def test_duplicate_members_in_edge_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="edge members must be distinct"):
+            FiniteHypergraph(
+                vertices=["a", "b"], edges=[["e", ["a", "a"]]]
+            )
+
+
+class TestParameters:
+    def test_basic(self) -> None:
+        r = compute_parameters(ParametersRequest(hypergraph=HYPERGRAPH))
+        assert r.vertex_count == 4
+        assert r.edge_count == 3
+        assert r.rank == 3
+        assert r.corank == 2
+        assert r.uniform_size is None
+        assert r.total_incidences == 8
+
+    def test_uniform(self) -> None:
+        r = compute_parameters(ParametersRequest(hypergraph=UNIFORM))
+        assert r.uniform_size == 2
+        assert r.rank == 2
+        assert r.corank == 2
+
+    def test_no_edges(self) -> None:
+        r = compute_parameters(ParametersRequest(hypergraph=NO_EDGES))
+        assert r.vertex_count == 2
+        assert r.edge_count == 0
+        assert r.rank == 0
+        assert r.corank == 0
+        assert r.uniform_size is None
+        assert r.total_incidences == 0
+
+    def test_singleton(self) -> None:
+        r = compute_parameters(ParametersRequest(hypergraph=SINGLETON))
+        assert r.vertex_count == 1
+        assert r.edge_count == 1
+        assert r.rank == 1
+        assert r.corank == 1
+        assert r.uniform_size == 1
+
+    def test_binding_rejects_wrong_vertex_count(self) -> None:
+        from jacobian.math.hypergraphs._models import ParametersResult
+
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        with pytest.raises(ValidationError, match="vertex_count"):
+            ParametersResult(
+                hypergraph=hg,
+                vertex_count=99,
+                edge_count=3,
+                rank=3,
+                corank=2,
+                uniform_size=None,
+                total_incidences=8,
+            )
+
+
+class TestVertexDegrees:
+    def test_degrees(self) -> None:
+        r = compute_vertex_degrees(VertexDegreesRequest(hypergraph=HYPERGRAPH))
+        d = dict(r.degrees)
+        assert d["a"] == 2  # e1, e3
+        assert d["b"] == 2  # e1, e2
+        assert d["c"] == 2  # e1, e2
+        assert d["d"] == 2  # e2, e3
+        assert dict(r.histogram) == {2: 4}
+
+    def test_uniform(self) -> None:
+        r = compute_vertex_degrees(VertexDegreesRequest(hypergraph=UNIFORM))
+        assert dict(r.degrees) == {"x": 2, "y": 2, "z": 2}
+
+    def test_no_edges(self) -> None:
+        r = compute_vertex_degrees(VertexDegreesRequest(hypergraph=NO_EDGES))
+        assert dict(r.degrees) == {"a": 0, "b": 0}
+        assert dict(r.histogram) == {0: 2}
+
+    def test_histogram_sorted(self) -> None:
+        hg = {
+            "vertices": ["a", "b", "c", "d"],
+            "edges": [["e", ["a", "b"]]],
+        }
+        r = compute_vertex_degrees(VertexDegreesRequest(hypergraph=hg))
+        assert dict(r.histogram) == {0: 2, 1: 2}
+        degrees = [d for _, d in r.histogram]
+        assert degrees == sorted(degrees)
+
+    def test_degrees_in_vertex_order(self) -> None:
+        r = compute_vertex_degrees(VertexDegreesRequest(hypergraph=HYPERGRAPH))
+        assert [v for v, _ in r.degrees] == ["a", "b", "c", "d"]
+
+
+class TestDual:
+    def test_dual_basic(self) -> None:
+        r = compute_dual(DualRequest(hypergraph=HYPERGRAPH))
+        dual = r.dual
+        assert dual.vertices == ("e1", "e2", "e3")
+        d_edges = dict(dual.edges)
+        assert d_edges["a"] == ("e1", "e3")
+        assert d_edges["b"] == ("e1", "e2")
+        assert d_edges["c"] == ("e1", "e2")
+        assert d_edges["d"] == ("e2", "e3")
+
+    def test_dual_of_dual_recovers_original(self) -> None:
+        r = compute_dual(DualRequest(hypergraph=HYPERGRAPH))
+        r2 = compute_dual(DualRequest(hypergraph=r.dual))
+        recovered = r2.dual
+        assert recovered.vertices == ("a", "b", "c", "d")
+        assert dict(recovered.edges) == {
+            "e1": ("a", "b", "c"),
+            "e2": ("b", "c", "d"),
+            "e3": ("a", "d"),
+        }
+
+    def test_dual_no_edges(self) -> None:
+        r = compute_dual(DualRequest(hypergraph=NO_EDGES))
+        assert r.dual.vertices == ()
+        assert r.dual.edges == (("a", ()), ("b", ()))
+
+    def test_dual_binding_rejects_wrong(self) -> None:
+        from jacobian.math.hypergraphs._models import DualResult
+
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        wrong = FiniteHypergraph(vertices=["e1"], edges=[["e1", ["e1"]]])
+        with pytest.raises(ValidationError, match="dual must be the exact"):
+            DualResult(hypergraph=hg, dual=wrong)
+
+
+class TestIncidenceGraph:
+    def test_incidence(self) -> None:
+        r = compute_incidence_graph(
+            IncidenceGraphRequest(hypergraph=HYPERGRAPH)
+        )
+        vi = dict(r.vertex_incidence)
+        assert vi["a"] == ("e1", "e3")
+        assert vi["b"] == ("e1", "e2")
+        assert vi["c"] == ("e1", "e2")
+        assert vi["d"] == ("e2", "e3")
+        ei = dict(r.edge_incidence)
+        assert ei["e1"] == ("a", "b", "c")
+        assert ei["e2"] == ("b", "c", "d")
+        assert ei["e3"] == ("a", "d")
+        assert set(r.edges) == {
+            ("a", "e1"), ("a", "e3"),
+            ("b", "e1"), ("b", "e2"),
+            ("c", "e1"), ("c", "e2"),
+            ("d", "e2"), ("d", "e3"),
+        }
+
+    def test_no_edges(self) -> None:
+        r = compute_incidence_graph(
+            IncidenceGraphRequest(hypergraph=NO_EDGES)
+        )
+        assert dict(r.vertex_incidence) == {"a": (), "b": ()}
+        assert r.edge_incidence == ()
+        assert r.edges == ()
+
+    def test_edge_incidence_is_canonical(self) -> None:
+        hg = FiniteHypergraph(
+            vertices=["a", "b", "c"],
+            edges=[["e", ["c", "a", "b"]]],
+        )
+        r = compute_incidence_graph(IncidenceGraphRequest(hypergraph=hg))
+        assert dict(r.edge_incidence)["e"] == ("a", "b", "c")
+
+    def test_vertex_incidence_preserves_edge_order(self) -> None:
+        hg = {
+            "vertices": ["v"],
+            "edges": [
+                ["z", ["v"]],
+                ["a", ["v"]],
+                ["m", ["v"]],
+            ],
+        }
+        r = compute_incidence_graph(IncidenceGraphRequest(hypergraph=hg))
+        assert dict(r.vertex_incidence)["v"] == ("z", "a", "m")
+
+
+class TestCliqueExpansion:
+    def test_basic(self) -> None:
+        r = compute_clique_expansion(
+            CliqueExpansionRequest(hypergraph=HYPERGRAPH)
+        )
+        assert r.vertices == ("a", "b", "c", "d")
+        adj = dict(r.adjacency)
+        assert adj["a"] == ("b", "c", "d")
+        assert adj["b"] == ("a", "c", "d")
+        assert adj["c"] == ("a", "b", "d")
+        assert adj["d"] == ("a", "b", "c")
+
+    def test_edges(self) -> None:
+        r = compute_clique_expansion(
+            CliqueExpansionRequest(hypergraph=HYPERGRAPH)
+        )
+        assert set(r.edges) == {
+            ("a", "b"), ("a", "c"), ("a", "d"),
+            ("b", "c"), ("b", "d"),
+            ("c", "d"),
+        }
+
+    def test_uniform_no_overlap(self) -> None:
+        hg = {
+            "vertices": ["a", "b", "c", "d"],
+            "edges": [
+                ["e1", ["a", "b"]],
+                ["e2", ["c", "d"]],
+            ],
+        }
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=hg))
+        adj = dict(r.adjacency)
+        assert adj["a"] == ("b",)
+        assert adj["b"] == ("a",)
+        assert adj["c"] == ("d",)
+        assert adj["d"] == ("c",)
+        assert set(r.edges) == {("a", "b"), ("c", "d")}
+
+    def test_no_edges_no_adjacency(self) -> None:
+        r = compute_clique_expansion(
+            CliqueExpansionRequest(hypergraph=NO_EDGES)
+        )
+        assert dict(r.adjacency) == {"a": (), "b": ()}
+        assert r.edges == ()
+
+    def test_singleton(self) -> None:
+        r = compute_clique_expansion(
+            CliqueExpansionRequest(hypergraph=SINGLETON)
+        )
+        assert dict(r.adjacency) == {"v": ()}
+        assert r.edges == ()
+
+    def test_edges_sorted_by_vertex_order(self) -> None:
+        hg = {
+            "vertices": ["d", "c", "b", "a"],
+            "edges": [["e", ["a", "b", "c", "d"]]],
+        }
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=hg))
+        idx = {v: i for i, v in enumerate(r.vertices)}
+        for u, v in r.edges:
+            assert idx[u] < idx[v]
+        edge_keys = [(idx[u], idx[v]) for u, v in r.edges]
+        assert edge_keys == sorted(edge_keys)
+
+
+class TestBindingSafety:
+    """Verify result binding fail-closes on tampered values."""
+
+    def test_vertex_degrees_binding(self) -> None:
+        from jacobian.math.hypergraphs._models import VertexDegreesResult
+
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        with pytest.raises(ValidationError, match="degrees must"):
+            VertexDegreesResult(
+                hypergraph=hg,
+                degrees=(("a", 99), ("b", 2), ("c", 2), ("d", 2)),
+                histogram=((2, 4),),
+            )
+
+    def test_incidence_binding(self) -> None:
+        from jacobian.math.hypergraphs._models import (
+            IncidenceGraphResult,
+        )
+
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        with pytest.raises(ValidationError, match="vertex_incidence"):
+            IncidenceGraphResult(
+                hypergraph=hg,
+                vertex_incidence=(
+                    ("a", ("e1",)),
+                    ("b", ("e1", "e2")),
+                    ("c", ("e1", "e2")),
+                    ("d", ("e2", "e3")),
+                ),
+                edge_incidence=(
+                    ("e1", ("a", "b", "c")),
+                    ("e2", ("b", "c", "d")),
+                    ("e3", ("a", "d")),
+                ),
+                edges=(("a", "e1"),),
+            )
+
+    def test_clique_expansion_binding(self) -> None:
+        from jacobian.math.hypergraphs._models import (
+            CliqueExpansionResult,
+        )
+
+        hg = FiniteHypergraph(**HYPERGRAPH)
+        with pytest.raises(ValidationError, match="adjacency"):
+            CliqueExpansionResult(
+                hypergraph=hg,
+                vertices=("a", "b", "c", "d"),
+                adjacency=(
+                    ("a", ("b",)),
+                    ("b", ("a", "c", "d")),
+                    ("c", ("a", "b", "d")),
+                    ("d", ("a", "b", "c")),
+                ),
+                edges=(
+                    ("a", "b"), ("a", "c"), ("a", "d"),
+                    ("b", "c"), ("b", "d"), ("c", "d"),
+                ),
+            )


### PR DESCRIPTION
## Summary

Implements the `hypergraphs` domain (issue #1742) with five bounded operations on a `FiniteHypergraph` value.

### Operations

- `hypergraph.parameters.compute` — vertex count, edge count, rank, corank, uniform size, total incidences
- `hypergraph.vertex_degrees.compute` — vertex-degree map (declared vertex order) and degree histogram (sorted by degree)
- `hypergraph.dual.compute` — dual hypergraph transposing vertices and edges
- `hypergraph.incidence_graph.compute` — bipartite incidence graph (Levi graph): vertex→edge and edge→vertex incidence
- `hypergraph.clique_expansion.compute` — 2-section graph where two vertices are adjacent iff they share a hyperedge

### Design

- `FiniteHypergraph` value: `vertices` (unique string labels) + `edges` (`(edge_id, vertex_subset)` pairs). Edge member order is canonicalized to sorted order so hypergraphs with the same members compare equal regardless of input order.
- Vertices are allowed to be empty so the dual of an edge-free hypergraph is representable.
- Each result model re-runs the kernel in a `model_validator(mode="after")` and verifies the supplied values match exactly (fail-closed binding).
- Domain is auto-discovered via `_admission.py` exporting `REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)`.

### Tests

33 tests covering known-answer cases, boundary hypergraphs (no edges, singleton, uniform, non-uniform), the dual-of-dual identity, binding-failure guards, and validation rejections. All pass:

```
uv run pytest tests/math/hypergraphs/ -x -q
33 passed
```

Registration verified:

```
['hypergraph.parameters.compute', 'hypergraph.vertex_degrees.compute',
 'hypergraph.dual.compute', 'hypergraph.incidence_graph.compute',
 'hypergraph.clique_expansion.compute']
```

Closes #1742

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/cccdaccc-6170-42f7-8b18-dcc747b08b95)