### PR TITLE
feat(math): add disjunctive sum operation to impartial games domain (#1907)

### DIFF
--- a/src/jacobian/math/impartial_games/_admission.py
+++ b/src/jacobian/math/impartial_games/_admission.py
@@ -35,6 +35,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "complete P/N position partition with Grundy values and terminal positions",
     ),
+    OperationAdmission(
+        "game.impartial.disjunctive_sum.compute",
+        AdmissionDecision.KEEP,
+        "exact Grundy value of a disjunctive sum by XOR of component Grundy values",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -16,10 +16,15 @@ from jacobian.math.impartial_games.values import (
     MAX_HEAP_BOUND,
     MAX_HEAP_SIZE,
     MAX_HEAPS,
+    MAX_POSITIONS,
     MAX_SUBTRACTION_VALUE,
     MAX_SUBTRACTION_WORK,
     ImpartialGame,
 )
+
+
+MAX_COMPONENT_GRUNDY = MAX_POSITIONS - 1
+MAX_DISJUNCTIVE_GRUNDY = (1 << MAX_COMPONENT_GRUNDY.bit_length()) - 1
 
 
 class GrundyTableRequest(StrictModel):
@@ -217,10 +222,13 @@ class DisjunctiveSumRequest(StrictModel):
 class DisjunctiveSumResult(StrictModel):
     """The exact Grundy value of a disjunctive sum of impartial games."""
 
-    grundy_value: int = Field(ge=0)
-    component_grundy_values: tuple[int, ...]
+    grundy_value: int = Field(ge=0, le=MAX_DISJUNCTIVE_GRUNDY)
+    component_grundy_values: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_HEAPS,
+    )
     is_p_position: bool
-    component_count: int = Field(ge=1)
+    component_count: int = Field(ge=1, le=MAX_HEAPS)
 
     @model_validator(mode="after")
     def require_exact_disjunctive_invariants(self) -> Self:
@@ -228,8 +236,14 @@ class DisjunctiveSumResult(StrictModel):
             raise ValueError(
                 "component_count must match component_grundy_values length"
             )
-        if any(value < 0 for value in self.component_grundy_values):
-            raise ValueError("component Grundy values must be nonnegative")
+        if any(
+            not 0 <= value <= MAX_COMPONENT_GRUNDY
+            for value in self.component_grundy_values
+        ):
+            raise ValueError(
+                f"component Grundy values must be between 0 and "
+                f"{MAX_COMPONENT_GRUNDY}"
+            )
         from functools import reduce
         from operator import xor
 

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -22,7 +22,6 @@ from jacobian.math.impartial_games.values import (
     ImpartialGame,
 )
 
-
 MAX_COMPONENT_GRUNDY = MAX_POSITIONS - 1
 MAX_DISJUNCTIVE_GRUNDY = (1 << MAX_COMPONENT_GRUNDY.bit_length()) - 1
 

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -221,3 +221,19 @@ class DisjunctiveSumResult(StrictModel):
     component_grundy_values: tuple[int, ...]
     is_p_position: bool
     component_count: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def require_exact_disjunctive_invariants(self) -> Self:
+        if self.component_count != len(self.component_grundy_values):
+            raise ValueError("component_count must match component_grundy_values length")
+        if any(value < 0 for value in self.component_grundy_values):
+            raise ValueError("component Grundy values must be nonnegative")
+        from functools import reduce
+        from operator import xor
+
+        expected = reduce(xor, self.component_grundy_values, 0)
+        if self.grundy_value != expected:
+            raise ValueError("grundy_value must be XOR of component_grundy_values")
+        if self.is_p_position != (expected == 0):
+            raise ValueError("is_p_position must agree with grundy_value == 0")
+        return self

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -240,8 +240,7 @@ class DisjunctiveSumResult(StrictModel):
             for value in self.component_grundy_values
         ):
             raise ValueError(
-                f"component Grundy values must be between 0 and "
-                f"{MAX_COMPONENT_GRUNDY}"
+                f"component Grundy values must be between 0 and {MAX_COMPONENT_GRUNDY}"
             )
         from functools import reduce
         from operator import xor

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -181,3 +181,43 @@ class OutcomeProfileResult(StrictModel):
     n_positions: tuple[str, ...]
     grundy_values: tuple[tuple[str, int], ...]
     terminal_positions: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Disjunctive sum operation
+# ---------------------------------------------------------------------------
+
+
+class DisjunctiveSumRequest(StrictModel):
+    """A disjunctive sum of finite impartial game components.
+
+    Each component specifies a game DAG and the label of the starting
+    position whose Grundy value represents that component in the sum.
+    The Grundy value of the disjunctive sum is the bitwise XOR of the
+    component Grundy values.
+    """
+
+    components: tuple[ImpartialGame, ...] = Field(min_length=1, max_length=MAX_HEAPS)
+    start_positions: tuple[str, ...] = Field(min_length=1, max_length=MAX_HEAPS)
+
+    @model_validator(mode="after")
+    def require_matching_bounded(self) -> Self:
+        if len(self.components) != len(self.start_positions):
+            raise ValueError("components and start_positions must have equal length")
+        for index, (game, start) in enumerate(
+            zip(self.components, self.start_positions, strict=True)
+        ):
+            if start not in game.positions:
+                raise ValueError(
+                    f"start position {index!r} is not in component {index}'s positions"
+                )
+        return self
+
+
+class DisjunctiveSumResult(StrictModel):
+    """The exact Grundy value of a disjunctive sum of impartial games."""
+
+    grundy_value: int = Field(ge=0)
+    component_grundy_values: tuple[int, ...]
+    is_p_position: bool
+    component_count: int = Field(ge=1)

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -225,7 +225,9 @@ class DisjunctiveSumResult(StrictModel):
     @model_validator(mode="after")
     def require_exact_disjunctive_invariants(self) -> Self:
         if self.component_count != len(self.component_grundy_values):
-            raise ValueError("component_count must match component_grundy_values length")
+            raise ValueError(
+                "component_count must match component_grundy_values length"
+            )
         if any(value < 0 for value in self.component_grundy_values):
             raise ValueError("component Grundy values must be nonnegative")
         from functools import reduce

--- a/src/jacobian/math/impartial_games/_operations.py
+++ b/src/jacobian/math/impartial_games/_operations.py
@@ -1,10 +1,10 @@
 """Wire adapters for exact bounded impartial-game operations."""
 
 from jacobian.math.impartial_games._models import (
-    DisjunctiveSumRequest,
-    DisjunctiveSumResult,
     BirthdayRequest,
     BirthdayResult,
+    DisjunctiveSumRequest,
+    DisjunctiveSumResult,
     GrundyEntry,
     GrundyTableRequest,
     GrundyTableResult,
@@ -67,8 +67,8 @@ def compute_subtraction_grundy_prefix(
 
 
 __all__ = [
-    "compute_disjunctive_sum",
     "compute_birthday",
+    "compute_disjunctive_sum",
     "compute_grundy_table",
     "compute_subtraction_grundy_prefix",
 ]

--- a/src/jacobian/math/impartial_games/_operations.py
+++ b/src/jacobian/math/impartial_games/_operations.py
@@ -1,6 +1,8 @@
 """Wire adapters for exact bounded impartial-game operations."""
 
 from jacobian.math.impartial_games._models import (
+    DisjunctiveSumRequest,
+    DisjunctiveSumResult,
     BirthdayRequest,
     BirthdayResult,
     GrundyEntry,
@@ -65,6 +67,7 @@ def compute_subtraction_grundy_prefix(
 
 
 __all__ = [
+    "compute_disjunctive_sum",
     "compute_birthday",
     "compute_grundy_table",
     "compute_subtraction_grundy_prefix",
@@ -108,4 +111,30 @@ def compute_outcome_profile(
         n_positions=n_positions,
         grundy_values=analysis.values,
         terminal_positions=terminal_positions,
+    )
+
+
+def compute_disjunctive_sum(
+    request: "DisjunctiveSumRequest",
+) -> "DisjunctiveSumResult":
+    """Compute the Grundy value of a disjunctive sum of impartial games.
+
+    The Grundy value of the disjunctive sum is the bitwise XOR of the
+    component Grundy values (the Grundy value of each component's
+    start position).
+    """
+    from functools import reduce
+    from operator import xor
+
+    component_grundy_values = []
+    for game, start in zip(request.components, request.start_positions, strict=True):
+        analysis = grundy_table(game)
+        grundy_map = dict(analysis.values)
+        component_grundy_values.append(grundy_map[start])
+    nim_sum = reduce(xor, component_grundy_values, 0)
+    return DisjunctiveSumResult(
+        grundy_value=nim_sum,
+        component_grundy_values=tuple(component_grundy_values),
+        is_p_position=(nim_sum == 0),
+        component_count=len(request.components),
     )

--- a/src/jacobian/math/impartial_games/_tools.py
+++ b/src/jacobian/math/impartial_games/_tools.py
@@ -9,6 +9,8 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.impartial_games._models import (
     BirthdayRequest,
     BirthdayResult,
+    DisjunctiveSumRequest,
+    DisjunctiveSumResult,
     GrundyTableRequest,
     GrundyTableResult,
     NimSumRequest,
@@ -20,6 +22,7 @@ from jacobian.math.impartial_games._models import (
 )
 from jacobian.math.impartial_games._operations import (
     compute_birthday,
+    compute_disjunctive_sum,
     compute_grundy_table,
     compute_nim_sum,
     compute_outcome_profile,
@@ -61,6 +64,19 @@ _GAME = {
         {"source": "2", "target": "1"},
         {"source": "2", "target": "0"},
         {"source": "1", "target": "0"},
+    ],
+}
+
+_GAME_A = {
+    "positions": ["a", "b"],
+    "moves": [{"source": "a", "target": "b"}],
+}
+
+_GAME_B = {
+    "positions": ["c", "d", "e"],
+    "moves": [
+        {"source": "c", "target": "d"},
+        {"source": "d", "target": "e"},
     ],
 }
 
@@ -163,6 +179,29 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "four_position_outcome",
                 "Compute the P/N outcome partition of a four-position DAG.",
                 {"game": _GAME},
+            ),
+        ),
+    ),
+    _op(
+        "game.impartial.disjunctive_sum.compute",
+        "Compute the Grundy value of a disjunctive sum",
+        "Compute the exact Grundy value of a disjunctive sum of finite "
+        "impartial game components by XOR of their component Grundy values.",
+        DisjunctiveSumRequest,
+        DisjunctiveSumResult,
+        compute_disjunctive_sum,
+        "game-theory",
+        "impartial",
+        "disjunctive-sum",
+        "exact",
+        examples=(
+            example(
+                "two_component_sum",
+                "Compute the disjunctive sum of two game components.",
+                {
+                    "components": [_GAME_A, _GAME_B],
+                    "start_positions": ["a", "c"],
+                },
             ),
         ),
     ),

--- a/tests/math/impartial_games/test_disjunctive_sum.py
+++ b/tests/math/impartial_games/test_disjunctive_sum.py
@@ -1,0 +1,159 @@
+"""Known-answer and adversarial tests for the disjunctive sum operation."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.impartial_games._models import (
+    DisjunctiveSumRequest,
+    DisjunctiveSumResult,
+)
+from jacobian.math.impartial_games._operations import compute_disjunctive_sum
+from jacobian.math.impartial_games._tools import TOOLS
+
+
+# -- helpers -----------------------------------------------------------------
+
+_TERMINAL = {"positions": ["start"], "moves": []}
+
+_SINGLE_MOVE = {
+    "positions": ["a", "b"],
+    "moves": [{"source": "a", "target": "b"}],
+}
+
+# Grundy value 2 at position "a"
+_G2 = {
+    "positions": ["a", "b", "c", "d"],
+    "moves": [
+        {"source": "a", "target": "b"},
+        {"source": "a", "target": "c"},
+        {"source": "c", "target": "d"},
+    ],
+}
+
+# Grundy value 3 at position "e"
+_G3 = {
+    "positions": ["e", "f", "g", "h", "i", "j", "k", "l"],
+    "moves": [
+        {"source": "e", "target": "f"},
+        {"source": "e", "target": "g"},
+        {"source": "g", "target": "i"},
+        {"source": "e", "target": "h"},
+        {"source": "h", "target": "j"},
+        {"source": "h", "target": "k"},
+        {"source": "k", "target": "l"},
+    ],
+}
+
+
+class TestDisjunctiveSum:
+    def test_two_terminal_games_xor_to_zero(self) -> None:
+        request = DisjunctiveSumRequest(
+            components=[_TERMINAL, _TERMINAL],
+            start_positions=["start", "start"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.grundy_value == 0
+        assert result.is_p_position is True
+        assert result.component_grundy_values == (0, 0)
+        assert result.component_count == 2
+
+    def test_terminal_plus_single_move_xor_to_one(self) -> None:
+        request = DisjunctiveSumRequest(
+            components=[_TERMINAL, _SINGLE_MOVE],
+            start_positions=["start", "a"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.grundy_value == 1
+        assert result.is_p_position is False
+
+    def test_two_single_moves_xor_to_zero(self) -> None:
+        request = DisjunctiveSumRequest(
+            components=[_SINGLE_MOVE, _SINGLE_MOVE],
+            start_positions=["a", "a"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.grundy_value == 0
+        assert result.is_p_position is True
+
+    def test_grundy_one_two_three_xor_to_zero(self) -> None:
+        """1 ^ 2 ^ 3 = 0."""
+        request = DisjunctiveSumRequest(
+            components=[_SINGLE_MOVE, _G2, _G3],
+            start_positions=["a", "a", "e"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.component_grundy_values == (1, 2, 3)
+        assert result.grundy_value == 0
+        assert result.is_p_position is True
+
+    def test_single_component(self) -> None:
+        request = DisjunctiveSumRequest(
+            components=[_SINGLE_MOVE],
+            start_positions=["a"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.grundy_value == 1
+        assert result.component_count == 1
+
+    def test_result_fields(self) -> None:
+        request = DisjunctiveSumRequest(
+            components=[_TERMINAL, _SINGLE_MOVE],
+            start_positions=["start", "a"],
+        )
+        result = compute_disjunctive_sum(request)
+        assert result.grundy_value == 1
+        assert result.component_grundy_values == (0, 1)
+        assert result.is_p_position is False
+        assert result.component_count == 2
+
+
+class TestDisjunctiveSumValidation:
+    def test_mismatched_lengths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="equal length"):
+            DisjunctiveSumRequest(
+                components=[_TERMINAL],
+                start_positions=["start", "start"],
+            )
+
+    def test_start_position_not_in_game_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not in component"):
+            DisjunctiveSumRequest(
+                components=[_TERMINAL],
+                start_positions=["nonexistent"],
+            )
+
+    def test_empty_components_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DisjunctiveSumRequest(components=[], start_positions=[])
+
+    def test_cyclic_component_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="acyclic"):
+            DisjunctiveSumRequest(
+                components=[
+                    {
+                        "positions": ["a", "b"],
+                        "moves": [
+                            {"source": "a", "target": "b"},
+                            {"source": "b", "target": "a"},
+                        ],
+                    }
+                ],
+                start_positions=["a"],
+            )
+
+
+class TestToolRegistration:
+    def test_tool_is_registered(self) -> None:
+        operation_ids = {t.operation_id for t in TOOLS}
+        assert "game.impartial.disjunctive_sum.compute" in operation_ids
+
+    def test_tool_has_correct_tags(self) -> None:
+        tool = next(
+            t
+            for t in TOOLS
+            if t.operation_id == "game.impartial.disjunctive_sum.compute"
+        )
+        assert "disjunctive-sum" in tool.tags
+        assert "impartial" in tool.tags
+        assert "exact" in tool.tags
+        assert "game-theory" in tool.tags

--- a/tests/math/impartial_games/test_disjunctive_sum.py
+++ b/tests/math/impartial_games/test_disjunctive_sum.py
@@ -5,11 +5,9 @@ from pydantic import ValidationError
 
 from jacobian.math.impartial_games._models import (
     DisjunctiveSumRequest,
-    DisjunctiveSumResult,
 )
 from jacobian.math.impartial_games._operations import compute_disjunctive_sum
 from jacobian.math.impartial_games._tools import TOOLS
-
 
 # -- helpers -----------------------------------------------------------------
 

--- a/tests/math/impartial_games/test_impartial_games.py
+++ b/tests/math/impartial_games/test_impartial_games.py
@@ -182,13 +182,14 @@ class TestNativePortfolio:
         with pytest.raises(ValueError, match="move bound"):
             subtraction_game(tuple(range(1, 101)), 100)
 
-    def test_only_five_audited_outcomes_are_public(self) -> None:
+    def test_all_audited_outcomes_are_public(self) -> None:
         assert {tool.operation_id for tool in TOOLS} == {
             "game.impartial.birthday.compute",
             "game.impartial.grundy_table.compute",
             "game.subtraction.grundy_prefix.compute",
             "game.nim.nim_sum.compute",
             "game.impartial.outcome_profile.compute",
+            "game.impartial.disjunctive_sum.compute",
         }
 
     def test_native_birthdays_equal_public_kernel(self) -> None:


### PR DESCRIPTION
## Summary

Add the `game.impartial.disjunctive_sum.compute` operation to the existing `impartial_games` domain, filling the last gap from issue #1907.

The existing domain already had:
- `game.impartial.grundy_table.compute` — Grundy values for all positions in a finite game DAG
- `game.impartial.birthday.compute` — position birthdays (heights)
- `game.subtraction.grundy_prefix.compute` — subtraction game Grundy values
- `game.nim.nim_sum.compute` — nim sum (XOR of heap sizes)
- `game.impartial.outcome_profile.compute` — P/N position partition

**This PR adds the missing piece:**
- `game.impartial.disjunctive_sum.compute` — computes the Grundy value of a disjunctive sum of finite impartial game components by XOR of their component Grundy values

## Changes
- `_models.py`: Add `DisjunctiveSumRequest` (with validation for matching component/start_position lengths and start position membership) and `DisjunctiveSumResult`
- `_operations.py`: Add `compute_disjunctive_sum` — computes each component's Grundy value via the existing `grundy_table` kernel and XORs them
- `_tools.py`: Register the new tool with `disjunctive-sum`, `impartial`, `exact` tags and an example
- `_admission.py`: Add KEEP admission for the new operation
- `test_disjunctive_sum.py`: 12 new tests (known-answer, validation, registration)
- `test_impartial_games.py`: Update existing tool-count assertion to include the 6th operation

## Testing
```bash
.venv/bin/python -m pytest tests/math/impartial_games/ -x -q
# 45 passed
```

```bash
.venv/bin/python -c "from jacobian.catalog.builtins import BUILTIN_TOOLS; tools = [t for t in BUILTIN_TOOLS if 'impartial' in t.operation_id]; print(len(tools)); [print(t.operation_id) for t in tools]"
# 4
# game.impartial.grundy_table.compute
# game.impartial.birthday.compute
# game.impartial.outcome_profile.compute
# game.impartial.disjunctive_sum.compute
```

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/cccdaccc-6170-42f7-8b18-dcc747b08b95)