### PR TITLE
fix(math): make public mathematical contracts canonical and composable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,13 +225,10 @@ source_modules = ["jacobian.dispatch"]
 forbidden_modules = ["jacobian.cli", "jacobian.mcp"]
 
 [[tool.importlinter.contracts]]
-name = "Finite-field values do not import private backends"
+name = "Finite-field values do not import the optional FLINT backend"
 type = "forbidden"
 source_modules = ["jacobian.math.finite_fields.values"]
-forbidden_modules = [
-    "jacobian.math.finite_fields._flint",
-    "jacobian.math.finite_fields._sympy",
-]
+forbidden_modules = ["jacobian.math.finite_fields._flint"]
 
 [tool.coverage.run]
 branch = true

--- a/src/jacobian/_models.py
+++ b/src/jacobian/_models.py
@@ -1,106 +1,15 @@
 """Narrow strict-model primitive shared by unrelated wire owners."""
 
-from __future__ import annotations
-
-from dataclasses import fields as dataclass_fields
-from dataclasses import is_dataclass
-from types import UnionType
-from typing import Annotated, Any, Union, get_args, get_origin
-
-from pydantic import BaseModel, ConfigDict, model_validator
-
-
-def _unwrap_annotation(annotation: Any) -> Any:
-    origin = get_origin(annotation)
-    if origin is Annotated:
-        args = get_args(annotation)
-        return _unwrap_annotation(args[0]) if args else annotation
-    return annotation
-
-
-def _tuple_annotation(annotation: Any) -> Any | None:
-    annotation = _unwrap_annotation(annotation)
-    origin = get_origin(annotation)
-    if origin is tuple:
-        return annotation
-    if origin in {Union, UnionType}:
-        tuple_args = [
-            arg
-            for arg in get_args(annotation)
-            if arg is not type(None) and get_origin(_unwrap_annotation(arg)) is tuple
-        ]
-        if len(tuple_args) == 1:
-            return tuple_args[0]
-    return None
-
-
-def _lists_to_tuples(value: Any) -> Any:
-    if isinstance(value, list):
-        return tuple(_lists_to_tuples(item) for item in value)
-    return value
-
-
-def _dataclass_annotation(annotation: Any) -> type[Any] | None:
-    annotation = _unwrap_annotation(annotation)
-    origin = get_origin(annotation)
-    if origin in {Union, UnionType}:
-        dataclass_args = [
-            arg
-            for arg in get_args(annotation)
-            if arg is not type(None) and _dataclass_annotation(arg) is not None
-        ]
-        if len(dataclass_args) == 1:
-            return _dataclass_annotation(dataclass_args[0])
-        return None
-    if (
-        isinstance(annotation, type)
-        and is_dataclass(annotation)
-        and not issubclass(annotation, BaseModel)
-    ):
-        return annotation
-    return None
-
-
-def _dataclass_from_json(cls: type[Any], value: Any) -> Any:
-    if isinstance(value, cls):
-        return value
-    if not isinstance(value, dict):
-        return value
-    allowed = {field.name for field in dataclass_fields(cls)}
-    unexpected = sorted(set(value) - allowed)
-    if unexpected:
-        raise ValueError(f"unexpected dataclass fields: {', '.join(unexpected)}")
-    prepared = {
-        name: _lists_to_tuples(item) if isinstance(item, list) else item
-        for name, item in value.items()
-    }
-    return cls(**prepared)
+from pydantic import BaseModel, ConfigDict
 
 
 class StrictModel(BaseModel):
-    """Closed, immutable model with JSON tuple/dataclass decoding."""
+    """Closed immutable model; Pydantic owns nested and JSON validation."""
 
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+    )
 
-    @model_validator(mode="before")
-    @classmethod
-    def accept_json_wire_shapes(cls, data: Any) -> Any:
-        """Decode JSON arrays and objects into declared tuple and dataclass fields."""
 
-        if isinstance(data, cls) or not isinstance(data, dict):
-            return data
-        coerced = dict(data)
-        for name, field in cls.model_fields.items():
-            if name not in coerced:
-                continue
-            value = coerced[name]
-            dataclass_type = _dataclass_annotation(field.annotation)
-            if dataclass_type is not None:
-                coerced[name] = _dataclass_from_json(dataclass_type, value)
-                continue
-            if _tuple_annotation(field.annotation) is None or not isinstance(
-                value, list
-            ):
-                continue
-            coerced[name] = _lists_to_tuples(value)
-        return coerced
+__all__ = ["StrictModel"]

--- a/src/jacobian/math/arithmetic_dynamics/_models.py
+++ b/src/jacobian/math/arithmetic_dynamics/_models.py
@@ -8,6 +8,7 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 from jacobian.math._rational_height import RationalHeight, sum_heights
 
@@ -146,26 +147,19 @@ def _mobius(value: int) -> int:
     return -1 if factors % 2 else 1
 
 
-def parse_canonical_rational(value: str, *, label: str) -> Fraction:
-    if len(value) > 2 * MAX_COEFFICIENT_DIGITS + 2:
-        raise ValueError(f"{label} exceeds the rational digit bound")
-    try:
-        parsed = Fraction(value)
-    except (ValueError, ZeroDivisionError):
-        raise ValueError(f"{label} must be a canonical rational") from None
-    if str(parsed) != value:
-        raise ValueError(f"{label} must be a reduced canonical rational")
-    if (
-        len(str(abs(parsed.numerator))) > MAX_COEFFICIENT_DIGITS
-        or len(str(parsed.denominator)) > MAX_COEFFICIENT_DIGITS
-    ):
-        raise ValueError(f"{label} exceeds the rational digit bound")
-    return parsed
+def _bounded_fraction(
+    value: CanonicalRational, *, max_digits: int, label: str
+) -> Fraction:
+    require_bounded_rational(value, max_digits=max_digits, label=label)
+    return value.as_fraction()
 
 
-def parse_polynomial_coefficients(values: tuple[str, ...]) -> tuple[Fraction, ...]:
+def parse_polynomial_coefficients(
+    values: tuple[CanonicalRational, ...],
+) -> tuple[Fraction, ...]:
     coefficients = tuple(
-        parse_canonical_rational(value, label="coefficient") for value in values
+        _bounded_fraction(value, max_digits=MAX_COEFFICIENT_DIGITS, label="coefficient")
+        for value in values
     )
     if len(coefficients) > 1 and coefficients[-1] == 0:
         raise ValueError("polynomial coefficients must omit trailing zeros")
@@ -173,7 +167,9 @@ def parse_polynomial_coefficients(values: tuple[str, ...]) -> tuple[Fraction, ..
 
 
 class PolynomialCoefficientRequest(StrictModel):
-    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DEGREE + 1)
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_DEGREE + 1
+    )
 
     @model_validator(mode="after")
     def require_canonical_coefficients(self) -> Self:
@@ -207,12 +203,12 @@ class MapIterateRequest(PolynomialCoefficientRequest):
 class OrbitPrefixRequest(PolynomialCoefficientRequest):
     """Compute until a first repeat or an explicit finite/output bound."""
 
-    start: str
+    start: CanonicalRational
     max_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
 
     @model_validator(mode="after")
     def require_canonical_start(self) -> Self:
-        parse_canonical_rational(self.start, label="start")
+        _bounded_fraction(self.start, max_digits=MAX_COEFFICIENT_DIGITS, label="start")
         return self
 
 
@@ -253,12 +249,17 @@ class DynatomicPolynomialRequest(PolynomialCoefficientRequest):
 class CycleMultiplierRequest(PolynomialCoefficientRequest):
     """Compute the multiplier of a supplied, validated exact rational cycle."""
 
-    cycle: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS)
+    cycle: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_ORBIT_STEPS
+    )
 
     @model_validator(mode="after")
     def require_exact_cycle(self) -> Self:
         points = tuple(
-            parse_canonical_rational(value, label="cycle point") for value in self.cycle
+            _bounded_fraction(
+                value, max_digits=MAX_COEFFICIENT_DIGITS, label="cycle point"
+            )
+            for value in self.cycle
         )
         if len(set(points)) != len(points):
             raise ValueError("cycle points must be distinct")
@@ -287,11 +288,11 @@ class FiniteFieldMapRequest(StrictModel):
 
 
 class MapIterateResult(StrictModel):
-    source_coefficients: tuple[str, ...] = Field(
+    source_coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_DEGREE + 1
     )
     n: int = Field(ge=0, le=MAX_ITERATE)
-    coefficients: tuple[str, ...] = Field(
+    coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_ITERATE_DEGREE + 1
     )
     degree: int = Field(ge=0, le=MAX_ITERATE_DEGREE)
@@ -301,13 +302,14 @@ class MapIterateResult(StrictModel):
     @model_validator(mode="after")
     def bind_degree_and_coefficients(self) -> Self:
         parse_polynomial_coefficients(self.source_coefficients)
-        values = tuple(Fraction(value) for value in self.coefficients)
-        if any(
-            str(Fraction(value)) != value
-            or len(value) > MAX_POLYNOMIAL_OUTPUT_DIGITS * 2 + 2
+        values = tuple(
+            _bounded_fraction(
+                value,
+                max_digits=MAX_POLYNOMIAL_OUTPUT_DIGITS,
+                label="iterate coefficient",
+            )
             for value in self.coefficients
-        ):
-            raise ValueError("iterate coefficients must be bounded and canonical")
+        )
         expected_degree = 0 if values == (Fraction(0),) else len(values) - 1
         if self.degree != expected_degree:
             raise ValueError("degree must match the canonical coefficient tuple")
@@ -330,11 +332,13 @@ class OrbitRepeatEvidence(StrictModel):
 
 
 class OrbitPrefixResult(StrictModel):
-    source_coefficients: tuple[str, ...] = Field(
+    source_coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_DEGREE + 1
     )
-    start: str
-    orbit: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS + 1)
+    start: CanonicalRational
+    orbit: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_ORBIT_STEPS + 1
+    )
     requested_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
     computed_steps: int = Field(ge=0, le=MAX_ORBIT_STEPS)
     termination: Literal["REPEAT_FOUND", "STEP_BOUND_REACHED", "OUTPUT_BOUND_REACHED"]
@@ -374,10 +378,10 @@ class OrbitPrefixResult(StrictModel):
 
 
 class DynatomicPolynomialResult(StrictModel):
-    source_coefficients: tuple[str, ...] = Field(
+    source_coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_DEGREE + 1
     )
-    coefficients: tuple[str, ...] = Field(
+    coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_DYNATOMIC_DEGREE + 1
     )
     degree: int = Field(ge=0, le=MAX_DYNATOMIC_DEGREE)
@@ -390,13 +394,14 @@ class DynatomicPolynomialResult(StrictModel):
     @model_validator(mode="after")
     def bind_degree_and_coefficients(self) -> Self:
         parse_polynomial_coefficients(self.source_coefficients)
-        values = tuple(Fraction(value) for value in self.coefficients)
-        if any(
-            str(Fraction(value)) != value
-            or len(value) > MAX_POLYNOMIAL_OUTPUT_DIGITS * 2 + 2
+        values = tuple(
+            _bounded_fraction(
+                value,
+                max_digits=MAX_POLYNOMIAL_OUTPUT_DIGITS,
+                label="dynatomic coefficient",
+            )
             for value in self.coefficients
-        ):
-            raise ValueError("dynatomic coefficients must be bounded and canonical")
+        )
         expected_degree = 0 if values == (Fraction(0),) else len(values) - 1
         if self.degree != expected_degree:
             raise ValueError("degree must match the canonical coefficient tuple")
@@ -404,11 +409,13 @@ class DynatomicPolynomialResult(StrictModel):
 
 
 class CycleMultiplierResult(StrictModel):
-    source_coefficients: tuple[str, ...] = Field(
+    source_coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1, max_length=MAX_DEGREE + 1
     )
-    multiplier: str
-    cycle: tuple[str, ...] = Field(min_length=1, max_length=MAX_ORBIT_STEPS)
+    multiplier: CanonicalRational
+    cycle: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_ORBIT_STEPS
+    )
     period: int = Field(ge=1, le=MAX_ORBIT_STEPS)
     validated_cycle: Literal[True] = True
     complete: Literal[True] = True
@@ -416,9 +423,7 @@ class CycleMultiplierResult(StrictModel):
     @model_validator(mode="after")
     def bind_period_and_multiplier(self) -> Self:
         source = parse_polynomial_coefficients(self.source_coefficients)
-        points = tuple(
-            parse_canonical_rational(value, label="cycle point") for value in self.cycle
-        )
+        points = tuple(value.as_fraction() for value in self.cycle)
         if len(set(points)) != len(points) or any(
             _evaluate(source, point) != points[(index + 1) % len(points)]
             for index, point in enumerate(points)
@@ -426,13 +431,11 @@ class CycleMultiplierResult(StrictModel):
             raise ValueError("cycle must be a distinct ordered cycle of the bound map")
         if self.period != len(self.cycle):
             raise ValueError("period must match cycle length")
-        value = Fraction(self.multiplier)
-        if (
-            str(value) != self.multiplier
-            or len(str(abs(value.numerator))) > MAX_POLYNOMIAL_OUTPUT_DIGITS
-            or len(str(value.denominator)) > MAX_POLYNOMIAL_OUTPUT_DIGITS
-        ):
-            raise ValueError("multiplier must be a bounded canonical rational")
+        require_bounded_rational(
+            self.multiplier,
+            max_digits=MAX_POLYNOMIAL_OUTPUT_DIGITS,
+            label="multiplier",
+        )
         return self
 
 
@@ -514,14 +517,19 @@ def _evaluate(coefficients: tuple[Fraction, ...], point: Fraction) -> Fraction:
 
 
 def _require_bound_orbit(
-    source_coefficients: tuple[str, ...],
-    start: str,
-    orbit_values: tuple[str, ...],
+    source_coefficients: tuple[CanonicalRational, ...],
+    start: CanonicalRational,
+    orbit_values: tuple[CanonicalRational, ...],
 ) -> None:
     source = parse_polynomial_coefficients(source_coefficients)
-    initial = parse_canonical_rational(start, label="start")
+    initial = _bounded_fraction(start, max_digits=MAX_COEFFICIENT_DIGITS, label="start")
     orbit = tuple(
-        parse_canonical_rational(value, label="orbit value") for value in orbit_values
+        _bounded_fraction(
+            value,
+            max_digits=MAX_ORBIT_VALUE_DIGITS,
+            label="orbit value",
+        )
+        for value in orbit_values
     )
     if orbit[0] != initial:
         raise ValueError("orbit must begin at the bound start point")

--- a/src/jacobian/math/arithmetic_dynamics/_operations.py
+++ b/src/jacobian/math/arithmetic_dynamics/_operations.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Any
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.arithmetic_dynamics._models import (
     CycleMultiplierRequest,
     CycleMultiplierResult,
@@ -34,11 +34,11 @@ def _polynomial(request: PolynomialCoefficientRequest) -> Any:
     return polynomial_from_coefficients(request.coefficient_values())
 
 
-def _format_coefficients(polynomial: Any) -> tuple[str, ...]:
-    values = tuple(str(value) for value in polynomial_coefficients(polynomial))
-    if any(len(value) > 65_538 for value in values):
-        raise ValueError("polynomial coefficient output exceeds digit bound")
-    return values
+def _format_coefficients(polynomial: Any) -> tuple[CanonicalRational, ...]:
+    return tuple(
+        CanonicalRational.from_fraction(value)
+        for value in polynomial_coefficients(polynomial)
+    )
 
 
 def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
@@ -54,7 +54,7 @@ def compute_map_iterate(request: MapIterateRequest) -> MapIterateResult:
 def compute_orbit_prefix(request: OrbitPrefixRequest) -> OrbitPrefixResult:
     result = orbit_prefix(
         _polynomial(request),
-        Fraction(request.start),
+        request.start.as_fraction(),
         request.max_steps,
     )
     repeat = (
@@ -71,7 +71,7 @@ def compute_orbit_prefix(request: OrbitPrefixRequest) -> OrbitPrefixResult:
     return OrbitPrefixResult(
         source_coefficients=request.coefficients,
         start=request.start,
-        orbit=tuple(str(value) for value in result.orbit),
+        orbit=tuple(CanonicalRational.from_fraction(value) for value in result.orbit),
         requested_steps=request.max_steps,
         computed_steps=len(result.orbit) - 1,
         termination=result.termination,
@@ -96,10 +96,12 @@ def compute_dynatomic_polynomial(
 def compute_cycle_multiplier(
     request: CycleMultiplierRequest,
 ) -> CycleMultiplierResult:
-    points = tuple(Fraction(value) for value in request.cycle)
+    points = tuple(value.as_fraction() for value in request.cycle)
     return CycleMultiplierResult(
         source_coefficients=request.coefficients,
-        multiplier=str(cycle_multiplier(_polynomial(request), points)),
+        multiplier=CanonicalRational.from_fraction(
+            cycle_multiplier(_polynomial(request), points)
+        ),
         cycle=request.cycle,
         period=len(points),
     )

--- a/src/jacobian/math/arithmetic_dynamics/_tools.py
+++ b/src/jacobian/math/arithmetic_dynamics/_tools.py
@@ -70,9 +70,17 @@ ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "f_x_squared_plus_1_iterate_2",
                 "Compute f^2 for f(x)=x^2+1; n must be non-negative.",
-                {"coefficients": ["1", "0", "1"], "n": 2},
+                {
+                    "coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "n": 2,
+                },
             ),
         ),
+        version="2",
     ),
     _op(
         "arithmetic_dynamics.point.orbit.compute",
@@ -92,9 +100,18 @@ ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "orbit_of_0_under_x2",
                 "Orbit of 0 under f(x)=x^2 for 5 steps; "
                 "start must be a rational number.",
-                {"coefficients": ["0", "0", "1"], "start": "0", "max_steps": 5},
+                {
+                    "coefficients": [
+                        {"num": "0", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "start": {"num": "0", "den": "1"},
+                    "max_steps": 5,
+                },
             ),
         ),
+        version="2",
     ),
     _op(
         "arithmetic_dynamics.dynatomic_polynomial.compute",
@@ -112,9 +129,17 @@ ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "dynatomic_n1_x2",
                 "Dynatomic polynomial for n=1 of f(x)=x^2; n must be at least 1.",
-                {"coefficients": ["0", "0", "1"], "n": 1},
+                {
+                    "coefficients": [
+                        {"num": "0", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "n": 1,
+                },
             ),
         ),
+        version="2",
     ),
     _op(
         "arithmetic_dynamics.cycle.multiplier.compute",
@@ -134,9 +159,17 @@ ARITHMETIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "multiplier_fixed_0_x2",
                 "Multiplier of the fixed point 0 under f(x)=x^2; "
                 "cycle points must be rational.",
-                {"coefficients": ["0", "0", "1"], "cycle": ["0"]},
+                {
+                    "coefficients": [
+                        {"num": "0", "den": "1"},
+                        {"num": "0", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "cycle": [{"num": "0", "den": "1"}],
+                },
             ),
         ),
+        version="2",
     ),
     _op(
         "arithmetic_dynamics.finite_field.functional_graph.compute",

--- a/src/jacobian/math/finite_fields/_models.py
+++ b/src/jacobian/math/finite_fields/_models.py
@@ -16,11 +16,26 @@ from jacobian.math.finite_fields import (
     ProjectiveLine,
     ProjectivePoint,
 )
+from jacobian.math.finite_fields.values import _direction_rank_work
+
+_MAX_PROJECTIVE_POINTS = 4_096
+_MAX_FINITE_MAP_WORK = 1_000_000
+_MAX_DIRECTION_RANK_WORK = 1_000_000
 
 
 class RestrictScalarsRequest(StrictModel):
     subspace: FiniteDimensionalSubspace
     direction: ProjectivePoint
+
+    @model_validator(mode="after")
+    def require_same_parent_and_axis(self) -> Self:
+        if self.direction.presentation != self.subspace.presentation:
+            raise ValueError("direction and subspace must share their presentation")
+        if self.direction.axis != self.subspace.row_axis:
+            raise ValueError("direction axis must match the subspace row axis")
+        if _direction_rank_work(self.subspace, 1) > _MAX_DIRECTION_RANK_WORK:
+            raise ValueError("restriction exceeds the operation work budget")
+        return self
 
 
 class LinearMapRankRequest(StrictModel):
@@ -46,12 +61,28 @@ class ProjectiveLineRequest(StrictModel):
             raise ValueError(
                 "projective-line enumeration requires a two-coordinate axis"
             )
+        count = self.presentation.order + 1
+        if count > _MAX_PROJECTIVE_POINTS:
+            raise ValueError("projective line exceeds the output-size budget")
         return self
 
 
 class DirectionRankLedgerRequest(StrictModel):
     subspace: FiniteDimensionalSubspace
     directions: ProjectiveLine
+
+    @model_validator(mode="after")
+    def require_same_parent_axis_and_work(self) -> Self:
+        if self.directions.presentation != self.subspace.presentation:
+            raise ValueError("directions and subspace must share their presentation")
+        if self.directions.axis != self.subspace.row_axis:
+            raise ValueError("direction axis must match the subspace row axis")
+        if (
+            _direction_rank_work(self.subspace, len(self.directions.points))
+            > _MAX_DIRECTION_RANK_WORK
+        ):
+            raise ValueError("direction-rank ledger exceeds the operation work budget")
+        return self
 
 
 class OrbitDistributionRequest(StrictModel):
@@ -60,6 +91,17 @@ class OrbitDistributionRequest(StrictModel):
 
 class FiniteMapTableRequest(StrictModel):
     polynomial_map: FinitePolynomialMap
+
+    @model_validator(mode="after")
+    def require_bounded_enumeration(self) -> Self:
+        work = (
+            self.polynomial_map.domain.order
+            * len(self.polynomial_map.polynomial.coefficients)
+            * self.polynomial_map.domain.degree
+        )
+        if work > _MAX_FINITE_MAP_WORK:
+            raise ValueError("finite map exceeds the operation work budget")
+        return self
 
 
 class FiberPartitionRequest(StrictModel):

--- a/src/jacobian/math/finite_fields/_operations.py
+++ b/src/jacobian/math/finite_fields/_operations.py
@@ -6,7 +6,6 @@ from jacobian.math.finite_fields import (
     CollisionResult,
     DirectionRankLedger,
     FiberPartition,
-    FiniteDimensionalSubspace,
     FiniteLinearMap,
     FiniteMapTable,
     OrbitDistribution,
@@ -34,12 +33,6 @@ from jacobian.math.finite_fields._models import (
     ProjectiveLineRequest,
     RestrictScalarsRequest,
 )
-
-_MAX_PROJECTIVE_POINTS = 4096
-_MAX_FINITE_MAP_ELEMENTS = 4096
-_MAX_FINITE_MAP_WORK = 1_000_000
-_MAX_FINITE_MAP_REPLAY_WORK = 1_000_000
-_MAX_DIRECTION_RANK_WORK = 1_000_000
 
 _FIELD: dict[str, object] = {
     "characteristic": 2,
@@ -131,13 +124,6 @@ _TABLE: dict[str, object] = {
 
 
 def _enumerate_projective_line(request: ProjectiveLineRequest) -> ProjectiveLine:
-    count = (request.presentation.order ** len(request.axis.labels) - 1) // (
-        request.presentation.order - 1
-    )
-    if count > _MAX_PROJECTIVE_POINTS:
-        raise ValueError(
-            f"projective line has {count} directions; limit is {_MAX_PROJECTIVE_POINTS}"
-        )
     return projective_line(request.presentation, request.axis)
 
 
@@ -150,92 +136,33 @@ def _rank(request: LinearMapRankRequest) -> RankResult:
 
 
 def _ledger(request: DirectionRankLedgerRequest) -> DirectionRankLedger:
-    _require_direction_rank_work(request.subspace, len(request.directions.points))
     return direction_rank_ledger(request.subspace, request.directions)
 
 
-def _direction_rank_work(
-    subspace: FiniteDimensionalSubspace,
-    direction_count: int,
-) -> int:
-    source_dimension = len(subspace.basis)
-    target_dimension = len(subspace.column_axis.labels) * subspace.presentation.degree
-    restriction_work = (
-        source_dimension * len(subspace.row_axis.labels) * target_dimension
-    )
-    rank_work = (
-        target_dimension * source_dimension * min(target_dimension, source_dimension)
-    )
-    return direction_count * (restriction_work + rank_work)
-
-
-def _require_direction_rank_work(
-    subspace: FiniteDimensionalSubspace,
-    direction_count: int,
-) -> None:
-    work = _direction_rank_work(subspace, direction_count)
-    if work > _MAX_DIRECTION_RANK_WORK:
-        raise ValueError(
-            f"direction-rank work is {work}; limit is {_MAX_DIRECTION_RANK_WORK}",
-        )
-
-
 def _orbit_distribution(request: OrbitDistributionRequest) -> OrbitDistribution:
-    _require_direction_rank_work(request.ledger.subspace, len(request.ledger.entries))
     return orbit_distribution(request.ledger)
 
 
 def _finite_map_table(request: FiniteMapTableRequest) -> FiniteMapTable:
-    polynomial_map = request.polynomial_map
-    count = polynomial_map.domain.order
-    if count > _MAX_FINITE_MAP_ELEMENTS:
-        raise ValueError(
-            f"finite map has {count} inputs; limit is {_MAX_FINITE_MAP_ELEMENTS}"
-        )
-    work = (
-        count
-        * len(polynomial_map.polynomial.coefficients)
-        * polynomial_map.domain.degree
-    )
-    if work > _MAX_FINITE_MAP_WORK:
-        raise ValueError(f"finite map work is {work}; limit is {_MAX_FINITE_MAP_WORK}")
     return finite_map_table(request.polynomial_map)
 
 
 def _fiber_partition(request: FiberPartitionRequest) -> FiberPartition:
-    _require_finite_map_replay_work(request)
     return fiber_partition(request.table)
 
 
 def _analyze_collisions(request: CollisionRequest) -> CollisionResult:
-    _require_finite_map_replay_work(request)
     return analyze_collisions(request.table)
 
 
 def _analyze_permutation(request: PermutationRequest) -> PermutationResult:
-    _require_finite_map_replay_work(request)
     return analyze_permutation(request.table)
-
-
-def _require_finite_map_replay_work(
-    request: FiberPartitionRequest | CollisionRequest | PermutationRequest,
-) -> None:
-    table = request.table
-    work = (
-        len(table.entries)
-        * len(table.map.polynomial.coefficients)
-        * table.map.domain.degree
-    )
-    if work > _MAX_FINITE_MAP_REPLAY_WORK:
-        raise ValueError(
-            f"finite map replay work is {work}; limit is {_MAX_FINITE_MAP_REPLAY_WORK}",
-        )
 
 
 def finite_field_operations() -> MathTools:
     projective_line_operation = MathTool(
         operation_id="finite_field.projective_line.enumerate",
-        version="1",
+        version="2",
         request_type=ProjectiveLineRequest,
         result_type=ProjectiveLine,
         run=_enumerate_projective_line,
@@ -252,7 +179,7 @@ def finite_field_operations() -> MathTools:
     )
     restrict_operation = MathTool(
         operation_id="finite_field.restrict_scalars.compute",
-        version="1",
+        version="2",
         request_type=RestrictScalarsRequest,
         result_type=FiniteLinearMap,
         run=_restrict,
@@ -269,7 +196,7 @@ def finite_field_operations() -> MathTools:
     )
     rank_operation = MathTool(
         operation_id="finite_field.linear_map.rank.compute",
-        version="1",
+        version="2",
         request_type=LinearMapRankRequest,
         result_type=RankResult,
         run=_rank,
@@ -286,7 +213,7 @@ def finite_field_operations() -> MathTools:
     )
     ledger_operation = MathTool(
         operation_id="finite_field.direction_rank_ledger.compute",
-        version="1",
+        version="2",
         request_type=DirectionRankLedgerRequest,
         result_type=DirectionRankLedger,
         run=_ledger,
@@ -303,7 +230,7 @@ def finite_field_operations() -> MathTools:
     )
     orbit_operation = MathTool(
         operation_id="finite_field.orbit_distribution.compute",
-        version="1",
+        version="2",
         request_type=OrbitDistributionRequest,
         result_type=OrbitDistribution,
         run=_orbit_distribution,
@@ -320,7 +247,7 @@ def finite_field_operations() -> MathTools:
     )
     table_operation = MathTool(
         operation_id="finite_field.polynomial_map.table.compute",
-        version="1",
+        version="2",
         request_type=FiniteMapTableRequest,
         result_type=FiniteMapTable,
         run=_finite_map_table,
@@ -337,7 +264,7 @@ def finite_field_operations() -> MathTools:
     )
     fiber_operation = MathTool(
         operation_id="finite_field.polynomial_map.fibers.compute",
-        version="1",
+        version="2",
         request_type=FiberPartitionRequest,
         result_type=FiberPartition,
         run=_fiber_partition,
@@ -354,7 +281,7 @@ def finite_field_operations() -> MathTools:
     )
     collision_operation = MathTool(
         operation_id="finite_field.polynomial_map.collision.analyze",
-        version="1",
+        version="2",
         request_type=CollisionRequest,
         result_type=CollisionResult,
         run=_analyze_collisions,
@@ -371,7 +298,7 @@ def finite_field_operations() -> MathTools:
     )
     permutation_operation = MathTool(
         operation_id="finite_field.polynomial_map.permutation.analyze",
-        version="1",
+        version="2",
         request_type=PermutationRequest,
         result_type=PermutationResult,
         run=_analyze_permutation,

--- a/src/jacobian/math/finite_fields/_sympy.py
+++ b/src/jacobian/math/finite_fields/_sympy.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from jacobian.math.finite_fields.values import (
+    Axis,
+    FiniteDimensionalSubspace,
     FiniteFieldElement,
     FiniteFieldPresentation,
+    FiniteLinearMap,
     FinitePolynomial,
+    ProjectivePoint,
 )
+from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
 
 def evaluate_polynomial_values(
@@ -95,4 +100,74 @@ def normalize_projective_coordinates(
             for power in range(presentation.degree)
         )
         for value in normalized
+    )
+
+
+def restrict_scalars(
+    subspace: FiniteDimensionalSubspace,
+    direction: ProjectivePoint,
+) -> FiniteLinearMap:
+    """Reference restriction map using exact SymPy quotient arithmetic."""
+
+    from sympy import Poly, symbols
+
+    variable = symbols("z")
+    characteristic = subspace.presentation.characteristic
+    modulus = Poly(
+        sum(
+            coefficient * variable**power
+            for power, coefficient in enumerate(
+                subspace.presentation.modulus_coefficients
+            )
+        ),
+        variable,
+        modulus=characteristic,
+    )
+
+    def polynomial(value: FiniteFieldElement) -> Poly:
+        return Poly(
+            sum(
+                coefficient * variable**power
+                for power, coefficient in enumerate(value.coordinates)
+            ),
+            variable,
+            modulus=characteristic,
+        )
+
+    direction_values = tuple(polynomial(value) for value in direction.coordinates)
+    columns: list[tuple[int, ...]] = []
+    for matrix in subspace.basis:
+        image = tuple(
+            sum(
+                (
+                    polynomial(matrix.entries[row][column]) * direction_values[row]
+                    for row in range(len(matrix.row_axis.labels))
+                ),
+                Poly(0, variable, modulus=characteristic),
+            ).rem(modulus)
+            for column in range(len(matrix.column_axis.labels))
+        )
+        columns.append(
+            tuple(
+                int(value.nth(power)) % characteristic
+                for value in image
+                for power in range(subspace.presentation.degree)
+            )
+        )
+    target_axis = Axis(
+        name=f"Res({subspace.column_axis.name})",
+        labels=tuple(
+            f"{label}:{basis}"
+            for label in subspace.column_axis.labels
+            for basis in subspace.presentation.ordered_basis
+        ),
+    )
+    return FiniteLinearMap(
+        source_axis=subspace.basis_axis,
+        target_axis=target_axis,
+        matrix=PrimeFieldMatrix(
+            prime=characteristic,
+            entries=tuple(zip(*columns, strict=True)),
+            columns=len(subspace.basis),
+        ),
     )

--- a/src/jacobian/math/finite_fields/operations.py
+++ b/src/jacobian/math/finite_fields/operations.py
@@ -208,27 +208,9 @@ def direction_rank_ledger(
     )
 
 
-class _InvalidDirectionRankLedgerError(ValueError):
-    """A ledger entry was not derived from its bound subspace and direction."""
-
-
-def _validate_direction_rank_ledger(ledger: DirectionRankLedger) -> None:
-    for entry in ledger.entries:
-        expected_map = restrict_scalars(ledger.subspace, entry.direction)
-        if entry.linear_map != expected_map:
-            raise _InvalidDirectionRankLedgerError(
-                "direction-rank ledger map does not match the bound subspace"
-            )
-        if entry.rank != linear_map_rank(entry.direction, expected_map).rank:
-            raise _InvalidDirectionRankLedgerError(
-                "direction-rank ledger rank does not match the bound linear map"
-            )
-
-
 def orbit_distribution(ledger: DirectionRankLedger) -> OrbitDistribution:
     """Aggregate projective orbit counts from a complete direction-rank ledger."""
 
-    _validate_direction_rank_ledger(ledger)
     return OrbitDistribution.from_ledger(ledger)
 
 
@@ -302,37 +284,15 @@ def finite_map_table(polynomial_map: FinitePolynomialMap) -> FiniteMapTable:
     )
 
 
-class _InvalidFiniteMapTableError(ValueError):
-    """The table does not evaluate its bound polynomial."""
-
-
-def _validate_finite_map_table(table: FiniteMapTable) -> None:
-    """Require every table target to be the bound polynomial's exact image."""
-
-    from jacobian.math.finite_fields import _sympy
-
-    targets = _sympy.evaluate_polynomial_values(
-        table.map.polynomial,
-        tuple(source for source, _ in table.entries),
-    )
-    for (_, target), coordinates in zip(table.entries, targets, strict=True):
-        if target.coordinates != coordinates:
-            raise _InvalidFiniteMapTableError(
-                "finite map table targets must match the bound polynomial"
-            )
-
-
 def fiber_partition(table: FiniteMapTable) -> FiberPartition:
     """Partition the complete domain by exact map image."""
 
-    _validate_finite_map_table(table)
     return FiberPartition.from_table(table)
 
 
 def analyze_collisions(table: FiniteMapTable) -> CollisionResult:
     """Return either the first canonical collision or an injectivity result."""
 
-    _validate_finite_map_table(table)
     seen: dict[str, tuple[FiniteFieldElement, FiniteFieldElement]] = {}
     for source, target in table.entries:
         previous = seen.get(target.digest)
@@ -351,7 +311,6 @@ def analyze_collisions(table: FiniteMapTable) -> CollisionResult:
 def analyze_permutation(table: FiniteMapTable) -> PermutationResult:
     """Return either an inverse table or a non-permutation result."""
 
-    _validate_finite_map_table(table)
     inverse_entries = tuple(
         sorted(
             ((target, source) for source, target in table.entries),

--- a/src/jacobian/math/finite_fields/values.py
+++ b/src/jacobian/math/finite_fields/values.py
@@ -15,6 +15,7 @@ _MAX_FIELD_ORDER = 4096
 _MIN_MODULUS_COEFFICIENTS = 3
 _MAX_MODULUS_COEFFICIENTS = 17
 _MAX_AXIS_LABELS = 256
+_MAX_DERIVATION_WORK = 1_000_000
 
 
 def _digest(payload: dict[str, Any]) -> str:
@@ -441,6 +442,8 @@ class RankResult(StrictModel):
         )
         if type(self.rank) is not int or not 0 <= self.rank <= maximum_rank:
             raise ValueError("rank is outside the linear-map dimensions")
+        if self.rank != rank(self.linear_map.matrix):
+            raise ValueError("rank must match the exact bound linear map")
         return self
 
     @property
@@ -455,17 +458,35 @@ class RankResult(StrictModel):
         )
 
 
+def _direction_rank_work(
+    subspace: FiniteDimensionalSubspace,
+    direction_count: int,
+) -> int:
+    source_dimension = len(subspace.basis)
+    target_dimension = len(subspace.column_axis.labels) * subspace.presentation.degree
+    restriction = source_dimension * len(subspace.row_axis.labels) * target_dimension
+    rank_work = (
+        target_dimension * source_dimension * min(target_dimension, source_dimension)
+    )
+    return direction_count * (restriction + rank_work)
+
+
 class DirectionRankLedger(StrictModel):
     """An ordered, exact binding from projective directions to rank results."""
 
     subspace: FiniteDimensionalSubspace
-    entries: tuple[RankResult, ...]
+    entries: tuple[RankResult, ...] = Field(min_length=1, max_length=_MAX_FIELD_ORDER)
 
     @model_validator(mode="after")
     def validate_ledger(self) -> Self:
-        if not self.entries:
-            raise ValueError("direction-rank ledger must be nonempty")
         first = self.entries[0]
+        expected_directions = (
+            self.subspace.presentation.order ** len(self.subspace.row_axis.labels) - 1
+        ) // (self.subspace.presentation.order - 1)
+        if len(self.entries) != expected_directions:
+            raise ValueError(
+                "direction-rank ledger must contain every projective direction"
+            )
         if len({entry.direction.digest for entry in self.entries}) != len(self.entries):
             raise ValueError("direction-rank ledger cannot repeat a direction")
         if any(
@@ -483,6 +504,18 @@ class DirectionRankLedger(StrictModel):
             raise ValueError("ledger directions must use the subspace row axis")
         if first.linear_map.source_axis != self.subspace.basis_axis:
             raise ValueError("ledger maps must use the subspace basis axis")
+        work = _direction_rank_work(self.subspace, len(self.entries))
+        if work > _MAX_DERIVATION_WORK:
+            raise ValueError("direction-rank ledger exceeds its derivation work budget")
+        from jacobian.math.finite_fields import _sympy
+
+        for entry in self.entries:
+            if entry.linear_map != _sympy.restrict_scalars(
+                self.subspace, entry.direction
+            ):
+                raise ValueError(
+                    "direction-rank ledger map does not match the bound subspace"
+                )
         return self
 
     @property
@@ -594,7 +627,10 @@ class FiniteMapTable(StrictModel):
     """A complete ordered evaluation table for one exact finite map."""
 
     map: FinitePolynomialMap
-    entries: tuple[tuple[FiniteFieldElement, FiniteFieldElement], ...]
+    entries: tuple[tuple[FiniteFieldElement, FiniteFieldElement], ...] = Field(
+        min_length=1,
+        max_length=_MAX_FIELD_ORDER,
+    )
 
     @model_validator(mode="after")
     def validate_table(self) -> Self:
@@ -613,6 +649,21 @@ class FiniteMapTable(StrictModel):
             raise ValueError("finite map table inputs must use canonical domain order")
         if any(value.presentation != self.map.codomain for _, value in self.entries):
             raise ValueError("finite map table outputs must use the exact codomain")
+        work = (
+            len(self.entries)
+            * len(self.map.polynomial.coefficients)
+            * self.map.domain.degree
+        )
+        if work > _MAX_DERIVATION_WORK:
+            raise ValueError("finite map table exceeds its derivation work budget")
+        from jacobian.math.finite_fields import _sympy
+
+        expected = _sympy.evaluate_polynomial_values(self.map.polynomial, inputs)
+        if any(
+            target.coordinates != coordinates
+            for (_, target), coordinates in zip(self.entries, expected, strict=True)
+        ):
+            raise ValueError("finite map table targets must match the bound polynomial")
         return self
 
     @property

--- a/src/jacobian/math/finite_game_theory/_models.py
+++ b/src/jacobian/math/finite_game_theory/_models.py
@@ -40,16 +40,16 @@ class ZeroSumGameRequest(StrictModel):
 class BestResponseResult(StrictModel):
     """Best response values for the row player."""
 
-    value: str
+    value: CanonicalRational
     best_row: int = Field(ge=0)
 
 
 class NashEquilibriumResult(StrictModel):
     """Nash equilibrium of a 2-player zero-sum game."""
 
-    row_strategy: tuple[str, ...]
-    col_strategy: tuple[str, ...]
-    value: str
+    row_strategy: tuple[CanonicalRational, ...]
+    col_strategy: tuple[CanonicalRational, ...]
+    value: CanonicalRational
 
 
 __all__ = [

--- a/src/jacobian/math/finite_game_theory/_models.py
+++ b/src/jacobian/math/finite_game_theory/_models.py
@@ -36,6 +36,16 @@ class ZeroSumGameRequest(StrictModel):
 
     payoff_matrix: PayoffMatrix
 
+    @model_validator(mode="after")
+    def require_bounded_exact_equilibrium(self) -> Self:
+        matrix = self.payoff_matrix
+        denominator_digits = sum(len(value.den) for value in matrix.entries)
+        numerator_digits = max(len(value.num.lstrip("-")) for value in matrix.entries)
+        elimination_dimension = max(matrix.n_rows, matrix.n_cols) + 2
+        if elimination_dimension * (denominator_digits + numerator_digits) > 32_768:
+            raise ValueError("payoffs exceed the exact-equilibrium result budget")
+        return self
+
 
 class BestResponseResult(StrictModel):
     """Best response values for the row player."""

--- a/src/jacobian/math/finite_game_theory/_operations.py
+++ b/src/jacobian/math/finite_game_theory/_operations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fractions import Fraction
 from math import lcm
 
-from jacobian.canonical import format_canonical_integer
+from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
     BestResponseResult,
     NashEquilibriumResult,
@@ -13,13 +13,8 @@ from jacobian.math.finite_game_theory._models import (
 )
 
 
-def _format_rational(value: Fraction) -> str:
-    if value.denominator == 1:
-        return format_canonical_integer(value.numerator)
-    return (
-        f"{format_canonical_integer(value.numerator)}/"
-        f"{format_canonical_integer(value.denominator)}"
-    )
+def _wire_rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(value)
 
 
 def _payoff_matrix(request: ZeroSumGameRequest) -> list[list[Fraction]]:
@@ -41,7 +36,7 @@ def compute_best_response(request: ZeroSumGameRequest) -> BestResponseResult:
         if row_min > best_value:
             best_value = row_min
             best_row = row_index
-    return BestResponseResult(value=_format_rational(best_value), best_row=best_row)
+    return BestResponseResult(value=_wire_rational(best_value), best_row=best_row)
 
 
 def compute_nash_equilibrium(request: ZeroSumGameRequest) -> NashEquilibriumResult:
@@ -113,9 +108,9 @@ def compute_nash_equilibrium(request: ZeroSumGameRequest) -> NashEquilibriumResu
     ):
         raise RuntimeError("column strategy does not attain the reported game value")
     return NashEquilibriumResult(
-        row_strategy=tuple(_format_rational(weight) for weight in row_strategy),
-        col_strategy=tuple(_format_rational(weight) for weight in column_strategy),
-        value=_format_rational(value),
+        row_strategy=tuple(_wire_rational(weight) for weight in row_strategy),
+        col_strategy=tuple(_wire_rational(weight) for weight in column_strategy),
+        value=_wire_rational(value),
     )
 
 

--- a/src/jacobian/math/finite_game_theory/_tools.py
+++ b/src/jacobian/math/finite_game_theory/_tools.py
@@ -78,6 +78,7 @@ FINITE_GAME_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 GAME_EXAMPLE,
             ),
         ),
+        version="2",
     ),
     _op(
         "game_theory.nash_equilibrium.compute",

--- a/src/jacobian/math/finite_stochastic_processes/_models.py
+++ b/src/jacobian/math/finite_stochastic_processes/_models.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 from jacobian.math.finite_stochastic_processes.values import (
     FiniteProbabilitySpace,
@@ -74,12 +75,18 @@ class DoobMartingaleRequest(StrictModel):
 
     space: FiniteProbabilitySpace
     observations: tuple[tuple[str, ...], ...] = Field(default=())
-    payoff: tuple[str, ...] = Field(min_length=1)
+    payoff: tuple[CanonicalRational, ...] = Field(min_length=1)
 
     @model_validator(mode="after")
     def require_payoff_matches_space(self) -> Self:
         if len(self.payoff) != len(self.space.samples):
             raise ValueError("payoff must have one entry per sample")
+        for value in self.payoff:
+            require_bounded_rational(
+                value,
+                max_digits=256,
+                label="payoff",
+            )
         for obs in self.observations:
             if len(obs) != len(self.space.samples):
                 raise ValueError("observation must have one entry per sample")
@@ -93,9 +100,9 @@ class FiltrationResult(StrictModel):
 
 
 class DoobMartingaleResult(StrictModel):
-    """The Doob martingale as a tuple of rational-string value tuples."""
+    """The Doob martingale as canonical rational value vectors."""
 
-    martingale: tuple[tuple[str, ...], ...] = Field(default=())
+    martingale: tuple[tuple[CanonicalRational, ...], ...] = Field(default=())
 
 
 __all__ = [

--- a/src/jacobian/math/finite_stochastic_processes/_models.py
+++ b/src/jacobian/math/finite_stochastic_processes/_models.py
@@ -53,6 +53,12 @@ class ConditionalExpectationRequest(StrictModel):
             raise ValueError(
                 "random variable and sigma algebra must share the same probability space"
             )
+        for value in self.rv.values:
+            require_bounded_rational(
+                value,
+                max_digits=256,
+                label="random-variable value",
+            )
         return self
 
 

--- a/src/jacobian/math/finite_stochastic_processes/_tools.py
+++ b/src/jacobian/math/finite_stochastic_processes/_tools.py
@@ -55,8 +55,15 @@ def _op[
     )
 
 
+def _rational(numerator: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(numerator), "den": str(denominator)}
+
+
 # A fair coin: samples {H, T}, masses 1/2, 1/2.
-_SPACE = {"samples": ["H", "T"], "masses": ["1/2", "1/2"]}
+_SPACE = {
+    "samples": ["H", "T"],
+    "masses": [_rational(1, 2), _rational(1, 2)],
+}
 
 FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _op(
@@ -77,6 +84,7 @@ FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"space": _SPACE, "observation": ["heads", "tails"]},
             ),
         ),
+        version="2",
     ),
     _op(
         "probability.finite_sigma_algebra.join.compute",
@@ -100,6 +108,7 @@ FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "probability.conditional_expectation.finite.compute",
@@ -118,11 +127,15 @@ FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "coin_conditional_expectation",
                 "Conditional expectation of a coin payoff on the trivial sigma algebra.",
                 {
-                    "rv": {"space": _SPACE, "values": ["1", "0"]},
+                    "rv": {
+                        "space": _SPACE,
+                        "values": [_rational(1), _rational(0)],
+                    },
                     "sigma": {"space": _SPACE, "blocks": [["H", "T"]]},
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "probability.filtration.natural.compute",
@@ -142,13 +155,14 @@ FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"space": _SPACE, "observations": [["heads", "tails"]]},
             ),
         ),
+        version="2",
     ),
     _op(
         "probability.process.doob_martingale.compute",
         "Compute the Doob martingale M_t = E[payoff | F_t]",
         "Return the Doob martingale of a payoff random variable with respect "
         "to the natural filtration of observations. The result is one tuple "
-        "of rational strings per time step.",
+        "of canonical rational values per time step.",
         DoobMartingaleRequest,
         DoobMartingaleResult,
         compute_doob_martingale,
@@ -162,10 +176,11 @@ FINIT_STOCHASTIC_PROCESS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {
                     "space": _SPACE,
                     "observations": [["heads", "tails"]],
-                    "payoff": ["1", "0"],
+                    "payoff": [_rational(1), _rational(0)],
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/finite_stochastic_processes/operations.py
+++ b/src/jacobian/math/finite_stochastic_processes/operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fractions import Fraction
 
+from jacobian._exact import CanonicalRational
+
 from .values import FiniteProbabilitySpace, FiniteRandomVariable, FiniteSigmaAlgebra
 
 __all__ = [
@@ -20,7 +22,7 @@ def _index_of(space: FiniteProbabilitySpace) -> dict[str, int]:
 
 
 def _mass(space: FiniteProbabilitySpace) -> list[Fraction]:
-    return [Fraction(m) for m in space.masses]
+    return [mass.as_fraction() for mass in space.masses]
 
 
 def sigma_algebra_from_observation(
@@ -72,8 +74,8 @@ def conditional_expectation(
         raise ValueError("random variable and sigma algebra must share the same space")
     idx = _index_of(rv.space)
     masses = _mass(rv.space)
-    values = [Fraction(v) for v in rv.values]
-    ce_values: list[str] = []
+    values = [value.as_fraction() for value in rv.values]
+    ce_values: list[CanonicalRational] = []
     for sample in rv.space.samples:
         block = None
         for b in sigma.blocks:
@@ -88,7 +90,7 @@ def conditional_expectation(
             si = idx[s]
             total_mass += masses[si]
             weighted_sum += masses[si] * values[si]
-        ce_values.append(str(weighted_sum / total_mass))
+        ce_values.append(CanonicalRational.from_fraction(weighted_sum / total_mass))
     return FiniteRandomVariable(space=rv.space, values=tuple(ce_values))
 
 
@@ -114,18 +116,18 @@ def filtration_natural(
 def doob_martingale(
     space: FiniteProbabilitySpace,
     observations: tuple[tuple[str, ...], ...],
-    payoff: tuple[str, ...],
-) -> tuple[tuple[str, ...], ...]:
+    payoff: tuple[CanonicalRational, ...],
+) -> tuple[tuple[CanonicalRational, ...], ...]:
     """Return the Doob martingale M_t = E[payoff | F_t] for each time t.
 
     The payoff is a rational-valued random variable. The result is one
-    tuple of rational strings per time step.
+    tuple of canonical rational values per time step.
     """
     if len(payoff) != len(space.samples):
         raise ValueError("payoff must have one entry per sample")
     sigmas = filtration_natural(space, observations)
     rv = FiniteRandomVariable(space=space, values=payoff)
-    result: list[tuple[str, ...]] = []
+    result: list[tuple[CanonicalRational, ...]] = []
     for sigma in sigmas:
         ce = conditional_expectation(rv, sigma)
         result.append(ce.values)

--- a/src/jacobian/math/finite_stochastic_processes/values.py
+++ b/src/jacobian/math/finite_stochastic_processes/values.py
@@ -62,12 +62,6 @@ class FiniteRandomVariable(StrictModel):
     def require_valid_rv(self) -> Self:
         if len(self.values) != len(self.space.samples):
             raise ValueError("values must have one entry per sample")
-        for value in self.values:
-            require_bounded_rational(
-                value,
-                max_digits=256,
-                label="random-variable value",
-            )
         return self
 
 

--- a/src/jacobian/math/finite_stochastic_processes/values.py
+++ b/src/jacobian/math/finite_stochastic_processes/values.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 
 MAX_SAMPLES = 64
@@ -14,12 +15,15 @@ MAX_SAMPLES = 64
 class FiniteProbabilitySpace(StrictModel):
     """An immutable finite probability space with positive-mass atoms.
 
-    ``samples`` are unique labels. ``masses`` are positive rational strings
-    that sum to exactly 1 (represented as strings for exactness).
+    ``samples`` are unique labels. ``masses`` are positive canonical rationals
+    that sum to exactly one.
     """
 
     samples: tuple[str, ...] = Field(min_length=1, max_length=MAX_SAMPLES)
-    masses: tuple[str, ...] = Field(min_length=1, max_length=MAX_SAMPLES)
+    masses: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_SAMPLES,
+    )
 
     @model_validator(mode="after")
     def require_well_formed(self) -> Self:
@@ -27,14 +31,15 @@ class FiniteProbabilitySpace(StrictModel):
             raise ValueError("samples and masses must have equal length")
         if len(set(self.samples)) != len(self.samples):
             raise ValueError("sample labels must be unique")
-        from fractions import Fraction
-
-        total = Fraction(0)
-        for m in self.masses:
-            f = Fraction(m)
-            if f <= 0:
+        total = sum((mass.as_fraction() for mass in self.masses), start=0)
+        for mass in self.masses:
+            require_bounded_rational(
+                mass,
+                max_digits=256,
+                label="probability mass",
+            )
+            if mass.as_fraction() <= 0:
                 raise ValueError("masses must be positive")
-            total += f
         if total != 1:
             raise ValueError("masses must sum to exactly 1")
         return self
@@ -43,21 +48,26 @@ class FiniteProbabilitySpace(StrictModel):
 class FiniteRandomVariable(StrictModel):
     """An immutable finite random variable on a probability space.
 
-    ``values`` is a tuple of rational strings, one per sample, in the same
+    ``values`` is a tuple of canonical rationals, one per sample, in the same
     order as the probability space's samples.
     """
 
     space: FiniteProbabilitySpace
-    values: tuple[str, ...] = Field(min_length=1)
+    values: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_SAMPLES,
+    )
 
     @model_validator(mode="after")
     def require_valid_rv(self) -> Self:
         if len(self.values) != len(self.space.samples):
             raise ValueError("values must have one entry per sample")
-        from fractions import Fraction
-
-        for v in self.values:
-            Fraction(v)
+        for value in self.values:
+            require_bounded_rational(
+                value,
+                max_digits=256,
+                label="random-variable value",
+            )
         return self
 
 

--- a/src/jacobian/math/galois_theory/_models.py
+++ b/src/jacobian/math/galois_theory/_models.py
@@ -1,101 +1,289 @@
-"""Typed wire contracts for Galois theory operations."""
+"""Typed wire contracts for bounded Galois-theory operations."""
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StringConstraints, model_validator
 
 from jacobian._models import StrictModel
 
-MAX_DEGREE = 12
+MAX_FACTOR_DEGREE = 12
+MAX_GALOIS_GROUP_DEGREE = 6
 MAX_FIELD_ORDER = 251
+GaloisCoefficient = Annotated[int, Field(ge=-(10**12), le=10**12, strict=True)]
+RootIdentifier = Annotated[
+    str,
+    StringConstraints(pattern=r"^root_[0-9]+$", strict=True),
+]
+PositiveFactorDegree = Annotated[
+    int,
+    Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True),
+]
+
+
+def _require_prime(value: int) -> None:
+    from sympy import isprime
+
+    if not isprime(value):
+        raise ValueError("field_order must be prime")
+
+
+def _supported_galois_polynomial(coefficients: tuple[int, ...]) -> None:
+    from sympy import Poly, Symbol
+
+    if coefficients[-1] == 0:
+        raise ValueError("leading coefficient must be nonzero")
+    polynomial = Poly.from_list(list(reversed(coefficients)), Symbol("x"), domain="QQ")
+    if not polynomial.is_irreducible:
+        raise ValueError(
+            "SymPy galois_group requires an irreducible polynomial over QQ"
+        )
 
 
 class GaloisFactorRequest(StrictModel):
-    """Factor a polynomial over GF(p) to study its splitting behavior."""
+    """A nonzero, nonconstant polynomial over the prime field ``GF(p)``."""
 
-    field_order: int = Field(ge=2, le=251)
-    coefficients: tuple[int, ...] = Field(min_length=2, max_length=MAX_DEGREE + 1)
+    field_order: int = Field(ge=2, le=MAX_FIELD_ORDER, strict=True)
+    coefficients: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=MAX_FACTOR_DEGREE + 1,
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        from sympy import isprime
-
-        if not isprime(self.field_order):
-            raise ValueError("field_order must be prime")
-        if any(not 0 <= c < self.field_order for c in self.coefficients):
+    def require_supported_polynomial(self) -> Self:
+        _require_prime(self.field_order)
+        if any(
+            not 0 <= coefficient < self.field_order for coefficient in self.coefficients
+        ):
             raise ValueError("coefficients must be canonical field residues")
+        if self.coefficients[-1] == 0:
+            raise ValueError(
+                "factorization requires a nonzero polynomial with canonical degree"
+            )
         return self
 
 
 class FrobeniusCycleRequest(StrictModel):
-    """Compute the Frobenius cycle type from a factorization pattern."""
+    """A positive factor-degree partition of a polynomial degree."""
 
-    field_order: int = Field(ge=2, le=251)
-    polynomial_degree: int = Field(ge=1, le=MAX_DEGREE)
-    factorization_degrees: tuple[int, ...] = Field(min_length=1, max_length=MAX_DEGREE)
+    field_order: int = Field(ge=2, le=MAX_FIELD_ORDER, strict=True)
+    polynomial_degree: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
+    factorization_degrees: tuple[PositiveFactorDegree, ...] = Field(
+        min_length=1,
+        max_length=MAX_FACTOR_DEGREE,
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        from sympy import isprime
-
-        if not isprime(self.field_order):
-            raise ValueError("field_order must be prime")
+    def require_positive_partition(self) -> Self:
+        _require_prime(self.field_order)
         if sum(self.factorization_degrees) != self.polynomial_degree:
             raise ValueError("factorization degrees must sum to polynomial degree")
         return self
 
 
-class GaloisGroupRequest(StrictModel):
-    """Compute the Galois group of a polynomial over Q."""
-
-    coefficients: tuple[int, ...] = Field(min_length=2, max_length=MAX_DEGREE + 1)
+class _SupportedGaloisPolynomialRequest(StrictModel):
+    coefficients: tuple[GaloisCoefficient, ...] = Field(
+        min_length=2,
+        max_length=MAX_GALOIS_GROUP_DEGREE + 1,
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if self.coefficients[-1] == 0:
-            raise ValueError("leading coefficient must be nonzero")
+    def require_backend_domain(self) -> Self:
+        _supported_galois_polynomial(self.coefficients)
         return self
 
 
-class SolvableRequest(StrictModel):
-    """Check if a polynomial is solvable by radicals."""
-
-    coefficients: tuple[int, ...] = Field(min_length=2, max_length=MAX_DEGREE + 1)
-
-    @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if self.coefficients[-1] == 0:
-            raise ValueError("leading coefficient must be nonzero")
-        return self
+class GaloisGroupRequest(_SupportedGaloisPolynomialRequest):
+    """An irreducible degree-one-through-six polynomial over ``QQ``."""
 
 
-# Results
+class SolvableRequest(_SupportedGaloisPolynomialRequest):
+    """The supported SymPy domain for deciding radical solvability."""
+
+
+class FiniteFieldFactor(StrictModel):
+    """One monic irreducible factor with positive multiplicity."""
+
+    coefficients: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=MAX_FACTOR_DEGREE + 1,
+    )
+    multiplicity: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
+
+
+def _multiply_mod(
+    left: tuple[int, ...], right: tuple[int, ...], prime: int
+) -> tuple[int, ...]:
+    result = [0] * (len(left) + len(right) - 1)
+    for left_degree, left_coefficient in enumerate(left):
+        for right_degree, right_coefficient in enumerate(right):
+            result[left_degree + right_degree] = (
+                result[left_degree + right_degree]
+                + left_coefficient * right_coefficient
+            ) % prime
+    while len(result) > 1 and result[-1] == 0:
+        result.pop()
+    return tuple(result)
 
 
 class GaloisFactorResult(StrictModel):
-    factors: tuple[tuple[int, ...], ...]
-    factor_count: int = Field(ge=1)
+    field_order: int = Field(ge=2, le=MAX_FIELD_ORDER, strict=True)
+    source_coefficients: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=MAX_FACTOR_DEGREE + 1,
+    )
+    unit: int = Field(ge=1, le=MAX_FIELD_ORDER - 1, strict=True)
+    factors: tuple[FiniteFieldFactor, ...] = Field(
+        min_length=1,
+        max_length=MAX_FACTOR_DEGREE,
+    )
+    distinct_factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
+    factor_count: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
     is_irreducible: bool
     method: str = "SYMPY_FACTOR_MOD_P"
 
+    @model_validator(mode="after")
+    def require_reconstruction_certificate(self) -> Self:
+        _require_prime(self.field_order)
+        _require_factor_residues(self)
+        if self.distinct_factor_count != len(self.factors):
+            raise ValueError("distinct_factor_count must equal the number of factors")
+        total = sum(factor.multiplicity for factor in self.factors)
+        if self.factor_count != total:
+            raise ValueError("factor_count must include factor multiplicities")
+        if _reconstruct_factorization(self) != self.source_coefficients:
+            raise ValueError("factorization must reconstruct the source modulo p")
+        if self.is_irreducible != _factorization_is_irreducible(self):
+            raise ValueError(
+                "irreducibility must agree with the complete factorization"
+            )
+        return self
+
+
+def _require_factor_residues(result: GaloisFactorResult) -> None:
+    prime = result.field_order
+    if result.unit >= prime:
+        raise ValueError("factorization unit must be a canonical nonzero residue")
+    if any(not 0 <= coefficient < prime for coefficient in result.source_coefficients):
+        raise ValueError("source coefficients must be canonical field residues")
+    for factor in result.factors:
+        if any(not 0 <= coefficient < prime for coefficient in factor.coefficients):
+            raise ValueError("factor coefficients must be canonical field residues")
+        if factor.coefficients[-1] != 1:
+            raise ValueError("finite-field factors must be monic")
+
+
+def _reconstruct_factorization(result: GaloisFactorResult) -> tuple[int, ...]:
+    reconstructed: tuple[int, ...] = (result.unit,)
+    for factor in result.factors:
+        for _ in range(factor.multiplicity):
+            reconstructed = _multiply_mod(
+                reconstructed, factor.coefficients, result.field_order
+            )
+    return reconstructed
+
+
+def _factorization_is_irreducible(result: GaloisFactorResult) -> bool:
+    return (
+        len(result.factors) == 1
+        and result.factors[0].multiplicity == 1
+        and len(result.factors[0].coefficients) == len(result.source_coefficients)
+    )
+
 
 class FrobeniusCycleResult(StrictModel):
-    cycle_type: tuple[int, ...]
-    degree: int = Field(ge=1)
+    cycle_type: tuple[PositiveFactorDegree, ...]
+    degree: int = Field(ge=1, le=MAX_FACTOR_DEGREE, strict=True)
     is_irreducible: bool
     method: str = "FACTOR_DEGREE_SUMMARY"
 
+    @model_validator(mode="after")
+    def require_canonical_partition(self) -> Self:
+        if sum(self.cycle_type) != self.degree:
+            raise ValueError("cycle type must partition the polynomial degree")
+        if self.cycle_type != tuple(sorted(self.cycle_type, reverse=True)):
+            raise ValueError("cycle type must be sorted in descending order")
+        if self.is_irreducible != (self.cycle_type == (self.degree,)):
+            raise ValueError("irreducibility must agree with the cycle type")
+        return self
+
+
+class FinitePermutationGroup(StrictModel):
+    """A composable permutation group on one explicit ordered root axis."""
+
+    root_axis: tuple[RootIdentifier, ...] = Field(
+        min_length=1,
+        max_length=MAX_GALOIS_GROUP_DEGREE,
+    )
+    generators: tuple[tuple[int, ...], ...] = Field(min_length=1, max_length=16)
+
+    @model_validator(mode="after")
+    def require_permutations_on_axis(self) -> Self:
+        if len(set(self.root_axis)) != len(self.root_axis):
+            raise ValueError("root axis entries must be unique")
+        expected = tuple(range(len(self.root_axis)))
+        if any(
+            len(generator) != len(expected) or tuple(sorted(generator)) != expected
+            for generator in self.generators
+        ):
+            raise ValueError("every generator must permute the complete root axis")
+        return self
+
+
+def _permutation_group_properties(group: FinitePermutationGroup) -> tuple[int, bool]:
+    from sympy.combinatorics import Permutation, PermutationGroup
+
+    backend = PermutationGroup(
+        *(Permutation(list(generator)) for generator in group.generators)
+    )
+    return int(backend.order()), bool(backend.is_solvable)
+
 
 class GaloisGroupResult(StrictModel):
+    group: FinitePermutationGroup
     group_name: str
     order: int = Field(ge=1)
-    degree: int = Field(ge=1)
+    degree: int = Field(ge=1, le=MAX_GALOIS_GROUP_DEGREE)
     is_solvable: bool
     method: str = "SYMPY_GALOIS_GROUP"
+
+    @model_validator(mode="after")
+    def require_group_degree(self) -> Self:
+        if self.degree != len(self.group.root_axis):
+            raise ValueError("group root axis must match the polynomial degree")
+        order, is_solvable = _permutation_group_properties(self.group)
+        if self.order != order or self.is_solvable != is_solvable:
+            raise ValueError(
+                "reported group properties must agree with the permutation generators"
+            )
+        return self
 
 
 class SolvableResult(StrictModel):
     solvable_by_radicals: bool
+    group: FinitePermutationGroup
     method: str = "GALOIS_GROUP_SOLVABILITY"
+
+    @model_validator(mode="after")
+    def require_group_certificate(self) -> Self:
+        _, is_solvable = _permutation_group_properties(self.group)
+        if self.solvable_by_radicals != is_solvable:
+            raise ValueError(
+                "radical solvability must agree with the permutation generators"
+            )
+        return self
+
+
+__all__ = [
+    "FiniteFieldFactor",
+    "FinitePermutationGroup",
+    "FrobeniusCycleRequest",
+    "FrobeniusCycleResult",
+    "GaloisFactorRequest",
+    "GaloisFactorResult",
+    "GaloisGroupRequest",
+    "GaloisGroupResult",
+    "SolvableRequest",
+    "SolvableResult",
+]

--- a/src/jacobian/math/galois_theory/_models.py
+++ b/src/jacobian/math/galois_theory/_models.py
@@ -162,6 +162,8 @@ class GaloisFactorResult(StrictModel):
 
 
 def _require_factor_residues(result: GaloisFactorResult) -> None:
+    from sympy import GF, Poly, Symbol
+
     prime = result.field_order
     if result.unit >= prime:
         raise ValueError("factorization unit must be a canonical nonzero residue")
@@ -172,6 +174,13 @@ def _require_factor_residues(result: GaloisFactorResult) -> None:
             raise ValueError("factor coefficients must be canonical field residues")
         if factor.coefficients[-1] != 1:
             raise ValueError("finite-field factors must be monic")
+        polynomial = Poly(
+            list(reversed(factor.coefficients)),
+            Symbol("x"),
+            domain=GF(prime),
+        )
+        if not polynomial.is_irreducible:
+            raise ValueError("every finite-field factor must be irreducible")
 
 
 def _reconstruct_factorization(result: GaloisFactorResult) -> tuple[int, ...]:

--- a/src/jacobian/math/galois_theory/_operations.py
+++ b/src/jacobian/math/galois_theory/_operations.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sympy.combinatorics.permutations import PermutationGroup
+    from sympy.combinatorics.perm_groups import PermutationGroup
 
 from jacobian.math.galois_theory._models import (
+    FiniteFieldFactor,
+    FinitePermutationGroup,
     FrobeniusCycleRequest,
     FrobeniusCycleResult,
     GaloisFactorRequest,
@@ -28,16 +30,29 @@ def compute_galois_factor(request: GaloisFactorRequest) -> GaloisFactorResult:
     coeffs = list(request.coefficients)
     terms = sum(c * x**i for i, c in enumerate(coeffs))
     poly = Poly(terms, domain=field)
-    _coeff, factor_polys = poly.factor_list()
-    result_factors = []
-    for factor_poly, _mult in factor_polys:
-        coeff_list = [int(c) for c in factor_poly.all_coeffs()]
-        result_factors.append(tuple(reversed(coeff_list)))
-
-    factor_count = len(result_factors)
-    is_irred = factor_count == 1
+    unit, factor_polys = poly.factor_list()
+    result_factors = tuple(
+        FiniteFieldFactor(
+            coefficients=tuple(
+                int(coefficient) % request.field_order
+                for coefficient in reversed(factor_poly.all_coeffs())
+            ),
+            multiplicity=int(multiplicity),
+        )
+        for factor_poly, multiplicity in factor_polys
+    )
+    factor_count = sum(factor.multiplicity for factor in result_factors)
+    is_irred = (
+        len(result_factors) == 1
+        and result_factors[0].multiplicity == 1
+        and len(result_factors[0].coefficients) == len(request.coefficients)
+    )
     return GaloisFactorResult(
-        factors=tuple(result_factors),
+        field_order=request.field_order,
+        source_coefficients=request.coefficients,
+        unit=int(unit) % request.field_order,
+        factors=result_factors,
+        distinct_factor_count=len(result_factors),
         factor_count=factor_count,
         is_irreducible=is_irred,
     )
@@ -45,7 +60,7 @@ def compute_galois_factor(request: GaloisFactorRequest) -> GaloisFactorResult:
 
 def compute_frobenius_cycle(request: FrobeniusCycleRequest) -> FrobeniusCycleResult:
     cycle_type = tuple(sorted(request.factorization_degrees, reverse=True))
-    is_irred = len(cycle_type) == 1
+    is_irred = cycle_type == (request.polynomial_degree,)
     return FrobeniusCycleResult(
         cycle_type=cycle_type,
         degree=request.polynomial_degree,
@@ -71,6 +86,18 @@ def _galois_group_from_coeffs(coeffs: tuple[int, ...]) -> PermutationGroup:
     return perm_group
 
 
+def _wire_group(perm_group: PermutationGroup, degree: int) -> FinitePermutationGroup:
+    """Project a SymPy group onto a complete explicit root axis."""
+
+    return FinitePermutationGroup(
+        root_axis=tuple(f"root_{index}" for index in range(degree)),
+        generators=tuple(
+            tuple(int(generator(index)) for index in range(degree))
+            for generator in perm_group.generators
+        ),
+    )
+
+
 def compute_galois_group(request: GaloisGroupRequest) -> GaloisGroupResult:
     """Compute the Galois group of a polynomial over Q."""
     perm_group = _galois_group_from_coeffs(request.coefficients)
@@ -79,6 +106,7 @@ def compute_galois_group(request: GaloisGroupRequest) -> GaloisGroupResult:
     is_solvable = bool(perm_group.is_solvable)
 
     return GaloisGroupResult(
+        group=_wire_group(perm_group, len(request.coefficients) - 1),
         group_name=group_name,
         order=order,
         degree=len(request.coefficients) - 1,
@@ -94,4 +122,7 @@ def compute_solvable(request: SolvableRequest) -> SolvableResult:
     """
     perm_group = _galois_group_from_coeffs(request.coefficients)
     is_solvable = bool(perm_group.is_solvable)
-    return SolvableResult(solvable_by_radicals=is_solvable)
+    return SolvableResult(
+        solvable_by_radicals=is_solvable,
+        group=_wire_group(perm_group, len(request.coefficients) - 1),
+    )

--- a/src/jacobian/math/galois_theory/_tools.py
+++ b/src/jacobian/math/galois_theory/_tools.py
@@ -53,7 +53,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "polynomial.galois.factor_mod_p.compute",
         "Factor a polynomial over GF(p)",
         "Factor a polynomial over a prime finite field GF(p) using SymPy, "
-        "returning the factorization and irreducibility.",
+        "retaining the unit, monic factors, positive multiplicities, and a "
+        "reconstruction-checked irreducibility result.",
         GaloisFactorRequest,
         GaloisFactorResult,
         compute_galois_factor,
@@ -67,6 +68,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 {"field_order": 5, "coefficients": [1, 0, 1]},
             ),
         ),
+        version="2",
     ),
     _op(
         "polynomial.galois.frobenius_cycle.compute",
@@ -90,12 +92,14 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "polynomial.galois_group.compute",
         "Compute the Galois group of a polynomial over Q",
         "Compute the Galois group of a polynomial with rational coefficients "
-        "using SymPy's galois_group function.",
+        "using SymPy's galois_group function. The request must be irreducible "
+        "and degree at most six; the result includes explicit generators.",
         GaloisGroupRequest,
         GaloisGroupResult,
         compute_galois_group,
@@ -109,12 +113,13 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 {"coefficients": [-2, 0, 1]},
             ),
         ),
+        version="2",
     ),
     _op(
         "polynomial.solvable_by_radicals.decide",
         "Decide if a polynomial is solvable by radicals",
         "Check whether a polynomial is solvable by radicals based on its "
-        "degree and Galois group solvability.",
+        "Galois group, within SymPy's irreducible degree-at-most-six domain.",
         SolvableRequest,
         SolvableResult,
         compute_solvable,
@@ -128,6 +133,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 {"coefficients": [-2, 0, 0, 1]},
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/graphical_models/_tools.py
+++ b/src/jacobian/math/graphical_models/_tools.py
@@ -51,13 +51,18 @@ def _op[
 _FACTOR1 = {
     "variables": [0, 1],
     "domain_sizes": [2, 2, 2],
-    "table": ["1/2", "1/2", "1/3", "2/3"],
+    "table": [
+        {"num": "1", "den": "2"},
+        {"num": "1", "den": "2"},
+        {"num": "1", "den": "3"},
+        {"num": "2", "den": "3"},
+    ],
 }
 
 _FACTOR_SINGLE = {
     "variables": [0],
     "domain_sizes": [2],
-    "table": ["1/3", "2/3"],
+    "table": [{"num": "1", "den": "3"}, {"num": "2", "den": "3"}],
 }
 
 GRAPHICAL_MODEL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
@@ -81,7 +86,10 @@ GRAPHICAL_MODEL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "right": {
                         "variables": [1],
                         "domain_sizes": [2, 2, 2],
-                        "table": ["1/2", "1/2"],
+                        "table": [
+                            {"num": "1", "den": "2"},
+                            {"num": "1", "den": "2"},
+                        ],
                     },
                 },
             ),
@@ -109,6 +117,7 @@ GRAPHICAL_MODEL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "graphical_model.d_separation.compute",
@@ -135,6 +144,7 @@ GRAPHICAL_MODEL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/graphical_models/_tools.py
+++ b/src/jacobian/math/graphical_models/_tools.py
@@ -94,6 +94,7 @@ GRAPHICAL_MODEL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "graphical_model.factor.marginalize",

--- a/src/jacobian/math/graphical_models/operations.py
+++ b/src/jacobian/math/graphical_models/operations.py
@@ -7,11 +7,11 @@ from collections.abc import Sequence
 from fractions import Fraction
 from itertools import combinations
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.graphical_models.values import (
     MAX_FACTOR_COUNT,
     MAX_MODEL_VARS,
     Factor,
-    parse_canonical_rational,
     scope_size,
 )
 
@@ -22,7 +22,7 @@ def factor_multiply(left: Factor, right: Factor) -> Factor:
     _require_compatible_domains((left, right), left.domain_sizes)
     variables = tuple(sorted(set(left.variables) | set(right.variables)))
     total = scope_size(variables, left.domain_sizes)
-    table: list[str] = []
+    table: list[CanonicalRational] = []
     for index in range(total):
         assignment = _index_to_assignment(index, variables, left.domain_sizes)
         left_index = _projected_index(
@@ -31,10 +31,11 @@ def factor_multiply(left: Factor, right: Factor) -> Factor:
         right_index = _projected_index(
             assignment, variables, right.variables, right.domain_sizes
         )
-        value = parse_canonical_rational(
-            left.table[left_index]
-        ) * parse_canonical_rational(right.table[right_index])
-        table.append(str(value))
+        value = (
+            left.table[left_index].as_fraction()
+            * right.table[right_index].as_fraction()
+        )
+        table.append(CanonicalRational.from_fraction(value))
     return Factor(
         variables=variables,
         domain_sizes=left.domain_sizes,
@@ -48,7 +49,7 @@ def factor_marginalize(factor: Factor, variable: int) -> Factor:
     if variable not in factor.variables:
         raise ValueError("variable is not in factor")
     variables = tuple(item for item in factor.variables if item != variable)
-    table: list[str] = []
+    table: list[CanonicalRational] = []
     for index in range(scope_size(variables, factor.domain_sizes)):
         assignment = _index_to_assignment(index, variables, factor.domain_sizes)
         total = Fraction(0)
@@ -60,8 +61,8 @@ def factor_marginalize(factor: Factor, variable: int) -> Factor:
                 factor.variables,
                 factor.domain_sizes,
             )
-            total += parse_canonical_rational(factor.table[source_index])
-        table.append(str(total))
+            total += factor.table[source_index].as_fraction()
+        table.append(CanonicalRational.from_fraction(total))
     return Factor(
         variables=variables,
         domain_sizes=factor.domain_sizes,

--- a/src/jacobian/math/graphical_models/values.py
+++ b/src/jacobian/math/graphical_models/values.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from typing import Annotated, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 
 MAX_MODEL_VARS = 16
@@ -17,25 +17,6 @@ MAX_RATIONAL_DIGITS = 256
 
 DomainSize = Annotated[int, Field(ge=1, le=MAX_VAR_DOMAIN)]
 Variable = Annotated[int, Field(ge=0, lt=MAX_MODEL_VARS)]
-
-
-def parse_canonical_rational(value: str) -> Fraction:
-    """Parse one bounded reduced rational string."""
-
-    if len(value) > 2 * MAX_RATIONAL_DIGITS + 2:
-        raise ValueError("factor entry exceeds the rational digit bound")
-    try:
-        parsed = Fraction(value)
-    except (ValueError, ZeroDivisionError):
-        raise ValueError("factor entries must be canonical rationals") from None
-    if str(parsed) != value:
-        raise ValueError("factor entries must be reduced canonical rationals")
-    if (
-        len(str(abs(parsed.numerator))) > MAX_RATIONAL_DIGITS
-        or len(str(parsed.denominator)) > MAX_RATIONAL_DIGITS
-    ):
-        raise ValueError("factor entry exceeds the rational digit bound")
-    return parsed
 
 
 def scope_size(variables: tuple[int, ...], domain_sizes: tuple[int, ...]) -> int:
@@ -62,7 +43,9 @@ class Factor(StrictModel):
     domain_sizes: tuple[DomainSize, ...] = Field(
         min_length=1, max_length=MAX_MODEL_VARS
     )
-    table: tuple[str, ...] = Field(min_length=1, max_length=MAX_FACTOR_TABLE_SIZE)
+    table: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_FACTOR_TABLE_SIZE
+    )
 
     @model_validator(mode="after")
     def require_valid_factor(self) -> Self:
@@ -74,7 +57,11 @@ class Factor(StrictModel):
                 f"table size {len(self.table)} does not match expected {expected_size}"
             )
         for value in self.table:
-            parse_canonical_rational(value)
+            require_bounded_rational(
+                value,
+                max_digits=MAX_RATIONAL_DIGITS,
+                label="factor entry",
+            )
         return self
 
 
@@ -85,6 +72,5 @@ __all__ = [
     "MAX_RATIONAL_DIGITS",
     "MAX_VAR_DOMAIN",
     "Factor",
-    "parse_canonical_rational",
     "scope_size",
 ]

--- a/src/jacobian/math/graphs/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/tree_decompositions/_models.py
@@ -87,6 +87,13 @@ class RestrictRequest(StrictModel):
     decomposition: TreeDecomposition
     subset: tuple[str, ...] = Field(min_length=1)
 
+    @model_validator(mode="after")
+    def require_source_vertices(self) -> Self:
+        source_vertices = set(self.decomposition.graph.vertices)
+        if not set(self.subset).issubset(source_vertices):
+            raise ValueError("subset must contain only declared source vertices")
+        return self
+
 
 class RestrictResult(StrictModel):
     """The restricted decomposition bound to the induced source graph."""

--- a/src/jacobian/math/graphs/tree_decompositions/_tools.py
+++ b/src/jacobian/math/graphs/tree_decompositions/_tools.py
@@ -177,6 +177,7 @@ TREE_DECOMPOSITION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"decomposition": _DECOMPOSITION, "subset": ["a", "b"]},
             ),
         ),
+        version="2",
     ),
     _op(
         "graph.tree_decomposition.bag_intersection_graph.compute",

--- a/src/jacobian/math/hyperplane_arrangements/_models.py
+++ b/src/jacobian/math/hyperplane_arrangements/_models.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Self
 
-import sympy
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 
 MAX_HYPERPLANES = 16
@@ -16,21 +16,15 @@ MAX_DIM = 8
 class RationalHyperplane(StrictModel):
     """A hyperplane {x : a . x = b} in R^n."""
 
-    coefficients: tuple[str, ...] = Field(min_length=1, max_length=MAX_DIM)
-    constant: str = Field(min_length=1)
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_DIM
+    )
+    constant: CanonicalRational
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
-        try:
-            parsed = [sympy.Rational(c) for c in self.coefficients]
-        except (ValueError, TypeError, sympy.SympifyError) as exc:
-            raise ValueError("coefficients must be exact rationals") from exc
-        if all(c == 0 for c in parsed):
+        if all(coefficient.as_fraction() == 0 for coefficient in self.coefficients):
             raise ValueError("hyperplane coefficients must not all be zero")
-        try:
-            sympy.Rational(self.constant)
-        except (ValueError, TypeError, sympy.SympifyError) as exc:
-            raise ValueError("constant must be an exact rational") from exc
         return self
 
 

--- a/src/jacobian/math/hyperplane_arrangements/_operations.py
+++ b/src/jacobian/math/hyperplane_arrangements/_operations.py
@@ -20,7 +20,7 @@ def compute_arrangement(
     """Check if an arrangement is central (all hyperplanes pass through origin)."""
     is_central = True
     for hp in request.hyperplanes:
-        if sympy.Rational(hp.constant) != 0:
+        if hp.constant.as_fraction() != 0:
             is_central = False
             break
     return HyperplaneArrangementResult(

--- a/src/jacobian/math/hyperplane_arrangements/_tools.py
+++ b/src/jacobian/math/hyperplane_arrangements/_tools.py
@@ -63,12 +63,25 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 {
                     "ambient_dimension": 2,
                     "hyperplanes": [
-                        {"coefficients": ["1", "0"], "constant": "0"},
-                        {"coefficients": ["0", "1"], "constant": "0"},
+                        {
+                            "coefficients": [
+                                {"num": "1", "den": "1"},
+                                {"num": "0", "den": "1"},
+                            ],
+                            "constant": {"num": "0", "den": "1"},
+                        },
+                        {
+                            "coefficients": [
+                                {"num": "0", "den": "1"},
+                                {"num": "1", "den": "1"},
+                            ],
+                            "constant": {"num": "0", "den": "1"},
+                        },
                     ],
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "arrangement.characteristic_polynomial.compute",

--- a/src/jacobian/math/matrices/symbolic/_models.py
+++ b/src/jacobian/math/matrices/symbolic/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import combinations, permutations
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
@@ -12,6 +13,87 @@ from jacobian.math.polynomials.values import PolynomialVariable, RationalFunctio
 MAX_SYMBOLIC_MATRIX_DIMENSION = 8
 MAX_SYMBOLIC_VARIABLES = 8
 MAX_SYMBOLIC_MATRIX_TERMS = 512
+MAX_SYMBOLIC_RESULT_TERMS = 256
+MAX_SYMBOLIC_RESULT_EXPONENT = 64
+MAX_SYMBOLIC_RESULT_COEFFICIENT_DIGITS = 128
+
+
+def _is_polynomial_entry(value: RationalFunction) -> bool:
+    terms = value.denominator.terms
+    return (
+        len(terms) == 1
+        and terms[0].coefficient.num == "1"
+        and terms[0].coefficient.den == "1"
+        and all(exponent == 0 for exponent in terms[0].exponents)
+    )
+
+
+def _principal_minor_term_bounds(
+    entries: tuple[tuple[RationalFunction, ...], ...],
+) -> tuple[int, ...]:
+    """Bound raw terms in each characteristic coefficient by Leibniz expansion."""
+
+    dimension = len(entries)
+    bounds = [1]
+    for size in range(1, dimension + 1):
+        coefficient_terms = 0
+        for axes in combinations(range(dimension), size):
+            for columns in permutations(axes):
+                product_terms = 1
+                for row, column in zip(axes, columns, strict=True):
+                    product_terms *= len(entries[row][column].numerator.terms)
+                coefficient_terms += product_terms
+        bounds.append(coefficient_terms)
+    return tuple(bounds)
+
+
+def _require_determinant_family_result_budget(
+    matrix: SymbolicMatrix,
+    *,
+    characteristic_polynomial: bool,
+) -> None:
+    dimension = len(matrix.entries)
+    if dimension == 1:
+        return
+    values = tuple(value for row in matrix.entries for value in row)
+    if any(not _is_polynomial_entry(value) for value in values):
+        raise ValueError(
+            "multi-dimensional determinant-family requests require polynomial entries"
+        )
+    term_bounds = _principal_minor_term_bounds(matrix.entries)
+    relevant_bounds = term_bounds[1:] if characteristic_polynomial else term_bounds[-1:]
+    if any(bound > MAX_SYMBOLIC_RESULT_TERMS for bound in relevant_bounds):
+        raise ValueError("determinant-family expansion exceeds the result term budget")
+    maximum_exponent = max(
+        (
+            exponent
+            for value in values
+            for term in value.numerator.terms
+            for exponent in term.exponents
+        ),
+        default=0,
+    )
+    if dimension * maximum_exponent > MAX_SYMBOLIC_RESULT_EXPONENT:
+        raise ValueError(
+            "determinant-family expansion exceeds the result exponent budget"
+        )
+    coefficient_digits = max(
+        (
+            len(component.lstrip("-"))
+            for value in values
+            for term in value.numerator.terms
+            for component in (term.coefficient.num, term.coefficient.den)
+        ),
+        default=1,
+    )
+    if any(
+        bound * dimension * coefficient_digits + len(str(max(bound, 1)))
+        > MAX_SYMBOLIC_RESULT_COEFFICIENT_DIGITS
+        for bound in relevant_bounds
+    ):
+        raise ValueError(
+            "determinant-family expansion exceeds the result coefficient budget"
+        )
 
 
 class SymbolicMatrix(StrictModel):
@@ -92,28 +174,41 @@ class SquareSymbolicMatrixRequest(SymbolicMatrixRequest):
 class SymbolicDeterminantRequest(SquareSymbolicMatrixRequest):
     """A square matrix whose exact determinant fits the public result type."""
 
+    matrix: SymbolicMatrix = Field(
+        description=(
+            "A square symbolic matrix. One-dimensional matrices may contain any "
+            "accepted rational function; larger matrices require polynomial "
+            "entries whose derived determinant expansion has at most 256 terms, "
+            "exponent 64, and 128-digit coefficient components."
+        )
+    )
+
     @model_validator(mode="after")
     def require_representable_determinant(self) -> Self:
-        # The input sparsity budget bounds backend work, but rational-function
-        # expansion can still exceed the canonical result representation.  Run
-        # the bounded exact kernel at admission so an accepted request cannot
-        # fail later while constructing its typed result.
-        from jacobian.math.matrices.symbolic import symbolic_determinant
-
-        symbolic_determinant(self.matrix.entries, self.matrix.variables)
+        _require_determinant_family_result_budget(
+            self.matrix,
+            characteristic_polynomial=False,
+        )
         return self
 
 
 class SymbolicCharacteristicPolynomialRequest(SquareSymbolicMatrixRequest):
     """A square matrix whose characteristic polynomial fits the result type."""
 
+    matrix: SymbolicMatrix = Field(
+        description=(
+            "A square symbolic matrix. One-dimensional matrices may contain any "
+            "accepted rational function; larger matrices require polynomial "
+            "entries whose derived principal-minor expansions each have at most "
+            "256 terms, exponent 64, and 128-digit coefficient components."
+        )
+    )
+
     @model_validator(mode="after")
     def require_representable_characteristic_polynomial(self) -> Self:
-        from jacobian.math.matrices.symbolic import symbolic_characteristic_polynomial
-
-        symbolic_characteristic_polynomial(
-            self.matrix.entries,
-            self.matrix.variables,
+        _require_determinant_family_result_budget(
+            self.matrix,
+            characteristic_polynomial=True,
         )
         return self
 

--- a/src/jacobian/math/matrices/symbolic/_models.py
+++ b/src/jacobian/math/matrices/symbolic/_models.py
@@ -7,26 +7,30 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import PolynomialVariable, RationalFunction
 
-MAX_SYMBOLIC_MATRIX_DIMENSION = 32
-MAX_SYMBOLIC_VARIABLES = 16
-MAX_SYMBOLIC_ENTRY_LENGTH = 4096
+MAX_SYMBOLIC_MATRIX_DIMENSION = 8
+MAX_SYMBOLIC_VARIABLES = 8
+MAX_SYMBOLIC_MATRIX_TERMS = 512
 
 
 class SymbolicMatrix(StrictModel):
     """One nonempty rectangular matrix over a multivariate rational-function field.
 
-    Each entry is a string SymPy expression in the declared variables, for
-    example ``"a*c"`` or ``"f/e"``.  The expression is parsed with SymPy and
-    reduced over ``QQ(t_1, ..., t_n)``.
+    Every entry is a canonical reduced numerator/denominator value over the
+    declared ordered variables. For example, the former expression ``a*c`` is
+    represented by one numerator term with exponents ``(1, 0, 1, ...)`` and a
+    unit denominator; ``f/e`` is represented by numerator ``f`` and denominator
+    ``e``. This preserves every element of ``QQ(t_1, ..., t_n)`` without parsing
+    caller text with SymPy.
     """
 
     matrix_schema_version: Literal["1"] = "1"
-    variables: tuple[str, ...] = Field(
+    variables: tuple[PolynomialVariable, ...] = Field(
         min_length=0,
         max_length=MAX_SYMBOLIC_VARIABLES,
     )
-    entries: tuple[tuple[str, ...], ...] = Field(
+    entries: tuple[tuple[RationalFunction, ...], ...] = Field(
         min_length=1,
         max_length=MAX_SYMBOLIC_MATRIX_DIMENSION,
     )
@@ -41,10 +45,19 @@ class SymbolicMatrix(StrictModel):
             )
         if any(len(row) != column_count for row in self.entries):
             raise ValueError("matrix rows must all have the same length")
-        for row in self.entries:
-            for value in row:
-                if len(value) > MAX_SYMBOLIC_ENTRY_LENGTH:
-                    raise ValueError("symbolic matrix entry exceeds the length bound")
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("symbolic matrix variables must be unique")
+        values = tuple(value for row in self.entries for value in row)
+        if any(value.variables != self.variables for value in values):
+            raise ValueError(
+                "every symbolic matrix entry must use the declared ordered field"
+            )
+        term_count = sum(
+            len(value.numerator.terms) + len(value.denominator.terms)
+            for value in values
+        )
+        if term_count > MAX_SYMBOLIC_MATRIX_TERMS:
+            raise ValueError("symbolic matrix exceeds the 512-term operation budget")
         return self
 
 
@@ -77,9 +90,9 @@ class SquareSymbolicMatrixRequest(SymbolicMatrixRequest):
 
 
 class SymbolicDeterminantResult(StrictModel):
-    """The exact symbolic determinant as a canonical SymPy expression string."""
+    """The exact determinant in the matrix's rational-function field."""
 
-    determinant: str
+    determinant: RationalFunction
     method: Literal["SYMPY_BAREISS"] = "SYMPY_BAREISS"
 
 
@@ -96,7 +109,7 @@ class SymbolicCharacteristicPolynomialResult(StrictModel):
 
     variable: Literal["lambda"] = "lambda"
     degree: int = Field(ge=1, le=MAX_SYMBOLIC_MATRIX_DIMENSION)
-    coefficients_descending: tuple[str, ...] = Field(
+    coefficients_descending: tuple[RationalFunction, ...] = Field(
         min_length=2,
         max_length=MAX_SYMBOLIC_MATRIX_DIMENSION + 1,
     )
@@ -125,7 +138,7 @@ class SymbolicEigenvaluesResult(StrictModel):
         min_length=1,
         max_length=MAX_SYMBOLIC_MATRIX_DIMENSION,
     )
-    characteristic_polynomial: tuple[str, ...] | None = Field(
+    characteristic_polynomial: tuple[RationalFunction, ...] | None = Field(
         default=None,
         min_length=2,
         max_length=MAX_SYMBOLIC_MATRIX_DIMENSION + 1,

--- a/src/jacobian/math/matrices/symbolic/_models.py
+++ b/src/jacobian/math/matrices/symbolic/_models.py
@@ -89,6 +89,35 @@ class SquareSymbolicMatrixRequest(SymbolicMatrixRequest):
         return self
 
 
+class SymbolicDeterminantRequest(SquareSymbolicMatrixRequest):
+    """A square matrix whose exact determinant fits the public result type."""
+
+    @model_validator(mode="after")
+    def require_representable_determinant(self) -> Self:
+        # The input sparsity budget bounds backend work, but rational-function
+        # expansion can still exceed the canonical result representation.  Run
+        # the bounded exact kernel at admission so an accepted request cannot
+        # fail later while constructing its typed result.
+        from jacobian.math.matrices.symbolic import symbolic_determinant
+
+        symbolic_determinant(self.matrix.entries, self.matrix.variables)
+        return self
+
+
+class SymbolicCharacteristicPolynomialRequest(SquareSymbolicMatrixRequest):
+    """A square matrix whose characteristic polynomial fits the result type."""
+
+    @model_validator(mode="after")
+    def require_representable_characteristic_polynomial(self) -> Self:
+        from jacobian.math.matrices.symbolic import symbolic_characteristic_polynomial
+
+        symbolic_characteristic_polynomial(
+            self.matrix.entries,
+            self.matrix.variables,
+        )
+        return self
+
+
 class SymbolicDeterminantResult(StrictModel):
     """The exact determinant in the matrix's rational-function field."""
 

--- a/src/jacobian/math/matrices/symbolic/_operations.py
+++ b/src/jacobian/math/matrices/symbolic/_operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from sympy.matrices.exceptions import MatrixError
+
 from jacobian.math.matrices.symbolic import (
     symbolic_characteristic_polynomial,
     symbolic_determinant,
@@ -22,8 +24,8 @@ def compute_symbolic_determinant(
     request: SquareSymbolicMatrixRequest,
 ) -> SymbolicDeterminantResult:
     determinant = symbolic_determinant(
-        [list(row) for row in request.matrix.entries],
-        list(request.matrix.variables),
+        request.matrix.entries,
+        request.matrix.variables,
     )
     return SymbolicDeterminantResult(determinant=determinant)
 
@@ -32,8 +34,8 @@ def compute_symbolic_rank(
     request: SymbolicMatrixRequest,
 ) -> SymbolicRankResult:
     rank, pivot_columns = symbolic_rank(
-        [list(row) for row in request.matrix.entries],
-        list(request.matrix.variables),
+        request.matrix.entries,
+        request.matrix.variables,
     )
     return SymbolicRankResult(rank=rank, pivot_columns=pivot_columns)
 
@@ -42,8 +44,8 @@ def compute_symbolic_characteristic_polynomial(
     request: SquareSymbolicMatrixRequest,
 ) -> SymbolicCharacteristicPolynomialResult:
     degree, coeffs = symbolic_characteristic_polynomial(
-        [list(row) for row in request.matrix.entries],
-        list(request.matrix.variables),
+        request.matrix.entries,
+        request.matrix.variables,
     )
     return SymbolicCharacteristicPolynomialResult(
         degree=degree,
@@ -54,11 +56,11 @@ def compute_symbolic_characteristic_polynomial(
 def compute_symbolic_eigenvalues(
     request: SquareSymbolicMatrixRequest,
 ) -> SymbolicEigenvaluesResult:
-    entries = [list(row) for row in request.matrix.entries]
-    variables = list(request.matrix.variables)
+    entries = request.matrix.entries
+    variables = request.matrix.variables
     try:
         eigenvalues = symbolic_eigenvalues(entries, variables)
-    except Exception:
+    except MatrixError:
         # SymPy raises MatrixError when eigenvalues cannot be represented
         # in radicals.  Return the exact characteristic polynomial instead.
         degree, coeffs = symbolic_characteristic_polynomial(entries, variables)

--- a/src/jacobian/math/matrices/symbolic/_operations.py
+++ b/src/jacobian/math/matrices/symbolic/_operations.py
@@ -11,8 +11,9 @@ from jacobian.math.matrices.symbolic import (
     symbolic_rank,
 )
 from jacobian.math.matrices.symbolic._models import (
-    SquareSymbolicMatrixRequest,
+    SymbolicCharacteristicPolynomialRequest,
     SymbolicCharacteristicPolynomialResult,
+    SymbolicDeterminantRequest,
     SymbolicDeterminantResult,
     SymbolicEigenvaluesResult,
     SymbolicMatrixRequest,
@@ -21,7 +22,7 @@ from jacobian.math.matrices.symbolic._models import (
 
 
 def compute_symbolic_determinant(
-    request: SquareSymbolicMatrixRequest,
+    request: SymbolicDeterminantRequest,
 ) -> SymbolicDeterminantResult:
     determinant = symbolic_determinant(
         request.matrix.entries,
@@ -41,7 +42,7 @@ def compute_symbolic_rank(
 
 
 def compute_symbolic_characteristic_polynomial(
-    request: SquareSymbolicMatrixRequest,
+    request: SymbolicCharacteristicPolynomialRequest,
 ) -> SymbolicCharacteristicPolynomialResult:
     degree, coeffs = symbolic_characteristic_polynomial(
         request.matrix.entries,
@@ -54,7 +55,7 @@ def compute_symbolic_characteristic_polynomial(
 
 
 def compute_symbolic_eigenvalues(
-    request: SquareSymbolicMatrixRequest,
+    request: SymbolicCharacteristicPolynomialRequest,
 ) -> SymbolicEigenvaluesResult:
     entries = request.matrix.entries
     variables = request.matrix.variables

--- a/src/jacobian/math/matrices/symbolic/_tools.py
+++ b/src/jacobian/math/matrices/symbolic/_tools.py
@@ -1,6 +1,7 @@
 """Exact symbolic matrix operation declarations."""
 
 from collections.abc import Callable
+from typing import Any
 
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
@@ -33,7 +34,7 @@ def symbolic_matrix_operation[
     operation: Callable[[RequestT], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
-    version: str = "1",
+    version: str = "2",
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
@@ -46,6 +47,49 @@ def symbolic_matrix_operation[
         tags=tags,
         examples=examples,
     )
+
+
+def _rational_function(
+    variables: tuple[str, ...],
+    *numerator_terms: tuple[int, tuple[int, ...]],
+) -> dict[str, Any]:
+    def polynomial(
+        terms: tuple[tuple[int, tuple[int, ...]], ...],
+    ) -> dict[str, Any]:
+        return {
+            "terms": [
+                {
+                    "coefficient": {"num": str(coefficient), "den": "1"},
+                    "exponents": list(exponents),
+                }
+                for coefficient, exponents in terms
+            ]
+        }
+
+    return {
+        "rational_function_schema_version": "1",
+        "domain": "QQ",
+        "variables": list(variables),
+        "numerator": polynomial(numerator_terms),
+        "denominator": polynomial(((1, (0,) * len(variables)),)),
+    }
+
+
+def _generic_two_by_two() -> dict[str, Any]:
+    variables = ("a", "b", "c", "d")
+    return {
+        "variables": list(variables),
+        "entries": [
+            [
+                _rational_function(variables, (1, (1, 0, 0, 0))),
+                _rational_function(variables, (1, (0, 0, 1, 0))),
+            ],
+            [
+                _rational_function(variables, (1, (0, 1, 0, 0))),
+                _rational_function(variables, (1, (0, 0, 0, 1))),
+            ],
+        ],
+    }
 
 
 SYMBOLIC_MATRIX_OPERATIONS = (
@@ -66,10 +110,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
                 "symbolic_determinant_two_by_two",
                 "Compute the determinant of [[a, c], [b, d]]; the matrix must be square and rectangular over declared variables.",
                 {
-                    "matrix": {
-                        "variables": ["a", "b", "c", "d"],
-                        "entries": [["a", "c"], ["b", "d"]],
-                    }
+                    "matrix": _generic_two_by_two(),
                 },
             ),
         ),
@@ -92,10 +133,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
                 "symbolic_rank_full",
                 "Compute the rank of a 2x2 symbolic matrix; rows must be nonempty and equal length over declared variables.",
                 {
-                    "matrix": {
-                        "variables": ["a", "b", "c", "d"],
-                        "entries": [["a", "c"], ["b", "d"]],
-                    }
+                    "matrix": _generic_two_by_two(),
                 },
             ),
         ),
@@ -117,10 +155,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
                 "symbolic_charpoly_two_by_two",
                 "Compute the characteristic polynomial of [[a, c], [b, d]]; the matrix must be square and rectangular.",
                 {
-                    "matrix": {
-                        "variables": ["a", "b", "c", "d"],
-                        "entries": [["a", "c"], ["b", "d"]],
-                    }
+                    "matrix": _generic_two_by_two(),
                 },
             ),
         ),
@@ -145,7 +180,16 @@ SYMBOLIC_MATRIX_OPERATIONS = (
                 {
                     "matrix": {
                         "variables": [],
-                        "entries": [["1", "2"], ["3", "4"]],
+                        "entries": [
+                            [
+                                _rational_function((), (1, ())),
+                                _rational_function((), (2, ())),
+                            ],
+                            [
+                                _rational_function((), (3, ())),
+                                _rational_function((), (4, ())),
+                            ],
+                        ],
                     }
                 },
             ),

--- a/src/jacobian/math/matrices/symbolic/_tools.py
+++ b/src/jacobian/math/matrices/symbolic/_tools.py
@@ -7,8 +7,9 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.matrices.symbolic._models import (
-    SquareSymbolicMatrixRequest,
+    SymbolicCharacteristicPolynomialRequest,
     SymbolicCharacteristicPolynomialResult,
+    SymbolicDeterminantRequest,
     SymbolicDeterminantResult,
     SymbolicEigenvaluesResult,
     SymbolicMatrixRequest,
@@ -97,7 +98,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
         "matrix.symbolic.determinant.compute",
         "Compute an exact symbolic matrix determinant (det) over QQ(t_1, ..., t_n)",
         "Compute the determinant of a square matrix whose entries are rational functions in declared algebraically independent variables, using SymPy's exact fraction-free Bareiss algorithm.",
-        SquareSymbolicMatrixRequest,
+        SymbolicDeterminantRequest,
         SymbolicDeterminantResult,
         compute_symbolic_determinant,
         "matrix",
@@ -142,7 +143,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
         "matrix.symbolic.characteristic_polynomial.compute",
         "Compute an exact symbolic characteristic polynomial",
         "Compute the dense monic coefficients of det(lambda I - A) for a square symbolic matrix whose entries are rational functions in declared algebraically independent variables.",
-        SquareSymbolicMatrixRequest,
+        SymbolicCharacteristicPolynomialRequest,
         SymbolicCharacteristicPolynomialResult,
         compute_symbolic_characteristic_polynomial,
         "matrix",
@@ -165,7 +166,7 @@ SYMBOLIC_MATRIX_OPERATIONS = (
         "matrix.symbolic.eigenvalues.compute",
         "Compute exact symbolic eigenvalues",
         "Compute the exact eigenvalues with algebraic multiplicities of a square symbolic matrix using SymPy's eigenvals. Entries may be rational functions in declared algebraically independent variables; eigenvalues are returned as canonical SymPy expression strings.",
-        SquareSymbolicMatrixRequest,
+        SymbolicCharacteristicPolynomialRequest,
         SymbolicEigenvaluesResult,
         compute_symbolic_eigenvalues,
         "matrix",

--- a/src/jacobian/math/matrices/symbolic/operations.py
+++ b/src/jacobian/math/matrices/symbolic/operations.py
@@ -1,84 +1,92 @@
 """Exact symbolic matrix operations backed by SymPy.
 
-The entries are SymPy expressions over a declared list of variables,
-interpreted as elements of the multivariate rational-function field
-``QQ(t_1, ..., t_n)``.
+The entries are canonical rational-function values over a declared variable
+axis.  SymPy objects are constructed programmatically from validated sparse
+terms; this module never parses caller text.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+)
+from jacobian.math.polynomials.values import RationalFunction
+
 __all__ = ["symbolic_determinant", "symbolic_rank"]
 
 
-def _parse_matrix(entries: list[list[str]], variables: list[str]) -> Any:
+def _matrix_from_values(
+    entries: tuple[tuple[RationalFunction, ...], ...],
+) -> Any:
     import sympy
 
     if not entries or not entries[0]:
         raise ValueError("symbolic matrix must be nonempty")
-    symbols = [sympy.Symbol(name) for name in variables]
     rows = len(entries)
     columns = len(entries[0])
     if any(len(row) != columns for row in entries):
         raise ValueError("symbolic matrix rows must all have the same length")
-    if rows > 32 or columns > 32:
-        raise ValueError("symbolic matrix dimensions must be between 1 and 32")
-    local = dict(zip(variables, symbols, strict=True))
-    matrix_rows = []
-    for row in entries:
-        matrix_rows.append([sympy.sympify(entry, locals=local) for entry in row])
-    matrix = sympy.Matrix(matrix_rows)
-    if any(entry.has(sympy.Float) for entry in matrix):
-        raise ValueError("symbolic matrix entries must be exact; no SymPy Float")
-    return matrix, symbols
+    if rows > 8 or columns > 8:
+        raise ValueError("symbolic matrix dimensions must be between 1 and 8")
+    return sympy.Matrix(
+        [[rational_function_to_sympy(entry) for entry in row] for row in entries]
+    )
 
 
 def symbolic_determinant(
-    entries: list[list[str]],
-    variables: list[str],
-) -> str:
-    """Return the exact symbolic determinant as a canonical SymPy string."""
-    matrix, _ = _parse_matrix(entries, variables)
+    entries: tuple[tuple[RationalFunction, ...], ...],
+    variables: tuple[str, ...],
+) -> RationalFunction:
+    """Return the determinant in the declared rational-function field."""
+    matrix = _matrix_from_values(entries)
     if matrix.rows != matrix.cols:
         raise ValueError("determinant requires a square matrix")
-    return str(matrix.det(method="bareiss"))
+    return rational_function_from_sympy(matrix.det(method="bareiss"), variables)
 
 
 def symbolic_rank(
-    entries: list[list[str]],
-    variables: list[str],
+    entries: tuple[tuple[RationalFunction, ...], ...],
+    variables: tuple[str, ...],
 ) -> tuple[int, tuple[int, ...]]:
     """Return the exact symbolic rank and RREF pivot columns."""
-    matrix, _ = _parse_matrix(entries, variables)
+    del variables
+    matrix = _matrix_from_values(entries)
     _, pivots = matrix.rref()
     return len(pivots), tuple(int(c) for c in pivots)
 
 
 def symbolic_characteristic_polynomial(
-    entries: list[list[str]],
-    variables: list[str],
-) -> tuple[int, list[str]]:
+    entries: tuple[tuple[RationalFunction, ...], ...],
+    variables: tuple[str, ...],
+) -> tuple[int, tuple[RationalFunction, ...]]:
     """Return (degree, descending coefficients) of det(lambda I - A)."""
     import sympy
 
-    matrix, _ = _parse_matrix(entries, variables)
+    matrix = _matrix_from_values(entries)
     if matrix.rows != matrix.cols:
         raise ValueError("characteristic polynomial requires a square matrix")
     lam = sympy.Symbol("lambda")
     poly = (sympy.eye(matrix.rows) * lam - matrix).det(method="bareiss")
     expanded = sympy.Poly(poly, lam)
     coeffs = expanded.all_coeffs()
-    return int(expanded.degree()), [str(c) for c in coeffs]
+    return int(expanded.degree()), tuple(
+        rational_function_from_sympy(coefficient, variables) for coefficient in coeffs
+    )
 
 
 def symbolic_eigenvalues(
-    entries: list[list[str]],
-    variables: list[str],
+    entries: tuple[tuple[RationalFunction, ...], ...],
+    variables: tuple[str, ...],
 ) -> list[tuple[str, int]]:
     """Return a list of (eigenvalue_string, multiplicity) pairs."""
-    matrix, _ = _parse_matrix(entries, variables)
+    from sympy import sstr
+
+    del variables
+    matrix = _matrix_from_values(entries)
     if matrix.rows != matrix.cols:
         raise ValueError("eigenvalues require a square matrix")
     eigenvalues = matrix.eigenvals()
-    return [(str(value), int(mult)) for value, mult in eigenvalues.items()]
+    return [(sstr(value), int(mult)) for value, mult in eigenvalues.items()]

--- a/src/jacobian/math/plane_algebraic_curves/_models.py
+++ b/src/jacobian/math/plane_algebraic_curves/_models.py
@@ -2,148 +2,103 @@
 
 from __future__ import annotations
 
-import keyword
 from typing import Literal, Self
 
-import sympy
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
+    require_polynomial_budget,
+)
 
 MAX_VARS = 3
-MAX_COEFF = 4096
 HOMOGENIZING_COORDINATE = "z"
+_MAX_TERMS = 256
+_MAX_EXPONENT = 64
+_MAX_COEFFICIENT_DIGITS = 128
 
 
-def _require_valid_variables(variables: tuple[str, ...]) -> None:
-    """Reject duplicate, empty, reserved, or non-identifier variable names."""
-    seen: set[str] = set()
-    for name in variables:
-        if not name or not name.isidentifier():
-            raise ValueError("variable names must be valid identifiers")
-        if keyword.iskeyword(name):
-            raise ValueError("variable names must not be Python keywords")
-        if name in seen:
-            raise ValueError("variable names must be unique")
-        seen.add(name)
-
-
-def _parse_polynomial(raw: str, variables: tuple[str, ...]) -> sympy.Basic:
-    """Parse *raw* as a sympy polynomial over *variables* with rational coefficients.
-
-    Converts parse failures and non-polynomial expressions into ValueError so
-    that a request the model accepts always yields a typed domain result.
-    Coefficients must be rational numbers (integers or rationals over QQ);
-    transcendental or symbolic constants such as pi are rejected.
-    """
-    var_symbols = sympy.symbols(variables)
-    var_map = dict(zip(variables, var_symbols, strict=True))
-    try:
-        expression = sympy.sympify(raw, locals=var_map)
-    except (sympy.SympifyError, TypeError, SyntaxError) as exc:
-        raise ValueError("polynomial must be a valid expression") from exc
-    free = {str(symbol) for symbol in expression.free_symbols}
-    undeclared = free - set(variables)
-    if undeclared:
-        raise ValueError(
-            f"polynomial references undeclared variables: {sorted(undeclared)}"
-        )
-    if not expression.is_polynomial(*var_symbols):
-        raise ValueError("polynomial expression must be a polynomial")
-    # Validate coefficients are rational (over QQ)
-    try:
-        poly = sympy.Poly(expression, *var_symbols, domain=sympy.QQ)
-    except sympy.CoercionFailed as exc:
-        raise ValueError("polynomial coefficients must be rational") from exc
-    if poly.domain != sympy.QQ:
-        raise ValueError(
-            f"polynomial coefficients must be rational, got domain {poly.domain}"
-        )
-    return expression
-
-
-def _require_polynomial(raw: str, variables: tuple[str, ...]) -> sympy.Basic:
-    _require_valid_variables(variables)
-    return _parse_polynomial(raw, variables)
+def _require_curve_polynomial(polynomial: RationalPolynomial) -> None:
+    require_polynomial_budget(
+        polynomial,
+        maximum_terms=_MAX_TERMS,
+        maximum_exponent=_MAX_EXPONENT,
+        maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+        label="curve polynomial",
+    )
+    if any(sum(term.exponents) > _MAX_EXPONENT for term in polynomial.polynomial.terms):
+        raise ValueError(f"curve polynomial exceeds total degree {_MAX_EXPONENT}")
 
 
 class AffineCurveRequest(StrictModel):
-    """An affine plane curve f(x, y) = 0."""
+    """An affine plane curve ``f(x, y) = 0`` over ``QQ``."""
 
-    variables: tuple[str, ...] = Field(min_length=2, max_length=2)
-    polynomial: str = Field(min_length=1, max_length=MAX_COEFF)
+    polynomial: RationalPolynomial
 
     @model_validator(mode="after")
-    def require_valid_polynomial(self) -> Self:
-        _require_polynomial(self.polynomial, self.variables)
+    def require_affine_plane(self) -> Self:
+        _require_curve_polynomial(self.polynomial)
+        if len(self.polynomial.variables) != 2:
+            raise ValueError("affine plane curves require exactly two variables")
         return self
 
 
 class ProjectiveClosureRequest(StrictModel):
-    """Compute the projective closure of an affine curve."""
+    """Homogenize an affine plane curve with the reserved coordinate ``z``."""
 
-    variables: tuple[str, ...] = Field(min_length=2, max_length=2)
-    polynomial: str = Field(min_length=1, max_length=MAX_COEFF)
+    polynomial: RationalPolynomial
 
     @model_validator(mode="after")
-    def require_valid_polynomial(self) -> Self:
-        _require_valid_variables(self.variables)
-        if HOMOGENIZING_COORDINATE in self.variables:
+    def require_available_homogenizing_coordinate(self) -> Self:
+        _require_curve_polynomial(self.polynomial)
+        if len(self.polynomial.variables) != 2:
+            raise ValueError("projective closure requires exactly two variables")
+        if HOMOGENIZING_COORDINATE in self.polynomial.variables:
             raise ValueError(
-                f"variable names must not include the reserved homogenizing "
-                f"coordinate '{HOMOGENIZING_COORDINATE}'"
+                "affine variable axis must not contain the reserved "
+                f"homogenizing coordinate {HOMOGENIZING_COORDINATE!r}"
             )
-        _parse_polynomial(self.polynomial, self.variables)
         return self
 
 
 class AffineChartRequest(StrictModel):
-    """Extract an affine chart from a projective curve."""
+    """Dehomogenize a homogeneous projective plane curve on one chart."""
 
-    variables: tuple[str, ...] = Field(min_length=3, max_length=3)
-    polynomial: str = Field(min_length=1, max_length=MAX_COEFF)
-    chart_variable: str = Field(min_length=1, max_length=64)
+    polynomial: RationalPolynomial
+    chart_variable: PolynomialVariable
 
     @model_validator(mode="after")
-    def require_valid_chart(self) -> Self:
-        _require_polynomial(self.polynomial, self.variables)
-        if self.chart_variable not in self.variables:
-            raise ValueError("chart_variable must be one of the projective variables")
-        # Validate that the polynomial is homogeneous (all terms have the same total degree)
-        var_symbols = sympy.symbols(self.variables)
-        poly = sympy.Poly(
-            _parse_polynomial(self.polynomial, self.variables),
-            *var_symbols,
-            domain=sympy.QQ,
-        )
-        if not poly.is_homogeneous:
+    def require_homogeneous_projective_plane(self) -> Self:
+        _require_curve_polynomial(self.polynomial)
+        if len(self.polynomial.variables) != 3:
+            raise ValueError("projective plane curves require exactly three variables")
+        if self.chart_variable not in self.polynomial.variables:
+            raise ValueError("chart_variable must belong to the polynomial axis")
+        if not rational_polynomial_to_sympy(self.polynomial).is_homogeneous:
             raise ValueError("projective polynomial must be homogeneous")
         return self
 
 
-# Results
-
-
 class AffineCurveResult(StrictModel):
     is_valid: bool
-    degree: int = Field(ge=0)
+    degree: int = Field(ge=0, le=_MAX_EXPONENT)
     method: Literal["SYMPY_CURVE_CHECK"] = "SYMPY_CURVE_CHECK"
 
 
 class ProjectiveClosureResult(StrictModel):
-    polynomial: str
-    variables: tuple[str, ...]
+    polynomial: RationalPolynomial
     method: Literal["HOMOGENIZATION"] = "HOMOGENIZATION"
 
 
 class AffineChartResult(StrictModel):
-    polynomial: str
-    variables: tuple[str, ...]
+    polynomial: RationalPolynomial
     method: Literal["DEHOMOGENIZATION"] = "DEHOMOGENIZATION"
 
 
 __all__ = [
-    "MAX_COEFF",
     "MAX_VARS",
     "AffineChartRequest",
     "AffineChartResult",

--- a/src/jacobian/math/plane_algebraic_curves/_operations.py
+++ b/src/jacobian/math/plane_algebraic_curves/_operations.py
@@ -5,25 +5,28 @@ from __future__ import annotations
 import sympy
 
 from jacobian.math.plane_algebraic_curves._models import (
+    HOMOGENIZING_COORDINATE,
     AffineChartRequest,
     AffineChartResult,
     AffineCurveRequest,
     AffineCurveResult,
     ProjectiveClosureRequest,
     ProjectiveClosureResult,
-    _parse_polynomial,
 )
-
-HOMOGENIZING_COORDINATE = "z"
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
 
 
 def compute_affine_curve_check(request: AffineCurveRequest) -> AffineCurveResult:
-    """Check that a polynomial defines a valid affine plane curve."""
-    poly = _parse_polynomial(request.polynomial, request.variables)
-    degree = int(sympy.total_degree(poly))
-    is_valid = poly != 0 and degree >= 1
+    """Check whether a nonconstant polynomial defines an affine plane curve."""
+
+    polynomial = rational_polynomial_to_sympy(request.polynomial)
+    degree = 0 if polynomial.is_zero else int(polynomial.total_degree())
     return AffineCurveResult(
-        is_valid=is_valid,
+        is_valid=not polynomial.is_zero and degree >= 1,
         degree=degree,
     )
 
@@ -31,38 +34,71 @@ def compute_affine_curve_check(request: AffineCurveRequest) -> AffineCurveResult
 def compute_projective_closure(
     request: ProjectiveClosureRequest,
 ) -> ProjectiveClosureResult:
-    """Compute the projective closure by homogenizing with a new variable."""
-    var_symbols = list(sympy.symbols(request.variables))
-    poly = _parse_polynomial(request.polynomial, request.variables)
-    z = sympy.Symbol(HOMOGENIZING_COORDINATE)
-    terms = sympy.Poly(poly, *var_symbols)
-    degree = terms.total_degree()
-    new_terms = []
-    for monom, coeff in terms.as_dict().items():
-        total_deg = sum(monom)
-        factor = z ** (degree - total_deg)
-        term = coeff
-        for i, exp in enumerate(monom):
-            term *= var_symbols[i] ** exp
-        new_terms.append(term * factor)
-    homogenized = sympy.expand(sum(new_terms))
+    """Homogenize an affine plane curve with the reserved coordinate ``z``."""
+
+    source = rational_polynomial_to_sympy(request.polynomial)
+    source_variables = symbols_for_variables(request.polynomial.variables)
+    homogenizing = sympy.Symbol(HOMOGENIZING_COORDINATE)
+    variables = (*request.polynomial.variables, HOMOGENIZING_COORDINATE)
+    degree = 0 if source.is_zero else int(source.total_degree())
+    expression = sum(
+        coefficient
+        * sympy.prod(
+            variable**exponent
+            for variable, exponent in zip(
+                source_variables,
+                monomial,
+                strict=True,
+            )
+        )
+        * homogenizing ** (degree - sum(monomial))
+        for monomial, coefficient in source.terms()
+    )
+    closure = sympy.Poly(
+        sympy.expand(expression),
+        *source_variables,
+        homogenizing,
+        domain=sympy.QQ,
+    )
     return ProjectiveClosureResult(
-        polynomial=str(homogenized),
-        variables=(*request.variables, HOMOGENIZING_COORDINATE),
+        polynomial=rational_polynomial_from_sympy(
+            closure,
+            variables,
+            maximum_terms=256,
+        )
     )
 
 
 def compute_affine_chart(request: AffineChartRequest) -> AffineChartResult:
-    """Extract an affine chart by dehomogenizing at the chart variable."""
-    chart_var = sympy.Symbol(request.chart_variable)
-    poly = _parse_polynomial(request.polynomial, request.variables)
-    idx = request.variables.index(request.chart_variable)
-    other_vars = [v for i, v in enumerate(request.variables) if i != idx]
+    """Dehomogenize a projective plane curve at one chart coordinate."""
 
-    dehomogenized = poly.subs(chart_var, 1)
-    dehomogenized = sympy.expand(dehomogenized)
-
-    return AffineChartResult(
-        polynomial=str(dehomogenized),
-        variables=tuple(other_vars),
+    source = rational_polynomial_to_sympy(request.polynomial)
+    chart_index = request.polynomial.variables.index(request.chart_variable)
+    symbols = symbols_for_variables(request.polynomial.variables)
+    remaining_variables = tuple(
+        variable
+        for index, variable in enumerate(request.polynomial.variables)
+        if index != chart_index
     )
+    remaining_symbols = tuple(
+        symbol for index, symbol in enumerate(symbols) if index != chart_index
+    )
+    chart = sympy.Poly(
+        sympy.expand(source.as_expr().subs(symbols[chart_index], 1)),
+        *remaining_symbols,
+        domain=sympy.QQ,
+    )
+    return AffineChartResult(
+        polynomial=rational_polynomial_from_sympy(
+            chart,
+            remaining_variables,
+            maximum_terms=256,
+        )
+    )
+
+
+__all__ = [
+    "compute_affine_chart",
+    "compute_affine_curve_check",
+    "compute_projective_closure",
+]

--- a/src/jacobian/math/plane_algebraic_curves/_tools.py
+++ b/src/jacobian/math/plane_algebraic_curves/_tools.py
@@ -21,6 +21,26 @@ from jacobian.math.plane_algebraic_curves._operations import (
 )
 
 
+def _polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[int, tuple[int, ...]],
+) -> dict[str, Any]:
+    return {
+        "polynomial_schema_version": "1",
+        "domain": "QQ",
+        "variables": list(variables),
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": str(coefficient), "den": "1"},
+                    "exponents": list(exponents),
+                }
+                for coefficient, exponents in terms
+            ]
+        },
+    }
+
+
 def _op[RequestT: StrictModel, ResultT: StrictModel](
     operation_id: str,
     title: str,
@@ -30,7 +50,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
     operation: Callable[[RequestT], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
-    version: str = "1",
+    version: str = "2",
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
@@ -60,10 +80,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "circle",
-                "Check the unit circle x^2 + y^2 - 1 = 0.",
+                "Check the unit circle x^2 + y^2 - 1 = 0; an affine plane "
+                "curve polynomial must use exactly two ordered variables.",
                 {
-                    "variables": ["x", "y"],
-                    "polynomial": "x**2 + y**2 - 1",
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (0, 2)),
+                        (-1, (0, 0)),
+                    ),
                 },
             ),
         ),
@@ -81,10 +106,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "circle_closure",
-                "Projective closure of x^2 + y^2 - 1.",
+                "Compute the projective closure of x^2 + y^2 - 1; the affine "
+                "axis must have two variables and leave z available.",
                 {
-                    "variables": ["x", "y"],
-                    "polynomial": "x**2 + y**2 - 1",
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (0, 2)),
+                        (-1, (0, 0)),
+                    ),
                 },
             ),
         ),
@@ -103,10 +133,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "chart_z",
-                "Extract the z=1 chart of x^2 + y^2 - z^2.",
+                "Extract the z=1 chart of x^2 + y^2 - z^2; the canonical "
+                "projective polynomial must be homogeneous in three variables.",
                 {
-                    "variables": ["x", "y", "z"],
-                    "polynomial": "x**2 + y**2 - z**2",
+                    "polynomial": _polynomial(
+                        ("x", "y", "z"),
+                        (1, (2, 0, 0)),
+                        (1, (0, 2, 0)),
+                        (-1, (0, 0, 2)),
+                    ),
                     "chart_variable": "z",
                 },
             ),

--- a/src/jacobian/math/polynomial_interpolation_ops/_kernel.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_kernel.py
@@ -1,0 +1,45 @@
+"""Shared exact kernels for polynomial interpolation contracts and operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+
+
+def divided_difference_coefficients(
+    nodes: tuple[CanonicalRational, ...],
+    values: tuple[CanonicalRational, ...],
+) -> tuple[Fraction, ...]:
+    """Return the exact Newton coefficients for pairwise-distinct nodes."""
+
+    node_values = tuple(node.as_fraction() for node in nodes)
+    row = [value.as_fraction() for value in values]
+    coefficients = [row[0]]
+    for width in range(1, len(node_values)):
+        row = [
+            (row[index + 1] - row[index])
+            / (node_values[index + width] - node_values[index])
+            for index in range(len(node_values) - width)
+        ]
+        coefficients.append(row[0])
+    return tuple(coefficients)
+
+
+def evaluate_newton_form(
+    nodes: tuple[CanonicalRational, ...],
+    coefficients: tuple[CanonicalRational, ...],
+    point: CanonicalRational,
+) -> Fraction:
+    """Evaluate one Newton form exactly with nested multiplication."""
+
+    node_values = tuple(node.as_fraction() for node in nodes)
+    coefficient_values = tuple(value.as_fraction() for value in coefficients)
+    point_value = point.as_fraction()
+    result = coefficient_values[-1]
+    for index in range(len(coefficient_values) - 2, -1, -1):
+        result = coefficient_values[index] + (point_value - node_values[index]) * result
+    return result
+
+
+__all__ = ["divided_difference_coefficients", "evaluate_newton_form"]

--- a/src/jacobian/math/polynomial_interpolation_ops/_models.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_models.py
@@ -1,4 +1,4 @@
-"""Typed wire contracts for polynomial interpolation operations."""
+"""Typed exact contracts for polynomial interpolation operations."""
 
 from __future__ import annotations
 
@@ -6,77 +6,116 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 
 MAX_POINTS = 32
+_MAX_RATIONAL_DIGITS = 256
 
 
-def _require_distinct(nodes: tuple[str, ...]) -> None:
-    """Reject repeated interpolation nodes."""
-    seen: set[str] = set()
-    for n in nodes:
-        if n in seen:
-            raise ValueError("interpolation nodes must be pairwise distinct")
-        seen.add(n)
+def _require_distinct(nodes: tuple[CanonicalRational, ...]) -> None:
+    if len({node.as_integer_ratio() for node in nodes}) != len(nodes):
+        raise ValueError("interpolation nodes must be pairwise distinct")
 
 
-class DividedDifferencesRequest(StrictModel):
-    """Compute divided differences from sample points."""
+def _require_bounded(values: tuple[CanonicalRational, ...], label: str) -> None:
+    for value in values:
+        require_bounded_rational(
+            value,
+            max_digits=_MAX_RATIONAL_DIGITS,
+            label=label,
+        )
 
-    nodes: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
-    values: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
+
+class InterpolationSamples(StrictModel):
+    """One bounded graph of a rational-valued function on distinct nodes."""
+
+    nodes: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+    )
+    values: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
+    def require_well_formed_samples(self) -> Self:
         if len(self.nodes) != len(self.values):
             raise ValueError("nodes and values must have the same length")
         _require_distinct(self.nodes)
+        _require_bounded(self.nodes, "interpolation node")
+        _require_bounded(self.values, "interpolation value")
         return self
 
 
-class NewtonFormRequest(StrictModel):
-    """Compute Newton form coefficients from divided differences."""
+class DividedDifferencesRequest(StrictModel):
+    samples: InterpolationSamples
 
-    nodes: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
-    values: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
+
+class NewtonFormRequest(StrictModel):
+    samples: InterpolationSamples
+
+
+class NewtonForm(StrictModel):
+    """A directly evaluable Newton-basis polynomial over ``QQ``."""
+
+    nodes: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+    )
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if len(self.nodes) != len(self.values):
-            raise ValueError("nodes and values must have the same length")
+    def require_basis_shape(self) -> Self:
+        if len(self.nodes) != len(self.coefficients):
+            raise ValueError("Newton nodes and coefficients must have the same length")
         _require_distinct(self.nodes)
+        _require_bounded(self.nodes, "Newton node")
+        _require_bounded(self.coefficients, "Newton coefficient")
         return self
 
 
 class NewtonEvaluateRequest(StrictModel):
-    """Evaluate a polynomial in Newton form at a point."""
-
-    nodes: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
-    values: tuple[str, ...] = Field(min_length=1, max_length=MAX_POINTS)
-    evaluation_point: str = Field(min_length=1)
+    newton_form: NewtonForm
+    evaluation_point: CanonicalRational
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if len(self.nodes) != len(self.values):
-            raise ValueError("nodes and values must have the same length")
-        _require_distinct(self.nodes)
+    def require_bounded_point(self) -> Self:
+        require_bounded_rational(
+            self.evaluation_point,
+            max_digits=_MAX_RATIONAL_DIGITS,
+            label="evaluation point",
+        )
         return self
 
 
-# Results
-
-
 class DividedDifferencesResult(StrictModel):
-    coefficients: tuple[str, ...]
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+    )
     method: str = "NEWTON_DIVIDED_DIFFERENCES"
 
 
-class NewtonFormResult(StrictModel):
-    coefficients: tuple[str, ...]
-    nodes: tuple[str, ...]
-    method: str = "NEWTON_FORM"
+NewtonFormResult = NewtonForm
 
 
 class NewtonEvaluateResult(StrictModel):
-    result: str
+    result: CanonicalRational
     method: str = "NEWTON_HORNER"
+
+
+__all__ = [
+    "DividedDifferencesRequest",
+    "DividedDifferencesResult",
+    "InterpolationSamples",
+    "NewtonEvaluateRequest",
+    "NewtonEvaluateResult",
+    "NewtonForm",
+    "NewtonFormRequest",
+    "NewtonFormResult",
+]

--- a/src/jacobian/math/polynomial_interpolation_ops/_models.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_models.py
@@ -6,8 +6,16 @@ from typing import Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian._models import StrictModel
+from jacobian.math.polynomial_interpolation_ops._kernel import (
+    divided_difference_coefficients,
+    evaluate_newton_form,
+)
 
 MAX_POINTS = 32
 _MAX_RATIONAL_DIGITS = 256
@@ -46,6 +54,12 @@ class InterpolationSamples(StrictModel):
         _require_distinct(self.nodes)
         _require_bounded(self.nodes, "interpolation node")
         _require_bounded(self.values, "interpolation value")
+        for coefficient in divided_difference_coefficients(self.nodes, self.values):
+            require_bounded_rational(
+                CanonicalRational.from_fraction(coefficient),
+                max_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+                label="derived Newton coefficient",
+            )
         return self
 
 
@@ -75,7 +89,6 @@ class NewtonForm(StrictModel):
             raise ValueError("Newton nodes and coefficients must have the same length")
         _require_distinct(self.nodes)
         _require_bounded(self.nodes, "Newton node")
-        _require_bounded(self.coefficients, "Newton coefficient")
         return self
 
 
@@ -89,6 +102,17 @@ class NewtonEvaluateRequest(StrictModel):
             self.evaluation_point,
             max_digits=_MAX_RATIONAL_DIGITS,
             label="evaluation point",
+        )
+        require_bounded_rational(
+            CanonicalRational.from_fraction(
+                evaluate_newton_form(
+                    self.newton_form.nodes,
+                    self.newton_form.coefficients,
+                    self.evaluation_point,
+                )
+            ),
+            max_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="derived Newton evaluation",
         )
         return self
 

--- a/src/jacobian/math/polynomial_interpolation_ops/_operations.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_operations.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from fractions import Fraction
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.polynomial_interpolation_ops._kernel import (
+    divided_difference_coefficients,
+    evaluate_newton_form,
+)
 from jacobian.math.polynomial_interpolation_ops._models import (
     DividedDifferencesRequest,
     DividedDifferencesResult,
@@ -15,23 +19,6 @@ from jacobian.math.polynomial_interpolation_ops._models import (
 )
 
 
-def _divided_difference_coefficients(
-    nodes: tuple[CanonicalRational, ...],
-    values: tuple[CanonicalRational, ...],
-) -> tuple[Fraction, ...]:
-    node_values = tuple(node.as_fraction() for node in nodes)
-    row = [value.as_fraction() for value in values]
-    coefficients = [row[0]]
-    for width in range(1, len(node_values)):
-        row = [
-            (row[index + 1] - row[index])
-            / (node_values[index + width] - node_values[index])
-            for index in range(len(node_values) - width)
-        ]
-        coefficients.append(row[0])
-    return tuple(coefficients)
-
-
 def _canonical(values: tuple[Fraction, ...]) -> tuple[CanonicalRational, ...]:
     return tuple(CanonicalRational.from_fraction(value) for value in values)
 
@@ -39,7 +26,7 @@ def _canonical(values: tuple[Fraction, ...]) -> tuple[CanonicalRational, ...]:
 def compute_divided_differences(
     request: DividedDifferencesRequest,
 ) -> DividedDifferencesResult:
-    coefficients = _divided_difference_coefficients(
+    coefficients = divided_difference_coefficients(
         request.samples.nodes,
         request.samples.values,
     )
@@ -47,7 +34,7 @@ def compute_divided_differences(
 
 
 def compute_newton_form(request: NewtonFormRequest) -> NewtonForm:
-    coefficients = _divided_difference_coefficients(
+    coefficients = divided_difference_coefficients(
         request.samples.nodes,
         request.samples.values,
     )
@@ -58,15 +45,15 @@ def compute_newton_form(request: NewtonFormRequest) -> NewtonForm:
 
 
 def compute_newton_evaluate(request: NewtonEvaluateRequest) -> NewtonEvaluateResult:
-    nodes = tuple(node.as_fraction() for node in request.newton_form.nodes)
-    coefficients = tuple(
-        coefficient.as_fraction() for coefficient in request.newton_form.coefficients
+    return NewtonEvaluateResult(
+        result=CanonicalRational.from_fraction(
+            evaluate_newton_form(
+                request.newton_form.nodes,
+                request.newton_form.coefficients,
+                request.evaluation_point,
+            )
+        )
     )
-    point = request.evaluation_point.as_fraction()
-    result = coefficients[-1]
-    for index in range(len(coefficients) - 2, -1, -1):
-        result = coefficients[index] + (point - nodes[index]) * result
-    return NewtonEvaluateResult(result=CanonicalRational.from_fraction(result))
 
 
 __all__ = [

--- a/src/jacobian/math/polynomial_interpolation_ops/_operations.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_operations.py
@@ -1,71 +1,76 @@
-"""Domain functions for polynomial interpolation operations."""
+"""Exact Newton interpolation kernels over canonical rationals."""
 
 from __future__ import annotations
 
-import sympy
+from fractions import Fraction
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.polynomial_interpolation_ops._models import (
     DividedDifferencesRequest,
     DividedDifferencesResult,
     NewtonEvaluateRequest,
     NewtonEvaluateResult,
+    NewtonForm,
     NewtonFormRequest,
-    NewtonFormResult,
 )
 
 
-def _parse_rational(s: str) -> sympy.Rational:
-    """Parse a canonical rational string into an exact sympy.Rational."""
-    return sympy.Rational(s)
+def _divided_difference_coefficients(
+    nodes: tuple[CanonicalRational, ...],
+    values: tuple[CanonicalRational, ...],
+) -> tuple[Fraction, ...]:
+    node_values = tuple(node.as_fraction() for node in nodes)
+    row = [value.as_fraction() for value in values]
+    coefficients = [row[0]]
+    for width in range(1, len(node_values)):
+        row = [
+            (row[index + 1] - row[index])
+            / (node_values[index + width] - node_values[index])
+            for index in range(len(node_values) - width)
+        ]
+        coefficients.append(row[0])
+    return tuple(coefficients)
 
 
-def _divided_differences(
-    nodes: list[sympy.Rational], values: list[sympy.Rational]
-) -> list[list[sympy.Rational]]:
-    """Compute the full divided-difference table."""
-    n = len(nodes)
-    table = [list(values)]
-    for j in range(1, n):
-        row = []
-        for i in range(n - j):
-            numerator = table[j - 1][i + 1] - table[j - 1][i]
-            denominator = nodes[i + j] - nodes[i]
-            row.append(numerator / denominator)
-        table.append(row)
-    return table
+def _canonical(values: tuple[Fraction, ...]) -> tuple[CanonicalRational, ...]:
+    return tuple(CanonicalRational.from_fraction(value) for value in values)
 
 
 def compute_divided_differences(
     request: DividedDifferencesRequest,
 ) -> DividedDifferencesResult:
-    """Compute Newton divided differences from sample points."""
-    nodes = [_parse_rational(x) for x in request.nodes]
-    values = [_parse_rational(v) for v in request.values]
-    table = _divided_differences(nodes, values)
-    n = len(nodes)
-    coeffs = tuple(str(sympy.simplify(table[j][0])) for j in range(n))
-    return DividedDifferencesResult(coefficients=coeffs)
+    coefficients = _divided_difference_coefficients(
+        request.samples.nodes,
+        request.samples.values,
+    )
+    return DividedDifferencesResult(coefficients=_canonical(coefficients))
 
 
-def compute_newton_form(request: NewtonFormRequest) -> NewtonFormResult:
-    """Compute Newton form coefficients (same as divided differences)."""
-    nodes = [_parse_rational(x) for x in request.nodes]
-    values = [_parse_rational(v) for v in request.values]
-    table = _divided_differences(nodes, values)
-    n = len(nodes)
-    coeffs = tuple(str(sympy.simplify(table[j][0])) for j in range(n))
-    return NewtonFormResult(coefficients=coeffs, nodes=request.nodes)
+def compute_newton_form(request: NewtonFormRequest) -> NewtonForm:
+    coefficients = _divided_difference_coefficients(
+        request.samples.nodes,
+        request.samples.values,
+    )
+    return NewtonForm(
+        coefficients=_canonical(coefficients),
+        nodes=request.samples.nodes,
+    )
 
 
 def compute_newton_evaluate(request: NewtonEvaluateRequest) -> NewtonEvaluateResult:
-    """Evaluate a polynomial in Newton form using Horner-like nesting."""
-    nodes = [_parse_rational(x) for x in request.nodes]
-    values = [_parse_rational(v) for v in request.values]
-    table = _divided_differences(nodes, values)
-    n = len(nodes)
-    coeffs = [table[j][0] for j in range(n)]
-    x = _parse_rational(request.evaluation_point)
-    result = coeffs[n - 1]
-    for j in range(n - 2, -1, -1):
-        result = coeffs[j] + (x - nodes[j]) * result
-    return NewtonEvaluateResult(result=str(sympy.simplify(result)))
+    nodes = tuple(node.as_fraction() for node in request.newton_form.nodes)
+    coefficients = tuple(
+        coefficient.as_fraction() for coefficient in request.newton_form.coefficients
+    )
+    point = request.evaluation_point.as_fraction()
+    result = coefficients[-1]
+    for index in range(len(coefficients) - 2, -1, -1):
+        result = coefficients[index] + (point - nodes[index]) * result
+    return NewtonEvaluateResult(result=CanonicalRational.from_fraction(result))
+
+
+__all__ = [
+    "compute_divided_differences",
+    "compute_newton_evaluate",
+    "compute_newton_form",
+]

--- a/src/jacobian/math/polynomial_interpolation_ops/_tools.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_tools.py
@@ -45,12 +45,23 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
     )
 
 
+def _rational(numerator: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(numerator), "den": str(denominator)}
+
+
+def _samples() -> dict[str, list[dict[str, str]]]:
+    return {
+        "nodes": [_rational(value) for value in (0, 1, 2)],
+        "values": [_rational(value) for value in (1, 2, 5)],
+    }
+
+
 TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "polynomial.interpolation.divided_differences.compute",
         "Compute Newton divided differences",
         "Compute the divided differences table from sample points using "
-        "exact rational arithmetic via SymPy.",
+        "bounded exact rational arithmetic.",
         DividedDifferencesRequest,
         DividedDifferencesResult,
         compute_divided_differences,
@@ -61,12 +72,10 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "three_points",
                 "Divided differences for points (0,1), (1,2), (2,5).",
-                {
-                    "nodes": ["0", "1", "2"],
-                    "values": ["1", "2", "5"],
-                },
+                {"samples": _samples()},
             ),
         ),
+        version="2",
     ),
     _op(
         "polynomial.interpolation.newton_form.compute",
@@ -83,18 +92,16 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "three_points",
                 "Newton form for points (0,1), (1,2), (2,5).",
-                {
-                    "nodes": ["0", "1", "2"],
-                    "values": ["1", "2", "5"],
-                },
+                {"samples": _samples()},
             ),
         ),
+        version="2",
     ),
     _op(
         "polynomial.interpolation.newton_evaluate.compute",
         "Evaluate a polynomial in Newton form at a point",
-        "Evaluate the interpolating polynomial in Newton form at a given "
-        "point using nested multiplication.",
+        "Evaluate a canonical NewtonForm directly at a rational point using "
+        "nested multiplication.",
         NewtonEvaluateRequest,
         NewtonEvaluateResult,
         compute_newton_evaluate,
@@ -106,12 +113,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "evaluate_at_3",
                 "Evaluate the interpolant of (0,1), (1,2), (2,5) at x=3.",
                 {
-                    "nodes": ["0", "1", "2"],
-                    "values": ["1", "2", "5"],
-                    "evaluation_point": "3",
+                    "newton_form": {
+                        "nodes": [_rational(value) for value in (0, 1, 2)],
+                        "coefficients": [_rational(1), _rational(1), _rational(1)],
+                    },
+                    "evaluation_point": _rational(3),
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/polynomial_vector_calc/_models.py
+++ b/src/jacobian/math/polynomial_vector_calc/_models.py
@@ -46,6 +46,11 @@ class ScalarFieldRequest(StrictModel):
     @model_validator(mode="after")
     def require_bounded_field(self) -> Self:
         _require_field_polynomial(self.polynomial, label="scalar field")
+        if (
+            len(self.polynomial.polynomial.terms) * len(self.polynomial.variables)
+            > _MAX_TERMS
+        ):
+            raise ValueError("scalar-field derivatives exceed the result-term budget")
         return self
 
 
@@ -65,6 +70,8 @@ class VectorFieldRequest(StrictModel):
             _require_field_polynomial(component, label="vector-field component")
             if component.variables != variables:
                 raise ValueError("vector-field components must use one ordered ring")
+        if sum(len(item.polynomial.terms) for item in self.components) > _MAX_TERMS:
+            raise ValueError("vector-field derivatives exceed the result-term budget")
         return self
 
 
@@ -95,6 +102,11 @@ class DirectionalDerivativeRequest(StrictModel):
                 max_digits=_MAX_COEFFICIENT_DIGITS,
                 label="direction coordinate",
             )
+        if (
+            len(self.polynomial.polynomial.terms) * len(self.polynomial.variables)
+            > _MAX_TERMS
+        ):
+            raise ValueError("directional derivative exceeds the result-term budget")
         return self
 
 

--- a/src/jacobian/math/polynomial_vector_calc/_models.py
+++ b/src/jacobian/math/polynomial_vector_calc/_models.py
@@ -2,84 +2,138 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    require_polynomial_budget,
+)
 
 MAX_VARS = 8
 MAX_POLYS = 8
+_MAX_TERMS = 256
+_MAX_EXPONENT = 64
+_MAX_COEFFICIENT_DIGITS = 128
+
+
+def _require_field_polynomial(
+    polynomial: RationalPolynomial,
+    *,
+    label: str,
+) -> None:
+    if len(polynomial.variables) > MAX_VARS:
+        raise ValueError(f"{label} exceeds the {MAX_VARS}-variable budget")
+    require_polynomial_budget(
+        polynomial,
+        maximum_terms=_MAX_TERMS,
+        maximum_exponent=_MAX_EXPONENT,
+        maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+        label=label,
+    )
+    if any(sum(term.exponents) > _MAX_EXPONENT for term in polynomial.polynomial.terms):
+        raise ValueError(f"{label} exceeds total degree {_MAX_EXPONENT}")
 
 
 class ScalarFieldRequest(StrictModel):
-    """A multivariate polynomial scalar field."""
+    """One bounded canonical multivariate polynomial scalar field."""
 
-    variables: tuple[str, ...] = Field(min_length=1, max_length=MAX_VARS)
-    polynomial: str = Field(min_length=1, max_length=4096)
+    polynomial: RationalPolynomial
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if any(not v.isidentifier() for v in self.variables):
-            raise ValueError("variable names must be valid identifiers")
-        if len(set(self.variables)) != len(self.variables):
-            raise ValueError("variable names must be distinct")
+    def require_bounded_field(self) -> Self:
+        _require_field_polynomial(self.polynomial, label="scalar field")
         return self
 
 
 class VectorFieldRequest(StrictModel):
-    """A multivariate polynomial vector field."""
+    """A polynomial vector field with one component per ordered variable."""
 
-    variables: tuple[str, ...] = Field(min_length=1, max_length=MAX_VARS)
-    components: tuple[str, ...] = Field(min_length=1, max_length=MAX_POLYS)
+    components: tuple[RationalPolynomial, ...] = Field(
+        min_length=1, max_length=MAX_POLYS
+    )
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if any(not v.isidentifier() for v in self.variables):
-            raise ValueError("variable names must be valid identifiers")
-        if len(set(self.variables)) != len(self.variables):
-            raise ValueError("variable names must be distinct")
-        if len(self.components) != len(self.variables):
-            raise ValueError(
-                "vector field must have one component per variable "
-                f"(got {len(self.components)} components, "
-                f"{len(self.variables)} variables)"
-            )
+    def require_one_vector_field_ring(self) -> Self:
+        variables = self.components[0].variables
+        if len(self.components) != len(variables):
+            raise ValueError("vector field must have one component per variable")
+        for component in self.components:
+            _require_field_polynomial(component, label="vector-field component")
+            if component.variables != variables:
+                raise ValueError("vector-field components must use one ordered ring")
+        return self
+
+
+class CurlRequest(VectorFieldRequest):
+    """A three-dimensional polynomial vector field."""
+
+    @model_validator(mode="after")
+    def require_three_dimensions(self) -> Self:
+        if len(self.components[0].variables) != 3:
+            raise ValueError("curl requires exactly three variables and components")
         return self
 
 
 class DirectionalDerivativeRequest(StrictModel):
-    """Directional derivative of a scalar field along a direction vector."""
+    """Directional derivative along one exact constant vector."""
 
-    variables: tuple[str, ...] = Field(min_length=1, max_length=MAX_VARS)
-    polynomial: str = Field(min_length=1, max_length=4096)
-    direction: tuple[str, ...] = Field(min_length=1, max_length=MAX_POLYS)
+    polynomial: RationalPolynomial
+    direction: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=MAX_VARS)
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if any(not v.isidentifier() for v in self.variables):
-            raise ValueError("variable names must be valid identifiers")
-        if len(set(self.variables)) != len(self.variables):
-            raise ValueError("variable names must be distinct")
-        if len(self.direction) != len(self.variables):
-            raise ValueError("direction vector length must match variables length")
+    def require_matching_bounded_direction(self) -> Self:
+        _require_field_polynomial(self.polynomial, label="scalar field")
+        if len(self.direction) != len(self.polynomial.variables):
+            raise ValueError("direction vector length must match the polynomial axis")
+        for coordinate in self.direction:
+            require_bounded_rational(
+                coordinate,
+                max_digits=_MAX_COEFFICIENT_DIGITS,
+                label="direction coordinate",
+            )
         return self
 
 
-# Results
+ScalarMethod = Literal[
+    "SYMPY_DIVERGENCE",
+    "SYMPY_LAPLACIAN",
+    "SYMPY_DIRECTIONAL_DERIVATIVE",
+]
+VectorMethod = Literal["SYMPY_GRADIENT", "SYMPY_CURL"]
 
 
 class ScalarResult(StrictModel):
-    """A scalar polynomial result."""
+    """One canonical scalar polynomial result."""
 
-    result: str
-    variables: tuple[str, ...] = ()
-    method: str = "SYMPY_GRADIENT"
+    result: RationalPolynomial
+    method: ScalarMethod
 
 
 class VectorResult(StrictModel):
-    """A vector polynomial result."""
+    """One canonical polynomial vector result."""
 
-    components: tuple[str, ...]
-    variables: tuple[str, ...] = ()
-    method: str = "SYMPY_GRADIENT"
+    components: tuple[RationalPolynomial, ...] = Field(
+        min_length=1, max_length=MAX_POLYS
+    )
+    method: VectorMethod
+
+    @model_validator(mode="after")
+    def require_one_result_ring(self) -> Self:
+        variables = self.components[0].variables
+        if any(component.variables != variables for component in self.components):
+            raise ValueError("vector result components must use one ordered ring")
+        return self
+
+
+__all__ = [
+    "CurlRequest",
+    "DirectionalDerivativeRequest",
+    "ScalarFieldRequest",
+    "ScalarResult",
+    "VectorFieldRequest",
+    "VectorResult",
+]

--- a/src/jacobian/math/polynomial_vector_calc/_operations.py
+++ b/src/jacobian/math/polynomial_vector_calc/_operations.py
@@ -2,108 +2,95 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import sympy
 
 from jacobian.math.polynomial_vector_calc._models import (
+    CurlRequest,
     DirectionalDerivativeRequest,
     ScalarFieldRequest,
     ScalarResult,
     VectorFieldRequest,
     VectorResult,
 )
+from jacobian.math.polynomials._conversions import (
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.values import RationalPolynomial
 
 
-def _parse_poly(expr_str: str, variables: tuple[str, ...]) -> sympy.Expr:
-    """Parse a polynomial expression string with given variable names.
+def _wire(expression: sympy.Expr, variables: tuple[str, ...]) -> RationalPolynomial:
+    return rational_polynomial_from_sympy(
+        sympy.Poly(
+            sympy.expand(expression), *symbols_for_variables(variables), domain=sympy.QQ
+        ),
+        variables,
+        maximum_terms=256,
+    )
 
-    Validates that the result is a polynomial in exactly the declared variables
-    with rational coefficients, rejecting transcendental expressions, foreign
-    symbols, and non-polynomial inputs.
-    """
-    var_symbols = sympy.symbols(variables)
-    if isinstance(var_symbols, sympy.Symbol):
-        var_symbols = (var_symbols,)
-    try:
-        expr = sympy.sympify(
-            expr_str, locals=dict(zip(variables, var_symbols, strict=True))
-        )
-    except Exception as exc:
-        raise ValueError(f"failed to parse expression: {expr_str}") from exc
-    # is_polynomial returns True, False, or None (unknown); treat None as False
-    if expr.is_polynomial(*var_symbols) is not True:
-        raise ValueError(
-            f"expression must be a polynomial in {variables}, "
-            f"got non-polynomial: {expr}"
-        )
-    free_symbols = expr.free_symbols
-    allowed = set(var_symbols)
-    extra = free_symbols - allowed
-    if extra:
-        raise ValueError(
-            f"expression contains undeclared symbols: {sorted(s.name for s in extra)}"
-        )
-    return expr
+
+def _expressions(
+    polynomials: Iterable[RationalPolynomial],
+) -> tuple[sympy.Expr, ...]:
+    return tuple(rational_polynomial_to_sympy(item).as_expr() for item in polynomials)
 
 
 def compute_gradient(request: ScalarFieldRequest) -> VectorResult:
-    var_symbols = sympy.symbols(request.variables)
-    if isinstance(var_symbols, sympy.Symbol):
-        var_symbols = (var_symbols,)
-    poly = _parse_poly(request.polynomial, request.variables)
-    grads = [sympy.diff(poly, v) for v in var_symbols]
+    variables = request.polynomial.variables
+    expression = rational_polynomial_to_sympy(request.polynomial).as_expr()
     return VectorResult(
-        components=tuple(str(g) for g in grads),
-        variables=request.variables,
+        components=tuple(
+            _wire(sympy.diff(expression, variable), variables)
+            for variable in symbols_for_variables(variables)
+        ),
         method="SYMPY_GRADIENT",
     )
 
 
 def compute_divergence(request: VectorFieldRequest) -> ScalarResult:
-    var_symbols = sympy.symbols(request.variables)
-    if isinstance(var_symbols, sympy.Symbol):
-        var_symbols = (var_symbols,)
-    polys = [_parse_poly(c, request.variables) for c in request.components]
-    div = sum(sympy.diff(p, v) for p, v in zip(polys, var_symbols, strict=True))
+    variables = request.components[0].variables
+    expression = sum(
+        sympy.diff(component, variable)
+        for component, variable in zip(
+            _expressions(request.components),
+            symbols_for_variables(variables),
+            strict=True,
+        )
+    )
     return ScalarResult(
-        result=str(sympy.expand(div)),
-        variables=request.variables,
+        result=_wire(expression, variables),
         method="SYMPY_DIVERGENCE",
     )
 
 
-def compute_curl(request: VectorFieldRequest) -> VectorResult:
-    """Curl in 3D: (d_z F_y - d_y F_z, d_x F_z - d_z F_x, d_y F_x - d_x F_y)."""
-    if len(request.variables) != 3:
-        raise ValueError("curl is defined for 3D vector fields")
-    x, y, z = sympy.symbols(request.variables)
-    fx, fy, fz = (
-        _parse_poly(request.components[0], request.variables),
-        _parse_poly(request.components[1], request.variables),
-        _parse_poly(request.components[2], request.variables),
-    )
-    curl_x = sympy.diff(fz, y) - sympy.diff(fy, z)
-    curl_y = sympy.diff(fx, z) - sympy.diff(fz, x)
-    curl_z = sympy.diff(fy, x) - sympy.diff(fx, y)
+def compute_curl(request: CurlRequest) -> VectorResult:
+    """Return the standard three-dimensional curl of a polynomial field."""
+
+    variables = request.components[0].variables
+    x, y, z = symbols_for_variables(variables)
+    fx, fy, fz = _expressions(request.components)
     return VectorResult(
         components=(
-            str(sympy.expand(curl_x)),
-            str(sympy.expand(curl_y)),
-            str(sympy.expand(curl_z)),
+            _wire(sympy.diff(fz, y) - sympy.diff(fy, z), variables),
+            _wire(sympy.diff(fx, z) - sympy.diff(fz, x), variables),
+            _wire(sympy.diff(fy, x) - sympy.diff(fx, y), variables),
         ),
-        variables=request.variables,
         method="SYMPY_CURL",
     )
 
 
 def compute_laplacian(request: ScalarFieldRequest) -> ScalarResult:
-    var_symbols = sympy.symbols(request.variables)
-    if isinstance(var_symbols, sympy.Symbol):
-        var_symbols = (var_symbols,)
-    poly = _parse_poly(request.polynomial, request.variables)
-    laplacian = sum(sympy.diff(poly, v, 2) for v in var_symbols)
+    variables = request.polynomial.variables
+    expression = rational_polynomial_to_sympy(request.polynomial).as_expr()
+    laplacian = sum(
+        sympy.diff(expression, variable, 2)
+        for variable in symbols_for_variables(variables)
+    )
     return ScalarResult(
-        result=str(sympy.expand(laplacian)),
-        variables=request.variables,
+        result=_wire(laplacian, variables),
         method="SYMPY_LAPLACIAN",
     )
 
@@ -111,15 +98,32 @@ def compute_laplacian(request: ScalarFieldRequest) -> ScalarResult:
 def compute_directional_derivative(
     request: DirectionalDerivativeRequest,
 ) -> ScalarResult:
-    var_symbols = sympy.symbols(request.variables)
-    if isinstance(var_symbols, sympy.Symbol):
-        var_symbols = (var_symbols,)
-    poly = _parse_poly(request.polynomial, request.variables)
-    grad = [sympy.diff(poly, v) for v in var_symbols]
-    direction = [sympy.sympify(d) for d in request.direction]
-    result = sum(g * d for g, d in zip(grad, direction, strict=True))
+    variables = request.polynomial.variables
+    expression = rational_polynomial_to_sympy(request.polynomial).as_expr()
+    gradient = (
+        sympy.diff(expression, variable)
+        for variable in symbols_for_variables(variables)
+    )
+    direction = (
+        sympy.Rational(*coordinate.as_integer_ratio())
+        for coordinate in request.direction
+    )
     return ScalarResult(
-        result=str(sympy.expand(result)),
-        variables=request.variables,
+        result=_wire(
+            sum(
+                derivative * coordinate
+                for derivative, coordinate in zip(gradient, direction, strict=True)
+            ),
+            variables,
+        ),
         method="SYMPY_DIRECTIONAL_DERIVATIVE",
     )
+
+
+__all__ = [
+    "compute_curl",
+    "compute_directional_derivative",
+    "compute_divergence",
+    "compute_gradient",
+    "compute_laplacian",
+]

--- a/src/jacobian/math/polynomial_vector_calc/_tools.py
+++ b/src/jacobian/math/polynomial_vector_calc/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.polynomial_vector_calc._models import (
+    CurlRequest,
     DirectionalDerivativeRequest,
     ScalarFieldRequest,
     ScalarResult,
@@ -22,6 +23,26 @@ from jacobian.math.polynomial_vector_calc._operations import (
 )
 
 
+def _polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[int, tuple[int, ...]],
+) -> dict[str, Any]:
+    return {
+        "polynomial_schema_version": "1",
+        "domain": "QQ",
+        "variables": list(variables),
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": str(coefficient), "den": "1"},
+                    "exponents": list(exponents),
+                }
+                for coefficient, exponents in terms
+            ]
+        },
+    }
+
+
 def _op[RequestT: StrictModel, ResultT: StrictModel](
     operation_id: str,
     title: str,
@@ -31,7 +52,7 @@ def _op[RequestT: StrictModel, ResultT: StrictModel](
     operation: Callable[[RequestT], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
-    version: str = "1",
+    version: str = "2",
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
@@ -61,8 +82,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "gradient_x2_y2",
-                "Gradient of x^2 + y^2 in (x, y).",
-                {"variables": ["x", "y"], "polynomial": "x**2 + y**2"},
+                "Compute the gradient of x^2 + y^2; the canonical polynomial "
+                "carries the complete ordered axis (x, y).",
+                {
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (0, 2)),
+                    )
+                },
             ),
         ),
     ),
@@ -80,8 +108,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "laplacian_x2_y2",
-                "Laplacian of x^2 + y^2 in (x, y).",
-                {"variables": ["x", "y"], "polynomial": "x**2 + y**2"},
+                "Compute the Laplacian of x^2 + y^2; the canonical polynomial "
+                "carries the complete ordered axis (x, y).",
+                {
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (0, 2)),
+                    )
+                },
             ),
         ),
     ),
@@ -99,11 +134,18 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "directional_deriv_x2_y2",
-                "Directional derivative of x^2 + y^2 along (1, 1).",
+                "Compute the directional derivative of x^2 + y^2 along the "
+                "exact constant vector (1, 1); its length must match the axis.",
                 {
-                    "variables": ["x", "y"],
-                    "polynomial": "x**2 + y**2",
-                    "direction": ["1", "1"],
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (0, 2)),
+                    ),
+                    "direction": [
+                        {"num": "1", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
                 },
             ),
         ),
@@ -122,10 +164,13 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "divergence_xy",
-                "Divergence of [x^2, y^2] in (x, y).",
+                "Compute the divergence of [x^2, y^2]; each component must "
+                "use the same complete ordered axis (x, y).",
                 {
-                    "variables": ["x", "y"],
-                    "components": ["x**2", "y**2"],
+                    "components": [
+                        _polynomial(("x", "y"), (1, (2, 0))),
+                        _polynomial(("x", "y"), (1, (0, 2))),
+                    ],
                 },
             ),
         ),
@@ -135,7 +180,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "Compute the curl of a 3D vector field",
         "Compute the curl of a 3D multivariate polynomial vector field "
         "using exact symbolic differentiation.",
-        VectorFieldRequest,
+        CurlRequest,
         VectorResult,
         compute_curl,
         "polynomial",
@@ -144,10 +189,14 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "curl_constant_field",
-                "Curl of [y, 0, 0] in (x, y, z).",
+                "Compute the curl of [y, 0, 0]; curl requires exactly three "
+                "components on the ordered axis (x, y, z).",
                 {
-                    "variables": ["x", "y", "z"],
-                    "components": ["y", "0", "0"],
+                    "components": [
+                        _polynomial(("x", "y", "z"), (1, (0, 1, 0))),
+                        _polynomial(("x", "y", "z")),
+                        _polynomial(("x", "y", "z")),
+                    ],
                 },
             ),
         ),

--- a/src/jacobian/math/polynomials/_conversions.py
+++ b/src/jacobian/math/polynomials/_conversions.py
@@ -7,6 +7,7 @@ from typing import Any
 from jacobian._exact import CanonicalRational
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_TERMS,
+    RationalFunction,
     RationalPolynomial,
     RationalPolynomialTerm,
     SparseRationalPolynomial,
@@ -14,8 +15,12 @@ from jacobian.math.polynomials.values import (
 
 __all__ = [
     "rational_from_sympy",
+    "rational_function_from_sympy",
+    "rational_function_to_sympy",
     "rational_polynomial_from_sympy",
     "rational_polynomial_to_sympy",
+    "sparse_rational_polynomial_from_sympy",
+    "sparse_rational_polynomial_to_sympy",
     "symbols_for_variables",
 ]
 
@@ -53,13 +58,33 @@ def rational_polynomial_to_sympy(polynomial: RationalPolynomial) -> Any:
     )
 
 
-def rational_polynomial_from_sympy(
+def sparse_rational_polynomial_to_sympy(
+    polynomial: SparseRationalPolynomial,
+    variables: tuple[str, ...],
+) -> Any:
+    """Construct a QQ ``Poly`` from validated sparse data."""
+
+    from sympy import QQ, Poly, Rational
+
+    if not variables:
+        raise ValueError("SymPy Poly requires at least one generator")
+    return Poly.from_dict(
+        {
+            term.exponents: Rational(*term.coefficient.as_integer_ratio())
+            for term in polynomial.terms
+        },
+        *symbols_for_variables(variables),
+        domain=QQ,
+    )
+
+
+def sparse_rational_polynomial_from_sympy(
     polynomial: Any,
     variables: tuple[str, ...],
     *,
     maximum_terms: int = MAX_POLYNOMIAL_TERMS,
-) -> RationalPolynomial:
-    """Convert a QQ ``Poly`` back to the canonical sparse contract."""
+) -> SparseRationalPolynomial:
+    """Convert a QQ ``Poly`` to canonical sparse term data."""
 
     from sympy import QQ
 
@@ -76,15 +101,107 @@ def rational_polynomial_from_sympy(
         raise ValueError(
             f"polynomial result exceeds the {maximum_terms}-term operation budget"
         )
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=rational_from_sympy(coefficient),
+                exponents=exponents,
+            )
+            for exponents, coefficient in terms
+        )
+    )
+
+
+def rational_function_to_sympy(value: RationalFunction) -> Any:
+    """Construct an exact SymPy expression from a canonical rational function."""
+
+    from sympy import Rational
+
+    if not value.variables:
+        if not value.numerator.terms:
+            return Rational(0)
+        return Rational(*value.numerator.terms[0].coefficient.as_integer_ratio())
+    numerator = sparse_rational_polynomial_to_sympy(value.numerator, value.variables)
+    denominator = sparse_rational_polynomial_to_sympy(
+        value.denominator, value.variables
+    )
+    return numerator.as_expr() / denominator.as_expr()
+
+
+def rational_function_from_sympy(
+    expression: Any,
+    variables: tuple[str, ...],
+    *,
+    maximum_terms: int = 256,
+) -> RationalFunction:
+    """Canonicalize an exact rational-function expression into wire data."""
+
+    from sympy import QQ, Poly, cancel, fraction
+
+    if not variables:
+        if isinstance(expression, bool):
+            raise ValueError("boolean is not an exact rational")
+        coefficient = (
+            CanonicalRational.from_integer_ratio(expression, 1)
+            if isinstance(expression, int)
+            else rational_from_sympy(expression)
+        )
+        return RationalFunction(
+            variables=(),
+            numerator=SparseRationalPolynomial(
+                terms=()
+                if coefficient.as_fraction() == 0
+                else (
+                    RationalPolynomialTerm(
+                        coefficient=coefficient,
+                        exponents=(),
+                    ),
+                )
+            ),
+            denominator=SparseRationalPolynomial(
+                terms=(
+                    RationalPolynomialTerm(
+                        coefficient=CanonicalRational(num="1", den="1"),
+                        exponents=(),
+                    ),
+                )
+            ),
+        )
+    symbols = symbols_for_variables(variables)
+    numerator_expression, denominator_expression = fraction(cancel(expression))
+    numerator = Poly(numerator_expression, *symbols, domain=QQ)
+    denominator = Poly(denominator_expression, *symbols, domain=QQ)
+    leading = denominator.LC()
+    numerator = (
+        numerator.monic() * (numerator.LC() / leading)
+        if not numerator.is_zero
+        else numerator
+    )
+    denominator = denominator.monic()
+    return RationalFunction(
+        variables=variables,
+        numerator=sparse_rational_polynomial_from_sympy(
+            numerator, variables, maximum_terms=maximum_terms
+        ),
+        denominator=sparse_rational_polynomial_from_sympy(
+            denominator, variables, maximum_terms=maximum_terms
+        ),
+    )
+
+
+def rational_polynomial_from_sympy(
+    polynomial: Any,
+    variables: tuple[str, ...],
+    *,
+    maximum_terms: int = MAX_POLYNOMIAL_TERMS,
+) -> RationalPolynomial:
+    """Convert a QQ ``Poly`` back to the canonical sparse contract."""
+
     return RationalPolynomial(
         variables=variables,
-        polynomial=SparseRationalPolynomial(
-            terms=tuple(
-                RationalPolynomialTerm(
-                    coefficient=rational_from_sympy(coefficient),
-                    exponents=exponents,
-                )
-                for exponents, coefficient in terms
-            )
+        polynomial=sparse_rational_polynomial_from_sympy(
+            polynomial,
+            variables,
+            maximum_terms=maximum_terms,
         ),
     )

--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -68,6 +69,14 @@ class EvalRequest(StrictModel):
             raise ValueError(
                 "evaluation point must use the polynomial's complete ordered axis"
             )
+        value = Fraction(0)
+        coordinates = tuple(item.as_fraction() for item in self.point.values)
+        for term in self.polynomial.polynomial.terms:
+            monomial = term.coefficient.as_fraction()
+            for coordinate, exponent in zip(coordinates, term.exponents, strict=True):
+                monomial *= coordinate**exponent
+            value += monomial
+        CanonicalRational.from_fraction(value)
         return self
 
 

--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -2,159 +2,153 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import Self
 
-import sympy
 from pydantic import Field, model_validator
-from sympy.polys.polyerrors import CoercionFailed
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
+    require_polynomial_budget,
+)
+
+_MAX_VARIABLES = 8
+_MAX_MAP_OUTPUTS = 20
+_MAX_TERMS = 256
+_MAX_EXPONENT = 64
+_MAX_COEFFICIENT_DIGITS = 128
+_MAX_COMPOSITION_DEGREE = 128
 
 
-class RationalPolynomialExpr(StrictModel):
-    """A rational polynomial as a SymPy-compatible string expression.
-
-    The polynomial is given as a string like "x**2 + 2*y" that sympy can parse.
-    Variables are named in the expression string itself.
-    """
-
-    expression: str = Field(
-        min_length=1,
-        max_length=2000,
-        description="Polynomial expression with rational coefficients.",
+def _require_map_polynomial(polynomial: RationalPolynomial, *, label: str) -> None:
+    if len(polynomial.variables) > _MAX_VARIABLES:
+        raise ValueError(f"{label} exceeds the {_MAX_VARIABLES}-variable budget")
+    require_polynomial_budget(
+        polynomial,
+        maximum_terms=_MAX_TERMS,
+        maximum_exponent=_MAX_EXPONENT,
+        maximum_coefficient_digits=_MAX_COEFFICIENT_DIGITS,
+        label=label,
     )
-
-    @model_validator(mode="after")
-    def require_polynomial(self) -> Self:
-        _require_polynomial_expression(self.expression)
-        return self
-
-
-def _require_polynomial_expression(raw: str) -> Any:
-    try:
-        expression = sympy.sympify(raw)
-    except (sympy.SympifyError, TypeError, SyntaxError) as exc:
-        raise ValueError("polynomial expression must be a polynomial") from exc
-    symbols = tuple(expression.free_symbols)
-    if symbols:
-        if not expression.is_polynomial(*symbols):
-            raise ValueError("polynomial expression must be a polynomial")
-        try:
-            sympy.Poly(expression, *symbols, domain=sympy.QQ)
-        except (CoercionFailed, sympy.PolynomialError, TypeError, ValueError) as exc:
-            raise ValueError(
-                "polynomial expression must have rational coefficients"
-            ) from exc
-    elif not expression.is_rational:
-        raise ValueError("polynomial expression must be a polynomial")
-    return expression
+    if any(sum(term.exponents) > _MAX_EXPONENT for term in polynomial.polynomial.terms):
+        raise ValueError(f"{label} exceeds total degree {_MAX_EXPONENT}")
 
 
 class VariablePoint(StrictModel):
-    """A rational point: ordered variable names and their rational values."""
+    """One rational point on an explicitly ordered polynomial axis."""
 
-    variables: tuple[str, ...] = Field(min_length=1, max_length=20)
-    values: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=20)
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1, max_length=_MAX_VARIABLES
+    )
+    values: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=_MAX_VARIABLES
+    )
 
     @model_validator(mode="after")
-    def require_matching_lengths(self) -> Self:
+    def require_matching_axis(self) -> Self:
         if len(self.variables) != len(self.values):
-            raise ValueError("variables and values must have the same length")
+            raise ValueError("point variables and values must have the same length")
         if len(set(self.variables)) != len(self.variables):
-            raise ValueError("variable names must be unique")
+            raise ValueError("point variables must be unique")
         return self
 
 
 class EvalRequest(StrictModel):
-    """Evaluate a polynomial at a rational point."""
+    """Evaluate one canonical rational polynomial at a complete rational point."""
 
-    polynomial: RationalPolynomialExpr
+    polynomial: RationalPolynomial
     point: VariablePoint
 
     @model_validator(mode="after")
-    def require_complete_rational_evaluation(self) -> Self:
-        expression = _require_polynomial_expression(self.polynomial.expression)
-        free = {str(symbol) for symbol in expression.free_symbols}
-        given = set(self.point.variables)
-        if not free <= given:
-            raise ValueError("evaluation point must cover every free variable")
+    def require_complete_ordered_point(self) -> Self:
+        _require_map_polynomial(self.polynomial, label="evaluation polynomial")
+        if self.point.variables != self.polynomial.variables:
+            raise ValueError(
+                "evaluation point must use the polynomial's complete ordered axis"
+            )
         return self
 
 
 class EvalResult(StrictModel):
-    """The rational value of the polynomial at the point."""
+    """The exact rational value at the requested point."""
 
-    value: str
+    value: CanonicalRational
 
 
 class JacobianRequest(StrictModel):
-    """Compute the Jacobian matrix of a polynomial map."""
+    """Compute the Jacobian of a canonical polynomial map."""
 
-    input_variables: tuple[str, ...] = Field(min_length=1, max_length=20)
-    output_polynomials: tuple[RationalPolynomialExpr, ...] = Field(
-        min_length=1, max_length=20
+    input_variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1, max_length=_MAX_VARIABLES
+    )
+    output_polynomials: tuple[RationalPolynomial, ...] = Field(
+        min_length=1, max_length=_MAX_MAP_OUTPUTS
     )
 
     @model_validator(mode="after")
-    def require_unique_and_complete_variables(self) -> Self:
+    def require_one_map_ring(self) -> Self:
         if len(set(self.input_variables)) != len(self.input_variables):
             raise ValueError("input variables must be unique")
-        declared = set(self.input_variables)
-        import sympy
-
-        for poly in self.output_polynomials:
-            expression = sympy.sympify(poly.expression)
-            free = {str(s) for s in expression.free_symbols}
-            undeclared = free - declared
-            if undeclared:
+        for polynomial in self.output_polynomials:
+            _require_map_polynomial(polynomial, label="map output polynomial")
+            if polynomial.variables != self.input_variables:
                 raise ValueError(
-                    f"output polynomial references undeclared variables: {undeclared}"
+                    "every map output must use the complete ordered input axis"
                 )
         return self
 
 
 class JacobianResult(StrictModel):
-    """The Jacobian matrix as a flat list of entries (row-major order)."""
+    """The row-major Jacobian matrix over the source polynomial ring."""
 
-    n_inputs: int = Field(ge=1)
-    n_outputs: int = Field(ge=1)
-    entries: tuple[str, ...]
+    n_inputs: int = Field(ge=1, le=_MAX_VARIABLES)
+    n_outputs: int = Field(ge=1, le=_MAX_MAP_OUTPUTS)
+    entries: tuple[RationalPolynomial, ...] = Field(max_length=160)
+
+    @model_validator(mode="after")
+    def require_matrix_shape(self) -> Self:
+        if len(self.entries) != self.n_inputs * self.n_outputs:
+            raise ValueError("Jacobian entry count must match its matrix dimensions")
+        if self.entries:
+            variables = self.entries[0].variables
+            if any(entry.variables != variables for entry in self.entries):
+                raise ValueError("Jacobian entries must use one ordered ring")
+        return self
 
 
 class CompositionRequest(StrictModel):
-    """Compose outer(f(g(x)))."""
+    """Compose two bounded univariate rational polynomials."""
 
-    outer: RationalPolynomialExpr
-    inner: RationalPolynomialExpr
-    inner_variable: str
-    outer_variable: str
+    outer: RationalPolynomial
+    inner: RationalPolynomial
+    inner_variable: PolynomialVariable
+    outer_variable: PolynomialVariable
 
     @model_validator(mode="after")
-    def require_valid_composition(self) -> Self:
-        import sympy
-
-        outer_expr = sympy.sympify(self.outer.expression)
-        outer_free = {str(s) for s in outer_expr.free_symbols}
-        if self.outer_variable not in outer_free:
-            raise ValueError(
-                f"outer variable '{self.outer_variable}' must appear in the outer polynomial"
-            )
-
-        inner_expr = sympy.sympify(self.inner.expression)
-        inner_free = {str(s) for s in inner_expr.free_symbols}
-        if self.inner_variable not in inner_free:
-            raise ValueError(
-                f"inner variable '{self.inner_variable}' must appear in the inner polynomial"
-            )
-
+    def require_univariate_bounded_composition(self) -> Self:
+        _require_map_polynomial(self.outer, label="outer polynomial")
+        _require_map_polynomial(self.inner, label="inner polynomial")
+        if self.outer.variables != (self.outer_variable,):
+            raise ValueError("outer polynomial must use exactly outer_variable")
+        if self.inner.variables != (self.inner_variable,):
+            raise ValueError("inner polynomial must use exactly inner_variable")
+        outer_degree = max(
+            (term.exponents[0] for term in self.outer.polynomial.terms), default=0
+        )
+        inner_degree = max(
+            (term.exponents[0] for term in self.inner.polynomial.terms), default=0
+        )
+        if outer_degree * inner_degree > _MAX_COMPOSITION_DEGREE:
+            raise ValueError(f"composition exceeds degree {_MAX_COMPOSITION_DEGREE}")
         return self
 
 
 class CompositionResult(StrictModel):
-    """The composed polynomial expression."""
+    """The canonical polynomial obtained by substitution."""
 
-    expression: str
+    polynomial: RationalPolynomial
 
 
 __all__ = [
@@ -164,6 +158,5 @@ __all__ = [
     "EvalResult",
     "JacobianRequest",
     "JacobianResult",
-    "RationalPolynomialExpr",
     "VariablePoint",
 ]

--- a/src/jacobian/math/polynomials/maps/_operations.py
+++ b/src/jacobian/math/polynomials/maps/_operations.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import sympy
-from sympy import Symbol, simplify, sympify
 
+from jacobian.math.polynomials._conversions import (
+    rational_from_sympy,
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
 from jacobian.math.polynomials.maps._models import (
     CompositionRequest,
     CompositionResult,
@@ -16,54 +21,63 @@ from jacobian.math.polynomials.maps._models import (
 
 
 def evaluate_polynomial(request: EvalRequest) -> EvalResult:
-    """Evaluate a polynomial at a rational point using SymPy."""
-    expr = sympify(request.polynomial.expression)
-    substitutions = {}
-    for var_name, var_value in zip(
-        request.point.variables,
-        request.point.values,
-        strict=True,
-    ):
-        sym = Symbol(var_name)
-        substitutions[sym] = var_value.as_fraction()
+    """Evaluate one exact polynomial at its complete ordered rational point."""
 
-    result = simplify(expr.subs(substitutions))
-    if result.free_symbols:
-        raise ValueError("evaluation point must cover every free variable")
-    return EvalResult(value=str(result))
+    polynomial = rational_polynomial_to_sympy(request.polynomial)
+    substitutions = dict(
+        zip(
+            symbols_for_variables(request.point.variables),
+            (value.as_fraction() for value in request.point.values),
+            strict=True,
+        )
+    )
+    value = polynomial.as_expr().subs(substitutions)
+    return EvalResult(value=rational_from_sympy(value))
 
 
 def compute_jacobian(request: JacobianRequest) -> JacobianResult:
-    """Compute the Jacobian matrix of a polynomial map using SymPy."""
-    input_vars = [Symbol(v) for v in request.input_variables]
-    outputs = [sympify(p.expression) for p in request.output_polynomials]
+    """Compute a row-major Jacobian over the map's source ring."""
 
-    n_outputs = len(outputs)
-    n_inputs = len(input_vars)
-
-    entries = []
-    for i in range(n_outputs):
-        for j in range(n_inputs):
-            derivative = sympy.diff(outputs[i], input_vars[j])
-            entries.append(str(derivative))
-
+    variables = symbols_for_variables(request.input_variables)
+    outputs = [
+        rational_polynomial_to_sympy(polynomial).as_expr()
+        for polynomial in request.output_polynomials
+    ]
+    entries = tuple(
+        rational_polynomial_from_sympy(
+            sympy.Poly(sympy.diff(output, variable), *variables, domain=sympy.QQ),
+            request.input_variables,
+            maximum_terms=256,
+        )
+        for output in outputs
+        for variable in variables
+    )
     return JacobianResult(
-        n_inputs=n_inputs,
-        n_outputs=n_outputs,
-        entries=tuple(entries),
+        n_inputs=len(variables),
+        n_outputs=len(outputs),
+        entries=entries,
     )
 
 
 def compose_polynomials(request: CompositionRequest) -> CompositionResult:
-    """Compose outer(inner(x)) using SymPy substitution."""
-    outer_expr = sympify(request.outer.expression)
-    inner_expr = sympify(request.inner.expression)
-    outer_var = Symbol(request.outer_variable)
+    """Substitute the inner univariate polynomial into the outer polynomial."""
 
-    composed = outer_expr.subs(outer_var, inner_expr)
-    composed = simplify(composed)
-
-    return CompositionResult(expression=str(composed))
+    outer = rational_polynomial_to_sympy(request.outer).as_expr()
+    inner = rational_polynomial_to_sympy(request.inner).as_expr()
+    outer_variable = symbols_for_variables(request.outer.variables)[0]
+    inner_variable = symbols_for_variables(request.inner.variables)[0]
+    composition = sympy.Poly(
+        sympy.expand(outer.subs(outer_variable, inner)),
+        inner_variable,
+        domain=sympy.QQ,
+    )
+    return CompositionResult(
+        polynomial=rational_polynomial_from_sympy(
+            composition,
+            request.inner.variables,
+            maximum_terms=256,
+        )
+    )
 
 
 __all__ = ["compose_polynomials", "compute_jacobian", "evaluate_polynomial"]

--- a/src/jacobian/math/polynomials/maps/_tools.py
+++ b/src/jacobian/math/polynomials/maps/_tools.py
@@ -21,6 +21,43 @@ from jacobian.math.polynomials.maps._operations import (
 )
 
 
+def _polynomial(
+    variable: str,
+    *terms: tuple[int, int],
+) -> dict[str, Any]:
+    return {
+        "polynomial_schema_version": "1",
+        "domain": "QQ",
+        "variables": [variable],
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": str(coefficient), "den": "1"},
+                    "exponents": [exponent],
+                }
+                for coefficient, exponent in terms
+            ]
+        },
+    }
+
+
+def _bivariate_polynomial(*terms: tuple[int, tuple[int, int]]) -> dict[str, Any]:
+    return {
+        "polynomial_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x", "y"],
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": str(coefficient), "den": "1"},
+                    "exponents": list(exponents),
+                }
+                for coefficient, exponents in terms
+            ]
+        },
+    }
+
+
 def _op[
     RequestT: StrictModel,
     ResultT: StrictModel,
@@ -33,7 +70,7 @@ def _op[
     operation: Callable[[RequestT], ResultT],
     *tags: str,
     examples: tuple[OperationExample, ...] = (),
-    version: str = "1",
+    version: str = "2",
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
@@ -52,7 +89,7 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "polynomial.map.evaluate",
         "Evaluate a polynomial at a rational point",
-        "Evaluate a polynomial expression at a rational point using SymPy.",
+        "Evaluate a canonical rational polynomial at a complete ordered rational point.",
         EvalRequest,
         EvalResult,
         evaluate_polynomial,
@@ -62,9 +99,13 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "simple_eval",
-                "Evaluate x**2 + 2*y at x=3, y=1.",
+                "Evaluate x^2 + 2y at x=3, y=1; the point must use the "
+                "polynomial's complete ordered axis.",
                 {
-                    "polynomial": {"expression": "x**2 + 2*y"},
+                    "polynomial": _bivariate_polynomial(
+                        (1, (2, 0)),
+                        (2, (0, 1)),
+                    ),
                     "point": {
                         "variables": ["x", "y"],
                         "values": [{"num": "3", "den": "1"}, {"num": "1", "den": "1"}],
@@ -76,7 +117,7 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "polynomial.map.jacobian",
         "Compute the Jacobian matrix of a polynomial map",
-        "Compute the Jacobian matrix dF/dx of a polynomial map using SymPy.",
+        "Compute the row-major Jacobian matrix of a canonical polynomial map.",
         JacobianRequest,
         JacobianResult,
         compute_jacobian,
@@ -86,12 +127,13 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "simple_jacobian",
-                "Jacobian of [x**2, y**2] w.r.t. (x, y).",
+                "Compute the Jacobian of [x^2, y^2] with respect to (x, y); "
+                "every output must use that complete ordered axis.",
                 {
                     "input_variables": ["x", "y"],
                     "output_polynomials": [
-                        {"expression": "x**2"},
-                        {"expression": "y**2"},
+                        _bivariate_polynomial((1, (2, 0))),
+                        _bivariate_polynomial((1, (0, 2))),
                     ],
                 },
             ),
@@ -100,7 +142,7 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "polynomial.map.compose",
         "Compose two polynomials",
-        "Compose outer(inner(x)) using SymPy substitution.",
+        "Compose two bounded univariate canonical rational polynomials.",
         CompositionRequest,
         CompositionResult,
         compose_polynomials,
@@ -110,10 +152,11 @@ POLYNOMIAL_MAP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "simple_compose",
-                "Compose x**2 with x+1.",
+                "Compose x^2 with x+1; each polynomial must use exactly its "
+                "declared substitution variable.",
                 {
-                    "outer": {"expression": "x**2"},
-                    "inner": {"expression": "x + 1"},
+                    "outer": _polynomial("x", (1, 2)),
+                    "inner": _polynomial("x", (1, 1), (1, 0)),
                     "inner_variable": "x",
                     "outer_variable": "x",
                 },

--- a/src/jacobian/math/polynomials/values.py
+++ b/src/jacobian/math/polynomials/values.py
@@ -21,7 +21,7 @@ MAX_POLYNOMIAL_EXPONENT = 32_768
 class RationalPolynomialTerm(StrictModel):
     coefficient: CanonicalRational
     exponents: tuple[int, ...] = Field(
-        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+        min_length=0, max_length=MAX_POLYNOMIAL_VARIABLES
     )
 
     @model_validator(mode="after")
@@ -92,6 +92,121 @@ class RationalPolynomial(StrictModel):
         return self
 
 
+class RationalPolynomialIdeal(StrictModel):
+    """A finitely generated ideal in one explicitly ordered ``QQ`` ring.
+
+    Generator lists are presentations, not canonical bases.  Every generator
+    nevertheless carries the same authoritative ring so ideals can pass
+    directly between operations without rendering or reparsing expressions.
+    """
+
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+    )
+    generators: tuple[RationalPolynomial, ...] = Field(
+        min_length=1,
+        max_length=64,
+    )
+
+    @model_validator(mode="after")
+    def require_one_ordered_ring(self) -> Self:
+        if len(set(self.variables)) != len(self.variables):
+            raise ValueError("ideal variables must be unique")
+        if any(generator.variables != self.variables for generator in self.generators):
+            raise ValueError("every ideal generator must use the declared ordered ring")
+        return self
+
+
+class RationalFunction(StrictModel):
+    """One reduced element of ``QQ(t_1, ..., t_n)``.
+
+    The denominator is monic and the numerator and denominator are coprime.
+    This makes the sparse representation unique for the declared variable
+    order.  With no variables, the value is a canonical rational represented
+    by one constant numerator over the constant denominator one.
+    """
+
+    rational_function_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ"] = "QQ"
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=0,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+    )
+    numerator: SparseRationalPolynomial
+    denominator: SparseRationalPolynomial
+
+    @model_validator(mode="after")
+    def require_canonical_fraction(self) -> Self:
+        _require_rational_function_shapes(self)
+        _require_rational_function_normal_form(self)
+        return self
+
+
+def _rational_function_one(variable_count: int) -> SparseRationalPolynomial:
+    return SparseRationalPolynomial(
+        terms=(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational(num="1", den="1"),
+                exponents=(0,) * variable_count,
+            ),
+        )
+    )
+
+
+def _require_rational_function_shapes(value: RationalFunction) -> None:
+    if len(set(value.variables)) != len(value.variables):
+        raise ValueError("rational-function variables must be unique")
+    for label, polynomial in (
+        ("numerator", value.numerator),
+        ("denominator", value.denominator),
+    ):
+        if any(
+            len(term.exponents) != len(value.variables) for term in polynomial.terms
+        ):
+            raise ValueError(
+                f"every {label} monomial must match the declared variable order"
+            )
+        require_sparse_polynomial_budget(
+            polynomial,
+            maximum_terms=256,
+            maximum_exponent=64,
+            maximum_coefficient_digits=128,
+            label=f"rational-function {label}",
+        )
+
+
+def _require_rational_function_normal_form(value: RationalFunction) -> None:
+    if not value.denominator.terms:
+        raise ValueError("rational-function denominator cannot be zero")
+    one = _rational_function_one(len(value.variables))
+    if not value.numerator.terms:
+        if value.denominator != one:
+            raise ValueError("canonical zero must have denominator one")
+        return
+    if not value.variables:
+        if value.denominator != one or len(value.numerator.terms) != 1:
+            raise ValueError(
+                "a rational function without variables must be a canonical rational"
+            )
+        return
+
+    # Construct exact polynomials from already validated term data. No caller
+    # text is parsed or evaluated at this boundary.
+    from jacobian.math.polynomials._conversions import (
+        sparse_rational_polynomial_to_sympy,
+    )
+
+    numerator = sparse_rational_polynomial_to_sympy(value.numerator, value.variables)
+    denominator = sparse_rational_polynomial_to_sympy(
+        value.denominator, value.variables
+    )
+    if denominator.LC() != 1:
+        raise ValueError("rational-function denominator must be monic")
+    if not numerator.gcd(denominator).is_one:
+        raise ValueError("rational-function numerator and denominator must be coprime")
+
+
 def require_sparse_polynomial_budget(
     polynomial: SparseRationalPolynomial,
     *,
@@ -140,7 +255,9 @@ __all__ = [
     "MAX_POLYNOMIAL_TERMS",
     "MAX_POLYNOMIAL_VARIABLES",
     "PolynomialVariable",
+    "RationalFunction",
     "RationalPolynomial",
+    "RationalPolynomialIdeal",
     "RationalPolynomialTerm",
     "SparseRationalPolynomial",
     "require_polynomial_budget",

--- a/src/jacobian/math/prime_field_linear_algebra.py
+++ b/src/jacobian/math/prime_field_linear_algebra.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import Any
+
+from pydantic import ConfigDict, StrictInt
+from pydantic.dataclasses import dataclass
 
 _MAX_DIMENSION = 256
 
@@ -18,13 +20,13 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(config=ConfigDict(extra="forbid"), frozen=True, slots=True)
 class PrimeFieldMatrix:
     """An immutable matrix with an exact prime and explicit empty shape."""
 
-    prime: int
-    entries: tuple[tuple[int, ...], ...]
-    columns: int
+    prime: StrictInt
+    entries: tuple[tuple[StrictInt, ...], ...]
+    columns: StrictInt
 
     def __post_init__(self) -> None:
         if type(self.prime) is not int or self.prime < 2:

--- a/src/jacobian/math/projective_coords_ops/_models.py
+++ b/src/jacobian/math/projective_coords_ops/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -67,8 +67,6 @@ class ChartTransitionRequest(StrictModel):
             raise ValueError("chart index out of range")
         if self.point.coordinates[self.chart_i].as_fraction() == 0:
             raise ValueError("chart_i coordinate must be nonzero")
-        if self.point.coordinates[self.chart_j].as_fraction() == 0:
-            raise ValueError("chart_j coordinate must be nonzero")
         return self
 
 
@@ -89,7 +87,30 @@ class StandardChartResult(StrictModel):
 
 
 class ChartTransitionResult(StrictModel):
-    transition: tuple[CanonicalRational, ...]
+    status: Literal["DEFINED", "OUTSIDE_TARGET_CHART"]
+    transition: tuple[CanonicalRational, ...] | None
     chart_i: int = Field(ge=0)
     chart_j: int = Field(ge=0)
+    projective_dimension: int = Field(ge=0, le=MAX_DIM)
     method: str = "CHART_TRANSITION"
+
+    @model_validator(mode="after")
+    def require_status_consistency(self) -> Self:
+        if (self.status == "DEFINED") != (self.transition is not None):
+            raise ValueError(
+                "DEFINED must carry target-chart coordinates and "
+                "OUTSIDE_TARGET_CHART must not"
+            )
+        if (
+            self.chart_i > self.projective_dimension
+            or self.chart_j > self.projective_dimension
+        ):
+            raise ValueError("chart axes must belong to the projective point")
+        if (
+            self.transition is not None
+            and len(self.transition) != self.projective_dimension
+        ):
+            raise ValueError(
+                "defined transition must contain every target-chart coordinate"
+            )
+        return self

--- a/src/jacobian/math/projective_coords_ops/_models.py
+++ b/src/jacobian/math/projective_coords_ops/_models.py
@@ -6,10 +6,24 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
 
 MAX_DIM = 16
+MAX_PROJECTIVE_COORDINATE_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS // 2
+
+
+def _require_ratio_result_budget(
+    coordinates: tuple[CanonicalRational, ...],
+) -> None:
+    if any(
+        len(component.lstrip("-")) > MAX_PROJECTIVE_COORDINATE_DIGITS
+        for coordinate in coordinates
+        for component in (coordinate.num, coordinate.den)
+    ):
+        raise ValueError(
+            "projective coordinate components exceed the 16,384-digit ratio budget"
+        )
 
 
 class RationalProjectivePoint(StrictModel):
@@ -30,11 +44,17 @@ class RationalProjectivePoint(StrictModel):
 
 class RationalPointConstructRequest(StrictModel):
     coordinates: tuple[CanonicalRational, ...] = Field(
-        min_length=1, max_length=MAX_DIM + 1
+        min_length=1,
+        max_length=MAX_DIM + 1,
+        description=(
+            "Homogeneous coordinates whose rational components are at most "
+            "16,384 digits so every normalization ratio remains representable."
+        ),
     )
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
+        _require_ratio_result_budget(self.coordinates)
         if all(c.as_fraction() == 0 for c in self.coordinates):
             raise ValueError(
                 "projective point must have at least one nonzero coordinate"
@@ -43,11 +63,17 @@ class RationalPointConstructRequest(StrictModel):
 
 
 class StandardChartRequest(StrictModel):
-    point: RationalProjectivePoint
+    point: RationalProjectivePoint = Field(
+        description=(
+            "A rational projective point whose coordinate components are at most "
+            "16,384 digits so every chart ratio remains representable."
+        )
+    )
     chart_index: int = Field(ge=0)
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
+        _require_ratio_result_budget(self.point.coordinates)
         if self.chart_index >= len(self.point.coordinates):
             raise ValueError("chart_index out of range")
         if self.point.coordinates[self.chart_index].as_fraction() == 0:
@@ -56,12 +82,18 @@ class StandardChartRequest(StrictModel):
 
 
 class ChartTransitionRequest(StrictModel):
-    point: RationalProjectivePoint
+    point: RationalProjectivePoint = Field(
+        description=(
+            "A rational projective point whose coordinate components are at most "
+            "16,384 digits so every target-chart ratio remains representable."
+        )
+    )
     chart_i: int = Field(ge=0)
     chart_j: int = Field(ge=0)
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
+        _require_ratio_result_budget(self.point.coordinates)
         n = len(self.point.coordinates)
         if self.chart_i >= n or self.chart_j >= n:
             raise ValueError("chart index out of range")

--- a/src/jacobian/math/projective_coords_ops/_operations.py
+++ b/src/jacobian/math/projective_coords_ops/_operations.py
@@ -58,17 +58,26 @@ def compute_standard_chart(request: StandardChartRequest) -> StandardChartResult
 
 
 def compute_chart_transition(request: ChartTransitionRequest) -> ChartTransitionResult:
-    """Compute the transition map from chart_i to chart_j coordinates."""
+    """Return the complete target-chart coordinates for the projective point."""
     coords = request.point.coordinates
-    xi = coords[request.chart_i].as_fraction()
     xj = coords[request.chart_j].as_fraction()
+    if xj == 0:
+        return ChartTransitionResult(
+            status="OUTSIDE_TARGET_CHART",
+            transition=None,
+            chart_i=request.chart_i,
+            chart_j=request.chart_j,
+            projective_dimension=len(coords) - 1,
+        )
     ratios = tuple(
-        _rational(coords[i].as_fraction() * xi / xj)
+        _rational(coords[i].as_fraction() / xj)
         for i in range(len(coords))
-        if i != request.chart_i and i != request.chart_j
+        if i != request.chart_j
     )
     return ChartTransitionResult(
+        status="DEFINED",
         transition=ratios,
         chart_i=request.chart_i,
         chart_j=request.chart_j,
+        projective_dimension=len(coords) - 1,
     )

--- a/src/jacobian/math/projective_coords_ops/_tools.py
+++ b/src/jacobian/math/projective_coords_ops/_tools.py
@@ -101,7 +101,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "projective.chart_transition.compute",
         "Compute the transition map between two charts",
-        "Compute the transition map from chart_i to chart_j for a projective point.",
+        "Return the complete target-chart coordinates for a projective point, "
+        "or OUTSIDE_TARGET_CHART when the target coordinate vanishes.",
         ChartTransitionRequest,
         ChartTransitionResult,
         compute_chart_transition,
@@ -125,6 +126,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -6,30 +6,32 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
+
+MAX_RATIONAL_DIGITS = 256
+
+
+def _require_rationals(values: tuple[CanonicalRational, ...], *, label: str) -> None:
+    for value in values:
+        require_bounded_rational(value, max_digits=MAX_RATIONAL_DIGITS, label=label)
 
 
 class RecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over QQ."""
 
-    sequence: tuple[str, ...] = Field(min_length=2, max_length=256)
+    sequence: tuple[CanonicalRational, ...] = Field(min_length=2, max_length=256)
 
     @model_validator(mode="after")
     def require_rational_sequence(self) -> Self:
-        from sympy import Rational
-
-        try:
-            tuple(Rational(parse_canonical_integer(value)) for value in self.sequence)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("sequence values must be rational numbers") from exc
+        _require_rationals(self.sequence, label="sequence value")
         return self
 
 
 class RecurrenceFindResult(StrictModel):
     """A fitted recurrence or an explicit finite-prefix missing outcome."""
 
-    coefficients: tuple[str, ...] = Field(max_length=255)
+    coefficients: tuple[CanonicalRational, ...] = Field(max_length=255)
     order: int = Field(ge=0, le=255)
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
     method: Literal["RATIONAL_INTERPOLATION"] = "RATIONAL_INTERPOLATION"
@@ -51,36 +53,25 @@ class RecurrenceFindResult(StrictModel):
 class ClosedFormRequest(StrictModel):
     """Compute a SymPy-expression closed form for a recurrence of degree at most four."""
 
-    characteristic_coefficients: tuple[str, ...] = Field(
+    characteristic_coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1,
         max_length=5,
         description="Characteristic polynomial coefficients in descending order, with degree at most four.",
     )
-    initial_values: tuple[str, ...] = Field(min_length=1, max_length=4)
+    initial_values: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=4)
 
     @model_validator(mode="after")
     def require_initial_values_for_order(self) -> Self:
-        from sympy import Rational
-
         order = len(self.characteristic_coefficients) - 1
         if order < 1:
             raise ValueError("characteristic polynomial must have positive degree")
         if len(self.initial_values) != order:
             raise ValueError("initial value count must match the recurrence order")
-        try:
-            coefficients = tuple(
-                Rational(parse_canonical_integer(value))
-                for value in self.characteristic_coefficients
-            )
-            tuple(
-                Rational(parse_canonical_integer(value))
-                for value in self.initial_values
-            )
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                "recurrence coefficients and initial values must be rational"
-            ) from exc
-        if coefficients[0] == 0:
+        _require_rationals(
+            self.characteristic_coefficients, label="characteristic coefficient"
+        )
+        _require_rationals(self.initial_values, label="initial value")
+        if self.characteristic_coefficients[0].as_fraction() == 0:
             raise ValueError(
                 "characteristic polynomial must have nonzero leading coefficient"
             )

--- a/src/jacobian/math/recurrence_solving/_tools.py
+++ b/src/jacobian/math/recurrence_solving/_tools.py
@@ -57,9 +57,26 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             example(
                 "fib_find",
                 "Find the recurrence of the Fibonacci sequence.",
-                {"sequence": ["1", "1", "2", "3", "5", "8", "13", "21", "34", "55"]},
+                {
+                    "sequence": [
+                        {"num": value, "den": "1"}
+                        for value in (
+                            "1",
+                            "1",
+                            "2",
+                            "3",
+                            "5",
+                            "8",
+                            "13",
+                            "21",
+                            "34",
+                            "55",
+                        )
+                    ]
+                },
             ),
         ),
+        version="2",
     ),
     rs_operation(
         "sequence.recurrence.closed_form.compute",
@@ -77,11 +94,19 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "repeated_root",
                 "Solve the recurrence with characteristic polynomial (x-1)^2.",
                 {
-                    "characteristic_coefficients": ["1", "-2", "1"],
-                    "initial_values": ["2", "5"],
+                    "characteristic_coefficients": [
+                        {"num": "1", "den": "1"},
+                        {"num": "-2", "den": "1"},
+                        {"num": "1", "den": "1"},
+                    ],
+                    "initial_values": [
+                        {"num": "2", "den": "1"},
+                        {"num": "5", "den": "1"},
+                    ],
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from jacobian.canonical import parse_canonical_integer
+from jacobian._exact import CanonicalRational
 
 __all__ = ["ClosedForm", "Recurrence", "closed_form", "find_recurrence"]
 
 
 @dataclass(frozen=True, slots=True)
 class Recurrence:
-    coefficients: tuple[str, ...]
+    coefficients: tuple[CanonicalRational, ...]
     order: int
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
 
@@ -22,16 +22,14 @@ class ClosedForm:
     expression: str
 
 
-def find_recurrence(sequence: tuple[str, ...]) -> Recurrence:
+def find_recurrence(sequence: tuple[CanonicalRational, ...]) -> Recurrence:
     import sympy
 
     from jacobian.math.recurrence_solving._models import RecurrenceFindRequest
 
     request = RecurrenceFindRequest(sequence=sequence)
 
-    values = [
-        sympy.Rational(parse_canonical_integer(value)) for value in request.sequence
-    ]
+    values = [sympy.Rational(*value.as_integer_ratio()) for value in request.sequence]
     for order in range(1, len(values)):
         coefficient_matrix = sympy.Matrix(
             [
@@ -47,7 +45,10 @@ def find_recurrence(sequence: tuple[str, ...]) -> Recurrence:
         if parameters:
             solution = solution.subs(dict.fromkeys(parameters, 0))
         return Recurrence(
-            coefficients=tuple(str(value) for value in solution),
+            coefficients=tuple(
+                CanonicalRational.from_integer_ratio(int(value.p), int(value.q))
+                for value in solution
+            ),
             order=order,
             status="FOUND",
         )
@@ -55,7 +56,8 @@ def find_recurrence(sequence: tuple[str, ...]) -> Recurrence:
 
 
 def closed_form(
-    char_coeffs: tuple[str, ...], initial_values: tuple[str, ...]
+    char_coeffs: tuple[CanonicalRational, ...],
+    initial_values: tuple[CanonicalRational, ...],
 ) -> ClosedForm:
     import sympy
 
@@ -69,8 +71,8 @@ def closed_form(
     x = sympy.Symbol("x")
     n = sympy.Symbol("n", integer=True, nonnegative=True)
     char_poly_coeffs = [
-        sympy.Rational(parse_canonical_integer(c))
-        for c in request.characteristic_coefficients
+        sympy.Rational(*value.as_integer_ratio())
+        for value in request.characteristic_coefficients
     ]
     char_poly = sum(
         c * x ** (len(char_poly_coeffs) - 1 - i) for i, c in enumerate(char_poly_coeffs)
@@ -84,7 +86,9 @@ def closed_form(
         for root in nonzero_roots
         for power in range(roots.count(root))
     )
-    init = [sympy.Rational(parse_canonical_integer(v)) for v in request.initial_values]
+    init = [
+        sympy.Rational(*value.as_integer_ratio()) for value in request.initial_values
+    ]
     a = sympy.Matrix([[term.subs(n, i) for term in basis] for i in range(len(basis))])
     b = sympy.Matrix(init)
     consts = a.solve(b)

--- a/src/jacobian/math/universal_algebra/__init__.py
+++ b/src/jacobian/math/universal_algebra/__init__.py
@@ -8,17 +8,21 @@ from jacobian.math.universal_algebra.operations import (
     quotient,
 )
 from jacobian.math.universal_algebra.values import (
+    ApplicationTerm,
     FiniteAlgebra,
     FlatTerm,
     OperationSymbol,
     Term,
+    VariableTerm,
 )
 
 __all__ = [
+    "ApplicationTerm",
     "FiniteAlgebra",
     "FlatTerm",
     "OperationSymbol",
     "Term",
+    "VariableTerm",
     "congruence_check",
     "equation_profile",
     "evaluate_term",

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -1,139 +1,184 @@
-"""Typed wire contracts for universal-algebra operations."""
+"""Typed bounded contracts for finite universal-algebra operations."""
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
-from jacobian.math.universal_algebra.values import FiniteAlgebra, FlatTerm
+from jacobian.math.universal_algebra.values import (
+    MAX_CARRIER_SIZE,
+    FiniteAlgebra,
+    FlatTerm,
+    require_term_for_algebra,
+)
+
+MAX_ENUMERATION_WORK = 1_000_000
+CarrierBlock = Annotated[
+    tuple[int, ...],
+    Field(min_length=1, max_length=MAX_CARRIER_SIZE),
+]
+
+
+def _require_partition(
+    algebra: FiniteAlgebra,
+    partition: tuple[CarrierBlock, ...],
+) -> None:
+    expected = set(range(len(algebra.carrier)))
+    seen: set[int] = set()
+    for block in partition:
+        for element in block:
+            if element not in expected:
+                raise ValueError("partition element out of carrier range")
+            if element in seen:
+                raise ValueError("partition blocks must be disjoint")
+            seen.add(element)
+    if seen != expected:
+        raise ValueError("partition blocks must exactly cover the carrier")
+
+
+def _congruence_work(algebra: FiniteAlgebra) -> int:
+    size = len(algebra.carrier)
+    return sum(
+        size**symbol.arity * max(1, symbol.arity) * size
+        for symbol in algebra.operations
+    )
 
 
 class EvaluateRequest(StrictModel):
-    """Evaluate a source-bound term under a complete assignment."""
-
     algebra: FiniteAlgebra
     term: FlatTerm
-    assignment: tuple[int, ...] = Field(default=())
+    assignment: tuple[int, ...] = Field(default=(), max_length=256)
 
     @model_validator(mode="after")
-    def require_valid_assignment(self) -> Self:
-        n = len(self.algebra.carrier)
-        if any(not 0 <= v < n for v in self.assignment):
+    def require_total_assignment(self) -> Self:
+        require_term_for_algebra(self.term, self.algebra)
+        if len(self.assignment) != self.term.variable_count:
+            raise ValueError("assignment must cover exactly the referenced variables")
+        size = len(self.algebra.carrier)
+        if any(not 0 <= value < size for value in self.assignment):
             raise ValueError("assignment value out of carrier range")
         return self
 
 
 class EvaluateResult(StrictModel):
-    """The exact carrier value t^A(alpha)."""
-
     value: int = Field(ge=0)
 
 
 class EquationProfileRequest(StrictModel):
-    """Evaluate s = t over all assignments."""
-
     algebra: FiniteAlgebra
     left: FlatTerm
     right: FlatTerm
-    variable_count: int = Field(ge=1)
+    variable_count: int = Field(ge=1, le=8, strict=True)
+
+    @model_validator(mode="after")
+    def require_bounded_complete_profile(self) -> Self:
+        require_term_for_algebra(self.left, self.algebra)
+        require_term_for_algebra(self.right, self.algebra)
+        if (
+            max(self.left.variable_count, self.right.variable_count)
+            > self.variable_count
+        ):
+            raise ValueError("variable_count must cover every referenced variable")
+        work = len(self.algebra.carrier) ** self.variable_count
+        if work > MAX_ENUMERATION_WORK:
+            raise ValueError("equation profile exceeds the assignment work budget")
+        return self
+
+
+class EquationCounterexample(StrictModel):
+    assignment: tuple[int, ...] = Field(max_length=8)
+    left_value: int = Field(ge=0, le=MAX_CARRIER_SIZE - 1)
+    right_value: int = Field(ge=0, le=MAX_CARRIER_SIZE - 1)
 
 
 class EquationProfileResult(StrictModel):
-    """HOLDS with satisfying count, or FAILS with first counterassignment."""
-
-    status: str
-    satisfying_count: int = Field(ge=0)
-    first_counterassignment: dict[str, object] | None = None
+    status: Literal["HOLDS", "FAILS"]
+    satisfying_count: int = Field(ge=0, le=MAX_ENUMERATION_WORK)
+    first_counterassignment: EquationCounterexample | None = None
 
     @model_validator(mode="after")
     def bind_status(self) -> Self:
-        if self.status not in ("HOLDS", "FAILS"):
-            raise ValueError("status must be HOLDS or FAILS")
+        if (self.status == "FAILS") != (self.first_counterassignment is not None):
+            raise ValueError("FAILS must carry exactly one first counterassignment")
         return self
 
 
 class SubalgebraRequest(StrictModel):
-    """Compute the least subalgebra containing the generating set."""
-
     algebra: FiniteAlgebra
-    generators: tuple[int, ...] = Field(default=())
+    generators: tuple[int, ...] = Field(
+        default=(),
+        max_length=MAX_CARRIER_SIZE,
+    )
 
     @model_validator(mode="after")
-    def require_valid_generators(self) -> Self:
-        n = len(self.algebra.carrier)
-        if any(not 0 <= g < n for g in self.generators):
+    def require_valid_bounded_generators(self) -> Self:
+        size = len(self.algebra.carrier)
+        if any(not 0 <= generator < size for generator in self.generators):
             raise ValueError("generator out of carrier range")
+        work = sum(size**symbol.arity for symbol in self.algebra.operations) * size
+        if work > MAX_ENUMERATION_WORK:
+            raise ValueError("subalgebra closure exceeds the operation work budget")
         return self
 
 
 class SubalgebraResult(StrictModel):
-    """The generated carrier, closure rounds, and closed-ness."""
-
     generated_carrier: tuple[int, ...]
     rounds: int = Field(ge=1)
     is_closed: bool
 
 
-class CongruenceRequest(StrictModel):
-    """Check whether a carrier partition is a congruence."""
-
+class _PartitionRequest(StrictModel):
     algebra: FiniteAlgebra
-    partition: tuple[tuple[int, ...], ...]
+    partition: tuple[CarrierBlock, ...] = Field(
+        min_length=1,
+        max_length=MAX_CARRIER_SIZE,
+    )
 
     @model_validator(mode="after")
-    def require_partition_covers_carrier(self) -> Self:
-        n = len(self.algebra.carrier)
-        seen = set()
-        for block in self.partition:
-            for elem in block:
-                if not 0 <= elem < n:
-                    raise ValueError("partition element out of carrier range")
-                if elem in seen:
-                    raise ValueError("partition blocks must be disjoint")
-                seen.add(elem)
+    def require_complete_bounded_partition(self) -> Self:
+        _require_partition(self.algebra, self.partition)
+        if _congruence_work(self.algebra) > MAX_ENUMERATION_WORK:
+            raise ValueError("congruence check exceeds the operation work budget")
         return self
 
 
-class CongruenceResult(StrictModel):
-    """Whether the partition is a congruence, with obstruction if not."""
+class CongruenceRequest(_PartitionRequest):
+    """Check one complete carrier partition for operation compatibility."""
 
+
+class CongruenceResult(StrictModel):
     is_congruence: bool
     obstruction: str | None = None
 
 
-class QuotientRequest(StrictModel):
-    """Compute the quotient algebra A/theta."""
-
-    algebra: FiniteAlgebra
-    partition: tuple[tuple[int, ...], ...]
-
-    @model_validator(mode="after")
-    def require_partition_covers_carrier(self) -> Self:
-        n = len(self.algebra.carrier)
-        seen: set[int] = set()
-        for block in self.partition:
-            for elem in block:
-                if not 0 <= elem < n:
-                    raise ValueError("partition element out of carrier range")
-                if elem in seen:
-                    raise ValueError("partition blocks must be disjoint")
-                seen.add(elem)
-        return self
+class QuotientRequest(_PartitionRequest):
+    """Construct ``A/theta`` for an admitted congruence partition."""
 
 
 class QuotientResult(StrictModel):
-    """The quotient algebra carrier, operations, and tables."""
+    """A directly composable quotient algebra and its carrier map."""
 
-    carrier: tuple[str, ...]
-    operations: tuple[tuple[str, int], ...]
-    tables: tuple[tuple[int, ...], ...]
+    algebra: FiniteAlgebra
+    quotient_map: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_CARRIER_SIZE,
+    )
+
+    @model_validator(mode="after")
+    def require_map_into_quotient(self) -> Self:
+        if any(
+            not 0 <= value < len(self.algebra.carrier) for value in self.quotient_map
+        ):
+            raise ValueError("quotient map value is outside the quotient carrier")
+        return self
 
 
 __all__ = [
     "CongruenceRequest",
     "CongruenceResult",
+    "EquationCounterexample",
     "EquationProfileRequest",
     "EquationProfileResult",
     "EvaluateRequest",

--- a/src/jacobian/math/universal_algebra/_operations.py
+++ b/src/jacobian/math/universal_algebra/_operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from jacobian.math.universal_algebra._models import (
     CongruenceRequest,
     CongruenceResult,
+    EquationCounterexample,
     EquationProfileRequest,
     EquationProfileResult,
     EvaluateRequest,
@@ -49,7 +50,9 @@ def compute_equation_profile(request: EquationProfileRequest) -> EquationProfile
     return EquationProfileResult(
         status="FAILS",
         satisfying_count=result["satisfying_count"],  # type: ignore[arg-type]
-        first_counterassignment=result.get("first_counterassignment"),  # type: ignore[arg-type]
+        first_counterassignment=EquationCounterexample.model_validate(
+            result["first_counterassignment"]
+        ),
     )
 
 
@@ -71,9 +74,8 @@ def compute_congruence(request: CongruenceRequest) -> CongruenceResult:
 
 
 def compute_quotient(request: QuotientRequest) -> QuotientResult:
-    result = quotient(request.algebra, request.partition)
+    algebra, quotient_map = quotient(request.algebra, request.partition)
     return QuotientResult(
-        carrier=result["carrier"],  # type: ignore[arg-type]
-        operations=result["operations"],  # type: ignore[arg-type]
-        tables=result["tables"],  # type: ignore[arg-type]
+        algebra=algebra,
+        quotient_map=quotient_map,
     )

--- a/src/jacobian/math/universal_algebra/_tools.py
+++ b/src/jacobian/math/universal_algebra/_tools.py
@@ -70,11 +70,10 @@ _ALGEBRA = {
 # Flat term: node 0 = variable 0, node 1 = variable 1, node 2 = application of op 0 with children (0, 1).
 _TERM = {
     "nodes": [
-        {"kind": "variable", "variable_id": 0, "operation": None, "children": []},
-        {"kind": "variable", "variable_id": 1, "operation": None, "children": []},
+        {"kind": "variable", "variable_id": 0},
+        {"kind": "variable", "variable_id": 1},
         {
             "kind": "application",
-            "variable_id": None,
             "operation": 0,
             "children": [0, 1],
         },
@@ -103,6 +102,7 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"algebra": _ALGEBRA, "term": _TERM, "assignment": [0, 1]},
             ),
         ),
+        version="2",
     ),
     _op(
         "universal_algebra.equation.profile.compute",
@@ -123,22 +123,26 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "Check AND(x,x) = x in the 2-element Boolean algebra.",
                 {
                     "algebra": _ALGEBRA,
-                    "left": _TERM,
-                    "right": {
+                    "left": {
                         "nodes": [
+                            {"kind": "variable", "variable_id": 0},
                             {
-                                "kind": "variable",
-                                "variable_id": 0,
-                                "operation": None,
-                                "children": [],
+                                "kind": "application",
+                                "operation": 0,
+                                "children": [0, 0],
                             },
                         ],
+                        "root": 1,
+                    },
+                    "right": {
+                        "nodes": [{"kind": "variable", "variable_id": 0}],
                         "root": 0,
                     },
-                    "variable_count": 2,
+                    "variable_count": 1,
                 },
             ),
         ),
+        version="2",
     ),
     _op(
         "universal_algebra.subalgebra.generated.compute",
@@ -159,6 +163,7 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"algebra": _ALGEBRA, "generators": [0]},
             ),
         ),
+        version="2",
     ),
     _op(
         "universal_algebra.congruence.check.compute",
@@ -180,12 +185,14 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"algebra": _ALGEBRA, "partition": [[0, 1]]},
             ),
         ),
+        version="2",
     ),
     _op(
         "universal_algebra.quotient.compute",
         "Compute the quotient algebra A/theta",
         "Return the quotient algebra induced by a congruence. The quotient "
-        "carrier is the set of blocks, and operations are applied block-wise.",
+        "carrier is the set of blocks; return a directly composable "
+        "FiniteAlgebra together with the quotient map.",
         QuotientRequest,
         QuotientResult,
         compute_quotient,
@@ -199,6 +206,7 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"algebra": _ALGEBRA, "partition": [[0, 1]]},
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from itertools import product as iproduct
 
-from .values import FiniteAlgebra, FlatTerm, OperationSymbol
+from .values import (
+    ApplicationTerm,
+    FiniteAlgebra,
+    FlatTerm,
+    OperationSymbol,
+    VariableTerm,
+    require_term_for_algebra,
+)
 
 __all__ = [
     "congruence_check",
@@ -23,26 +30,17 @@ def _evaluate_node(
     index: int,
 ) -> int:
     node = term.nodes[index]
-    if node.kind == "variable":
-        if node.variable_id is None:
-            raise ValueError("variable node missing variable_id")
+    if isinstance(node, VariableTerm):
         if node.variable_id not in assignment:
             raise ValueError("incomplete assignment")
         return assignment[node.variable_id]
-    if node.kind == "application":
-        if node.operation is None:
-            raise ValueError("application node missing operation index")
-        if node.operation < 0 or node.operation >= len(algebra.operations):
-            raise ValueError("operation index out of range")
-        arity = algebra.operations[node.operation].arity
-        if len(node.children) != arity:
-            raise ValueError("application arity mismatch")
+    if isinstance(node, ApplicationTerm):
         args = [_evaluate_node(algebra, term, assignment, n, c) for c in node.children]
         cell_index = 0
         for arg in args:
             cell_index = cell_index * n + arg
         return algebra.tables[node.operation][cell_index]
-    raise ValueError(f"unknown node kind: {node.kind}")
+    raise AssertionError("closed term union admitted an unknown node")
 
 
 def evaluate_term(
@@ -53,6 +51,7 @@ def evaluate_term(
     Return the exact carrier value ``t^A(alpha)``.
     """
     n = len(algebra.carrier)
+    require_term_for_algebra(term, algebra)
     if any(not 0 <= v < n for v in assignment.values()):
         raise ValueError("assignment value out of carrier range")
     return _evaluate_node(algebra, term, assignment, n, term.root)
@@ -213,7 +212,7 @@ def congruence_check(
 
 def quotient(
     algebra: FiniteAlgebra, partition: tuple[tuple[int, ...], ...]
-) -> dict[str, object]:
+) -> tuple[FiniteAlgebra, tuple[int, ...]]:
     """Return the quotient algebra ``A/theta`` induced by a congruence."""
     check = congruence_check(algebra, partition)
     if not check["is_congruence"]:
@@ -242,10 +241,10 @@ def quotient(
                 output = algebra.tables[op_idx][cell_index]
                 table.append(block_of[output])
             quotient_tables.append(tuple(table))
-    return {
-        "carrier": quotient_carrier,
-        "operations": tuple(
-            (sym.operation_id, sym.arity) for sym in algebra.operations
-        ),
-        "tables": tuple(quotient_tables),
-    }
+    quotient_algebra = FiniteAlgebra(
+        carrier=quotient_carrier,
+        operations=algebra.operations,
+        tables=tuple(quotient_tables),
+    )
+    quotient_map = tuple(block_of[element] for element in range(n))
+    return quotient_algebra, quotient_map

--- a/src/jacobian/math/universal_algebra/values.py
+++ b/src/jacobian/math/universal_algebra/values.py
@@ -9,7 +9,7 @@ is introduced.
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -18,6 +18,9 @@ from jacobian._models import StrictModel
 MAX_CARRIER_SIZE = 32
 MAX_SIGNATURE_SIZE = 16
 MAX_ARITY = 4
+MAX_TERM_NODES = 256
+MAX_TERM_DEPTH = 64
+MAX_TABLE_CELLS = 65_536
 
 
 class OperationSymbol(StrictModel):
@@ -49,6 +52,12 @@ class FiniteAlgebra(StrictModel):
             raise ValueError("carrier labels must be unique")
         if len(self.tables) != len(self.operations):
             raise ValueError("tables must have one entry per operation symbol")
+        if len({symbol.operation_id for symbol in self.operations}) != len(
+            self.operations
+        ):
+            raise ValueError("operation identifiers must be unique")
+        if sum(len(table) for table in self.tables) > MAX_TABLE_CELLS:
+            raise ValueError("operation tables exceed the bounded cell budget")
         for symbol, table in zip(self.operations, self.tables, strict=True):
             expected_cells = len(self.carrier) ** symbol.arity
             if len(table) != expected_cells:
@@ -61,42 +70,96 @@ class FiniteAlgebra(StrictModel):
         return self
 
 
-class Term(StrictModel):
-    """A closed source-bound AST node for a finite-algebra term.
+class VariableTerm(StrictModel):
+    kind: Literal["variable"]
+    variable_id: int = Field(ge=0, le=255, strict=True)
 
-    ``kind`` is ``"variable"`` or ``"application"``.  For variables,
-    ``variable_id`` is the variable index.  For applications, ``operation`` is
-    the operation index in the algebra's signature, and ``children`` are child
-    term indices (recursively, but Pydantic does not allow recursive models
-    directly — use a flat node list with parent/child indices instead).
-    """
 
-    kind: str
-    variable_id: int | None = None
-    operation: int | None = None
-    children: tuple[int, ...] = ()
+class ApplicationTerm(StrictModel):
+    kind: Literal["application"]
+    operation: int = Field(ge=0, le=MAX_SIGNATURE_SIZE - 1, strict=True)
+    children: tuple[int, ...] = Field(default=(), max_length=MAX_ARITY)
+
+
+Term = Annotated[VariableTerm | ApplicationTerm, Field(discriminator="kind")]
 
 
 class FlatTerm(StrictModel):
     """A flat term representation: a list of nodes where each application node
     references its children by index."""
 
-    nodes: tuple[Term, ...] = Field(min_length=1)
+    nodes: tuple[Term, ...] = Field(min_length=1, max_length=MAX_TERM_NODES)
     root: int = Field(ge=0)
 
     @model_validator(mode="after")
-    def require_valid_root(self) -> Self:
+    def require_closed_acyclic_ast(self) -> Self:
         if self.root >= len(self.nodes):
             raise ValueError("root index out of range")
+        for index, node in enumerate(self.nodes):
+            if isinstance(node, ApplicationTerm) and any(
+                child < 0 or child >= index for child in node.children
+            ):
+                raise ValueError("application children must reference earlier nodes")
+        reachable = _reachable_nodes(self.nodes, self.root)
+        if reachable != set(range(len(self.nodes))):
+            raise ValueError("every term node must be reachable from the root")
+        if _term_depths(self.nodes)[self.root] > MAX_TERM_DEPTH:
+            raise ValueError("term depth exceeds the bounded budget")
         return self
+
+    @property
+    def variable_count(self) -> int:
+        identifiers = tuple(
+            node.variable_id for node in self.nodes if isinstance(node, VariableTerm)
+        )
+        return max(identifiers, default=-1) + 1
+
+
+def _reachable_nodes(nodes: tuple[Term, ...], root: int) -> set[int]:
+    reachable: set[int] = set()
+    pending = [root]
+    while pending:
+        index = pending.pop()
+        if index in reachable:
+            continue
+        reachable.add(index)
+        node = nodes[index]
+        if isinstance(node, ApplicationTerm):
+            pending.extend(node.children)
+    return reachable
+
+
+def _term_depths(nodes: tuple[Term, ...]) -> tuple[int, ...]:
+    depths: list[int] = []
+    for node in nodes:
+        if isinstance(node, VariableTerm) or not node.children:
+            depths.append(1)
+        else:
+            depths.append(1 + max(depths[child] for child in node.children))
+    return tuple(depths)
+
+
+def require_term_for_algebra(term: FlatTerm, algebra: FiniteAlgebra) -> None:
+    """Bind application nodes to one finite signature before evaluation."""
+
+    for node in term.nodes:
+        if not isinstance(node, ApplicationTerm):
+            continue
+        if node.operation >= len(algebra.operations):
+            raise ValueError("term operation index out of range")
+        if len(node.children) != algebra.operations[node.operation].arity:
+            raise ValueError("term application arity does not match the operation")
 
 
 __all__ = [
     "MAX_ARITY",
     "MAX_CARRIER_SIZE",
     "MAX_SIGNATURE_SIZE",
+    "ApplicationTerm",
     "FiniteAlgebra",
     "FlatTerm",
     "OperationSymbol",
     "Term",
+    "VariableTerm",
+    "require_term_for_algebra",
 ]

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.number_field import ring_of_integers
 from jacobian.math.number_field._models import NumberFieldRequest
 from jacobian.math.number_field._operations import compute_nf_discriminant
@@ -30,6 +31,10 @@ def _quadratic(constant: str) -> list[dict[str, str]]:
         {"num": "0", "den": "1"},
         {"num": constant, "den": "1"},
     ]
+
+
+def _r(value: int) -> CanonicalRational:
+    return CanonicalRational(num=str(value), den="1")
 
 
 def test_root_isolation_returns_intervals_aligned_with_multiplicities() -> None:
@@ -150,30 +155,30 @@ def test_number_field_requires_a_monic_irreducible_integer_polynomial() -> None:
 
 def test_recurrence_finder_solves_for_coefficients() -> None:
     result = compute_find_recurrence(
-        RecurrenceFindRequest(sequence=("3", "6", "12", "24"))
+        RecurrenceFindRequest(sequence=tuple(_r(value) for value in (3, 6, 12, 24)))
     )
 
     assert result.order == 1
-    assert result.coefficients == ("2",)
+    assert result.coefficients == (_r(2),)
 
 
 def test_native_recurrence_api_enforces_the_sequence_contract() -> None:
     from jacobian.math.recurrence_solving import closed_form, find_recurrence
 
-    recurrence = find_recurrence(("3", "6", "12", "24"))
+    recurrence = find_recurrence(tuple(_r(value) for value in (3, 6, 12, 24)))
     assert recurrence.status == "FOUND"
-    assert recurrence.coefficients == ("2",)
-    assert closed_form(("1", "-2"), ("3",)).expression == "3*2**n"
+    assert recurrence.coefficients == (_r(2),)
+    assert closed_form((_r(1), _r(-2)), (_r(3),)).expression == "3*2**n"
 
     with pytest.raises(ValidationError, match="at least 2"):
-        find_recurrence(("1",))
+        find_recurrence((_r(1),))
 
     with pytest.raises(ValidationError, match="initial value count"):
-        closed_form(("1", "-1", "-1"), ("1",))
+        closed_form((_r(1), _r(-1), _r(-1)), (_r(1),))
 
 
 def test_recurrence_finder_reports_a_missing_nonvacuous_fit() -> None:
-    result = compute_find_recurrence(RecurrenceFindRequest(sequence=("0", "1")))
+    result = compute_find_recurrence(RecurrenceFindRequest(sequence=(_r(0), _r(1))))
 
     assert result.status == "NO_FITTING_RECURRENCE"
     assert result.order == 0
@@ -183,8 +188,8 @@ def test_recurrence_finder_reports_a_missing_nonvacuous_fit() -> None:
 def test_repeated_root_closed_form_preserves_polynomial_factor() -> None:
     result = compute_closed_form(
         ClosedFormRequest(
-            characteristic_coefficients=("1", "-2", "1"),
-            initial_values=("2", "5"),
+            characteristic_coefficients=(_r(1), _r(-2), _r(1)),
+            initial_values=(_r(2), _r(5)),
         )
     )
 
@@ -194,8 +199,8 @@ def test_repeated_root_closed_form_preserves_polynomial_factor() -> None:
 def test_closed_form_handles_repeated_zero_characteristic_roots() -> None:
     result = compute_closed_form(
         ClosedFormRequest(
-            characteristic_coefficients=("1", "0", "0"),
-            initial_values=("2", "5"),
+            characteristic_coefficients=(_r(1), _r(0), _r(0)),
+            initial_values=(_r(2), _r(5)),
         )
     )
 
@@ -207,13 +212,16 @@ def test_closed_form_contract_rejects_characteristic_polynomials_above_degree_fo
 ):
     with pytest.raises(ValidationError):
         ClosedFormRequest(
-            characteristic_coefficients=("1", "0", "0", "0", "-1", "-1"),
-            initial_values=("0", "0", "0", "0", "0"),
+            characteristic_coefficients=tuple(
+                _r(value) for value in (1, 0, 0, 0, -1, -1)
+            ),
+            initial_values=tuple(_r(0) for _ in range(5)),
         )
 
 
 def test_closed_form_contract_requires_every_initial_value() -> None:
     with pytest.raises(ValidationError, match="initial value count"):
         ClosedFormRequest(
-            characteristic_coefficients=("1", "-1", "-1"), initial_values=("1",)
+            characteristic_coefficients=(_r(1), _r(-1), _r(-1)),
+            initial_values=(_r(1),),
         )

--- a/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
+++ b/tests/math/arithmetic_dynamics/test_arithmetic_dynamics.py
@@ -6,6 +6,7 @@ import pytest
 import sympy
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.arithmetic_dynamics import (
     finite_field_functional_graph,
     fixed_point_equation,
@@ -32,42 +33,50 @@ from jacobian.math.arithmetic_dynamics._operations import (
 from jacobian.math.arithmetic_dynamics._tools import TOOLS
 
 
+def _r(value: int | str) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
 class TestMapIterate:
     def test_zero_iterate_is_identity(self) -> None:
         result = compute_map_iterate(
-            MapIterateRequest(coefficients=("1", "0", "1"), n=0)
+            MapIterateRequest(coefficients=(_r(1), _r(0), _r(1)), n=0)
         )
 
-        assert result.coefficients == ("0", "1")
+        assert result.coefficients == (_r(0), _r(1))
         assert result.degree == 1
         assert result.complete is True
 
     def test_second_iterate_is_exact(self) -> None:
         result = compute_map_iterate(
-            MapIterateRequest(coefficients=("1", "0", "1"), n=2)
+            MapIterateRequest(coefficients=(_r(1), _r(0), _r(1)), n=2)
         )
 
-        assert result.coefficients == ("2", "0", "2", "0", "1")
+        assert result.coefficients == (_r(2), _r(0), _r(2), _r(0), _r(1))
         assert result.degree == 4
 
     def test_zero_polynomial_iterates_without_backend_degree_coercion(self) -> None:
-        result = compute_map_iterate(MapIterateRequest(coefficients=("0",), n=3))
+        result = compute_map_iterate(MapIterateRequest(coefficients=(_r(0),), n=3))
 
-        assert result.coefficients == ("0",)
+        assert result.coefficients == (_r(0),)
         assert result.degree == 0
 
     def test_degree_growth_beyond_output_bound_is_rejected(self) -> None:
         with pytest.raises(ValidationError, match="iterate output degree"):
-            MapIterateRequest(coefficients=("1", "0", "0", "0", "0", "1"), n=5)
+            MapIterateRequest(
+                coefficients=(_r(1), _r(0), _r(0), _r(0), _r(0), _r(1)), n=5
+            )
 
 
 class TestOrbitPrefix:
     def test_repeat_proves_preperiod_and_period(self) -> None:
         result = compute_orbit_prefix(
-            OrbitPrefixRequest(coefficients=("0", "0", "1"), start="0", max_steps=5)
+            OrbitPrefixRequest(
+                coefficients=(_r(0), _r(0), _r(1)), start=_r(0), max_steps=5
+            )
         )
 
-        assert result.orbit == ("0", "0")
+        assert result.orbit == (_r(0), _r(0))
         assert result.termination == "REPEAT_FOUND"
         assert result.repeat is not None
         assert result.repeat.preperiod == 0
@@ -77,10 +86,10 @@ class TestOrbitPrefix:
 
     def test_finite_nonrepeating_prefix_does_not_imply_eventual_behavior(self) -> None:
         result = compute_orbit_prefix(
-            OrbitPrefixRequest(coefficients=("1", "1"), start="0", max_steps=3)
+            OrbitPrefixRequest(coefficients=(_r(1), _r(1)), start=_r(0), max_steps=3)
         )
 
-        assert result.orbit == ("0", "1", "2", "3")
+        assert result.orbit == (_r(0), _r(1), _r(2), _r(3))
         assert result.termination == "STEP_BOUND_REACHED"
         assert result.repeat is None
         assert result.eventual_behavior_complete is False
@@ -88,20 +97,20 @@ class TestOrbitPrefix:
 
     def test_zero_step_request_is_an_explicit_truncated_prefix(self) -> None:
         result = compute_orbit_prefix(
-            OrbitPrefixRequest(coefficients=("1", "1"), start="0", max_steps=0)
+            OrbitPrefixRequest(coefficients=(_r(1), _r(1)), start=_r(0), max_steps=0)
         )
 
-        assert result.orbit == ("0",)
+        assert result.orbit == (_r(0),)
         assert result.computed_steps == 0
         assert result.termination == "STEP_BOUND_REACHED"
         assert result.truncated is True
 
     def test_output_growth_stops_with_nonconcluding_typed_boundary(self) -> None:
-        degree_thirty = ("0",) * 30 + ("1",)
+        degree_thirty = (_r(0),) * 30 + (_r(1),)
         result = compute_orbit_prefix(
             OrbitPrefixRequest(
                 coefficients=degree_thirty,
-                start="1" + "0" * 127,
+                start=_r("1" + "0" * 127),
                 max_steps=2,
             )
         )
@@ -115,9 +124,9 @@ class TestOrbitPrefix:
     def test_result_model_rejects_completion_without_repeat_evidence(self) -> None:
         with pytest.raises(ValidationError, match="cannot imply eventual behavior"):
             OrbitPrefixResult(
-                source_coefficients=("1", "1"),
-                start="0",
-                orbit=("0", "1"),
+                source_coefficients=(_r(1), _r(1)),
+                start=_r(0),
+                orbit=(_r(0), _r(1)),
                 requested_steps=1,
                 computed_steps=1,
                 termination="STEP_BOUND_REACHED",
@@ -129,9 +138,9 @@ class TestOrbitPrefix:
     def test_result_model_rejects_orbit_not_bound_to_source_map(self) -> None:
         with pytest.raises(ValidationError, match="bound polynomial map"):
             OrbitPrefixResult(
-                source_coefficients=("1", "1"),
-                start="0",
-                orbit=("0", "2"),
+                source_coefficients=(_r(1), _r(1)),
+                start=_r(0),
+                orbit=(_r(0), _r(2)),
                 requested_steps=1,
                 computed_steps=1,
                 termination="STEP_BOUND_REACHED",
@@ -144,69 +153,63 @@ class TestOrbitPrefix:
 class TestDynatomicPolynomial:
     def test_first_dynatomic_polynomial(self) -> None:
         result = compute_dynatomic_polynomial(
-            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=1)
+            DynatomicPolynomialRequest(coefficients=(_r(0), _r(0), _r(1)), n=1)
         )
 
-        assert result.coefficients == ("0", "-1", "1")
+        assert result.coefficients == (_r(0), _r(-1), _r(1))
 
     def test_square_factor_mobius_case_and_divisor_product_identity(self) -> None:
         source = polynomial_from_coefficients((0, 0, 1))
         phi_1 = compute_dynatomic_polynomial(
-            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=1)
+            DynatomicPolynomialRequest(coefficients=(_r(0), _r(0), _r(1)), n=1)
         )
         phi_2 = compute_dynatomic_polynomial(
-            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=2)
+            DynatomicPolynomialRequest(coefficients=(_r(0), _r(0), _r(1)), n=2)
         )
         phi_4 = compute_dynatomic_polynomial(
-            DynatomicPolynomialRequest(coefficients=("0", "0", "1"), n=4)
+            DynatomicPolynomialRequest(coefficients=(_r(0), _r(0), _r(1)), n=4)
         )
-        product = polynomial_from_coefficients(tuple(map(Fraction, phi_1.coefficients)))
-        product *= polynomial_from_coefficients(
-            tuple(map(Fraction, phi_2.coefficients))
+        product = polynomial_from_coefficients(
+            tuple(value.as_fraction() for value in phi_1.coefficients)
         )
         product *= polynomial_from_coefficients(
-            tuple(map(Fraction, phi_4.coefficients))
+            tuple(value.as_fraction() for value in phi_2.coefficients)
+        )
+        product *= polynomial_from_coefficients(
+            tuple(value.as_fraction() for value in phi_4.coefficients)
         )
 
-        assert phi_4.coefficients == (
-            "1",
-            "0",
-            "0",
-            "1",
-            "0",
-            "0",
-            "1",
-            "0",
-            "0",
-            "1",
-            "0",
-            "0",
-            "1",
+        assert phi_4.coefficients == tuple(
+            _r(value) for value in (1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1)
         )
         assert product == fixed_point_equation(source, 4)
 
     def test_linear_map_is_outside_dynatomic_contract(self) -> None:
         with pytest.raises(ValidationError, match="degree at least two"):
-            DynatomicPolynomialRequest(coefficients=("1", "1"), n=2)
+            DynatomicPolynomialRequest(coefficients=(_r(1), _r(1)), n=2)
 
 
 class TestCycleMultiplier:
     def test_validated_two_cycle_multiplier(self) -> None:
         result = compute_cycle_multiplier(
-            CycleMultiplierRequest(coefficients=("1", "-1"), cycle=("0", "1"))
+            CycleMultiplierRequest(coefficients=(_r(1), _r(-1)), cycle=(_r(0), _r(1)))
         )
 
-        assert result.multiplier == "1"
+        assert result.multiplier == _r(1)
         assert result.period == 2
         assert result.validated_cycle is True
 
     def test_arbitrary_points_cannot_be_labeled_a_cycle(self) -> None:
         with pytest.raises(ValidationError, match="follow the polynomial map"):
-            CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("0", "1"))
+            CycleMultiplierRequest(
+                coefficients=(_r(0), _r(0), _r(1)), cycle=(_r(0), _r(1))
+            )
 
     def test_repeated_cycle_points_are_rejected(self) -> None:
         with pytest.raises(ValidationError, match="distinct"):
-            CycleMultiplierRequest(coefficients=("0", "0", "1"), cycle=("0", "0"))
+            CycleMultiplierRequest(
+                coefficients=(_r(0), _r(0), _r(1)), cycle=(_r(0), _r(0))
+            )
 
 
 class TestFiniteFieldFunctionalGraph:
@@ -288,16 +291,19 @@ class TestFiniteFieldFunctionalGraph:
 
 
 class TestCanonicalAndPortfolioContracts:
-    @pytest.mark.parametrize("coefficient", ["01", "+1", "2/4", "1.0"])
+    @pytest.mark.parametrize(
+        "coefficient",
+        ["1", {"num": "01", "den": "1"}, {"num": "2", "den": "4"}],
+    )
     def test_noncanonical_rational_coefficients_are_rejected(
-        self, coefficient: str
+        self, coefficient: object
     ) -> None:
-        with pytest.raises(ValidationError, match="canonical"):
-            MapIterateRequest(coefficients=(coefficient,), n=1)
+        with pytest.raises(ValidationError):
+            MapIterateRequest.model_validate({"coefficients": [coefficient], "n": 1})
 
     def test_trailing_zero_coefficients_are_rejected(self) -> None:
         with pytest.raises(ValidationError, match="trailing zeros"):
-            MapIterateRequest(coefficients=("1", "0"), n=1)
+            MapIterateRequest(coefficients=(_r(1), _r(0)), n=1)
 
     def test_fixed_point_equation_is_native_not_a_catalog_slot(self) -> None:
         operation_ids = {tool.operation_id for tool in TOOLS}

--- a/tests/math/arithmetic_dynamics/test_iterate_height.py
+++ b/tests/math/arithmetic_dynamics/test_iterate_height.py
@@ -1,21 +1,30 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.arithmetic_dynamics._models import (
     DynatomicPolynomialRequest,
     MapIterateRequest,
 )
 
 
+def _integer(value: str) -> CanonicalRational:
+    return CanonicalRational(num=value, den="1")
+
+
 def test_monomial_counterexample_is_rejected_by_request_validation() -> None:
     coefficient = "1" + "0" * 127
     with pytest.raises(ValidationError, match="iterate coefficient growth"):
-        MapIterateRequest(coefficients=("0", "0", coefficient), n=10)
+        MapIterateRequest(
+            coefficients=(_integer("0"), _integer("0"), _integer(coefficient)), n=10
+        )
 
 
 def test_near_boundary_monomial_remains_admitted() -> None:
     coefficient = "1" + "0" * 30
-    request = MapIterateRequest(coefficients=("0", "0", coefficient), n=10)
+    request = MapIterateRequest(
+        coefficients=(_integer("0"), _integer("0"), _integer(coefficient)), n=10
+    )
 
     assert request.n == 10
 
@@ -23,10 +32,12 @@ def test_near_boundary_monomial_remains_admitted() -> None:
 def test_dense_polynomial_additive_growth_is_propagated() -> None:
     coefficient = "1" + "0" * 127
     with pytest.raises(ValidationError, match="iterate coefficient growth"):
-        MapIterateRequest(coefficients=(coefficient, coefficient, coefficient), n=9)
+        MapIterateRequest(coefficients=(_integer(coefficient),) * 3, n=9)
 
 
 def test_dynatomic_request_checks_each_required_iterate() -> None:
     coefficient = "1" + "0" * 127
     with pytest.raises(ValidationError, match="iterate coefficient growth"):
-        DynatomicPolynomialRequest(coefficients=("0", "0", coefficient), n=9)
+        DynatomicPolynomialRequest(
+            coefficients=(_integer("0"), _integer("0"), _integer(coefficient)), n=9
+        )

--- a/tests/math/finite_fields/test_polynomial_maps.py
+++ b/tests/math/finite_fields/test_polynomial_maps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.finite_fields import (
     CollisionResult,
@@ -116,18 +117,11 @@ def test_certificates_reject_values_not_bound_to_the_exact_table() -> None:
 def test_table_consumers_reject_unevaluated_targets() -> None:
     identity_table = finite_map_table(_map(1))
     zero = identity_table.entries[0][1]
-    forged = FiniteMapTable(
-        map=identity_table.map,
-        entries=tuple((source, zero) for source, _ in identity_table.entries),
-    )
-
-    for consumer in (
-        fiber_partition,
-        analyze_collisions,
-        analyze_permutation,
-    ):
-        with pytest.raises(ValueError, match="bound polynomial"):
-            consumer(forged)
+    with pytest.raises(ValidationError, match="bound polynomial"):
+        FiniteMapTable(
+            map=identity_table.map,
+            entries=tuple((source, zero) for source, _ in identity_table.entries),
+        )
 
 
 def test_slice_b_reuses_one_table_for_fiber_and_certificate_handoff() -> None:

--- a/tests/math/finite_fields/test_public_api.py
+++ b/tests/math/finite_fields/test_public_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from flint import nmod_mat
+from pydantic import ValidationError
 
 from jacobian.math import finite_fields
 from jacobian.math.finite_fields import (
@@ -177,10 +178,8 @@ def test_orbit_distribution_rejects_a_forged_in_range_rank() -> None:
     subspace, directions = _slice_a_values()
     ledger_payload = direction_rank_ledger(subspace, directions).model_dump(mode="json")
     ledger_payload["entries"][0]["rank"] = 0
-    forged = DirectionRankLedger.model_validate(ledger_payload)
-
-    with pytest.raises(ValueError, match="rank does not match"):
-        orbit_distribution(forged)
+    with pytest.raises(ValidationError, match="rank must match"):
+        DirectionRankLedger.model_validate(ledger_payload)
 
 
 def test_slice_a_composes_restriction_into_rank_without_wire_conversion() -> None:
@@ -253,6 +252,52 @@ def test_slice_a_rejects_wrong_presentation_and_axis() -> None:
         restrict_scalars(subspace, wrong_parent_direction)
     with pytest.raises(ValueError, match="axis"):
         restrict_scalars(subspace, wrong_axis_direction)
+
+
+def test_permuting_a_declared_row_axis_preserves_restriction_ranks() -> None:
+    subspace, directions = _slice_a_values()
+    permuted_axis = Axis(
+        name=subspace.row_axis.name,
+        labels=tuple(reversed(subspace.row_axis.labels)),
+    )
+    permuted_subspace = FiniteDimensionalSubspace(
+        presentation=subspace.presentation,
+        basis_axis=subspace.basis_axis,
+        basis=tuple(
+            AxisBoundMatrix(
+                presentation=matrix.presentation,
+                row_axis=permuted_axis,
+                column_axis=matrix.column_axis,
+                entries=tuple(reversed(matrix.entries)),
+            )
+            for matrix in subspace.basis
+        ),
+    )
+    for direction in directions.points:
+        original = restrict_scalars(subspace, direction)
+        permuted_direction = projective_point(
+            subspace.presentation,
+            permuted_axis,
+            tuple(reversed(direction.coordinates)),
+        )
+        transported = restrict_scalars(permuted_subspace, permuted_direction)
+
+        assert transported.source_axis == original.source_axis
+        assert transported.target_axis == original.target_axis
+        assert rank(transported.matrix) == rank(original.matrix)
+
+    fixed_direction = directions.points[2]
+    assert fixed_direction.coordinates == tuple(reversed(fixed_direction.coordinates))
+    fixed_original = restrict_scalars(subspace, fixed_direction)
+    fixed_transport = restrict_scalars(
+        permuted_subspace,
+        projective_point(
+            subspace.presentation,
+            permuted_axis,
+            tuple(reversed(fixed_direction.coordinates)),
+        ),
+    )
+    assert fixed_transport.matrix == fixed_original.matrix
 
 
 def test_exact_public_api_symbols() -> None:

--- a/tests/math/finite_fields/test_tools.py
+++ b/tests/math/finite_fields/test_tools.py
@@ -82,21 +82,17 @@ def test_projective_enumeration_refuses_large_output_before_allocation() -> None
 
 
 def test_finite_map_table_refuses_excessive_polynomial_work() -> None:
-    operation = TOOLS[5]
     presentation = finite_field(2, (1, 1, 0, 1, 1, 0, 0, 0, 1))
     one = element(presentation, (1,) + (0,) * 7)
-    request = FiniteMapTableRequest(
-        polynomial_map=finite_polynomial_map(
-            finite_polynomial(presentation, (one,) * 512)
+    with pytest.raises(ValidationError, match="finite map exceeds"):
+        FiniteMapTableRequest(
+            polynomial_map=finite_polynomial_map(
+                finite_polynomial(presentation, (one,) * 512)
+            )
         )
-    )
-
-    with pytest.raises(ValueError, match="finite map work"):
-        operation.run(request)
 
 
 def test_direction_rank_ledger_refuses_excessive_aggregate_work() -> None:
-    operation = TOOLS[3]
     presentation = finite_field(2, (1, 1, 1))
     row_axis = Axis(name="rows", labels=("r0", "r1"))
     column_axis = Axis(
@@ -121,17 +117,15 @@ def test_direction_rank_ledger_refuses_excessive_aggregate_work() -> None:
         )
         for index in range(64)
     )
-    request = DirectionRankLedgerRequest(
-        subspace=FiniteDimensionalSubspace(
-            presentation=presentation,
-            basis_axis=basis_axis,
-            basis=basis,
-        ),
-        directions=projective_line(presentation, row_axis),
-    )
-
-    with pytest.raises(ValueError, match="direction-rank work"):
-        operation.run(request)
+    with pytest.raises(ValidationError, match="direction-rank ledger exceeds"):
+        DirectionRankLedgerRequest(
+            subspace=FiniteDimensionalSubspace(
+                presentation=presentation,
+                basis_axis=basis_axis,
+                basis=basis,
+            ),
+            directions=projective_line(presentation, row_axis),
+        )
 
 
 def test_oversized_presentation_rejects_during_request_parsing() -> None:

--- a/tests/math/finite_fields/test_values.py
+++ b/tests/math/finite_fields/test_values.py
@@ -114,6 +114,20 @@ def test_malformed_prime_field_matrix_reports_nested_validation_error() -> None:
         }
     ]
 
+    with pytest.raises(ValidationError, match="Unexpected keyword argument"):
+        FiniteLinearMap.model_validate(
+            {
+                "source_axis": {"name": "source", "labels": ["x"]},
+                "target_axis": {"name": "target", "labels": ["z"]},
+                "matrix": {
+                    "prime": 2,
+                    "entries": [[1]],
+                    "columns": 1,
+                    "unexpected": True,
+                },
+            }
+        )
+
 
 def test_subspace_rejects_dependent_basis_matrices() -> None:
     presentation = _presentation()

--- a/tests/math/finite_fields/test_values.py
+++ b/tests/math/finite_fields/test_values.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.finite_fields import (
     Axis,
@@ -90,6 +91,28 @@ def test_values_reject_same_shape_substitutions_with_wrong_parent_or_axis() -> N
         coordinates=(one, zero),
     )
     assert RankResult(direction=point, linear_map=matrix, rank=2).rank == 2
+
+
+def test_malformed_prime_field_matrix_reports_nested_validation_error() -> None:
+    with pytest.raises(ValidationError) as error:
+        FiniteLinearMap.model_validate(
+            {
+                "source_axis": {"name": "source", "labels": ["x", "y"]},
+                "target_axis": {"name": "target", "labels": ["z"]},
+                "matrix": {"prime": 2, "entries": [[1]], "columns": 2},
+            }
+        )
+
+    assert error.value.errors(include_url=False, include_context=False) == [
+        {
+            "type": "value_error",
+            "loc": ("matrix",),
+            "msg": (
+                "Value error, every matrix row must match the declared column count"
+            ),
+            "input": {"prime": 2, "entries": [[1]], "columns": 2},
+        }
+    ]
 
 
 def test_subspace_rejects_dependent_basis_matrices() -> None:

--- a/tests/math/finite_game_theory/test_finite_game_theory.py
+++ b/tests/math/finite_game_theory/test_finite_game_theory.py
@@ -2,6 +2,7 @@
 
 from fractions import Fraction
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
     PayoffMatrix,
     ZeroSumGameRequest,
@@ -12,17 +13,21 @@ from jacobian.math.finite_game_theory._operations import (
 )
 
 
+def _r(value: int | Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
 class TestBestResponse:
-    def test_simple(self):
+    def test_simple(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
                 entries=(
-                    {"num": "3", "den": "1"},
-                    {"num": "0", "den": "1"},
-                    {"num": "0", "den": "1"},
-                    {"num": "2", "den": "1"},
+                    _r(3),
+                    _r(0),
+                    _r(0),
+                    _r(2),
                 ),
             ),
         )
@@ -31,101 +36,113 @@ class TestBestResponse:
 
 
 class TestNashEquilibrium:
-    def test_pure_strategy(self):
+    def test_pure_strategy(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
                 entries=(
-                    {"num": "1", "den": "1"},
-                    {"num": "1", "den": "1"},
-                    {"num": "0", "den": "1"},
-                    {"num": "0", "den": "1"},
+                    _r(1),
+                    _r(1),
+                    _r(0),
+                    _r(0),
                 ),
             ),
         )
         result = compute_nash_equilibrium(req)
-        assert result.value == "1"  # (0,0) is the pure Nash equilibrium
+        assert result.value.as_fraction() == 1  # (0,0) is the pure equilibrium
 
-    def test_mixed_equilibrium(self):
+    def test_mixed_equilibrium(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
                 entries=(
-                    {"num": "2", "den": "1"},
-                    {"num": "0", "den": "1"},
-                    {"num": "-1", "den": "1"},
-                    {"num": "3", "den": "1"},
+                    _r(2),
+                    _r(0),
+                    _r(-1),
+                    _r(3),
                 ),
             ),
         )
         result = compute_nash_equilibrium(req)
-        assert result.row_strategy == ("2/3", "1/3")
-        assert result.col_strategy == ("1/2", "1/2")
-        assert result.value == "1"
+        assert tuple(value.as_fraction() for value in result.row_strategy) == (
+            Fraction(2, 3),
+            Fraction(1, 3),
+        )
+        assert tuple(value.as_fraction() for value in result.col_strategy) == (
+            Fraction(1, 2),
+            Fraction(1, 2),
+        )
+        assert result.value.as_fraction() == 1
 
-    def test_degenerate_game_uses_exact_linear_programming(self):
+    def test_degenerate_game_uses_exact_linear_programming(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=3,
                 n_cols=3,
-                entries=tuple(
-                    {"num": str(value), "den": "1"}
-                    for value in (1, -1, 0, -1, 1, 0, 0, 0, 0)
-                ),
+                entries=tuple(_r(value) for value in (1, -1, 0, -1, 1, 0, 0, 0, 0)),
             ),
         )
 
         result = compute_nash_equilibrium(req)
 
-        assert result.value == "0"
-        assert sum(Fraction(value) for value in result.row_strategy) == 1
-        assert sum(Fraction(value) for value in result.col_strategy) == 1
+        assert result.value.as_fraction() == 0
+        assert sum(value.as_fraction() for value in result.row_strategy) == 1
+        assert sum(value.as_fraction() for value in result.col_strategy) == 1
 
-    def test_negative_game_value_is_not_clamped_by_simplex_nonnegativity(self):
+    def test_negative_game_value_is_not_clamped_by_simplex_nonnegativity(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
-                entries=tuple(
-                    {"num": str(value), "den": "1"} for value in (-2, -3, -4, -5)
-                ),
+                entries=tuple(_r(value) for value in (-2, -3, -4, -5)),
             ),
         )
 
         result = compute_nash_equilibrium(req)
 
-        assert result.row_strategy == ("1", "0")
-        assert result.col_strategy == ("0", "1")
-        assert result.value == "-3"
+        assert tuple(value.as_fraction() for value in result.row_strategy) == (
+            Fraction(1),
+            Fraction(0),
+        )
+        assert tuple(value.as_fraction() for value in result.col_strategy) == (
+            Fraction(0),
+            Fraction(1),
+        )
+        assert result.value.as_fraction() == -3
 
-    def test_fractional_payoffs_are_scaled_before_exact_linear_programming(self):
+    def test_fractional_payoffs_are_scaled_before_exact_linear_programming(
+        self,
+    ) -> None:
         values = (Fraction(1, 3), Fraction(-2, 5), Fraction(7, 4), Fraction(1, 2))
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
-                entries=tuple(
-                    {"num": str(value.numerator), "den": str(value.denominator)}
-                    for value in values
-                ),
+                entries=tuple(_r(value) for value in values),
             ),
         )
 
         result = compute_nash_equilibrium(req)
 
-        assert result.row_strategy == ("0", "1")
-        assert result.col_strategy == ("0", "1")
-        assert result.value == "1/2"
+        assert tuple(value.as_fraction() for value in result.row_strategy) == (
+            Fraction(0),
+            Fraction(1),
+        )
+        assert tuple(value.as_fraction() for value in result.col_strategy) == (
+            Fraction(0),
+            Fraction(1),
+        )
+        assert result.value.as_fraction() == Fraction(1, 2)
 
-    def test_maximin_uses_actual_payoff(self):
+    def test_maximin_uses_actual_payoff(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=1,
                 n_cols=1,
-                entries=({"num": "-100000000000000000000", "den": "1"},),
+                entries=(_r(-100000000000000000000),),
             ),
         )
         result = compute_best_response(req)
-        assert result.value == "-100000000000000000000"
+        assert result.value.as_fraction() == -100000000000000000000

--- a/tests/math/finite_game_theory/test_finite_game_theory.py
+++ b/tests/math/finite_game_theory/test_finite_game_theory.py
@@ -2,6 +2,9 @@
 
 from fractions import Fraction
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
     PayoffMatrix,
@@ -36,6 +39,22 @@ class TestBestResponse:
 
 
 class TestNashEquilibrium:
+    def test_payoffs_must_bound_exact_strategy_growth(self) -> None:
+        large = 10**32_767
+        with pytest.raises(ValidationError, match="exact-equilibrium result budget"):
+            ZeroSumGameRequest(
+                payoff_matrix=PayoffMatrix(
+                    n_rows=2,
+                    n_cols=2,
+                    entries=(
+                        _r(Fraction(1, large - 1)),
+                        _r(0),
+                        _r(0),
+                        _r(Fraction(1, large - 2)),
+                    ),
+                )
+            )
+
     def test_pure_strategy(self) -> None:
         req = ZeroSumGameRequest(
             payoff_matrix=PayoffMatrix(

--- a/tests/math/finite_stochastic_processes/test_finite_stochastic_processes.py
+++ b/tests/math/finite_stochastic_processes/test_finite_stochastic_processes.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
-
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.finite_stochastic_processes import (
     FiniteProbabilitySpace,
     FiniteRandomVariable,
@@ -32,7 +31,14 @@ from jacobian.math.finite_stochastic_processes._tools import TOOLS
 
 
 def _coin_space() -> FiniteProbabilitySpace:
-    return FiniteProbabilitySpace(samples=("H", "T"), masses=("1/2", "1/2"))
+    return FiniteProbabilitySpace(
+        samples=("H", "T"),
+        masses=(_q(1, 2), _q(1, 2)),
+    )
+
+
+def _q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(numerator, denominator)
 
 
 # ---------------------------------------------------------------------------
@@ -100,24 +106,22 @@ class TestJoin:
 
 class TestConditionalExpectation:
     def test_trivial_sigma(self) -> None:
-        rv = FiniteRandomVariable(space=_coin_space(), values=("1", "0"))
+        rv = FiniteRandomVariable(space=_coin_space(), values=(_q(1), _q(0)))
         sigma = FiniteSigmaAlgebra(space=_coin_space(), blocks=(("H", "T"),))
         result = compute_conditional_expectation(
             ConditionalExpectationRequest(rv=rv, sigma=sigma)
         )
         # E[X | trivial sigma] = E[X] = 1/2
-        assert Fraction(result.values[0]) == Fraction(1, 2)
-        assert Fraction(result.values[1]) == Fraction(1, 2)
+        assert result.values == (_q(1, 2), _q(1, 2))
 
     def test_discrete_sigma(self) -> None:
-        rv = FiniteRandomVariable(space=_coin_space(), values=("1", "0"))
+        rv = FiniteRandomVariable(space=_coin_space(), values=(_q(1), _q(0)))
         sigma = FiniteSigmaAlgebra(space=_coin_space(), blocks=(("H",), ("T",)))
         result = compute_conditional_expectation(
             ConditionalExpectationRequest(rv=rv, sigma=sigma)
         )
         # E[X | {H}] = 1, E[X | {T}] = 0
-        assert Fraction(result.values[0]) == 1
-        assert Fraction(result.values[1]) == 0
+        assert result.values == (_q(1), _q(0))
 
 
 # ---------------------------------------------------------------------------
@@ -147,12 +151,11 @@ class TestDoobMartingale:
             DoobMartingaleRequest(
                 space=_coin_space(),
                 observations=(("heads", "tails"),),
-                payoff=("1", "0"),
+                payoff=(_q(1), _q(0)),
             )
         )
         assert len(result.martingale) == 1
-        assert Fraction(result.martingale[0][0]) == 1
-        assert Fraction(result.martingale[0][1]) == 0
+        assert result.martingale[0] == (_q(1), _q(0))
 
 
 # ---------------------------------------------------------------------------
@@ -163,12 +166,26 @@ class TestDoobMartingale:
 class TestValidation:
     def test_nonpositive_mass_rejected(self) -> None:
         with pytest.raises(ValidationError, match="positive"):
-            FiniteProbabilitySpace(samples=("a",), masses=("0",))
+            FiniteProbabilitySpace(samples=("a",), masses=(_q(0),))
 
     def test_masses_not_summing_to_one_rejected(self) -> None:
         with pytest.raises(ValidationError, match="sum to exactly 1"):
-            FiniteProbabilitySpace(samples=("a", "b"), masses=("1/3", "1/3"))
+            FiniteProbabilitySpace(samples=("a", "b"), masses=(_q(1, 3), _q(1, 3)))
 
     def test_duplicate_samples_rejected(self) -> None:
         with pytest.raises(ValidationError, match="unique"):
-            FiniteProbabilitySpace(samples=("a", "a"), masses=("1/2", "1/2"))
+            FiniteProbabilitySpace(samples=("a", "a"), masses=(_q(1, 2), _q(1, 2)))
+
+    @pytest.mark.parametrize(
+        "payoff",
+        ["0/0", "1/0", {"num": "0", "den": "0"}, {"num": "1", "den": "0"}],
+    )
+    def test_doob_rejects_invalid_payoff_rationals(self, payoff: object) -> None:
+        with pytest.raises(ValidationError):
+            DoobMartingaleRequest.model_validate(
+                {
+                    "space": _coin_space().model_dump(mode="json"),
+                    "observations": [["heads", "tails"]],
+                    "payoff": [payoff, {"num": "0", "den": "1"}],
+                }
+            )

--- a/tests/math/finite_stochastic_processes/test_finite_stochastic_processes.py
+++ b/tests/math/finite_stochastic_processes/test_finite_stochastic_processes.py
@@ -123,6 +123,20 @@ class TestConditionalExpectation:
         # E[X | {H}] = 1, E[X | {T}] = 0
         assert result.values == (_q(1), _q(0))
 
+    def test_exact_result_may_grow_beyond_input_digit_bound(self) -> None:
+        left = 10**255 + 19
+        right = 10**255 + 21
+        rv = FiniteRandomVariable(
+            space=_coin_space(), values=(_q(1, left), _q(1, right))
+        )
+        sigma = FiniteSigmaAlgebra(space=_coin_space(), blocks=(("H", "T"),))
+
+        result = compute_conditional_expectation(
+            ConditionalExpectationRequest(rv=rv, sigma=sigma)
+        )
+
+        assert len(result.values[0].den) > 256
+
 
 # ---------------------------------------------------------------------------
 # Filtration

--- a/tests/math/galois_theory/test_galois_theory.py
+++ b/tests/math/galois_theory/test_galois_theory.py
@@ -1,8 +1,13 @@
-"""Tests for Galois theory operations."""
+"""Contract and mathematical-property tests for Galois operations."""
+
+import pytest
+from pydantic import ValidationError
+from sympy.combinatorics import Permutation, PermutationGroup
 
 from jacobian.math.galois_theory._models import (
     FrobeniusCycleRequest,
     GaloisFactorRequest,
+    GaloisFactorResult,
     GaloisGroupRequest,
     SolvableRequest,
 )
@@ -24,72 +29,191 @@ def test_catalog_contains_only_audited_operations() -> None:
     }
 
 
-def test_factor_x2_plus_1_over_f5() -> None:
-    request = GaloisFactorRequest(field_order=5, coefficients=(1, 0, 1))
-    result = compute_galois_factor(request)
+def _multiply_mod(
+    left: tuple[int, ...], right: tuple[int, ...], prime: int
+) -> tuple[int, ...]:
+    result = [0] * (len(left) + len(right) - 1)
+    for i, left_coefficient in enumerate(left):
+        for j, right_coefficient in enumerate(right):
+            result[i + j] = (
+                result[i + j] + left_coefficient * right_coefficient
+            ) % prime
+    return tuple(result)
+
+
+def _reconstruct(result: GaloisFactorResult) -> tuple[int, ...]:
+    polynomial = (result.unit,)
+    for factor in result.factors:
+        for _ in range(factor.multiplicity):
+            polynomial = _multiply_mod(
+                polynomial, factor.coefficients, result.field_order
+            )
+    return polynomial
+
+
+@pytest.mark.parametrize(
+    ("prime", "coefficients"),
+    [
+        (5, (1, 0, 1)),
+        (3, (0, 0, 1)),
+        (3, (2, 2)),
+        (7, (6, 0, 0, 1)),
+        (2, (1, 1, 1, 1, 1)),
+    ],
+)
+def test_factorization_reconstructs_source(
+    prime: int, coefficients: tuple[int, ...]
+) -> None:
+    result = compute_galois_factor(
+        GaloisFactorRequest(field_order=prime, coefficients=coefficients)
+    )
+    assert _reconstruct(result) == coefficients
+    assert result.factor_count == sum(factor.multiplicity for factor in result.factors)
+    assert all(
+        0 <= coefficient < prime
+        for factor in result.factors
+        for coefficient in factor.coefficients
+    )
+
+
+def test_repeated_factor_is_not_reported_irreducible() -> None:
+    result = compute_galois_factor(
+        GaloisFactorRequest(field_order=3, coefficients=(0, 0, 1))
+    )
+    assert result.unit == 1
+    assert result.factors[0].coefficients == (0, 1)
+    assert result.factors[0].multiplicity == 2
+    assert result.distinct_factor_count == 1
     assert result.factor_count == 2
-    assert not result.is_irreducible
-
-
-def test_frobenius_cycle_irreducible() -> None:
-    request = FrobeniusCycleRequest(
-        field_order=3, polynomial_degree=2, factorization_degrees=(2,)
-    )
-    result = compute_frobenius_cycle(request)
-    assert result.cycle_type == (2,)
-    assert result.is_irreducible is True
-
-
-def test_frobenius_cycle_split() -> None:
-    request = FrobeniusCycleRequest(
-        field_order=5, polynomial_degree=2, factorization_degrees=(1, 1)
-    )
-    result = compute_frobenius_cycle(request)
-    assert result.cycle_type == (1, 1)
     assert result.is_irreducible is False
 
 
-# --- Issue 1: galois_group() second return value is not solvability ---
+def test_nonmonic_factorization_retains_unit() -> None:
+    result = compute_galois_factor(
+        GaloisFactorRequest(field_order=3, coefficients=(2, 2))
+    )
+    assert result.unit == 2
+    assert result.factors[0].coefficients == (1, 1)
+    assert _reconstruct(result) == (2, 2)
 
 
-def test_galois_group_solvable_quintic() -> None:
-    """x^5 - 2 has a solvable Galois group (Frobenius group of order 20)."""
-    # coefficients in ascending order: (-2, 0, 0, 0, 0, 1) = -2 + x^5
-    request = GaloisGroupRequest(coefficients=(-2, 0, 0, 0, 0, 1))
-    result = compute_galois_group(request)
+@pytest.mark.parametrize(
+    ("prime", "coefficients"),
+    [
+        (3, (1, 0, 1)),
+        (5, (2, 1, 0, 1)),
+        (7, (6, 0, 1, 1)),
+    ],
+)
+def test_multiplying_by_every_field_unit_preserves_monic_factors(
+    prime: int, coefficients: tuple[int, ...]
+) -> None:
+    base = compute_galois_factor(
+        GaloisFactorRequest(field_order=prime, coefficients=coefficients)
+    )
+
+    for scalar in range(1, prime):
+        scaled_coefficients = tuple(
+            scalar * coefficient % prime for coefficient in coefficients
+        )
+        scaled = compute_galois_factor(
+            GaloisFactorRequest(
+                field_order=prime,
+                coefficients=scaled_coefficients,
+            )
+        )
+
+        assert scaled.factors == base.factors
+        assert scaled.unit == scalar * base.unit % prime
+        assert _reconstruct(scaled) == scaled_coefficients
+
+
+def test_zero_and_noncanonical_degree_are_rejected_before_sympy() -> None:
+    with pytest.raises(ValidationError, match="nonzero polynomial"):
+        GaloisFactorRequest(field_order=3, coefficients=(0, 0))
+    with pytest.raises(ValidationError, match="nonzero polynomial"):
+        GaloisFactorRequest(field_order=3, coefficients=(1, 0))
+
+
+def test_factorization_result_rejects_a_forged_certificate() -> None:
+    result = compute_galois_factor(
+        GaloisFactorRequest(field_order=5, coefficients=(1, 0, 1))
+    )
+    payload = result.model_dump()
+    payload["unit"] = 2
+    with pytest.raises(ValidationError, match="reconstruct"):
+        GaloisFactorResult.model_validate(payload)
+
+    payload = result.model_dump()
+    payload["field_order"] = 4
+    with pytest.raises(ValidationError, match="prime"):
+        GaloisFactorResult.model_validate(payload)
+
+
+def test_frobenius_cycle_is_canonical_positive_partition() -> None:
+    result = compute_frobenius_cycle(
+        FrobeniusCycleRequest(
+            field_order=5,
+            polynomial_degree=4,
+            factorization_degrees=(1, 3),
+        )
+    )
+    assert result.cycle_type == (3, 1)
+    assert result.is_irreducible is False
+    irreducible = compute_frobenius_cycle(
+        FrobeniusCycleRequest(
+            field_order=3,
+            polynomial_degree=2,
+            factorization_degrees=(2,),
+        )
+    )
+    assert irreducible.cycle_type == (2,)
+    assert irreducible.is_irreducible is True
+
+
+@pytest.mark.parametrize("degrees", [(2, 0), (3, -1)])
+def test_frobenius_rejects_nonpositive_factor_degrees(
+    degrees: tuple[int, ...],
+) -> None:
+    with pytest.raises(ValidationError):
+        FrobeniusCycleRequest(
+            field_order=3,
+            polynomial_degree=2,
+            factorization_degrees=degrees,
+        )
+
+
+@pytest.mark.parametrize("request_type", [GaloisGroupRequest, SolvableRequest])
+def test_galois_backend_domain_is_enforced_before_execution(request_type: type) -> None:
+    with pytest.raises(ValidationError, match="irreducible"):
+        request_type(coefficients=(0, 0, 0, 0, 1))
+    with pytest.raises(ValidationError, match="at most 7 items"):
+        request_type(coefficients=(-2, 0, 0, 0, 0, 0, 0, 1))
+
+
+def _group_from_result(result: object) -> PermutationGroup:
+    group = result.group  # type: ignore[attr-defined]
+    return PermutationGroup(
+        *(Permutation(list(generator)) for generator in group.generators)
+    )
+
+
+def test_galois_group_returns_composable_generators() -> None:
+    result = compute_galois_group(GaloisGroupRequest(coefficients=(-1, -1, 0, 0, 0, 1)))
     assert result.degree == 5
-    assert result.is_solvable is True
-    assert result.order == 20
-
-
-def test_galois_group_unsolvable_quintic() -> None:
-    """x^5 - x - 1 has Galois group S_5 (not solvable)."""
-    # coefficients in ascending order: (-1, -1, 0, 0, 0, 1) = -1 - x + x^5
-    request = GaloisGroupRequest(coefficients=(-1, -1, 0, 0, 0, 1))
-    result = compute_galois_group(request)
-    assert result.degree == 5
+    assert result.order == 120
     assert result.is_solvable is False
-    assert result.order == 120  # |S_5| = 120
+    assert result.group.root_axis == tuple(f"root_{index}" for index in range(5))
+    assert _group_from_result(result).order() == result.order
 
 
-# --- Issue 2: radical solvability must use actual Galois group, not degree ---
-
-
-def test_solvable_cubic() -> None:
-    request = SolvableRequest(coefficients=(-2, 0, 0, 1))
-    result = compute_solvable(request)
+def test_solvable_quintic_returns_the_group_certificate() -> None:
+    result = compute_solvable(SolvableRequest(coefficients=(-2, 0, 0, 0, 0, 1)))
     assert result.solvable_by_radicals is True
+    assert _group_from_result(result).order() == 20
 
 
-def test_solvable_quintic_x5_minus_2() -> None:
-    """x^5 - 2 is solvable by radicals even though degree is 5."""
-    request = SolvableRequest(coefficients=(-2, 0, 0, 0, 0, 1))
-    result = compute_solvable(request)
-    assert result.solvable_by_radicals is True
-
-
-def test_not_solvable_quintic_s5() -> None:
-    """x^5 - x - 1 has Galois group S_5, not solvable by radicals."""
-    request = SolvableRequest(coefficients=(-1, -1, 0, 0, 0, 1))
-    result = compute_solvable(request)
+def test_unsolvable_quintic_uses_actual_group() -> None:
+    result = compute_solvable(SolvableRequest(coefficients=(-1, -1, 0, 0, 0, 1)))
     assert result.solvable_by_radicals is False
+    assert _group_from_result(result).order() == 120

--- a/tests/math/galois_theory/test_galois_theory.py
+++ b/tests/math/galois_theory/test_galois_theory.py
@@ -149,6 +149,22 @@ def test_factorization_result_rejects_a_forged_certificate() -> None:
     with pytest.raises(ValidationError, match="prime"):
         GaloisFactorResult.model_validate(payload)
 
+    with pytest.raises(ValidationError, match="factor must be irreducible"):
+        GaloisFactorResult(
+            field_order=3,
+            source_coefficients=(2, 0, 1),
+            unit=1,
+            factors=(
+                {
+                    "coefficients": (2, 0, 1),
+                    "multiplicity": 1,
+                },
+            ),
+            distinct_factor_count=1,
+            factor_count=1,
+            is_irreducible=True,
+        )
+
 
 def test_frobenius_cycle_is_canonical_positive_partition() -> None:
     result = compute_frobenius_cycle(

--- a/tests/math/graphical_models/test_graphical_models.py
+++ b/tests/math/graphical_models/test_graphical_models.py
@@ -115,6 +115,17 @@ class TestFactorValuesAndOperations:
 
 
 class TestBoundResultContracts:
+    def test_factor_multiply_contract_version_tracks_wire_shape(self) -> None:
+        from jacobian.math.graphical_models._tools import TOOLS
+
+        operation = next(
+            tool
+            for tool in TOOLS
+            if tool.operation_id == "graphical_model.factor.multiply"
+        )
+
+        assert operation.version == "2"
+
     def test_multiply_adapter_binds_operands(self) -> None:
         request = FactorMultiplyRequest(
             left=_factor((0,), ("1", "2")),
@@ -215,7 +226,6 @@ class TestVariableElimination:
         assert "graphical_model.variable_elimination.compute" not in {
             tool.operation_id for tool in TOOLS
         }
-
 
 class TestDSeparation:
     @pytest.mark.parametrize(

--- a/tests/math/graphical_models/test_graphical_models.py
+++ b/tests/math/graphical_models/test_graphical_models.py
@@ -1,8 +1,11 @@
 """Known-answer and adversarial tests for finite graphical models."""
 
+from fractions import Fraction
+
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.graphical_models import (
     Factor,
     d_separation,
@@ -29,7 +32,19 @@ def _factor(
     table: tuple[str, ...],
     domain_sizes: tuple[int, ...] = (2, 2, 2),
 ) -> Factor:
-    return Factor(variables=variables, domain_sizes=domain_sizes, table=table)
+    return Factor(
+        variables=variables,
+        domain_sizes=domain_sizes,
+        table=_table(*table),
+    )
+
+
+def _table(*values: str) -> tuple[CanonicalRational, ...]:
+    return tuple(CanonicalRational.from_fraction(Fraction(value)) for value in values)
+
+
+def _strings(values: tuple[CanonicalRational, ...]) -> tuple[str, ...]:
+    return tuple(str(value.as_fraction()) for value in values)
 
 
 class TestFactorValuesAndOperations:
@@ -40,7 +55,7 @@ class TestFactorValuesAndOperations:
         result = factor_multiply(left, right)
 
         assert result.variables == (0, 1)
-        assert result.table == ("1/6", "1/3", "1/6", "1/3")
+        assert _strings(result.table) == ("1/6", "1/3", "1/6", "1/3")
 
     def test_multiply_projects_noncanonical_input_scope_orders(self) -> None:
         left = _factor((1, 0), ("1", "2", "3", "4"))
@@ -49,24 +64,35 @@ class TestFactorValuesAndOperations:
         result = factor_multiply(left, right)
 
         assert result.variables == (0, 1, 2)
-        assert result.table == ("5", "7", "18", "24", "10", "14", "24", "32")
+        assert _strings(result.table) == (
+            "5",
+            "7",
+            "18",
+            "24",
+            "10",
+            "14",
+            "24",
+            "32",
+        )
 
     def test_marginalize_one_variable(self) -> None:
         result = factor_marginalize(_factor((0, 1), ("1/4", "1/4", "1/4", "1/4")), 0)
 
         assert result.variables == (1,)
-        assert result.table == ("1/2", "1/2")
+        assert _strings(result.table) == ("1/2", "1/2")
 
     def test_marginalize_last_variable_returns_exact_scalar(self) -> None:
         result = factor_marginalize(_factor((0,), ("1/3", "2/3")), 0)
 
         assert result.variables == ()
-        assert result.table == ("1",)
+        assert _strings(result.table) == ("1",)
 
     @pytest.mark.parametrize("value", ["01", "+1", "2/4", "1.0"])
     def test_factor_entries_must_be_canonical_rationals(self, value: str) -> None:
-        with pytest.raises(ValidationError, match="canonical"):
-            _factor((), (value,))
+        with pytest.raises(ValidationError, match="valid dictionary"):
+            Factor.model_validate(
+                {"variables": (), "domain_sizes": (2,), "table": (value,)}
+            )
 
     def test_duplicate_factor_variables_are_rejected(self) -> None:
         with pytest.raises(ValidationError, match="distinct"):
@@ -74,7 +100,7 @@ class TestFactorValuesAndOperations:
 
     def test_zero_domain_size_is_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Factor(variables=(0,), domain_sizes=(0,), table=("1",))
+            Factor(variables=(0,), domain_sizes=(0,), table=_table("1"))
 
     def test_wrong_table_size_is_rejected(self) -> None:
         with pytest.raises(ValidationError, match="table size"):
@@ -99,7 +125,7 @@ class TestBoundResultContracts:
 
         assert result.left == request.left
         assert result.right == request.right
-        assert result.factor.table == ("3", "8")
+        assert _strings(result.factor.table) == ("3", "8")
 
     def test_false_product_is_rejected(self) -> None:
         left = _factor((0,), ("1", "2"))
@@ -116,7 +142,7 @@ class TestBoundResultContracts:
 
         assert result.source_factor == source
         assert result.variable == 0
-        assert result.factor.table == ("3",)
+        assert _strings(result.factor.table) == ("3",)
 
 
 class TestVariableElimination:
@@ -131,7 +157,7 @@ class TestVariableElimination:
         )
 
         assert result.variables == (1,)
-        assert result.table == ("3/8", "5/8")
+        assert _strings(result.table) == ("3/8", "5/8")
 
     def test_eliminating_all_variables_returns_partition_scalar(self) -> None:
         result = variable_elimination(
@@ -142,7 +168,7 @@ class TestVariableElimination:
         )
 
         assert result.variables == ()
-        assert result.table == ("5",)
+        assert _strings(result.table) == ("5",)
 
     def test_incomplete_elimination_order_is_rejected_before_computation(self) -> None:
         with pytest.raises(ValueError, match="every non-query"):
@@ -167,12 +193,12 @@ class TestVariableElimination:
         left = Factor(
             variables=tuple(range(8)),
             domain_sizes=domain_sizes,
-            table=("1",) * 256,
+            table=_table(*(("1",) * 256)),
         )
         right = Factor(
             variables=tuple(range(8, 16)),
             domain_sizes=domain_sizes,
-            table=("1",) * 256,
+            table=_table(*(("1",) * 256)),
         )
 
         with pytest.raises(ValueError, match="size bound"):

--- a/tests/math/graphical_models/test_graphical_models.py
+++ b/tests/math/graphical_models/test_graphical_models.py
@@ -227,6 +227,7 @@ class TestVariableElimination:
             tool.operation_id for tool in TOOLS
         }
 
+
 class TestDSeparation:
     @pytest.mark.parametrize(
         ("edges", "set_c", "expected"),

--- a/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
+++ b/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
@@ -174,6 +174,13 @@ class TestRestrict:
         # {a,b} becomes {a,b}. The redundant single-element bag {b} should be
         # pruned if it is contained in its neighbor {a,b}.
 
+    def test_rejects_vertices_outside_the_source_graph(self) -> None:
+        with pytest.raises(ValidationError, match="declared source vertices"):
+            RestrictRequest(
+                decomposition=_path_decomposition(),
+                subset=("a", "missing"),
+            )
+
 
 # ---------------------------------------------------------------------------
 # Bag intersection graph

--- a/tests/math/hyperplane_arrangements/test_hyperplane_arrangements.py
+++ b/tests/math/hyperplane_arrangements/test_hyperplane_arrangements.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.hyperplane_arrangements._models import (
     ChamberCountRequest,
     CharacteristicPolynomialRequest,
@@ -17,6 +18,10 @@ from jacobian.math.hyperplane_arrangements._operations import (
 from jacobian.math.hyperplane_arrangements._tools import TOOLS
 
 
+def _r(num: int, den: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(num, den)
+
+
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "arrangement.construct",
@@ -29,8 +34,8 @@ def test_arrangement_central() -> None:
     request = HyperplaneArrangementRequest(
         ambient_dimension=2,
         hyperplanes=(
-            {"coefficients": ("1", "0"), "constant": "0"},
-            {"coefficients": ("0", "1"), "constant": "0"},
+            RationalHyperplane(coefficients=(_r(1), _r(0)), constant=_r(0)),
+            RationalHyperplane(coefficients=(_r(0), _r(1)), constant=_r(0)),
         ),
     )
     result = compute_arrangement(request)
@@ -42,8 +47,8 @@ def test_arrangement_noncentral() -> None:
     request = HyperplaneArrangementRequest(
         ambient_dimension=2,
         hyperplanes=(
-            {"coefficients": ("1", "0"), "constant": "0"},
-            {"coefficients": ("0", "1"), "constant": "1"},
+            RationalHyperplane(coefficients=(_r(1), _r(0)), constant=_r(0)),
+            RationalHyperplane(coefficients=(_r(0), _r(1)), constant=_r(1)),
         ),
     )
     result = compute_arrangement(request)
@@ -118,27 +123,33 @@ def test_chamber_count_zaslavsky_consistency() -> None:
 
 
 def test_rational_hyperplane_valid() -> None:
-    hp = RationalHyperplane(coefficients=("1", "0"), constant="0")
-    assert hp.coefficients == ("1", "0")
-    assert hp.constant == "0"
+    hp = RationalHyperplane(coefficients=(_r(1), _r(0)), constant=_r(0))
+    assert hp.coefficients == (_r(1), _r(0))
+    assert hp.constant == _r(0)
 
 
 def test_rational_hyperplane_rejects_non_rational() -> None:
     with pytest.raises(ValidationError):
-        RationalHyperplane(coefficients=("sqrt(2)", "0"), constant="0")
+        RationalHyperplane(
+            coefficients=("sqrt(2)", _r(0)),  # type: ignore[arg-type]
+            constant=_r(0),
+        )
 
 
 def test_rational_hyperplane_rejects_all_zero_coefficients() -> None:
     with pytest.raises(ValidationError):
-        RationalHyperplane(coefficients=("0", "0"), constant="0")
+        RationalHyperplane(coefficients=(_r(0), _r(0)), constant=_r(0))
 
 
 def test_rational_hyperplane_rejects_non_rational_constant() -> None:
     with pytest.raises(ValidationError):
-        RationalHyperplane(coefficients=("1", "0"), constant="abc")
+        RationalHyperplane(
+            coefficients=(_r(1), _r(0)),
+            constant="abc",  # type: ignore[arg-type]
+        )
 
 
 def test_rational_hyperplane_accepts_negative_rationals() -> None:
-    hp = RationalHyperplane(coefficients=("-1/2", "3/4"), constant="5/6")
-    assert hp.coefficients == ("-1/2", "3/4")
-    assert hp.constant == "5/6"
+    hp = RationalHyperplane(coefficients=(_r(-1, 2), _r(3, 4)), constant=_r(5, 6))
+    assert hp.coefficients == (_r(-1, 2), _r(3, 4))
+    assert hp.constant == _r(5, 6)

--- a/tests/math/matrices/test_symbolic_matrix.py
+++ b/tests/math/matrices/test_symbolic_matrix.py
@@ -148,10 +148,23 @@ def test_determinant_request_rejects_unrepresentable_expansion() -> None:
         for row in range(8)
     )
 
-    with pytest.raises(ValidationError, match="term operation budget"):
+    with pytest.raises(ValidationError, match="result term budget"):
         SymbolicDeterminantRequest(
             matrix=SymbolicMatrix(variables=variables, entries=entries)
         )
+
+
+def test_determinant_request_admission_does_not_execute_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.matrices.symbolic as symbolic
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("determinant kernel ran during request validation")
+
+    monkeypatch.setattr(symbolic, "symbolic_determinant", fail_if_called)
+
+    assert isinstance(_generic_two_by_two(), SymbolicDeterminantRequest)
 
 
 def test_symbolic_rank_of_full_and_singular_matrices() -> None:

--- a/tests/math/matrices/test_symbolic_matrix.py
+++ b/tests/math/matrices/test_symbolic_matrix.py
@@ -1,15 +1,19 @@
-"""Domain tests for exact symbolic matrix operations over QQ(t_1, ..., t_n)."""
+"""Domain tests for exact symbolic matrices over rational-function fields."""
 
 from __future__ import annotations
+
+from collections.abc import Sequence
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.matrices.symbolic._models import (
     SquareSymbolicMatrixRequest,
     SymbolicCharacteristicPolynomialResult,
     SymbolicDeterminantResult,
     SymbolicEigenvaluesResult,
+    SymbolicMatrix,
     SymbolicMatrixRequest,
     SymbolicRankResult,
 )
@@ -20,85 +24,151 @@ from jacobian.math.matrices.symbolic._operations import (
     compute_symbolic_rank,
 )
 from jacobian.math.matrices.symbolic._tools import TOOLS
+from jacobian.math.polynomials.values import (
+    RationalFunction,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+Term = tuple[int, int, tuple[int, ...]]
+
+
+def _sparse(*terms: Term) -> SparseRationalPolynomial:
+    return SparseRationalPolynomial(
+        terms=tuple(
+            RationalPolynomialTerm(
+                coefficient=CanonicalRational.from_integer_ratio(
+                    numerator, denominator
+                ),
+                exponents=exponents,
+            )
+            for numerator, denominator, exponents in terms
+        )
+    )
+
+
+def _rf(
+    variables: tuple[str, ...],
+    *numerator: Term,
+    denominator: Sequence[Term] | None = None,
+) -> RationalFunction:
+    if denominator is None:
+        denominator = ((1, 1, (0,) * len(variables)),)
+    return RationalFunction(
+        variables=variables,
+        numerator=_sparse(*numerator),
+        denominator=_sparse(*denominator),
+    )
+
+
+def _constant(value: int) -> RationalFunction:
+    return _rf((), *((value, 1, ()),) if value else ())
+
+
+def _variable(variables: tuple[str, ...], index: int) -> RationalFunction:
+    exponents = tuple(
+        1 if position == index else 0 for position in range(len(variables))
+    )
+    return _rf(variables, (1, 1, exponents))
 
 
 def _request(
-    entries: list[list[str]], variables: list[str] | None = None
+    entries: Sequence[Sequence[RationalFunction]],
+    variables: tuple[str, ...],
 ) -> SymbolicMatrixRequest:
-    if variables is None:
-        variables = []
-    return SymbolicMatrixRequest.model_validate(
-        {"matrix": {"variables": variables, "entries": entries}}
+    return SymbolicMatrixRequest(
+        matrix=SymbolicMatrix(variables=variables, entries=tuple(map(tuple, entries)))
     )
 
 
 def _square_request(
-    entries: list[list[str]], variables: list[str] | None = None
+    entries: Sequence[Sequence[RationalFunction]],
+    variables: tuple[str, ...],
 ) -> SquareSymbolicMatrixRequest:
-    if variables is None:
-        variables = []
-    return SquareSymbolicMatrixRequest.model_validate(
-        {"matrix": {"variables": variables, "entries": entries}}
+    return SquareSymbolicMatrixRequest(
+        matrix=SymbolicMatrix(variables=variables, entries=tuple(map(tuple, entries)))
     )
 
 
+def _generic_two_by_two() -> SquareSymbolicMatrixRequest:
+    variables = ("a", "b", "c", "d")
+    a, b, c, d = (_variable(variables, index) for index in range(4))
+    return _square_request(((a, c), (b, d)), variables)
+
+
 def test_symbolic_determinant_of_two_by_two() -> None:
-    request = _request([["a", "c"], ["b", "d"]], ["a", "b", "c", "d"])
-    result = compute_symbolic_determinant(request)
+    result = compute_symbolic_determinant(_generic_two_by_two())
     assert isinstance(result, SymbolicDeterminantResult)
-    assert result.determinant == "a*d - b*c"
+    assert result.determinant == _rf(
+        ("a", "b", "c", "d"),
+        (1, 1, (1, 0, 0, 1)),
+        (-1, 1, (0, 1, 1, 0)),
+    )
 
 
 def test_symbolic_determinant_of_constant_matrix() -> None:
-    request = _request([["1", "2"], ["3", "4"]], [])
-    result = compute_symbolic_determinant(request)
-    # SymPy may render integer results as "10" or "-2" etc.
-    assert result.determinant in ("-2", "(-2)")
+    request = _square_request(
+        ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
+    )
+    assert compute_symbolic_determinant(request).determinant == _constant(-2)
 
 
-def test_symbolic_rank_of_full_matrix() -> None:
-    request = _request([["a", "c"], ["b", "d"]], ["a", "b", "c", "d"])
-    result = compute_symbolic_rank(request)
-    assert isinstance(result, SymbolicRankResult)
-    assert result.rank == 2
-    assert result.pivot_columns == (0, 1)
+def test_symbolic_rank_of_full_and_singular_matrices() -> None:
+    full = compute_symbolic_rank(_generic_two_by_two())
+    assert isinstance(full, SymbolicRankResult)
+    assert full.rank == 2
+    assert full.pivot_columns == (0, 1)
+
+    variables = ("a",)
+    a = _variable(variables, 0)
+    singular = compute_symbolic_rank(_request(((a, a), (a, a)), variables))
+    assert singular.rank == 1
 
 
-def test_symbolic_rank_of_singular_matrix() -> None:
-    # Rows are multiples over a rational function field
-    request = _request([["a", "a"], ["a", "a"]], ["a"])
-    result = compute_symbolic_rank(request)
-    assert result.rank == 1
+def test_rational_function_entries_use_the_advertised_field() -> None:
+    variables = ("x",)
+    inverse_x = _rf(
+        variables,
+        (1, 1, (0,)),
+        denominator=((1, 1, (1,)),),
+    )
+    result = compute_symbolic_determinant(_square_request(((inverse_x,),), variables))
+    assert result.determinant == inverse_x
 
 
 def test_symbolic_characteristic_polynomial_of_constant_matrix() -> None:
-    request = _request([["1", "2"], ["3", "4"]], [])
+    request = _square_request(
+        ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
+    )
     result = compute_symbolic_characteristic_polynomial(request)
     assert isinstance(result, SymbolicCharacteristicPolynomialResult)
     assert result.degree == 2
-    assert result.coefficients_descending == ("1", "-5", "-2")
+    assert result.coefficients_descending == (
+        _constant(1),
+        _constant(-5),
+        _constant(-2),
+    )
 
 
 def test_symbolic_characteristic_polynomial_of_zero_matrix() -> None:
-    request = _request([["0", "0"], ["0", "0"]], [])
-    result = compute_symbolic_characteristic_polynomial(request)
-    assert result.coefficients_descending == ("1", "0", "0")
+    zero = _constant(0)
+    result = compute_symbolic_characteristic_polynomial(
+        _square_request(((zero, zero), (zero, zero)), ())
+    )
+    assert result.coefficients_descending == (
+        _constant(1),
+        _constant(0),
+        _constant(0),
+    )
 
 
 def test_symbolic_eigenvalues_of_constant_matrix() -> None:
-    request = _request([["1", "2"], ["3", "4"]], [])
+    request = _square_request(
+        ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
+    )
     result = compute_symbolic_eigenvalues(request)
     assert isinstance(result, SymbolicEigenvaluesResult)
-    # eigenvalues are (5 - sqrt(33))/2 and (5 + sqrt(33)/2, each with multiplicity 1
-    assert len(result.eigenvalues) == 2
-    assert result.multiplicities == (1, 1)
-
-
-def test_symbolic_eigenvalues_of_quadratic_algebraic_entries() -> None:
-    # A = [[1/4, sqrt(3)/4], [sqrt(3)/4, 3/4]] -> eigenvalues 0 and 1
-    request = _request([["1/4", "sqrt(3)/4"], ["sqrt(3)/4", "3/4"]], [])
-    result = compute_symbolic_eigenvalues(request)
-    assert sorted(result.eigenvalues) == ["0", "1"]
+    assert len(result.eigenvalues or ()) == 2
     assert result.multiplicities == (1, 1)
 
 
@@ -110,49 +180,34 @@ def test_symbolic_eigenvalues_of_quadratic_algebraic_entries() -> None:
         "matrix.symbolic.eigenvalues.compute",
     ),
 )
-def test_square_only_symbolic_descriptors_reject_rectangular_input(
-    operation_id: str,
-) -> None:
+def test_square_only_descriptors_reject_rectangular_input(operation_id: str) -> None:
     operation = next(tool for tool in TOOLS if tool.operation_id == operation_id)
     with pytest.raises(ValidationError, match="square"):
         operation.request_type.model_validate(
-            {"matrix": {"variables": ["a", "b"], "entries": [["a", "b"]]}}
+            {
+                "matrix": {
+                    "variables": [],
+                    "entries": [[_constant(1).model_dump(), _constant(2).model_dump()]],
+                }
+            }
         )
 
 
-def test_rectangular_accepted_by_rank_request() -> None:
-    """Rectangular matrices remain valid for the rank operation."""
-    request = _request([["a", "b", "c"]], ["a", "b", "c"])
-    result = compute_symbolic_rank(request)
+def test_rectangular_matrix_is_accepted_only_by_rank_contract() -> None:
+    result = compute_symbolic_rank(
+        _request(((_constant(1), _constant(2), _constant(3)),), ())
+    )
     assert result.rank == 1
 
 
-def test_symbolic_determinant_of_one_by_one() -> None:
-    result = compute_symbolic_determinant(_square_request([["a"]], ["a"]))
-    assert result.determinant == "a"
+def test_symbolic_matrix_dimensions_are_bounded_at_eight() -> None:
+    entries = tuple(tuple(_constant(1) for _ in range(8)) for _ in range(8))
+    _square_request(entries, ())
+    with pytest.raises(ValidationError, match="8"):
+        _request((tuple(_constant(1) for _ in range(9)),), ())
 
 
-def test_symbolic_characteristic_polynomial_of_one_by_one() -> None:
-    result = compute_symbolic_characteristic_polynomial(_square_request([["a"]], ["a"]))
-    assert result.degree == 1
-    assert result.coefficients_descending == ("1", "-a")
-
-
-def test_symbolic_eigenvalues_of_one_by_one() -> None:
-    result = compute_symbolic_eigenvalues(_square_request([["a"]], ["a"]))
-    assert result.eigenvalues == ("a",)
-    assert result.multiplicities == (1,)
-
-
-def test_square_request_accepts_32x32() -> None:
-    """32x32 boundary shape validates for all square-only operations."""
-    entries = [["1"] * 32 for _ in range(32)]
-    SquareSymbolicMatrixRequest.model_validate(
-        {"matrix": {"variables": [], "entries": entries}}
-    )
-
-
-def test_symbolic_descriptors_publish_their_actual_request_boundaries() -> None:
+def test_symbolic_descriptors_publish_operation_specific_boundaries() -> None:
     request_types = {tool.operation_id: tool.request_type for tool in TOOLS}
     assert request_types == {
         "matrix.symbolic.determinant.compute": SquareSymbolicMatrixRequest,
@@ -162,40 +217,60 @@ def test_symbolic_descriptors_publish_their_actual_request_boundaries() -> None:
     }
 
 
-def test_symbolic_matrix_rejects_non_rectangular() -> None:
-    with pytest.raises(ValueError, match="same length"):
-        SymbolicMatrixRequest.model_validate(
-            {"matrix": {"variables": ["a"], "entries": [["a", "b"], ["a"]]}}
+def test_matrix_rejects_nonrectangular_mismatched_and_invalid_axes() -> None:
+    a = _variable(("a",), 0)
+    with pytest.raises(ValidationError, match="same length"):
+        SymbolicMatrix(variables=("a",), entries=((a, a), (a,)))
+    with pytest.raises(ValidationError, match="declared ordered field"):
+        SymbolicMatrix(variables=("b",), entries=((a,),))
+    with pytest.raises(ValidationError, match="string_pattern_mismatch"):
+        SymbolicMatrix.model_validate(
+            {"variables": [""], "entries": [[a.model_dump()]]}
         )
 
 
-def test_symbolic_matrix_rejects_oversized() -> None:
-    with pytest.raises(ValueError, match="32"):
+def test_public_matrix_entries_reject_expression_strings_without_execution(
+    tmp_path,
+) -> None:
+    marker = tmp_path / "sympy-evaluated"
+    payload = f"__import__('pathlib').Path({str(marker)!r}).touch()"
+    with pytest.raises(ValidationError):
         SymbolicMatrixRequest.model_validate(
-            {
-                "matrix": {
-                    "variables": ["a"],
-                    "entries": [["a"] * 33],
-                }
-            }
+            {"matrix": {"variables": [], "entries": [[payload]]}}
+        )
+    assert not marker.exists()
+
+
+def test_noncanonical_rational_functions_are_rejected() -> None:
+    variables = ("x",)
+    with pytest.raises(ValidationError, match="monic"):
+        _rf(
+            variables,
+            (1, 1, (0,)),
+            denominator=((2, 1, (1,)),),
+        )
+    with pytest.raises(ValidationError, match="coprime"):
+        _rf(
+            variables,
+            (1, 1, (1,)),
+            denominator=((1, 1, (1,)),),
         )
 
 
-def test_symbolic_eigenvalues_returns_polynomial_for_unrepresentable() -> None:
-    """Parameterized quintic companion matrix returns ROOTS_BY_POLYNOMIAL."""
-    request = SymbolicMatrixRequest.model_validate(
-        {
-            "matrix": {
-                "variables": ["a"],
-                "entries": [
-                    ["0", "0", "0", "0", "a"],
-                    ["1", "0", "0", "0", "1"],
-                    ["0", "1", "0", "0", "0"],
-                    ["0", "0", "1", "0", "0"],
-                    ["0", "0", "0", "1", "0"],
-                ],
-            }
-        }
+def test_symbolic_eigenvalues_returns_polynomial_for_unrepresentable_roots() -> None:
+    variables = ("a",)
+    zero = _rf(variables)
+    one = _rf(variables, (1, 1, (0,)))
+    a = _variable(variables, 0)
+    request = _square_request(
+        (
+            (zero, zero, zero, zero, a),
+            (one, zero, zero, zero, one),
+            (zero, one, zero, zero, zero),
+            (zero, zero, one, zero, zero),
+            (zero, zero, zero, one, zero),
+        ),
+        variables,
     )
     result = compute_symbolic_eigenvalues(request)
     assert result.representation == "ROOTS_BY_POLYNOMIAL"
@@ -204,9 +279,10 @@ def test_symbolic_eigenvalues_returns_polynomial_for_unrepresentable() -> None:
     assert result.eigenvalues is None
 
 
-def test_symbolic_eigenvalues_explicit_for_representable() -> None:
-    """Regular 2x2 matrix returns EXPLICIT_ROOTS."""
-    request = _request([["1", "2"], ["3", "4"]], [])
+def test_symbolic_eigenvalues_explicit_for_representable_roots() -> None:
+    request = _square_request(
+        ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
+    )
     result = compute_symbolic_eigenvalues(request)
     assert result.representation == "EXPLICIT_ROOTS"
     assert result.eigenvalues is not None

--- a/tests/math/matrices/test_symbolic_matrix.py
+++ b/tests/math/matrices/test_symbolic_matrix.py
@@ -10,7 +10,9 @@ from pydantic import ValidationError
 from jacobian._exact import CanonicalRational
 from jacobian.math.matrices.symbolic._models import (
     SquareSymbolicMatrixRequest,
+    SymbolicCharacteristicPolynomialRequest,
     SymbolicCharacteristicPolynomialResult,
+    SymbolicDeterminantRequest,
     SymbolicDeterminantResult,
     SymbolicEigenvaluesResult,
     SymbolicMatrix,
@@ -90,10 +92,26 @@ def _square_request(
     )
 
 
-def _generic_two_by_two() -> SquareSymbolicMatrixRequest:
+def _determinant_request(
+    entries: Sequence[Sequence[RationalFunction]],
+    variables: tuple[str, ...],
+) -> SymbolicDeterminantRequest:
+    return SymbolicDeterminantRequest(matrix=_square_request(entries, variables).matrix)
+
+
+def _characteristic_request(
+    entries: Sequence[Sequence[RationalFunction]],
+    variables: tuple[str, ...],
+) -> SymbolicCharacteristicPolynomialRequest:
+    return SymbolicCharacteristicPolynomialRequest(
+        matrix=_square_request(entries, variables).matrix
+    )
+
+
+def _generic_two_by_two() -> SymbolicDeterminantRequest:
     variables = ("a", "b", "c", "d")
     a, b, c, d = (_variable(variables, index) for index in range(4))
-    return _square_request(((a, c), (b, d)), variables)
+    return _determinant_request(((a, c), (b, d)), variables)
 
 
 def test_symbolic_determinant_of_two_by_two() -> None:
@@ -107,10 +125,33 @@ def test_symbolic_determinant_of_two_by_two() -> None:
 
 
 def test_symbolic_determinant_of_constant_matrix() -> None:
-    request = _square_request(
+    request = _determinant_request(
         ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
     )
     assert compute_symbolic_determinant(request).determinant == _constant(-2)
+
+
+def test_determinant_request_rejects_unrepresentable_expansion() -> None:
+    variables = tuple(f"x{index}" for index in range(8))
+    zero = _rf(variables)
+    diagonal = tuple(
+        _rf(
+            variables,
+            (1, 1, tuple(2 if position == index else 0 for position in range(8))),
+            (1, 1, tuple(1 if position == index else 0 for position in range(8))),
+            (1, 1, (0,) * 8),
+        )
+        for index in range(8)
+    )
+    entries = tuple(
+        tuple(diagonal[row] if row == column else zero for column in range(8))
+        for row in range(8)
+    )
+
+    with pytest.raises(ValidationError, match="term operation budget"):
+        SymbolicDeterminantRequest(
+            matrix=SymbolicMatrix(variables=variables, entries=entries)
+        )
 
 
 def test_symbolic_rank_of_full_and_singular_matrices() -> None:
@@ -132,12 +173,14 @@ def test_rational_function_entries_use_the_advertised_field() -> None:
         (1, 1, (0,)),
         denominator=((1, 1, (1,)),),
     )
-    result = compute_symbolic_determinant(_square_request(((inverse_x,),), variables))
+    result = compute_symbolic_determinant(
+        _determinant_request(((inverse_x,),), variables)
+    )
     assert result.determinant == inverse_x
 
 
 def test_symbolic_characteristic_polynomial_of_constant_matrix() -> None:
-    request = _square_request(
+    request = _characteristic_request(
         ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
     )
     result = compute_symbolic_characteristic_polynomial(request)
@@ -153,7 +196,7 @@ def test_symbolic_characteristic_polynomial_of_constant_matrix() -> None:
 def test_symbolic_characteristic_polynomial_of_zero_matrix() -> None:
     zero = _constant(0)
     result = compute_symbolic_characteristic_polynomial(
-        _square_request(((zero, zero), (zero, zero)), ())
+        _characteristic_request(((zero, zero), (zero, zero)), ())
     )
     assert result.coefficients_descending == (
         _constant(1),
@@ -163,7 +206,7 @@ def test_symbolic_characteristic_polynomial_of_zero_matrix() -> None:
 
 
 def test_symbolic_eigenvalues_of_constant_matrix() -> None:
-    request = _square_request(
+    request = _characteristic_request(
         ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
     )
     result = compute_symbolic_eigenvalues(request)
@@ -210,10 +253,10 @@ def test_symbolic_matrix_dimensions_are_bounded_at_eight() -> None:
 def test_symbolic_descriptors_publish_operation_specific_boundaries() -> None:
     request_types = {tool.operation_id: tool.request_type for tool in TOOLS}
     assert request_types == {
-        "matrix.symbolic.determinant.compute": SquareSymbolicMatrixRequest,
+        "matrix.symbolic.determinant.compute": SymbolicDeterminantRequest,
         "matrix.symbolic.rank.compute": SymbolicMatrixRequest,
-        "matrix.symbolic.characteristic_polynomial.compute": SquareSymbolicMatrixRequest,
-        "matrix.symbolic.eigenvalues.compute": SquareSymbolicMatrixRequest,
+        "matrix.symbolic.characteristic_polynomial.compute": SymbolicCharacteristicPolynomialRequest,
+        "matrix.symbolic.eigenvalues.compute": SymbolicCharacteristicPolynomialRequest,
     }
 
 
@@ -262,7 +305,7 @@ def test_symbolic_eigenvalues_returns_polynomial_for_unrepresentable_roots() -> 
     zero = _rf(variables)
     one = _rf(variables, (1, 1, (0,)))
     a = _variable(variables, 0)
-    request = _square_request(
+    request = _characteristic_request(
         (
             (zero, zero, zero, zero, a),
             (one, zero, zero, zero, one),
@@ -280,7 +323,7 @@ def test_symbolic_eigenvalues_returns_polynomial_for_unrepresentable_roots() -> 
 
 
 def test_symbolic_eigenvalues_explicit_for_representable_roots() -> None:
-    request = _square_request(
+    request = _characteristic_request(
         ((_constant(1), _constant(2)), (_constant(3), _constant(4))), ()
     )
     result = compute_symbolic_eigenvalues(request)

--- a/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.plane_algebraic_curves._models import (
     AffineChartRequest,
     AffineCurveRequest,
@@ -14,6 +15,29 @@ from jacobian.math.plane_algebraic_curves._operations import (
     compute_projective_closure,
 )
 from jacobian.math.plane_algebraic_curves._tools import TOOLS
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[int, tuple[int, ...]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_integer_ratio(coefficient, 1),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
 
 
 def test_catalog_contains_only_audited_operations() -> None:
@@ -25,108 +49,112 @@ def test_catalog_contains_only_audited_operations() -> None:
 
 
 def test_affine_curve_check_circle() -> None:
-    request = AffineCurveRequest(variables=("x", "y"), polynomial="x**2 + y**2 - 1")
+    request = AffineCurveRequest(
+        polynomial=_polynomial(("x", "y"), (1, (2, 0)), (1, (0, 2)), (-1, (0, 0)))
+    )
     result = compute_affine_curve_check(request)
     assert result.is_valid is True
     assert result.degree == 2
 
 
-def test_projective_closure_circle() -> None:
-    request = ProjectiveClosureRequest(
-        variables=("x", "y"), polynomial="x**2 + y**2 - 1"
+def test_projective_closure_circle_is_canonical_polynomial() -> None:
+    source = _polynomial(("x", "y"), (1, (2, 0)), (1, (0, 2)), (-1, (0, 0)))
+    result = compute_projective_closure(ProjectiveClosureRequest(polynomial=source))
+    assert result.polynomial == _polynomial(
+        ("x", "y", "z"),
+        (1, (2, 0, 0)),
+        (1, (0, 2, 0)),
+        (-1, (0, 0, 2)),
     )
-    result = compute_projective_closure(request)
-    assert "z" in result.polynomial
 
 
-def test_affine_chart_circle() -> None:
-    request = AffineChartRequest(
-        variables=("x", "y", "z"),
-        polynomial="x**2 + y**2 - z**2",
-        chart_variable="z",
+def test_affine_chart_circle_is_directly_composable() -> None:
+    projective = _polynomial(
+        ("x", "y", "z"),
+        (1, (2, 0, 0)),
+        (1, (0, 2, 0)),
+        (-1, (0, 0, 2)),
     )
-    result = compute_affine_chart(request)
-    assert result.polynomial == "x**2 + y**2 - 1"
-    assert result.variables == ("x", "y")
-
-
-# --- Issue 6: round-trip, non-polynomial rejection, variable named "z",
-#     constant polynomial -----------------------------------------------
+    result = compute_affine_chart(
+        AffineChartRequest(polynomial=projective, chart_variable="z")
+    )
+    assert result.polynomial == _polynomial(
+        ("x", "y"), (1, (2, 0)), (1, (0, 2)), (-1, (0, 0))
+    )
+    AffineCurveRequest(polynomial=result.polynomial)
 
 
 def test_homogenize_dehomogenize_round_trip() -> None:
-    """Homogenizing an affine curve then taking the z=1 chart recovers it."""
-    affine = "x**3 - 2*x*y + y - 7"
-    request = ProjectiveClosureRequest(variables=("x", "y"), polynomial=affine)
-    closure = compute_projective_closure(request)
-    assert closure.variables == ("x", "y", "z")
-    chart = compute_affine_chart(
-        AffineChartRequest(
-            variables=closure.variables,
-            polynomial=closure.polynomial,
-            chart_variable="z",
-        )
+    affine = _polynomial(
+        ("x", "y"),
+        (1, (3, 0)),
+        (-2, (1, 1)),
+        (1, (0, 1)),
+        (-7, (0, 0)),
     )
-    recovered = chart.polynomial.replace(" ", "")
-    original = affine.replace(" ", "")
-    assert recovered == original
-    assert chart.variables == ("x", "y")
+    closure = compute_projective_closure(ProjectiveClosureRequest(polynomial=affine))
+    chart = compute_affine_chart(
+        AffineChartRequest(polynomial=closure.polynomial, chart_variable="z")
+    )
+    assert chart.polynomial == affine
 
 
-def test_non_polynomial_expression_is_rejected() -> None:
-    """A non-polynomial expression must be rejected at parse time."""
-    for model in (AffineCurveRequest, ProjectiveClosureRequest, AffineChartRequest):
-        if model is AffineChartRequest:
-            kwargs = {
-                "variables": ("x", "y", "z"),
-                "polynomial": "sin(x) + y",
-                "chart_variable": "z",
-            }
-        else:
-            kwargs = {"variables": ("x", "y"), "polynomial": "sin(x) + y"}
+def test_expression_strings_are_not_a_public_polynomial_contract() -> None:
+    for payload in (
+        "sin(x) + y",
+        "x +* y",
+        "x + t",
+        "__import__('os').getcwd()",
+    ):
         with pytest.raises(ValidationError, match="polynomial"):
-            model(**kwargs)
+            AffineCurveRequest.model_validate({"polynomial": payload})
 
 
-def test_unparseable_expression_is_rejected() -> None:
-    with pytest.raises(ValidationError, match="polynomial"):
-        AffineCurveRequest(variables=("x", "y"), polynomial="x +* y")
-
-
-def test_undeclared_variable_is_rejected() -> None:
-    with pytest.raises(ValidationError, match="undeclared"):
-        AffineCurveRequest(variables=("x", "y"), polynomial="x + t")
-
-
-def test_duplicate_variable_names_are_rejected() -> None:
+def test_duplicate_and_invalid_variable_names_are_rejected() -> None:
     with pytest.raises(ValidationError, match="unique"):
-        AffineCurveRequest(variables=("x", "x"), polynomial="x + 1")
+        _polynomial(("x", "x"), (1, (1, 0)))
+    with pytest.raises(ValidationError, match="string_pattern_mismatch"):
+        _polynomial(("", "y"), (1, (1, 0)))
 
 
 def test_variable_named_z_rejected_in_projective_closure() -> None:
-    """The homogenizing coordinate 'z' must not collide with a user variable."""
     with pytest.raises(ValidationError, match="homogenizing"):
-        ProjectiveClosureRequest(variables=("x", "z"), polynomial="x**2 - z")
+        ProjectiveClosureRequest(
+            polynomial=_polynomial(("x", "z"), (1, (2, 0)), (-1, (0, 1)))
+        )
 
 
-def test_constant_polynomial_is_not_a_valid_curve() -> None:
-    request = AffineCurveRequest(variables=("x", "y"), polynomial="5")
-    result = compute_affine_curve_check(request)
+@pytest.mark.parametrize("constant", [0, 5])
+def test_constant_polynomial_is_not_a_valid_curve(constant: int) -> None:
+    terms = () if constant == 0 else ((constant, (0, 0)),)
+    result = compute_affine_curve_check(
+        AffineCurveRequest(polynomial=_polynomial(("x", "y"), *terms))
+    )
     assert result.is_valid is False
     assert result.degree == 0
 
 
-def test_zero_polynomial_is_not_a_valid_curve() -> None:
-    request = AffineCurveRequest(variables=("x", "y"), polynomial="0")
-    result = compute_affine_curve_check(request)
-    assert result.is_valid is False
-    assert result.degree == 0
-
-
-def test_chart_variable_must_be_a_projective_variable() -> None:
-    with pytest.raises(ValidationError, match="chart_variable must be"):
+def test_chart_requires_three_variables_and_a_homogeneous_polynomial() -> None:
+    with pytest.raises(ValidationError, match="exactly three"):
         AffineChartRequest(
-            variables=("x", "y", "z"),
-            polynomial="x**2 + y**2 - z**2",
+            polynomial=_polynomial(("x", "y"), (1, (2, 0))),
+            chart_variable="x",
+        )
+    with pytest.raises(ValidationError, match="homogeneous"):
+        AffineChartRequest(
+            polynomial=_polynomial(("x", "y", "z"), (1, (2, 0, 0)), (1, (0, 1, 0))),
+            chart_variable="z",
+        )
+
+
+def test_chart_variable_must_be_on_the_projective_axis() -> None:
+    with pytest.raises(ValidationError, match="must belong"):
+        AffineChartRequest(
+            polynomial=_polynomial(
+                ("x", "y", "z"),
+                (1, (2, 0, 0)),
+                (1, (0, 2, 0)),
+                (-1, (0, 0, 2)),
+            ),
             chart_variable="w",
         )

--- a/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
+++ b/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
@@ -77,6 +77,21 @@ def test_rational_interpolation_has_exact_coefficients_and_evaluation() -> None:
     assert result.result == _q(7, 4)
 
 
+def test_newton_coefficients_may_grow_beyond_input_digit_bound() -> None:
+    left = 10**255 + 19
+    right = 10**255 + 21
+    form = compute_newton_form(
+        NewtonFormRequest(
+            samples=_samples(
+                nodes=(_q(0), _q(1)),
+                values=(_q(1, left), _q(1, right)),
+            )
+        )
+    )
+
+    assert len(form.coefficients[1].den) > 256
+
+
 def test_equal_rational_nodes_are_rejected_before_division() -> None:
     with pytest.raises(ValidationError, match="pairwise distinct"):
         InterpolationSamples(

--- a/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
+++ b/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
@@ -1,10 +1,12 @@
-"""Tests for polynomial interpolation operations."""
+"""Exact contract and reconstruction tests for Newton interpolation."""
 
 import pytest
 from pydantic import ValidationError
 
+from jacobian._exact import CanonicalRational
 from jacobian.math.polynomial_interpolation_ops._models import (
     DividedDifferencesRequest,
+    InterpolationSamples,
     NewtonEvaluateRequest,
     NewtonFormRequest,
 )
@@ -16,6 +18,17 @@ from jacobian.math.polynomial_interpolation_ops._operations import (
 from jacobian.math.polynomial_interpolation_ops._tools import TOOLS
 
 
+def _q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(numerator, denominator)
+
+
+def _samples(
+    nodes: tuple[CanonicalRational, ...] = (_q(0), _q(1), _q(2)),
+    values: tuple[CanonicalRational, ...] = (_q(1), _q(2), _q(5)),
+) -> InterpolationSamples:
+    return InterpolationSamples(nodes=nodes, values=values)
+
+
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "polynomial.interpolation.divided_differences.compute",
@@ -24,111 +37,71 @@ def test_catalog_contains_only_audited_operations() -> None:
     }
 
 
-def test_divided_differences_basic() -> None:
-    request = DividedDifferencesRequest(nodes=("0", "1", "2"), values=("1", "2", "5"))
-    result = compute_divided_differences(request)
-    assert result.coefficients == ("1", "1", "1")
+def test_divided_differences_are_canonical_rationals() -> None:
+    result = compute_divided_differences(DividedDifferencesRequest(samples=_samples()))
+    assert result.coefficients == (_q(1), _q(1), _q(1))
 
 
-def test_newton_form_basic() -> None:
-    request = NewtonFormRequest(nodes=("0", "1", "2"), values=("1", "2", "5"))
-    result = compute_newton_form(request)
-    assert result.coefficients == ("1", "1", "1")
-    assert result.nodes == ("0", "1", "2")
-
-
-def test_newton_evaluate_at_3() -> None:
-    request = NewtonEvaluateRequest(
-        nodes=("0", "1", "2"),
-        values=("1", "2", "5"),
-        evaluation_point="3",
+def test_newton_form_is_directly_evaluable() -> None:
+    form = compute_newton_form(NewtonFormRequest(samples=_samples()))
+    assert form.coefficients == (_q(1), _q(1), _q(1))
+    result = compute_newton_evaluate(
+        NewtonEvaluateRequest(newton_form=form, evaluation_point=_q(3))
     )
-    result = compute_newton_evaluate(request)
-    assert result.result == "10"
+    assert result.result == _q(10)
 
 
-def test_newton_evaluate_at_node() -> None:
-    request = NewtonEvaluateRequest(
-        nodes=("0", "1", "2"),
-        values=("1", "2", "5"),
-        evaluation_point="1",
+def test_interpolation_reconstructs_every_sample() -> None:
+    samples = _samples(
+        nodes=(_q(0), _q(1, 2), _q(1), _q(3, 2)),
+        values=(_q(1), _q(3, 2), _q(2), _q(11, 4)),
     )
-    result = compute_newton_evaluate(request)
-    assert result.result == "2"
+    form = compute_newton_form(NewtonFormRequest(samples=samples))
+    for node, expected in zip(samples.nodes, samples.values, strict=True):
+        result = compute_newton_evaluate(
+            NewtonEvaluateRequest(newton_form=form, evaluation_point=node)
+        )
+        assert result.result == expected
 
 
-# --- Issue 1: require pairwise-distinct nodes ---
+def test_rational_interpolation_has_exact_coefficients_and_evaluation() -> None:
+    samples = _samples(
+        nodes=(_q(0), _q(1, 2), _q(1)),
+        values=(_q(1), _q(3, 2), _q(2)),
+    )
+    form = compute_newton_form(NewtonFormRequest(samples=samples))
+    assert form.coefficients == (_q(1), _q(1), _q(0))
+    result = compute_newton_evaluate(
+        NewtonEvaluateRequest(newton_form=form, evaluation_point=_q(3, 4))
+    )
+    assert result.result == _q(7, 4)
 
 
-def test_divided_differences_rejects_repeated_nodes() -> None:
-    with pytest.raises(ValidationError):
-        DividedDifferencesRequest(nodes=("0", "1", "1"), values=("1", "2", "5"))
-
-
-def test_newton_form_rejects_repeated_nodes() -> None:
-    with pytest.raises(ValidationError):
-        NewtonFormRequest(nodes=("0", "1", "1"), values=("1", "2", "5"))
-
-
-def test_newton_evaluate_rejects_repeated_nodes() -> None:
-    with pytest.raises(ValidationError):
-        NewtonEvaluateRequest(
-            nodes=("0", "1", "1"), values=("1", "2", "5"), evaluation_point="3"
+def test_equal_rational_nodes_are_rejected_before_division() -> None:
+    with pytest.raises(ValidationError, match="pairwise distinct"):
+        InterpolationSamples(
+            nodes=(_q(0), _q(1, 2), _q(1, 2)),
+            values=(_q(1), _q(2), _q(3)),
         )
 
 
-# --- Issue 2: require len(nodes) == len(values) ---
+def test_samples_require_equal_lengths() -> None:
+    with pytest.raises(ValidationError, match="same length"):
+        InterpolationSamples(nodes=(_q(0), _q(1)), values=(_q(1),))
 
 
-def test_newton_form_requires_equal_length() -> None:
+@pytest.mark.parametrize(
+    "bad_rational",
+    ["1/2", {"num": "1", "den": "0"}, {"num": "2", "den": "4"}],
+)
+def test_noncanonical_rational_inputs_are_rejected(bad_rational: object) -> None:
     with pytest.raises(ValidationError):
-        NewtonFormRequest(nodes=("0", "1", "2"), values=("1", "2"))
-
-
-def test_newton_evaluate_requires_equal_length() -> None:
-    with pytest.raises(ValidationError):
-        NewtonEvaluateRequest(
-            nodes=("0", "1", "2"), values=("1", "2"), evaluation_point="3"
-        )
-
-
-# --- Issue 3: consistent scalar domain (all operations use exact rationals) ---
-
-
-def test_divided_differences_with_rationals() -> None:
-    request = DividedDifferencesRequest(
-        nodes=("0", "1/2", "1"), values=("1", "3/2", "2")
-    )
-    result = compute_divided_differences(request)
-    assert result.coefficients == ("1", "1", "0")
-
-
-def test_newton_form_with_rationals() -> None:
-    request = NewtonFormRequest(nodes=("0", "1/2", "1"), values=("1", "3/2", "2"))
-    result = compute_newton_form(request)
-    assert result.coefficients == ("1", "1", "0")
-
-
-def test_newton_evaluate_with_rationals() -> None:
-    request = NewtonEvaluateRequest(
-        nodes=("0", "1/2", "1"),
-        values=("1", "3/2", "2"),
-        evaluation_point="3/4",
-    )
-    result = compute_newton_evaluate(request)
-    assert result.result == "7/4"
-
-
-# --- Interpolation correctness ---
-
-
-def test_interpolation_passes_through_sample_points() -> None:
-    """Newton evaluation at every node must return the corresponding value."""
-    nodes = ("0", "1", "2", "3")
-    values = ("1", "2", "5", "10")
-    for i, (n, v) in enumerate(zip(nodes, values, strict=True)):
-        request = NewtonEvaluateRequest(nodes=nodes, values=values, evaluation_point=n)
-        result = compute_newton_evaluate(request)
-        assert result.result == v, (
-            f"interpolation mismatch at node {i}: expected {v}, got {result.result}"
+        InterpolationSamples.model_validate(
+            {
+                "nodes": [{"num": "0", "den": "1"}, bad_rational],
+                "values": [
+                    {"num": "1", "den": "1"},
+                    {"num": "2", "den": "1"},
+                ],
+            }
         )

--- a/tests/math/polynomial_vector_calc/test_polynomial_vector_calc.py
+++ b/tests/math/polynomial_vector_calc/test_polynomial_vector_calc.py
@@ -161,6 +161,22 @@ def test_vector_components_must_share_the_same_ring() -> None:
         )
 
 
+def test_vector_field_rejects_aggregate_result_term_growth() -> None:
+    variables = ("x", "y")
+    monomials = [
+        (left, right) for left in range(1, 64) for right in range(1, 64 - left)
+    ]
+    first = dict.fromkeys(monomials[:128], 1)
+    second = dict.fromkeys(monomials[128:257], 1)
+    with pytest.raises(ValidationError, match="result-term budget"):
+        VectorFieldRequest(
+            components=(
+                _polynomial(variables, first),
+                _polynomial(variables, second),
+            )
+        )
+
+
 def test_direction_length_must_match_polynomial_axis() -> None:
     with pytest.raises(ValidationError, match="length must match"):
         DirectionalDerivativeRequest(

--- a/tests/math/polynomial_vector_calc/test_polynomial_vector_calc.py
+++ b/tests/math/polynomial_vector_calc/test_polynomial_vector_calc.py
@@ -1,6 +1,15 @@
-"""Tests for polynomial vector calculus operations."""
+"""Tests for canonical polynomial vector-calculus operations."""
 
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
 from jacobian.math.polynomial_vector_calc._models import (
+    CurlRequest,
     DirectionalDerivativeRequest,
     ScalarFieldRequest,
     VectorFieldRequest,
@@ -13,6 +22,30 @@ from jacobian.math.polynomial_vector_calc._operations import (
     compute_laplacian,
 )
 from jacobian.math.polynomial_vector_calc._tools import TOOLS
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _polynomial(
+    variables: tuple[str, ...],
+    terms: dict[tuple[int, ...], int | Fraction],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(Fraction(coefficient)),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+                if coefficient
+            )
+        ),
+    )
 
 
 def test_catalog_contains_only_audited_operations() -> None:
@@ -25,116 +58,112 @@ def test_catalog_contains_only_audited_operations() -> None:
     }
 
 
-def test_gradient_of_x2_y2() -> None:
-    request = ScalarFieldRequest(variables=("x", "y"), polynomial="x**2 + y**2")
-    result = compute_gradient(request)
-    assert result.components == ("2*x", "2*y")
-
-
-def test_laplacian_of_x3_y3() -> None:
-    request = ScalarFieldRequest(variables=("x", "y"), polynomial="x**3 + y**3")
-    result = compute_laplacian(request)
-    assert result.result == "6*x + 6*y"
-
-
-def test_directional_derivative() -> None:
-    request = DirectionalDerivativeRequest(
-        variables=("x", "y"),
-        polynomial="x**2 + y**2",
-        direction=("1", "1"),
+def test_gradient_returns_composable_polynomials() -> None:
+    source = _polynomial(("x", "y"), {(2, 0): 1, (0, 2): 1})
+    result = compute_gradient(ScalarFieldRequest(polynomial=source))
+    assert result.components == (
+        _polynomial(("x", "y"), {(1, 0): 2}),
+        _polynomial(("x", "y"), {(0, 1): 2}),
     )
-    result = compute_directional_derivative(request)
-    assert "2*x" in result.result and "2*y" in result.result
 
 
-def test_divergence() -> None:
-    request = VectorFieldRequest(variables=("x", "y"), components=("x**2", "y**2"))
-    result = compute_divergence(request)
-    assert result.result == "2*x + 2*y"
-
-
-def test_curl_3d() -> None:
-    request = VectorFieldRequest(variables=("x", "y", "z"), components=("y", "0", "0"))
-    result = compute_curl(request)
-    assert result.components == ("0", "0", "-1")
-
-
-def test_curl_requires_3d() -> None:
-    import pytest
-
-    request = VectorFieldRequest(variables=("x", "y"), components=("x", "y"))
-    with pytest.raises(ValueError, match="3D"):
-        compute_curl(request)
-
-
-class TestVectorFieldValidation:
-    """Tests for the strengthened VectorFieldRequest contract."""
-
-    def test_component_count_mismatch_rejected(self) -> None:
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="one component per variable"):
-            VectorFieldRequest(variables=("x", "y"), components=("x**2",))
-
-    def test_too_many_components_rejected(self) -> None:
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="one component per variable"):
-            VectorFieldRequest(variables=("x", "y"), components=("x", "y", "x*y"))
-
-    def test_correct_component_count_accepted(self) -> None:
-        vf = VectorFieldRequest(variables=("x", "y", "z"), components=("x", "y", "z"))
-        assert len(vf.components) == 3
-
-    def test_non_polynomial_rejected(self) -> None:
-        """The parser should reject non-polynomial expressions like 1/x."""
-        import pytest
-
-        with pytest.raises((ValueError, TypeError)):
-            compute_gradient(ScalarFieldRequest(variables=("x",), polynomial="1/x"))
-
-    def test_foreign_symbol_rejected(self) -> None:
-        """The parser should reject symbols not in the declared variables."""
-        import pytest
-
-        with pytest.raises(ValueError, match="undeclared symbols"):
-            compute_gradient(ScalarFieldRequest(variables=("x",), polynomial="y + x"))
-
-    def test_distinct_variables_required(self) -> None:
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="distinct"):
-            ScalarFieldRequest(variables=("x", "x"), polynomial="x")
-
-
-def test_gradient_single_variable() -> None:
-    """Gradient of x**2 in one variable should give (2*x,)."""
-    request = ScalarFieldRequest(variables=("x",), polynomial="x**2")
-    result = compute_gradient(request)
-    assert result.components == ("2*x",)
-
-
-def test_divergence_single_variable() -> None:
-    """Divergence of a 1D vector field (x**2) should give 2*x."""
-    request = VectorFieldRequest(variables=("x",), components=("x**2",))
-    result = compute_divergence(request)
-    assert result.result == "2*x"
-
-
-def test_laplacian_single_variable() -> None:
-    """Laplacian of x**3 in one variable should give 6*x."""
-    request = ScalarFieldRequest(variables=("x",), polynomial="x**3")
-    result = compute_laplacian(request)
-    assert result.result == "6*x"
-
-
-def test_directional_derivative_single_variable() -> None:
-    """Directional derivative of x**2 along (2,) should give 4*x."""
-    request = DirectionalDerivativeRequest(
-        variables=("x",), polynomial="x**2", direction=("2",)
+def test_renaming_the_declared_axis_transports_the_gradient() -> None:
+    original = compute_gradient(
+        ScalarFieldRequest(polynomial=_polynomial(("x", "y"), {(2, 0): 1, (0, 1): 3}))
     )
-    result = compute_directional_derivative(request)
-    assert result.result == "4*x"
+    renamed = compute_gradient(
+        ScalarFieldRequest(polynomial=_polynomial(("u", "v"), {(2, 0): 1, (0, 1): 3}))
+    )
+
+    assert tuple(component.polynomial for component in original.components) == tuple(
+        component.polynomial for component in renamed.components
+    )
+    assert all(component.variables == ("x", "y") for component in original.components)
+    assert all(component.variables == ("u", "v") for component in renamed.components)
+
+
+def test_laplacian_returns_a_composable_polynomial() -> None:
+    source = _polynomial(("x", "y"), {(3, 0): 1, (0, 3): 1})
+    result = compute_laplacian(ScalarFieldRequest(polynomial=source))
+    assert result.result == _polynomial(
+        ("x", "y"),
+        {(1, 0): 6, (0, 1): 6},
+    )
+
+
+def test_directional_derivative_uses_exact_rational_coordinates() -> None:
+    source = _polynomial(("x", "y"), {(2, 0): 1, (0, 2): 1})
+    result = compute_directional_derivative(
+        DirectionalDerivativeRequest(
+            polynomial=source,
+            direction=(
+                CanonicalRational(num="1", den="2"),
+                CanonicalRational(num="1", den="1"),
+            ),
+        )
+    )
+    assert result.result == _polynomial(
+        ("x", "y"),
+        {(1, 0): 1, (0, 1): 2},
+    )
+
+
+def test_divergence_uses_one_authoritative_axis() -> None:
+    result = compute_divergence(
+        VectorFieldRequest(
+            components=(
+                _polynomial(("x", "y"), {(2, 0): 1}),
+                _polynomial(("x", "y"), {(0, 2): 1}),
+            )
+        )
+    )
+    assert result.result == _polynomial(
+        ("x", "y"),
+        {(1, 0): 2, (0, 1): 2},
+    )
+
+
+def test_curl_is_rejected_at_the_request_boundary_outside_three_dimensions() -> None:
+    with pytest.raises(ValidationError, match="exactly three"):
+        CurlRequest(
+            components=(
+                _polynomial(("x", "y"), {(1, 0): 1}),
+                _polynomial(("x", "y"), {(0, 1): 1}),
+            )
+        )
+
+
+def test_curl_three_dimensional_orientation() -> None:
+    variables = ("x", "y", "z")
+    result = compute_curl(
+        CurlRequest(
+            components=(
+                _polynomial(variables, {(0, 1, 0): 1}),
+                _polynomial(variables, {}),
+                _polynomial(variables, {}),
+            )
+        )
+    )
+    assert result.components == (
+        _polynomial(variables, {}),
+        _polynomial(variables, {}),
+        _polynomial(variables, {(0, 0, 0): -1}),
+    )
+
+
+def test_vector_components_must_share_the_same_ring() -> None:
+    with pytest.raises(ValidationError, match="one ordered ring"):
+        VectorFieldRequest(
+            components=(
+                _polynomial(("x", "y"), {(1, 0): 1}),
+                _polynomial(("y", "x"), {(1, 0): 1}),
+            )
+        )
+
+
+def test_direction_length_must_match_polynomial_axis() -> None:
+    with pytest.raises(ValidationError, match="length must match"):
+        DirectionalDerivativeRequest(
+            polynomial=_polynomial(("x", "y"), {(1, 0): 1}),
+            direction=(CanonicalRational(num="1", den="1"),),
+        )

--- a/tests/math/polynomials/test_polynomial_maps.py
+++ b/tests/math/polynomials/test_polynomial_maps.py
@@ -1,10 +1,17 @@
-"""Tests for polynomial map operations."""
+"""Tests for canonical polynomial map operations."""
 
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
 from jacobian.math.polynomials.maps._models import (
     CompositionRequest,
     EvalRequest,
     JacobianRequest,
-    RationalPolynomialExpr,
     VariablePoint,
 )
 from jacobian.math.polynomials.maps._operations import (
@@ -12,95 +19,104 @@ from jacobian.math.polynomials.maps._operations import (
     compute_jacobian,
     evaluate_polynomial,
 )
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
 
 
-class TestEvaluate:
-    def test_simple(self):
-        req = EvalRequest(
-            polynomial=RationalPolynomialExpr(expression="x**2 + 2*y"),
-            point=VariablePoint(
-                variables=("x", "y"),
-                values=(
-                    {"num": "3", "den": "1"},
-                    {"num": "1", "den": "1"},
-                ),
+def _polynomial(
+    variables: tuple[str, ...],
+    terms: dict[tuple[int, ...], int | Fraction],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(Fraction(coefficient)),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+                if coefficient
+            )
+        ),
+    )
+
+
+def test_evaluation_returns_a_canonical_rational() -> None:
+    request = EvalRequest(
+        polynomial=_polynomial(("x", "y"), {(2, 0): 1, (0, 1): 2}),
+        point=VariablePoint(
+            variables=("x", "y"),
+            values=(
+                CanonicalRational(num="3", den="1"),
+                CanonicalRational(num="1", den="1"),
             ),
-        )
-        result = evaluate_polynomial(req)
-        assert result.value == "11"  # 9 + 2 = 11
+        ),
+    )
+    assert evaluate_polynomial(request).value == CanonicalRational(num="11", den="1")
 
-    def test_zero(self):
-        req = EvalRequest(
-            polynomial=RationalPolynomialExpr(expression="x**2"),
+
+def test_evaluation_requires_the_complete_ordered_axis() -> None:
+    with pytest.raises(ValidationError, match="complete ordered axis"):
+        EvalRequest(
+            polynomial=_polynomial(("x", "y"), {(1, 0): 1}),
             point=VariablePoint(
                 variables=("x",),
-                values=({"num": "0", "den": "1"},),
+                values=(CanonicalRational(num="1", den="1"),),
             ),
         )
-        result = evaluate_polynomial(req)
-        assert result.value == "0"
-
-    def test_rejects_rational_function(self):
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="polynomial"):
-            EvalRequest(
-                polynomial=RationalPolynomialExpr(expression="1/x"),
-                point=VariablePoint(
-                    variables=("x",),
-                    values=({"num": "1", "den": "1"},),
-                ),
-            )
-
-    def test_rejects_irrational_coefficient(self):
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="rational coefficients"):
-            RationalPolynomialExpr(expression="pi*x")
-
-    def test_rejects_incomplete_substitution(self):
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError, match="every free variable"):
-            EvalRequest(
-                polynomial=RationalPolynomialExpr(expression="x + y"),
-                point=VariablePoint(
-                    variables=("x",),
-                    values=({"num": "1", "den": "1"},),
-                ),
-            )
 
 
-class TestJacobian:
-    def test_simple(self):
-        req = JacobianRequest(
+def test_jacobian_entries_are_directly_composable_polynomials() -> None:
+    request = JacobianRequest(
+        input_variables=("x", "y"),
+        output_polynomials=(
+            _polynomial(("x", "y"), {(2, 0): 1}),
+            _polynomial(("x", "y"), {(0, 2): 1}),
+        ),
+    )
+    result = compute_jacobian(request)
+    assert result.n_inputs == 2
+    assert result.n_outputs == 2
+    assert result.entries == (
+        _polynomial(("x", "y"), {(1, 0): 2}),
+        _polynomial(("x", "y"), {}),
+        _polynomial(("x", "y"), {}),
+        _polynomial(("x", "y"), {(0, 1): 2}),
+    )
+
+
+def test_jacobian_rejects_a_mismatched_output_ring() -> None:
+    with pytest.raises(ValidationError, match="complete ordered input axis"):
+        JacobianRequest(
             input_variables=("x", "y"),
-            output_polynomials=(
-                RationalPolynomialExpr(expression="x**2"),
-                RationalPolynomialExpr(expression="y**2"),
-            ),
+            output_polynomials=(_polynomial(("x",), {(2,): 1}),),
         )
-        result = compute_jacobian(req)
-        assert result.n_inputs == 2
-        assert result.n_outputs == 2
-        assert result.entries[0] == "2*x"  # d(x^2)/dx
-        assert result.entries[3] == "2*y"  # d(y^2)/dy
 
 
-class TestComposition:
-    def test_simple(self):
-        req = CompositionRequest(
-            outer=RationalPolynomialExpr(expression="x**2"),
-            inner=RationalPolynomialExpr(expression="x + 1"),
+def test_univariate_composition_returns_a_canonical_polynomial() -> None:
+    result = compose_polynomials(
+        CompositionRequest(
+            outer=_polynomial(("u",), {(2,): 1}),
+            inner=_polynomial(("x",), {(1,): 1, (0,): 1}),
             inner_variable="x",
-            outer_variable="x",
+            outer_variable="u",
         )
-        result = compose_polynomials(req)
-        # (x+1)^2 = x^2 + 2*x + 1
-        from sympy import expand, sympify
+    )
+    assert result.polynomial == _polynomial(
+        ("x",),
+        {(2,): 1, (1,): 2, (0,): 1},
+    )
 
-        result_expr = expand(sympify(result.expression))
-        assert result_expr == expand(sympify("(x + 1)**2"))
+
+def test_composition_rejects_multivariate_operands() -> None:
+    with pytest.raises(ValidationError, match="exactly outer_variable"):
+        CompositionRequest(
+            outer=_polynomial(("u", "v"), {(1, 0): 1}),
+            inner=_polynomial(("x",), {(1,): 1}),
+            inner_variable="x",
+            outer_variable="u",
+        )

--- a/tests/math/polynomials/test_polynomial_maps.py
+++ b/tests/math/polynomials/test_polynomial_maps.py
@@ -70,6 +70,17 @@ def test_evaluation_requires_the_complete_ordered_axis() -> None:
         )
 
 
+def test_evaluation_rejects_a_point_whose_exact_value_exceeds_result_bound() -> None:
+    with pytest.raises(ValidationError, match="32,768-digit"):
+        EvalRequest(
+            polynomial=_polynomial(("x",), {(64,): 1}),
+            point=VariablePoint(
+                variables=("x",),
+                values=(CanonicalRational(num="1" + "0" * 600, den="1"),),
+            ),
+        )
+
+
 def test_jacobian_entries_are_directly_composable_polynomials() -> None:
     request = JacobianRequest(
         input_variables=("x", "y"),

--- a/tests/math/prime_field_linear_algebra/test_public_api.py
+++ b/tests/math/prime_field_linear_algebra/test_public_api.py
@@ -80,7 +80,7 @@ def test_matrix_rejects_noncanonical_entries() -> None:
         PrimeFieldMatrix(prime=2, entries=((3,),), columns=1)
     with pytest.raises(ValueError, match="canonical"):
         PrimeFieldMatrix(prime=3, entries=((1, -1),), columns=2)
-    with pytest.raises(ValueError, match="canonical"):
+    with pytest.raises(ValueError):
         PrimeFieldMatrix(prime=2, entries=((1.0,),), columns=1)
 
 

--- a/tests/math/projective_coords_ops/test_projective_coords.py
+++ b/tests/math/projective_coords_ops/test_projective_coords.py
@@ -2,10 +2,15 @@
 
 from fractions import Fraction
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian._exact import CanonicalRational
 from jacobian.math.projective_coords_ops._models import (
     ChartTransitionRequest,
+    ChartTransitionResult,
     RationalPointConstructRequest,
+    RationalProjectivePoint,
     StandardChartRequest,
 )
 from jacobian.math.projective_coords_ops._operations import (
@@ -18,6 +23,10 @@ from jacobian.math.projective_coords_ops._tools import TOOLS
 
 def _r(num: str, den: str = "1") -> CanonicalRational:
     return CanonicalRational(num=num, den=den)
+
+
+def _point(*coordinates: CanonicalRational) -> RationalProjectivePoint:
+    return RationalProjectivePoint(coordinates=coordinates)
 
 
 def test_catalog_contains_only_audited_operations() -> None:
@@ -37,9 +46,7 @@ def test_rational_point_construct() -> None:
 
 def test_standard_chart() -> None:
     request = StandardChartRequest(
-        point={
-            "coordinates": [_r("1"), _r("2"), _r("3")],
-        },
+        point=_point(_r("1"), _r("2"), _r("3")),
         chart_index=0,
     )
     result = compute_standard_chart(request)
@@ -49,11 +56,69 @@ def test_standard_chart() -> None:
 
 def test_chart_transition() -> None:
     request = ChartTransitionRequest(
-        point={
-            "coordinates": [_r("1"), _r("2"), _r("3")],
-        },
+        point=_point(_r("1"), _r("2"), _r("3")),
         chart_i=0,
         chart_j=1,
     )
     result = compute_chart_transition(request)
-    assert result.transition[0].as_fraction() == Fraction(3, 2)
+    assert result.status == "DEFINED"
+    assert result.transition is not None
+    assert tuple(value.as_fraction() for value in result.transition) == (
+        Fraction(1, 2),
+        Fraction(3, 2),
+    )
+
+
+def test_chart_transition_is_invariant_under_homogeneous_rescaling() -> None:
+    original = ChartTransitionRequest(
+        point=_point(_r("1"), _r("2"), _r("3")),
+        chart_i=0,
+        chart_j=1,
+    )
+    rescaled = ChartTransitionRequest(
+        point=_point(_r("5"), _r("10"), _r("15")),
+        chart_i=0,
+        chart_j=1,
+    )
+
+    assert (
+        compute_chart_transition(original).transition
+        == compute_chart_transition(rescaled).transition
+    )
+
+
+def test_chart_transition_reports_outside_target_chart() -> None:
+    result = compute_chart_transition(
+        ChartTransitionRequest(
+            point=_point(_r("1"), _r("0"), _r("3")),
+            chart_i=0,
+            chart_j=1,
+        )
+    )
+
+    assert result.status == "OUTSIDE_TARGET_CHART"
+    assert result.transition is None
+
+
+def test_chart_transition_round_trips_between_defined_charts() -> None:
+    point = _point(_r("2"), _r("3"), _r("5"))
+    forward = compute_chart_transition(
+        ChartTransitionRequest(point=point, chart_i=0, chart_j=1)
+    )
+    backward = compute_chart_transition(
+        ChartTransitionRequest(point=point, chart_i=1, chart_j=0)
+    )
+
+    assert forward.transition == (_r("2", "3"), _r("5", "3"))
+    assert backward.transition == (_r("3", "2"), _r("5", "2"))
+
+
+def test_chart_transition_result_rejects_an_incomplete_target_chart() -> None:
+    with pytest.raises(ValidationError, match="every target-chart coordinate"):
+        ChartTransitionResult(
+            status="DEFINED",
+            transition=(_r("1"),),
+            chart_i=0,
+            chart_j=1,
+            projective_dimension=2,
+        )

--- a/tests/math/projective_coords_ops/test_projective_coords.py
+++ b/tests/math/projective_coords_ops/test_projective_coords.py
@@ -100,6 +100,22 @@ def test_chart_transition_reports_outside_target_chart() -> None:
     assert result.transition is None
 
 
+def test_chart_transition_rejects_unrepresentable_ratio_growth() -> None:
+    component = "1" + "0" * 16_384
+
+    with pytest.raises(ValidationError, match="ratio budget"):
+        ChartTransitionRequest(
+            point=RationalProjectivePoint(
+                coordinates=(
+                    CanonicalRational(num=component, den="1"),
+                    CanonicalRational(num="1", den=component),
+                )
+            ),
+            chart_i=0,
+            chart_j=1,
+        )
+
+
 def test_chart_transition_round_trips_between_defined_charts() -> None:
     point = _point(_r("2"), _r("3"), _r("5"))
     forward = compute_chart_transition(

--- a/tests/math/universal_algebra/test_public_api.py
+++ b/tests/math/universal_algebra/test_public_api.py
@@ -7,10 +7,12 @@ from jacobian.math import universal_algebra
 
 def test_exact_public_api_symbols() -> None:
     expected = (
+        "ApplicationTerm",
         "FiniteAlgebra",
         "FlatTerm",
         "OperationSymbol",
         "Term",
+        "VariableTerm",
         "congruence_check",
         "equation_profile",
         "evaluate_term",

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -6,10 +6,11 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.universal_algebra import (
+    ApplicationTerm,
     FiniteAlgebra,
     FlatTerm,
     OperationSymbol,
-    Term,
+    VariableTerm,
 )
 from jacobian.math.universal_algebra._models import (
     CongruenceRequest,
@@ -44,15 +45,17 @@ def _boolean_algebra() -> FiniteAlgebra:
 
 
 def _variable_term(variable_id: int) -> FlatTerm:
-    return FlatTerm(nodes=(Term(kind="variable", variable_id=variable_id),), root=0)
+    return FlatTerm(
+        nodes=(VariableTerm(kind="variable", variable_id=variable_id),), root=0
+    )
 
 
 def _and_term() -> FlatTerm:
     return FlatTerm(
         nodes=(
-            Term(kind="variable", variable_id=0),
-            Term(kind="variable", variable_id=1),
-            Term(kind="application", operation=0, children=(0, 1)),
+            VariableTerm(kind="variable", variable_id=0),
+            VariableTerm(kind="variable", variable_id=1),
+            ApplicationTerm(kind="application", operation=0, children=(0, 1)),
         ),
         root=2,
     )
@@ -107,11 +110,10 @@ class TestEquationProfile:
         # Term: AND(x0, x0) — application of operation 0 (and) with children (0, 0).
         left = FlatTerm(
             nodes=(
-                Term(kind="variable", variable_id=0),
-                Term(kind="variable", variable_id=0),
-                Term(kind="application", operation=0, children=(0, 0)),
+                VariableTerm(kind="variable", variable_id=0),
+                ApplicationTerm(kind="application", operation=0, children=(0, 0)),
             ),
-            root=2,
+            root=1,
         )
         right = _variable_term(0)
         result = compute_equation_profile(
@@ -186,8 +188,10 @@ class TestQuotient:
         result = compute_quotient(
             QuotientRequest(algebra=_boolean_algebra(), partition=((0, 1),))
         )
-        assert result.carrier == ("B0",)
-        assert len(result.operations) == 2
+        assert result.algebra.carrier == ("B0",)
+        assert len(result.algebra.operations) == 2
+        assert result.quotient_map == (0, 0)
+        SubalgebraRequest(algebra=result.algebra, generators=(0,))
 
 
 # ---------------------------------------------------------------------------
@@ -218,4 +222,67 @@ class TestValidation:
                 carrier=("a", "b"),
                 operations=(OperationSymbol(operation_id="f", arity=1),),
                 tables=((0, 2),),  # 2 is out of range
+            )
+
+    @pytest.mark.parametrize("kind", ["", "VARIABLE", "arbitrary"])
+    def test_term_node_kind_is_closed(self, kind: str) -> None:
+        with pytest.raises(ValidationError):
+            FlatTerm.model_validate(
+                {"nodes": [{"kind": kind, "variable_id": 0}], "root": 0}
+            )
+
+    def test_term_rejects_cycles_forward_edges_and_unreachable_nodes(self) -> None:
+        with pytest.raises(ValidationError, match="earlier nodes"):
+            FlatTerm.model_validate(
+                {
+                    "nodes": [{"kind": "application", "operation": 0, "children": [0]}],
+                    "root": 0,
+                }
+            )
+        with pytest.raises(ValidationError, match="reachable"):
+            FlatTerm(
+                nodes=(
+                    VariableTerm(kind="variable", variable_id=0),
+                    VariableTerm(kind="variable", variable_id=1),
+                ),
+                root=1,
+            )
+
+    def test_term_signature_and_assignment_are_checked_in_request(self) -> None:
+        wrong_arity = FlatTerm(
+            nodes=(
+                VariableTerm(kind="variable", variable_id=0),
+                ApplicationTerm(kind="application", operation=0, children=(0,)),
+            ),
+            root=1,
+        )
+        with pytest.raises(ValidationError, match="arity"):
+            EvaluateRequest(
+                algebra=_boolean_algebra(), term=wrong_arity, assignment=(0,)
+            )
+        with pytest.raises(ValidationError, match="cover exactly"):
+            EvaluateRequest(
+                algebra=_boolean_algebra(), term=_and_term(), assignment=(0,)
+            )
+
+    @pytest.mark.parametrize("partition", [((0,),), ((), (0, 1)), ((0, 1), (1,))])
+    def test_partition_must_be_nonempty_disjoint_exact_cover(
+        self, partition: tuple[tuple[int, ...], ...]
+    ) -> None:
+        with pytest.raises(ValidationError):
+            CongruenceRequest(algebra=_boolean_algebra(), partition=partition)
+
+    def test_equation_profile_rejects_work_before_enumeration(self) -> None:
+        algebra = FiniteAlgebra(
+            carrier=tuple(str(index) for index in range(10)),
+            operations=(),
+            tables=(),
+        )
+        term = _variable_term(0)
+        with pytest.raises(ValidationError, match="work budget"):
+            EquationProfileRequest(
+                algebra=algebra,
+                left=term,
+                right=term,
+                variable_count=7,
             )


### PR DESCRIPTION
## Problem

Public mathematical operations accepted loosely related strings, axes, parents,
and derived structures that did not establish the domains required by their
implementations. Several results also discarded units, multiplicities,
generators, quotient maps, or other data needed for reconstruction and
composition.

Advances #2174.

Closes #2122.
Closes #2125.
Closes #2126.
Closes #2127.
Closes #2128.
Closes #2131.
Closes #2133.
Closes #2134.
Closes #2135.
Closes #2136.
Closes #2137.
Closes #2141.
Closes #2145.
Closes #2146.
Closes #2147.
Closes #2148.
Closes #2149.
Closes #2151.
Closes #2152.
Closes #2153.
Closes #2154.
Closes #2156.
Closes #2157.
Closes #2158.
Closes #2159.

## Solution

Replace expression-shaped polynomial and rational inputs with canonical exact
values carrying their ordered domains. Enforce parent, axis, dimension,
degeneracy, and work constraints in operation request models before backend
execution. Return composable certificates for finite-field factorizations,
Galois groups, Newton forms, quotient algebras, projective coordinates, and
authoritative finite-field derivations.

The established mathematical kernels remain delegated to SymPy and FLINT. This
PR changes Jacobian's public contracts and conversions around them.

## Testing

- `make check` — 1,986 tests passed; Ruff, formatting, complexity, and mypy passed.
- Specialist validation run (if any): none for this branch.

## Public contract impact

Breaking pre-stable request and result schema changes across affected operations.
Canonical polynomial, rational-function, finite-field, universal-algebra, and
derived certificate values replace expression strings and incomplete result
shapes. Operation versions and invocation examples are updated with their
contracts; no new operation IDs are introduced.

## Public operation admission

- Concrete gap: existing operations accepted values outside their mathematical or backend domains and returned values that were not reliably composable.
- Why existing operations or typed values are insufficient: the old string and field-bag representations did not carry complete parent, axis, or reconstruction information.
- Stable mathematical result: exact canonical values and complete bounded certificates for the existing operations.
- Admission decision: retain the existing owner-local `KEEP` decisions with corrected pre-stable contracts.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Canonical exact inputs | delivered | Existing affected operation IDs |
| Complete Galois certificates | delivered | `polynomial.galois.*` |
| Authentic finite-field derivations | delivered | `finite_field.*` |
| Closed universal-algebra terms and quotients | delivered | `universal_algebra.*` |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes retain owner-local admission decisions
- [x] Result semantics distinguish exact and unavailable outcomes where applicable
- [x] Shared canonical values serve multiple production domains

