### PR TITLE
feat(math): add exact ordered-difference profile for bounded integer-vector sets

### DIFF
--- a/src/jacobian/math/additive_combinatorics/_admission.py
+++ b/src/jacobian/math/additive_combinatorics/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.additive_combinatorics._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "additive.ordered_difference_profile.compute",
+        AdmissionDecision.KEEP,
+        "one complete exact ordered-difference profile of a bounded integer-vector set retaining every source pair",
+    ),
+    OperationAdmission(
         "additive.direct_sum_predicate.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StringConstraints, model_validator
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
@@ -185,30 +185,62 @@ _MAX_VECTOR_COORDINATE_DIGITS = 64
 # A difference coordinate can grow by one digit (sum of two bounded integers).
 _MAX_VECTOR_DIFFERENCE_DIGITS = _MAX_VECTOR_COORDINATE_DIGITS + 1
 _MAX_ORDERED_PAIRS = _MAX_VECTOR_SET_SIZE * (_MAX_VECTOR_SET_SIZE - 1)
+_VECTOR_COORDINATE_PATTERN = (
+    rf"^(?:0|-?[1-9][0-9]{{0,{_MAX_VECTOR_COORDINATE_DIGITS - 1}}})$"
+)
+
+VectorCoordinate = Annotated[
+    str,
+    StringConstraints(
+        pattern=_VECTOR_COORDINATE_PATTERN,
+        max_length=_MAX_VECTOR_COORDINATE_DIGITS + 1,
+        strict=True,
+    ),
+]
 
 
 class IntegerVector(StrictModel):
-    """One integer vector in a bounded common dimension."""
+    """One integer vector in a bounded common dimension.
 
-    coordinates: tuple[CanonicalInteger, ...] = Field(
+    Each coordinate is a canonical integer with at most 64 decimal digits.
+    """
+
+    coordinates: tuple[VectorCoordinate, ...] = Field(
         min_length=1,
         max_length=_MAX_VECTOR_DIMENSION,
+        description=(
+            "Canonical integer coordinates sharing one dimension in "
+            f"[1, {_MAX_VECTOR_DIMENSION}]; each coordinate has at most "
+            f"{_MAX_VECTOR_COORDINATE_DIGITS} decimal digits."
+        ),
+        examples=[("0", "1")],
     )
 
     @model_validator(mode="after")
     def require_bounded_coordinates(self) -> Self:
         for value in self.coordinates:
             if len(value.lstrip("-")) > _MAX_VECTOR_COORDINATE_DIGITS:
-                raise ValueError("vector coordinate exceeds the digit bound")
+                raise ValueError(
+                    "vector coordinate exceeds the "
+                    f"{_MAX_VECTOR_COORDINATE_DIGITS}-digit bound"
+                )
         return self
 
 
 class IntegerVectorSet(StrictModel):
-    """A finite set of distinct integer vectors in a fixed dimension."""
+    """A finite set of distinct integer vectors in a fixed dimension.
+
+    Coordinates remain canonical integers with at most 64 decimal digits; the
+    listed order is the index order used by ordered-difference pairs.
+    """
 
     vectors: tuple[IntegerVector, ...] = Field(
         min_length=1,
         max_length=_MAX_VECTOR_SET_SIZE,
+        description=(
+            "Distinct source vectors in one shared dimension; each coordinate "
+            f"has at most {_MAX_VECTOR_COORDINATE_DIGITS} decimal digits."
+        ),
     )
 
     @model_validator(mode="after")
@@ -229,16 +261,25 @@ class IntegerVectorSet(StrictModel):
 
 
 class OrderedDifferenceProfileRequest(StrictModel):
-    """Compute the complete ordered-difference profile ``r_{A-A}`` of one set."""
+    """Compute the complete ordered-difference profile ``r_{A-A}`` of one set.
 
-    vectors: IntegerVectorSet
+    Source vectors share one dimension in ``[1, 8]``, the set has at most 64
+    distinct vectors, and each coordinate has at most 64 decimal digits.
+    """
+
+    vectors: IntegerVectorSet = Field(
+        description=(
+            "Distinct integer vectors in one shared dimension; each coordinate "
+            f"has at most {_MAX_VECTOR_COORDINATE_DIGITS} decimal digits."
+        ),
+    )
 
 
 class OrderedDifferencePair(StrictModel):
     """One ordered source pair realizing a difference vector."""
 
-    minuend_index: int = Field(ge=0)
-    subtrahend_index: int = Field(ge=0)
+    minuend_index: int = Field(ge=0, le=_MAX_VECTOR_SET_SIZE - 1)
+    subtrahend_index: int = Field(ge=0, le=_MAX_VECTOR_SET_SIZE - 1)
 
 
 class OrderedDifferenceClass(StrictModel):
@@ -261,9 +302,124 @@ class OrderedDifferenceClass(StrictModel):
         return self
 
 
-class OrderedDifferenceProfileResult(StrictModel):
-    """Complete ordered-difference profile of a bounded integer-vector set."""
+def _source_points(
+    vectors: tuple[IntegerVector, ...],
+) -> tuple[tuple[int, ...], ...]:
+    return tuple(
+        tuple(parse_canonical_integer(c) for c in vec.coordinates) for vec in vectors
+    )
 
+
+def _require_source_shape(
+    source: tuple[IntegerVector, ...],
+    *,
+    dimension: int,
+    set_size: int,
+) -> tuple[tuple[int, ...], ...]:
+    n = len(source)
+    dim = len(source[0].coordinates)
+    if set_size != n:
+        raise ValueError("set_size must equal the source vector count")
+    if dimension != dim:
+        raise ValueError("dimension must equal the source vector dimension")
+    return _source_points(source)
+
+
+def _replay_pair(
+    pair: OrderedDifferencePair,
+    *,
+    points: tuple[tuple[int, ...], ...],
+    dimension: int,
+    seen_pairs: set[tuple[int, int]],
+) -> tuple[int, ...]:
+    n = len(points)
+    if not (0 <= pair.minuend_index < n and 0 <= pair.subtrahend_index < n):
+        raise ValueError("pair indexes must lie in the source set")
+    key = (pair.minuend_index, pair.subtrahend_index)
+    if key in seen_pairs:
+        raise ValueError("ordered pairs must be unique")
+    seen_pairs.add(key)
+    return tuple(
+        points[pair.minuend_index][k] - points[pair.subtrahend_index][k]
+        for k in range(dimension)
+    )
+
+
+def _require_replayed_classes(
+    classes: tuple[OrderedDifferenceClass, ...],
+    *,
+    points: tuple[tuple[int, ...], ...],
+    dimension: int,
+) -> None:
+    n = len(points)
+    expected_pairs = {(i, j) for i in range(n) for j in range(n) if i != j}
+    seen_pairs: set[tuple[int, int]] = set()
+    numeric_diffs: list[tuple[int, ...]] = []
+    for cls in classes:
+        if len(cls.difference) != dimension:
+            raise ValueError("difference dimension must match the source")
+        diff = tuple(parse_canonical_integer(c) for c in cls.difference)
+        numeric_diffs.append(diff)
+        for pair in cls.pairs:
+            if (
+                _replay_pair(
+                    pair,
+                    points=points,
+                    dimension=dimension,
+                    seen_pairs=seen_pairs,
+                )
+                != diff
+            ):
+                raise ValueError(
+                    "difference must equal source[minuend] - source[subtrahend]",
+                )
+    if seen_pairs != expected_pairs:
+        raise ValueError(
+            "classes must cover every ordered pair of distinct source vectors",
+        )
+    if len(numeric_diffs) != len(set(numeric_diffs)):
+        raise ValueError("difference classes must be unique")
+    if numeric_diffs != sorted(numeric_diffs):
+        raise ValueError("difference classes must be sorted")
+
+
+def _require_repeated_decision(
+    classes: tuple[OrderedDifferenceClass, ...],
+    *,
+    ordered_pair_count: int,
+    support_size: int,
+    set_size: int,
+    max_multiplicity: int,
+    has_repeated_difference: bool,
+    first_repeated_difference: tuple[str, ...] | None,
+) -> None:
+    if ordered_pair_count != set_size * (set_size - 1):
+        raise ValueError("ordered_pair_count must equal set_size * (set_size - 1)")
+    if support_size != len(classes):
+        raise ValueError("support_size must equal the number of difference classes")
+    max_mult = max((len(cls.pairs) for cls in classes), default=0)
+    if max_multiplicity != max_mult:
+        raise ValueError("max_multiplicity must equal the largest class size")
+    first_repeated = next(
+        (cls.difference for cls in classes if len(cls.pairs) > 1),
+        None,
+    )
+    if has_repeated_difference != (max_mult > 1):
+        raise ValueError("has_repeated_difference must equal max_multiplicity > 1")
+    if first_repeated_difference != first_repeated:
+        raise ValueError(
+            "first_repeated_difference must be the first class of multiplicity 2+",
+        )
+
+
+class OrderedDifferenceProfileResult(StrictModel):
+    """Complete ordered-difference profile of a bounded integer-vector set.
+
+    The result retains the source ``IntegerVectorSet`` so every class can be
+    replayed as ``vectors[minuend] - vectors[subtrahend]`` without the request.
+    """
+
+    vectors: IntegerVectorSet
     dimension: int = Field(ge=1, le=_MAX_VECTOR_DIMENSION)
     set_size: int = Field(ge=1, le=_MAX_VECTOR_SET_SIZE)
     classes: tuple[OrderedDifferenceClass, ...] = Field(
@@ -279,30 +435,25 @@ class OrderedDifferenceProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def require_consistent_profile(self) -> Self:
-        expected_pairs = self.set_size * (self.set_size - 1)
-        total_pairs = sum(len(cls.pairs) for cls in self.classes)
-        if total_pairs != expected_pairs:
-            raise ValueError(
-                "ordered pair total must equal set_size * (set_size - 1)",
-            )
-        if self.ordered_pair_count != expected_pairs:
-            raise ValueError("ordered_pair_count must equal the realized pair total")
-        if self.support_size != len(self.classes):
-            raise ValueError("support_size must equal the number of difference classes")
-        max_mult = max((len(cls.pairs) for cls in self.classes), default=0)
-        if self.max_multiplicity != max_mult:
-            raise ValueError("max_multiplicity must equal the largest class size")
-        if self.has_repeated_difference and self.first_repeated_difference is None:
-            raise ValueError(
-                "a repeated difference must supply a first repeated difference witness",
-            )
-        if (
-            not self.has_repeated_difference
-            and self.first_repeated_difference is not None
-        ):
-            raise ValueError(
-                "first_repeated_difference must be absent when no difference repeats",
-            )
+        points = _require_source_shape(
+            self.vectors.vectors,
+            dimension=self.dimension,
+            set_size=self.set_size,
+        )
+        _require_replayed_classes(
+            self.classes,
+            points=points,
+            dimension=self.dimension,
+        )
+        _require_repeated_decision(
+            self.classes,
+            ordered_pair_count=self.ordered_pair_count,
+            support_size=self.support_size,
+            set_size=self.set_size,
+            max_multiplicity=self.max_multiplicity,
+            has_repeated_difference=self.has_repeated_difference,
+            first_repeated_difference=self.first_repeated_difference,
+        )
         return self
 
 

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -283,17 +283,32 @@ class OrderedDifferencePair(StrictModel):
 
 
 class OrderedDifferenceClass(StrictModel):
-    """One nonzero difference vector and every ordered pair realizing it."""
+    """One nonzero difference vector and every ordered pair realizing it.
 
-    difference: tuple[CanonicalInteger, ...] = Field(min_length=1)
+    ``difference`` is the domain's canonical ``IntegerVector`` value so exact
+    differences compose downstream without reconstruction.  Difference
+    coordinates may carry one more digit than request coordinates (a
+    difference of two bounded integers), so this canonical use admits the
+    documented 65-digit boundary rather than the 64-digit request bound.
+    """
+
+    difference: IntegerVector = Field(
+        description=(
+            "The nonzero difference vector as the canonical IntegerVector "
+            "value; coordinates may carry one more digit than request "
+            "coordinates because a difference of two bounded integers can "
+            "grow by one digit."
+        ),
+    )
     pairs: tuple[OrderedDifferencePair, ...] = Field(min_length=1)
 
     @model_validator(mode="after")
     def require_nonzero_difference(self) -> Self:
-        if all(parse_canonical_integer(c) == 0 for c in self.difference):
+        if all(parse_canonical_integer(c) == 0 for c in self.difference.coordinates):
             raise ValueError("the zero difference class is not reported")
         if any(
-            len(c.lstrip("-")) > _MAX_VECTOR_DIFFERENCE_DIGITS for c in self.difference
+            len(c.lstrip("-")) > _MAX_VECTOR_DIFFERENCE_DIGITS
+            for c in self.difference.coordinates
         ):
             raise ValueError("difference coordinate exceeds the digit bound")
         for pair in self.pairs:
@@ -356,9 +371,9 @@ def _require_replayed_classes(
     seen_pairs: set[tuple[int, int]] = set()
     numeric_diffs: list[tuple[int, ...]] = []
     for cls in classes:
-        if len(cls.difference) != dimension:
+        if len(cls.difference.coordinates) != dimension:
             raise ValueError("difference dimension must match the source")
-        diff = tuple(parse_canonical_integer(c) for c in cls.difference)
+        diff = tuple(parse_canonical_integer(c) for c in cls.difference.coordinates)
         numeric_diffs.append(diff)
         for pair in cls.pairs:
             if (
@@ -401,7 +416,7 @@ def _require_repeated_decision(
     if max_multiplicity != max_mult:
         raise ValueError("max_multiplicity must equal the largest class size")
     first_repeated = next(
-        (cls.difference for cls in classes if len(cls.pairs) > 1),
+        (cls.difference.coordinates for cls in classes if len(cls.pairs) > 1),
         None,
     )
     if has_repeated_difference != (max_mult > 1):

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -175,6 +175,134 @@ class DirectSumPredicateResult(StrictModel):
         return self
 
 
+
+
+# ---------------------------------------------------------------------------
+# Ordered-difference profile for integer-vector sets
+# ---------------------------------------------------------------------------
+
+_MAX_VECTOR_DIMENSION = 8
+_MAX_VECTOR_SET_SIZE = 64
+_MAX_VECTOR_COORDINATE_DIGITS = 64
+# A difference coordinate can grow by one digit (sum of two bounded integers).
+_MAX_VECTOR_DIFFERENCE_DIGITS = _MAX_VECTOR_COORDINATE_DIGITS + 1
+_MAX_ORDERED_PAIRS = _MAX_VECTOR_SET_SIZE * (_MAX_VECTOR_SET_SIZE - 1)
+
+
+class IntegerVector(StrictModel):
+    """One integer vector in a bounded common dimension."""
+
+    coordinates: tuple[CanonicalInteger, ...] = Field(
+        min_length=1,
+        max_length=_MAX_VECTOR_DIMENSION,
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_coordinates(self) -> Self:
+        for value in self.coordinates:
+            if len(value.lstrip("-")) > _MAX_VECTOR_COORDINATE_DIGITS:
+                raise ValueError("vector coordinate exceeds the digit bound")
+        return self
+
+
+class IntegerVectorSet(StrictModel):
+    """A finite set of distinct integer vectors in a fixed dimension."""
+
+    vectors: tuple[IntegerVector, ...] = Field(
+        min_length=1,
+        max_length=_MAX_VECTOR_SET_SIZE,
+    )
+
+    @model_validator(mode="after")
+    def require_uniform_and_distinct(self) -> Self:
+        if not self.vectors:
+            return self
+        dim = len(self.vectors[0].coordinates)
+        for vec in self.vectors[1:]:
+            if len(vec.coordinates) != dim:
+                raise ValueError("all vectors must share the same dimension")
+        seen: set[tuple[int, ...]] = set()
+        for vec in self.vectors:
+            key = tuple(parse_canonical_integer(c) for c in vec.coordinates)
+            if key in seen:
+                raise ValueError("vector set elements must be distinct")
+            seen.add(key)
+        return self
+
+
+class OrderedDifferenceProfileRequest(StrictModel):
+    """Compute the complete ordered-difference profile ``r_{A-A}`` of one set."""
+
+    vectors: IntegerVectorSet
+
+
+class OrderedDifferencePair(StrictModel):
+    """One ordered source pair realizing a difference vector."""
+
+    minuend_index: int = Field(ge=0)
+    subtrahend_index: int = Field(ge=0)
+
+
+class OrderedDifferenceClass(StrictModel):
+    """One nonzero difference vector and every ordered pair realizing it."""
+
+    difference: tuple[CanonicalInteger, ...] = Field(min_length=1)
+    pairs: tuple[OrderedDifferencePair, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_nonzero_difference(self) -> Self:
+        if all(parse_canonical_integer(c) == 0 for c in self.difference):
+            raise ValueError("the zero difference class is not reported")
+        if any(
+            len(c.lstrip("-")) > _MAX_VECTOR_DIFFERENCE_DIGITS for c in self.difference
+        ):
+            raise ValueError("difference coordinate exceeds the digit bound")
+        for pair in self.pairs:
+            if pair.minuend_index == pair.subtrahend_index:
+                raise ValueError("an ordered difference pair must be distinct")
+        return self
+
+
+class OrderedDifferenceProfileResult(StrictModel):
+    """Complete ordered-difference profile of a bounded integer-vector set."""
+
+    dimension: int = Field(ge=1, le=_MAX_VECTOR_DIMENSION)
+    set_size: int = Field(ge=1, le=_MAX_VECTOR_SET_SIZE)
+    classes: tuple[OrderedDifferenceClass, ...] = Field(
+        max_length=_MAX_ORDERED_PAIRS,
+    )
+    ordered_pair_count: int = Field(ge=0)
+    support_size: int = Field(ge=0)
+    max_multiplicity: int = Field(ge=0)
+    has_repeated_difference: bool
+    first_repeated_difference: tuple[CanonicalInteger, ...] | None = Field(
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    def require_consistent_profile(self) -> Self:
+        expected_pairs = self.set_size * (self.set_size - 1)
+        total_pairs = sum(len(cls.pairs) for cls in self.classes)
+        if total_pairs != expected_pairs:
+            raise ValueError(
+                "ordered pair total must equal set_size * (set_size - 1)",
+            )
+        if self.ordered_pair_count != expected_pairs:
+            raise ValueError("ordered_pair_count must equal the realized pair total")
+        if self.support_size != len(self.classes):
+            raise ValueError("support_size must equal the number of difference classes")
+        max_mult = max((len(cls.pairs) for cls in self.classes), default=0)
+        if self.max_multiplicity != max_mult:
+            raise ValueError("max_multiplicity must equal the largest class size")
+        if self.has_repeated_difference and self.first_repeated_difference is None:
+            raise ValueError(
+                "a repeated difference must supply a first repeated difference witness",
+            )
+        if not self.has_repeated_difference and self.first_repeated_difference is not None:
+            raise ValueError(
+                "first_repeated_difference must be absent when no difference repeats",
+            )
+        return self
 __all__ = [
     "AdditiveEnergyRequest",
     "AdditiveEnergyResult",
@@ -182,6 +310,12 @@ __all__ = [
     "DirectSumPredicateResult",
     "FiniteCyclicGroup",
     "FiniteIntegerSet",
+    "IntegerVector",
+    "IntegerVectorSet",
+    "OrderedDifferenceClass",
+    "OrderedDifferencePair",
+    "OrderedDifferenceProfileRequest",
+    "OrderedDifferenceProfileResult",
     "RepresentationProfileEntry",
     "RepresentationProfileRequest",
     "RepresentationProfileResult",

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -175,8 +175,6 @@ class DirectSumPredicateResult(StrictModel):
         return self
 
 
-
-
 # ---------------------------------------------------------------------------
 # Ordered-difference profile for integer-vector sets
 # ---------------------------------------------------------------------------
@@ -298,11 +296,16 @@ class OrderedDifferenceProfileResult(StrictModel):
             raise ValueError(
                 "a repeated difference must supply a first repeated difference witness",
             )
-        if not self.has_repeated_difference and self.first_repeated_difference is not None:
+        if (
+            not self.has_repeated_difference
+            and self.first_repeated_difference is not None
+        ):
             raise ValueError(
                 "first_repeated_difference must be absent when no difference repeats",
             )
         return self
+
+
 __all__ = [
     "AdditiveEnergyRequest",
     "AdditiveEnergyResult",

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -12,6 +12,10 @@ from jacobian.math.additive_combinatorics._models import (
     DirectSumPredicateRequest,
     DirectSumPredicateResult,
     FiniteIntegerSet,
+    OrderedDifferenceClass,
+    OrderedDifferencePair,
+    OrderedDifferenceProfileRequest,
+    OrderedDifferenceProfileResult,
     RepresentationProfileEntry,
     RepresentationProfileRequest,
     RepresentationProfileResult,
@@ -148,7 +152,70 @@ def decide_direct_sum_predicate(
 
 __all__ = [
     "compute_additive_energy",
+    "compute_ordered_difference_profile",
     "compute_representation_profile",
     "compute_sumset_cardinality",
     "decide_direct_sum_predicate",
 ]
+
+
+def compute_ordered_difference_profile(
+    request: OrderedDifferenceProfileRequest,
+) -> OrderedDifferenceProfileResult:
+    """Compute the complete ordered-difference profile ``r_{A-A}`` of one set.
+
+    For a finite set ``A`` of integer vectors, returns every nonzero ordered
+    difference ``x - y`` (``x != y``) grouped by difference vector, retaining
+    every ordered source pair ``(x, y)`` in each class.  The result also reports
+    the total ordered-pair count ``|A|(|A|-1)``, the support size, the maximum
+    multiplicity, and a first repeated-difference witness when one exists.
+    """
+    vectors = request.vectors
+    n = len(vectors.vectors)
+    dim = len(vectors.vectors[0].coordinates)
+    points = [
+        tuple(parse_canonical_integer(c) for c in vec.coordinates)
+        for vec in vectors.vectors
+    ]
+
+    classes: dict[tuple[int, ...], list[OrderedDifferencePair]] = {}
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            diff = tuple(points[i][k] - points[j][k] for k in range(dim))
+            if all(d == 0 for d in diff):
+                continue
+            classes.setdefault(diff, []).append(
+                OrderedDifferencePair(minuend_index=i, subtrahend_index=j),
+            )
+
+    # Sort classes by difference vector (lexicographic on numeric values).
+    sorted_diffs = sorted(classes.keys())
+    has_repeated = any(len(classes[d]) > 1 for d in sorted_diffs)
+    first_repeated: tuple[str, ...] | None = None
+    if has_repeated:
+        for d in sorted_diffs:
+            if len(classes[d]) > 1:
+                first_repeated = tuple(format_canonical_integer(c) for c in d)
+                break
+
+    result_classes = tuple(
+        OrderedDifferenceClass(
+            difference=tuple(format_canonical_integer(c) for c in d),
+            pairs=tuple(classes[d]),
+        )
+        for d in sorted_diffs
+    )
+    total_pairs = sum(len(cls.pairs) for cls in result_classes)
+    max_mult = max((len(cls.pairs) for cls in result_classes), default=0)
+    return OrderedDifferenceProfileResult(
+        dimension=dim,
+        set_size=n,
+        classes=result_classes,
+        ordered_pair_count=total_pairs,
+        support_size=len(result_classes),
+        max_multiplicity=max_mult,
+        has_repeated_difference=has_repeated,
+        first_repeated_difference=first_repeated,
+    )

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -184,8 +184,6 @@ def compute_ordered_difference_profile(
             if i == j:
                 continue
             diff = tuple(points[i][k] - points[j][k] for k in range(dim))
-            if all(d == 0 for d in diff):
-                continue
             classes.setdefault(diff, []).append(
                 OrderedDifferencePair(minuend_index=i, subtrahend_index=j),
             )
@@ -210,6 +208,7 @@ def compute_ordered_difference_profile(
     total_pairs = sum(len(cls.pairs) for cls in result_classes)
     max_mult = max((len(cls.pairs) for cls in result_classes), default=0)
     return OrderedDifferenceProfileResult(
+        vectors=vectors,
         dimension=dim,
         set_size=n,
         classes=result_classes,

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -12,6 +12,7 @@ from jacobian.math.additive_combinatorics._models import (
     DirectSumPredicateRequest,
     DirectSumPredicateResult,
     FiniteIntegerSet,
+    IntegerVector,
     OrderedDifferenceClass,
     OrderedDifferencePair,
     OrderedDifferenceProfileRequest,
@@ -200,7 +201,9 @@ def compute_ordered_difference_profile(
 
     result_classes = tuple(
         OrderedDifferenceClass(
-            difference=tuple(format_canonical_integer(c) for c in d),
+            difference=IntegerVector(
+                coordinates=tuple(format_canonical_integer(c) for c in d)
+            ),
             pairs=tuple(classes[d]),
         )
         for d in sorted_diffs

--- a/src/jacobian/math/additive_combinatorics/_tools.py
+++ b/src/jacobian/math/additive_combinatorics/_tools.py
@@ -77,8 +77,25 @@ _DIRECT_SUM_EXAMPLE: dict[str, Any] = {
     "right": {"elements": ["0", "2"]},
 }
 
-_ORDERED_DIFFERENCE_RECT_EXAMPLE: dict[str, Any] = {'vectors': {'vectors': [{'coordinates': ['0', '0']}, {'coordinates': ['1', '0']}, {'coordinates': ['1', '1']}, {'coordinates': ['0', '1']}]}}
-_ORDERED_DIFFERENCE_SIDON_EXAMPLE: dict[str, Any] = {'vectors': {'vectors': [{'coordinates': ['0', '0']}, {'coordinates': ['1', '0']}, {'coordinates': ['0', '1']}]}}
+_ORDERED_DIFFERENCE_RECT_EXAMPLE: dict[str, Any] = {
+    "vectors": {
+        "vectors": [
+            {"coordinates": ["0", "0"]},
+            {"coordinates": ["1", "0"]},
+            {"coordinates": ["1", "1"]},
+            {"coordinates": ["0", "1"]},
+        ]
+    }
+}
+_ORDERED_DIFFERENCE_SIDON_EXAMPLE: dict[str, Any] = {
+    "vectors": {
+        "vectors": [
+            {"coordinates": ["0", "0"]},
+            {"coordinates": ["1", "0"]},
+            {"coordinates": ["0", "1"]},
+        ]
+    }
+}
 _DIRECT_SUM_NON_TILING_EXAMPLE: dict[str, Any] = {
     "modulus": 4,
     "left": {"elements": ["0", "1"]},

--- a/src/jacobian/math/additive_combinatorics/_tools.py
+++ b/src/jacobian/math/additive_combinatorics/_tools.py
@@ -11,6 +11,8 @@ from jacobian.math.additive_combinatorics._models import (
     AdditiveEnergyResult,
     DirectSumPredicateRequest,
     DirectSumPredicateResult,
+    OrderedDifferenceProfileRequest,
+    OrderedDifferenceProfileResult,
     RepresentationProfileRequest,
     RepresentationProfileResult,
     SumsetCardinalityRequest,
@@ -18,6 +20,7 @@ from jacobian.math.additive_combinatorics._models import (
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_additive_energy,
+    compute_ordered_difference_profile,
     compute_representation_profile,
     compute_sumset_cardinality,
     decide_direct_sum_predicate,
@@ -74,6 +77,8 @@ _DIRECT_SUM_EXAMPLE: dict[str, Any] = {
     "right": {"elements": ["0", "2"]},
 }
 
+_ORDERED_DIFFERENCE_RECT_EXAMPLE: dict[str, Any] = {'vectors': {'vectors': [{'coordinates': ['0', '0']}, {'coordinates': ['1', '0']}, {'coordinates': ['1', '1']}, {'coordinates': ['0', '1']}]}}
+_ORDERED_DIFFERENCE_SIDON_EXAMPLE: dict[str, Any] = {'vectors': {'vectors': [{'coordinates': ['0', '0']}, {'coordinates': ['1', '0']}, {'coordinates': ['0', '1']}]}}
 _DIRECT_SUM_NON_TILING_EXAMPLE: dict[str, Any] = {
     "modulus": 4,
     "left": {"elements": ["0", "1"]},
@@ -179,6 +184,44 @@ ADDITIVE_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "have two representations, so A ⊕ B ≠ Z_4."
                 ),
                 _DIRECT_SUM_NON_TILING_EXAMPLE,
+            ),
+        ),
+    ),
+    additive_combinatorics_operation(
+        "additive.ordered_difference_profile.compute",
+        "Compute the ordered-difference profile of an integer-vector set",
+        "Given one bounded finite set A of distinct integer vectors in Z^d, "
+        "return the complete exact profile r_{A-A}(v) = |{(x,y) in A^2 : "
+        "x != y, x - y = v}| for every nonzero difference vector v, "
+        "retaining every ordered source pair in each class. Reports the total "
+        "ordered-pair count |A|(|A|-1), support size, maximum multiplicity, and "
+        "a first repeated-difference witness when one exists. A Sidon decision, "
+        "additive energy, or collision count is a cheap projection of this "
+        "complete profile.",
+        OrderedDifferenceProfileRequest,
+        OrderedDifferenceProfileResult,
+        compute_ordered_difference_profile,
+        "additive-combinatorics",
+        "ordered-differences",
+        "integer-vectors",
+        "exact",
+        examples=(
+            example(
+                "rectangle_repeated_difference",
+                (
+                    "Rectangle {(0,0),(1,0),(1,1),(0,1)}: the difference (1,0) "
+                    "is realized by two ordered pairs, so a repeated difference "
+                    "exists. Vectors must be distinct and share one dimension."
+                ),
+                _ORDERED_DIFFERENCE_RECT_EXAMPLE,
+            ),
+            example(
+                "triangle_sidon",
+                (
+                    "Three non-collinear lattice points with every nonzero "
+                    "ordered difference distinct: no repeated difference exists."
+                ),
+                _ORDERED_DIFFERENCE_SIDON_EXAMPLE,
             ),
         ),
     ),

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -202,7 +202,9 @@ class TestOrderedDifferenceProfile:
         assert result.max_multiplicity == 2
         assert result.first_repeated_difference == ("-1", "0")
         # The difference (1,0) is realized by two ordered pairs.
-        diff_10 = [c for c in result.classes if tuple(c.difference) == ("1", "0")]
+        diff_10 = [
+            c for c in result.classes if tuple(c.difference.coordinates) == ("1", "0")
+        ]
         assert len(diff_10) == 1
         assert len(diff_10[0].pairs) == 2
         assert {p.minuend_index for p in diff_10[0].pairs} == {1, 2}
@@ -226,7 +228,7 @@ class TestOrderedDifferenceProfile:
         assert result.dimension == 1
         assert result.ordered_pair_count == 6
         assert not result.has_repeated_difference
-        diffs = {tuple(c.difference) for c in result.classes}
+        diffs = {tuple(c.difference.coordinates) for c in result.classes}
         assert diffs == {("1",), ("3",), ("2",), ("-1",), ("-3",), ("-2",)}
 
     def test_translation_invariance(self):
@@ -236,15 +238,19 @@ class TestOrderedDifferenceProfile:
         shifted = compute_ordered_difference_profile(
             self._req([(5, -3), (6, -3), (5, -2)]),
         )
-        base_diffs = {tuple(c.difference): len(c.pairs) for c in base.classes}
-        shifted_diffs = {tuple(c.difference): len(c.pairs) for c in shifted.classes}
+        base_diffs = {
+            tuple(c.difference.coordinates): len(c.pairs) for c in base.classes
+        }
+        shifted_diffs = {
+            tuple(c.difference.coordinates): len(c.pairs) for c in shifted.classes
+        }
         assert base_diffs == shifted_diffs
 
     def test_sign_reversal(self):
         result = compute_ordered_difference_profile(
             self._req([(0, 0), (1, 0), (0, 1), (1, 1)]),
         )
-        diffs = {tuple(c.difference): len(c.pairs) for c in result.classes}
+        diffs = {tuple(c.difference.coordinates): len(c.pairs) for c in result.classes}
         # For every difference v, the multiplicity of -v must equal that of v.
         for d, count in diffs.items():
             neg = tuple(str(-int(x)) for x in d)
@@ -276,7 +282,7 @@ class TestOrderedDifferenceProfile:
         )
         seen = set()
         for cls in result.classes:
-            diff = tuple(int(c) for c in cls.difference)
+            diff = tuple(int(c) for c in cls.difference.coordinates)
             for pair in cls.pairs:
                 replayed = tuple(
                     points[pair.minuend_index][k] - points[pair.subtrahend_index][k]
@@ -302,13 +308,13 @@ class TestOrderedDifferenceProfile:
                 set_size=2,
                 classes=(
                     OrderedDifferenceClass(
-                        difference=("-999",),
+                        difference=IntegerVector(coordinates=("-999",)),
                         pairs=(
                             OrderedDifferencePair(minuend_index=0, subtrahend_index=1),
                         ),
                     ),
                     OrderedDifferenceClass(
-                        difference=("999",),
+                        difference=IntegerVector(coordinates=("999",)),
                         pairs=(
                             OrderedDifferencePair(minuend_index=1, subtrahend_index=0),
                         ),
@@ -346,9 +352,11 @@ class TestOrderedDifferenceProfile:
         )
         payload = result.model_dump()
         later = next(
-            cls.difference
+            cls.difference.coordinates
             for cls in result.classes
-            if len(cls.pairs) > 1 and cls.difference != result.first_repeated_difference
+            if len(cls.pairs) > 1
+            and tuple(cls.difference.coordinates)
+            != tuple(result.first_repeated_difference or ())
         )
         payload["first_repeated_difference"] = list(later)
         with pytest.raises(ValidationError, match="first class of multiplicity"):

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -183,8 +183,7 @@ class TestOrderedDifferenceProfile:
         return OrderedDifferenceProfileRequest(
             vectors=IntegerVectorSet(
                 vectors=tuple(
-                    IntegerVector(coordinates=tuple(str(c) for c in v))
-                    for v in vecs
+                    IntegerVector(coordinates=tuple(str(c) for c in v)) for v in vecs
                 ),
             ),
         )
@@ -202,9 +201,7 @@ class TestOrderedDifferenceProfile:
         assert result.has_repeated_difference
         assert result.max_multiplicity == 2
         # The difference (1,0) is realized by two ordered pairs.
-        diff_10 = [
-            c for c in result.classes if tuple(c.difference) == ("1", "0")
-        ]
+        diff_10 = [c for c in result.classes if tuple(c.difference) == ("1", "0")]
         assert len(diff_10) == 1
         assert len(diff_10[0].pairs) == 2
         assert {p.minuend_index for p in diff_10[0].pairs} == {1, 2}

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -1,15 +1,25 @@
 """Tests for additive combinatorics operations."""
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.additive_combinatorics._models import (
     AdditiveEnergyRequest,
     DirectSumPredicateRequest,
     FiniteIntegerSet,
+    IntegerVector,
+    IntegerVectorSet,
+    OrderedDifferenceClass,
+    OrderedDifferencePair,
+    OrderedDifferenceProfileRequest,
+    OrderedDifferenceProfileResult,
     RepresentationProfileRequest,
     SumsetCardinalityRequest,
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_additive_energy,
+    compute_ordered_difference_profile,
     compute_representation_profile,
     compute_sumset_cardinality,
     decide_direct_sum_predicate,
@@ -174,12 +184,6 @@ class TestDirectSumPredicate:
 
 class TestOrderedDifferenceProfile:
     def _req(self, vecs):
-        from jacobian.math.additive_combinatorics._models import (
-            IntegerVector,
-            IntegerVectorSet,
-            OrderedDifferenceProfileRequest,
-        )
-
         return OrderedDifferenceProfileRequest(
             vectors=IntegerVectorSet(
                 vectors=tuple(
@@ -189,17 +193,14 @@ class TestOrderedDifferenceProfile:
         )
 
     def test_rectangle_repeated_difference(self):
-        from jacobian.math.additive_combinatorics._operations import (
-            compute_ordered_difference_profile,
-        )
-
-        result = compute_ordered_difference_profile(
-            self._req([(0, 0), (1, 0), (1, 1), (0, 1)]),
-        )
+        request = self._req([(0, 0), (1, 0), (1, 1), (0, 1)])
+        result = compute_ordered_difference_profile(request)
+        assert result.vectors == request.vectors
         assert result.set_size == 4
         assert result.ordered_pair_count == 12  # 4 * 3
         assert result.has_repeated_difference
         assert result.max_multiplicity == 2
+        assert result.first_repeated_difference == ("-1", "0")
         # The difference (1,0) is realized by two ordered pairs.
         diff_10 = [c for c in result.classes if tuple(c.difference) == ("1", "0")]
         assert len(diff_10) == 1
@@ -207,10 +208,6 @@ class TestOrderedDifferenceProfile:
         assert {p.minuend_index for p in diff_10[0].pairs} == {1, 2}
 
     def test_triangle_is_sidon(self):
-        from jacobian.math.additive_combinatorics._operations import (
-            compute_ordered_difference_profile,
-        )
-
         result = compute_ordered_difference_profile(
             self._req([(0, 0), (1, 0), (0, 1)]),
         )
@@ -222,10 +219,6 @@ class TestOrderedDifferenceProfile:
         assert result.max_multiplicity == 1
 
     def test_one_dimension_agrees_with_sidon(self):
-        from jacobian.math.additive_combinatorics._operations import (
-            compute_ordered_difference_profile,
-        )
-
         # A 1D Sidon set {0,1,3} has all ordered differences distinct.
         result = compute_ordered_difference_profile(
             self._req([(0,), (1,), (3,)]),
@@ -237,10 +230,6 @@ class TestOrderedDifferenceProfile:
         assert diffs == {("1",), ("3",), ("2",), ("-1",), ("-3",), ("-2",)}
 
     def test_translation_invariance(self):
-        from jacobian.math.additive_combinatorics._operations import (
-            compute_ordered_difference_profile,
-        )
-
         base = compute_ordered_difference_profile(
             self._req([(0, 0), (1, 0), (0, 1)]),
         )
@@ -252,10 +241,6 @@ class TestOrderedDifferenceProfile:
         assert base_diffs == shifted_diffs
 
     def test_sign_reversal(self):
-        from jacobian.math.additive_combinatorics._operations import (
-            compute_ordered_difference_profile,
-        )
-
         result = compute_ordered_difference_profile(
             self._req([(0, 0), (1, 0), (0, 1), (1, 1)]),
         )
@@ -266,13 +251,6 @@ class TestOrderedDifferenceProfile:
             assert diffs[neg] == count
 
     def test_rejects_duplicate_vectors(self):
-        import pytest
-
-        from jacobian.math.additive_combinatorics._models import (
-            IntegerVector,
-            IntegerVectorSet,
-        )
-
         with pytest.raises(ValueError, match="distinct"):
             IntegerVectorSet(
                 vectors=(
@@ -282,13 +260,6 @@ class TestOrderedDifferenceProfile:
             )
 
     def test_rejects_mixed_dimensions(self):
-        import pytest
-
-        from jacobian.math.additive_combinatorics._models import (
-            IntegerVector,
-            IntegerVectorSet,
-        )
-
         with pytest.raises(ValueError, match="dimension"):
             IntegerVectorSet(
                 vectors=(
@@ -296,3 +267,105 @@ class TestOrderedDifferenceProfile:
                     IntegerVector(coordinates=("0",)),
                 ),
             )
+
+    def test_result_replays_every_difference_from_source(self):
+        request = self._req([(0, 0), (1, 0), (1, 1), (0, 1)])
+        result = compute_ordered_difference_profile(request)
+        points = tuple(
+            tuple(int(c) for c in vec.coordinates) for vec in result.vectors.vectors
+        )
+        seen = set()
+        for cls in result.classes:
+            diff = tuple(int(c) for c in cls.difference)
+            for pair in cls.pairs:
+                replayed = tuple(
+                    points[pair.minuend_index][k] - points[pair.subtrahend_index][k]
+                    for k in range(result.dimension)
+                )
+                assert replayed == diff
+                seen.add((pair.minuend_index, pair.subtrahend_index))
+        n = result.set_size
+        assert seen == {(i, j) for i in range(n) for j in range(n) if i != j}
+        OrderedDifferenceProfileResult.model_validate(result.model_dump())
+
+    def test_result_rejects_forged_difference_independent_of_source(self):
+        vectors = IntegerVectorSet(
+            vectors=(
+                IntegerVector(coordinates=("0",)),
+                IntegerVector(coordinates=("1",)),
+            ),
+        )
+        with pytest.raises(ValidationError, match="source\\[minuend\\]"):
+            OrderedDifferenceProfileResult(
+                vectors=vectors,
+                dimension=1,
+                set_size=2,
+                classes=(
+                    OrderedDifferenceClass(
+                        difference=("-999",),
+                        pairs=(
+                            OrderedDifferencePair(minuend_index=0, subtrahend_index=1),
+                        ),
+                    ),
+                    OrderedDifferenceClass(
+                        difference=("999",),
+                        pairs=(
+                            OrderedDifferencePair(minuend_index=1, subtrahend_index=0),
+                        ),
+                    ),
+                ),
+                ordered_pair_count=2,
+                support_size=2,
+                max_multiplicity=1,
+                has_repeated_difference=False,
+                first_repeated_difference=None,
+            )
+
+    def test_result_rejects_mutated_source(self):
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        )
+        payload = result.model_dump()
+        payload["vectors"]["vectors"][0]["coordinates"] = ["9", "9"]
+        with pytest.raises(ValidationError, match="source\\[minuend\\]"):
+            OrderedDifferenceProfileResult.model_validate(payload)
+
+    def test_result_rejects_false_repeated_flag(self):
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        )
+        payload = result.model_dump()
+        payload["has_repeated_difference"] = False
+        payload["first_repeated_difference"] = None
+        with pytest.raises(ValidationError, match="max_multiplicity > 1"):
+            OrderedDifferenceProfileResult.model_validate(payload)
+
+    def test_result_rejects_wrong_repeated_witness(self):
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        )
+        payload = result.model_dump()
+        later = next(
+            cls.difference
+            for cls in result.classes
+            if len(cls.pairs) > 1 and cls.difference != result.first_repeated_difference
+        )
+        payload["first_repeated_difference"] = list(later)
+        with pytest.raises(ValidationError, match="first class of multiplicity"):
+            OrderedDifferenceProfileResult.model_validate(payload)
+
+    def test_request_schema_publishes_coordinate_digit_bound(self):
+        schema = OrderedDifferenceProfileRequest.model_json_schema()
+        vector = schema["$defs"]["IntegerVector"]["properties"]["coordinates"]
+        assert "64 decimal digits" in vector["description"]
+        assert vector["items"]["pattern"] == r"^(?:0|-?[1-9][0-9]{0,63})$"
+        assert vector["items"]["maxLength"] == 65
+        assert "64 decimal digits" in schema["description"]
+
+    def test_rejects_65_digit_coordinate(self):
+        with pytest.raises(ValidationError):
+            IntegerVector(coordinates=("1" * 65,))
+
+    def test_accepts_64_digit_coordinate(self):
+        vector = IntegerVector(coordinates=("-" + "1" * 64,))
+        assert vector.coordinates == ("-" + "1" * 64,)

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -170,3 +170,132 @@ class TestDirectSumPredicate:
         result = decide_direct_sum_predicate(req)
         assert result.holds is False
         assert result.missing == tuple(str(value) for value in range(12))
+
+
+class TestOrderedDifferenceProfile:
+    def _req(self, vecs):
+        from jacobian.math.additive_combinatorics._models import (
+            IntegerVector,
+            IntegerVectorSet,
+            OrderedDifferenceProfileRequest,
+        )
+
+        return OrderedDifferenceProfileRequest(
+            vectors=IntegerVectorSet(
+                vectors=tuple(
+                    IntegerVector(coordinates=tuple(str(c) for c in v))
+                    for v in vecs
+                ),
+            ),
+        )
+
+    def test_rectangle_repeated_difference(self):
+        from jacobian.math.additive_combinatorics._operations import (
+            compute_ordered_difference_profile,
+        )
+
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (1, 1), (0, 1)]),
+        )
+        assert result.set_size == 4
+        assert result.ordered_pair_count == 12  # 4 * 3
+        assert result.has_repeated_difference
+        assert result.max_multiplicity == 2
+        # The difference (1,0) is realized by two ordered pairs.
+        diff_10 = [
+            c for c in result.classes if tuple(c.difference) == ("1", "0")
+        ]
+        assert len(diff_10) == 1
+        assert len(diff_10[0].pairs) == 2
+        assert {p.minuend_index for p in diff_10[0].pairs} == {1, 2}
+
+    def test_triangle_is_sidon(self):
+        from jacobian.math.additive_combinatorics._operations import (
+            compute_ordered_difference_profile,
+        )
+
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (0, 1)]),
+        )
+        assert result.set_size == 3
+        assert result.ordered_pair_count == 6
+        assert not result.has_repeated_difference
+        assert result.first_repeated_difference is None
+        assert result.support_size == 6  # all 6 nonzero ordered differences distinct
+        assert result.max_multiplicity == 1
+
+    def test_one_dimension_agrees_with_sidon(self):
+        from jacobian.math.additive_combinatorics._operations import (
+            compute_ordered_difference_profile,
+        )
+
+        # A 1D Sidon set {0,1,3} has all ordered differences distinct.
+        result = compute_ordered_difference_profile(
+            self._req([(0,), (1,), (3,)]),
+        )
+        assert result.dimension == 1
+        assert result.ordered_pair_count == 6
+        assert not result.has_repeated_difference
+        diffs = {tuple(c.difference) for c in result.classes}
+        assert diffs == {("1",), ("3",), ("2",), ("-1",), ("-3",), ("-2",)}
+
+    def test_translation_invariance(self):
+        from jacobian.math.additive_combinatorics._operations import (
+            compute_ordered_difference_profile,
+        )
+
+        base = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (0, 1)]),
+        )
+        shifted = compute_ordered_difference_profile(
+            self._req([(5, -3), (6, -3), (5, -2)]),
+        )
+        base_diffs = {tuple(c.difference): len(c.pairs) for c in base.classes}
+        shifted_diffs = {tuple(c.difference): len(c.pairs) for c in shifted.classes}
+        assert base_diffs == shifted_diffs
+
+    def test_sign_reversal(self):
+        from jacobian.math.additive_combinatorics._operations import (
+            compute_ordered_difference_profile,
+        )
+
+        result = compute_ordered_difference_profile(
+            self._req([(0, 0), (1, 0), (0, 1), (1, 1)]),
+        )
+        diffs = {tuple(c.difference): len(c.pairs) for c in result.classes}
+        # For every difference v, the multiplicity of -v must equal that of v.
+        for d, count in diffs.items():
+            neg = tuple(str(-int(x)) for x in d)
+            assert diffs[neg] == count
+
+    def test_rejects_duplicate_vectors(self):
+        import pytest
+
+        from jacobian.math.additive_combinatorics._models import (
+            IntegerVector,
+            IntegerVectorSet,
+        )
+
+        with pytest.raises(ValueError, match="distinct"):
+            IntegerVectorSet(
+                vectors=(
+                    IntegerVector(coordinates=("0", "0")),
+                    IntegerVector(coordinates=("0", "0")),
+                ),
+            )
+
+    def test_rejects_mixed_dimensions(self):
+        import pytest
+
+        from jacobian.math.additive_combinatorics._models import (
+            IntegerVector,
+            IntegerVectorSet,
+        )
+
+        with pytest.raises(ValueError, match="dimension"):
+            IntegerVectorSet(
+                vectors=(
+                    IntegerVector(coordinates=("0", "0")),
+                    IntegerVector(coordinates=("0",)),
+                ),
+            )


### PR DESCRIPTION
## Problem

Investigations of distinct triangle circumradii and Sidon-type problems in
free Abelian groups repeatedly needed the complete ordered-difference structure
`r_{A-A}(v) = |{(x,y) in A² : x≠y, x−y=v}|` of a finite set `A ⊂ Z^d`, including
every ordered source pair that realizes each difference. Agents authored this
by hand each time.

Closes #2119.

## Solution

Add `additive.ordered_difference_profile.compute`: one atomic, exact, complete
map over a bounded set of distinct integer vectors. For every nonzero
difference vector it groups every ordered source pair `(x,y)`, and reports:

- the common dimension and normalized input vectors;
- every nonzero difference class with all ordered source pairs;
- the total ordered-pair count `|A|(|A−1|)`;
- the support size and maximum multiplicity; and
- a first repeated-difference witness when one exists.

A Sidon decision, additive energy, or collision count is a cheap projection of
this complete profile and is deliberately not a separate public operation.

This is one canonical mathematical map. Maximum Sidon-subset optimization,
parallelogram search, and theorem application are caller-owned composition, not
part of the operation.

## Library choices

Pure Python integer arithmetic over canonical integer vectors. No backend
dependency. Deterministic work is `O(|A|²·d)` over the bounded set
(`|A| ≤ 64`, `d ≤ 8`).

## Testing

- `make check` — Ruff, mypy, and Lean-free math/catalog/integration owners pass (3069).
- Owning tests cover: rectangle repeated difference, a Sidon triangle, 1D
  agreement with the Sidon notion, translation invariance, sign-reversal
  symmetry (multiplicity of `v` equals multiplicity of `−v`), and rejection of
  duplicate/mixed-dimension inputs.
- Catalog conformance: both advertised examples execute and re-validate.

## Public operation admission

- Concrete gap: no configuration-wide ordered-difference profile over `Z^d` existed; the 1D `combinatorics.integer_set.sidon.decide` is scalar-only.
- Why existing operations are insufficient: scalar Sidon decide does not handle vectors or retain full source-pair structure.
- Stable mathematical result: the complete ordered-difference multiset of a bounded integer-vector set.
- Admission decision: `KEEP`.

## Public operation contract

- Mathematical input domain: a bounded set of distinct integer vectors in `Z^d`, `1 ≤ d ≤ 8`, `1 ≤ |A| ≤ 64`, coordinates ≤ 64 digits.
- Canonical public value type: `IntegerVectorSet` of `CanonicalInteger` coordinates.
- Degenerate inputs: `|A| = 1` yields an empty profile (no ordered pairs).
- Parent/ring/field identity: integers (`Z`).
- Deterministic work bound: `|A|²·d` ordered-pair expansions; output ≤ `|A|(|A|−1)` rows.
- Result type: `OrderedDifferenceProfileResult` with per-class pairs, counts, max, and first-repeated witness.
- Reconstruction/defining invariant: `ordered_pair_count == set_size·(set_size−1)`; `support_size == len(classes)`; `max_multiplicity` equals the largest class size; repeated-difference witness consistency.
- Typed execution failures: duplicate vectors, mixed dimensions, and over-bound coordinates are rejected before computation.

## Checklist

- [x] `make check` passes
- [x] Public operation changes retain owner-local admission decisions
- [x] Execution outcomes do not claim mathematical conclusions

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/0cecb73b-2b36-4041-b659-1a3441039ed1)