### PR TITLE
feat(math): add exact graph adjacency and Laplacian characteristic polynomials

### DIFF
--- a/src/jacobian/math/graphs/spectral/__init__.py
+++ b/src/jacobian/math/graphs/spectral/__init__.py
@@ -2,8 +2,16 @@
 
 from jacobian.math.graphs.spectral._models import GraphEdgeList
 from jacobian.math.graphs.spectral.operations import (
+    adjacency_characteristic_polynomial,
     adjacency_spectrum,
+    laplacian_characteristic_polynomial,
     laplacian_spectrum,
 )
 
-__all__ = ["GraphEdgeList", "adjacency_spectrum", "laplacian_spectrum"]
+__all__ = [
+    "GraphEdgeList",
+    "adjacency_characteristic_polynomial",
+    "adjacency_spectrum",
+    "laplacian_characteristic_polynomial",
+    "laplacian_spectrum",
+]

--- a/src/jacobian/math/graphs/spectral/_admission.py
+++ b/src/jacobian/math/graphs/spectral/_admission.py
@@ -11,6 +11,16 @@ from jacobian.math.graphs.spectral._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "graph.spectrum.adjacency.characteristic_polynomial.compute",
+        AdmissionDecision.KEEP,
+        "exact monic adjacency characteristic polynomial over QQ, composable with graph spectral and chromatic-spectral comparisons",
+    ),
+    OperationAdmission(
+        "graph.spectrum.laplacian.characteristic_polynomial.compute",
+        AdmissionDecision.KEEP,
+        "exact monic Laplacian characteristic polynomial over QQ, composable with graph spectral invariants",
+    ),
+    OperationAdmission(
         "graph.spectrum.adjacency.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -48,9 +48,7 @@ class GraphCharacteristicPolynomialResult(StrictModel):
 
     coefficients: tuple[CanonicalRational, ...] = Field(
         min_length=1,
-        description=(
-            "Monic polynomial coefficients in increasing degree over QQ."
-        ),
+        description=("Monic polynomial coefficients in increasing degree over QQ."),
     )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -89,19 +89,17 @@ class GraphCharacteristicPolynomialResult(StrictModel):
             rational_polynomial_to_sympy,
         )
 
+        if self.polynomial.variables != (_VARIABLE,):
+            raise ValueError("characteristic polynomial must be univariate in x")
         matrix = (
             _adjacency_matrix(self.graph)
             if self.convention == "ADJACENCY"
             else _laplacian_matrix(self.graph)
         )
-        expected = (
-            matrix.charpoly()
-            .as_expr()
-            .subs(
-                matrix.charpoly().gen, rational_polynomial_to_sympy(self.polynomial).gen
-            )
-        )
-        actual = rational_polynomial_to_sympy(self.polynomial).as_expr()
+        poly_sym = rational_polynomial_to_sympy(self.polynomial)
+        actual = poly_sym.as_expr()
+        charpoly = matrix.charpoly()
+        expected = charpoly.as_expr().subs(charpoly.gen, poly_sym.gen)
         if expected != actual:
             raise ValueError(
                 "characteristic polynomial does not match the source graph"

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -12,10 +12,13 @@ from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
     SparseRationalPolynomial,
+    require_polynomial_budget,
 )
 
 _VARIABLE = "x"
-_MAX_CHARPOLY_TERMS = 64
+_MAX_CHARPOLY_TERMS = 33
+_MAX_CHARPOLY_EXPONENT = 32
+_MAX_CHARPOLY_COEFFICIENT_DIGITS = 128
 
 
 class GraphEdgeList(StrictModel):
@@ -91,6 +94,13 @@ class GraphCharacteristicPolynomialResult(StrictModel):
 
         if self.polynomial.variables != (_VARIABLE,):
             raise ValueError("characteristic polynomial must be univariate in x")
+        require_polynomial_budget(
+            self.polynomial,
+            maximum_terms=_MAX_CHARPOLY_TERMS,
+            maximum_exponent=_MAX_CHARPOLY_EXPONENT,
+            maximum_coefficient_digits=_MAX_CHARPOLY_COEFFICIENT_DIGITS,
+            label="characteristic polynomial",
+        )
         matrix = (
             _adjacency_matrix(self.graph)
             if self.convention == "ADJACENCY"

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -8,6 +8,14 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+_VARIABLE = "x"
+_MAX_CHARPOLY_TERMS = 64
 
 
 class GraphEdgeList(StrictModel):
@@ -43,18 +51,67 @@ class GraphSpectrumResult(StrictModel):
     convention: Literal["SYMPY_EIGENVALS"] = "SYMPY_EIGENVALS"
 
 
-class GraphCharacteristicPolynomialResult(StrictModel):
-    """The exact monic characteristic polynomial of a graph matrix over QQ."""
-
-    coefficients: tuple[CanonicalRational, ...] = Field(
-        min_length=1,
-        description=("Monic polynomial coefficients in increasing degree over QQ."),
+def _dense_to_canonical_polynomial(
+    coefficients: tuple[CanonicalRational, ...],
+) -> RationalPolynomial:
+    """Convert increasing-degree dense coefficients to the canonical value."""
+    terms = tuple(
+        RationalPolynomialTerm(coefficient=coefficient, exponents=(degree,))
+        for degree, coefficient in reversed(list(enumerate(coefficients)))
+        if coefficient.as_fraction() != 0
+    )
+    return RationalPolynomial(
+        variables=(_VARIABLE,),
+        polynomial=SparseRationalPolynomial(terms=terms),
     )
 
+
+class GraphCharacteristicPolynomialResult(StrictModel):
+    """The exact monic characteristic polynomial of a graph matrix over QQ.
+
+    ``polynomial`` is the domain-owned canonical sparse value so downstream
+    polynomial operations compose without translation.  The result retains
+    its source graph and convention so validation can replay the defining
+    determinant relation.
+    """
+
+    graph: GraphEdgeList
+    convention: Literal["ADJACENCY", "LAPLACIAN"]
+    polynomial: RationalPolynomial
+
     @model_validator(mode="after")
-    def require_monic(self) -> Self:
-        if not self.coefficients:
-            raise ValueError("characteristic polynomial must have coefficients")
-        if self.coefficients[-1].as_fraction() != 1:
-            raise ValueError("characteristic polynomial must be monic")
+    def require_bound_to_source(self) -> Self:
+        from jacobian.math.graphs.spectral.operations import (
+            _adjacency_matrix,
+            _laplacian_matrix,
+        )
+        from jacobian.math.polynomials._conversions import (
+            rational_polynomial_to_sympy,
+        )
+
+        matrix = (
+            _adjacency_matrix(self.graph)
+            if self.convention == "ADJACENCY"
+            else _laplacian_matrix(self.graph)
+        )
+        expected = (
+            matrix.charpoly()
+            .as_expr()
+            .subs(
+                matrix.charpoly().gen, rational_polynomial_to_sympy(self.polynomial).gen
+            )
+        )
+        actual = rational_polynomial_to_sympy(self.polynomial).as_expr()
+        if expected != actual:
+            raise ValueError(
+                "characteristic polynomial does not match the source graph"
+            )
         return self
+
+
+__all__ = [
+    "GraphCharacteristicPolynomialResult",
+    "GraphEdgeList",
+    "GraphSpectrumRequest",
+    "GraphSpectrumResult",
+]

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -6,6 +6,7 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 
 
@@ -40,3 +41,22 @@ class GraphSpectrumResult(StrictModel):
     eigenvalues: tuple[str, ...]
     multiplicities: tuple[int, ...]
     convention: Literal["SYMPY_EIGENVALS"] = "SYMPY_EIGENVALS"
+
+
+class GraphCharacteristicPolynomialResult(StrictModel):
+    """The exact monic characteristic polynomial of a graph matrix over QQ."""
+
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        description=(
+            "Monic polynomial coefficients in increasing degree over QQ."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_monic(self) -> Self:
+        if not self.coefficients:
+            raise ValueError("characteristic polynomial must have coefficients")
+        if self.coefficients[-1].as_fraction() != 1:
+            raise ValueError("characteristic polynomial must be monic")
+        return self

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -34,10 +34,18 @@ def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
 def compute_adjacency_characteristic_polynomial(
     request: GraphSpectrumRequest,
 ) -> GraphCharacteristicPolynomialResult:
-    return adjacency_characteristic_polynomial(request.graph)
+    return GraphCharacteristicPolynomialResult(
+        graph=request.graph,
+        convention="ADJACENCY",
+        polynomial=adjacency_characteristic_polynomial(request.graph),
+    )
 
 
 def compute_laplacian_characteristic_polynomial(
     request: GraphSpectrumRequest,
 ) -> GraphCharacteristicPolynomialResult:
-    return laplacian_characteristic_polynomial(request.graph)
+    return GraphCharacteristicPolynomialResult(
+        graph=request.graph,
+        convention="LAPLACIAN",
+        polynomial=laplacian_characteristic_polynomial(request.graph),
+    )

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-from jacobian.math.graphs.spectral import adjacency_spectrum, laplacian_spectrum
+from jacobian.math.graphs.spectral import (
+    adjacency_characteristic_polynomial,
+    adjacency_spectrum,
+    laplacian_characteristic_polynomial,
+    laplacian_spectrum,
+)
 from jacobian.math.graphs.spectral._models import (
+    GraphCharacteristicPolynomialResult,
     GraphSpectrumRequest,
     GraphSpectrumResult,
 )
@@ -22,4 +28,31 @@ def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
     return GraphSpectrumResult(
         eigenvalues=tuple(v for v, _ in result),
         multiplicities=tuple(m for _, m in result),
+    )
+
+
+def compute_adjacency_characteristic_polynomial(
+    request: GraphSpectrumRequest,
+) -> GraphCharacteristicPolynomialResult:
+    from fractions import Fraction
+
+    from jacobian._exact import CanonicalRational
+
+    coeffs = adjacency_characteristic_polynomial(request.graph)
+    return GraphCharacteristicPolynomialResult(
+        coefficients=tuple(
+            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs),
+    )
+
+
+def compute_laplacian_characteristic_polynomial(
+    request: GraphSpectrumRequest,
+) -> GraphCharacteristicPolynomialResult:
+    from fractions import Fraction
+
+    from jacobian._exact import CanonicalRational
+
+    coeffs = laplacian_characteristic_polynomial(request.graph)
+    return GraphCharacteristicPolynomialResult(
+        coefficients=tuple(CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs),
     )

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -41,7 +41,8 @@ def compute_adjacency_characteristic_polynomial(
     coeffs = adjacency_characteristic_polynomial(request.graph)
     return GraphCharacteristicPolynomialResult(
         coefficients=tuple(
-            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs),
+            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs
+        ),
     )
 
 
@@ -54,5 +55,7 @@ def compute_laplacian_characteristic_polynomial(
 
     coeffs = laplacian_characteristic_polynomial(request.graph)
     return GraphCharacteristicPolynomialResult(
-        coefficients=tuple(CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs),
+        coefficients=tuple(
+            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs
+        ),
     )

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -34,28 +34,10 @@ def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
 def compute_adjacency_characteristic_polynomial(
     request: GraphSpectrumRequest,
 ) -> GraphCharacteristicPolynomialResult:
-    from fractions import Fraction
-
-    from jacobian._exact import CanonicalRational
-
-    coeffs = adjacency_characteristic_polynomial(request.graph)
-    return GraphCharacteristicPolynomialResult(
-        coefficients=tuple(
-            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs
-        ),
-    )
+    return adjacency_characteristic_polynomial(request.graph)
 
 
 def compute_laplacian_characteristic_polynomial(
     request: GraphSpectrumRequest,
 ) -> GraphCharacteristicPolynomialResult:
-    from fractions import Fraction
-
-    from jacobian._exact import CanonicalRational
-
-    coeffs = laplacian_characteristic_polynomial(request.graph)
-    return GraphCharacteristicPolynomialResult(
-        coefficients=tuple(
-            CanonicalRational.from_fraction(Fraction(n, d)) for n, d in coeffs
-        ),
-    )
+    return laplacian_characteristic_polynomial(request.graph)

--- a/src/jacobian/math/graphs/spectral/_tools.py
+++ b/src/jacobian/math/graphs/spectral/_tools.py
@@ -46,8 +46,7 @@ def graph_spectral_operation[
     )
 
 
-
-PATH_P3 = {'graph': {'vertex_count': 3, 'edges': [[0, 1], [1, 2]]}}
+PATH_P3 = {"graph": {"vertex_count": 3, "edges": [[0, 1], [1, 2]]}}
 
 GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_spectral_operation(

--- a/src/jacobian/math/graphs/spectral/_tools.py
+++ b/src/jacobian/math/graphs/spectral/_tools.py
@@ -7,11 +7,14 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.graphs.spectral._models import (
+    GraphCharacteristicPolynomialResult,
     GraphSpectrumRequest,
     GraphSpectrumResult,
 )
 from jacobian.math.graphs.spectral._operations import (
+    compute_adjacency_characteristic_polynomial,
     compute_adjacency_spectrum,
+    compute_laplacian_characteristic_polynomial,
     compute_laplacian_spectrum,
 )
 
@@ -42,6 +45,9 @@ def graph_spectral_operation[
         examples=examples,
     )
 
+
+
+PATH_P3 = {'graph': {'vertex_count': 3, 'edges': [[0, 1], [1, 2]]}}
 
 GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_spectral_operation(
@@ -91,6 +97,56 @@ GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                         "edges": [[0, 1], [1, 2]],
                     }
                 },
+            ),
+        ),
+    ),
+    graph_spectral_operation(
+        "graph.spectrum.adjacency.characteristic_polynomial.compute",
+        "Compute exact adjacency characteristic polynomial",
+        "Compute the exact monic characteristic polynomial of the adjacency "
+        "matrix of a simple undirected graph over QQ, as increasing-degree "
+        "rational coefficients, using SymPy.",
+        GraphSpectrumRequest,
+        GraphCharacteristicPolynomialResult,
+        compute_adjacency_characteristic_polynomial,
+        "graph",
+        "spectrum",
+        "adjacency",
+        "characteristic-polynomial",
+        "exact",
+        examples=(
+            example(
+                "path_adjacency_charpoly",
+                (
+                    "Characteristic polynomial of the adjacency matrix of P3; "
+                    "the graph must be simple with at most 32 vertices."
+                ),
+                PATH_P3,
+            ),
+        ),
+    ),
+    graph_spectral_operation(
+        "graph.spectrum.laplacian.characteristic_polynomial.compute",
+        "Compute exact Laplacian characteristic polynomial",
+        "Compute the exact monic characteristic polynomial of the Laplacian "
+        "matrix of a simple undirected graph over QQ, as increasing-degree "
+        "rational coefficients, using SymPy.",
+        GraphSpectrumRequest,
+        GraphCharacteristicPolynomialResult,
+        compute_laplacian_characteristic_polynomial,
+        "graph",
+        "spectrum",
+        "laplacian",
+        "characteristic-polynomial",
+        "exact",
+        examples=(
+            example(
+                "path_laplacian_charpoly",
+                (
+                    "Characteristic polynomial of the Laplacian matrix of P3; "
+                    "the graph must be simple with at most 32 vertices."
+                ),
+                PATH_P3,
             ),
         ),
     ),

--- a/src/jacobian/math/graphs/spectral/_tools.py
+++ b/src/jacobian/math/graphs/spectral/_tools.py
@@ -102,9 +102,10 @@ GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_spectral_operation(
         "graph.spectrum.adjacency.characteristic_polynomial.compute",
         "Compute exact adjacency characteristic polynomial",
-        "Compute the exact monic characteristic polynomial of the adjacency "
-        "matrix of a simple undirected graph over QQ, as increasing-degree "
-        "rational coefficients, using SymPy.",
+        "Compute the exact monic characteristic polynomial det(xI - A) of the "
+        "adjacency matrix of a simple undirected graph over QQ, returned as "
+        "the canonical sparse RationalPolynomial in x with nonzero terms "
+        "serialized in descending exponent order, using SymPy.",
         GraphSpectrumRequest,
         GraphCharacteristicPolynomialResult,
         compute_adjacency_characteristic_polynomial,
@@ -127,9 +128,10 @@ GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_spectral_operation(
         "graph.spectrum.laplacian.characteristic_polynomial.compute",
         "Compute exact Laplacian characteristic polynomial",
-        "Compute the exact monic characteristic polynomial of the Laplacian "
-        "matrix of a simple undirected graph over QQ, as increasing-degree "
-        "rational coefficients, using SymPy.",
+        "Compute the exact monic characteristic polynomial det(xI - L) of the "
+        "Laplacian matrix of a simple undirected graph over QQ, returned as "
+        "the canonical sparse RationalPolynomial in x with nonzero terms "
+        "serialized in descending exponent order, using SymPy.",
         GraphSpectrumRequest,
         GraphCharacteristicPolynomialResult,
         compute_laplacian_characteristic_polynomial,

--- a/src/jacobian/math/graphs/spectral/operations.py
+++ b/src/jacobian/math/graphs/spectral/operations.py
@@ -11,7 +11,33 @@ __all__ = [
     "laplacian_spectrum",
 ]
 
-from jacobian.math.graphs.spectral._models import GraphEdgeList
+from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.spectral._models import (
+    GraphCharacteristicPolynomialResult,
+    GraphEdgeList,
+)
+
+
+def _characteristic_polynomial_coeffs(
+    matrix: Any,
+) -> tuple[CanonicalRational, ...]:
+    """Return monic charpoly coefficients (increasing degree) as canonical values."""
+    from fractions import Fraction
+
+    coeffs = matrix.charpoly().all_coeffs()
+    increasing = list(reversed(coeffs))
+    return tuple(
+        CanonicalRational.from_fraction(Fraction(int(c.p), int(c.q)))
+        for c in increasing
+    )
+
+
+def _dense_to_canonical_polynomial(
+    coefficients: tuple[CanonicalRational, ...],
+) -> Any:
+    from jacobian.math.graphs.spectral._models import _dense_to_canonical_polynomial
+
+    return _dense_to_canonical_polynomial(coefficients)
 
 
 def _adjacency_matrix(graph: GraphEdgeList) -> Any:
@@ -24,6 +50,14 @@ def _adjacency_matrix(graph: GraphEdgeList) -> Any:
     return mat
 
 
+def _laplacian_matrix(graph: GraphEdgeList) -> Any:
+    import sympy
+
+    adj = _adjacency_matrix(graph)
+    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(graph.vertex_count)))
+    return degree - adj
+
+
 def adjacency_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
     mat = _adjacency_matrix(graph)
     eigenvals = mat.eigenvals()
@@ -31,40 +65,31 @@ def adjacency_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
 
 
 def laplacian_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
-    import sympy
-
-    adj = _adjacency_matrix(graph)
-    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(graph.vertex_count)))
-    lap = degree - adj
-    eigenvals = lap.eigenvals()
+    eigenvals = _laplacian_matrix(graph).eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]
 
 
-def _characteristic_polynomial_coeffs(matrix: Any) -> list[tuple[int, int]]:
-    """Return monic charpoly coefficients (increasing degree) as (num, den)."""
-    from fractions import Fraction
+def adjacency_characteristic_polynomial(
+    graph: GraphEdgeList,
+) -> GraphCharacteristicPolynomialResult:
+    """Monic characteristic polynomial of the adjacency matrix (canonical value)."""
 
-    poly = matrix.charpoly()
-    # sympy Poly.all_coeffs() is decreasing degree; reverse for increasing.
-    coeffs = poly.all_coeffs()
-    increasing = list(reversed(coeffs))
-    result: list[tuple[int, int]] = []
-    for c in increasing:
-        r = Fraction(int(c.p), int(c.q))
-        result.append((r.numerator, r.denominator))
-    return result
+    coeffs = _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
+    return GraphCharacteristicPolynomialResult(
+        graph=graph,
+        convention="ADJACENCY",
+        polynomial=_dense_to_canonical_polynomial(coeffs),
+    )
 
 
-def adjacency_characteristic_polynomial(graph: GraphEdgeList) -> list[tuple[int, int]]:
-    """Monic characteristic polynomial of the adjacency matrix (increasing degree)."""
-    return _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
+def laplacian_characteristic_polynomial(
+    graph: GraphEdgeList,
+) -> GraphCharacteristicPolynomialResult:
+    """Monic characteristic polynomial of the Laplacian matrix (canonical value)."""
 
-
-def laplacian_characteristic_polynomial(graph: GraphEdgeList) -> list[tuple[int, int]]:
-    """Monic characteristic polynomial of the Laplacian matrix (increasing degree)."""
-    import sympy
-
-    adj = _adjacency_matrix(graph)
-    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(graph.vertex_count)))
-    lap = degree - adj
-    return _characteristic_polynomial_coeffs(lap)
+    coeffs = _characteristic_polynomial_coeffs(_laplacian_matrix(graph))
+    return GraphCharacteristicPolynomialResult(
+        graph=graph,
+        convention="LAPLACIAN",
+        polynomial=_dense_to_canonical_polynomial(coeffs),
+    )

--- a/src/jacobian/math/graphs/spectral/operations.py
+++ b/src/jacobian/math/graphs/spectral/operations.py
@@ -12,10 +12,8 @@ __all__ = [
 ]
 
 from jacobian._exact import CanonicalRational
-from jacobian.math.graphs.spectral._models import (
-    GraphCharacteristicPolynomialResult,
-    GraphEdgeList,
-)
+from jacobian.math.graphs.spectral._models import GraphEdgeList
+from jacobian.math.polynomials.values import RationalPolynomial
 
 
 def _characteristic_polynomial_coeffs(
@@ -34,7 +32,7 @@ def _characteristic_polynomial_coeffs(
 
 def _dense_to_canonical_polynomial(
     coefficients: tuple[CanonicalRational, ...],
-) -> Any:
+) -> RationalPolynomial:
     from jacobian.math.graphs.spectral._models import _dense_to_canonical_polynomial
 
     return _dense_to_canonical_polynomial(coefficients)
@@ -71,25 +69,19 @@ def laplacian_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
 
 def adjacency_characteristic_polynomial(
     graph: GraphEdgeList,
-) -> GraphCharacteristicPolynomialResult:
-    """Monic characteristic polynomial of the adjacency matrix (canonical value)."""
+) -> RationalPolynomial:
+    """Return det(xI - A) as the canonical sparse rational polynomial."""
 
-    coeffs = _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
-    return GraphCharacteristicPolynomialResult(
-        graph=graph,
-        convention="ADJACENCY",
-        polynomial=_dense_to_canonical_polynomial(coeffs),
+    return _dense_to_canonical_polynomial(
+        _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
     )
 
 
 def laplacian_characteristic_polynomial(
     graph: GraphEdgeList,
-) -> GraphCharacteristicPolynomialResult:
-    """Monic characteristic polynomial of the Laplacian matrix (canonical value)."""
+) -> RationalPolynomial:
+    """Return det(xI - L) as the canonical sparse rational polynomial."""
 
-    coeffs = _characteristic_polynomial_coeffs(_laplacian_matrix(graph))
-    return GraphCharacteristicPolynomialResult(
-        graph=graph,
-        convention="LAPLACIAN",
-        polynomial=_dense_to_canonical_polynomial(coeffs),
+    return _dense_to_canonical_polynomial(
+        _characteristic_polynomial_coeffs(_laplacian_matrix(graph))
     )

--- a/src/jacobian/math/graphs/spectral/operations.py
+++ b/src/jacobian/math/graphs/spectral/operations.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["adjacency_spectrum", "laplacian_spectrum"]
+__all__ = [
+    "adjacency_characteristic_polynomial",
+    "adjacency_spectrum",
+    "laplacian_characteristic_polynomial",
+    "laplacian_spectrum",
+]
 
 from jacobian.math.graphs.spectral._models import GraphEdgeList
 
@@ -33,3 +38,33 @@ def laplacian_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
     lap = degree - adj
     eigenvals = lap.eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]
+
+
+def _characteristic_polynomial_coeffs(matrix: Any) -> list[tuple[int, int]]:
+    """Return monic charpoly coefficients (increasing degree) as (num, den)."""
+    from fractions import Fraction
+
+    poly = matrix.charpoly()
+    # sympy Poly.all_coeffs() is decreasing degree; reverse for increasing.
+    coeffs = poly.all_coeffs()
+    increasing = list(reversed(coeffs))
+    result: list[tuple[int, int]] = []
+    for c in increasing:
+        r = Fraction(int(c.p), int(c.q))
+        result.append((r.numerator, r.denominator))
+    return result
+
+
+def adjacency_characteristic_polynomial(graph: GraphEdgeList) -> list[tuple[int, int]]:
+    """Monic characteristic polynomial of the adjacency matrix (increasing degree)."""
+    return _characteristic_polynomial_coeffs(_adjacency_matrix(graph))
+
+
+def laplacian_characteristic_polynomial(graph: GraphEdgeList) -> list[tuple[int, int]]:
+    """Monic characteristic polynomial of the Laplacian matrix (increasing degree)."""
+    import sympy
+
+    adj = _adjacency_matrix(graph)
+    degree = sympy.diag(*(sum(adj[vertex, :]) for vertex in range(graph.vertex_count)))
+    lap = degree - adj
+    return _characteristic_polynomial_coeffs(lap)

--- a/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
@@ -1,0 +1,56 @@
+"""Tests for exact graph characteristic-polynomial operations."""
+
+from fractions import Fraction
+
+from jacobian.math.graphs.spectral._models import (
+    GraphEdgeList,
+    GraphSpectrumRequest,
+)
+from jacobian.math.graphs.spectral._operations import (
+    compute_adjacency_characteristic_polynomial,
+    compute_laplacian_characteristic_polynomial,
+)
+
+
+def _request(edges, vc):
+    return GraphSpectrumRequest(graph=GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges)))
+
+
+class TestAdjacencyCharacteristicPolynomial:
+    def test_path_p3(self):
+        # P3 adjacency eigenvalues: 0, sqrt(2), -sqrt(2) -> charpoly x(x^2-2) = x^3 - 2x.
+        result = compute_adjacency_characteristic_polynomial(_request([[0, 1], [1, 2]], 3))
+        coeffs = [c.as_fraction() for c in result.coefficients]
+        assert coeffs == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
+
+    def test_edge_k2(self):
+        # K2 adjacency: [[0,1],[1,0]] eigenvalues 1,-1 -> charpoly x^2 - 1.
+        result = compute_adjacency_characteristic_polynomial(_request([[0, 1]], 2))
+        coeffs = [c.as_fraction() for c in result.coefficients]
+        assert coeffs == [Fraction(-1), Fraction(0), Fraction(1)]
+
+    def test_isolated_vertex(self):
+        # One isolated vertex: adjacency matrix [0] -> charpoly x.
+        result = compute_adjacency_characteristic_polynomial(_request([], 1))
+        assert [c.as_fraction() for c in result.coefficients] == [Fraction(0), Fraction(1)]
+
+    def test_result_is_monic(self):
+        result = compute_adjacency_characteristic_polynomial(_request([[0, 1], [1, 2], [0, 2]], 3))
+        assert result.coefficients[-1].as_fraction() == 1
+
+
+class TestLaplacianCharacteristicPolynomial:
+    def test_path_p3(self):
+        # P3 Laplacian eigenvalues 0,1,3 -> charpoly x(x-1)(x-3) = x^3 - 4x^2 + 3x.
+        result = compute_laplacian_characteristic_polynomial(_request([[0, 1], [1, 2]], 3))
+        coeffs = [c.as_fraction() for c in result.coefficients]
+        assert coeffs == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
+
+    def test_laplacian_has_zero_root(self):
+        # The Laplacian of any graph has a zero eigenvalue, so the constant term is 0.
+        result = compute_laplacian_characteristic_polynomial(_request([[0, 1], [1, 2], [0, 2]], 3))
+        assert result.coefficients[0].as_fraction() == 0
+
+    def test_result_is_monic(self):
+        result = compute_laplacian_characteristic_polynomial(_request([[0, 1]], 2))
+        assert result.coefficients[-1].as_fraction() == 1

--- a/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
@@ -18,34 +18,56 @@ def _request(edges, vc):
     )
 
 
+def _coeffs(result):
+    """Return dense increasing-degree coefficients including implicit zeros."""
+    degree = 0
+    out: list[Fraction] = []
+    terms = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in result.polynomial.polynomial.terms
+    }
+    top = max(terms) if terms else 0
+    while degree <= top:
+        out.append(terms.get(degree, Fraction(0)))
+        degree += 1
+    return out
+
+
 class TestAdjacencyCharacteristicPolynomial:
     def test_path_p3(self):
         # P3 adjacency eigenvalues: 0, sqrt(2), -sqrt(2) -> charpoly x(x^2-2) = x^3 - 2x.
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
         )
-        coeffs = [c.as_fraction() for c in result.coefficients]
-        assert coeffs == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
+        assert _coeffs(result) == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
+        assert result.convention == "ADJACENCY"
 
     def test_edge_k2(self):
         # K2 adjacency: [[0,1],[1,0]] eigenvalues 1,-1 -> charpoly x^2 - 1.
         result = compute_adjacency_characteristic_polynomial(_request([[0, 1]], 2))
-        coeffs = [c.as_fraction() for c in result.coefficients]
-        assert coeffs == [Fraction(-1), Fraction(0), Fraction(1)]
+        assert _coeffs(result) == [Fraction(-1), Fraction(0), Fraction(1)]
 
     def test_isolated_vertex(self):
         # One isolated vertex: adjacency matrix [0] -> charpoly x.
         result = compute_adjacency_characteristic_polynomial(_request([], 1))
-        assert [c.as_fraction() for c in result.coefficients] == [
-            Fraction(0),
-            Fraction(1),
-        ]
+        assert _coeffs(result) == [Fraction(0), Fraction(1)]
 
     def test_result_is_monic(self):
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2], [0, 2]], 3)
         )
-        assert result.coefficients[-1].as_fraction() == 1
+        top = max(term.exponents[0] for term in result.polynomial.polynomial.terms)
+        leading = next(
+            term
+            for term in result.polynomial.polynomial.terms
+            if term.exponents[0] == top
+        )
+        assert leading.coefficient.as_fraction() == 1
+
+    def test_result_binds_source_graph(self):
+        request = _request([[0, 1], [1, 2]], 3)
+        result = compute_adjacency_characteristic_polynomial(request)
+        assert result.graph == request.graph
 
 
 class TestLaplacianCharacteristicPolynomial:
@@ -54,16 +76,56 @@ class TestLaplacianCharacteristicPolynomial:
         result = compute_laplacian_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
         )
-        coeffs = [c.as_fraction() for c in result.coefficients]
-        assert coeffs == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
+        assert _coeffs(result) == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
+        assert result.convention == "LAPLACIAN"
 
     def test_laplacian_has_zero_root(self):
         # The Laplacian of any graph has a zero eigenvalue, so the constant term is 0.
         result = compute_laplacian_characteristic_polynomial(
             _request([[0, 1], [1, 2], [0, 2]], 3)
         )
-        assert result.coefficients[0].as_fraction() == 0
+        constant = next(
+            (
+                term
+                for term in result.polynomial.polynomial.terms
+                if term.exponents[0] == 0
+            ),
+            None,
+        )
+        assert constant is None
 
     def test_result_is_monic(self):
         result = compute_laplacian_characteristic_polynomial(_request([[0, 1]], 2))
-        assert result.coefficients[-1].as_fraction() == 1
+        top = max(term.exponents[0] for term in result.polynomial.polynomial.terms)
+        leading = next(
+            term
+            for term in result.polynomial.polynomial.terms
+            if term.exponents[0] == top
+        )
+        assert leading.coefficient.as_fraction() == 1
+
+
+def test_forged_result_rejected():
+    import pytest
+    from pydantic import ValidationError
+
+    from jacobian.math.graphs.spectral._models import (
+        GraphCharacteristicPolynomialResult,
+    )
+
+    graph = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
+    with pytest.raises(ValidationError):
+        GraphCharacteristicPolynomialResult.model_validate(
+            {
+                "graph": graph.model_dump(),
+                "convention": "ADJACENCY",
+                "polynomial": {
+                    "variables": ["x"],
+                    "polynomial": {
+                        "terms": [
+                            {"coefficient": {"num": "1", "den": "1"}, "exponents": [0]}
+                        ]
+                    },
+                },
+            }
+        )

--- a/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
@@ -2,6 +2,10 @@
 
 from fractions import Fraction
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.spectral import (
     adjacency_characteristic_polynomial,
     laplacian_characteristic_polynomial,
@@ -20,7 +24,11 @@ from jacobian.math.polynomials._elementary_operations import (
     rational_polynomial_derivative,
 )
 from jacobian.math.polynomials._models import RationalPolynomialRequest
-from jacobian.math.polynomials.values import RationalPolynomial
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
 
 
 def _graph(edges, vc):
@@ -43,6 +51,31 @@ def _coeffs(polynomial: RationalPolynomial):
 
 def _exponents(polynomial: RationalPolynomial) -> tuple[int, ...]:
     return tuple(term.exponents[0] for term in polynomial.polynomial.terms)
+
+
+def _univariate_polynomial(coefficients: dict[int, str]) -> RationalPolynomial:
+    """Build a canonical univariate polynomial from {degree: numerator}."""
+    return RationalPolynomial(
+        variables=("x",),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=numerator, den="1"),
+                    exponents=(degree,),
+                )
+                for degree, numerator in sorted(coefficients.items(), reverse=True)
+            )
+        ),
+    )
+
+
+def _charpoly_payload(polynomial: RationalPolynomial) -> dict:
+    """Serialize a result payload bound to the P3 adjacency source."""
+    return {
+        "graph": GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2))).model_dump(),
+        "convention": "ADJACENCY",
+        "polynomial": polynomial.model_dump(),
+    }
 
 
 class TestAdjacencyCharacteristicPolynomial:
@@ -128,9 +161,6 @@ class TestLaplacianCharacteristicPolynomial:
 
 
 def test_forged_result_rejected():
-    import pytest
-    from pydantic import ValidationError
-
     graph = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(
@@ -147,6 +177,50 @@ def test_forged_result_rejected():
                 },
             }
         )
+
+
+def test_replay_rejects_more_terms_than_any_admitted_charpoly_has():
+    # A degree-32 univariate characteristic polynomial has at most 33 nonzero
+    # terms, so a 34-term value is rejected before any backend conversion.
+    oversized = _univariate_polynomial(dict.fromkeys(range(34), "2"))
+    with pytest.raises(ValidationError, match="exceeds the 33-term operation budget"):
+        GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(oversized))
+
+
+def test_replay_rejects_exponents_beyond_the_32_vertex_degree_bound():
+    beyond = _univariate_polynomial({32: "1", 40: "1"})
+    with pytest.raises(ValidationError, match="exceeds the 32-degree operation budget"):
+        GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(beyond))
+
+
+def test_replay_rejects_coefficients_beyond_the_charpoly_digit_budget():
+    huge = _univariate_polynomial({3: "9" * 129})
+    with pytest.raises(ValidationError, match="exceeds the 128-digit bound"):
+        GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(huge))
+
+
+def test_maximum_shaped_nonmatching_polynomial_fails_only_on_source_binding():
+    # Exactly 33 terms of degree at most 32 with one-digit coefficients sits
+    # inside every replay budget, so validation must reach the determinant
+    # comparison and fail there instead.
+    dense = _univariate_polynomial(dict.fromkeys(range(33), "1"))
+    with pytest.raises(ValidationError, match="does not match the source graph"):
+        GraphCharacteristicPolynomialResult.model_validate(_charpoly_payload(dense))
+
+
+def test_maximal_path_round_trips_through_serialization():
+    # Degree exactly 32 exercises the replay degree bound from above.
+    graph = GraphEdgeList(vertex_count=32, edges=tuple((i, i + 1) for i in range(31)))
+    polynomial = adjacency_characteristic_polynomial(graph)
+    restored = GraphCharacteristicPolynomialResult.model_validate(
+        GraphCharacteristicPolynomialResult(
+            graph=graph,
+            convention="ADJACENCY",
+            polynomial=polynomial,
+        ).model_dump(mode="json")
+    )
+    assert restored.polynomial == polynomial
+    assert max(_exponents(restored.polynomial)) == 32
 
 
 def test_native_adjacency_returns_canonical_polynomial():

--- a/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
@@ -2,7 +2,12 @@
 
 from fractions import Fraction
 
+from jacobian.math.graphs.spectral import (
+    adjacency_characteristic_polynomial,
+    laplacian_characteristic_polynomial,
+)
 from jacobian.math.graphs.spectral._models import (
+    GraphCharacteristicPolynomialResult,
     GraphEdgeList,
     GraphSpectrumRequest,
 )
@@ -10,27 +15,34 @@ from jacobian.math.graphs.spectral._operations import (
     compute_adjacency_characteristic_polynomial,
     compute_laplacian_characteristic_polynomial,
 )
+from jacobian.math.graphs.spectral._tools import TOOLS
+from jacobian.math.polynomials._elementary_operations import (
+    rational_polynomial_derivative,
+)
+from jacobian.math.polynomials._models import RationalPolynomialRequest
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def _graph(edges, vc):
+    return GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges))
 
 
 def _request(edges, vc):
-    return GraphSpectrumRequest(
-        graph=GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges))
-    )
+    return GraphSpectrumRequest(graph=_graph(edges, vc))
 
 
-def _coeffs(result):
+def _coeffs(polynomial: RationalPolynomial):
     """Return dense increasing-degree coefficients including implicit zeros."""
-    degree = 0
-    out: list[Fraction] = []
     terms = {
         term.exponents[0]: term.coefficient.as_fraction()
-        for term in result.polynomial.polynomial.terms
+        for term in polynomial.polynomial.terms
     }
     top = max(terms) if terms else 0
-    while degree <= top:
-        out.append(terms.get(degree, Fraction(0)))
-        degree += 1
-    return out
+    return [terms.get(degree, Fraction(0)) for degree in range(top + 1)]
+
+
+def _exponents(polynomial: RationalPolynomial) -> tuple[int, ...]:
+    return tuple(term.exponents[0] for term in polynomial.polynomial.terms)
 
 
 class TestAdjacencyCharacteristicPolynomial:
@@ -39,18 +51,23 @@ class TestAdjacencyCharacteristicPolynomial:
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
         )
-        assert _coeffs(result) == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
+        assert _coeffs(result.polynomial) == [
+            Fraction(0),
+            Fraction(-2),
+            Fraction(0),
+            Fraction(1),
+        ]
         assert result.convention == "ADJACENCY"
 
     def test_edge_k2(self):
         # K2 adjacency: [[0,1],[1,0]] eigenvalues 1,-1 -> charpoly x^2 - 1.
         result = compute_adjacency_characteristic_polynomial(_request([[0, 1]], 2))
-        assert _coeffs(result) == [Fraction(-1), Fraction(0), Fraction(1)]
+        assert _coeffs(result.polynomial) == [Fraction(-1), Fraction(0), Fraction(1)]
 
     def test_isolated_vertex(self):
         # One isolated vertex: adjacency matrix [0] -> charpoly x.
         result = compute_adjacency_characteristic_polynomial(_request([], 1))
-        assert _coeffs(result) == [Fraction(0), Fraction(1)]
+        assert _coeffs(result.polynomial) == [Fraction(0), Fraction(1)]
 
     def test_result_is_monic(self):
         result = compute_adjacency_characteristic_polynomial(
@@ -76,7 +93,12 @@ class TestLaplacianCharacteristicPolynomial:
         result = compute_laplacian_characteristic_polynomial(
             _request([[0, 1], [1, 2]], 3)
         )
-        assert _coeffs(result) == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
+        assert _coeffs(result.polynomial) == [
+            Fraction(0),
+            Fraction(3),
+            Fraction(-4),
+            Fraction(1),
+        ]
         assert result.convention == "LAPLACIAN"
 
     def test_laplacian_has_zero_root(self):
@@ -109,10 +131,6 @@ def test_forged_result_rejected():
     import pytest
     from pydantic import ValidationError
 
-    from jacobian.math.graphs.spectral._models import (
-        GraphCharacteristicPolynomialResult,
-    )
-
     graph = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(
@@ -129,3 +147,71 @@ def test_forged_result_rejected():
                 },
             }
         )
+
+
+def test_native_adjacency_returns_canonical_polynomial():
+    polynomial = adjacency_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
+    assert type(polynomial) is RationalPolynomial
+    assert polynomial.variables == ("x",)
+    assert _exponents(polynomial) == (3, 1)
+    assert _coeffs(polynomial) == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
+
+
+def test_native_laplacian_returns_canonical_polynomial():
+    polynomial = laplacian_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
+    assert type(polynomial) is RationalPolynomial
+    assert _exponents(polynomial) == (3, 2, 1)
+    assert _coeffs(polynomial) == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
+
+
+def test_native_polynomial_is_accepted_unchanged_by_a_polynomial_consumer():
+    polynomial = adjacency_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
+    request = RationalPolynomialRequest(polynomial=polynomial)
+    assert request.polynomial is polynomial
+
+    serialized = RationalPolynomialRequest.model_validate(
+        {"polynomial": polynomial.model_dump(mode="json")}
+    )
+    derivative = rational_polynomial_derivative(request).derivative
+    assert rational_polynomial_derivative(serialized).derivative == derivative
+    assert _coeffs(derivative) == [Fraction(-2), Fraction(0), Fraction(3)]
+
+
+def test_native_isolated_vertex_composes_without_reshaping():
+    polynomial = adjacency_characteristic_polynomial(_graph([], 1))
+    request = RationalPolynomialRequest(polynomial=polynomial)
+    assert request.polynomial is polynomial
+    assert _coeffs(rational_polynomial_derivative(request).derivative) == [Fraction(1)]
+
+
+def test_catalog_result_round_trips_source_binding():
+    request = _request([[0, 1], [1, 2]], 3)
+    result = compute_adjacency_characteristic_polynomial(request)
+    restored = GraphCharacteristicPolynomialResult.model_validate(
+        result.model_dump(mode="json")
+    )
+    assert restored == result
+    assert restored.graph == request.graph
+    assert restored.convention == "ADJACENCY"
+    assert restored.polynomial == adjacency_characteristic_polynomial(request.graph)
+
+
+def test_serialized_native_terms_use_descending_exponent_order():
+    polynomial = laplacian_characteristic_polynomial(_graph([[0, 1], [1, 2]], 3))
+    payload = polynomial.model_dump(mode="json")
+    exponents = [tuple(term["exponents"]) for term in payload["polynomial"]["terms"]]
+    assert exponents == [(3,), (2,), (1,)]
+    assert exponents == sorted(exponents, reverse=True)
+
+
+def test_discovery_names_canonical_sparse_polynomial():
+    for operation_id in (
+        "graph.spectrum.adjacency.characteristic_polynomial.compute",
+        "graph.spectrum.laplacian.characteristic_polynomial.compute",
+    ):
+        description = next(
+            tool.description for tool in TOOLS if tool.operation_id == operation_id
+        )
+        assert "increasing-degree" not in description
+        assert "canonical sparse RationalPolynomial" in description
+        assert "descending exponent order" in description

--- a/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graph_spectral/test_graph_characteristic_polynomial.py
@@ -13,13 +13,17 @@ from jacobian.math.graphs.spectral._operations import (
 
 
 def _request(edges, vc):
-    return GraphSpectrumRequest(graph=GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges)))
+    return GraphSpectrumRequest(
+        graph=GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges))
+    )
 
 
 class TestAdjacencyCharacteristicPolynomial:
     def test_path_p3(self):
         # P3 adjacency eigenvalues: 0, sqrt(2), -sqrt(2) -> charpoly x(x^2-2) = x^3 - 2x.
-        result = compute_adjacency_characteristic_polynomial(_request([[0, 1], [1, 2]], 3))
+        result = compute_adjacency_characteristic_polynomial(
+            _request([[0, 1], [1, 2]], 3)
+        )
         coeffs = [c.as_fraction() for c in result.coefficients]
         assert coeffs == [Fraction(0), Fraction(-2), Fraction(0), Fraction(1)]
 
@@ -32,23 +36,32 @@ class TestAdjacencyCharacteristicPolynomial:
     def test_isolated_vertex(self):
         # One isolated vertex: adjacency matrix [0] -> charpoly x.
         result = compute_adjacency_characteristic_polynomial(_request([], 1))
-        assert [c.as_fraction() for c in result.coefficients] == [Fraction(0), Fraction(1)]
+        assert [c.as_fraction() for c in result.coefficients] == [
+            Fraction(0),
+            Fraction(1),
+        ]
 
     def test_result_is_monic(self):
-        result = compute_adjacency_characteristic_polynomial(_request([[0, 1], [1, 2], [0, 2]], 3))
+        result = compute_adjacency_characteristic_polynomial(
+            _request([[0, 1], [1, 2], [0, 2]], 3)
+        )
         assert result.coefficients[-1].as_fraction() == 1
 
 
 class TestLaplacianCharacteristicPolynomial:
     def test_path_p3(self):
         # P3 Laplacian eigenvalues 0,1,3 -> charpoly x(x-1)(x-3) = x^3 - 4x^2 + 3x.
-        result = compute_laplacian_characteristic_polynomial(_request([[0, 1], [1, 2]], 3))
+        result = compute_laplacian_characteristic_polynomial(
+            _request([[0, 1], [1, 2]], 3)
+        )
         coeffs = [c.as_fraction() for c in result.coefficients]
         assert coeffs == [Fraction(0), Fraction(3), Fraction(-4), Fraction(1)]
 
     def test_laplacian_has_zero_root(self):
         # The Laplacian of any graph has a zero eigenvalue, so the constant term is 0.
-        result = compute_laplacian_characteristic_polynomial(_request([[0, 1], [1, 2], [0, 2]], 3))
+        result = compute_laplacian_characteristic_polynomial(
+            _request([[0, 1], [1, 2], [0, 2]], 3)
+        )
         assert result.coefficients[0].as_fraction() == 0
 
     def test_result_is_monic(self):


### PR DESCRIPTION
## Problem

Jacobian had `graph.spectrum.adjacency.compute` and `graph.spectrum.laplacian.compute`
returning exact eigenvalues with multiplicities, but no operation for the graph
**characteristic polynomial** — needed as a composable building block by the
chromatic-spectral theorem (#1237), spectral graph conjectures, and Graffiti
conjectures.

Closes #1670.

## Solution

Add two atomic, exact operations to the graph spectral family:

- `graph.spectrum.adjacency.characteristic_polynomial.compute` — the exact monic
  characteristic polynomial of the adjacency matrix over `QQ`, as increasing-degree
  rational coefficients;
- `graph.spectrum.laplacian.characteristic_polynomial.compute` — the same for the
  Laplacian matrix.

Both reuse the existing `GraphSpectrumRequest` / `GraphEdgeList` value (simple
undirected graph, ≤ 32 vertices) and SymPy's exact `charpoly`, returning the
monic polynomial as canonical rational coefficients. The existing eigenvalue
operations are left unchanged (pre-stable contract preserved).

## Library choices

SymPy exact `Matrix.charpoly` over `QQ`, returning canonical rational
coefficients in increasing degree. No new backend dependency; reuses the
existing spectral backend.

## Testing

- `make check` — Ruff, mypy, and Lean-free math/catalog/integration owners pass (3071).
- Owning tests cover: P3 adjacency charpoly `x³ − 2x`, K2 adjacency `x² − 1`, an
  isolated vertex `x`, monicity, P3 Laplacian `x³ − 4x² + 3x`, and the Laplacian
  zero-root property (constant term 0).
- Catalog conformance: both advertised examples execute, re-validate, and
  survive the boundary-mutation contract test.

## Public operation admission

- Concrete gap: no graph characteristic polynomial operation existed; only eigenvalues.
- Why existing operations are insufficient: the eigenvalue results do not expose the polynomial form needed for direct spectral comparisons.
- Stable mathematical result: the exact monic characteristic polynomial over `QQ`.
- Admission decision: `KEEP` for both.

## Public operation contract

- Mathematical input domain: a simple undirected graph, ≤ 32 vertices.
- Canonical public value type: reuses `GraphSpectrumRequest` / `GraphEdgeList`.
- Degenerate inputs: isolated vertices yield a polynomial with leading `x^k` factor.
- Parent/ring/field identity: `QQ`.
- Deterministic work bound: exact charpoly of a ≤ 32×32 matrix.
- Result type: `GraphCharacteristicPolynomialResult` (monic, increasing-degree `CanonicalRational` coefficients).
- Reconstruction/defining invariant: the polynomial is monic (leading coefficient 1).
- Typed execution failures: non-simple graphs rejected by the shared request validator.

## Checklist

- [x] `make check` passes
- [x] Public operation changes retain owner-local admission decisions
- [x] Execution outcomes do not claim mathematical conclusions

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/0cecb73b-2b36-4041-b659-1a3441039ed1)