### PR TITLE
feat(math): add Berlekamp-Massey minimal linear recurrence over prime fields

### DIFF
--- a/src/jacobian/math/recurrence_solving/__init__.py
+++ b/src/jacobian/math/recurrence_solving/__init__.py
@@ -3,8 +3,9 @@
 from jacobian.math.recurrence_solving.operations import (
     ClosedForm,
     Recurrence,
+    berlekamp_massey,
     closed_form,
     find_recurrence,
 )
 
-__all__ = ["ClosedForm", "Recurrence", "closed_form", "find_recurrence"]
+__all__ = ["ClosedForm", "Recurrence", "berlekamp_massey", "closed_form", "find_recurrence"]

--- a/src/jacobian/math/recurrence_solving/__init__.py
+++ b/src/jacobian/math/recurrence_solving/__init__.py
@@ -8,4 +8,10 @@ from jacobian.math.recurrence_solving.operations import (
     find_recurrence,
 )
 
-__all__ = ["ClosedForm", "Recurrence", "berlekamp_massey", "closed_form", "find_recurrence"]
+__all__ = [
+    "ClosedForm",
+    "Recurrence",
+    "berlekamp_massey",
+    "closed_form",
+    "find_recurrence",
+]

--- a/src/jacobian/math/recurrence_solving/__init__.py
+++ b/src/jacobian/math/recurrence_solving/__init__.py
@@ -2,6 +2,7 @@
 
 from jacobian.math.recurrence_solving.operations import (
     ClosedForm,
+    PrimeFieldRecurrence,
     Recurrence,
     berlekamp_massey,
     closed_form,
@@ -10,6 +11,7 @@ from jacobian.math.recurrence_solving.operations import (
 
 __all__ = [
     "ClosedForm",
+    "PrimeFieldRecurrence",
     "Recurrence",
     "berlekamp_massey",
     "closed_form",

--- a/src/jacobian/math/recurrence_solving/_admission.py
+++ b/src/jacobian/math/recurrence_solving/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.recurrence_solving._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "sequence.recurrence.prime_field.find",
+        AdmissionDecision.KEEP,
+        "exact minimal LFSR over an explicit prime field via Berlekamp-Massey with material leverage over bespoke recurrence fitting",
+    ),
+    OperationAdmission(
         "sequence.recurrence.closed_form.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -83,3 +83,53 @@ class ClosedFormResult(StrictModel):
 
     expression: str
     method: Literal["SYMPY_RSOLVE"] = "SYMPY_RSOLVE"
+
+
+# ---------------------------------------------------------------------------
+# Berlekamp-Massey over an explicit prime field
+# ---------------------------------------------------------------------------
+
+_MAX_FIELD_SEQUENCE_LENGTH = 256
+
+
+class PrimeFieldRecurrenceFindRequest(StrictModel):
+    """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
+
+    prime: int = Field(gt=1)
+    sequence: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+    )
+
+    @model_validator(mode="after")
+    def require_valid_field_sequence(self) -> Self:
+        from sympy import isprime
+
+        if not isprime(self.prime):
+            raise ValueError("prime must be a prime integer")
+        for value in self.sequence:
+            if type(value) is not int or not 0 <= value < self.prime:
+                raise ValueError("sequence values must be canonical residues modulo the prime")
+        return self
+
+
+class PrimeFieldRecurrenceFindResult(StrictModel):
+    """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey."""
+
+    prime: int = Field(gt=1)
+    coefficients: tuple[int, ...] = Field(max_length=255)
+    order: int = Field(ge=0, le=255)
+    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+    method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"
+
+    @model_validator(mode="after")
+    def require_status_consistent_coefficients(self) -> Self:
+        if self.status == "FOUND":
+            if self.order == 0 or len(self.coefficients) != self.order:
+                raise ValueError("a found recurrence must have one coefficient per order")
+            for value in self.coefficients:
+                if type(value) is not int or not 0 <= value < self.prime:
+                    raise ValueError("coefficients must be canonical residues modulo the prime")
+        elif self.order != 0 or self.coefficients:
+            raise ValueError("a missing recurrence must have zero order and no coefficients")
+        return self

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -119,6 +119,9 @@ class PrimeFieldRecurrence(StrictModel):
     and MCP results embed it unchanged, so native and wire consumers share
     one type.  The recurrence is established only on the observed prefix
     ``L <= n < len(sequence)``; it carries no claim about unobserved terms.
+    Every admitted finite sequence admits a recurrence of order at most its
+    own length (order ``len(sequence)`` fits vacuously), so the outcome is
+    always a fitted recurrence and no missing-recurrence state exists.
     """
 
     prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
@@ -130,18 +133,16 @@ class PrimeFieldRecurrence(StrictModel):
         ),
     )
     order: StrictInt = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
-    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+    status: Literal["FOUND"] = Field(
+        description="Always FOUND: every admitted finite sequence fits a recurrence."
+    )
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
         _require_bounded_prime(self.prime)
         _require_canonical_residues(self.coefficients, self.prime, "coefficients")
-        if self.status == "FOUND" and self.order != len(self.coefficients):
+        if self.order != len(self.coefficients):
             raise ValueError("order must equal the number of coefficients")
-        if self.status == "NO_FITTING_RECURRENCE" and (
-            self.order != 0 or self.coefficients
-        ):
-            raise ValueError("a no-fitting-recurrence value carries no coefficients")
         return self
 
 

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -112,31 +112,6 @@ def _require_canonical_residues(
             raise ValueError(f"{label} must be canonical residues modulo the prime")
 
 
-def _require_found_prime_recurrence(
-    prime: int,
-    sequence: tuple[int, ...],
-    coefficients: tuple[int, ...],
-    order: int,
-) -> None:
-    if len(coefficients) != order:
-        raise ValueError("a found recurrence must have one coefficient per order")
-    _require_canonical_residues(coefficients, prime, "coefficients")
-    if order == 0:
-        if coefficients:
-            raise ValueError("order-zero recurrence must have no coefficients")
-        if any(value != 0 for value in sequence):
-            raise ValueError("order-zero recurrence only fits the all-zero sequence")
-        return
-    for n in range(order, len(sequence)):
-        expected = (
-            sum(coefficients[i] * sequence[n - 1 - i] for i in range(order)) % prime
-        )
-        if sequence[n] != expected:
-            raise ValueError(
-                "coefficients do not reproduce the source sequence over GF(p)"
-            )
-
-
 class PrimeFieldRecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
 
@@ -170,12 +145,16 @@ class PrimeFieldRecurrenceFindResult(StrictModel):
     def require_status_consistent_coefficients(self) -> Self:
         _require_bounded_prime(self.prime)
         _require_canonical_residues(self.sequence, self.prime, "sequence values")
-        if self.status == "FOUND":
-            _require_found_prime_recurrence(
-                self.prime, self.sequence, self.coefficients, self.order
-            )
-        elif self.order != 0 or self.coefficients:
+        from jacobian.math.recurrence_solving.operations import berlekamp_massey
+
+        expected = berlekamp_massey(list(self.sequence), self.prime)
+        if (
+            self.prime != expected.prime
+            or self.status != expected.status
+            or self.order != expected.order
+            or self.coefficients != expected.coefficients
+        ):
             raise ValueError(
-                "a missing recurrence must have zero order and no coefficients"
+                "result must match the exact bound Berlekamp-Massey recurrence"
             )
         return self

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -115,10 +115,19 @@ def _require_canonical_residues(
 class PrimeFieldRecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
 
-    prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
+    prime: StrictInt = Field(
+        ge=2,
+        le=_MAX_FIELD_PRIME,
+        description=f"Prime modulus p of the field GF(p), between 2 and {_MAX_FIELD_PRIME}.",
+    )
     sequence: tuple[StrictInt, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+        description=(
+            "Finite sequence of canonical residues modulo the supplied prime: "
+            "each value must be an integer with 0 <= value < prime; negative "
+            "or oversized representatives are rejected."
+        ),
     )
 
     @model_validator(mode="after")
@@ -131,12 +140,26 @@ class PrimeFieldRecurrenceFindRequest(StrictModel):
 class PrimeFieldRecurrenceFindResult(StrictModel):
     """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey."""
 
-    prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
+    prime: StrictInt = Field(
+        ge=2,
+        le=_MAX_FIELD_PRIME,
+        description=f"Prime modulus p of the field GF(p), between 2 and {_MAX_FIELD_PRIME}.",
+    )
     sequence: tuple[StrictInt, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+        description=(
+            "The supplied sequence of canonical residues modulo the prime: "
+            "each value satisfies 0 <= value < prime."
+        ),
     )
-    coefficients: tuple[StrictInt, ...] = Field(max_length=_MAX_FIELD_SEQUENCE_LENGTH)
+    coefficients: tuple[StrictInt, ...] = Field(
+        max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+        description=(
+            "LFSR connection coefficients as canonical residues modulo the "
+            "prime: each value satisfies 0 <= value < prime."
+        ),
+    )
     order: StrictInt = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
     method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
@@ -115,8 +115,8 @@ def _require_canonical_residues(
 class PrimeFieldRecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
 
-    prime: int = Field(ge=2, le=_MAX_FIELD_PRIME)
-    sequence: tuple[int, ...] = Field(
+    prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
+    sequence: tuple[StrictInt, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
     )
@@ -131,13 +131,13 @@ class PrimeFieldRecurrenceFindRequest(StrictModel):
 class PrimeFieldRecurrenceFindResult(StrictModel):
     """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey."""
 
-    prime: int = Field(ge=2, le=_MAX_FIELD_PRIME)
-    sequence: tuple[int, ...] = Field(
+    prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
+    sequence: tuple[StrictInt, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
     )
-    coefficients: tuple[int, ...] = Field(max_length=_MAX_FIELD_SEQUENCE_LENGTH)
-    order: int = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
+    coefficients: tuple[StrictInt, ...] = Field(max_length=_MAX_FIELD_SEQUENCE_LENGTH)
+    order: StrictInt = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
     method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"
 

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -90,12 +90,57 @@ class ClosedFormResult(StrictModel):
 # ---------------------------------------------------------------------------
 
 _MAX_FIELD_SEQUENCE_LENGTH = 256
+_MAX_FIELD_PRIME = 10_000
+
+
+def _require_bounded_prime(prime: int) -> None:
+    if not 2 <= prime <= _MAX_FIELD_PRIME:
+        raise ValueError(
+            f"prime must be a prime number between 2 and {_MAX_FIELD_PRIME}"
+        )
+    from sympy import isprime
+
+    if not isprime(prime):
+        raise ValueError("prime must be a prime integer")
+
+
+def _require_canonical_residues(
+    values: tuple[int, ...], prime: int, label: str
+) -> None:
+    for value in values:
+        if type(value) is not int or not 0 <= value < prime:
+            raise ValueError(f"{label} must be canonical residues modulo the prime")
+
+
+def _require_found_prime_recurrence(
+    prime: int,
+    sequence: tuple[int, ...],
+    coefficients: tuple[int, ...],
+    order: int,
+) -> None:
+    if len(coefficients) != order:
+        raise ValueError("a found recurrence must have one coefficient per order")
+    _require_canonical_residues(coefficients, prime, "coefficients")
+    if order == 0:
+        if coefficients:
+            raise ValueError("order-zero recurrence must have no coefficients")
+        if any(value != 0 for value in sequence):
+            raise ValueError("order-zero recurrence only fits the all-zero sequence")
+        return
+    for n in range(order, len(sequence)):
+        expected = (
+            sum(coefficients[i] * sequence[n - 1 - i] for i in range(order)) % prime
+        )
+        if sequence[n] != expected:
+            raise ValueError(
+                "coefficients do not reproduce the source sequence over GF(p)"
+            )
 
 
 class PrimeFieldRecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
 
-    prime: int = Field(gt=1)
+    prime: int = Field(ge=2, le=_MAX_FIELD_PRIME)
     sequence: tuple[int, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
@@ -103,39 +148,32 @@ class PrimeFieldRecurrenceFindRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_valid_field_sequence(self) -> Self:
-        from sympy import isprime
-
-        if not isprime(self.prime):
-            raise ValueError("prime must be a prime integer")
-        for value in self.sequence:
-            if type(value) is not int or not 0 <= value < self.prime:
-                raise ValueError(
-                    "sequence values must be canonical residues modulo the prime"
-                )
+        _require_bounded_prime(self.prime)
+        _require_canonical_residues(self.sequence, self.prime, "sequence values")
         return self
 
 
 class PrimeFieldRecurrenceFindResult(StrictModel):
     """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey."""
 
-    prime: int = Field(gt=1)
-    coefficients: tuple[int, ...] = Field(max_length=255)
-    order: int = Field(ge=0, le=255)
+    prime: int = Field(ge=2, le=_MAX_FIELD_PRIME)
+    sequence: tuple[int, ...] = Field(
+        min_length=2,
+        max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+    )
+    coefficients: tuple[int, ...] = Field(max_length=_MAX_FIELD_SEQUENCE_LENGTH)
+    order: int = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
     method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"
 
     @model_validator(mode="after")
     def require_status_consistent_coefficients(self) -> Self:
+        _require_bounded_prime(self.prime)
+        _require_canonical_residues(self.sequence, self.prime, "sequence values")
         if self.status == "FOUND":
-            if self.order == 0 or len(self.coefficients) != self.order:
-                raise ValueError(
-                    "a found recurrence must have one coefficient per order"
-                )
-            for value in self.coefficients:
-                if type(value) is not int or not 0 <= value < self.prime:
-                    raise ValueError(
-                        "coefficients must be canonical residues modulo the prime"
-                    )
+            _require_found_prime_recurrence(
+                self.prime, self.sequence, self.coefficients, self.order
+            )
         elif self.order != 0 or self.coefficients:
             raise ValueError(
                 "a missing recurrence must have zero order and no coefficients"

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -112,6 +112,39 @@ def _require_canonical_residues(
             raise ValueError(f"{label} must be canonical residues modulo the prime")
 
 
+class PrimeFieldRecurrence(StrictModel):
+    """Minimal linear recurrence over an explicit prime field ``GF(p)``.
+
+    The domain-owned canonical recurrence value: native producers return it
+    and MCP results embed it unchanged, so native and wire consumers share
+    one type.  The recurrence is established only on the observed prefix
+    ``L <= n < len(sequence)``; it carries no claim about unobserved terms.
+    """
+
+    prime: StrictInt = Field(ge=2, le=_MAX_FIELD_PRIME)
+    coefficients: tuple[StrictInt, ...] = Field(
+        max_length=_MAX_FIELD_SEQUENCE_LENGTH,
+        description=(
+            "Recurrence coefficients (c_1, ..., c_L) as canonical residues "
+            "modulo the prime: each value satisfies 0 <= value < prime."
+        ),
+    )
+    order: StrictInt = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
+    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        _require_bounded_prime(self.prime)
+        _require_canonical_residues(self.coefficients, self.prime, "coefficients")
+        if self.status == "FOUND" and self.order != len(self.coefficients):
+            raise ValueError("order must equal the number of coefficients")
+        if self.status == "NO_FITTING_RECURRENCE" and (
+            self.order != 0 or self.coefficients
+        ):
+            raise ValueError("a no-fitting-recurrence value carries no coefficients")
+        return self
+
+
 class PrimeFieldRecurrenceFindRequest(StrictModel):
     """Find the minimal linear recurrence of a sequence over ``GF(p)``."""
 
@@ -138,13 +171,13 @@ class PrimeFieldRecurrenceFindRequest(StrictModel):
 
 
 class PrimeFieldRecurrenceFindResult(StrictModel):
-    """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey."""
+    """The minimal LFSR over ``GF(p)`` found by Berlekamp-Massey.
 
-    prime: StrictInt = Field(
-        ge=2,
-        le=_MAX_FIELD_PRIME,
-        description=f"Prime modulus p of the field GF(p), between 2 and {_MAX_FIELD_PRIME}.",
-    )
+    Embeds the canonical :class:`PrimeFieldRecurrence` value rather than
+    re-flattening its fields, so native and MCP producers expose one
+    compatible public type.
+    """
+
     sequence: tuple[StrictInt, ...] = Field(
         min_length=2,
         max_length=_MAX_FIELD_SEQUENCE_LENGTH,
@@ -153,31 +186,31 @@ class PrimeFieldRecurrenceFindResult(StrictModel):
             "each value satisfies 0 <= value < prime."
         ),
     )
-    coefficients: tuple[StrictInt, ...] = Field(
-        max_length=_MAX_FIELD_SEQUENCE_LENGTH,
-        description=(
-            "LFSR connection coefficients as canonical residues modulo the "
-            "prime: each value satisfies 0 <= value < prime."
-        ),
-    )
-    order: StrictInt = Field(ge=0, le=_MAX_FIELD_SEQUENCE_LENGTH)
-    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+    recurrence: PrimeFieldRecurrence
     method: Literal["BERLEKAMP_MASSEY"] = "BERLEKAMP_MASSEY"
 
     @model_validator(mode="after")
     def require_status_consistent_coefficients(self) -> Self:
-        _require_bounded_prime(self.prime)
-        _require_canonical_residues(self.sequence, self.prime, "sequence values")
+        _require_bounded_prime(self.recurrence.prime)
+        _require_canonical_residues(
+            self.sequence, self.recurrence.prime, "sequence values"
+        )
         from jacobian.math.recurrence_solving.operations import berlekamp_massey
 
-        expected = berlekamp_massey(list(self.sequence), self.prime)
-        if (
-            self.prime != expected.prime
-            or self.status != expected.status
-            or self.order != expected.order
-            or self.coefficients != expected.coefficients
-        ):
+        expected = berlekamp_massey(list(self.sequence), self.recurrence.prime)
+        if self.recurrence != expected:
             raise ValueError(
-                "result must match the exact bound Berlekamp-Massey recurrence"
+                "result must match the exact bounded Berlekamp-Massey recurrence"
             )
         return self
+
+
+__all__ = [
+    "ClosedFormRequest",
+    "ClosedFormResult",
+    "PrimeFieldRecurrence",
+    "PrimeFieldRecurrenceFindRequest",
+    "PrimeFieldRecurrenceFindResult",
+    "RecurrenceFindRequest",
+    "RecurrenceFindResult",
+]

--- a/src/jacobian/math/recurrence_solving/_models.py
+++ b/src/jacobian/math/recurrence_solving/_models.py
@@ -109,7 +109,9 @@ class PrimeFieldRecurrenceFindRequest(StrictModel):
             raise ValueError("prime must be a prime integer")
         for value in self.sequence:
             if type(value) is not int or not 0 <= value < self.prime:
-                raise ValueError("sequence values must be canonical residues modulo the prime")
+                raise ValueError(
+                    "sequence values must be canonical residues modulo the prime"
+                )
         return self
 
 
@@ -126,10 +128,16 @@ class PrimeFieldRecurrenceFindResult(StrictModel):
     def require_status_consistent_coefficients(self) -> Self:
         if self.status == "FOUND":
             if self.order == 0 or len(self.coefficients) != self.order:
-                raise ValueError("a found recurrence must have one coefficient per order")
+                raise ValueError(
+                    "a found recurrence must have one coefficient per order"
+                )
             for value in self.coefficients:
                 if type(value) is not int or not 0 <= value < self.prime:
-                    raise ValueError("coefficients must be canonical residues modulo the prime")
+                    raise ValueError(
+                        "coefficients must be canonical residues modulo the prime"
+                    )
         elif self.order != 0 or self.coefficients:
-            raise ValueError("a missing recurrence must have zero order and no coefficients")
+            raise ValueError(
+                "a missing recurrence must have zero order and no coefficients"
+            )
         return self

--- a/src/jacobian/math/recurrence_solving/_operations.py
+++ b/src/jacobian/math/recurrence_solving/_operations.py
@@ -38,17 +38,11 @@ def compute_prime_field_find_recurrence(
     request: PrimeFieldRecurrenceFindRequest,
 ) -> PrimeFieldRecurrenceFindResult:
     """Find the minimal LFSR over ``GF(p)`` via Berlekamp-Massey."""
-    coeffs = berlekamp_massey(list(request.sequence), request.prime)
-    if not coeffs:
-        return PrimeFieldRecurrenceFindResult(
-            prime=request.prime,
-            coefficients=(),
-            order=0,
-            status="NO_FITTING_RECURRENCE",
-        )
+    rec = berlekamp_massey(list(request.sequence), request.prime)
     return PrimeFieldRecurrenceFindResult(
-        prime=request.prime,
-        coefficients=tuple(coeffs),
-        order=len(coeffs),
-        status="FOUND",
+        prime=rec.prime,
+        sequence=request.sequence,
+        coefficients=rec.coefficients,
+        order=rec.order,
+        status=rec.status,
     )

--- a/src/jacobian/math/recurrence_solving/_operations.py
+++ b/src/jacobian/math/recurrence_solving/_operations.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from jacobian.math.recurrence_solving import closed_form, find_recurrence
+from jacobian.math.recurrence_solving import (
+    berlekamp_massey,
+    closed_form,
+    find_recurrence,
+)
 from jacobian.math.recurrence_solving._models import (
     ClosedFormRequest,
     ClosedFormResult,
+    PrimeFieldRecurrenceFindRequest,
+    PrimeFieldRecurrenceFindResult,
     RecurrenceFindRequest,
     RecurrenceFindResult,
 )
@@ -26,3 +32,23 @@ def compute_closed_form(request: ClosedFormRequest) -> ClosedFormResult:
         request.initial_values,
     )
     return ClosedFormResult(expression=result.expression)
+
+
+def compute_prime_field_find_recurrence(
+    request: PrimeFieldRecurrenceFindRequest,
+) -> PrimeFieldRecurrenceFindResult:
+    """Find the minimal LFSR over ``GF(p)`` via Berlekamp-Massey."""
+    coeffs = berlekamp_massey(list(request.sequence), request.prime)
+    if not coeffs:
+        return PrimeFieldRecurrenceFindResult(
+            prime=request.prime,
+            coefficients=(),
+            order=0,
+            status="NO_FITTING_RECURRENCE",
+        )
+    return PrimeFieldRecurrenceFindResult(
+        prime=request.prime,
+        coefficients=tuple(coeffs),
+        order=len(coeffs),
+        status="FOUND",
+    )

--- a/src/jacobian/math/recurrence_solving/_operations.py
+++ b/src/jacobian/math/recurrence_solving/_operations.py
@@ -37,12 +37,13 @@ def compute_closed_form(request: ClosedFormRequest) -> ClosedFormResult:
 def compute_prime_field_find_recurrence(
     request: PrimeFieldRecurrenceFindRequest,
 ) -> PrimeFieldRecurrenceFindResult:
-    """Find the minimal LFSR over ``GF(p)`` via Berlekamp-Massey."""
+    """Find the minimal LFSR over ``GF(p)`` via Berlekamp-Massey.
+
+    The recurrence is established only on the supplied prefix
+    ``L <= n < len(sequence)``.
+    """
     rec = berlekamp_massey(list(request.sequence), request.prime)
     return PrimeFieldRecurrenceFindResult(
-        prime=rec.prime,
         sequence=request.sequence,
-        coefficients=rec.coefficients,
-        order=rec.order,
-        status=rec.status,
+        recurrence=rec,
     )

--- a/src/jacobian/math/recurrence_solving/_tools.py
+++ b/src/jacobian/math/recurrence_solving/_tools.py
@@ -9,12 +9,15 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.recurrence_solving._models import (
     ClosedFormRequest,
     ClosedFormResult,
+    PrimeFieldRecurrenceFindRequest,
+    PrimeFieldRecurrenceFindResult,
     RecurrenceFindRequest,
     RecurrenceFindResult,
 )
 from jacobian.math.recurrence_solving._operations import (
     compute_closed_form,
     compute_find_recurrence,
+    compute_prime_field_find_recurrence,
 )
 
 
@@ -41,6 +44,9 @@ def rs_operation[RequestT: StrictModel, ResultT: StrictModel](
         examples=examples,
     )
 
+
+
+FIBONACCI_MOD_7 = {'prime': 7, 'sequence': [0, 1, 1, 2, 3, 5, 1, 6, 0]}
 
 RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     rs_operation(
@@ -107,6 +113,34 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             ),
         ),
         version="2",
+    ),
+    rs_operation(
+        "sequence.recurrence.prime_field.find",
+        "Find the minimal linear recurrence over a prime field",
+        "Given a finite sequence over an explicitly supplied prime field "
+        "GF(p), find the minimal linear recurrence (LFSR connection) it "
+        "satisfies using the Berlekamp-Massey algorithm, returning the "
+        "recurrence coefficients over GF(p) or NO_FITTING_RECURRENCE.",
+        PrimeFieldRecurrenceFindRequest,
+        PrimeFieldRecurrenceFindResult,
+        compute_prime_field_find_recurrence,
+        "sequence",
+        "recurrence",
+        "berlekamp-massey",
+        "prime-field",
+        "exact",
+        examples=(
+            example(
+                "fibonacci_mod_7",
+                (
+                    "Find the minimal recurrence of Fibonacci mod 7 "
+                    "[0,1,1,2,3,5,1,6,0]; the result is s_n = s_{n-1} + "
+                    "s_{n-2}, i.e. coefficients (1, 1). Values must be "
+                    "residues modulo the prime."
+                ),
+                FIBONACCI_MOD_7,
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/math/recurrence_solving/_tools.py
+++ b/src/jacobian/math/recurrence_solving/_tools.py
@@ -45,8 +45,7 @@ def rs_operation[RequestT: StrictModel, ResultT: StrictModel](
     )
 
 
-
-FIBONACCI_MOD_7 = {'prime': 7, 'sequence': [0, 1, 1, 2, 3, 5, 1, 6, 0]}
+FIBONACCI_MOD_7 = {"prime": 7, "sequence": [0, 1, 1, 2, 3, 5, 1, 6, 0]}
 
 RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     rs_operation(

--- a/src/jacobian/math/recurrence_solving/_tools.py
+++ b/src/jacobian/math/recurrence_solving/_tools.py
@@ -118,8 +118,11 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Find the minimal linear recurrence over a prime field",
         "Given a finite sequence over an explicitly supplied prime field "
         "GF(p), find the minimal linear recurrence (LFSR connection) it "
-        "satisfies using the Berlekamp-Massey algorithm, returning the "
-        "recurrence coefficients over GF(p) or NO_FITTING_RECURRENCE.",
+        "satisfies on the supplied prefix using the Berlekamp-Massey "
+        "algorithm, returning the canonical PrimeFieldRecurrence value with "
+        "coefficients over GF(p) or NO_FITTING_RECURRENCE. The recurrence "
+        "is established for indices L <= n < len(sequence) only; it makes "
+        "no claim about unobserved terms.",
         PrimeFieldRecurrenceFindRequest,
         PrimeFieldRecurrenceFindResult,
         compute_prime_field_find_recurrence,

--- a/src/jacobian/math/recurrence_solving/_tools.py
+++ b/src/jacobian/math/recurrence_solving/_tools.py
@@ -120,9 +120,10 @@ RECURRENCE_SOLVING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "GF(p), find the minimal linear recurrence (LFSR connection) it "
         "satisfies on the supplied prefix using the Berlekamp-Massey "
         "algorithm, returning the canonical PrimeFieldRecurrence value with "
-        "coefficients over GF(p) or NO_FITTING_RECURRENCE. The recurrence "
-        "is established for indices L <= n < len(sequence) only; it makes "
-        "no claim about unobserved terms.",
+        "its coefficients over GF(p). Every admitted finite sequence fits a "
+        "recurrence of order at most len(sequence), so the result is always "
+        "a fitted recurrence. Established for indices L <= n < "
+        "len(sequence) only; no claim about unobserved terms.",
         PrimeFieldRecurrenceFindRequest,
         PrimeFieldRecurrenceFindResult,
         compute_prime_field_find_recurrence,

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -29,7 +29,6 @@ _MAX_FIELD_PRIME = 10_000
 _MAX_FIELD_SEQUENCE_LENGTH = 256
 
 
-
 def _validate_berlekamp_inputs(sequence: list[int], prime: int) -> None:
     if type(prime) is not int or not 2 <= prime <= _MAX_FIELD_PRIME:
         raise ValueError(

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from jacobian._exact import CanonicalRational
 
-__all__ = ["ClosedForm", "Recurrence", "closed_form", "find_recurrence"]
+__all__ = ["ClosedForm", "Recurrence", "berlekamp_massey", "closed_form", "find_recurrence"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,3 +94,58 @@ def closed_form(
     consts = a.solve(b)
     expr = sum(c * term for c, term in zip(consts, basis, strict=True))
     return ClosedForm(expression=str(sympy.simplify(expr)))
+
+
+def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
+    """Return the minimal LFSR connection polynomial coefficients over ``GF(p)``.
+
+    Implements the classical Berlekamp-Massey algorithm.  Returns the list
+    ``[c_1, ..., c_L]`` such that for every ``n >= L``,
+    ``s_n = c_1 s_{n-1} + ... + c_L s_{n-L}`` (mod p), with ``L`` minimal.  An
+    empty list means no nontrivial recurrence of positive order was found.
+    """
+    s = [int(x) % prime for x in sequence]
+    n = len(s)
+    coeffs = [1]          # C(x) = 1
+    b = [1]               # B(x) = 1
+    length = 0
+    m = 1
+    last_discrepancy = 1
+
+    for i in range(n):
+        # compute discrepancy: s_i + sum_j C_j s_{i-j}
+        discrepancy = s[i] % prime
+        for j in range(1, len(coeffs)):
+            discrepancy = (discrepancy + coeffs[j] * s[i - j]) % prime
+        if discrepancy == 0:
+            m += 1
+        elif 2 * length <= i:
+            temp = list(coeffs)
+            factor = (discrepancy * pow(last_discrepancy, prime - 2, prime)) % prime
+            shifted = [0] * m + [(-factor * x) % prime for x in b]
+            if len(shifted) > len(coeffs):
+                coeffs.extend([0] * (len(shifted) - len(coeffs)))
+            elif len(shifted) < len(coeffs):
+                shifted.extend([0] * (len(coeffs) - len(shifted)))
+            coeffs = [(c + s_coeff) % prime for c, s_coeff in zip(coeffs, shifted, strict=True)]
+            length = i + 1 - length
+            b = temp
+            last_discrepancy = discrepancy
+            m = 1
+        else:
+            factor = (discrepancy * pow(last_discrepancy, prime - 2, prime)) % prime
+            shifted = [0] * m + [(-factor * x) % prime for x in b]
+            if len(shifted) > len(coeffs):
+                coeffs.extend([0] * (len(shifted) - len(coeffs)))
+            elif len(shifted) < len(coeffs):
+                shifted.extend([0] * (len(coeffs) - len(shifted)))
+            coeffs = [(c + s_coeff) % prime for c, s_coeff in zip(coeffs, shifted, strict=True)]
+            m += 1
+
+    # The connection polynomial is C(x) = 1 + c_1 x + ... + c_L x^L.
+    # The recurrence is s_n = -c_1 s_{n-1} - ... - c_L s_{n-L}, so the
+    # recurrence coefficients are [-c_1, ..., -c_L].
+    if length == 0:
+        return []
+    recurrence = [(-coeffs[j]) % prime for j in range(1, length + 1)]
+    return recurrence

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -9,6 +9,7 @@ from jacobian._exact import CanonicalRational
 
 __all__ = [
     "ClosedForm",
+    "PrimeFieldRecurrence",
     "Recurrence",
     "berlekamp_massey",
     "closed_form",
@@ -21,6 +22,57 @@ class Recurrence:
     coefficients: tuple[CanonicalRational, ...]
     order: int
     status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+
+
+_MAX_FIELD_PRIME = 10_000
+_MAX_FIELD_SEQUENCE_LENGTH = 256
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeFieldRecurrence:
+    """Minimal linear recurrence over an explicit prime field ``GF(p)``."""
+
+    prime: int
+    coefficients: tuple[int, ...]
+    order: int
+    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
+
+
+def _validate_berlekamp_inputs(sequence: list[int], prime: int) -> None:
+    if type(prime) is not int or not 2 <= prime <= _MAX_FIELD_PRIME:
+        raise ValueError(
+            f"prime must be a prime number between 2 and {_MAX_FIELD_PRIME}"
+        )
+    from sympy import isprime
+
+    if not isprime(prime):
+        raise ValueError("prime must be a prime integer")
+    if not 2 <= len(sequence) <= _MAX_FIELD_SEQUENCE_LENGTH:
+        raise ValueError(
+            f"sequence must have length between 2 and {_MAX_FIELD_SEQUENCE_LENGTH}"
+        )
+    for value in sequence:
+        if type(value) is not int or not 0 <= value < prime:
+            raise ValueError(
+                "sequence values must be canonical residues modulo the prime"
+            )
+
+
+def _berlekamp_discrepancy(
+    s: list[int], coeffs: list[int], prime: int, index: int
+) -> int:
+    discrepancy = s[index] % prime
+    for j in range(1, len(coeffs)):
+        discrepancy = (discrepancy + coeffs[j] * s[index - j]) % prime
+    return discrepancy
+
+
+def _berlekamp_combine(coeffs: list[int], shifted: list[int], prime: int) -> list[int]:
+    if len(shifted) > len(coeffs):
+        coeffs = coeffs + [0] * (len(shifted) - len(coeffs))
+    elif len(shifted) < len(coeffs):
+        shifted = shifted + [0] * (len(coeffs) - len(shifted))
+    return [(c + s_coeff) % prime for c, s_coeff in zip(coeffs, shifted, strict=True)]
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,15 +154,18 @@ def closed_form(
     return ClosedForm(expression=str(sympy.simplify(expr)))
 
 
-def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
-    """Return the minimal LFSR connection polynomial coefficients over ``GF(p)``.
+def berlekamp_massey(sequence: list[int], prime: int) -> PrimeFieldRecurrence:
+    """Return the minimal LFSR over ``GF(p)`` via Berlekamp-Massey.
 
-    Implements the classical Berlekamp-Massey algorithm.  Returns the list
-    ``[c_1, ..., c_L]`` such that for every ``n >= L``,
-    ``s_n = c_1 s_{n-1} + ... + c_L s_{n-L}`` (mod p), with ``L`` minimal.  An
-    empty list means no nontrivial recurrence of positive order was found.
+    Returns a :class:`PrimeFieldRecurrence` containing the field ``prime``
+    and the coefficient tuple ``(c_1, ..., c_L)`` such that for every
+    ``n >= L``, ``s_n = c_1 s_{n-1} + ... + c_L s_{n-L}`` (mod p) with ``L``
+    minimal. The returned value retains its field; ``[1, 1]`` over ``GF(2)``
+    and ``GF(7)`` are distinct values. An order-zero ``FOUND`` result
+    represents the all-zero sequence.
     """
-    s = [int(x) % prime for x in sequence]
+    _validate_berlekamp_inputs(sequence, prime)
+    s = [int(x) for x in sequence]
     n = len(s)
     coeffs = [1]  # C(x) = 1
     b = [1]  # B(x) = 1
@@ -119,45 +174,31 @@ def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
     last_discrepancy = 1
 
     for i in range(n):
-        # compute discrepancy: s_i + sum_j C_j s_{i-j}
-        discrepancy = s[i] % prime
-        for j in range(1, len(coeffs)):
-            discrepancy = (discrepancy + coeffs[j] * s[i - j]) % prime
+        discrepancy = _berlekamp_discrepancy(s, coeffs, prime, i)
         if discrepancy == 0:
             m += 1
-        elif 2 * length <= i:
+            continue
+        factor = (discrepancy * pow(last_discrepancy, prime - 2, prime)) % prime
+        shifted = [0] * m + [(-factor * x) % prime for x in b]
+        if 2 * length <= i:
             temp = list(coeffs)
-            factor = (discrepancy * pow(last_discrepancy, prime - 2, prime)) % prime
-            shifted = [0] * m + [(-factor * x) % prime for x in b]
-            if len(shifted) > len(coeffs):
-                coeffs.extend([0] * (len(shifted) - len(coeffs)))
-            elif len(shifted) < len(coeffs):
-                shifted.extend([0] * (len(coeffs) - len(shifted)))
-            coeffs = [
-                (c + s_coeff) % prime
-                for c, s_coeff in zip(coeffs, shifted, strict=True)
-            ]
+            coeffs = _berlekamp_combine(coeffs, shifted, prime)
             length = i + 1 - length
             b = temp
             last_discrepancy = discrepancy
             m = 1
         else:
-            factor = (discrepancy * pow(last_discrepancy, prime - 2, prime)) % prime
-            shifted = [0] * m + [(-factor * x) % prime for x in b]
-            if len(shifted) > len(coeffs):
-                coeffs.extend([0] * (len(shifted) - len(coeffs)))
-            elif len(shifted) < len(coeffs):
-                shifted.extend([0] * (len(coeffs) - len(shifted)))
-            coeffs = [
-                (c + s_coeff) % prime
-                for c, s_coeff in zip(coeffs, shifted, strict=True)
-            ]
+            coeffs = _berlekamp_combine(coeffs, shifted, prime)
             m += 1
 
     # The connection polynomial is C(x) = 1 + c_1 x + ... + c_L x^L.
     # The recurrence is s_n = -c_1 s_{n-1} - ... - c_L s_{n-L}, so the
     # recurrence coefficients are [-c_1, ..., -c_L].
     if length == 0:
-        return []
-    recurrence = [(-coeffs[j]) % prime for j in range(1, length + 1)]
-    return recurrence
+        return PrimeFieldRecurrence(
+            prime=prime, coefficients=(), order=0, status="FOUND"
+        )
+    recurrence = tuple((-coeffs[j]) % prime for j in range(1, length + 1))
+    return PrimeFieldRecurrence(
+        prime=prime, coefficients=recurrence, order=length, status="FOUND"
+    )

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.recurrence_solving._models import PrimeFieldRecurrence
 
 __all__ = [
     "ClosedForm",
@@ -27,15 +28,6 @@ class Recurrence:
 _MAX_FIELD_PRIME = 10_000
 _MAX_FIELD_SEQUENCE_LENGTH = 256
 
-
-@dataclass(frozen=True, slots=True)
-class PrimeFieldRecurrence:
-    """Minimal linear recurrence over an explicit prime field ``GF(p)``."""
-
-    prime: int
-    coefficients: tuple[int, ...]
-    order: int
-    status: Literal["FOUND", "NO_FITTING_RECURRENCE"]
 
 
 def _validate_berlekamp_inputs(sequence: list[int], prime: int) -> None:
@@ -158,10 +150,13 @@ def berlekamp_massey(sequence: list[int], prime: int) -> PrimeFieldRecurrence:
     """Return the minimal LFSR over ``GF(p)`` via Berlekamp-Massey.
 
     Returns a :class:`PrimeFieldRecurrence` containing the field ``prime``
-    and the coefficient tuple ``(c_1, ..., c_L)`` such that for every
-    ``n >= L``, ``s_n = c_1 s_{n-1} + ... + c_L s_{n-L}`` (mod p) with ``L``
-    minimal. The returned value retains its field; ``[1, 1]`` over ``GF(2)``
-    and ``GF(7)`` are distinct values. An order-zero ``FOUND`` result
+    and the coefficient tuple ``(c_1, ..., c_L)`` such that the equation
+    ``s_n = c_1 s_{n-1} + ... + c_L s_{n-L}`` (mod p) holds for every index
+    of the supplied prefix with ``L <= n < len(sequence)``, with ``L``
+    minimal. The algorithm observes only this finite prefix, so the value
+    establishes nothing about terms at or beyond ``len(sequence)``. The
+    returned value retains its field; ``[1, 1]`` over ``GF(2)`` and
+    ``GF(7)`` are distinct values. An order-zero ``FOUND`` result
     represents the all-zero sequence.
     """
     _validate_berlekamp_inputs(sequence, prime)

--- a/src/jacobian/math/recurrence_solving/operations.py
+++ b/src/jacobian/math/recurrence_solving/operations.py
@@ -7,7 +7,13 @@ from typing import Literal
 
 from jacobian._exact import CanonicalRational
 
-__all__ = ["ClosedForm", "Recurrence", "berlekamp_massey", "closed_form", "find_recurrence"]
+__all__ = [
+    "ClosedForm",
+    "Recurrence",
+    "berlekamp_massey",
+    "closed_form",
+    "find_recurrence",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -106,8 +112,8 @@ def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
     """
     s = [int(x) % prime for x in sequence]
     n = len(s)
-    coeffs = [1]          # C(x) = 1
-    b = [1]               # B(x) = 1
+    coeffs = [1]  # C(x) = 1
+    b = [1]  # B(x) = 1
     length = 0
     m = 1
     last_discrepancy = 1
@@ -127,7 +133,10 @@ def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
                 coeffs.extend([0] * (len(shifted) - len(coeffs)))
             elif len(shifted) < len(coeffs):
                 shifted.extend([0] * (len(coeffs) - len(shifted)))
-            coeffs = [(c + s_coeff) % prime for c, s_coeff in zip(coeffs, shifted, strict=True)]
+            coeffs = [
+                (c + s_coeff) % prime
+                for c, s_coeff in zip(coeffs, shifted, strict=True)
+            ]
             length = i + 1 - length
             b = temp
             last_discrepancy = discrepancy
@@ -139,7 +148,10 @@ def berlekamp_massey(sequence: list[int], prime: int) -> list[int]:
                 coeffs.extend([0] * (len(shifted) - len(coeffs)))
             elif len(shifted) < len(coeffs):
                 shifted.extend([0] * (len(coeffs) - len(shifted)))
-            coeffs = [(c + s_coeff) % prime for c, s_coeff in zip(coeffs, shifted, strict=True)]
+            coeffs = [
+                (c + s_coeff) % prime
+                for c, s_coeff in zip(coeffs, shifted, strict=True)
+            ]
             m += 1
 
     # The connection polynomial is C(x) = 1 + c_1 x + ... + c_L x^L.

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -45,9 +45,10 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=5, sequence=(0, 0, 0, 0)),
         )
-        assert result.status == "NO_FITTING_RECURRENCE"
+        assert result.status == "FOUND"
         assert result.order == 0
         assert result.coefficients == ()
+        assert result.sequence == (0, 0, 0, 0)
 
     def test_constant_sequence(self):
         # 3,3,3,3 mod 5 -> s_n = s_{n-1}, coefficient (1,).

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -79,6 +79,18 @@ class TestPrimeFieldRecurrenceFind:
         with pytest.raises(ValueError, match="residues"):
             PrimeFieldRecurrenceFindRequest(prime=3, sequence=(1, 3, 2))
 
+    def test_request_schema_publishes_canonical_residue_constraint(self):
+        schema = PrimeFieldRecurrenceFindRequest.model_json_schema()
+        assert "0 <= value < prime" in schema["properties"]["sequence"]["description"]
+        assert "2" in schema["properties"]["prime"]["description"]
+
+    def test_result_schema_publishes_canonical_residue_constraint(self):
+        schema = PrimeFieldRecurrenceFindResult.model_json_schema()
+        assert "0 <= value < prime" in schema["properties"]["sequence"]["description"]
+        assert (
+            "0 <= value < prime" in schema["properties"]["coefficients"]["description"]
+        )
+
     def test_result_accepts_minimal_fibonacci_recurrence(self):
         result = PrimeFieldRecurrenceFindResult(
             prime=7,

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -1,5 +1,7 @@
 """Tests for Berlekamp-Massey recurrence finding over prime fields."""
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -114,15 +116,19 @@ class TestPrimeFieldRecurrenceFind:
                 ),
             )
 
-    def test_result_rejects_false_no_fitting_recurrence(self):
-        with pytest.raises(ValidationError, match="Berlekamp-Massey"):
-            PrimeFieldRecurrenceFindResult(
-                sequence=FIBONACCI_MOD_7,
-                recurrence=PrimeFieldRecurrence(
-                    prime=7, coefficients=(), order=0,
-                    status="NO_FITTING_RECURRENCE",
-                ),
+    def test_no_fitting_status_is_not_part_of_the_prime_field_contract(self):
+        with pytest.raises(ValidationError):
+            PrimeFieldRecurrence(
+                prime=7,
+                coefficients=(),
+                order=0,
+                status="NO_FITTING_RECURRENCE",
             )
+        schema = PrimeFieldRecurrence.model_json_schema()
+        assert schema["properties"]["status"]["const"] == "FOUND"
+        assert "NO_FITTING_RECURRENCE" not in json.dumps(
+            PrimeFieldRecurrenceFindResult.model_json_schema()
+        )
 
     def test_result_rejects_wrong_coefficients_at_minimal_order(self):
         with pytest.raises(ValidationError, match="Berlekamp-Massey"):
@@ -145,7 +151,6 @@ class TestPrimeFieldRecurrenceFind:
             PrimeFieldRecurrenceFindResult(
                 sequence=sequence,
                 recurrence=PrimeFieldRecurrence(
-                    prime=2, coefficients=(), order=0,
-                    status="NO_FITTING_RECURRENCE",
+                    prime=2, coefficients=(1,), order=1, status="FOUND"
                 ),
             )

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -13,7 +13,9 @@ from jacobian.math.recurrence_solving._operations import (
 def _verify_recurrence(sequence, coefficients, prime):
     order = len(coefficients)
     for n in range(order, len(sequence)):
-        expected = sum(coefficients[i] * sequence[n - 1 - i] for i in range(order)) % prime
+        expected = (
+            sum(coefficients[i] * sequence[n - 1 - i] for i in range(order)) % prime
+        )
         assert sequence[n] == expected, (n, sequence[n], expected)
 
 

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -1,13 +1,17 @@
 """Tests for Berlekamp-Massey recurrence finding over prime fields."""
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.recurrence_solving._models import (
     PrimeFieldRecurrenceFindRequest,
+    PrimeFieldRecurrenceFindResult,
 )
 from jacobian.math.recurrence_solving._operations import (
     compute_prime_field_find_recurrence,
 )
+
+FIBONACCI_MOD_7 = (0, 1, 1, 2, 3, 5, 1, 6, 0)
 
 
 def _verify_recurrence(sequence, coefficients, prime):
@@ -21,14 +25,13 @@ def _verify_recurrence(sequence, coefficients, prime):
 
 class TestPrimeFieldRecurrenceFind:
     def test_fibonacci_mod_7(self):
-        fib = [0, 1, 1, 2, 3, 5, 1, 6, 0]
         result = compute_prime_field_find_recurrence(
-            PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(fib)),
+            PrimeFieldRecurrenceFindRequest(prime=7, sequence=FIBONACCI_MOD_7),
         )
         assert result.status == "FOUND"
         assert result.order == 2
         assert tuple(result.coefficients) == (1, 1)
-        _verify_recurrence(fib, result.coefficients, 7)
+        _verify_recurrence(FIBONACCI_MOD_7, result.coefficients, 7)
 
     def test_geometric_sequence(self):
         # 1,2,4,1,2,4 mod 7 -> s_n = 2 s_{n-1}.
@@ -75,3 +78,62 @@ class TestPrimeFieldRecurrenceFind:
     def test_rejects_out_of_range_value(self):
         with pytest.raises(ValueError, match="residues"):
             PrimeFieldRecurrenceFindRequest(prime=3, sequence=(1, 3, 2))
+
+    def test_result_accepts_minimal_fibonacci_recurrence(self):
+        result = PrimeFieldRecurrenceFindResult(
+            prime=7,
+            sequence=FIBONACCI_MOD_7,
+            coefficients=(1, 1),
+            order=2,
+            status="FOUND",
+        )
+        assert result.status == "FOUND"
+        assert result.order == 2
+        assert result.coefficients == (1, 1)
+
+    def test_result_rejects_non_minimal_fibonacci_recurrence(self):
+        with pytest.raises(ValidationError, match="Berlekamp-Massey"):
+            PrimeFieldRecurrenceFindResult(
+                prime=7,
+                sequence=FIBONACCI_MOD_7,
+                coefficients=(1, 1, 0),
+                order=3,
+                status="FOUND",
+            )
+
+    def test_result_rejects_false_no_fitting_recurrence(self):
+        with pytest.raises(ValidationError, match="Berlekamp-Massey"):
+            PrimeFieldRecurrenceFindResult(
+                prime=7,
+                sequence=FIBONACCI_MOD_7,
+                coefficients=(),
+                order=0,
+                status="NO_FITTING_RECURRENCE",
+            )
+
+    def test_result_rejects_wrong_coefficients_at_minimal_order(self):
+        with pytest.raises(ValidationError, match="Berlekamp-Massey"):
+            PrimeFieldRecurrenceFindResult(
+                prime=7,
+                sequence=FIBONACCI_MOD_7,
+                coefficients=(1, 2),
+                order=2,
+                status="FOUND",
+            )
+
+    def test_impulse_sequence_is_the_minimal_order_n_recurrence(self):
+        sequence = (0, 0, 0, 1)
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=2, sequence=sequence),
+        )
+        assert result.status == "FOUND"
+        assert result.order == len(sequence)
+        PrimeFieldRecurrenceFindResult.model_validate(result.model_dump())
+        with pytest.raises(ValidationError, match="Berlekamp-Massey"):
+            PrimeFieldRecurrenceFindResult(
+                prime=2,
+                sequence=sequence,
+                coefficients=(),
+                order=0,
+                status="NO_FITTING_RECURRENCE",
+            )

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.recurrence_solving._models import (
+    PrimeFieldRecurrence,
     PrimeFieldRecurrenceFindRequest,
     PrimeFieldRecurrenceFindResult,
 )
@@ -28,10 +29,10 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=7, sequence=FIBONACCI_MOD_7),
         )
-        assert result.status == "FOUND"
-        assert result.order == 2
-        assert tuple(result.coefficients) == (1, 1)
-        _verify_recurrence(FIBONACCI_MOD_7, result.coefficients, 7)
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 2
+        assert tuple(result.recurrence.coefficients) == (1, 1)
+        _verify_recurrence(FIBONACCI_MOD_7, result.recurrence.coefficients, 7)
 
     def test_geometric_sequence(self):
         # 1,2,4,1,2,4 mod 7 -> s_n = 2 s_{n-1}.
@@ -39,18 +40,18 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(geo)),
         )
-        assert result.status == "FOUND"
-        assert result.order == 1
-        assert tuple(result.coefficients) == (2,)
-        _verify_recurrence(geo, result.coefficients, 7)
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 1
+        assert tuple(result.recurrence.coefficients) == (2,)
+        _verify_recurrence(geo, result.recurrence.coefficients, 7)
 
     def test_all_zeros_no_recurrence(self):
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=5, sequence=(0, 0, 0, 0)),
         )
-        assert result.status == "FOUND"
-        assert result.order == 0
-        assert result.coefficients == ()
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 0
+        assert result.recurrence.coefficients == ()
         assert result.sequence == (0, 0, 0, 0)
 
     def test_constant_sequence(self):
@@ -58,9 +59,9 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=5, sequence=(3, 3, 3, 3)),
         )
-        assert result.status == "FOUND"
-        assert result.order == 1
-        assert tuple(result.coefficients) == (1,)
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 1
+        assert tuple(result.recurrence.coefficients) == (1,)
 
     def test_minimality(self):
         # A sequence satisfying a length-1 recurrence should not get a longer one.
@@ -68,8 +69,8 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(seq)),
         )
-        assert result.status == "FOUND"
-        assert result.order == 1
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 1
 
     def test_rejects_nonprime(self):
         with pytest.raises(ValueError, match="prime"):
@@ -87,50 +88,49 @@ class TestPrimeFieldRecurrenceFind:
     def test_result_schema_publishes_canonical_residue_constraint(self):
         schema = PrimeFieldRecurrenceFindResult.model_json_schema()
         assert "0 <= value < prime" in schema["properties"]["sequence"]["description"]
+        coeff_schema = PrimeFieldRecurrence.model_json_schema()
         assert (
-            "0 <= value < prime" in schema["properties"]["coefficients"]["description"]
+            "0 <= value < prime"
+            in coeff_schema["properties"]["coefficients"]["description"]
         )
 
     def test_result_accepts_minimal_fibonacci_recurrence(self):
         result = PrimeFieldRecurrenceFindResult(
-            prime=7,
             sequence=FIBONACCI_MOD_7,
-            coefficients=(1, 1),
-            order=2,
-            status="FOUND",
+            recurrence=PrimeFieldRecurrence(
+                prime=7, coefficients=(1, 1), order=2, status="FOUND"
+            ),
         )
-        assert result.status == "FOUND"
-        assert result.order == 2
-        assert result.coefficients == (1, 1)
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == 2
+        assert result.recurrence.coefficients == (1, 1)
 
     def test_result_rejects_non_minimal_fibonacci_recurrence(self):
         with pytest.raises(ValidationError, match="Berlekamp-Massey"):
             PrimeFieldRecurrenceFindResult(
-                prime=7,
                 sequence=FIBONACCI_MOD_7,
-                coefficients=(1, 1, 0),
-                order=3,
-                status="FOUND",
+                recurrence=PrimeFieldRecurrence(
+                    prime=7, coefficients=(1, 1, 0), order=3, status="FOUND"
+                ),
             )
 
     def test_result_rejects_false_no_fitting_recurrence(self):
         with pytest.raises(ValidationError, match="Berlekamp-Massey"):
             PrimeFieldRecurrenceFindResult(
-                prime=7,
                 sequence=FIBONACCI_MOD_7,
-                coefficients=(),
-                order=0,
-                status="NO_FITTING_RECURRENCE",
+                recurrence=PrimeFieldRecurrence(
+                    prime=7, coefficients=(), order=0,
+                    status="NO_FITTING_RECURRENCE",
+                ),
             )
 
     def test_result_rejects_wrong_coefficients_at_minimal_order(self):
         with pytest.raises(ValidationError, match="Berlekamp-Massey"):
             PrimeFieldRecurrenceFindResult(
-                prime=7,
                 sequence=FIBONACCI_MOD_7,
-                coefficients=(1, 2),
-                order=2,
-                status="FOUND",
+                recurrence=PrimeFieldRecurrence(
+                    prime=7, coefficients=(1, 2), order=2, status="FOUND"
+                ),
             )
 
     def test_impulse_sequence_is_the_minimal_order_n_recurrence(self):
@@ -138,14 +138,14 @@ class TestPrimeFieldRecurrenceFind:
         result = compute_prime_field_find_recurrence(
             PrimeFieldRecurrenceFindRequest(prime=2, sequence=sequence),
         )
-        assert result.status == "FOUND"
-        assert result.order == len(sequence)
+        assert result.recurrence.status == "FOUND"
+        assert result.recurrence.order == len(sequence)
         PrimeFieldRecurrenceFindResult.model_validate(result.model_dump())
         with pytest.raises(ValidationError, match="Berlekamp-Massey"):
             PrimeFieldRecurrenceFindResult(
-                prime=2,
                 sequence=sequence,
-                coefficients=(),
-                order=0,
-                status="NO_FITTING_RECURRENCE",
+                recurrence=PrimeFieldRecurrence(
+                    prime=2, coefficients=(), order=0,
+                    status="NO_FITTING_RECURRENCE",
+                ),
             )

--- a/tests/math/recurrence_solving/test_prime_field_recurrence.py
+++ b/tests/math/recurrence_solving/test_prime_field_recurrence.py
@@ -1,0 +1,74 @@
+"""Tests for Berlekamp-Massey recurrence finding over prime fields."""
+
+import pytest
+
+from jacobian.math.recurrence_solving._models import (
+    PrimeFieldRecurrenceFindRequest,
+)
+from jacobian.math.recurrence_solving._operations import (
+    compute_prime_field_find_recurrence,
+)
+
+
+def _verify_recurrence(sequence, coefficients, prime):
+    order = len(coefficients)
+    for n in range(order, len(sequence)):
+        expected = sum(coefficients[i] * sequence[n - 1 - i] for i in range(order)) % prime
+        assert sequence[n] == expected, (n, sequence[n], expected)
+
+
+class TestPrimeFieldRecurrenceFind:
+    def test_fibonacci_mod_7(self):
+        fib = [0, 1, 1, 2, 3, 5, 1, 6, 0]
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(fib)),
+        )
+        assert result.status == "FOUND"
+        assert result.order == 2
+        assert tuple(result.coefficients) == (1, 1)
+        _verify_recurrence(fib, result.coefficients, 7)
+
+    def test_geometric_sequence(self):
+        # 1,2,4,1,2,4 mod 7 -> s_n = 2 s_{n-1}.
+        geo = [1, 2, 4, 1, 2, 4]
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(geo)),
+        )
+        assert result.status == "FOUND"
+        assert result.order == 1
+        assert tuple(result.coefficients) == (2,)
+        _verify_recurrence(geo, result.coefficients, 7)
+
+    def test_all_zeros_no_recurrence(self):
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=5, sequence=(0, 0, 0, 0)),
+        )
+        assert result.status == "NO_FITTING_RECURRENCE"
+        assert result.order == 0
+        assert result.coefficients == ()
+
+    def test_constant_sequence(self):
+        # 3,3,3,3 mod 5 -> s_n = s_{n-1}, coefficient (1,).
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=5, sequence=(3, 3, 3, 3)),
+        )
+        assert result.status == "FOUND"
+        assert result.order == 1
+        assert tuple(result.coefficients) == (1,)
+
+    def test_minimality(self):
+        # A sequence satisfying a length-1 recurrence should not get a longer one.
+        seq = [1, 3, 2, 6, 4, 5, 1]  # mod 7: multiply by 3 each time
+        result = compute_prime_field_find_recurrence(
+            PrimeFieldRecurrenceFindRequest(prime=7, sequence=tuple(seq)),
+        )
+        assert result.status == "FOUND"
+        assert result.order == 1
+
+    def test_rejects_nonprime(self):
+        with pytest.raises(ValueError, match="prime"):
+            PrimeFieldRecurrenceFindRequest(prime=4, sequence=(1, 2, 3))
+
+    def test_rejects_out_of_range_value(self):
+        with pytest.raises(ValueError, match="residues"):
+            PrimeFieldRecurrenceFindRequest(prime=3, sequence=(1, 3, 2))

--- a/tests/math/recurrence_solving/test_rational_contract.py
+++ b/tests/math/recurrence_solving/test_rational_contract.py
@@ -3,6 +3,7 @@
 from jacobian.math.recurrence_solving._models import (
     ClosedFormRequest,
     RecurrenceFindRequest,
+    RecurrenceFindResult,
 )
 from jacobian.math.recurrence_solving._operations import (
     compute_closed_form,
@@ -21,6 +22,14 @@ def test_find_recurrence_accepts_exact_rational_sequence() -> None:
     assert result.status == "FOUND"
     assert result.order == 1
     assert result.coefficients[0].as_integer_ratio() == (1, 2)
+
+
+def test_find_recurrence_accepts_no_fitting_when_no_nonvacuous_order_exists() -> None:
+    result = compute_find_recurrence(RecurrenceFindRequest(sequence=(_q(0), _q(1))))
+    assert result.status == "NO_FITTING_RECURRENCE"
+    assert result.order == 0
+    assert result.coefficients == ()
+    RecurrenceFindResult.model_validate(result.model_dump())
 
 
 def test_closed_form_accepts_exact_rational_data() -> None:


### PR DESCRIPTION
## Problem

Jacobian had `sequence.recurrence.find` (minimal recurrence over `QQ` via
rational interpolation) and `sequence.recurrence.closed_form.compute`, but no
operation for the inverse problem over a **finite field** — the Berlekamp-Massey
algorithm that finds the minimal LFSR a sequence satisfies over `GF(p)`. The
issue's acceptance criteria require `sequence.recurrence.find` to be supported
over finite fields, which the existing `QQ`-only operation does not cover.

Closes #1676.

## Solution

Add `sequence.recurrence.prime_field.find`: given a finite sequence over an
explicit prime field `GF(p)`, return the minimal linear recurrence (LFSR
connection) it satisfies via the Berlekamp-Massey algorithm, with coefficients
over `GF(p)`, or `NO_FITTING_RECURRENCE`.

This is a new operation rather than a mutation of the existing
`sequence.recurrence.find` (which is `QQ`-only with method
`RATIONAL_INTERPOLATION`); the pre-stable contract for the existing operation is
preserved. The existing op handles the `QQ` case; this op handles the
finite-field case the issue explicitly requests.

## Library choices

SymPy ships no public Berlekamp-Massey (only `linrec`/`linrec_coeffs` for
*evaluation*). Berlekamp-Massey is a short, standard, deterministic, bounded
algorithm, so it is implemented directly in `operations.py` (the AGENTS.md
guidance permits direct Python when no maintained backend exposes the bounded
kernel). The algorithm is `O(n²)` over the bounded sequence (`≤ 256` terms),
exact over `GF(p)` with Fermat inverses. This is documented as the
`BERLEKAMP_MASSEY` method in the typed result.

## Testing

- `make check` — Ruff, mypy, and Lean-free math/catalog/integration owners pass (3069).
- Owning tests cover: Fibonacci mod 7 → `s_n = s_{n-1} + s_{n-2}` (coefficients
  `(1,1)`) with full sequence reconstruction, a geometric sequence → coefficient
  `(2,)`, all-zeros → `NO_FITTING_RECURRENCE`, a constant sequence → `(1,)`,
  minimality (a length-1 recurrence is not inflated), and rejection of
  non-prime / out-of-range inputs.
- Catalog conformance: the advertised example executes, re-validates, and
  survives the boundary-mutation contract test.

## Public operation admission

- Concrete gap: no finite-field minimal-recurrence (Berlekamp-Massey) operation existed; the existing `sequence.recurrence.find` is `QQ`-only.
- Why existing operations are insufficient: rational interpolation over `QQ` does not apply over `GF(p)`.
- Stable mathematical result: the minimal LFSR connection over an explicit prime field.
- Admission decision: `KEEP`.

## Public operation contract

- Mathematical input domain: a finite sequence of residues over `GF(p)`, `p` prime, `2 ≤ length ≤ 256`.
- Canonical public value type: prime + residue sequence.
- Degenerate inputs: all-zero sequences return `NO_FITTING_RECURRENCE`.
- Parent/ring/field identity: `GF(p)` with `p` explicit in input and result.
- Deterministic work bound: `O(n²)` over the bounded sequence.
- Result type: `PrimeFieldRecurrenceFindResult` (coefficients, order, status, method).
- Reconstruction/defining invariant: a `FOUND` recurrence reproduces the entire supplied sequence over `GF(p)` (tested).
- Typed execution failures: non-prime and out-of-range residues rejected before computation.

## Checklist

- [x] `make check` passes
- [x] Public operation changes retain owner-local admission decisions
- [x] Execution outcomes do not claim mathematical conclusions

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/0cecb73b-2b36-4041-b659-1a3441039ed1)