### PR TITLE
feat(math): add ideal membership and normal form operations (#1665)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,8 @@ ignore_imports = [
     "jacobian.math.logic._operations -> jacobian.process",
     # General ideal radical/quotient run in a bounded one-shot Singular process.
     "jacobian.math.commutative_algebra_ops._singular -> jacobian.process",
+    # The complete-kernel strategy runs killably in a bounded one-shot process.
+    "jacobian.math.polynomials._groebner_worker -> jacobian.process",
 ]
 
 [[tool.importlinter.contracts]]

--- a/src/jacobian/math/polynomials/_admission.py
+++ b/src/jacobian/math/polynomials/_admission.py
@@ -11,6 +11,16 @@ from jacobian.math.polynomials._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "polynomial.ideal.membership.decide",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
+    OperationAdmission(
+        "polynomial.ideal.normal_form.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
+    OperationAdmission(
         "polynomial.compute.discriminant",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -8,7 +8,11 @@ a wall clock and hard resource limits — and reports a tagged outcome:
 of the submitted generating set leaves an output budget (sound evidence,
 because that basis is unique), ``aborted`` when an intermediate prefix of
 an incremental strategy left a budget (a work bound, never a conclusion,
-since later generators can shrink an ideal), or ``failed``.
+since later generators can shrink an ideal), or ``failed`` when the
+kernel or the wire codec raised inside the attempt — a broken adapter is
+a transport fault, so the parent surfaces it as
+:class:`GroebnerWorkerExecutionError` instead of projecting it into a
+domain status.
 """
 
 from __future__ import annotations
@@ -17,7 +21,7 @@ import json
 import shutil
 import sys
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
@@ -201,6 +205,37 @@ def _resolve_memory_enforcement() -> str | None:
     return None
 
 
+def _decode_report(raw: bytes) -> dict[str, Any]:
+    """Decode one worker report, failing closed on protocol violations."""
+
+    try:
+        report = json.loads(raw.decode("utf-8"))
+    except Exception as error:
+        raise GroebnerWorkerExecutionError(str(error)) from None
+    if not isinstance(report, dict):
+        # A decoded payload with the wrong top-level shape is a broken
+        # worker protocol, not evidence about the ideal.
+        raise GroebnerWorkerExecutionError(
+            f"groebner worker report is {type(report).__name__}, not a JSON object"
+        )
+    return report
+
+
+def _basis_from_report(report: dict[str, Any]) -> tuple[RationalPolynomial, ...]:
+    """Convert a worker ``ok`` report to the canonical wire basis."""
+
+    from pydantic import ValidationError
+
+    try:
+        return tuple(
+            RationalPolynomial.model_validate(element) for element in report["basis"]
+        )
+    except (ValidationError, TypeError, KeyError, ValueError) as error:
+        # A declared basis outside the canonical contract is a worker fault,
+        # not evidence about the ideal.
+        raise GroebnerWorkerExecutionError(str(error)) from None
+
+
 def complete_basis_in_worker(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
@@ -214,15 +249,16 @@ def complete_basis_in_worker(
     one unguarded call where Buchberger sees every collapsing pair from
     the start.  Returns ``("ok", basis)`` when the attempt concluded
     within every output budget, ``("exceeded", None)`` for evidenced
-    complete-basis overflow, and ``("aborted"|"failed", None)`` when the
-    attempt self-reports no conclusion. Launch failures, cancellation,
-    wall-clock timeouts, and malformed worker exits are execution/deployment
-    faults, not mathematical conclusions: they raise their typed
+    complete-basis overflow, and ``("aborted", None)`` when an incremental
+    strategy self-reports a bounded non-conclusion. A worker ``failed``
+    report — a kernel or codec exception inside the attempt — raises
+    :class:`GroebnerWorkerExecutionError`: a broken worker/backend adapter
+    is a transport fault, never work exhaustion. Launch failures,
+    cancellation, wall-clock timeouts, malformed worker exits, and
+    reports with the wrong top-level shape raise their typed
     ``GroebnerWorkerError`` subclasses instead of collapsing into a domain
     status.
     """
-
-    from pydantic import ValidationError
 
     payload = {
         "variables": list(ideal.variables),
@@ -273,24 +309,18 @@ def complete_basis_in_worker(
             f"groebner worker exited with returncode "
             f"{completed.returncode} without a report"
         )
-    try:
-        report = json.loads(completed.stdout.decode("utf-8"))
-    except Exception as error:
-        raise GroebnerWorkerExecutionError(str(error)) from None
+    report = _decode_report(completed.stdout)
     status = report.get("status")
-    if status in ("exceeded", "aborted", "failed"):
+    if status in ("exceeded", "aborted"):
         return status, None
+    if status == "failed":
+        raise GroebnerWorkerExecutionError(
+            "groebner worker reported an internal kernel or codec failure "
+            "without any mathematical conclusion"
+        )
     if status != "ok":
         raise GroebnerWorkerExecutionError(f"unknown worker status {status!r}")
-    try:
-        basis = tuple(
-            RationalPolynomial.model_validate(element) for element in report["basis"]
-        )
-    except (ValidationError, TypeError, KeyError, ValueError) as error:
-        # A declared basis outside the canonical contract is a worker fault,
-        # not evidence about the ideal.
-        raise GroebnerWorkerExecutionError(str(error)) from None
-    return "ok", basis
+    return "ok", _basis_from_report(report)
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -152,7 +152,7 @@ main()
 """
 
 
-WorkerStatus = Literal["ok", "exceeded", "aborted", "failed", "unavailable"]
+WorkerStatus = Literal["ok", "exceeded", "aborted"]
 
 
 class GroebnerWorkerError(RuntimeError):
@@ -176,6 +176,31 @@ class GroebnerWorkerExecutionError(GroebnerWorkerError):
     """The worker ran but exited without a parseable, well-formed report."""
 
 
+class GroebnerWorkerTimeoutError(GroebnerWorkerError):
+    """The worker was killed by its wall-clock deadline without reporting.
+
+    Host load or an unexpectedly slow machine can trigger this for work that
+    would conclude elsewhere, so it must stay retryable and distinguishable
+    from any mathematical conclusion.
+    """
+
+
+def _resolve_memory_enforcement() -> str | None:
+    """Resolve the prlimit executable or fail closed without a hard cap."""
+    prlimit = shutil.which("prlimit")
+    if prlimit is not None:
+        return str(Path(prlimit).resolve())
+    import resource
+
+    if not hasattr(resource, "prlimit"):
+        raise GroebnerWorkerLaunchError(
+            "the groebner worker's hard address-space cap cannot be "
+            "enforced on this platform (no util-linux prlimit and no "
+            "resource.prlimit); refusing to run unbounded-memory work"
+        )
+    return None
+
+
 def complete_basis_in_worker(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
@@ -189,11 +214,10 @@ def complete_basis_in_worker(
     one unguarded call where Buchberger sees every collapsing pair from
     the start.  Returns ``("ok", basis)`` when the attempt concluded
     within every output budget, ``("exceeded", None)`` for evidenced
-    complete-basis overflow, ``("aborted"|"failed", None)`` when the attempt
-    self-reports no conclusion, and ``("unavailable", None)`` when the hard
-    wall-clock safety net expires on a runaway attempt. Launch failures,
-    cancellation, and malformed worker exits are execution/deployment faults,
-    not mathematical conclusions: they raise their typed
+    complete-basis overflow, and ``("aborted"|"failed", None)`` when the
+    attempt self-reports no conclusion. Launch failures, cancellation,
+    wall-clock timeouts, and malformed worker exits are execution/deployment
+    faults, not mathematical conclusions: they raise their typed
     ``GroebnerWorkerError`` subclasses instead of collapsing into a domain
     status.
     """
@@ -216,9 +240,7 @@ def complete_basis_in_worker(
             for generator in ideal.generators
         ],
     }
-    prlimit = shutil.which("prlimit")
-    if prlimit is not None:
-        prlimit = str(Path(prlimit).resolve())
+    prlimit = _resolve_memory_enforcement()
     try:
         completed = run_bounded_process(
             [sys.executable, "-c", _WORKER_PROGRAM],
@@ -241,10 +263,11 @@ def complete_basis_in_worker(
             "groebner worker was cancelled before reporting"
         )
     if completed.timed_out:
-        # The hard wall-clock safety net expired on a runaway attempt: the
-        # worker produced no report, so there is no conclusion either way
-        # about the ideal (a mathematically hard request).
-        return "unavailable", None
+        raise GroebnerWorkerTimeoutError(
+            "groebner worker exceeded its wall-clock deadline before "
+            "reporting; the attempt may have been slowed by host load and "
+            "is retryable"
+        )
     if completed.returncode != 0:
         raise GroebnerWorkerExecutionError(
             f"groebner worker exited with returncode "
@@ -275,6 +298,7 @@ __all__ = [
     "GroebnerWorkerError",
     "GroebnerWorkerExecutionError",
     "GroebnerWorkerLaunchError",
+    "GroebnerWorkerTimeoutError",
     "WorkerStatus",
     "complete_basis_in_worker",
 ]

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -8,11 +8,13 @@ a wall clock and hard resource limits — and reports a tagged outcome:
 of the submitted generating set leaves an output budget (sound evidence,
 because that basis is unique), ``aborted`` when an intermediate prefix of
 an incremental strategy left a budget (a work bound, never a conclusion,
-since later generators can shrink an ideal), or ``failed`` when the
-kernel or the wire codec raised inside the attempt — a broken adapter is
-a transport fault, so the parent surfaces it as
-:class:`GroebnerWorkerExecutionError` instead of projecting it into a
-domain status.
+since later generators can shrink an ideal), ``exhausted`` when the hard
+address-space cap ended the attempt inside the kernel or during basis
+materialization (bounded work, likewise never a mathematical conclusion),
+or ``failed`` when the kernel or the wire codec raised for any other
+reason inside the attempt — a broken adapter is a transport fault, so the
+parent surfaces it as :class:`GroebnerWorkerExecutionError` instead of
+projecting it into a domain status.
 """
 
 from __future__ import annotations
@@ -54,6 +56,21 @@ from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
 from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
+_EXHAUSTED_REPORT = '{"status": "exhausted"}\\n'
+
+
+def _emit_exhausted() -> None:
+    # The hard address-space cap ended this attempt.  Report the bounded
+    # non-conclusion from a pre-serialized literal so the emission itself
+    # cannot need a large allocation immediately after an allocation
+    # failure; if even that write exhausts memory, the process exits
+    # without a report and the parent raises its typed execution fault.
+    try:
+        sys.stdout.write(_EXHAUSTED_REPORT)
+        sys.stdout.flush()
+    except MemoryError:
+        pass
+
 
 def _leaves_output_budget(polys) -> bool:
     aggregate = 0
@@ -71,21 +88,47 @@ def _leaves_output_budget(polys) -> bool:
     return False
 
 
+def _kernel_attempt(generators, symbols, order):
+    # Run one kernel Groebner call inside the attempt boundary.  Returns
+    # ``(polys, over_budget, outcome)``: ``outcome`` is ``None`` when the
+    # kernel concluded and the basis materialized, otherwise "exhausted"
+    # when the address-space cap ended the attempt -- a work bound on this
+    # attempt, never a mathematical claim -- or "failed" for any other
+    # kernel exception, which is a broken adapter.
+    try:
+        basis = groebner(generators, *symbols, order=order, domain=QQ)
+        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
+        over_budget = _leaves_output_budget(polys)
+    except MemoryError:
+        return None, None, "exhausted"
+    except Exception:
+        return None, None, "failed"
+    return polys, over_budget, None
+
+
 def _emit_ok(polys, variables) -> None:
     try:
         elements = [
             rational_polynomial_from_sympy(poly, tuple(variables)) for poly in polys
         ]
+    except MemoryError:
+        _emit_exhausted()
+        return
     except ValidationError:
         print(json.dumps({"status": "exceeded"}))
         return
     except Exception:
         print(json.dumps({"status": "failed"}))
         return
-    print(json.dumps({
-        "status": "ok",
-        "basis": [element.model_dump() for element in elements],
-    }))
+    try:
+        report = json.dumps({
+            "status": "ok",
+            "basis": [element.model_dump() for element in elements],
+        })
+    except MemoryError:
+        _emit_exhausted()
+        return
+    sys.stdout.write(report + "\\n")
 
 
 def main() -> None:
@@ -93,6 +136,7 @@ def main() -> None:
     variables = tuple(payload["variables"])
     symbols = tuple(Symbol(name) for name in variables)
     strategy = payload["strategy"]
+    order = payload["monomial_order"]
     try:
         generators = []
         for terms in payload["generators"]:
@@ -110,16 +154,14 @@ def main() -> None:
         return
 
     if strategy == "complete":
-        try:
-            basis = groebner(
-                generators, *symbols,
-                order=payload["monomial_order"], domain=QQ,
-            )
-        except Exception:
-            print(json.dumps({"status": "failed"}))
+        polys, over_budget, outcome = _kernel_attempt(generators, symbols, order)
+        if outcome is not None:
+            if outcome == "exhausted":
+                _emit_exhausted()
+            else:
+                print(json.dumps({"status": "failed"}))
             return
-        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
-        if _leaves_output_budget(polys):
+        if over_budget:
             print(json.dumps({"status": "exceeded"}))
             return
         _emit_ok(polys, variables)
@@ -129,18 +171,19 @@ def main() -> None:
     ordered = indices if strategy == "ascending" else reversed(indices)
     current = []
     last = len(generators) - 1
+    polys = []
     for position, index in enumerate(ordered):
         current.append(generators[index])
-        try:
-            basis = groebner(
-                current, *symbols,
-                order=payload["monomial_order"], domain=QQ,
-            )
-        except Exception:
-            print(json.dumps({"status": "failed"}))
+        polys, over_budget, outcome = _kernel_attempt(current, symbols, order)
+        if outcome is not None:
+            if outcome == "exhausted":
+                # The cap ended this prefix attempt: a work bound on the
+                # strategy, never evidence about any basis of the ideal.
+                _emit_exhausted()
+            else:
+                print(json.dumps({"status": "failed"}))
             return
-        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
-        if not _leaves_output_budget(polys):
+        if not over_budget:
             continue
         if position == last:
             # The complete generating set was submitted: this basis is the
@@ -156,7 +199,11 @@ main()
 """
 
 
-WorkerStatus = Literal["ok", "exceeded", "aborted"]
+WorkerStatus = Literal["ok", "exceeded", "aborted", "exhausted"]
+
+# Aggregate term boundary every returned basis must respect (mirrored by
+# the result-model validators and by the worker's own budget check).
+_MAX_OUTPUT_TERMS = 1_024
 
 
 class GroebnerWorkerError(RuntimeError):
@@ -221,19 +268,46 @@ def _decode_report(raw: bytes) -> dict[str, Any]:
     return report
 
 
-def _basis_from_report(report: dict[str, Any]) -> tuple[RationalPolynomial, ...]:
-    """Convert a worker ``ok`` report to the canonical wire basis."""
+def _basis_from_report(
+    report: dict[str, Any], ideal: RationalPolynomialIdeal
+) -> tuple[RationalPolynomial, ...]:
+    """Convert a worker ``ok`` report to the canonical wire basis.
+
+    The complete returned-basis contract is validated here, at the worker
+    protocol layer, so a malformed nested response can never escape as a
+    generic downstream result-model failure: every element must live in
+    the submitted ideal's ordered ring, no element may be the zero
+    polynomial, and the aggregate term count must stay inside the output
+    boundary.  (An empty basis is admissible wire form for the zero
+    ideal; the result-model replay validators enforce that correlation.)
+    """
 
     from pydantic import ValidationError
 
     try:
-        return tuple(
+        basis = tuple(
             RationalPolynomial.model_validate(element) for element in report["basis"]
         )
     except (ValidationError, TypeError, KeyError, ValueError) as error:
         # A declared basis outside the canonical contract is a worker fault,
         # not evidence about the ideal.
         raise GroebnerWorkerExecutionError(str(error)) from None
+    if any(element.variables != ideal.variables for element in basis):
+        raise GroebnerWorkerExecutionError(
+            "groebner worker returned a basis polynomial outside the "
+            "submitted ideal's ordered ring"
+        )
+    if any(not element.polynomial.terms for element in basis):
+        raise GroebnerWorkerExecutionError(
+            "groebner worker returned a zero polynomial inside its basis"
+        )
+    aggregate_terms = sum(len(element.polynomial.terms) for element in basis)
+    if aggregate_terms > _MAX_OUTPUT_TERMS:
+        raise GroebnerWorkerExecutionError(
+            f"groebner worker returned a {aggregate_terms}-term basis beyond "
+            f"the {_MAX_OUTPUT_TERMS}-term output boundary"
+        )
+    return basis
 
 
 def complete_basis_in_worker(
@@ -249,11 +323,17 @@ def complete_basis_in_worker(
     one unguarded call where Buchberger sees every collapsing pair from
     the start.  Returns ``("ok", basis)`` when the attempt concluded
     within every output budget, ``("exceeded", None)`` for evidenced
-    complete-basis overflow, and ``("aborted", None)`` when an incremental
-    strategy self-reports a bounded non-conclusion. A worker ``failed``
-    report — a kernel or codec exception inside the attempt — raises
-    :class:`GroebnerWorkerExecutionError`: a broken worker/backend adapter
-    is a transport fault, never work exhaustion. Launch failures,
+    complete-basis overflow, ``("aborted", None)`` when an incremental
+    strategy self-reports a bounded non-conclusion, and
+    ``("exhausted", None)`` when the hard address-space cap ended the
+    attempt — a work bound that decides nothing. A worker ``failed``
+    report — a kernel or codec exception inside the attempt for any other
+    reason — raises :class:`GroebnerWorkerExecutionError`: a broken
+    worker/backend adapter is a transport fault, never work exhaustion.
+    An ``ok`` basis that violates the returned-basis contract (foreign
+    ordered ring, zero element, or aggregate term overflow) is likewise a
+    broken worker protocol and raises :class:`GroebnerWorkerExecutionError`
+    before any caller can consume it. Launch failures,
     cancellation, wall-clock timeouts, malformed worker exits, and
     reports with the wrong top-level shape raise their typed
     ``GroebnerWorkerError`` subclasses instead of collapsing into a domain
@@ -311,7 +391,7 @@ def complete_basis_in_worker(
         )
     report = _decode_report(completed.stdout)
     status = report.get("status")
-    if status in ("exceeded", "aborted"):
+    if status in ("exceeded", "aborted", "exhausted"):
         return status, None
     if status == "failed":
         raise GroebnerWorkerExecutionError(
@@ -320,7 +400,7 @@ def complete_basis_in_worker(
         )
     if status != "ok":
         raise GroebnerWorkerExecutionError(f"unknown worker status {status!r}")
-    return "ok", _basis_from_report(report)
+    return "ok", _basis_from_report(report, ideal)
 
 
 __all__ = [

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -1,28 +1,43 @@
-"""Bounded killable SymPy-kernel worker for complete Gröbner bases.
+"""Bounded killable SymPy-kernel worker for source Gröbner bases.
 
-Both guarded incremental strategies can abort while one unguarded kernel
-call over the complete generating set still finishes quickly: Buchberger
-sees every ideal-collapsing pair from the start, so it need never
-materialize the exploding intermediate bases of any prefix.  The kernel
-cannot bound itself, so this owner runs it killably in a subprocess with
-a wall clock; a timeout, kill, or failure yields no mathematical
-conclusion.
+No Gröbner attempt runs in the service process: an admitted hard system
+can consume unbounded time or memory inside the kernel before any output
+boundary is noticed.  Each attempt therefore runs here — killably, under
+a wall clock and hard resource limits — and reports a tagged outcome:
+``ok`` with the wire basis, ``exceeded`` when the complete reduced basis
+of the submitted generating set leaves an output budget (sound evidence,
+because that basis is unique), ``aborted`` when an intermediate prefix of
+an incremental strategy left a budget (a work bound, never a conclusion,
+since later generators can shrink an ideal), or ``failed``.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import sys
+from pathlib import Path
+from typing import Literal
 
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialIdeal,
 )
-from jacobian.process import run_bounded_process, worker_environment
+from jacobian.process import (
+    ProcessPlatformTools,
+    ProcessResourceLimits,
+    run_bounded_process,
+    worker_environment,
+)
 
 _TIMEOUT_SECONDS = 10.0
+_CPU_SECONDS = 10
+_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
+_FILE_SIZE_BYTES = 1024 * 1024
 _STDOUT_LIMIT = 128_000_000
 _STDERR_LIMIT = 4096
+
+_STRATEGIES = ("ascending", "descending", "complete")
 
 _WORKER_PROGRAM = """\
 import json
@@ -31,37 +46,31 @@ import sys
 from pydantic import ValidationError
 from sympy import Poly, QQ, Symbol, groebner
 
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
+from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
 
-def main() -> None:
-    payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
-    variables = tuple(payload["variables"])
-    symbols = tuple(Symbol(name) for name in variables)
+def _leaves_output_budget(polys) -> bool:
+    aggregate = 0
+    bound = 10**MAX_CANONICAL_RATIONAL_DIGITS
+    for poly in polys:
+        terms = poly.terms()
+        aggregate += len(terms)
+        if aggregate > 1024:
+            return True
+        for monom, coefficient in terms:
+            if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
+                return True
+            if abs(int(coefficient.p)) >= bound or abs(int(coefficient.q)) >= bound:
+                return True
+    return False
+
+
+def _emit_ok(polys, variables) -> None:
     try:
-        generators = []
-        for terms in payload["generators"]:
-            poly = Poly.from_dict(
-                {
-                    tuple(term["exponents"]): QQ(int(term["num"]), int(term["den"]))
-                    for term in terms
-                },
-                *symbols,
-                domain=QQ,
-            )
-            generators.append(poly.as_expr())
-        basis = groebner(
-            generators,
-            *symbols,
-            order=payload["monomial_order"],
-            domain=QQ,
-        )
-        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
-        if sum(len(poly.terms()) for poly in polys) > 1024:
-            print(json.dumps({"status": "exceeded"}))
-            return
         elements = [
-            rational_polynomial_from_sympy(poly, variables) for poly in polys
+            rational_polynomial_from_sympy(poly, tuple(variables)) for poly in polys
         ]
     except ValidationError:
         print(json.dumps({"status": "exceeded"}))
@@ -75,21 +84,92 @@ def main() -> None:
     }))
 
 
+def main() -> None:
+    payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    variables = tuple(payload["variables"])
+    symbols = tuple(Symbol(name) for name in variables)
+    strategy = payload["strategy"]
+    try:
+        generators = []
+        for terms in payload["generators"]:
+            poly = Poly.from_dict(
+                {
+                    tuple(term["exponents"]): QQ(int(term["num"]), int(term["den"]))
+                    for term in terms
+                },
+                *symbols,
+                domain=QQ,
+            )
+            generators.append(poly.as_expr())
+    except Exception:
+        print(json.dumps({"status": "failed"}))
+        return
+
+    if strategy == "complete":
+        try:
+            basis = groebner(
+                generators, *symbols,
+                order=payload["monomial_order"], domain=QQ,
+            )
+        except Exception:
+            print(json.dumps({"status": "failed"}))
+            return
+        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
+        if _leaves_output_budget(polys):
+            print(json.dumps({"status": "exceeded"}))
+            return
+        _emit_ok(polys, variables)
+        return
+
+    indices = range(len(generators))
+    ordered = indices if strategy == "ascending" else reversed(indices)
+    current = []
+    last = len(generators) - 1
+    for position, index in enumerate(ordered):
+        current.append(generators[index])
+        try:
+            basis = groebner(
+                current, *symbols,
+                order=payload["monomial_order"], domain=QQ,
+            )
+        except Exception:
+            print(json.dumps({"status": "failed"}))
+            return
+        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
+        if not _leaves_output_budget(polys):
+            continue
+        if position == last:
+            # The complete generating set was submitted: this basis is the
+            # unique reduced basis of the ideal, so the overflow is real.
+            print(json.dumps({"status": "exceeded"}))
+            return
+        print(json.dumps({"status": "aborted"}))
+        return
+    _emit_ok(polys, variables)
+
+
 main()
 """
+
+
+WorkerStatus = Literal["ok", "exceeded", "aborted", "failed", "unavailable"]
 
 
 def complete_basis_in_worker(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
-) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
-    """Run the unguarded kernel once and return its wire basis or evidence.
+    strategy: str,
+) -> tuple[WorkerStatus, tuple[RationalPolynomial, ...] | None]:
+    """Run one bounded kernel attempt and report its outcome.
 
-    Returns ``(basis, False)`` when the worker concluded within every
-    output budget, ``(None, True)`` when it decided the complete reduced
-    basis against those budgets — sound evidence for the typed budget
-    outcome — and ``(None, False)`` on timeout, kill, or failure, where no
-    conclusion exists.
+    ``strategy`` selects the generator order: ``ascending`` and
+    ``descending`` run the guarded incremental construction over content-
+    derived orders, while ``complete`` submits the whole generating set to
+    one unguarded call where Buchberger sees every collapsing pair from
+    the start.  Returns ``("ok", basis)`` when the attempt concluded
+    within every output budget, ``("exceeded", None)`` for evidenced
+    complete-basis overflow, and ``("aborted"|"failed"|"unavailable",
+    None)`` when the attempt yields no mathematical conclusion.
     """
 
     from pydantic import ValidationError
@@ -97,6 +177,7 @@ def complete_basis_in_worker(
     payload = {
         "variables": list(ideal.variables),
         "monomial_order": monomial_order,
+        "strategy": strategy,
         "generators": [
             [
                 {
@@ -109,6 +190,9 @@ def complete_basis_in_worker(
             for generator in ideal.generators
         ],
     }
+    prlimit = shutil.which("prlimit")
+    if prlimit is not None:
+        prlimit = str(Path(prlimit).resolve())
     try:
         completed = run_bounded_process(
             [sys.executable, "-c", _WORKER_PROGRAM],
@@ -117,20 +201,26 @@ def complete_basis_in_worker(
             environment=worker_environment(),
             stdout_limit=_STDOUT_LIMIT,
             stderr_limit=_STDERR_LIMIT,
+            resource_limits=ProcessResourceLimits(
+                cpu_seconds=_CPU_SECONDS,
+                address_space_bytes=_ADDRESS_SPACE_BYTES,
+                file_size_bytes=_FILE_SIZE_BYTES,
+            ),
+            platform_tools=ProcessPlatformTools(prlimit_executable=prlimit),
         )
     except Exception:
-        return None, False
+        return "unavailable", None
     if completed.timed_out or completed.cancelled or completed.returncode != 0:
-        return None, False
+        return "unavailable", None
     try:
         report = json.loads(completed.stdout.decode("utf-8"))
     except Exception:
-        return None, False
+        return "unavailable", None
     status = report.get("status")
-    if status == "exceeded":
-        return None, True
+    if status in ("exceeded", "aborted", "failed"):
+        return status, None
     if status != "ok":
-        return None, False
+        return "unavailable", None
     try:
         basis = tuple(
             RationalPolynomial.model_validate(element) for element in report["basis"]
@@ -138,8 +228,8 @@ def complete_basis_in_worker(
     except (ValidationError, TypeError, KeyError, ValueError):
         # A declared basis outside the canonical contract is evidence for
         # no conclusion.
-        return None, False
-    return basis, False
+        return "unavailable", None
+    return "ok", basis
 
 
-__all__ = ["complete_basis_in_worker"]
+__all__ = ["WorkerStatus", "complete_basis_in_worker"]

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -34,8 +34,8 @@ from jacobian.process import (
     worker_environment,
 )
 
-_TIMEOUT_SECONDS = 10.0
-_CPU_SECONDS = 10
+_TIMEOUT_SECONDS = 60.0
+_CPU_SECONDS = 60
 _ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
 _FILE_SIZE_BYTES = 1024 * 1024
 _STDOUT_LIMIT = 128_000_000

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -1,0 +1,145 @@
+"""Bounded killable SymPy-kernel worker for complete Gröbner bases.
+
+Both guarded incremental strategies can abort while one unguarded kernel
+call over the complete generating set still finishes quickly: Buchberger
+sees every ideal-collapsing pair from the start, so it need never
+materialize the exploding intermediate bases of any prefix.  The kernel
+cannot bound itself, so this owner runs it killably in a subprocess with
+a wall clock; a timeout, kill, or failure yields no mathematical
+conclusion.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialIdeal,
+)
+from jacobian.process import run_bounded_process, worker_environment
+
+_TIMEOUT_SECONDS = 10.0
+_STDOUT_LIMIT = 128_000_000
+_STDERR_LIMIT = 4096
+
+_WORKER_PROGRAM = """\
+import json
+import sys
+
+from pydantic import ValidationError
+from sympy import Poly, QQ, Symbol, groebner
+
+from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    variables = tuple(payload["variables"])
+    symbols = tuple(Symbol(name) for name in variables)
+    try:
+        generators = []
+        for terms in payload["generators"]:
+            poly = Poly.from_dict(
+                {
+                    tuple(term["exponents"]): QQ(int(term["num"]), int(term["den"]))
+                    for term in terms
+                },
+                *symbols,
+                domain=QQ,
+            )
+            generators.append(poly.as_expr())
+        basis = groebner(
+            generators,
+            *symbols,
+            order=payload["monomial_order"],
+            domain=QQ,
+        )
+        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
+        if sum(len(poly.terms()) for poly in polys) > 1024:
+            print(json.dumps({"status": "exceeded"}))
+            return
+        elements = [
+            rational_polynomial_from_sympy(poly, variables) for poly in polys
+        ]
+    except ValidationError:
+        print(json.dumps({"status": "exceeded"}))
+        return
+    except Exception:
+        print(json.dumps({"status": "failed"}))
+        return
+    print(json.dumps({
+        "status": "ok",
+        "basis": [element.model_dump() for element in elements],
+    }))
+
+
+main()
+"""
+
+
+def complete_basis_in_worker(
+    ideal: RationalPolynomialIdeal,
+    monomial_order: str,
+) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
+    """Run the unguarded kernel once and return its wire basis or evidence.
+
+    Returns ``(basis, False)`` when the worker concluded within every
+    output budget, ``(None, True)`` when it decided the complete reduced
+    basis against those budgets — sound evidence for the typed budget
+    outcome — and ``(None, False)`` on timeout, kill, or failure, where no
+    conclusion exists.
+    """
+
+    from pydantic import ValidationError
+
+    payload = {
+        "variables": list(ideal.variables),
+        "monomial_order": monomial_order,
+        "generators": [
+            [
+                {
+                    "exponents": list(term.exponents),
+                    "num": term.coefficient.num,
+                    "den": term.coefficient.den,
+                }
+                for term in generator.polynomial.terms
+            ]
+            for generator in ideal.generators
+        ],
+    }
+    try:
+        completed = run_bounded_process(
+            [sys.executable, "-c", _WORKER_PROGRAM],
+            input_bytes=json.dumps(payload).encode("utf-8"),
+            timeout_seconds=_TIMEOUT_SECONDS,
+            environment=worker_environment(),
+            stdout_limit=_STDOUT_LIMIT,
+            stderr_limit=_STDERR_LIMIT,
+        )
+    except Exception:
+        return None, False
+    if completed.timed_out or completed.cancelled or completed.returncode != 0:
+        return None, False
+    try:
+        report = json.loads(completed.stdout.decode("utf-8"))
+    except Exception:
+        return None, False
+    status = report.get("status")
+    if status == "exceeded":
+        return None, True
+    if status != "ok":
+        return None, False
+    try:
+        basis = tuple(
+            RationalPolynomial.model_validate(element) for element in report["basis"]
+        )
+    except (ValidationError, TypeError, KeyError, ValueError):
+        # A declared basis outside the canonical contract is evidence for
+        # no conclusion.
+        return None, False
+    return basis, False
+
+
+__all__ = ["complete_basis_in_worker"]

--- a/src/jacobian/math/polynomials/_groebner_worker.py
+++ b/src/jacobian/math/polynomials/_groebner_worker.py
@@ -155,6 +155,27 @@ main()
 WorkerStatus = Literal["ok", "exceeded", "aborted", "failed", "unavailable"]
 
 
+class GroebnerWorkerError(RuntimeError):
+    """Base class for worker transport failures.
+
+    These are execution/deployment faults, not mathematical conclusions: a
+    caller cannot treat them as evidence about the ideal, so they surface as
+    typed failures instead of being projected into a domain status.
+    """
+
+
+class GroebnerWorkerLaunchError(GroebnerWorkerError):
+    """The worker process could not be launched (deployment failure)."""
+
+
+class GroebnerWorkerCancelledError(GroebnerWorkerError):
+    """The worker was cancelled before it could report any outcome."""
+
+
+class GroebnerWorkerExecutionError(GroebnerWorkerError):
+    """The worker ran but exited without a parseable, well-formed report."""
+
+
 def complete_basis_in_worker(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
@@ -168,8 +189,13 @@ def complete_basis_in_worker(
     one unguarded call where Buchberger sees every collapsing pair from
     the start.  Returns ``("ok", basis)`` when the attempt concluded
     within every output budget, ``("exceeded", None)`` for evidenced
-    complete-basis overflow, and ``("aborted"|"failed"|"unavailable",
-    None)`` when the attempt yields no mathematical conclusion.
+    complete-basis overflow, ``("aborted"|"failed", None)`` when the attempt
+    self-reports no conclusion, and ``("unavailable", None)`` when the hard
+    wall-clock safety net expires on a runaway attempt. Launch failures,
+    cancellation, and malformed worker exits are execution/deployment faults,
+    not mathematical conclusions: they raise their typed
+    ``GroebnerWorkerError`` subclasses instead of collapsing into a domain
+    status.
     """
 
     from pydantic import ValidationError
@@ -208,28 +234,47 @@ def complete_basis_in_worker(
             ),
             platform_tools=ProcessPlatformTools(prlimit_executable=prlimit),
         )
-    except Exception:
+    except OSError as error:
+        raise GroebnerWorkerLaunchError(str(error)) from None
+    if completed.cancelled:
+        raise GroebnerWorkerCancelledError(
+            "groebner worker was cancelled before reporting"
+        )
+    if completed.timed_out:
+        # The hard wall-clock safety net expired on a runaway attempt: the
+        # worker produced no report, so there is no conclusion either way
+        # about the ideal (a mathematically hard request).
         return "unavailable", None
-    if completed.timed_out or completed.cancelled or completed.returncode != 0:
-        return "unavailable", None
+    if completed.returncode != 0:
+        raise GroebnerWorkerExecutionError(
+            f"groebner worker exited with returncode "
+            f"{completed.returncode} without a report"
+        )
     try:
         report = json.loads(completed.stdout.decode("utf-8"))
-    except Exception:
-        return "unavailable", None
+    except Exception as error:
+        raise GroebnerWorkerExecutionError(str(error)) from None
     status = report.get("status")
     if status in ("exceeded", "aborted", "failed"):
         return status, None
     if status != "ok":
-        return "unavailable", None
+        raise GroebnerWorkerExecutionError(f"unknown worker status {status!r}")
     try:
         basis = tuple(
             RationalPolynomial.model_validate(element) for element in report["basis"]
         )
-    except (ValidationError, TypeError, KeyError, ValueError):
-        # A declared basis outside the canonical contract is evidence for
-        # no conclusion.
-        return "unavailable", None
+    except (ValidationError, TypeError, KeyError, ValueError) as error:
+        # A declared basis outside the canonical contract is a worker fault,
+        # not evidence about the ideal.
+        raise GroebnerWorkerExecutionError(str(error)) from None
     return "ok", basis
 
 
-__all__ = ["WorkerStatus", "complete_basis_in_worker"]
+__all__ = [
+    "GroebnerWorkerCancelledError",
+    "GroebnerWorkerError",
+    "GroebnerWorkerExecutionError",
+    "GroebnerWorkerLaunchError",
+    "WorkerStatus",
+    "complete_basis_in_worker",
+]

--- a/src/jacobian/math/polynomials/_invariants.py
+++ b/src/jacobian/math/polynomials/_invariants.py
@@ -266,21 +266,24 @@ POLYNOMIAL_INVARIANT_OPERATIONS = (
                 "membership_x_squared",
                 "Decide if x lies in <x^2> in Q[x].",
                 {
-                    "generators": [
-                        {
-                            "polynomial_schema_version": "1",
-                            "domain": "QQ",
-                            "variables": ["x"],
-                            "polynomial": {
-                                "terms": [
-                                    {
-                                        "coefficient": {"num": "1", "den": "1"},
-                                        "exponents": [2],
-                                    },
-                                ],
+                    "ideal": {
+                        "variables": ["x"],
+                        "generators": [
+                            {
+                                "polynomial_schema_version": "1",
+                                "domain": "QQ",
+                                "variables": ["x"],
+                                "polynomial": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [2],
+                                        },
+                                    ],
+                                },
                             },
-                        },
-                    ],
+                        ],
+                    },
                     "polynomial": {
                         "polynomial_schema_version": "1",
                         "domain": "QQ",
@@ -314,21 +317,24 @@ POLYNOMIAL_INVARIANT_OPERATIONS = (
                 "normal_form_x_mod_x_squared",
                 "Reduce x modulo <x^2> in Q[x]; the remainder is x.",
                 {
-                    "generators": [
-                        {
-                            "polynomial_schema_version": "1",
-                            "domain": "QQ",
-                            "variables": ["x"],
-                            "polynomial": {
-                                "terms": [
-                                    {
-                                        "coefficient": {"num": "1", "den": "1"},
-                                        "exponents": [2],
-                                    },
-                                ],
+                    "ideal": {
+                        "variables": ["x"],
+                        "generators": [
+                            {
+                                "polynomial_schema_version": "1",
+                                "domain": "QQ",
+                                "variables": ["x"],
+                                "polynomial": {
+                                    "terms": [
+                                        {
+                                            "coefficient": {"num": "1", "den": "1"},
+                                            "exponents": [2],
+                                        },
+                                    ],
+                                },
                             },
-                        },
-                    ],
+                        ],
+                    },
                     "polynomial": {
                         "polynomial_schema_version": "1",
                         "domain": "QQ",

--- a/src/jacobian/math/polynomials/_invariants.py
+++ b/src/jacobian/math/polynomials/_invariants.py
@@ -264,7 +264,11 @@ POLYNOMIAL_INVARIANT_OPERATIONS = (
         examples=(
             example(
                 "membership_x_squared",
-                "Decide if x lies in <x^2> in Q[x].",
+                "Decide if x lies in <x^2> in Q[x]; the ideal and "
+                "polynomial must share one identical ordered QQ ring, with "
+                "at most 16 generators of per-term total degree at most 12, "
+                "at most 1,024 queried polynomial terms, and coefficient "
+                "components of at most 128 digits.",
                 {
                     "ideal": {
                         "variables": ["x"],
@@ -315,7 +319,11 @@ POLYNOMIAL_INVARIANT_OPERATIONS = (
         examples=(
             example(
                 "normal_form_x_mod_x_squared",
-                "Reduce x modulo <x^2> in Q[x]; the remainder is x.",
+                "Reduce x modulo <x^2> in Q[x]; the ideal and polynomial "
+                "must share one identical ordered QQ ring, with at most 16 "
+                "generators of per-term total degree at most 12, at most "
+                "1,024 queried polynomial terms, and coefficient components "
+                "of at most 128 digits.",
                 {
                     "ideal": {
                         "variables": ["x"],

--- a/src/jacobian/math/polynomials/_invariants.py
+++ b/src/jacobian/math/polynomials/_invariants.py
@@ -2,6 +2,9 @@
 
 from jacobian.catalog._examples import example
 from jacobian.math.polynomials._models import (
+    IdealMembershipRequest,
+    IdealMembershipResult,
+    IdealNormalFormResult,
     PolynomialDiscriminantRequest,
     PolynomialDiscriminantResult,
     PolynomialFactorizationResult,
@@ -17,6 +20,8 @@ from jacobian.math.polynomials._operations import (
     polynomial_discriminant,
     polynomial_factorization,
     polynomial_gcd,
+    polynomial_ideal_membership,
+    polynomial_ideal_normal_form,
     polynomial_resultant,
     polynomial_square_free_decomposition,
 )
@@ -240,6 +245,103 @@ POLYNOMIAL_INVARIANT_OPERATIONS = (
                             ]
                         },
                     }
+                },
+            ),
+        ),
+    ),
+    polynomial_operation(
+        "polynomial.ideal.membership.decide",
+        "Decide ideal membership and return the normal form",
+        "Decide whether a bounded rational polynomial lies in a bounded "
+        "ideal over QQ, and return the canonical remainder modulo the "
+        "ideal under an explicit monomial order.",
+        IdealMembershipRequest,
+        IdealMembershipResult,
+        polynomial_ideal_membership,
+        "ideal-membership",
+        "normal-form",
+        "exact",
+        examples=(
+            example(
+                "membership_x_squared",
+                "Decide if x lies in <x^2> in Q[x].",
+                {
+                    "generators": [
+                        {
+                            "polynomial_schema_version": "1",
+                            "domain": "QQ",
+                            "variables": ["x"],
+                            "polynomial": {
+                                "terms": [
+                                    {
+                                        "coefficient": {"num": "1", "den": "1"},
+                                        "exponents": [2],
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1],
+                                },
+                            ],
+                        },
+                    },
+                },
+            ),
+        ),
+    ),
+    polynomial_operation(
+        "polynomial.ideal.normal_form.compute",
+        "Reduce a polynomial modulo an ideal",
+        "Compute the canonical remainder of a bounded rational polynomial "
+        "modulo a bounded ideal over QQ under an explicit monomial order.",
+        IdealMembershipRequest,
+        IdealNormalFormResult,
+        polynomial_ideal_normal_form,
+        "normal-form",
+        "ideal",
+        "exact",
+        examples=(
+            example(
+                "normal_form_x_mod_x_squared",
+                "Reduce x modulo <x^2> in Q[x]; the remainder is x.",
+                {
+                    "generators": [
+                        {
+                            "polynomial_schema_version": "1",
+                            "domain": "QQ",
+                            "variables": ["x"],
+                            "polynomial": {
+                                "terms": [
+                                    {
+                                        "coefficient": {"num": "1", "den": "1"},
+                                        "exponents": [2],
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    "polynomial": {
+                        "polynomial_schema_version": "1",
+                        "domain": "QQ",
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [1],
+                                },
+                            ],
+                        },
+                    },
                 },
             ),
         ),

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -404,8 +404,10 @@ class IdealMembershipRequest(StrictModel):
     Accepts the domain-owned canonical ``RationalPolynomialIdeal`` value so
     serialized ideals compose without unpacking.  The ideal is bounded to 16
     generators with total degree at most 12 and the request polynomial to
-    1,024 terms so the bounded backend work cannot expand into an
-    unrepresentable exact result without the typed budget outcome.
+    1,024 terms, per-term total degree at most 12, and coefficient
+    components of at most 128 digits, so the bounded backend work cannot
+    expand into an unrepresentable exact result without the typed budget
+    outcome.
     """
 
     ideal: RationalPolynomialIdeal = Field(
@@ -416,7 +418,14 @@ class IdealMembershipRequest(StrictModel):
             "128 digits."
         ),
     )
-    polynomial: RationalPolynomial
+    polynomial: RationalPolynomial = Field(
+        description=(
+            "The queried polynomial in the ideal's ring: at most 1,024 "
+            "terms, per-term total degree at most 12, and coefficient "
+            "components of at most 128 digits; requests outside these "
+            "operation-specific limits are rejected."
+        ),
+    )
     monomial_order: Literal["lex", "grlex", "grevlex"] = "grevlex"
 
     @model_validator(mode="after")

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -334,16 +334,9 @@ _IDEAL_GENERATOR_TOTAL_DEGREE = 12
 """Total-degree cap per ideal generator term; subsumes each variable's exponent."""
 
 
-def _validate_membership_source(
-    ideal: RationalPolynomialIdeal, polynomial: RationalPolynomial
-) -> None:
-    """Apply the advertised ideal-membership work budgets to source values."""
+def _require_ideal_generator_budget(ideal: RationalPolynomialIdeal) -> None:
+    """Apply the advertised per-generator admission limits."""
 
-    variables = ideal.variables
-    if any(gen.variables != variables for gen in ideal.generators):
-        raise ValueError("all ideal generators must use the same ordered ring")
-    if polynomial.variables != variables:
-        raise ValueError("polynomial must use the same ordered ring as the ideal")
     if len(ideal.generators) > _IDEAL_GENERATOR_COUNT_LIMIT:
         raise ValueError(
             f"ideal exceeds the {_IDEAL_GENERATOR_COUNT_LIMIT}-generator operation budget"
@@ -364,9 +357,16 @@ def _validate_membership_source(
                     "ideal generator degree exceeds the "
                     f"{_IDEAL_GENERATOR_TOTAL_DEGREE}-total-degree operation budget"
                 )
-    # The normal form of the zero ideal is the input polynomial itself;
-    # cap the input at the 1,024-term result boundary so an accepted
-    # request can never leak a result-budget host exception.
+
+
+def _require_queried_polynomial_budget(polynomial: RationalPolynomial) -> None:
+    """Apply the advertised queried-polynomial admission limits.
+
+    The normal form of the zero ideal is the input polynomial itself;
+    cap the input at the 1,024-term result boundary so an accepted
+    request can never leak a result-budget host exception.
+    """
+
     if len(polynomial.polynomial.terms) > _MAX_RESULT_POLYNOMIAL_TERMS:
         raise ValueError("polynomial exceeds the 1,024-term exact-result limit")
     require_polynomial_budget(
@@ -386,6 +386,20 @@ def _validate_membership_source(
             )
 
 
+def _validate_membership_source(
+    ideal: RationalPolynomialIdeal, polynomial: RationalPolynomial
+) -> None:
+    """Apply the advertised ideal-membership work budgets to source values."""
+
+    variables = ideal.variables
+    if any(gen.variables != variables for gen in ideal.generators):
+        raise ValueError("all ideal generators must use the same ordered ring")
+    if polynomial.variables != variables:
+        raise ValueError("polynomial must use the same ordered ring as the ideal")
+    _require_ideal_generator_budget(ideal)
+    _require_queried_polynomial_budget(polynomial)
+
+
 def _validate_retained_basis(
     groebner_basis: tuple[RationalPolynomial, ...] | None,
     variables: tuple[PolynomialVariable, ...],
@@ -403,7 +417,9 @@ def _validate_retained_basis(
     if any(not element.polynomial.terms for element in groebner_basis):
         raise ValueError("retained Gröbner basis must contain nonzero polynomials only")
     if sum(len(element.polynomial.terms) for element in groebner_basis) > 1024:
-        raise ValueError("retained Gröbner basis exceeds the aggregate output term limit")
+        raise ValueError(
+            "retained Gröbner basis exceeds the aggregate output term limit"
+        )
 
 
 class IdealMembershipRequest(StrictModel):
@@ -442,6 +458,55 @@ class IdealMembershipRequest(StrictModel):
         return self
 
 
+def _require_authentic_retained_basis(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    monomial_order: str,
+) -> None:
+    """Check the retained basis spans the ideal and is its reduced basis.
+
+    One kernel replay substantiates authenticity: equality with the
+    recomputed reduced Gröbner basis subsumes membership of every
+    retained element in the source ideal.
+    """
+
+    if not generators_reduce_to_zero(ideal, groebner_basis, monomial_order):
+        raise ValueError("retained basis does not reduce every ideal generator to zero")
+    if not retained_basis_is_groebner(ideal, groebner_basis, monomial_order):
+        raise ValueError("retained basis is not the Gröbner basis of the source ideal")
+
+
+def _require_substantiated_budget_outcome(
+    ideal: RationalPolynomialIdeal,
+    polynomial: RationalPolynomial,
+    groebner_basis: tuple[RationalPolynomial, ...] | None,
+    monomial_order: str,
+) -> None:
+    """Require kernel evidence for a ``BUDGET_EXCEEDED`` outcome.
+
+    With a retained basis, that basis must be authentic and its replayed
+    reduction must genuinely overflow.  A stripped result is accepted only
+    when the recomputed source Gröbner basis itself leaves the output
+    budget.
+    """
+
+    if groebner_basis is None:
+        if not retained_source_basis_exceeds_budget(ideal, monomial_order):
+            raise ValueError(
+                "BUDGET_EXCEEDED without a retained basis requires the "
+                "source basis to exceed the output budget"
+            )
+        return
+    _require_authentic_retained_basis(ideal, groebner_basis, monomial_order)
+    if not replayed_remainder_exceeds_budget(
+        ideal,
+        groebner_basis,
+        polynomial,
+        monomial_order,
+    ):
+        raise ValueError("BUDGET_EXCEEDED contradicts an in-budget replayed reduction")
+
+
 class IdealNormalFormResult(StrictModel):
     """The canonical remainder of one polynomial modulo an ideal.
 
@@ -463,72 +528,35 @@ class IdealNormalFormResult(StrictModel):
     def require_replayable_reduction(self) -> Self:
         _validate_membership_source(self.ideal, self.polynomial)
         _validate_retained_basis(self.groebner_basis, self.ideal.variables)
-        if self.status == "COMPUTED":
-            if self.groebner_basis is None or self.remainder is None:
-                raise ValueError(
-                    "COMPUTED requires both the retained basis and the remainder"
-                )
-            if self.remainder.variables != self.ideal.variables:
-                raise ValueError("remainder must use the same ring as the ideal")
-            if not generators_reduce_to_zero(
-                self.ideal, self.groebner_basis, self.monomial_order
-            ):
-                raise ValueError(
-                    "retained basis does not reduce every ideal generator to zero"
-                )
-            # One kernel run substantiates authenticity: equality with the
-            # recomputed reduced Gröbner basis subsumes membership of every
-            # retained element in the source ideal.
-            if not retained_basis_is_groebner(
-                self.ideal, self.groebner_basis, self.monomial_order
-            ):
-                raise ValueError("retained basis is not the Gröbner basis of the source ideal")
-            if not remainder_matches_claim(
-                self.ideal,
-                self.groebner_basis,
-                self.polynomial,
-                self.monomial_order,
-                self.remainder,
-            ):
-                raise ValueError(
-                    "remainder does not replay against the retained Gröbner basis"
-                )
-        else:
+        if self.status == "BUDGET_EXCEEDED":
             if self.remainder is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a remainder")
-            if self.groebner_basis is not None:
-                if not generators_reduce_to_zero(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained basis does not reduce every ideal generator to zero"
-                    )
-                if not retained_basis_is_groebner(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained basis is not the Gröbner basis of the source ideal"
-                    )
-                if not replayed_remainder_exceeds_budget(
-                    self.ideal,
-                    self.groebner_basis,
-                    self.polynomial,
-                    self.monomial_order,
-                ):
-                    raise ValueError(
-                        "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
-                    )
-            else:
-                # A budget outcome without a retained basis is only
-                # substantiated when the recomputed source Gröbner basis
-                # itself leaves the output budget.
-                if not retained_source_basis_exceeds_budget(
-                    self.ideal, self.monomial_order
-                ):
-                    raise ValueError(
-                        "BUDGET_EXCEEDED without a retained basis requires the "
-                        "source basis to exceed the output budget"
-                    )
+            _require_substantiated_budget_outcome(
+                self.ideal,
+                self.polynomial,
+                self.groebner_basis,
+                self.monomial_order,
+            )
+            return self
+        if self.groebner_basis is None or self.remainder is None:
+            raise ValueError(
+                "COMPUTED requires both the retained basis and the remainder"
+            )
+        if self.remainder.variables != self.ideal.variables:
+            raise ValueError("remainder must use the same ring as the ideal")
+        _require_authentic_retained_basis(
+            self.ideal, self.groebner_basis, self.monomial_order
+        )
+        if not remainder_matches_claim(
+            self.ideal,
+            self.groebner_basis,
+            self.polynomial,
+            self.monomial_order,
+            self.remainder,
+        ):
+            raise ValueError(
+                "remainder does not replay against the retained Gröbner basis"
+            )
         return self
 
 
@@ -557,39 +585,12 @@ class IdealMembershipResult(StrictModel):
         if self.status == "BUDGET_EXCEEDED":
             if self.normal_form is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a normal form")
-            if self.groebner_basis is not None:
-                if not generators_reduce_to_zero(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained basis does not reduce every ideal generator to zero"
-                    )
-                if not retained_basis_is_groebner(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained basis is not the Gröbner basis of the source ideal"
-                    )
-                if not replayed_remainder_exceeds_budget(
-                    self.ideal,
-                    self.groebner_basis,
-                    self.polynomial,
-                    self.monomial_order,
-                ):
-                    raise ValueError(
-                        "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
-                    )
-            else:
-                # A budget outcome without a retained basis is only
-                # substantiated when the recomputed source Gröbner basis
-                # itself leaves the output budget.
-                if not retained_source_basis_exceeds_budget(
-                    self.ideal, self.monomial_order
-                ):
-                    raise ValueError(
-                        "BUDGET_EXCEEDED without a retained basis requires the "
-                        "source basis to exceed the output budget"
-                    )
+            _require_substantiated_budget_outcome(
+                self.ideal,
+                self.polynomial,
+                self.groebner_basis,
+                self.monomial_order,
+            )
             return self
         if self.groebner_basis is None or self.normal_form is None:
             raise ValueError(f"{self.status} requires the basis and the normal form")
@@ -598,16 +599,9 @@ class IdealMembershipResult(StrictModel):
         normal_form_is_zero = not self.normal_form.polynomial.terms
         if (self.status == "IN_IDEAL") is not normal_form_is_zero:
             raise ValueError("status must equal (normal_form == 0)")
-        if not generators_reduce_to_zero(
+        _require_authentic_retained_basis(
             self.ideal, self.groebner_basis, self.monomial_order
-        ):
-            raise ValueError(
-                "retained basis does not reduce every ideal generator to zero"
-            )
-        if not retained_basis_is_groebner(
-            self.ideal, self.groebner_basis, self.monomial_order
-        ):
-            raise ValueError("retained basis is not the Gröbner basis of the source ideal")
+        )
         if not remainder_matches_claim(
             self.ideal,
             self.groebner_basis,

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -316,6 +316,54 @@ class PolynomialGroebnerBasisResult(StrictModel):
         return self
 
 
+class IdealMembershipRequest(StrictModel):
+    """Decide membership of one polynomial in a bounded polynomial ideal."""
+
+    generators: tuple[RationalPolynomial, ...] = Field(min_length=1, max_length=16)
+    polynomial: RationalPolynomial
+    monomial_order: Literal["lex", "grlex", "grevlex"] = "grevlex"
+
+    @model_validator(mode="after")
+    def require_matching_rings(self) -> Self:
+        variables = self.generators[0].variables
+        if any(gen.variables != variables for gen in self.generators):
+            raise ValueError("all ideal generators must use the same ordered ring")
+        if self.polynomial.variables != variables:
+            raise ValueError("polynomial must use the same ordered ring as the ideal")
+        if sum(len(gen.polynomial.terms) for gen in self.generators) > 256:
+            raise ValueError("ideal generators exceed the aggregate term budget")
+        for gen in self.generators:
+            require_polynomial_budget(
+                gen,
+                maximum_terms=MAX_POLYNOMIAL_TERMS,
+                maximum_exponent=12,
+                maximum_coefficient_digits=128,
+                label="ideal generator",
+            )
+        require_polynomial_budget(
+            self.polynomial,
+            maximum_terms=MAX_POLYNOMIAL_TERMS,
+            maximum_exponent=12,
+            maximum_coefficient_digits=128,
+            label="polynomial",
+        )
+        return self
+
+
+class IdealNormalFormResult(StrictModel):
+    """The canonical remainder of one polynomial modulo an ideal."""
+
+    remainder: RationalPolynomial
+    monomial_order: Literal["lex", "grlex", "grevlex"]
+
+
+class IdealMembershipResult(StrictModel):
+    """Whether a polynomial lies in an ideal, with the normal form."""
+
+    in_ideal: bool
+    normal_form: RationalPolynomial
+
+
 class IntegerPolynomial(StrictModel):
     """Canonical dense polynomial in ``ZZ[x]``, highest degree first."""
 
@@ -526,6 +574,9 @@ class RationalPartialFractionResult(StrictModel):
 
 
 __all__ = [
+    "IdealMembershipRequest",
+    "IdealMembershipResult",
+    "IdealNormalFormResult",
     "IntegerPolynomial",
     "IntegerPolynomialCompositionRequest",
     "IntegerPolynomialCompositionResult",

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -360,9 +360,7 @@ class IdealMembershipRequest(StrictModel):
         # cap the input at the 1,024-term result boundary so an accepted
         # request can never leak a result-budget host exception.
         if len(self.polynomial.polynomial.terms) > _MAX_RESULT_POLYNOMIAL_TERMS:
-            raise ValueError(
-                "polynomial exceeds the 1,024-term exact-result limit"
-            )
+            raise ValueError("polynomial exceeds the 1,024-term exact-result limit")
         require_polynomial_budget(
             self.polynomial,
             maximum_terms=MAX_POLYNOMIAL_TERMS,
@@ -395,9 +393,7 @@ class IdealMembershipResult(StrictModel):
     def bind_membership_to_normal_form(self) -> Self:
         remainder_is_zero = not self.normal_form.polynomial.terms
         if self.in_ideal is not remainder_is_zero:
-            raise ValueError(
-                "in_ideal must equal (normal_form == 0)"
-            )
+            raise ValueError("in_ideal must equal (normal_form == 0)")
         return self
 
 

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -12,6 +12,11 @@ from jacobian._exact import (
     CanonicalRational,
 )
 from jacobian._models import StrictModel
+from jacobian.math.polynomials._replay import (
+    generators_reduce_to_zero,
+    remainder_matches_claim,
+    replayed_remainder_term_count,
+)
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_TERMS,
     MAX_POLYNOMIAL_VARIABLES,
@@ -320,20 +325,91 @@ class PolynomialGroebnerBasisResult(StrictModel):
         return self
 
 
+_IDEAL_GENERATOR_COUNT_LIMIT = 16
+"""Generators admitted per ideal-membership request, matching the description."""
+
+_IDEAL_GENERATOR_TOTAL_DEGREE = 12
+"""Total-degree cap per ideal generator term; subsumes each variable's exponent."""
+
+
+def _validate_membership_source(
+    ideal: RationalPolynomialIdeal, polynomial: RationalPolynomial
+) -> None:
+    """Apply the advertised ideal-membership work budgets to source values."""
+
+    variables = ideal.variables
+    if any(gen.variables != variables for gen in ideal.generators):
+        raise ValueError("all ideal generators must use the same ordered ring")
+    if polynomial.variables != variables:
+        raise ValueError("polynomial must use the same ordered ring as the ideal")
+    if len(ideal.generators) > _IDEAL_GENERATOR_COUNT_LIMIT:
+        raise ValueError(
+            f"ideal exceeds the {_IDEAL_GENERATOR_COUNT_LIMIT}-generator operation budget"
+        )
+    if sum(len(gen.polynomial.terms) for gen in ideal.generators) > 256:
+        raise ValueError("ideal generators exceed the aggregate term budget")
+    for gen in ideal.generators:
+        require_polynomial_budget(
+            gen,
+            maximum_terms=MAX_POLYNOMIAL_TERMS,
+            maximum_exponent=_IDEAL_GENERATOR_TOTAL_DEGREE,
+            maximum_coefficient_digits=128,
+            label="ideal generator",
+        )
+        for term in gen.polynomial.terms:
+            if sum(term.exponents) > _IDEAL_GENERATOR_TOTAL_DEGREE:
+                raise ValueError(
+                    "ideal generator degree exceeds the "
+                    f"{_IDEAL_GENERATOR_TOTAL_DEGREE}-total-degree operation budget"
+                )
+    # The normal form of the zero ideal is the input polynomial itself;
+    # cap the input at the 1,024-term result boundary so an accepted
+    # request can never leak a result-budget host exception.
+    if len(polynomial.polynomial.terms) > _MAX_RESULT_POLYNOMIAL_TERMS:
+        raise ValueError("polynomial exceeds the 1,024-term exact-result limit")
+    require_polynomial_budget(
+        polynomial,
+        maximum_terms=MAX_POLYNOMIAL_TERMS,
+        maximum_exponent=12,
+        maximum_coefficient_digits=128,
+        label="polynomial",
+    )
+
+
+def _validate_retained_basis(
+    groebner_basis: tuple[RationalPolynomial, ...] | None,
+    variables: tuple[PolynomialVariable, ...],
+) -> None:
+    """Check a retained Gröbner basis stays inside the aggregate output budget."""
+
+    if groebner_basis is None:
+        return
+    if not groebner_basis:
+        raise ValueError("retained Gröbner basis must not be empty")
+    if any(element.variables != variables for element in groebner_basis):
+        raise ValueError("every retained basis polynomial must use the declared ring")
+    if any(not element.polynomial.terms for element in groebner_basis):
+        raise ValueError("retained Gröbner basis must contain nonzero polynomials only")
+    if sum(len(element.polynomial.terms) for element in groebner_basis) > 1024:
+        raise ValueError("retained Gröbner basis exceeds the aggregate output term limit")
+
+
 class IdealMembershipRequest(StrictModel):
     """Decide membership of one polynomial in a bounded polynomial ideal.
 
     Accepts the domain-owned canonical ``RationalPolynomialIdeal`` value so
-    serialized ideals compose without unpacking.  The request polynomial is
-    bounded to 1,024 terms because the zero ideal returns it unchanged as
-    the normal form and the exact-result contract caps at 1,024 terms.
+    serialized ideals compose without unpacking.  The ideal is bounded to 16
+    generators with total degree at most 12 and the request polynomial to
+    1,024 terms so the bounded backend work cannot expand into an
+    unrepresentable exact result without the typed budget outcome.
     """
 
     ideal: RationalPolynomialIdeal = Field(
         description=(
             "A bounded polynomial ideal in one ordered QQ ring: at most 16 "
-            "generators with at most 256 aggregate terms, degree at most 12, "
-            "and coefficient components at most 128 digits."
+            "generators with at most 256 aggregate terms, total degree at "
+            "most 12 per generator term, and coefficient components at most "
+            "128 digits."
         ),
     )
     polynomial: RationalPolynomial
@@ -341,59 +417,127 @@ class IdealMembershipRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_matching_rings(self) -> Self:
-        variables = self.ideal.variables
-        if any(gen.variables != variables for gen in self.ideal.generators):
-            raise ValueError("all ideal generators must use the same ordered ring")
-        if self.polynomial.variables != variables:
-            raise ValueError("polynomial must use the same ordered ring as the ideal")
-        if sum(len(gen.polynomial.terms) for gen in self.ideal.generators) > 256:
-            raise ValueError("ideal generators exceed the aggregate term budget")
-        for gen in self.ideal.generators:
-            require_polynomial_budget(
-                gen,
-                maximum_terms=MAX_POLYNOMIAL_TERMS,
-                maximum_exponent=12,
-                maximum_coefficient_digits=128,
-                label="ideal generator",
-            )
-        # The normal form of the zero ideal is the input polynomial itself;
-        # cap the input at the 1,024-term result boundary so an accepted
-        # request can never leak a result-budget host exception.
-        if len(self.polynomial.polynomial.terms) > _MAX_RESULT_POLYNOMIAL_TERMS:
-            raise ValueError("polynomial exceeds the 1,024-term exact-result limit")
-        require_polynomial_budget(
-            self.polynomial,
-            maximum_terms=MAX_POLYNOMIAL_TERMS,
-            maximum_exponent=12,
-            maximum_coefficient_digits=128,
-            label="polynomial",
-        )
+        _validate_membership_source(self.ideal, self.polynomial)
         return self
 
 
 class IdealNormalFormResult(StrictModel):
-    """The canonical remainder of one polynomial modulo an ideal."""
+    """The canonical remainder of one polynomial modulo an ideal.
 
-    remainder: RationalPolynomial
+    The result retains its complete source and the computed Gröbner basis so
+    validation replays the defining reduction relation exactly.  When the
+    exact remainder exceeds the 1,024-term output boundary the status reports
+    ``BUDGET_EXCEEDED`` instead of a mathematical conclusion; no partial
+    remainder is returned.
+    """
+
+    ideal: RationalPolynomialIdeal
+    polynomial: RationalPolynomial
     monomial_order: Literal["lex", "grlex", "grevlex"]
+    status: Literal["COMPUTED", "BUDGET_EXCEEDED"]
+    groebner_basis: tuple[RationalPolynomial, ...] | None
+    remainder: RationalPolynomial | None
+
+    @model_validator(mode="after")
+    def require_replayable_reduction(self) -> Self:
+        _validate_membership_source(self.ideal, self.polynomial)
+        _validate_retained_basis(self.groebner_basis, self.ideal.variables)
+        if self.status == "COMPUTED":
+            if self.groebner_basis is None or self.remainder is None:
+                raise ValueError(
+                    "COMPUTED requires both the retained basis and the remainder"
+                )
+            if self.remainder.variables != self.ideal.variables:
+                raise ValueError("remainder must use the same ring as the ideal")
+            if not generators_reduce_to_zero(
+                self.ideal, self.groebner_basis, self.monomial_order
+            ):
+                raise ValueError(
+                    "retained basis does not reduce every ideal generator to zero"
+                )
+            if not remainder_matches_claim(
+                self.ideal,
+                self.groebner_basis,
+                self.polynomial,
+                self.monomial_order,
+                self.remainder,
+            ):
+                raise ValueError(
+                    "remainder does not replay against the retained Gröbner basis"
+                )
+        else:
+            if self.remainder is not None:
+                raise ValueError("BUDGET_EXCEEDED must not carry a remainder")
+            if self.groebner_basis is not None and replayed_remainder_term_count(
+                self.ideal,
+                self.groebner_basis,
+                self.polynomial,
+                self.monomial_order,
+            ) <= _MAX_RESULT_POLYNOMIAL_TERMS:
+                raise ValueError(
+                    "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
+                )
+        return self
 
 
 class IdealMembershipResult(StrictModel):
     """Whether a polynomial lies in an ideal, with the normal form.
 
-    Membership is defined exactly as the normal form being zero; the two
-    fields are validated against each other so a contradictory payload can
-    never validate.
+    ``IN_IDEAL`` is defined exactly as the normal form being zero and
+    ``NOT_IN_IDEAL`` as it being nonzero; both carry the full defining
+    relation (source ideal, source polynomial, monomial order, computed
+    Gröbner basis) so validation can replay the reduction.  When the exact
+    normal form exceeds the output boundary the status reports
+    ``BUDGET_EXCEEDED`` and asserts no membership conclusion.
     """
 
-    in_ideal: bool
-    normal_form: RationalPolynomial
+    ideal: RationalPolynomialIdeal
+    polynomial: RationalPolynomial
+    monomial_order: Literal["lex", "grlex", "grevlex"]
+    status: Literal["IN_IDEAL", "NOT_IN_IDEAL", "BUDGET_EXCEEDED"]
+    groebner_basis: tuple[RationalPolynomial, ...] | None
+    normal_form: RationalPolynomial | None
 
     @model_validator(mode="after")
-    def bind_membership_to_normal_form(self) -> Self:
-        remainder_is_zero = not self.normal_form.polynomial.terms
-        if self.in_ideal is not remainder_is_zero:
-            raise ValueError("in_ideal must equal (normal_form == 0)")
+    def require_replayable_membership(self) -> Self:
+        _validate_membership_source(self.ideal, self.polynomial)
+        _validate_retained_basis(self.groebner_basis, self.ideal.variables)
+        if self.status == "BUDGET_EXCEEDED":
+            if self.normal_form is not None:
+                raise ValueError("BUDGET_EXCEEDED must not carry a normal form")
+            if self.groebner_basis is not None and replayed_remainder_term_count(
+                self.ideal,
+                self.groebner_basis,
+                self.polynomial,
+                self.monomial_order,
+            ) <= _MAX_RESULT_POLYNOMIAL_TERMS:
+                raise ValueError(
+                    "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
+                )
+            return self
+        if self.groebner_basis is None or self.normal_form is None:
+            raise ValueError(f"{self.status} requires the basis and the normal form")
+        if self.normal_form.variables != self.ideal.variables:
+            raise ValueError("normal form must use the same ring as the ideal")
+        normal_form_is_zero = not self.normal_form.polynomial.terms
+        if (self.status == "IN_IDEAL") is not normal_form_is_zero:
+            raise ValueError("status must equal (normal_form == 0)")
+        if not generators_reduce_to_zero(
+            self.ideal, self.groebner_basis, self.monomial_order
+        ):
+            raise ValueError(
+                "retained basis does not reduce every ideal generator to zero"
+            )
+        if not remainder_matches_claim(
+            self.ideal,
+            self.groebner_basis,
+            self.polynomial,
+            self.monomial_order,
+            self.normal_form,
+        ):
+            raise ValueError(
+                "normal form does not replay against the retained Gröbner basis"
+            )
         return self
 
 

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -514,13 +514,15 @@ class IdealNormalFormResult(StrictModel):
     validation replays the defining reduction relation exactly.  When the
     exact remainder exceeds the 1,024-term output boundary the status reports
     ``BUDGET_EXCEEDED`` instead of a mathematical conclusion; no partial
-    remainder is returned.
+    remainder is returned.  ``UNKNOWN`` reports that the bounded kernel could
+    not complete any strategy within its work bounds and asserts neither a
+    reduction nor a budget overflow; it carries no partial artifact.
     """
 
     ideal: RationalPolynomialIdeal
     polynomial: RationalPolynomial
     monomial_order: Literal["lex", "grlex", "grevlex"]
-    status: Literal["COMPUTED", "BUDGET_EXCEEDED"]
+    status: Literal["COMPUTED", "BUDGET_EXCEEDED", "UNKNOWN"]
     groebner_basis: tuple[RationalPolynomial, ...] | None
     remainder: RationalPolynomial | None
 
@@ -528,6 +530,10 @@ class IdealNormalFormResult(StrictModel):
     def require_replayable_reduction(self) -> Self:
         _validate_membership_source(self.ideal, self.polynomial)
         _validate_retained_basis(self.groebner_basis, self.ideal.variables)
+        if self.status == "UNKNOWN":
+            if self.groebner_basis is not None or self.remainder is not None:
+                raise ValueError("UNKNOWN must not carry a partial artifact")
+            return self
         if self.status == "BUDGET_EXCEEDED":
             if self.remainder is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a remainder")
@@ -568,13 +574,16 @@ class IdealMembershipResult(StrictModel):
     relation (source ideal, source polynomial, monomial order, computed
     Gröbner basis) so validation can replay the reduction.  When the exact
     normal form exceeds the output boundary the status reports
-    ``BUDGET_EXCEEDED`` and asserts no membership conclusion.
+    ``BUDGET_EXCEEDED`` and asserts no membership conclusion.  ``UNKNOWN``
+    reports that the bounded kernel could not complete any strategy within
+    its work bounds and asserts neither membership nor a budget overflow;
+    it carries no partial artifact.
     """
 
     ideal: RationalPolynomialIdeal
     polynomial: RationalPolynomial
     monomial_order: Literal["lex", "grlex", "grevlex"]
-    status: Literal["IN_IDEAL", "NOT_IN_IDEAL", "BUDGET_EXCEEDED"]
+    status: Literal["IN_IDEAL", "NOT_IN_IDEAL", "BUDGET_EXCEEDED", "UNKNOWN"]
     groebner_basis: tuple[RationalPolynomial, ...] | None
     normal_form: RationalPolynomial | None
 
@@ -582,6 +591,10 @@ class IdealMembershipResult(StrictModel):
     def require_replayable_membership(self) -> Self:
         _validate_membership_source(self.ideal, self.polynomial)
         _validate_retained_basis(self.groebner_basis, self.ideal.variables)
+        if self.status == "UNKNOWN":
+            if self.groebner_basis is not None or self.normal_form is not None:
+                raise ValueError("UNKNOWN must not carry a partial artifact")
+            return self
         if self.status == "BUDGET_EXCEEDED":
             if self.normal_form is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a normal form")

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -376,6 +376,14 @@ def _validate_membership_source(
         maximum_coefficient_digits=128,
         label="polynomial",
     )
+    # The advertised work domain bounds per-term total degree, not just
+    # each individual exponent.
+    for term in polynomial.polynomial.terms:
+        if sum(term.exponents) > _IDEAL_GENERATOR_TOTAL_DEGREE:
+            raise ValueError(
+                "polynomial degree exceeds the "
+                f"{_IDEAL_GENERATOR_TOTAL_DEGREE}-total-degree operation budget"
+            )
 
 
 def _validate_retained_basis(

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -16,9 +16,8 @@ from jacobian.math.polynomials._replay import (
     generators_reduce_to_zero,
     remainder_matches_claim,
     replayed_remainder_exceeds_budget,
-    replayed_remainder_term_count,
-    retained_basis_in_ideal,
     retained_basis_is_groebner,
+    retained_source_basis_exceeds_budget,
 )
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_TERMS,
@@ -460,10 +459,9 @@ class IdealNormalFormResult(StrictModel):
                 raise ValueError(
                     "retained basis does not reduce every ideal generator to zero"
                 )
-            if not retained_basis_in_ideal(
-                self.ideal, self.groebner_basis, self.monomial_order
-            ):
-                raise ValueError("retained Gröbner basis element is not in the source ideal")
+            # One kernel run substantiates authenticity: equality with the
+            # recomputed reduced Gröbner basis subsumes membership of every
+            # retained element in the source ideal.
             if not retained_basis_is_groebner(
                 self.ideal, self.groebner_basis, self.monomial_order
             ):
@@ -488,12 +486,6 @@ class IdealNormalFormResult(StrictModel):
                     raise ValueError(
                         "retained basis does not reduce every ideal generator to zero"
                     )
-                if not retained_basis_in_ideal(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained Gröbner basis element is not in the source ideal"
-                    )
                 if not retained_basis_is_groebner(
                     self.ideal, self.groebner_basis, self.monomial_order
                 ):
@@ -508,6 +500,17 @@ class IdealNormalFormResult(StrictModel):
                 ):
                     raise ValueError(
                         "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
+                    )
+            else:
+                # A budget outcome without a retained basis is only
+                # substantiated when the recomputed source Gröbner basis
+                # itself leaves the output budget.
+                if not retained_source_basis_exceeds_budget(
+                    self.ideal, self.monomial_order
+                ):
+                    raise ValueError(
+                        "BUDGET_EXCEEDED without a retained basis requires the "
+                        "source basis to exceed the output budget"
                     )
         return self
 
@@ -544,12 +547,6 @@ class IdealMembershipResult(StrictModel):
                     raise ValueError(
                         "retained basis does not reduce every ideal generator to zero"
                     )
-                if not retained_basis_in_ideal(
-                    self.ideal, self.groebner_basis, self.monomial_order
-                ):
-                    raise ValueError(
-                        "retained Gröbner basis element is not in the source ideal"
-                    )
                 if not retained_basis_is_groebner(
                     self.ideal, self.groebner_basis, self.monomial_order
                 ):
@@ -565,6 +562,17 @@ class IdealMembershipResult(StrictModel):
                     raise ValueError(
                         "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
                     )
+            else:
+                # A budget outcome without a retained basis is only
+                # substantiated when the recomputed source Gröbner basis
+                # itself leaves the output budget.
+                if not retained_source_basis_exceeds_budget(
+                    self.ideal, self.monomial_order
+                ):
+                    raise ValueError(
+                        "BUDGET_EXCEEDED without a retained basis requires the "
+                        "source basis to exceed the output budget"
+                    )
             return self
         if self.groebner_basis is None or self.normal_form is None:
             raise ValueError(f"{self.status} requires the basis and the normal form")
@@ -579,10 +587,6 @@ class IdealMembershipResult(StrictModel):
             raise ValueError(
                 "retained basis does not reduce every ideal generator to zero"
             )
-        if not retained_basis_in_ideal(
-            self.ideal, self.groebner_basis, self.monomial_order
-        ):
-            raise ValueError("retained Gröbner basis element is not in the source ideal")
         if not retained_basis_is_groebner(
             self.ideal, self.groebner_basis, self.monomial_order
         ):

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -15,7 +15,10 @@ from jacobian._models import StrictModel
 from jacobian.math.polynomials._replay import (
     generators_reduce_to_zero,
     remainder_matches_claim,
+    replayed_remainder_exceeds_budget,
     replayed_remainder_term_count,
+    retained_basis_in_ideal,
+    retained_basis_is_groebner,
 )
 from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_TERMS,
@@ -385,7 +388,9 @@ def _validate_retained_basis(
     if groebner_basis is None:
         return
     if not groebner_basis:
-        raise ValueError("retained Gröbner basis must not be empty")
+        # Empty basis is valid only for the zero ideal; the per-result
+        # validators enforce the correct correlation via the replay checks.
+        return
     if any(element.variables != variables for element in groebner_basis):
         raise ValueError("every retained basis polynomial must use the declared ring")
     if any(not element.polynomial.terms for element in groebner_basis):
@@ -455,6 +460,14 @@ class IdealNormalFormResult(StrictModel):
                 raise ValueError(
                     "retained basis does not reduce every ideal generator to zero"
                 )
+            if not retained_basis_in_ideal(
+                self.ideal, self.groebner_basis, self.monomial_order
+            ):
+                raise ValueError("retained Gröbner basis element is not in the source ideal")
+            if not retained_basis_is_groebner(
+                self.ideal, self.groebner_basis, self.monomial_order
+            ):
+                raise ValueError("retained basis is not the Gröbner basis of the source ideal")
             if not remainder_matches_claim(
                 self.ideal,
                 self.groebner_basis,
@@ -468,15 +481,34 @@ class IdealNormalFormResult(StrictModel):
         else:
             if self.remainder is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a remainder")
-            if self.groebner_basis is not None and replayed_remainder_term_count(
-                self.ideal,
-                self.groebner_basis,
-                self.polynomial,
-                self.monomial_order,
-            ) <= _MAX_RESULT_POLYNOMIAL_TERMS:
-                raise ValueError(
-                    "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
-                )
+            if self.groebner_basis is not None:
+                if not generators_reduce_to_zero(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained basis does not reduce every ideal generator to zero"
+                    )
+                if not retained_basis_in_ideal(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained Gröbner basis element is not in the source ideal"
+                    )
+                if not retained_basis_is_groebner(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained basis is not the Gröbner basis of the source ideal"
+                    )
+                if not replayed_remainder_exceeds_budget(
+                    self.ideal,
+                    self.groebner_basis,
+                    self.polynomial,
+                    self.monomial_order,
+                ):
+                    raise ValueError(
+                        "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
+                    )
         return self
 
 
@@ -505,15 +537,34 @@ class IdealMembershipResult(StrictModel):
         if self.status == "BUDGET_EXCEEDED":
             if self.normal_form is not None:
                 raise ValueError("BUDGET_EXCEEDED must not carry a normal form")
-            if self.groebner_basis is not None and replayed_remainder_term_count(
-                self.ideal,
-                self.groebner_basis,
-                self.polynomial,
-                self.monomial_order,
-            ) <= _MAX_RESULT_POLYNOMIAL_TERMS:
-                raise ValueError(
-                    "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
-                )
+            if self.groebner_basis is not None:
+                if not generators_reduce_to_zero(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained basis does not reduce every ideal generator to zero"
+                    )
+                if not retained_basis_in_ideal(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained Gröbner basis element is not in the source ideal"
+                    )
+                if not retained_basis_is_groebner(
+                    self.ideal, self.groebner_basis, self.monomial_order
+                ):
+                    raise ValueError(
+                        "retained basis is not the Gröbner basis of the source ideal"
+                    )
+                if not replayed_remainder_exceeds_budget(
+                    self.ideal,
+                    self.groebner_basis,
+                    self.polynomial,
+                    self.monomial_order,
+                ):
+                    raise ValueError(
+                        "BUDGET_EXCEEDED contradicts an in-budget replayed reduction"
+                    )
             return self
         if self.groebner_basis is None or self.normal_form is None:
             raise ValueError(f"{self.status} requires the basis and the normal form")
@@ -528,6 +579,14 @@ class IdealMembershipResult(StrictModel):
             raise ValueError(
                 "retained basis does not reduce every ideal generator to zero"
             )
+        if not retained_basis_in_ideal(
+            self.ideal, self.groebner_basis, self.monomial_order
+        ):
+            raise ValueError("retained Gröbner basis element is not in the source ideal")
+        if not retained_basis_is_groebner(
+            self.ideal, self.groebner_basis, self.monomial_order
+        ):
+            raise ValueError("retained basis is not the Gröbner basis of the source ideal")
         if not remainder_matches_claim(
             self.ideal,
             self.groebner_basis,

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -511,12 +511,15 @@ class IdealNormalFormResult(StrictModel):
     """The canonical remainder of one polynomial modulo an ideal.
 
     The result retains its complete source and the computed Gröbner basis so
-    validation replays the defining reduction relation exactly.  When the
-    exact remainder exceeds the 1,024-term output boundary the status reports
-    ``BUDGET_EXCEEDED`` instead of a mathematical conclusion; no partial
-    remainder is returned.  ``UNKNOWN`` reports that the bounded kernel could
-    not complete any strategy within its work bounds and asserts neither a
-    reduction nor a budget overflow; it carries no partial artifact.
+    validation replays the defining reduction relation exactly.  The status
+    reports ``BUDGET_EXCEEDED`` instead of a mathematical conclusion when
+    either of the two separately bounded exact artifacts leaves its own
+    1,024-term boundary: an oversized Gröbner-basis certificate (the basis
+    is stripped) or an oversized canonical remainder (a computed basis is
+    retained, but no partial remainder).  ``UNKNOWN`` reports that the
+    bounded kernel could not complete any strategy within its work bounds
+    and asserts neither a reduction nor a budget overflow; it carries no
+    partial artifact.
     """
 
     ideal: RationalPolynomialIdeal
@@ -572,9 +575,12 @@ class IdealMembershipResult(StrictModel):
     ``IN_IDEAL`` is defined exactly as the normal form being zero and
     ``NOT_IN_IDEAL`` as it being nonzero; both carry the full defining
     relation (source ideal, source polynomial, monomial order, computed
-    Gröbner basis) so validation can replay the reduction.  When the exact
-    normal form exceeds the output boundary the status reports
-    ``BUDGET_EXCEEDED`` and asserts no membership conclusion.  ``UNKNOWN``
+    Gröbner basis) so validation can replay the reduction.  The status
+    reports ``BUDGET_EXCEEDED`` and asserts no membership conclusion when
+    either of the two separately bounded exact artifacts leaves its own
+    output boundary: an oversized Gröbner-basis certificate (the basis is
+    stripped) or an oversized normal-form remainder (a computed basis is
+    retained, but no partial remainder).  ``UNKNOWN``
     reports that the bounded kernel could not complete any strategy within
     its work bounds and asserts neither membership nor a budget overflow;
     it carries no partial artifact.

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -17,8 +17,12 @@ from jacobian.math.polynomials.values import (
     MAX_POLYNOMIAL_VARIABLES,
     PolynomialVariable,
     RationalPolynomial,
+    RationalPolynomialIdeal,
     require_polynomial_budget,
 )
+
+_MAX_RESULT_POLYNOMIAL_TERMS = 1_024
+"""Exact-result term boundary shared by the polynomial output converters."""
 
 _MAX_COEFFICIENT_DIGITS = 256
 _MAX_GCD_TERMS = 512
@@ -317,28 +321,47 @@ class PolynomialGroebnerBasisResult(StrictModel):
 
 
 class IdealMembershipRequest(StrictModel):
-    """Decide membership of one polynomial in a bounded polynomial ideal."""
+    """Decide membership of one polynomial in a bounded polynomial ideal.
 
-    generators: tuple[RationalPolynomial, ...] = Field(min_length=1, max_length=16)
+    Accepts the domain-owned canonical ``RationalPolynomialIdeal`` value so
+    serialized ideals compose without unpacking.  The request polynomial is
+    bounded to 1,024 terms because the zero ideal returns it unchanged as
+    the normal form and the exact-result contract caps at 1,024 terms.
+    """
+
+    ideal: RationalPolynomialIdeal = Field(
+        description=(
+            "A bounded polynomial ideal in one ordered QQ ring: at most 16 "
+            "generators with at most 256 aggregate terms, degree at most 12, "
+            "and coefficient components at most 128 digits."
+        ),
+    )
     polynomial: RationalPolynomial
     monomial_order: Literal["lex", "grlex", "grevlex"] = "grevlex"
 
     @model_validator(mode="after")
     def require_matching_rings(self) -> Self:
-        variables = self.generators[0].variables
-        if any(gen.variables != variables for gen in self.generators):
+        variables = self.ideal.variables
+        if any(gen.variables != variables for gen in self.ideal.generators):
             raise ValueError("all ideal generators must use the same ordered ring")
         if self.polynomial.variables != variables:
             raise ValueError("polynomial must use the same ordered ring as the ideal")
-        if sum(len(gen.polynomial.terms) for gen in self.generators) > 256:
+        if sum(len(gen.polynomial.terms) for gen in self.ideal.generators) > 256:
             raise ValueError("ideal generators exceed the aggregate term budget")
-        for gen in self.generators:
+        for gen in self.ideal.generators:
             require_polynomial_budget(
                 gen,
                 maximum_terms=MAX_POLYNOMIAL_TERMS,
                 maximum_exponent=12,
                 maximum_coefficient_digits=128,
                 label="ideal generator",
+            )
+        # The normal form of the zero ideal is the input polynomial itself;
+        # cap the input at the 1,024-term result boundary so an accepted
+        # request can never leak a result-budget host exception.
+        if len(self.polynomial.polynomial.terms) > _MAX_RESULT_POLYNOMIAL_TERMS:
+            raise ValueError(
+                "polynomial exceeds the 1,024-term exact-result limit"
             )
         require_polynomial_budget(
             self.polynomial,
@@ -358,10 +381,24 @@ class IdealNormalFormResult(StrictModel):
 
 
 class IdealMembershipResult(StrictModel):
-    """Whether a polynomial lies in an ideal, with the normal form."""
+    """Whether a polynomial lies in an ideal, with the normal form.
+
+    Membership is defined exactly as the normal form being zero; the two
+    fields are validated against each other so a contradictory payload can
+    never validate.
+    """
 
     in_ideal: bool
     normal_form: RationalPolynomial
+
+    @model_validator(mode="after")
+    def bind_membership_to_normal_form(self) -> Self:
+        remainder_is_zero = not self.normal_form.polynomial.terms
+        if self.in_ideal is not remainder_is_zero:
+            raise ValueError(
+                "in_ideal must equal (normal_form == 0)"
+            )
+        return self
 
 
 class IntegerPolynomial(StrictModel):

--- a/src/jacobian/math/polynomials/_models.py
+++ b/src/jacobian/math/polynomials/_models.py
@@ -470,8 +470,13 @@ def _require_authentic_retained_basis(
     retained element in the source ideal.
     """
 
-    if not generators_reduce_to_zero(ideal, groebner_basis, monomial_order):
+    verdict = generators_reduce_to_zero(ideal, groebner_basis, monomial_order)
+    if verdict is False:
         raise ValueError("retained basis does not reduce every ideal generator to zero")
+    # A ``None`` verdict means the capped replay exhausted its work budget on
+    # some presentation generator: that is inconclusive about this
+    # presentation, not a refutation, and authenticity is still established
+    # by the independent reduced-basis recomputation below.
     if not retained_basis_is_groebner(ideal, groebner_basis, monomial_order):
         raise ValueError("retained basis is not the Gröbner basis of the source ideal")
 

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -46,14 +46,23 @@ class PolynomialOutputBudgetError(RuntimeError):
 
 
 def _result_polynomial(poly: object, variables: tuple[str, ...]) -> RationalPolynomial:
+    from pydantic import ValidationError
+
     try:
         return rational_polynomial_from_sympy(
             poly,
             variables,
             maximum_terms=_MAX_OUTPUT_TERMS,
         )
+    except ValidationError as exc:
+        # Exponent cap (32_768), term representation, or canonical-rational
+        # limits during result materialization are budget overflows, not host
+        # exceptions.  Map every such validation failure to the typed outcome.
+        raise PolynomialOutputBudgetError(str(exc)) from exc
     except ValueError as exc:
         if "term operation budget" in str(exc):
+            raise PolynomialOutputBudgetError(str(exc)) from exc
+        if "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
             raise PolynomialOutputBudgetError(str(exc)) from exc
         raise
 
@@ -251,8 +260,17 @@ def _compute_membership_context(
             )
             for expr in basis.exprs
         )
-    except PolynomialOutputBudgetError:
-        return None, basis
+    except (PolynomialOutputBudgetError, Exception) as exc:
+        # _result_polynomial already maps ValidationError/exponent overflows to
+        # PolynomialOutputBudgetError; any other validation failure during
+        # retained-basis materialization is also a budget overflow.
+        if isinstance(exc, PolynomialOutputBudgetError):
+            return None, basis
+        from pydantic import ValidationError
+
+        if isinstance(exc, ValidationError) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
+            return None, basis
+        raise
     if sum(len(element.polynomial.terms) for element in wire_basis) > 1024:
         return None, basis
     return wire_basis, basis
@@ -281,14 +299,18 @@ def polynomial_ideal_normal_form(
             sympy.Poly(basis.reduce(poly)[1], *symbols, domain=sympy.QQ),
             variables,
         )
-    except PolynomialOutputBudgetError:
-        return IdealNormalFormResult(
-            **source,
-            monomial_order=request.monomial_order,
-            status="BUDGET_EXCEEDED",
-            groebner_basis=wire_basis,
-            remainder=None,
-        )
+    except (PolynomialOutputBudgetError, Exception) as exc:
+        from pydantic import ValidationError
+
+        if isinstance(exc, PolynomialOutputBudgetError) or isinstance(exc, ValidationError) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
+            return IdealNormalFormResult(
+                **source,
+                monomial_order=request.monomial_order,
+                status="BUDGET_EXCEEDED",
+                groebner_basis=wire_basis,
+                remainder=None,
+            )
+        raise
     return IdealNormalFormResult(
         **source,
         monomial_order=request.monomial_order,

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -227,11 +227,11 @@ def polynomial_ideal_normal_form(
 ) -> IdealNormalFormResult:
     """Reduce a polynomial modulo an ideal using a Groebner basis."""
 
-    variables = request.generators[0].variables
+    variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
     generators = [
         rational_polynomial_to_sympy(generator).as_expr()
-        for generator in request.generators
+        for generator in request.ideal.generators
     ]
     basis = sympy.groebner(
         generators,

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import sympy
+
 from jacobian.math import polynomials
 from jacobian.math.polynomials._conversions import (
     rational_from_sympy,
@@ -12,6 +14,9 @@ from jacobian.math.polynomials._conversions import (
     symbols_for_variables,
 )
 from jacobian.math.polynomials._models import (
+    IdealMembershipRequest,
+    IdealMembershipResult,
+    IdealNormalFormResult,
     PolynomialBezoutIdentity,
     PolynomialDiscriminantRequest,
     PolynomialDiscriminantResult,
@@ -214,4 +219,45 @@ def polynomial_groebner_basis(
         variables=variables,
         monomial_order=request.monomial_order,
         basis=wire_basis,
+    )
+
+
+def polynomial_ideal_normal_form(
+    request: IdealMembershipRequest,
+) -> IdealNormalFormResult:
+    """Reduce a polynomial modulo an ideal using a Groebner basis."""
+
+    variables = request.generators[0].variables
+    symbols = symbols_for_variables(variables)
+    generators = [
+        rational_polynomial_to_sympy(generator).as_expr()
+        for generator in request.generators
+    ]
+    basis = sympy.groebner(
+        generators,
+        *symbols,
+        order=request.monomial_order,
+        domain=sympy.QQ,
+    )
+    poly = rational_polynomial_to_sympy(request.polynomial).as_expr()
+    remainder = basis.reduce(poly)[1]
+    return IdealNormalFormResult(
+        remainder=_result_polynomial(
+            sympy.Poly(remainder, *symbols, domain=sympy.QQ),
+            variables,
+        ),
+        monomial_order=request.monomial_order,
+    )
+
+
+def polynomial_ideal_membership(
+    request: IdealMembershipRequest,
+) -> IdealMembershipResult:
+    """Decide whether a polynomial lies in an ideal."""
+
+    normal_form = polynomial_ideal_normal_form(request)
+    is_zero = len(normal_form.remainder.polynomial.terms) == 0
+    return IdealMembershipResult(
+        in_ideal=is_zero,
+        normal_form=normal_form.remainder,
     )

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -222,10 +222,15 @@ def polynomial_groebner_basis(
     )
 
 
-def polynomial_ideal_normal_form(
+def _compute_membership_context(
     request: IdealMembershipRequest,
-) -> IdealNormalFormResult:
-    """Reduce a polynomial modulo an ideal using a Groebner basis."""
+) -> tuple[tuple[RationalPolynomial, ...] | None, Any]:
+    """Compute the Gröbner basis and return its wire form with the SymPy basis.
+
+    The wire basis is ``None`` when the computed basis itself exceeds the
+    1,024-term aggregate output boundary; the caller then reports the typed
+    budget outcome instead of a partial exact artifact.
+    """
 
     variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
@@ -239,14 +244,57 @@ def polynomial_ideal_normal_form(
         order=request.monomial_order,
         domain=sympy.QQ,
     )
+    try:
+        wire_basis = tuple(
+            _result_polynomial(
+                sympy.Poly(expr.as_expr(), *symbols, domain=sympy.QQ), variables
+            )
+            for expr in basis.exprs
+        )
+    except PolynomialOutputBudgetError:
+        return None, basis
+    if sum(len(element.polynomial.terms) for element in wire_basis) > 1024:
+        return None, basis
+    return wire_basis, basis
+
+
+def polynomial_ideal_normal_form(
+    request: IdealMembershipRequest,
+) -> IdealNormalFormResult:
+    """Reduce a polynomial modulo an ideal using a Groebner basis."""
+
+    variables = request.ideal.variables
+    symbols = symbols_for_variables(variables)
+    wire_basis, basis = _compute_membership_context(request)
+    source = {"ideal": request.ideal, "polynomial": request.polynomial}
+    if wire_basis is None:
+        return IdealNormalFormResult(
+            **source,
+            monomial_order=request.monomial_order,
+            status="BUDGET_EXCEEDED",
+            groebner_basis=None,
+            remainder=None,
+        )
     poly = rational_polynomial_to_sympy(request.polynomial).as_expr()
-    remainder = basis.reduce(poly)[1]
-    return IdealNormalFormResult(
-        remainder=_result_polynomial(
-            sympy.Poly(remainder, *symbols, domain=sympy.QQ),
+    try:
+        remainder = _result_polynomial(
+            sympy.Poly(basis.reduce(poly)[1], *symbols, domain=sympy.QQ),
             variables,
-        ),
+        )
+    except PolynomialOutputBudgetError:
+        return IdealNormalFormResult(
+            **source,
+            monomial_order=request.monomial_order,
+            status="BUDGET_EXCEEDED",
+            groebner_basis=wire_basis,
+            remainder=None,
+        )
+    return IdealNormalFormResult(
+        **source,
         monomial_order=request.monomial_order,
+        status="COMPUTED",
+        groebner_basis=wire_basis,
+        remainder=remainder,
     )
 
 
@@ -256,8 +304,21 @@ def polynomial_ideal_membership(
     """Decide whether a polynomial lies in an ideal."""
 
     normal_form = polynomial_ideal_normal_form(request)
+    source = {
+        "ideal": normal_form.ideal,
+        "polynomial": normal_form.polynomial,
+        "monomial_order": normal_form.monomial_order,
+        "groebner_basis": normal_form.groebner_basis,
+    }
+    if normal_form.status == "BUDGET_EXCEEDED":
+        return IdealMembershipResult(
+            **source,
+            status="BUDGET_EXCEEDED",
+            normal_form=None,
+        )
     is_zero = len(normal_form.remainder.polynomial.terms) == 0
     return IdealMembershipResult(
-        in_ideal=is_zero,
+        **source,
+        status="IN_IDEAL" if is_zero else "NOT_IN_IDEAL",
         normal_form=normal_form.remainder,
     )

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -281,6 +281,22 @@ def _compute_membership_context(
     return wire_basis, basis
 
 
+def _budget_exceeded_normal_form(
+    request: IdealMembershipRequest,
+    groebner_basis: tuple[RationalPolynomial, ...] | None,
+) -> IdealNormalFormResult:
+    """Report the typed budget outcome without a partial exact artifact."""
+
+    return IdealNormalFormResult(
+        ideal=request.ideal,
+        polynomial=request.polynomial,
+        monomial_order=request.monomial_order,
+        status="BUDGET_EXCEEDED",
+        groebner_basis=groebner_basis,
+        remainder=None,
+    )
+
+
 def polynomial_ideal_normal_form(
     request: IdealMembershipRequest,
 ) -> IdealNormalFormResult:
@@ -289,15 +305,8 @@ def polynomial_ideal_normal_form(
     variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
     wire_basis, _source_basis = _compute_membership_context(request)
-    source = {"ideal": request.ideal, "polynomial": request.polynomial}
     if wire_basis is None:
-        return IdealNormalFormResult(
-            **source,
-            monomial_order=request.monomial_order,
-            status="BUDGET_EXCEEDED",
-            groebner_basis=None,
-            remainder=None,
-        )
+        return _budget_exceeded_normal_form(request, None)
     # Reduce with a bounded sparse-ring division so an admitted request can
     # never expand an unbounded intermediate remainder before the 1,024-term
     # output boundary is noticed; overflow becomes the typed budget outcome.
@@ -306,13 +315,7 @@ def polynomial_ideal_normal_form(
     dividend = _ring_element(ring_context, request.polynomial)
     replayed = budgeted_reduce(ring_context, dividend, divisors)
     if replayed is None:
-        return IdealNormalFormResult(
-            **source,
-            monomial_order=request.monomial_order,
-            status="BUDGET_EXCEEDED",
-            groebner_basis=wire_basis,
-            remainder=None,
-        )
+        return _budget_exceeded_normal_form(request, wire_basis)
     try:
         remainder = _result_polynomial(
             sympy.Poly.from_dict(
@@ -331,17 +334,16 @@ def polynomial_ideal_normal_form(
     except (PolynomialOutputBudgetError, Exception) as exc:
         from pydantic import ValidationError
 
-        if isinstance(exc, (PolynomialOutputBudgetError, ValidationError)) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
-            return IdealNormalFormResult(
-                **source,
-                monomial_order=request.monomial_order,
-                status="BUDGET_EXCEEDED",
-                groebner_basis=wire_basis,
-                remainder=None,
-            )
+        if (
+            isinstance(exc, (PolynomialOutputBudgetError, ValidationError))
+            or "exponent" in str(exc).lower()
+            or "representation limit" in str(exc).lower()
+        ):
+            return _budget_exceeded_normal_form(request, wire_basis)
         raise
     return IdealNormalFormResult(
-        **source,
+        ideal=request.ideal,
+        polynomial=request.polynomial,
         monomial_order=request.monomial_order,
         status="COMPUTED",
         groebner_basis=wire_basis,
@@ -355,21 +357,26 @@ def polynomial_ideal_membership(
     """Decide whether a polynomial lies in an ideal."""
 
     normal_form = polynomial_ideal_normal_form(request)
-    source = {
-        "ideal": normal_form.ideal,
-        "polynomial": normal_form.polynomial,
-        "monomial_order": normal_form.monomial_order,
-        "groebner_basis": normal_form.groebner_basis,
-    }
     if normal_form.status == "BUDGET_EXCEEDED":
         return IdealMembershipResult(
-            **source,
+            ideal=normal_form.ideal,
+            polynomial=normal_form.polynomial,
+            monomial_order=normal_form.monomial_order,
+            groebner_basis=normal_form.groebner_basis,
             status="BUDGET_EXCEEDED",
             normal_form=None,
         )
-    is_zero = len(normal_form.remainder.polynomial.terms) == 0
+    remainder = normal_form.remainder
+    if remainder is None:
+        raise PolynomialOutputBudgetError(
+            "COMPUTED normal form must carry its exact remainder"
+        )
+    is_zero = len(remainder.polynomial.terms) == 0
     return IdealMembershipResult(
-        **source,
+        ideal=normal_form.ideal,
+        polynomial=normal_form.polynomial,
+        monomial_order=normal_form.monomial_order,
+        groebner_basis=normal_form.groebner_basis,
         status="IN_IDEAL" if is_zero else "NOT_IN_IDEAL",
-        normal_form=normal_form.remainder,
+        normal_form=remainder,
     )

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -37,9 +37,9 @@ from jacobian.math.polynomials._models import (
     PolynomialValue,
 )
 from jacobian.math.polynomials._replay import (
+    ReductionWorkLimitError,
     _ring_element,
     _sparse_ring,
-    ReductionWorkLimitExceeded,
     budgeted_reduce,
 )
 from jacobian.math.polynomials.values import RationalPolynomial
@@ -292,7 +292,7 @@ def polynomial_ideal_normal_form(
     dividend = _ring_element(ring_context, request.polynomial)
     try:
         replayed = budgeted_reduce(ring_context, dividend, divisors)
-    except ReductionWorkLimitExceeded:
+    except ReductionWorkLimitError:
         # Work exhaustion without an overflowing artifact is a
         # non-conclusion, not evidenced overflow: the exact remainder may
         # sit well inside the output boundary while the naive reduction

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -36,6 +36,11 @@ from jacobian.math.polynomials._models import (
     PolynomialSquareFreeRequest,
     PolynomialValue,
 )
+from jacobian.math.polynomials._replay import (
+    _ring_element,
+    _sparse_ring,
+    budgeted_reduce,
+)
 from jacobian.math.polynomials.values import RationalPolynomial
 
 _MAX_OUTPUT_TERMS = 1024
@@ -283,7 +288,7 @@ def polynomial_ideal_normal_form(
 
     variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
-    wire_basis, basis = _compute_membership_context(request)
+    wire_basis, _source_basis = _compute_membership_context(request)
     source = {"ideal": request.ideal, "polynomial": request.polynomial}
     if wire_basis is None:
         return IdealNormalFormResult(
@@ -293,16 +298,40 @@ def polynomial_ideal_normal_form(
             groebner_basis=None,
             remainder=None,
         )
-    poly = rational_polynomial_to_sympy(request.polynomial).as_expr()
+    # Reduce with a bounded sparse-ring division so an admitted request can
+    # never expand an unbounded intermediate remainder before the 1,024-term
+    # output boundary is noticed; overflow becomes the typed budget outcome.
+    ring_context = _sparse_ring(variables, request.monomial_order)
+    divisors = [_ring_element(ring_context, element) for element in wire_basis]
+    dividend = _ring_element(ring_context, request.polynomial)
+    replayed = budgeted_reduce(ring_context, dividend, divisors)
+    if replayed is None:
+        return IdealNormalFormResult(
+            **source,
+            monomial_order=request.monomial_order,
+            status="BUDGET_EXCEEDED",
+            groebner_basis=wire_basis,
+            remainder=None,
+        )
     try:
         remainder = _result_polynomial(
-            sympy.Poly(basis.reduce(poly)[1], *symbols, domain=sympy.QQ),
+            sympy.Poly.from_dict(
+                {
+                    tuple(int(e) for e in monom): sympy.Rational(
+                        int(coefficient.numerator),
+                        int(coefficient.denominator),
+                    )
+                    for monom, coefficient in replayed.terms()
+                },
+                *symbols,
+                domain=sympy.QQ,
+            ),
             variables,
         )
     except (PolynomialOutputBudgetError, Exception) as exc:
         from pydantic import ValidationError
 
-        if isinstance(exc, PolynomialOutputBudgetError) or isinstance(exc, ValidationError) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
+        if isinstance(exc, (PolynomialOutputBudgetError, ValidationError)) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
             return IdealNormalFormResult(
                 **source,
                 monomial_order=request.monomial_order,

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import sympy
 
@@ -238,60 +238,33 @@ def polynomial_groebner_basis(
 
 def _compute_membership_context(
     request: IdealMembershipRequest,
-) -> tuple[tuple[RationalPolynomial, ...] | None, Any]:
-    """Compute the Gröbner basis and return its wire form with the SymPy basis.
+) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
+    """Compute the source Gröbner basis and report the bounded outcome.
 
-    The wire basis is ``None`` when the computation exceeds a work or
-    representability boundary — decided only on the complete source
-    basis, never on an intermediate prefix — so the caller reports the
-    typed budget outcome instead of expanding an unrepresentable exact
-    artifact.
+    The basis is wire-form when some bounded strategy concluded within
+    every output budget.  ``None`` with ``exceeded`` reports evidenced
+    complete-basis overflow for the typed budget outcome; ``None``
+    without it reports that no strategy concluded, for the typed
+    non-conclusion outcome.
     """
 
-    variables = request.ideal.variables
-    symbols = symbols_for_variables(variables)
     from jacobian.math.polynomials._replay import incremental_source_groebner
 
-    source_basis, exceeded = incremental_source_groebner(
-        request.ideal, request.monomial_order
-    )
-    if source_basis is None or exceeded:
-        return None, None
-    basis = source_basis
-    from pydantic import ValidationError
-
-    try:
-        wire_basis = tuple(
-            _result_polynomial(
-                sympy.Poly(expr.as_expr(), *symbols, domain=sympy.QQ), variables
-            )
-            for expr in basis.exprs
-        )
-    except (PolynomialOutputBudgetError, Exception) as exc:
-        # _result_polynomial already maps ValidationError/exponent overflows to
-        # PolynomialOutputBudgetError; any other validation failure during
-        # retained-basis materialization is also a budget overflow.
-        if isinstance(exc, (PolynomialOutputBudgetError, ValidationError)):
-            return None, basis
-        if "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
-            return None, basis
-        raise
-    if sum(len(element.polynomial.terms) for element in wire_basis) > 1024:
-        return None, basis
-    return wire_basis, basis
+    return incremental_source_groebner(request.ideal, request.monomial_order)
 
 
-def _budget_exceeded_normal_form(
+def _incomplete_normal_form(
     request: IdealMembershipRequest,
+    status: Literal["BUDGET_EXCEEDED", "UNKNOWN"],
     groebner_basis: tuple[RationalPolynomial, ...] | None,
 ) -> IdealNormalFormResult:
-    """Report the typed budget outcome without a partial exact artifact."""
+    """Report a non-computed outcome without a partial exact artifact."""
 
     return IdealNormalFormResult(
         ideal=request.ideal,
         polynomial=request.polynomial,
         monomial_order=request.monomial_order,
-        status="BUDGET_EXCEEDED",
+        status=status,
         groebner_basis=groebner_basis,
         remainder=None,
     )
@@ -304,9 +277,12 @@ def polynomial_ideal_normal_form(
 
     variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
-    wire_basis, _source_basis = _compute_membership_context(request)
+    wire_basis, exceeded = _compute_membership_context(request)
     if wire_basis is None:
-        return _budget_exceeded_normal_form(request, None)
+        status: Literal["BUDGET_EXCEEDED", "UNKNOWN"] = (
+            "BUDGET_EXCEEDED" if exceeded else "UNKNOWN"
+        )
+        return _incomplete_normal_form(request, status, None)
     # Reduce with a bounded sparse-ring division so an admitted request can
     # never expand an unbounded intermediate remainder before the 1,024-term
     # output boundary is noticed; overflow becomes the typed budget outcome.
@@ -315,7 +291,7 @@ def polynomial_ideal_normal_form(
     dividend = _ring_element(ring_context, request.polynomial)
     replayed = budgeted_reduce(ring_context, dividend, divisors)
     if replayed is None:
-        return _budget_exceeded_normal_form(request, wire_basis)
+        return _incomplete_normal_form(request, "BUDGET_EXCEEDED", wire_basis)
     try:
         remainder = _result_polynomial(
             sympy.Poly.from_dict(
@@ -339,7 +315,7 @@ def polynomial_ideal_normal_form(
             or "exponent" in str(exc).lower()
             or "representation limit" in str(exc).lower()
         ):
-            return _budget_exceeded_normal_form(request, wire_basis)
+            return _incomplete_normal_form(request, "BUDGET_EXCEEDED", wire_basis)
         raise
     return IdealNormalFormResult(
         ideal=request.ideal,
@@ -357,6 +333,15 @@ def polynomial_ideal_membership(
     """Decide whether a polynomial lies in an ideal."""
 
     normal_form = polynomial_ideal_normal_form(request)
+    if normal_form.status == "UNKNOWN":
+        return IdealMembershipResult(
+            ideal=normal_form.ideal,
+            polynomial=normal_form.polynomial,
+            monomial_order=normal_form.monomial_order,
+            groebner_basis=None,
+            status="UNKNOWN",
+            normal_form=None,
+        )
     if normal_form.status == "BUDGET_EXCEEDED":
         return IdealMembershipResult(
             ideal=normal_form.ideal,

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -39,6 +39,7 @@ from jacobian.math.polynomials._models import (
 from jacobian.math.polynomials._replay import (
     _ring_element,
     _sparse_ring,
+    ReductionWorkLimitExceeded,
     budgeted_reduce,
 )
 from jacobian.math.polynomials.values import RationalPolynomial
@@ -289,7 +290,14 @@ def polynomial_ideal_normal_form(
     ring_context = _sparse_ring(variables, request.monomial_order)
     divisors = [_ring_element(ring_context, element) for element in wire_basis]
     dividend = _ring_element(ring_context, request.polynomial)
-    replayed = budgeted_reduce(ring_context, dividend, divisors)
+    try:
+        replayed = budgeted_reduce(ring_context, dividend, divisors)
+    except ReductionWorkLimitExceeded:
+        # Work exhaustion without an overflowing artifact is a
+        # non-conclusion, not evidenced overflow: the exact remainder may
+        # sit well inside the output boundary while the naive reduction
+        # order temporarily expands a larger intermediate.
+        return _incomplete_normal_form(request, "UNKNOWN", None)
     if replayed is None:
         return _incomplete_normal_form(request, "BUDGET_EXCEEDED", wire_basis)
     try:

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -242,10 +242,10 @@ def _compute_membership_context(
     """Compute the Gröbner basis and return its wire form with the SymPy basis.
 
     The wire basis is ``None`` when the computation exceeds a work or
-    representability boundary — including intermediate basis growth,
-    which the incremental bounded kernel checks after every generator —
-    so the caller reports the typed budget outcome instead of expanding
-    an unrepresentable exact artifact.
+    representability boundary — decided only on the complete source
+    basis, never on an intermediate prefix — so the caller reports the
+    typed budget outcome instead of expanding an unrepresentable exact
+    artifact.
     """
 
     variables = request.ideal.variables

--- a/src/jacobian/math/polynomials/_operations.py
+++ b/src/jacobian/math/polynomials/_operations.py
@@ -241,23 +241,25 @@ def _compute_membership_context(
 ) -> tuple[tuple[RationalPolynomial, ...] | None, Any]:
     """Compute the Gröbner basis and return its wire form with the SymPy basis.
 
-    The wire basis is ``None`` when the computed basis itself exceeds the
-    1,024-term aggregate output boundary; the caller then reports the typed
-    budget outcome instead of a partial exact artifact.
+    The wire basis is ``None`` when the computation exceeds a work or
+    representability boundary — including intermediate basis growth,
+    which the incremental bounded kernel checks after every generator —
+    so the caller reports the typed budget outcome instead of expanding
+    an unrepresentable exact artifact.
     """
 
     variables = request.ideal.variables
     symbols = symbols_for_variables(variables)
-    generators = [
-        rational_polynomial_to_sympy(generator).as_expr()
-        for generator in request.ideal.generators
-    ]
-    basis = sympy.groebner(
-        generators,
-        *symbols,
-        order=request.monomial_order,
-        domain=sympy.QQ,
+    from jacobian.math.polynomials._replay import incremental_source_groebner
+
+    source_basis, exceeded = incremental_source_groebner(
+        request.ideal, request.monomial_order
     )
+    if source_basis is None or exceeded:
+        return None, None
+    basis = source_basis
+    from pydantic import ValidationError
+
     try:
         wire_basis = tuple(
             _result_polynomial(
@@ -269,11 +271,9 @@ def _compute_membership_context(
         # _result_polynomial already maps ValidationError/exponent overflows to
         # PolynomialOutputBudgetError; any other validation failure during
         # retained-basis materialization is also a budget overflow.
-        if isinstance(exc, PolynomialOutputBudgetError):
+        if isinstance(exc, (PolynomialOutputBudgetError, ValidationError)):
             return None, basis
-        from pydantic import ValidationError
-
-        if isinstance(exc, ValidationError) or "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
+        if "exponent" in str(exc).lower() or "representation limit" in str(exc).lower():
             return None, basis
         raise
     if sum(len(element.polynomial.terms) for element in wire_basis) > 1024:

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -32,6 +32,66 @@ _MAX_OUTPUT_TERMS = 1_024
 _MAX_INTERMEDIATE_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
 
+_COMPLETE_KERNEL_TIMEOUT_SECONDS = 10.0
+"""Wall clock for one killable complete-kernel attempt in a subprocess."""
+
+_COMPLETE_KERNEL_STDOUT_LIMIT = 128_000_000
+"""Bound on the serialized complete basis a worker may stream back."""
+
+_WORKER_PROGRAM = """\
+import json
+import sys
+
+from pydantic import ValidationError
+from sympy import Poly, QQ, Symbol, groebner
+
+from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    variables = tuple(payload["variables"])
+    symbols = tuple(Symbol(name) for name in variables)
+    try:
+        generators = []
+        for terms in payload["generators"]:
+            poly = Poly.from_dict(
+                {
+                    tuple(term["exponents"]): QQ(int(term["num"]), int(term["den"]))
+                    for term in terms
+                },
+                *symbols,
+                domain=QQ,
+            )
+            generators.append(poly.as_expr())
+        basis = groebner(
+            generators,
+            *symbols,
+            order=payload["monomial_order"],
+            domain=QQ,
+        )
+        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
+        if sum(len(poly.terms()) for poly in polys) > 1024:
+            print(json.dumps({"status": "exceeded"}))
+            return
+        elements = [
+            rational_polynomial_from_sympy(poly, variables) for poly in polys
+        ]
+    except ValidationError:
+        print(json.dumps({"status": "exceeded"}))
+        return
+    except Exception:
+        print(json.dumps({"status": "failed"}))
+        return
+    print(json.dumps({
+        "status": "ok",
+        "basis": [element.model_dump() for element in elements],
+    }))
+
+
+main()
+"""
+
 
 def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
     """Check one integer pair against the canonical rational digit limit."""
@@ -46,17 +106,13 @@ def _basis_exceeds_output_budget(
     basis: Any,
     symbols: tuple[Any, ...],
     maximum_terms: int = _MAX_OUTPUT_TERMS,
-    enforce_aggregate_terms: bool = True,
 ) -> bool:
-    """Check one computed Gröbner basis against an aggregate term budget.
+    """Check one computed Gröbner basis against the output budgets.
 
-    Exponent and canonical-coefficient representability limits apply at
-    every scale: a basis element that could not be materialized as a
-    canonical value is outside every work envelope, not only the output
-    boundary.  The aggregate term count, by contrast, is enforced only
-    when ``enforce_aggregate_terms`` is set — callers replaying prefixes
-    must not charge it there because adding a generator can shrink the
-    reduced basis.
+    The aggregate 1,024-term boundary and the representability limits
+    (32,768 exponents, canonical coefficient digits) apply only to a
+    complete basis: the reduced Gröbner basis of the full generating set
+    is unique, so its budget status is a function of the ideal value.
     """
 
     from sympy import QQ, Poly
@@ -67,10 +123,9 @@ def _basis_exceeds_output_budget(
     for expr in basis.exprs:
         poly = Poly(expr, *symbols, domain=QQ)
         terms = poly.terms()
-        if enforce_aggregate_terms:
-            aggregate_terms += len(terms)
-            if aggregate_terms > maximum_terms:
-                return True
+        aggregate_terms += len(terms)
+        if aggregate_terms > maximum_terms:
+            return True
         for monom, coefficient in terms:
             if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
                 return True
@@ -108,37 +163,174 @@ def _canonical_generator_order(ideal: RationalPolynomialIdeal) -> tuple[int, ...
     return tuple(sorted(range(len(ideal.generators)), key=sort_key))
 
 
-def incremental_source_groebner(
-    ideal: RationalPolynomialIdeal,
+def _guarded_incremental(
+    exprs: list[Any],
+    symbols: tuple[Any, ...],
     monomial_order: str,
-) -> tuple[Any | None, bool]:
-    """Compute the source reduced Gröbner basis with bounded basis growth.
+) -> tuple[str, Any]:
+    """Run the kernel over one generator order under a work bound.
 
-    The kernel runs incrementally, one generator at a time, in the
-    canonical content-derived order of ``_canonical_generator_order``, so
-    its outcome is a function of the ideal value rather than of the
-    presentation order of an equivalent generating set.
-
-    Budgets are two-tier.  Canonical representability (exponent and
-    coefficient-digit limits) applies at every prefix: a basis element
-    that cannot be materialized as a canonical value stops the kernel
-    immediately, since no later stage could construct the exact artifact.
-    The aggregate 1,024-term output boundary, by contrast, is decided
-    only on the complete final basis and never on an intermediate
-    prefix: adding a generator grows the ideal but can shrink its
-    reduced basis, so a prefix's term count is presentation-dependent
-    evidence that must not decide the outcome.  Adding generators and
-    re-reducing converges to the unique reduced basis, so the final
-    result equals a single-shot computation whenever that stays within
-    budget.
-
-    Returns ``(basis, exceeded)``: ``basis`` is ``None`` when the kernel
-    failed or left a budget; ``exceeded`` distinguishes a genuine budget
-    overflow (evidence for a typed budget outcome) from an opaque kernel
-    failure.
+    Returns ``("OK", basis)`` when every prefix stayed representable,
+    ``("EXCEEDED", None)`` when the complete generating set's basis leaves
+    an output budget, ``("ABORTED", None)`` when a mid-sequence prefix
+    left a budget — a work bound, not a conclusion, because later
+    generators can still shrink the ideal — and ``("FAILED", None)`` when
+    the kernel itself failed, which is likewise no evidence.
     """
 
     from sympy import QQ, groebner
+
+    current: list[Any] = []
+    basis = None
+    for position, expr in enumerate(exprs):
+        current.append(expr)
+        try:
+            basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
+        except Exception:
+            return "FAILED", None
+        try:
+            exceeded = _basis_exceeds_output_budget(basis, symbols)
+        except Exception:
+            return "FAILED", None
+        if exceeded:
+            if position == len(exprs) - 1:
+                return "EXCEEDED", None
+            return "ABORTED", None
+    if basis is None:
+        return "FAILED", None
+    return "OK", basis
+
+
+def _finalize_strategy_basis(
+    basis: Any,
+    symbols: tuple[Any, ...],
+    variables: tuple[str, ...],
+) -> tuple[str, tuple[RationalPolynomial, ...] | None]:
+    """Convert one completed sympy basis to wire form, deciding the budgets.
+
+    Representability failures (canonical term limits, exponent or digit
+    bounds) are complete-basis overflow evidence; other failures carry no
+    conclusion.
+    """
+
+    from pydantic import ValidationError
+    from sympy import QQ, Poly
+
+    from jacobian.math.polynomials._conversions import (
+        rational_polynomial_from_sympy,
+    )
+
+    try:
+        polys = [Poly(expr.as_expr(), *symbols, domain=QQ) for expr in basis.exprs]
+        if sum(len(poly.terms()) for poly in polys) > _MAX_OUTPUT_TERMS:
+            return "EXCEEDED", None
+        return "OK", tuple(
+            rational_polynomial_from_sympy(poly, variables) for poly in polys
+        )
+    except ValidationError:
+        return "EXCEEDED", None
+    except Exception:
+        return "FAILED", None
+
+
+def _complete_basis_in_worker(
+    ideal: RationalPolynomialIdeal,
+    monomial_order: str,
+) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
+    """Run one unguarded kernel call over the complete generating set.
+
+    Both guarded orders can abort while a single-shot call still finishes
+    quickly: Buchberger sees every ideal-collapsing pair from the start,
+    so it need never materialize the exploding intermediate bases of any
+    prefix.  The kernel cannot bound itself, so this strategy runs
+    killably in a subprocess with a wall clock; a timeout, kill, or
+    failure yields no conclusion.
+    """
+
+    import json
+    import sys
+
+    from jacobian.math.polynomials.values import RationalPolynomial
+    from jacobian.process import run_bounded_process, worker_environment
+
+    payload = {
+        "variables": list(ideal.variables),
+        "monomial_order": monomial_order,
+        "generators": [
+            [
+                {
+                    "exponents": list(term.exponents),
+                    "num": term.coefficient.num,
+                    "den": term.coefficient.den,
+                }
+                for term in generator.polynomial.terms
+            ]
+            for generator in ideal.generators
+        ],
+    }
+    try:
+        completed = run_bounded_process(
+            [sys.executable, "-c", _WORKER_PROGRAM],
+            input_bytes=json.dumps(payload).encode("utf-8"),
+            timeout_seconds=_COMPLETE_KERNEL_TIMEOUT_SECONDS,
+            environment=worker_environment(),
+            stdout_limit=_COMPLETE_KERNEL_STDOUT_LIMIT,
+            stderr_limit=4096,
+        )
+    except Exception:
+        return None, False
+    if completed.timed_out or completed.cancelled or completed.returncode != 0:
+        return None, False
+    try:
+        report = json.loads(completed.stdout.decode("utf-8"))
+    except Exception:
+        return None, False
+    status = report.get("status")
+    if status == "exceeded":
+        # The worker decided the complete reduced basis against the same
+        # output budgets: sound evidence for the typed budget outcome.
+        return None, True
+    if status != "ok":
+        return None, False
+    try:
+        basis = tuple(
+            RationalPolynomial.model_validate(element) for element in report["basis"]
+        )
+    except Exception:
+        # A declared basis outside the canonical contract is evidence for
+        # no conclusion.
+        return None, False
+    return basis, False
+
+
+def incremental_source_groebner(
+    ideal: RationalPolynomialIdeal,
+    monomial_order: str,
+) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
+    """Compute the source reduced Gröbner basis in wire form.
+
+    No output-budget decision is ever taken from an intermediate prefix:
+    adding a generator grows the ideal but can shrink its reduced basis
+    (one trailing coprime generator collapses the ideal to the unit
+    ideal), so every prefix property — aggregate term count, exponent,
+    coefficient digits — is presentation-dependent evidence that later
+    generators may invalidate.  Only the basis of the complete generating
+    set, whose reduced form is unique, decides an overflow.
+
+    Each guarded strategy runs the kernel incrementally in a
+    content-derived order and aborts at its first mid-sequence budget
+    trip purely as a work bound: strategy one uses the canonical
+    ascending order, strategy two its reverse.  When both abort or fail,
+    a third strategy runs the kernel once over the complete generating
+    set inside a killable subprocess with a wall clock, where collapsing
+    pairs are visible from the start.  A strategy that cannot conclude
+    yields no evidence either way.
+
+    Returns ``(basis, exceeded)``: ``basis`` is the complete reduced
+    Gröbner basis when some bounded strategy concluded within budget;
+    ``(None, True)`` reports evidenced overflow for the typed budget
+    outcome, and ``(None, False)`` reports that no conclusion exists.
+    """
 
     from jacobian.math.polynomials._conversions import (
         rational_polynomial_to_sympy,
@@ -153,31 +345,21 @@ def incremental_source_groebner(
         ]
     except Exception:
         return None, False
-    ordered = [exprs[index] for index in _canonical_generator_order(ideal)]
-    current: list[Any] = []
-    basis = None
-    for expr in ordered:
-        current.append(expr)
-        try:
-            basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
-        except Exception:
-            return None, False
-        try:
-            if _basis_exceeds_output_budget(
-                basis, symbols, enforce_aggregate_terms=False
-            ):
-                # Representability is scale-free: this exact artifact can
-                # never be materialized as canonical values.
-                return None, True
-        except Exception:
-            return None, False
-    try:
-        exceeded = _basis_exceeds_output_budget(basis, symbols)
-    except Exception:
-        return None, False
-    if exceeded:
-        return None, True
-    return basis, False
+    canonical = _canonical_generator_order(ideal)
+    for ordered in (canonical, tuple(reversed(canonical))):
+        outcome, basis = _guarded_incremental(
+            [exprs[index] for index in ordered], symbols, monomial_order
+        )
+        if outcome == "EXCEEDED":
+            return None, True
+        if outcome != "OK":
+            continue
+        concluded, wire_basis = _finalize_strategy_basis(basis, symbols, variables)
+        if concluded == "OK":
+            return wire_basis, False
+        if concluded == "EXCEEDED":
+            return None, True
+    return _complete_basis_in_worker(ideal, monomial_order)
 
 
 def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
@@ -366,33 +548,16 @@ def retained_basis_is_groebner(
     """Check the retained tuple is the reduced Gröbner basis of the ideal.
 
     Recomputes the exact Gröbner basis from the source generators with
-    bounded basis growth and compares it to the retained wire basis as
+    bounded strategies and compares it to the retained wire basis as
     wire-form sets.  This ensures the retained basis is not merely a
     generating set but a Gröbner basis, so remainder replay via
     sparse-ring division is the unique normal form.
     """
 
-    from jacobian.math.polynomials._conversions import (
-        rational_polynomial_from_sympy,
-        symbols_for_variables,
-    )
-
-    variables = ideal.variables
-    symbols = symbols_for_variables(variables)
     source_gb, exceeded = incremental_source_groebner(ideal, monomial_order)
     if source_gb is None or exceeded:
         return False
-    try:
-        computed_polys = tuple(
-            rational_polynomial_from_sympy(
-                # ``source_gb.exprs`` convert to ``Poly`` over QQ
-                __import__("sympy").Poly(expr, *symbols, domain=__import__("sympy").QQ),
-                variables,
-            )
-            for expr in source_gb.exprs
-        )
-    except Exception:
-        return False
+    computed_polys = source_gb
     # Empty source ideal must correspond to empty retained basis.
     if not computed_polys and not groebner_basis:
         return True
@@ -407,6 +572,8 @@ def retained_basis_is_groebner(
         )
 
     try:
-        return sorted(computed_polys, key=_key) == sorted(groebner_basis, key=_key)
+        return bool(
+            sorted(computed_polys, key=_key) == sorted(groebner_basis, key=_key)
+        )
     except Exception:
         return False

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -74,11 +74,11 @@ def incremental_source_groebner(
     Strategy one and two run the guarded incremental construction over
     content-derived ascending and descending generator orders; a
     mid-sequence budget trip there aborts that strategy as a pure work
-    bound.  When both abort or fail, strategy three submits the whole
-    generating set to one unguarded kernel call, where Buchberger sees
-    every ideal-collapsing pair from the start and need never materialize
-    any exploding prefix.  An attempt that cannot conclude yields no
-    evidence either way.
+    bound.  When both abort, strategy three submits the whole generating
+    set to one unguarded kernel call, where Buchberger sees every
+    ideal-collapsing pair from the start and need never materialize any
+    exploding prefix.  An attempt that cannot conclude yields no evidence
+    either way.
 
     Returns ``(basis, exceeded)``: ``basis`` is the complete reduced
     Gröbner basis when some bounded strategy concluded within budget;
@@ -96,7 +96,7 @@ def incremental_source_groebner(
             return basis, False
         if status == "exceeded":
             return None, True
-        # Aborted or failed attempts decide nothing; retry.
+        # Aborted attempts decide nothing; retry.
     status, basis = complete_basis_in_worker(ideal, monomial_order, "complete")
     if status == "ok":
         return basis, False

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -233,8 +233,16 @@ def generators_reduce_to_zero(
     ideal: RationalPolynomialIdeal,
     groebner_basis: tuple[RationalPolynomial, ...],
     monomial_order: str,
-) -> bool:
-    """Check every retained ideal generator reduces to zero modulo the basis."""
+) -> bool | None:
+    """Check every retained ideal generator reduces to zero modulo the basis.
+
+    Returns ``True`` when every generator reduces to zero, ``False`` when
+    some generator provably does not, and ``None`` when the capped replay
+    exhausted its work budget on some presentation generator: exhaustion is
+    inconclusive about this particular presentation, not evidence against
+    the basis (a redundant generator can expand enormously while the basis
+    itself stays small).
+    """
 
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     zero = ring_context.zero
@@ -244,7 +252,7 @@ def generators_reduce_to_zero(
                 ideal, groebner_basis, generator, monomial_order
             )
         except ReductionWorkLimitError:
-            return False
+            return None
         # An overflowing reduction cannot be corroborated, so fail closed.
         if replayed is None or replayed != zero:
             return False

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
+    "ReductionWorkLimitExceeded",
     "generators_reduce_to_zero",
     "remainder_matches_claim",
     "retained_basis_is_groebner",
@@ -31,6 +32,19 @@ __all__ = [
 _MAX_OUTPUT_TERMS = 1_024
 _MAX_INTERMEDIATE_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
+
+
+class ReductionWorkLimitExceeded(RuntimeError):
+    """Bounded division ran out of algorithmic work without any exact
+    artifact leaving its boundary.
+
+    This is a work bound, never a mathematical conclusion: the retained
+    basis, the dividend, and the true remainder may all sit inside their
+    budgets while the naive reduction order temporarily expands a larger
+    intermediate.  Callers must map it to the typed non-conclusion
+    outcome (``UNKNOWN``), not to ``BUDGET_EXCEEDED``, which asserts that
+    an exact artifact left its own boundary.
+    """
 
 
 def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
@@ -106,9 +120,13 @@ def budgeted_reduce(
     cancels the current leading monomial against the one basis element
     whose leading monomial divides it (introducing only strictly smaller
     monomials, so the loop terminates), or moves the leading term into
-    the remainder. Returns ``None`` when the work or output budget is
-    exceeded; the caller then reports a typed budget outcome instead of
-    materializing an unbounded intermediate polynomial.
+    the remainder. Returns ``None`` only when the exact remainder itself
+    leaves the 1,024-term output boundary; raises
+    :class:`ReductionWorkLimitExceeded` when the reduction's algorithmic
+    work (division steps or a temporarily expanded intermediate) exhausts
+    its cap without any artifact overflowing, so callers can report the
+    typed non-conclusion outcome instead of an unsubstantiated budget
+    claim.
     """
 
     remainder = ring_context.zero
@@ -117,7 +135,9 @@ def budgeted_reduce(
     while work:
         steps += 1
         if steps > _MAX_REDUCTION_STEPS:
-            return None
+            raise ReductionWorkLimitExceeded(
+                "bounded reduction exceeded the division-step work cap"
+            )
         lead_monom = work.leading_expv()
         reducer = None
         for divisor in divisors:
@@ -131,7 +151,9 @@ def budgeted_reduce(
             scale = ring_context.term_new(diff, work[lead_monom] / reducer[lm])
             work = work - scale * reducer
             if len(work.monoms()) > _MAX_INTERMEDIATE_TERMS:
-                return None
+                raise ReductionWorkLimitExceeded(
+                    "bounded reduction exceeded the intermediate work cap"
+                )
         else:
             lead_term = ring_context.term_new(lead_monom, work[lead_monom])
             remainder = remainder + lead_term
@@ -192,12 +214,15 @@ def remainder_matches_claim(
 ) -> bool:
     """Check that the claimed wire remainder equals the replayed reduction.
 
-    A replay whose bounded reduction overflows cannot corroborate a
-    ``COMPUTED`` claim, so it reports a mismatch.
+    A replay whose bounded reduction overflows or runs out of work cannot
+    corroborate a ``COMPUTED`` claim, so it reports a mismatch.
     """
 
     ring_context = _sparse_ring(ideal.variables, monomial_order)
-    replayed = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    try:
+        replayed = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    except ReductionWorkLimitExceeded:
+        return False
     if replayed is None:
         return False
     claimed = _ring_element(ring_context, claimed_remainder)
@@ -214,7 +239,12 @@ def generators_reduce_to_zero(
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     zero = ring_context.zero
     for generator in ideal.generators:
-        replayed = _replay_division(ideal, groebner_basis, generator, monomial_order)
+        try:
+            replayed = _replay_division(
+                ideal, groebner_basis, generator, monomial_order
+            )
+        except ReductionWorkLimitExceeded:
+            return False
         # An overflowing reduction cannot be corroborated, so fail closed.
         if replayed is None or replayed != zero:
             return False
@@ -231,10 +261,16 @@ def replayed_remainder_exceeds_budget(
 
     from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
-    remainder = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    try:
+        remainder = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    except ReductionWorkLimitExceeded:
+        # Work exhaustion without an overflowing artifact is not evidence
+        # that the remainder leaves its boundary, so it cannot
+        # substantiate a BUDGET_EXCEEDED claim.
+        return False
     if remainder is None:
-        # The bounded reduction itself overflowed: the remainder is
-        # certainly outside the output budget.
+        # The bounded reduction overflowed on the remainder artifact
+        # itself: the remainder is certainly outside the output budget.
         return True
     try:
         for monom in remainder.monoms():

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -72,12 +72,15 @@ def incremental_source_groebner(
 
     The kernel runs incrementally, one generator at a time, and every
     intermediate basis is checked against the output budget (aggregate
-    1,024-term, exponent, and canonical-coefficient limits) before the
-    next generator is added.  This conservatively bounds basis growth so
-    admitted requests cannot drive an unbounded intermediate coefficient
-    expansion inside the kernel.  Adding generators and re-reducing
-    converges to the unique reduced basis, so the final result equals a
-    single-shot computation whenever that stays within budget.
+    1,024-term, exponent, and canonical-coefficient limits).  Because a
+    later generator can collapse an oversized intermediate ideal — most
+    simply a nonzero constant generator, which makes any ideal the unit
+    ideal regardless of presentation order — constant generators are
+    detected up front and short-circuit to their own in-budget basis
+    instead of letting an oversized prefix decide the outcome.  Adding
+    generators and re-reducing converges to the unique reduced basis, so
+    the final result equals a single-shot computation whenever that stays
+    within budget.
 
     Returns ``(basis, exceeded)``: ``basis`` is ``None`` when the kernel
     failed or an intermediate left the budget; ``exceeded`` distinguishes
@@ -98,6 +101,18 @@ def incremental_source_groebner(
         exprs = [rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators]
     except Exception:
         return None, False
+    # A nonzero constant generator collapses the ideal to the unit ideal no
+    # matter how an oversized prefix basis looks; presentation order must
+    # not turn that collapse into a false budget overflow.
+    for expr in exprs:
+        if getattr(expr, "is_Number", False) and expr != 0:
+            try:
+                basis = groebner(
+                    [expr], *symbols, order=monomial_order, domain=QQ
+                )
+            except Exception:
+                return None, False
+            return basis, False
     current: list[Any] = []
     basis = None
     for expr in exprs:

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -32,66 +32,6 @@ _MAX_OUTPUT_TERMS = 1_024
 _MAX_INTERMEDIATE_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
 
-_COMPLETE_KERNEL_TIMEOUT_SECONDS = 10.0
-"""Wall clock for one killable complete-kernel attempt in a subprocess."""
-
-_COMPLETE_KERNEL_STDOUT_LIMIT = 128_000_000
-"""Bound on the serialized complete basis a worker may stream back."""
-
-_WORKER_PROGRAM = """\
-import json
-import sys
-
-from pydantic import ValidationError
-from sympy import Poly, QQ, Symbol, groebner
-
-from jacobian.math.polynomials._conversions import rational_polynomial_from_sympy
-
-
-def main() -> None:
-    payload = json.loads(sys.stdin.buffer.read().decode("utf-8"))
-    variables = tuple(payload["variables"])
-    symbols = tuple(Symbol(name) for name in variables)
-    try:
-        generators = []
-        for terms in payload["generators"]:
-            poly = Poly.from_dict(
-                {
-                    tuple(term["exponents"]): QQ(int(term["num"]), int(term["den"]))
-                    for term in terms
-                },
-                *symbols,
-                domain=QQ,
-            )
-            generators.append(poly.as_expr())
-        basis = groebner(
-            generators,
-            *symbols,
-            order=payload["monomial_order"],
-            domain=QQ,
-        )
-        polys = [Poly(expr, *symbols, domain=QQ) for expr in basis.exprs]
-        if sum(len(poly.terms()) for poly in polys) > 1024:
-            print(json.dumps({"status": "exceeded"}))
-            return
-        elements = [
-            rational_polynomial_from_sympy(poly, variables) for poly in polys
-        ]
-    except ValidationError:
-        print(json.dumps({"status": "exceeded"}))
-        return
-    except Exception:
-        print(json.dumps({"status": "failed"}))
-        return
-    print(json.dumps({
-        "status": "ok",
-        "basis": [element.model_dump() for element in elements],
-    }))
-
-
-main()
-"""
-
 
 def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
     """Check one integer pair against the canonical rational digit limit."""
@@ -233,76 +173,6 @@ def _finalize_strategy_basis(
         return "FAILED", None
 
 
-def _complete_basis_in_worker(
-    ideal: RationalPolynomialIdeal,
-    monomial_order: str,
-) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
-    """Run one unguarded kernel call over the complete generating set.
-
-    Both guarded orders can abort while a single-shot call still finishes
-    quickly: Buchberger sees every ideal-collapsing pair from the start,
-    so it need never materialize the exploding intermediate bases of any
-    prefix.  The kernel cannot bound itself, so this strategy runs
-    killably in a subprocess with a wall clock; a timeout, kill, or
-    failure yields no conclusion.
-    """
-
-    import json
-    import sys
-
-    from jacobian.math.polynomials.values import RationalPolynomial
-    from jacobian.process import run_bounded_process, worker_environment
-
-    payload = {
-        "variables": list(ideal.variables),
-        "monomial_order": monomial_order,
-        "generators": [
-            [
-                {
-                    "exponents": list(term.exponents),
-                    "num": term.coefficient.num,
-                    "den": term.coefficient.den,
-                }
-                for term in generator.polynomial.terms
-            ]
-            for generator in ideal.generators
-        ],
-    }
-    try:
-        completed = run_bounded_process(
-            [sys.executable, "-c", _WORKER_PROGRAM],
-            input_bytes=json.dumps(payload).encode("utf-8"),
-            timeout_seconds=_COMPLETE_KERNEL_TIMEOUT_SECONDS,
-            environment=worker_environment(),
-            stdout_limit=_COMPLETE_KERNEL_STDOUT_LIMIT,
-            stderr_limit=4096,
-        )
-    except Exception:
-        return None, False
-    if completed.timed_out or completed.cancelled or completed.returncode != 0:
-        return None, False
-    try:
-        report = json.loads(completed.stdout.decode("utf-8"))
-    except Exception:
-        return None, False
-    status = report.get("status")
-    if status == "exceeded":
-        # The worker decided the complete reduced basis against the same
-        # output budgets: sound evidence for the typed budget outcome.
-        return None, True
-    if status != "ok":
-        return None, False
-    try:
-        basis = tuple(
-            RationalPolynomial.model_validate(element) for element in report["basis"]
-        )
-    except Exception:
-        # A declared basis outside the canonical contract is evidence for
-        # no conclusion.
-        return None, False
-    return basis, False
-
-
 def incremental_source_groebner(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
@@ -359,7 +229,9 @@ def incremental_source_groebner(
             return wire_basis, False
         if concluded == "EXCEEDED":
             return None, True
-    return _complete_basis_in_worker(ideal, monomial_order)
+    from jacobian.math.polynomials._groebner_worker import complete_basis_in_worker
+
+    return complete_basis_in_worker(ideal, monomial_order)
 
 
 def _coefficient_exceeds_canonical_limit(value: Any) -> bool:

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -25,11 +25,12 @@ __all__ = [
 
 # Bounded-reduction budget: intermediate reduction work is capped so a
 # pathological request cannot expand an unbounded remainder before the
-# 1,024-term output boundary is noticed. The intermediate work cap is a
-# conservative multiple of the output term budget; the step cap bounds
+# 1,024-term output boundary is noticed. The intermediate caps are
+# conservative multiples of the output term budget; the step cap bounds
 # the division loop itself.
 _MAX_OUTPUT_TERMS = 1_024
 _MAX_INTERMEDIATE_TERMS = 4_096
+_MAX_INTERMEDIATE_BASIS_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
 
 
@@ -42,10 +43,18 @@ def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
     return abs(numerator) >= bound or abs(denominator) >= bound
 
 
-def _basis_exceeds_output_budget(basis: Any, symbols: tuple[Any, ...]) -> bool:
-    """Check one computed Gröbner basis against the retained-output budget."""
+def _basis_exceeds_output_budget(
+    basis: Any, symbols: tuple[Any, ...], maximum_terms: int = _MAX_OUTPUT_TERMS
+) -> bool:
+    """Check one computed Gröbner basis against an aggregate term budget.
 
-    from sympy import Poly, QQ
+    Exponent and canonical-coefficient representability limits apply at
+    every scale: a basis element that could not be materialized as a
+    canonical value is outside every work envelope, not only the output
+    boundary.
+    """
+
+    from sympy import QQ, Poly
 
     from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
@@ -54,7 +63,7 @@ def _basis_exceeds_output_budget(basis: Any, symbols: tuple[Any, ...]) -> bool:
         poly = Poly(expr, *symbols, domain=QQ)
         terms = poly.terms()
         aggregate_terms += len(terms)
-        if aggregate_terms > _MAX_OUTPUT_TERMS:
+        if aggregate_terms > maximum_terms:
             return True
         for monom, coefficient in terms:
             if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
@@ -64,28 +73,63 @@ def _basis_exceeds_output_budget(basis: Any, symbols: tuple[Any, ...]) -> bool:
     return False
 
 
+def _canonical_generator_order(ideal: RationalPolynomialIdeal) -> tuple[int, ...]:
+    """Order generator indices by mathematical content alone.
+
+    The key (ascending maximum total degree, then term count, then full
+    term fingerprint) is a deterministic function of the ideal value, so
+    the bounded kernel's behavior never depends on the presentation order
+    of an equivalent generating set.  Simpler generators first also lets
+    collapsing elements — most simply nonzero constants, of degree zero —
+    shrink every later prefix instead of arriving after one has grown.
+    """
+
+    def sort_key(
+        index: int,
+    ) -> tuple[int, int, tuple[tuple[tuple[int, ...], str, str], ...]]:
+        terms = ideal.generators[index].polynomial.terms
+        return (
+            max((sum(term.exponents) for term in terms), default=0),
+            len(terms),
+            tuple(
+                sorted(
+                    (term.exponents, term.coefficient.num, term.coefficient.den)
+                    for term in terms
+                )
+            ),
+        )
+
+    return tuple(sorted(range(len(ideal.generators)), key=sort_key))
+
+
 def incremental_source_groebner(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
 ) -> tuple[Any | None, bool]:
     """Compute the source reduced Gröbner basis with bounded basis growth.
 
-    The kernel runs incrementally, one generator at a time, and every
-    intermediate basis is checked against the output budget (aggregate
-    1,024-term, exponent, and canonical-coefficient limits).  Because a
-    later generator can collapse an oversized intermediate ideal — most
-    simply a nonzero constant generator, which makes any ideal the unit
-    ideal regardless of presentation order — constant generators are
-    detected up front and short-circuit to their own in-budget basis
-    instead of letting an oversized prefix decide the outcome.  Adding
-    generators and re-reducing converges to the unique reduced basis, so
-    the final result equals a single-shot computation whenever that stays
-    within budget.
+    The kernel runs incrementally, one generator at a time, in the
+    canonical content-derived order of ``_canonical_generator_order``, so
+    its outcome is a function of the ideal value rather than of the
+    presentation order of an equivalent generating set.
+
+    Budgets are two-tier.  Every intermediate prefix basis is checked
+    against a work envelope of ``_MAX_INTERMEDIATE_BASIS_TERMS`` aggregate
+    terms (plus exponent and canonical-coefficient representability): a
+    prefix beyond that envelope cannot be processed further without
+    unbounded kernel expansion, so it reports the typed budget outcome.
+    The public 1,024-term output boundary is decided only on the complete
+    final basis: an intermediate prefix may legitimately exceed it and
+    still shrink once later generators are incorporated (adding a
+    generator grows the ideal but can shrink its reduced basis), so a
+    prefix must never decide the output outcome.  Adding generators and
+    re-reducing converges to the unique reduced basis, so the final result
+    equals a single-shot computation whenever that stays within budget.
 
     Returns ``(basis, exceeded)``: ``basis`` is ``None`` when the kernel
-    failed or an intermediate left the budget; ``exceeded`` distinguishes
-    a genuine budget overflow (evidence for a typed budget outcome) from
-    an opaque kernel failure.
+    failed or left a budget; ``exceeded`` distinguishes a genuine budget
+    overflow (evidence for a typed budget outcome) from an opaque kernel
+    failure.
     """
 
     from sympy import QQ, groebner
@@ -101,28 +145,22 @@ def incremental_source_groebner(
         exprs = [rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators]
     except Exception:
         return None, False
-    # A nonzero constant generator collapses the ideal to the unit ideal no
-    # matter how an oversized prefix basis looks; presentation order must
-    # not turn that collapse into a false budget overflow.
-    for expr in exprs:
-        if getattr(expr, "is_Number", False) and expr != 0:
-            try:
-                basis = groebner(
-                    [expr], *symbols, order=monomial_order, domain=QQ
-                )
-            except Exception:
-                return None, False
-            return basis, False
+    ordered = [exprs[index] for index in _canonical_generator_order(ideal)]
     current: list[Any] = []
     basis = None
-    for expr in exprs:
+    for position, expr in enumerate(ordered):
         current.append(expr)
         try:
             basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
         except Exception:
             return None, False
         try:
-            exceeded = _basis_exceeds_output_budget(basis, symbols)
+            if position == len(ordered) - 1:
+                exceeded = _basis_exceeds_output_budget(basis, symbols)
+            else:
+                exceeded = _basis_exceeds_output_budget(
+                    basis, symbols, maximum_terms=_MAX_INTERMEDIATE_BASIS_TERMS
+                )
         except Exception:
             return None, False
         if exceeded:
@@ -301,13 +339,13 @@ def retained_source_basis_exceeds_budget(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
 ) -> bool:
-    """Recompute the source Gröbner basis and check it leaves the output budget.
+    """Recompute the source Gröbner basis and check it leaves the budgets.
 
     This substantiates a ``BUDGET_EXCEEDED`` result that retains no basis:
-    such an outcome is accepted only when the recomputed source basis
-    genuinely violates the aggregate 1,024-term, exponent, or canonical
-    coefficient output boundary.  Any kernel failure is not evidence and
-    returns ``False`` so authored results stay rejected.
+    such an outcome is accepted only when the recomputation genuinely
+    violates the aggregate 1,024-term output boundary, a representability
+    limit, or the intermediate work envelope.  Any kernel failure is not
+    evidence and returns ``False`` so authored results stay rejected.
     """
 
     _basis, exceeded = incremental_source_groebner(ideal, monomial_order)

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -112,13 +112,24 @@ def replayed_remainder_term_count(
     )
 
 
+def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
+    """Check whether one exact QQ coefficient leaves the canonical rational domain."""
+
+    from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
+
+    bound = 10**MAX_CANONICAL_RATIONAL_DIGITS
+    numerator = abs(int(value.numerator))
+    denominator = abs(int(value.denominator))
+    return numerator >= bound or denominator >= bound
+
+
 def replayed_remainder_exceeds_budget(
     ideal: RationalPolynomialIdeal,
     groebner_basis: tuple[RationalPolynomial, ...],
     polynomial: RationalPolynomial,
     monomial_order: str,
 ) -> bool:
-    """Check whether the replayed remainder exceeds the 1,024-term or 32,768-exponent budget."""
+    """Check whether the replayed remainder exceeds the 1,024-term, 32,768-exponent, or canonical-coefficient budget."""
 
     from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
@@ -129,6 +140,12 @@ def replayed_remainder_exceeds_budget(
         # Check exponent cap efficiently via monoms
         for monom in remainder.monoms():
             if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
+                return True
+        # A remainder whose coefficients leave the canonical rational domain is
+        # likewise outside the representable result contract: the operation
+        # reports BUDGET_EXCEEDED for it, so the replay predicate must agree.
+        for _, coefficient in remainder.terms():
+            if _coefficient_exceeds_canonical_limit(coefficient):
                 return True
     except Exception:
         # If we cannot inspect monoms, conservatively treat as exceeding

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -42,6 +42,79 @@ def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
     return abs(numerator) >= bound or abs(denominator) >= bound
 
 
+def _basis_exceeds_output_budget(basis: Any, symbols: tuple[Any, ...]) -> bool:
+    """Check one computed Gröbner basis against the retained-output budget."""
+
+    from sympy import Poly, QQ
+
+    from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
+
+    aggregate_terms = 0
+    for expr in basis.exprs:
+        poly = Poly(expr, *symbols, domain=QQ)
+        terms = poly.terms()
+        aggregate_terms += len(terms)
+        if aggregate_terms > _MAX_OUTPUT_TERMS:
+            return True
+        for monom, coefficient in terms:
+            if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
+                return True
+            if _component_exceeds_limit(int(coefficient.p), int(coefficient.q)):
+                return True
+    return False
+
+
+def incremental_source_groebner(
+    ideal: RationalPolynomialIdeal,
+    monomial_order: str,
+) -> tuple[Any | None, bool]:
+    """Compute the source reduced Gröbner basis with bounded basis growth.
+
+    The kernel runs incrementally, one generator at a time, and every
+    intermediate basis is checked against the output budget (aggregate
+    1,024-term, exponent, and canonical-coefficient limits) before the
+    next generator is added.  This conservatively bounds basis growth so
+    admitted requests cannot drive an unbounded intermediate coefficient
+    expansion inside the kernel.  Adding generators and re-reducing
+    converges to the unique reduced basis, so the final result equals a
+    single-shot computation whenever that stays within budget.
+
+    Returns ``(basis, exceeded)``: ``basis`` is ``None`` when the kernel
+    failed or an intermediate left the budget; ``exceeded`` distinguishes
+    a genuine budget overflow (evidence for a typed budget outcome) from
+    an opaque kernel failure.
+    """
+
+    from sympy import QQ, groebner
+
+    from jacobian.math.polynomials._conversions import (
+        rational_polynomial_to_sympy,
+        symbols_for_variables,
+    )
+
+    variables = ideal.variables
+    symbols = symbols_for_variables(variables)
+    try:
+        exprs = [rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators]
+    except Exception:
+        return None, False
+    current: list[Any] = []
+    basis = None
+    for expr in exprs:
+        current.append(expr)
+        try:
+            basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
+        except Exception:
+            return None, False
+        try:
+            exceeded = _basis_exceeds_output_budget(basis, symbols)
+        except Exception:
+            return None, False
+        if exceeded:
+            return None, True
+    return basis, False
+
+
 def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
     """Check whether one exact QQ coefficient leaves the canonical rational domain."""
 
@@ -222,39 +295,8 @@ def retained_source_basis_exceeds_budget(
     returns ``False`` so authored results stay rejected.
     """
 
-    from sympy import QQ, Poly, groebner
-
-    from jacobian.math.polynomials._conversions import (
-        rational_polynomial_to_sympy,
-        symbols_for_variables,
-    )
-    from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
-
-    variables = ideal.variables
-    symbols = symbols_for_variables(variables)
-    try:
-        source_exprs = [
-            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
-        ]
-        source_gb = groebner(source_exprs, *symbols, order=monomial_order, domain=QQ)
-    except Exception:
-        return False
-    aggregate_terms = 0
-    try:
-        for expr in source_gb.exprs:
-            poly = Poly(expr, *symbols, domain=QQ)
-            terms = poly.terms()
-            aggregate_terms += len(terms)
-            if aggregate_terms > 1024:
-                return True
-            for monom, coefficient in terms:
-                if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
-                    return True
-                if _component_exceeds_limit(int(coefficient.p), int(coefficient.q)):
-                    return True
-    except Exception:
-        return False
-    return False
+    _basis, exceeded = incremental_source_groebner(ideal, monomial_order)
+    return exceeded
 
 
 def retained_basis_is_groebner(
@@ -264,32 +306,28 @@ def retained_basis_is_groebner(
 ) -> bool:
     """Check the retained tuple is the reduced Gröbner basis of the ideal.
 
-    Recomputes the exact Gröbner basis from the source generators and
-    compares it to the retained wire basis as SymPy ``Poly`` sets.  This
-    ensures the retained basis is not merely a generating set but a
-    Gröbner basis, so remainder replay via sparse-ring division is the
-    unique normal form.
+    Recomputes the exact Gröbner basis from the source generators with
+    bounded basis growth and compares it to the retained wire basis as
+    wire-form sets.  This ensures the retained basis is not merely a
+    generating set but a Gröbner basis, so remainder replay via
+    sparse-ring division is the unique normal form.
     """
-
-    from sympy import QQ, groebner
 
     from jacobian.math.polynomials._conversions import (
         rational_polynomial_from_sympy,
-        rational_polynomial_to_sympy,
         symbols_for_variables,
     )
 
     variables = ideal.variables
     symbols = symbols_for_variables(variables)
+    source_gb, exceeded = incremental_source_groebner(ideal, monomial_order)
+    if source_gb is None or exceeded:
+        return False
     try:
-        source_exprs = [
-            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
-        ]
-        source_gb = groebner(source_exprs, *symbols, order=monomial_order, domain=QQ)
         computed_polys = tuple(
             rational_polynomial_from_sympy(
-                # ``source_gb.polys`` are ``Poly``; ensure domain QQ
-                __import__("sympy").Poly(expr, *symbols, domain=QQ),
+                # ``source_gb.exprs`` convert to ``Poly`` over QQ
+                __import__("sympy").Poly(expr, *symbols, domain=__import__("sympy").QQ),
                 variables,
             )
             for expr in source_gb.exprs

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -21,6 +21,8 @@ __all__ = [
     "generators_reduce_to_zero",
     "remainder_matches_claim",
     "replayed_remainder_term_count",
+    "retained_basis_in_ideal",
+    "retained_basis_is_groebner",
 ]
 
 
@@ -108,3 +110,131 @@ def replayed_remainder_term_count(
     return _term_count(
         _replay_division(ideal, groebner_basis, polynomial, monomial_order)
     )
+
+
+def replayed_remainder_exceeds_budget(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    polynomial: RationalPolynomial,
+    monomial_order: str,
+) -> bool:
+    """Check whether the replayed remainder exceeds the 1,024-term or 32,768-exponent budget."""
+
+    from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
+
+    remainder = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    if _term_count(remainder) > 1024:
+        return True
+    try:
+        # Check exponent cap efficiently via monoms
+        for monom in remainder.monoms():
+            if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
+                return True
+    except Exception:
+        # If we cannot inspect monoms, conservatively treat as exceeding
+        return True
+    return False
+
+
+def retained_basis_in_ideal(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    monomial_order: str,
+) -> bool:
+    """Check every retained basis element belongs to the source ideal.
+
+    Each ``groebner_basis`` element must reduce to zero modulo the Gröbner
+    basis of the source ``ideal``.  This catches forgeries such as
+    ``<x^2>`` with retained basis ``(1)`` where generators still reduce to
+    zero modulo ``(1)`` but ``1`` is not in ``<x^2>``.
+    """
+
+    if not groebner_basis:
+        return True
+    # Compute a Groebner basis for the source ideal once.
+    from sympy import QQ, groebner
+
+    from jacobian.math.polynomials._conversions import (
+        rational_polynomial_to_sympy,
+        symbols_for_variables,
+    )
+
+    variables = ideal.variables
+    symbols = symbols_for_variables(variables)
+    try:
+        source_exprs = [
+            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
+        ]
+        source_gb = groebner(source_exprs, *symbols, order=monomial_order, domain=QQ)
+    except Exception:
+        return False
+    # For the zero ideal, SymPy's Groebner basis is empty; no nonzero
+    # polynomial belongs to it, so any non-empty retained basis must be rejected
+    # (which the reduction check below will do: reducing a nonzero element
+    # modulo an empty basis leaves it unchanged, not zero).
+    for element in groebner_basis:
+        try:
+            expr = rational_polynomial_to_sympy(element).as_expr()
+            remainder = source_gb.reduce(expr)[1]
+            if remainder != 0:
+                return False
+        except Exception:
+            return False
+    return True
+
+
+def retained_basis_is_groebner(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    monomial_order: str,
+) -> bool:
+    """Check the retained tuple is the reduced Gröbner basis of the ideal.
+
+    Recomputes the exact Gröbner basis from the source generators and
+    compares it to the retained wire basis as SymPy ``Poly`` sets.  This
+    ensures the retained basis is not merely a generating set but a
+    Gröbner basis, so remainder replay via sparse-ring division is the
+    unique normal form.
+    """
+
+    from sympy import QQ, groebner
+
+    from jacobian.math.polynomials._conversions import (
+        rational_polynomial_from_sympy,
+        rational_polynomial_to_sympy,
+        symbols_for_variables,
+    )
+
+    variables = ideal.variables
+    symbols = symbols_for_variables(variables)
+    try:
+        source_exprs = [
+            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
+        ]
+        source_gb = groebner(source_exprs, *symbols, order=monomial_order, domain=QQ)
+        computed_polys = tuple(
+            rational_polynomial_from_sympy(
+                # ``source_gb.polys`` are ``Poly``; ensure domain QQ
+                __import__("sympy").Poly(expr, *symbols, domain=QQ),
+                variables,
+            )
+            for expr in source_gb.exprs
+        )
+    except Exception:
+        return False
+    # Empty source ideal must correspond to empty retained basis.
+    if not computed_polys and not groebner_basis:
+        return True
+    if len(computed_polys) != len(groebner_basis):
+        return False
+    # Compare as unordered sets of wire forms (sorted fingerprint).
+    def _key(poly: RationalPolynomial) -> tuple[tuple[tuple[int, ...], str, str], ...]:
+        return tuple(
+            (term.exponents, term.coefficient.num, term.coefficient.den)
+            for term in poly.polynomial.terms
+        )
+
+    try:
+        return sorted(computed_polys, key=_key) == sorted(groebner_basis, key=_key)
+    except Exception:
+        return False

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -38,7 +38,7 @@ def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
 
     from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
 
-    bound = 10**MAX_CANONICAL_RATIONAL_DIGITS
+    bound: int = 10**MAX_CANONICAL_RATIONAL_DIGITS
     return abs(numerator) >= bound or abs(denominator) >= bound
 
 
@@ -148,7 +148,9 @@ def incremental_source_groebner(
     variables = ideal.variables
     symbols = symbols_for_variables(variables)
     try:
-        exprs = [rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators]
+        exprs = [
+            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
+        ]
     except Exception:
         return None, False
     ordered = [exprs[index] for index in _canonical_generator_order(ideal)]
@@ -181,9 +183,7 @@ def incremental_source_groebner(
 def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
     """Check whether one exact QQ coefficient leaves the canonical rational domain."""
 
-    return _component_exceeds_limit(
-        int(value.numerator), int(value.denominator)
-    )
+    return _component_exceeds_limit(int(value.numerator), int(value.denominator))
 
 
 def budgeted_reduce(
@@ -211,9 +211,7 @@ def budgeted_reduce(
         reducer = None
         for divisor in divisors:
             lm = divisor.leading_expv()
-            if lm is not None and all(
-                lead_monom[k] >= lm[k] for k in range(len(lm))
-            ):
+            if lm is not None and all(lead_monom[k] >= lm[k] for k in range(len(lm))):
                 reducer = divisor
                 break
         if reducer is not None:
@@ -292,7 +290,7 @@ def remainder_matches_claim(
     if replayed is None:
         return False
     claimed = _ring_element(ring_context, claimed_remainder)
-    return replayed == claimed
+    return bool(replayed == claimed)
 
 
 def generators_reduce_to_zero(
@@ -305,9 +303,7 @@ def generators_reduce_to_zero(
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     zero = ring_context.zero
     for generator in ideal.generators:
-        replayed = _replay_division(
-            ideal, groebner_basis, generator, monomial_order
-        )
+        replayed = _replay_division(ideal, groebner_basis, generator, monomial_order)
         # An overflowing reduction cannot be corroborated, so fail closed.
         if replayed is None or replayed != zero:
             return False
@@ -402,6 +398,7 @@ def retained_basis_is_groebner(
         return True
     if len(computed_polys) != len(groebner_basis):
         return False
+
     # Compare as unordered sets of wire forms (sorted fingerprint).
     def _key(poly: RationalPolynomial) -> tuple[tuple[tuple[int, ...], str, str], ...]:
         return tuple(

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -20,10 +20,80 @@ if TYPE_CHECKING:
 __all__ = [
     "generators_reduce_to_zero",
     "remainder_matches_claim",
-    "replayed_remainder_term_count",
-    "retained_basis_in_ideal",
     "retained_basis_is_groebner",
 ]
+
+# Bounded-reduction budget: intermediate reduction work is capped so a
+# pathological request cannot expand an unbounded remainder before the
+# 1,024-term output boundary is noticed. The intermediate work cap is a
+# conservative multiple of the output term budget; the step cap bounds
+# the division loop itself.
+_MAX_OUTPUT_TERMS = 1_024
+_MAX_INTERMEDIATE_TERMS = 4_096
+_MAX_REDUCTION_STEPS = 200_000
+
+
+def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
+    """Check one integer pair against the canonical rational digit limit."""
+
+    from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
+
+    bound = 10**MAX_CANONICAL_RATIONAL_DIGITS
+    return abs(numerator) >= bound or abs(denominator) >= bound
+
+
+def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
+    """Check whether one exact QQ coefficient leaves the canonical rational domain."""
+
+    return _component_exceeds_limit(
+        int(value.numerator), int(value.denominator)
+    )
+
+
+def budgeted_reduce(
+    ring_context: Any, dividend: Any, divisors: list[Any]
+) -> Any | None:
+    """Divide ``dividend`` by a fixed Gröbner basis with bounded work.
+
+    This is the standard multivariate long division: each step either
+    cancels the current leading monomial against the one basis element
+    whose leading monomial divides it (introducing only strictly smaller
+    monomials, so the loop terminates), or moves the leading term into
+    the remainder. Returns ``None`` when the work or output budget is
+    exceeded; the caller then reports a typed budget outcome instead of
+    materializing an unbounded intermediate polynomial.
+    """
+
+    remainder = ring_context.zero
+    work = dividend
+    steps = 0
+    while work:
+        steps += 1
+        if steps > _MAX_REDUCTION_STEPS:
+            return None
+        lead_monom = work.leading_expv()
+        reducer = None
+        for divisor in divisors:
+            lm = divisor.leading_expv()
+            if lm is not None and all(
+                lead_monom[k] >= lm[k] for k in range(len(lm))
+            ):
+                reducer = divisor
+                break
+        if reducer is not None:
+            lm = reducer.leading_expv()
+            diff = tuple(a - b for a, b in zip(lead_monom, lm, strict=True))
+            scale = ring_context.term_new(diff, work[lead_monom] / reducer[lm])
+            work = work - scale * reducer
+            if len(work.monoms()) > _MAX_INTERMEDIATE_TERMS:
+                return None
+        else:
+            lead_term = ring_context.term_new(lead_monom, work[lead_monom])
+            remainder = remainder + lead_term
+            work = work - lead_term
+            if len(remainder.monoms()) > _MAX_OUTPUT_TERMS:
+                return None
+    return remainder
 
 
 def _sparse_ring(variables: tuple[str, ...], order: str) -> Any:
@@ -55,14 +125,13 @@ def _replay_division(
     groebner_basis: tuple[RationalPolynomial, ...],
     polynomial: RationalPolynomial,
     monomial_order: str,
-) -> Any:
-    """Return the unique remainder of ``polynomial`` modulo ``groebner_basis``."""
+) -> Any | None:
+    """Return the unique remainder modulo ``groebner_basis``, or ``None`` on budget overflow."""
 
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     divisors = [_ring_element(ring_context, element) for element in groebner_basis]
     dividend = _ring_element(ring_context, polynomial)
-    _, remainder = dividend.div(divisors)
-    return remainder
+    return budgeted_reduce(ring_context, dividend, divisors)
 
 
 def _term_count(element: Any) -> int:
@@ -76,10 +145,16 @@ def remainder_matches_claim(
     monomial_order: str,
     claimed_remainder: RationalPolynomial,
 ) -> bool:
-    """Check that the claimed wire remainder equals the replayed reduction."""
+    """Check that the claimed wire remainder equals the replayed reduction.
+
+    A replay whose bounded reduction overflows cannot corroborate a
+    ``COMPUTED`` claim, so it reports a mismatch.
+    """
 
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     replayed = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    if replayed is None:
+        return False
     claimed = _ring_element(ring_context, claimed_remainder)
     return replayed == claimed
 
@@ -91,36 +166,16 @@ def generators_reduce_to_zero(
 ) -> bool:
     """Check every retained ideal generator reduces to zero modulo the basis."""
 
+    ring_context = _sparse_ring(ideal.variables, monomial_order)
+    zero = ring_context.zero
     for generator in ideal.generators:
-        zero = _sparse_ring(ideal.variables, monomial_order).zero
-        replayed = _replay_division(ideal, groebner_basis, generator, monomial_order)
-        if replayed != zero:
+        replayed = _replay_division(
+            ideal, groebner_basis, generator, monomial_order
+        )
+        # An overflowing reduction cannot be corroborated, so fail closed.
+        if replayed is None or replayed != zero:
             return False
     return True
-
-
-def replayed_remainder_term_count(
-    ideal: RationalPolynomialIdeal,
-    groebner_basis: tuple[RationalPolynomial, ...],
-    polynomial: RationalPolynomial,
-    monomial_order: str,
-) -> int:
-    """Return the replayed remainder's term count without materializing wire data."""
-
-    return _term_count(
-        _replay_division(ideal, groebner_basis, polynomial, monomial_order)
-    )
-
-
-def _coefficient_exceeds_canonical_limit(value: Any) -> bool:
-    """Check whether one exact QQ coefficient leaves the canonical rational domain."""
-
-    from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS
-
-    bound = 10**MAX_CANONICAL_RATIONAL_DIGITS
-    numerator = abs(int(value.numerator))
-    denominator = abs(int(value.denominator))
-    return numerator >= bound or denominator >= bound
 
 
 def replayed_remainder_exceeds_budget(
@@ -134,10 +189,11 @@ def replayed_remainder_exceeds_budget(
     from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
     remainder = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
-    if _term_count(remainder) > 1024:
+    if remainder is None:
+        # The bounded reduction itself overflowed: the remainder is
+        # certainly outside the output budget.
         return True
     try:
-        # Check exponent cap efficiently via monoms
         for monom in remainder.monoms():
             if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
                 return True
@@ -153,28 +209,26 @@ def replayed_remainder_exceeds_budget(
     return False
 
 
-def retained_basis_in_ideal(
+def retained_source_basis_exceeds_budget(
     ideal: RationalPolynomialIdeal,
-    groebner_basis: tuple[RationalPolynomial, ...],
     monomial_order: str,
 ) -> bool:
-    """Check every retained basis element belongs to the source ideal.
+    """Recompute the source Gröbner basis and check it leaves the output budget.
 
-    Each ``groebner_basis`` element must reduce to zero modulo the Gröbner
-    basis of the source ``ideal``.  This catches forgeries such as
-    ``<x^2>`` with retained basis ``(1)`` where generators still reduce to
-    zero modulo ``(1)`` but ``1`` is not in ``<x^2>``.
+    This substantiates a ``BUDGET_EXCEEDED`` result that retains no basis:
+    such an outcome is accepted only when the recomputed source basis
+    genuinely violates the aggregate 1,024-term, exponent, or canonical
+    coefficient output boundary.  Any kernel failure is not evidence and
+    returns ``False`` so authored results stay rejected.
     """
 
-    if not groebner_basis:
-        return True
-    # Compute a Groebner basis for the source ideal once.
-    from sympy import QQ, groebner
+    from sympy import QQ, Poly, groebner
 
     from jacobian.math.polynomials._conversions import (
         rational_polynomial_to_sympy,
         symbols_for_variables,
     )
+    from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
 
     variables = ideal.variables
     symbols = symbols_for_variables(variables)
@@ -185,19 +239,22 @@ def retained_basis_in_ideal(
         source_gb = groebner(source_exprs, *symbols, order=monomial_order, domain=QQ)
     except Exception:
         return False
-    # For the zero ideal, SymPy's Groebner basis is empty; no nonzero
-    # polynomial belongs to it, so any non-empty retained basis must be rejected
-    # (which the reduction check below will do: reducing a nonzero element
-    # modulo an empty basis leaves it unchanged, not zero).
-    for element in groebner_basis:
-        try:
-            expr = rational_polynomial_to_sympy(element).as_expr()
-            remainder = source_gb.reduce(expr)[1]
-            if remainder != 0:
-                return False
-        except Exception:
-            return False
-    return True
+    aggregate_terms = 0
+    try:
+        for expr in source_gb.exprs:
+            poly = Poly(expr, *symbols, domain=QQ)
+            terms = poly.terms()
+            aggregate_terms += len(terms)
+            if aggregate_terms > 1024:
+                return True
+            for monom, coefficient in terms:
+                if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
+                    return True
+                if _component_exceeds_limit(int(coefficient.p), int(coefficient.q)):
+                    return True
+    except Exception:
+        return False
+    return False
 
 
 def retained_basis_is_groebner(

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
-    "ReductionWorkLimitExceeded",
+    "ReductionWorkLimitError",
     "generators_reduce_to_zero",
     "remainder_matches_claim",
     "retained_basis_is_groebner",
@@ -34,7 +34,7 @@ _MAX_INTERMEDIATE_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
 
 
-class ReductionWorkLimitExceeded(RuntimeError):
+class ReductionWorkLimitError(RuntimeError):
     """Bounded division ran out of algorithmic work without any exact
     artifact leaving its boundary.
 
@@ -122,7 +122,7 @@ def budgeted_reduce(
     monomials, so the loop terminates), or moves the leading term into
     the remainder. Returns ``None`` only when the exact remainder itself
     leaves the 1,024-term output boundary; raises
-    :class:`ReductionWorkLimitExceeded` when the reduction's algorithmic
+    :class:`ReductionWorkLimitError` when the reduction's algorithmic
     work (division steps or a temporarily expanded intermediate) exhausts
     its cap without any artifact overflowing, so callers can report the
     typed non-conclusion outcome instead of an unsubstantiated budget
@@ -135,7 +135,7 @@ def budgeted_reduce(
     while work:
         steps += 1
         if steps > _MAX_REDUCTION_STEPS:
-            raise ReductionWorkLimitExceeded(
+            raise ReductionWorkLimitError(
                 "bounded reduction exceeded the division-step work cap"
             )
         lead_monom = work.leading_expv()
@@ -151,7 +151,7 @@ def budgeted_reduce(
             scale = ring_context.term_new(diff, work[lead_monom] / reducer[lm])
             work = work - scale * reducer
             if len(work.monoms()) > _MAX_INTERMEDIATE_TERMS:
-                raise ReductionWorkLimitExceeded(
+                raise ReductionWorkLimitError(
                     "bounded reduction exceeded the intermediate work cap"
                 )
         else:
@@ -221,7 +221,7 @@ def remainder_matches_claim(
     ring_context = _sparse_ring(ideal.variables, monomial_order)
     try:
         replayed = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
-    except ReductionWorkLimitExceeded:
+    except ReductionWorkLimitError:
         return False
     if replayed is None:
         return False
@@ -243,7 +243,7 @@ def generators_reduce_to_zero(
             replayed = _replay_division(
                 ideal, groebner_basis, generator, monomial_order
             )
-        except ReductionWorkLimitExceeded:
+        except ReductionWorkLimitError:
             return False
         # An overflowing reduction cannot be corroborated, so fail closed.
         if replayed is None or replayed != zero:
@@ -263,7 +263,7 @@ def replayed_remainder_exceeds_budget(
 
     try:
         remainder = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
-    except ReductionWorkLimitExceeded:
+    except ReductionWorkLimitError:
         # Work exhaustion without an overflowing artifact is not evidence
         # that the remainder leaves its boundary, so it cannot
         # substantiate a BUDGET_EXCEEDED claim.

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -42,159 +42,29 @@ def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
     return abs(numerator) >= bound or abs(denominator) >= bound
 
 
-def _basis_exceeds_output_budget(
-    basis: Any,
-    symbols: tuple[Any, ...],
-    maximum_terms: int = _MAX_OUTPUT_TERMS,
-) -> bool:
-    """Check one computed Gröbner basis against the output budgets.
-
-    The aggregate 1,024-term boundary and the representability limits
-    (32,768 exponents, canonical coefficient digits) apply only to a
-    complete basis: the reduced Gröbner basis of the full generating set
-    is unique, so its budget status is a function of the ideal value.
-    """
-
-    from sympy import QQ, Poly
-
-    from jacobian.math.polynomials.values import MAX_POLYNOMIAL_EXPONENT
-
-    aggregate_terms = 0
-    for expr in basis.exprs:
-        poly = Poly(expr, *symbols, domain=QQ)
-        terms = poly.terms()
-        aggregate_terms += len(terms)
-        if aggregate_terms > maximum_terms:
-            return True
-        for monom, coefficient in terms:
-            if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
-                return True
-            if _component_exceeds_limit(int(coefficient.p), int(coefficient.q)):
-                return True
-    return False
-
-
-def _canonical_generator_order(ideal: RationalPolynomialIdeal) -> tuple[int, ...]:
-    """Order generator indices by mathematical content alone.
-
-    The key (ascending maximum total degree, then term count, then full
-    term fingerprint) is a deterministic function of the ideal value, so
-    the bounded kernel's behavior never depends on the presentation order
-    of an equivalent generating set.  Simpler generators first also lets
-    collapsing elements — most simply nonzero constants, of degree zero —
-    shrink every later prefix instead of arriving after one has grown.
-    """
-
-    def sort_key(
-        index: int,
-    ) -> tuple[int, int, tuple[tuple[tuple[int, ...], str, str], ...]]:
-        terms = ideal.generators[index].polynomial.terms
-        return (
-            max((sum(term.exponents) for term in terms), default=0),
-            len(terms),
-            tuple(
-                sorted(
-                    (term.exponents, term.coefficient.num, term.coefficient.den)
-                    for term in terms
-                )
-            ),
-        )
-
-    return tuple(sorted(range(len(ideal.generators)), key=sort_key))
-
-
-def _guarded_incremental(
-    exprs: list[Any],
-    symbols: tuple[Any, ...],
-    monomial_order: str,
-) -> tuple[str, Any]:
-    """Run the kernel over one generator order under a work bound.
-
-    Returns ``("OK", basis)`` when every prefix stayed representable,
-    ``("EXCEEDED", None)`` when the complete generating set's basis leaves
-    an output budget, ``("ABORTED", None)`` when a mid-sequence prefix
-    left a budget — a work bound, not a conclusion, because later
-    generators can still shrink the ideal — and ``("FAILED", None)`` when
-    the kernel itself failed, which is likewise no evidence.
-    """
-
-    from sympy import QQ, groebner
-
-    current: list[Any] = []
-    basis = None
-    for position, expr in enumerate(exprs):
-        current.append(expr)
-        try:
-            basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
-        except Exception:
-            return "FAILED", None
-        try:
-            exceeded = _basis_exceeds_output_budget(basis, symbols)
-        except Exception:
-            return "FAILED", None
-        if exceeded:
-            if position == len(exprs) - 1:
-                return "EXCEEDED", None
-            return "ABORTED", None
-    if basis is None:
-        return "FAILED", None
-    return "OK", basis
-
-
-def _finalize_strategy_basis(
-    basis: Any,
-    symbols: tuple[Any, ...],
-    variables: tuple[str, ...],
-) -> tuple[str, tuple[RationalPolynomial, ...] | None]:
-    """Convert one completed sympy basis to wire form, deciding the budgets.
-
-    Representability failures (canonical term limits, exponent or digit
-    bounds) are complete-basis overflow evidence; other failures carry no
-    conclusion.
-    """
-
-    from pydantic import ValidationError
-    from sympy import QQ, Poly
-
-    from jacobian.math.polynomials._conversions import (
-        rational_polynomial_from_sympy,
-    )
-
-    try:
-        polys = [Poly(expr.as_expr(), *symbols, domain=QQ) for expr in basis.exprs]
-        if sum(len(poly.terms()) for poly in polys) > _MAX_OUTPUT_TERMS:
-            return "EXCEEDED", None
-        return "OK", tuple(
-            rational_polynomial_from_sympy(poly, variables) for poly in polys
-        )
-    except ValidationError:
-        return "EXCEEDED", None
-    except Exception:
-        return "FAILED", None
-
-
 def incremental_source_groebner(
     ideal: RationalPolynomialIdeal,
     monomial_order: str,
 ) -> tuple[tuple[RationalPolynomial, ...] | None, bool]:
     """Compute the source reduced Gröbner basis in wire form.
 
-    No output-budget decision is ever taken from an intermediate prefix:
-    adding a generator grows the ideal but can shrink its reduced basis
-    (one trailing coprime generator collapses the ideal to the unit
-    ideal), so every prefix property — aggregate term count, exponent,
-    coefficient digits — is presentation-dependent evidence that later
-    generators may invalidate.  Only the basis of the complete generating
-    set, whose reduced form is unique, decides an overflow.
+    No Gröbner attempt ever runs in the service process: an admitted hard
+    system can consume unbounded kernel time or memory before any output
+    boundary is noticed.  Every attempt instead runs killably in a
+    subprocess under a wall clock and hard resource limits (see
+    ``_groebner_worker``), and no attempt ever decides an output budget
+    from an intermediate prefix — adding a generator grows the ideal but
+    can shrink its reduced basis, so only the basis of the complete
+    generating set, whose reduced form is unique, decides an overflow.
 
-    Each guarded strategy runs the kernel incrementally in a
-    content-derived order and aborts at its first mid-sequence budget
-    trip purely as a work bound: strategy one uses the canonical
-    ascending order, strategy two its reverse.  When both abort or fail,
-    a third strategy runs the kernel once over the complete generating
-    set inside a killable subprocess with a wall clock, where collapsing
-    pairs are visible from the start.  A strategy that cannot conclude
-    yields no evidence either way.
+    Strategy one and two run the guarded incremental construction over
+    content-derived ascending and descending generator orders; a
+    mid-sequence budget trip there aborts that strategy as a pure work
+    bound.  When both abort or fail, strategy three submits the whole
+    generating set to one unguarded kernel call, where Buchberger sees
+    every ideal-collapsing pair from the start and need never materialize
+    any exploding prefix.  An attempt that cannot conclude yields no
+    evidence either way.
 
     Returns ``(basis, exceeded)``: ``basis`` is the complete reduced
     Gröbner basis when some bounded strategy concluded within budget;
@@ -202,36 +72,23 @@ def incremental_source_groebner(
     outcome, and ``(None, False)`` reports that no conclusion exists.
     """
 
-    from jacobian.math.polynomials._conversions import (
-        rational_polynomial_to_sympy,
-        symbols_for_variables,
+    from jacobian.math.polynomials._groebner_worker import (
+        complete_basis_in_worker,
     )
 
-    variables = ideal.variables
-    symbols = symbols_for_variables(variables)
-    try:
-        exprs = [
-            rational_polynomial_to_sympy(gen).as_expr() for gen in ideal.generators
-        ]
-    except Exception:
-        return None, False
-    canonical = _canonical_generator_order(ideal)
-    for ordered in (canonical, tuple(reversed(canonical))):
-        outcome, basis = _guarded_incremental(
-            [exprs[index] for index in ordered], symbols, monomial_order
-        )
-        if outcome == "EXCEEDED":
+    for strategy in ("ascending", "descending"):
+        status, basis = complete_basis_in_worker(ideal, monomial_order, strategy)
+        if status == "ok":
+            return basis, False
+        if status == "exceeded":
             return None, True
-        if outcome != "OK":
-            continue
-        concluded, wire_basis = _finalize_strategy_basis(basis, symbols, variables)
-        if concluded == "OK":
-            return wire_basis, False
-        if concluded == "EXCEEDED":
-            return None, True
-    from jacobian.math.polynomials._groebner_worker import complete_basis_in_worker
-
-    return complete_basis_in_worker(ideal, monomial_order)
+        # Aborted or failed attempts decide nothing; retry.
+    status, basis = complete_basis_in_worker(ideal, monomial_order, "complete")
+    if status == "ok":
+        return basis, False
+    if status == "exceeded":
+        return None, True
+    return None, False
 
 
 def _coefficient_exceeds_canonical_limit(value: Any) -> bool:

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -30,7 +30,6 @@ __all__ = [
 # the division loop itself.
 _MAX_OUTPUT_TERMS = 1_024
 _MAX_INTERMEDIATE_TERMS = 4_096
-_MAX_INTERMEDIATE_BASIS_TERMS = 4_096
 _MAX_REDUCTION_STEPS = 200_000
 
 
@@ -44,14 +43,20 @@ def _component_exceeds_limit(numerator: int, denominator: int) -> bool:
 
 
 def _basis_exceeds_output_budget(
-    basis: Any, symbols: tuple[Any, ...], maximum_terms: int = _MAX_OUTPUT_TERMS
+    basis: Any,
+    symbols: tuple[Any, ...],
+    maximum_terms: int = _MAX_OUTPUT_TERMS,
+    enforce_aggregate_terms: bool = True,
 ) -> bool:
     """Check one computed Gröbner basis against an aggregate term budget.
 
     Exponent and canonical-coefficient representability limits apply at
     every scale: a basis element that could not be materialized as a
     canonical value is outside every work envelope, not only the output
-    boundary.
+    boundary.  The aggregate term count, by contrast, is enforced only
+    when ``enforce_aggregate_terms`` is set — callers replaying prefixes
+    must not charge it there because adding a generator can shrink the
+    reduced basis.
     """
 
     from sympy import QQ, Poly
@@ -62,9 +67,10 @@ def _basis_exceeds_output_budget(
     for expr in basis.exprs:
         poly = Poly(expr, *symbols, domain=QQ)
         terms = poly.terms()
-        aggregate_terms += len(terms)
-        if aggregate_terms > maximum_terms:
-            return True
+        if enforce_aggregate_terms:
+            aggregate_terms += len(terms)
+            if aggregate_terms > maximum_terms:
+                return True
         for monom, coefficient in terms:
             if any(exp > MAX_POLYNOMIAL_EXPONENT for exp in monom):
                 return True
@@ -113,18 +119,18 @@ def incremental_source_groebner(
     its outcome is a function of the ideal value rather than of the
     presentation order of an equivalent generating set.
 
-    Budgets are two-tier.  Every intermediate prefix basis is checked
-    against a work envelope of ``_MAX_INTERMEDIATE_BASIS_TERMS`` aggregate
-    terms (plus exponent and canonical-coefficient representability): a
-    prefix beyond that envelope cannot be processed further without
-    unbounded kernel expansion, so it reports the typed budget outcome.
-    The public 1,024-term output boundary is decided only on the complete
-    final basis: an intermediate prefix may legitimately exceed it and
-    still shrink once later generators are incorporated (adding a
-    generator grows the ideal but can shrink its reduced basis), so a
-    prefix must never decide the output outcome.  Adding generators and
-    re-reducing converges to the unique reduced basis, so the final result
-    equals a single-shot computation whenever that stays within budget.
+    Budgets are two-tier.  Canonical representability (exponent and
+    coefficient-digit limits) applies at every prefix: a basis element
+    that cannot be materialized as a canonical value stops the kernel
+    immediately, since no later stage could construct the exact artifact.
+    The aggregate 1,024-term output boundary, by contrast, is decided
+    only on the complete final basis and never on an intermediate
+    prefix: adding a generator grows the ideal but can shrink its
+    reduced basis, so a prefix's term count is presentation-dependent
+    evidence that must not decide the outcome.  Adding generators and
+    re-reducing converges to the unique reduced basis, so the final
+    result equals a single-shot computation whenever that stays within
+    budget.
 
     Returns ``(basis, exceeded)``: ``basis`` is ``None`` when the kernel
     failed or left a budget; ``exceeded`` distinguishes a genuine budget
@@ -148,23 +154,27 @@ def incremental_source_groebner(
     ordered = [exprs[index] for index in _canonical_generator_order(ideal)]
     current: list[Any] = []
     basis = None
-    for position, expr in enumerate(ordered):
+    for expr in ordered:
         current.append(expr)
         try:
             basis = groebner(current, *symbols, order=monomial_order, domain=QQ)
         except Exception:
             return None, False
         try:
-            if position == len(ordered) - 1:
-                exceeded = _basis_exceeds_output_budget(basis, symbols)
-            else:
-                exceeded = _basis_exceeds_output_budget(
-                    basis, symbols, maximum_terms=_MAX_INTERMEDIATE_BASIS_TERMS
-                )
+            if _basis_exceeds_output_budget(
+                basis, symbols, enforce_aggregate_terms=False
+            ):
+                # Representability is scale-free: this exact artifact can
+                # never be materialized as canonical values.
+                return None, True
         except Exception:
             return None, False
-        if exceeded:
-            return None, True
+    try:
+        exceeded = _basis_exceeds_output_budget(basis, symbols)
+    except Exception:
+        return None, False
+    if exceeded:
+        return None, True
     return basis, False
 
 
@@ -343,8 +353,8 @@ def retained_source_basis_exceeds_budget(
 
     This substantiates a ``BUDGET_EXCEEDED`` result that retains no basis:
     such an outcome is accepted only when the recomputation genuinely
-    violates the aggregate 1,024-term output boundary, a representability
-    limit, or the intermediate work envelope.  Any kernel failure is not
+    violates the aggregate 1,024-term output boundary or a
+    representability limit.  Any kernel failure is not
     evidence and returns ``False`` so authored results stay rejected.
     """
 

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -78,7 +78,9 @@ def incremental_source_groebner(
     set to one unguarded kernel call, where Buchberger sees every
     ideal-collapsing pair from the start and need never materialize any
     exploding prefix.  An attempt that cannot conclude yields no evidence
-    either way.
+    either way — including an attempt ended by the worker's hard
+    address-space cap, which is bounded work and never a mathematical
+    claim, so it too falls through to the next strategy.
 
     Returns ``(basis, exceeded)``: ``basis`` is the complete reduced
     Gröbner basis when some bounded strategy concluded within budget;
@@ -96,7 +98,7 @@ def incremental_source_groebner(
             return basis, False
         if status == "exceeded":
             return None, True
-        # Aborted attempts decide nothing; retry.
+        # Aborted and memory-exhausted attempts decide nothing; retry.
     status, basis = complete_basis_in_worker(ideal, monomial_order, "complete")
     if status == "ok":
         return basis, False

--- a/src/jacobian/math/polynomials/_replay.py
+++ b/src/jacobian/math/polynomials/_replay.py
@@ -1,0 +1,110 @@
+"""Replay of Gröbner reduction against a retained basis.
+
+The normal-form operations return their computed Gröbner basis together with
+the remainder so result validation can replay the defining reduction relation
+without re-running the Gröbner kernel: division of one polynomial by a fixed
+Gröbner basis under the declared monomial order has a unique remainder, and
+every ideal generator must reduce to zero.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from jacobian.math.polynomials.values import (
+        RationalPolynomial,
+        RationalPolynomialIdeal,
+    )
+
+__all__ = [
+    "generators_reduce_to_zero",
+    "remainder_matches_claim",
+    "replayed_remainder_term_count",
+]
+
+
+def _sparse_ring(variables: tuple[str, ...], order: str) -> Any:
+    """Return one SymPy sparse polynomial ring in the declared order."""
+
+    from sympy import QQ
+    from sympy.polys.rings import ring
+
+    return ring(", ".join(variables), QQ, order=order)[0]
+
+
+def _ring_element(ring_context: Any, polynomial: RationalPolynomial) -> Any:
+    """Build one sparse-ring element from validated wire data (no parsing)."""
+
+    from sympy import QQ
+
+    if not polynomial.polynomial.terms:
+        return ring_context.zero
+    return ring_context.from_dict(
+        {
+            tuple(term.exponents): QQ(*term.coefficient.as_integer_ratio())
+            for term in polynomial.polynomial.terms
+        }
+    )
+
+
+def _replay_division(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    polynomial: RationalPolynomial,
+    monomial_order: str,
+) -> Any:
+    """Return the unique remainder of ``polynomial`` modulo ``groebner_basis``."""
+
+    ring_context = _sparse_ring(ideal.variables, monomial_order)
+    divisors = [_ring_element(ring_context, element) for element in groebner_basis]
+    dividend = _ring_element(ring_context, polynomial)
+    _, remainder = dividend.div(divisors)
+    return remainder
+
+
+def _term_count(element: Any) -> int:
+    return len(element.monoms())
+
+
+def remainder_matches_claim(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    polynomial: RationalPolynomial,
+    monomial_order: str,
+    claimed_remainder: RationalPolynomial,
+) -> bool:
+    """Check that the claimed wire remainder equals the replayed reduction."""
+
+    ring_context = _sparse_ring(ideal.variables, monomial_order)
+    replayed = _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    claimed = _ring_element(ring_context, claimed_remainder)
+    return replayed == claimed
+
+
+def generators_reduce_to_zero(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    monomial_order: str,
+) -> bool:
+    """Check every retained ideal generator reduces to zero modulo the basis."""
+
+    for generator in ideal.generators:
+        zero = _sparse_ring(ideal.variables, monomial_order).zero
+        replayed = _replay_division(ideal, groebner_basis, generator, monomial_order)
+        if replayed != zero:
+            return False
+    return True
+
+
+def replayed_remainder_term_count(
+    ideal: RationalPolynomialIdeal,
+    groebner_basis: tuple[RationalPolynomial, ...],
+    polynomial: RationalPolynomial,
+    monomial_order: str,
+) -> int:
+    """Return the replayed remainder's term count without materializing wire data."""
+
+    return _term_count(
+        _replay_division(ideal, groebner_basis, polynomial, monomial_order)
+    )

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -226,6 +226,41 @@ def test_budget_exceeded_with_retained_basis_validates() -> None:
     )
 
 
+def test_coefficient_growth_beyond_canonical_rational_reports_typed_budget() -> None:
+    # Reducing x1^12 modulo <x1-C*x2^12, x2-C*x3^12, x3-C*x4^12> with
+    # C=10**127 yields the single term C^1884*x4^20736: its term count and
+    # exponent respect the output budgets while its 239,269-digit coefficient
+    # leaves the canonical rational domain.  Both operations must report the
+    # typed budget outcome instead of failing result validation.
+    variables = ("x1", "x2", "x3", "x4")
+    coefficient = 10**127
+
+    def chain_generator(shift: int) -> RationalPolynomial:
+        return _poly(
+            variables,
+            {
+                tuple(12 if index == shift else 0 for index in range(4)): coefficient,
+                tuple(1 if index == shift - 1 else 0 for index in range(4)): -1,
+            },
+        )
+
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=tuple(chain_generator(shift) for shift in (1, 2, 3)),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(12, 0, 0, 0): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "BUDGET_EXCEEDED"
+    assert result.remainder is None
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "BUDGET_EXCEEDED"
+    assert membership.normal_form is None
+
+
 def test_generator_count_and_total_degree_budgets_enforced() -> None:
     generators = tuple(_poly(("x", "y"), {(1, 0): 1}) for _ in range(17))
     with pytest.raises(ValueError, match="16-generator"):

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -1,0 +1,120 @@
+"""Contract and mathematical tests for ideal membership and normal form."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.polynomials._invariants import POLYNOMIAL_INVARIANT_OPERATIONS
+from jacobian.math.polynomials._models import IdealMembershipRequest
+from jacobian.math.polynomials._operations import (
+    polynomial_ideal_membership,
+    polynomial_ideal_normal_form,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _poly(
+    variables: tuple[str, ...],
+    terms: dict[tuple[int, ...], int | Fraction],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(Fraction(coefficient)),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+                if coefficient
+            )
+        ),
+    )
+
+
+def test_operations_in_catalog() -> None:
+    ids = {tool.operation_id for tool in POLYNOMIAL_INVARIANT_OPERATIONS}
+    assert "polynomial.ideal.membership.decide" in ids
+    assert "polynomial.ideal.normal_form.compute" in ids
+
+
+def test_member_is_in_ideal() -> None:
+    req = IdealMembershipRequest(
+        generators=(_poly(("x",), {(2,): 1}),),
+        polynomial=_poly(("x",), {(2,): 1}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.in_ideal is True
+    assert len(result.normal_form.polynomial.terms) == 0
+
+
+def test_non_member_is_not_in_ideal() -> None:
+    req = IdealMembershipRequest(
+        generators=(_poly(("x",), {(2,): 1}),),
+        polynomial=_poly(("x",), {(1,): 1}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.in_ideal is False
+    assert len(result.normal_form.polynomial.terms) == 1
+
+
+def test_zero_is_in_any_ideal() -> None:
+    req = IdealMembershipRequest(
+        generators=(_poly(("x", "y"), {(1, 0): 1, (0, 1): 1}),),
+        polynomial=_poly(("x", "y"), {}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.in_ideal is True
+
+
+def test_normal_form_returns_canonical_remainder() -> None:
+    # x + 1 mod <x^2> = x + 1
+    req = IdealMembershipRequest(
+        generators=(_poly(("x",), {(2,): 1}),),
+        polynomial=_poly(("x",), {(1,): 1, (0,): 1}),
+    )
+    result = polynomial_ideal_normal_form(req)
+    assert result.monomial_order == "grevlex"
+    assert len(result.remainder.polynomial.terms) == 2
+    assert result.remainder.polynomial.terms[0].exponents == (1,)
+
+
+def test_membership_rejects_mismatched_rings() -> None:
+    with pytest.raises(ValueError, match="same ordered ring"):
+        IdealMembershipRequest(
+            generators=(_poly(("x",), {(2,): 1}),),
+            polynomial=_poly(("y",), {(1,): 1}),
+        )
+
+
+def test_multivariate_membership() -> None:
+    # Is y in <x, y-x> = <x, y>?
+    req = IdealMembershipRequest(
+        generators=(
+            _poly(("x", "y"), {(1, 0): 1}),
+            _poly(("x", "y"), {(0, 1): 1, (1, 0): -1}),
+        ),
+        polynomial=_poly(("x", "y"), {(0, 1): 1}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.in_ideal is True
+
+
+def test_multivariate_non_membership() -> None:
+    # Is 1 in <x, y>? No.
+    req = IdealMembershipRequest(
+        generators=(
+            _poly(("x", "y"), {(1, 0): 1}),
+            _poly(("x", "y"), {(0, 1): 1}),
+        ),
+        polynomial=_poly(("x", "y"), {(0, 0): 1}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.in_ideal is False

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -334,3 +334,70 @@ def test_computed_result_without_source_context_rejected() -> None:
             groebner_basis=result.groebner_basis,
             remainder=result.remainder,
         )
+
+
+def test_expansion_beyond_intermediate_budget_reports_typed_outcome_quickly() -> None:
+    # <x - (1+y1+y2+y3+y4+y5)^5> with polynomial x^12: the exact remainder
+    # would expand to millions of monomials.  The bounded reduction must
+    # report the typed budget outcome instead of materializing it.
+    variables = ("x", "y1", "y2", "y3", "y4", "y5")
+
+    def term(exponents: tuple[int, ...]) -> RationalPolynomialTerm:
+        return RationalPolynomialTerm(
+            coefficient=CanonicalRational.from_fraction(Fraction(1)),
+            exponents=exponents,
+        )
+
+    # Every monomial of degree at most 5 in y1..y5: exactly
+    # (1 + y1 + y2 + y3 + y4 + y5)^5, whose 252 terms plus the leading
+    # x term give the reviewed 253-term generator.
+    expansion_combos = [
+        combo
+        for combo in __import__("itertools").product(range(6), repeat=5)
+        if sum(combo) <= 5
+    ]
+    assert len(expansion_combos) == 252
+    generator_terms = [term((1, 0, 0, 0, 0, 0))] + [
+        term((0, *combo)) for combo in expansion_combos
+    ]
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=(
+            RationalPolynomial(
+                variables=variables,
+                polynomial=SparseRationalPolynomial(
+                    terms=tuple(
+                        sorted(generator_terms, key=lambda t: t.exponents, reverse=True)
+                    )
+                ),
+            ),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(12, 0, 0, 0, 0, 0): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "BUDGET_EXCEEDED"
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "BUDGET_EXCEEDED"
+
+
+def test_unsubstantiated_budget_outcome_without_basis_rejected() -> None:
+    # <x^2>, polynomial x: the basis and remainder are in budget, so an
+    # authored BUDGET_EXCEEDED with both outputs stripped asserts an
+    # arbitrary execution outcome without evidence and must be rejected.
+    req = IdealMembershipRequest(
+        ideal=_ideal1(),
+        polynomial=_poly(("x",), {(1,): 1}),
+    )
+    with pytest.raises(ValidationError, match="source basis to exceed"):
+        IdealMembershipResult(
+            ideal=req.ideal,
+            polynomial=req.polynomial,
+            monomial_order="grevlex",
+            status="BUDGET_EXCEEDED",
+            groebner_basis=None,
+            normal_form=None,
+        )

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -1069,3 +1069,191 @@ class TestWorkerFailurePreservation:
             polynomial_ideal_normal_form(request)
         with pytest.raises(GroebnerWorkerExecutionError):
             polynomial_ideal_membership(request)
+
+
+def _fake_worker_result(stdout: bytes):
+    from collections import namedtuple
+
+    return namedtuple("Result", "timed_out cancelled returncode stdout")(
+        timed_out=False, cancelled=False, returncode=0, stdout=stdout
+    )
+
+
+class TestMemoryExhaustionAsBoundedWork:
+    """The hard address-space cap ends an admitted attempt as bounded
+    work: a typed non-conclusion, never a transport failure."""
+
+    def test_exhausted_report_returns_bounded_status(self, monkeypatch):
+        import json
+
+        from jacobian.math.polynomials._groebner_worker import (
+            complete_basis_in_worker,
+        )
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: _fake_worker_result(
+                json.dumps({"status": "exhausted"}).encode()
+            ),
+        )
+        status, basis = complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+        assert status == "exhausted"
+        assert basis is None
+
+    def test_all_exhausted_strategies_report_unknown(self, monkeypatch):
+        """Memory-cap exhaustion across every strategy is a bounded
+        non-conclusion, not a GroebnerWorkerExecutionError."""
+        import json
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: _fake_worker_result(
+                json.dumps({"status": "exhausted"}).encode()
+            ),
+        )
+        request = IdealMembershipRequest(
+            ideal=_ideal1(),
+            polynomial=_poly(("x",), {(5,): 1}),
+            monomial_order="grevlex",
+        )
+        normal_form = polynomial_ideal_normal_form(request)
+        assert normal_form.status == "UNKNOWN"
+        assert normal_form.groebner_basis is None and normal_form.remainder is None
+        membership = polynomial_ideal_membership(request)
+        assert membership.status == "UNKNOWN"
+        assert membership.groebner_basis is None and membership.normal_form is None
+
+    def test_exhausted_attempt_falls_through_to_next_strategy(self, monkeypatch):
+        """One memory-capped strategy must not decide the outcome: the
+        parent retries, and a later concluding strategy still computes."""
+        import json
+
+        def exhausted_then_concluding(argv, *args, input_bytes, **kwargs):
+            strategy = json.loads(input_bytes.decode())["strategy"]
+            exhausted = strategy == "ascending" and not exhausted_then_concluding.called
+            exhausted_then_concluding.called = True
+            report = (
+                {"status": "exhausted"}
+                if exhausted
+                else {
+                    "status": "ok",
+                    "basis": [_poly(("x",), {(2,): 1}).model_dump()],
+                }
+            )
+            return _fake_worker_result(json.dumps(report).encode())
+
+        exhausted_then_concluding.called = False
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            exhausted_then_concluding,
+        )
+        request = IdealMembershipRequest(
+            ideal=_ideal1(),
+            polynomial=_poly(("x",), {(3,): 1}),
+            monomial_order="grevlex",
+        )
+        result = polynomial_ideal_normal_form(request)
+        assert result.status == "COMPUTED"
+        assert result.groebner_basis is not None
+        assert result.remainder is not None
+        assert len(result.remainder.polynomial.terms) == 0
+
+
+class TestWorkerReportBasisContract:
+    """An ``ok`` payload must satisfy the complete returned-basis
+    contract at the worker protocol layer, raising the typed execution
+    fault before any caller can consume the malformed basis."""
+
+    @staticmethod
+    def _fake_ok_report(monkeypatch, basis_elements) -> None:
+        import json
+
+        def fake_run(*args, **kwargs):
+            return _fake_worker_result(
+                json.dumps({"status": "ok", "basis": basis_elements}).encode()
+            )
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            fake_run,
+        )
+
+    def test_basis_in_foreign_ring_raises_execution_error(self, monkeypatch):
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        self._fake_ok_report(monkeypatch, [_poly(("y",), {(2,): 1}).model_dump()])
+        with pytest.raises(GroebnerWorkerExecutionError, match="ordered ring"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_basis_with_reordered_ring_raises_execution_error(self, monkeypatch):
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        self._fake_ok_report(monkeypatch, [_poly(("y", "x"), {(1, 1): 1}).model_dump()])
+        with pytest.raises(GroebnerWorkerExecutionError, match="ordered ring"):
+            complete_basis_in_worker(_ideal_xy(), "grevlex", "ascending")
+
+    def test_basis_with_zero_element_raises_execution_error(self, monkeypatch):
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        self._fake_ok_report(monkeypatch, [_poly(("x",), {}).model_dump()])
+        with pytest.raises(GroebnerWorkerExecutionError, match="zero polynomial"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_basis_exceeding_aggregate_terms_raises_execution_error(self, monkeypatch):
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        bloated = _poly(("x",), {(exponent,): 1 for exponent in range(1025)})
+        self._fake_ok_report(monkeypatch, [bloated.model_dump()])
+        with pytest.raises(GroebnerWorkerExecutionError, match="term output"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_public_operation_surfaces_typed_fault_not_validation_error(
+        self, monkeypatch
+    ):
+        """A malformed nested ``ok`` payload escapes as the typed worker
+        protocol failure, never a generic downstream ValidationError, and
+        without running in-process reduction over foreign-ring data."""
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+        )
+
+        self._fake_ok_report(monkeypatch, [_poly(("y",), {(2,): 1}).model_dump()])
+        request = IdealMembershipRequest(
+            ideal=_ideal1(),
+            polynomial=_poly(("x",), {(5,): 1}),
+            monomial_order="grevlex",
+        )
+        with pytest.raises(GroebnerWorkerExecutionError):
+            polynomial_ideal_normal_form(request)
+        with pytest.raises(GroebnerWorkerExecutionError):
+            polynomial_ideal_membership(request)
+
+    def test_wellformed_basis_still_accepted(self, monkeypatch):
+        """The added contract checks keep admitting a genuine reduced
+        basis reported in the submitted ring."""
+        from jacobian.math.polynomials._groebner_worker import (
+            complete_basis_in_worker,
+        )
+
+        self._fake_ok_report(
+            monkeypatch,
+            [
+                _poly(("x",), {(2,): 1}).model_dump(),
+                _poly(("x",), {(1,): Fraction(1, 2)}).model_dump(),
+            ],
+        )
+        status, basis = complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+        assert status == "ok"
+        assert basis is not None and len(basis) == 2

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -415,7 +415,9 @@ def test_basis_growth_beyond_representability_reports_typed_outcome() -> None:
         return _poly(
             variables,
             {
-                tuple(12 if index == shift + 1 else 0 for index in range(8)): coefficient,
+                tuple(
+                    12 if index == shift + 1 else 0 for index in range(8)
+                ): coefficient,
                 tuple(1 if index == shift else 0 for index in range(8)): -1,
             },
         )
@@ -470,7 +472,13 @@ def test_later_generator_collapse_not_reported_as_budget_overflow() -> None:
         return RationalPolynomial(
             variables=variables,
             polynomial=SparseRationalPolynomial(
-                terms=tuple(sorted((term(e) for e in terms), key=lambda t: t.exponents, reverse=True))
+                terms=tuple(
+                    sorted(
+                        (term(e) for e in terms),
+                        key=lambda t: t.exponents,
+                        reverse=True,
+                    )
+                )
             ),
         )
 
@@ -520,7 +528,13 @@ def _collapse_ideal_generators() -> tuple[RationalPolynomial, ...]:
         return RationalPolynomial(
             variables=variables,
             polynomial=SparseRationalPolynomial(
-                terms=tuple(sorted((term(e) for e in terms), key=lambda t: t.exponents, reverse=True))
+                terms=tuple(
+                    sorted(
+                        (term(e) for e in terms),
+                        key=lambda t: t.exponents,
+                        reverse=True,
+                    )
+                )
             ),
         )
 
@@ -610,9 +624,7 @@ def test_prefix_cap_does_not_decide_outcome_for_late_collapse() -> None:
     from itertools import product
 
     variables = ("x", "y", "z")
-    f_terms = {
-        (0, a, b): 1 for a, b in product(range(9), repeat=2) if a + b <= 8
-    }
+    f_terms = {(0, a, b): 1 for a, b in product(range(9), repeat=2) if a + b <= 8}
     assert len(f_terms) == 45
     ideal = RationalPolynomialIdeal(
         variables=variables,

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -401,3 +401,41 @@ def test_unsubstantiated_budget_outcome_without_basis_rejected() -> None:
             groebner_basis=None,
             normal_form=None,
         )
+
+
+def test_basis_growth_beyond_representability_reports_typed_outcome() -> None:
+    # The eight-variable lex chain <x1-C*x2^12, ..., x7-C*x8^12> with
+    # C = 10**127 has a reduced basis element whose coefficient would carry
+    # hundreds of millions of digits.  The incremental bounded kernel must
+    # report the typed budget outcome before constructing it.
+    variables = tuple(f"x{i}" for i in range(1, 9))
+    coefficient = 10**127
+
+    def chain_generator(shift: int) -> RationalPolynomial:
+        return _poly(
+            variables,
+            {
+                tuple(12 if index == shift + 1 else 0 for index in range(8)): coefficient,
+                tuple(1 if index == shift else 0 for index in range(8)): -1,
+            },
+        )
+
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=tuple(chain_generator(shift) for shift in range(7)),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(1,) + (0,) * 7: 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_membership(request)
+    assert result.status == "BUDGET_EXCEEDED"
+
+
+def test_request_schema_publishes_polynomial_admission_limits() -> None:
+    schema = IdealMembershipRequest.model_json_schema()
+    description = schema["properties"]["polynomial"]["description"]
+    assert "degree at most 12" in description
+    assert "128" in description
+    assert "1,024" in description

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -407,7 +407,9 @@ def test_unsubstantiated_budget_outcome_without_basis_rejected() -> None:
         )
 
 
-def test_basis_growth_beyond_representability_reports_non_conclusion() -> None:
+def test_basis_growth_beyond_representability_reports_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # The eight-variable lex chain <x1-C*x2^12, ..., x7-C*x8^12> with
     # C = 10**127 has a reduced basis element whose coefficient would carry
     # hundreds of millions of digits.  No prefix may decide that outcome
@@ -440,11 +442,16 @@ def test_basis_growth_beyond_representability_reports_non_conclusion() -> None:
     )
     # The worker is killed by its wall-clock deadline before its own work
     # guards can report: a retryable transport fault, not a mathematical
-    # conclusion about the ideal.
+    # conclusion about the ideal. The production safety net stays generous
+    # for admitted heavy instances, so this kill-path exercise injects a
+    # short deadline instead of waiting out the real one.
+    import jacobian.math.polynomials._groebner_worker as worker_module
     from jacobian.math.polynomials._groebner_worker import (
         GroebnerWorkerTimeoutError,
     )
 
+    monkeypatch.setattr(worker_module, "_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(worker_module, "_CPU_SECONDS", 2)
     with pytest.raises(GroebnerWorkerTimeoutError):
         polynomial_ideal_normal_form(request)
     with pytest.raises(GroebnerWorkerTimeoutError):

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -336,10 +336,12 @@ def test_computed_result_without_source_context_rejected() -> None:
         )
 
 
-def test_expansion_beyond_intermediate_budget_reports_typed_outcome_quickly() -> None:
+def test_expansion_beyond_work_caps_reports_non_conclusion_quickly() -> None:
     # <x - (1+y1+y2+y3+y4+y5)^5> with polynomial x^12: the exact remainder
-    # would expand to millions of monomials.  The bounded reduction must
-    # report the typed budget outcome instead of materializing it.
+    # would expand to millions of monomials.  Work exhaustion inside the
+    # bounded reduction carries no evidence about the true remainder size,
+    # so the kernel must report the typed non-conclusion quickly instead of
+    # materializing the expansion or claiming an unsubstantiated overflow.
     variables = ("x", "y1", "y2", "y3", "y4", "y5")
 
     def term(exponents: tuple[int, ...]) -> RationalPolynomialTerm:
@@ -379,9 +381,11 @@ def test_expansion_beyond_intermediate_budget_reports_typed_outcome_quickly() ->
         monomial_order="lex",
     )
     result = polynomial_ideal_normal_form(request)
-    assert result.status == "BUDGET_EXCEEDED"
+    assert result.status == "UNKNOWN"
+    assert result.groebner_basis is None and result.remainder is None
     membership = polynomial_ideal_membership(request)
-    assert membership.status == "BUDGET_EXCEEDED"
+    assert membership.status == "UNKNOWN"
+    assert membership.groebner_basis is None and membership.normal_form is None
 
 
 def test_unsubstantiated_budget_outcome_without_basis_rejected() -> None:
@@ -792,3 +796,77 @@ def test_prefix_cap_does_not_decide_outcome_for_late_collapse() -> None:
     assert result.status == "COMPUTED"
     assert result.remainder is not None
     assert len(result.remainder.polynomial.terms) == 0
+
+
+def _work_limited_request() -> IdealMembershipRequest:
+    """Ideal <x - prod(1+y_i), y_i^2>, query x^12 under lex order.
+
+    The exact normal form is prod(1+12*y_i) with 128 terms, well inside
+    the 1,024-term boundary, but reducing the x powers first temporarily
+    expands prod(1+y_i)^12 toward its full 13^7-monomial box before any
+    y_i^2 reducer fires, exhausting the 4,096-term intermediate work cap
+    (review counterexample).
+    """
+    from itertools import product
+
+    variables = ("x",) + tuple(f"y{i}" for i in range(1, 8))
+    f_terms = {
+        (0,) + exponents: 1 for exponents in product((0, 1), repeat=7)
+    }
+    assert len(f_terms) == 128
+    generators = (
+        _poly(variables, {(1,) + (0,) * 7: 1, **f_terms}),
+        *(
+            _poly(variables, {(0,) * (1 + i) + (2,) + (0,) * (6 - i): 1})
+            for i in range(7)
+        ),
+    )
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=generators,
+    )
+    return IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(12,) + (0,) * 7: 1}),
+        monomial_order="lex",
+    )
+
+
+def test_work_cap_without_artifact_overflow_reports_unknown() -> None:
+    """Work exhaustion is a non-conclusion, not evidenced overflow.
+
+    The exact remainder prod(1+12*y_i) has 128 terms and respects every
+    artifact boundary; only the naive reduction order exceeds the work
+    caps, so the typed outcome must be UNKNOWN and must carry no partial
+    artifact instead of a BUDGET_EXCEEDED claim no replay can substantiate.
+    """
+    request = _work_limited_request()
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "UNKNOWN"
+    assert result.groebner_basis is None and result.remainder is None
+    IdealNormalFormResult.model_validate(result.model_dump())
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "UNKNOWN"
+    assert membership.groebner_basis is None and membership.normal_form is None
+
+
+def test_forged_budget_exceeded_for_work_limited_reduction_rejected() -> None:
+    """A serialized BUDGET_EXCEEDED whose replay only exhausts work, with no
+    artifact leaving its boundary, must fail validation."""
+    request = _work_limited_request()
+    from jacobian.math.polynomials._operations import _compute_membership_context
+
+    basis, exceeded = _compute_membership_context(request)
+    assert basis is not None and not exceeded
+    with pytest.raises(ValidationError, match="contradicts"):
+        IdealNormalFormResult.model_validate(
+            {
+                "ideal": request.ideal,
+                "polynomial": request.polynomial,
+                "monomial_order": request.monomial_order,
+                "status": "BUDGET_EXCEEDED",
+                "groebner_basis": basis,
+                "remainder": None,
+            }
+        )
+

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -486,6 +486,25 @@ def test_request_schema_publishes_polynomial_admission_limits() -> None:
     assert "1,024" in description
 
 
+def test_budget_exceeded_semantics_cover_both_bounded_artifacts() -> None:
+    # BUDGET_EXCEEDED fires when either separately bounded artifact leaves
+    # its 1,024-term boundary: an oversized Gröbner-basis certificate
+    # (basis stripped) or an oversized reduction (computed basis retained).
+    # The published result schemas must document both so callers can tell
+    # them apart.
+    normal_form_description = " ".join(
+        IdealNormalFormResult.model_json_schema()["description"].split()
+    )
+    assert "Gröbner-basis certificate" in normal_form_description
+    assert "canonical remainder" in normal_form_description
+    assert "basis is stripped" in normal_form_description
+    membership_description = " ".join(
+        IdealMembershipResult.model_json_schema()["description"].split()
+    )
+    assert "Gröbner-basis certificate" in membership_description
+    assert "normal-form remainder" in membership_description
+
+
 def test_queried_polynomial_total_degree_budget_enforced() -> None:
     # x^12*y^12 keeps every exponent at 12 while its total degree is 24;
     # the advertised work domain bounds total degree, so it is rejected.

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -15,6 +15,7 @@ from jacobian.math.polynomials._operations import (
 )
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
+    RationalPolynomialIdeal,
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
@@ -39,6 +40,45 @@ def _poly(
     )
 
 
+_XY_VARS = ("x", "y")
+
+
+def _ideal1() -> RationalPolynomialIdeal:
+    return RationalPolynomialIdeal(
+        variables=("x",),
+        generators=(_poly(("x",), {(2,): 1}),),
+    )
+
+
+def _ideal_xy() -> RationalPolynomialIdeal:
+    return RationalPolynomialIdeal(
+        variables=_XY_VARS,
+        generators=(
+            _poly(_XY_VARS, {(1, 0): 1, (0, 1): 1}),
+        ),
+    )
+
+
+def _ideal_line_through_origin() -> RationalPolynomialIdeal:
+    return RationalPolynomialIdeal(
+        variables=_XY_VARS,
+        generators=(
+            _poly(_XY_VARS, {(1, 0): 1}),
+            _poly(_XY_VARS, {(0, 1): 1, (1, 0): -1}),
+        ),
+    )
+
+
+def _ideal_coordinate_axes() -> RationalPolynomialIdeal:
+    return RationalPolynomialIdeal(
+        variables=_XY_VARS,
+        generators=(
+            _poly(_XY_VARS, {(1, 0): 1}),
+            _poly(_XY_VARS, {(0, 1): 1}),
+        ),
+    )
+
+
 def test_operations_in_catalog() -> None:
     ids = {tool.operation_id for tool in POLYNOMIAL_INVARIANT_OPERATIONS}
     assert "polynomial.ideal.membership.decide" in ids
@@ -47,7 +87,7 @@ def test_operations_in_catalog() -> None:
 
 def test_member_is_in_ideal() -> None:
     req = IdealMembershipRequest(
-        generators=(_poly(("x",), {(2,): 1}),),
+        ideal=_ideal1(),
         polynomial=_poly(("x",), {(2,): 1}),
     )
     result = polynomial_ideal_membership(req)
@@ -57,7 +97,7 @@ def test_member_is_in_ideal() -> None:
 
 def test_non_member_is_not_in_ideal() -> None:
     req = IdealMembershipRequest(
-        generators=(_poly(("x",), {(2,): 1}),),
+        ideal=_ideal1(),
         polynomial=_poly(("x",), {(1,): 1}),
     )
     result = polynomial_ideal_membership(req)
@@ -67,7 +107,7 @@ def test_non_member_is_not_in_ideal() -> None:
 
 def test_zero_is_in_any_ideal() -> None:
     req = IdealMembershipRequest(
-        generators=(_poly(("x", "y"), {(1, 0): 1, (0, 1): 1}),),
+        ideal=_ideal_xy(),
         polynomial=_poly(("x", "y"), {}),
     )
     result = polynomial_ideal_membership(req)
@@ -77,7 +117,7 @@ def test_zero_is_in_any_ideal() -> None:
 def test_normal_form_returns_canonical_remainder() -> None:
     # x + 1 mod <x^2> = x + 1
     req = IdealMembershipRequest(
-        generators=(_poly(("x",), {(2,): 1}),),
+        ideal=_ideal1(),
         polynomial=_poly(("x",), {(1,): 1, (0,): 1}),
     )
     result = polynomial_ideal_normal_form(req)
@@ -89,7 +129,7 @@ def test_normal_form_returns_canonical_remainder() -> None:
 def test_membership_rejects_mismatched_rings() -> None:
     with pytest.raises(ValueError, match="same ordered ring"):
         IdealMembershipRequest(
-            generators=(_poly(("x",), {(2,): 1}),),
+            ideal=_ideal1(),
             polynomial=_poly(("y",), {(1,): 1}),
         )
 
@@ -97,10 +137,7 @@ def test_membership_rejects_mismatched_rings() -> None:
 def test_multivariate_membership() -> None:
     # Is y in <x, y-x> = <x, y>?
     req = IdealMembershipRequest(
-        generators=(
-            _poly(("x", "y"), {(1, 0): 1}),
-            _poly(("x", "y"), {(0, 1): 1, (1, 0): -1}),
-        ),
+        ideal=_ideal_line_through_origin(),
         polynomial=_poly(("x", "y"), {(0, 1): 1}),
     )
     result = polynomial_ideal_membership(req)
@@ -110,10 +147,7 @@ def test_multivariate_membership() -> None:
 def test_multivariate_non_membership() -> None:
     # Is 1 in <x, y>? No.
     req = IdealMembershipRequest(
-        generators=(
-            _poly(("x", "y"), {(1, 0): 1}),
-            _poly(("x", "y"), {(0, 1): 1}),
-        ),
+        ideal=_ideal_coordinate_axes(),
         polynomial=_poly(("x", "y"), {(0, 0): 1}),
     )
     result = polynomial_ideal_membership(req)

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -499,3 +499,100 @@ def test_later_generator_collapse_not_reported_as_budget_overflow() -> None:
     basis_terms = result.groebner_basis[0].polynomial.terms
     assert len(basis_terms) == 1
     assert basis_terms[0].coefficient.as_fraction() == 1
+
+
+def _collapse_ideal_generators() -> tuple[RationalPolynomial, ...]:
+    # Generators <x+f, x^12, x> where f is the sum of all monomials of
+    # degree at most 4 in y,z.  The two-generator prefix <x+f, x^12> has
+    # an oversized reduced basis containing f^12 (1,225 terms), while the
+    # complete ideal is <x, f> with a 16-term reduced basis.
+    from itertools import product
+
+    variables = ("x", "y", "z")
+
+    def term(exponents: tuple[int, ...]) -> RationalPolynomialTerm:
+        return RationalPolynomialTerm(
+            coefficient=CanonicalRational.from_fraction(Fraction(1)),
+            exponents=exponents,
+        )
+
+    def poly(terms: tuple[tuple[int, ...], ...]):
+        return RationalPolynomial(
+            variables=variables,
+            polynomial=SparseRationalPolynomial(
+                terms=tuple(sorted((term(e) for e in terms), key=lambda t: t.exponents, reverse=True))
+            ),
+        )
+
+    combos = [c for c in product(range(5), repeat=2) if sum(c) <= 4]
+    assert len(combos) == 15
+    return (
+        poly(((1, 0, 0), *((0, cy, cz) for cy, cz in combos))),
+        poly(((12, 0, 0),)),
+        poly(((1, 0, 0),)),
+    )
+
+
+def test_nonconstant_late_generator_collapse_not_reported_as_overflow() -> None:
+    # An oversized prefix basis must never decide the outcome: processing
+    # the trailing generator x collapses <x+f, x^12> to the small ideal
+    # <x, f>, so x^12 has normal form zero and no budget overflow exists.
+    request = IdealMembershipRequest(
+        ideal=RationalPolynomialIdeal(
+            variables=("x", "y", "z"),
+            generators=_collapse_ideal_generators(),
+        ),
+        polynomial=_poly(("x", "y", "z"), {(12, 0, 0): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "COMPUTED"
+    assert result.remainder is not None and len(result.remainder.polynomial.terms) == 0
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "IN_IDEAL"
+
+
+def test_budget_outcome_is_independent_of_generator_presentation_order() -> None:
+    # The bounded kernel must be a function of the ideal value, not of the
+    # presentation order of an equivalent generating set.
+    from itertools import permutations
+
+    generators = _collapse_ideal_generators()
+    polynomial = _poly(("x", "y", "z"), {(12, 0, 0): 1})
+    statuses = set()
+    for permutation in permutations(generators):
+        membership = polynomial_ideal_membership(
+            IdealMembershipRequest(
+                ideal=RationalPolynomialIdeal(
+                    variables=("x", "y", "z"), generators=permutation
+                ),
+                polynomial=polynomial,
+                monomial_order="lex",
+            )
+        )
+        statuses.add(membership.status)
+    assert statuses == {"IN_IDEAL"}
+
+
+def test_complete_basis_output_overflow_reports_typed_outcome() -> None:
+    # <x-(1+y+z)^4, x^12>: no later generator shrinks this ideal, and its
+    # complete reduced basis contains (1+y+z)^48 (1,225 aggregate terms),
+    # genuinely beyond the 1,024-term output boundary.
+    expanded = _expanded_ideal()
+    padded = RationalPolynomialIdeal(
+        variables=expanded.ideal.variables,
+        generators=(
+            *expanded.ideal.generators,
+            _poly(expanded.ideal.variables, {(12, 0, 0): 1}),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=padded,
+        polynomial=expanded.polynomial,
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "BUDGET_EXCEEDED"
+    assert result.groebner_basis is None and result.remainder is None
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "BUDGET_EXCEEDED"

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -438,21 +438,17 @@ def test_basis_growth_beyond_representability_reports_non_conclusion() -> None:
         polynomial=_poly(variables, {(1,) + (0,) * 7: 1}),
         monomial_order="lex",
     )
-    result = polynomial_ideal_normal_form(request)
-    assert result.status == "UNKNOWN"
-    assert result.groebner_basis is None and result.remainder is None
-    membership = polynomial_ideal_membership(request)
-    assert membership.status == "UNKNOWN"
-    IdealNormalFormResult.model_validate(
-        {
-            "ideal": result.ideal,
-            "polynomial": result.polynomial,
-            "monomial_order": result.monomial_order,
-            "status": "UNKNOWN",
-            "groebner_basis": None,
-            "remainder": None,
-        }
+    # The worker is killed by its wall-clock deadline before its own work
+    # guards can report: a retryable transport fault, not a mathematical
+    # conclusion about the ideal.
+    from jacobian.math.polynomials._groebner_worker import (
+        GroebnerWorkerTimeoutError,
     )
+
+    with pytest.raises(GroebnerWorkerTimeoutError):
+        polynomial_ideal_normal_form(request)
+    with pytest.raises(GroebnerWorkerTimeoutError):
+        polynomial_ideal_membership(request)
 
 
 def test_unknown_result_must_not_carry_partial_artifacts() -> None:
@@ -924,10 +920,14 @@ class TestWorkerFailurePreservation:
         with pytest.raises(GroebnerWorkerExecutionError, match="returncode 3"):
             complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
 
-    def test_hard_timeout_remains_a_non_conclusion(self, monkeypatch):
+    def test_hard_timeout_raises_typed_transport_failure(self, monkeypatch):
+        """A deadline-killed worker is retryable timing, not a conclusion."""
         from collections import namedtuple
 
-        from jacobian.math.polynomials._replay import incremental_source_groebner
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerTimeoutError,
+            complete_basis_in_worker,
+        )
 
         fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
             timed_out=True, cancelled=False, returncode=-9, stdout=b""
@@ -936,8 +936,31 @@ class TestWorkerFailurePreservation:
             "jacobian.math.polynomials._groebner_worker.run_bounded_process",
             lambda *args, **kwargs: fake,
         )
-        basis, exceeded = incremental_source_groebner(_ideal1(), "grevlex")
-        assert basis is None and exceeded is False
+        with pytest.raises(GroebnerWorkerTimeoutError):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_memory_cap_enforcement_fails_closed_without_prlimit(self, monkeypatch):
+        """No hard memory cap on this platform means no unbounded run."""
+        import shutil as _shutil
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerLaunchError,
+            complete_basis_in_worker,
+        )
+
+        monkeypatch.setattr(_shutil, "which", lambda name: None)
+        import resource as _resource
+
+        if not hasattr(_resource, "prlimit"):
+            with pytest.raises(GroebnerWorkerLaunchError, match="address-space"):
+                complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+        else:
+            try:
+                complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+            except GroebnerWorkerLaunchError as error:
+                raise AssertionError(
+                    "platform supports resource.prlimit; launch must proceed"
+                ) from error
 
     def test_public_operations_surface_transport_faults(self, monkeypatch):
         """A broken worker installation is not a mathematical UNKNOWN."""

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -449,3 +449,53 @@ def test_queried_polynomial_total_degree_budget_enforced() -> None:
             ideal=_ideal_xy(),
             polynomial=_poly(("x", "y"), {(12, 12): 1}),
         )
+
+
+def test_later_generator_collapse_not_reported_as_budget_overflow() -> None:
+    # <x-(1+y+z)^4, x^12, 1>: an oversized prefix basis must not decide the
+    # outcome; the trailing nonzero constant generator collapses the ideal
+    # to the unit ideal regardless of presentation order, so x^12 is in the
+    # ideal and no budget overflow is reported.
+    from itertools import product
+
+    variables = ("x", "y", "z")
+
+    def term(exponents: tuple[int, ...]) -> RationalPolynomialTerm:
+        return RationalPolynomialTerm(
+            coefficient=CanonicalRational.from_fraction(Fraction(1)),
+            exponents=exponents,
+        )
+
+    def poly(terms: tuple[tuple[int, ...], ...]):
+        return RationalPolynomial(
+            variables=variables,
+            polynomial=SparseRationalPolynomial(
+                terms=tuple(sorted((term(e) for e in terms), key=lambda t: t.exponents, reverse=True))
+            ),
+        )
+
+    combos = [c for c in product(range(5), repeat=2) if sum(c) <= 4]
+    g1_terms: tuple[tuple[int, ...], ...] = (
+        (1, 0, 0),
+        *((0, c[0], c[1]) for c in combos),
+    )
+    assert len(g1_terms) == 16
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=(
+            poly(g1_terms),
+            poly(((12, 0, 0),)),
+            poly(((0, 0, 0),)),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=poly(((12, 0, 0),)),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "COMPUTED"
+    assert result.groebner_basis is not None
+    basis_terms = result.groebner_basis[0].polynomial.terms
+    assert len(basis_terms) == 1
+    assert basis_terms[0].coefficient.as_fraction() == 1

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -596,3 +596,38 @@ def test_complete_basis_output_overflow_reports_typed_outcome() -> None:
     assert result.groebner_basis is None and result.remainder is None
     membership = polynomial_ideal_membership(request)
     assert membership.status == "BUDGET_EXCEEDED"
+
+
+def test_prefix_cap_does_not_decide_outcome_for_late_collapse() -> None:
+    # Reviewer counterexample (bounded instance): f is the sum of all
+    # monomials of degree at most 8 in y,z (45 terms), so the canonical
+    # prefix <x+f, x^12> has a reduced basis containing f^12 with 4,753
+    # aggregate terms — beyond the retired 4,096-term intermediate work
+    # envelope.  The complete ideal is instead <x, f> with a small basis,
+    # and x has normal form zero, so the aggregate term count of a prefix
+    # must never decide the outcome; only representability limits apply
+    # before the complete source basis exists.
+    from itertools import product
+
+    variables = ("x", "y", "z")
+    f_terms = {
+        (0, a, b): 1 for a, b in product(range(9), repeat=2) if a + b <= 8
+    }
+    assert len(f_terms) == 45
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=(
+            _poly(variables, {(1, 0, 0): 1, **f_terms}),
+            _poly(variables, {(12, 0, 0): 1}),
+            _poly(variables, {(1, 0, 0): 1, (12, 0, 0): 1}),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(12, 0, 0): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "COMPUTED"
+    assert result.remainder is not None
+    assert len(result.remainder.polynomial.terms) == 0

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from fractions import Fraction
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.polynomials._invariants import POLYNOMIAL_INVARIANT_OPERATIONS
-from jacobian.math.polynomials._models import IdealMembershipRequest
+from jacobian.math.polynomials._models import (
+    IdealMembershipRequest,
+    IdealMembershipResult,
+    IdealNormalFormResult,
+)
 from jacobian.math.polynomials._operations import (
     polynomial_ideal_membership,
     polynomial_ideal_normal_form,
@@ -89,7 +94,8 @@ def test_member_is_in_ideal() -> None:
         polynomial=_poly(("x",), {(2,): 1}),
     )
     result = polynomial_ideal_membership(req)
-    assert result.in_ideal is True
+    assert result.status == "IN_IDEAL"
+    assert result.normal_form is not None
     assert len(result.normal_form.polynomial.terms) == 0
 
 
@@ -99,7 +105,8 @@ def test_non_member_is_not_in_ideal() -> None:
         polynomial=_poly(("x",), {(1,): 1}),
     )
     result = polynomial_ideal_membership(req)
-    assert result.in_ideal is False
+    assert result.status == "NOT_IN_IDEAL"
+    assert result.normal_form is not None
     assert len(result.normal_form.polynomial.terms) == 1
 
 
@@ -109,7 +116,7 @@ def test_zero_is_in_any_ideal() -> None:
         polynomial=_poly(("x", "y"), {}),
     )
     result = polynomial_ideal_membership(req)
-    assert result.in_ideal is True
+    assert result.status == "IN_IDEAL"
 
 
 def test_normal_form_returns_canonical_remainder() -> None:
@@ -139,7 +146,7 @@ def test_multivariate_membership() -> None:
         polynomial=_poly(("x", "y"), {(0, 1): 1}),
     )
     result = polynomial_ideal_membership(req)
-    assert result.in_ideal is True
+    assert result.status == "IN_IDEAL"
 
 
 def test_multivariate_non_membership() -> None:
@@ -149,4 +156,146 @@ def test_multivariate_non_membership() -> None:
         polynomial=_poly(("x", "y"), {(0, 0): 1}),
     )
     result = polynomial_ideal_membership(req)
-    assert result.in_ideal is False
+    assert result.status == "NOT_IN_IDEAL"
+
+
+def _expanded_ideal(order: str = "lex") -> IdealMembershipRequest:
+    """Ideal <x - (1+y+z)^4> with polynomial x^12 under lex order.
+
+    The normal form is (1+y+z)^48, whose 1,226 terms exceed the 1,024-term
+    exact-result boundary even though every admission budget is respected.
+    """
+
+    import sympy
+
+    y_sym, z_sym = sympy.symbols("y z")
+    expansion = sympy.Poly((1 + y_sym + z_sym) ** 4, y_sym, z_sym, domain=sympy.QQ)
+    generator_terms = tuple(
+        RationalPolynomialTerm(
+            coefficient=CanonicalRational.from_fraction(Fraction(int(c))),
+            exponents=(0, ey, ez),
+        )
+        for (ey, ez), c in expansion.terms()
+    )
+    ideal = RationalPolynomialIdeal(
+        variables=("x", "y", "z"),
+        generators=(
+            RationalPolynomial(
+                variables=("x", "y", "z"),
+                polynomial=SparseRationalPolynomial(
+                    terms=(
+                        RationalPolynomialTerm(
+                            coefficient=CanonicalRational.from_fraction(Fraction(1)),
+                            exponents=(1, 0, 0),
+                        ),
+                        *generator_terms,
+                    )
+                ),
+            ),
+        ),
+    )
+    return IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(("x", "y", "z"), {(12, 0, 0): 1}),
+        monomial_order=order,
+    )
+
+
+def test_expansion_beyond_result_boundary_reports_typed_budget_outcome() -> None:
+    request = _expanded_ideal()
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "BUDGET_EXCEEDED"
+    assert result.remainder is None
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "BUDGET_EXCEEDED"
+    assert membership.normal_form is None
+
+
+def test_budget_exceeded_with_retained_basis_validates() -> None:
+    result = polynomial_ideal_normal_form(_expanded_ideal())
+    assert result.groebner_basis is not None
+    IdealNormalFormResult.model_validate(
+        {
+            "ideal": result.ideal,
+            "polynomial": result.polynomial,
+            "monomial_order": result.monomial_order,
+            "status": "BUDGET_EXCEEDED",
+            "groebner_basis": result.groebner_basis,
+            "remainder": None,
+        }
+    )
+
+
+def test_generator_count_and_total_degree_budgets_enforced() -> None:
+    generators = tuple(_poly(("x", "y"), {(1, 0): 1}) for _ in range(17))
+    with pytest.raises(ValueError, match="16-generator"):
+        IdealMembershipRequest(
+            ideal=RationalPolynomialIdeal(variables=_XY_VARS, generators=generators),
+            polynomial=_poly(_XY_VARS, {(1, 0): 1}),
+        )
+    with pytest.raises(ValueError, match="total-degree"):
+        IdealMembershipRequest(
+            ideal=RationalPolynomialIdeal(
+                variables=_XY_VARS,
+                generators=(_poly(_XY_VARS, {(12, 12): 1}),),
+            ),
+            polynomial=_poly(_XY_VARS, {(1, 0): 1}),
+        )
+
+
+def test_detached_contradictory_membership_rejected() -> None:
+    req = IdealMembershipRequest(
+        ideal=_ideal1(),
+        polynomial=_poly(("x",), {(2,): 1}),
+    )
+    result = polynomial_ideal_membership(req)
+    assert result.normal_form is not None and result.groebner_basis is not None
+    with pytest.raises(ValidationError):
+        IdealMembershipResult(
+            ideal=result.ideal,
+            polynomial=result.polynomial,
+            monomial_order=result.monomial_order,
+            status="NOT_IN_IDEAL",
+            groebner_basis=result.groebner_basis,
+            normal_form=result.normal_form,
+        )
+
+
+def test_tampered_normal_form_does_not_validate() -> None:
+    req = IdealMembershipRequest(
+        ideal=_ideal1(),
+        polynomial=_poly(("x",), {(3,): 1}),
+    )
+    result = polynomial_ideal_normal_form(req)
+    assert result.remainder is not None and result.groebner_basis is not None
+    tampered = _poly(("x",), {(5,): 1})
+    with pytest.raises(ValidationError):
+        IdealNormalFormResult(
+            ideal=result.ideal,
+            polynomial=result.polynomial,
+            monomial_order=result.monomial_order,
+            status="COMPUTED",
+            groebner_basis=result.groebner_basis,
+            remainder=tampered,
+        )
+
+
+def test_computed_result_without_source_context_rejected() -> None:
+    req = IdealMembershipRequest(
+        ideal=_ideal_xy(),
+        polynomial=_poly(_XY_VARS, {(2, 0): 1, (0, 2): 1}),
+    )
+    result = polynomial_ideal_normal_form(req)
+    assert result.remainder is not None
+    with pytest.raises(ValidationError):
+        IdealNormalFormResult(
+            ideal=RationalPolynomialIdeal(
+                variables=_XY_VARS,
+                generators=(_poly(_XY_VARS, {(1, 0): 1, (0, 1): 2}),),
+            ),
+            polynomial=result.polynomial,
+            monomial_order=result.monomial_order,
+            status="COMPUTED",
+            groebner_basis=result.groebner_basis,
+            remainder=result.remainder,
+        )

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -920,6 +920,51 @@ class TestWorkerFailurePreservation:
         with pytest.raises(GroebnerWorkerExecutionError, match="returncode 3"):
             complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
 
+    @pytest.mark.parametrize("stdout", [b"[]", b"null", b'"ok"', b"42"])
+    def test_non_object_report_raises_execution_error(self, monkeypatch, stdout):
+        """A valid-JSON report with a non-object top level is a broken
+        worker protocol, not an AttributeError escape or a conclusion."""
+        from collections import namedtuple
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
+            timed_out=False, cancelled=False, returncode=0, stdout=stdout
+        )
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: fake,
+        )
+        with pytest.raises(GroebnerWorkerExecutionError, match="not a JSON object"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_failed_worker_report_raises_execution_error(self, monkeypatch):
+        """The worker's own ``failed`` tag is an internal adapter fault,
+        not inconclusive mathematical work."""
+        import json
+        from collections import namedtuple
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
+            timed_out=False,
+            cancelled=False,
+            returncode=0,
+            stdout=json.dumps({"status": "failed"}).encode(),
+        )
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: fake,
+        )
+        with pytest.raises(GroebnerWorkerExecutionError, match="internal"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
     def test_hard_timeout_raises_typed_transport_failure(self, monkeypatch):
         """A deadline-killed worker is retryable timing, not a conclusion."""
         from collections import namedtuple
@@ -982,3 +1027,38 @@ class TestWorkerFailurePreservation:
         )
         with pytest.raises(GroebnerWorkerLaunchError):
             polynomial_ideal_normal_form(request)
+
+    def test_public_operations_surface_failed_worker_reports(self, monkeypatch):
+        """A worker that self-reports ``failed`` is a broken adapter, so
+        both public operations raise the typed execution fault instead of
+        reporting mathematical UNKNOWN after exhausting the strategies."""
+        import json
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+        )
+
+        def report_failed(*args, **kwargs):
+            from collections import namedtuple
+
+            Result = namedtuple("Result", "timed_out cancelled returncode stdout")
+            return Result(
+                timed_out=False,
+                cancelled=False,
+                returncode=0,
+                stdout=json.dumps({"status": "failed"}).encode(),
+            )
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            report_failed,
+        )
+        request = IdealMembershipRequest(
+            ideal=_ideal1(),
+            polynomial=_poly(("x",), {(5,): 1}),
+            monomial_order="grevlex",
+        )
+        with pytest.raises(GroebnerWorkerExecutionError):
+            polynomial_ideal_normal_form(request)
+        with pytest.raises(GroebnerWorkerExecutionError):
+            polynomial_ideal_membership(request)

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -809,10 +809,8 @@ def _work_limited_request() -> IdealMembershipRequest:
     """
     from itertools import product
 
-    variables = ("x",) + tuple(f"y{i}" for i in range(1, 8))
-    f_terms = {
-        (0,) + exponents: 1 for exponents in product((0, 1), repeat=7)
-    }
+    variables = ("x", *tuple(f"y{i}" for i in range(1, 8)))
+    f_terms = {(0, *exponents): 1 for exponents in product((0, 1), repeat=7)}
     assert len(f_terms) == 128
     generators = (
         _poly(variables, {(1,) + (0,) * 7: 1, **f_terms}),
@@ -869,4 +867,3 @@ def test_forged_budget_exceeded_for_work_limited_reduction_rejected() -> None:
                 "remainder": None,
             }
         )
-

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -53,9 +53,7 @@ def _ideal1() -> RationalPolynomialIdeal:
 def _ideal_xy() -> RationalPolynomialIdeal:
     return RationalPolynomialIdeal(
         variables=_XY_VARS,
-        generators=(
-            _poly(_XY_VARS, {(1, 0): 1, (0, 1): 1}),
-        ),
+        generators=(_poly(_XY_VARS, {(1, 0): 1, (0, 1): 1}),),
     )
 
 

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -867,3 +867,95 @@ def test_forged_budget_exceeded_for_work_limited_reduction_rejected() -> None:
                 "remainder": None,
             }
         )
+
+
+class TestWorkerFailurePreservation:
+    """Transport faults stay typed failures instead of becoming UNKNOWN."""
+
+    def test_launch_failure_raises_typed_error(self, monkeypatch):
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerLaunchError,
+            complete_basis_in_worker,
+        )
+
+        def refuse_launch(*args, **kwargs):
+            raise OSError("cannot spawn worker: missing interpreter")
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            refuse_launch,
+        )
+        with pytest.raises(GroebnerWorkerLaunchError, match="missing interpreter"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_cancelled_worker_raises_typed_error(self, monkeypatch):
+        from collections import namedtuple
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerCancelledError,
+            complete_basis_in_worker,
+        )
+
+        fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
+            timed_out=False, cancelled=True, returncode=-15, stdout=b""
+        )
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: fake,
+        )
+        with pytest.raises(GroebnerWorkerCancelledError):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_nonzero_exit_without_timeout_raises_execution_error(self, monkeypatch):
+        from collections import namedtuple
+
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerExecutionError,
+            complete_basis_in_worker,
+        )
+
+        fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
+            timed_out=False, cancelled=False, returncode=3, stdout=b""
+        )
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: fake,
+        )
+        with pytest.raises(GroebnerWorkerExecutionError, match="returncode 3"):
+            complete_basis_in_worker(_ideal1(), "grevlex", "ascending")
+
+    def test_hard_timeout_remains_a_non_conclusion(self, monkeypatch):
+        from collections import namedtuple
+
+        from jacobian.math.polynomials._replay import incremental_source_groebner
+
+        fake = namedtuple("Result", "timed_out cancelled returncode stdout")(
+            timed_out=True, cancelled=False, returncode=-9, stdout=b""
+        )
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            lambda *args, **kwargs: fake,
+        )
+        basis, exceeded = incremental_source_groebner(_ideal1(), "grevlex")
+        assert basis is None and exceeded is False
+
+    def test_public_operations_surface_transport_faults(self, monkeypatch):
+        """A broken worker installation is not a mathematical UNKNOWN."""
+        from jacobian.math.polynomials._groebner_worker import (
+            GroebnerWorkerLaunchError,
+        )
+
+        def refuse_launch(*args, **kwargs):
+            raise OSError("broken worker installation")
+
+        monkeypatch.setattr(
+            "jacobian.math.polynomials._groebner_worker.run_bounded_process",
+            refuse_launch,
+        )
+        request = IdealMembershipRequest(
+            ideal=_ideal1(),
+            polynomial=_poly(("x",), {(5,): 1}),
+            monomial_order="grevlex",
+        )
+        with pytest.raises(GroebnerWorkerLaunchError):
+            polynomial_ideal_normal_form(request)

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -403,11 +403,14 @@ def test_unsubstantiated_budget_outcome_without_basis_rejected() -> None:
         )
 
 
-def test_basis_growth_beyond_representability_reports_typed_outcome() -> None:
+def test_basis_growth_beyond_representability_reports_non_conclusion() -> None:
     # The eight-variable lex chain <x1-C*x2^12, ..., x7-C*x8^12> with
     # C = 10**127 has a reduced basis element whose coefficient would carry
-    # hundreds of millions of digits.  The incremental bounded kernel must
-    # report the typed budget outcome before constructing it.
+    # hundreds of millions of digits.  No prefix may decide that outcome
+    # (later generators can shrink an ideal), and every complete strategy
+    # exceeds its work bound here, so the operations report the typed
+    # non-conclusion outcome instead of asserting an overflow they cannot
+    # establish.
     variables = tuple(f"x{i}" for i in range(1, 9))
     coefficient = 10**127
 
@@ -431,8 +434,48 @@ def test_basis_growth_beyond_representability_reports_typed_outcome() -> None:
         polynomial=_poly(variables, {(1,) + (0,) * 7: 1}),
         monomial_order="lex",
     )
-    result = polynomial_ideal_membership(request)
-    assert result.status == "BUDGET_EXCEEDED"
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "UNKNOWN"
+    assert result.groebner_basis is None and result.remainder is None
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "UNKNOWN"
+    IdealNormalFormResult.model_validate(
+        {
+            "ideal": result.ideal,
+            "polynomial": result.polynomial,
+            "monomial_order": result.monomial_order,
+            "status": "UNKNOWN",
+            "groebner_basis": None,
+            "remainder": None,
+        }
+    )
+
+
+def test_unknown_result_must_not_carry_partial_artifacts() -> None:
+    req = IdealMembershipRequest(
+        ideal=_ideal1(),
+        polynomial=_poly(("x",), {(3,): 1}),
+    )
+    computed = polynomial_ideal_normal_form(req)
+    assert computed.groebner_basis is not None and computed.remainder is not None
+    with pytest.raises(ValidationError, match="UNKNOWN must not carry"):
+        IdealNormalFormResult(
+            ideal=req.ideal,
+            polynomial=req.polynomial,
+            monomial_order="grevlex",
+            status="UNKNOWN",
+            groebner_basis=computed.groebner_basis,
+            remainder=None,
+        )
+    with pytest.raises(ValidationError, match="UNKNOWN must not carry"):
+        IdealMembershipResult(
+            ideal=req.ideal,
+            polynomial=req.polynomial,
+            monomial_order="grevlex",
+            status="UNKNOWN",
+            groebner_basis=None,
+            normal_form=_poly(("x",), {}),
+        )
 
 
 def test_request_schema_publishes_polynomial_admission_limits() -> None:
@@ -564,6 +607,93 @@ def test_nonconstant_late_generator_collapse_not_reported_as_overflow() -> None:
     assert result.remainder is not None and len(result.remainder.polynomial.terms) == 0
     membership = polynomial_ideal_membership(request)
     assert membership.status == "IN_IDEAL"
+
+
+def test_prefix_exponent_overflow_not_reported_for_late_unit_collapse() -> None:
+    # Reviewer counterexample: <x1^11, x1-x2^11, ..., x4-x5^11, 1+x1^12>
+    # under lex.  The five degree-11 generators come first in the canonical
+    # order and their prefix basis contains x5^161051, whose exponent
+    # leaves the shared representation limit; the trailing generator is
+    # coprime to x1^11, so the complete ideal is the unit ideal with basis
+    # (1) and x5 has normal form zero.  No prefix property may decide a
+    # budget outcome that later generators invalidate.
+    variables = tuple(f"x{i}" for i in range(1, 6))
+
+    def chain_generator(shift: int) -> RationalPolynomial:
+        return _poly(
+            variables,
+            {
+                tuple(1 if index == shift else 0 for index in range(5)): 1,
+                tuple(11 if index == shift + 1 else 0 for index in range(5)): -1,
+            },
+        )
+
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=(
+            _poly(variables, {(11, 0, 0, 0, 0): 1}),
+            *(chain_generator(shift) for shift in range(4)),
+            _poly(variables, {(12, 0, 0, 0, 0): 1, (0, 0, 0, 0, 0): 1}),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(0, 0, 0, 0, 1): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "COMPUTED"
+    assert result.groebner_basis is not None
+    assert len(result.groebner_basis) == 1
+    assert result.groebner_basis[0].polynomial.terms[0].exponents == (0,) * 5
+    assert result.remainder is not None
+    assert len(result.remainder.polynomial.terms) == 0
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "IN_IDEAL"
+
+
+def test_complete_basis_exponent_overflow_reports_typed_outcome() -> None:
+    # The same chain without the trailing coprime generator: no later
+    # generator shrinks this ideal, and its complete reduced basis contains
+    # x5^161051, whose exponent genuinely leaves the representability limit.
+    variables = tuple(f"x{i}" for i in range(1, 6))
+
+    def chain_generator(shift: int) -> RationalPolynomial:
+        return _poly(
+            variables,
+            {
+                tuple(1 if index == shift else 0 for index in range(5)): 1,
+                tuple(11 if index == shift + 1 else 0 for index in range(5)): -1,
+            },
+        )
+
+    ideal = RationalPolynomialIdeal(
+        variables=variables,
+        generators=(
+            _poly(variables, {(11, 0, 0, 0, 0): 1}),
+            *(chain_generator(shift) for shift in range(4)),
+        ),
+    )
+    request = IdealMembershipRequest(
+        ideal=ideal,
+        polynomial=_poly(variables, {(0, 0, 0, 0, 1): 1}),
+        monomial_order="lex",
+    )
+    result = polynomial_ideal_normal_form(request)
+    assert result.status == "BUDGET_EXCEEDED"
+    assert result.groebner_basis is None and result.remainder is None
+    membership = polynomial_ideal_membership(request)
+    assert membership.status == "BUDGET_EXCEEDED"
+    IdealNormalFormResult.model_validate(
+        {
+            "ideal": result.ideal,
+            "polynomial": result.polynomial,
+            "monomial_order": result.monomial_order,
+            "status": "BUDGET_EXCEEDED",
+            "groebner_basis": None,
+            "remainder": None,
+        }
+    )
 
 
 def test_budget_outcome_is_independent_of_generator_presentation_order() -> None:

--- a/tests/math/polynomials/test_ideal_membership.py
+++ b/tests/math/polynomials/test_ideal_membership.py
@@ -439,3 +439,13 @@ def test_request_schema_publishes_polynomial_admission_limits() -> None:
     assert "degree at most 12" in description
     assert "128" in description
     assert "1,024" in description
+
+
+def test_queried_polynomial_total_degree_budget_enforced() -> None:
+    # x^12*y^12 keeps every exponent at 12 while its total degree is 24;
+    # the advertised work domain bounds total degree, so it is rejected.
+    with pytest.raises(ValidationError, match="total-degree"):
+        IdealMembershipRequest(
+            ideal=_ideal_xy(),
+            polynomial=_poly(("x", "y"), {(12, 12): 1}),
+        )

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -20,6 +20,7 @@ _EXTERNAL_OPERATION_OWNERS = frozenset(
         _PROCESS_OWNER,
         PurePosixPath("src/jacobian/math/commutative_algebra_ops/_singular.py"),
         PurePosixPath("src/jacobian/math/logic/_operations.py"),
+        PurePosixPath("src/jacobian/math/polynomials/_groebner_worker.py"),
     }
 )
 _GENERATED_DIRECTORIES = frozenset(


### PR DESCRIPTION
## Summary

Add two atomic operations for exact polynomial ideal computations over QQ:

- `polynomial.ideal.membership.decide`: decides whether a bounded rational polynomial lies in a bounded ideal, returning both the decision and the canonical normal form (remainder)
- `polynomial.ideal.normal_form.compute`: reduces a polynomial modulo an ideal using a Gröbner basis under an explicit monomial order

## Design

Both operations use SymPy's `groebner` basis computation followed by `basis.reduce()` as the computational backend. The operations accept bounded rational polynomial generators with an explicit monomial order (lex, grlex, or grevlex) and use the existing `RationalPolynomial` canonical type.

This follows the bitter lesson: ideal membership and normal form reduction are fundamental algebraic primitives that compose across algebraic geometry, invariant theory, and computational algebra — they are not task-specific solutions.

## Tests

- Member and non-member detection (univariate)
- Zero in any ideal
- Canonical remainder computation
- Mismatched ring rejection
- Multivariate membership and non-membership

Closes #1665

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/636bb865-8fa9-4348-a437-f0b719b854e9)
