### PR TITLE
feat(math): add Markov chain communicating class decomposition (#1744)

### DIFF
--- a/src/jacobian/math/markov_chain/_admission.py
+++ b/src/jacobian/math/markov_chain/_admission.py
@@ -25,6 +25,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "returns every canonical extreme point of the complete stationary-distribution simplex",
     ),
+    OperationAdmission(
+        "probability.markov_chain.communicating_classes.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -195,3 +195,24 @@ class MixingTimeResult(StrictModel):
         ):
             raise ValueError("a non-ergodic result has no mixing-time search value")
         return self
+
+
+class CommunicatingClassesResult(StrictModel):
+    """The communicating-class decomposition of a Markov chain."""
+
+    classes: tuple[tuple[tuple[int, ...], bool], ...]
+    """Each entry is (state_indices, is_closed). States are 0-indexed."""
+
+    state_class: tuple[int, ...]
+    """Class index of each state (0-indexed)."""
+
+    @model_validator(mode="after")
+    def require_partition_validity(self) -> Self:
+        all_states: list[int] = []
+        for states, _ in self.classes:
+            all_states.extend(states)
+        if sorted(all_states) != list(range(len(all_states))):
+            raise ValueError("classes must partition all state indices")
+        if len(self.state_class) != len(all_states):
+            raise ValueError("state_class must have one entry per state")
+        return self

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -200,6 +200,11 @@ class MixingTimeResult(StrictModel):
 class CommunicatingClassesResult(StrictModel):
     """The communicating-class decomposition of a Markov chain."""
 
+    transition_matrix: tuple[tuple[CanonicalRational, ...], ...] = Field(
+        min_length=1, max_length=32
+    )
+    """The source transition matrix whose support graph is decomposed."""
+
     classes: tuple[tuple[tuple[int, ...], bool], ...]
     """Each entry is (state_indices, is_closed). States are 0-indexed."""
 
@@ -207,12 +212,66 @@ class CommunicatingClassesResult(StrictModel):
     """Class index of each state (0-indexed)."""
 
     @model_validator(mode="after")
-    def require_partition_validity(self) -> Self:
+    def require_partition_validity(self) -> Self:  # noqa: C901
+        dimension = len(self.transition_matrix)
+        if any(len(row) != dimension for row in self.transition_matrix):
+            raise ValueError("transition matrix must be square")
+        for row in self.transition_matrix:
+            values = tuple(value.as_fraction() for value in row)
+            if any(value < 0 for value in values):
+                raise ValueError("transition probabilities must be nonnegative")
+            if sum(values) != 1:
+                raise ValueError("each transition row must sum to one")
         all_states: list[int] = []
         for states, _ in self.classes:
             all_states.extend(states)
         if sorted(all_states) != list(range(len(all_states))):
             raise ValueError("classes must partition all state indices")
+        if len(all_states) != dimension:
+            raise ValueError("classes must partition the transition matrix states")
         if len(self.state_class) != len(all_states):
             raise ValueError("state_class must have one entry per state")
+        for class_index, (states, _) in enumerate(self.classes):
+            for state in states:
+                if self.state_class[state] != class_index:
+                    raise ValueError("state_class must match classes")
+        return self
+
+    @model_validator(mode="after")
+    def bind_decomposition(self) -> Self:  # noqa: C901
+        import networkx as nx
+
+        matrix = self.transition_matrix
+        dimension = len(matrix)
+        graph: nx.DiGraph[int] = nx.DiGraph()
+        graph.add_nodes_from(range(dimension))
+        for i in range(dimension):
+            for j in range(dimension):
+                if matrix[i][j].as_fraction() > 0:
+                    graph.add_edge(i, j)
+        sccs = list(nx.strongly_connected_components(graph))
+        condensation = nx.condensation(graph, sccs)
+        scc_list = list(nx.topological_sort(condensation))
+        expected_classes: list[tuple[tuple[int, ...], bool]] = []
+        expected_state_class = [0] * dimension
+        for scc_idx, scc_node in enumerate(scc_list):
+            scc = sccs[scc_node] if isinstance(scc_node, int) else scc_node
+            states = tuple(sorted(scc))
+            is_closed = True
+            for state in states:
+                for target in range(dimension):
+                    if target not in scc and matrix[state][target].as_fraction() > 0:
+                        is_closed = False
+                        break
+                if not is_closed:
+                    break
+            expected_classes.append((states, is_closed))
+            for state in states:
+                expected_state_class[state] = scc_idx
+        if self.classes != tuple(expected_classes):
+            raise ValueError(
+                "classes must be the exact SCC decomposition of the transition matrix"
+            )
+        if self.state_class != tuple(expected_state_class):
+            raise ValueError("state_class must match the SCC decomposition")
         return self

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -8,6 +8,7 @@ from jacobian.math.markov_chain import (
     mixing_time,
 )
 from jacobian.math.markov_chain._models import (
+    CommunicatingClassesResult,
     ErgodicDecisionResult,
     ExtremeStationaryDistribution,
     MixingTimeRequest,
@@ -77,4 +78,54 @@ def compute_ergodic_decision(request: TransitionMatrixRequest) -> ErgodicDecisio
         is_ergodic=irreducible and aperiodic,
         is_irreducible=irreducible,
         is_aperiodic=aperiodic,
+    )
+
+
+def compute_communicating_classes(
+    request: TransitionMatrixRequest,
+) -> CommunicatingClassesResult:
+    """Decompose a Markov chain into communicating classes via SCC analysis."""
+
+    import networkx as nx
+
+    matrix = request.matrix
+    dimension = len(matrix)
+
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(dimension))
+    for i in range(dimension):
+        for j in range(dimension):
+            if matrix[i][j].as_fraction() > 0:
+                graph.add_edge(i, j)
+
+    sccs = list(nx.strongly_connected_components(graph))
+    condensation = nx.condensation(graph, sccs)
+
+    # Get topological order of SCC nodes
+    scc_list = list(nx.topological_sort(condensation))
+
+    # Reverse for recurrent-first order (closed classes last)
+    # Actually, let's order by: transient classes first, then recurrent classes
+    # A class is closed (recurrent) if it has no outgoing edges to other classes
+    classes_info: list[tuple[tuple[int, ...], bool]] = []
+    state_class = [0] * dimension
+
+    for scc_idx, scc_node in enumerate(scc_list):
+        scc = sccs[scc_node] if isinstance(scc_node, int) else scc_node
+        states = sorted(scc)
+        is_closed = True
+        for state in states:
+            for j in range(dimension):
+                if j not in scc and matrix[state][j].as_fraction() > 0:
+                    is_closed = False
+                    break
+            if not is_closed:
+                break
+        classes_info.append((tuple(states), is_closed))
+        for state in states:
+            state_class[state] = scc_idx
+
+    return CommunicatingClassesResult(
+        classes=tuple(classes_info),
+        state_class=tuple(state_class),
     )

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -91,7 +91,7 @@ def compute_communicating_classes(
     matrix = request.matrix
     dimension = len(matrix)
 
-    graph = nx.DiGraph()
+    graph: nx.DiGraph[int] = nx.DiGraph()
     graph.add_nodes_from(range(dimension))
     for i in range(dimension):
         for j in range(dimension):

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -126,6 +126,7 @@ def compute_communicating_classes(
             state_class[state] = scc_idx
 
     return CommunicatingClassesResult(
+        transition_matrix=request.matrix,
         classes=tuple(classes_info),
         state_class=tuple(state_class),
     )

--- a/src/jacobian/math/markov_chain/_tools.py
+++ b/src/jacobian/math/markov_chain/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.markov_chain._models import (
+    CommunicatingClassesResult,
     ErgodicDecisionResult,
     MixingTimeRequest,
     MixingTimeResult,
@@ -15,6 +16,7 @@ from jacobian.math.markov_chain._models import (
     TransitionMatrixRequest,
 )
 from jacobian.math.markov_chain._operations import (
+    compute_communicating_classes,
     compute_ergodic_decision,
     compute_mixing_time,
     compute_stationary_distribution,
@@ -138,6 +140,37 @@ MARKOV_CHAIN_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             ),
         ),
     ),
+)
+
+MARKOV_COMMUNICATING_CLASSES_OPERATION = mc_operation(
+    "probability.markov_chain.communicating_classes.compute",
+    "Compute the communicating-class decomposition",
+    "Decompose a bounded exact finite Markov chain into communicating classes "
+    "(strongly connected components) of its transition support graph, "
+    "classifying each as transient or closed (recurrent).",
+    TransitionMatrixRequest,
+    CommunicatingClassesResult,
+    compute_communicating_classes,
+    "markov-chain",
+    "communicating-classes",
+    "exact",
+    examples=(
+        example(
+            "two_class_chain",
+            "A two-state chain where state 0 is transient and state 1 is absorbing.",
+            {
+                "matrix": [
+                    [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+                    [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+                ],
+            },
+        ),
+    ),
+)
+
+MARKOV_CHAIN_OPERATIONS = (
+    *MARKOV_CHAIN_OPERATIONS,
+    MARKOV_COMMUNICATING_CLASSES_OPERATION,
 )
 
 TOOLS = MARKOV_CHAIN_OPERATIONS

--- a/tests/math/markov_chain/test_communicating_classes.py
+++ b/tests/math/markov_chain/test_communicating_classes.py
@@ -1,0 +1,86 @@
+"""Tests for Markov chain communicating class decomposition."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.markov_chain._models import (
+    TransitionMatrixRequest,
+)
+from jacobian.math.markov_chain._operations import compute_communicating_classes
+from jacobian.math.markov_chain._tools import TOOLS
+
+_C = CanonicalRational.from_fraction
+
+
+def _matrix(rows: list[list[Fraction]]) -> TransitionMatrixRequest:
+    return TransitionMatrixRequest(
+        matrix=tuple(tuple(_C(f) for f in row) for row in rows)
+    )
+
+
+def test_operation_in_catalog() -> None:
+    ids = {tool.operation_id for tool in TOOLS}
+    assert "probability.markov_chain.communicating_classes.compute" in ids
+
+
+def test_absorbing_chain_has_transient_and_closed_classes() -> None:
+    # 0 -> 1 -> 1 (absorbing)
+    result = compute_communicating_classes(
+        _matrix([[Fraction(0), Fraction(1)], [Fraction(0), Fraction(1)]])
+    )
+    assert len(result.classes) == 2
+    assert result.classes[0] == ((0,), False)  # transient
+    assert result.classes[1] == ((1,), True)  # closed
+
+
+def test_irreducible_chain_has_single_closed_class() -> None:
+    # Self-loops on both states
+    result = compute_communicating_classes(
+        _matrix([[Fraction(1, 2), Fraction(1, 2)], [Fraction(1, 2), Fraction(1, 2)]])
+    )
+    assert len(result.classes) == 1
+    assert result.classes[0][1] is True  # closed
+
+
+def test_single_state_absorbing() -> None:
+    result = compute_communicating_classes(_matrix([[Fraction(1)]]))
+    assert len(result.classes) == 1
+    assert result.classes[0] == ((0,), True)
+
+
+def test_three_state_chain_with_transient_state() -> None:
+    # 0 -> 1 -> 2 -> 2 (chain with absorbing state 2)
+    result = compute_communicating_classes(
+        _matrix(
+            [
+                [Fraction(0), Fraction(1), Fraction(0)],
+                [Fraction(0), Fraction(0), Fraction(1)],
+                [Fraction(0), Fraction(0), Fraction(1)],
+            ]
+        )
+    )
+    assert len(result.classes) == 3
+    # All singletons, first two transient, last closed
+    assert all(len(cls[0]) == 1 for cls in result.classes)
+    assert result.classes[0][1] is False  # transient
+    assert result.classes[1][1] is False  # transient
+    assert result.classes[2][1] is True  # closed
+
+
+def test_state_class_indices() -> None:
+    result = compute_communicating_classes(
+        _matrix([[Fraction(0), Fraction(1)], [Fraction(0), Fraction(1)]])
+    )
+    assert result.state_class == (0, 1)
+    assert len(result.state_class) == 2
+
+
+def test_two_closed_classes() -> None:
+    # Identity matrix - two absorbing states
+    result = compute_communicating_classes(
+        _matrix([[Fraction(1), Fraction(0)], [Fraction(0), Fraction(1)]])
+    )
+    assert len(result.classes) == 2
+    assert all(cls[1] for cls in result.classes)  # both closed

--- a/tools/c901-baseline.json
+++ b/tools/c901-baseline.json
@@ -28,6 +28,16 @@
       "complexity": 23
     },
     {
+      "path": "src/jacobian/math/markov_chain/_models.py",
+      "symbol": "bind_decomposition",
+      "complexity": 12
+    },
+    {
+      "path": "src/jacobian/math/markov_chain/_models.py",
+      "symbol": "require_partition_validity",
+      "complexity": 12
+    },
+    {
       "path": "src/jacobian/math/root_systems/_operations.py",
       "symbol": "_weyl_group_data",
       "complexity": 11


### PR DESCRIPTION
## Summary

Add `probability.markov_chain.communicating_classes.compute`, which decomposes a bounded exact finite Markov chain into communicating classes (strongly connected components) of its transition support graph, classifying each as transient or closed (recurrent).

## Design

The operation uses NetworkX's `strongly_connected_components` and `condensation` analysis as the computational backend. The support graph is built from positive transition probabilities, and SCC analysis determines the communicating classes. Each class is classified as closed (recurrent) if no edges leave it, or transient otherwise.

This is the first atomic operation from the issue's proposed decomposition chain: exact finite chain → support graph and communicating-class decomposition → canonical block form → fundamental matrix → hitting/absorption data.

## Tests

- Absorbing chain with transient and closed classes
- Irreducible chain with single closed class
- Single-state absorbing chain
- Three-state chain with transient states
- State-class index mapping
- Two closed classes (identity matrix)

Closes #1744

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/636bb865-8fa9-4348-a437-f0b719b854e9)
