### PR TITLE
feat(math): add configuration-level geometry operations

### DIFF
--- a/src/jacobian/math/geometry/_admission.py
+++ b/src/jacobian/math/geometry/_admission.py
@@ -95,6 +95,16 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.DROP,
         "elementary exact formula without material leverage over direct Python",
     ),
+    OperationAdmission(
+        "geometry.points.general_position.search",
+        AdmissionDecision.KEEP,
+        "distinct exact or explicitly bounded search outcome with material computational leverage",
+    ),
+    OperationAdmission(
+        "geometry.points.circumradius_profile.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/geometry/_configuration.py
+++ b/src/jacobian/math/geometry/_configuration.py
@@ -1,0 +1,74 @@
+"""Configuration-level geometry operations."""
+
+from jacobian.catalog._examples import example
+from jacobian.math.geometry._models import (
+    CircumradiusProfileRequest,
+    CircumradiusProfileResult,
+    GeneralPositionRequest,
+    GeneralPositionResult,
+)
+from jacobian.math.geometry._operations import (
+    circumradius_profile,
+    general_position_search,
+)
+from jacobian.math.geometry._support import geometry_operation
+
+CONFIGURATION_OPERATIONS = (
+    geometry_operation(
+        "geometry.points.general_position.search",
+        "Search for collinear triples and concyclic quadruples",
+        "Given a bounded rational planar point configuration, exhaustively "
+        "find all collinear triples and all concyclic quadruples, or establish "
+        "that none exist. Returns source-labelled witnesses with sorted indices.",
+        GeneralPositionRequest,
+        GeneralPositionResult,
+        general_position_search,
+        "geometry",
+        "incidence",
+        "configuration",
+        examples=(
+            example(
+                "square_general_position",
+                "Search a unit square for collinear triples and concyclic "
+                "quadruples; the four vertices of a square are concyclic.",
+                {
+                    "points": [
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "1", "den": "1"}, "y": {"num": "1", "den": "1"}},
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}},
+                    ],
+                },
+            ),
+        ),
+    ),
+    geometry_operation(
+        "geometry.points.circumradius_profile.compute",
+        "Compute circumradius data for all triples",
+        "Given a bounded rational planar point configuration, return the "
+        "complete circumradius squared for every unordered triple, with "
+        "explicit degenerate (collinear) disposition. Each entry includes "
+        "the source-labelled triple indices and the exact rational squared "
+        "circumradius.",
+        CircumradiusProfileRequest,
+        CircumradiusProfileResult,
+        circumradius_profile,
+        "geometry",
+        "circumradius",
+        "configuration",
+        examples=(
+            example(
+                "unit_triangle",
+                "Compute circumradius profile for a triangle; the three "
+                "vertices must be unique points.",
+                {
+                    "points": [
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "1", "den": "1"}, "y": {"num": "0", "den": "1"}},
+                        {"x": {"num": "0", "den": "1"}, "y": {"num": "1", "den": "1"}},
+                    ],
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/geometry/_configuration.py
+++ b/src/jacobian/math/geometry/_configuration.py
@@ -18,7 +18,7 @@ CONFIGURATION_OPERATIONS = (
         "geometry.points.general_position.search",
         "Search for collinear triples and concyclic quadruples",
         "Given a bounded rational planar point configuration (3..32 points, each "
-        "coordinate at most 256 digits, aggregate n*max_digits<=1024 to bound the "
+        "coordinate at most 256 digits, C(n,4)*max_digits^2<=1000000 to bound the "
         "exhaustive determinant work) exhaustively find all collinear triples and "
         "all concyclic quadruples, or establish that none exist. Returns "
         "source-labelled witnesses with sorted indices.",
@@ -32,9 +32,9 @@ CONFIGURATION_OPERATIONS = (
             example(
                 "square_general_position",
                 "Search a unit square for collinear triples and concyclic "
-                "quadruples; the four vertices of a square are concyclic (points "
-                "are bounded: 3..32 points, each coordinate <=256 digits, "
-                "n*max_digits<=1024).",
+                 "quadruples; the four vertices of a square are concyclic (points "
+                 "are bounded: 3..32 points, each coordinate <=256 digits, "
+                 "C(n,4)*max_digits^2<=1000000).",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},

--- a/src/jacobian/math/geometry/_configuration.py
+++ b/src/jacobian/math/geometry/_configuration.py
@@ -17,9 +17,10 @@ CONFIGURATION_OPERATIONS = (
     geometry_operation(
         "geometry.points.general_position.search",
         "Search for collinear triples and concyclic quadruples",
-        "Given a bounded rational planar point configuration, exhaustively "
-        "find all collinear triples and all concyclic quadruples, or establish "
-        "that none exist. Returns source-labelled witnesses with sorted indices.",
+        "Given a bounded rational planar point configuration (3..32 points, each "
+        "coordinate at most 256 digits) exhaustively find all collinear triples and "
+        "all concyclic quadruples, or establish that none exist. Returns "
+        "source-labelled witnesses with sorted indices.",
         GeneralPositionRequest,
         GeneralPositionResult,
         general_position_search,
@@ -30,7 +31,8 @@ CONFIGURATION_OPERATIONS = (
             example(
                 "square_general_position",
                 "Search a unit square for collinear triples and concyclic "
-                "quadruples; the four vertices of a square are concyclic.",
+                "quadruples; the four vertices of a square are concyclic (points "
+                "are bounded: 3..32 points, each coordinate <=256 digits).",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
@@ -45,9 +47,10 @@ CONFIGURATION_OPERATIONS = (
     geometry_operation(
         "geometry.points.circumradius_profile.compute",
         "Compute circumradius data for all triples",
-        "Given a bounded rational planar point configuration, return the "
-        "complete circumradius squared for every unordered triple, with "
-        "explicit degenerate (collinear) disposition. Each entry includes "
+        "Given a bounded rational planar point configuration (3..32 points, each "
+        "coordinate at most 256 digits, aggregate n*max_digits<=2048 and estimated "
+        "8 MiB envelope) return the complete circumradius squared for every unordered "
+        "triple, with explicit degenerate (collinear) disposition. Each entry includes "
         "the source-labelled triple indices and the exact rational squared "
         "circumradius.",
         CircumradiusProfileRequest,
@@ -60,7 +63,8 @@ CONFIGURATION_OPERATIONS = (
             example(
                 "unit_triangle",
                 "Compute circumradius profile for a triangle; the three "
-                "vertices must be unique points.",
+                "vertices must be unique points and coordinates are bounded to "
+                "256 digits with aggregate n*digits<=2048.",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},

--- a/src/jacobian/math/geometry/_configuration.py
+++ b/src/jacobian/math/geometry/_configuration.py
@@ -32,9 +32,9 @@ CONFIGURATION_OPERATIONS = (
             example(
                 "square_general_position",
                 "Search a unit square for collinear triples and concyclic "
-                 "quadruples; the four vertices of a square are concyclic (points "
-                 "are bounded: 3..32 points, each coordinate <=256 digits, "
-                 "C(n,4)*max_digits^2<=1000000).",
+                "quadruples; the four vertices of a square are concyclic (points "
+                "are bounded: 3..32 points, each coordinate <=256 digits, "
+                "C(n,4)*max_digits^2<=1000000).",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},

--- a/src/jacobian/math/geometry/_configuration.py
+++ b/src/jacobian/math/geometry/_configuration.py
@@ -18,7 +18,8 @@ CONFIGURATION_OPERATIONS = (
         "geometry.points.general_position.search",
         "Search for collinear triples and concyclic quadruples",
         "Given a bounded rational planar point configuration (3..32 points, each "
-        "coordinate at most 256 digits) exhaustively find all collinear triples and "
+        "coordinate at most 256 digits, aggregate n*max_digits<=1024 to bound the "
+        "exhaustive determinant work) exhaustively find all collinear triples and "
         "all concyclic quadruples, or establish that none exist. Returns "
         "source-labelled witnesses with sorted indices.",
         GeneralPositionRequest,
@@ -32,7 +33,8 @@ CONFIGURATION_OPERATIONS = (
                 "square_general_position",
                 "Search a unit square for collinear triples and concyclic "
                 "quadruples; the four vertices of a square are concyclic (points "
-                "are bounded: 3..32 points, each coordinate <=256 digits).",
+                "are bounded: 3..32 points, each coordinate <=256 digits, "
+                "n*max_digits<=1024).",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},
@@ -48,8 +50,9 @@ CONFIGURATION_OPERATIONS = (
         "geometry.points.circumradius_profile.compute",
         "Compute circumradius data for all triples",
         "Given a bounded rational planar point configuration (3..32 points, each "
-        "coordinate at most 256 digits, aggregate n*max_digits<=2048 and estimated "
-        "8 MiB envelope) return the complete circumradius squared for every unordered "
+        "coordinate at most 256 digits, worst-case profile size "
+        "C(n,3)*(80*max_digits+80) characters within the 8,000,000-character "
+        "output budget) return the complete circumradius squared for every unordered "
         "triple, with explicit degenerate (collinear) disposition. Each entry includes "
         "the source-labelled triple indices and the exact rational squared "
         "circumradius.",
@@ -64,7 +67,7 @@ CONFIGURATION_OPERATIONS = (
                 "unit_triangle",
                 "Compute circumradius profile for a triangle; the three "
                 "vertices must be unique points and coordinates are bounded to "
-                "256 digits with aggregate n*digits<=2048.",
+                "256 digits with the worst-case profile size within budget.",
                 {
                     "points": [
                         {"x": {"num": "0", "den": "1"}, "y": {"num": "0", "den": "1"}},

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -13,6 +13,10 @@ from jacobian._models import StrictModel
 
 MAX_CONFIGURATION_POINTS = 32
 MAX_COORDINATE_DIGITS = 256
+# Joint bound for circumradius: n * max_digits <= 2048 keeps serialized output
+# under the 10 MiB transport envelope (32 points with 256-digit coords would be
+# 8192 and is rejected; 32 points with 64-digit coords is 2048 and passes).
+_MAX_CIRCUMRADIUS_N_TIMES_DIGITS = 2048
 
 
 def _require_bounded_point(point: RationalPoint2D) -> None:
@@ -27,6 +31,31 @@ def _require_bounded_point(point: RationalPoint2D) -> None:
 def _require_bounded_configuration(points: tuple[RationalPoint2D, ...]) -> None:
     for point in points:
         _require_bounded_point(point)
+
+
+def _require_circumradius_aggregate_bound(points: tuple[RationalPoint2D, ...]) -> None:
+    n = len(points)
+    if n == 0:
+        return
+    max_digits = max(
+        max(len(p.x.num.lstrip("-")), len(p.x.den), len(p.y.num.lstrip("-")), len(p.y.den))
+        for p in points
+    )
+    if n * max_digits > _MAX_CIRCUMRADIUS_N_TIMES_DIGITS:
+        raise ValueError(
+            f"circumradius profile with {n} points and {max_digits}-digit coordinates "
+            f"would exceed the transport envelope (n*digits={n*max_digits} > "
+            f"{_MAX_CIRCUMRADIUS_N_TIMES_DIGITS}); reduce point count or coordinate size"
+        )
+    # Also bound total serialized estimate
+    triples = n * (n - 1) * (n - 2) // 6
+    # Rough estimate: each radius_squared needs ~4*max_digits digits (numerator+denominator)
+    estimated_chars = triples * (4 * max_digits + 50)
+    if estimated_chars > 8_000_000:
+        raise ValueError(
+            f"circumradius profile estimated size {estimated_chars} chars exceeds 8 MiB; "
+            "reduce point count or coordinate size"
+        )
 
 
 def _is_collinear_frac(
@@ -641,10 +670,21 @@ class ConvexPolygonTriangulationResult(StrictModel):
 
 
 class GeneralPositionRequest(StrictModel):
-    """Search a bounded point configuration for collinear triples and concyclic quadruples."""
+    """Search a bounded point configuration for collinear triples and concyclic quadruples.
+
+    Each rational coordinate is bounded to at most 256 digits in numerator and
+    denominator (operation-specific, stricter than the global 32,768-digit
+    CanonicalRational limit).
+    """
 
     points: tuple[RationalPoint2D, ...] = Field(
-        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+        min_length=3,
+        max_length=MAX_CONFIGURATION_POINTS,
+        description=(
+            "Bounded point configuration with 3..32 points; each rational coordinate "
+            f"(numerator/denominator) is bounded to at most {MAX_COORDINATE_DIGITS} digits "
+            "(operation-specific limit, stricter than CanonicalRational's 32768-digit global limit)"
+        ),
     )
 
     @model_validator(mode="after")
@@ -694,15 +734,29 @@ class GeneralPositionResult(StrictModel):
 
 
 class CircumradiusProfileRequest(StrictModel):
-    """Compute circumradius data for every unordered triple in a point configuration."""
+    """Compute circumradius data for every unordered triple in a point configuration.
+
+    Each rational coordinate is bounded to at most 256 digits, and the aggregate
+    output size is bounded by n*max_digits <= 2048 and an 8 MiB estimate (to keep
+    the profile under the 10 MiB transport envelope).
+    """
 
     points: tuple[RationalPoint2D, ...] = Field(
-        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+        min_length=3,
+        max_length=MAX_CONFIGURATION_POINTS,
+        description=(
+            "Bounded point configuration with 3..32 points; each rational coordinate "
+            f"is bounded to at most {MAX_COORDINATE_DIGITS} digits (operation-specific, "
+            "stricter than CanonicalRational's 32768-digit limit); additionally "
+            "n*max_digits <= 2048 and estimated serialized size <=8 MiB to keep the "
+            f"C(n,3) profile under the 10 MiB envelope"
+        ),
     )
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
         _require_bounded_configuration(self.points)
+        _require_circumradius_aggregate_bound(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
@@ -742,6 +796,7 @@ class CircumradiusProfileResult(StrictModel):
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
         _require_bounded_configuration(self.points)
+        _require_circumradius_aggregate_bound(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -16,12 +16,15 @@ MAX_COORDINATE_DIGITS = 256
 # Serialized-output budget for the circumradius profile, kept below the 10 MiB
 # transport envelope to leave room for request and JSON overhead.
 _MAX_PROFILE_OUTPUT_CHARS = 8_000_000
-# Joint work bound for the exhaustive general-position search: determinant
-# count grows like n^4 while every Fraction operation grows quadratically in
-# digit count, so n * max_digits <= 1024 keeps both the search and its
-# source-binding replay within the bounded-work envelope at any shape
-# (e.g. 32 points x 32 digits, or 4 points x 256 digits).
-_MAX_GENERAL_POSITION_N_TIMES_DIGITS = 1024
+# Joint work bound for the exhaustive general-position search.  The sweep
+# performs one exact 4x4 determinant per point quadruple, so the determinant
+# count grows as C(n,4) while every Fraction multiplication grows
+# quadratically in coordinate digit count; the admitted work proxy is
+# ``C(n,4) * max_digits**2`` (measured reference: 32 points x 32 digits
+# costs about 36M proxy units and roughly 16s, so a 1M-unit budget keeps an
+# accepted request well under a second for both the search and its
+# source-binding replay).
+_MAX_GENERAL_POSITION_DETERMINANT_WORK = 1_000_000
 
 
 def _require_bounded_point(point: RationalPoint2D) -> None:
@@ -57,13 +60,15 @@ def _require_general_position_work_bound(
     if n == 0:
         return
     max_digits = _max_coordinate_digits(points)
-    if n * max_digits > _MAX_GENERAL_POSITION_N_TIMES_DIGITS:
+    quadruples = n * (n - 1) * (n - 2) * (n - 3) // 24
+    work = quadruples * max_digits * max_digits
+    if work > _MAX_GENERAL_POSITION_DETERMINANT_WORK:
         raise ValueError(
             f"general-position search with {n} points and {max_digits}-digit "
             f"coordinates exceeds the exhaustive work bound "
-            f"(n*digits={n * max_digits} > "
-            f"{_MAX_GENERAL_POSITION_N_TIMES_DIGITS}); reduce point count or "
-            "coordinate size"
+            f"(C(n,4)*digits^2={work} > "
+            f"{_MAX_GENERAL_POSITION_DETERMINANT_WORK}); reduce point count "
+            "or coordinate size"
         )
 
 
@@ -711,8 +716,9 @@ class GeneralPositionRequest(StrictModel):
 
     Each rational coordinate is bounded to at most 256 digits in numerator and
     denominator (operation-specific, stricter than the global 32,768-digit
-    CanonicalRational limit). The exhaustive determinant work is coupled to the
-    point count: ``n * max_digits <= 1024`` keeps both the search and its
+    CanonicalRational limit). The exhaustive determinant work is coupled to
+    both the combinatorial point count and rational complexity:
+    ``C(n,4) * max_digits**2 <= 1,000,000`` keeps both the search and its
     source-binding replay within the bounded-work envelope.
     """
 
@@ -723,8 +729,8 @@ class GeneralPositionRequest(StrictModel):
             "Bounded point configuration with 3..32 points; each rational coordinate "
             f"(numerator/denominator) is bounded to at most {MAX_COORDINATE_DIGITS} digits "
             "(operation-specific limit, stricter than CanonicalRational's 32768-digit "
-            "global limit); additionally n*max_digits <= 1024 bounds the exhaustive "
-            "determinant work"
+            "global limit); additionally C(n,4)*max_digits^2 <= 1000000 bounds the "
+            "exhaustive determinant work"
         ),
     )
 

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -13,10 +13,15 @@ from jacobian._models import StrictModel
 
 MAX_CONFIGURATION_POINTS = 32
 MAX_COORDINATE_DIGITS = 256
-# Joint bound for circumradius: n * max_digits <= 2048 keeps serialized output
-# under the 10 MiB transport envelope (32 points with 256-digit coords would be
-# 8192 and is rejected; 32 points with 64-digit coords is 2048 and passes).
-_MAX_CIRCUMRADIUS_N_TIMES_DIGITS = 2048
+# Serialized-output budget for the circumradius profile, kept below the 10 MiB
+# transport envelope to leave room for request and JSON overhead.
+_MAX_PROFILE_OUTPUT_CHARS = 8_000_000
+# Joint work bound for the exhaustive general-position search: determinant
+# count grows like n^4 while every Fraction operation grows quadratically in
+# digit count, so n * max_digits <= 1024 keeps both the search and its
+# source-binding replay within the bounded-work envelope at any shape
+# (e.g. 32 points x 32 digits, or 4 points x 256 digits).
+_MAX_GENERAL_POSITION_N_TIMES_DIGITS = 1024
 
 
 def _require_bounded_point(point: RationalPoint2D) -> None:
@@ -33,28 +38,60 @@ def _require_bounded_configuration(points: tuple[RationalPoint2D, ...]) -> None:
         _require_bounded_point(point)
 
 
-def _require_circumradius_aggregate_bound(points: tuple[RationalPoint2D, ...]) -> None:
+def _max_coordinate_digits(points: tuple[RationalPoint2D, ...]) -> int:
+    return max(
+        max(
+            len(p.x.num.lstrip("-")),
+            len(p.x.den),
+            len(p.y.num.lstrip("-")),
+            len(p.y.den),
+        )
+        for p in points
+    )
+
+
+def _require_general_position_work_bound(
+    points: tuple[RationalPoint2D, ...],
+) -> None:
     n = len(points)
     if n == 0:
         return
-    max_digits = max(
-        max(len(p.x.num.lstrip("-")), len(p.x.den), len(p.y.num.lstrip("-")), len(p.y.den))
-        for p in points
-    )
-    if n * max_digits > _MAX_CIRCUMRADIUS_N_TIMES_DIGITS:
+    max_digits = _max_coordinate_digits(points)
+    if n * max_digits > _MAX_GENERAL_POSITION_N_TIMES_DIGITS:
         raise ValueError(
-            f"circumradius profile with {n} points and {max_digits}-digit coordinates "
-            f"would exceed the transport envelope (n*digits={n*max_digits} > "
-            f"{_MAX_CIRCUMRADIUS_N_TIMES_DIGITS}); reduce point count or coordinate size"
+            f"general-position search with {n} points and {max_digits}-digit "
+            f"coordinates exceeds the exhaustive work bound "
+            f"(n*digits={n * max_digits} > "
+            f"{_MAX_GENERAL_POSITION_N_TIMES_DIGITS}); reduce point count or "
+            "coordinate size"
         )
-    # Also bound total serialized estimate
+
+
+def _require_circumradius_output_bound(points: tuple[RationalPoint2D, ...]) -> None:
+    """Bound the serialized profile size before execution.
+
+    Derivation from exact rational growth with ``d`` = max coordinate digits:
+    a coordinate difference has numerator and denominator of at most ``2d``
+    digits; a squared length reaches ``8d`` digits on each side; the squared
+    circumradius ``|AB||BC||CA| / (2*cross)^2`` therefore carries at most
+    ``40d`` digits in its numerator and ``40d`` in its denominator. Allowing
+    80 characters of sign/slash/JSON overhead per entry gives the conservative
+    per-entry estimate ``80*d + 80`` characters.
+    """
+
+    n = len(points)
+    if n == 0:
+        return
+    max_digits = _max_coordinate_digits(points)
     triples = n * (n - 1) * (n - 2) // 6
-    # Rough estimate: each radius_squared needs ~4*max_digits digits (numerator+denominator)
-    estimated_chars = triples * (4 * max_digits + 50)
-    if estimated_chars > 8_000_000:
+    estimated_chars = triples * (80 * max_digits + 80)
+    if estimated_chars > _MAX_PROFILE_OUTPUT_CHARS:
         raise ValueError(
-            f"circumradius profile estimated size {estimated_chars} chars exceeds 8 MiB; "
-            "reduce point count or coordinate size"
+            f"circumradius profile for {n} points with {max_digits}-digit "
+            f"coordinates can serialize up to {estimated_chars} characters "
+            f"(worst-case rational growth), exceeding the "
+            f"{_MAX_PROFILE_OUTPUT_CHARS}-character output budget; reduce "
+            "point count or coordinate size"
         )
 
 
@@ -674,7 +711,9 @@ class GeneralPositionRequest(StrictModel):
 
     Each rational coordinate is bounded to at most 256 digits in numerator and
     denominator (operation-specific, stricter than the global 32,768-digit
-    CanonicalRational limit).
+    CanonicalRational limit). The exhaustive determinant work is coupled to the
+    point count: ``n * max_digits <= 1024`` keeps both the search and its
+    source-binding replay within the bounded-work envelope.
     """
 
     points: tuple[RationalPoint2D, ...] = Field(
@@ -683,13 +722,16 @@ class GeneralPositionRequest(StrictModel):
         description=(
             "Bounded point configuration with 3..32 points; each rational coordinate "
             f"(numerator/denominator) is bounded to at most {MAX_COORDINATE_DIGITS} digits "
-            "(operation-specific limit, stricter than CanonicalRational's 32768-digit global limit)"
+            "(operation-specific limit, stricter than CanonicalRational's 32768-digit "
+            "global limit); additionally n*max_digits <= 1024 bounds the exhaustive "
+            "determinant work"
         ),
     )
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
         _require_bounded_configuration(self.points)
+        _require_general_position_work_bound(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
@@ -719,6 +761,7 @@ class GeneralPositionResult(StrictModel):
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
         _require_bounded_configuration(self.points)
+        _require_general_position_work_bound(self.points)
         _validate_general_position_points(self.points, self.num_points)
         _validate_general_position_witnesses(
             self.collinear_triples,
@@ -736,9 +779,12 @@ class GeneralPositionResult(StrictModel):
 class CircumradiusProfileRequest(StrictModel):
     """Compute circumradius data for every unordered triple in a point configuration.
 
-    Each rational coordinate is bounded to at most 256 digits, and the aggregate
-    output size is bounded by n*max_digits <= 2048 and an 8 MiB estimate (to keep
-    the profile under the 10 MiB transport envelope).
+    Each rational coordinate is bounded to at most 256 digits. The serialized
+    profile is bounded before execution by worst-case rational growth: with
+    ``d`` = max coordinate digits, each squared circumradius can carry ``40d``
+    digits in numerator and denominator, so the request is admitted only when
+    ``C(n,3) * (80*d + 80)`` characters stay within the 8,000,000-character
+    output budget (under the 10 MiB transport envelope).
     """
 
     points: tuple[RationalPoint2D, ...] = Field(
@@ -748,15 +794,15 @@ class CircumradiusProfileRequest(StrictModel):
             "Bounded point configuration with 3..32 points; each rational coordinate "
             f"is bounded to at most {MAX_COORDINATE_DIGITS} digits (operation-specific, "
             "stricter than CanonicalRational's 32768-digit limit); additionally "
-            "n*max_digits <= 2048 and estimated serialized size <=8 MiB to keep the "
-            f"C(n,3) profile under the 10 MiB envelope"
+            "C(n,3)*(80*max_digits+80) characters of worst-case profile size must "
+            "stay within the 8,000,000-character output budget"
         ),
     )
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
         _require_bounded_configuration(self.points)
-        _require_circumradius_aggregate_bound(self.points)
+        _require_circumradius_output_bound(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
@@ -796,7 +842,7 @@ class CircumradiusProfileResult(StrictModel):
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
         _require_bounded_configuration(self.points)
-        _require_circumradius_aggregate_bound(self.points)
+        _require_circumradius_output_bound(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -437,3 +437,118 @@ class ConvexPolygonTriangulationResult(StrictModel):
     objective: Literal["NON_HULL_DIAGONAL_WEIGHT_SUM"] = "NON_HULL_DIAGONAL_WEIGHT_SUM"
     tie_break: Literal["LOWEST_SPLIT_INDEX"] = "LOWEST_SPLIT_INDEX"
     exactness: Literal["EXACT_RATIONAL"] = "EXACT_RATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Configuration-level operations (issues #2107, #2106)
+# ---------------------------------------------------------------------------
+
+class GeneralPositionRequest(StrictModel):
+    """Search a bounded point configuration for collinear triples and concyclic quadruples."""
+
+    points: tuple[RationalPoint2D, ...] = Field(min_length=3, max_length=32)
+
+    @model_validator(mode="after")
+    def require_unique(self) -> Self:
+        keys = tuple(
+            (p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points
+        )
+        if len(keys) != len(set(keys)):
+            raise ValueError("point-set coordinates must be unique")
+        return self
+
+
+class CollinearTripleWitness(StrictModel):
+    indices: tuple[int, int, int]
+
+
+class ConcyclicQuadrupleWitness(StrictModel):
+    indices: tuple[int, int, int, int]
+
+
+class GeneralPositionResult(StrictModel):
+    """Complete search result for collinear triples and concyclic quadruples."""
+
+    num_points: int = Field(ge=0)
+    has_collinear_triple: bool
+    has_concyclic_quadruple: bool
+    collinear_triples: tuple[CollinearTripleWitness, ...] = Field(default=())
+    concyclic_quadruples: tuple[ConcyclicQuadrupleWitness, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        for witness in self.collinear_triples:
+            idx = witness.indices
+            if len(idx) != 3 or len(set(idx)) != 3:
+                raise ValueError("collinear triple indices must be 3 distinct values")
+            if idx != tuple(sorted(idx)):
+                raise ValueError("collinear triple indices must be sorted")
+            if any(i >= self.num_points for i in idx):
+                raise ValueError("index out of range")
+        for witness in self.concyclic_quadruples:
+            idx = witness.indices
+            if len(idx) != 4 or len(set(idx)) != 4:
+                raise ValueError("concyclic quadruple indices must be 4 distinct values")
+            if idx != tuple(sorted(idx)):
+                raise ValueError("concyclic quadruple indices must be sorted")
+            if any(i >= self.num_points for i in idx):
+                raise ValueError("index out of range")
+        if self.has_collinear_triple != bool(self.collinear_triples):
+            raise ValueError("has_collinear_triple must match collinear_triples")
+        if self.has_concyclic_quadruple != bool(self.concyclic_quadruples):
+            raise ValueError("has_concyclic_quadruple must match concyclic_quadruples")
+        return self
+
+
+class CircumradiusProfileRequest(StrictModel):
+    """Compute circumradius data for every unordered triple in a point configuration."""
+
+    points: tuple[RationalPoint2D, ...] = Field(min_length=3, max_length=32)
+
+    @model_validator(mode="after")
+    def require_unique(self) -> Self:
+        keys = tuple(
+            (p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points
+        )
+        if len(keys) != len(set(keys)):
+            raise ValueError("point-set coordinates must be unique")
+        return self
+
+
+class CircumradiusTripleEntry(StrictModel):
+    """One triple and its circumradius disposition."""
+
+    indices: tuple[int, int, int]
+    is_degenerate: bool
+    radius_squared: CanonicalRational | None = None
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        idx = self.indices
+        if len(idx) != 3 or len(set(idx)) != 3:
+            raise ValueError("triple indices must be 3 distinct values")
+        if idx != tuple(sorted(idx)):
+            raise ValueError("triple indices must be sorted")
+        if self.is_degenerate and self.radius_squared is not None:
+            raise ValueError("degenerate triple cannot have a radius")
+        if not self.is_degenerate and self.radius_squared is None:
+            raise ValueError("non-degenerate triple must have a radius")
+        return self
+
+
+class CircumradiusProfileResult(StrictModel):
+    """Complete circumradius profile for every unordered triple."""
+
+    num_points: int = Field(ge=0)
+    entries: tuple[CircumradiusTripleEntry, ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        if len(self.entries) != self.num_points * (self.num_points - 1) * (self.num_points - 2) // 6:
+            raise ValueError("entries must cover exactly C(n,3) triples")
+        seen: set[tuple[int, int, int]] = set()
+        for entry in self.entries:
+            if entry.indices in seen:
+                raise ValueError("duplicate triple in circumradius profile")
+            seen.add(entry.indices)
+        return self

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -3,12 +3,208 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from itertools import combinations
 from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+
+MAX_CONFIGURATION_POINTS = 32
+MAX_COORDINATE_DIGITS = 256
+
+
+def _require_bounded_point(point: RationalPoint2D) -> None:
+    require_bounded_rational(
+        point.x, max_digits=MAX_COORDINATE_DIGITS, label="point x-coordinate"
+    )
+    require_bounded_rational(
+        point.y, max_digits=MAX_COORDINATE_DIGITS, label="point y-coordinate"
+    )
+
+
+def _require_bounded_configuration(points: tuple[RationalPoint2D, ...]) -> None:
+    for point in points:
+        _require_bounded_point(point)
+
+
+def _is_collinear_frac(
+    a: tuple[Fraction, Fraction],
+    b: tuple[Fraction, Fraction],
+    c: tuple[Fraction, Fraction],
+) -> bool:
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]) == 0
+
+
+def _det3_frac(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+    return (
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    )
+
+
+def _det4_frac(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+    result = Fraction(0)
+    for col in range(4):
+        sub = tuple(
+            tuple(row[col2] for col2 in range(4) if col2 != col) for row in m[1:]
+        )
+        cofactor = _det3_frac(sub)
+        sign = 1 if col % 2 == 0 else -1
+        result += sign * m[0][col] * cofactor
+    return result
+
+
+def _expected_collinear_indices(
+    pts: list[tuple[Fraction, Fraction]],
+) -> set[tuple[int, int, int]]:
+    result: set[tuple[int, int, int]] = set()
+    for i, j, k in combinations(range(len(pts)), 3):
+        if _is_collinear_frac(pts[i], pts[j], pts[k]):
+            result.add((i, j, k))
+    return result
+
+
+def _expected_concyclic_indices(
+    pts: list[tuple[Fraction, Fraction]],
+    collinear_set: set[tuple[int, int, int]],
+) -> set[tuple[int, int, int, int]]:
+    result: set[tuple[int, int, int, int]] = set()
+    n = len(pts)
+    for i, j, k, m in combinations(range(n), 4):
+        if (
+            (i, j, k) in collinear_set
+            or (i, j, m) in collinear_set
+            or (i, k, m) in collinear_set
+            or (j, k, m) in collinear_set
+        ):
+            continue
+        rows = tuple(
+            (px * px + py * py, px, py, Fraction(1))
+            for px, py in (pts[i], pts[j], pts[k], pts[m])
+        )
+        if _det4_frac(rows) == 0:
+            result.add((i, j, k, m))
+    return result
+
+
+def _check_witness_sorted_distinct(
+    indices: tuple[int, ...], n: int, expected: int, label: str
+) -> None:
+    if len(indices) != expected or len(set(indices)) != expected:
+        raise ValueError(f"{label} indices must be {expected} distinct values")
+    if indices != tuple(sorted(indices)):
+        raise ValueError(f"{label} indices must be sorted")
+    if any(i >= n for i in indices):
+        raise ValueError("index out of range")
+
+
+def _validate_general_position_points(
+    points: tuple[RationalPoint2D, ...], num_points: int
+) -> None:
+    keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in points)
+    if len(keys) != len(set(keys)):
+        raise ValueError("point-set coordinates must be unique")
+    if num_points != len(points):
+        raise ValueError("num_points must equal len(points)")
+
+
+def _validate_general_position_witnesses(
+    collinear: tuple[CollinearTripleWitness, ...],
+    concyclic: tuple[ConcyclicQuadrupleWitness, ...],
+    has_collinear: bool,
+    has_concyclic: bool,
+    n: int,
+) -> None:
+    for triple in collinear:
+        _check_witness_sorted_distinct(triple.indices, n, 3, "collinear triple")
+    for quad in concyclic:
+        _check_witness_sorted_distinct(quad.indices, n, 4, "concyclic quadruple")
+    if has_collinear != bool(collinear):
+        raise ValueError("has_collinear_triple must match collinear_triples")
+    if has_concyclic != bool(concyclic):
+        raise ValueError("has_concyclic_quadruple must match concyclic_quadruples")
+    if tuple(sorted(collinear, key=lambda w: w.indices)) != collinear:
+        raise ValueError("collinear_triples must be sorted lexicographically")
+    if len({w.indices for w in collinear}) != len(collinear):
+        raise ValueError("collinear_triples must be unique")
+    if tuple(sorted(concyclic, key=lambda w: w.indices)) != concyclic:
+        raise ValueError("concyclic_quadruples must be sorted lexicographically")
+    if len({w.indices for w in concyclic}) != len(concyclic):
+        raise ValueError("concyclic_quadruples must be unique")
+
+
+def _validate_general_position_binding(
+    points: tuple[RationalPoint2D, ...],
+    collinear: tuple[CollinearTripleWitness, ...],
+    concyclic: tuple[ConcyclicQuadrupleWitness, ...],
+) -> None:
+    pts = [(p.x.as_fraction(), p.y.as_fraction()) for p in points]
+    expected_collinear = _expected_collinear_indices(pts)
+    actual_collinear = {w.indices for w in collinear}
+    if actual_collinear != expected_collinear:
+        raise ValueError(
+            "collinear_triples must exactly match the configuration's collinear triples"
+        )
+    expected_concyclic = _expected_concyclic_indices(pts, expected_collinear)
+    actual_concyclic = {w.indices for w in concyclic}
+    if actual_concyclic != expected_concyclic:
+        raise ValueError(
+            "concyclic_quadruples must exactly match the configuration's concyclic quadruples "
+            "(excluding collinear quadruples)"
+        )
+
+
+def _validate_circumradius_entries_basic(
+    entries: tuple[CircumradiusTripleEntry, ...], n: int
+) -> set[tuple[int, int, int]]:
+    seen: set[tuple[int, int, int]] = set()
+    for e in entries:
+        if e.indices in seen:
+            raise ValueError("duplicate triple in circumradius profile")
+        seen.add(e.indices)
+        if any(i >= n for i in e.indices):
+            raise ValueError("index out of range")
+    if tuple(sorted(entries, key=lambda e: e.indices)) != entries:
+        raise ValueError("entries must be sorted lexicographically")
+    expected = set(combinations(range(n), 3))
+    if seen != expected:
+        raise ValueError("entries must cover exactly C(n,3) triples")
+    return seen
+
+
+def _validate_circumradius_binding(
+    points: tuple[RationalPoint2D, ...],
+    entries: tuple[CircumradiusTripleEntry, ...],
+) -> None:
+    pts = [(p.x.as_fraction(), p.y.as_fraction()) for p in points]
+    for e in entries:
+        i, j, k = e.indices
+        ax, ay = pts[i]
+        bx, by = pts[j]
+        cx, cy = pts[k]
+        cross = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
+        is_deg = cross == 0
+        if e.is_degenerate != is_deg:
+            raise ValueError("is_degenerate must match collinearity")
+        if is_deg:
+            if e.radius_squared is not None:
+                raise ValueError("degenerate triple cannot have a radius")
+        else:
+            if e.radius_squared is None:
+                raise ValueError("non-degenerate triple must have a radius")
+            ab_sq = (bx - ax) ** 2 + (by - ay) ** 2
+            bc_sq = (cx - bx) ** 2 + (cy - by) ** 2
+            ca_sq = (ax - cx) ** 2 + (ay - cy) ** 2
+            r_sq = Fraction(ab_sq * bc_sq * ca_sq) / Fraction(4 * cross * cross)
+            expected = CanonicalRational.from_fraction(r_sq)
+            require_bounded_rational(
+                expected, max_digits=MAX_COORDINATE_DIGITS * 40, label="circumradius"
+            )
+            if e.radius_squared != expected:
+                raise ValueError("radius_squared must match exact circumradius")
 
 
 class RationalPoint2D(StrictModel):
@@ -447,10 +643,13 @@ class ConvexPolygonTriangulationResult(StrictModel):
 class GeneralPositionRequest(StrictModel):
     """Search a bounded point configuration for collinear triples and concyclic quadruples."""
 
-    points: tuple[RationalPoint2D, ...] = Field(min_length=3, max_length=32)
+    points: tuple[RationalPoint2D, ...] = Field(
+        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+    )
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
+        _require_bounded_configuration(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
@@ -466,8 +665,11 @@ class ConcyclicQuadrupleWitness(StrictModel):
 
 
 class GeneralPositionResult(StrictModel):
-    """Complete search result for collinear triples and concyclic quadruples."""
+    """Complete search result for collinear triples and concyclic quadruples, bound to its source points."""
 
+    points: tuple[RationalPoint2D, ...] = Field(
+        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+    )
     num_points: int = Field(ge=0)
     has_collinear_triple: bool
     has_concyclic_quadruple: bool
@@ -476,36 +678,31 @@ class GeneralPositionResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        def _check_sorted_distinct(
-            idx: tuple[int, ...], *, expected: int, label: str
-        ) -> None:
-            if len(idx) != expected or len(set(idx)) != expected:
-                raise ValueError(f"{label} indices must be {expected} distinct values")
-            if idx != tuple(sorted(idx)):
-                raise ValueError(f"{label} indices must be sorted")
-            if any(i >= self.num_points for i in idx):
-                raise ValueError("index out of range")
-
-        for triple in self.collinear_triples:
-            _check_sorted_distinct(triple.indices, expected=3, label="collinear triple")
-        for quadruple in self.concyclic_quadruples:
-            _check_sorted_distinct(
-                quadruple.indices, expected=4, label="concyclic quadruple"
-            )
-        if self.has_collinear_triple != bool(self.collinear_triples):
-            raise ValueError("has_collinear_triple must match collinear_triples")
-        if self.has_concyclic_quadruple != bool(self.concyclic_quadruples):
-            raise ValueError("has_concyclic_quadruple must match concyclic_quadruples")
+        _require_bounded_configuration(self.points)
+        _validate_general_position_points(self.points, self.num_points)
+        _validate_general_position_witnesses(
+            self.collinear_triples,
+            self.concyclic_quadruples,
+            self.has_collinear_triple,
+            self.has_concyclic_quadruple,
+            len(self.points),
+        )
+        _validate_general_position_binding(
+            self.points, self.collinear_triples, self.concyclic_quadruples
+        )
         return self
 
 
 class CircumradiusProfileRequest(StrictModel):
     """Compute circumradius data for every unordered triple in a point configuration."""
 
-    points: tuple[RationalPoint2D, ...] = Field(min_length=3, max_length=32)
+    points: tuple[RationalPoint2D, ...] = Field(
+        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+    )
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
+        _require_bounded_configuration(self.points)
         keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
@@ -534,21 +731,25 @@ class CircumradiusTripleEntry(StrictModel):
 
 
 class CircumradiusProfileResult(StrictModel):
-    """Complete circumradius profile for every unordered triple."""
+    """Complete circumradius profile for every unordered triple, bound to its source points."""
 
+    points: tuple[RationalPoint2D, ...] = Field(
+        min_length=3, max_length=MAX_CONFIGURATION_POINTS
+    )
     num_points: int = Field(ge=0)
     entries: tuple[CircumradiusTripleEntry, ...] = Field(default=())
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        if (
-            len(self.entries)
-            != self.num_points * (self.num_points - 1) * (self.num_points - 2) // 6
-        ):
+        _require_bounded_configuration(self.points)
+        keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
+        if len(keys) != len(set(keys)):
+            raise ValueError("point-set coordinates must be unique")
+        n = len(self.points)
+        if self.num_points != n:
+            raise ValueError("num_points must equal len(points)")
+        if len(self.entries) != n * (n - 1) * (n - 2) // 6:
             raise ValueError("entries must cover exactly C(n,3) triples")
-        seen: set[tuple[int, int, int]] = set()
-        for entry in self.entries:
-            if entry.indices in seen:
-                raise ValueError("duplicate triple in circumradius profile")
-            seen.add(entry.indices)
+        _validate_circumradius_entries_basic(self.entries, n)
+        _validate_circumradius_binding(self.points, self.entries)
         return self

--- a/src/jacobian/math/geometry/_models.py
+++ b/src/jacobian/math/geometry/_models.py
@@ -443,6 +443,7 @@ class ConvexPolygonTriangulationResult(StrictModel):
 # Configuration-level operations (issues #2107, #2106)
 # ---------------------------------------------------------------------------
 
+
 class GeneralPositionRequest(StrictModel):
     """Search a bounded point configuration for collinear triples and concyclic quadruples."""
 
@@ -450,9 +451,7 @@ class GeneralPositionRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
-        keys = tuple(
-            (p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points
-        )
+        keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
         return self
@@ -477,22 +476,22 @@ class GeneralPositionResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        for witness in self.collinear_triples:
-            idx = witness.indices
-            if len(idx) != 3 or len(set(idx)) != 3:
-                raise ValueError("collinear triple indices must be 3 distinct values")
+        def _check_sorted_distinct(
+            idx: tuple[int, ...], *, expected: int, label: str
+        ) -> None:
+            if len(idx) != expected or len(set(idx)) != expected:
+                raise ValueError(f"{label} indices must be {expected} distinct values")
             if idx != tuple(sorted(idx)):
-                raise ValueError("collinear triple indices must be sorted")
+                raise ValueError(f"{label} indices must be sorted")
             if any(i >= self.num_points for i in idx):
                 raise ValueError("index out of range")
-        for witness in self.concyclic_quadruples:
-            idx = witness.indices
-            if len(idx) != 4 or len(set(idx)) != 4:
-                raise ValueError("concyclic quadruple indices must be 4 distinct values")
-            if idx != tuple(sorted(idx)):
-                raise ValueError("concyclic quadruple indices must be sorted")
-            if any(i >= self.num_points for i in idx):
-                raise ValueError("index out of range")
+
+        for triple in self.collinear_triples:
+            _check_sorted_distinct(triple.indices, expected=3, label="collinear triple")
+        for quadruple in self.concyclic_quadruples:
+            _check_sorted_distinct(
+                quadruple.indices, expected=4, label="concyclic quadruple"
+            )
         if self.has_collinear_triple != bool(self.collinear_triples):
             raise ValueError("has_collinear_triple must match collinear_triples")
         if self.has_concyclic_quadruple != bool(self.concyclic_quadruples):
@@ -507,9 +506,7 @@ class CircumradiusProfileRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_unique(self) -> Self:
-        keys = tuple(
-            (p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points
-        )
+        keys = tuple((p.x.num, p.x.den, p.y.num, p.y.den) for p in self.points)
         if len(keys) != len(set(keys)):
             raise ValueError("point-set coordinates must be unique")
         return self
@@ -544,7 +541,10 @@ class CircumradiusProfileResult(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        if len(self.entries) != self.num_points * (self.num_points - 1) * (self.num_points - 2) // 6:
+        if (
+            len(self.entries)
+            != self.num_points * (self.num_points - 1) * (self.num_points - 2) // 6
+        ):
             raise ValueError("entries must cover exactly C(n,3) triples")
         seen: set[tuple[int, int, int]] = set()
         for entry in self.entries:

--- a/src/jacobian/math/geometry/_operations.py
+++ b/src/jacobian/math/geometry/_operations.py
@@ -9,11 +9,15 @@ from typing import Any, cast
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.geometry._models import (
+    CircumcircleRequest,
     CircumradiusProfileRequest,
     CircumradiusProfileResult,
     CircumradiusTripleEntry,
-    CircumcircleRequest,
     ClosedSegment2D,
+    CollinearTripleWitness,
+    ConcyclicQuadrupleWitness,
+    GeneralPositionRequest,
+    GeneralPositionResult,
     GeometryBooleanResult,
     GeometryCircleResult,
     GeometryConvexHullResult,
@@ -27,10 +31,6 @@ from jacobian.math.geometry._models import (
     PointPairRequest,
     PointQuadrupleRequest,
     PointSetRequest,
-    GeneralPositionRequest,
-    GeneralPositionResult,
-    CollinearTripleWitness,
-    ConcyclicQuadrupleWitness,
     PointTripleRequest,
     PolygonIntersectionWitness,
     PolygonPointClassificationResult,
@@ -456,9 +456,10 @@ def general_position_search(request: GeneralPositionRequest) -> GeneralPositionR
             collinear_triples.append(CollinearTripleWitness(indices=(i, j, k)))
 
     concyclic_quadruples: list[ConcyclicQuadrupleWitness] = []
-    for i, j, k, l in combinations(range(n), 4):
+    for i, j, k, m in combinations(range(n), 4):
         a, b = pts[i], pts[j]
-        c, d = pts[k], pts[l]
+        c, d = pts[k], pts[m]
+
         # Check concyclicity via determinant
         # A 4x4 determinant: |x^2+y^2, x, y, 1| for each point
         def det4(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
@@ -485,7 +486,7 @@ def general_position_search(request: GeneralPositionRequest) -> GeneralPositionR
             rows.append((px * px + py * py, px, py, Fraction(1)))
         determinant = det4(tuple(rows))
         if determinant == 0:
-            concyclic_quadruples.append(ConcyclicQuadrupleWitness(indices=(i, j, k, l)))
+            concyclic_quadruples.append(ConcyclicQuadrupleWitness(indices=(i, j, k, m)))
 
     return GeneralPositionResult(
         num_points=n,
@@ -496,10 +497,12 @@ def general_position_search(request: GeneralPositionRequest) -> GeneralPositionR
     )
 
 
-def circumradius_profile(request: CircumradiusProfileRequest) -> CircumradiusProfileResult:
+def circumradius_profile(
+    request: CircumradiusProfileRequest,
+) -> CircumradiusProfileResult:
     """Compute circumradius squared for every unordered triple in a configuration."""
-    from itertools import combinations
     from fractions import Fraction
+    from itertools import combinations
 
     pts = _points_to_fractions(request.points)
     n = len(pts)
@@ -520,10 +523,12 @@ def circumradius_profile(request: CircumradiusProfileRequest) -> CircumradiusPro
         cross = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
 
         if cross == 0:
-            entries.append(CircumradiusTripleEntry(
-                indices=(i, j, k),
-                is_degenerate=True,
-            ))
+            entries.append(
+                CircumradiusTripleEntry(
+                    indices=(i, j, k),
+                    is_degenerate=True,
+                )
+            )
         else:
             # Squared side lengths
             ab_sq = (bx - ax) ** 2 + (by - ay) ** 2
@@ -534,11 +539,13 @@ def circumradius_profile(request: CircumradiusProfileRequest) -> CircumradiusPro
             # R = abc/(4*Area), R^2 = a^2*b^2*c^2 / (16 * Area^2)
             # = a^2*b^2*c^2 / (16 * cross^2/4) = a^2*b^2*c^2 / (4*cross^2)
             r_sq = Fraction(ab_sq * bc_sq * ca_sq) / Fraction(4 * cross * cross)
-            entries.append(CircumradiusTripleEntry(
-                indices=(i, j, k),
-                is_degenerate=False,
-                radius_squared=_wire_rational(r_sq),
-            ))
+            entries.append(
+                CircumradiusTripleEntry(
+                    indices=(i, j, k),
+                    is_degenerate=False,
+                    radius_squared=_wire_rational(r_sq),
+                )
+            )
 
     return CircumradiusProfileResult(
         num_points=n,

--- a/src/jacobian/math/geometry/_operations.py
+++ b/src/jacobian/math/geometry/_operations.py
@@ -9,6 +9,9 @@ from typing import Any, cast
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.geometry._models import (
+    CircumradiusProfileRequest,
+    CircumradiusProfileResult,
+    CircumradiusTripleEntry,
     CircumcircleRequest,
     ClosedSegment2D,
     GeometryBooleanResult,
@@ -24,6 +27,10 @@ from jacobian.math.geometry._models import (
     PointPairRequest,
     PointQuadrupleRequest,
     PointSetRequest,
+    GeneralPositionRequest,
+    GeneralPositionResult,
+    CollinearTripleWitness,
+    ConcyclicQuadrupleWitness,
     PointTripleRequest,
     PolygonIntersectionWitness,
     PolygonPointClassificationResult,
@@ -419,3 +426,121 @@ def convex_hull_points(request: PointSetRequest) -> GeometryConvexHullResult:
     else:
         points = tuple(cast(Polygon, hull).vertices)
     return GeometryConvexHullResult(points=_canonical_points(points))
+
+
+# ---------------------------------------------------------------------------
+# Configuration-level operations (issues #2107, #2106)
+# ---------------------------------------------------------------------------
+
+
+def _points_to_fractions(
+    points: tuple[RationalPoint2D, ...],
+) -> list[tuple[Fraction, Fraction]]:
+    return [(p.x.as_fraction(), p.y.as_fraction()) for p in points]
+
+
+def general_position_search(request: GeneralPositionRequest) -> GeneralPositionResult:
+    """Find all collinear triples and concyclic quadruples in a point configuration."""
+    from itertools import combinations
+
+    pts = _points_to_fractions(request.points)
+    n = len(pts)
+
+    collinear_triples: list[CollinearTripleWitness] = []
+    for i, j, k in combinations(range(n), 3):
+        a, b, c = pts[i], pts[j], pts[k]
+        d1 = (b[0] - a[0], b[1] - a[1])
+        d2 = (c[0] - a[0], c[1] - a[1])
+        cross = d1[0] * d2[1] - d1[1] * d2[0]
+        if cross == 0:
+            collinear_triples.append(CollinearTripleWitness(indices=(i, j, k)))
+
+    concyclic_quadruples: list[ConcyclicQuadrupleWitness] = []
+    for i, j, k, l in combinations(range(n), 4):
+        a, b = pts[i], pts[j]
+        c, d = pts[k], pts[l]
+        # Check concyclicity via determinant
+        # A 4x4 determinant: |x^2+y^2, x, y, 1| for each point
+        def det4(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+            result = Fraction(0)
+            for col in range(4):
+                sub = tuple(
+                    tuple(row[col2] for col2 in range(4) if col2 != col)
+                    for row in m[1:]
+                )
+                cofactor = det3(sub)
+                sign = 1 if col % 2 == 0 else -1
+                result += sign * m[0][col] * cofactor
+            return result
+
+        def det3(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+            return (
+                m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+            )
+
+        rows = []
+        for px, py in (a, b, c, d):
+            rows.append((px * px + py * py, px, py, Fraction(1)))
+        determinant = det4(tuple(rows))
+        if determinant == 0:
+            concyclic_quadruples.append(ConcyclicQuadrupleWitness(indices=(i, j, k, l)))
+
+    return GeneralPositionResult(
+        num_points=n,
+        has_collinear_triple=bool(collinear_triples),
+        has_concyclic_quadruple=bool(concyclic_quadruples),
+        collinear_triples=tuple(collinear_triples),
+        concyclic_quadruples=tuple(concyclic_quadruples),
+    )
+
+
+def circumradius_profile(request: CircumradiusProfileRequest) -> CircumradiusProfileResult:
+    """Compute circumradius squared for every unordered triple in a configuration."""
+    from itertools import combinations
+    from fractions import Fraction
+
+    pts = _points_to_fractions(request.points)
+    n = len(pts)
+
+    entries: list[CircumradiusTripleEntry] = []
+    for i, j, k in combinations(range(n), 3):
+        ax, ay = pts[i]
+        bx, by = pts[j]
+        cx, cy = pts[k]
+        # Compute squared circumradius R^2 = abc / (4 * Area)
+        # where a, b, c are side lengths and Area is the signed area.
+        # Using the formula: R^2 = (|AB|^2 * |BC|^2 * |CA|^2) / (16 * Area^2)
+        # where Area = cross(B-A, C-A) / 2.
+        # Actually: R = abc / (4 * Area), so R^2 = a^2 * b^2 * c^2 / (16 * Area^2)
+        # Area^2 = (cross / 2)^2 = cross^2 / 4
+        # So R^2 = a^2 * b^2 * c^2 / (16 * cross^2 / 4) = a^2 * b^2 * c^2 / (4 * cross^2)
+
+        cross = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
+
+        if cross == 0:
+            entries.append(CircumradiusTripleEntry(
+                indices=(i, j, k),
+                is_degenerate=True,
+            ))
+        else:
+            # Squared side lengths
+            ab_sq = (bx - ax) ** 2 + (by - ay) ** 2
+            bc_sq = (cx - bx) ** 2 + (cy - by) ** 2
+            ca_sq = (ax - cx) ** 2 + (ay - cy) ** 2
+            # R^2 = (a^2 * b^2 * c^2) / (4 * cross^2)
+            # But cross is the 2*Area (signed), so Area = cross/2
+            # R = abc/(4*Area), R^2 = a^2*b^2*c^2 / (16 * Area^2)
+            # = a^2*b^2*c^2 / (16 * cross^2/4) = a^2*b^2*c^2 / (4*cross^2)
+            r_sq = Fraction(ab_sq * bc_sq * ca_sq) / Fraction(4 * cross * cross)
+            entries.append(CircumradiusTripleEntry(
+                indices=(i, j, k),
+                is_degenerate=False,
+                radius_squared=_wire_rational(r_sq),
+            ))
+
+    return CircumradiusProfileResult(
+        num_points=n,
+        entries=tuple(entries),
+    )

--- a/src/jacobian/math/geometry/_operations.py
+++ b/src/jacobian/math/geometry/_operations.py
@@ -439,6 +439,34 @@ def _points_to_fractions(
     return [(p.x.as_fraction(), p.y.as_fraction()) for p in points]
 
 
+def _det3_frac(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+    return (
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    )
+
+
+def _det4_frac(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
+    result = Fraction(0)
+    for col in range(4):
+        sub = tuple(
+            tuple(row[col2] for col2 in range(4) if col2 != col) for row in m[1:]
+        )
+        cofactor = _det3_frac(sub)
+        sign = 1 if col % 2 == 0 else -1
+        result += sign * m[0][col] * cofactor
+    return result
+
+
+def _is_collinear_pts(
+    a: tuple[Fraction, Fraction],
+    b: tuple[Fraction, Fraction],
+    c: tuple[Fraction, Fraction],
+) -> bool:
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]) == 0
+
+
 def general_position_search(request: GeneralPositionRequest) -> GeneralPositionResult:
     """Find all collinear triples and concyclic quadruples in a point configuration."""
     from itertools import combinations
@@ -447,48 +475,36 @@ def general_position_search(request: GeneralPositionRequest) -> GeneralPositionR
     n = len(pts)
 
     collinear_triples: list[CollinearTripleWitness] = []
+    collinear_set: set[tuple[int, int, int]] = set()
     for i, j, k in combinations(range(n), 3):
-        a, b, c = pts[i], pts[j], pts[k]
-        d1 = (b[0] - a[0], b[1] - a[1])
-        d2 = (c[0] - a[0], c[1] - a[1])
-        cross = d1[0] * d2[1] - d1[1] * d2[0]
-        if cross == 0:
+        if _is_collinear_pts(pts[i], pts[j], pts[k]):
             collinear_triples.append(CollinearTripleWitness(indices=(i, j, k)))
+            collinear_set.add((i, j, k))
 
     concyclic_quadruples: list[ConcyclicQuadrupleWitness] = []
     for i, j, k, m in combinations(range(n), 4):
-        a, b = pts[i], pts[j]
-        c, d = pts[k], pts[m]
-
-        # Check concyclicity via determinant
-        # A 4x4 determinant: |x^2+y^2, x, y, 1| for each point
-        def det4(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
-            result = Fraction(0)
-            for col in range(4):
-                sub = tuple(
-                    tuple(row[col2] for col2 in range(4) if col2 != col)
-                    for row in m[1:]
-                )
-                cofactor = det3(sub)
-                sign = 1 if col % 2 == 0 else -1
-                result += sign * m[0][col] * cofactor
-            return result
-
-        def det3(m: tuple[tuple[Fraction, ...], ...]) -> Fraction:
-            return (
-                m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
-                - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
-                + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
-            )
-
-        rows = []
+        # Exclude collinear quadruples: any 3 collinear points are degenerate
+        # (collinear points lie on a line, not a finite circle). The
+        # determinant criterion |x^2+y^2, x, y, 1| is zero for four collinear
+        # points, but no Euclidean circle contains three distinct collinear
+        # points, so such quadruples must not be reported as concyclic.
+        if (
+            (i, j, k) in collinear_set
+            or (i, j, m) in collinear_set
+            or (i, k, m) in collinear_set
+            or (j, k, m) in collinear_set
+        ):
+            continue
+        a, b, c, d = pts[i], pts[j], pts[k], pts[m]
+        rows: list[tuple[Fraction, Fraction, Fraction, Fraction]] = []
         for px, py in (a, b, c, d):
             rows.append((px * px + py * py, px, py, Fraction(1)))
-        determinant = det4(tuple(rows))
+        determinant = _det4_frac(tuple(rows))
         if determinant == 0:
             concyclic_quadruples.append(ConcyclicQuadrupleWitness(indices=(i, j, k, m)))
 
     return GeneralPositionResult(
+        points=request.points,
         num_points=n,
         has_collinear_triple=bool(collinear_triples),
         has_concyclic_quadruple=bool(concyclic_quadruples),
@@ -512,14 +528,6 @@ def circumradius_profile(
         ax, ay = pts[i]
         bx, by = pts[j]
         cx, cy = pts[k]
-        # Compute squared circumradius R^2 = abc / (4 * Area)
-        # where a, b, c are side lengths and Area is the signed area.
-        # Using the formula: R^2 = (|AB|^2 * |BC|^2 * |CA|^2) / (16 * Area^2)
-        # where Area = cross(B-A, C-A) / 2.
-        # Actually: R = abc / (4 * Area), so R^2 = a^2 * b^2 * c^2 / (16 * Area^2)
-        # Area^2 = (cross / 2)^2 = cross^2 / 4
-        # So R^2 = a^2 * b^2 * c^2 / (16 * cross^2 / 4) = a^2 * b^2 * c^2 / (4 * cross^2)
-
         cross = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax)
 
         if cross == 0:
@@ -530,14 +538,9 @@ def circumradius_profile(
                 )
             )
         else:
-            # Squared side lengths
             ab_sq = (bx - ax) ** 2 + (by - ay) ** 2
             bc_sq = (cx - bx) ** 2 + (cy - by) ** 2
             ca_sq = (ax - cx) ** 2 + (ay - cy) ** 2
-            # R^2 = (a^2 * b^2 * c^2) / (4 * cross^2)
-            # But cross is the 2*Area (signed), so Area = cross/2
-            # R = abc/(4*Area), R^2 = a^2*b^2*c^2 / (16 * Area^2)
-            # = a^2*b^2*c^2 / (16 * cross^2/4) = a^2*b^2*c^2 / (4*cross^2)
             r_sq = Fraction(ab_sq * bc_sq * ca_sq) / Fraction(4 * cross * cross)
             entries.append(
                 CircumradiusTripleEntry(
@@ -547,7 +550,10 @@ def circumradius_profile(
                 )
             )
 
+    # Ensure deterministic lexicographic order (combinations already yields sorted).
+    entries.sort(key=lambda e: e.indices)
     return CircumradiusProfileResult(
+        points=request.points,
         num_points=n,
         entries=tuple(entries),
     )

--- a/src/jacobian/math/geometry/_tools.py
+++ b/src/jacobian/math/geometry/_tools.py
@@ -1,6 +1,7 @@
 """Exact rational planar-geometry operations."""
 
 from jacobian.catalog.models import MathTools
+from jacobian.math.geometry._configuration import CONFIGURATION_OPERATIONS
 from jacobian.math.geometry._lines import LINE_OPERATIONS
 from jacobian.math.geometry._points import POINT_OPERATIONS
 from jacobian.math.geometry._polygons import POLYGON_OPERATIONS
@@ -15,4 +16,5 @@ TOOLS: MathTools = (
     *LINE_OPERATIONS,
     *TRIANGLE_OPERATIONS,
     *POLYGON_OPERATIONS,
+    *CONFIGURATION_OPERATIONS,
 )

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -152,14 +152,29 @@ class TestAdmissionBounds:
         assert len(result.entries) == 220
 
     def test_general_position_rejects_work_bound_violation(self):
-        """32 points x 255-digit coordinates exceed n*max_digits <= 1024."""
+        """32 points x 255-digit coordinates exceed the exhaustive work bound."""
         big = 10**254 + 1
         points = tuple(_point(str(big + i), str(big + 2 * i)) for i in range(32))
         with pytest.raises(ValueError, match="work bound"):
             GeneralPositionRequest(points=points)
 
+    def test_general_position_rejects_quartic_point_growth(self):
+        """32 points x 32 digits pass n*digits=1024 but C(32,4)*digits^2 is
+        about 36M; the combinatorial count must gate admission instead."""
+        points = tuple(_point(str(10**31 + i), str(10**31 + 2 * i)) for i in range(32))
+        with pytest.raises(ValueError, match="work bound"):
+            GeneralPositionRequest(points=points)
+
+    def test_general_position_accepts_moderate_configurations(self):
+        """Shapes within the C(n,4)*digits^2 budget still run end to end."""
+        points = tuple(
+            _point(str(i), str(i * i + 1)) for i in range(16)
+        )
+        result = general_position_search(GeneralPositionRequest(points=points))
+        assert result.num_points == 16
+
     def test_general_position_accepts_small_high_digit_config(self):
-        """Few points may still carry large coordinates (4 x 256 = 1024)."""
+        """Few points may still carry large coordinates (1 * 256^2 units)."""
         big = 10**254 + 1
         points = (
             _point("0", "0"),

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -1,0 +1,121 @@
+"""Tests for configuration-level geometry operations (#2107, #2106)."""
+
+from fractions import Fraction
+
+import pytest
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.geometry._models import (
+    CircumradiusProfileRequest,
+    GeneralPositionRequest,
+    RationalPoint2D,
+)
+from jacobian.math.geometry._operations import (
+    circumradius_profile,
+    general_position_search,
+)
+
+
+def _point(x: str, y: str) -> RationalPoint2D:
+    return RationalPoint2D(
+        x=CanonicalRational.from_fraction(Fraction(x)),
+        y=CanonicalRational.from_fraction(Fraction(y)),
+    )
+
+
+class TestGeneralPosition:
+    def test_square_concyclic(self):
+        """Four vertices of a square are concyclic."""
+        points = [
+            _point("0", "0"), _point("1", "0"),
+            _point("1", "1"), _point("0", "1"),
+        ]
+        result = general_position_search(GeneralPositionRequest(points=tuple(points)))
+        assert result.num_points == 4
+        assert not result.has_collinear_triple
+        assert result.has_concyclic_quadruple
+        assert len(result.concyclic_quadruples) == 1
+        assert result.concyclic_quadruples[0].indices == (0, 1, 2, 3)
+
+    def test_collinear_triple(self):
+        """Three points on the x-axis are collinear."""
+        points = [
+            _point("0", "0"), _point("1", "0"),
+            _point("2", "0"), _point("0", "1"),
+        ]
+        result = general_position_search(GeneralPositionRequest(points=tuple(points)))
+        assert result.has_collinear_triple
+        assert not result.has_concyclic_quadruple
+        assert len(result.collinear_triples) == 1
+        assert result.collinear_triples[0].indices == (0, 1, 2)
+
+    def test_general_position(self):
+        """Four points in general position."""
+        points = [
+            _point("-1", "0"), _point("1", "0"),
+            _point("0", "2"), _point("0", "-2"),
+        ]
+        result = general_position_search(GeneralPositionRequest(points=tuple(points)))
+        assert not result.has_collinear_triple
+        assert not result.has_concyclic_quadruple
+
+    def test_triangle_only(self):
+        """A triangle has no collinear triple and no quadruple."""
+        points = [_point("0", "0"), _point("1", "0"), _point("0", "1")]
+        result = general_position_search(GeneralPositionRequest(points=tuple(points)))
+        assert not result.has_collinear_triple
+        assert not result.has_concyclic_quadruple
+
+    def test_duplicate_points_rejected(self):
+        """Duplicate points should be rejected."""
+        with pytest.raises(Exception):
+            GeneralPositionRequest(
+                points=(_point("0", "0"), _point("0", "0"), _point("1", "0"))
+            )
+
+
+class TestCircumradiusProfile:
+    def test_triangle(self):
+        """A single triangle has one circumradius entry."""
+        points = [_point("0", "0"), _point("1", "0"), _point("0", "1")]
+        result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
+        assert result.num_points == 3
+        assert len(result.entries) == 1
+        assert not result.entries[0].is_degenerate
+        assert result.entries[0].radius_squared is not None
+        assert result.entries[0].indices == (0, 1, 2)
+
+    def test_collinear_triple_degenerate(self):
+        """Collinear triple is marked as degenerate."""
+        points = [
+            _point("0", "0"), _point("1", "0"), _point("2", "0"),
+        ]
+        result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
+        assert len(result.entries) == 1
+        assert result.entries[0].is_degenerate
+        assert result.entries[0].radius_squared is None
+
+    def test_four_points(self):
+        """Four points have C(4,3) = 4 triples."""
+        points = [
+            _point("0", "0"), _point("1", "0"),
+            _point("0", "1"), _point("1", "1"),
+        ]
+        result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
+        assert result.num_points == 4
+        assert len(result.entries) == 4
+        for entry in result.entries:
+            assert not entry.is_degenerate
+
+    def test_equal_circumradius(self):
+        """All four triangles of a unit square have equal circumradius."""
+        points = [
+            _point("0", "0"), _point("1", "0"),
+            _point("1", "1"), _point("0", "1"),
+        ]
+        result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
+        radii = set()
+        for entry in result.entries:
+            if not entry.is_degenerate and entry.radius_squared:
+                radii.add((entry.radius_squared.num, entry.radius_squared.den))
+        assert len(radii) == 1

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -27,8 +27,10 @@ class TestGeneralPosition:
     def test_square_concyclic(self):
         """Four vertices of a square are concyclic."""
         points = [
-            _point("0", "0"), _point("1", "0"),
-            _point("1", "1"), _point("0", "1"),
+            _point("0", "0"),
+            _point("1", "0"),
+            _point("1", "1"),
+            _point("0", "1"),
         ]
         result = general_position_search(GeneralPositionRequest(points=tuple(points)))
         assert result.num_points == 4
@@ -40,8 +42,10 @@ class TestGeneralPosition:
     def test_collinear_triple(self):
         """Three points on the x-axis are collinear."""
         points = [
-            _point("0", "0"), _point("1", "0"),
-            _point("2", "0"), _point("0", "1"),
+            _point("0", "0"),
+            _point("1", "0"),
+            _point("2", "0"),
+            _point("0", "1"),
         ]
         result = general_position_search(GeneralPositionRequest(points=tuple(points)))
         assert result.has_collinear_triple
@@ -52,8 +56,10 @@ class TestGeneralPosition:
     def test_general_position(self):
         """Four points in general position."""
         points = [
-            _point("-1", "0"), _point("1", "0"),
-            _point("0", "2"), _point("0", "-2"),
+            _point("-1", "0"),
+            _point("1", "0"),
+            _point("0", "2"),
+            _point("0", "-2"),
         ]
         result = general_position_search(GeneralPositionRequest(points=tuple(points)))
         assert not result.has_collinear_triple
@@ -68,7 +74,7 @@ class TestGeneralPosition:
 
     def test_duplicate_points_rejected(self):
         """Duplicate points should be rejected."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             GeneralPositionRequest(
                 points=(_point("0", "0"), _point("0", "0"), _point("1", "0"))
             )
@@ -88,7 +94,9 @@ class TestCircumradiusProfile:
     def test_collinear_triple_degenerate(self):
         """Collinear triple is marked as degenerate."""
         points = [
-            _point("0", "0"), _point("1", "0"), _point("2", "0"),
+            _point("0", "0"),
+            _point("1", "0"),
+            _point("2", "0"),
         ]
         result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
         assert len(result.entries) == 1
@@ -98,8 +106,10 @@ class TestCircumradiusProfile:
     def test_four_points(self):
         """Four points have C(4,3) = 4 triples."""
         points = [
-            _point("0", "0"), _point("1", "0"),
-            _point("0", "1"), _point("1", "1"),
+            _point("0", "0"),
+            _point("1", "0"),
+            _point("0", "1"),
+            _point("1", "1"),
         ]
         result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
         assert result.num_points == 4
@@ -110,8 +120,10 @@ class TestCircumradiusProfile:
     def test_equal_circumradius(self):
         """All four triangles of a unit square have equal circumradius."""
         points = [
-            _point("0", "0"), _point("1", "0"),
-            _point("1", "1"), _point("0", "1"),
+            _point("0", "0"),
+            _point("1", "0"),
+            _point("1", "1"),
+            _point("0", "1"),
         ]
         result = circumradius_profile(CircumradiusProfileRequest(points=tuple(points)))
         radii = set()

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -131,3 +131,42 @@ class TestCircumradiusProfile:
             if not entry.is_degenerate and entry.radius_squared:
                 radii.add((entry.radius_squared.num, entry.radius_squared.den))
         assert len(radii) == 1
+
+
+class TestAdmissionBounds:
+    def test_circumradius_rejects_profile_exceeding_output_budget(self):
+        """32 points with 64-digit coordinates pass n*d=2048 but the exact
+        rational growth of C(32,3) radii exceeds the output budget; the
+        request must be rejected before execution."""
+        points = tuple(
+            _point(str(10**63 + 4 * i + 1), str(10**63 + 4 * i + 3)) for i in range(32)
+        )
+        with pytest.raises(ValueError, match="output budget"):
+            CircumradiusProfileRequest(points=points)
+
+    def test_circumradius_accepts_config_within_output_budget(self):
+        """A moderate configuration still runs end to end."""
+        points = tuple(_point(f"{i}", f"{i * i}") for i in range(12))
+        result = circumradius_profile(CircumradiusProfileRequest(points=points))
+        assert result.num_points == 12
+        assert len(result.entries) == 220
+
+    def test_general_position_rejects_work_bound_violation(self):
+        """32 points x 255-digit coordinates exceed n*max_digits <= 1024."""
+        big = 10**254 + 1
+        points = tuple(_point(str(big + i), str(big + 2 * i)) for i in range(32))
+        with pytest.raises(ValueError, match="work bound"):
+            GeneralPositionRequest(points=points)
+
+    def test_general_position_accepts_small_high_digit_config(self):
+        """Few points may still carry large coordinates (4 x 256 = 1024)."""
+        big = 10**254 + 1
+        points = (
+            _point("0", "0"),
+            _point(str(big), "0"),
+            _point("0", str(big)),
+            _point(str(big), str(big)),
+        )
+        result = general_position_search(GeneralPositionRequest(points=points))
+        assert result.has_concyclic_quadruple
+        assert not result.has_collinear_triple

--- a/tests/math/geometry/test_configuration_ops.py
+++ b/tests/math/geometry/test_configuration_ops.py
@@ -167,9 +167,7 @@ class TestAdmissionBounds:
 
     def test_general_position_accepts_moderate_configurations(self):
         """Shapes within the C(n,4)*digits^2 budget still run end to end."""
-        points = tuple(
-            _point(str(i), str(i * i + 1)) for i in range(16)
-        )
+        points = tuple(_point(str(i), str(i * i + 1)) for i in range(16))
         result = general_position_search(GeneralPositionRequest(points=points))
         assert result.num_points == 16
 


### PR DESCRIPTION
## Closes #2107, closes #2106

## Summary

Adds two configuration-level geometry operations that operate on bounded rational planar point sets:

- `geometry.points.general_position.search` (#2107): Exhaustively finds all collinear triples and all concyclic quadruples in a point configuration, or establishes that none exist. Returns source-labelled witnesses with sorted indices.
- `geometry.points.circumradius_profile.compute` (#2106): Returns the complete circumradius squared for every unordered triple in a configuration, with explicit degenerate (collinear) disposition.

## Design

Both operations take a `GeneralPositionRequest` / `CircumradiusProfileRequest` with up to 32 unique rational points. They reuse the existing `RationalPoint2D` and `CanonicalRational` types from the geometry domain.

**General position search** uses exact rational cross-product for collinearity and exact 4×4 determinant for concyclicity — no floating-point tolerances. The concyclicity test checks whether the 4×4 matrix of (x²+y², x, y, 1) has zero determinant.

**Circumradius profile** uses the exact formula R² = (a² · b² · c²) / (4 · cross²) where a, b, c are side lengths and cross is the signed area determinant. Degenerate (collinear) triples are explicitly marked rather than producing a division by zero.

## Test plan

- [x] 9 new tests pass (5 general-position, 4 circumradius)
- [x] 24 total geometry tests pass
- [x] Catalog example tests pass for both operations
- [x] No existing tests broken

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/5c0104fc-f35c-4623-a8ab-87311599050e)