### PR TITLE
feat(math): add structural simplicial complex operations (#1850)

### DIFF
--- a/src/jacobian/math/topology/_admission.py
+++ b/src/jacobian/math/topology/_admission.py
@@ -48,7 +48,7 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "topology.simplicial_complex.deletion.compute",
         AdmissionDecision.KEEP,
-        "exact vertex deletion: remove all facets containing a declared vertex subset",
+        "exact vertex deletion: the induced subcomplex on the undeclared vertices",
     ),
     OperationAdmission(
         "topology.simplicial_complex.skeleton.compute",

--- a/src/jacobian/math/topology/_admission.py
+++ b/src/jacobian/math/topology/_admission.py
@@ -40,6 +40,46 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "exact link of a simplex with maximal facets of the link complex",
     ),
+    OperationAdmission(
+        "topology.simplicial_complex.star.compute",
+        AdmissionDecision.KEEP,
+        "exact closed star of a simplex: all facets containing the simplex",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.deletion.compute",
+        AdmissionDecision.KEEP,
+        "exact vertex deletion: remove all facets containing a declared vertex subset",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.skeleton.compute",
+        AdmissionDecision.KEEP,
+        "exact k-skeleton subcomplex of a simplicial complex",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.join.compute",
+        AdmissionDecision.KEEP,
+        "exact join of two simplicial complexes on disjoint vertex sets",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.barycentric_subdivision.compute",
+        AdmissionDecision.KEEP,
+        "exact barycentric subdivision (order complex) of a simplicial complex",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.pseudomanifold.decide",
+        AdmissionDecision.KEEP,
+        "exact pseudomanifold decision with closed/boundary distinction",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.shelling.check",
+        AdmissionDecision.KEEP,
+        "exact shelling order checker for a submitted facet permutation",
+    ),
+    OperationAdmission(
+        "topology.simplicial_complex.elementary_collapse.check",
+        AdmissionDecision.KEEP,
+        "exact elementary collapse: verify a free face and remove it with its coface",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -855,6 +855,27 @@ class StarResult(TopologyExactResult):
     simplex: tuple[str, ...]
     star_facets: tuple[tuple[str, ...], ...]
     star_is_empty: bool
+    star_complex: FiniteSimplicialComplex | None = None
+
+    @model_validator(mode="after")
+    def require_star_canonical(self) -> Self:
+        if self.star_is_empty:
+            if self.star_complex is not None:
+                raise ValueError("empty star must have no complex")
+            if self.star_facets:
+                raise ValueError("empty star must have no facets")
+        else:
+            if self.star_complex is None:
+                raise ValueError("non-empty star requires star_complex")
+            if tuple(sorted(self.star_complex.maximal_simplices)) != tuple(
+                sorted(tuple(sorted(f)) for f in self.star_facets)
+            ):
+                raise ValueError("star_complex maximal simplices must match star_facets")
+            if set(self.star_complex.vertices) != set(
+                v for facet in self.star_facets for v in facet
+            ):
+                raise ValueError("star_complex vertices must match star_facets")
+        return self
 
 
 class VertexDeletionRequest(StrictModel):
@@ -879,6 +900,31 @@ class VertexDeletionResult(TopologyExactResult):
     deleted_vertices: tuple[str, ...]
     remaining_vertices: tuple[str, ...]
     remaining_facets: tuple[tuple[str, ...], ...]
+    remaining_complex: FiniteSimplicialComplex | None = None
+
+    @model_validator(mode="after")
+    def require_deletion_canonical(self) -> Self:
+        if not self.remaining_facets:
+            if self.remaining_complex is not None:
+                raise ValueError("empty deletion must have no remaining_complex")
+            if self.remaining_vertices:
+                raise ValueError("empty deletion must have no remaining_vertices")
+        else:
+            if self.remaining_complex is None:
+                raise ValueError("non-empty deletion requires remaining_complex")
+            if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
+                sorted(tuple(sorted(f)) for f in self.remaining_facets)
+            ):
+                raise ValueError(
+                    "remaining_complex maximal simplices must match remaining_facets"
+                )
+            if tuple(sorted(self.remaining_complex.vertices)) != tuple(
+                sorted(self.remaining_vertices)
+            ):
+                raise ValueError(
+                    "remaining_complex vertices must match remaining_vertices"
+                )
+        return self
 
 
 class SkeletonRequest(StrictModel):
@@ -894,6 +940,29 @@ class SkeletonResult(TopologyExactResult):
     k: int
     skeleton_facets: tuple[tuple[str, ...], ...]
     skeleton_vertices: tuple[str, ...]
+    skeleton_complex: FiniteSimplicialComplex | None = None
+
+    @model_validator(mode="after")
+    def require_skeleton_canonical(self) -> Self:
+        if not self.skeleton_facets:
+            if self.skeleton_complex is not None:
+                raise ValueError("empty skeleton must have no complex")
+        else:
+            if self.skeleton_complex is None:
+                raise ValueError("non-empty skeleton requires skeleton_complex")
+            if tuple(sorted(self.skeleton_complex.maximal_simplices)) != tuple(
+                sorted(tuple(sorted(f)) for f in self.skeleton_facets)
+            ):
+                raise ValueError(
+                    "skeleton_complex maximal simplices must match skeleton_facets"
+                )
+            if tuple(sorted(self.skeleton_complex.vertices)) != tuple(
+                sorted(self.skeleton_vertices)
+            ):
+                raise ValueError(
+                    "skeleton_complex vertices must match skeleton_vertices"
+                )
+        return self
 
 
 class JoinRequest(StrictModel):
@@ -919,12 +988,51 @@ class JoinResult(TopologyExactResult):
     join_vertices: tuple[str, ...]
     join_facets: tuple[tuple[str, ...], ...]
     join_dimension: int
+    join_complex: FiniteSimplicialComplex | None = None
+
+    @model_validator(mode="after")
+    def require_join_canonical(self) -> Self:
+        if not self.join_facets:
+            if self.join_complex is not None:
+                raise ValueError("empty join must have no complex")
+        else:
+            if self.join_complex is None:
+                raise ValueError("non-empty join requires join_complex")
+            if tuple(sorted(self.join_complex.maximal_simplices)) != tuple(
+                sorted(tuple(sorted(f)) for f in self.join_facets)
+            ):
+                raise ValueError("join_complex maximal simplices must match join_facets")
+            if tuple(sorted(self.join_complex.vertices)) != tuple(
+                sorted(self.join_vertices)
+            ):
+                raise ValueError("join_complex vertices must match join_vertices")
+            if self.join_complex.dimension != self.join_dimension:
+                raise ValueError("join_complex dimension must match join_dimension")
+        return self
 
 
 class BarycentricSubdivisionRequest(StrictModel):
     """Subdivide a complex via its order complex (barycentric subdivision)."""
 
     complex: SimplicialComplexRequest
+
+    @model_validator(mode="after")
+    def require_barycentric_work_bounds(self) -> Self:
+        closure = face_closure(tuple(tuple(sorted(f)) for f in self.complex.facets))
+        face_count = sum(len(part) for part in closure)
+        if face_count > 64:
+            raise ValueError(
+                f"barycentric subdivision requires at most 64 faces (got {face_count}); "
+                "input is too large for exact bounded subdivision"
+            )
+        # Bound subdivision output size: number of maximal chains for 64 faces is
+        # still bounded by factorial-like growth but with face_count<=64 the
+        # resulting facet count remains within transport limits for tested cases.
+        if face_count > 31:
+            # For 6-vertex simplex (63 faces) subdivision has 720 maximal chains;
+            # allow but note bound.
+            pass
+        return self
 
 
 class BarycentricSubdivisionResult(TopologyExactResult):
@@ -935,6 +1043,40 @@ class BarycentricSubdivisionResult(TopologyExactResult):
     subdivision_vertices: tuple[str, ...]
     subdivision_facets: tuple[tuple[str, ...], ...]
     num_new_vertices: int
+    subdivision_complex: FiniteSimplicialComplex | None = None
+    subdivision_vertex_faces: tuple[tuple[str, ...], ...] = Field(default=())
+
+    @model_validator(mode="after")
+    def require_subdivision_canonical(self) -> Self:
+        if not self.subdivision_facets:
+            if self.subdivision_complex is not None:
+                raise ValueError("empty subdivision must have no complex")
+        else:
+            if self.subdivision_complex is None:
+                raise ValueError("non-empty subdivision requires subdivision_complex")
+            if tuple(sorted(self.subdivision_complex.maximal_simplices)) != tuple(
+                sorted(tuple(sorted(f)) for f in self.subdivision_facets)
+            ):
+                raise ValueError(
+                    "subdivision_complex maximal simplices must match subdivision_facets"
+                )
+            if tuple(sorted(self.subdivision_complex.vertices)) != tuple(
+                sorted(self.subdivision_vertices)
+            ):
+                raise ValueError(
+                    "subdivision_complex vertices must match subdivision_vertices"
+                )
+            if len(self.subdivision_vertex_faces) != len(self.subdivision_vertices):
+                raise ValueError(
+                    "subdivision_vertex_faces must align with subdivision_vertices"
+                )
+            # Validate vertex labels are bounded and injective
+            if len(set(self.subdivision_vertices)) != len(self.subdivision_vertices):
+                raise ValueError("subdivision vertices must be unique")
+            for label in self.subdivision_vertices:
+                if len(label) > 32 or not label[0].isalnum():
+                    raise ValueError(f"invalid subdivision vertex label: {label}")
+        return self
 
 
 class PseudomanifoldRequest(StrictModel):
@@ -944,13 +1086,47 @@ class PseudomanifoldRequest(StrictModel):
 
 
 class PseudomanifoldResult(TopologyExactResult):
-    """Pseudomanifold decision result."""
+    """Pseudomanifold decision result bound to its source complex."""
 
+    complex: SimplicialComplexRequest | None = None
     is_pseudomanifold: bool
     is_closed: bool
     dimension: int
     num_facets: int
     obstruction: str | None = None
+
+    @model_validator(mode="after")
+    def require_pseudomanifold_binding(self) -> Self:
+        if self.complex is None:
+            # Allow legacy payloads without binding to validate for backward compat,
+            # but require new code to provide binding.
+            return self
+        facets = [frozenset(f) for f in self.complex.facets]
+        dim = max(len(f) - 1 for f in facets) if facets else 0
+        if self.dimension != dim or self.num_facets != len(facets):
+            raise ValueError("dimension/num_facets must match source complex")
+        # Recompute pseudomanifold decision
+        is_pure = all(len(f) - 1 == dim for f in facets) if facets else False
+        if not is_pure and self.is_pseudomanifold:
+            raise ValueError("impure complex cannot be pseudomanifold")
+        if dim < 1 and self.is_pseudomanifold:
+            raise ValueError("dimension <1 cannot be pseudomanifold")
+        if self.is_pseudomanifold:
+            # Check codim-1 counts
+            codim1_count: dict[frozenset[str], int] = {}
+            for facet in facets:
+                for face in combinations(sorted(facet), len(facet) - 1):
+                    key = frozenset(face)
+                    codim1_count[key] = codim1_count.get(key, 0) + 1
+            for count in codim1_count.values():
+                if count > 2:
+                    raise ValueError("pseudomanifold must have codim-1 count <=2")
+            is_closed_expected = all(c == 2 for c in codim1_count.values()) if codim1_count else False
+            if self.is_closed != is_closed_expected:
+                raise ValueError("is_closed must match codim-1 incidence")
+            if self.is_closed and self.obstruction is not None:
+                raise ValueError("closed pseudomanifold must have no obstruction")
+        return self
 
 
 class ShellingCheckRequest(StrictModel):
@@ -1000,6 +1176,40 @@ class ElementaryCollapseResult(TopologyExactResult):
     coface: tuple[str, ...]
     remaining_facets: tuple[tuple[str, ...], ...]
     remaining_vertices: tuple[str, ...]
+    remaining_complex: FiniteSimplicialComplex | None = None
+
+    @model_validator(mode="after")
+    def require_collapse_canonical(self) -> Self:
+        if self.is_free_face:
+            if not self.remaining_facets:
+                if self.remaining_complex is not None:
+                    raise ValueError("empty collapsed complex must have no remaining_complex")
+                if self.remaining_vertices:
+                    raise ValueError("empty collapsed complex must have no remaining_vertices")
+            else:
+                if self.remaining_complex is None:
+                    raise ValueError("non-empty collapse requires remaining_complex")
+                if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
+                    sorted(tuple(sorted(f)) for f in self.remaining_facets)
+                ):
+                    raise ValueError(
+                        "remaining_complex maximal simplices must match remaining_facets"
+                    )
+                if tuple(sorted(self.remaining_complex.vertices)) != tuple(
+                    sorted(self.remaining_vertices)
+                ):
+                    raise ValueError(
+                        "remaining_complex vertices must match remaining_vertices"
+                    )
+        else:
+            # When not a free face, remaining should be unchanged; allow both but
+            # if complex present it must match.
+            if self.remaining_complex is not None:
+                if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
+                    sorted(tuple(sorted(f)) for f in self.remaining_facets)
+                ):
+                    raise ValueError("remaining_complex must match remaining_facets")
+        return self
 
 
 __all__.extend(

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -6,7 +6,7 @@ import hashlib
 from collections.abc import Iterable
 from enum import StrEnum
 from itertools import combinations, pairwise
-from typing import Annotated, Literal, NamedTuple, Self
+from typing import Annotated, Any, Literal, NamedTuple, Self
 
 from pydantic import (
     Field,
@@ -17,6 +17,8 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
 
 from jacobian._digest import Sha256Digest
 from jacobian._exact import CanonicalInteger
@@ -520,6 +522,31 @@ class SimplicialComplexRequest(StrictModel):
             )
         _require_request_complex(self.vertices, self.facets)
         return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: Any,
+    ) -> JsonSchemaValue:
+        """Advertise both accepted input shapes in the published schema.
+
+        The runtime accepts either the facet presentation or an unchanged
+        canonical ``FiniteSimplicialComplex`` dump (the before-validator
+        normalizes the latter), so schema-guided callers must see both
+        alternatives; otherwise a serialized canonical value could not be
+        validated against any advertised consumer schema.
+        """
+        facet_presentation = handler(core_schema)
+        canonical_value = handler(FiniteSimplicialComplex.__pydantic_core_schema__)
+        facet_presentation.pop("title", None)
+        return {
+            "anyOf": [facet_presentation, canonical_value],
+            "description": (
+                "Either the facet presentation (vertices + facets) or an "
+                "unchanged canonical FiniteSimplicialComplex value."
+            ),
+        }
 
 
 class FacesInDimension(StrictModel):
@@ -1444,6 +1471,44 @@ class SkeletonResult(TopologyExactResult):
         return self
 
 
+def _require_join_admission(
+    complex_a: SimplicialComplexRequest,
+    complex_b: SimplicialComplexRequest,
+) -> None:
+    """Shared join admission checked BEFORE any facet-product expansion.
+
+    Disjoint maximal operand facets pair into pairwise-distinct maximal
+    unions, so the exact join facet count is the product below and every
+    derived bound (vertices, facet width, facet count) is checkable
+    without expanding that product or running the quadratic maximal-face
+    scan.
+    """
+    va = set(complex_a.vertices)
+    vb = set(complex_b.vertices)
+    if va & vb:
+        raise ValueError("join requires disjoint vertex sets; rename vertices first")
+    combined_vertices = tuple(sorted(va | vb))
+    if len(combined_vertices) > MAX_TOPOLOGY_VERTICES:
+        raise ValueError(
+            f"join would span {len(combined_vertices)} vertices, above "
+            f"the {MAX_TOPOLOGY_VERTICES}-vertex canonical bound"
+        )
+    widest_join_facet = max(len(facet) for facet in complex_a.facets) + max(
+        len(facet) for facet in complex_b.facets
+    )
+    if widest_join_facet > MAX_TOPOLOGY_DIMENSION + 1:
+        raise ValueError(
+            f"join facets would span {widest_join_facet} vertices, "
+            f"above the {MAX_TOPOLOGY_DIMENSION + 1}-vertex facet bound"
+        )
+    join_facet_count = len(complex_a.facets) * len(complex_b.facets)
+    if join_facet_count > MAX_TOPOLOGY_FACETS:
+        raise ValueError(
+            f"join would carry {join_facet_count} maximal facets, above "
+            f"the {MAX_TOPOLOGY_FACETS}-facet result contract"
+        )
+
+
 class JoinRequest(StrictModel):
     """Join two simplicial complexes on disjoint vertex sets."""
 
@@ -1452,36 +1517,10 @@ class JoinRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_admissible_join(self) -> Self:
-        va = set(self.complex_a.vertices)
-        vb = set(self.complex_b.vertices)
-        if va & vb:
-            raise ValueError(
-                "join requires disjoint vertex sets; rename vertices first"
-            )
-        # Disjoint maximal operand facets pair into pairwise-distinct
-        # maximal unions, so the exact join facet count is the product
-        # below. Check every derived bound BEFORE expanding that product
-        # so an oversized join is rejected without quadratic work.
-        combined_vertices = tuple(sorted(va | vb))
-        if len(combined_vertices) > MAX_TOPOLOGY_VERTICES:
-            raise ValueError(
-                f"join would span {len(combined_vertices)} vertices, above "
-                f"the {MAX_TOPOLOGY_VERTICES}-vertex canonical bound"
-            )
-        widest_join_facet = max(len(facet) for facet in self.complex_a.facets) + max(
-            len(facet) for facet in self.complex_b.facets
+        _require_join_admission(self.complex_a, self.complex_b)
+        combined_vertices = tuple(
+            sorted(set(self.complex_a.vertices) | set(self.complex_b.vertices))
         )
-        if widest_join_facet > MAX_TOPOLOGY_DIMENSION + 1:
-            raise ValueError(
-                f"join facets would span {widest_join_facet} vertices, "
-                f"above the {MAX_TOPOLOGY_DIMENSION + 1}-vertex facet bound"
-            )
-        join_facet_count = len(self.complex_a.facets) * len(self.complex_b.facets)
-        if join_facet_count > MAX_TOPOLOGY_FACETS:
-            raise ValueError(
-                f"join would carry {join_facet_count} maximal facets, above "
-                f"the {MAX_TOPOLOGY_FACETS}-facet result contract"
-            )
         join_facets = _join_maximal_facets(self.complex_a.facets, self.complex_b.facets)
         SimplicialComplexRequest(vertices=combined_vertices, facets=join_facets)
         return self
@@ -1526,10 +1565,11 @@ class JoinResult(TopologyExactResult):
     def require_join_canonical(self) -> Self:
         # Replay the facet union against the retained operands so any
         # internally canonical complex cannot pass as "the" join result.
+        # Apply join admission FIRST so an oversized serialized operand
+        # pair is rejected without repeating the expensive expansion.
+        _require_join_admission(self.complex_a, self.complex_b)
         vertices_a = set(self.complex_a.vertices)
         vertices_b = set(self.complex_b.vertices)
-        if vertices_a & vertices_b:
-            raise ValueError("join operands must have disjoint vertex sets")
         expected_facets = _join_maximal_facets(
             self.complex_a.facets, self.complex_b.facets
         )

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -481,8 +481,7 @@ class SimplicialComplexRequest(StrictModel):
         facets = normalized.get("facets")
         if isinstance(facets, list):
             normalized["facets"] = tuple(
-                tuple(facet) if isinstance(facet, list) else facet
-                for facet in facets
+                tuple(facet) if isinstance(facet, list) else facet for facet in facets
             )
         data = normalized
         if "facets" in data and "maximal_simplices" in data:
@@ -507,9 +506,7 @@ class SimplicialComplexRequest(StrictModel):
             ) from error
         return {
             "vertices": tuple(canonical.vertices),
-            "facets": tuple(
-                tuple(facet) for facet in canonical.maximal_simplices
-            ),
+            "facets": tuple(tuple(facet) for facet in canonical.maximal_simplices),
         }
 
     @model_validator(mode="after")
@@ -1368,9 +1365,7 @@ class VertexDeletionResult(TopologyExactResult):
                 "retained source complex"
             )
         if tuple(self.remaining_vertices) != expected_vertices:
-            raise ValueError(
-                "remaining_vertices must match the source-complex replay"
-            )
+            raise ValueError("remaining_vertices must match the source-complex replay")
         if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
             sorted(tuple(sorted(f)) for f in self.remaining_facets)
         ):
@@ -1463,9 +1458,30 @@ class JoinRequest(StrictModel):
             raise ValueError(
                 "join requires disjoint vertex sets; rename vertices first"
             )
-        # Admit the join only when its exact result complex satisfies every
-        # canonical bound (vertices, facet sizes, facet count, face closure).
+        # Disjoint maximal operand facets pair into pairwise-distinct
+        # maximal unions, so the exact join facet count is the product
+        # below. Check every derived bound BEFORE expanding that product
+        # so an oversized join is rejected without quadratic work.
         combined_vertices = tuple(sorted(va | vb))
+        if len(combined_vertices) > MAX_TOPOLOGY_VERTICES:
+            raise ValueError(
+                f"join would span {len(combined_vertices)} vertices, above "
+                f"the {MAX_TOPOLOGY_VERTICES}-vertex canonical bound"
+            )
+        widest_join_facet = max(len(facet) for facet in self.complex_a.facets) + max(
+            len(facet) for facet in self.complex_b.facets
+        )
+        if widest_join_facet > MAX_TOPOLOGY_DIMENSION + 1:
+            raise ValueError(
+                f"join facets would span {widest_join_facet} vertices, "
+                f"above the {MAX_TOPOLOGY_DIMENSION + 1}-vertex facet bound"
+            )
+        join_facet_count = len(self.complex_a.facets) * len(self.complex_b.facets)
+        if join_facet_count > MAX_TOPOLOGY_FACETS:
+            raise ValueError(
+                f"join would carry {join_facet_count} maximal facets, above "
+                f"the {MAX_TOPOLOGY_FACETS}-facet result contract"
+            )
         join_facets = _join_maximal_facets(self.complex_a.facets, self.complex_b.facets)
         SimplicialComplexRequest(vertices=combined_vertices, facets=join_facets)
         return self
@@ -1525,9 +1541,7 @@ class JoinResult(TopologyExactResult):
         if tuple(self.join_vertices) != expected_vertices:
             raise ValueError("join_vertices must match the operand vertex sets")
         expected_dimension = (
-            max(len(facet) - 1 for facet in expected_facets)
-            if expected_facets
-            else 0
+            max(len(facet) - 1 for facet in expected_facets) if expected_facets else 0
         )
         if self.join_dimension != expected_dimension:
             raise ValueError("join_dimension must match the replayed facet union")

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -249,8 +249,9 @@ def _expected_pseudomanifold_decision(
         return _PseudomanifoldExpectation(
             False, False, "not pure: facets have different dimensions"
         )
-    if dim < 1:
-        return _PseudomanifoldExpectation(False, False, "dimension must be at least 1")
+    # Dimension-zero complexes participate in the same incidence definition:
+    # each vertex facet contains exactly one codimension-one face, the empty
+    # face, so one point has it once (boundary) and two points twice (closed).
     counts = _codim1_incidence(facets)
     if any(count > 2 for count in counts.values()):
         for face, count in counts.items():
@@ -1343,6 +1344,11 @@ class ShellingCheckResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_shelling_binding(self) -> Self:
+        # Apply the request model's permutation requirement before replay: a
+        # partial or duplicated order visits only its own facets and must not
+        # authenticate a decision about facets it omits.
+        if sorted(self.facet_order) != list(range(len(self.complex.facets))):
+            raise ValueError("facet_order must be a permutation of facet indices")
         # Replay the shelling condition over the retained complex and order so
         # an authored decision cannot validate independently of its source.
         expected_is_shelling, expected_failed_at, expected_reason = _evaluate_shelling(
@@ -1418,9 +1424,33 @@ class ElementaryCollapseRequest(StrictModel):
         return self
 
 
-class ElementaryCollapseResult(TopologyExactResult):
-    """Result of checking one elementary collapse step."""
+def _require_collapse_complex(
+    remaining_facets: tuple[tuple[str, ...], ...],
+    remaining_vertices: tuple[str, ...],
+    remaining_complex: FiniteSimplicialComplex | None,
+) -> None:
+    """Require ``remaining_complex`` to restate the residual facet list."""
 
+    if not remaining_facets:
+        if remaining_complex is not None:
+            raise ValueError("empty collapsed complex must have no remaining_complex")
+        return
+    if remaining_complex is None:
+        raise ValueError("non-empty collapse requires remaining_complex")
+    if tuple(sorted(remaining_complex.maximal_simplices)) != tuple(
+        sorted(tuple(sorted(f)) for f in remaining_facets)
+    ):
+        raise ValueError(
+            "remaining_complex maximal simplices must match remaining_facets"
+        )
+    if tuple(sorted(remaining_complex.vertices)) != tuple(sorted(remaining_vertices)):
+        raise ValueError("remaining_complex vertices must match remaining_vertices")
+
+
+class ElementaryCollapseResult(TopologyExactResult):
+    """Result of checking one elementary collapse step, bound to its source."""
+
+    complex: SimplicialComplexRequest
     is_free_face: bool
     free_face: tuple[str, ...]
     coface: tuple[str, ...]
@@ -1429,39 +1459,50 @@ class ElementaryCollapseResult(TopologyExactResult):
     remaining_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_collapse_canonical(self) -> Self:
-        if self.is_free_face:
-            if not self.remaining_facets:
-                if self.remaining_complex is not None:
-                    raise ValueError(
-                        "empty collapsed complex must have no remaining_complex"
-                    )
-                if self.remaining_vertices:
-                    raise ValueError(
-                        "empty collapsed complex must have no remaining_vertices"
-                    )
-            else:
-                if self.remaining_complex is None:
-                    raise ValueError("non-empty collapse requires remaining_complex")
-                if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
-                    sorted(tuple(sorted(f)) for f in self.remaining_facets)
-                ):
-                    raise ValueError(
-                        "remaining_complex maximal simplices must match remaining_facets"
-                    )
-                if tuple(sorted(self.remaining_complex.vertices)) != tuple(
-                    sorted(self.remaining_vertices)
-                ):
-                    raise ValueError(
-                        "remaining_complex vertices must match remaining_vertices"
-                    )
+    def require_collapse_binding(self) -> Self:
+        free_face = tuple(sorted(self.free_face))
+        coface = tuple(sorted(self.coface))
+        if self.free_face != free_face or self.coface != coface:
+            raise ValueError("free_face and coface must use canonical vertex order")
+        if (
+            len(set(free_face)) != len(free_face)
+            or len(set(coface)) != len(coface)
+            or len(coface) != len(free_face) + 1
+            or not set(free_face).issubset(coface)
+        ):
+            raise ValueError("free_face must be codimension-one in coface")
+        # Replay freeness and the residual construction against the retained
+        # source complex so a serialized decision cannot validate on its own.
+        replayed_facets = _collapse_remaining_facets(
+            self.complex.facets, free_face, coface
+        )
+        if replayed_facets is None:
+            if self.is_free_face:
+                raise ValueError(
+                    "is_free_face does not match the retained source complex"
+                )
+            expected_facets = self.complex.facets
+            expected_vertices = self.complex.vertices
         else:
-            # When not a free face, remaining should be unchanged; allow both but
-            # if complex present it must match.
-            if self.remaining_complex is not None and tuple(
-                sorted(self.remaining_complex.maximal_simplices)
-            ) != tuple(sorted(tuple(sorted(f)) for f in self.remaining_facets)):
-                raise ValueError("remaining_complex must match remaining_facets")
+            if not self.is_free_face:
+                raise ValueError(
+                    "is_free_face does not match the retained source complex"
+                )
+            expected_facets = replayed_facets
+            expected_vertices = tuple(
+                sorted({vertex for facet in replayed_facets for vertex in facet})
+            )
+        if tuple(sorted(self.remaining_facets)) != tuple(sorted(expected_facets)):
+            raise ValueError("remaining_facets do not match the source-complex replay")
+        if tuple(sorted(self.remaining_vertices)) != tuple(sorted(expected_vertices)):
+            raise ValueError(
+                "remaining_vertices do not match the source-complex replay"
+            )
+        _require_collapse_complex(
+            self.remaining_facets,
+            self.remaining_vertices,
+            self.remaining_complex,
+        )
         return self
 
 

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -979,6 +979,24 @@ class JoinRequest(StrictModel):
             raise ValueError(
                 "join requires disjoint vertex sets; rename vertices first"
             )
+        # Validate join result bounds: combined facet dimension must be <=7,
+        # vertex count <=64, and facet count within limits.
+        combined_vertices = len(va | vb)
+        if combined_vertices > MAX_TOPOLOGY_VERTICES:
+            raise ValueError(
+                f"join would have {combined_vertices} vertices exceeding {MAX_TOPOLOGY_VERTICES}"
+            )
+        max_joined_size = 0
+        for fa in self.complex_a.facets:
+            for fb in self.complex_b.facets:
+                joined_size = len(set(fa) | set(fb))
+                max_joined_size = max(max_joined_size, joined_size)
+                if joined_size > MAX_TOPOLOGY_DIMENSION + 1:
+                    raise ValueError(
+                        f"join facet size {joined_size} exceeds dimension {MAX_TOPOLOGY_DIMENSION} limit"
+                    )
+        # Check closure size estimate for join: upper bound is product of face counts
+        # For two 4-simplices (32 faces each), join has 63 faces? Actually 5+5=10 vertices => 1023 faces >2048? But dimension already fails.
         return self
 
 
@@ -1020,18 +1038,13 @@ class BarycentricSubdivisionRequest(StrictModel):
     def require_barycentric_work_bounds(self) -> Self:
         closure = face_closure(tuple(tuple(sorted(f)) for f in self.complex.facets))
         face_count = sum(len(part) for part in closure)
-        if face_count > 64:
-            raise ValueError(
-                f"barycentric subdivision requires at most 64 faces (got {face_count}); "
-                "input is too large for exact bounded subdivision"
-            )
-        # Bound subdivision output size: number of maximal chains for 64 faces is
-        # still bounded by factorial-like growth but with face_count<=64 the
-        # resulting facet count remains within transport limits for tested cases.
         if face_count > 31:
-            # For 6-vertex simplex (63 faces) subdivision has 720 maximal chains;
-            # allow but note bound.
-            pass
+            raise ValueError(
+                f"barycentric subdivision requires at most 31 faces (got {face_count}); "
+                "input would produce >128 subdivision facets exceeding result contract"
+            )
+        # Additional check: subdivision of a 5-vertex simplex has 120 facets within 128 limit;
+        # 6-vertex simplex would have 720 >128, so 31 is safe.
         return self
 
 
@@ -1088,7 +1101,7 @@ class PseudomanifoldRequest(StrictModel):
 class PseudomanifoldResult(TopologyExactResult):
     """Pseudomanifold decision result bound to its source complex."""
 
-    complex: SimplicialComplexRequest | None = None
+    complex: SimplicialComplexRequest
     is_pseudomanifold: bool
     is_closed: bool
     dimension: int
@@ -1097,35 +1110,64 @@ class PseudomanifoldResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_pseudomanifold_binding(self) -> Self:
-        if self.complex is None:
-            # Allow legacy payloads without binding to validate for backward compat,
-            # but require new code to provide binding.
-            return self
         facets = [frozenset(f) for f in self.complex.facets]
         dim = max(len(f) - 1 for f in facets) if facets else 0
         if self.dimension != dim or self.num_facets != len(facets):
             raise ValueError("dimension/num_facets must match source complex")
-        # Recompute pseudomanifold decision
+        # Recompute expected decision
         is_pure = all(len(f) - 1 == dim for f in facets) if facets else False
-        if not is_pure and self.is_pseudomanifold:
-            raise ValueError("impure complex cannot be pseudomanifold")
-        if dim < 1 and self.is_pseudomanifold:
-            raise ValueError("dimension <1 cannot be pseudomanifold")
-        if self.is_pseudomanifold:
-            # Check codim-1 counts
-            codim1_count: dict[frozenset[str], int] = {}
+        codim1_count: dict[frozenset[str], int] = {}
+        is_closed_expected = False
+        obstruction_expected: str | None = None
+        expected_is_pseudo = False
+        if not is_pure:
+            expected_is_pseudo = False
+            obstruction_expected = "not pure: facets have different dimensions"
+        elif dim < 1:
+            expected_is_pseudo = False
+            obstruction_expected = "dimension must be at least 1"
+        else:
             for facet in facets:
                 for face in combinations(sorted(facet), len(facet) - 1):
                     key = frozenset(face)
                     codim1_count[key] = codim1_count.get(key, 0) + 1
-            for count in codim1_count.values():
-                if count > 2:
-                    raise ValueError("pseudomanifold must have codim-1 count <=2")
-            is_closed_expected = all(c == 2 for c in codim1_count.values()) if codim1_count else False
-            if self.is_closed != is_closed_expected:
-                raise ValueError("is_closed must match codim-1 incidence")
-            if self.is_closed and self.obstruction is not None:
-                raise ValueError("closed pseudomanifold must have no obstruction")
+            has_over = any(c > 2 for c in codim1_count.values())
+            if has_over:
+                expected_is_pseudo = False
+                # find first over face
+                for face, cnt in codim1_count.items():
+                    if cnt > 2:
+                        obstruction_expected = f"codim-1 face {sorted(face)} is in {cnt} facets"
+                        break
+            else:
+                expected_is_pseudo = True
+                is_closed_expected = all(c == 2 for c in codim1_count.values()) if codim1_count else False
+                if is_closed_expected:
+                    obstruction_expected = None
+                else:
+                    obstruction_expected = "pseudomanifold with boundary"
+                if self.is_closed != is_closed_expected:
+                    raise ValueError("is_closed must match codim-1 incidence")
+                if self.is_closed and self.obstruction is not None:
+                    raise ValueError("closed pseudomanifold must have no obstruction")
+                if not self.is_closed and self.obstruction is None:
+                    raise ValueError("pseudomanifold with boundary must have obstruction")
+        if self.is_pseudomanifold != expected_is_pseudo:
+            raise ValueError(
+                f"is_pseudomanifold {self.is_pseudomanifold} does not match expected {expected_is_pseudo}"
+            )
+        # For non-pseudomanifold, obstruction must match expected (allow any non-None when expected is not None? strict)
+        if not expected_is_pseudo:
+            if self.is_closed:
+                raise ValueError("non-pseudomanifold cannot be closed")
+            # Obstruction should be present
+            if self.obstruction is None:
+                raise ValueError("non-pseudomanifold must have obstruction")
+        else:
+            if self.obstruction != obstruction_expected:
+                raise ValueError(
+                    f"obstruction {self.obstruction!r} does not match expected {obstruction_expected!r}"
+                )
         return self
 
 
@@ -1151,7 +1193,7 @@ class ShellingCheckResult(TopologyExactResult):
 
 
 class ElementaryCollapseRequest(StrictModel):
-    """Check and perform one elementary collapse step."""
+    """Check and perform one elementary collapse step (free face must be codimension-one)."""
 
     complex: SimplicialComplexRequest
     free_face: tuple[VertexLabel, ...] = Field(min_length=1)
@@ -1165,6 +1207,11 @@ class ElementaryCollapseRequest(StrictModel):
             raise ValueError("free_face must be a proper subset of coface")
         if not face_set.issubset(coface_set):
             raise ValueError("free_face must be contained in coface")
+        if len(coface_set) != len(face_set) + 1:
+            raise ValueError(
+                "elementary collapse requires free_face to be codimension-one in coface "
+                f"(got |free|={len(face_set)}, |coface|={len(coface_set)})"
+            )
         return self
 
 

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -18,7 +18,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema
 
 from jacobian._digest import Sha256Digest
 from jacobian._exact import CanonicalInteger
@@ -526,7 +525,7 @@ class SimplicialComplexRequest(StrictModel):
     @classmethod
     def __get_pydantic_json_schema__(
         cls,
-        core_schema: CoreSchema,
+        core_schema: Any,
         handler: Any,
     ) -> JsonSchemaValue:
         """Advertise both accepted input shapes in the published schema.

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -829,3 +829,196 @@ class LinkResult(TopologyExactResult):
 
 
 __all__.extend(["FVectorRequest", "FVectorResult", "LinkRequest", "LinkResult"])
+
+
+class StarRequest(StrictModel):
+    """Request the closed star of a simplex in a simplicial complex."""
+
+    complex: SimplicialComplexRequest
+    simplex: tuple[VertexLabel, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_star_simplex(self) -> Self:
+        simplex = set(self.simplex)
+        if len(simplex) != len(self.simplex):
+            raise ValueError("simplex vertices must be distinct")
+        if not simplex.issubset(self.complex.vertices):
+            raise ValueError("simplex vertices must be in the complex")
+        if not any(simplex.issubset(facet) for facet in self.complex.facets):
+            raise ValueError("simplex must be a face of the complex")
+        return self
+
+
+class StarResult(TopologyExactResult):
+    """The closed star of a simplex: all facets containing sigma."""
+
+    simplex: tuple[str, ...]
+    star_facets: tuple[tuple[str, ...], ...]
+    star_is_empty: bool
+
+
+class VertexDeletionRequest(StrictModel):
+    """Delete a vertex subset from a simplicial complex."""
+
+    complex: SimplicialComplexRequest
+    vertices_to_delete: tuple[VertexLabel, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_deletion(self) -> Self:
+        vtd = set(self.vertices_to_delete)
+        if len(vtd) != len(self.vertices_to_delete):
+            raise ValueError("vertices_to_delete must be distinct")
+        if not vtd.issubset(set(self.complex.vertices)):
+            raise ValueError("vertices_to_delete must be in the complex")
+        return self
+
+
+class VertexDeletionResult(TopologyExactResult):
+    """The complex after deleting a vertex subset."""
+
+    deleted_vertices: tuple[str, ...]
+    remaining_vertices: tuple[str, ...]
+    remaining_facets: tuple[tuple[str, ...], ...]
+
+
+class SkeletonRequest(StrictModel):
+    """Request the k-skeleton of a simplicial complex."""
+
+    complex: SimplicialComplexRequest
+    k: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
+
+
+class SkeletonResult(TopologyExactResult):
+    """The k-skeleton as a facet list."""
+
+    k: int
+    skeleton_facets: tuple[tuple[str, ...], ...]
+    skeleton_vertices: tuple[str, ...]
+
+
+class JoinRequest(StrictModel):
+    """Join two simplicial complexes on disjoint vertex sets."""
+
+    complex_a: SimplicialComplexRequest
+    complex_b: SimplicialComplexRequest
+
+    @model_validator(mode="after")
+    def require_disjoint_vertices(self) -> Self:
+        va = set(self.complex_a.vertices)
+        vb = set(self.complex_b.vertices)
+        if va & vb:
+            raise ValueError(
+                "join requires disjoint vertex sets; rename vertices first"
+            )
+        return self
+
+
+class JoinResult(TopologyExactResult):
+    """The join of two complexes."""
+
+    join_vertices: tuple[str, ...]
+    join_facets: tuple[tuple[str, ...], ...]
+    join_dimension: int
+
+
+class BarycentricSubdivisionRequest(StrictModel):
+    """Subdivide a complex via its order complex (barycentric subdivision)."""
+
+    complex: SimplicialComplexRequest
+
+
+class BarycentricSubdivisionResult(TopologyExactResult):
+    """The barycentric subdivision as a facet list."""
+
+    original_vertices: tuple[str, ...]
+    original_dimension: int
+    subdivision_vertices: tuple[str, ...]
+    subdivision_facets: tuple[tuple[str, ...], ...]
+    num_new_vertices: int
+
+
+class PseudomanifoldRequest(StrictModel):
+    """Decide whether a complex is a pseudomanifold."""
+
+    complex: SimplicialComplexRequest
+
+
+class PseudomanifoldResult(TopologyExactResult):
+    """Pseudomanifold decision result."""
+
+    is_pseudomanifold: bool
+    is_closed: bool
+    dimension: int
+    num_facets: int
+    obstruction: str | None = None
+
+
+class ShellingCheckRequest(StrictModel):
+    """Check a submitted shelling order of a pure complex."""
+
+    complex: SimplicialComplexRequest
+    facet_order: tuple[int, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_valid_order(self) -> Self:
+        if sorted(self.facet_order) != list(range(len(self.complex.facets))):
+            raise ValueError("facet_order must be a permutation of facet indices")
+        return self
+
+
+class ShellingCheckResult(TopologyExactResult):
+    """Result of checking a shelling order."""
+
+    is_shelling: bool
+    failed_at: int | None = None
+    failure_reason: str | None = None
+
+
+class ElementaryCollapseRequest(StrictModel):
+    """Check and perform one elementary collapse step."""
+
+    complex: SimplicialComplexRequest
+    free_face: tuple[VertexLabel, ...] = Field(min_length=1)
+    coface: tuple[VertexLabel, ...] = Field(min_length=2)
+
+    @model_validator(mode="after")
+    def require_valid_collapse(self) -> Self:
+        face_set = set(self.free_face)
+        coface_set = set(self.coface)
+        if face_set == coface_set:
+            raise ValueError("free_face must be a proper subset of coface")
+        if not face_set.issubset(coface_set):
+            raise ValueError("free_face must be contained in coface")
+        return self
+
+
+class ElementaryCollapseResult(TopologyExactResult):
+    """Result of checking one elementary collapse step."""
+
+    is_free_face: bool
+    free_face: tuple[str, ...]
+    coface: tuple[str, ...]
+    remaining_facets: tuple[tuple[str, ...], ...]
+    remaining_vertices: tuple[str, ...]
+
+
+__all__.extend(
+    [
+        "BarycentricSubdivisionRequest",
+        "BarycentricSubdivisionResult",
+        "ElementaryCollapseRequest",
+        "ElementaryCollapseResult",
+        "JoinRequest",
+        "JoinResult",
+        "PseudomanifoldRequest",
+        "PseudomanifoldResult",
+        "ShellingCheckRequest",
+        "ShellingCheckResult",
+        "SkeletonRequest",
+        "SkeletonResult",
+        "StarRequest",
+        "StarResult",
+        "VertexDeletionRequest",
+        "VertexDeletionResult",
+    ]
+)

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterable
 from enum import StrEnum
 from itertools import combinations, pairwise
-from typing import Annotated, Literal, Self
+from typing import Annotated, Literal, NamedTuple, Self
 
 from pydantic import (
     Field,
@@ -84,6 +85,185 @@ def face_closure(facets: tuple[Simplex, ...]) -> tuple[tuple[Simplex, ...], ...]
             faces[size - 1].update(combinations(facet, size))
     highest = max(index for index, values in enumerate(faces) if values)
     return tuple(tuple(sorted(values)) for values in faces[: highest + 1])
+
+
+def _all_nonempty_faces(facets: tuple[Simplex, ...]) -> set[Simplex]:
+    faces: set[Simplex] = set()
+    for facet in facets:
+        canonical = tuple(sorted(facet))
+        for size in range(1, len(canonical) + 1):
+            faces.update(combinations(canonical, size))
+    return faces
+
+
+def _maximal_faces(faces: Iterable[Simplex]) -> tuple[tuple[str, ...], ...]:
+    """Extract maximal faces in canonical (-size, face) order."""
+
+    maximal: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in sorted(faces, key=lambda f: (-len(f), f)):
+        face_set = frozenset(face)
+        if not any(existing.issuperset(face_set) for existing in seen):
+            maximal.append(tuple(sorted(face)))
+            seen.add(face_set)
+    return tuple(maximal)
+
+
+def _join_maximal_facets(
+    facets_a: tuple[Simplex, ...],
+    facets_b: tuple[Simplex, ...],
+) -> tuple[tuple[str, ...], ...]:
+    return _maximal_faces(
+        tuple(sorted(set(fa) | set(fb))) for fa in facets_a for fb in facets_b
+    )
+
+
+def _skeleton_maximal_facets(
+    facets: tuple[Simplex, ...],
+    k: int,
+) -> tuple[tuple[str, ...], ...]:
+    faces = {
+        face
+        for facet in facets
+        for face in combinations(sorted(facet), min(k + 1, len(facet)))
+    }
+    return _maximal_faces(faces)
+
+
+def _collapse_remaining_facets(
+    facets: tuple[Simplex, ...],
+    free_face: tuple[str, ...],
+    coface_face: tuple[str, ...],
+) -> tuple[tuple[str, ...], ...] | None:
+    """Mirror the elementary-collapse interval removal.
+
+    Returns the remaining maximal facets when the collapse applies (the free
+    face is contained in exactly one facet equal to the coface) and ``None``
+    when the operation would report ``is_free_face=False`` instead.
+    """
+
+    free_set = frozenset(free_face)
+    coface_set = frozenset(coface_face)
+    containing = [
+        frozenset(facet) for facet in facets if free_set.issubset(frozenset(facet))
+    ]
+    if len(containing) != 1 or containing[0] != coface_set:
+        return None
+    remaining = {
+        face
+        for face in _all_nonempty_faces(facets)
+        if not (free_set.issubset(set(face)) and set(face).issubset(coface_set))
+    }
+    return _maximal_faces(remaining)
+
+
+def _shelling_restriction_failure(
+    facet_i: set[str],
+    prev_facets: list[set[str]],
+) -> str | None:
+    """Check the standard shelling restriction for one new facet.
+
+    ``R(F_i)`` — the faces of ``F_i`` contained in no earlier facet — must be
+    a nonempty interval of the face lattice, i.e. have exactly one minimal
+    face. Returns the failure description or ``None`` when the restriction is
+    admissible.
+    """
+
+    faces_not_in_prev: set[tuple[str, ...]] = set()
+    n = len(facet_i)
+    for r in range(1, n + 1):
+        for subset in combinations(sorted(facet_i), r):
+            face_set = set(subset)
+            if not any(face_set.issubset(pf) for pf in prev_facets):
+                faces_not_in_prev.add(subset)
+    if not faces_not_in_prev:
+        return "has no new faces"
+    face_sets = {frozenset(face) for face in faces_not_in_prev}
+    min_faces = [
+        face
+        for face in face_sets
+        if not any(other < face for other in face_sets if other != face)
+    ]
+    if len(min_faces) != 1:
+        return "restriction is not an interval"
+    return None
+
+
+def _evaluate_shelling(
+    facets: tuple[Simplex, ...],
+    facet_order: tuple[int, ...],
+) -> tuple[bool, int | None, str | None]:
+    """Recompute the shelling decision for a submitted facet order."""
+
+    dim = len(facets[0])
+    if not all(len(facet) == dim for facet in facets):
+        return False, 0, "complex is not pure"
+
+    for i, idx in enumerate(order := facet_order):
+        facet_i = set(facets[idx])
+        if i == 0:
+            continue
+        prev_facets = [set(facets[order[j]]) for j in range(i)]
+        for j in range(i):
+            intersection = facet_i & set(facets[order[j]])
+            if intersection == facet_i:
+                return (
+                    False,
+                    i,
+                    f"facet {idx} is contained in earlier facet",
+                )
+        failure = _shelling_restriction_failure(facet_i, prev_facets)
+        if failure is not None:
+            return False, i, f"facet {idx} {failure}"
+
+    return True, None, None
+
+
+class _PseudomanifoldExpectation(NamedTuple):
+    """Recomputed pseudomanifold decision for one facet family."""
+
+    is_pseudomanifold: bool
+    is_closed: bool
+    obstruction: str | None
+
+
+def _codim1_incidence(
+    facets: list[frozenset[str]],
+) -> dict[frozenset[str], int]:
+    counts: dict[frozenset[str], int] = {}
+    for facet in facets:
+        for face in combinations(sorted(facet), len(facet) - 1):
+            key = frozenset(face)
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _expected_pseudomanifold_decision(
+    facets: list[frozenset[str]],
+    dim: int,
+) -> _PseudomanifoldExpectation:
+    """Recompute the bounded pseudomanifold decision from incidence."""
+
+    is_pure = all(len(facet) - 1 == dim for facet in facets) if facets else False
+    if not is_pure:
+        return _PseudomanifoldExpectation(
+            False, False, "not pure: facets have different dimensions"
+        )
+    if dim < 1:
+        return _PseudomanifoldExpectation(False, False, "dimension must be at least 1")
+    counts = _codim1_incidence(facets)
+    if any(count > 2 for count in counts.values()):
+        for face, count in counts.items():
+            if count > 2:
+                return _PseudomanifoldExpectation(
+                    False,
+                    False,
+                    f"codim-1 face {sorted(face)} is in {count} facets",
+                )
+    is_closed = all(count == 2 for count in counts.values()) if counts else False
+    return _PseudomanifoldExpectation(
+        True, is_closed, None if is_closed else "pseudomanifold with boundary"
+    )
 
 
 def _require_request_complex(
@@ -870,10 +1050,12 @@ class StarResult(TopologyExactResult):
             if tuple(sorted(self.star_complex.maximal_simplices)) != tuple(
                 sorted(tuple(sorted(f)) for f in self.star_facets)
             ):
-                raise ValueError("star_complex maximal simplices must match star_facets")
-            if set(self.star_complex.vertices) != set(
+                raise ValueError(
+                    "star_complex maximal simplices must match star_facets"
+                )
+            if set(self.star_complex.vertices) != {
                 v for facet in self.star_facets for v in facet
-            ):
+            }:
                 raise ValueError("star_complex vertices must match star_facets")
         return self
 
@@ -933,6 +1115,18 @@ class SkeletonRequest(StrictModel):
     complex: SimplicialComplexRequest
     k: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
 
+    @model_validator(mode="after")
+    def require_admissible_skeleton(self) -> Self:
+        # Admit the request only when the exact k-skeleton satisfies every
+        # canonical result bound before execution (e.g. the 3-skeleton of
+        # eight disjoint 7-simplices yields 560 tetrahedra > 128 facets).
+        skeleton_facets = _skeleton_maximal_facets(self.complex.facets, self.k)
+        skeleton_vertices = tuple(
+            sorted({v for facet in skeleton_facets for v in facet})
+        )
+        SimplicialComplexRequest(vertices=skeleton_vertices, facets=skeleton_facets)
+        return self
+
 
 class SkeletonResult(TopologyExactResult):
     """The k-skeleton as a facet list."""
@@ -972,31 +1166,18 @@ class JoinRequest(StrictModel):
     complex_b: SimplicialComplexRequest
 
     @model_validator(mode="after")
-    def require_disjoint_vertices(self) -> Self:
+    def require_admissible_join(self) -> Self:
         va = set(self.complex_a.vertices)
         vb = set(self.complex_b.vertices)
         if va & vb:
             raise ValueError(
                 "join requires disjoint vertex sets; rename vertices first"
             )
-        # Validate join result bounds: combined facet dimension must be <=7,
-        # vertex count <=64, and facet count within limits.
-        combined_vertices = len(va | vb)
-        if combined_vertices > MAX_TOPOLOGY_VERTICES:
-            raise ValueError(
-                f"join would have {combined_vertices} vertices exceeding {MAX_TOPOLOGY_VERTICES}"
-            )
-        max_joined_size = 0
-        for fa in self.complex_a.facets:
-            for fb in self.complex_b.facets:
-                joined_size = len(set(fa) | set(fb))
-                max_joined_size = max(max_joined_size, joined_size)
-                if joined_size > MAX_TOPOLOGY_DIMENSION + 1:
-                    raise ValueError(
-                        f"join facet size {joined_size} exceeds dimension {MAX_TOPOLOGY_DIMENSION} limit"
-                    )
-        # Check closure size estimate for join: upper bound is product of face counts
-        # For two 4-simplices (32 faces each), join has 63 faces? Actually 5+5=10 vertices => 1023 faces >2048? But dimension already fails.
+        # Admit the join only when its exact result complex satisfies every
+        # canonical bound (vertices, facet sizes, facet count, face closure).
+        combined_vertices = tuple(sorted(va | vb))
+        join_facets = _join_maximal_facets(self.complex_a.facets, self.complex_b.facets)
+        SimplicialComplexRequest(vertices=combined_vertices, facets=join_facets)
         return self
 
 
@@ -1019,7 +1200,9 @@ class JoinResult(TopologyExactResult):
             if tuple(sorted(self.join_complex.maximal_simplices)) != tuple(
                 sorted(tuple(sorted(f)) for f in self.join_facets)
             ):
-                raise ValueError("join_complex maximal simplices must match join_facets")
+                raise ValueError(
+                    "join_complex maximal simplices must match join_facets"
+                )
             if tuple(sorted(self.join_complex.vertices)) != tuple(
                 sorted(self.join_vertices)
             ):
@@ -1114,60 +1297,25 @@ class PseudomanifoldResult(TopologyExactResult):
         dim = max(len(f) - 1 for f in facets) if facets else 0
         if self.dimension != dim or self.num_facets != len(facets):
             raise ValueError("dimension/num_facets must match source complex")
-        # Recompute expected decision
-        is_pure = all(len(f) - 1 == dim for f in facets) if facets else False
-        codim1_count: dict[frozenset[str], int] = {}
-        is_closed_expected = False
-        obstruction_expected: str | None = None
-        expected_is_pseudo = False
-        if not is_pure:
-            expected_is_pseudo = False
-            obstruction_expected = "not pure: facets have different dimensions"
-        elif dim < 1:
-            expected_is_pseudo = False
-            obstruction_expected = "dimension must be at least 1"
-        else:
-            for facet in facets:
-                for face in combinations(sorted(facet), len(facet) - 1):
-                    key = frozenset(face)
-                    codim1_count[key] = codim1_count.get(key, 0) + 1
-            has_over = any(c > 2 for c in codim1_count.values())
-            if has_over:
-                expected_is_pseudo = False
-                # find first over face
-                for face, cnt in codim1_count.items():
-                    if cnt > 2:
-                        obstruction_expected = f"codim-1 face {sorted(face)} is in {cnt} facets"
-                        break
-            else:
-                expected_is_pseudo = True
-                is_closed_expected = all(c == 2 for c in codim1_count.values()) if codim1_count else False
-                if is_closed_expected:
-                    obstruction_expected = None
-                else:
-                    obstruction_expected = "pseudomanifold with boundary"
-                if self.is_closed != is_closed_expected:
-                    raise ValueError("is_closed must match codim-1 incidence")
-                if self.is_closed and self.obstruction is not None:
-                    raise ValueError("closed pseudomanifold must have no obstruction")
-                if not self.is_closed and self.obstruction is None:
-                    raise ValueError("pseudomanifold with boundary must have obstruction")
-        if self.is_pseudomanifold != expected_is_pseudo:
+        expected = _expected_pseudomanifold_decision(facets, dim)
+        if self.is_pseudomanifold != expected.is_pseudomanifold:
             raise ValueError(
-                f"is_pseudomanifold {self.is_pseudomanifold} does not match expected {expected_is_pseudo}"
+                f"is_pseudomanifold {self.is_pseudomanifold} does not match "
+                f"expected {expected.is_pseudomanifold}"
             )
-        # For non-pseudomanifold, obstruction must match expected (allow any non-None when expected is not None? strict)
-        if not expected_is_pseudo:
+        if not expected.is_pseudomanifold:
             if self.is_closed:
                 raise ValueError("non-pseudomanifold cannot be closed")
-            # Obstruction should be present
             if self.obstruction is None:
                 raise ValueError("non-pseudomanifold must have obstruction")
-        else:
-            if self.obstruction != obstruction_expected:
-                raise ValueError(
-                    f"obstruction {self.obstruction!r} does not match expected {obstruction_expected!r}"
-                )
+            return self
+        if self.is_closed != expected.is_closed:
+            raise ValueError("is_closed must match codim-1 incidence")
+        if self.obstruction != expected.obstruction:
+            raise ValueError(
+                f"obstruction {self.obstruction!r} does not match expected "
+                f"{expected.obstruction!r}"
+            )
         return self
 
 
@@ -1185,11 +1333,37 @@ class ShellingCheckRequest(StrictModel):
 
 
 class ShellingCheckResult(TopologyExactResult):
-    """Result of checking a shelling order."""
+    """Result of checking a shelling order, bound to its checked source."""
 
+    complex: SimplicialComplexRequest
+    facet_order: tuple[int, ...] = Field(min_length=1)
     is_shelling: bool
     failed_at: int | None = None
     failure_reason: str | None = None
+
+    @model_validator(mode="after")
+    def require_shelling_binding(self) -> Self:
+        # Replay the shelling condition over the retained complex and order so
+        # an authored decision cannot validate independently of its source.
+        expected_is_shelling, expected_failed_at, expected_reason = _evaluate_shelling(
+            self.complex.facets, self.facet_order
+        )
+        if self.is_shelling != expected_is_shelling:
+            raise ValueError(
+                f"is_shelling {self.is_shelling} does not match replayed "
+                f"decision {expected_is_shelling}"
+            )
+        if self.failed_at != expected_failed_at:
+            raise ValueError(
+                f"failed_at {self.failed_at} does not match replayed "
+                f"{expected_failed_at}"
+            )
+        if self.failure_reason != expected_reason:
+            raise ValueError(
+                f"failure_reason {self.failure_reason!r} does not match "
+                f"replayed {expected_reason!r}"
+            )
+        return self
 
 
 class ElementaryCollapseRequest(StrictModel):
@@ -1201,6 +1375,18 @@ class ElementaryCollapseRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_valid_collapse(self) -> Self:
+        # Repeated labels do not represent simplices; validate uniqueness
+        # before converting either field to a set.
+        if len(set(self.free_face)) != len(self.free_face):
+            raise ValueError(
+                "free_face vertices must be unique; repeated labels do not "
+                "represent a simplex"
+            )
+        if len(set(self.coface)) != len(self.coface):
+            raise ValueError(
+                "coface vertices must be unique; repeated labels do not "
+                "represent a simplex"
+            )
         face_set = set(self.free_face)
         coface_set = set(self.coface)
         if face_set == coface_set:
@@ -1211,6 +1397,23 @@ class ElementaryCollapseRequest(StrictModel):
             raise ValueError(
                 "elementary collapse requires free_face to be codimension-one in coface "
                 f"(got |free|={len(face_set)}, |coface|={len(coface_set)})"
+            )
+        # Admit the request only when the exact residual complex satisfies the
+        # canonical result bounds before execution (e.g. collapsing one face
+        # of a 7-simplex beside 127 edges would leave 134 maximal facets).
+        remaining_facets = _collapse_remaining_facets(
+            self.complex.facets,
+            tuple(sorted(self.free_face)),
+            tuple(sorted(self.coface)),
+        )
+        if remaining_facets is not None:
+            remaining_vertices = tuple(
+                sorted({v for facet in remaining_facets for v in facet})
+            )
+            if not remaining_vertices:
+                return self
+            SimplicialComplexRequest(
+                vertices=remaining_vertices, facets=remaining_facets
             )
         return self
 
@@ -1230,9 +1433,13 @@ class ElementaryCollapseResult(TopologyExactResult):
         if self.is_free_face:
             if not self.remaining_facets:
                 if self.remaining_complex is not None:
-                    raise ValueError("empty collapsed complex must have no remaining_complex")
+                    raise ValueError(
+                        "empty collapsed complex must have no remaining_complex"
+                    )
                 if self.remaining_vertices:
-                    raise ValueError("empty collapsed complex must have no remaining_vertices")
+                    raise ValueError(
+                        "empty collapsed complex must have no remaining_vertices"
+                    )
             else:
                 if self.remaining_complex is None:
                     raise ValueError("non-empty collapse requires remaining_complex")
@@ -1251,11 +1458,10 @@ class ElementaryCollapseResult(TopologyExactResult):
         else:
             # When not a free face, remaining should be unchanged; allow both but
             # if complex present it must match.
-            if self.remaining_complex is not None:
-                if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
-                    sorted(tuple(sorted(f)) for f in self.remaining_facets)
-                ):
-                    raise ValueError("remaining_complex must match remaining_facets")
+            if self.remaining_complex is not None and tuple(
+                sorted(self.remaining_complex.maximal_simplices)
+            ) != tuple(sorted(tuple(sorted(f)) for f in self.remaining_facets)):
+                raise ValueError("remaining_complex must match remaining_facets")
         return self
 
 

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -227,6 +227,134 @@ class _PseudomanifoldExpectation(NamedTuple):
     obstruction: str | None
 
 
+def _all_faces(facets: tuple[Simplex, ...]) -> set[tuple[str, ...]]:
+    """Return the complete set of nonempty faces for a facet list."""
+    faces: set[tuple[str, ...]] = set()
+    for facet in facets:
+        n = len(facet)
+        for r in range(1, n + 1):
+            for subset in combinations(facet, r):
+                faces.add(tuple(sorted(subset)))
+    return faces
+
+
+def _cover_relations(face_frozens: list[frozenset[str]]) -> list[list[int]]:
+    """Compute the cover relation of the face lattice: i covers j when
+    ``face_frozens[i] < face_frozens[j]`` with no strict intermediate."""
+
+    n = len(face_frozens)
+    covers: list[list[int]] = [[] for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            if face_frozens[i] < face_frozens[j]:
+                has_intermediate = any(
+                    face_frozens[i] < face_frozens[k] < face_frozens[j]
+                    for k in range(n)
+                )
+                if not has_intermediate:
+                    covers[i].append(j)
+    return covers
+
+
+def _minimal_face_indices(face_frozens: list[frozenset[str]]) -> list[int]:
+    is_minimal = [True] * len(face_frozens)
+    for i in range(len(face_frozens)):
+        for j in range(len(face_frozens)):
+            if face_frozens[j] < face_frozens[i]:
+                is_minimal[i] = False
+                break
+    return [i for i, minimal in enumerate(is_minimal) if minimal]
+
+
+def _maximal_chains_from_covers(
+    covers: list[list[int]],
+    minimal_indices: list[int],
+    n: int,
+    sorted_faces: list[tuple[str, ...]],
+    face_frozens: list[frozenset[str]],
+) -> list[list[int]]:
+    maximal_chains: list[list[int]] = []
+
+    def dfs(chain: list[int]) -> None:
+        last = chain[-1]
+        if not covers[last]:
+            maximal_chains.append(list(chain))
+            return
+        for nxt in covers[last]:
+            chain.append(nxt)
+            dfs(chain)
+            chain.pop()
+
+    for start in minimal_indices:
+        dfs([start])
+    # If no minimal (should not happen) fallback to each face as chain
+    if not maximal_chains and sorted_faces:
+        # Single-face complex
+        for i in range(n):
+            if not any(face_frozens[i] < face_frozens[j] for j in range(n)):
+                # maximal element
+                maximal_chains.append([i])
+    return maximal_chains
+
+
+def _replayed_barycentric_subdivision(
+    facets: tuple[Simplex, ...],
+    faces: list[tuple[str, ...]],
+) -> tuple[tuple[str, ...], ...]:
+    """Recompute the barycentric-subdivision facets for ``bv{i}`` labels
+    assigned to ``faces`` in the given canonical order."""
+
+    face_frozens = [frozenset(face) for face in faces]
+    covers = _cover_relations(face_frozens)
+    minimal_indices = _minimal_face_indices(face_frozens)
+    maximal_chains = _maximal_chains_from_covers(
+        covers, minimal_indices, len(faces), faces, face_frozens
+    )
+    vertex_map = {face: f"bv{idx}" for idx, face in enumerate(faces)}
+    subdivision_facets = [
+        tuple(sorted(vertex_map[faces[idx]] for idx in chain))
+        for chain in maximal_chains
+    ]
+    return tuple(sorted(set(subdivision_facets), key=lambda f: (-len(f), f)))
+
+
+def _require_subdivision_replay(
+    *,
+    source_complex: SimplicialComplexRequest,
+    original_vertices: tuple[str, ...],
+    subdivision_vertices: tuple[str, ...],
+    subdivision_vertex_faces: tuple[tuple[str, ...], ...],
+    num_new_vertices: int,
+    subdivision_facets: tuple[tuple[str, ...], ...],
+) -> None:
+    """Replay the deterministic subdivision against the retained source so
+    every derived field — including the indexed vertex-to-face map — must
+    equal what the kernel produces for this exact labeling.  In particular,
+    swapping entries of ``subdivision_vertex_faces`` while keeping the
+    subdivision complex unchanged cannot validate."""
+
+    faces = sorted(_all_faces(source_complex.facets), key=lambda f: (len(f), f))
+    expected_labels = [f"bv{i}" for i in range(len(faces))]
+    if (
+        list(subdivision_vertices) != expected_labels
+        or list(subdivision_vertex_faces) != faces
+        or num_new_vertices != len(faces)
+    ):
+        raise ValueError(
+            "subdivision_vertices and subdivision_vertex_faces must be "
+            "the canonical indexed bijection onto the source complex's "
+            "non-empty faces"
+        )
+    expected = _replayed_barycentric_subdivision(source_complex.facets, faces)
+    if (
+        tuple(subdivision_facets) != expected
+        or original_vertices != source_complex.vertices
+    ):
+        raise ValueError(
+            "subdivision facets do not match the retained source complex"
+        )
+
+
 def _codim1_incidence(
     facets: list[frozenset[str]],
 ) -> dict[frozenset[str], int]:
@@ -299,8 +427,30 @@ def _require_request_complex(
     return tuple(sorted(canonical))
 
 
+_CANONICAL_COMPLEX_DUMP_KEYS = frozenset(
+    {
+        "complex_format",
+        "vertices",
+        "maximal_simplices",
+        "faces_by_dimension",
+        "dimension",
+        "f_vector",
+        "closure_size",
+        "orientation_convention",
+        "empty_simplex_stored",
+        "complex_digest",
+    }
+)
+
+
 class SimplicialComplexRequest(StrictModel):
-    """A bounded facet presentation for canonicalization."""
+    """A bounded facet presentation for canonicalization.
+
+    Accepts either the facet presentation (``vertices`` + ``facets``) or an
+    unchanged canonical :class:`FiniteSimplicialComplex` value, so results
+    such as ``VertexDeletionResult.remaining_complex`` can feed structural
+    requests directly.
+    """
 
     vertices: tuple[VertexLabel, ...] = Field(
         min_length=1,
@@ -310,6 +460,37 @@ class SimplicialComplexRequest(StrictModel):
         min_length=1,
         max_length=MAX_TOPOLOGY_FACETS,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_canonical_complex_value(cls, data: object) -> object:
+        if isinstance(data, FiniteSimplicialComplex):
+            return {
+                "vertices": list(data.vertices),
+                "facets": [list(facet) for facet in data.maximal_simplices],
+            }
+        if not isinstance(data, dict):
+            return data
+        if "facets" in data and "maximal_simplices" in data:
+            raise ValueError(
+                "pass either facets or a canonical FiniteSimplicialComplex "
+                "value, not both"
+            )
+        if "maximal_simplices" not in data:
+            if set(data) - {"vertices", "facets"}:
+                return data
+            return data
+        unknown = sorted(set(data) - _CANONICAL_COMPLEX_DUMP_KEYS)
+        if unknown:
+            raise ValueError(
+                f"unknown fields alongside maximal_simplices: {unknown}"
+            )
+        if "vertices" not in data:
+            raise ValueError("canonical complex value must carry vertices")
+        return {
+            "vertices": data["vertices"],
+            "facets": data["maximal_simplices"],
+        }
 
     @model_validator(mode="after")
     def require_bounded_maximal_facets(self) -> Self:
@@ -987,7 +1168,10 @@ class LinkRequest(StrictModel):
     """Request the link of a simplex in a simplicial complex."""
 
     complex: SimplicialComplexRequest
-    simplex: tuple[VertexLabel, ...] = Field(min_length=1)
+    simplex: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
 
     @model_validator(mode="after")
     def require_valid_simplex(self) -> Self:
@@ -1016,7 +1200,10 @@ class StarRequest(StrictModel):
     """Request the closed star of a simplex in a simplicial complex."""
 
     complex: SimplicialComplexRequest
-    simplex: tuple[VertexLabel, ...] = Field(min_length=1)
+    simplex: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
 
     @model_validator(mode="after")
     def require_valid_star_simplex(self) -> Self:
@@ -1065,7 +1252,10 @@ class VertexDeletionRequest(StrictModel):
     """Delete a vertex subset from a simplicial complex."""
 
     complex: SimplicialComplexRequest
-    vertices_to_delete: tuple[VertexLabel, ...] = Field(min_length=1)
+    vertices_to_delete: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_VERTICES,
+    )
 
     @model_validator(mode="after")
     def require_valid_deletion(self) -> Self:
@@ -1240,6 +1430,7 @@ class BarycentricSubdivisionResult(TopologyExactResult):
     subdivision_vertices: tuple[str, ...]
     subdivision_facets: tuple[tuple[str, ...], ...]
     num_new_vertices: int
+    complex: SimplicialComplexRequest
     subdivision_complex: FiniteSimplicialComplex | None = None
     subdivision_vertex_faces: tuple[tuple[str, ...], ...] = Field(default=())
 
@@ -1263,16 +1454,20 @@ class BarycentricSubdivisionResult(TopologyExactResult):
                 raise ValueError(
                     "subdivision_complex vertices must match subdivision_vertices"
                 )
-            if len(self.subdivision_vertex_faces) != len(self.subdivision_vertices):
-                raise ValueError(
-                    "subdivision_vertex_faces must align with subdivision_vertices"
-                )
             # Validate vertex labels are bounded and injective
             if len(set(self.subdivision_vertices)) != len(self.subdivision_vertices):
                 raise ValueError("subdivision vertices must be unique")
             for label in self.subdivision_vertices:
                 if len(label) > 32 or not label[0].isalnum():
                     raise ValueError(f"invalid subdivision vertex label: {label}")
+        _require_subdivision_replay(
+            source_complex=self.complex,
+            original_vertices=self.original_vertices,
+            subdivision_vertices=self.subdivision_vertices,
+            subdivision_vertex_faces=self.subdivision_vertex_faces,
+            num_new_vertices=self.num_new_vertices,
+            subdivision_facets=self.subdivision_facets,
+        )
         return self
 
 
@@ -1324,7 +1519,10 @@ class ShellingCheckRequest(StrictModel):
     """Check a submitted shelling order of a pure complex."""
 
     complex: SimplicialComplexRequest
-    facet_order: tuple[int, ...] = Field(min_length=1)
+    facet_order: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_FACETS,
+    )
 
     @model_validator(mode="after")
     def require_valid_order(self) -> Self:
@@ -1337,7 +1535,10 @@ class ShellingCheckResult(TopologyExactResult):
     """Result of checking a shelling order, bound to its checked source."""
 
     complex: SimplicialComplexRequest
-    facet_order: tuple[int, ...] = Field(min_length=1)
+    facet_order: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_FACETS,
+    )
     is_shelling: bool
     failed_at: int | None = None
     failure_reason: str | None = None
@@ -1376,8 +1577,17 @@ class ElementaryCollapseRequest(StrictModel):
     """Check and perform one elementary collapse step (free face must be codimension-one)."""
 
     complex: SimplicialComplexRequest
-    free_face: tuple[VertexLabel, ...] = Field(min_length=1)
-    coface: tuple[VertexLabel, ...] = Field(min_length=2)
+    # A coface is a facet, so it carries at most MAX_TOPOLOGY_DIMENSION + 1
+    # vertices; capping the candidate tuples keeps accepted request work tied
+    # to the complex's bounds even when labels are not vertices at all.
+    free_face: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION,
+    )
+    coface: tuple[VertexLabel, ...] = Field(
+        min_length=2,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
 
     @model_validator(mode="after")
     def require_valid_collapse(self) -> Self:
@@ -1452,8 +1662,8 @@ class ElementaryCollapseResult(TopologyExactResult):
 
     complex: SimplicialComplexRequest
     is_free_face: bool
-    free_face: tuple[str, ...]
-    coface: tuple[str, ...]
+    free_face: tuple[str, ...] = Field(max_length=MAX_TOPOLOGY_DIMENSION)
+    coface: tuple[str, ...] = Field(max_length=MAX_TOPOLOGY_DIMENSION + 1)
     remaining_facets: tuple[tuple[str, ...], ...]
     remaining_vertices: tuple[str, ...]
     remaining_complex: FiniteSimplicialComplex | None = None

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -1856,8 +1856,17 @@ class ElementaryCollapseResult(TopologyExactResult):
                 raise ValueError(
                     "is_free_face does not match the retained source complex"
                 )
-            expected_facets = self.complex.facets
-            expected_vertices = self.complex.vertices
+            # The kernel echoes a rejected collapse in canonical vertex order
+            # (each facet sorted, vertices from the facet union), so the
+            # expected artifacts must be canonicalized the same way before
+            # comparison; raw source order would make the operation reject
+            # its own typed result for a noncanonical presentation.
+            expected_facets = tuple(
+                tuple(sorted(facet)) for facet in self.complex.facets
+            )
+            expected_vertices = tuple(
+                sorted({vertex for facet in self.complex.facets for vertex in facet})
+            )
         else:
             if not self.is_free_face:
                 raise ValueError(

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -12,6 +12,7 @@ from pydantic import (
     Field,
     StrictInt,
     StringConstraints,
+    ValidationError,
     ValidationInfo,
     field_validator,
     model_validator,
@@ -350,9 +351,7 @@ def _require_subdivision_replay(
         tuple(subdivision_facets) != expected
         or original_vertices != source_complex.vertices
     ):
-        raise ValueError(
-            "subdivision facets do not match the retained source complex"
-        )
+        raise ValueError("subdivision facets do not match the retained source complex")
 
 
 def _codim1_incidence(
@@ -477,19 +476,23 @@ class SimplicialComplexRequest(StrictModel):
                 "value, not both"
             )
         if "maximal_simplices" not in data:
-            if set(data) - {"vertices", "facets"}:
-                return data
             return data
         unknown = sorted(set(data) - _CANONICAL_COMPLEX_DUMP_KEYS)
         if unknown:
-            raise ValueError(
-                f"unknown fields alongside maximal_simplices: {unknown}"
-            )
+            raise ValueError(f"unknown fields alongside maximal_simplices: {unknown}")
         if "vertices" not in data:
             raise ValueError("canonical complex value must carry vertices")
+        try:
+            canonical = FiniteSimplicialComplex.model_validate(data)
+        except ValidationError as error:
+            raise ValueError(
+                "canonical complex value must be a valid "
+                f"FiniteSimplicialComplex dump: {error.error_count()} "
+                "check(s) failed"
+            ) from error
         return {
-            "vertices": data["vertices"],
-            "facets": data["maximal_simplices"],
+            "vertices": list(canonical.vertices),
+            "facets": [list(facet) for facet in canonical.maximal_simplices],
         }
 
     @model_validator(mode="after")
@@ -1218,20 +1221,41 @@ class StarRequest(StrictModel):
 
 
 class StarResult(TopologyExactResult):
-    """The closed star of a simplex: all facets containing sigma."""
+    """The closed star of a simplex, bound to its source complex."""
 
+    complex: SimplicialComplexRequest
     simplex: tuple[str, ...]
     star_facets: tuple[tuple[str, ...], ...]
     star_is_empty: bool
     star_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
-    def require_star_canonical(self) -> Self:
+    def require_star_binding(self) -> Self:
+        target = frozenset(self.simplex)
+        if len(target) != len(self.simplex):
+            raise ValueError("star simplex vertices must be distinct")
+        # Replay the star relation over the retained source so an authored
+        # simplex or facet list cannot validate independently of it.
+        if not any(target.issubset(frozenset(facet)) for facet in self.complex.facets):
+            raise ValueError("simplex must be a face of the retained complex")
+        expected_facets = tuple(
+            tuple(sorted(facet))
+            for facet in sorted(
+                (
+                    frozenset(facet)
+                    for facet in self.complex.facets
+                    if target.issubset(facet)
+                ),
+                key=lambda value: (-len(value), sorted(value)),
+            )
+        )
+        if self.star_is_empty != (not expected_facets):
+            raise ValueError("star_is_empty does not match the source replay")
+        if tuple(self.star_facets) != expected_facets:
+            raise ValueError("star_facets do not match the source-complex replay")
         if self.star_is_empty:
             if self.star_complex is not None:
                 raise ValueError("empty star must have no complex")
-            if self.star_facets:
-                raise ValueError("empty star must have no facets")
         else:
             if self.star_complex is None:
                 raise ValueError("non-empty star requires star_complex")
@@ -1264,39 +1288,36 @@ class VertexDeletionRequest(StrictModel):
             raise ValueError("vertices_to_delete must be distinct")
         if not vtd.issubset(set(self.complex.vertices)):
             raise ValueError("vertices_to_delete must be in the complex")
+        # The canonical complex value cannot represent the empty complex, so
+        # a deletion whose induced subcomplex would be empty is out of
+        # contract and must be rejected at the boundary.
+        if all(frozenset(facet).issubset(vtd) for facet in self.complex.facets):
+            raise ValueError(
+                "deletion must leave at least one simplex on the remaining vertices"
+            )
         return self
 
 
 class VertexDeletionResult(TopologyExactResult):
-    """The complex after deleting a vertex subset."""
+    """The induced subcomplex after deleting a vertex subset."""
 
     deleted_vertices: tuple[str, ...]
     remaining_vertices: tuple[str, ...]
     remaining_facets: tuple[tuple[str, ...], ...]
-    remaining_complex: FiniteSimplicialComplex | None = None
+    remaining_complex: FiniteSimplicialComplex
 
     @model_validator(mode="after")
     def require_deletion_canonical(self) -> Self:
-        if not self.remaining_facets:
-            if self.remaining_complex is not None:
-                raise ValueError("empty deletion must have no remaining_complex")
-            if self.remaining_vertices:
-                raise ValueError("empty deletion must have no remaining_vertices")
-        else:
-            if self.remaining_complex is None:
-                raise ValueError("non-empty deletion requires remaining_complex")
-            if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
-                sorted(tuple(sorted(f)) for f in self.remaining_facets)
-            ):
-                raise ValueError(
-                    "remaining_complex maximal simplices must match remaining_facets"
-                )
-            if tuple(sorted(self.remaining_complex.vertices)) != tuple(
-                sorted(self.remaining_vertices)
-            ):
-                raise ValueError(
-                    "remaining_complex vertices must match remaining_vertices"
-                )
+        if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
+            sorted(tuple(sorted(f)) for f in self.remaining_facets)
+        ):
+            raise ValueError(
+                "remaining_complex maximal simplices must match remaining_facets"
+            )
+        if tuple(sorted(self.remaining_complex.vertices)) != tuple(
+            sorted(self.remaining_vertices)
+        ):
+            raise ValueError("remaining_complex vertices must match remaining_vertices")
         return self
 
 
@@ -1502,8 +1523,11 @@ class PseudomanifoldResult(TopologyExactResult):
         if not expected.is_pseudomanifold:
             if self.is_closed:
                 raise ValueError("non-pseudomanifold cannot be closed")
-            if self.obstruction is None:
-                raise ValueError("non-pseudomanifold must have obstruction")
+            if self.obstruction != expected.obstruction:
+                raise ValueError(
+                    f"obstruction {self.obstruction!r} does not match replayed "
+                    f"{expected.obstruction!r}"
+                )
             return self
         if self.is_closed != expected.is_closed:
             raise ValueError("is_closed must match codim-1 incidence")

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -1293,12 +1293,22 @@ class StarResult(TopologyExactResult):
 
 
 class VertexDeletionRequest(StrictModel):
-    """Delete a vertex subset from a simplicial complex."""
+    """Delete a vertex subset from a simplicial complex.
+
+    The deletion must leave at least one simplex on the remaining vertices;
+    deleting every vertex is rejected because the empty complex has no
+    canonical value.
+    """
 
     complex: SimplicialComplexRequest
     vertices_to_delete: tuple[VertexLabel, ...] = Field(
         min_length=1,
         max_length=MAX_TOPOLOGY_VERTICES,
+        description=(
+            "Vertex subset to remove. The deletion must leave at least one "
+            "simplex on the remaining vertices: deleting every vertex is "
+            "rejected because the empty complex has no canonical value."
+        ),
     )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -1241,7 +1241,10 @@ class StarResult(TopologyExactResult):
     """The closed star of a simplex, bound to its source complex."""
 
     complex: SimplicialComplexRequest
-    simplex: tuple[str, ...]
+    simplex: tuple[str, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
     star_facets: tuple[tuple[str, ...], ...]
     star_is_empty: bool
     star_complex: FiniteSimplicialComplex | None = None
@@ -1319,7 +1322,10 @@ class VertexDeletionResult(TopologyExactResult):
     """The induced subcomplex after deleting a vertex subset."""
 
     complex: SimplicialComplexRequest
-    deleted_vertices: tuple[VertexLabel, ...]
+    deleted_vertices: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_VERTICES,
+    )
     remaining_vertices: tuple[str, ...]
     remaining_facets: tuple[tuple[str, ...], ...]
     remaining_complex: FiniteSimplicialComplex
@@ -1564,6 +1570,11 @@ class BarycentricSubdivisionResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_subdivision_canonical(self) -> Self:
+        # Replay must satisfy the subdivision request's work admission, so a
+        # serialized result cannot bypass the bounded source domain (a source
+        # whose exact subdivision exceeds the result contract is impossible
+        # to obtain from the operation).
+        BarycentricSubdivisionRequest(complex=self.complex)
         # The advertised original dimension must equal the dimension derived
         # from the retained source complex's facets.
         source_dimension = max(len(facet) for facet in self.complex.facets) - 1

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -463,13 +463,28 @@ class SimplicialComplexRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def accept_canonical_complex_value(cls, data: object) -> object:
+        # A before-validator switches the remaining validation to python
+        # semantics, where strict tuples reject JSON arrays; normalize the
+        # accepted array shapes to tuples so strict JSON dispatch (the only
+        # transport path) keeps admitting facet presentations.
         if isinstance(data, FiniteSimplicialComplex):
             return {
-                "vertices": list(data.vertices),
-                "facets": [list(facet) for facet in data.maximal_simplices],
+                "vertices": tuple(data.vertices),
+                "facets": tuple(tuple(facet) for facet in data.maximal_simplices),
             }
         if not isinstance(data, dict):
             return data
+        normalized = dict(data)
+        vertices = normalized.get("vertices")
+        if isinstance(vertices, list):
+            normalized["vertices"] = tuple(vertices)
+        facets = normalized.get("facets")
+        if isinstance(facets, list):
+            normalized["facets"] = tuple(
+                tuple(facet) if isinstance(facet, list) else facet
+                for facet in facets
+            )
+        data = normalized
         if "facets" in data and "maximal_simplices" in data:
             raise ValueError(
                 "pass either facets or a canonical FiniteSimplicialComplex "
@@ -491,8 +506,10 @@ class SimplicialComplexRequest(StrictModel):
                 "check(s) failed"
             ) from error
         return {
-            "vertices": list(canonical.vertices),
-            "facets": [list(facet) for facet in canonical.maximal_simplices],
+            "vertices": tuple(canonical.vertices),
+            "facets": tuple(
+                tuple(facet) for facet in canonical.maximal_simplices
+            ),
         }
 
     @model_validator(mode="after")
@@ -1301,13 +1318,43 @@ class VertexDeletionRequest(StrictModel):
 class VertexDeletionResult(TopologyExactResult):
     """The induced subcomplex after deleting a vertex subset."""
 
-    deleted_vertices: tuple[str, ...]
+    complex: SimplicialComplexRequest
+    deleted_vertices: tuple[VertexLabel, ...]
     remaining_vertices: tuple[str, ...]
     remaining_facets: tuple[tuple[str, ...], ...]
     remaining_complex: FiniteSimplicialComplex
 
     @model_validator(mode="after")
     def require_deletion_canonical(self) -> Self:
+        # Replay the induced-subcomplex relation against the retained source
+        # so a serialized result cannot validate independently of it.
+        deleted = set(self.deleted_vertices)
+        if len(deleted) != len(self.deleted_vertices):
+            raise ValueError("deleted_vertices must be distinct")
+        if not deleted.issubset(set(self.complex.vertices)):
+            raise ValueError("deleted_vertices must be in the retained complex")
+        if tuple(self.deleted_vertices) != tuple(sorted(self.deleted_vertices)):
+            raise ValueError("deleted_vertices must use canonical vertex order")
+        remaining_faces = [
+            face
+            for face in _all_nonempty_faces(
+                tuple(tuple(sorted(f)) for f in self.complex.facets)
+            )
+            if not (set(face) & deleted)
+        ]
+        expected_facets = _maximal_faces(remaining_faces)
+        expected_vertices = tuple(
+            sorted({v for facet in expected_facets for v in facet})
+        )
+        if tuple(self.remaining_facets) != expected_facets:
+            raise ValueError(
+                "remaining_facets must be the induced subcomplex of the "
+                "retained source complex"
+            )
+        if tuple(self.remaining_vertices) != expected_vertices:
+            raise ValueError(
+                "remaining_vertices must match the source-complex replay"
+            )
         if tuple(sorted(self.remaining_complex.maximal_simplices)) != tuple(
             sorted(tuple(sorted(f)) for f in self.remaining_facets)
         ):
@@ -1341,15 +1388,30 @@ class SkeletonRequest(StrictModel):
 
 
 class SkeletonResult(TopologyExactResult):
-    """The k-skeleton as a facet list."""
+    """The k-skeleton as a facet list, bound to its source complex."""
 
-    k: int
+    complex: SimplicialComplexRequest
+    k: StrictInt = Field(ge=0, le=MAX_TOPOLOGY_DIMENSION)
     skeleton_facets: tuple[tuple[str, ...], ...]
     skeleton_vertices: tuple[str, ...]
     skeleton_complex: FiniteSimplicialComplex | None = None
 
     @model_validator(mode="after")
     def require_skeleton_canonical(self) -> Self:
+        # Replay the exact k-skeleton against the retained source so the
+        # returned complex cannot disagree with k (e.g. an edge in a
+        # 0-skeleton) or with the source itself.
+        expected_facets = _skeleton_maximal_facets(self.complex.facets, self.k)
+        if tuple(self.skeleton_facets) != expected_facets:
+            raise ValueError(
+                "skeleton_facets must be the exact k-skeleton of the "
+                "retained source complex"
+            )
+        expected_vertices = tuple(
+            sorted({v for facet in expected_facets for v in facet})
+        )
+        if tuple(self.skeleton_vertices) != expected_vertices:
+            raise ValueError("skeleton_vertices must match the k-skeleton replay")
         if not self.skeleton_facets:
             if self.skeleton_complex is not None:
                 raise ValueError("empty skeleton must have no complex")
@@ -1393,9 +1455,36 @@ class JoinRequest(StrictModel):
         return self
 
 
-class JoinResult(TopologyExactResult):
-    """The join of two complexes."""
+def _require_complex_matches_facets(
+    complex_value: FiniteSimplicialComplex | None,
+    *,
+    facets: tuple[tuple[str, ...], ...],
+    vertices: tuple[str, ...],
+    empty_message: str,
+    missing_message: str,
+    facets_message: str,
+    vertices_message: str,
+) -> None:
+    """Require an optional canonical complex value to restate a facet list."""
+    if not facets:
+        if complex_value is not None:
+            raise ValueError(empty_message)
+        return
+    if complex_value is None:
+        raise ValueError(missing_message)
+    if tuple(sorted(complex_value.maximal_simplices)) != tuple(
+        sorted(tuple(sorted(f)) for f in facets)
+    ):
+        raise ValueError(facets_message)
+    if tuple(sorted(complex_value.vertices)) != tuple(sorted(vertices)):
+        raise ValueError(vertices_message)
 
+
+class JoinResult(TopologyExactResult):
+    """The join of two complexes, bound to both operands."""
+
+    complex_a: SimplicialComplexRequest
+    complex_b: SimplicialComplexRequest
     join_vertices: tuple[str, ...]
     join_facets: tuple[tuple[str, ...], ...]
     join_dimension: int
@@ -1403,24 +1492,42 @@ class JoinResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_join_canonical(self) -> Self:
-        if not self.join_facets:
-            if self.join_complex is not None:
-                raise ValueError("empty join must have no complex")
-        else:
-            if self.join_complex is None:
-                raise ValueError("non-empty join requires join_complex")
-            if tuple(sorted(self.join_complex.maximal_simplices)) != tuple(
-                sorted(tuple(sorted(f)) for f in self.join_facets)
-            ):
-                raise ValueError(
-                    "join_complex maximal simplices must match join_facets"
-                )
-            if tuple(sorted(self.join_complex.vertices)) != tuple(
-                sorted(self.join_vertices)
-            ):
-                raise ValueError("join_complex vertices must match join_vertices")
-            if self.join_complex.dimension != self.join_dimension:
-                raise ValueError("join_complex dimension must match join_dimension")
+        # Replay the facet union against the retained operands so any
+        # internally canonical complex cannot pass as "the" join result.
+        vertices_a = set(self.complex_a.vertices)
+        vertices_b = set(self.complex_b.vertices)
+        if vertices_a & vertices_b:
+            raise ValueError("join operands must have disjoint vertex sets")
+        expected_facets = _join_maximal_facets(
+            self.complex_a.facets, self.complex_b.facets
+        )
+        if tuple(self.join_facets) != expected_facets:
+            raise ValueError(
+                "join_facets must be the exact facet union of the retained operands"
+            )
+        expected_vertices = tuple(sorted(vertices_a | vertices_b))
+        if tuple(self.join_vertices) != expected_vertices:
+            raise ValueError("join_vertices must match the operand vertex sets")
+        expected_dimension = (
+            max(len(facet) - 1 for facet in expected_facets)
+            if expected_facets
+            else 0
+        )
+        if self.join_dimension != expected_dimension:
+            raise ValueError("join_dimension must match the replayed facet union")
+        _require_complex_matches_facets(
+            self.join_complex,
+            facets=self.join_facets,
+            vertices=self.join_vertices,
+            empty_message="empty join must have no complex",
+            missing_message="non-empty join requires join_complex",
+            facets_message="join_complex maximal simplices must match join_facets",
+            vertices_message="join_complex vertices must match join_vertices",
+        )
+        if self.join_complex is not None and (
+            self.join_complex.dimension != self.join_dimension
+        ):
+            raise ValueError("join_complex dimension must match join_dimension")
         return self
 
 
@@ -1457,6 +1564,13 @@ class BarycentricSubdivisionResult(TopologyExactResult):
 
     @model_validator(mode="after")
     def require_subdivision_canonical(self) -> Self:
+        # The advertised original dimension must equal the dimension derived
+        # from the retained source complex's facets.
+        source_dimension = max(len(facet) for facet in self.complex.facets) - 1
+        if self.original_dimension != source_dimension:
+            raise ValueError(
+                "original_dimension must match the retained source complex"
+            )
         if not self.subdivision_facets:
             if self.subdivision_complex is not None:
                 raise ValueError("empty subdivision must have no complex")
@@ -1686,8 +1800,14 @@ class ElementaryCollapseResult(TopologyExactResult):
 
     complex: SimplicialComplexRequest
     is_free_face: bool
-    free_face: tuple[str, ...] = Field(max_length=MAX_TOPOLOGY_DIMENSION)
-    coface: tuple[str, ...] = Field(max_length=MAX_TOPOLOGY_DIMENSION + 1)
+    free_face: tuple[VertexLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TOPOLOGY_DIMENSION,
+    )
+    coface: tuple[VertexLabel, ...] = Field(
+        min_length=2,
+        max_length=MAX_TOPOLOGY_DIMENSION + 1,
+    )
     remaining_facets: tuple[tuple[str, ...], ...]
     remaining_vertices: tuple[str, ...]
     remaining_complex: FiniteSimplicialComplex | None = None

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -807,25 +807,27 @@ def compute_star(request: StarRequest) -> StarResult:
             star_facets, key=lambda value: (-len(value), sorted(value))
         )
     )
+    is_empty = not ordered_facets
+    star_complex = None
+    if not is_empty:
+        star_vertices = tuple(sorted({v for facet in ordered_facets for v in facet}))
+        star_complex = _canonical_complex(star_vertices, ordered_facets)
     return StarResult(
         simplex=request.simplex,
         star_facets=ordered_facets,
-        star_is_empty=not ordered_facets,
+        star_is_empty=is_empty,
+        star_complex=star_complex,
     )
 
 
 def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionResult:
     """Compute the induced subcomplex after deleting a vertex subset."""
     to_delete = set(request.vertices_to_delete)
-    # The deletion is the induced subcomplex on the remaining vertices.
-    # We need all faces of the original complex that do not contain
-    # any deleted vertex, then extract the maximal ones.
     all_faces_set = _all_faces(request.complex.facets)
     remaining_faces = {
         face for face in all_faces_set
         if not (set(face) & to_delete)
     }
-    # Extract maximal faces
     sorted_remaining = sorted(remaining_faces, key=lambda f: (-len(f), f))
     maximal_list: list[tuple[str, ...]] = []
     seen: set[frozenset[str]] = set()
@@ -834,13 +836,18 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
         if not any(existing.issuperset(face_set) for existing in seen):
             maximal_list.append(face)
             seen.add(face_set)
-    remaining_vertices = tuple(
-        v for v in request.complex.vertices if v not in to_delete
-    )
+    remaining_facets = tuple(maximal_list)
+    if remaining_facets:
+        remaining_vertices = tuple(sorted({v for facet in remaining_facets for v in facet}))
+        remaining_complex = _canonical_complex(remaining_vertices, remaining_facets)
+    else:
+        remaining_vertices = ()
+        remaining_complex = None
     return VertexDeletionResult(
         deleted_vertices=tuple(sorted(to_delete)),
         remaining_vertices=remaining_vertices,
-        remaining_facets=tuple(maximal_list),
+        remaining_facets=remaining_facets,
+        remaining_complex=remaining_complex,
     )
 
 
@@ -848,11 +855,9 @@ def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
     """Compute the k-skeleton of a simplicial complex."""
     k = request.k
     all_faces_set = _all_faces(request.complex.facets)
-    # Filter to faces of dimension <= k
     skeleton_faces = {
         face for face in all_faces_set if len(face) <= k + 1
     }
-    # Extract maximal faces
     skeleton_list = sorted(skeleton_faces, key=lambda f: (-len(f), f))
     maximal: list[tuple[str, ...]] = []
     seen: set[frozenset[str]] = set()
@@ -861,14 +866,16 @@ def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
         if not any(existing.issuperset(face_set) for existing in seen):
             maximal.append(face)
             seen.add(face_set)
-    # Vertices that appear in the skeleton
-    skeleton_vertices = tuple(
-        sorted({v for face in maximal for v in face})
-    )
+    skeleton_facets = tuple(maximal)
+    skeleton_vertices = tuple(sorted({v for face in skeleton_facets for v in face}))
+    skeleton_complex = None
+    if skeleton_facets:
+        skeleton_complex = _canonical_complex(skeleton_vertices, skeleton_facets)
     return SkeletonResult(
         k=k,
-        skeleton_facets=tuple(maximal),
+        skeleton_facets=skeleton_facets,
         skeleton_vertices=skeleton_vertices,
+        skeleton_complex=skeleton_complex,
     )
 
 
@@ -882,7 +889,6 @@ def compute_join(request: JoinRequest) -> JoinResult:
         for fb in request.complex_b.facets:
             joined = tuple(sorted(set(fa) | set(fb)))
             join_facets.append(joined)
-    # Remove non-maximal
     sorted_join = sorted(join_facets, key=lambda f: (-len(f), f))
     maximal: list[tuple[str, ...]] = []
     seen: set[frozenset[str]] = set()
@@ -891,11 +897,17 @@ def compute_join(request: JoinRequest) -> JoinResult:
         if not any(existing.issuperset(face_set) for existing in seen):
             maximal.append(face)
             seen.add(face_set)
-    join_dim = max(len(f) - 1 for f in maximal) if maximal else 0
+    join_facets_tuple = tuple(maximal)
+    join_dim = max(len(f) - 1 for f in join_facets_tuple) if join_facets_tuple else 0
+    join_complex = None
+    if join_facets_tuple:
+        # join_vertices already sorted unique
+        join_complex = _canonical_complex(all_vertices, join_facets_tuple)
     return JoinResult(
         join_vertices=all_vertices,
-        join_facets=tuple(maximal),
+        join_facets=join_facets_tuple,
         join_dimension=join_dim,
+        join_complex=join_complex,
     )
 
 
@@ -904,41 +916,80 @@ def compute_barycentric_subdivision(
 ) -> BarycentricSubdivisionResult:
     """Compute the barycentric subdivision of a simplicial complex."""
     all_faces_set = _all_faces(request.complex.facets)
-    # Sort faces by size for deterministic vertex labeling
     sorted_faces = sorted(all_faces_set, key=lambda f: (len(f), f))
-    # New vertices are named by face content
-    new_vertices = [",".join(face) for face in sorted_faces]
-    vertex_map = {face: ",".join(face) for face in sorted_faces}
-    # Simplices in the subdivision are chains of strict inclusions
-    from itertools import combinations as _comb
-
-    all_face_list = list(sorted_faces)
-    subdivision_facets: list[tuple[str, ...]] = []
-    for r in range(1, len(all_face_list) + 1):
-        for chain in _comb(all_face_list, r):
-            # Check if chain is totally ordered by inclusion
-            chain_sets = [frozenset(f) for f in chain]
-            if all(
-                chain_sets[i] < chain_sets[i + 1] for i in range(len(chain_sets) - 1)
-            ):
-                subdivision_facets.append(
-                    tuple(sorted(vertex_map[f] for f in chain))
+    # Bounded injective encoding: use short valid labels "bv{i}" instead of
+    # comma-joined face content which violates VertexLabel.
+    new_vertices = [f"bv{i}" for i in range(len(sorted_faces))]
+    vertex_map = {face: new_vertices[idx] for idx, face in enumerate(sorted_faces)}
+    # Enumerate maximal chains via cover relation (efficient, not power set).
+    face_frozens = [frozenset(f) for f in sorted_faces]
+    n = len(sorted_faces)
+    # Compute cover relation: f covers g if f<g and no h with f<h<g
+    covers: list[list[int]] = [[] for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            if face_frozens[i] < face_frozens[j]:
+                has_intermediate = any(
+                    face_frozens[i] < face_frozens[k] < face_frozens[j]
+                    for k in range(n)
                 )
-    # Remove non-maximal
-    sorted_sub = sorted(subdivision_facets, key=lambda f: (-len(f), f))
-    maximal: list[tuple[str, ...]] = []
-    seen: set[frozenset[str]] = set()
-    for face in sorted_sub:
-        face_set = frozenset(face)
-        if not any(existing.issuperset(face_set) for existing in seen):
-            maximal.append(face)
-            seen.add(face_set)
+                if not has_intermediate:
+                    covers[i].append(j)
+    # Minimal faces have no proper subset
+    is_minimal = [True] * n
+    for i in range(n):
+        for j in range(n):
+            if face_frozens[j] < face_frozens[i]:
+                is_minimal[i] = False
+                break
+    minimal_indices = [i for i, v in enumerate(is_minimal) if v]
+    maximal_chains: list[list[int]] = []
+
+    def dfs(chain: list[int]) -> None:
+        last = chain[-1]
+        if not covers[last]:
+            maximal_chains.append(list(chain))
+            return
+        for nxt in covers[last]:
+            chain.append(nxt)
+            dfs(chain)
+            chain.pop()
+
+    for start in minimal_indices:
+        dfs([start])
+    # If no minimal (should not happen) fallback to each face as chain
+    if not maximal_chains and sorted_faces:
+        # Single-face complex
+        for i in range(n):
+            if not any(face_frozens[i] < face_frozens[j] for j in range(n)):
+                # maximal element
+                maximal_chains.append([i])
+
+    subdivision_facets = [
+        tuple(sorted(vertex_map[sorted_faces[idx]] for idx in chain))
+        for chain in maximal_chains
+    ]
+    # Ensure maximality (covers already guarantees, but keep dedup)
+    # Remove duplicates and sort deterministically
+    unique_facets = sorted(set(subdivision_facets), key=lambda f: (-len(f), f))
+    # No further filtering needed; they are maximal chains.
+    maximal = unique_facets
+    subdivision_vertex_faces = tuple(sorted_faces)
+    # Build canonical complex for subdivision
+    subdivision_complex = None
+    if maximal:
+        sub_vertices = tuple(sorted(new_vertices))
+        # maximal facets for complex must be sorted tuple of sorted vertices
+        canon_facets = tuple(sorted(tuple(sorted(f)) for f in maximal))
+        subdivision_complex = _canonical_complex(sub_vertices, canon_facets)
     return BarycentricSubdivisionResult(
         original_vertices=request.complex.vertices,
         original_dimension=max(len(f) - 1 for f in request.complex.facets),
         subdivision_vertices=tuple(new_vertices),
         subdivision_facets=tuple(maximal),
         num_new_vertices=len(new_vertices),
+        subdivision_complex=subdivision_complex,
+        subdivision_vertex_faces=subdivision_vertex_faces,
     )
 
 
@@ -952,6 +1003,7 @@ def compute_pseudomanifold_decision(
     # Purity: all facets must have the same dimension
     if not all(len(f) - 1 == dim for f in facets):
         return PseudomanifoldResult(
+            complex=request.complex,
             is_pseudomanifold=False,
             is_closed=False,
             dimension=dim,
@@ -962,6 +1014,7 @@ def compute_pseudomanifold_decision(
     # Each codimension-1 face must be in exactly 1 or 2 facets
     if dim < 1:
         return PseudomanifoldResult(
+            complex=request.complex,
             is_pseudomanifold=False,
             is_closed=False,
             dimension=dim,
@@ -978,6 +1031,7 @@ def compute_pseudomanifold_decision(
     for face, count in codim1_count.items():
         if count > 2:
             return PseudomanifoldResult(
+                complex=request.complex,
                 is_pseudomanifold=False,
                 is_closed=False,
                 dimension=dim,
@@ -987,6 +1041,7 @@ def compute_pseudomanifold_decision(
 
     is_closed = all(count == 2 for count in codim1_count.values())
     return PseudomanifoldResult(
+        complex=request.complex,
         is_pseudomanifold=True,
         is_closed=is_closed,
         dimension=dim,
@@ -1086,26 +1141,53 @@ def compute_elementary_collapse(
     free_face_set = frozenset(request.free_face)
     coface_set = frozenset(request.coface)
 
-    # Check that free_face is a face of the complex
     all_faces_set = _all_faces(request.complex.facets)
-    if tuple(sorted(request.free_face)) not in all_faces_set:
+    coface_tuple = tuple(sorted(request.coface))
+    free_tuple = tuple(sorted(request.free_face))
+
+    def _collapse_result(is_free: bool, facets, vertices) -> ElementaryCollapseResult:
+        # Helper to build result with canonical complex
+        if facets:
+            verts = tuple(sorted({v for f in facets for v in f}))
+            # vertices may include isolated? Use facets-derived vertices
+            remaining_complex = _canonical_complex(verts, facets)
+            rem_vertices = verts
+            rem_facets = facets
+        else:
+            remaining_complex = None
+            rem_vertices = ()
+            rem_facets = ()
+        # For is_free=False, the remaining should be original complex canonicalized
+        if not is_free:
+            # Ensure remaining facets/vertices are original (passed in)
+            # facets and vertices are already original
+            if facets:
+                remaining_complex = _canonical_complex(vertices, facets)
+                rem_vertices = vertices
+                rem_facets = facets
+            else:
+                remaining_complex = None
+                rem_vertices = ()
+                rem_facets = ()
         return ElementaryCollapseResult(
-            is_free_face=False,
-            free_face=tuple(sorted(request.free_face)),
-            coface=tuple(sorted(request.coface)),
-            remaining_facets=request.complex.facets,
-            remaining_vertices=request.complex.vertices,
+            is_free_face=is_free,
+            free_face=free_tuple,
+            coface=coface_tuple,
+            remaining_facets=rem_facets,
+            remaining_vertices=rem_vertices,
+            remaining_complex=remaining_complex,
+        )
+
+    # Check that free_face is a face of the complex
+    if free_tuple not in all_faces_set:
+        return _collapse_result(
+            False, request.complex.facets, request.complex.vertices
         )
 
     # Check that coface is a facet of the complex
-    coface_tuple = tuple(sorted(request.coface))
     if coface_tuple not in request.complex.facets:
-        return ElementaryCollapseResult(
-            is_free_face=False,
-            free_face=tuple(sorted(request.free_face)),
-            coface=coface_tuple,
-            remaining_facets=request.complex.facets,
-            remaining_vertices=request.complex.vertices,
+        return _collapse_result(
+            False, request.complex.facets, request.complex.vertices
         )
 
     # Check that free_face is a free face: it is contained in exactly one facet
@@ -1115,36 +1197,43 @@ def compute_elementary_collapse(
     ]
 
     if len(containing_facets) != 1:
-        return ElementaryCollapseResult(
-            is_free_face=False,
-            free_face=tuple(sorted(request.free_face)),
-            coface=coface_tuple,
-            remaining_facets=request.complex.facets,
-            remaining_vertices=request.complex.vertices,
+        return _collapse_result(
+            False, request.complex.facets, request.complex.vertices
         )
 
-    # Check that the containing facet is the coface
     if containing_facets[0] != coface_set:
-        return ElementaryCollapseResult(
-            is_free_face=False,
-            free_face=tuple(sorted(request.free_face)),
-            coface=coface_tuple,
-            remaining_facets=request.complex.facets,
-            remaining_vertices=request.complex.vertices,
+        return _collapse_result(
+            False, request.complex.facets, request.complex.vertices
         )
 
-    # Perform the collapse: remove the coface and free_face
-    remaining_facets = tuple(
-        f for f in request.complex.facets if frozenset(f) != coface_set
-    )
-    remaining_vertices = tuple(
-        v for v in request.complex.vertices
-    )
-
+    # Perform the collapse: remove all faces sigma with free_face <= sigma <= coface
+    # Remaining faces are those not in the interval [free_face, coface]
+    remaining_faces = {
+        face
+        for face in all_faces_set
+        if not (free_face_set.issubset(set(face)) and set(face).issubset(coface_set))
+    }
+    # Extract maximal facets from remaining faces
+    sorted_remaining = sorted(remaining_faces, key=lambda f: (-len(f), f))
+    maximal: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in sorted_remaining:
+        fs = frozenset(face)
+        if not any(existing.issuperset(fs) for existing in seen):
+            maximal.append(face)
+            seen.add(fs)
+    remaining_facets = tuple(maximal)
+    if remaining_facets:
+        remaining_vertices = tuple(sorted({v for f in remaining_facets for v in f}))
+        remaining_complex = _canonical_complex(remaining_vertices, remaining_facets)
+    else:
+        remaining_vertices = ()
+        remaining_complex = None
     return ElementaryCollapseResult(
         is_free_face=True,
-        free_face=tuple(sorted(request.free_face)),
+        free_face=free_tuple,
         coface=coface_tuple,
         remaining_facets=remaining_facets,
         remaining_vertices=remaining_vertices,
+        remaining_complex=remaining_complex,
     )

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -22,22 +22,10 @@ from jacobian.math.topology._models import (
     BarycentricSubdivisionResult,
     BoundarySquareLedgerEntry,
     ChainCoefficientRing,
-    ElementaryCollapseRequest,
-    ElementaryCollapseResult,
-    JoinRequest,
-    JoinResult,
-    PseudomanifoldRequest,
-    PseudomanifoldResult,
-    ShellingCheckRequest,
-    ShellingCheckResult,
-    SkeletonRequest,
-    SkeletonResult,
-    StarRequest,
-    StarResult,
-    VertexDeletionRequest,
-    VertexDeletionResult,
     ChainComplexRequest,
     ChainComplexResult,
+    ElementaryCollapseRequest,
+    ElementaryCollapseResult,
     FacesInDimension,
     FiniteSimplicialComplex,
     FVectorRequest,
@@ -50,16 +38,29 @@ from jacobian.math.topology._models import (
     IntegralSimplicialHomologyResult,
     IntegralTorsionGenerator,
     IntegralVector,
+    JoinRequest,
+    JoinResult,
     LinkRequest,
     LinkResult,
     ModularVector,
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
+    ShellingCheckRequest,
+    ShellingCheckResult,
     SimplexBasis,
     SimplicialComplexCanonicalizationResult,
     SimplicialComplexRequest,
     SimplicialHomologyRequest,
     SimplicialHomologyResult,
+    SkeletonRequest,
+    SkeletonResult,
     SparseBoundaryMatrix,
     SparseMatrixEntry,
+    StarRequest,
+    StarResult,
+    VertexDeletionRequest,
+    VertexDeletionResult,
+    _evaluate_shelling,
     face_closure,
     simplicial_complex_digest,
 )
@@ -797,9 +798,7 @@ def compute_star(request: StarRequest) -> StarResult:
     """Compute the closed star of a simplex."""
     target = frozenset(request.simplex)
     star_facets = {
-        frozenset(facet)
-        for facet in request.complex.facets
-        if target.issubset(facet)
+        frozenset(facet) for facet in request.complex.facets if target.issubset(facet)
     }
     ordered_facets = tuple(
         tuple(sorted(simplex))
@@ -824,10 +823,7 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
     """Compute the induced subcomplex after deleting a vertex subset."""
     to_delete = set(request.vertices_to_delete)
     all_faces_set = _all_faces(request.complex.facets)
-    remaining_faces = {
-        face for face in all_faces_set
-        if not (set(face) & to_delete)
-    }
+    remaining_faces = {face for face in all_faces_set if not (set(face) & to_delete)}
     sorted_remaining = sorted(remaining_faces, key=lambda f: (-len(f), f))
     maximal_list: list[tuple[str, ...]] = []
     seen: set[frozenset[str]] = set()
@@ -838,7 +834,9 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
             seen.add(face_set)
     remaining_facets = tuple(maximal_list)
     if remaining_facets:
-        remaining_vertices = tuple(sorted({v for facet in remaining_facets for v in facet}))
+        remaining_vertices = tuple(
+            sorted({v for facet in remaining_facets for v in facet})
+        )
         remaining_complex = _canonical_complex(remaining_vertices, remaining_facets)
     else:
         remaining_vertices = ()
@@ -855,9 +853,7 @@ def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
     """Compute the k-skeleton of a simplicial complex."""
     k = request.k
     all_faces_set = _all_faces(request.complex.facets)
-    skeleton_faces = {
-        face for face in all_faces_set if len(face) <= k + 1
-    }
+    skeleton_faces = {face for face in all_faces_set if len(face) <= k + 1}
     skeleton_list = sorted(skeleton_faces, key=lambda f: (-len(f), f))
     maximal: list[tuple[str, ...]] = []
     seen: set[frozenset[str]] = set()
@@ -911,20 +907,11 @@ def compute_join(request: JoinRequest) -> JoinResult:
     )
 
 
-def compute_barycentric_subdivision(
-    request: BarycentricSubdivisionRequest,
-) -> BarycentricSubdivisionResult:
-    """Compute the barycentric subdivision of a simplicial complex."""
-    all_faces_set = _all_faces(request.complex.facets)
-    sorted_faces = sorted(all_faces_set, key=lambda f: (len(f), f))
-    # Bounded injective encoding: use short valid labels "bv{i}" instead of
-    # comma-joined face content which violates VertexLabel.
-    new_vertices = [f"bv{i}" for i in range(len(sorted_faces))]
-    vertex_map = {face: new_vertices[idx] for idx, face in enumerate(sorted_faces)}
-    # Enumerate maximal chains via cover relation (efficient, not power set).
-    face_frozens = [frozenset(f) for f in sorted_faces]
-    n = len(sorted_faces)
-    # Compute cover relation: f covers g if f<g and no h with f<h<g
+def _cover_relations(face_frozens: list[frozenset[str]]) -> list[list[int]]:
+    """Compute the cover relation of the face lattice: i covers j when
+    ``face_frozens[i] < face_frozens[j]`` with no strict intermediate."""
+
+    n = len(face_frozens)
     covers: list[list[int]] = [[] for _ in range(n)]
     for i in range(n):
         for j in range(n):
@@ -935,14 +922,26 @@ def compute_barycentric_subdivision(
                 )
                 if not has_intermediate:
                     covers[i].append(j)
-    # Minimal faces have no proper subset
-    is_minimal = [True] * n
-    for i in range(n):
-        for j in range(n):
+    return covers
+
+
+def _minimal_face_indices(face_frozens: list[frozenset[str]]) -> list[int]:
+    is_minimal = [True] * len(face_frozens)
+    for i in range(len(face_frozens)):
+        for j in range(len(face_frozens)):
             if face_frozens[j] < face_frozens[i]:
                 is_minimal[i] = False
                 break
-    minimal_indices = [i for i, v in enumerate(is_minimal) if v]
+    return [i for i, minimal in enumerate(is_minimal) if minimal]
+
+
+def _maximal_chains_from_covers(
+    covers: list[list[int]],
+    minimal_indices: list[int],
+    n: int,
+    sorted_faces: list[tuple[str, ...]],
+    face_frozens: list[frozenset[str]],
+) -> list[list[int]]:
     maximal_chains: list[list[int]] = []
 
     def dfs(chain: list[int]) -> None:
@@ -964,7 +963,27 @@ def compute_barycentric_subdivision(
             if not any(face_frozens[i] < face_frozens[j] for j in range(n)):
                 # maximal element
                 maximal_chains.append([i])
+    return maximal_chains
 
+
+def compute_barycentric_subdivision(
+    request: BarycentricSubdivisionRequest,
+) -> BarycentricSubdivisionResult:
+    """Compute the barycentric subdivision of a simplicial complex."""
+    all_faces_set = _all_faces(request.complex.facets)
+    sorted_faces = sorted(all_faces_set, key=lambda f: (len(f), f))
+    # Bounded injective encoding: use short valid labels "bv{i}" instead of
+    # comma-joined face content which violates VertexLabel.
+    new_vertices = [f"bv{i}" for i in range(len(sorted_faces))]
+    vertex_map = {face: new_vertices[idx] for idx, face in enumerate(sorted_faces)}
+    # Enumerate maximal chains via cover relation (efficient, not power set).
+    face_frozens = [frozenset(f) for f in sorted_faces]
+    n = len(sorted_faces)
+    covers = _cover_relations(face_frozens)
+    minimal_indices = _minimal_face_indices(face_frozens)
+    maximal_chains = _maximal_chains_from_covers(
+        covers, minimal_indices, n, sorted_faces, face_frozens
+    )
     subdivision_facets = [
         tuple(sorted(vertex_map[sorted_faces[idx]] for idx in chain))
         for chain in maximal_chains
@@ -1052,86 +1071,17 @@ def compute_pseudomanifold_decision(
 
 def compute_shelling_check(request: ShellingCheckRequest) -> ShellingCheckResult:
     """Check whether a submitted facet order is a valid shelling order."""
-    facets = request.complex.facets
-    order = request.facet_order
 
-    # Check purity (all facets same dimension)
-    dim = len(facets[0])
-    if not all(len(f) == dim for f in facets):
-        return ShellingCheckResult(
-            is_shelling=False,
-            failed_at=0,
-            failure_reason="complex is not pure",
-        )
-
-    for i, idx in enumerate(order):
-        facet_i = set(facets[idx])
-        if i == 0:
-            continue
-        # The intersection of F_i with the previously added facets
-        # must be a pure (dim-2)-dimensional subcomplex of the boundary of F_i
-        # i.e., every nonempty face of F_i ∩ (previous facets) that is not
-        # the whole F_i must be contained in some previous facet
-        # Standard shelling condition: for each j < i, the intersection
-        # of F_i with the union of previous facets is a nonempty union of
-        # proper faces of F_i
-        prev_facets = [set(facets[order[j]]) for j in range(i)]
-        intersection_i = facet_i.copy()
-        for pf in prev_facets:
-            intersection_i &= pf
-        # The intersection of F_i with all previous facets must be
-        # a union of proper faces (not the entire facet)
-        # Check: for every j < i, F_i ∩ F_j is a proper face of F_i
-        for j in range(i):
-            facet_j = set(facets[order[j]])
-            intersection = facet_i & facet_j
-            if intersection == facet_i:
-                # F_i is contained in F_j -- means duplicate
-                return ShellingCheckResult(
-                    is_shelling=False,
-                    failed_at=i,
-                    failure_reason=f"facet {idx} is contained in earlier facet",
-                )
-        # The intersection must be a pure subcomplex of the boundary of F_i
-        # For simplicity, check the standard condition: the restriction R(F)
-        # is nonempty for each new facet
-        # R(F_i) = {faces of F_i not in any previous facet}
-        # These must form a nonempty interval in the face lattice of F_i
-        faces_not_in_prev: set[tuple[str, ...]] = set()
-        all_faces_i = set()
-        n = len(facet_i)
-        for r in range(1, n + 1):
-            for subset in combinations(sorted(facet_i), r):
-                all_faces_i.add(tuple(sorted(subset)))
-        for face in all_faces_i:
-            face_set = set(face)
-            in_prev = any(
-                face_set.issubset(pf) for pf in prev_facets
-            )
-            if not in_prev:
-                faces_not_in_prev.add(face)
-        if not faces_not_in_prev:
-            return ShellingCheckResult(
-                is_shelling=False,
-                failed_at=i,
-                failure_reason=f"facet {idx} has no new faces",
-            )
-        # Check that these faces form a nonempty interval [min, F_i)
-        # i.e., there is a unique minimal face (no other face is a proper subset)
-        face_sets = {frozenset(f) for f in faces_not_in_prev}
-        min_faces = [
-            frozenset(f)
-            for f in faces_not_in_prev
-            if not any(other < frozenset(f) for other in face_sets if other != frozenset(f))
-        ]
-        if len(min_faces) != 1:
-            return ShellingCheckResult(
-                is_shelling=False,
-                failed_at=i,
-                failure_reason=f"facet {idx} restriction is not an interval",
-            )
-
-    return ShellingCheckResult(is_shelling=True)
+    is_shelling, failed_at, failure_reason = _evaluate_shelling(
+        request.complex.facets, request.facet_order
+    )
+    return ShellingCheckResult(
+        complex=request.complex,
+        facet_order=request.facet_order,
+        is_shelling=is_shelling,
+        failed_at=failed_at,
+        failure_reason=failure_reason,
+    )
 
 
 def compute_elementary_collapse(
@@ -1146,29 +1096,15 @@ def compute_elementary_collapse(
     free_tuple = tuple(sorted(request.free_face))
 
     def _collapse_result(is_free: bool, facets, vertices) -> ElementaryCollapseResult:
-        # Helper to build result with canonical complex
         if facets:
             verts = tuple(sorted({v for f in facets for v in f}))
-            # vertices may include isolated? Use facets-derived vertices
-            remaining_complex = _canonical_complex(verts, facets)
+            rem_facets = tuple(tuple(sorted(f)) for f in facets)
+            remaining_complex = _canonical_complex(verts, rem_facets)
             rem_vertices = verts
-            rem_facets = facets
         else:
             remaining_complex = None
             rem_vertices = ()
             rem_facets = ()
-        # For is_free=False, the remaining should be original complex canonicalized
-        if not is_free:
-            # Ensure remaining facets/vertices are original (passed in)
-            # facets and vertices are already original
-            if facets:
-                remaining_complex = _canonical_complex(vertices, facets)
-                rem_vertices = vertices
-                rem_facets = facets
-            else:
-                remaining_complex = None
-                rem_vertices = ()
-                rem_facets = ()
         return ElementaryCollapseResult(
             is_free_face=is_free,
             free_face=free_tuple,
@@ -1180,31 +1116,24 @@ def compute_elementary_collapse(
 
     # Check that free_face is a face of the complex
     if free_tuple not in all_faces_set:
-        return _collapse_result(
-            False, request.complex.facets, request.complex.vertices
-        )
+        return _collapse_result(False, request.complex.facets, request.complex.vertices)
 
     # Check that coface is a facet of the complex
     if coface_tuple not in request.complex.facets:
-        return _collapse_result(
-            False, request.complex.facets, request.complex.vertices
-        )
+        return _collapse_result(False, request.complex.facets, request.complex.vertices)
 
     # Check that free_face is a free face: it is contained in exactly one facet
     containing_facets = [
-        frozenset(f) for f in request.complex.facets
+        frozenset(f)
+        for f in request.complex.facets
         if free_face_set.issubset(frozenset(f))
     ]
 
     if len(containing_facets) != 1:
-        return _collapse_result(
-            False, request.complex.facets, request.complex.vertices
-        )
+        return _collapse_result(False, request.complex.facets, request.complex.vertices)
 
     if containing_facets[0] != coface_set:
-        return _collapse_result(
-            False, request.complex.facets, request.complex.vertices
-        )
+        return _collapse_result(False, request.complex.facets, request.complex.vertices)
 
     # Perform the collapse: remove all faces sigma with free_face <= sigma <= coface
     # Remaining faces are those not in the interval [free_face, coface]

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -60,7 +60,11 @@ from jacobian.math.topology._models import (
     StarResult,
     VertexDeletionRequest,
     VertexDeletionResult,
+    _all_faces,
+    _cover_relations,
     _evaluate_shelling,
+    _maximal_chains_from_covers,
+    _minimal_face_indices,
     face_closure,
     simplicial_complex_digest,
 )
@@ -783,17 +787,6 @@ def compute_link(request: LinkRequest) -> LinkResult:
 # ---------------------------------------------------------------------------
 
 
-def _all_faces(facets: tuple[tuple[str, ...], ...]) -> set[tuple[str, ...]]:
-    """Return the complete set of nonempty faces for a facet list."""
-    faces: set[tuple[str, ...]] = set()
-    for facet in facets:
-        n = len(facet)
-        for r in range(1, n + 1):
-            for subset in combinations(facet, r):
-                faces.add(tuple(sorted(subset)))
-    return faces
-
-
 def compute_star(request: StarRequest) -> StarResult:
     """Compute the closed star of a simplex."""
     target = frozenset(request.simplex)
@@ -907,65 +900,6 @@ def compute_join(request: JoinRequest) -> JoinResult:
     )
 
 
-def _cover_relations(face_frozens: list[frozenset[str]]) -> list[list[int]]:
-    """Compute the cover relation of the face lattice: i covers j when
-    ``face_frozens[i] < face_frozens[j]`` with no strict intermediate."""
-
-    n = len(face_frozens)
-    covers: list[list[int]] = [[] for _ in range(n)]
-    for i in range(n):
-        for j in range(n):
-            if face_frozens[i] < face_frozens[j]:
-                has_intermediate = any(
-                    face_frozens[i] < face_frozens[k] < face_frozens[j]
-                    for k in range(n)
-                )
-                if not has_intermediate:
-                    covers[i].append(j)
-    return covers
-
-
-def _minimal_face_indices(face_frozens: list[frozenset[str]]) -> list[int]:
-    is_minimal = [True] * len(face_frozens)
-    for i in range(len(face_frozens)):
-        for j in range(len(face_frozens)):
-            if face_frozens[j] < face_frozens[i]:
-                is_minimal[i] = False
-                break
-    return [i for i, minimal in enumerate(is_minimal) if minimal]
-
-
-def _maximal_chains_from_covers(
-    covers: list[list[int]],
-    minimal_indices: list[int],
-    n: int,
-    sorted_faces: list[tuple[str, ...]],
-    face_frozens: list[frozenset[str]],
-) -> list[list[int]]:
-    maximal_chains: list[list[int]] = []
-
-    def dfs(chain: list[int]) -> None:
-        last = chain[-1]
-        if not covers[last]:
-            maximal_chains.append(list(chain))
-            return
-        for nxt in covers[last]:
-            chain.append(nxt)
-            dfs(chain)
-            chain.pop()
-
-    for start in minimal_indices:
-        dfs([start])
-    # If no minimal (should not happen) fallback to each face as chain
-    if not maximal_chains and sorted_faces:
-        # Single-face complex
-        for i in range(n):
-            if not any(face_frozens[i] < face_frozens[j] for j in range(n)):
-                # maximal element
-                maximal_chains.append([i])
-    return maximal_chains
-
-
 def compute_barycentric_subdivision(
     request: BarycentricSubdivisionRequest,
 ) -> BarycentricSubdivisionResult:
@@ -1007,6 +941,7 @@ def compute_barycentric_subdivision(
         subdivision_vertices=tuple(new_vertices),
         subdivision_facets=tuple(maximal),
         num_new_vertices=len(new_vertices),
+        complex=request.complex,
         subdivision_complex=subdivision_complex,
         subdivision_vertex_faces=subdivision_vertex_faces,
     )

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from itertools import combinations
 
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
@@ -17,8 +18,24 @@ from jacobian.math.matrices.certified_snf.operations import (
 )
 from jacobian.math.matrices.certified_snf.values import CertifiedIntegerMatrix
 from jacobian.math.topology._models import (
+    BarycentricSubdivisionRequest,
+    BarycentricSubdivisionResult,
     BoundarySquareLedgerEntry,
     ChainCoefficientRing,
+    ElementaryCollapseRequest,
+    ElementaryCollapseResult,
+    JoinRequest,
+    JoinResult,
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
+    ShellingCheckRequest,
+    ShellingCheckResult,
+    SkeletonRequest,
+    SkeletonResult,
+    StarRequest,
+    StarResult,
+    VertexDeletionRequest,
+    VertexDeletionResult,
     ChainComplexRequest,
     ChainComplexResult,
     FacesInDimension,
@@ -757,4 +774,377 @@ def compute_link(request: LinkRequest) -> LinkResult:
         simplex=request.simplex,
         link_facets=ordered_facets,
         link_is_empty=not ordered_facets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural simplicial operations (#1850)
+# ---------------------------------------------------------------------------
+
+
+def _all_faces(facets: tuple[tuple[str, ...], ...]) -> set[tuple[str, ...]]:
+    """Return the complete set of nonempty faces for a facet list."""
+    faces: set[tuple[str, ...]] = set()
+    for facet in facets:
+        n = len(facet)
+        for r in range(1, n + 1):
+            for subset in combinations(facet, r):
+                faces.add(tuple(sorted(subset)))
+    return faces
+
+
+def compute_star(request: StarRequest) -> StarResult:
+    """Compute the closed star of a simplex."""
+    target = frozenset(request.simplex)
+    star_facets = {
+        frozenset(facet)
+        for facet in request.complex.facets
+        if target.issubset(facet)
+    }
+    ordered_facets = tuple(
+        tuple(sorted(simplex))
+        for simplex in sorted(
+            star_facets, key=lambda value: (-len(value), sorted(value))
+        )
+    )
+    return StarResult(
+        simplex=request.simplex,
+        star_facets=ordered_facets,
+        star_is_empty=not ordered_facets,
+    )
+
+
+def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionResult:
+    """Compute the induced subcomplex after deleting a vertex subset."""
+    to_delete = set(request.vertices_to_delete)
+    # The deletion is the induced subcomplex on the remaining vertices.
+    # We need all faces of the original complex that do not contain
+    # any deleted vertex, then extract the maximal ones.
+    all_faces_set = _all_faces(request.complex.facets)
+    remaining_faces = {
+        face for face in all_faces_set
+        if not (set(face) & to_delete)
+    }
+    # Extract maximal faces
+    sorted_remaining = sorted(remaining_faces, key=lambda f: (-len(f), f))
+    maximal_list: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in sorted_remaining:
+        face_set = frozenset(face)
+        if not any(existing.issuperset(face_set) for existing in seen):
+            maximal_list.append(face)
+            seen.add(face_set)
+    remaining_vertices = tuple(
+        v for v in request.complex.vertices if v not in to_delete
+    )
+    return VertexDeletionResult(
+        deleted_vertices=tuple(sorted(to_delete)),
+        remaining_vertices=remaining_vertices,
+        remaining_facets=tuple(maximal_list),
+    )
+
+
+def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
+    """Compute the k-skeleton of a simplicial complex."""
+    k = request.k
+    all_faces_set = _all_faces(request.complex.facets)
+    # Filter to faces of dimension <= k
+    skeleton_faces = {
+        face for face in all_faces_set if len(face) <= k + 1
+    }
+    # Extract maximal faces
+    skeleton_list = sorted(skeleton_faces, key=lambda f: (-len(f), f))
+    maximal: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in skeleton_list:
+        face_set = frozenset(face)
+        if not any(existing.issuperset(face_set) for existing in seen):
+            maximal.append(face)
+            seen.add(face_set)
+    # Vertices that appear in the skeleton
+    skeleton_vertices = tuple(
+        sorted({v for face in maximal for v in face})
+    )
+    return SkeletonResult(
+        k=k,
+        skeleton_facets=tuple(maximal),
+        skeleton_vertices=skeleton_vertices,
+    )
+
+
+def compute_join(request: JoinRequest) -> JoinResult:
+    """Compute the join of two simplicial complexes."""
+    all_vertices = tuple(
+        sorted(set(request.complex_a.vertices) | set(request.complex_b.vertices))
+    )
+    join_facets: list[tuple[str, ...]] = []
+    for fa in request.complex_a.facets:
+        for fb in request.complex_b.facets:
+            joined = tuple(sorted(set(fa) | set(fb)))
+            join_facets.append(joined)
+    # Remove non-maximal
+    sorted_join = sorted(join_facets, key=lambda f: (-len(f), f))
+    maximal: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in sorted_join:
+        face_set = frozenset(face)
+        if not any(existing.issuperset(face_set) for existing in seen):
+            maximal.append(face)
+            seen.add(face_set)
+    join_dim = max(len(f) - 1 for f in maximal) if maximal else 0
+    return JoinResult(
+        join_vertices=all_vertices,
+        join_facets=tuple(maximal),
+        join_dimension=join_dim,
+    )
+
+
+def compute_barycentric_subdivision(
+    request: BarycentricSubdivisionRequest,
+) -> BarycentricSubdivisionResult:
+    """Compute the barycentric subdivision of a simplicial complex."""
+    all_faces_set = _all_faces(request.complex.facets)
+    # Sort faces by size for deterministic vertex labeling
+    sorted_faces = sorted(all_faces_set, key=lambda f: (len(f), f))
+    # New vertices are named by face content
+    new_vertices = [",".join(face) for face in sorted_faces]
+    vertex_map = {face: ",".join(face) for face in sorted_faces}
+    # Simplices in the subdivision are chains of strict inclusions
+    from itertools import combinations as _comb
+
+    all_face_list = list(sorted_faces)
+    subdivision_facets: list[tuple[str, ...]] = []
+    for r in range(1, len(all_face_list) + 1):
+        for chain in _comb(all_face_list, r):
+            # Check if chain is totally ordered by inclusion
+            chain_sets = [frozenset(f) for f in chain]
+            if all(
+                chain_sets[i] < chain_sets[i + 1] for i in range(len(chain_sets) - 1)
+            ):
+                subdivision_facets.append(
+                    tuple(sorted(vertex_map[f] for f in chain))
+                )
+    # Remove non-maximal
+    sorted_sub = sorted(subdivision_facets, key=lambda f: (-len(f), f))
+    maximal: list[tuple[str, ...]] = []
+    seen: set[frozenset[str]] = set()
+    for face in sorted_sub:
+        face_set = frozenset(face)
+        if not any(existing.issuperset(face_set) for existing in seen):
+            maximal.append(face)
+            seen.add(face_set)
+    return BarycentricSubdivisionResult(
+        original_vertices=request.complex.vertices,
+        original_dimension=max(len(f) - 1 for f in request.complex.facets),
+        subdivision_vertices=tuple(new_vertices),
+        subdivision_facets=tuple(maximal),
+        num_new_vertices=len(new_vertices),
+    )
+
+
+def compute_pseudomanifold_decision(
+    request: PseudomanifoldRequest,
+) -> PseudomanifoldResult:
+    """Decide whether a complex is a pseudomanifold."""
+    facets = [frozenset(f) for f in request.complex.facets]
+    dim = max(len(f) - 1 for f in facets) if facets else 0
+
+    # Purity: all facets must have the same dimension
+    if not all(len(f) - 1 == dim for f in facets):
+        return PseudomanifoldResult(
+            is_pseudomanifold=False,
+            is_closed=False,
+            dimension=dim,
+            num_facets=len(facets),
+            obstruction="not pure: facets have different dimensions",
+        )
+
+    # Each codimension-1 face must be in exactly 1 or 2 facets
+    if dim < 1:
+        return PseudomanifoldResult(
+            is_pseudomanifold=False,
+            is_closed=False,
+            dimension=dim,
+            num_facets=len(facets),
+            obstruction="dimension must be at least 1",
+        )
+
+    codim1_count: dict[frozenset[str], int] = {}
+    for facet in facets:
+        for face in combinations(sorted(facet), len(facet) - 1):
+            key = frozenset(face)
+            codim1_count[key] = codim1_count.get(key, 0) + 1
+
+    for face, count in codim1_count.items():
+        if count > 2:
+            return PseudomanifoldResult(
+                is_pseudomanifold=False,
+                is_closed=False,
+                dimension=dim,
+                num_facets=len(facets),
+                obstruction=f"codim-1 face {sorted(face)} is in {count} facets",
+            )
+
+    is_closed = all(count == 2 for count in codim1_count.values())
+    return PseudomanifoldResult(
+        is_pseudomanifold=True,
+        is_closed=is_closed,
+        dimension=dim,
+        num_facets=len(facets),
+        obstruction=None if is_closed else "pseudomanifold with boundary",
+    )
+
+
+def compute_shelling_check(request: ShellingCheckRequest) -> ShellingCheckResult:
+    """Check whether a submitted facet order is a valid shelling order."""
+    facets = request.complex.facets
+    order = request.facet_order
+
+    # Check purity (all facets same dimension)
+    dim = len(facets[0])
+    if not all(len(f) == dim for f in facets):
+        return ShellingCheckResult(
+            is_shelling=False,
+            failed_at=0,
+            failure_reason="complex is not pure",
+        )
+
+    for i, idx in enumerate(order):
+        facet_i = set(facets[idx])
+        if i == 0:
+            continue
+        # The intersection of F_i with the previously added facets
+        # must be a pure (dim-2)-dimensional subcomplex of the boundary of F_i
+        # i.e., every nonempty face of F_i ∩ (previous facets) that is not
+        # the whole F_i must be contained in some previous facet
+        # Standard shelling condition: for each j < i, the intersection
+        # of F_i with the union of previous facets is a nonempty union of
+        # proper faces of F_i
+        prev_facets = [set(facets[order[j]]) for j in range(i)]
+        intersection_i = facet_i.copy()
+        for pf in prev_facets:
+            intersection_i &= pf
+        # The intersection of F_i with all previous facets must be
+        # a union of proper faces (not the entire facet)
+        # Check: for every j < i, F_i ∩ F_j is a proper face of F_i
+        for j in range(i):
+            facet_j = set(facets[order[j]])
+            intersection = facet_i & facet_j
+            if intersection == facet_i:
+                # F_i is contained in F_j -- means duplicate
+                return ShellingCheckResult(
+                    is_shelling=False,
+                    failed_at=i,
+                    failure_reason=f"facet {idx} is contained in earlier facet",
+                )
+        # The intersection must be a pure subcomplex of the boundary of F_i
+        # For simplicity, check the standard condition: the restriction R(F)
+        # is nonempty for each new facet
+        # R(F_i) = {faces of F_i not in any previous facet}
+        # These must form a nonempty interval in the face lattice of F_i
+        faces_not_in_prev: set[tuple[str, ...]] = set()
+        all_faces_i = set()
+        n = len(facet_i)
+        for r in range(1, n + 1):
+            for subset in combinations(sorted(facet_i), r):
+                all_faces_i.add(tuple(sorted(subset)))
+        for face in all_faces_i:
+            face_set = set(face)
+            in_prev = any(
+                face_set.issubset(pf) for pf in prev_facets
+            )
+            if not in_prev:
+                faces_not_in_prev.add(face)
+        if not faces_not_in_prev:
+            return ShellingCheckResult(
+                is_shelling=False,
+                failed_at=i,
+                failure_reason=f"facet {idx} has no new faces",
+            )
+        # Check that these faces form a nonempty interval [min, F_i)
+        # i.e., there is a unique minimal face
+        face_sets = {frozenset(f) for f in faces_not_in_prev}
+        min_faces = [
+            frozenset(f)
+            for f in faces_not_in_prev
+            if not any(f != other and frozenset(f) < other for other in face_sets)
+        ]
+        if len(min_faces) != 1:
+            return ShellingCheckResult(
+                is_shelling=False,
+                failed_at=i,
+                failure_reason=f"facet {idx} restriction is not an interval",
+            )
+
+    return ShellingCheckResult(is_shelling=True)
+
+
+def compute_elementary_collapse(
+    request: ElementaryCollapseRequest,
+) -> ElementaryCollapseResult:
+    """Check and perform one elementary collapse step."""
+    free_face_set = frozenset(request.free_face)
+    coface_set = frozenset(request.coface)
+
+    # Check that free_face is a face of the complex
+    all_faces_set = _all_faces(request.complex.facets)
+    if tuple(sorted(request.free_face)) not in all_faces_set:
+        return ElementaryCollapseResult(
+            is_free_face=False,
+            free_face=tuple(sorted(request.free_face)),
+            coface=tuple(sorted(request.coface)),
+            remaining_facets=request.complex.facets,
+            remaining_vertices=request.complex.vertices,
+        )
+
+    # Check that coface is a facet of the complex
+    coface_tuple = tuple(sorted(request.coface))
+    if coface_tuple not in request.complex.facets:
+        return ElementaryCollapseResult(
+            is_free_face=False,
+            free_face=tuple(sorted(request.free_face)),
+            coface=coface_tuple,
+            remaining_facets=request.complex.facets,
+            remaining_vertices=request.complex.vertices,
+        )
+
+    # Check that free_face is a free face: it is contained in exactly one facet
+    containing_facets = [
+        frozenset(f) for f in request.complex.facets
+        if free_face_set.issubset(frozenset(f))
+    ]
+
+    if len(containing_facets) != 1:
+        return ElementaryCollapseResult(
+            is_free_face=False,
+            free_face=tuple(sorted(request.free_face)),
+            coface=coface_tuple,
+            remaining_facets=request.complex.facets,
+            remaining_vertices=request.complex.vertices,
+        )
+
+    # Check that the containing facet is the coface
+    if containing_facets[0] != coface_set:
+        return ElementaryCollapseResult(
+            is_free_face=False,
+            free_face=tuple(sorted(request.free_face)),
+            coface=coface_tuple,
+            remaining_facets=request.complex.facets,
+            remaining_vertices=request.complex.vertices,
+        )
+
+    # Perform the collapse: remove the coface and free_face
+    remaining_facets = tuple(
+        f for f in request.complex.facets if frozenset(f) != coface_set
+    )
+    remaining_vertices = tuple(
+        v for v in request.complex.vertices
+    )
+
+    return ElementaryCollapseResult(
+        is_free_face=True,
+        free_face=tuple(sorted(request.free_face)),
+        coface=coface_tuple,
+        remaining_facets=remaining_facets,
+        remaining_vertices=remaining_vertices,
     )

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -805,6 +805,7 @@ def compute_star(request: StarRequest) -> StarResult:
         star_vertices = tuple(sorted({v for facet in ordered_facets for v in facet}))
         star_complex = _canonical_complex(star_vertices, ordered_facets)
     return StarResult(
+        complex=request.complex,
         simplex=request.simplex,
         star_facets=ordered_facets,
         star_is_empty=is_empty,
@@ -826,19 +827,12 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
             maximal_list.append(face)
             seen.add(face_set)
     remaining_facets = tuple(maximal_list)
-    if remaining_facets:
-        remaining_vertices = tuple(
-            sorted({v for facet in remaining_facets for v in facet})
-        )
-        remaining_complex = _canonical_complex(remaining_vertices, remaining_facets)
-    else:
-        remaining_vertices = ()
-        remaining_complex = None
+    remaining_vertices = tuple(sorted({v for facet in remaining_facets for v in facet}))
     return VertexDeletionResult(
         deleted_vertices=tuple(sorted(to_delete)),
         remaining_vertices=remaining_vertices,
         remaining_facets=remaining_facets,
-        remaining_complex=remaining_complex,
+        remaining_complex=_canonical_complex(remaining_vertices, remaining_facets),
     )
 
 

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -1117,12 +1117,12 @@ def compute_shelling_check(request: ShellingCheckRequest) -> ShellingCheckResult
                 failure_reason=f"facet {idx} has no new faces",
             )
         # Check that these faces form a nonempty interval [min, F_i)
-        # i.e., there is a unique minimal face
+        # i.e., there is a unique minimal face (no other face is a proper subset)
         face_sets = {frozenset(f) for f in faces_not_in_prev}
         min_faces = [
             frozenset(f)
             for f in faces_not_in_prev
-            if not any(f != other and frozenset(f) < other for other in face_sets)
+            if not any(other < frozenset(f) for other in face_sets if other != frozenset(f))
         ]
         if len(min_faces) != 1:
             return ShellingCheckResult(

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -829,6 +829,7 @@ def compute_vertex_deletion(request: VertexDeletionRequest) -> VertexDeletionRes
     remaining_facets = tuple(maximal_list)
     remaining_vertices = tuple(sorted({v for facet in remaining_facets for v in facet}))
     return VertexDeletionResult(
+        complex=request.complex,
         deleted_vertices=tuple(sorted(to_delete)),
         remaining_vertices=remaining_vertices,
         remaining_facets=remaining_facets,
@@ -855,6 +856,7 @@ def compute_skeleton(request: SkeletonRequest) -> SkeletonResult:
     if skeleton_facets:
         skeleton_complex = _canonical_complex(skeleton_vertices, skeleton_facets)
     return SkeletonResult(
+        complex=request.complex,
         k=k,
         skeleton_facets=skeleton_facets,
         skeleton_vertices=skeleton_vertices,
@@ -887,6 +889,8 @@ def compute_join(request: JoinRequest) -> JoinResult:
         # join_vertices already sorted unique
         join_complex = _canonical_complex(all_vertices, join_facets_tuple)
     return JoinResult(
+        complex_a=request.complex_a,
+        complex_b=request.complex_b,
         join_vertices=all_vertices,
         join_facets=join_facets_tuple,
         join_dimension=join_dim,
@@ -1043,8 +1047,9 @@ def compute_elementary_collapse(
     if free_tuple not in all_faces_set:
         return _collapse_result(False, request.complex.facets)
 
-    # Check that coface is a facet of the complex
-    if coface_tuple not in request.complex.facets:
+    # Check that coface is a facet of the complex; simplices are vertex
+    # sets, so the comparison must not depend on stored label order.
+    if coface_set not in {frozenset(facet) for facet in request.complex.facets}:
         return _collapse_result(False, request.complex.facets)
 
     # Check that free_face is a free face: it is contained in exactly one facet

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -1030,24 +1030,16 @@ def compute_pseudomanifold_decision(
             obstruction="not pure: facets have different dimensions",
         )
 
-    # Each codimension-1 face must be in exactly 1 or 2 facets
-    if dim < 1:
-        return PseudomanifoldResult(
-            complex=request.complex,
-            is_pseudomanifold=False,
-            is_closed=False,
-            dimension=dim,
-            num_facets=len(facets),
-            obstruction="dimension must be at least 1",
-        )
-
+    # Each codimension-1 face must be in exactly 1 or 2 facets; for a
+    # dimension-zero complex that face is the empty face, contained once per
+    # vertex facet.
     codim1_count: dict[frozenset[str], int] = {}
     for facet in facets:
         for face in combinations(sorted(facet), len(facet) - 1):
             key = frozenset(face)
             codim1_count[key] = codim1_count.get(key, 0) + 1
 
-    for face, count in codim1_count.items():
+    for codim_face, count in codim1_count.items():
         if count > 2:
             return PseudomanifoldResult(
                 complex=request.complex,
@@ -1055,7 +1047,7 @@ def compute_pseudomanifold_decision(
                 is_closed=False,
                 dimension=dim,
                 num_facets=len(facets),
-                obstruction=f"codim-1 face {sorted(face)} is in {count} facets",
+                obstruction=f"codim-1 face {sorted(codim_face)} is in {count} facets",
             )
 
     is_closed = all(count == 2 for count in codim1_count.values())
@@ -1095,7 +1087,10 @@ def compute_elementary_collapse(
     coface_tuple = tuple(sorted(request.coface))
     free_tuple = tuple(sorted(request.free_face))
 
-    def _collapse_result(is_free: bool, facets, vertices) -> ElementaryCollapseResult:
+    def _collapse_result(
+        is_free: bool,
+        facets: tuple[tuple[str, ...], ...],
+    ) -> ElementaryCollapseResult:
         if facets:
             verts = tuple(sorted({v for f in facets for v in f}))
             rem_facets = tuple(tuple(sorted(f)) for f in facets)
@@ -1106,6 +1101,7 @@ def compute_elementary_collapse(
             rem_vertices = ()
             rem_facets = ()
         return ElementaryCollapseResult(
+            complex=request.complex,
             is_free_face=is_free,
             free_face=free_tuple,
             coface=coface_tuple,
@@ -1116,11 +1112,11 @@ def compute_elementary_collapse(
 
     # Check that free_face is a face of the complex
     if free_tuple not in all_faces_set:
-        return _collapse_result(False, request.complex.facets, request.complex.vertices)
+        return _collapse_result(False, request.complex.facets)
 
     # Check that coface is a facet of the complex
     if coface_tuple not in request.complex.facets:
-        return _collapse_result(False, request.complex.facets, request.complex.vertices)
+        return _collapse_result(False, request.complex.facets)
 
     # Check that free_face is a free face: it is contained in exactly one facet
     containing_facets = [
@@ -1130,10 +1126,10 @@ def compute_elementary_collapse(
     ]
 
     if len(containing_facets) != 1:
-        return _collapse_result(False, request.complex.facets, request.complex.vertices)
+        return _collapse_result(False, request.complex.facets)
 
     if containing_facets[0] != coface_set:
-        return _collapse_result(False, request.complex.facets, request.complex.vertices)
+        return _collapse_result(False, request.complex.facets)
 
     # Perform the collapse: remove all faces sigma with free_face <= sigma <= coface
     # Remaining faces are those not in the interval [free_face, coface]
@@ -1159,6 +1155,7 @@ def compute_elementary_collapse(
         remaining_vertices = ()
         remaining_complex = None
     return ElementaryCollapseResult(
+        complex=request.complex,
         is_free_face=True,
         free_face=free_tuple,
         coface=coface_tuple,

--- a/src/jacobian/math/topology/_tools.py
+++ b/src/jacobian/math/topology/_tools.py
@@ -3,18 +3,47 @@
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
 from jacobian.math.topology._models import (
+    BarycentricSubdivisionRequest,
+    BarycentricSubdivisionResult,
+    ElementaryCollapseRequest,
+    ElementaryCollapseResult,
     FVectorRequest,
     FVectorResult,
+    JoinRequest,
+    JoinResult,
     LinkRequest,
     LinkResult,
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
+    ShellingCheckRequest,
+    ShellingCheckResult,
+    SkeletonRequest,
+    SkeletonResult,
+    StarRequest,
+    StarResult,
+    VertexDeletionRequest,
+    VertexDeletionResult,
 )
 from jacobian.math.topology._operations import (
     TOPOLOGY_OPERATIONS,
+    compute_barycentric_subdivision,
+    compute_elementary_collapse,
     compute_f_vector,
+    compute_join,
     compute_link,
+    compute_pseudomanifold_decision,
+    compute_shelling_check,
+    compute_skeleton,
+    compute_star,
+    compute_vertex_deletion,
 )
 
 __all__ = ["TOOLS"]
+
+_CIRCLE = {
+    "vertices": ["a", "b", "c"],
+    "facets": [["a", "b"], ["b", "c"], ["a", "c"]],
+}
 
 _f_vector_tool = MathTool(
     operation_id="topology.simplicial_complex.f_vector.compute",
@@ -70,4 +99,231 @@ _link_tool = MathTool(
     ),
 )
 
-TOOLS: MathTools = (*TOPOLOGY_OPERATIONS, _f_vector_tool, _link_tool)
+_star_tool = MathTool(
+    operation_id="topology.simplicial_complex.star.compute",
+    version="1",
+    title="Compute the closed star of a simplex",
+    description=(
+        "Compute the closed star of a simplex sigma in a finite simplicial "
+        "complex: all facets of the complex that contain sigma."
+    ),
+    request_type=StarRequest,
+    result_type=StarResult,
+    run=compute_star,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "star_of_vertex_in_triangle",
+            "Compute the star of one vertex in a triangle.",
+            {
+                "complex": {
+                    "vertices": ["v0", "v1", "v2"],
+                    "facets": [["v0", "v1", "v2"]],
+                },
+                "simplex": ["v0"],
+            },
+        ),
+    ),
+)
+
+_vertex_deletion_tool = MathTool(
+    operation_id="topology.simplicial_complex.deletion.compute",
+    version="1",
+    title="Compute the deletion of a vertex subset",
+    description=(
+        "Delete a vertex subset from a finite simplicial complex: remove all "
+        "facets containing any deleted vertex and return the remaining facets."
+    ),
+    request_type=VertexDeletionRequest,
+    result_type=VertexDeletionResult,
+    run=compute_vertex_deletion,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "delete_vertex_from_triangle",
+            "Delete one vertex from a triangle, leaving an edge.",
+            {
+                "complex": {
+                    "vertices": ["v0", "v1", "v2"],
+                    "facets": [["v0", "v1", "v2"]],
+                },
+                "vertices_to_delete": ["v2"],
+            },
+        ),
+    ),
+)
+
+_skeleton_tool = MathTool(
+    operation_id="topology.simplicial_complex.skeleton.compute",
+    version="1",
+    title="Compute the k-skeleton of a simplicial complex",
+    description=(
+        "Compute the k-skeleton of a finite simplicial complex: the subcomplex "
+        "consisting of all faces of dimension at most k."
+    ),
+    request_type=SkeletonRequest,
+    result_type=SkeletonResult,
+    run=compute_skeleton,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "one_skeleton_of_triangle",
+            "Compute the 1-skeleton of a triangle (all edges).",
+            {
+                "complex": {
+                    "vertices": ["v0", "v1", "v2"],
+                    "facets": [["v0", "v1", "v2"]],
+                },
+                "k": 1,
+            },
+        ),
+    ),
+)
+
+_join_tool = MathTool(
+    operation_id="topology.simplicial_complex.join.compute",
+    version="1",
+    title="Compute the join of two simplicial complexes",
+    description=(
+        "Compute the join of two simplicial complexes on disjoint vertex sets: "
+        "the facets are unions of a facet from each complex."
+    ),
+    request_type=JoinRequest,
+    result_type=JoinResult,
+    run=compute_join,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "join_of_two_points",
+            "Join two single-vertex complexes (a point join a point is an edge).",
+            {
+                "complex_a": {
+                    "vertices": ["a"],
+                    "facets": [["a"]],
+                },
+                "complex_b": {
+                    "vertices": ["b"],
+                    "facets": [["b"]],
+                },
+            },
+        ),
+    ),
+)
+
+_barycentric_subdivision_tool = MathTool(
+    operation_id="topology.simplicial_complex.barycentric_subdivision.compute",
+    version="1",
+    title="Compute the barycentric subdivision of a simplicial complex",
+    description=(
+        "Compute the barycentric subdivision (order complex) of a finite "
+        "simplicial complex: new vertices are nonempty faces, new simplices "
+        "are strict face chains."
+    ),
+    request_type=BarycentricSubdivisionRequest,
+    result_type=BarycentricSubdivisionResult,
+    run=compute_barycentric_subdivision,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "barycentric_subdivision_of_edge",
+            "Subdivide an edge into two edges.",
+            {
+                "complex": {
+                    "vertices": ["a", "b"],
+                    "facets": [["a", "b"]],
+                },
+            },
+        ),
+    ),
+)
+
+_pseudomanifold_tool = MathTool(
+    operation_id="topology.simplicial_complex.pseudomanifold.decide",
+    version="1",
+    title="Decide whether a complex is a pseudomanifold",
+    description=(
+        "Decide whether a finite simplicial complex is a pseudomanifold: "
+        "pure, every codimension-1 face in exactly 1 or 2 facets. "
+        "Reports closed vs. with-boundary."
+    ),
+    request_type=PseudomanifoldRequest,
+    result_type=PseudomanifoldResult,
+    run=compute_pseudomanifold_decision,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "circle_is_pseudomanifold",
+            "Check that a triangle boundary is a closed pseudomanifold.",
+            {"complex": _CIRCLE},
+        ),
+    ),
+)
+
+_shelling_check_tool = MathTool(
+    operation_id="topology.simplicial_complex.shelling.check",
+    version="1",
+    title="Check a submitted shelling order",
+    description=(
+        "Check whether a submitted facet order is a valid shelling order "
+        "for a pure finite simplicial complex."
+    ),
+    request_type=ShellingCheckRequest,
+    result_type=ShellingCheckResult,
+    run=compute_shelling_check,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "valid_shelling_of_edge",
+            "Check a valid shelling of a single edge.",
+            {
+                "complex": {
+                    "vertices": ["a", "b"],
+                    "facets": [["a", "b"]],
+                },
+                "facet_order": [0],
+            },
+        ),
+    ),
+)
+
+_elementary_collapse_tool = MathTool(
+    operation_id="topology.simplicial_complex.elementary_collapse.check",
+    version="1",
+    title="Check and perform an elementary collapse",
+    description=(
+        "Verify that a free face is contained in exactly one coface facet, "
+        "then remove both the free face and the coface from the complex."
+    ),
+    request_type=ElementaryCollapseRequest,
+    result_type=ElementaryCollapseResult,
+    run=compute_elementary_collapse,
+    tags=("topology", "simplicial", "exact"),
+    examples=(
+        example(
+            "collapse_edge_endpoint",
+            "Collapse a free vertex from an edge (the vertex is free, the edge is the coface).",
+            {
+                "complex": {
+                    "vertices": ["a", "b"],
+                    "facets": [["a", "b"]],
+                },
+                "free_face": ["a"],
+                "coface": ["a", "b"],
+            },
+        ),
+    ),
+)
+
+TOOLS: MathTools = (
+    *TOPOLOGY_OPERATIONS,
+    _f_vector_tool,
+    _link_tool,
+    _star_tool,
+    _vertex_deletion_tool,
+    _skeleton_tool,
+    _join_tool,
+    _barycentric_subdivision_tool,
+    _pseudomanifold_tool,
+    _shelling_check_tool,
+    _elementary_collapse_tool,
+)

--- a/src/jacobian/math/topology/_tools.py
+++ b/src/jacobian/math/topology/_tools.py
@@ -131,8 +131,9 @@ _vertex_deletion_tool = MathTool(
     version="1",
     title="Compute the deletion of a vertex subset",
     description=(
-        "Delete a vertex subset from a finite simplicial complex: remove all "
-        "facets containing any deleted vertex and return the remaining facets."
+        "Delete a vertex subset from a finite simplicial complex and return "
+        "the induced subcomplex on the remaining vertices: every face "
+        "disjoint from the deleted set, given by its maximal facets."
     ),
     request_type=VertexDeletionRequest,
     result_type=VertexDeletionResult,

--- a/src/jacobian/math/topology/_tools.py
+++ b/src/jacobian/math/topology/_tools.py
@@ -133,7 +133,9 @@ _vertex_deletion_tool = MathTool(
     description=(
         "Delete a vertex subset from a finite simplicial complex and return "
         "the induced subcomplex on the remaining vertices: every face "
-        "disjoint from the deleted set, given by its maximal facets."
+        "disjoint from the deleted set, given by its maximal facets. The "
+        "deletion must leave at least one simplex on the remaining "
+        "vertices; deleting every vertex is out of contract."
     ),
     request_type=VertexDeletionRequest,
     result_type=VertexDeletionResult,
@@ -142,7 +144,8 @@ _vertex_deletion_tool = MathTool(
     examples=(
         example(
             "delete_vertex_from_triangle",
-            "Delete one vertex from a triangle, leaving an edge.",
+            "Delete one vertex from a triangle, leaving the opposite edge; "
+            "the deletion must leave at least one simplex.",
             {
                 "complex": {
                     "vertices": ["v0", "v1", "v2"],

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -9,6 +9,7 @@ from jacobian.math.topology._models import (
     JoinRequest,
     PseudomanifoldRequest,
     ShellingCheckRequest,
+    ShellingCheckResult,
     SkeletonRequest,
     StarRequest,
     VertexDeletionRequest,
@@ -135,9 +136,7 @@ class TestBarycentricSubdivision:
 
 class TestPseudomanifold:
     def test_circle_is_closed_pseudomanifold(self) -> None:
-        result = compute_pseudomanifold_decision(
-            PseudomanifoldRequest(complex=CIRCLE)
-        )
+        result = compute_pseudomanifold_decision(PseudomanifoldRequest(complex=CIRCLE))
         assert result.is_pseudomanifold
         assert result.is_closed
         assert result.dimension == 1
@@ -186,9 +185,7 @@ class TestShellingCheck:
 class TestElementaryCollapse:
     def test_collapse_free_vertex_from_edge(self) -> None:
         result = compute_elementary_collapse(
-            ElementaryCollapseRequest(
-                complex=EDGE, free_face=["a"], coface=["a", "b"]
-            )
+            ElementaryCollapseRequest(complex=EDGE, free_face=["a"], coface=["a", "b"])
         )
         assert result.is_free_face
         assert result.remaining_facets == (("b",),)
@@ -206,9 +203,131 @@ class TestElementaryCollapse:
         assert not result.is_free_face
 
     def test_coface_not_a_facet(self) -> None:
+        # ['a', 'c'] is codimension-one in shape but not a facet of EDGE
         result = compute_elementary_collapse(
-            ElementaryCollapseRequest(
-                complex=EDGE, free_face=["a"], coface=["a", "b", "c"]
-            )
+            ElementaryCollapseRequest(complex=EDGE, free_face=["a"], coface=["a", "c"])
         )
         assert not result.is_free_face
+
+    def test_repeated_vertices_in_collapse_faces_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="free_face vertices must be unique"):
+            ElementaryCollapseRequest(
+                complex=EDGE, free_face=["a", "a"], coface=["a", "a", "b"]
+            )
+        with pytest.raises(ValidationError, match="coface vertices must be unique"):
+            ElementaryCollapseRequest(
+                complex=EDGE, free_face=["a"], coface=["a", "b", "b"]
+            )
+
+
+class TestJoinBounds:
+    def test_join_of_two_4_simplices_rejected(self) -> None:
+        """Disjoint 4-simplices join to a 9-simplex (10-vertex facet)."""
+        complex_a = {
+            "vertices": ["a0", "a1", "a2", "a3", "a4"],
+            "facets": [["a0", "a1", "a2", "a3", "a4"]],
+        }
+        complex_b = {
+            "vertices": ["b0", "b1", "b2", "b3", "b4"],
+            "facets": [["b0", "b1", "b2", "b3", "b4"]],
+        }
+        with pytest.raises(ValidationError, match="between 1 and 8"):
+            JoinRequest(complex_a=complex_a, complex_b=complex_b)
+
+    def test_join_exceeding_face_closure_rejected(self) -> None:
+        """Two complexes whose join closure would exceed 2048 faces."""
+        # A 7-simplex has 255 faces; its join with another 7-simplex has
+        # 256*256-1 = 65535 faces, far beyond the closure bound.
+        simplex = ["v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7"]
+        complex_a = {"vertices": simplex, "facets": [simplex]}
+        complex_b = {
+            "vertices": ["w0", "w1", "w2", "w3", "w4", "w5", "w6", "w7"],
+            "facets": [["w0", "w1", "w2", "w3", "w4", "w5", "w6", "w7"]],
+        }
+        with pytest.raises(ValidationError):
+            JoinRequest(complex_a=complex_a, complex_b=complex_b)
+
+
+class TestSkeletonBounds:
+    def test_skeleton_facet_explosion_rejected(self) -> None:
+        """k=3 on eight disjoint 7-simplices yields 560 tetrahedra > 128."""
+        vertices = []
+        facets = []
+        for i in range(8):
+            base = [f"v{i}_{j}" for j in range(8)]
+            vertices.extend(base)
+            facets.append(base)
+        complex_data = {"vertices": vertices, "facets": facets}
+        with pytest.raises(ValidationError, match="at most 128"):
+            SkeletonRequest(complex=complex_data, k=3)
+
+    def test_admissible_skeleton_still_works(self) -> None:
+        """A single 7-simplex has C(8,4) = 70 tetrahedra in its 3-skeleton."""
+        simplex = ["v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7"]
+        result = compute_skeleton(
+            SkeletonRequest(complex={"vertices": simplex, "facets": [simplex]}, k=3)
+        )
+        assert len(result.skeleton_facets) == 70
+
+
+class TestCollapseResidualBounds:
+    def test_residual_facets_exceeding_limit_rejected(self) -> None:
+        """Collapsing a codim-one face of a 7-simplex beside 122 edges
+        leaves 129 maximal facets and must be rejected before execution."""
+        simplex = ["s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7"]
+        edges = [[f"g{i // 8}", f"h{i % 8}"] for i in range(122)]
+        vertices = sorted(
+            simplex + [f"g{i}" for i in range(16)] + [f"h{i}" for i in range(8)]
+        )
+        complex_data = {"vertices": vertices, "facets": [simplex, *edges]}
+        with pytest.raises(ValidationError):
+            ElementaryCollapseRequest(
+                complex=complex_data,
+                free_face=["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
+                coface=simplex,
+            )
+
+    def test_residual_within_bounds_admitted(self) -> None:
+        triangle_plus_edge = {
+            "vertices": ["t0", "t1", "t2", "u0", "u1"],
+            "facets": [["t0", "t1", "t2"], ["u0", "u1"]],
+        }
+        result = compute_elementary_collapse(
+            ElementaryCollapseRequest(
+                complex=triangle_plus_edge,
+                free_face=["t0", "t1"],
+                coface=["t0", "t1", "t2"],
+            )
+        )
+        assert result.is_free_face
+        assert set(result.remaining_facets) == {
+            ("t0", "t2"),
+            ("t1", "t2"),
+            ("u0", "u1"),
+        }
+
+
+class TestShellingSourceBinding:
+    def test_result_binds_to_complex_and_order(self) -> None:
+        request = ShellingCheckRequest(complex=CIRCLE, facet_order=[0, 1, 2])
+        result = compute_shelling_check(request)
+        assert result.complex == request.complex
+        assert result.facet_order == (0, 1, 2)
+        payload = result.model_dump()
+        assert ShellingCheckResult.model_validate(payload) == result
+
+    def test_forged_shelling_decision_rejected(self) -> None:
+        """Two disjoint edges in order [0, 1] is not a shelling order; a
+        forged is_shelling=True cannot validate against the retained source."""
+        two_edges = {
+            "vertices": ["a", "b", "c", "d"],
+            "facets": [["a", "b"], ["c", "d"]],
+        }
+        with pytest.raises(ValidationError, match="is_shelling"):
+            ShellingCheckResult(
+                complex=two_edges,
+                facet_order=[0, 1],
+                is_shelling=True,
+                failed_at=None,
+                failure_reason=None,
+            )

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from jacobian.math.topology._models import (
     BarycentricSubdivisionRequest,
+    BarycentricSubdivisionResult,
     ElementaryCollapseRequest,
     ElementaryCollapseResult,
     JoinRequest,
@@ -134,6 +135,103 @@ class TestBarycentricSubdivision:
         assert result.num_new_vertices == 7
         # Subdivision of a triangle has 6 maximal simplices (each is a chain)
         assert len(result.subdivision_facets) == 6
+
+    def test_result_retains_source_and_roundtrips(self) -> None:
+        request = BarycentricSubdivisionRequest(complex=CIRCLE)
+        result = compute_barycentric_subdivision(request)
+        assert result.complex == request.complex
+        assert BarycentricSubdivisionResult.model_validate(
+            result.model_dump()
+        ) == result
+
+    def test_vertex_face_map_is_canonical_bijection(self) -> None:
+        from jacobian.math.topology._models import _all_faces
+
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=EDGE)
+        )
+        faces = sorted(_all_faces(EDGE["facets"]), key=lambda f: (len(f), f))
+        assert list(result.subdivision_vertex_faces) == faces
+        assert list(result.subdivision_vertices) == [
+            f"bv{i}" for i in range(len(faces))
+        ]
+
+    def test_swapped_vertex_face_map_rejected(self) -> None:
+        """Swapping entries of the indexed vertex-to-face map must not
+        validate while the subdivision complex stays unchanged."""
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=CIRCLE)
+        )
+        payload = result.model_dump(mode="json")
+        faces = payload["subdivision_vertex_faces"]
+        faces[0], faces[2] = faces[2], faces[0]
+        with pytest.raises(ValidationError, match="bijection"):
+            BarycentricSubdivisionResult.model_validate(payload)
+
+
+class TestCanonicalComplexFeeding:
+    """A canonical ``FiniteSimplicialComplex`` value must feed structural
+    requests unchanged (review thread: deletion result -> skeleton)."""
+
+    def test_deletion_result_feeds_skeleton_request(self) -> None:
+        deleted = compute_vertex_deletion(
+            VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v0"])
+        )
+        assert deleted.remaining_complex is not None
+        skeleton = compute_skeleton(
+            SkeletonRequest(
+                complex=deleted.remaining_complex.model_dump(mode="json"), k=0
+            )
+        )
+        assert skeleton.skeleton_facets == (("v1",), ("v2",))
+
+    def test_subdivision_complex_feeds_star_request(self) -> None:
+        subdivided = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=EDGE)
+        )
+        star = compute_star(
+            StarRequest(complex=subdivided.subdivision_complex.model_dump(), simplex=["bv0"])
+        )
+        assert not star.star_is_empty
+
+    def test_mixed_presentations_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not both"):
+            SkeletonRequest(
+                complex={
+                    "vertices": ["a", "b"],
+                    "facets": [["a", "b"]],
+                    "maximal_simplices": [["a", "b"]],
+                },
+                k=0,
+            )
+
+    def test_unknown_fields_in_canonical_shape_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="unknown fields"):
+            SkeletonRequest(
+                complex={
+                    "vertices": ["a", "b"],
+                    "maximal_simplices": [["a", "b"]],
+                    "surprise": 1,
+                },
+                k=0,
+            )
+
+
+class TestCollapseCandidateBounds:
+    def test_oversized_candidate_labels_rejected(self) -> None:
+        labels = [f"x{i}" for i in range(9)]
+        with pytest.raises(ValidationError):
+            ElementaryCollapseRequest(
+                complex=EDGE, free_face=labels, coface=[*labels, "extra"]
+            )
+
+    def test_coface_cap_matches_dimension_bound(self) -> None:
+        with pytest.raises(ValidationError):
+            ElementaryCollapseRequest(
+                complex=EDGE,
+                free_face=["a"],
+                coface=["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            )
 
 
 class TestPseudomanifold:

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -9,11 +9,13 @@ from jacobian.math.topology._models import (
     ElementaryCollapseRequest,
     ElementaryCollapseResult,
     JoinRequest,
+    JoinResult,
     PseudomanifoldRequest,
     PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
     SkeletonRequest,
+    SkeletonResult,
     StarRequest,
     StarResult,
     VertexDeletionRequest,
@@ -651,3 +653,99 @@ class TestShellingSourceBinding:
                 failed_at=None,
                 failure_reason=None,
             )
+
+
+class TestResultSourceBindingRegression:
+    """Serialized results must replay against their retained sources."""
+
+    def test_forged_deletion_keeping_deleted_vertex_rejected(self) -> None:
+        payload = compute_vertex_deletion(
+            VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v0"])
+        ).model_dump()
+        assert payload["deleted_vertices"] == ("v0",)
+        # The reviewer counterexample: a singleton source still carrying the
+        # allegedly deleted vertex cannot validate against the claimed output.
+        payload["complex"] = {"vertices": ["v0"], "facets": [["v0"]]}
+        with pytest.raises(ValidationError, match="induced subcomplex"):
+            VertexDeletionResult.model_validate(payload)
+
+    def test_deletion_roundtrip(self) -> None:
+        result = compute_vertex_deletion(
+            VertexDeletionRequest(complex=CIRCLE, vertices_to_delete=["b"])
+        )
+        assert result.remaining_facets == (("a", "c"),)
+        assert VertexDeletionResult.model_validate(result.model_dump()) == result
+
+    def test_edge_in_zero_skeleton_rejected(self) -> None:
+        request = SkeletonRequest(complex=EDGE, k=0)
+        with pytest.raises(ValidationError, match="exact k-skeleton"):
+            SkeletonResult(
+                complex=request.complex,
+                k=0,
+                skeleton_facets=(("a", "b"),),
+                skeleton_vertices=("a", "b"),
+                skeleton_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+            )
+
+    def test_skeleton_roundtrip(self) -> None:
+        result = compute_skeleton(SkeletonRequest(complex=TRIANGLE, k=1))
+        assert result.skeleton_facets == (("v0", "v1"), ("v0", "v2"), ("v1", "v2"))
+        assert SkeletonResult.model_validate(result.model_dump()) == result
+
+    def test_single_point_join_result_rejected(self) -> None:
+        request = JoinRequest(
+            complex_a={"vertices": ["a"], "facets": [["a"]]},
+            complex_b={"vertices": ["b"], "facets": [["b"]]},
+        )
+        with pytest.raises(ValidationError, match="facet union"):
+            JoinResult(
+                complex_a=request.complex_a,
+                complex_b=request.complex_b,
+                join_vertices=("a",),
+                join_facets=(("a",),),
+                join_dimension=0,
+                join_complex=_canonical_complex(("a",), (("a",),)),
+            )
+
+    def test_join_roundtrip(self) -> None:
+        result = compute_join(
+            JoinRequest(
+                complex_a={"vertices": ["a"], "facets": [["a"]]},
+                complex_b={"vertices": ["b", "c"], "facets": [["b", "c"]]},
+            )
+        )
+        assert result.join_facets == (("a", "b", "c"),)
+        assert JoinResult.model_validate(result.model_dump()) == result
+
+    def test_subdivision_original_dimension_tamper_rejected(self) -> None:
+        request = BarycentricSubdivisionRequest(complex=EDGE)
+        payload = compute_barycentric_subdivision(request).model_dump()
+        payload["original_dimension"] = 7
+        with pytest.raises(ValidationError, match="original_dimension"):
+            BarycentricSubdivisionResult.model_validate(payload)
+
+    def test_collapse_result_empty_free_face_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ElementaryCollapseResult(
+                complex=EDGE,
+                is_free_face=True,
+                free_face=(),
+                coface=("a",),
+                remaining_facets=(("b",),),
+                remaining_vertices=("b",),
+                remaining_complex=None,
+            )
+
+    def test_collapse_accepts_reordered_facet_labels(self) -> None:
+        """Freeness is a set relation: facet label order cannot flip it."""
+        reordered = {
+            "vertices": ["a", "b"],
+            "facets": [["b", "a"]],
+        }
+        result = compute_elementary_collapse(
+            ElementaryCollapseRequest(
+                complex=reordered, free_face=["a"], coface=["a", "b"]
+            )
+        )
+        assert result.is_free_face
+        assert ElementaryCollapseResult.model_validate(result.model_dump()) == result

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -563,6 +563,24 @@ class TestElementaryCollapse:
         assert set(result.remaining_vertices) == {"a", "b", "c"}
         assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
 
+    def test_non_free_result_with_noncanonical_source_facets(self) -> None:
+        """A noncanonical facet presentation must not make the operation
+        reject its own typed negative decision (review counterexample:
+        facets [["b","a"],["c","a"]] with free_face ["a"])."""
+        request = ElementaryCollapseRequest(
+            complex={
+                "vertices": ["c", "b", "a"],
+                "facets": [["b", "a"], ["c", "a"]],
+            },
+            free_face=["a"],
+            coface=["a", "b"],
+        )
+        result = compute_elementary_collapse(request)
+        assert not result.is_free_face
+        assert result.remaining_facets == (("a", "b"), ("a", "c"))
+        assert result.remaining_vertices == ("a", "b", "c")
+        assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
+
 
 class TestJoinBounds:
     def test_join_of_two_4_simplices_rejected(self) -> None:

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -191,7 +191,10 @@ class TestElementaryCollapse:
             )
         )
         assert result.is_free_face
-        assert result.remaining_facets == ()
+        assert result.remaining_facets == (("b",),)
+        assert result.remaining_vertices == ("b",)
+        assert result.remaining_complex is not None
+        assert result.remaining_complex.maximal_simplices == (("b",),)
 
     def test_non_free_face(self) -> None:
         # In the circle, vertex 'a' is in 2 facets, so it's not free

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -593,7 +593,7 @@ class TestJoinBounds:
             "vertices": ["b0", "b1", "b2", "b3", "b4"],
             "facets": [["b0", "b1", "b2", "b3", "b4"]],
         }
-        with pytest.raises(ValidationError, match="between 1 and 8"):
+        with pytest.raises(ValidationError, match=r"10-vertex facet bound|span 10"):
             JoinRequest(complex_a=complex_a, complex_b=complex_b)
 
     def test_join_exceeding_face_closure_rejected(self) -> None:
@@ -608,6 +608,35 @@ class TestJoinBounds:
         }
         with pytest.raises(ValidationError):
             JoinRequest(complex_a=complex_a, complex_b=complex_b)
+
+    def test_join_facet_product_rejected_before_expansion(self) -> None:
+        """128 maximal edges per side pair into 16384 distinct maximal
+        unions; admission rejects the product without expanding it."""
+
+        def edge_complex(prefix: str) -> dict[str, object]:
+            vertices = [f"{prefix}{i}" for i in range(32)]
+            facets = [
+                [f"{prefix}{i}", f"{prefix}{(i + step) % 32}"]
+                for step in range(1, 5)
+                for i in range(32)
+            ]
+            return {"vertices": vertices, "facets": facets}
+
+        with pytest.raises(ValidationError, match="16384 maximal facets"):
+            JoinRequest(complex_a=edge_complex("a"), complex_b=edge_complex("b"))
+
+    def test_join_vertex_bound_rejected(self) -> None:
+        """A join spanning more than 64 vertices is rejected up front."""
+
+        def star_complex(prefix: str) -> dict[str, object]:
+            vertices = [f"{prefix}{i}" for i in range(40)]
+            return {
+                "vertices": vertices,
+                "facets": [[f"{prefix}0", v] for v in vertices[1:]],
+            }
+
+        with pytest.raises(ValidationError, match="80 vertices"):
+            JoinRequest(complex_a=star_complex("a"), complex_b=star_complex("b"))
 
 
 class TestSkeletonBounds:
@@ -839,4 +868,6 @@ class TestResultDomainMirrorsRequest:
         result = compute_barycentric_subdivision(
             BarycentricSubdivisionRequest(complex=CIRCLE)
         )
-        assert BarycentricSubdivisionResult.model_validate(result.model_dump()) == result
+        assert (
+            BarycentricSubdivisionResult.model_validate(result.model_dump()) == result
+        )

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -14,6 +14,7 @@ from jacobian.math.topology._models import (
     PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
+    SimplicialComplexRequest,
     SkeletonRequest,
     SkeletonResult,
     StarRequest,
@@ -637,6 +638,38 @@ class TestJoinBounds:
 
         with pytest.raises(ValidationError, match="80 vertices"):
             JoinRequest(complex_a=star_complex("a"), complex_b=star_complex("b"))
+
+    def test_forged_oversized_join_result_rejected_before_expansion(self) -> None:
+        """Serialized operands above the facet-product bound are rejected
+        by admission before the result replay expands the union."""
+
+        def edge_complex(prefix: str) -> dict[str, object]:
+            vertices = [f"{prefix}{i}" for i in range(32)]
+            facets = [
+                [f"{prefix}{i}", f"{prefix}{(i + step) % 32}"]
+                for step in range(1, 5)
+                for i in range(32)
+            ]
+            return {"vertices": vertices, "facets": facets}
+
+        with pytest.raises(ValidationError, match="16384 maximal facets"):
+            JoinResult(
+                complex_a=edge_complex("a"),
+                complex_b=edge_complex("b"),
+                join_vertices=tuple(f"a{i}" for i in range(32)),
+                join_facets=(("a0", "a1"),),
+                join_dimension=1,
+            )
+
+    def test_request_schema_advertises_canonical_alternative(self) -> None:
+        """The published input schema shows both accepted shapes so
+        schema-guided callers can pass a canonical complex unchanged."""
+        schema = SimplicialComplexRequest.model_json_schema()
+        assert "anyOf" in schema
+        branches = schema["anyOf"]
+        property_sets = [frozenset(branch.get("properties", {})) for branch in branches]
+        assert any("facets" in props for props in property_sets)
+        assert any("maximal_simplices" in props for props in property_sets)
 
 
 class TestSkeletonBounds:

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -33,6 +33,7 @@ from jacobian.math.topology._operations import (
     compute_star,
     compute_vertex_deletion,
 )
+from jacobian.math.topology._tools import TOOLS
 
 TRIANGLE = {"vertices": ["v0", "v1", "v2"], "facets": [["v0", "v1", "v2"]]}
 CIRCLE = {
@@ -118,6 +119,27 @@ class TestVertexDeletion:
                 complex={"vertices": ["a"], "facets": [["a"]]},
                 vertices_to_delete=["a"],
             )
+
+    def test_nonempty_residual_precondition_is_schema_visible(self) -> None:
+        """The reviewer counterexample: deleting 'a' from the singleton {a}
+        satisfies the generated field schema, so the nonempty-residual
+        restriction must be stated in the published schema guidance rather
+        than discovered only through a failed invocation."""
+        schema = VertexDeletionRequest.model_json_schema()
+        field_schema = schema["properties"]["vertices_to_delete"]
+        assert "at least one simplex" in field_schema["description"]
+        assert "empty complex" in field_schema["description"]
+
+    def test_deletion_discovery_metadata_states_precondition(self) -> None:
+        tool = next(
+            t
+            for t in TOOLS
+            if t.operation_id == "topology.simplicial_complex.deletion.compute"
+        )
+        assert "leave at least one simplex" in tool.description
+        assert all(
+            "at least one simplex" in example.description for example in tool.examples
+        )
 
     def test_delete_leaving_single_vertex_admitted(self) -> None:
         result = compute_vertex_deletion(

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -749,3 +749,54 @@ class TestResultSourceBindingRegression:
         )
         assert result.is_free_face
         assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
+
+
+class TestResultDomainMirrorsRequest:
+    """Serialized results must satisfy the request's own admission domain."""
+
+    def test_star_result_empty_simplex_rejected(self) -> None:
+        """No accepted invocation can request the star of the empty face, so
+        a serialized result cannot authenticate it either."""
+        with pytest.raises(ValidationError, match="at least 1 item"):
+            StarResult(
+                complex=EDGE,
+                simplex=(),
+                star_facets=(("a", "b"),),
+                star_is_empty=False,
+                star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+            )
+
+    def test_deletion_result_empty_deleted_vertices_rejected(self) -> None:
+        """An identity transformation is not a deletion result: the request
+        requires at least one deleted vertex."""
+        with pytest.raises(ValidationError, match="at least 1 item"):
+            VertexDeletionResult(
+                complex=CIRCLE,
+                deleted_vertices=(),
+                remaining_vertices=("a", "b", "c"),
+                remaining_facets=(("a", "b"), ("b", "c"), ("a", "c")),
+                remaining_complex=_canonical_complex(
+                    ("a", "b", "c"), (("a", "b"), ("b", "c"), ("a", "c"))
+                ),
+            )
+
+    def test_subdivision_result_oversized_source_rejected(self) -> None:
+        """The retained source must satisfy the subdivision request's
+        31-face work admission, which the bare complex type does not carry."""
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=CIRCLE)
+        )
+        payload = result.model_dump()
+        simplex4_plus_point = {
+            "vertices": ["v0", "v1", "v2", "v3", "v4", "p"],
+            "facets": [["v0", "v1", "v2", "v3", "v4"], ["p"]],
+        }
+        payload["complex"] = simplex4_plus_point
+        with pytest.raises(ValidationError, match="at most 31 faces"):
+            BarycentricSubdivisionResult.model_validate(payload)
+
+    def test_subdivision_roundtrip_still_admitted(self) -> None:
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=CIRCLE)
+        )
+        assert BarycentricSubdivisionResult.model_validate(result.model_dump()) == result

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -6,8 +6,10 @@ from pydantic import ValidationError
 from jacobian.math.topology._models import (
     BarycentricSubdivisionRequest,
     ElementaryCollapseRequest,
+    ElementaryCollapseResult,
     JoinRequest,
     PseudomanifoldRequest,
+    PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
     SkeletonRequest,
@@ -162,6 +164,48 @@ class TestPseudomanifold:
         assert not result.is_pseudomanifold
         assert "pure" in result.obstruction
 
+    def test_single_point_is_pseudomanifold_with_boundary(self) -> None:
+        """The empty codim-1 face lies in one facet: boundary case."""
+        point = {"vertices": ["a"], "facets": [["a"]]}
+        result = compute_pseudomanifold_decision(PseudomanifoldRequest(complex=point))
+        assert result.is_pseudomanifold
+        assert not result.is_closed
+        assert result.dimension == 0
+        assert result.obstruction == "pseudomanifold with boundary"
+
+    def test_two_points_are_closed_zero_dimensional_pseudomanifold(self) -> None:
+        two_points = {"vertices": ["a", "b"], "facets": [["a"], ["b"]]}
+        result = compute_pseudomanifold_decision(
+            PseudomanifoldRequest(complex=two_points)
+        )
+        assert result.is_pseudomanifold
+        assert result.is_closed
+        assert result.obstruction is None
+
+    def test_three_points_fail_incidence(self) -> None:
+        three_points = {
+            "vertices": ["a", "b", "c"],
+            "facets": [["a"], ["b"], ["c"]],
+        }
+        result = compute_pseudomanifold_decision(
+            PseudomanifoldRequest(complex=three_points)
+        )
+        assert not result.is_pseudomanifold
+        assert "3 facets" in result.obstruction
+
+    def test_forged_zero_dimensional_decision_rejected(self) -> None:
+        """A serialized negative decision for a singleton cannot validate."""
+        point = {"vertices": ["a"], "facets": [["a"]]}
+        with pytest.raises(ValidationError, match="is_pseudomanifold"):
+            PseudomanifoldResult(
+                complex=point,
+                is_pseudomanifold=False,
+                is_closed=False,
+                dimension=0,
+                num_facets=1,
+                obstruction="dimension must be at least 1",
+            )
+
 
 class TestShellingCheck:
     def test_valid_shelling_of_single_facet(self) -> None:
@@ -180,6 +224,33 @@ class TestShellingCheck:
     def test_invalid_order(self) -> None:
         with pytest.raises(ValidationError, match="permutation"):
             ShellingCheckRequest(complex=EDGE, facet_order=[1, 0])
+
+    def test_partial_order_cannot_authenticate_decision(self) -> None:
+        """A two-facet complex revalidated with facet_order=[0] must not
+        accept is_shelling=True: the omitted disjoint facet makes the full
+        order non-shelling (review counterexample)."""
+        two_facets = {
+            "vertices": ["a", "b", "c", "d"],
+            "facets": [["a", "b"], ["c", "d"]],
+        }
+        with pytest.raises(ValidationError, match="permutation"):
+            ShellingCheckResult(
+                complex=two_facets,
+                facet_order=[0],
+                is_shelling=True,
+                failed_at=None,
+                failure_reason=None,
+            )
+
+    def test_duplicate_indices_rejected_in_result(self) -> None:
+        with pytest.raises(ValidationError, match="permutation"):
+            ShellingCheckResult(
+                complex=CIRCLE,
+                facet_order=[0, 0, 1],
+                is_shelling=False,
+                failed_at=1,
+                failure_reason="facet 1 restriction is not an interval",
+            )
 
 
 class TestElementaryCollapse:
@@ -218,6 +289,53 @@ class TestElementaryCollapse:
             ElementaryCollapseRequest(
                 complex=EDGE, free_face=["a"], coface=["a", "b", "b"]
             )
+
+    def test_result_binds_to_source_complex_roundtrip(self) -> None:
+        request = ElementaryCollapseRequest(
+            complex=EDGE, free_face=["a"], coface=["a", "b"]
+        )
+        result = compute_elementary_collapse(request)
+        assert result.complex == request.complex
+        assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
+
+    def test_forged_free_face_with_empty_residual_rejected(self) -> None:
+        """A serialized free-face decision with an empty residual cannot
+        validate: collapsing ('a',) from the edge {a, b} must leave {b}
+        (review counterexample)."""
+        with pytest.raises(ValidationError, match="remaining_facets"):
+            ElementaryCollapseResult(
+                complex=EDGE,
+                is_free_face=True,
+                free_face=("a",),
+                coface=("a", "b"),
+                remaining_facets=(),
+                remaining_vertices=(),
+            )
+
+    def test_forged_non_free_decision_rejected(self) -> None:
+        """A free pair replayed against its source must stay positive."""
+        with pytest.raises(ValidationError, match="is_free_face"):
+            ElementaryCollapseResult(
+                complex=EDGE,
+                is_free_face=False,
+                free_face=("a",),
+                coface=("a", "b"),
+                remaining_facets=(("a", "b"),),
+                remaining_vertices=("a", "b"),
+                remaining_complex=None,
+            )
+
+    def test_non_free_result_retains_source_facets(self) -> None:
+        request = ElementaryCollapseRequest(
+            complex=CIRCLE, free_face=["a"], coface=["a", "b"]
+        )
+        result = compute_elementary_collapse(request)
+        assert not result.is_free_face
+        assert tuple(sorted(result.remaining_facets)) == tuple(
+            sorted(tuple(sorted(f)) for f in CIRCLE["facets"])
+        )
+        assert set(result.remaining_vertices) == {"a", "b", "c"}
+        assert ElementaryCollapseResult.model_validate(result.model_dump()) == result
 
 
 class TestJoinBounds:

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -1,0 +1,211 @@
+"""Tests for structural simplicial complex operations (#1850)."""
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.topology._models import (
+    BarycentricSubdivisionRequest,
+    ElementaryCollapseRequest,
+    JoinRequest,
+    PseudomanifoldRequest,
+    ShellingCheckRequest,
+    SkeletonRequest,
+    StarRequest,
+    VertexDeletionRequest,
+)
+from jacobian.math.topology._operations import (
+    compute_barycentric_subdivision,
+    compute_elementary_collapse,
+    compute_join,
+    compute_pseudomanifold_decision,
+    compute_shelling_check,
+    compute_skeleton,
+    compute_star,
+    compute_vertex_deletion,
+)
+
+TRIANGLE = {"vertices": ["v0", "v1", "v2"], "facets": [["v0", "v1", "v2"]]}
+CIRCLE = {
+    "vertices": ["a", "b", "c"],
+    "facets": [["a", "b"], ["b", "c"], ["a", "c"]],
+}
+EDGE = {"vertices": ["a", "b"], "facets": [["a", "b"]]}
+
+
+class TestStar:
+    def test_star_of_vertex_in_triangle(self) -> None:
+        result = compute_star(StarRequest(complex=TRIANGLE, simplex=["v0"]))
+        assert not result.star_is_empty
+        assert result.star_facets == (("v0", "v1", "v2"),)
+
+    def test_star_of_edge_in_triangle(self) -> None:
+        result = compute_star(StarRequest(complex=TRIANGLE, simplex=["v0", "v1"]))
+        assert result.star_facets == (("v0", "v1", "v2"),)
+
+    def test_star_of_vertex_in_circle(self) -> None:
+        result = compute_star(StarRequest(complex=CIRCLE, simplex=["a"]))
+        assert result.star_facets == (("a", "b"), ("a", "c"))
+
+    def test_star_not_a_face(self) -> None:
+        with pytest.raises(ValidationError, match="must be in the complex"):
+            StarRequest(complex=TRIANGLE, simplex=["v0", "v1", "v2", "v3"])
+
+
+class TestVertexDeletion:
+    def test_delete_vertex_from_triangle(self) -> None:
+        result = compute_vertex_deletion(
+            VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v2"])
+        )
+        assert result.deleted_vertices == ("v2",)
+        assert "v2" not in result.remaining_vertices
+        assert ("v0", "v1") in result.remaining_facets
+
+    def test_delete_all_facets_containing_vertex(self) -> None:
+        result = compute_vertex_deletion(
+            VertexDeletionRequest(complex=CIRCLE, vertices_to_delete=["a"])
+        )
+        assert result.remaining_facets == (("b", "c"),)
+
+    def test_delete_unknown_vertex(self) -> None:
+        with pytest.raises(ValidationError, match="must be in the complex"):
+            VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v9"])
+
+
+class TestSkeleton:
+    def test_one_skeleton_of_triangle(self) -> None:
+        result = compute_skeleton(SkeletonRequest(complex=TRIANGLE, k=1))
+        assert result.k == 1
+        assert result.skeleton_facets == (
+            ("v0", "v1"),
+            ("v0", "v2"),
+            ("v1", "v2"),
+        )
+
+    def test_zero_skeleton(self) -> None:
+        result = compute_skeleton(SkeletonRequest(complex=TRIANGLE, k=0))
+        assert result.skeleton_facets == (("v0",), ("v1",), ("v2",))
+
+    def test_full_skeleton(self) -> None:
+        result = compute_skeleton(SkeletonRequest(complex=TRIANGLE, k=2))
+        assert result.skeleton_facets == (("v0", "v1", "v2"),)
+
+
+class TestJoin:
+    def test_join_two_points(self) -> None:
+        point_a = {"vertices": ["a"], "facets": [["a"]]}
+        point_b = {"vertices": ["b"], "facets": [["b"]]}
+        result = compute_join(JoinRequest(complex_a=point_a, complex_b=point_b))
+        assert result.join_vertices == ("a", "b")
+        assert result.join_facets == (("a", "b"),)
+        assert result.join_dimension == 1
+
+    def test_join_overlapping_vertices_fails(self) -> None:
+        point_a = {"vertices": ["a"], "facets": [["a"]]}
+        point_b = {"vertices": ["a"], "facets": [["a"]]}
+        with pytest.raises(ValidationError, match="disjoint"):
+            JoinRequest(complex_a=point_a, complex_b=point_b)
+
+    def test_join_edge_and_point(self) -> None:
+        edge = {"vertices": ["a", "b"], "facets": [["a", "b"]]}
+        point = {"vertices": ["c"], "facets": [["c"]]}
+        result = compute_join(JoinRequest(complex_a=edge, complex_b=point))
+        assert result.join_dimension == 2
+        assert result.join_facets == (("a", "b", "c"),)
+
+
+class TestBarycentricSubdivision:
+    def test_subdivide_edge(self) -> None:
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=EDGE)
+        )
+        # Edge has 3 faces: {a}, {b}, {a,b}
+        assert result.num_new_vertices == 3
+        # Subdivision of an edge is two edges
+        assert len(result.subdivision_facets) == 2
+
+    def test_subdivide_triangle(self) -> None:
+        result = compute_barycentric_subdivision(
+            BarycentricSubdivisionRequest(complex=TRIANGLE)
+        )
+        # Triangle has 7 faces: 3 vertices + 3 edges + 1 triangle
+        assert result.num_new_vertices == 7
+        # Subdivision of a triangle has 6 maximal simplices (each is a chain)
+        assert len(result.subdivision_facets) == 6
+
+
+class TestPseudomanifold:
+    def test_circle_is_closed_pseudomanifold(self) -> None:
+        result = compute_pseudomanifold_decision(
+            PseudomanifoldRequest(complex=CIRCLE)
+        )
+        assert result.is_pseudomanifold
+        assert result.is_closed
+        assert result.dimension == 1
+
+    def test_triangle_is_not_pseudomanifold(self) -> None:
+        # Triangle boundary is a 2-simplex (solid triangle)
+        result = compute_pseudomanifold_decision(
+            PseudomanifoldRequest(complex=TRIANGLE)
+        )
+        # A solid triangle is 2-dimensional, each edge is in exactly 1 facet
+        # That's a pseudomanifold with boundary
+        assert result.is_pseudomanifold
+        assert not result.is_closed
+
+    def test_non_pure_is_not_pseudomanifold(self) -> None:
+        complex_data = {
+            "vertices": ["a", "b", "c", "d"],
+            "facets": [["a", "b", "c"], ["c", "d"]],
+        }
+        result = compute_pseudomanifold_decision(
+            PseudomanifoldRequest(complex=complex_data)
+        )
+        assert not result.is_pseudomanifold
+        assert "pure" in result.obstruction
+
+
+class TestShellingCheck:
+    def test_valid_shelling_of_single_facet(self) -> None:
+        result = compute_shelling_check(
+            ShellingCheckRequest(complex=EDGE, facet_order=[0])
+        )
+        assert result.is_shelling
+
+    def test_valid_shelling_of_circle(self) -> None:
+        # Circle has 3 edges; any order should be a shelling
+        result = compute_shelling_check(
+            ShellingCheckRequest(complex=CIRCLE, facet_order=[0, 1, 2])
+        )
+        assert result.is_shelling
+
+    def test_invalid_order(self) -> None:
+        with pytest.raises(ValidationError, match="permutation"):
+            ShellingCheckRequest(complex=EDGE, facet_order=[1, 0])
+
+
+class TestElementaryCollapse:
+    def test_collapse_free_vertex_from_edge(self) -> None:
+        result = compute_elementary_collapse(
+            ElementaryCollapseRequest(
+                complex=EDGE, free_face=["a"], coface=["a", "b"]
+            )
+        )
+        assert result.is_free_face
+        assert result.remaining_facets == ()
+
+    def test_non_free_face(self) -> None:
+        # In the circle, vertex 'a' is in 2 facets, so it's not free
+        result = compute_elementary_collapse(
+            ElementaryCollapseRequest(
+                complex=CIRCLE, free_face=["a"], coface=["a", "b"]
+            )
+        )
+        assert not result.is_free_face
+
+    def test_coface_not_a_facet(self) -> None:
+        result = compute_elementary_collapse(
+            ElementaryCollapseRequest(
+                complex=EDGE, free_face=["a"], coface=["a", "b", "c"]
+            )
+        )
+        assert not result.is_free_face

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -15,9 +15,13 @@ from jacobian.math.topology._models import (
     ShellingCheckResult,
     SkeletonRequest,
     StarRequest,
+    StarResult,
     VertexDeletionRequest,
+    VertexDeletionResult,
 )
 from jacobian.math.topology._operations import (
+    _CANONICAL_CIRCLE,
+    _canonical_complex,
     compute_barycentric_subdivision,
     compute_elementary_collapse,
     compute_join,
@@ -41,6 +45,7 @@ class TestStar:
         result = compute_star(StarRequest(complex=TRIANGLE, simplex=["v0"]))
         assert not result.star_is_empty
         assert result.star_facets == (("v0", "v1", "v2"),)
+        assert result.star_complex is not None
 
     def test_star_of_edge_in_triangle(self) -> None:
         result = compute_star(StarRequest(complex=TRIANGLE, simplex=["v0", "v1"]))
@@ -53,6 +58,35 @@ class TestStar:
     def test_star_not_a_face(self) -> None:
         with pytest.raises(ValidationError, match="must be in the complex"):
             StarRequest(complex=TRIANGLE, simplex=["v0", "v1", "v2", "v3"])
+
+    def test_result_binds_to_source_complex_roundtrip(self) -> None:
+        request = StarRequest(complex=CIRCLE, simplex=["a"])
+        result = compute_star(request)
+        assert result.complex == request.complex
+        assert StarResult.model_validate(result.model_dump()) == result
+
+    def test_forged_simplex_outside_source_rejected(self) -> None:
+        """The reviewer counterexample: a star for ('z',) presented on the
+        edge {a, b} cannot validate because 'z' is not a face of the source."""
+        with pytest.raises(ValidationError, match="face of the retained complex"):
+            StarResult(
+                complex=EDGE,
+                simplex=("z",),
+                star_facets=(("a", "b"),),
+                star_is_empty=False,
+                star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+            )
+
+    def test_truncated_star_facets_rejected(self) -> None:
+        """Dropping one containing facet must fail the source replay."""
+        with pytest.raises(ValidationError, match="star_facets"):
+            StarResult(
+                complex=CIRCLE,
+                simplex=("a",),
+                star_facets=(("a", "b"),),
+                star_is_empty=False,
+                star_complex=_canonical_complex(("a", "b"), (("a", "b"),)),
+            )
 
 
 class TestVertexDeletion:
@@ -73,6 +107,35 @@ class TestVertexDeletion:
     def test_delete_unknown_vertex(self) -> None:
         with pytest.raises(ValidationError, match="must be in the complex"):
             VertexDeletionRequest(complex=TRIANGLE, vertices_to_delete=["v9"])
+
+    def test_delete_all_vertices_rejected(self) -> None:
+        """A deletion whose induced subcomplex is empty is out of contract;
+        the canonical complex value cannot represent the empty complex."""
+        with pytest.raises(ValidationError, match="leave at least one simplex"):
+            VertexDeletionRequest(
+                complex={"vertices": ["a"], "facets": [["a"]]},
+                vertices_to_delete=["a"],
+            )
+
+    def test_delete_leaving_single_vertex_admitted(self) -> None:
+        result = compute_vertex_deletion(
+            VertexDeletionRequest(
+                complex={"vertices": ["a", "b"], "facets": [["a"], ["b"]]},
+                vertices_to_delete=["b"],
+            )
+        )
+        assert result.remaining_vertices == ("a",)
+        assert result.remaining_facets == (("a",),)
+        assert result.remaining_complex is not None
+        assert result.remaining_complex.maximal_simplices == (("a",),)
+
+    def test_result_requires_canonical_complex(self) -> None:
+        with pytest.raises(ValidationError):
+            VertexDeletionResult(
+                deleted_vertices=("v2",),
+                remaining_vertices=("v0", "v1"),
+                remaining_facets=(("v0", "v1"),),
+            )
 
 
 class TestSkeleton:
@@ -140,9 +203,9 @@ class TestBarycentricSubdivision:
         request = BarycentricSubdivisionRequest(complex=CIRCLE)
         result = compute_barycentric_subdivision(request)
         assert result.complex == request.complex
-        assert BarycentricSubdivisionResult.model_validate(
-            result.model_dump()
-        ) == result
+        assert (
+            BarycentricSubdivisionResult.model_validate(result.model_dump()) == result
+        )
 
     def test_vertex_face_map_is_canonical_bijection(self) -> None:
         from jacobian.math.topology._models import _all_faces
@@ -190,7 +253,9 @@ class TestCanonicalComplexFeeding:
             BarycentricSubdivisionRequest(complex=EDGE)
         )
         star = compute_star(
-            StarRequest(complex=subdivided.subdivision_complex.model_dump(), simplex=["bv0"])
+            StarRequest(
+                complex=subdivided.subdivision_complex.model_dump(), simplex=["bv0"]
+            )
         )
         assert not star.star_is_empty
 
@@ -212,6 +277,28 @@ class TestCanonicalComplexFeeding:
                     "vertices": ["a", "b"],
                     "maximal_simplices": [["a", "b"]],
                     "surprise": 1,
+                },
+                k=0,
+            )
+
+    def test_tampered_canonical_dump_rejected(self) -> None:
+        """Changing maximal_simplices while retaining the original digest
+        must not be accepted as a different request complex."""
+        tampered = {
+            **_CANONICAL_CIRCLE,
+            "maximal_simplices": [["a", "b"], ["a", "c"]],
+        }
+        with pytest.raises(ValidationError, match="FiniteSimplicialComplex"):
+            SkeletonRequest(complex=tampered, k=0)
+
+    def test_incomplete_canonical_dump_rejected(self) -> None:
+        """A canonical-shape dump missing derived fields cannot bypass
+        validation of the owning canonical type."""
+        with pytest.raises(ValidationError, match="FiniteSimplicialComplex"):
+            SkeletonRequest(
+                complex={
+                    "vertices": ["a", "b"],
+                    "maximal_simplices": [["a", "b"]],
                 },
                 k=0,
             )
@@ -302,6 +389,23 @@ class TestPseudomanifold:
                 dimension=0,
                 num_facets=1,
                 obstruction="dimension must be at least 1",
+            )
+
+    def test_forged_negative_obstruction_must_match_replay(self) -> None:
+        """A purity failure cannot be revalidated with a foreign non-null
+        obstruction: negative conclusions replay their exact description."""
+        nonpure = {
+            "vertices": ["a", "b", "c", "d", "e"],
+            "facets": [["a", "b", "c"], ["d", "e"]],
+        }
+        with pytest.raises(ValidationError, match="obstruction"):
+            PseudomanifoldResult(
+                complex=nonpure,
+                is_pseudomanifold=False,
+                is_closed=False,
+                dimension=2,
+                num_facets=2,
+                obstruction="codim-1 face [] is in 3 facets",
             )
 
 


### PR DESCRIPTION
## Summary

Add 8 structural simplicial complex operations to the topology domain, reusing the existing `FiniteSimplicialComplex` infrastructure.

## New operations

| Operation | Description |
|---|---|
| `topology.simplicial_complex.star.compute` | Closed star of a simplex: all facets containing it |
| `topology.simplicial_complex.deletion.compute` | Induced subcomplex after vertex deletion |
| `topology.simplicial_complex.skeleton.compute` | k-skeleton subcomplex |
| `topology.simplicial_complex.join.compute` | Join of two complexes on disjoint vertex sets |
| `topology.simplicial_complex.barycentric_subdivision.compute` | Order complex (barycentric subdivision) |
| `topology.simplicial_complex.pseudomanifold.decide` | Pseudomanifold decision with closed/boundary distinction |
| `topology.simplicial_complex.shelling.check` | Validate a submitted facet shelling order |
| `topology.simplicial_complex.elementary_collapse.check` | Verify free face and remove coface |

## Design choices

- **Reuse existing infrastructure**: All operations work with `SimplicialComplexRequest` (vertices + maximal facets) and do not create a second complex representation.
- **Atomic and composable**: Each operation is a standalone typed transform that returns a concrete mathematical value.
- **Bounded and exact**: All results are deterministic and exact — no floating point, no sentinels.
- **No external libraries**: Pure Python combinatorics; no Sage/FLINT dependency needed for these structural operations.

## Testing

24 new tests cover edge cases, triangle/circle/disk examples, boundary conditions, and rejection of invalid inputs. All 43 topology tests and 27 catalog tests pass.

Closes #1850

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/43b95243-5d01-4634-9139-f8fd635cec03)