### PR TITLE
feat(math): add finite based chain complex algebra (#1824)

### DIFF
--- a/src/jacobian/math/chain_complexes/__init__.py
+++ b/src/jacobian/math/chain_complexes/__init__.py
@@ -20,15 +20,14 @@ from jacobian.math.chain_complexes.operations import (
 # directly. The remainder are the wire-envelope handlers used by MCP.
 __all__ = [
     "chain_map_commutes",
-    "differential_squares_to_zero",
-    "homology_groups",
-    "mapping_cone",
-    "tensor_product_complex",
-    # Wire-envelope handlers used by the MCP projection.
     "compute_homology",
     "compute_mapping_cone",
     "compute_tensor_product",
     "construct_chain_complex",
+    "differential_squares_to_zero",
+    "homology_groups",
+    "mapping_cone",
+    "tensor_product_complex",
     "verify_chain_map",
     "verify_differential",
 ]

--- a/src/jacobian/math/chain_complexes/__init__.py
+++ b/src/jacobian/math/chain_complexes/__init__.py
@@ -1,5 +1,12 @@
 """Finite based chain complexes over exact fields."""
 
+from jacobian.math.chain_complexes.native import (
+    chain_map_commutes,
+    differential_squares_to_zero,
+    homology_groups,
+    mapping_cone,
+    tensor_product_complex,
+)
 from jacobian.math.chain_complexes.operations import (
     compute_homology,
     compute_mapping_cone,
@@ -9,7 +16,15 @@ from jacobian.math.chain_complexes.operations import (
     verify_differential,
 )
 
+# The first five names are the native surface: they accept domain values
+# directly. The remainder are the wire-envelope handlers used by MCP.
 __all__ = [
+    "chain_map_commutes",
+    "differential_squares_to_zero",
+    "homology_groups",
+    "mapping_cone",
+    "tensor_product_complex",
+    # Wire-envelope handlers used by the MCP projection.
     "compute_homology",
     "compute_mapping_cone",
     "compute_tensor_product",

--- a/src/jacobian/math/chain_complexes/__init__.py
+++ b/src/jacobian/math/chain_complexes/__init__.py
@@ -1,0 +1,19 @@
+"""Finite based chain complexes over exact fields."""
+
+from jacobian.math.chain_complexes.operations import (
+    compute_homology,
+    compute_mapping_cone,
+    compute_tensor_product,
+    construct_chain_complex,
+    verify_chain_map,
+    verify_differential,
+)
+
+__all__ = [
+    "compute_homology",
+    "compute_mapping_cone",
+    "compute_tensor_product",
+    "construct_chain_complex",
+    "verify_chain_map",
+    "verify_differential",
+]

--- a/src/jacobian/math/chain_complexes/__init__.py
+++ b/src/jacobian/math/chain_complexes/__init__.py
@@ -7,27 +7,15 @@ from jacobian.math.chain_complexes.native import (
     mapping_cone,
     tensor_product_complex,
 )
-from jacobian.math.chain_complexes.operations import (
-    compute_homology,
-    compute_mapping_cone,
-    compute_tensor_product,
-    construct_chain_complex,
-    verify_chain_map,
-    verify_differential,
-)
 
-# The first five names are the native surface: they accept domain values
-# directly. The remainder are the wire-envelope handlers used by MCP.
+# The authoritative native surface: every export accepts domain values
+# directly. Wire-envelope request handlers live in
+# ``jacobian.math.chain_complexes.operations`` and are projected to MCP
+# through ``_tools.py``; they are not part of this native API.
 __all__ = [
     "chain_map_commutes",
-    "compute_homology",
-    "compute_mapping_cone",
-    "compute_tensor_product",
-    "construct_chain_complex",
     "differential_squares_to_zero",
     "homology_groups",
     "mapping_cone",
     "tensor_product_complex",
-    "verify_chain_map",
-    "verify_differential",
 ]

--- a/src/jacobian/math/chain_complexes/_admission.py
+++ b/src/jacobian/math/chain_complexes/_admission.py
@@ -1,0 +1,45 @@
+"""Owner-local admission decisions for chain complex operations."""
+
+from __future__ import annotations
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.chain_complexes._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "chain_complex.construct.compute",
+        AdmissionDecision.KEEP,
+        "finite based chain complex from differential matrices over QQ or GF(p)",
+    ),
+    OperationAdmission(
+        "chain_complex.verify_differential.compute",
+        AdmissionDecision.KEEP,
+        "exact verification that d^2 = 0",
+    ),
+    OperationAdmission(
+        "chain_complex.verify_chain_map.compute",
+        AdmissionDecision.KEEP,
+        "exact verification that a chain map commutes with differentials",
+    ),
+    OperationAdmission(
+        "chain_complex.homology.compute",
+        AdmissionDecision.KEEP,
+        "exact homology groups of a finite chain complex",
+    ),
+    OperationAdmission(
+        "chain_complex.mapping_cone.compute",
+        AdmissionDecision.KEEP,
+        "exact mapping cone of a chain map",
+    ),
+    OperationAdmission(
+        "chain_complex.tensor_product.compute",
+        AdmissionDecision.KEEP,
+        "exact tensor product of two chain complexes",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -9,7 +9,6 @@ from pydantic import Field, model_validator
 from jacobian._models import StrictModel
 from jacobian.math.chain_complexes.values import (
     MAX_TENSOR_GROUP_DIMENSION,
-    MAX_TENSOR_SERIALIZED_CHARS,
     MAX_TENSOR_TOTAL_CELLS,
     ChainComplexValue,
     CoefficientField,
@@ -430,12 +429,33 @@ def _require_admissible_tensor_work(
         basis_sizes=tuple(group_sizes),
         differential_matrices=placeholder_diffs,
     )
-    max_entry_chars = 2 * 512 + 8
-    if max(allocated_cells, 1) * max_entry_chars > MAX_TENSOR_SERIALIZED_CHARS:
+    # Every populated tensor cell copies one admitted coefficient string
+    # (a Koszul negation may add a leading '-') and every remaining cell
+    # prints "0", so the expanded differentials print at most this many
+    # characters. The derived value enforces MAX_MATRIX_ENTRY_CHARS
+    # against its real coefficients, so admission must couple the same
+    # budget to the expansion instead of to shape alone.
+    from jacobian.math.chain_complexes.values import MAX_MATRIX_ENTRY_CHARS
+
+    def _max_entry_length(complex_value: ChainComplexValue) -> int:
+        return max(
+            (
+                len(entry)
+                for matrix in complex_value.differential_matrices
+                for row in matrix
+                for entry in row
+            ),
+            default=1,
+        )
+
+    worst_entry_chars = max(_max_entry_length(left), _max_entry_length(right)) + 1
+    expanded_entry_chars = allocated_cells * worst_entry_chars
+    if expanded_entry_chars > MAX_MATRIX_ENTRY_CHARS:
         raise ValueError(
-            "tensor product serialization exceeds the canonical output "
-            f"ceiling ({allocated_cells} cells x ~{max_entry_chars} "
-            "characters); supply smaller coefficients"
+            "tensor product serialization exceeds the canonical "
+            f"{MAX_MATRIX_ENTRY_CHARS}-character budget: {allocated_cells} "
+            f"expanded cells x ~{worst_entry_chars} characters per copied "
+            "coefficient; supply smaller coefficients"
         )
 
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -88,6 +88,10 @@ def _require_chain_map_components(
             f"{label} requires one map component per chain degree "
             f"({expected_count}), got {len(map_matrices)}"
         )
+    from jacobian.math.chain_complexes.values import (
+        _require_rational_entry_grammar,
+    )
+
     for index, matrix in enumerate(map_matrices):
         rows = target.basis_sizes[index]
         cols = source.basis_sizes[index]
@@ -96,6 +100,12 @@ def _require_chain_map_components(
                 f"{label} map component {index} must have shape "
                 f"{rows}x{cols} (target rows x source columns)"
             )
+        for row in matrix:
+            for entry in row:
+                # Shape alone does not make an entry parseable: the exact
+                # kernels parse entries with Fraction/int and would turn an
+                # accepted request into a host exception.
+                _require_rational_entry_grammar(source.coefficient_field, entry)
 
 
 class VerifyChainMapRequest(StrictModel):
@@ -153,11 +163,13 @@ class TensorProductRequest(StrictModel):
             or self.left.prime != self.right.prime
         ):
             raise ValueError("tensor product requires same coefficient field and prime")
-        # Bound the derived tensor dimensions before any allocation: each
-        # tensor-product group and the total cell count stay within a
-        # conservative budget derived from the input bounds.
+        # Bound the derived tensor work before any allocation: each
+        # tensor-product group dimension, the total group cells, and the
+        # dense differential cells actually allocated between consecutive
+        # groups all stay within conservative budgets derived from the
+        # input bounds.
         group_count = len(self.left.basis_sizes) + len(self.right.basis_sizes) - 1
-        total = 0
+        group_sizes: list[int] = []
         for degree in range(group_count):
             size = 0
             for i in range(min(degree + 1, len(self.left.basis_sizes))):
@@ -169,11 +181,16 @@ class TensorProductRequest(StrictModel):
                     f"tensor product group dimension {size} exceeds the "
                     f"{MAX_TENSOR_GROUP_DIMENSION}-dimension work bound"
                 )
-            total += size
-        if total > MAX_TENSOR_TOTAL_CELLS:
+            group_sizes.append(size)
+        total = sum(group_sizes)
+        allocated_cells = sum(
+            group_sizes[degree - 1] * group_sizes[degree]
+            for degree in range(1, group_count)
+        )
+        if total > MAX_TENSOR_TOTAL_CELLS or allocated_cells > MAX_TENSOR_TOTAL_CELLS:
             raise ValueError(
-                f"tensor product totals {total} cells, exceeding the "
-                f"{MAX_TENSOR_TOTAL_CELLS}-cell work bound"
+                f"tensor product allocates {max(total, allocated_cells)} "
+                f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
             )
         return self
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -16,20 +16,36 @@ from jacobian.math.chain_complexes.values import (
 
 
 class ConstructChainComplexRequest(StrictModel):
-    """Construct a chain complex from differential matrices."""
+    """Construct a chain complex from differential matrices.
+
+    A valid request contains exactly one fewer differential matrix than
+    basis sizes; matrix ``i`` has shape ``basis_sizes[i] x
+    basis_sizes[i+1]``, and adjacent matrices must compose to zero so the
+    constructed value satisfies d^2 = 0.
+    """
 
     coefficient_field: CoefficientField = CoefficientField.RATIONAL
     prime: int | None = Field(default=None, ge=2)
-    basis_sizes: tuple[int, ...] = Field(min_length=1)
+    basis_sizes: tuple[int, ...] = Field(
+        min_length=1,
+        description=(
+            "One dimension per chain group ordered by increasing degree; "
+            "there must be exactly one more basis size than differential "
+            "matrices."
+        ),
+    )
     differential_matrices: tuple[tuple[tuple[str, ...], ...], ...] = Field(
         description=(
-            "Dense row-major differential matrices; entry i maps chain group "
-            "i+1 into chain group i. Each entry is one canonical "
-            "coefficient string: an integer with no leading zeros and no "
-            "negative zero ('0', '5', '-3'), or for QQ a fully reduced "
-            "fraction with denominator >= 2 ('-1/2'); for GF(p) only "
-            "integer residues in [0, p) are accepted. Parsing is plain "
-            "integer/fraction string parsing and never evaluates input."
+            "Exactly one fewer dense row-major differential matrix than "
+            "basis sizes. Matrix i maps chain group i+1 into chain group i "
+            "and must have shape basis_sizes[i] x basis_sizes[i+1]; "
+            "adjacent matrices must compose to zero (d^2 = 0). Each entry "
+            "is one canonical coefficient string: an integer with no "
+            "leading zeros and no negative zero ('0', '5', '-3'), or for "
+            "QQ a fully reduced fraction with denominator >= 2 ('-1/2'); "
+            "for GF(p) only integer residues in [0, p) are accepted. "
+            "Parsing is plain integer/fraction string parsing and never "
+            "evaluates input."
         )
     )
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -73,6 +73,11 @@ class ConstructChainComplexRequest(StrictModel):
                 differentials[index],
                 differentials[index + 1],
                 prime=prime,
+                # Declared group widths keep zero-row/zero-width composites
+                # shape-faithful: an empty 0 x n map must not be re-inferred
+                # as zero-width during the construct-time replay.
+                left_declared_columns=self.basis_sizes[index + 1],
+                result_columns=self.basis_sizes[index + 2],
             )
             if any(any(entry != 0 for entry in row) for row in composite):
                 raise ValueError(

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -250,6 +250,7 @@ class MappingConeRequest(StrictModel):
             map_mats,
             prime,
             list(self.source.basis_sizes),
+            list(self.target.basis_sizes),
         )
         return self
 
@@ -273,6 +274,76 @@ def _require_serializable_entries(*complex_values) -> None:
                         )
 
 
+def _require_admissible_tensor_work(
+    left: ChainComplexValue, right: ChainComplexValue
+) -> None:
+    """Bound the derived tensor work before any allocation.
+
+    Shared by the request model and the result validator's construction
+    replay: each tensor-product group dimension, the total group cells,
+    and the dense differential cells actually allocated between
+    consecutive groups stay within conservative budgets derived from the
+    input bounds.
+    """
+    if left.coefficient_field != right.coefficient_field or left.prime != right.prime:
+        raise ValueError("tensor product requires same coefficient field and prime")
+    group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
+    group_sizes: list[int] = []
+    for degree in range(group_count):
+        size = 0
+        for i in range(min(degree + 1, len(left.basis_sizes))):
+            j = degree - i
+            if j < len(right.basis_sizes):
+                size += left.basis_sizes[i] * right.basis_sizes[j]
+        if size > MAX_TENSOR_GROUP_DIMENSION:
+            raise ValueError(
+                f"tensor product group dimension {size} exceeds the "
+                f"{MAX_TENSOR_GROUP_DIMENSION}-dimension work bound"
+            )
+        group_sizes.append(size)
+    total = sum(group_sizes)
+    allocated_cells = sum(
+        group_sizes[degree - 1] * group_sizes[degree]
+        for degree in range(1, group_count)
+    )
+    if total > MAX_TENSOR_TOTAL_CELLS or allocated_cells > MAX_TENSOR_TOTAL_CELLS:
+        raise ValueError(
+            f"tensor product allocates {max(total, allocated_cells)} "
+            f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
+        )
+    _require_serializable_entries(left, right)
+    _require_square_zero_at_admission(left, label="tensor product left")
+    _require_square_zero_at_admission(right, label="tensor product right")
+    # Admission guarantees the derived complex value is canonical: the
+    # degree interval must fit the shared chain-degree bounds, so
+    # constructing it here fails at the boundary rather than inside
+    # execution when the result is exposed as a ChainComplexValue.
+    from jacobian.math.chain_complexes.values import ChainComplexValue
+
+    tensor_degree_min = left.degree_min + right.degree_min
+    # Shape-correct zero placeholders: differential deg has
+    # group_sizes[deg] rows and group_sizes[deg+1] columns.
+    placeholder_diffs = tuple(
+        tuple(("0",) * group_sizes[deg + 1] for _ in range(group_sizes[deg]))
+        for deg in range(max(0, group_count - 1))
+    )
+    ChainComplexValue(
+        coefficient_field=left.coefficient_field,
+        prime=left.prime,
+        degree_min=tensor_degree_min,
+        degree_max=tensor_degree_min + group_count - 1,
+        basis_sizes=tuple(group_sizes),
+        differential_matrices=placeholder_diffs,
+    )
+    max_entry_chars = 2 * 512 + 8
+    if max(allocated_cells, 1) * max_entry_chars > MAX_TENSOR_SERIALIZED_CHARS:
+        raise ValueError(
+            "tensor product serialization exceeds the canonical output "
+            f"ceiling ({allocated_cells} cells x ~{max_entry_chars} "
+            "characters); supply smaller coefficients"
+        )
+
+
 class TensorProductRequest(StrictModel):
     """Compute the tensor product of two chain complexes."""
 
@@ -281,71 +352,7 @@ class TensorProductRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_admissible_tensor_work(self) -> Self:
-        if (
-            self.left.coefficient_field != self.right.coefficient_field
-            or self.left.prime != self.right.prime
-        ):
-            raise ValueError("tensor product requires same coefficient field and prime")
-        # Bound the derived tensor work before any allocation: each
-        # tensor-product group dimension, the total group cells, and the
-        # dense differential cells actually allocated between consecutive
-        # groups all stay within conservative budgets derived from the
-        # input bounds.
-        group_count = len(self.left.basis_sizes) + len(self.right.basis_sizes) - 1
-        group_sizes: list[int] = []
-        for degree in range(group_count):
-            size = 0
-            for i in range(min(degree + 1, len(self.left.basis_sizes))):
-                j = degree - i
-                if j < len(self.right.basis_sizes):
-                    size += self.left.basis_sizes[i] * self.right.basis_sizes[j]
-            if size > MAX_TENSOR_GROUP_DIMENSION:
-                raise ValueError(
-                    f"tensor product group dimension {size} exceeds the "
-                    f"{MAX_TENSOR_GROUP_DIMENSION}-dimension work bound"
-                )
-            group_sizes.append(size)
-        total = sum(group_sizes)
-        allocated_cells = sum(
-            group_sizes[degree - 1] * group_sizes[degree]
-            for degree in range(1, group_count)
-        )
-        if total > MAX_TENSOR_TOTAL_CELLS or allocated_cells > MAX_TENSOR_TOTAL_CELLS:
-            raise ValueError(
-                f"tensor product allocates {max(total, allocated_cells)} "
-                f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
-            )
-        _require_serializable_entries(self.left, self.right)
-        _require_square_zero_at_admission(self.left, label="tensor product left")
-        _require_square_zero_at_admission(self.right, label="tensor product right")
-        # Admission guarantees the derived complex value is canonical: the
-        # degree interval must fit the shared chain-degree bounds, so
-        # constructing it here fails at the boundary rather than inside
-        # execution when the result is exposed as a ChainComplexValue.
-        from jacobian.math.chain_complexes.values import ChainComplexValue
-
-        tensor_degree_min = self.left.degree_min + self.right.degree_min
-        # Shape-correct zero placeholders: differential deg has
-        # group_sizes[deg] rows and group_sizes[deg+1] columns.
-        placeholder_diffs = tuple(
-            tuple(("0",) * group_sizes[deg + 1] for _ in range(group_sizes[deg]))
-            for deg in range(max(0, group_count - 1))
-        )
-        ChainComplexValue(
-            coefficient_field=self.left.coefficient_field,
-            prime=self.left.prime,
-            degree_min=tensor_degree_min,
-            degree_max=tensor_degree_min + group_count - 1,
-            basis_sizes=group_sizes,
-            differential_matrices=placeholder_diffs,
-        )
-        max_entry_chars = 2 * 512 + 8
-        if max(allocated_cells, 1) * max_entry_chars > MAX_TENSOR_SERIALIZED_CHARS:
-            raise ValueError(
-                "tensor product serialization exceeds the canonical output "
-                f"ceiling ({allocated_cells} cells x ~{max_entry_chars} "
-                "characters); supply smaller coefficients"
-            )
+        _require_admissible_tensor_work(self.left, self.right)
         return self
 
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -207,6 +207,50 @@ class MappingConeRequest(StrictModel):
         )
         _require_square_zero_at_admission(self.source, label="mapping cone source")
         _require_square_zero_at_admission(self.target, label="mapping cone target")
+        # The mapping cone is defined only for a genuine chain map, so the
+        # commutation relation d_target * f_{i+1} == f_i * d_source is part
+        # of the accepted request domain: checking it here keeps an accepted
+        # math.run request from dying in execution.
+        from jacobian.math.chain_complexes.operations import (
+            _matrix_to_fractions,
+            _require_chain_map_relation,
+        )
+
+        prime = self.source.prime
+        source_diffs = [
+            _matrix_to_fractions(
+                m,
+                self.source.basis_sizes[i],
+                self.source.basis_sizes[i + 1],
+                prime,
+            )
+            for i, m in enumerate(self.source.differential_matrices)
+        ]
+        target_diffs = [
+            _matrix_to_fractions(
+                m,
+                self.target.basis_sizes[i],
+                self.target.basis_sizes[i + 1],
+                prime,
+            )
+            for i, m in enumerate(self.target.differential_matrices)
+        ]
+        map_mats = [
+            _matrix_to_fractions(
+                m,
+                self.target.basis_sizes[i],
+                self.source.basis_sizes[i],
+                prime,
+            )
+            for i, m in enumerate(self.map_matrices)
+        ]
+        _require_chain_map_relation(
+            source_diffs,
+            target_diffs,
+            map_mats,
+            prime,
+            list(self.source.basis_sizes),
+        )
         return self
 
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -22,7 +22,17 @@ class ConstructChainComplexRequest(StrictModel):
     coefficient_field: CoefficientField = CoefficientField.RATIONAL
     prime: int | None = Field(default=None, ge=2)
     basis_sizes: tuple[int, ...] = Field(min_length=1)
-    differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    differential_matrices: tuple[tuple[tuple[str, ...], ...], ...] = Field(
+        description=(
+            "Dense row-major differential matrices; entry i maps chain group "
+            "i+1 into chain group i. Each entry is one canonical "
+            "coefficient string: an integer with no leading zeros and no "
+            "negative zero ('0', '5', '-3'), or for QQ a fully reduced "
+            "fraction with denominator >= 2 ('-1/2'); for GF(p) only "
+            "integer residues in [0, p) are accepted. Parsing is plain "
+            "integer/fraction string parsing and never evaluates input."
+        )
+    )
 
     @model_validator(mode="after")
     def require_consistent_dimensions(self) -> Self:
@@ -149,7 +159,15 @@ class VerifyChainMapRequest(StrictModel):
 
     source: ChainComplexValue
     target: ChainComplexValue
-    map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...] = Field(
+        description=(
+            "One dense component per chain degree, each shaped "
+            "(target basis size) x (source basis size). Entries follow the "
+            "same canonical coefficient grammar as differential matrices: "
+            "integers without leading zeros, reduced QQ fractions, and "
+            "GF(p) residues in [0, p); strings are parsed, never evaluated."
+        )
+    )
 
     @model_validator(mode="after")
     def require_admissible_map_components(self) -> Self:
@@ -193,12 +211,83 @@ class ComputeHomologyRequest(StrictModel):
         return self
 
 
+def _entry_character_count(complex_value: ChainComplexValue) -> int:
+    """Total printed characters across one complex's differential cells."""
+    return sum(
+        len(entry)
+        for matrix in complex_value.differential_matrices
+        for row in matrix
+        for entry in row
+    )
+
+
+def _require_admissible_cone_value(
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...],
+) -> None:
+    """Bound the derived mapping-cone work before any allocation.
+
+    The cone becomes a first-class ``ChainComplexValue``, so its degree
+    interval, group dimensions, dense cell budget, and serialization
+    envelope must be established at admission rather than discovered
+    during execution.
+    """
+    from jacobian.math.chain_complexes.operations import _cone_group_sizes
+    from jacobian.math.chain_complexes.values import (
+        MAX_MATRIX_ENTRY_CHARS,
+        ChainComplexValue,
+    )
+
+    cone_basis_sizes = _cone_group_sizes(source, target)
+    degree_min = source.degree_min
+    placeholder_diffs = tuple(
+        tuple(("0",) * cone_basis_sizes[deg + 1] for _ in range(cone_basis_sizes[deg]))
+        for deg in range(max(0, len(cone_basis_sizes) - 1))
+    )
+    ChainComplexValue(
+        coefficient_field=source.coefficient_field,
+        prime=source.prime,
+        degree_min=degree_min,
+        degree_max=degree_min + len(cone_basis_sizes) - 1,
+        basis_sizes=cone_basis_sizes,
+        differential_matrices=placeholder_diffs,
+    )
+    # Every populated cone cell copies one admitted coefficient string
+    # (possibly gaining a leading '-') and every remaining cell prints
+    # "0", so this bounds the derived serialization from above.
+    cone_cells = sum(
+        cone_basis_sizes[i] * cone_basis_sizes[i + 1]
+        for i in range(len(cone_basis_sizes) - 1)
+    )
+    worst_case_chars = (
+        _entry_character_count(source)
+        + _entry_character_count(target)
+        + sum(len(entry) for matrix in map_matrices for row in matrix for entry in row)
+        + cone_cells
+    )
+    if worst_case_chars > MAX_MATRIX_ENTRY_CHARS:
+        raise ValueError(
+            "mapping cone serialization exceeds the canonical output "
+            f"ceiling ({worst_case_chars} characters against "
+            f"{MAX_MATRIX_ENTRY_CHARS}); supply smaller coefficients"
+        )
+
+
 class MappingConeRequest(StrictModel):
     """Compute the mapping cone of a chain map."""
 
     source: ChainComplexValue
     target: ChainComplexValue
-    map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...] = Field(
+        description=(
+            "One dense component per chain degree, each shaped "
+            "(target basis size) x (source basis size). Entries follow the "
+            "same canonical coefficient grammar as differential matrices: "
+            "integers without leading zeros, reduced QQ fractions, and "
+            "GF(p) residues in [0, p); strings are parsed, never evaluated."
+        )
+    )
 
     @model_validator(mode="after")
     def require_admissible_map_components(self) -> Self:
@@ -255,6 +344,9 @@ class MappingConeRequest(StrictModel):
             list(self.source.basis_sizes),
             list(self.target.basis_sizes),
         )
+        # The returned cone is exposed as a first-class canonical value, so
+        # its derived bounds are part of the accepted request domain.
+        _require_admissible_cone_value(self.source, self.target, self.map_matrices)
         return self
 
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -9,6 +9,7 @@ from pydantic import Field, model_validator
 from jacobian._models import StrictModel
 from jacobian.math.chain_complexes.values import (
     MAX_TENSOR_GROUP_DIMENSION,
+    MAX_TENSOR_SERIALIZED_CHARS,
     MAX_TENSOR_TOTAL_CELLS,
     ChainComplexValue,
     CoefficientField,
@@ -180,6 +181,23 @@ class MappingConeRequest(StrictModel):
         return self
 
 
+def _require_serializable_entries(*complex_values) -> None:
+    """Tensor inputs stay within the serialization envelope: printed
+    entries are products/sums of two coefficients, so each component is
+    capped at 512 digits."""
+    for complex_value in complex_values:
+        for matrix in complex_value.differential_matrices:
+            for row in matrix:
+                for entry in row:
+                    numerator, slash, denominator = entry.partition("/")
+                    significant = denominator or numerator
+                    if len(significant.lstrip("-")) > 512:
+                        raise ValueError(
+                            "tensor product inputs are limited to "
+                            "512-digit coefficients"
+                        )
+
+
 class TensorProductRequest(StrictModel):
     """Compute the tensor product of two chain complexes."""
 
@@ -221,6 +239,14 @@ class TensorProductRequest(StrictModel):
             raise ValueError(
                 f"tensor product allocates {max(total, allocated_cells)} "
                 f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
+            )
+        _require_serializable_entries(self.left, self.right)
+        max_entry_chars = 2 * 512 + 8
+        if max(allocated_cells, 1) * max_entry_chars > MAX_TENSOR_SERIALIZED_CHARS:
+            raise ValueError(
+                "tensor product serialization exceeds the canonical output "
+                f"ceiling ({allocated_cells} cells x ~{max_entry_chars} "
+                "characters); supply smaller coefficients"
             )
         return self
 

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -8,11 +8,10 @@ from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
 from jacobian.math.chain_complexes.values import (
+    MAX_TENSOR_GROUP_DIMENSION,
+    MAX_TENSOR_TOTAL_CELLS,
     ChainComplexValue,
     CoefficientField,
-    HomologyResult,
-    MappingConeResult,
-    TensorProductResult,
 )
 
 
@@ -27,9 +26,20 @@ class ConstructChainComplexRequest(StrictModel):
     @model_validator(mode="after")
     def require_consistent_dimensions(self) -> Self:
         if len(self.basis_sizes) != len(self.differential_matrices) + 1:
-            raise ValueError(
-                "need one more basis size than differential matrices"
-            )
+            raise ValueError("need one more basis size than differential matrices")
+        # Full canonical admission: the constructed value must satisfy the
+        # chain-complex value contract here rather than failing inside
+        # execution.
+        from jacobian.math.chain_complexes.values import ChainComplexValue
+
+        ChainComplexValue(
+            coefficient_field=self.coefficient_field,
+            prime=self.prime,
+            degree_min=0,
+            degree_max=len(self.basis_sizes) - 1,
+            basis_sizes=self.basis_sizes,
+            differential_matrices=self.differential_matrices,
+        )
         return self
 
 
@@ -39,12 +49,71 @@ class VerifyDifferentialRequest(StrictModel):
     complex: ChainComplexValue
 
 
+def _require_chain_map_components(
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...],
+    *,
+    label: str,
+) -> None:
+    """Admit only complete, correctly shaped degree-aligned chain maps.
+
+    One component per source degree is required; component ``i`` must have
+    exactly ``target.basis_sizes[i]`` rows and ``source.basis_sizes[i]``
+    columns. Degree intervals must coincide so tuple indices are actual
+    chain degrees.
+    """
+    if source.coefficient_field != target.coefficient_field:
+        raise ValueError(
+            f"{label} requires equal coefficient fields "
+            f"({source.coefficient_field} vs {target.coefficient_field})"
+        )
+    if source.prime != target.prime:
+        raise ValueError(
+            f"{label} requires equal prime moduli ({source.prime} vs {target.prime})"
+        )
+    if (source.degree_min, source.degree_max) != (
+        target.degree_min,
+        target.degree_max,
+    ):
+        raise ValueError(
+            f"{label} requires source and target complexes concentrated on "
+            "the same degree interval "
+            f"({source.degree_min}..{source.degree_max} vs "
+            f"{target.degree_min}..{target.degree_max})"
+        )
+    expected_count = len(source.basis_sizes)
+    if len(map_matrices) != expected_count:
+        raise ValueError(
+            f"{label} requires one map component per chain degree "
+            f"({expected_count}), got {len(map_matrices)}"
+        )
+    for index, matrix in enumerate(map_matrices):
+        rows = target.basis_sizes[index]
+        cols = source.basis_sizes[index]
+        if len(matrix) != rows or any(len(row) != cols for row in matrix):
+            raise ValueError(
+                f"{label} map component {index} must have shape "
+                f"{rows}x{cols} (target rows x source columns)"
+            )
+
+
 class VerifyChainMapRequest(StrictModel):
     """Verify that a chain map commutes with differentials."""
 
     source: ChainComplexValue
     target: ChainComplexValue
     map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+    @model_validator(mode="after")
+    def require_admissible_map_components(self) -> Self:
+        _require_chain_map_components(
+            self.source,
+            self.target,
+            self.map_matrices,
+            label="chain-map verification",
+        )
+        return self
 
 
 class ComputeHomologyRequest(StrictModel):
@@ -60,12 +129,53 @@ class MappingConeRequest(StrictModel):
     target: ChainComplexValue
     map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
 
+    @model_validator(mode="after")
+    def require_admissible_map_components(self) -> Self:
+        _require_chain_map_components(
+            self.source,
+            self.target,
+            self.map_matrices,
+            label="mapping cone",
+        )
+        return self
+
 
 class TensorProductRequest(StrictModel):
     """Compute the tensor product of two chain complexes."""
 
     left: ChainComplexValue
     right: ChainComplexValue
+
+    @model_validator(mode="after")
+    def require_admissible_tensor_work(self) -> Self:
+        if (
+            self.left.coefficient_field != self.right.coefficient_field
+            or self.left.prime != self.right.prime
+        ):
+            raise ValueError("tensor product requires same coefficient field and prime")
+        # Bound the derived tensor dimensions before any allocation: each
+        # tensor-product group and the total cell count stay within a
+        # conservative budget derived from the input bounds.
+        group_count = len(self.left.basis_sizes) + len(self.right.basis_sizes) - 1
+        total = 0
+        for degree in range(group_count):
+            size = 0
+            for i in range(min(degree + 1, len(self.left.basis_sizes))):
+                j = degree - i
+                if j < len(self.right.basis_sizes):
+                    size += self.left.basis_sizes[i] * self.right.basis_sizes[j]
+            if size > MAX_TENSOR_GROUP_DIMENSION:
+                raise ValueError(
+                    f"tensor product group dimension {size} exceeds the "
+                    f"{MAX_TENSOR_GROUP_DIMENSION}-dimension work bound"
+                )
+            total += size
+        if total > MAX_TENSOR_TOTAL_CELLS:
+            raise ValueError(
+                f"tensor product totals {total} cells, exceeding the "
+                f"{MAX_TENSOR_TOTAL_CELLS}-cell work bound"
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -50,7 +50,7 @@ class VerifyDifferentialRequest(StrictModel):
     complex: ChainComplexValue
 
 
-def _require_component_entry_grammar(coefficient_field, matrix):
+def _require_component_entry_grammar(coefficient_field, matrix, *, prime=None):
     """Validate one component's entries; return its (cells, characters)."""
     from jacobian.math.chain_complexes.values import (
         _require_rational_entry_grammar,
@@ -61,7 +61,9 @@ def _require_component_entry_grammar(coefficient_field, matrix):
             # Shape alone does not make an entry parseable: the exact
             # kernels parse entries with Fraction/int and would turn an
             # accepted request into a host exception.
-            _require_rational_entry_grammar(coefficient_field, entry)
+            _require_rational_entry_grammar(
+                coefficient_field, entry, prime=prime
+            )
     return (
         sum(len(row) for row in matrix),
         sum(len(entry) for row in matrix for entry in row),
@@ -123,7 +125,7 @@ def _require_chain_map_components(
                 f"{rows}x{cols} (target rows x source columns)"
             )
         cells, chars = _require_component_entry_grammar(
-            source.coefficient_field, matrix
+            source.coefficient_field, matrix, prime=source.prime
         )
         total_map_cells += cells
         total_entry_chars += chars

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -159,10 +159,35 @@ class VerifyChainMapRequest(StrictModel):
         return self
 
 
+def _require_square_zero_at_admission(
+    complex_value: ChainComplexValue, *, label: str
+) -> None:
+    """Homology-type outputs are defined only for genuine complexes."""
+    from jacobian.math.chain_complexes.operations import (
+        _parsed_differentials,
+        _require_square_zero,
+    )
+
+    _require_square_zero(
+        _parsed_differentials(complex_value),
+        complex_value.prime,
+        label=label,
+        group_columns=list(complex_value.basis_sizes),
+        degree_min=complex_value.degree_min,
+    )
+
+
 class ComputeHomologyRequest(StrictModel):
     """Compute homology of a chain complex."""
 
     complex: ChainComplexValue
+
+    @model_validator(mode="after")
+    def require_genuine_chain_complex(self) -> Self:
+        # Homology is defined only when d^2 = 0; checking here keeps an
+        # unbounded execution failure out of math.run's typed contract.
+        _require_square_zero_at_admission(self.complex, label="homology")
+        return self
 
 
 class MappingConeRequest(StrictModel):
@@ -180,6 +205,8 @@ class MappingConeRequest(StrictModel):
             self.map_matrices,
             label="mapping cone",
         )
+        _require_square_zero_at_admission(self.source, label="mapping cone source")
+        _require_square_zero_at_admission(self.target, label="mapping cone target")
         return self
 
 
@@ -245,6 +272,8 @@ class TensorProductRequest(StrictModel):
                 f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
             )
         _require_serializable_entries(self.left, self.right)
+        _require_square_zero_at_admission(self.left, label="tensor product left")
+        _require_square_zero_at_admission(self.right, label="tensor product right")
         # Admission guarantees the derived complex value is canonical: the
         # degree interval must fit the shared chain-degree bounds, so
         # constructing it here fails at the boundary rather than inside

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -49,6 +49,24 @@ class VerifyDifferentialRequest(StrictModel):
     complex: ChainComplexValue
 
 
+def _require_component_entry_grammar(coefficient_field, matrix):
+    """Validate one component's entries; return its (cells, characters)."""
+    from jacobian.math.chain_complexes.values import (
+        _require_rational_entry_grammar,
+    )
+
+    for row in matrix:
+        for entry in row:
+            # Shape alone does not make an entry parseable: the exact
+            # kernels parse entries with Fraction/int and would turn an
+            # accepted request into a host exception.
+            _require_rational_entry_grammar(coefficient_field, entry)
+    return (
+        sum(len(row) for row in matrix),
+        sum(len(entry) for row in matrix for entry in row),
+    )
+
+
 def _require_chain_map_components(
     source: ChainComplexValue,
     target: ChainComplexValue,
@@ -89,9 +107,12 @@ def _require_chain_map_components(
             f"({expected_count}), got {len(map_matrices)}"
         )
     from jacobian.math.chain_complexes.values import (
-        _require_rational_entry_grammar,
+        MAX_CHAIN_MAP_CELLS,
+        MAX_CHAIN_MAP_ENTRY_CHARS,
     )
 
+    total_map_cells = 0
+    total_entry_chars = 0
     for index, matrix in enumerate(map_matrices):
         rows = target.basis_sizes[index]
         cols = source.basis_sizes[index]
@@ -100,12 +121,21 @@ def _require_chain_map_components(
                 f"{label} map component {index} must have shape "
                 f"{rows}x{cols} (target rows x source columns)"
             )
-        for row in matrix:
-            for entry in row:
-                # Shape alone does not make an entry parseable: the exact
-                # kernels parse entries with Fraction/int and would turn an
-                # accepted request into a host exception.
-                _require_rational_entry_grammar(source.coefficient_field, entry)
+        cells, chars = _require_component_entry_grammar(
+            source.coefficient_field, matrix
+        )
+        total_map_cells += cells
+        total_entry_chars += chars
+    if total_map_cells > MAX_CHAIN_MAP_CELLS:
+        raise ValueError(
+            f"{label} map components total {total_map_cells} cells, "
+            f"exceeding the {MAX_CHAIN_MAP_CELLS}-cell aggregate budget"
+        )
+    if total_entry_chars > MAX_CHAIN_MAP_ENTRY_CHARS:
+        raise ValueError(
+            f"{label} map components total {total_entry_chars} entry "
+            f"characters, exceeding the {MAX_CHAIN_MAP_ENTRY_CHARS}-character aggregate budget"
+        )
 
 
 class VerifyChainMapRequest(StrictModel):

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -1,0 +1,78 @@
+"""Typed wire contracts for chain complex operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.chain_complexes.values import (
+    ChainComplexValue,
+    CoefficientField,
+    HomologyResult,
+    MappingConeResult,
+    TensorProductResult,
+)
+
+
+class ConstructChainComplexRequest(StrictModel):
+    """Construct a chain complex from differential matrices."""
+
+    coefficient_field: CoefficientField = CoefficientField.RATIONAL
+    prime: int | None = Field(default=None, ge=2)
+    basis_sizes: tuple[int, ...] = Field(min_length=1)
+    differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+    @model_validator(mode="after")
+    def require_consistent_dimensions(self) -> Self:
+        if len(self.basis_sizes) != len(self.differential_matrices) + 1:
+            raise ValueError(
+                "need one more basis size than differential matrices"
+            )
+        return self
+
+
+class VerifyDifferentialRequest(StrictModel):
+    """Verify that d^2 = 0 for a chain complex."""
+
+    complex: ChainComplexValue
+
+
+class VerifyChainMapRequest(StrictModel):
+    """Verify that a chain map commutes with differentials."""
+
+    source: ChainComplexValue
+    target: ChainComplexValue
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+
+class ComputeHomologyRequest(StrictModel):
+    """Compute homology of a chain complex."""
+
+    complex: ChainComplexValue
+
+
+class MappingConeRequest(StrictModel):
+    """Compute the mapping cone of a chain map."""
+
+    source: ChainComplexValue
+    target: ChainComplexValue
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+
+class TensorProductRequest(StrictModel):
+    """Compute the tensor product of two chain complexes."""
+
+    left: ChainComplexValue
+    right: ChainComplexValue
+
+
+__all__ = [
+    "ComputeHomologyRequest",
+    "ConstructChainComplexRequest",
+    "MappingConeRequest",
+    "TensorProductRequest",
+    "VerifyChainMapRequest",
+    "VerifyDifferentialRequest",
+]

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -50,7 +50,12 @@ class VerifyDifferentialRequest(StrictModel):
     complex: ChainComplexValue
 
 
-def _require_component_entry_grammar(coefficient_field, matrix, *, prime=None):
+def _require_component_entry_grammar(
+    coefficient_field: CoefficientField,
+    matrix: tuple[tuple[str, ...], ...],
+    *,
+    prime: int | None = None,
+) -> tuple[int, int]:
     """Validate one component's entries; return its (cells, characters)."""
     from jacobian.math.chain_complexes.values import (
         _require_rational_entry_grammar,
@@ -61,9 +66,7 @@ def _require_component_entry_grammar(coefficient_field, matrix, *, prime=None):
             # Shape alone does not make an entry parseable: the exact
             # kernels parse entries with Fraction/int and would turn an
             # accepted request into a host exception.
-            _require_rational_entry_grammar(
-                coefficient_field, entry, prime=prime
-            )
+            _require_rational_entry_grammar(coefficient_field, entry, prime=prime)
     return (
         sum(len(row) for row in matrix),
         sum(len(entry) for row in matrix for entry in row),
@@ -255,7 +258,7 @@ class MappingConeRequest(StrictModel):
         return self
 
 
-def _require_serializable_entries(*complex_values) -> None:
+def _require_serializable_entries(*complex_values: ChainComplexValue) -> None:
     """Tensor inputs stay within the serialization envelope: printed
     entries are products/sums of two coefficients, so each component is
     capped at 512 digits."""
@@ -263,7 +266,7 @@ def _require_serializable_entries(*complex_values) -> None:
         for matrix in complex_value.differential_matrices:
             for row in matrix:
                 for entry in row:
-                    numerator, slash, denominator = entry.partition("/")
+                    numerator, _, denominator = entry.partition("/")
                     if (
                         len(numerator.lstrip("-")) > 512
                         or len(denominator.lstrip("-")) > 512

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -190,8 +190,10 @@ def _require_serializable_entries(*complex_values) -> None:
             for row in matrix:
                 for entry in row:
                     numerator, slash, denominator = entry.partition("/")
-                    significant = denominator or numerator
-                    if len(significant.lstrip("-")) > 512:
+                    if (
+                        len(numerator.lstrip("-")) > 512
+                        or len(denominator.lstrip("-")) > 512
+                    ):
                         raise ValueError(
                             "tensor product inputs are limited to "
                             "512-digit coefficients"
@@ -241,6 +243,27 @@ class TensorProductRequest(StrictModel):
                 f"cells, exceeding the {MAX_TENSOR_TOTAL_CELLS}-cell work bound"
             )
         _require_serializable_entries(self.left, self.right)
+        # Admission guarantees the derived complex value is canonical: the
+        # degree interval must fit the shared chain-degree bounds, so
+        # constructing it here fails at the boundary rather than inside
+        # execution when the result is exposed as a ChainComplexValue.
+        from jacobian.math.chain_complexes.values import ChainComplexValue
+
+        tensor_degree_min = self.left.degree_min + self.right.degree_min
+        # Shape-correct zero placeholders: differential deg has
+        # group_sizes[deg] rows and group_sizes[deg+1] columns.
+        placeholder_diffs = tuple(
+            tuple(("0",) * group_sizes[deg + 1] for _ in range(group_sizes[deg]))
+            for deg in range(max(0, group_count - 1))
+        )
+        ChainComplexValue(
+            coefficient_field=self.left.coefficient_field,
+            prime=self.left.prime,
+            degree_min=tensor_degree_min,
+            degree_max=tensor_degree_min + group_count - 1,
+            basis_sizes=group_sizes,
+            differential_matrices=placeholder_diffs,
+        )
         max_entry_chars = 2 * 512 + 8
         if max(allocated_cells, 1) * max_entry_chars > MAX_TENSOR_SERIALIZED_CHARS:
             raise ValueError(

--- a/src/jacobian/math/chain_complexes/_models.py
+++ b/src/jacobian/math/chain_complexes/_models.py
@@ -50,6 +50,36 @@ class ConstructChainComplexRequest(StrictModel):
             basis_sizes=self.basis_sizes,
             differential_matrices=self.differential_matrices,
         )
+        # A chain complex must satisfy d^2 = 0; unchecked candidate data
+        # would let the public operation label arbitrary matrices as an
+        # exact chain complex.
+        from jacobian.math.chain_complexes.operations import (
+            _matrix_multiply,
+            _matrix_to_fractions,
+        )
+
+        prime = self.prime
+        differentials = [
+            _matrix_to_fractions(
+                matrix,
+                self.basis_sizes[index],
+                self.basis_sizes[index + 1],
+                prime=prime,
+            )
+            for index, matrix in enumerate(self.differential_matrices)
+        ]
+        for index in range(len(differentials) - 1):
+            composite = _matrix_multiply(
+                differentials[index],
+                differentials[index + 1],
+                prime=prime,
+            )
+            if any(any(entry != 0 for entry in row) for row in composite):
+                raise ValueError(
+                    "differential matrices must satisfy d^2 = 0: the "
+                    f"composite of degrees {index + 1} and {index} is "
+                    "nonzero"
+                )
         return self
 
 

--- a/src/jacobian/math/chain_complexes/_tools.py
+++ b/src/jacobian/math/chain_complexes/_tools.py
@@ -53,7 +53,11 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "circle_chain_complex",
-                "Construct the chain complex of a circle (3 edges, 3 vertices).",
+                "Construct the chain complex of a circle (3 edges, 3 "
+                "vertices). Supply exactly one fewer differential matrix "
+                "than basis sizes; matrix i must have shape basis_sizes[i] "
+                "x basis_sizes[i+1], and adjacent matrices must compose to "
+                "zero (d^2 = 0).",
                 {
                     "coefficient_field": "QQ",
                     "basis_sizes": [3, 3],

--- a/src/jacobian/math/chain_complexes/_tools.py
+++ b/src/jacobian/math/chain_complexes/_tools.py
@@ -1,7 +1,5 @@
 """Chain complex operation declarations."""
 
-from typing import Any
-
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
 from jacobian.math.chain_complexes._models import (
@@ -21,13 +19,12 @@ from jacobian.math.chain_complexes.operations import (
     verify_differential,
 )
 from jacobian.math.chain_complexes.values import (
-    VerificationResult,
     ChainComplexValue,
     HomologyResult,
     MappingConeResult,
     TensorProductResult,
+    VerificationResult,
 )
-
 
 _CIRCLE_COMPLEX = {
     "coefficient_field": "QQ",

--- a/src/jacobian/math/chain_complexes/_tools.py
+++ b/src/jacobian/math/chain_complexes/_tools.py
@@ -1,0 +1,175 @@
+"""Chain complex operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.chain_complexes._models import (
+    ComputeHomologyRequest,
+    ConstructChainComplexRequest,
+    MappingConeRequest,
+    TensorProductRequest,
+    VerifyChainMapRequest,
+    VerifyDifferentialRequest,
+)
+from jacobian.math.chain_complexes.operations import (
+    compute_homology,
+    compute_mapping_cone,
+    compute_tensor_product,
+    construct_chain_complex,
+    verify_chain_map,
+    verify_differential,
+)
+from jacobian.math.chain_complexes.values import (
+    VerificationResult,
+    ChainComplexValue,
+    HomologyResult,
+    MappingConeResult,
+    TensorProductResult,
+)
+
+
+_CIRCLE_COMPLEX = {
+    "coefficient_field": "QQ",
+    "degree_min": 0,
+    "degree_max": 1,
+    "basis_sizes": [3, 3],
+    "differential_matrices": [
+        [["-1", "1", "0"], ["0", "-1", "1"], ["0", "0", "0"]],
+    ],
+}
+
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="chain_complex.construct.compute",
+        version="1",
+        title="Construct a finite based chain complex",
+        description=(
+            "Construct a bounded homological chain complex from differential "
+            "matrices over QQ or a prime field."
+        ),
+        request_type=ConstructChainComplexRequest,
+        result_type=ChainComplexValue,
+        run=construct_chain_complex,
+        tags=("chain-complex", "exact"),
+        examples=(
+            example(
+                "circle_chain_complex",
+                "Construct the chain complex of a circle (3 edges, 3 vertices).",
+                {
+                    "coefficient_field": "QQ",
+                    "basis_sizes": [3, 3],
+                    "differential_matrices": [
+                        [["-1", "1", "0"], ["0", "-1", "1"], ["0", "0", "0"]],
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="chain_complex.verify_differential.compute",
+        version="1",
+        title="Verify d^2 = 0",
+        description="Verify that the differential of a chain complex squares to zero.",
+        request_type=VerifyDifferentialRequest,
+        result_type=VerificationResult,
+        run=verify_differential,
+        tags=("chain-complex", "exact"),
+        examples=(
+            example(
+                "verify_circle_d2",
+                "Verify d^2 = 0 for the circle chain complex.",
+                {"complex": _CIRCLE_COMPLEX},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="chain_complex.verify_chain_map.compute",
+        version="1",
+        title="Verify a chain map commutes",
+        description="Verify that a chain map f: C -> D commutes with differentials.",
+        request_type=VerifyChainMapRequest,
+        result_type=VerificationResult,
+        run=verify_chain_map,
+        tags=("chain-complex", "exact"),
+        examples=(
+            example(
+                "verify_identity_map",
+                "Verify the identity map commutes.",
+                {
+                    "source": _CIRCLE_COMPLEX,
+                    "target": _CIRCLE_COMPLEX,
+                    "map_matrices": [
+                        [["1", "0", "0"], ["0", "1", "0"], ["0", "0", "1"]],
+                        [["1", "0", "0"], ["0", "1", "0"], ["0", "0", "1"]],
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="chain_complex.homology.compute",
+        version="1",
+        title="Compute homology of a chain complex",
+        description=(
+            "Compute the homology groups (Betti numbers) of a bounded chain "
+            "complex over QQ or a prime field using exact linear algebra."
+        ),
+        request_type=ComputeHomologyRequest,
+        result_type=HomologyResult,
+        run=compute_homology,
+        tags=("chain-complex", "homology", "exact"),
+        examples=(
+            example(
+                "circle_homology",
+                "Compute homology of the circle (Betti numbers 1, 1).",
+                {"complex": _CIRCLE_COMPLEX},
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="chain_complex.mapping_cone.compute",
+        version="1",
+        title="Compute the mapping cone",
+        description="Compute the mapping cone of a chain map f: C -> D.",
+        request_type=MappingConeRequest,
+        result_type=MappingConeResult,
+        run=compute_mapping_cone,
+        tags=("chain-complex", "exact"),
+        examples=(
+            example(
+                "identity_mapping_cone",
+                "Mapping cone of the identity on a circle.",
+                {
+                    "source": _CIRCLE_COMPLEX,
+                    "target": _CIRCLE_COMPLEX,
+                    "map_matrices": [
+                        [["1", "0", "0"], ["0", "1", "0"], ["0", "0", "1"]],
+                        [["1", "0", "0"], ["0", "1", "0"], ["0", "0", "1"]],
+                    ],
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="chain_complex.tensor_product.compute",
+        version="1",
+        title="Compute the tensor product of two chain complexes",
+        description="Compute the tensor product (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j.",
+        request_type=TensorProductRequest,
+        result_type=TensorProductResult,
+        run=compute_tensor_product,
+        tags=("chain-complex", "exact"),
+        examples=(
+            example(
+                "tensor_two_circles",
+                "Tensor product of two circle chain complexes.",
+                {"left": _CIRCLE_COMPLEX, "right": _CIRCLE_COMPLEX},
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -83,9 +83,7 @@ def mapping_cone(
     """Compute the mapping cone of a chain-map value."""
     from jacobian.math.chain_complexes.operations import _compute_mapping_cone
 
-    cone_basis_sizes, cone_diffs = _compute_mapping_cone(
-        source, target, map_matrices
-    )
+    cone_basis_sizes, cone_diffs = _compute_mapping_cone(source, target, map_matrices)
     return MappingConeResult(
         cone_basis_sizes=cone_basis_sizes,
         cone_differential_matrices=cone_diffs,

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -1,14 +1,13 @@
-"""Native domain functions accepting chain-complex domain values."""
+"""Native domain functions accepting chain-complex domain values.
+
+Each wrapper invokes the typed domain kernel directly and assembles its
+declared result value, so direct callers compose through the mathematical
+kernels without constructing wire request envelopes or repeating transport
+admission.
+"""
 
 from __future__ import annotations
 
-from jacobian.math.chain_complexes._models import (
-    ComputeHomologyRequest,
-    MappingConeRequest,
-    TensorProductRequest,
-    VerifyChainMapRequest,
-    VerifyDifferentialRequest,
-)
 from jacobian.math.chain_complexes.values import (
     ChainComplexValue,
     HomologyResult,
@@ -37,20 +36,27 @@ def homology_groups(
     degree interval so homology over different fields stays
     distinguishable as a serialized value.
     """
-    from jacobian.math.chain_complexes.operations import (
-        compute_homology,
-    )
+    from jacobian.math.chain_complexes.operations import _compute_homology_groups
 
-    return compute_homology(ComputeHomologyRequest(complex=complex_value))
+    groups = _compute_homology_groups(complex_value)
+    return HomologyResult(
+        homology_groups=tuple(groups),
+        coefficient_field=complex_value.coefficient_field,
+        prime=complex_value.prime,
+        degree_min=complex_value.degree_min,
+        degree_max=complex_value.degree_max,
+        complex=complex_value,
+    )
 
 
 def differential_squares_to_zero(
     complex_value: ChainComplexValue,
 ) -> VerificationResult:
     """Verify d^2 = 0 for one chain-complex value."""
-    from jacobian.math.chain_complexes.operations import verify_differential
+    from jacobian.math.chain_complexes.operations import _differential_verdict
 
-    return verify_differential(VerifyDifferentialRequest(complex=complex_value))
+    is_valid, detail = _differential_verdict(complex_value)
+    return VerificationResult(is_valid=is_valid, detail=detail, complex=complex_value)
 
 
 def chain_map_commutes(
@@ -59,10 +65,15 @@ def chain_map_commutes(
     map_matrices: MapMatrices,
 ) -> VerificationResult:
     """Verify that a component-wise chain map commutes with differentials."""
-    from jacobian.math.chain_complexes.operations import verify_chain_map
+    from jacobian.math.chain_complexes.operations import _chain_map_verdict
 
-    return verify_chain_map(
-        VerifyChainMapRequest(source=source, target=target, map_matrices=map_matrices)
+    is_valid, detail = _chain_map_verdict(source, target, map_matrices)
+    return VerificationResult(
+        is_valid=is_valid,
+        detail=detail,
+        source=source,
+        target=target,
+        map_matrices=map_matrices,
     )
 
 
@@ -70,17 +81,60 @@ def mapping_cone(
     source: ChainComplexValue, target: ChainComplexValue, map_matrices: MapMatrices
 ) -> MappingConeResult:
     """Compute the mapping cone of a chain-map value."""
-    from jacobian.math.chain_complexes.operations import compute_mapping_cone
+    from jacobian.math.chain_complexes.operations import _compute_mapping_cone
 
-    return compute_mapping_cone(
-        MappingConeRequest(source=source, target=target, map_matrices=map_matrices)
+    cone_basis_sizes, cone_diffs = _compute_mapping_cone(
+        source, target, map_matrices
+    )
+    return MappingConeResult(
+        cone_basis_sizes=cone_basis_sizes,
+        cone_differential_matrices=cone_diffs,
+        source_degree_min=source.degree_min,
+        target_degree_min=target.degree_min,
+        source=source,
+        target=target,
+        map_matrices=map_matrices,
+        value=ChainComplexValue(
+            coefficient_field=source.coefficient_field,
+            prime=source.prime,
+            degree_min=source.degree_min,
+            degree_max=source.degree_min + len(cone_basis_sizes) - 1,
+            basis_sizes=cone_basis_sizes,
+            differential_matrices=cone_diffs,
+        ),
     )
 
 
 def tensor_product_complex(
     left: ChainComplexValue, right: ChainComplexValue
 ) -> TensorProductResult:
-    """Compute the tensor product of two chain-complex values."""
-    from jacobian.math.chain_complexes.operations import compute_tensor_product
+    """Compute the tensor product of two chain-complex values.
 
-    return compute_tensor_product(TensorProductRequest(left=left, right=right))
+    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j with differential d_C ⊗ id + (-1)^i id ⊗ d_D.
+    """
+    from jacobian.math.chain_complexes.operations import _compute_tensor_product
+
+    tensor_basis_sizes, tensor_diffs = _compute_tensor_product(left, right)
+    # Tensor degrees are pairwise sums: the derived complex concentrates
+    # on [deg_min, deg_min + group_count - 1].
+    group_count = len(tensor_basis_sizes)
+    degree_min = left.degree_min + right.degree_min
+    degree_max = degree_min + group_count - 1
+    return TensorProductResult(
+        tensor_basis_sizes=tensor_basis_sizes,
+        tensor_differential_matrices=tensor_diffs,
+        coefficient_field=left.coefficient_field,
+        prime=left.prime,
+        degree_min=degree_min,
+        degree_max=degree_max,
+        left=left,
+        right=right,
+        value=ChainComplexValue(
+            coefficient_field=left.coefficient_field,
+            prime=left.prime,
+            degree_min=degree_min,
+            degree_max=degree_max,
+            basis_sizes=tensor_basis_sizes,
+            differential_matrices=tensor_diffs,
+        ),
+    )

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -1,0 +1,70 @@
+"""Native domain functions accepting chain-complex domain values."""
+
+from __future__ import annotations
+
+from jacobian.math.chain_complexes._models import (
+    MappingConeRequest,
+    TensorProductRequest,
+    VerifyChainMapRequest,
+    VerifyDifferentialRequest,
+)
+from jacobian.math.chain_complexes.values import (
+    ChainComplexValue,
+    HomologyGroupValue,
+    MappingConeResult,
+    TensorProductResult,
+    VerificationResult,
+)
+
+__all__ = [
+    "chain_map_commutes",
+    "differential_squares_to_zero",
+    "homology_groups",
+    "mapping_cone",
+    "tensor_product_complex",
+]
+
+
+def homology_groups(
+    complex_value: ChainComplexValue,
+) -> tuple[HomologyGroupValue, ...]:
+    """Exact homology groups of one finite based chain complex."""
+    from jacobian.math.chain_complexes.operations import (
+        _compute_homology_groups,
+    )
+
+    return _compute_homology_groups(complex_value)
+
+
+def differential_squares_to_zero(
+    complex_value: ChainComplexValue,
+) -> VerificationResult:
+    """Verify d^2 = 0 for one chain-complex value."""
+    from jacobian.math.chain_complexes.operations import verify_differential
+
+    return verify_differential(VerifyDifferentialRequest(complex=complex_value))
+
+
+def chain_map_commutes(source: ChainComplexValue, target: ChainComplexValue, map_matrices) -> VerificationResult:
+    """Verify that a component-wise chain map commutes with differentials."""
+    from jacobian.math.chain_complexes.operations import verify_chain_map
+
+    return verify_chain_map(
+        VerifyChainMapRequest(source=source, target=target, map_matrices=map_matrices)
+    )
+
+
+def mapping_cone(source: ChainComplexValue, target: ChainComplexValue, map_matrices) -> MappingConeResult:
+    """Compute the mapping cone of a chain-map value."""
+    from jacobian.math.chain_complexes.operations import compute_mapping_cone
+
+    return compute_mapping_cone(
+        MappingConeRequest(source=source, target=target, map_matrices=map_matrices)
+    )
+
+
+def tensor_product_complex(left: ChainComplexValue, right: ChainComplexValue) -> TensorProductResult:
+    """Compute the tensor product of two chain-complex values."""
+    from jacobian.math.chain_complexes.operations import compute_tensor_product
+
+    return compute_tensor_product(TensorProductRequest(left=left, right=right))

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -45,7 +45,9 @@ def differential_squares_to_zero(
     return verify_differential(VerifyDifferentialRequest(complex=complex_value))
 
 
-def chain_map_commutes(source: ChainComplexValue, target: ChainComplexValue, map_matrices) -> VerificationResult:
+def chain_map_commutes(
+    source: ChainComplexValue, target: ChainComplexValue, map_matrices
+) -> VerificationResult:
     """Verify that a component-wise chain map commutes with differentials."""
     from jacobian.math.chain_complexes.operations import verify_chain_map
 
@@ -54,7 +56,9 @@ def chain_map_commutes(source: ChainComplexValue, target: ChainComplexValue, map
     )
 
 
-def mapping_cone(source: ChainComplexValue, target: ChainComplexValue, map_matrices) -> MappingConeResult:
+def mapping_cone(
+    source: ChainComplexValue, target: ChainComplexValue, map_matrices
+) -> MappingConeResult:
     """Compute the mapping cone of a chain-map value."""
     from jacobian.math.chain_complexes.operations import compute_mapping_cone
 
@@ -63,7 +67,9 @@ def mapping_cone(source: ChainComplexValue, target: ChainComplexValue, map_matri
     )
 
 
-def tensor_product_complex(left: ChainComplexValue, right: ChainComplexValue) -> TensorProductResult:
+def tensor_product_complex(
+    left: ChainComplexValue, right: ChainComplexValue
+) -> TensorProductResult:
     """Compute the tensor product of two chain-complex values."""
     from jacobian.math.chain_complexes.operations import compute_tensor_product
 

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -25,6 +25,8 @@ __all__ = [
     "tensor_product_complex",
 ]
 
+MapMatrices = tuple[tuple[tuple[str, ...], ...], ...]
+
 
 def homology_groups(
     complex_value: ChainComplexValue,
@@ -52,7 +54,9 @@ def differential_squares_to_zero(
 
 
 def chain_map_commutes(
-    source: ChainComplexValue, target: ChainComplexValue, map_matrices
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+    map_matrices: MapMatrices,
 ) -> VerificationResult:
     """Verify that a component-wise chain map commutes with differentials."""
     from jacobian.math.chain_complexes.operations import verify_chain_map
@@ -63,7 +67,7 @@ def chain_map_commutes(
 
 
 def mapping_cone(
-    source: ChainComplexValue, target: ChainComplexValue, map_matrices
+    source: ChainComplexValue, target: ChainComplexValue, map_matrices: MapMatrices
 ) -> MappingConeResult:
     """Compute the mapping cone of a chain-map value."""
     from jacobian.math.chain_complexes.operations import compute_mapping_cone

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from jacobian.math.chain_complexes._models import (
+    ComputeHomologyRequest,
     MappingConeRequest,
     TensorProductRequest,
     VerifyChainMapRequest,
@@ -10,7 +11,7 @@ from jacobian.math.chain_complexes._models import (
 )
 from jacobian.math.chain_complexes.values import (
     ChainComplexValue,
-    HomologyGroupValue,
+    HomologyResult,
     MappingConeResult,
     TensorProductResult,
     VerificationResult,
@@ -27,13 +28,18 @@ __all__ = [
 
 def homology_groups(
     complex_value: ChainComplexValue,
-) -> tuple[HomologyGroupValue, ...]:
-    """Exact homology groups of one finite based chain complex."""
+) -> HomologyResult:
+    """Exact homology groups bound to their source complex and field.
+
+    The full ``HomologyResult`` carries the coefficient field, prime, and
+    degree interval so homology over different fields stays
+    distinguishable as a serialized value.
+    """
     from jacobian.math.chain_complexes.operations import (
-        _compute_homology_groups,
+        compute_homology,
     )
 
-    return _compute_homology_groups(complex_value)
+    return compute_homology(ComputeHomologyRequest(complex=complex_value))
 
 
 def differential_squares_to_zero(

--- a/src/jacobian/math/chain_complexes/native.py
+++ b/src/jacobian/math/chain_complexes/native.py
@@ -110,8 +110,16 @@ def tensor_product_complex(
 
     (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j with differential d_C ⊗ id + (-1)^i id ⊗ d_D.
     """
+    # Native callers bypass the MCP request model, so the shared tensor
+    # work admission must run here too: otherwise canonical inputs whose
+    # derived group dimensions exceed the budgets reach the dense kernel
+    # expansion before any bound rejects them.
+    from jacobian.math.chain_complexes._models import (
+        _require_admissible_tensor_work,
+    )
     from jacobian.math.chain_complexes.operations import _compute_tensor_product
 
+    _require_admissible_tensor_work(left, right)
     tensor_basis_sizes, tensor_diffs = _compute_tensor_product(left, right)
     # Tensor degrees are pairwise sums: the derived complex concentrates
     # on [deg_min, deg_min + group_count - 1].

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fractions import Fraction
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.chain_complexes._models import (
     ComputeHomologyRequest,
     ConstructChainComplexRequest,
@@ -51,66 +52,69 @@ def _matrix_to_fractions(
     return result
 
 
+def _rank_over_prime_field(mat: list[list[Fraction]], prime: int) -> int:
+    """Gauss-Jordan elimination inside GF(p) using modular inverses."""
+    rows = len(mat)
+    cols = len(mat[0])
+    work = [[int(v) % prime for v in row] for row in mat]
+    rank = 0
+    for col in range(cols):
+        pivot = next(
+            (row for row in range(rank, rows) if work[row][col] % prime != 0),
+            None,
+        )
+        if pivot is None:
+            continue
+        work[rank], work[pivot] = work[pivot], work[rank]
+        inverse = pow(work[rank][col], -1, prime)
+        for j in range(cols):
+            work[rank][j] = (work[rank][j] * inverse) % prime
+        for row in range(rows):
+            if row == rank:
+                continue
+            factor = work[row][col] % prime
+            if factor != 0:
+                for j in range(cols):
+                    work[row][j] = (work[row][j] - factor * work[rank][j]) % prime
+        rank += 1
+        if rank == rows:
+            break
+    return rank
+
+
+def _rank_over_rationals(mat: list[list[Fraction]]) -> int:
+    """Gauss-Jordan elimination over QQ."""
+    rows = len(mat)
+    cols = len(mat[0])
+    work = [row[:] for row in mat]
+    rank = 0
+    for col in range(cols):
+        pivot = next(
+            (row for row in range(rank, rows) if work[row][col] != 0),
+            None,
+        )
+        if pivot is None:
+            continue
+        work[rank], work[pivot] = work[pivot], work[rank]
+        for row in range(rows):
+            if row == rank or work[row][col] == 0:
+                continue
+            factor = work[row][col] / work[rank][col]
+            for j in range(cols):
+                work[row][j] -= factor * work[rank][j]
+        rank += 1
+        if rank == rows:
+            break
+    return rank
+
+
 def _matrix_rank(matrix: list[list[Fraction]], prime: int | None = None) -> int:
     """Compute rank of a matrix over QQ or GF(p)."""
     if not matrix or not matrix[0]:
         return 0
-    rows = len(matrix)
-    cols = len(matrix[0])
     if prime is not None:
-        # Perform elimination inside GF(p) using modular inverses
-        # Convert Fractions to ints modulo p (they are already residues)
-        mat = [[int(v) % prime for v in row] for row in matrix]
-        rank = 0
-        for col in range(cols):
-            # Find pivot with non-zero residue
-            pivot = None
-            for row in range(rank, rows):
-                if mat[row][col] % prime != 0:
-                    pivot = row
-                    break
-            if pivot is None:
-                continue
-            mat[rank], mat[pivot] = mat[pivot], mat[rank]
-            inv = pow(int(mat[rank][col]), -1, prime)  # modular inverse
-            # Normalize pivot row
-            for j in range(cols):
-                mat[rank][j] = (mat[rank][j] * inv) % prime
-            # Eliminate other rows
-            for row in range(rows):
-                if row == rank:
-                    continue
-                factor = mat[row][col] % prime
-                if factor != 0:
-                    for j in range(cols):
-                        mat[row][j] = (mat[row][j] - factor * mat[rank][j]) % prime
-            rank += 1
-            if rank == rows:
-                break
-        return rank
-    else:
-        mat = [row[:] for row in matrix]
-        rank = 0
-        for col in range(cols):
-            pivot = None
-            for row in range(rank, rows):
-                if mat[row][col] != 0:
-                    pivot = row
-                    break
-            if pivot is None:
-                continue
-            mat[rank], mat[pivot] = mat[pivot], mat[rank]
-            for row in range(rows):
-                if row == rank:
-                    continue
-                if mat[row][col] != 0:
-                    factor = mat[row][col] / mat[rank][col]
-                    for j in range(cols):
-                        mat[row][j] -= factor * mat[rank][j]
-            rank += 1
-            if rank == rows:
-                break
-        return rank
+        return _rank_over_prime_field(matrix, prime)
+    return _rank_over_rationals(matrix)
 
 
 def _matrix_multiply(
@@ -174,7 +178,7 @@ def _require_square_zero(
     prime: int | None = None,
     *,
     label: str,
-    group_columns=None,
+    group_columns: list[int] | None = None,
     degree_min: int = 0,
 ) -> None:
     """Require d^2 = 0 for a parsed differential sequence.
@@ -185,7 +189,9 @@ def _require_square_zero(
     """
     for i in range(len(diffs) - 1):
         result_columns = group_columns[i + 2] if group_columns is not None else None
-        left_declared_columns = group_columns[i + 1] if group_columns is not None else None
+        left_declared_columns = (
+            group_columns[i + 1] if group_columns is not None else None
+        )
         product = _matrix_multiply(
             diffs[i],
             diffs[i + 1],
@@ -204,8 +210,8 @@ def _require_chain_map_relation(
     target_diffs: list[list[list[Fraction]]],
     map_mats: list[list[list[Fraction]]],
     prime: int | None = None,
-    source_group_columns=None,
-    target_group_columns=None,
+    source_group_columns: list[int] | None = None,
+    target_group_columns: list[int] | None = None,
 ) -> None:
     """Require d_target * f_{i+1} == f_i * d_source at every differential.
 
@@ -463,14 +469,30 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
 
 
 def _serialize_entry(value: Fraction, prime: int | None) -> str:
-    """One canonical matrix-entry spelling; GF(p) entries are residues."""
+    """One canonical matrix-entry spelling; GF(p) entries are residues.
+
+    Prime-field coefficients reduce modulo the modulus so an accepted
+    GF(p) request serializes canonical residues in ``[0, p)`` instead of
+    signed representatives that downstream values would reject.
+    """
+    if value.denominator != 1:
+        if prime is not None:
+            raise ValueError("prime-field coefficients must be integers")
+        return (
+            f"{format_canonical_integer(value.numerator)}/"
+            f"{format_canonical_integer(value.denominator)}"
+        )
+    coefficient = int(value)
     if prime is not None:
-        # Canonical GF(p) residues in [0, p): signed contributions must not
-        # serialize as negative integers.
-        return str(int(value) % prime)
-    if value.denominator == 1:
-        return str(int(value))
-    return f"{value.numerator}/{value.denominator}"
+        return format_canonical_integer(coefficient % prime)
+    return format_canonical_integer(coefficient)
+
+
+def _serialized_matrix(
+    mat: list[list[Fraction]], prime: int | None
+) -> tuple[tuple[str, ...], ...]:
+    """Canonical string form of one exact derived matrix."""
+    return tuple(tuple(_serialize_entry(v, prime) for v in row) for row in mat)
 
 
 def _require_mapping_cone_parents(
@@ -493,6 +515,120 @@ def _require_mapping_cone_parents(
         )
 
 
+def _cone_group_sizes(
+    source: ChainComplexValue, target: ChainComplexValue
+) -> tuple[int, ...]:
+    """Cone groups are cone_n = C_{n-1} ⊕ D_n."""
+    max_len = max(len(source.basis_sizes), len(target.basis_sizes))
+    sizes = []
+    for i in range(max_len + 1):
+        d_size = target.basis_sizes[i] if i < len(target.basis_sizes) else 0
+        c_size2 = (
+            source.basis_sizes[i - 1]
+            if i > 0 and i - 1 < len(source.basis_sizes)
+            else 0
+        )
+        sizes.append(c_size2 + d_size)
+    return tuple(sizes)
+
+
+def _cone_block_dimensions(
+    n: int,
+    source_sizes: tuple[int, ...],
+    target_sizes: tuple[int, ...],
+) -> tuple[int, int, int, int]:
+    """Sizes (c_{n-2}, c_{n-1}, d_{n-1}, d_n) around cone degree n."""
+    c_n_minus2 = source_sizes[n - 2] if n - 2 >= 0 and n - 2 < len(source_sizes) else 0
+    c_n_minus1 = source_sizes[n - 1] if 0 <= n - 1 < len(source_sizes) else 0
+    d_n = target_sizes[n] if n < len(target_sizes) else 0
+    d_n_minus1 = target_sizes[n - 1] if n - 1 < len(target_sizes) else 0
+    return c_n_minus2, c_n_minus1, d_n_minus1, d_n
+
+
+def _fill_source_block(
+    block: list[list[Fraction]],
+    source_diffs: list[list[list[Fraction]]],
+    n: int,
+    c_n_minus2: int,
+    c_n_minus1: int,
+) -> None:
+    """Top-left block carries -d_C^{n-1}: C_{n-1} -> C_{n-2}."""
+    if not (c_n_minus2 and c_n_minus1 and n - 2 < len(source_diffs)):
+        return
+    d_c = source_diffs[n - 2]
+    for i in range(c_n_minus2):
+        for j in range(c_n_minus1):
+            block[i][j] = -d_c[i][j]
+
+
+def _fill_target_block(
+    block: list[list[Fraction]],
+    target_diffs: list[list[list[Fraction]]],
+    n: int,
+    c_n_minus2: int,
+    c_n_minus1: int,
+    d_n_minus1: int,
+    d_n: int,
+) -> None:
+    """Bottom-right block carries d_D^{n}: D_n -> D_{n-1}."""
+    if not (d_n_minus1 and d_n and n - 1 < len(target_diffs)):
+        return
+    d_d = target_diffs[n - 1]
+    for i in range(d_n_minus1):
+        for j in range(d_n):
+            block[c_n_minus2 + i][c_n_minus1 + j] = d_d[i][j]
+
+
+def _fill_map_block(
+    block: list[list[Fraction]],
+    map_mats: list[list[list[Fraction]]],
+    n: int,
+    c_n_minus2: int,
+    c_n_minus1: int,
+    d_n_minus1: int,
+) -> None:
+    """Bottom-left block carries f_{n-1}: C_{n-1} -> D_{n-1}."""
+    if not (d_n_minus1 and c_n_minus1 and n - 1 < len(map_mats)):
+        return
+    f = map_mats[n - 1]
+    for i in range(d_n_minus1):
+        for j in range(c_n_minus1):
+            if i < len(f) and j < len(f[0]):
+                block[c_n_minus2 + i][j] = f[i][j]
+
+
+def _cone_differential_for_degree(
+    n: int,
+    cone_basis_sizes: tuple[int, ...],
+    source_basis_sizes: tuple[int, ...],
+    target_basis_sizes: tuple[int, ...],
+    source_diffs: list[list[list[Fraction]]],
+    target_diffs: list[list[list[Fraction]]],
+    map_mats: list[list[list[Fraction]]],
+    prime: int | None,
+) -> tuple[tuple[str, ...], ...]:
+    """One cone differential cone_n -> cone_{n-1} as canonical strings.
+
+    Blocks: top-left = -d_C^{n-1}, top-right = 0, bottom-left = f_{n-1},
+    bottom-right = d_D^{n}.
+    """
+    rows = cone_basis_sizes[n - 1]
+    cols = cone_basis_sizes[n]
+    if rows == 0 or cols == 0:
+        # Zero-cell differentials keep their declared row count so the
+        # outer matrix shape stays reconstructible.
+        return tuple(() for _ in range(rows))
+    block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
+    c_n_minus2, c_n_minus1, d_n_minus1, d_n = _cone_block_dimensions(
+        n, source_basis_sizes, target_basis_sizes
+    )
+
+    _fill_source_block(block, source_diffs, n, c_n_minus2, c_n_minus1)
+    _fill_target_block(block, target_diffs, n, c_n_minus2, c_n_minus1, d_n_minus1, d_n)
+    _fill_map_block(block, map_mats, n, c_n_minus2, c_n_minus1, d_n_minus1)
+    return _serialized_matrix(block, prime)
+
+
 def _compute_mapping_cone(
     source: ChainComplexValue,
     target: ChainComplexValue,
@@ -503,25 +639,11 @@ def _compute_mapping_cone(
     _require_mapping_cone_parents(source, target)
     prime = source.prime
 
-    # Verify degree alignment: source and target should have same degree_min for simplicity, else shift
-    # Compute cone basis sizes: cone_n = C_{n-1} ⊕ D_n
-    max_len = max(len(source.basis_sizes), len(target.basis_sizes))
-    cone_basis_sizes = tuple(
-        (target.basis_sizes[i] if i < len(target.basis_sizes) else 0)
-        + (
-            source.basis_sizes[i - 1]
-            if i > 0 and i - 1 < len(source.basis_sizes)
-            else 0
-        )
-        for i in range(max_len + 1)
-    )
+    # Compute cone basis sizes: cone_n = C_{n-1} ⊕ D_n.
+    cone_basis_sizes = _cone_group_sizes(source, target)
 
-    # Build block differentials for each degree
-    # For each cone differential cone_{n} -> cone_{n-1}, we need matrix of size cone_basis_sizes[n-1] x cone_basis_sizes[n]
-    # Blocks: top-left = -d_C^{n-1}, top-right = 0, bottom-left = f_{n-1}, bottom-right = d_D^{n}
-    # For simplicity, we construct string matrices with entries as fractions strings.
-    # Need to parse source and target diffs and maps.
-
+    # Parse source and target differentials plus the map components.
+    # map matrices: f_i: C_i -> D_i, shape target_basis[i] x source_basis[i].
     source_diffs = [
         _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
         for i, m in enumerate(source.differential_matrices)
@@ -530,7 +652,6 @@ def _compute_mapping_cone(
         _matrix_to_fractions(m, target.basis_sizes[i], target.basis_sizes[i + 1], prime)
         for i, m in enumerate(target.differential_matrices)
     ]
-    # map matrices: f_i: C_i -> D_i, shape target_basis[i] x source_basis[i]
     map_mats = [
         _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
         for i, m in enumerate(map_matrices)
@@ -562,57 +683,19 @@ def _compute_mapping_cone(
         target_group_columns=list(target.basis_sizes),
     )
 
-    def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
-        return tuple(
-            tuple(_serialize_entry(v, prime) for v in row) for row in mat
+    cone_diffs = tuple(
+        _cone_differential_for_degree(
+            n,
+            cone_basis_sizes,
+            source.basis_sizes,
+            target.basis_sizes,
+            source_diffs,
+            target_diffs,
+            map_mats,
+            prime,
         )
-
-    cone_diffs: list[tuple[tuple[str, ...], ...]] = []
-    for n in range(1, len(cone_basis_sizes)):
-        rows = cone_basis_sizes[n - 1]
-        cols = cone_basis_sizes[n]
-        if rows == 0 or cols == 0:
-            # Zero-cell differentials keep their declared row count so the
-            # outer matrix shape stays reconstructible.
-            cone_diffs.append(tuple(() for _ in range(rows)))
-            continue
-        # Build zero matrix
-        block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
-        # Sizes for decomposition: cone_{n} = C_{n-1} ⊕ D_n, cone_{n-1}= C_{n-2} ⊕ D_{n-1}
-        c_n_minus1 = (
-            source.basis_sizes[n - 1] if 0 <= n - 1 < len(source.basis_sizes) else 0
-        )
-        d_n = target.basis_sizes[n] if n < len(target.basis_sizes) else 0
-        c_n_minus2 = (
-            source.basis_sizes[n - 2]
-            if n - 2 >= 0 and n - 2 < len(source.basis_sizes)
-            else 0
-        )
-        d_n_minus1 = target.basis_sizes[n - 1] if n - 1 < len(target.basis_sizes) else 0
-
-        # Fill blocks
-        # Top-left: -d_C^{n-1} : size c_{n-2} x c_{n-1}
-        if c_n_minus2 and c_n_minus1 and n - 2 < len(source_diffs):
-            d_c = source_diffs[n - 2]  # C_{n-1} -> C_{n-2}
-            for i in range(c_n_minus2):
-                for j in range(c_n_minus1):
-                    block[i][j] = -d_c[i][j]
-        # Bottom-right: d_D^{n}: size d_{n-1} x d_n
-        if d_n_minus1 and d_n and n - 1 < len(target_diffs):
-            d_d = target_diffs[n - 1]
-            for i in range(d_n_minus1):
-                for j in range(d_n):
-                    block[c_n_minus2 + i][c_n_minus1 + j] = d_d[i][j]
-        # Bottom-left: f_{n-1}: size d_{n-1} x c_{n-1}
-        if d_n_minus1 and c_n_minus1 and n - 1 < len(map_mats):
-            f = map_mats[n - 1]
-            for i in range(d_n_minus1):
-                for j in range(c_n_minus1):
-                    # f is target x source, so need to map correctly
-                    if i < len(f) and j < len(f[0]):
-                        block[c_n_minus2 + i][j] = f[i][j]
-
-        cone_diffs.append(_to_str_matrix(block))
+        for n in range(1, len(cone_basis_sizes))
+    )
 
     # Defining invariant of the returned decomposition: the cone
     # differentials must themselves be square-zero. Declared cone group
@@ -631,7 +714,7 @@ def _compute_mapping_cone(
         degree_min=source.degree_min,
     )
 
-    return cone_basis_sizes, tuple(cone_diffs)
+    return cone_basis_sizes, cone_diffs
 
 
 def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
@@ -655,6 +738,138 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     )
 
 
+def _tensor_group_sizes(
+    left: ChainComplexValue, right: ChainComplexValue
+) -> tuple[int, ...]:
+    """Tensor groups are the graded sums (C⊗D)_n = ⊕_{i+j=n} C_i ⊗ D_j."""
+    group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
+    sizes = []
+    for degree in range(group_count):
+        size = 0
+        for i in range(min(degree + 1, len(left.basis_sizes))):
+            j = degree - i
+            if j < len(right.basis_sizes):
+                size += left.basis_sizes[i] * right.basis_sizes[j]
+        sizes.append(size)
+    return tuple(sizes)
+
+
+def _tensor_group_offsets(
+    degree: int,
+    left_sizes: tuple[int, ...],
+    right_sizes: tuple[int, ...],
+) -> dict[tuple[int, int], int]:
+    """Column offsets of every (i, j) summand contributing to one degree."""
+    offsets: dict[tuple[int, int], int] = {}
+    off = 0
+    for i in range(min(degree + 1, len(left_sizes))):
+        j = degree - i
+        if j < len(right_sizes) and j >= 0:
+            offsets[(i, j)] = off
+            off += left_sizes[i] * right_sizes[j]
+    return offsets
+
+
+def _apply_left_factor_differential(
+    block: list[list[Fraction]],
+    *,
+    i: int,
+    col_off: int,
+    row_off: int,
+    left: ChainComplexValue,
+    left_diffs: list[list[list[Fraction]]],
+    d_j_size: int,
+) -> None:
+    """d_C ⊗ id_D contribution from C_i ⊗ D_j down to C_{i-1} ⊗ D_j."""
+    d_left = left_diffs[i - 1]
+    for a in range(left.basis_sizes[i - 1]):
+        for b in range(left.basis_sizes[i]):
+            coeff = d_left[a][b]
+            if coeff == 0:
+                continue
+            for c in range(d_j_size):
+                row = row_off + a * d_j_size + c
+                col = col_off + b * d_j_size + c
+                block[row][col] += coeff
+
+
+def _apply_right_factor_differential(
+    block: list[list[Fraction]],
+    *,
+    i: int,
+    j: int,
+    col_off: int,
+    row_off: int,
+    left: ChainComplexValue,
+    right: ChainComplexValue,
+    right_diffs: list[list[list[Fraction]]],
+) -> None:
+    """(-1)^i id_C ⊗ d_D contribution from C_i ⊗ D_j down to C_i ⊗ D_{j-1}.
+
+    The sign uses ``i`` as the actual chain degree of the left factor,
+    not its tuple index.
+    """
+    d_right = right_diffs[j - 1]
+    sign = -1 if (left.degree_min + i) % 2 == 1 else 1
+    for a in range(left.basis_sizes[i]):
+        for c2 in range(right.basis_sizes[j - 1]):
+            for d in range(right.basis_sizes[j]):
+                coeff = d_right[c2][d] * sign
+                if coeff == 0:
+                    continue
+                row = row_off + a * right.basis_sizes[j - 1] + c2
+                col = col_off + a * right.basis_sizes[j] + d
+                block[row][col] += coeff
+
+
+def _tensor_differential_for_degree(
+    deg: int,
+    group_sizes: tuple[int, ...],
+    left: ChainComplexValue,
+    right: ChainComplexValue,
+    left_diffs: list[list[list[Fraction]]],
+    right_diffs: list[list[list[Fraction]]],
+    prime: int | None,
+) -> tuple[tuple[str, ...], ...]:
+    """One tensor differential (C⊗D)_deg -> (C⊗D)_{deg-1} as strings.
+
+    Each summand C_i ⊗ D_j contributes via d_C down to C_{i-1} ⊗ D_j and
+    via the Koszul-signed id ⊗ d_D down to C_i ⊗ D_{j-1}.
+    """
+    rows = group_sizes[deg - 1]
+    cols = group_sizes[deg]
+    if rows == 0 or cols == 0:
+        # Zero-cell differentials keep their declared row count so the
+        # outer matrix shape stays reconstructible.
+        return tuple(() for _ in range(rows))
+    block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
+    offsets_deg = _tensor_group_offsets(deg, left.basis_sizes, right.basis_sizes)
+    offsets_prev = _tensor_group_offsets(deg - 1, left.basis_sizes, right.basis_sizes)
+    for (i, j), col_off in offsets_deg.items():
+        if i > 0 and (i - 1, j) in offsets_prev:
+            _apply_left_factor_differential(
+                block,
+                i=i,
+                col_off=col_off,
+                row_off=offsets_prev[(i - 1, j)],
+                left=left,
+                left_diffs=left_diffs,
+                d_j_size=right.basis_sizes[j],
+            )
+        if j > 0 and (i, j - 1) in offsets_prev:
+            _apply_right_factor_differential(
+                block,
+                i=i,
+                j=j,
+                col_off=col_off,
+                row_off=offsets_prev[(i, j - 1)],
+                left=left,
+                right=right,
+                right_diffs=right_diffs,
+            )
+    return _serialized_matrix(block, prime)
+
+
 def _compute_tensor_product(
     left: ChainComplexValue,
     right: ChainComplexValue,
@@ -665,23 +880,7 @@ def _compute_tensor_product(
         raise ValueError("tensor product requires same coefficient field and prime")
     prime = left.prime
 
-    n = len(left.basis_sizes) + len(right.basis_sizes) - 1
-
-    # Basis sizes for the tensor product
-    group_sizes: list[int] = []
-    for degree in range(n):
-        size = 0
-        for i in range(min(degree + 1, len(left.basis_sizes))):
-            j = degree - i
-            if j < len(right.basis_sizes):
-                size += left.basis_sizes[i] * right.basis_sizes[j]
-        group_sizes.append(size)
-    tensor_basis_sizes = tuple(group_sizes)
-
-    # Build signed differentials for each degree.
-    # For each n, differential d_n: (C⊗D)_n -> (C⊗D)_{n-1} is block matrix with
-    # contributions from d^C and d^D with signs.
-    # We construct rational matrices as Fractions and convert to strings.
+    tensor_basis_sizes = _tensor_group_sizes(left, right)
 
     left_diffs = [
         _matrix_to_fractions(m, left.basis_sizes[i], left.basis_sizes[i + 1], prime)
@@ -709,77 +908,14 @@ def _compute_tensor_product(
         degree_min=right.degree_min,
     )
 
-    def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
-        return tuple(
-            tuple(_serialize_entry(v, prime) for v in row) for row in mat
+    tensor_diffs = tuple(
+        _tensor_differential_for_degree(
+            deg, tensor_basis_sizes, left, right, left_diffs, right_diffs, prime
         )
+        for deg in range(1, len(tensor_basis_sizes))
+    )
 
-    tensor_diffs: list[tuple[tuple[str, ...], ...]] = []
-    for deg in range(1, n):
-        rows = tensor_basis_sizes[deg - 1]
-        cols = tensor_basis_sizes[deg]
-        if rows == 0 or cols == 0:
-            # Zero-cell differentials keep their declared row count so the
-            # outer matrix shape stays reconstructible.
-            tensor_diffs.append(tuple(() for _ in range(rows)))
-            continue
-        block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
-        # We need to map block structure: (C⊗D)_deg = ⊕_{i+j=deg} C_i⊗D_j
-        # Similarly for deg-1 = ⊕_{p+q=deg-1} C_p⊗D_q
-        # For each i,j contributing to deg, its differential contributes to two possible targets:
-        # - via d_C: C_i⊗D_j -> C_{i-1}⊗D_j (if i>0)
-        # - via d_D: C_i⊗D_j -> C_i⊗D_{j-1} with sign (-1)^i
-        # We need to compute offset positions for each summand.
-        # First compute offsets for deg and deg-1
-        offsets_deg = {}
-        off = 0
-        for i in range(min(deg + 1, len(left.basis_sizes))):
-            j = deg - i
-            if j < len(right.basis_sizes):
-                offsets_deg[(i, j)] = off
-                off += left.basis_sizes[i] * right.basis_sizes[j]
-        offsets_deg_minus1 = {}
-        off = 0
-        for p in range(min(deg, len(left.basis_sizes))):
-            q = deg - 1 - p
-            if q < len(right.basis_sizes) and q >= 0:
-                offsets_deg_minus1[(p, q)] = off
-                off += left.basis_sizes[p] * right.basis_sizes[q]
-
-        for (i, j), col_off in offsets_deg.items():
-            # d_C contribution
-            if i > 0 and (i - 1, j) in offsets_deg_minus1:
-                d_left = left_diffs[i - 1]  # shape left_basis[i-1] x left_basis[i]
-                row_off = offsets_deg_minus1[(i - 1, j)]
-                # Tensor product with identity on D_j
-                for a in range(left.basis_sizes[i - 1]):
-                    for b in range(left.basis_sizes[i]):
-                        coeff = d_left[a][b]
-                        if coeff == 0:
-                            continue
-                        for c in range(right.basis_sizes[j]):
-                            row = row_off + a * right.basis_sizes[j] + c
-                            col = col_off + b * right.basis_sizes[j] + c
-                            block[row][col] += coeff
-            # d_D contribution with sign (-1)^i where i is the actual chain
-            # degree of the left factor, not its tuple index.
-            if j > 0 and (i, j - 1) in offsets_deg_minus1:
-                d_right = right_diffs[j - 1]
-                left_degree = left.degree_min + i
-                sign = -1 if left_degree % 2 == 1 else 1
-                row_off = offsets_deg_minus1[(i, j - 1)]
-                for a in range(left.basis_sizes[i]):
-                    for c2 in range(right.basis_sizes[j - 1]):
-                        for d in range(right.basis_sizes[j]):
-                            coeff = d_right[c2][d] * sign
-                            if coeff == 0:
-                                continue
-                            row = row_off + a * right.basis_sizes[j - 1] + c2
-                            col = col_off + a * right.basis_sizes[j] + d
-                            block[row][col] += coeff
-        tensor_diffs.append(_to_str_matrix(block))
-
-    return tensor_basis_sizes, tuple(tensor_diffs)
+    return tensor_basis_sizes, tensor_diffs
 
 
 def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult:

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -118,9 +118,13 @@ def _matrix_multiply(
     b: list[list[Fraction]],
     prime: int | None = None,
     result_columns: int | None = None,
+    left_declared_columns: int | None = None,
 ) -> list[list[Fraction]]:
     rows_a = len(a)
-    cols_a = len(a[0]) if a else 0
+    # A zero-row left operand keeps its declared column count so the
+    # inner product dimension matches the shape contract, mirroring how
+    # the right operand's outer width is preserved below.
+    cols_a = len(a[0]) if a else (left_declared_columns or 0)
     if b:
         cols_b = len(b[0])
         if len(b) != cols_a:
@@ -181,7 +185,14 @@ def _require_square_zero(
     """
     for i in range(len(diffs) - 1):
         result_columns = group_columns[i + 2] if group_columns is not None else None
-        product = _matrix_multiply(diffs[i], diffs[i + 1], prime, result_columns)
+        left_declared_columns = group_columns[i + 1] if group_columns is not None else None
+        product = _matrix_multiply(
+            diffs[i],
+            diffs[i + 1],
+            prime,
+            result_columns,
+            left_declared_columns=left_declared_columns,
+        )
         if any(value != 0 for row in product for value in row):
             raise ValueError(
                 f"{label} complex violates d^2=0 at chain degree {degree_min + i}"
@@ -241,12 +252,18 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
         # Correct order: d_i * d_{i+1} where diffs[i] is C_i x C_{i+1}, diffs[i+1] is C_{i+1} x C_{i+2}
         d_i = diffs[i]
         d_ip1 = diffs[i + 1]
-        product = _matrix_multiply(d_i, d_ip1, prime, cx.basis_sizes[i + 2])
+        product = _matrix_multiply(
+            d_i,
+            d_ip1,
+            prime,
+            cx.basis_sizes[i + 2],
+            left_declared_columns=cx.basis_sizes[i + 1],
+        )
         is_zero = all(all(val == 0 for val in row) for row in product)
         if not is_zero:
             return VerificationResult(
                 is_valid=False,
-                detail=f"d^2 != 0 at degree {i + 1}",
+                detail=f"d^2 != 0 at degree {cx.degree_min + i + 1}",
                 complex=request.complex,
             )
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -267,12 +267,9 @@ def construct_chain_complex(request: ConstructChainComplexRequest) -> ChainCompl
     )
 
 
-def verify_differential(request: VerifyDifferentialRequest) -> VerificationResult:
-    """Verify that d^2 = 0 for a chain complex.
-
-    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
-    """
-    cx = request.complex
+def _differential_verdict(complex_value: ChainComplexValue) -> tuple[bool, str]:
+    """Decide d^2 = 0 exactly and derive the authoritative detail string."""
+    cx = complex_value
     prime = cx.prime
     diffs = [
         _matrix_to_fractions(m, cx.basis_sizes[i], cx.basis_sizes[i + 1], prime)
@@ -292,34 +289,23 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
         )
         is_zero = all(all(val == 0 for val in row) for row in product)
         if not is_zero:
-            return VerificationResult(
-                is_valid=False,
-                detail=f"d^2 != 0 at degree {cx.degree_min + i + 1}",
-                complex=request.complex,
-            )
+            return False, f"d^2 != 0 at degree {cx.degree_min + i + 1}"
 
-    return VerificationResult(
-        is_valid=True,
-        detail="d^2 = 0 for all degrees",
-        complex=request.complex,
-    )
+    return True, "d^2 = 0 for all degrees"
 
 
-def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
-    """Verify that a chain map commutes with differentials.
+def _chain_map_verdict(
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...],
+) -> tuple[bool, str]:
+    """Decide the chain-map relation exactly and derive its detail string.
 
-    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
-
-    Request admission guarantees equal coefficient fields and prime, so a
-    field mismatch can never reach this kernel as a verdict.
+    Endpoints violating d^2 = 0 make the verification false by definition;
+    the relation itself must commute at every differential degree.
     """
-    source = request.source
-    target = request.target
     prime = source.prime
 
-    # A chain map exists only between chain complexes; endpoints violating
-    # d^2=0 make the verification false by definition. Check every
-    # consecutive differential product of each endpoint.
     for label, complex_value in (("source", source), ("target", target)):
         if len(complex_value.differential_matrices) > 1:
             try:
@@ -330,21 +316,15 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
                     group_columns=list(complex_value.basis_sizes),
                 )
             except ValueError as error:
-                return VerificationResult(
-                    is_valid=False,
-                    detail=str(error) + ", so no chain map between these "
+                return (
+                    False,
+                    str(error) + ", so no chain map between these "
                     "endpoints exists",
-                    source=source,
-                    target=target,
-                    map_matrices=request.map_matrices,
                 )
 
-    # Request admission guarantees one component per degree, equal shape
-    # (target rows x source columns) per component, and coinciding degree
-    # intervals, so tuple index equals actual chain degree.
     map_mats = [
         _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
-        for i, m in enumerate(request.map_matrices)
+        for i, m in enumerate(map_matrices)
     ]
     source_diffs = [
         _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
@@ -355,10 +335,6 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
         for i, m in enumerate(target.differential_matrices)
     ]
 
-    # f_i: C_i -> D_i has shape target_basis[i] x source_basis[i], so the
-    # chain-map equation at every differential is
-    # d_target_i * f_{i+1} == f_i * d_source_i. Declared widths keep
-    # empty-row differentials and components shape-faithful.
     for i in range(len(source_diffs)):
         result_columns = source.basis_sizes[i + 1]
         left = _matrix_multiply(
@@ -376,19 +352,40 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
             left_declared_columns=source.basis_sizes[i],
         )
         if left != right:
-            return VerificationResult(
-                is_valid=False,
-                detail=f"chain map does not commute at degree {source.degree_min + i}",
-                source=source,
-                target=target,
-                map_matrices=request.map_matrices,
-            )
+            return False, f"chain map does not commute at degree {source.degree_min + i}"
 
+    return True, "chain map commutes with differentials"
+
+
+def verify_differential(request: VerifyDifferentialRequest) -> VerificationResult:
+    """Verify that d^2 = 0 for a chain complex.
+
+    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
+    """
+    is_valid, detail = _differential_verdict(request.complex)
     return VerificationResult(
-        is_valid=True,
-        detail="chain map commutes with differentials",
-        source=source,
-        target=target,
+        is_valid=is_valid,
+        detail=detail,
+        complex=request.complex,
+    )
+
+
+def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
+    """Verify that a chain map commutes with differentials.
+
+    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
+
+    Request admission guarantees equal coefficient fields and prime, so a
+    field mismatch can never reach this kernel as a verdict.
+    """
+    is_valid, detail = _chain_map_verdict(
+        request.source, request.target, request.map_matrices
+    )
+    return VerificationResult(
+        is_valid=is_valid,
+        detail=detail,
+        source=request.source,
+        target=request.target,
         map_matrices=request.map_matrices,
     )
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -1,0 +1,281 @@
+"""Exact finite based chain complex operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian.math.chain_complexes._models import (
+    ComputeHomologyRequest,
+    ConstructChainComplexRequest,
+    MappingConeRequest,
+    TensorProductRequest,
+    VerifyChainMapRequest,
+    VerifyDifferentialRequest,
+)
+from jacobian.math.chain_complexes.values import (
+    VerificationResult,
+    ChainComplexValue,
+    CoefficientField,
+    HomologyGroupValue,
+    HomologyResult,
+    MappingConeResult,
+    TensorProductResult,
+)
+
+
+def _parse_fraction(s: str, prime: int | None = None) -> Fraction:
+    if prime is not None:
+        return Fraction(int(s) % prime)
+    if "/" in s:
+        num, den = s.split("/", 1)
+        return Fraction(int(num), int(den))
+    return Fraction(int(s))
+
+
+def _matrix_to_fractions(
+    matrix: tuple[tuple[str, ...], ...],
+    rows: int,
+    cols: int,
+    prime: int | None = None,
+) -> list[list[Fraction]]:
+    result = [[Fraction(0)] * cols for _ in range(rows)]
+    for i, row in enumerate(matrix):
+        for j, val in enumerate(row):
+            result[i][j] = _parse_fraction(val, prime)
+    return result
+
+
+def _matrix_rank(matrix: list[list[Fraction]], prime: int | None = None) -> int:
+    """Compute rank of a matrix over QQ or GF(p)."""
+    if not matrix or not matrix[0]:
+        return 0
+    rows = len(matrix)
+    cols = len(matrix[0])
+    mat = [row[:] for row in matrix]
+    rank = 0
+    for col in range(cols):
+        pivot = None
+        for row in range(rank, rows):
+            if mat[row][col] != 0:
+                pivot = row
+                break
+        if pivot is None:
+            continue
+        mat[rank], mat[pivot] = mat[pivot], mat[rank]
+        for row in range(rows):
+            if row == rank:
+                continue
+            if mat[row][col] != 0:
+                factor = mat[row][col] / mat[rank][col]
+                for j in range(cols):
+                    mat[row][j] -= factor * mat[rank][j]
+                if prime is not None:
+                    for j in range(cols):
+                        mat[row][j] = mat[row][j] % prime
+        rank += 1
+        if rank == rows:
+            break
+    return rank
+
+
+def _matrix_multiply(
+    a: list[list[Fraction]],
+    b: list[list[Fraction]],
+) -> list[list[Fraction]]:
+    rows_a = len(a)
+    cols_a = len(a[0]) if a else 0
+    cols_b = len(b[0]) if b else 0
+    result = [[Fraction(0)] * cols_b for _ in range(rows_a)]
+    for i in range(rows_a):
+        for j in range(cols_b):
+            for k in range(cols_a):
+                result[i][j] += a[i][k] * b[k][j]
+    return result
+
+
+def construct_chain_complex(request: ConstructChainComplexRequest) -> ChainComplexValue:
+    """Construct a chain complex from differential matrices."""
+    basis_sizes = request.basis_sizes
+    n = len(basis_sizes)
+    degree_min = 0
+    degree_max = n - 1
+
+    return ChainComplexValue(
+        coefficient_field=request.coefficient_field,
+        prime=request.prime,
+        degree_min=degree_min,
+        degree_max=degree_max,
+        basis_sizes=basis_sizes,
+        differential_matrices=request.differential_matrices,
+    )
+
+
+def verify_differential(request: VerifyDifferentialRequest) -> VerificationResult:
+    """Verify that d^2 = 0 for a chain complex.
+
+    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
+    """
+    cx = request.complex
+    prime = cx.prime
+    diffs = [
+        _matrix_to_fractions(m, cx.basis_sizes[i], cx.basis_sizes[i + 1], prime)
+        for i, m in enumerate(cx.differential_matrices)
+    ]
+
+    for i in range(len(diffs) - 1):
+        d_n = diffs[i + 1]
+        d_n_minus_1 = diffs[i]
+        product = _matrix_multiply(d_n, d_n_minus_1)
+        is_zero = all(
+            all(val == 0 for val in row) for row in product
+        )
+        if not is_zero:
+            return VerificationResult(
+                is_valid=False,
+                detail= f"d^2 != 0 at degree {i + 1}",
+            )
+
+    return VerificationResult(is_valid=True, detail="d^2 = 0 for all degrees")
+
+
+def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
+    """Verify that a chain map commutes with differentials.
+
+    Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
+    """
+    source = request.source
+    target = request.target
+    prime = source.prime or target.prime
+
+    source_diffs = [
+        _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
+        for i, m in enumerate(source.differential_matrices)
+    ]
+    target_diffs = [
+        _matrix_to_fractions(m, target.basis_sizes[i], target.basis_sizes[i + 1], prime)
+        for i, m in enumerate(target.differential_matrices)
+    ]
+    map_mats = [
+        _matrix_to_fractions(m, source.basis_sizes[i], target.basis_sizes[i], prime)
+        for i, m in enumerate(request.map_matrices)
+    ]
+
+    for i in range(len(source_diffs)):
+        d_source = source_diffs[i]
+        d_target = target_diffs[i]
+        f_n = map_mats[i]
+        f_n_minus_1 = map_mats[i + 1] if i + 1 < len(map_mats) else None
+
+        # d_target * f_n should equal f_{n-1} * d_source
+        left = _matrix_multiply(f_n, d_target)  # f_n: C_n -> D_n, d_target: D_n -> D_{n-1}
+        if f_n_minus_1 is not None:
+            right = _matrix_multiply(d_source, f_n_minus_1)  # d_source: C_n -> C_{n-1}, f_{n-1}: C_{n-1} -> D_{n-1}
+        else:
+            right = [[Fraction(0)] * len(left[0]) for _ in range(len(left))]
+
+        if left != right:
+            return VerificationResult(
+                is_valid=False,
+                detail= f"chain map does not commute at degree {i}",
+            )
+
+    return VerificationResult(is_valid=True, detail="chain map commutes with differentials")
+
+
+def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
+    """Compute the homology groups of a chain complex."""
+    cx = request.complex
+    prime = cx.prime
+    n = len(cx.basis_sizes)
+
+    diffs = [
+        _matrix_to_fractions(m, cx.basis_sizes[i], cx.basis_sizes[i + 1], prime)
+        for i, m in enumerate(cx.differential_matrices)
+    ]
+
+    groups = []
+    for degree in range(n):
+        chain_rank = cx.basis_sizes[degree]
+
+        # outgoing differential d_n: C_n -> C_{n-1}
+        if degree < len(diffs):
+            d_out = diffs[degree]
+            outgoing_rank = _matrix_rank(d_out, prime)
+        else:
+            outgoing_rank = 0
+
+        # incoming differential d_{n+1}: C_{n+1} -> C_n
+        if degree > 0:
+            d_in = diffs[degree - 1]
+            incoming_rank = _matrix_rank(d_in, prime)
+        else:
+            incoming_rank = 0
+
+        cycle_rank = chain_rank - outgoing_rank
+        betti = cycle_rank - incoming_rank
+
+        groups.append(
+            HomologyGroupValue(
+                degree=degree,
+                cycle_rank=cycle_rank,
+                boundary_rank=incoming_rank,
+                betti_number=max(0, betti),
+            )
+        )
+
+    return HomologyResult(
+        homology_groups=tuple(groups),
+        coefficient_field=cx.coefficient_field,
+    )
+
+
+def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
+    """Compute the mapping cone of a chain map f: C -> D.
+
+    The mapping cone has groups cone_n = C_{n-1} ⊕ D_n.
+    """
+    source = request.source
+    target = request.target
+    prime = source.prime or target.prime
+
+    n = max(len(source.basis_sizes), len(target.basis_sizes))
+    cone_basis_sizes = tuple(
+        source.basis_sizes[i - 1] + target.basis_sizes[i]
+        if i > 0 and i - 1 < len(source.basis_sizes) and i < len(target.basis_sizes)
+        else source.basis_sizes[i - 1] if i > 0 and i - 1 < len(source.basis_sizes)
+        else target.basis_sizes[i] if i < len(target.basis_sizes)
+        else 0
+        for i in range(n + 1)
+    )
+
+    return MappingConeResult(
+        cone_basis_sizes=cone_basis_sizes,
+        cone_differential_matrices=(),  # Simplified: full cone differentials need block matrices
+        source_degree_min=source.degree_min,
+        target_degree_min=target.degree_min,
+    )
+
+
+def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult:
+    """Compute the tensor product of two chain complexes.
+
+    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j
+    """
+    left = request.left
+    right = request.right
+    n = len(left.basis_sizes) + len(right.basis_sizes) - 1
+
+    # Basis sizes for the tensor product
+    tensor_basis_sizes = []
+    for degree in range(n):
+        size = 0
+        for i in range(min(degree + 1, len(left.basis_sizes))):
+            j = degree - i
+            if j < len(right.basis_sizes):
+                size += left.basis_sizes[i] * right.basis_sizes[j]
+        tensor_basis_sizes.append(size)
+
+    return TensorProductResult(
+        tensor_basis_sizes=tuple(tensor_basis_sizes),
+        tensor_differential_matrices=(),  # Full differentials need block construction
+    )

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -171,18 +171,20 @@ def _require_square_zero(
     *,
     label: str,
     group_columns=None,
+    degree_min: int = 0,
 ) -> None:
     """Require d^2 = 0 for a parsed differential sequence.
 
     ``group_columns`` carries chain-group dimensions so zero-width groups
-    preserve outer product dimensions.
+    preserve outer product dimensions; diagnostics report the declared
+    chain degree (``degree_min + index``), not the tuple index.
     """
     for i in range(len(diffs) - 1):
         result_columns = group_columns[i + 2] if group_columns is not None else None
         product = _matrix_multiply(diffs[i], diffs[i + 1], prime, result_columns)
         if any(value != 0 for row in product for value in row):
             raise ValueError(
-                f"{label} complex violates d^2=0 at differential index {i}"
+                f"{label} complex violates d^2=0 at chain degree {degree_min + i}"
             )
 
 
@@ -341,7 +343,8 @@ def _compute_homology_groups(
         prod = _matrix_multiply(diffs[i], diffs[i + 1], prime, cx.basis_sizes[i + 2])
         if any(any(v != 0 for v in row) for row in prod):
             raise ValueError(
-                f"chain complex does not satisfy d^2=0 at index {i}: product non-zero"
+                f"chain complex does not satisfy d^2=0 at chain degree "
+                f"{cx.degree_min + i}: product non-zero"
             )
 
     groups = []
@@ -450,10 +453,18 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     # complexes and the map is a genuine chain map; validate both defining
     # equations before returning any exact decomposition.
     _require_square_zero(
-        source_diffs, prime, label="source", group_columns=list(source.basis_sizes)
+        source_diffs,
+        prime,
+        label="source",
+        group_columns=list(source.basis_sizes),
+        degree_min=source.degree_min,
     )
     _require_square_zero(
-        target_diffs, prime, label="target", group_columns=list(target.basis_sizes)
+        target_diffs,
+        prime,
+        label="target",
+        group_columns=list(target.basis_sizes),
+        degree_min=target.degree_min,
     )
     _require_chain_map_relation(
         source_diffs,
@@ -578,10 +589,18 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
     # A tensor product of chain complexes is a chain complex only when both
     # factors satisfy d^2 = 0; validate before building anything.
     _require_square_zero(
-        left_diffs, prime, label="left", group_columns=list(left.basis_sizes)
+        left_diffs,
+        prime,
+        label="left",
+        group_columns=list(left.basis_sizes),
+        degree_min=left.degree_min,
     )
     _require_square_zero(
-        right_diffs, prime, label="right", group_columns=list(right.basis_sizes)
+        right_diffs,
+        prime,
+        label="right",
+        group_columns=list(right.basis_sizes),
+        degree_min=right.degree_min,
     )
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -735,6 +735,14 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
         source=request.source,
         target=request.target,
         map_matrices=request.map_matrices,
+        value=ChainComplexValue(
+            coefficient_field=request.source.coefficient_field,
+            prime=request.source.prime,
+            degree_min=request.source.degree_min,
+            degree_max=request.source.degree_min + len(cone_basis_sizes) - 1,
+            basis_sizes=cone_basis_sizes,
+            differential_matrices=cone_diffs,
+        ),
     )
 
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -205,14 +205,39 @@ def _require_chain_map_relation(
     map_mats: list[list[list[Fraction]]],
     prime: int | None = None,
     source_group_columns=None,
+    target_group_columns=None,
 ) -> None:
-    """Require d_target * f_{i+1} == f_i * d_source at every differential."""
+    """Require d_target * f_{i+1} == f_i * d_source at every differential.
+
+    Declared group widths keep empty operands' inner dimensions intact:
+    ``target_diffs[i]`` spans ``target_group_columns[i + 1]`` columns and
+    ``map_mats[i]`` spans ``source_group_columns[i]``, so a zero-row
+    differential or component still carries its mathematical width.
+    """
     for i in range(len(source_diffs)):
         result_columns = (
             source_group_columns[i + 1] if source_group_columns is not None else None
         )
-        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime, result_columns)
-        right = _matrix_multiply(map_mats[i], source_diffs[i], prime, result_columns)
+        left_declared_columns = (
+            target_group_columns[i + 1] if target_group_columns is not None else None
+        )
+        right_declared_columns = (
+            source_group_columns[i] if source_group_columns is not None else None
+        )
+        left = _matrix_multiply(
+            target_diffs[i],
+            map_mats[i + 1],
+            prime,
+            result_columns,
+            left_declared_columns=left_declared_columns,
+        )
+        right = _matrix_multiply(
+            map_mats[i],
+            source_diffs[i],
+            prime,
+            result_columns,
+            left_declared_columns=right_declared_columns,
+        )
         if left != right:
             raise ValueError(
                 f"chain map does not commute with differentials at degree index {i}"
@@ -326,11 +351,24 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
 
     # f_i: C_i -> D_i has shape target_basis[i] x source_basis[i], so the
     # chain-map equation at every differential is
-    # d_target_i * f_{i+1} == f_i * d_source_i.
+    # d_target_i * f_{i+1} == f_i * d_source_i. Declared widths keep
+    # empty-row differentials and components shape-faithful.
     for i in range(len(source_diffs)):
         result_columns = source.basis_sizes[i + 1]
-        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime, result_columns)
-        right = _matrix_multiply(map_mats[i], source_diffs[i], prime, result_columns)
+        left = _matrix_multiply(
+            target_diffs[i],
+            map_mats[i + 1],
+            prime,
+            result_columns,
+            left_declared_columns=target.basis_sizes[i + 1],
+        )
+        right = _matrix_multiply(
+            map_mats[i],
+            source_diffs[i],
+            prime,
+            result_columns,
+            left_declared_columns=source.basis_sizes[i],
+        )
         if left != right:
             return VerificationResult(
                 is_valid=False,
@@ -362,14 +400,15 @@ def _compute_homology_groups(
         for i, m in enumerate(cx.differential_matrices)
     ]
 
-    # Require square-zero before computing homology
-    for i in range(len(diffs) - 1):
-        prod = _matrix_multiply(diffs[i], diffs[i + 1], prime, cx.basis_sizes[i + 2])
-        if any(any(v != 0 for v in row) for row in prod):
-            raise ValueError(
-                f"chain complex does not satisfy d^2=0 at chain degree "
-                f"{cx.degree_min + i}: product non-zero"
-            )
+    # Require square-zero before computing homology; declared group
+    # widths keep zero-row differentials shape-faithful.
+    _require_square_zero(
+        diffs,
+        prime,
+        label="chain complex",
+        group_columns=list(cx.basis_sizes),
+        degree_min=cx.degree_min,
+    )
 
     groups = []
     for idx in range(n):
@@ -520,6 +559,7 @@ def _compute_mapping_cone(
         map_mats,
         prime,
         source_group_columns=list(source.basis_sizes),
+        target_group_columns=list(target.basis_sizes),
     )
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
@@ -575,14 +615,21 @@ def _compute_mapping_cone(
         cone_diffs.append(_to_str_matrix(block))
 
     # Defining invariant of the returned decomposition: the cone
-    # differentials must themselves be square-zero.
+    # differentials must themselves be square-zero. Declared cone group
+    # widths keep zero-cell groups shape-faithful.
     cone_parsed = [
         _matrix_to_fractions(
             cone_diffs[i], cone_basis_sizes[i], cone_basis_sizes[i + 1], prime
         )
         for i in range(len(cone_diffs))
     ]
-    _require_square_zero(cone_parsed, prime, label="mapping cone")
+    _require_square_zero(
+        cone_parsed,
+        prime,
+        label="mapping cone",
+        group_columns=list(cone_basis_sizes),
+        degree_min=source.degree_min,
+    )
 
     return cone_basis_sizes, tuple(cone_diffs)
 
@@ -608,13 +655,12 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     )
 
 
-def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult:
-    """Compute the tensor product of two chain complexes.
-
-    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j with differential d_C ⊗ id + (-1)^i id ⊗ d_D.
-    """
-    left = request.left
-    right = request.right
+def _compute_tensor_product(
+    left: ChainComplexValue,
+    right: ChainComplexValue,
+) -> tuple[tuple[int, ...], tuple[tuple[tuple[str, ...], ...], ...]]:
+    """Exact tensor-product construction shared by the operation and its
+    result validator."""
     if left.coefficient_field != right.coefficient_field or left.prime != right.prime:
         raise ValueError("tensor product requires same coefficient field and prime")
     prime = left.prime
@@ -622,15 +668,15 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
     n = len(left.basis_sizes) + len(right.basis_sizes) - 1
 
     # Basis sizes for the tensor product
-    tensor_basis_sizes = []
+    group_sizes: list[int] = []
     for degree in range(n):
         size = 0
         for i in range(min(degree + 1, len(left.basis_sizes))):
             j = degree - i
             if j < len(right.basis_sizes):
                 size += left.basis_sizes[i] * right.basis_sizes[j]
-        tensor_basis_sizes.append(size)
-    tensor_basis_sizes = tuple(tensor_basis_sizes)
+        group_sizes.append(size)
+    tensor_basis_sizes = tuple(group_sizes)
 
     # Build signed differentials for each degree.
     # For each n, differential d_n: (C⊗D)_n -> (C⊗D)_{n-1} is block matrix with
@@ -733,25 +779,39 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
                             block[row][col] += coeff
         tensor_diffs.append(_to_str_matrix(block))
 
+    return tensor_basis_sizes, tuple(tensor_diffs)
+
+
+def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult:
+    """Compute the tensor product of two chain complexes.
+
+    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j with differential d_C ⊗ id + (-1)^i id ⊗ d_D.
+    """
+    left = request.left
+    right = request.right
+    tensor_basis_sizes, tensor_diffs = _compute_tensor_product(left, right)
+
     # Tensor degrees are pairwise sums: the derived complex concentrates
     # on [deg_min, deg_min + group_count - 1].
-    group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
+    group_count = len(tensor_basis_sizes)
     degree_min = left.degree_min + right.degree_min
-    from jacobian.math.chain_complexes.values import ChainComplexValue
+    degree_max = degree_min + group_count - 1
 
     return TensorProductResult(
         tensor_basis_sizes=tensor_basis_sizes,
-        tensor_differential_matrices=tuple(tensor_diffs),
+        tensor_differential_matrices=tensor_diffs,
         coefficient_field=left.coefficient_field,
-        prime=prime,
+        prime=left.prime,
         degree_min=degree_min,
-        degree_max=degree_min + group_count - 1,
+        degree_max=degree_max,
+        left=left,
+        right=right,
         value=ChainComplexValue(
             coefficient_field=left.coefficient_field,
-            prime=prime,
+            prime=left.prime,
             degree_min=degree_min,
-            degree_max=degree_min + group_count - 1,
+            degree_max=degree_max,
             basis_sizes=tensor_basis_sizes,
-            differential_matrices=tuple(tensor_diffs),
+            differential_matrices=tensor_diffs,
         ),
     )

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -270,9 +270,11 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     )
 
 
-def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
-    """Compute the homology groups of a chain complex."""
-    cx = request.complex
+def _compute_homology_groups(
+    cx: ChainComplexValue,
+) -> tuple[HomologyGroupValue, ...]:
+    """Exact homology groups shared by the operation and its validator."""
+
     prime = cx.prime
     n = len(cx.basis_sizes)
 
@@ -323,12 +325,21 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
             )
         )
 
+    return tuple(groups)
+
+
+def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
+    """Compute the homology groups of a chain complex."""
+    cx = request.complex
+    prime = cx.prime
+    groups = _compute_homology_groups(cx)
     return HomologyResult(
         homology_groups=tuple(groups),
         coefficient_field=cx.coefficient_field,
         prime=prime,
         degree_min=cx.degree_min,
         degree_max=cx.degree_max,
+        complex=cx,
     )
 
 
@@ -404,7 +415,7 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
         cols = cone_basis_sizes[n]
         if rows == 0 or cols == 0:
             # Zero-cell differentials carry no entries.
-            cone_diffs.append(tuple())
+            cone_diffs.append(())
             continue
         # Build zero matrix
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
@@ -500,6 +511,11 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
         for i, m in enumerate(right.differential_matrices)
     ]
 
+    # A tensor product of chain complexes is a chain complex only when both
+    # factors satisfy d^2 = 0; validate before building anything.
+    _require_square_zero(left_diffs, prime, label="left")
+    _require_square_zero(right_diffs, prime, label="right")
+
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
         return tuple(
             tuple(
@@ -515,7 +531,7 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
         cols = tensor_basis_sizes[deg]
         if rows == 0 or cols == 0:
             # Zero-cell differentials carry no entries.
-            tensor_diffs.append(tuple())
+            tensor_diffs.append(())
             continue
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
         # We need to map block structure: (C⊗D)_deg = ⊕_{i+j=deg} C_i⊗D_j

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -185,7 +185,8 @@ def _require_square_zero(
 
     ``group_columns`` carries chain-group dimensions so zero-width groups
     preserve outer product dimensions; diagnostics report the declared
-    chain degree (``degree_min + index``), not the tuple index.
+    chain degree of the composed pair (``degree_min + index + 1``, matching
+    the verification operation's verdict), not the tuple index.
     """
     for i in range(len(diffs) - 1):
         result_columns = group_columns[i + 2] if group_columns is not None else None
@@ -201,7 +202,7 @@ def _require_square_zero(
         )
         if any(value != 0 for row in product for value in row):
             raise ValueError(
-                f"{label} complex violates d^2=0 at chain degree {degree_min + i}"
+                f"{label} complex violates d^2=0 at chain degree {degree_min + i + 1}"
             )
 
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -154,6 +154,17 @@ def _matrix_multiply(
     return result
 
 
+def _parsed_differentials(
+    cx: ChainComplexValue,
+    prime: int | None = None,
+) -> list[list[list[Fraction]]]:
+    """Parse a complex's differentials into exact fraction matrices."""
+    return [
+        _matrix_to_fractions(m, cx.basis_sizes[i], cx.basis_sizes[i + 1], prime)
+        for i, m in enumerate(cx.differential_matrices)
+    ]
+
+
 def _require_square_zero(
     diffs: list[list[list[Fraction]]],
     prime: int | None = None,
@@ -167,9 +178,7 @@ def _require_square_zero(
     preserve outer product dimensions.
     """
     for i in range(len(diffs) - 1):
-        result_columns = (
-            group_columns[i + 2] if group_columns is not None else None
-        )
+        result_columns = group_columns[i + 2] if group_columns is not None else None
         product = _matrix_multiply(diffs[i], diffs[i + 1], prime, result_columns)
         if any(value != 0 for row in product for value in row):
             raise ValueError(
@@ -189,12 +198,8 @@ def _require_chain_map_relation(
         result_columns = (
             source_group_columns[i + 1] if source_group_columns is not None else None
         )
-        left = _matrix_multiply(
-            target_diffs[i], map_mats[i + 1], prime, result_columns
-        )
-        right = _matrix_multiply(
-            map_mats[i], source_diffs[i], prime, result_columns
-        )
+        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime, result_columns)
+        right = _matrix_multiply(map_mats[i], source_diffs[i], prime, result_columns)
         if left != right:
             raise ValueError(
                 f"chain map does not commute with differentials at degree index {i}"
@@ -259,29 +264,22 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     prime = source.prime
 
     # A chain map exists only between chain complexes; endpoints violating
-    # d^2=0 make the verification false by definition. Check the first
+    # d^2=0 make the verification false by definition. Check every
     # consecutive differential product of each endpoint.
     for label, complex_value in (("source", source), ("target", target)):
-        diffs = [
-            _matrix_to_fractions(
-                m, complex_value.basis_sizes[k], complex_value.basis_sizes[k + 1], prime
-            )
-            for k, m in enumerate(complex_value.differential_matrices)
-        ]
-        if len(diffs) > 1:
-            product = _matrix_multiply(
-                diffs[0],
-                diffs[1],
-                prime,
-                complex_value.basis_sizes[2],
-            )
-            if any(v != 0 for row in product for v in row):
+        if len(complex_value.differential_matrices) > 1:
+            try:
+                _require_square_zero(
+                    _parsed_differentials(complex_value, prime),
+                    prime,
+                    label=label,
+                    group_columns=list(complex_value.basis_sizes),
+                )
+            except ValueError as error:
                 return VerificationResult(
                     is_valid=False,
-                    detail=(
-                        f"{label} complex violates d^2=0, so no chain map "
-                        "between these endpoints exists"
-                    ),
+                    detail=str(error) + ", so no chain map between these "
+                    "endpoints exists",
                     source=source,
                     target=target,
                 )
@@ -307,12 +305,8 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     # d_target_i * f_{i+1} == f_i * d_source_i.
     for i in range(len(source_diffs)):
         result_columns = source.basis_sizes[i + 1]
-        left = _matrix_multiply(
-            target_diffs[i], map_mats[i + 1], prime, result_columns
-        )
-        right = _matrix_multiply(
-            map_mats[i], source_diffs[i], prime, result_columns
-        )
+        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime, result_columns)
+        right = _matrix_multiply(map_mats[i], source_diffs[i], prime, result_columns)
         if left != right:
             return VerificationResult(
                 is_valid=False,
@@ -483,8 +477,9 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
         rows = cone_basis_sizes[n - 1]
         cols = cone_basis_sizes[n]
         if rows == 0 or cols == 0:
-            # Zero-cell differentials carry no entries.
-            cone_diffs.append(())
+            # Zero-cell differentials keep their declared row count so the
+            # outer matrix shape stays reconstructible.
+            cone_diffs.append(tuple(() for _ in range(rows)))
             continue
         # Build zero matrix
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
@@ -603,8 +598,9 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
         rows = tensor_basis_sizes[deg - 1]
         cols = tensor_basis_sizes[deg]
         if rows == 0 or cols == 0:
-            # Zero-cell differentials carry no entries.
-            tensor_diffs.append(())
+            # Zero-cell differentials keep their declared row count so the
+            # outer matrix shape stays reconstructible.
+            tensor_diffs.append(tuple(() for _ in range(rows)))
             continue
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
         # We need to map block structure: (C⊗D)_deg = ⊕_{i+j=deg} C_i⊗D_j
@@ -662,7 +658,15 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
                             block[row][col] += coeff
         tensor_diffs.append(_to_str_matrix(block))
 
+    # Tensor degrees are pairwise sums: the derived complex concentrates
+    # on [deg_min, deg_min + group_count - 1].
+    group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
+    degree_min = left.degree_min + right.degree_min
     return TensorProductResult(
         tensor_basis_sizes=tensor_basis_sizes,
         tensor_differential_matrices=tuple(tensor_diffs),
+        coefficient_field=left.coefficient_field,
+        prime=prime,
+        degree_min=degree_min,
+        degree_max=degree_min + group_count - 1,
     )

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -267,7 +267,11 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
                 complex=request.complex,
             )
 
-    return VerificationResult(is_valid=True, detail="d^2 = 0 for all degrees")
+    return VerificationResult(
+        is_valid=True,
+        detail="d^2 = 0 for all degrees",
+        complex=request.complex,
+    )
 
 
 def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
@@ -301,6 +305,7 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
                     "endpoints exists",
                     source=source,
                     target=target,
+                    map_matrices=request.map_matrices,
                 )
 
     # Request admission guarantees one component per degree, equal shape
@@ -332,6 +337,7 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
                 detail=f"chain map does not commute at degree {source.degree_min + i}",
                 source=source,
                 target=target,
+                map_matrices=request.map_matrices,
             )
 
     return VerificationResult(
@@ -339,6 +345,7 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
         detail="chain map commutes with differentials",
         source=source,
         target=target,
+        map_matrices=request.map_matrices,
     )
 
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -13,13 +13,12 @@ from jacobian.math.chain_complexes._models import (
     VerifyDifferentialRequest,
 )
 from jacobian.math.chain_complexes.values import (
-    VerificationResult,
     ChainComplexValue,
-    CoefficientField,
     HomologyGroupValue,
     HomologyResult,
     MappingConeResult,
     TensorProductResult,
+    VerificationResult,
 )
 
 
@@ -28,8 +27,10 @@ def _parse_fraction(s: str, prime: int | None = None) -> Fraction:
         # Prime-field entries are canonical residues 0..p-1; accept integer strings only
         try:
             val = int(s)
-        except ValueError:
-            raise ValueError(f"prime-field entry '{s}' must be an integer residue")
+        except ValueError as error:
+            raise ValueError(
+                f"prime-field entry '{s}' must be an integer residue"
+            ) from error
         return Fraction(val % prime)
     if "/" in s:
         num, den = s.split("/", 1)
@@ -143,6 +144,37 @@ def _matrix_multiply(
     return result
 
 
+def _require_square_zero(
+    diffs: list[list[list[Fraction]]],
+    prime: int | None = None,
+    *,
+    label: str,
+) -> None:
+    """Require d^2 = 0 for a parsed differential sequence."""
+    for i in range(len(diffs) - 1):
+        product = _matrix_multiply(diffs[i], diffs[i + 1], prime)
+        if any(value != 0 for row in product for value in row):
+            raise ValueError(
+                f"{label} complex violates d^2=0 at differential index {i}"
+            )
+
+
+def _require_chain_map_relation(
+    source_diffs: list[list[list[Fraction]]],
+    target_diffs: list[list[list[Fraction]]],
+    map_mats: list[list[list[Fraction]]],
+    prime: int | None = None,
+) -> None:
+    """Require d_target * f_{i+1} == f_i * d_source at every differential."""
+    for i in range(len(source_diffs)):
+        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime)
+        right = _matrix_multiply(map_mats[i], source_diffs[i], prime)
+        if left != right:
+            raise ValueError(
+                f"chain map does not commute with differentials at degree index {i}"
+            )
+
+
 def construct_chain_complex(request: ConstructChainComplexRequest) -> ChainComplexValue:
     """Construct a chain complex from differential matrices."""
     basis_sizes = request.basis_sizes
@@ -177,13 +209,11 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
         d_i = diffs[i]
         d_ip1 = diffs[i + 1]
         product = _matrix_multiply(d_i, d_ip1, prime)
-        is_zero = all(
-            all(val == 0 for val in row) for row in product
-        )
+        is_zero = all(all(val == 0 for val in row) for row in product)
         if not is_zero:
             return VerificationResult(
                 is_valid=False,
-                detail= f"d^2 != 0 at degree {i + 1}",
+                detail=f"d^2 != 0 at degree {i + 1}",
                 complex=request.complex,
             )
 
@@ -194,38 +224,21 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     """Verify that a chain map commutes with differentials.
 
     Returns a dictionary with 'is_valid' (bool) and 'detail' (str).
+
+    Request admission guarantees equal coefficient fields and prime, so a
+    field mismatch can never reach this kernel as a verdict.
     """
     source = request.source
     target = request.target
-    # Reject incompatible fields
-    if source.coefficient_field != target.coefficient_field:
-        return VerificationResult(
-            is_valid=False,
-            detail=f"chain map between incompatible coefficient fields {source.coefficient_field} vs {target.coefficient_field}",
-            source=source,
-            target=target,
-        )
-    if source.prime != target.prime:
-        return VerificationResult(
-            is_valid=False,
-            detail=f"chain map between different primes {source.prime} vs {target.prime}",
-            source=source,
-            target=target,
-        )
     prime = source.prime
 
-    if len(source.basis_sizes) != len(target.basis_sizes):
-        # For simplicity require same length; otherwise need to handle different degree ranges
-        # But we can still proceed with min length
-        pass
-    if len(request.map_matrices) != len(source.basis_sizes):
-        return VerificationResult(
-            is_valid=False,
-            detail=f"map_matrices count {len(request.map_matrices)} != basis count {len(source.basis_sizes)}",
-            source=source,
-            target=target,
-        )
-
+    # Request admission guarantees one component per degree, equal shape
+    # (target rows x source columns) per component, and coinciding degree
+    # intervals, so tuple index equals actual chain degree.
+    map_mats = [
+        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
+        for i, m in enumerate(request.map_matrices)
+    ]
     source_diffs = [
         _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
         for i, m in enumerate(source.differential_matrices)
@@ -234,52 +247,27 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
         _matrix_to_fractions(m, target.basis_sizes[i], target.basis_sizes[i + 1], prime)
         for i, m in enumerate(target.differential_matrices)
     ]
-    map_mats = [
-        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)  # note: rows=target, cols=source, so transpose from previous
-        for i, m in enumerate(request.map_matrices)
-    ]
-    # Actually _matrix_to_fractions expects rows=target_basis[i], cols=source_basis[i] to represent map C_i -> D_i as matrix D_i x C_i
-    # The original code had rows=source, cols=target which is transposed. We need to check dimensions.
-    # Let's instead construct maps as (target_basis[i] rows x source_basis[i] cols) by transposing the input if needed.
-    # The input map_matrices[i] is given as tuple of rows where each row length = target_basis? No, spec says map_matrices[i] has shape source_basis[i] x target_basis[i]? We need to infer from tests.
-    # Tests use identity 3x3 for circle (basis 3,3). Identity 3x3 is square, so ambiguous.
-    # For now we will keep original orientation (source rows x target cols) and compute correctly: we need d_target * f_{i+1} == f_i * d_source
-    # Let's recompute with correct orientation assuming f_i is target_rows x source_cols? Wait we need to decide.
-    # For now, we will implement the mathematically correct check using the stored orientation as source_rows x target_cols (as in original code).
-    # That means f_i has shape source_basis[i] rows x target_basis[i] cols? But then d_target * f_{i+1} would be (target_basis[i] x target_basis[i+1]) * (source_basis[i+1] x target_basis[i+1]) -> dimensions mismatch.
-    # So original orientation must be target x source? Let's re-evaluate: In original code, they called _matrix_to_fractions(m, source_basis[i], target_basis[i], prime) where rows=source, cols=target. That would create matrix with rows=source, cols=target, i.e., source x target. But a map C_i -> D_i should be D_i rows x C_i cols. So that is transposed.
-    # To make multiplication work, they did left = f_n * d_target where f_n is source x target and d_target is target x target_next. That product would be source x target_next, while right is source_next x source * source_next x target? Not matching.
-    # The correct is to have f as D x C, so rows=target, cols=source. So we should call _matrix_to_fractions with rows=target, cols=source.
-    # Let's fix map_mats construction to use target rows, source cols.
 
-    # Rebuild map_mats correctly
-    map_mats = [
-        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
-        for i, m in enumerate(request.map_matrices)
-    ]
-
+    # f_i: C_i -> D_i has shape target_basis[i] x source_basis[i], so the
+    # chain-map equation at every differential is
+    # d_target_i * f_{i+1} == f_i * d_source_i.
     for i in range(len(source_diffs)):
-        d_source = source_diffs[i]  # rows=source_basis[i], cols=source_basis[i+1]
-        d_target = target_diffs[i]  # rows=target_basis[i], cols=target_basis[i+1]
-        # f_{i+1}: C_{i+1} -> D_{i+1}, shape target_basis[i+1] x source_basis[i+1]
-        # f_i: C_i -> D_i, shape target_basis[i] x source_basis[i]
-        f_ip1 = map_mats[i + 1] if i + 1 < len(map_mats) else None
-        f_i = map_mats[i]
-        if f_ip1 is None:
-            continue  # No next map, skip? But need to check at top degree where no differential?
-        # left = d_target * f_{i+1}: (target_i x target_{i+1}) * (target_{i+1} x source_{i+1}) => target_i x source_{i+1}
-        left = _matrix_multiply(d_target, f_ip1, prime)
-        # right = f_i * d_source: (target_i x source_i) * (source_i x source_{i+1}) => target_i x source_{i+1}
-        right = _matrix_multiply(f_i, d_source, prime)
+        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime)
+        right = _matrix_multiply(map_mats[i], source_diffs[i], prime)
         if left != right:
             return VerificationResult(
                 is_valid=False,
-                detail=f"chain map does not commute at degree {i+1}",
+                detail=f"chain map does not commute at degree {source.degree_min + i}",
                 source=source,
                 target=target,
             )
 
-    return VerificationResult(is_valid=True, detail="chain map commutes with differentials", source=source, target=target)
+    return VerificationResult(
+        is_valid=True,
+        detail="chain map commutes with differentials",
+        source=source,
+        target=target,
+    )
 
 
 def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
@@ -297,7 +285,9 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
     for i in range(len(diffs) - 1):
         prod = _matrix_multiply(diffs[i], diffs[i + 1], prime)
         if any(any(v != 0 for v in row) for row in prod):
-            raise ValueError(f"chain complex does not satisfy d^2=0 at index {i}: product non-zero")
+            raise ValueError(
+                f"chain complex does not satisfy d^2=0 at index {i}: product non-zero"
+            )
 
     groups = []
     for idx in range(n):
@@ -320,7 +310,9 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
         cycle_rank = chain_rank - outgoing_rank
         betti = cycle_rank - incoming_rank
         if betti < 0:
-            raise ValueError(f"negative Betti number at degree {actual_degree}: indicates invalid complex")
+            raise ValueError(
+                f"negative Betti number at degree {actual_degree}: indicates invalid complex"
+            )
 
         groups.append(
             HomologyGroupValue(
@@ -348,7 +340,10 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     """
     source = request.source
     target = request.target
-    if source.coefficient_field != target.coefficient_field or source.prime != target.prime:
+    if (
+        source.coefficient_field != target.coefficient_field
+        or source.prime != target.prime
+    ):
         raise ValueError("mapping cone requires same coefficient field and prime")
     prime = source.prime
 
@@ -357,12 +352,13 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     max_len = max(len(source.basis_sizes), len(target.basis_sizes))
     cone_basis_sizes = []
     for i in range(max_len + 1):
-        c_size = source.basis_sizes[i - 1] if 0 < i < len(source.basis_sizes) + 1 and i-1 < len(source.basis_sizes) else 0
-        # Actually C_{n-1} corresponds to source index n-1 - (source.degree_min offset). For degree_min 0, this simplifies.
-        # For general degree_min, we align by index offset.
-        # Simplify to degree_min 0 case as in tests; for non-zero, use same logic with index shift.
+        # C_{n-1} corresponds to source index n-1 - (source.degree_min offset). For degree_min 0, this simplifies.
         d_size = target.basis_sizes[i] if i < len(target.basis_sizes) else 0
-        c_size2 = source.basis_sizes[i - 1] if i > 0 and i - 1 < len(source.basis_sizes) else 0
+        c_size2 = (
+            source.basis_sizes[i - 1]
+            if i > 0 and i - 1 < len(source.basis_sizes)
+            else 0
+        )
         cone_basis_sizes.append(c_size2 + d_size)
     cone_basis_sizes = tuple(cone_basis_sizes)
 
@@ -386,22 +382,42 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
         for i, m in enumerate(request.map_matrices)
     ]
 
+    # A mapping cone is a chain complex only when both inputs are chain
+    # complexes and the map is a genuine chain map; validate both defining
+    # equations before returning any exact decomposition.
+    _require_square_zero(source_diffs, prime, label="source")
+    _require_square_zero(target_diffs, prime, label="target")
+    _require_chain_map_relation(source_diffs, target_diffs, map_mats, prime)
+
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
-        return tuple(tuple(str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}" for v in row) for row in mat)
+        return tuple(
+            tuple(
+                str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}"
+                for v in row
+            )
+            for row in mat
+        )
 
     cone_diffs: list[tuple[tuple[str, ...], ...]] = []
     for n in range(1, len(cone_basis_sizes)):
         rows = cone_basis_sizes[n - 1]
         cols = cone_basis_sizes[n]
         if rows == 0 or cols == 0:
-            cone_diffs.append(tuple(tuple("0" for _ in range(cols)) for _ in range(rows)) if rows and cols else tuple())
+            # Zero-cell differentials carry no entries.
+            cone_diffs.append(tuple())
             continue
         # Build zero matrix
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
         # Sizes for decomposition: cone_{n} = C_{n-1} ⊕ D_n, cone_{n-1}= C_{n-2} ⊕ D_{n-1}
-        c_n_minus1 = source.basis_sizes[n - 1] if 0 <= n - 1 < len(source.basis_sizes) else 0
+        c_n_minus1 = (
+            source.basis_sizes[n - 1] if 0 <= n - 1 < len(source.basis_sizes) else 0
+        )
         d_n = target.basis_sizes[n] if n < len(target.basis_sizes) else 0
-        c_n_minus2 = source.basis_sizes[n - 2] if n - 2 >= 0 and n - 2 < len(source.basis_sizes) else 0
+        c_n_minus2 = (
+            source.basis_sizes[n - 2]
+            if n - 2 >= 0 and n - 2 < len(source.basis_sizes)
+            else 0
+        )
         d_n_minus1 = target.basis_sizes[n - 1] if n - 1 < len(target.basis_sizes) else 0
 
         # Fill blocks
@@ -427,6 +443,16 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
                         block[c_n_minus2 + i][j] = f[i][j]
 
         cone_diffs.append(_to_str_matrix(block))
+
+    # Defining invariant of the returned decomposition: the cone
+    # differentials must themselves be square-zero.
+    cone_parsed = [
+        _matrix_to_fractions(
+            cone_diffs[i], cone_basis_sizes[i], cone_basis_sizes[i + 1], prime
+        )
+        for i in range(len(cone_diffs))
+    ]
+    _require_square_zero(cone_parsed, prime, label="mapping cone")
 
     return MappingConeResult(
         cone_basis_sizes=cone_basis_sizes,
@@ -475,19 +501,23 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
     ]
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
-        return tuple(tuple(str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}" for v in row) for row in mat)
+        return tuple(
+            tuple(
+                str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}"
+                for v in row
+            )
+            for row in mat
+        )
 
     tensor_diffs: list[tuple[tuple[str, ...], ...]] = []
     for deg in range(1, n):
         rows = tensor_basis_sizes[deg - 1]
         cols = tensor_basis_sizes[deg]
         if rows == 0 or cols == 0:
-            tensor_diffs.append(tuple(tuple("0" for _ in range(cols)) for _ in range(rows)) if rows and cols else tuple())
+            # Zero-cell differentials carry no entries.
+            tensor_diffs.append(tuple())
             continue
         block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
-        # Iterate over i,j for source degree deg
-        row_offset = 0
-        col_offset = 0
         # We need to map block structure: (C⊗D)_deg = ⊕_{i+j=deg} C_i⊗D_j
         # Similarly for deg-1 = ⊕_{p+q=deg-1} C_p⊗D_q
         # For each i,j contributing to deg, its differential contributes to two possible targets:
@@ -500,23 +530,23 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
         for i in range(min(deg + 1, len(left.basis_sizes))):
             j = deg - i
             if j < len(right.basis_sizes):
-                offsets_deg[(i,j)] = off
+                offsets_deg[(i, j)] = off
                 off += left.basis_sizes[i] * right.basis_sizes[j]
         offsets_deg_minus1 = {}
         off = 0
         for p in range(min(deg, len(left.basis_sizes))):
             q = deg - 1 - p
-            if q < len(right.basis_sizes) and q >=0:
-                offsets_deg_minus1[(p,q)] = off
+            if q < len(right.basis_sizes) and q >= 0:
+                offsets_deg_minus1[(p, q)] = off
                 off += left.basis_sizes[p] * right.basis_sizes[q]
 
-        for (i,j), col_off in offsets_deg.items():
+        for (i, j), col_off in offsets_deg.items():
             # d_C contribution
-            if i > 0 and (i-1, j) in offsets_deg_minus1:
+            if i > 0 and (i - 1, j) in offsets_deg_minus1:
                 d_left = left_diffs[i - 1]  # shape left_basis[i-1] x left_basis[i]
-                row_off = offsets_deg_minus1[(i-1, j)]
+                row_off = offsets_deg_minus1[(i - 1, j)]
                 # Tensor product with identity on D_j
-                for a in range(left.basis_sizes[i-1]):
+                for a in range(left.basis_sizes[i - 1]):
                     for b in range(left.basis_sizes[i]):
                         coeff = d_left[a][b]
                         if coeff == 0:
@@ -525,18 +555,20 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
                             row = row_off + a * right.basis_sizes[j] + c
                             col = col_off + b * right.basis_sizes[j] + c
                             block[row][col] += coeff
-            # d_D contribution with sign (-1)^i
-            if j > 0 and (i, j-1) in offsets_deg_minus1:
+            # d_D contribution with sign (-1)^i where i is the actual chain
+            # degree of the left factor, not its tuple index.
+            if j > 0 and (i, j - 1) in offsets_deg_minus1:
                 d_right = right_diffs[j - 1]
-                sign = -1 if i % 2 == 1 else 1
-                row_off = offsets_deg_minus1[(i, j-1)]
+                left_degree = left.degree_min + i
+                sign = -1 if left_degree % 2 == 1 else 1
+                row_off = offsets_deg_minus1[(i, j - 1)]
                 for a in range(left.basis_sizes[i]):
-                    for c2 in range(right.basis_sizes[j-1]):
+                    for c2 in range(right.basis_sizes[j - 1]):
                         for d in range(right.basis_sizes[j]):
                             coeff = d_right[c2][d] * sign
                             if coeff == 0:
                                 continue
-                            row = row_off + a * right.basis_sizes[j-1] + c2
+                            row = row_off + a * right.basis_sizes[j - 1] + c2
                             col = col_off + a * right.basis_sizes[j] + d
                             block[row][col] += coeff
         tensor_diffs.append(_to_str_matrix(block))

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -662,6 +662,8 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
     # on [deg_min, deg_min + group_count - 1].
     group_count = len(left.basis_sizes) + len(right.basis_sizes) - 1
     degree_min = left.degree_min + right.degree_min
+    from jacobian.math.chain_complexes.values import ChainComplexValue
+
     return TensorProductResult(
         tensor_basis_sizes=tensor_basis_sizes,
         tensor_differential_matrices=tuple(tensor_diffs),
@@ -669,4 +671,12 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
         prime=prime,
         degree_min=degree_min,
         degree_max=degree_min + group_count - 1,
+        value=ChainComplexValue(
+            coefficient_field=left.coefficient_field,
+            prime=prime,
+            degree_min=degree_min,
+            degree_max=degree_min + group_count - 1,
+            basis_sizes=tensor_basis_sizes,
+            differential_matrices=tuple(tensor_diffs),
+        ),
     )

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -434,35 +434,48 @@ def _serialize_entry(value: Fraction, prime: int | None) -> str:
     return f"{value.numerator}/{value.denominator}"
 
 
-def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
-    """Compute the mapping cone of a chain map f: C -> D.
-
-    The mapping cone has groups cone_n = C_{n-1} ⊕ D_n and differential
-    [[ -d_C, 0 ], [ f, d_D ]] as block matrices.
-    """
-    source = request.source
-    target = request.target
+def _require_mapping_cone_parents(
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+) -> None:
+    """A cone is defined only over one coefficient field on one interval."""
     if (
         source.coefficient_field != target.coefficient_field
         or source.prime != target.prime
     ):
         raise ValueError("mapping cone requires same coefficient field and prime")
+    if (source.degree_min, source.degree_max) != (
+        target.degree_min,
+        target.degree_max,
+    ):
+        raise ValueError(
+            "mapping cone requires source and target concentrated on "
+            "the same degree interval"
+        )
+
+
+def _compute_mapping_cone(
+    source: ChainComplexValue,
+    target: ChainComplexValue,
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...],
+) -> tuple[tuple[int, ...], tuple[tuple[tuple[str, ...], ...], ...]]:
+    """Exact mapping-cone construction shared by the operation and its
+    result validator."""
+    _require_mapping_cone_parents(source, target)
     prime = source.prime
 
     # Verify degree alignment: source and target should have same degree_min for simplicity, else shift
     # Compute cone basis sizes: cone_n = C_{n-1} ⊕ D_n
     max_len = max(len(source.basis_sizes), len(target.basis_sizes))
-    cone_basis_sizes = []
-    for i in range(max_len + 1):
-        # C_{n-1} corresponds to source index n-1 - (source.degree_min offset). For degree_min 0, this simplifies.
-        d_size = target.basis_sizes[i] if i < len(target.basis_sizes) else 0
-        c_size2 = (
+    cone_basis_sizes = tuple(
+        (target.basis_sizes[i] if i < len(target.basis_sizes) else 0)
+        + (
             source.basis_sizes[i - 1]
             if i > 0 and i - 1 < len(source.basis_sizes)
             else 0
         )
-        cone_basis_sizes.append(c_size2 + d_size)
-    cone_basis_sizes = tuple(cone_basis_sizes)
+        for i in range(max_len + 1)
+    )
 
     # Build block differentials for each degree
     # For each cone differential cone_{n} -> cone_{n-1}, we need matrix of size cone_basis_sizes[n-1] x cone_basis_sizes[n]
@@ -481,7 +494,7 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     # map matrices: f_i: C_i -> D_i, shape target_basis[i] x source_basis[i]
     map_mats = [
         _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
-        for i, m in enumerate(request.map_matrices)
+        for i, m in enumerate(map_matrices)
     ]
 
     # A mapping cone is a chain complex only when both inputs are chain
@@ -571,11 +584,27 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     ]
     _require_square_zero(cone_parsed, prime, label="mapping cone")
 
+    return cone_basis_sizes, tuple(cone_diffs)
+
+
+def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
+    """Compute the mapping cone of a chain map f: C -> D.
+
+    The mapping cone has groups cone_n = C_{n-1} ⊕ D_n and differential
+    [[ -d_C, 0 ], [ f, d_D ]] as block matrices.
+    """
+    cone_basis_sizes, cone_diffs = _compute_mapping_cone(
+        request.source, request.target, request.map_matrices
+    )
+
     return MappingConeResult(
         cone_basis_sizes=cone_basis_sizes,
-        cone_differential_matrices=tuple(cone_diffs),
-        source_degree_min=source.degree_min,
-        target_degree_min=target.degree_min,
+        cone_differential_matrices=cone_diffs,
+        source_degree_min=request.source.degree_min,
+        target_degree_min=request.target.degree_min,
+        source=request.source,
+        target=request.target,
+        map_matrices=request.map_matrices,
     )
 
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -314,12 +314,12 @@ def _chain_map_verdict(
                     prime,
                     label=label,
                     group_columns=list(complex_value.basis_sizes),
+                    degree_min=complex_value.degree_min,
                 )
             except ValueError as error:
                 return (
                     False,
-                    str(error) + ", so no chain map between these "
-                    "endpoints exists",
+                    str(error) + ", so no chain map between these endpoints exists",
                 )
 
     map_mats = [
@@ -352,7 +352,10 @@ def _chain_map_verdict(
             left_declared_columns=source.basis_sizes[i],
         )
         if left != right:
-            return False, f"chain map does not commute at degree {source.degree_min + i}"
+            return (
+                False,
+                f"chain map does not commute at degree {source.degree_min + i}",
+            )
 
     return True, "chain map commutes with differentials"
 

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -399,6 +399,17 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
     )
 
 
+def _serialize_entry(value: Fraction, prime: int | None) -> str:
+    """One canonical matrix-entry spelling; GF(p) entries are residues."""
+    if prime is not None:
+        # Canonical GF(p) residues in [0, p): signed contributions must not
+        # serialize as negative integers.
+        return str(int(value) % prime)
+    if value.denominator == 1:
+        return str(int(value))
+    return f"{value.numerator}/{value.denominator}"
+
+
 def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     """Compute the mapping cone of a chain map f: C -> D.
 
@@ -476,11 +487,7 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
         return tuple(
-            tuple(
-                str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}"
-                for v in row
-            )
-            for row in mat
+            tuple(_serialize_entry(v, prime) for v in row) for row in mat
         )
 
     cone_diffs: list[tuple[tuple[str, ...], ...]] = []
@@ -605,11 +612,7 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
         return tuple(
-            tuple(
-                str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}"
-                for v in row
-            )
-            for row in mat
+            tuple(_serialize_entry(v, prime) for v in row) for row in mat
         )
 
     tensor_diffs: list[tuple[tuple[str, ...], ...]] = []

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -117,10 +117,20 @@ def _matrix_multiply(
     a: list[list[Fraction]],
     b: list[list[Fraction]],
     prime: int | None = None,
+    result_columns: int | None = None,
 ) -> list[list[Fraction]]:
     rows_a = len(a)
     cols_a = len(a[0]) if a else 0
-    cols_b = len(b[0]) if b else 0
+    if b:
+        cols_b = len(b[0])
+        if len(b) != cols_a:
+            raise ValueError("inner product dimensions do not match")
+    else:
+        # A zero-row right operand keeps its declared column count so the
+        # outer dimensions of a zero-width product are preserved.
+        cols_b = result_columns if result_columns is not None else 0
+        if cols_a and not b:
+            raise ValueError("inner product dimensions do not match")
     result = [[Fraction(0)] * cols_b for _ in range(rows_a)]
     for i in range(rows_a):
         for j in range(cols_b):
@@ -149,10 +159,18 @@ def _require_square_zero(
     prime: int | None = None,
     *,
     label: str,
+    group_columns=None,
 ) -> None:
-    """Require d^2 = 0 for a parsed differential sequence."""
+    """Require d^2 = 0 for a parsed differential sequence.
+
+    ``group_columns`` carries chain-group dimensions so zero-width groups
+    preserve outer product dimensions.
+    """
     for i in range(len(diffs) - 1):
-        product = _matrix_multiply(diffs[i], diffs[i + 1], prime)
+        result_columns = (
+            group_columns[i + 2] if group_columns is not None else None
+        )
+        product = _matrix_multiply(diffs[i], diffs[i + 1], prime, result_columns)
         if any(value != 0 for row in product for value in row):
             raise ValueError(
                 f"{label} complex violates d^2=0 at differential index {i}"
@@ -164,11 +182,19 @@ def _require_chain_map_relation(
     target_diffs: list[list[list[Fraction]]],
     map_mats: list[list[list[Fraction]]],
     prime: int | None = None,
+    source_group_columns=None,
 ) -> None:
     """Require d_target * f_{i+1} == f_i * d_source at every differential."""
     for i in range(len(source_diffs)):
-        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime)
-        right = _matrix_multiply(map_mats[i], source_diffs[i], prime)
+        result_columns = (
+            source_group_columns[i + 1] if source_group_columns is not None else None
+        )
+        left = _matrix_multiply(
+            target_diffs[i], map_mats[i + 1], prime, result_columns
+        )
+        right = _matrix_multiply(
+            map_mats[i], source_diffs[i], prime, result_columns
+        )
         if left != right:
             raise ValueError(
                 f"chain map does not commute with differentials at degree index {i}"
@@ -208,7 +234,7 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
         # Correct order: d_i * d_{i+1} where diffs[i] is C_i x C_{i+1}, diffs[i+1] is C_{i+1} x C_{i+2}
         d_i = diffs[i]
         d_ip1 = diffs[i + 1]
-        product = _matrix_multiply(d_i, d_ip1, prime)
+        product = _matrix_multiply(d_i, d_ip1, prime, cx.basis_sizes[i + 2])
         is_zero = all(all(val == 0 for val in row) for row in product)
         if not is_zero:
             return VerificationResult(
@@ -232,6 +258,34 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     target = request.target
     prime = source.prime
 
+    # A chain map exists only between chain complexes; endpoints violating
+    # d^2=0 make the verification false by definition. Check the first
+    # consecutive differential product of each endpoint.
+    for label, complex_value in (("source", source), ("target", target)):
+        diffs = [
+            _matrix_to_fractions(
+                m, complex_value.basis_sizes[k], complex_value.basis_sizes[k + 1], prime
+            )
+            for k, m in enumerate(complex_value.differential_matrices)
+        ]
+        if len(diffs) > 1:
+            product = _matrix_multiply(
+                diffs[0],
+                diffs[1],
+                prime,
+                complex_value.basis_sizes[2],
+            )
+            if any(v != 0 for row in product for v in row):
+                return VerificationResult(
+                    is_valid=False,
+                    detail=(
+                        f"{label} complex violates d^2=0, so no chain map "
+                        "between these endpoints exists"
+                    ),
+                    source=source,
+                    target=target,
+                )
+
     # Request admission guarantees one component per degree, equal shape
     # (target rows x source columns) per component, and coinciding degree
     # intervals, so tuple index equals actual chain degree.
@@ -252,8 +306,13 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     # chain-map equation at every differential is
     # d_target_i * f_{i+1} == f_i * d_source_i.
     for i in range(len(source_diffs)):
-        left = _matrix_multiply(target_diffs[i], map_mats[i + 1], prime)
-        right = _matrix_multiply(map_mats[i], source_diffs[i], prime)
+        result_columns = source.basis_sizes[i + 1]
+        left = _matrix_multiply(
+            target_diffs[i], map_mats[i + 1], prime, result_columns
+        )
+        right = _matrix_multiply(
+            map_mats[i], source_diffs[i], prime, result_columns
+        )
         if left != right:
             return VerificationResult(
                 is_valid=False,
@@ -285,7 +344,7 @@ def _compute_homology_groups(
 
     # Require square-zero before computing homology
     for i in range(len(diffs) - 1):
-        prod = _matrix_multiply(diffs[i], diffs[i + 1], prime)
+        prod = _matrix_multiply(diffs[i], diffs[i + 1], prime, cx.basis_sizes[i + 2])
         if any(any(v != 0 for v in row) for row in prod):
             raise ValueError(
                 f"chain complex does not satisfy d^2=0 at index {i}: product non-zero"
@@ -396,9 +455,19 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     # A mapping cone is a chain complex only when both inputs are chain
     # complexes and the map is a genuine chain map; validate both defining
     # equations before returning any exact decomposition.
-    _require_square_zero(source_diffs, prime, label="source")
-    _require_square_zero(target_diffs, prime, label="target")
-    _require_chain_map_relation(source_diffs, target_diffs, map_mats, prime)
+    _require_square_zero(
+        source_diffs, prime, label="source", group_columns=list(source.basis_sizes)
+    )
+    _require_square_zero(
+        target_diffs, prime, label="target", group_columns=list(target.basis_sizes)
+    )
+    _require_chain_map_relation(
+        source_diffs,
+        target_diffs,
+        map_mats,
+        prime,
+        source_group_columns=list(source.basis_sizes),
+    )
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
         return tuple(
@@ -513,8 +582,12 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
 
     # A tensor product of chain complexes is a chain complex only when both
     # factors satisfy d^2 = 0; validate before building anything.
-    _require_square_zero(left_diffs, prime, label="left")
-    _require_square_zero(right_diffs, prime, label="right")
+    _require_square_zero(
+        left_diffs, prime, label="left", group_columns=list(left.basis_sizes)
+    )
+    _require_square_zero(
+        right_diffs, prime, label="right", group_columns=list(right.basis_sizes)
+    )
 
     def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
         return tuple(

--- a/src/jacobian/math/chain_complexes/operations.py
+++ b/src/jacobian/math/chain_complexes/operations.py
@@ -25,7 +25,12 @@ from jacobian.math.chain_complexes.values import (
 
 def _parse_fraction(s: str, prime: int | None = None) -> Fraction:
     if prime is not None:
-        return Fraction(int(s) % prime)
+        # Prime-field entries are canonical residues 0..p-1; accept integer strings only
+        try:
+            val = int(s)
+        except ValueError:
+            raise ValueError(f"prime-field entry '{s}' must be an integer residue")
+        return Fraction(val % prime)
     if "/" in s:
         num, den = s.split("/", 1)
         return Fraction(int(num), int(den))
@@ -51,36 +56,66 @@ def _matrix_rank(matrix: list[list[Fraction]], prime: int | None = None) -> int:
         return 0
     rows = len(matrix)
     cols = len(matrix[0])
-    mat = [row[:] for row in matrix]
-    rank = 0
-    for col in range(cols):
-        pivot = None
-        for row in range(rank, rows):
-            if mat[row][col] != 0:
-                pivot = row
-                break
-        if pivot is None:
-            continue
-        mat[rank], mat[pivot] = mat[pivot], mat[rank]
-        for row in range(rows):
-            if row == rank:
+    if prime is not None:
+        # Perform elimination inside GF(p) using modular inverses
+        # Convert Fractions to ints modulo p (they are already residues)
+        mat = [[int(v) % prime for v in row] for row in matrix]
+        rank = 0
+        for col in range(cols):
+            # Find pivot with non-zero residue
+            pivot = None
+            for row in range(rank, rows):
+                if mat[row][col] % prime != 0:
+                    pivot = row
+                    break
+            if pivot is None:
                 continue
-            if mat[row][col] != 0:
-                factor = mat[row][col] / mat[rank][col]
-                for j in range(cols):
-                    mat[row][j] -= factor * mat[rank][j]
-                if prime is not None:
+            mat[rank], mat[pivot] = mat[pivot], mat[rank]
+            inv = pow(int(mat[rank][col]), -1, prime)  # modular inverse
+            # Normalize pivot row
+            for j in range(cols):
+                mat[rank][j] = (mat[rank][j] * inv) % prime
+            # Eliminate other rows
+            for row in range(rows):
+                if row == rank:
+                    continue
+                factor = mat[row][col] % prime
+                if factor != 0:
                     for j in range(cols):
-                        mat[row][j] = mat[row][j] % prime
-        rank += 1
-        if rank == rows:
-            break
-    return rank
+                        mat[row][j] = (mat[row][j] - factor * mat[rank][j]) % prime
+            rank += 1
+            if rank == rows:
+                break
+        return rank
+    else:
+        mat = [row[:] for row in matrix]
+        rank = 0
+        for col in range(cols):
+            pivot = None
+            for row in range(rank, rows):
+                if mat[row][col] != 0:
+                    pivot = row
+                    break
+            if pivot is None:
+                continue
+            mat[rank], mat[pivot] = mat[pivot], mat[rank]
+            for row in range(rows):
+                if row == rank:
+                    continue
+                if mat[row][col] != 0:
+                    factor = mat[row][col] / mat[rank][col]
+                    for j in range(cols):
+                        mat[row][j] -= factor * mat[rank][j]
+            rank += 1
+            if rank == rows:
+                break
+        return rank
 
 
 def _matrix_multiply(
     a: list[list[Fraction]],
     b: list[list[Fraction]],
+    prime: int | None = None,
 ) -> list[list[Fraction]]:
     rows_a = len(a)
     cols_a = len(a[0]) if a else 0
@@ -88,8 +123,23 @@ def _matrix_multiply(
     result = [[Fraction(0)] * cols_b for _ in range(rows_a)]
     for i in range(rows_a):
         for j in range(cols_b):
+            s = Fraction(0)
             for k in range(cols_a):
-                result[i][j] += a[i][k] * b[k][j]
+                s += a[i][k] * b[k][j]
+            if prime is not None:
+                # Reduce modulo p: convert to int residue then back to Fraction
+                # Since entries are residues, product sums are integers mod p
+                # We need to map via int(s) % prime
+                # Handle Fractions that are already residues (denominator 1)
+                # For general prime field, s should be integer; reduce mod p
+                if s.denominator != 1:
+                    # For prime field, denominators should be 1; if not, it's an error, but convert via modular inverse
+                    # Compute numerator * inv(denominator) mod p
+                    inv_den = pow(s.denominator, -1, prime)
+                    s = Fraction((s.numerator * inv_den) % prime, 1)
+                else:
+                    s = Fraction(int(s) % prime, 1)
+            result[i][j] = s
     return result
 
 
@@ -123,9 +173,10 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
     ]
 
     for i in range(len(diffs) - 1):
-        d_n = diffs[i + 1]
-        d_n_minus_1 = diffs[i]
-        product = _matrix_multiply(d_n, d_n_minus_1)
+        # Correct order: d_i * d_{i+1} where diffs[i] is C_i x C_{i+1}, diffs[i+1] is C_{i+1} x C_{i+2}
+        d_i = diffs[i]
+        d_ip1 = diffs[i + 1]
+        product = _matrix_multiply(d_i, d_ip1, prime)
         is_zero = all(
             all(val == 0 for val in row) for row in product
         )
@@ -133,6 +184,7 @@ def verify_differential(request: VerifyDifferentialRequest) -> VerificationResul
             return VerificationResult(
                 is_valid=False,
                 detail= f"d^2 != 0 at degree {i + 1}",
+                complex=request.complex,
             )
 
     return VerificationResult(is_valid=True, detail="d^2 = 0 for all degrees")
@@ -145,7 +197,34 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
     """
     source = request.source
     target = request.target
-    prime = source.prime or target.prime
+    # Reject incompatible fields
+    if source.coefficient_field != target.coefficient_field:
+        return VerificationResult(
+            is_valid=False,
+            detail=f"chain map between incompatible coefficient fields {source.coefficient_field} vs {target.coefficient_field}",
+            source=source,
+            target=target,
+        )
+    if source.prime != target.prime:
+        return VerificationResult(
+            is_valid=False,
+            detail=f"chain map between different primes {source.prime} vs {target.prime}",
+            source=source,
+            target=target,
+        )
+    prime = source.prime
+
+    if len(source.basis_sizes) != len(target.basis_sizes):
+        # For simplicity require same length; otherwise need to handle different degree ranges
+        # But we can still proceed with min length
+        pass
+    if len(request.map_matrices) != len(source.basis_sizes):
+        return VerificationResult(
+            is_valid=False,
+            detail=f"map_matrices count {len(request.map_matrices)} != basis count {len(source.basis_sizes)}",
+            source=source,
+            target=target,
+        )
 
     source_diffs = [
         _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
@@ -156,30 +235,51 @@ def verify_chain_map(request: VerifyChainMapRequest) -> VerificationResult:
         for i, m in enumerate(target.differential_matrices)
     ]
     map_mats = [
-        _matrix_to_fractions(m, source.basis_sizes[i], target.basis_sizes[i], prime)
+        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)  # note: rows=target, cols=source, so transpose from previous
+        for i, m in enumerate(request.map_matrices)
+    ]
+    # Actually _matrix_to_fractions expects rows=target_basis[i], cols=source_basis[i] to represent map C_i -> D_i as matrix D_i x C_i
+    # The original code had rows=source, cols=target which is transposed. We need to check dimensions.
+    # Let's instead construct maps as (target_basis[i] rows x source_basis[i] cols) by transposing the input if needed.
+    # The input map_matrices[i] is given as tuple of rows where each row length = target_basis? No, spec says map_matrices[i] has shape source_basis[i] x target_basis[i]? We need to infer from tests.
+    # Tests use identity 3x3 for circle (basis 3,3). Identity 3x3 is square, so ambiguous.
+    # For now we will keep original orientation (source rows x target cols) and compute correctly: we need d_target * f_{i+1} == f_i * d_source
+    # Let's recompute with correct orientation assuming f_i is target_rows x source_cols? Wait we need to decide.
+    # For now, we will implement the mathematically correct check using the stored orientation as source_rows x target_cols (as in original code).
+    # That means f_i has shape source_basis[i] rows x target_basis[i] cols? But then d_target * f_{i+1} would be (target_basis[i] x target_basis[i+1]) * (source_basis[i+1] x target_basis[i+1]) -> dimensions mismatch.
+    # So original orientation must be target x source? Let's re-evaluate: In original code, they called _matrix_to_fractions(m, source_basis[i], target_basis[i], prime) where rows=source, cols=target. That would create matrix with rows=source, cols=target, i.e., source x target. But a map C_i -> D_i should be D_i rows x C_i cols. So that is transposed.
+    # To make multiplication work, they did left = f_n * d_target where f_n is source x target and d_target is target x target_next. That product would be source x target_next, while right is source_next x source * source_next x target? Not matching.
+    # The correct is to have f as D x C, so rows=target, cols=source. So we should call _matrix_to_fractions with rows=target, cols=source.
+    # Let's fix map_mats construction to use target rows, source cols.
+
+    # Rebuild map_mats correctly
+    map_mats = [
+        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
         for i, m in enumerate(request.map_matrices)
     ]
 
     for i in range(len(source_diffs)):
-        d_source = source_diffs[i]
-        d_target = target_diffs[i]
-        f_n = map_mats[i]
-        f_n_minus_1 = map_mats[i + 1] if i + 1 < len(map_mats) else None
-
-        # d_target * f_n should equal f_{n-1} * d_source
-        left = _matrix_multiply(f_n, d_target)  # f_n: C_n -> D_n, d_target: D_n -> D_{n-1}
-        if f_n_minus_1 is not None:
-            right = _matrix_multiply(d_source, f_n_minus_1)  # d_source: C_n -> C_{n-1}, f_{n-1}: C_{n-1} -> D_{n-1}
-        else:
-            right = [[Fraction(0)] * len(left[0]) for _ in range(len(left))]
-
+        d_source = source_diffs[i]  # rows=source_basis[i], cols=source_basis[i+1]
+        d_target = target_diffs[i]  # rows=target_basis[i], cols=target_basis[i+1]
+        # f_{i+1}: C_{i+1} -> D_{i+1}, shape target_basis[i+1] x source_basis[i+1]
+        # f_i: C_i -> D_i, shape target_basis[i] x source_basis[i]
+        f_ip1 = map_mats[i + 1] if i + 1 < len(map_mats) else None
+        f_i = map_mats[i]
+        if f_ip1 is None:
+            continue  # No next map, skip? But need to check at top degree where no differential?
+        # left = d_target * f_{i+1}: (target_i x target_{i+1}) * (target_{i+1} x source_{i+1}) => target_i x source_{i+1}
+        left = _matrix_multiply(d_target, f_ip1, prime)
+        # right = f_i * d_source: (target_i x source_i) * (source_i x source_{i+1}) => target_i x source_{i+1}
+        right = _matrix_multiply(f_i, d_source, prime)
         if left != right:
             return VerificationResult(
                 is_valid=False,
-                detail= f"chain map does not commute at degree {i}",
+                detail=f"chain map does not commute at degree {i+1}",
+                source=source,
+                target=target,
             )
 
-    return VerificationResult(is_valid=True, detail="chain map commutes with differentials")
+    return VerificationResult(is_valid=True, detail="chain map commutes with differentials", source=source, target=target)
 
 
 def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
@@ -193,64 +293,144 @@ def compute_homology(request: ComputeHomologyRequest) -> HomologyResult:
         for i, m in enumerate(cx.differential_matrices)
     ]
 
-    groups = []
-    for degree in range(n):
-        chain_rank = cx.basis_sizes[degree]
+    # Require square-zero before computing homology
+    for i in range(len(diffs) - 1):
+        prod = _matrix_multiply(diffs[i], diffs[i + 1], prime)
+        if any(any(v != 0 for v in row) for row in prod):
+            raise ValueError(f"chain complex does not satisfy d^2=0 at index {i}: product non-zero")
 
-        # outgoing differential d_n: C_n -> C_{n-1}
-        if degree < len(diffs):
-            d_out = diffs[degree]
+    groups = []
+    for idx in range(n):
+        chain_rank = cx.basis_sizes[idx]
+        actual_degree = cx.degree_min + idx
+
+        # Correct assignment: diffs[idx-1] is outgoing from C_{idx} -> C_{idx-1} (if idx>0), diffs[idx] is incoming from C_{idx+1} -> C_{idx}
+        if idx > 0:
+            d_out = diffs[idx - 1]
             outgoing_rank = _matrix_rank(d_out, prime)
         else:
             outgoing_rank = 0
 
-        # incoming differential d_{n+1}: C_{n+1} -> C_n
-        if degree > 0:
-            d_in = diffs[degree - 1]
+        if idx < len(diffs):
+            d_in = diffs[idx]
             incoming_rank = _matrix_rank(d_in, prime)
         else:
             incoming_rank = 0
 
         cycle_rank = chain_rank - outgoing_rank
         betti = cycle_rank - incoming_rank
+        if betti < 0:
+            raise ValueError(f"negative Betti number at degree {actual_degree}: indicates invalid complex")
 
         groups.append(
             HomologyGroupValue(
-                degree=degree,
+                degree=actual_degree,
                 cycle_rank=cycle_rank,
                 boundary_rank=incoming_rank,
-                betti_number=max(0, betti),
+                betti_number=betti,
             )
         )
 
     return HomologyResult(
         homology_groups=tuple(groups),
         coefficient_field=cx.coefficient_field,
+        prime=prime,
+        degree_min=cx.degree_min,
+        degree_max=cx.degree_max,
     )
 
 
 def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
     """Compute the mapping cone of a chain map f: C -> D.
 
-    The mapping cone has groups cone_n = C_{n-1} ⊕ D_n.
+    The mapping cone has groups cone_n = C_{n-1} ⊕ D_n and differential
+    [[ -d_C, 0 ], [ f, d_D ]] as block matrices.
     """
     source = request.source
     target = request.target
-    prime = source.prime or target.prime
+    if source.coefficient_field != target.coefficient_field or source.prime != target.prime:
+        raise ValueError("mapping cone requires same coefficient field and prime")
+    prime = source.prime
 
-    n = max(len(source.basis_sizes), len(target.basis_sizes))
-    cone_basis_sizes = tuple(
-        source.basis_sizes[i - 1] + target.basis_sizes[i]
-        if i > 0 and i - 1 < len(source.basis_sizes) and i < len(target.basis_sizes)
-        else source.basis_sizes[i - 1] if i > 0 and i - 1 < len(source.basis_sizes)
-        else target.basis_sizes[i] if i < len(target.basis_sizes)
-        else 0
-        for i in range(n + 1)
-    )
+    # Verify degree alignment: source and target should have same degree_min for simplicity, else shift
+    # Compute cone basis sizes: cone_n = C_{n-1} ⊕ D_n
+    max_len = max(len(source.basis_sizes), len(target.basis_sizes))
+    cone_basis_sizes = []
+    for i in range(max_len + 1):
+        c_size = source.basis_sizes[i - 1] if 0 < i < len(source.basis_sizes) + 1 and i-1 < len(source.basis_sizes) else 0
+        # Actually C_{n-1} corresponds to source index n-1 - (source.degree_min offset). For degree_min 0, this simplifies.
+        # For general degree_min, we align by index offset.
+        # Simplify to degree_min 0 case as in tests; for non-zero, use same logic with index shift.
+        d_size = target.basis_sizes[i] if i < len(target.basis_sizes) else 0
+        c_size2 = source.basis_sizes[i - 1] if i > 0 and i - 1 < len(source.basis_sizes) else 0
+        cone_basis_sizes.append(c_size2 + d_size)
+    cone_basis_sizes = tuple(cone_basis_sizes)
+
+    # Build block differentials for each degree
+    # For each cone differential cone_{n} -> cone_{n-1}, we need matrix of size cone_basis_sizes[n-1] x cone_basis_sizes[n]
+    # Blocks: top-left = -d_C^{n-1}, top-right = 0, bottom-left = f_{n-1}, bottom-right = d_D^{n}
+    # For simplicity, we construct string matrices with entries as fractions strings.
+    # Need to parse source and target diffs and maps.
+
+    source_diffs = [
+        _matrix_to_fractions(m, source.basis_sizes[i], source.basis_sizes[i + 1], prime)
+        for i, m in enumerate(source.differential_matrices)
+    ]
+    target_diffs = [
+        _matrix_to_fractions(m, target.basis_sizes[i], target.basis_sizes[i + 1], prime)
+        for i, m in enumerate(target.differential_matrices)
+    ]
+    # map matrices: f_i: C_i -> D_i, shape target_basis[i] x source_basis[i]
+    map_mats = [
+        _matrix_to_fractions(m, target.basis_sizes[i], source.basis_sizes[i], prime)
+        for i, m in enumerate(request.map_matrices)
+    ]
+
+    def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
+        return tuple(tuple(str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}" for v in row) for row in mat)
+
+    cone_diffs: list[tuple[tuple[str, ...], ...]] = []
+    for n in range(1, len(cone_basis_sizes)):
+        rows = cone_basis_sizes[n - 1]
+        cols = cone_basis_sizes[n]
+        if rows == 0 or cols == 0:
+            cone_diffs.append(tuple(tuple("0" for _ in range(cols)) for _ in range(rows)) if rows and cols else tuple())
+            continue
+        # Build zero matrix
+        block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
+        # Sizes for decomposition: cone_{n} = C_{n-1} ⊕ D_n, cone_{n-1}= C_{n-2} ⊕ D_{n-1}
+        c_n_minus1 = source.basis_sizes[n - 1] if 0 <= n - 1 < len(source.basis_sizes) else 0
+        d_n = target.basis_sizes[n] if n < len(target.basis_sizes) else 0
+        c_n_minus2 = source.basis_sizes[n - 2] if n - 2 >= 0 and n - 2 < len(source.basis_sizes) else 0
+        d_n_minus1 = target.basis_sizes[n - 1] if n - 1 < len(target.basis_sizes) else 0
+
+        # Fill blocks
+        # Top-left: -d_C^{n-1} : size c_{n-2} x c_{n-1}
+        if c_n_minus2 and c_n_minus1 and n - 2 < len(source_diffs):
+            d_c = source_diffs[n - 2]  # C_{n-1} -> C_{n-2}
+            for i in range(c_n_minus2):
+                for j in range(c_n_minus1):
+                    block[i][j] = -d_c[i][j]
+        # Bottom-right: d_D^{n}: size d_{n-1} x d_n
+        if d_n_minus1 and d_n and n - 1 < len(target_diffs):
+            d_d = target_diffs[n - 1]
+            for i in range(d_n_minus1):
+                for j in range(d_n):
+                    block[c_n_minus2 + i][c_n_minus1 + j] = d_d[i][j]
+        # Bottom-left: f_{n-1}: size d_{n-1} x c_{n-1}
+        if d_n_minus1 and c_n_minus1 and n - 1 < len(map_mats):
+            f = map_mats[n - 1]
+            for i in range(d_n_minus1):
+                for j in range(c_n_minus1):
+                    # f is target x source, so need to map correctly
+                    if i < len(f) and j < len(f[0]):
+                        block[c_n_minus2 + i][j] = f[i][j]
+
+        cone_diffs.append(_to_str_matrix(block))
 
     return MappingConeResult(
         cone_basis_sizes=cone_basis_sizes,
-        cone_differential_matrices=(),  # Simplified: full cone differentials need block matrices
+        cone_differential_matrices=tuple(cone_diffs),
         source_degree_min=source.degree_min,
         target_degree_min=target.degree_min,
     )
@@ -259,10 +439,14 @@ def compute_mapping_cone(request: MappingConeRequest) -> MappingConeResult:
 def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult:
     """Compute the tensor product of two chain complexes.
 
-    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j
+    (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j with differential d_C ⊗ id + (-1)^i id ⊗ d_D.
     """
     left = request.left
     right = request.right
+    if left.coefficient_field != right.coefficient_field or left.prime != right.prime:
+        raise ValueError("tensor product requires same coefficient field and prime")
+    prime = left.prime
+
     n = len(left.basis_sizes) + len(right.basis_sizes) - 1
 
     # Basis sizes for the tensor product
@@ -274,8 +458,90 @@ def compute_tensor_product(request: TensorProductRequest) -> TensorProductResult
             if j < len(right.basis_sizes):
                 size += left.basis_sizes[i] * right.basis_sizes[j]
         tensor_basis_sizes.append(size)
+    tensor_basis_sizes = tuple(tensor_basis_sizes)
+
+    # Build signed differentials for each degree.
+    # For each n, differential d_n: (C⊗D)_n -> (C⊗D)_{n-1} is block matrix with
+    # contributions from d^C and d^D with signs.
+    # We construct rational matrices as Fractions and convert to strings.
+
+    left_diffs = [
+        _matrix_to_fractions(m, left.basis_sizes[i], left.basis_sizes[i + 1], prime)
+        for i, m in enumerate(left.differential_matrices)
+    ]
+    right_diffs = [
+        _matrix_to_fractions(m, right.basis_sizes[i], right.basis_sizes[i + 1], prime)
+        for i, m in enumerate(right.differential_matrices)
+    ]
+
+    def _to_str_matrix(mat: list[list[Fraction]]) -> tuple[tuple[str, ...], ...]:
+        return tuple(tuple(str(int(v)) if v.denominator == 1 else f"{v.numerator}/{v.denominator}" for v in row) for row in mat)
+
+    tensor_diffs: list[tuple[tuple[str, ...], ...]] = []
+    for deg in range(1, n):
+        rows = tensor_basis_sizes[deg - 1]
+        cols = tensor_basis_sizes[deg]
+        if rows == 0 or cols == 0:
+            tensor_diffs.append(tuple(tuple("0" for _ in range(cols)) for _ in range(rows)) if rows and cols else tuple())
+            continue
+        block = [[Fraction(0) for _ in range(cols)] for _ in range(rows)]
+        # Iterate over i,j for source degree deg
+        row_offset = 0
+        col_offset = 0
+        # We need to map block structure: (C⊗D)_deg = ⊕_{i+j=deg} C_i⊗D_j
+        # Similarly for deg-1 = ⊕_{p+q=deg-1} C_p⊗D_q
+        # For each i,j contributing to deg, its differential contributes to two possible targets:
+        # - via d_C: C_i⊗D_j -> C_{i-1}⊗D_j (if i>0)
+        # - via d_D: C_i⊗D_j -> C_i⊗D_{j-1} with sign (-1)^i
+        # We need to compute offset positions for each summand.
+        # First compute offsets for deg and deg-1
+        offsets_deg = {}
+        off = 0
+        for i in range(min(deg + 1, len(left.basis_sizes))):
+            j = deg - i
+            if j < len(right.basis_sizes):
+                offsets_deg[(i,j)] = off
+                off += left.basis_sizes[i] * right.basis_sizes[j]
+        offsets_deg_minus1 = {}
+        off = 0
+        for p in range(min(deg, len(left.basis_sizes))):
+            q = deg - 1 - p
+            if q < len(right.basis_sizes) and q >=0:
+                offsets_deg_minus1[(p,q)] = off
+                off += left.basis_sizes[p] * right.basis_sizes[q]
+
+        for (i,j), col_off in offsets_deg.items():
+            # d_C contribution
+            if i > 0 and (i-1, j) in offsets_deg_minus1:
+                d_left = left_diffs[i - 1]  # shape left_basis[i-1] x left_basis[i]
+                row_off = offsets_deg_minus1[(i-1, j)]
+                # Tensor product with identity on D_j
+                for a in range(left.basis_sizes[i-1]):
+                    for b in range(left.basis_sizes[i]):
+                        coeff = d_left[a][b]
+                        if coeff == 0:
+                            continue
+                        for c in range(right.basis_sizes[j]):
+                            row = row_off + a * right.basis_sizes[j] + c
+                            col = col_off + b * right.basis_sizes[j] + c
+                            block[row][col] += coeff
+            # d_D contribution with sign (-1)^i
+            if j > 0 and (i, j-1) in offsets_deg_minus1:
+                d_right = right_diffs[j - 1]
+                sign = -1 if i % 2 == 1 else 1
+                row_off = offsets_deg_minus1[(i, j-1)]
+                for a in range(left.basis_sizes[i]):
+                    for c2 in range(right.basis_sizes[j-1]):
+                        for d in range(right.basis_sizes[j]):
+                            coeff = d_right[c2][d] * sign
+                            if coeff == 0:
+                                continue
+                            row = row_off + a * right.basis_sizes[j-1] + c2
+                            col = col_off + a * right.basis_sizes[j] + d
+                            block[row][col] += coeff
+        tensor_diffs.append(_to_str_matrix(block))
 
     return TensorProductResult(
-        tensor_basis_sizes=tuple(tensor_basis_sizes),
-        tensor_differential_matrices=(),  # Full differentials need block construction
+        tensor_basis_sizes=tensor_basis_sizes,
+        tensor_differential_matrices=tuple(tensor_diffs),
     )

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -277,12 +277,43 @@ class HomologyResult(StrictModel):
 
 
 class MappingConeResult(StrictModel):
-    """The mapping cone of a chain map."""
+    """The mapping cone of a retained chain map."""
 
     cone_basis_sizes: tuple[int, ...]
     cone_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
     source_degree_min: int
     target_degree_min: int
+    source: ChainComplexValue
+    target: ChainComplexValue
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+    @model_validator(mode="after")
+    def bind_cone_to_source(self) -> Self:
+        """Replay the defining construction so only the exact mapping
+        cone of the retained chain map validates."""
+        from jacobian.math.chain_complexes.operations import (
+            _compute_mapping_cone,
+        )
+
+        if (
+            self.source_degree_min != self.source.degree_min
+            or self.target_degree_min != self.target.degree_min
+        ):
+            raise ValueError(
+                "cone degree provenance must match the retained endpoints"
+            )
+        basis_sizes, differential_matrices = _compute_mapping_cone(
+            self.source, self.target, self.map_matrices
+        )
+        if (
+            self.cone_basis_sizes != basis_sizes
+            or self.cone_differential_matrices != differential_matrices
+        ):
+            raise ValueError(
+                "cone must be the exact mapping cone of the retained "
+                "chain map"
+            )
+        return self
 
 
 class TensorProductResult(StrictModel):
@@ -386,6 +417,20 @@ class VerificationResult(StrictModel):
             and self.target is not None
             and self.map_matrices is not None
         ):
+            from jacobian.math.chain_complexes._models import (
+                _require_chain_map_components,
+            )
+
+            # Replay must apply the request model's complete component
+            # and parent checks: otherwise endpoints with different
+            # coefficient fields, primes, or degree intervals validate
+            # by being interpreted under the source modulus alone.
+            _require_chain_map_components(
+                self.source,
+                self.target,
+                self.map_matrices,
+                label="chain-map verification",
+            )
             prime = self.source.prime
             try:
                 map_mats = [

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -22,8 +22,6 @@ MAX_TENSOR_TOTAL_CELLS = 65536
 # conservative budgets.
 MAX_CHAIN_MAP_CELLS = 4096
 MAX_CHAIN_MAP_ENTRY_CHARS = 65536
-# Serialization envelope for expanded tensor differentials.
-MAX_TENSOR_SERIALIZED_CHARS = 4_000_000
 # Aggregate printed characters across every differential cell. Coupling
 # total coefficient size to the matrix work bounds rational elimination
 # bit complexity at admission instead of only bounding input shape.

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -275,7 +275,12 @@ class HomologyResult(StrictModel):
 
 
 class MappingConeResult(StrictModel):
-    """The mapping cone of a retained chain map."""
+    """The mapping cone of a retained chain map.
+
+    The derived complex retains its coefficient field, prime, and degree
+    interval as a first-class chain-complex value so it composes into
+    homology, tensor, map, and cone operations unchanged.
+    """
 
     cone_basis_sizes: tuple[int, ...]
     cone_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
@@ -284,6 +289,7 @@ class MappingConeResult(StrictModel):
     source: ChainComplexValue
     target: ChainComplexValue
     map_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    value: ChainComplexValue
 
     @model_validator(mode="after")
     def bind_cone_to_source(self) -> Self:
@@ -319,6 +325,23 @@ class MappingConeResult(StrictModel):
         ):
             raise ValueError(
                 "cone must be the exact mapping cone of the retained chain map"
+            )
+        if (
+            self.value.basis_sizes != basis_sizes
+            or self.value.differential_matrices != differential_matrices
+        ):
+            raise ValueError(
+                "retained canonical value must equal the exact mapping cone"
+            )
+        expected_degree_max = self.source.degree_min + len(basis_sizes) - 1
+        if (
+            self.value.coefficient_field != self.source.coefficient_field
+            or self.value.prime != self.source.prime
+            or self.value.degree_min != self.source.degree_min
+            or self.value.degree_max != expected_degree_max
+        ):
+            raise ValueError(
+                "canonical value context must match the retained endpoints"
             )
         return self
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -345,20 +345,103 @@ __all__ = [
 
 
 class VerificationResult(StrictModel):
-    """Result of verifying a chain complex property."""
+    """Result of verifying a chain complex property, bound to its input."""
 
     is_valid: bool
     detail: str
     complex: ChainComplexValue | None = None
     source: ChainComplexValue | None = None
     target: ChainComplexValue | None = None
+    map_matrices: tuple[tuple[tuple[str, ...], ...], ...] | None = None
 
     @model_validator(mode="after")
     def bind_verification_to_source(self) -> Self:
-        # If a source complex is present, ensure the verdict is replayable
-        # by checking that the stored detail matches the expected pattern for the claimed complex.
-        # For now, require that at least one of complex/source is set when is_valid is claimed.
-        # The operation-level validators will ensure the boolean matches the actual check.
+        """Replay the checked relation against the retained inputs so a
+        detached or forged verdict cannot validate."""
+        from jacobian.math.chain_complexes.operations import (
+            _matrix_to_fractions,
+            _parsed_differentials,
+            _require_chain_map_relation,
+            _require_square_zero,
+        )
+        if self.complex is not None:
+            if self.source or self.target or self.map_matrices:
+                raise ValueError(
+                    "a differential verification result must not carry "
+                    "chain-map inputs"
+                )
+            try:
+                _require_square_zero(
+                    _parsed_differentials(self.complex),
+                    self.complex.prime,
+                    label="verified",
+                    group_columns=list(self.complex.basis_sizes),
+                    degree_min=self.complex.degree_min,
+                )
+                holds = True
+            except ValueError:
+                holds = False
+        elif (
+            self.source is not None
+            and self.target is not None
+            and self.map_matrices is not None
+        ):
+            prime = self.source.prime
+            try:
+                map_mats = [
+                    _matrix_to_fractions(
+                        m, self.target.basis_sizes[i], self.source.basis_sizes[i], prime
+                    )
+                    for i, m in enumerate(self.map_matrices)
+                ]
+                source_diffs = [
+                    _matrix_to_fractions(
+                        m,
+                        self.source.basis_sizes[i],
+                        self.source.basis_sizes[i + 1],
+                        prime,
+                    )
+                    for i, m in enumerate(self.source.differential_matrices)
+                ]
+                target_diffs = [
+                    _matrix_to_fractions(
+                        m,
+                        self.target.basis_sizes[i],
+                        self.target.basis_sizes[i + 1],
+                        prime,
+                    )
+                    for i, m in enumerate(self.target.differential_matrices)
+                ]
+                # Producer semantics: endpoints must be genuine complexes
+                # and the map must commute at every differential.
+                for endpoint in (self.source, self.target):
+                    _require_square_zero(
+                        _parsed_differentials(endpoint),
+                        endpoint.prime,
+                        label="chain-map",
+                        group_columns=list(endpoint.basis_sizes),
+                        degree_min=endpoint.degree_min,
+                    )
+                _require_chain_map_relation(
+                    source_diffs,
+                    target_diffs,
+                    map_mats,
+                    prime,
+                    source_group_columns=list(self.source.basis_sizes),
+                )
+                holds = True
+            except (ValueError, IndexError):
+                holds = False
+        else:
+            raise ValueError(
+                "a verification result must retain the complete checked "
+                "input (the complex, or both endpoints with their map)"
+            )
+        if holds != self.is_valid:
+            raise ValueError(
+                "verification verdict must be the exact replay of the "
+                "retained relation"
+            )
         return self
 
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -152,13 +152,14 @@ class HomologyGroupValue(StrictModel):
 
 
 class HomologyResult(StrictModel):
-    """Homology of a chain complex."""
+    """Homology of a retained source chain complex."""
 
     homology_groups: tuple[HomologyGroupValue, ...]
     coefficient_field: CoefficientField
     prime: int | None = Field(default=None, ge=2)
     degree_min: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
     degree_max: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
+    complex: ChainComplexValue
 
     @model_validator(mode="after")
     def require_prime_coupling(self) -> Self:
@@ -168,6 +169,46 @@ class HomologyResult(StrictModel):
         else:
             if self.prime is not None:
                 raise ValueError("QQ homology must not have a prime")
+        return self
+
+    @model_validator(mode="after")
+    def bind_profile_to_source(self) -> Self:
+        # Source-bound replay: the profile must be the exact homology of
+        # the retained complex, with contiguous degrees and the defining
+        # rank identity per group.
+        from jacobian.math.chain_complexes.operations import (
+            _compute_homology_groups,
+        )
+
+        if (
+            self.degree_min != self.complex.degree_min
+            or self.degree_max != self.complex.degree_max
+        ):
+            raise ValueError("degree interval must match the retained complex")
+        expected_degrees = list(
+            range(self.complex.degree_min, self.complex.degree_max + 1)
+        )
+        if [group.degree for group in self.homology_groups] != expected_degrees:
+            raise ValueError(
+                "homology groups must cover every degree of the retained "
+                "complex exactly once"
+            )
+        for group in self.homology_groups:
+            if (
+                group.betti_number != group.cycle_rank - group.boundary_rank
+                or group.betti_number < 0
+                or group.cycle_rank < 0
+                or group.boundary_rank < 0
+            ):
+                raise ValueError(
+                    f"homology group at degree {group.degree} violates "
+                    "betti_number = cycle_rank - boundary_rank"
+                )
+        expected = _compute_homology_groups(self.complex)
+        if self.homology_groups != tuple(expected):
+            raise ValueError(
+                "homology groups must be the exact homology of the retained complex"
+            )
         return self
 
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -329,11 +329,12 @@ class MappingConeResult(StrictModel):
 
 
 class TensorProductResult(StrictModel):
-    """The tensor product of two chain complexes.
+    """The tensor product of two retained chain complexes.
 
     The derived complex retains its coefficient field, prime, and degree
     interval so it composes into downstream consumers as a first-class
-    chain-complex value.
+    chain-complex value, and both factors are retained so validation can
+    replay the defining construction.
     """
 
     tensor_basis_sizes: tuple[int, ...]
@@ -342,28 +343,67 @@ class TensorProductResult(StrictModel):
     prime: int | None = Field(default=None, ge=2)
     degree_min: int
     degree_max: int
+    left: ChainComplexValue
+    right: ChainComplexValue
     value: ChainComplexValue
 
     @model_validator(mode="after")
     def require_consistent_context(self) -> Self:
         # One canonical tensor-product value carries the mathematical
-        # result; every duplicated projection must agree with it so a
-        # revalidated result cannot hold two contradictory products.
-        if (
-            self.tensor_basis_sizes != self.value.basis_sizes
-            or self.tensor_differential_matrices
-            != self.value.differential_matrices
+        # result; it must be the exact tensor product of the retained
+        # factors, so a revalidated result cannot hold a forged or merely
+        # shape-compatible product.
+        from jacobian.math.chain_complexes._models import (
+            _require_admissible_tensor_work,
+        )
+        from jacobian.math.chain_complexes.operations import (
+            _compute_tensor_product,
+        )
+
+        if self.left.prime != self.right.prime or (
+            self.left.coefficient_field != self.right.coefficient_field
         ):
             raise ValueError(
-                "tensor projections must equal the retained canonical "
-                "tensor-product complex"
+                "tensor product requires same coefficient field and prime"
             )
+        # Bound the replay work before expanding any derived intermediate.
+        _require_admissible_tensor_work(self.left, self.right)
         if self.coefficient_field != self.value.coefficient_field:
             raise ValueError("coefficient field must match the retained value")
         if self.prime != self.value.prime:
             raise ValueError("prime must match the retained value")
-        if self.degree_min != self.value.degree_min or self.degree_max != self.value.degree_max:
-            raise ValueError("degree interval must match the retained value")
+        expected_sizes, expected_diffs = _compute_tensor_product(self.left, self.right)
+        group_count = len(expected_sizes)
+        derived_min = self.left.degree_min + self.right.degree_min
+        derived_max = derived_min + group_count - 1
+        if (self.degree_min, self.degree_max) != (derived_min, derived_max):
+            raise ValueError(
+                "degree interval must equal the pairwise-sum interval of "
+                "the retained factors"
+            )
+        expected_value = ChainComplexValue(
+            coefficient_field=self.left.coefficient_field,
+            prime=self.left.prime,
+            degree_min=derived_min,
+            degree_max=derived_max,
+            basis_sizes=expected_sizes,
+            differential_matrices=expected_diffs,
+        )
+        if self.value != expected_value:
+            raise ValueError(
+                "tensor projections must equal the retained canonical "
+                "tensor-product complex"
+            )
+        if self.tensor_basis_sizes != self.value.basis_sizes:
+            raise ValueError(
+                "tensor projections must equal the retained canonical "
+                "tensor-product complex"
+            )
+        if self.tensor_differential_matrices != self.value.differential_matrices:
+            raise ValueError(
+                "tensor projections must equal the retained canonical "
+                "tensor-product complex"
+            )
         if (
             self.coefficient_field is CoefficientField.PRIME_FIELD
             and self.prime is None
@@ -485,6 +525,7 @@ class VerificationResult(StrictModel):
                     map_mats,
                     prime,
                     source_group_columns=list(self.source.basis_sizes),
+                    target_group_columns=list(self.target.basis_sizes),
                 )
                 holds = True
             except (ValueError, IndexError):

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -291,10 +291,22 @@ class MappingConeResult(StrictModel):
     def bind_cone_to_source(self) -> Self:
         """Replay the defining construction so only the exact mapping
         cone of the retained chain map validates."""
+        from jacobian.math.chain_complexes._models import (
+            _require_chain_map_components,
+        )
         from jacobian.math.chain_complexes.operations import (
             _compute_mapping_cone,
         )
 
+        # The retained map must satisfy the request contract before the
+        # replay: _matrix_to_fractions zero-pads undersized matrices, so an
+        # unpadded replay alone could bind a cone to a malformed non-map.
+        _require_chain_map_components(
+            self.source,
+            self.target,
+            self.map_matrices,
+            label="mapping cone",
+        )
         if (
             self.source_degree_min != self.source.degree_min
             or self.target_degree_min != self.target.degree_min

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -234,10 +234,34 @@ class MappingConeResult(StrictModel):
 
 
 class TensorProductResult(StrictModel):
-    """The tensor product of two chain complexes."""
+    """The tensor product of two chain complexes.
+
+    The derived complex retains its coefficient field, prime, and degree
+    interval so it composes into downstream consumers as a first-class
+    chain-complex value.
+    """
 
     tensor_basis_sizes: tuple[int, ...]
     tensor_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    coefficient_field: CoefficientField | None = None
+    prime: int | None = Field(default=None, ge=2)
+    degree_min: int | None = None
+    degree_max: int | None = None
+
+    @model_validator(mode="after")
+    def require_consistent_context(self) -> Self:
+        if (self.degree_min is None) != (self.degree_max is None):
+            raise ValueError("degree interval must be provided for both endpoints")
+        if (
+            self.coefficient_field is CoefficientField.PRIME_FIELD
+            and self.prime is None
+        ):
+            raise ValueError("GF_p tensor products must carry their prime")
+        if self.coefficient_field is not CoefficientField.PRIME_FIELD and (
+            self.prime is not None
+        ):
+            raise ValueError("QQ tensor products must not carry a prime")
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -1,0 +1,85 @@
+"""Provider-independent exact values for finite based chain complexes."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from fractions import Fraction
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+
+MAX_CHAIN_DEGREE = 32
+MAX_BASIS_SIZE = 64
+MAX_MATRIX_CELLS = 4096
+
+
+class CoefficientField(StrEnum):
+    RATIONAL = "QQ"
+    PRIME_FIELD = "GF_p"
+
+
+class ChainComplexValue(StrictModel):
+    """A finite based chain complex over an exact field."""
+
+    coefficient_field: CoefficientField
+    prime: int | None = Field(default=None, ge=2)
+    degree_min: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
+    degree_max: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE)
+    basis_sizes: tuple[int, ...]
+    differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+
+class HomologyGroupValue(StrictModel):
+    """One homology group of a chain complex."""
+
+    degree: int
+    cycle_rank: int = Field(ge=0)
+    boundary_rank: int = Field(ge=0)
+    betti_number: int = Field(ge=0)
+
+
+class HomologyResult(StrictModel):
+    """Homology of a chain complex."""
+
+    homology_groups: tuple[HomologyGroupValue, ...]
+    coefficient_field: CoefficientField
+
+
+class MappingConeResult(StrictModel):
+    """The mapping cone of a chain map."""
+
+    cone_basis_sizes: tuple[int, ...]
+    cone_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+    source_degree_min: int
+    target_degree_min: int
+
+
+class TensorProductResult(StrictModel):
+    """The tensor product of two chain complexes."""
+
+    tensor_basis_sizes: tuple[int, ...]
+    tensor_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
+
+
+__all__ = [
+    "ChainComplexValue",
+    "CoefficientField",
+    "HomologyGroupValue",
+    "HomologyResult",
+    "MappingConeResult",
+    "TensorProductResult",
+    "MAX_BASIS_SIZE",
+    "MAX_CHAIN_DEGREE",
+    "MAX_MATRIX_CELLS",
+]
+
+
+class VerificationResult(StrictModel):
+    """Result of verifying a chain complex property."""
+
+    is_valid: bool
+    detail: str
+
+
+__all__.append("VerificationResult")

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -18,6 +18,11 @@ MAX_MATRIX_CELLS = 4096
 # accepted request can allocate an unbounded dense intermediate.
 MAX_TENSOR_GROUP_DIMENSION = 256
 MAX_TENSOR_TOTAL_CELLS = 65536
+# Chain-map admission bounds the aggregate component work: across all
+# components, dense cells and printed entry characters stay within these
+# conservative budgets.
+MAX_CHAIN_MAP_CELLS = 4096
+MAX_CHAIN_MAP_ENTRY_CHARS = 65536
 
 
 class CoefficientField(StrEnum):
@@ -185,6 +190,13 @@ class HomologyResult(StrictModel):
             or self.degree_max != self.complex.degree_max
         ):
             raise ValueError("degree interval must match the retained complex")
+        if (
+            self.coefficient_field != self.complex.coefficient_field
+            or self.prime != self.complex.prime
+        ):
+            raise ValueError(
+                "coefficient field and prime must match the retained complex"
+            )
         expected_degrees = list(
             range(self.complex.degree_min, self.complex.degree_max + 1)
         )

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -25,6 +24,10 @@ MAX_CHAIN_MAP_CELLS = 4096
 MAX_CHAIN_MAP_ENTRY_CHARS = 65536
 # Serialization envelope for expanded tensor differentials.
 MAX_TENSOR_SERIALIZED_CHARS = 4_000_000
+# Aggregate printed characters across every differential cell. Coupling
+# total coefficient size to the matrix work bounds rational elimination
+# bit complexity at admission instead of only bounding input shape.
+MAX_MATRIX_ENTRY_CHARS = 65536
 
 
 class CoefficientField(StrEnum):
@@ -68,6 +71,7 @@ class ChainComplexValue(StrictModel):
     def _require_matrix_shapes(self) -> None:
         """Every differential has basis-size shape and bounded exact entries."""
         total_cells = 0
+        total_entry_chars = 0
         for idx, mat in enumerate(self.differential_matrices):
             rows_expected = self.basis_sizes[idx]
             cols_expected = self.basis_sizes[idx + 1]
@@ -84,11 +88,20 @@ class ChainComplexValue(StrictModel):
                     _require_rational_entry_grammar(
                         self.coefficient_field,
                         entry,
+                        prime=self.prime,
                     )
+                    total_entry_chars += len(entry)
             total_cells += rows_expected * cols_expected
         if total_cells > MAX_MATRIX_CELLS:
             raise ValueError(
                 f"total matrix cells {total_cells} exceeds MAX_MATRIX_CELLS {MAX_MATRIX_CELLS}"
+            )
+        if total_entry_chars > MAX_MATRIX_ENTRY_CHARS:
+            raise ValueError(
+                f"total differential characters {total_entry_chars} exceeds "
+                f"MAX_MATRIX_ENTRY_CHARS {MAX_MATRIX_ENTRY_CHARS}; coefficient "
+                "size is coupled to matrix work so exact elimination stays "
+                "inside the admitted request boundary"
             )
 
 
@@ -114,15 +127,51 @@ def _require_prime_coupling(
         raise ValueError("QQ coefficient field must not have a prime modulus")
 
 
-def _require_rational_entry_grammar(
-    coefficient_field: CoefficientField, entry: object
-) -> None:
-    """One matrix entry: exact rational grammar with digit bounds.
+def _require_canonical_integer_spelling(entry: str, part: str) -> int:
+    """Parse one canonical integer: no leading zeros, no negative zero."""
+    if len(part) > 1 and (part[0] == "0" or part.startswith("-0")):
+        raise ValueError(f"entry '{entry}' is not canonically spelled")
+    return int(part)
 
-    Prime-field entries are integer residues; a fractional string such as
-    "1/2" would pass the rational regex but every downstream kernel parses
-    prime-field entries with int(), so admitting it here would turn an
-    accepted request into an execution failure.
+
+def _require_canonical_fraction_entry(entry: str) -> None:
+    """Fraction spellings are reduced with denominator >= 2 and digit bounds."""
+    from math import gcd
+
+    num_str, den_str = entry.split("/", 1)
+    numerator = _require_canonical_integer_spelling(entry, num_str)
+    denominator = _require_canonical_integer_spelling(entry, den_str)
+    if den_str.lstrip("-").lstrip("0") == "" or denominator == 0:
+        raise ValueError(f"entry '{entry}' has zero denominator")
+    if numerator == 0:
+        raise ValueError(
+            f"entry '{entry}' is not canonically spelled; spell zero as '0'"
+        )
+    if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
+        raise ValueError("differential entry exceeds digit bound")
+    # One rational has one reduced spelling.
+    if denominator <= 1 or gcd(abs(numerator), denominator) != 1:
+        raise ValueError(
+            f"entry '{entry}' is not a reduced fraction; use its "
+            "canonical reduced spelling"
+        )
+
+
+def _require_rational_entry_grammar(
+    coefficient_field: CoefficientField,
+    entry: object,
+    *,
+    prime: int | None = None,
+) -> None:
+    """One canonical matrix entry: reduced rational grammar with digit bounds.
+
+    Spellings must be canonical so one based complex has exactly one
+    serialized identity: integers carry no leading zeros and no negative
+    zero, fraction strings are fully reduced with denominator >= 2, and
+    prime-field entries are residues in ``[0, p)``. A fractional string
+    such as "1/2" would pass the rational regex but every downstream
+    kernel parses prime-field entries with int(), so admitting it here
+    would turn an accepted request into an execution failure.
     """
     import re
 
@@ -130,23 +179,24 @@ def _require_rational_entry_grammar(
         raise ValueError("differential entries must be strings")
     if not re.fullmatch(r"-?\d+(/\d+)?", entry):
         raise ValueError(f"entry '{entry}' does not match rational string grammar")
-    if coefficient_field == CoefficientField.PRIME_FIELD and "/" in entry:
-        raise ValueError(f"prime-field entry '{entry}' must be an integer residue")
-    # Check denominator not zero and digits bound
+
     if "/" in entry:
-        num_str, den_str = entry.split("/", 1)
-        if den_str.lstrip("-").lstrip("0") == "" or int(den_str) == 0:
-            raise ValueError(f"entry '{entry}' has zero denominator")
-        if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
-            raise ValueError("differential entry exceeds digit bound")
-    else:
-        if len(entry.lstrip("-")) > 4096:
-            raise ValueError("differential entry exceeds digit bound")
-    # Ensure it parses as Fraction
-    try:
-        Fraction(entry)
-    except Exception as error:
-        raise ValueError(f"entry '{entry}' is not a valid rational: {error}") from error
+        if coefficient_field == CoefficientField.PRIME_FIELD:
+            raise ValueError(
+                f"prime-field entry '{entry}' must be an integer residue"
+            )
+        _require_canonical_fraction_entry(entry)
+        return
+    value = _require_canonical_integer_spelling(entry, entry)
+    if len(entry.lstrip("-")) > 4096:
+        raise ValueError("differential entry exceeds digit bound")
+    if coefficient_field == CoefficientField.PRIME_FIELD and (
+        value < 0 or (prime is not None and value >= prime)
+    ):
+        raise ValueError(
+            f"prime-field entry '{entry}' must be a canonical "
+            f"integer residue in [0, {prime})"
+        )
 
 
 class HomologyGroupValue(StrictModel):
@@ -245,25 +295,37 @@ class TensorProductResult(StrictModel):
 
     tensor_basis_sizes: tuple[int, ...]
     tensor_differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
-    coefficient_field: CoefficientField | None = None
+    coefficient_field: CoefficientField
     prime: int | None = Field(default=None, ge=2)
-    degree_min: int | None = None
-    degree_max: int | None = None
-    value: ChainComplexValue | None = None
+    degree_min: int
+    degree_max: int
+    value: ChainComplexValue
 
     @model_validator(mode="after")
     def require_consistent_context(self) -> Self:
-        if (self.degree_min is None) != (self.degree_max is None):
-            raise ValueError("degree interval must be provided for both endpoints")
+        # One canonical tensor-product value carries the mathematical
+        # result; every duplicated projection must agree with it so a
+        # revalidated result cannot hold two contradictory products.
+        if (
+            self.tensor_basis_sizes != self.value.basis_sizes
+            or self.tensor_differential_matrices
+            != self.value.differential_matrices
+        ):
+            raise ValueError(
+                "tensor projections must equal the retained canonical "
+                "tensor-product complex"
+            )
+        if self.coefficient_field != self.value.coefficient_field:
+            raise ValueError("coefficient field must match the retained value")
+        if self.prime != self.value.prime:
+            raise ValueError("prime must match the retained value")
+        if self.degree_min != self.value.degree_min or self.degree_max != self.value.degree_max:
+            raise ValueError("degree interval must match the retained value")
         if (
             self.coefficient_field is CoefficientField.PRIME_FIELD
             and self.prime is None
         ):
             raise ValueError("GF_p tensor products must carry their prime")
-        if self.coefficient_field is not CoefficientField.PRIME_FIELD and (
-            self.prime is not None
-        ):
-            raise ValueError("QQ tensor products must not carry a prime")
         return self
 
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from fractions import Fraction
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
 
@@ -29,6 +29,83 @@ class ChainComplexValue(StrictModel):
     basis_sizes: tuple[int, ...]
     differential_matrices: tuple[tuple[tuple[str, ...], ...], ...]
 
+    @model_validator(mode="after")
+    def require_canonical_chain_complex(self) -> Self:
+        import re
+        from fractions import Fraction
+
+        # Prime coupling
+        if self.coefficient_field == CoefficientField.PRIME_FIELD:
+            if self.prime is None:
+                raise ValueError("GF_p requires a prime modulus")
+            # Check prime is within bound and is prime
+            if not 2 <= self.prime <= 1000003:
+                raise ValueError("prime modulus exceeds the bounded prime limit")
+            # simple primality
+            n = self.prime
+            if n % 2 == 0:
+                if n != 2:
+                    raise ValueError(f"prime {n} is not prime")
+            else:
+                d = 3
+                while d * d <= n:
+                    if n % d == 0:
+                        raise ValueError(f"prime {n} is not prime")
+                    d += 2
+        else:
+            if self.prime is not None:
+                raise ValueError("QQ coefficient field must not have a prime modulus")
+
+        # Degree consistency
+        if self.degree_max < self.degree_min:
+            raise ValueError("degree_max must be >= degree_min")
+        expected_len = self.degree_max - self.degree_min + 1
+        if len(self.basis_sizes) != expected_len:
+            raise ValueError("basis_sizes length must match degree interval")
+        if not 1 <= len(self.basis_sizes) <= 2 * MAX_CHAIN_DEGREE + 1:
+            raise ValueError("basis_sizes length out of bounds")
+        for sz in self.basis_sizes:
+            if not 0 <= sz <= MAX_BASIS_SIZE:
+                raise ValueError(f"basis size {sz} exceeds MAX_BASIS_SIZE {MAX_BASIS_SIZE}")
+
+        if len(self.differential_matrices) != max(0, len(self.basis_sizes) - 1):
+            raise ValueError("differential_matrices count must be len(basis_sizes)-1")
+
+        total_cells = 0
+        entry_pat = re.compile(r"^-?\d+(/\d+)?$")
+        for idx, mat in enumerate(self.differential_matrices):
+            rows_expected = self.basis_sizes[idx]
+            cols_expected = self.basis_sizes[idx + 1]
+            if len(mat) != rows_expected:
+                raise ValueError(f"differential_matrices[{idx}] row count {len(mat)} != basis size {rows_expected}")
+            for row in mat:
+                if len(row) != cols_expected:
+                    raise ValueError(f"differential_matrices[{idx}] column count {len(row)} != {cols_expected}")
+                for entry in row:
+                    if not isinstance(entry, str):
+                        raise ValueError("differential entries must be strings")
+                    if not entry_pat.match(entry):
+                        raise ValueError(f"entry '{entry}' does not match rational string grammar")
+                    # Check denominator not zero and digits bound
+                    if "/" in entry:
+                        num_str, den_str = entry.split("/", 1)
+                        if den_str.lstrip("-").lstrip("0") == "" or int(den_str) == 0:
+                            raise ValueError(f"entry '{entry}' has zero denominator")
+                        if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
+                            raise ValueError("differential entry exceeds digit bound")
+                    else:
+                        if len(entry.lstrip("-")) > 4096:
+                            raise ValueError("differential entry exceeds digit bound")
+                    # Ensure it parses as Fraction
+                    try:
+                        Fraction(entry)
+                    except Exception as e:
+                        raise ValueError(f"entry '{entry}' is not a valid rational: {e}")
+            total_cells += rows_expected * cols_expected
+        if total_cells > MAX_MATRIX_CELLS:
+            raise ValueError(f"total matrix cells {total_cells} exceeds MAX_MATRIX_CELLS {MAX_MATRIX_CELLS}")
+        return self
+
 
 class HomologyGroupValue(StrictModel):
     """One homology group of a chain complex."""
@@ -44,6 +121,19 @@ class HomologyResult(StrictModel):
 
     homology_groups: tuple[HomologyGroupValue, ...]
     coefficient_field: CoefficientField
+    prime: int | None = Field(default=None, ge=2)
+    degree_min: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
+    degree_max: int = Field(ge=-MAX_CHAIN_DEGREE, le=MAX_CHAIN_DEGREE, default=0)
+
+    @model_validator(mode="after")
+    def require_prime_coupling(self) -> Self:
+        if self.coefficient_field == CoefficientField.PRIME_FIELD:
+            if self.prime is None:
+                raise ValueError("GF_p homology requires a prime")
+        else:
+            if self.prime is not None:
+                raise ValueError("QQ homology must not have a prime")
+        return self
 
 
 class MappingConeResult(StrictModel):
@@ -80,6 +170,17 @@ class VerificationResult(StrictModel):
 
     is_valid: bool
     detail: str
+    complex: ChainComplexValue | None = None
+    source: ChainComplexValue | None = None
+    target: ChainComplexValue | None = None
+
+    @model_validator(mode="after")
+    def bind_verification_to_source(self) -> Self:
+        # If a source complex is present, ensure the verdict is replayable
+        # by checking that the stored detail matches the expected pattern for the claimed complex.
+        # For now, require that at least one of complex/source is set when is_valid is claimed.
+        # The operation-level validators will ensure the boolean matches the actual check.
+        return self
 
 
 __all__.append("VerificationResult")

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 from fractions import Fraction
+from typing import Self
 
 from pydantic import Field, model_validator
 
@@ -12,6 +13,11 @@ from jacobian._models import StrictModel
 MAX_CHAIN_DEGREE = 32
 MAX_BASIS_SIZE = 64
 MAX_MATRIX_CELLS = 4096
+# Derived tensor-product work bounds: each tensor group dimension and the
+# total tensor cell count stay within these conservative limits so no
+# accepted request can allocate an unbounded dense intermediate.
+MAX_TENSOR_GROUP_DIMENSION = 256
+MAX_TENSOR_TOTAL_CELLS = 65536
 
 
 class CoefficientField(StrEnum):
@@ -31,31 +37,7 @@ class ChainComplexValue(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical_chain_complex(self) -> Self:
-        import re
-        from fractions import Fraction
-
-        # Prime coupling
-        if self.coefficient_field == CoefficientField.PRIME_FIELD:
-            if self.prime is None:
-                raise ValueError("GF_p requires a prime modulus")
-            # Check prime is within bound and is prime
-            if not 2 <= self.prime <= 1000003:
-                raise ValueError("prime modulus exceeds the bounded prime limit")
-            # simple primality
-            n = self.prime
-            if n % 2 == 0:
-                if n != 2:
-                    raise ValueError(f"prime {n} is not prime")
-            else:
-                d = 3
-                while d * d <= n:
-                    if n % d == 0:
-                        raise ValueError(f"prime {n} is not prime")
-                    d += 2
-        else:
-            if self.prime is not None:
-                raise ValueError("QQ coefficient field must not have a prime modulus")
-
+        _require_prime_coupling(self.coefficient_field, self.prime)
         # Degree consistency
         if self.degree_max < self.degree_min:
             raise ValueError("degree_max must be >= degree_min")
@@ -66,45 +48,98 @@ class ChainComplexValue(StrictModel):
             raise ValueError("basis_sizes length out of bounds")
         for sz in self.basis_sizes:
             if not 0 <= sz <= MAX_BASIS_SIZE:
-                raise ValueError(f"basis size {sz} exceeds MAX_BASIS_SIZE {MAX_BASIS_SIZE}")
+                raise ValueError(
+                    f"basis size {sz} exceeds MAX_BASIS_SIZE {MAX_BASIS_SIZE}"
+                )
 
         if len(self.differential_matrices) != max(0, len(self.basis_sizes) - 1):
             raise ValueError("differential_matrices count must be len(basis_sizes)-1")
 
+        self._require_matrix_shapes()
+        return self
+
+    def _require_matrix_shapes(self) -> None:
+        """Every differential has basis-size shape and bounded exact entries."""
         total_cells = 0
-        entry_pat = re.compile(r"^-?\d+(/\d+)?$")
         for idx, mat in enumerate(self.differential_matrices):
             rows_expected = self.basis_sizes[idx]
             cols_expected = self.basis_sizes[idx + 1]
             if len(mat) != rows_expected:
-                raise ValueError(f"differential_matrices[{idx}] row count {len(mat)} != basis size {rows_expected}")
+                raise ValueError(
+                    f"differential_matrices[{idx}] row count {len(mat)} != basis size {rows_expected}"
+                )
             for row in mat:
                 if len(row) != cols_expected:
-                    raise ValueError(f"differential_matrices[{idx}] column count {len(row)} != {cols_expected}")
+                    raise ValueError(
+                        f"differential_matrices[{idx}] column count {len(row)} != {cols_expected}"
+                    )
                 for entry in row:
-                    if not isinstance(entry, str):
-                        raise ValueError("differential entries must be strings")
-                    if not entry_pat.match(entry):
-                        raise ValueError(f"entry '{entry}' does not match rational string grammar")
-                    # Check denominator not zero and digits bound
-                    if "/" in entry:
-                        num_str, den_str = entry.split("/", 1)
-                        if den_str.lstrip("-").lstrip("0") == "" or int(den_str) == 0:
-                            raise ValueError(f"entry '{entry}' has zero denominator")
-                        if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
-                            raise ValueError("differential entry exceeds digit bound")
-                    else:
-                        if len(entry.lstrip("-")) > 4096:
-                            raise ValueError("differential entry exceeds digit bound")
-                    # Ensure it parses as Fraction
-                    try:
-                        Fraction(entry)
-                    except Exception as e:
-                        raise ValueError(f"entry '{entry}' is not a valid rational: {e}")
+                    _require_rational_entry_grammar(
+                        self.coefficient_field,
+                        entry,
+                    )
             total_cells += rows_expected * cols_expected
         if total_cells > MAX_MATRIX_CELLS:
-            raise ValueError(f"total matrix cells {total_cells} exceeds MAX_MATRIX_CELLS {MAX_MATRIX_CELLS}")
-        return self
+            raise ValueError(
+                f"total matrix cells {total_cells} exceeds MAX_MATRIX_CELLS {MAX_MATRIX_CELLS}"
+            )
+
+
+def _require_prime_coupling(
+    coefficient_field: CoefficientField, prime: int | None
+) -> None:
+    """GF_p carries a bounded prime modulus; QQ carries none."""
+    if coefficient_field == CoefficientField.PRIME_FIELD:
+        if prime is None:
+            raise ValueError("GF_p requires a prime modulus")
+        if not 2 <= prime <= 1000003:
+            raise ValueError("prime modulus exceeds the bounded prime limit")
+        if prime % 2 == 0:
+            if prime != 2:
+                raise ValueError(f"prime {prime} is not prime")
+            return
+        divisor = 3
+        while divisor * divisor <= prime:
+            if prime % divisor == 0:
+                raise ValueError(f"prime {prime} is not prime")
+            divisor += 2
+    elif prime is not None:
+        raise ValueError("QQ coefficient field must not have a prime modulus")
+
+
+def _require_rational_entry_grammar(
+    coefficient_field: CoefficientField, entry: object
+) -> None:
+    """One matrix entry: exact rational grammar with digit bounds.
+
+    Prime-field entries are integer residues; a fractional string such as
+    "1/2" would pass the rational regex but every downstream kernel parses
+    prime-field entries with int(), so admitting it here would turn an
+    accepted request into an execution failure.
+    """
+    import re
+
+    if not isinstance(entry, str):
+        raise ValueError("differential entries must be strings")
+    if not re.fullmatch(r"-?\d+(/\d+)?", entry):
+        raise ValueError(f"entry '{entry}' does not match rational string grammar")
+    if coefficient_field == CoefficientField.PRIME_FIELD and "/" in entry:
+        raise ValueError(f"prime-field entry '{entry}' must be an integer residue")
+    # Check denominator not zero and digits bound
+    if "/" in entry:
+        num_str, den_str = entry.split("/", 1)
+        if den_str.lstrip("-").lstrip("0") == "" or int(den_str) == 0:
+            raise ValueError(f"entry '{entry}' has zero denominator")
+        if len(num_str.lstrip("-")) > 4096 or len(den_str.lstrip("-")) > 4096:
+            raise ValueError("differential entry exceeds digit bound")
+    else:
+        if len(entry.lstrip("-")) > 4096:
+            raise ValueError("differential entry exceeds digit bound")
+    # Ensure it parses as Fraction
+    try:
+        Fraction(entry)
+    except Exception as error:
+        raise ValueError(f"entry '{entry}' is not a valid rational: {error}") from error
 
 
 class HomologyGroupValue(StrictModel):
@@ -153,15 +188,17 @@ class TensorProductResult(StrictModel):
 
 
 __all__ = [
+    "MAX_BASIS_SIZE",
+    "MAX_CHAIN_DEGREE",
+    "MAX_MATRIX_CELLS",
+    "MAX_TENSOR_GROUP_DIMENSION",
+    "MAX_TENSOR_TOTAL_CELLS",
     "ChainComplexValue",
     "CoefficientField",
     "HomologyGroupValue",
     "HomologyResult",
     "MappingConeResult",
     "TensorProductResult",
-    "MAX_BASIS_SIZE",
-    "MAX_CHAIN_DEGREE",
-    "MAX_MATRIX_CELLS",
 ]
 
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -182,9 +182,7 @@ def _require_rational_entry_grammar(
 
     if "/" in entry:
         if coefficient_field == CoefficientField.PRIME_FIELD:
-            raise ValueError(
-                f"prime-field entry '{entry}' must be an integer residue"
-            )
+            raise ValueError(f"prime-field entry '{entry}' must be an integer residue")
         _require_canonical_fraction_entry(entry)
         return
     value = _require_canonical_integer_spelling(entry, entry)
@@ -311,9 +309,7 @@ class MappingConeResult(StrictModel):
             self.source_degree_min != self.source.degree_min
             or self.target_degree_min != self.target.degree_min
         ):
-            raise ValueError(
-                "cone degree provenance must match the retained endpoints"
-            )
+            raise ValueError("cone degree provenance must match the retained endpoints")
         basis_sizes, differential_matrices = _compute_mapping_cone(
             self.source, self.target, self.map_matrices
         )
@@ -322,8 +318,7 @@ class MappingConeResult(StrictModel):
             or self.cone_differential_matrices != differential_matrices
         ):
             raise ValueError(
-                "cone must be the exact mapping cone of the retained "
-                "chain map"
+                "cone must be the exact mapping cone of the retained chain map"
             )
         return self
 
@@ -363,9 +358,7 @@ class TensorProductResult(StrictModel):
         if self.left.prime != self.right.prime or (
             self.left.coefficient_field != self.right.coefficient_field
         ):
-            raise ValueError(
-                "tensor product requires same coefficient field and prime"
-            )
+            raise ValueError("tensor product requires same coefficient field and prime")
         # Bound the replay work before expanding any derived intermediate.
         _require_admissible_tensor_work(self.left, self.right)
         if self.coefficient_field != self.value.coefficient_field:
@@ -447,11 +440,11 @@ class VerificationResult(StrictModel):
             _require_chain_map_relation,
             _require_square_zero,
         )
+
         if self.complex is not None:
             if self.source or self.target or self.map_matrices:
                 raise ValueError(
-                    "a differential verification result must not carry "
-                    "chain-map inputs"
+                    "a differential verification result must not carry chain-map inputs"
                 )
             try:
                 _require_square_zero(
@@ -537,8 +530,7 @@ class VerificationResult(StrictModel):
             )
         if holds != self.is_valid:
             raise ValueError(
-                "verification verdict must be the exact replay of the "
-                "retained relation"
+                "verification verdict must be the exact replay of the retained relation"
             )
         return self
 

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -23,6 +23,8 @@ MAX_TENSOR_TOTAL_CELLS = 65536
 # conservative budgets.
 MAX_CHAIN_MAP_CELLS = 4096
 MAX_CHAIN_MAP_ENTRY_CHARS = 65536
+# Serialization envelope for expanded tensor differentials.
+MAX_TENSOR_SERIALIZED_CHARS = 4_000_000
 
 
 class CoefficientField(StrEnum):
@@ -247,6 +249,7 @@ class TensorProductResult(StrictModel):
     prime: int | None = Field(default=None, ge=2)
     degree_min: int | None = None
     degree_max: int | None = None
+    value: ChainComplexValue | None = None
 
     @model_validator(mode="after")
     def require_consistent_context(self) -> Self:

--- a/src/jacobian/math/chain_complexes/values.py
+++ b/src/jacobian/math/chain_complexes/values.py
@@ -454,12 +454,14 @@ class VerificationResult(StrictModel):
     @model_validator(mode="after")
     def bind_verification_to_source(self) -> Self:
         """Replay the checked relation against the retained inputs so a
-        detached or forged verdict cannot validate."""
+        detached or forged verdict cannot validate, and require the detail
+        to be the exact authoritative explanation of that replay."""
+        from jacobian.math.chain_complexes._models import (
+            _require_chain_map_components,
+        )
         from jacobian.math.chain_complexes.operations import (
-            _matrix_to_fractions,
-            _parsed_differentials,
-            _require_chain_map_relation,
-            _require_square_zero,
+            _chain_map_verdict,
+            _differential_verdict,
         )
 
         if self.complex is not None:
@@ -467,26 +469,12 @@ class VerificationResult(StrictModel):
                 raise ValueError(
                     "a differential verification result must not carry chain-map inputs"
                 )
-            try:
-                _require_square_zero(
-                    _parsed_differentials(self.complex),
-                    self.complex.prime,
-                    label="verified",
-                    group_columns=list(self.complex.basis_sizes),
-                    degree_min=self.complex.degree_min,
-                )
-                holds = True
-            except ValueError:
-                holds = False
+            holds, expected_detail = _differential_verdict(self.complex)
         elif (
             self.source is not None
             and self.target is not None
             and self.map_matrices is not None
         ):
-            from jacobian.math.chain_complexes._models import (
-                _require_chain_map_components,
-            )
-
             # Replay must apply the request model's complete component
             # and parent checks: otherwise endpoints with different
             # coefficient fields, primes, or degree intervals validate
@@ -497,53 +485,9 @@ class VerificationResult(StrictModel):
                 self.map_matrices,
                 label="chain-map verification",
             )
-            prime = self.source.prime
-            try:
-                map_mats = [
-                    _matrix_to_fractions(
-                        m, self.target.basis_sizes[i], self.source.basis_sizes[i], prime
-                    )
-                    for i, m in enumerate(self.map_matrices)
-                ]
-                source_diffs = [
-                    _matrix_to_fractions(
-                        m,
-                        self.source.basis_sizes[i],
-                        self.source.basis_sizes[i + 1],
-                        prime,
-                    )
-                    for i, m in enumerate(self.source.differential_matrices)
-                ]
-                target_diffs = [
-                    _matrix_to_fractions(
-                        m,
-                        self.target.basis_sizes[i],
-                        self.target.basis_sizes[i + 1],
-                        prime,
-                    )
-                    for i, m in enumerate(self.target.differential_matrices)
-                ]
-                # Producer semantics: endpoints must be genuine complexes
-                # and the map must commute at every differential.
-                for endpoint in (self.source, self.target):
-                    _require_square_zero(
-                        _parsed_differentials(endpoint),
-                        endpoint.prime,
-                        label="chain-map",
-                        group_columns=list(endpoint.basis_sizes),
-                        degree_min=endpoint.degree_min,
-                    )
-                _require_chain_map_relation(
-                    source_diffs,
-                    target_diffs,
-                    map_mats,
-                    prime,
-                    source_group_columns=list(self.source.basis_sizes),
-                    target_group_columns=list(self.target.basis_sizes),
-                )
-                holds = True
-            except (ValueError, IndexError):
-                holds = False
+            holds, expected_detail = _chain_map_verdict(
+                self.source, self.target, self.map_matrices
+            )
         else:
             raise ValueError(
                 "a verification result must retain the complete checked "
@@ -552,6 +496,11 @@ class VerificationResult(StrictModel):
         if holds != self.is_valid:
             raise ValueError(
                 "verification verdict must be the exact replay of the retained relation"
+            )
+        if self.detail != expected_detail:
+            raise ValueError(
+                "verification detail must be the exact explanation of the "
+                "replayed relation"
             )
         return self
 

--- a/src/jacobian/math/topology/__init__.py
+++ b/src/jacobian/math/topology/__init__.py
@@ -1,3 +1,5 @@
 """Topology operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.topology.native import simplicial_chain_complex_value
+
+__all__ = ["simplicial_chain_complex_value"]

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -317,7 +317,12 @@ def require_linear_algebra_bounds(complex_: FiniteSimplicialComplex) -> None:
 
 
 def _require_canonical_conversion_bounds(complex_: FiniteSimplicialComplex) -> None:
-    """Unreduced GF(p) chains must fit the canonical value's bounds."""
+    """Unreduced GF(p) chains must fit the canonical value's bounds.
+
+    ``ChainComplexValue`` caps the aggregate cells across every
+    differential, so admission must check the same sum rather than each
+    boundary product separately.
+    """
     from jacobian.math.chain_complexes.values import (
         MAX_BASIS_SIZE,
         MAX_MATRIX_CELLS,
@@ -330,10 +335,12 @@ def _require_canonical_conversion_bounds(complex_: FiniteSimplicialComplex) -> N
             f"{MAX_BASIS_SIZE} faces per chain group"
         )
     padded = (0, *sizes)
-    if any(rows * columns > MAX_MATRIX_CELLS for rows, columns in pairwise(padded)):
+    total_cells = sum(rows * columns for rows, columns in pairwise(padded))
+    if total_cells > MAX_MATRIX_CELLS:
         raise ValueError(
-            "unreduced prime-field chain complexes require every boundary "
-            f"matrix within {MAX_MATRIX_CELLS} cells"
+            "unreduced prime-field chain complexes require "
+            f"{total_cells} aggregate boundary cells within the canonical "
+            f"{MAX_MATRIX_CELLS}-cell bound"
         )
 
 

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -20,6 +20,7 @@ from jacobian._digest import Sha256Digest
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import canonicalize_json
+from jacobian.math.chain_complexes.values import ChainComplexValue
 from jacobian.math.matrices.certified_snf.values import (
     CertifiedIntegerMatrix,
     SmithNormalFormCertificate,
@@ -315,6 +316,27 @@ def require_linear_algebra_bounds(complex_: FiniteSimplicialComplex) -> None:
         )
 
 
+def _require_canonical_conversion_bounds(complex_: FiniteSimplicialComplex) -> None:
+    """Unreduced GF(p) chains must fit the canonical value's bounds."""
+    from jacobian.math.chain_complexes.values import (
+        MAX_BASIS_SIZE,
+        MAX_MATRIX_CELLS,
+    )
+
+    sizes = complex_.f_vector
+    if any(size > MAX_BASIS_SIZE for size in sizes):
+        raise ValueError(
+            "unreduced prime-field chain complexes require at most "
+            f"{MAX_BASIS_SIZE} faces per chain group"
+        )
+    padded = (0, *sizes)
+    if any(rows * columns > MAX_MATRIX_CELLS for rows, columns in pairwise(padded)):
+        raise ValueError(
+            "unreduced prime-field chain complexes require every boundary "
+            f"matrix within {MAX_MATRIX_CELLS} cells"
+        )
+
+
 class ChainComplexRequest(StrictModel):
     complex: FiniteSimplicialComplex
     coefficient_ring: ChainCoefficientRing = ChainCoefficientRing.INTEGER
@@ -329,6 +351,14 @@ class ChainComplexRequest(StrictModel):
         elif self.prime is None or not is_bounded_prime(self.prime):
             raise ValueError("prime-field chain complexes require a bounded prime")
         require_linear_algebra_bounds(self.complex)
+        # Every accepted unreduced prime-field producer result must carry
+        # its canonical chain-complex value, whose basis and cell bounds
+        # are tighter than the sparse internal ones.
+        if (
+            self.coefficient_ring is ChainCoefficientRing.PRIME_FIELD
+            and self.convention is HomologyConvention.UNREDUCED
+        ):
+            _require_canonical_conversion_bounds(self.complex)
         return self
 
 
@@ -419,6 +449,7 @@ class ChainComplexResult(TopologyExactResult):
         default=(),
         max_length=MAX_TOPOLOGY_DIMENSION,
     )
+    canonical_value: ChainComplexValue | None = None
 
     @model_validator(mode="after")
     def require_coherent_chain_contract(self) -> Self:
@@ -441,6 +472,26 @@ class ChainComplexResult(TopologyExactResult):
             expected_ledger
         ):
             raise ValueError("boundary-square ledger must cover every adjacent pair")
+        # The canonical value is part of the public result boundary: an
+        # unreduced GF(p) producer result must carry it exactly, and no
+        # other ring or convention admits one.
+        from jacobian.math.topology._operations import (
+            _canonical_value_from_parts,
+        )
+
+        expected_value = _canonical_value_from_parts(
+            self.coefficient_ring,
+            self.convention,
+            self.prime,
+            self.simplex_bases,
+            self.boundary_matrices,
+        )
+        if self.canonical_value != expected_value:
+            raise ValueError(
+                "canonical chain-complex value must be the exact "
+                "unreduced prime-field conversion of the retained "
+                "boundary data"
+            )
         return self
 
 

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -7,6 +7,12 @@ from collections.abc import Sequence
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math import prime_field_linear_algebra as prime_field
+from jacobian.math.chain_complexes.values import (
+    MAX_BASIS_SIZE,
+    MAX_MATRIX_CELLS,
+    ChainComplexValue,
+    CoefficientField,
+)
 from jacobian.math.matrices.certified_snf.operations import (
     certificate_from_reduction,
     inverse_unimodular,
@@ -237,6 +243,13 @@ def _chain_result(request: ChainComplexRequest) -> ChainComplexResult:
         boundary_matrices=boundaries,
         augmentation=augmentation,
         boundary_squared_zero=tuple(ledger),
+        canonical_value=_canonical_value_from_parts(
+            request.coefficient_ring,
+            request.convention,
+            request.prime,
+            bases,
+            boundaries,
+        ),
     )
 
 
@@ -244,6 +257,76 @@ def _chain(
     request: ChainComplexRequest,
 ) -> ChainComplexResult:
     return _chain_result(request)
+
+
+def _canonical_value_from_parts(
+    coefficient_ring: ChainCoefficientRing,
+    convention: HomologyConvention,
+    prime: int | None,
+    simplex_bases: tuple[SimplexBasis, ...],
+    boundary_matrices: tuple[SparseBoundaryMatrix, ...],
+) -> ChainComplexValue | None:
+    """The canonical chain-complex value of one simplicial chain complex.
+
+    Only unreduced prime-field results convert: integral boundaries live
+    over ZZ rather than QQ or GF(p), and reduced chains carry an
+    augmentation map outside the canonical value's representation. The
+    ordered lexicographic face bases remain the implicit column/row
+    ordering of each dense differential; simplex labels do not survive
+    because the canonical value is based but unlabeled.
+    """
+    if coefficient_ring is not ChainCoefficientRing.PRIME_FIELD:
+        return None
+    if convention is HomologyConvention.REDUCED:
+        return None
+    if prime is None:
+        raise ValueError("prime-field chains must declare their modulus")
+    basis_sizes = tuple(len(basis.simplices) for basis in simplex_bases)
+    total_cells = sum(matrix.rows * matrix.columns for matrix in boundary_matrices)
+    if any(size > MAX_BASIS_SIZE for size in basis_sizes):
+        raise ValueError(
+            f"simplicial chain group exceeds the canonical basis bound {MAX_BASIS_SIZE}"
+        )
+    if total_cells > MAX_MATRIX_CELLS:
+        raise ValueError(
+            f"simplicial boundary data exceeds the canonical cell bound "
+            f"{MAX_MATRIX_CELLS}"
+        )
+    # Boundary matrix k maps C_k -> C_{k-1}; the canonical value stores
+    # differentials[i] as C_{i+1} -> C_i, i.e. boundary_matrices[i + 1].
+    differential_matrices = []
+    for matrix in boundary_matrices[1:]:
+        dense = [[0] * matrix.columns for _ in range(matrix.rows)]
+        for entry in matrix.entries:
+            dense[entry.row][entry.column] = entry.value % prime
+        differential_matrices.append(
+            tuple(tuple(str(value) for value in row) for row in dense)
+        )
+    return ChainComplexValue(
+        coefficient_field=CoefficientField.PRIME_FIELD,
+        prime=prime,
+        degree_min=0,
+        degree_max=len(basis_sizes) - 1,
+        basis_sizes=basis_sizes,
+        differential_matrices=tuple(differential_matrices),
+    )
+
+
+def _canonical_chain_complex_value(result: ChainComplexResult) -> ChainComplexValue:
+    """The canonical chain-complex value carried by one chain result."""
+    value = _canonical_value_from_parts(
+        result.coefficient_ring,
+        result.convention,
+        result.prime,
+        result.simplex_bases,
+        result.boundary_matrices,
+    )
+    if value is None:
+        raise ValueError(
+            "only unreduced prime-field simplicial chain complexes convert "
+            "to a canonical chain-complex value"
+        )
+    return value
 
 
 def _prime_matrix(

--- a/src/jacobian/math/topology/native.py
+++ b/src/jacobian/math/topology/native.py
@@ -1,0 +1,77 @@
+"""Native topology functions exposing cross-domain canonical values."""
+
+from __future__ import annotations
+
+from jacobian.math.chain_complexes.values import (
+    MAX_BASIS_SIZE,
+    MAX_MATRIX_CELLS,
+    ChainComplexValue,
+    CoefficientField,
+)
+from jacobian.math.topology._models import (
+    ChainCoefficientRing,
+    ChainComplexResult,
+    HomologyConvention,
+)
+
+__all__ = ["simplicial_chain_complex_value"]
+
+
+def simplicial_chain_complex_value(result: ChainComplexResult) -> ChainComplexValue:
+    """The canonical chain-complex value of one simplicial chain complex.
+
+    Accepts the producer's ``ChainComplexResult`` unchanged and returns the
+    domain-owned ``ChainComplexValue`` consumed by homology, tensor, map,
+    and cone operations, so no caller-side reconstruction is needed. The
+    ordered lexicographic face bases remain the implicit column/row
+    ordering of each dense differential; simplex labels do not survive
+    because the canonical value is based but unlabeled.
+
+    Unreduced prime-field results only: integral boundaries live over ZZ
+    rather than QQ or GF(p), and reduced chains carry an augmentation map
+    outside the canonical value's representation.
+    """
+    if result.coefficient_ring is not ChainCoefficientRing.PRIME_FIELD:
+        raise ValueError(
+            "only prime-field simplicial chain complexes convert to a "
+            "canonical chain-complex value"
+        )
+    if result.convention is HomologyConvention.REDUCED:
+        raise ValueError(
+            "reduced simplicial chains carry an augmentation map outside "
+            "the canonical chain-complex value"
+        )
+    if result.prime is None:
+        raise ValueError("prime-field chains must declare their modulus")
+    prime = result.prime
+    basis_sizes = tuple(len(basis.simplices) for basis in result.simplex_bases)
+    total_cells = sum(
+        matrix.rows * matrix.columns for matrix in result.boundary_matrices
+    )
+    if any(size > MAX_BASIS_SIZE for size in basis_sizes):
+        raise ValueError(
+            f"simplicial chain group exceeds the canonical basis bound {MAX_BASIS_SIZE}"
+        )
+    if total_cells > MAX_MATRIX_CELLS:
+        raise ValueError(
+            f"simplicial boundary data exceeds the canonical cell bound "
+            f"{MAX_MATRIX_CELLS}"
+        )
+    # Boundary matrix k maps C_k -> C_{k-1}; the canonical value stores
+    # differentials[i] as C_{i+1} -> C_i, i.e. boundary_matrices[i + 1].
+    differential_matrices = []
+    for matrix in result.boundary_matrices[1:]:
+        dense = [[0] * matrix.columns for _ in range(matrix.rows)]
+        for entry in matrix.entries:
+            dense[entry.row][entry.column] = entry.value % prime
+        differential_matrices.append(
+            tuple(tuple(str(value) for value in row) for row in dense)
+        )
+    return ChainComplexValue(
+        coefficient_field=CoefficientField.PRIME_FIELD,
+        prime=prime,
+        degree_min=0,
+        degree_max=len(basis_sizes) - 1,
+        basis_sizes=basis_sizes,
+        differential_matrices=tuple(differential_matrices),
+    )

--- a/src/jacobian/math/topology/native.py
+++ b/src/jacobian/math/topology/native.py
@@ -2,17 +2,8 @@
 
 from __future__ import annotations
 
-from jacobian.math.chain_complexes.values import (
-    MAX_BASIS_SIZE,
-    MAX_MATRIX_CELLS,
-    ChainComplexValue,
-    CoefficientField,
-)
-from jacobian.math.topology._models import (
-    ChainCoefficientRing,
-    ChainComplexResult,
-    HomologyConvention,
-)
+from jacobian.math.chain_complexes.values import ChainComplexValue
+from jacobian.math.topology._models import ChainComplexResult
 
 __all__ = ["simplicial_chain_complex_value"]
 
@@ -20,58 +11,16 @@ __all__ = ["simplicial_chain_complex_value"]
 def simplicial_chain_complex_value(result: ChainComplexResult) -> ChainComplexValue:
     """The canonical chain-complex value of one simplicial chain complex.
 
-    Accepts the producer's ``ChainComplexResult`` unchanged and returns the
-    domain-owned ``ChainComplexValue`` consumed by homology, tensor, map,
-    and cone operations, so no caller-side reconstruction is needed. The
-    ordered lexicographic face bases remain the implicit column/row
-    ordering of each dense differential; simplex labels do not survive
-    because the canonical value is based but unlabeled.
-
-    Unreduced prime-field results only: integral boundaries live over ZZ
-    rather than QQ or GF(p), and reduced chains carry an augmentation map
-    outside the canonical value's representation.
+    Accepts the producer's ``ChainComplexResult`` unchanged and returns
+    the domain-owned ``ChainComplexValue`` consumed by homology, tensor,
+    map, and cone operations. Producer results already carry this value
+    as ``canonical_value``; this wrapper serves callers holding an older
+    deserialized result.
     """
-    if result.coefficient_ring is not ChainCoefficientRing.PRIME_FIELD:
-        raise ValueError(
-            "only prime-field simplicial chain complexes convert to a "
-            "canonical chain-complex value"
-        )
-    if result.convention is HomologyConvention.REDUCED:
-        raise ValueError(
-            "reduced simplicial chains carry an augmentation map outside "
-            "the canonical chain-complex value"
-        )
-    if result.prime is None:
-        raise ValueError("prime-field chains must declare their modulus")
-    prime = result.prime
-    basis_sizes = tuple(len(basis.simplices) for basis in result.simplex_bases)
-    total_cells = sum(
-        matrix.rows * matrix.columns for matrix in result.boundary_matrices
+    from jacobian.math.topology._operations import (
+        _canonical_chain_complex_value,
     )
-    if any(size > MAX_BASIS_SIZE for size in basis_sizes):
-        raise ValueError(
-            f"simplicial chain group exceeds the canonical basis bound {MAX_BASIS_SIZE}"
-        )
-    if total_cells > MAX_MATRIX_CELLS:
-        raise ValueError(
-            f"simplicial boundary data exceeds the canonical cell bound "
-            f"{MAX_MATRIX_CELLS}"
-        )
-    # Boundary matrix k maps C_k -> C_{k-1}; the canonical value stores
-    # differentials[i] as C_{i+1} -> C_i, i.e. boundary_matrices[i + 1].
-    differential_matrices = []
-    for matrix in result.boundary_matrices[1:]:
-        dense = [[0] * matrix.columns for _ in range(matrix.rows)]
-        for entry in matrix.entries:
-            dense[entry.row][entry.column] = entry.value % prime
-        differential_matrices.append(
-            tuple(tuple(str(value) for value in row) for row in dense)
-        )
-    return ChainComplexValue(
-        coefficient_field=CoefficientField.PRIME_FIELD,
-        prime=prime,
-        degree_min=0,
-        degree_max=len(basis_sizes) - 1,
-        basis_sizes=basis_sizes,
-        differential_matrices=tuple(differential_matrices),
-    )
+
+    if result.canonical_value is not None:
+        return result.canonical_value
+    return _canonical_chain_complex_value(result)

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -282,6 +282,47 @@ class TestMappingConeDefiningEquations:
                 MappingConeRequest(source=bad, target=bad, map_matrices=(one, one, one))
             )
 
+    def test_noncommuting_map_rejected_at_admission(self) -> None:
+        """Correctly shaped square-zero endpoints with a noncommuting map
+        are out of the operation's domain: admission rejects the request
+        instead of letting execution die inside the cone construction."""
+        zero = self._complex("0")
+        one = self._complex("1")
+        with pytest.raises(ValidationError, match="commute"):
+            MappingConeRequest(
+                source=zero,
+                target=one,
+                # f_0 = 0, f_1 = 1: d_target * f_1 = 1 != 0 = f_0 * d_source
+                map_matrices=((("0",),), (("1",),)),
+            )
+
+    def test_retained_map_components_must_match_request_contract(self) -> None:
+        """A serialized cone cannot revalidate against an undersized
+        retained map that replay padding would silently accept."""
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        target = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        result = compute_mapping_cone(
+            MappingConeRequest(source=source, target=target, map_matrices=((("0",),),))
+        )
+        payload = result.model_dump()
+        payload["map_matrices"] = [()]
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        with pytest.raises(ValidationError, match="shape"):
+            MappingConeResult.model_validate(payload)
+
 
 class TestTensorProductSignAndBudget:
     def test_koszul_sign_uses_actual_chain_degree(self) -> None:

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -479,6 +479,66 @@ class TestZeroWidthProducts:
         # Component 0: 1x1 zero; component 1: target has no degree-1 group.
         map_matrices = ((("0",),), ())
         result = verify_chain_map(
-            VerifyChainMapRequest(source=source, target=target, map_matrices=map_matrices)
+            VerifyChainMapRequest(
+                source=source, target=target, map_matrices=map_matrices
+            )
         )
         assert result.is_valid
+
+
+class TestTensorContextAndShapes:
+    def test_tensor_carries_canonical_context(self) -> None:
+        result = compute_tensor_product(
+            TensorProductRequest(left=_point_complex(), right=_point_complex())
+        )
+        assert result.coefficient_field == CoefficientField.RATIONAL
+        assert result.prime is None
+        assert (result.degree_min, result.degree_max) == (0, 0)
+
+    def test_shifted_tensor_degree_interval(self) -> None:
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=-1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = _point_complex()
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert (result.degree_min, result.degree_max) == (-1, -1)
+
+    def test_zero_width_differential_keeps_rows(self) -> None:
+        """A (1,0)-by-point tensor must represent its zero differential as a
+        one-row zero-width matrix, not an empty matrix."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 0),
+            differential_matrices=(((),),),
+        )
+        right = _point_complex()
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert result.tensor_basis_sizes == (1, 0)
+        assert result.tensor_differential_matrices == (((),),)
+
+    def test_every_endpoint_product_checked(self) -> None:
+        """A four-term endpoint with differentials (0, 1, 1) has d0*d1 == 0
+        but d1*d2 != 0; the identity map must fail verification."""
+        from jacobian.math.chain_complexes.operations import verify_chain_map
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=3,
+            basis_sizes=(1, 1, 1, 1),
+            differential_matrices=((("0",),), (("1",),), (("1",),)),
+        )
+        one = (("1",),)
+        result = verify_chain_map(
+            VerifyChainMapRequest(
+                source=bad, target=bad, map_matrices=(one, one, one, one)
+            )
+        )
+        assert result.is_valid is False
+        assert "d^2=0" in result.detail

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -366,3 +366,51 @@ class TestHomologySourceBinding:
                 degree_max=0,
                 complex=_point_complex(),
             )
+
+
+class TestAggregateChainMapWork:
+    def test_aggregate_component_cells_bounded(self) -> None:
+        """Alternating (64, 0) sizes pass per-complex cell checks but would
+        admit dozens of dense 64x64 map components; the aggregate budget
+        rejects them."""
+        alternating = tuple(64 if i % 2 == 0 else 0 for i in range(33))
+        complex_value = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=32,
+            basis_sizes=alternating,
+            differential_matrices=tuple(
+                ((),) * 64 if i % 2 == 0 else () for i in range(32)
+            ),
+        )
+        identity_64 = tuple(
+            tuple("1" if i == j else "0" for j in range(64)) for i in range(64)
+        )
+        components = tuple(identity_64 if i % 2 == 0 else () for i in range(33))
+        with pytest.raises(ValueError, match="aggregate"):
+            VerifyChainMapRequest(
+                source=complex_value, target=complex_value, map_matrices=components
+            )
+
+
+class TestHomologyParentMatch:
+    def test_parent_mismatch_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import (
+            CoefficientField,
+            HomologyGroupValue,
+            HomologyResult,
+        )
+
+        with pytest.raises(ValueError, match="field and prime must match"):
+            HomologyResult(
+                homology_groups=(
+                    HomologyGroupValue(
+                        degree=0, cycle_rank=1, boundary_rank=0, betti_number=1
+                    ),
+                ),
+                coefficient_field=CoefficientField.PRIME_FIELD,
+                prime=2,
+                degree_min=0,
+                degree_max=0,
+                complex=_point_complex(),
+            )

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -1624,3 +1624,47 @@ class TestMappingConeSourceBinding:
         revalidated = MappingConeResult.model_validate(result.model_dump())
         assert revalidated.source_degree_min == -1
         assert revalidated.cone_basis_sizes == (3, 6, 3)
+
+
+class TestReviewRegressions2236:
+    def test_empty_width_construct_replay_preserves_declared_widths(self):
+        """A valid declared 0x1 map survives the construct-time d^2 replay."""
+        from jacobian.math.chain_complexes._models import (
+            CoefficientField,
+            ConstructChainComplexRequest,
+        )
+
+        request = ConstructChainComplexRequest(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=5,
+            basis_sizes=(0, 1, 1),
+            differential_matrices=((), (("1",),)),
+        )
+        assert request.basis_sizes == (0, 1, 1)
+
+    def test_endpoint_replay_reports_shifted_chain_degrees(self):
+        """The shared endpoint replay names declared chain degrees, not 0."""
+
+        from jacobian.math.chain_complexes.operations import (
+            _matrix_to_fractions,
+            _require_square_zero,
+        )
+
+        def broken_diffs():
+            # Two 2x2 identity differentials over GF(5): d^2 != 0 by design.
+            identity = (("1", "0"), ("0", "1"))
+            return [
+                _matrix_to_fractions(identity, 2, 2, 5),
+                _matrix_to_fractions(identity, 2, 2, 5),
+            ]
+
+        with pytest.raises(ValueError) as shifted_error:
+            _require_square_zero(
+                broken_diffs(),
+                5,
+                label="source",
+                group_columns=[2, 2, 2],
+                degree_min=-5,
+            )
+        detail = str(shifted_error.value)
+        assert "at chain degree -5" in detail, detail

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -88,6 +88,76 @@ class TestTensorProduct:
         # Tensor of two points is a point: one group of size 1
         assert result.tensor_basis_sizes == (1,)
 
+    def test_result_requires_canonical_value(self) -> None:
+        """A tensor result without its canonical value cannot validate, and
+        projections that disagree with the retained value are rejected."""
+        from pydantic import ValidationError
+
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        with pytest.raises(ValidationError):
+            TensorProductResult(
+                tensor_basis_sizes=(1,), tensor_differential_matrices=()
+            )
+        result = compute_tensor_product(
+            TensorProductRequest(left=_point_complex(), right=_point_complex())
+        )
+        payload = result.model_dump()
+        payload["tensor_basis_sizes"] = (5,)
+        with pytest.raises(ValidationError, match="canonical"):
+            TensorProductResult.model_validate(payload)
+
+
+class TestCanonicalCoefficientSpellings:
+    def test_noncanonical_spellings_rejected(self) -> None:
+        """One rational has one spelling: no leading zeros, reduced
+        fractions, integer denominators spelled as integers."""
+        from pydantic import ValidationError
+
+        for bad in ("01", "2/4", "3/1", "-0", "0/2", "007"):
+            with pytest.raises(ValidationError):
+                ChainComplexValue(
+                    coefficient_field=CoefficientField.RATIONAL,
+                    degree_min=0,
+                    degree_max=1,
+                    basis_sizes=(1, 1),
+                    differential_matrices=(((bad,),),),
+                )
+
+    def test_prime_field_residues_bounded(self) -> None:
+        """GF_p entries are residues in [0, p), canonically spelled."""
+        from pydantic import ValidationError
+
+        for bad in ("7", "-1"):
+            with pytest.raises(ValidationError, match="residue"):
+                ChainComplexValue(
+                    coefficient_field=CoefficientField.PRIME_FIELD,
+                    prime=5,
+                    degree_min=0,
+                    degree_max=1,
+                    basis_sizes=(1, 1),
+                    differential_matrices=(((bad,),),),
+                )
+
+
+class TestAggregateEntryWorkBound:
+    def test_dense_high_height_matrix_rejected(self) -> None:
+        """A dense 32x32 matrix of 500-digit entries is sub-megabyte but
+        exceeds the aggregate digit-work budget coupled to elimination."""
+        from pydantic import ValidationError
+
+        big = tuple(
+            tuple(str(10**500 + r * 33 + c) for c in range(32)) for r in range(32)
+        )
+        with pytest.raises(ValidationError, match="MAX_MATRIX_ENTRY_CHARS"):
+            ChainComplexValue(
+                coefficient_field=CoefficientField.RATIONAL,
+                degree_min=0,
+                degree_max=1,
+                basis_sizes=(32, 32),
+                differential_matrices=(big,),
+            )
+
 
 class TestMappingCone:
     def test_mapping_cone_identity(self) -> None:

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -605,6 +605,95 @@ class TestZeroWidthProducts:
         assert result.is_valid
 
 
+class TestEmptyRowWidthChainMaps:
+    """A zero-row differential or component keeps its declared inner
+    width in the chain-map equation instead of raising an
+    inner-dimension error on an admitted request."""
+
+    def _source(self) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("0",),),),
+        )
+
+    def _target(self) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(0, 1),
+            differential_matrices=((),),
+        )
+
+    def _map(self) -> tuple[tuple[str, ...], ...]:
+        return ((), (("1",),))
+
+    def test_zero_row_target_differential_verifies(self) -> None:
+        from jacobian.math.chain_complexes.operations import verify_chain_map
+
+        request = VerifyChainMapRequest(
+            source=self._source(),
+            target=self._target(),
+            map_matrices=self._map(),
+        )
+        result = verify_chain_map(request)
+        assert result.is_valid
+        assert type(result).model_validate(result.model_dump()).is_valid
+
+    def test_corresponding_cone_is_admitted_and_returned(self) -> None:
+        from jacobian.math.chain_complexes.operations import compute_mapping_cone
+
+        request = MappingConeRequest(
+            source=self._source(),
+            target=self._target(),
+            map_matrices=self._map(),
+        )
+        result = compute_mapping_cone(request)
+        # cone_n = target_n + source_{n-1}: (0, 1+1, 0+1).
+        assert result.cone_basis_sizes == (0, 2, 1)
+
+    def test_zero_row_homology_request_returns_typed_result(self) -> None:
+        """The homology kernel's square-zero replay keeps declared widths
+        for a complex whose first group is empty."""
+        from jacobian.math.chain_complexes.operations import compute_homology
+
+        shifted = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(0, 1, 1),
+            differential_matrices=((), (("1",),)),
+        )
+        result = compute_homology(ComputeHomologyRequest(complex=shifted))
+        assert [group.betti_number for group in result.homology_groups] == [0, 0, 0]
+
+    def test_empty_middle_cone_group_round_trips(self) -> None:
+        """A cone whose zeroth group is empty keeps its widths through
+        construction and validation."""
+        from jacobian.math.chain_complexes.operations import compute_mapping_cone
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        endpoint = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(0, 1),
+            differential_matrices=((),),
+        )
+        result = compute_mapping_cone(
+            MappingConeRequest(
+                source=endpoint,
+                target=endpoint,
+                map_matrices=((), (("1",),)),
+            )
+        )
+        revalidated = MappingConeResult.model_validate(result.model_dump())
+        assert revalidated.cone_basis_sizes == (0, 1, 1)
+
+
 class TestTensorContextAndShapes:
     def test_tensor_carries_canonical_context(self) -> None:
         result = compute_tensor_product(
@@ -674,6 +763,99 @@ class TestTensorValueComposition:
         assert isinstance(result.value, ChainComplexValue)
         assert result.value.basis_sizes == (1,)
         homology_groups(result.value)
+
+
+class TestTensorProductFactorBinding:
+    """A tensor result replays its defining construction against retained
+    factors so detached or forged products cannot validate."""
+
+    def test_forged_unrelated_value_rejected(self) -> None:
+        """Matching duplicate projections do not make an authored value
+        an exact tensor product."""
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        unrelated = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(7,),
+            differential_matrices=(),
+        )
+        with pytest.raises(ValidationError, match="canonical"):
+            TensorProductResult(
+                tensor_basis_sizes=(7,),
+                tensor_differential_matrices=(),
+                coefficient_field=CoefficientField.RATIONAL,
+                degree_min=0,
+                degree_max=0,
+                left=_point_complex(),
+                right=_point_complex(),
+                value=unrelated,
+            )
+
+    def test_non_square_zero_factor_rejected_by_replay(self) -> None:
+        """A retained factor violating d^2=0 fails the construction
+        replay instead of surviving under the tensor-product claim."""
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        with pytest.raises(ValidationError, match="d\\^2"):
+            TensorProductResult(
+                tensor_basis_sizes=(1, 1, 1),
+                tensor_differential_matrices=((("1",),), (("1",),)),
+                coefficient_field=CoefficientField.RATIONAL,
+                degree_min=0,
+                degree_max=2,
+                left=bad,
+                right=_point_complex(),
+                value=bad,
+            )
+
+    def test_genuine_result_round_trips(self) -> None:
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        circle = _circle_complex()
+        point = _point_complex()
+        result = compute_tensor_product(
+            TensorProductRequest(left=circle, right=point)
+        )
+        revalidated = TensorProductResult.model_validate(result.model_dump())
+        assert revalidated.value.basis_sizes == (3, 3)
+
+    def test_tampered_factor_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        result = compute_tensor_product(
+            TensorProductRequest(left=_point_complex(), right=_point_complex())
+        )
+        payload = result.model_dump()
+        payload["right"] = payload["right"] | {"basis_sizes": (2,)}
+        with pytest.raises(ValidationError, match="canonical"):
+            TensorProductResult.model_validate(payload)
+
+    def test_tampered_degree_provenance_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import TensorProductResult
+
+        shifted = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=-1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        result = compute_tensor_product(
+            TensorProductRequest(left=shifted, right=_point_complex())
+        )
+        payload = result.model_dump()
+        payload["degree_min"] = 0
+        with pytest.raises(ValidationError, match="degree interval"):
+            TensorProductResult.model_validate(payload)
 
 
 def homology_groups(complex_value):

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -561,3 +561,22 @@ def homology_groups(complex_value):
     from jacobian.math.chain_complexes import homology_groups as native
 
     return native(complex_value)
+
+
+class TestChainDegreeDiagnostics:
+    def test_diagnostics_report_declared_degree(self) -> None:
+        """A shifted complex reports its declared chain degree, not the
+        tuple index, in d^2 failures."""
+        from jacobian.math.chain_complexes._models import (
+            ComputeHomologyRequest,
+        )
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-2,
+            degree_max=0,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        with pytest.raises(ValueError, match="chain degree -2"):
+            compute_homology(ComputeHomologyRequest(complex=bad))

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -273,3 +273,96 @@ class TestPrimeFieldEntries:
         )
         result = verify_differential(VerifyDifferentialRequest(complex=complex_value))
         assert result.is_valid
+
+
+class TestChainMapEntryGrammar:
+    def test_unparseable_entries_rejected_at_admission(self) -> None:
+        """Correctly shaped components with junk entries fail at the
+        boundary instead of inside _parse_fraction."""
+        circle = _circle_complex()
+        identity = (("1", "0", "0"), ("0", "1", "0"), ("0", "x", "1"))
+        with pytest.raises(ValueError, match="rational string grammar"):
+            VerifyChainMapRequest(
+                source=circle, target=circle, map_matrices=(identity, identity)
+            )
+        zero_den = (("1", "0", "0"), ("0", "1/0", "0"), ("0", "0", "1"))
+        with pytest.raises(ValueError):
+            MappingConeRequest(
+                source=circle, target=circle, map_matrices=(zero_den, zero_den)
+            )
+
+
+class TestTensorProductPreconditions:
+    def test_non_square_zero_factor_rejected(self) -> None:
+        """Tensoring complexes violating d^2=0 is rejected before building."""
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        point = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        with pytest.raises(ValueError, match="d\\^2=0"):
+            compute_tensor_product(TensorProductRequest(left=bad, right=point))
+        with pytest.raises(ValueError, match="d\\^2=0"):
+            compute_tensor_product(TensorProductRequest(left=point, right=bad))
+
+    def test_allocated_differential_cells_are_bounded(self) -> None:
+        """A singleton 64-dim left factor against a 65-degree right factor
+        passes group-dimension checks but allocates ~4M dense cells; the
+        cell-count work bound rejects it."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(64,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=32,
+            basis_sizes=(4,) * 33,
+            differential_matrices=((("0", "0", "0", "0"),) * 4,) * 32,
+        )
+        with pytest.raises(ValueError, match="work bound"):
+            TensorProductRequest(left=left, right=right)
+
+
+class TestHomologySourceBinding:
+    def test_result_retains_and_replays_source(self) -> None:
+        from jacobian.math.chain_complexes.values import HomologyResult
+
+        complex_value = _circle_complex()
+        request = ComputeHomologyRequest(complex=complex_value)
+        result = compute_homology(request)
+        assert result.complex == complex_value
+        revalidated = HomologyResult.model_validate(result.model_dump())
+        assert revalidated.homology_groups == result.homology_groups
+
+    def test_forged_profile_is_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import (
+            HomologyGroupValue,
+            HomologyResult,
+        )
+
+        payload_groups = (
+            HomologyGroupValue(
+                degree=0, cycle_rank=5, boundary_rank=0, betti_number=100
+            ),
+        )
+        with pytest.raises(ValueError, match="betti_number"):
+            HomologyResult(
+                homology_groups=payload_groups,
+                coefficient_field=CoefficientField.RATIONAL,
+                degree_min=0,
+                degree_max=0,
+                complex=_point_complex(),
+            )

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -632,6 +632,24 @@ class TestNativeSurface:
         product = tensor_product_complex(_point_complex(), _point_complex())
         assert product.tensor_basis_sizes == (1,)
 
+    def test_native_tensor_applies_work_admission_before_expansion(self) -> None:
+        """Native callers cannot reach the dense kernel with canonical
+        inputs whose derived group dimensions exceed the work bounds."""
+        from jacobian.math.chain_complexes import tensor_product_complex
+
+        factor = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            prime=None,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(64, 64),
+            differential_matrices=([["0"] * 64 for _ in range(64)],),
+        )
+        # The derived tensor group sizes would be (4096, 8192, 4096); the
+        # admission bound must reject before any dense expansion allocates.
+        with pytest.raises(ValueError, match="work bound"):
+            tensor_product_complex(factor, factor)
+
     def test_native_surface_excludes_wire_envelope_handlers(self) -> None:
         """The authoritative package __all__ advertises only value-based
         functions; request handlers stay private to operations/_tools."""

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -345,6 +345,52 @@ class TestTensorProductSignAndBudget:
         assert result.tensor_basis_sizes == (1, 1)
         assert result.tensor_differential_matrices == ((("-1",),),)
 
+    def test_expanded_coefficients_rejected_at_admission(self) -> None:
+        """A (7,7) dense 512-digit differential by an 8-dimensional point
+        repeats 49 coefficients eight times; admission must reject the
+        expansion instead of failing inside result construction."""
+        big_row = tuple(str(10**511 + i) for i in range(7))
+        big = tuple(big_row for _ in range(7))
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(7, 7),
+            differential_matrices=(big,),
+        )
+        point = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(8,),
+            differential_matrices=(),
+        )
+        with pytest.raises(ValueError, match="serialization exceeds"):
+            TensorProductRequest(left=left, right=point)
+
+    def test_small_coefficient_expansion_still_accepted(self) -> None:
+        """The same shapes with single-digit coefficients stay inside the
+        expanded-character budget and return the typed tensor value."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(7, 7),
+            differential_matrices=((("1",) * 7,) * 7,),
+        )
+        point = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(8,),
+            differential_matrices=(),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=point))
+        assert result.tensor_basis_sizes == (56, 56)
+        assert verify_differential(
+            VerifyDifferentialRequest(complex=result.value)
+        ).is_valid
+
     def test_tensor_intermediate_dimensions_are_bounded(self) -> None:
         """Two 64+64 factors meet the input cell limit but their middle
         tensor group has dimension 8192; admission must reject it."""

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -1,5 +1,7 @@
 """Tests for chain complex operations (#1824)."""
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -777,3 +779,191 @@ class TestVerificationVerdictBinding:
         assert result.complex is not None
         revalidated = type(result).model_validate(result.model_dump())
         assert revalidated.is_valid
+
+
+class TestVerificationReplayParentChecks:
+    """A replayed chain-map verdict applies the request model's complete
+    endpoint checks, not the source modulus alone."""
+
+    def _point(self, field: CoefficientField, prime: int | None) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=field,
+            prime=prime,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+
+    def test_cross_field_endpoints_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        with pytest.raises(ValidationError, match="equal coefficient fields"):
+            VerificationResult(
+                is_valid=True,
+                detail="commutes",
+                source=self._point(CoefficientField.RATIONAL, None),
+                target=self._point(CoefficientField.PRIME_FIELD, 2),
+                map_matrices=((("1",),),),
+            )
+
+    def test_mismatched_primes_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        with pytest.raises(ValidationError, match="equal prime moduli"):
+            VerificationResult(
+                is_valid=True,
+                detail="commutes",
+                source=self._point(CoefficientField.PRIME_FIELD, 2),
+                target=self._point(CoefficientField.PRIME_FIELD, 3),
+                map_matrices=((("1",),),),
+            )
+
+    def test_shifted_degree_intervals_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        shifted = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=-1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        with pytest.raises(ValidationError, match="same degree interval"):
+            VerificationResult(
+                is_valid=True,
+                detail="commutes",
+                source=_point_complex(),
+                target=shifted,
+                map_matrices=((("1",),),),
+            )
+
+    def test_out_of_range_map_residue_rejected(self) -> None:
+        """GF(3) map entries are replayed under p=3, so '4' cannot pass."""
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        gf3 = self._point(CoefficientField.PRIME_FIELD, 3)
+        with pytest.raises(ValidationError, match="residue"):
+            VerificationResult(
+                is_valid=True,
+                detail="commutes",
+                source=gf3,
+                target=gf3,
+                map_matrices=((("4",),),),
+            )
+
+    def test_genuine_verdict_round_trips(self) -> None:
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        point = _point_complex()
+        verdict = VerificationResult(
+            is_valid=True,
+            detail="commutes",
+            source=point,
+            target=point,
+            map_matrices=((("1",),),),
+        )
+        assert type(verdict).model_validate(verdict.model_dump()).is_valid
+
+
+class TestMappingConeSourceBinding:
+    """A cone result replays its defining construction against retained
+    endpoints so detached or forged cones cannot validate."""
+
+    def _circle(self) -> ChainComplexValue:
+        return _circle_complex()
+
+    def _identity(self) -> tuple[tuple[str, ...], ...]:
+        return (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
+
+    def _cone_payload(self) -> dict[str, Any]:
+        circle = self._circle()
+        identity = self._identity()
+        result = compute_mapping_cone(
+            MappingConeRequest(source=circle, target=circle, map_matrices=(identity,) * 2)
+        )
+        return result.model_dump()
+
+    def test_genuine_cone_round_trips(self) -> None:
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        revalidated = MappingConeResult.model_validate(self._cone_payload())
+        assert revalidated.cone_basis_sizes == (3, 6, 3)
+
+    def test_detached_cone_rejected(self) -> None:
+        """Without retained endpoints no cone payload validates at all."""
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        with pytest.raises(ValidationError):
+            MappingConeResult.model_validate(
+                {
+                    "cone_basis_sizes": (1, 1, 1),
+                    "cone_differential_matrices": ((("1",),), (("1",),)),
+                    "source_degree_min": 0,
+                    "target_degree_min": 0,
+                }
+            )
+
+    def test_non_chain_complex_endpoints_rejected(self) -> None:
+        """Endpoints violating d^2=0 admit no cone, even if the authored
+        matrices happen to be square-zero themselves."""
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        one = (("1",),)
+        with pytest.raises(ValidationError):
+            MappingConeResult(
+                cone_basis_sizes=(1, 1, 1),
+                cone_differential_matrices=((("1",),), (("1",),)),
+                source_degree_min=0,
+                target_degree_min=0,
+                source=bad,
+                target=bad,
+                map_matrices=(one, one, one),
+            )
+
+    def test_tampered_cone_differentials_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        payload = self._cone_payload()
+        payload["cone_differential_matrices"] = (
+            (("1",) * 6,) * 6,
+            (("0",) * 6,) * 6,
+        )
+        with pytest.raises(ValidationError, match="exact mapping cone"):
+            MappingConeResult.model_validate(payload)
+
+    def test_tampered_degree_provenance_rejected(self) -> None:
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        payload = self._cone_payload()
+        payload["source_degree_min"] = 5
+        with pytest.raises(ValidationError, match="provenance"):
+            MappingConeResult.model_validate(payload)
+
+    def test_shifted_genuine_cone_round_trips(self) -> None:
+        """Cone provenance follows the declared interval of a shifted pair."""
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        shifted = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=0,
+            basis_sizes=(3, 3),
+            differential_matrices=(
+                (("-1", "1", "0"), ("0", "-1", "1"), ("0", "0", "0")),
+            ),
+        )
+        identity = self._identity()
+        result = compute_mapping_cone(
+            MappingConeRequest(source=shifted, target=shifted, map_matrices=(identity,) * 2)
+        )
+        revalidated = MappingConeResult.model_validate(result.model_dump())
+        assert revalidated.source_degree_min == -1
+        assert revalidated.cone_basis_sizes == (3, 6, 3)

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -1103,7 +1103,9 @@ class TestChainDegreeDiagnostics:
             basis_sizes=(1, 1, 1),
             differential_matrices=((("1",),), (("1",),)),
         )
-        with pytest.raises(ValueError, match="chain degree -2"):
+        # The failing pair is (d_{-2}, d_{-1}); its composition is reported
+        # at the middle declared degree -1, matching verify_differential.
+        with pytest.raises(ValueError, match="chain degree -1"):
             compute_homology(ComputeHomologyRequest(complex=bad))
 
 
@@ -1667,4 +1669,65 @@ class TestReviewRegressions2236:
                 degree_min=-5,
             )
         detail = str(shifted_error.value)
-        assert "at chain degree -5" in detail, detail
+        # The composed pair's middle declared degree, matching the
+        # verification operation's verdict for the same complex.
+        assert "at chain degree -4" in detail, detail
+
+
+class TestNativeWrappersCallKernelsDirectly:
+    """Native wrappers invoke typed kernels without the wire envelope."""
+
+    @staticmethod
+    def _circle() -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("0",),),),
+        )
+
+    def test_native_paths_survive_disabled_wire_handlers(self, monkeypatch):
+        """Blocking every wire handler still yields correct native results."""
+        import jacobian.math.chain_complexes.operations as ops
+
+        def blocked(*args, **kwargs):
+            raise AssertionError("wire handler reached from the native path")
+
+        for name in (
+            "compute_homology",
+            "verify_differential",
+            "verify_chain_map",
+            "compute_mapping_cone",
+            "compute_tensor_product",
+        ):
+            monkeypatch.setattr(ops, name, blocked)
+
+        from jacobian.math.chain_complexes import native
+
+        circle = self._circle()
+        homology = native.homology_groups(circle)
+        assert homology.homology_groups[0].betti_number == 1
+        assert native.differential_squares_to_zero(circle).is_valid is True
+        identity_map = ((("1",),),)
+        assert len(identity_map) == 1
+        identity_map = ((("1",),), (("1",),))
+        cone = native.mapping_cone(circle, circle, identity_map)
+        assert cone.source_degree_min == 0
+        tensor = native.tensor_product_complex(circle, circle)
+        assert tensor.value.degree_max == 2
+
+    def test_native_chain_map_verdict_matches_wire_semantics(self, monkeypatch):
+        import jacobian.math.chain_complexes.operations as ops
+
+        def blocked(*args, **kwargs):
+            raise AssertionError("wire handler reached from the native path")
+
+        monkeypatch.setattr(ops, "verify_chain_map", blocked)
+        from jacobian.math.chain_complexes import native
+
+        circle = self._circle()
+        # One component per chain group: the identity chain map.
+        identity = ((("1",),), (("1",),))
+        verdict = native.chain_map_commutes(circle, circle, identity)
+        assert verdict.is_valid is True

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -542,3 +542,22 @@ class TestTensorContextAndShapes:
         )
         assert result.is_valid is False
         assert "d^2=0" in result.detail
+
+
+class TestTensorValueComposition:
+    def test_tensor_result_exposes_chain_complex_value(self) -> None:
+        """The derived complex composes as a first-class value."""
+        from jacobian.math.chain_complexes.values import ChainComplexValue
+
+        result = compute_tensor_product(
+            TensorProductRequest(left=_point_complex(), right=_point_complex())
+        )
+        assert isinstance(result.value, ChainComplexValue)
+        assert result.value.basis_sizes == (1,)
+        homology_groups(result.value)
+
+
+def homology_groups(complex_value):
+    from jacobian.math.chain_complexes import homology_groups as native
+
+    return native(complex_value)

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -1,6 +1,7 @@
 """Tests for chain complex operations (#1824)."""
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.chain_complexes._models import (
     ComputeHomologyRequest,
@@ -747,3 +748,32 @@ class TestZeroWidthGroupComposition:
         result = verify_differential(VerifyDifferentialRequest(complex=neg))
         assert not result.is_valid
         assert "-4" in result.detail
+
+
+class TestVerificationVerdictBinding:
+    def test_forged_verdict_rejected(self) -> None:
+        """A successful verdict cannot validate against a complex whose
+        d^2 is nonzero, and a detached verdict cannot validate at all."""
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        with pytest.raises(ValidationError, match="exact replay"):
+            VerificationResult(is_valid=True, detail="d^2 = 0", complex=bad)
+        with pytest.raises(ValidationError, match="retain"):
+            VerificationResult(is_valid=True, detail="d^2 = 0")
+
+    def test_true_verdict_retains_complex(self) -> None:
+        """Successful differential verification retains its input."""
+        result = verify_differential(
+            VerifyDifferentialRequest(complex=_circle_complex())
+        )
+        assert result.is_valid
+        assert result.complex is not None
+        revalidated = type(result).model_validate(result.model_dump())
+        assert revalidated.is_valid

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -555,6 +555,155 @@ class TestNativeSurface:
         product = tensor_product_complex(_point_complex(), _point_complex())
         assert product.tensor_basis_sizes == (1,)
 
+    def test_native_surface_excludes_wire_envelope_handlers(self) -> None:
+        """The authoritative package __all__ advertises only value-based
+        functions; request handlers stay private to operations/_tools."""
+        import jacobian.math.chain_complexes as chain_complexes_package
+
+        assert set(chain_complexes_package.__all__) == {
+            "chain_map_commutes",
+            "differential_squares_to_zero",
+            "homology_groups",
+            "mapping_cone",
+            "tensor_product_complex",
+        }
+        from jacobian.math.chain_complexes.operations import compute_homology
+
+        request = compute_homology.__annotations__.get("request")
+        assert request is not None
+
+
+class TestMappingConeCanonicalValue:
+    """The cone is returned as a first-class chain-complex value whose
+    derived bounds are admitted at the request boundary."""
+
+    def test_identity_cone_composes_into_homology_unchanged(self) -> None:
+        """The identity cone of a point feeds ComputeHomologyRequest
+        directly through its canonical value."""
+        from jacobian.math.chain_complexes._models import ComputeHomologyRequest
+        from jacobian.math.chain_complexes.operations import compute_homology
+
+        point = _point_complex()
+        one = (("1",),)
+        result = compute_mapping_cone(
+            MappingConeRequest(source=point, target=point, map_matrices=(one,))
+        )
+        homology = compute_homology(ComputeHomologyRequest(complex=result.value))
+        assert [group.betti_number for group in homology.homology_groups] == [
+            0,
+            0,
+        ]
+        assert result.value.degree_min == point.degree_min
+
+    def test_derived_group_dimension_rejected_at_admission(self) -> None:
+        """A cone group of 64 + 64 faces exceeds the canonical basis bound
+        and fails the request instead of dying inside execution."""
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(64, 0),
+            differential_matrices=(((),) * 64,),
+        )
+        target = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(0, 64),
+            differential_matrices=((),),
+        )
+        with pytest.raises(ValueError, match="MAX_BASIS_SIZE"):
+            MappingConeRequest(
+                source=source,
+                target=target,
+                map_matrices=((), ((),) * 64),
+            )
+
+    def test_derived_degree_interval_rejected_at_admission(self) -> None:
+        """A 33-group source forces a 34-group cone whose degree interval
+        leaves the canonical chain-degree range."""
+        sizes = (1,) * 33
+        zeros = ((("0",),),) * 32
+        complex_value = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=32,
+            basis_sizes=sizes,
+            differential_matrices=zeros,
+        )
+        one = (("1",),)
+        with pytest.raises(ValueError, match="less than or equal"):
+            MappingConeRequest(
+                source=complex_value,
+                target=complex_value,
+                map_matrices=(one,) * 33,
+            )
+
+    def test_derived_serialization_envelope_rejected_at_admission(self) -> None:
+        """Copied coefficients push the cone past the canonical entry-char
+        ceiling; admission rejects it before any dense allocation."""
+        digits = 200
+        row = tuple(str(10**digits + i) for i in range(16))
+        big_zero = tuple(row for _ in range(16))
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(16, 16),
+            differential_matrices=(big_zero,),
+        )
+        target = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(16, 16),
+            differential_matrices=(big_zero,),
+        )
+        identity_16 = tuple(
+            tuple("1" if i == j else "0" for j in range(16)) for i in range(16)
+        )
+        with pytest.raises(ValueError, match="serialization exceeds"):
+            MappingConeRequest(
+                source=source,
+                target=target,
+                map_matrices=(identity_16, identity_16),
+            )
+
+    def test_result_round_trips_and_rejects_tampered_value(self) -> None:
+        from pydantic import ValidationError
+
+        from jacobian.math.chain_complexes.values import MappingConeResult
+
+        point = _point_complex()
+        one = (("1",),)
+        result = compute_mapping_cone(
+            MappingConeRequest(source=point, target=point, map_matrices=(one,))
+        )
+        revalidated = MappingConeResult.model_validate(result.model_dump())
+        assert revalidated == result
+
+        payload = result.model_dump()
+        payload["value"]["basis_sizes"] = (2, *payload["value"]["basis_sizes"][1:])
+        with pytest.raises(ValidationError):
+            MappingConeResult.model_validate(payload)
+
+
+class TestSchemaVisibleCoefficientGrammar:
+    def test_construct_schema_documents_entry_grammar(self) -> None:
+        description = ConstructChainComplexRequest.model_json_schema()["properties"][
+            "differential_matrices"
+        ]["description"]
+        assert "residues in [0, p)" in description
+        assert "never evaluates" in description
+
+    def test_chain_map_schemas_document_map_matrix_grammar(self) -> None:
+        for model in (VerifyChainMapRequest, MappingConeRequest):
+            description = model.model_json_schema()["properties"]["map_matrices"][
+                "description"
+            ]
+            assert "canonical coefficient grammar" in description
+            assert "residues in [0, p)" in description
+
 
 class TestChainMapEndpointPrecondition:
     def test_non_square_zero_endpoints_fail_verification(self) -> None:

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -496,8 +496,13 @@ class TestNativeSurface:
         )
 
         circle = _circle_complex()
-        groups = homology_groups(circle)
-        assert groups[0].betti_number == 1 and groups[1].betti_number == 1
+        result = homology_groups(circle)
+        assert result.homology_groups[0].betti_number == 1
+        assert result.homology_groups[1].betti_number == 1
+        # The native value carries the source's field context so GF(p) and
+        # QQ homology stay distinguishable.
+        assert result.coefficient_field == circle.coefficient_field
+        assert result.prime == circle.prime
 
         identity = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
         verdict = chain_map_commutes(circle, circle, (identity, identity))
@@ -650,3 +655,52 @@ class TestChainDegreeDiagnostics:
         )
         with pytest.raises(ValueError, match="chain degree -2"):
             compute_homology(ComputeHomologyRequest(complex=bad))
+
+
+class TestTensorPrimeFieldResidues:
+    def test_signed_tensor_coefficients_reduced_modulo_p(self) -> None:
+        """A GF(3) tensor with a sign negation serializes the canonical
+        residue 2, not -1, so the derived value validates."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=1,
+            degree_max=1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        entries = [
+            entry
+            for matrix in result.tensor_differential_matrices
+            for row in matrix
+            for entry in row
+        ]
+        assert entries
+        assert all(not entry.startswith("-") for entry in entries)
+        assert all(entry in {"0", "1", "2"} for entry in entries)
+
+    def test_out_of_range_chain_map_entry_rejected(self) -> None:
+        """GF(p) chain maps enforce canonical residues like complexes do."""
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("2",),),),
+        )
+        with pytest.raises(ValueError, match="residue"):
+            VerifyChainMapRequest(
+                source=source,
+                target=source,
+                map_matrices=((("4",),), (("4",),)),
+            )

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -1,0 +1,111 @@
+"""Tests for chain complex operations (#1824)."""
+
+import pytest
+
+from jacobian.math.chain_complexes._models import (
+    ComputeHomologyRequest,
+    ConstructChainComplexRequest,
+    MappingConeRequest,
+    TensorProductRequest,
+    VerifyChainMapRequest,
+    VerifyDifferentialRequest,
+)
+from jacobian.math.chain_complexes.operations import (
+    compute_homology,
+    compute_mapping_cone,
+    compute_tensor_product,
+    construct_chain_complex,
+    verify_chain_map,
+    verify_differential,
+)
+from jacobian.math.chain_complexes.values import ChainComplexValue, CoefficientField
+
+
+def _circle_complex() -> ChainComplexValue:
+    return ChainComplexValue(
+        coefficient_field=CoefficientField.RATIONAL,
+        degree_min=0,
+        degree_max=1,
+        basis_sizes=(3, 3),
+        differential_matrices=(
+            (("-1", "1", "0"), ("0", "-1", "1"), ("0", "0", "0")),
+        ),
+    )
+
+
+def _point_complex() -> ChainComplexValue:
+    """A single point: H_0 = 1, all others 0."""
+    return ChainComplexValue(
+        coefficient_field=CoefficientField.RATIONAL,
+        degree_min=0,
+        degree_max=0,
+        basis_sizes=(1,),
+        differential_matrices=(),
+    )
+
+
+class TestConstructChainComplex:
+    def test_construct_circle(self) -> None:
+        result = construct_chain_complex(
+            ConstructChainComplexRequest(
+                basis_sizes=(3, 3),
+                differential_matrices=(
+                    (("-1", "1", "0"), ("0", "-1", "1"), ("0", "0", "0")),
+                ),
+            )
+        )
+        assert result.basis_sizes == (3, 3)
+        assert result.degree_max == 1
+
+
+class TestVerifyDifferential:
+    def test_valid_d2_zero(self) -> None:
+        result = verify_differential(
+            VerifyDifferentialRequest(complex=_circle_complex())
+        )
+        assert result.is_valid
+
+    def test_point_has_valid_d2(self) -> None:
+        result = verify_differential(
+            VerifyDifferentialRequest(complex=_point_complex())
+        )
+        assert result.is_valid
+
+
+class TestComputeHomology:
+    def test_circle_homology(self) -> None:
+        result = compute_homology(
+            ComputeHomologyRequest(complex=_circle_complex())
+        )
+        assert result.homology_groups[0].betti_number == 1
+        assert result.homology_groups[1].betti_number == 1
+
+    def test_point_homology(self) -> None:
+        result = compute_homology(
+            ComputeHomologyRequest(complex=_point_complex())
+        )
+        assert result.homology_groups[0].betti_number == 1
+
+
+class TestTensorProduct:
+    def test_tensor_two_points(self) -> None:
+        result = compute_tensor_product(
+            TensorProductRequest(left=_point_complex(), right=_point_complex())
+        )
+        # Tensor of two points is a point: one group of size 1
+        assert result.tensor_basis_sizes == (1,)
+
+
+class TestMappingCone:
+    def test_mapping_cone_identity(self) -> None:
+        circle = _circle_complex()
+        identity_3x3 = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
+        identity = (identity_3x3,)
+        result = compute_mapping_cone(
+            MappingConeRequest(
+                source=circle,
+                target=circle,
+                map_matrices=identity,
+            )
+        )
+        assert result.cone_basis_sizes is not None

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -704,3 +704,46 @@ class TestTensorPrimeFieldResidues:
                 target=source,
                 map_matrices=((("4",),), (("4",),)),
             )
+
+
+class TestZeroWidthGroupComposition:
+    def test_zero_row_left_operand_preserves_declared_width(self) -> None:
+        """A (0 x 1) differential followed by (1 x 1) composes to a valid
+        zero product instead of raising an inner-dimension error."""
+        shifted = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(0, 1, 1),
+            differential_matrices=((), (("1",),)),
+        )
+        result = verify_differential(VerifyDifferentialRequest(complex=shifted))
+        assert result.is_valid
+
+    def test_nonsquare_zero_homology_rejected_at_request(self) -> None:
+        """Homology requests whose d^2 != 0 fail at the typed boundary."""
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        with pytest.raises(ValueError, match="d\\^2"):
+            ComputeHomologyRequest(complex=bad)
+        with pytest.raises(ValueError, match="d\\^2"):
+            TensorProductRequest(left=bad, right=_point_complex())
+
+    def test_differential_failure_reports_declared_degree(self) -> None:
+        """A complex concentrated in degrees -5..-3 reports degree -4, not
+        the tuple index."""
+        neg = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-5,
+            degree_max=-3,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        result = verify_differential(VerifyDifferentialRequest(complex=neg))
+        assert not result.is_valid
+        assert "-4" in result.detail

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -822,9 +822,7 @@ class TestTensorProductFactorBinding:
 
         circle = _circle_complex()
         point = _point_complex()
-        result = compute_tensor_product(
-            TensorProductRequest(left=circle, right=point)
-        )
+        result = compute_tensor_product(TensorProductRequest(left=circle, right=point))
         revalidated = TensorProductResult.model_validate(result.model_dump())
         assert revalidated.value.basis_sizes == (3, 3)
 
@@ -914,6 +912,73 @@ class TestTensorPrimeFieldResidues:
         assert all(not entry.startswith("-") for entry in entries)
         assert all(entry in {"0", "1", "2"} for entry in entries)
 
+    def test_signed_tensor_coefficient_exact_residue(self) -> None:
+        """The reviewer's counterexample returns exactly the residue 2,
+        both as the serialized projection and the retained complex."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=1,
+            degree_max=1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert result.tensor_differential_matrices == ((("2",),),)
+        assert result.value.differential_matrices == ((("2",),),)
+        assert verify_differential(
+            VerifyDifferentialRequest(complex=result.value)
+        ).is_valid
+
+    def test_koszul_sign_boundary_mod_two(self) -> None:
+        """The p = 2 boundary: the Koszul sign -1 is the residue 1."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=2,
+            degree_min=1,
+            degree_max=1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=2,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert result.tensor_differential_matrices == ((("1",),),)
+
+    def test_rational_tensor_keeps_signed_spelling(self) -> None:
+        """QQ tensor products keep their exact signed coefficients, so the
+        reduction is specific to prime-field serialization."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=-1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert result.tensor_differential_matrices == ((("-1",),),)
+
     def test_out_of_range_chain_map_entry_rejected(self) -> None:
         """GF(p) chain maps enforce canonical residues like complexes do."""
         source = ChainComplexValue(
@@ -930,6 +995,129 @@ class TestTensorPrimeFieldResidues:
                 target=source,
                 map_matrices=((("4",),), (("4",),)),
             )
+
+    def _gf_point(self, prime: int) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=prime,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+
+    def test_map_entry_modulus_boundaries(self) -> None:
+        """Every spelling outside [0, p) fails admission for both chain-map
+        requests; an in-range residue still verifies."""
+        point = self._gf_point(3)
+        for bad in ("3", "4", "-1"):
+            with pytest.raises(ValueError, match="residue"):
+                VerifyChainMapRequest(
+                    source=point, target=point, map_matrices=(((bad,),),)
+                )
+            with pytest.raises(ValueError, match="residue"):
+                MappingConeRequest(
+                    source=point, target=point, map_matrices=(((bad,),),)
+                )
+        from jacobian.math.chain_complexes.operations import verify_chain_map
+
+        request = VerifyChainMapRequest(
+            source=point, target=point, map_matrices=((("2",),),)
+        )
+        assert verify_chain_map(request).is_valid
+
+    def test_rational_map_entries_keep_integer_grammar(self) -> None:
+        """The modulus check applies only to prime-field components: "4"
+        remains admissible over QQ."""
+        rational_point = _point_complex()
+        request = VerifyChainMapRequest(
+            source=rational_point,
+            target=rational_point,
+            map_matrices=((("4",),),),
+        )
+        assert request.map_matrices == ((("4",),),)
+
+
+class TestPrimeFieldDerivedSerialization:
+    def test_mapping_cone_serializes_prime_field_residues(self) -> None:
+        """The cone's -d_C block becomes the canonical GF(p) residue and
+        the decomposition composes as a square-zero chain complex."""
+        gf3_two_term = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        one = (("1",),)
+        result = compute_mapping_cone(
+            MappingConeRequest(
+                source=gf3_two_term, target=gf3_two_term, map_matrices=(one, one)
+            )
+        )
+        assert result.cone_differential_matrices == (
+            (("1", "1"),),
+            (("2",), ("1",)),
+        )
+        cone = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=3,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=result.cone_basis_sizes,
+            differential_matrices=result.cone_differential_matrices,
+        )
+        assert verify_differential(VerifyDifferentialRequest(complex=cone)).is_valid
+
+
+class TestNativeHomologyFieldBinding:
+    """The native homology wrapper returns the source-bound result, so
+    homology over different coefficient fields stays distinct."""
+
+    @staticmethod
+    def _native(complex_value: ChainComplexValue):
+        from jacobian.math.chain_complexes import (
+            homology_groups as native_homology_groups,
+        )
+
+        return native_homology_groups(complex_value)
+
+    def _gf_point(self, prime: int) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=prime,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+
+    def test_result_carries_coefficient_field(self) -> None:
+        from jacobian.math.chain_complexes.values import HomologyResult
+
+        point = self._gf_point(2)
+        result = self._native(point)
+        assert isinstance(result, HomologyResult)
+        assert result.coefficient_field == CoefficientField.PRIME_FIELD
+        assert result.prime == 2
+        assert result.complex == point
+
+    def test_different_fields_yield_distinct_results(self) -> None:
+        over_two = self._native(self._gf_point(2))
+        over_three = self._native(self._gf_point(3))
+        assert over_two.prime == 2
+        assert over_three.prime == 3
+        assert over_two != over_three
+
+    def test_matches_wire_operation(self) -> None:
+        from jacobian.math.chain_complexes._models import ComputeHomologyRequest
+        from jacobian.math.chain_complexes.operations import compute_homology
+
+        point = self._gf_point(3)
+        native_result = self._native(point)
+        wire_result = compute_homology(ComputeHomologyRequest(complex=point))
+        assert native_result == wire_result
 
 
 class TestZeroWidthGroupComposition:
@@ -1103,7 +1291,9 @@ class TestMappingConeSourceBinding:
         circle = self._circle()
         identity = self._identity()
         result = compute_mapping_cone(
-            MappingConeRequest(source=circle, target=circle, map_matrices=(identity,) * 2)
+            MappingConeRequest(
+                source=circle, target=circle, map_matrices=(identity,) * 2
+            )
         )
         return result.model_dump()
 
@@ -1185,7 +1375,9 @@ class TestMappingConeSourceBinding:
         )
         identity = self._identity()
         result = compute_mapping_cone(
-            MappingConeRequest(source=shifted, target=shifted, map_matrices=(identity,) * 2)
+            MappingConeRequest(
+                source=shifted, target=shifted, map_matrices=(identity,) * 2
+            )
         )
         revalidated = MappingConeResult.model_validate(result.model_dump())
         assert revalidated.source_degree_min == -1

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -414,3 +414,71 @@ class TestHomologyParentMatch:
                 degree_max=0,
                 complex=_point_complex(),
             )
+
+
+class TestNativeSurface:
+    def test_domain_value_functions(self) -> None:
+        """Native exports accept domain values, not request envelopes."""
+        from jacobian.math.chain_complexes import (
+            chain_map_commutes,
+            homology_groups,
+            tensor_product_complex,
+        )
+
+        circle = _circle_complex()
+        groups = homology_groups(circle)
+        assert groups[0].betti_number == 1 and groups[1].betti_number == 1
+
+        identity = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
+        verdict = chain_map_commutes(circle, circle, (identity, identity))
+        assert verdict.is_valid
+
+        product = tensor_product_complex(_point_complex(), _point_complex())
+        assert product.tensor_basis_sizes == (1,)
+
+
+class TestChainMapEndpointPrecondition:
+    def test_non_square_zero_endpoints_fail_verification(self) -> None:
+        """Endpoints violating d^2=0 admit no chain map; the identity
+        components must not validate as commuting."""
+        from jacobian.math.chain_complexes.operations import verify_chain_map
+
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        one = (("1",),)
+        result = verify_chain_map(
+            VerifyChainMapRequest(source=bad, target=bad, map_matrices=(one, one, one))
+        )
+        assert result.is_valid is False
+        assert "d^2=0" in result.detail
+
+
+class TestZeroWidthProducts:
+    def test_zero_row_operand_preserves_columns(self) -> None:
+        from jacobian.math.chain_complexes.operations import verify_chain_map
+
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("0",),),),
+        )
+        target = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 0),
+            differential_matrices=(((),),),
+        )
+        # Component 0: 1x1 zero; component 1: target has no degree-1 group.
+        map_matrices = ((("0",),), ())
+        result = verify_chain_map(
+            VerifyChainMapRequest(source=source, target=target, map_matrices=map_matrices)
+        )
+        assert result.is_valid

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -15,7 +15,6 @@ from jacobian.math.chain_complexes.operations import (
     compute_mapping_cone,
     compute_tensor_product,
     construct_chain_complex,
-    verify_chain_map,
     verify_differential,
 )
 from jacobian.math.chain_complexes.values import ChainComplexValue, CoefficientField
@@ -27,9 +26,7 @@ def _circle_complex() -> ChainComplexValue:
         degree_min=0,
         degree_max=1,
         basis_sizes=(3, 3),
-        differential_matrices=(
-            (("-1", "1", "0"), ("0", "-1", "1"), ("0", "0", "0")),
-        ),
+        differential_matrices=((("-1", "1", "0"), ("0", "-1", "1"), ("0", "0", "0")),),
     )
 
 
@@ -74,16 +71,12 @@ class TestVerifyDifferential:
 
 class TestComputeHomology:
     def test_circle_homology(self) -> None:
-        result = compute_homology(
-            ComputeHomologyRequest(complex=_circle_complex())
-        )
+        result = compute_homology(ComputeHomologyRequest(complex=_circle_complex()))
         assert result.homology_groups[0].betti_number == 1
         assert result.homology_groups[1].betti_number == 1
 
     def test_point_homology(self) -> None:
-        result = compute_homology(
-            ComputeHomologyRequest(complex=_point_complex())
-        )
+        result = compute_homology(ComputeHomologyRequest(complex=_point_complex()))
         assert result.homology_groups[0].betti_number == 1
 
 
@@ -100,7 +93,7 @@ class TestMappingCone:
     def test_mapping_cone_identity(self) -> None:
         circle = _circle_complex()
         identity_3x3 = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
-        identity = (identity_3x3,)
+        identity = (identity_3x3, identity_3x3)
         result = compute_mapping_cone(
             MappingConeRequest(
                 source=circle,
@@ -109,3 +102,174 @@ class TestMappingCone:
             )
         )
         assert result.cone_basis_sizes is not None
+
+
+class TestChainMapAdmission:
+    """Thread fixes: shapes, degree alignment, and defining equations are
+    validated at the request boundary."""
+
+    def _two_term(self, degree_min: int, differential: str) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=degree_min,
+            degree_max=degree_min + 1,
+            basis_sizes=(1, 1),
+            differential_matrices=(((differential,),),),
+        )
+
+    def test_padded_zero_map_is_rejected(self) -> None:
+        """A one-dimensional to two-dimensional map cannot silently pad."""
+        source = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        target = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=0,
+            basis_sizes=(2,),
+            differential_matrices=(),
+        )
+        with pytest.raises(ValueError, match="2x1"):
+            VerifyChainMapRequest(source=source, target=target, map_matrices=((),))
+        with pytest.raises(ValueError, match="2x1"):
+            MappingConeRequest(source=source, target=target, map_matrices=((),))
+
+    def test_oversized_matrix_is_rejected(self) -> None:
+        circle = _circle_complex()
+        oversized = (("1", "0", "0", "0"), ("0", "1", "0", "0"), ("0", "0", "1", "0"))
+        with pytest.raises(ValueError, match="3x3"):
+            VerifyChainMapRequest(
+                source=circle,
+                target=circle,
+                map_matrices=(oversized, oversized),
+            )
+
+    def test_mismatched_degree_intervals_are_rejected(self) -> None:
+        shifted = self._two_term(-1, "1")
+        circle = _circle_complex()
+        ones = (("1",),)
+        with pytest.raises(ValueError, match="same degree interval"):
+            VerifyChainMapRequest(
+                source=circle, target=shifted, map_matrices=(ones, ones)
+            )
+        with pytest.raises(ValueError, match="same degree interval"):
+            MappingConeRequest(source=circle, target=shifted, map_matrices=(ones, ones))
+
+    def test_incomplete_component_count_is_rejected(self) -> None:
+        circle = _circle_complex()
+        identity = (("1", "0", "0"), ("0", "1", "0"), ("0", "0", "1"))
+        with pytest.raises(ValueError, match="per chain degree"):
+            VerifyChainMapRequest(
+                source=circle, target=circle, map_matrices=(identity,)
+            )
+        with pytest.raises(ValueError, match="per chain degree"):
+            MappingConeRequest(source=circle, target=circle, map_matrices=(identity,))
+
+
+class TestMappingConeDefiningEquations:
+    """A cone is returned only for square-zero complexes and genuine chain maps."""
+
+    def _complex(self, differential: str) -> ChainComplexValue:
+        return ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=(((differential,),),),
+        )
+
+    def test_non_chain_map_cone_is_rejected(self) -> None:
+        """Source d=[1], target d=[0], f=[1]: the cone would not be a chain complex."""
+        source = self._complex("1")
+        target = self._complex("0")
+        one = (("1",),)
+        with pytest.raises(ValueError, match="commute"):
+            compute_mapping_cone(
+                MappingConeRequest(
+                    source=source, target=target, map_matrices=(one, one)
+                )
+            )
+
+    def test_non_square_zero_source_cone_is_rejected(self) -> None:
+        """A three-term complex violating d^2=0 is rejected before the cone."""
+        bad = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=2,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("1",),), (("1",),)),
+        )
+        one = (("1",),)
+        with pytest.raises(ValueError, match="d\\^2=0"):
+            compute_mapping_cone(
+                MappingConeRequest(source=bad, target=bad, map_matrices=(one, one, one))
+            )
+
+
+class TestTensorProductSignAndBudget:
+    def test_koszul_sign_uses_actual_chain_degree(self) -> None:
+        """A left factor concentrated in odd degree -1 negates id ⊗ d_D."""
+        left = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=-1,
+            degree_max=-1,
+            basis_sizes=(1,),
+            differential_matrices=(),
+        )
+        right = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(1, 1),
+            differential_matrices=((("1",),),),
+        )
+        result = compute_tensor_product(TensorProductRequest(left=left, right=right))
+        assert result.tensor_basis_sizes == (1, 1)
+        assert result.tensor_differential_matrices == ((("-1",),),)
+
+    def test_tensor_intermediate_dimensions_are_bounded(self) -> None:
+        """Two 64+64 factors meet the input cell limit but their middle
+        tensor group has dimension 8192; admission must reject it."""
+        zeros_row = tuple("0" for _ in range(64))
+        zeros = tuple(zeros_row for _ in range(64))
+        big = ChainComplexValue(
+            coefficient_field=CoefficientField.RATIONAL,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(64, 64),
+            differential_matrices=(zeros,),
+        )
+        with pytest.raises(ValueError, match="work bound"):
+            TensorProductRequest(left=big, right=big)
+
+
+class TestPrimeFieldEntries:
+    def test_fractional_prime_field_entry_rejected(self) -> None:
+        """GF_p entries must be integer residues; "1/2" cannot reach execution."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="integer residue"):
+            ChainComplexValue(
+                coefficient_field=CoefficientField.PRIME_FIELD,
+                prime=5,
+                degree_min=0,
+                degree_max=1,
+                basis_sizes=(1, 1),
+                differential_matrices=((("1/2",),),),
+            )
+
+    def test_integer_residues_accepted(self) -> None:
+        complex_value = ChainComplexValue(
+            coefficient_field=CoefficientField.PRIME_FIELD,
+            prime=5,
+            degree_min=0,
+            degree_max=1,
+            basis_sizes=(2, 2),
+            differential_matrices=((("4", "1"), ("2", "3")),),
+        )
+        result = verify_differential(VerifyDifferentialRequest(complex=complex_value))
+        assert result.is_valid

--- a/tests/math/chain_complexes/test_chain_complexes.py
+++ b/tests/math/chain_complexes/test_chain_complexes.py
@@ -72,6 +72,37 @@ class TestVerifyDifferential:
         assert result.is_valid
 
 
+class TestConstructAdmitsOnlyChainComplexes:
+    def test_non_square_zero_differentials_rejected_at_admission(self) -> None:
+        """Identity differentials on 1-dim groups compose to the identity,
+        not zero: the public construct operation must refuse them instead
+        of labelling arbitrary matrices an exact chain complex."""
+        with pytest.raises(ValidationError, match="d\^2 = 0"):
+            ConstructChainComplexRequest(
+                coefficient_field=CoefficientField.RATIONAL,
+                basis_sizes=(1, 1, 1),
+                differential_matrices=((("1",),), (("1",),)),
+            )
+
+    def test_square_zero_differentials_admitted(self) -> None:
+        from jacobian.math.chain_complexes.values import ChainComplexValue
+
+        request = ConstructChainComplexRequest(
+            coefficient_field=CoefficientField.RATIONAL,
+            basis_sizes=(1, 1, 1),
+            differential_matrices=((("0",),), (("0",),)),
+        )
+        value = ChainComplexValue(
+            coefficient_field=request.coefficient_field,
+            prime=request.prime,
+            degree_min=0,
+            degree_max=len(request.basis_sizes) - 1,
+            basis_sizes=request.basis_sizes,
+            differential_matrices=request.differential_matrices,
+        )
+        assert value.basis_sizes == (1, 1, 1)
+
+
 class TestComputeHomology:
     def test_circle_homology(self) -> None:
         result = compute_homology(ComputeHomologyRequest(complex=_circle_complex()))
@@ -1376,6 +1407,22 @@ class TestVerificationVerdictBinding:
         with pytest.raises(ValidationError, match="retain"):
             VerificationResult(is_valid=True, detail="d^2 = 0")
 
+    def test_contradictory_detail_rejected(self) -> None:
+        """The detail is authoritative: a square-zero point cannot carry
+        an explanation contradicting its replayed verdict."""
+        from jacobian.math.chain_complexes.values import VerificationResult
+
+        point = _point_complex()
+        with pytest.raises(ValidationError, match="exact explanation"):
+            VerificationResult(
+                is_valid=True,
+                detail="d^2 != 0",
+                complex=point,
+            )
+        genuine = verify_differential(VerifyDifferentialRequest(complex=point))
+        revalidated = VerificationResult.model_validate(genuine.model_dump())
+        assert revalidated.detail == "d^2 = 0 for all degrees"
+
     def test_true_verdict_retains_complex(self) -> None:
         """Successful differential verification retains its input."""
         result = verify_differential(
@@ -1464,7 +1511,7 @@ class TestVerificationReplayParentChecks:
         point = _point_complex()
         verdict = VerificationResult(
             is_valid=True,
-            detail="commutes",
+            detail="chain map commutes with differentials",
             source=point,
             target=point,
             map_matrices=((("1",),),),

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -64,6 +64,37 @@ def test_gf_p_chain_result_enters_homology_unchanged() -> None:
     ]
 
 
+def test_producer_result_carries_its_canonical_value() -> None:
+    """The public GF(p) producer exposes the canonical chain-complex
+    value on the serialized result boundary itself."""
+    from pydantic import ValidationError
+
+    result = _prime_field_chain(_circle(), 2)
+    assert result.canonical_value is not None
+    assert result.canonical_value == simplicial_chain_complex_value(result)
+    homology = compute_homology(ComputeHomologyRequest(complex=result.canonical_value))
+    assert [group.betti_number for group in homology.homology_groups] == [1, 1]
+
+    payload = result.model_dump()
+    payload["canonical_value"]["prime"] = 3
+    with pytest.raises(ValidationError, match="exact"):
+        type(result).model_validate(payload)
+
+
+def test_integral_producer_result_admits_no_canonical_value() -> None:
+    """Integral boundaries live over ZZ, so no canonical value exists."""
+    integral = _operation("topology.simplicial_complex.chain_complex.compute").run(
+        ChainComplexRequest(
+            complex=_circle(),
+            coefficient_ring=ChainCoefficientRing.INTEGER,
+            convention=HomologyConvention.UNREDUCED,
+        )
+    )
+    assert integral.canonical_value is None
+    with pytest.raises(ValueError, match="unreduced prime-field"):
+        simplicial_chain_complex_value(integral)
+
+
 def test_converted_profile_matches_topology_homology_producer() -> None:
     """The composed profile agrees with the topology domain's own exact
     homology of the same complex over the same field."""
@@ -126,37 +157,27 @@ def test_reduced_chains_carry_an_unrepresentable_augmentation() -> None:
             convention=HomologyConvention.REDUCED,
         )
     )
-    with pytest.raises(ValueError, match="augmentation"):
+    assert reduced.canonical_value is None
+    with pytest.raises(ValueError, match="unreduced prime-field"):
         simplicial_chain_complex_value(reduced)
 
 
 def test_oversized_simplicial_groups_stay_outside_the_canonical_domain() -> None:
-    """A producer result whose groups exceed the canonical value's bounds
-    is rejected explicitly instead of failing inside construction."""
-    from jacobian.math.topology._models import (
-        MAX_TOPOLOGY_CHAIN_GROUP,
-        SimplexBasis,
-        SparseBoundaryMatrix,
-    )
-    from jacobian.math.topology._models import HomologyConvention as Convention
+    """A GF(p) request whose groups exceed the canonical value's basis
+    bound is rejected at admission: every accepted producer result must
+    carry its canonical chain-complex value."""
+    from jacobian.math.chain_complexes.values import MAX_BASIS_SIZE
 
-    oversized = type(_prime_field_chain(_circle(), 2))(
-        complex_digest="sha256:" + "0" * 64,
-        coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
-        prime=2,
-        convention=Convention.UNREDUCED,
-        simplex_bases=(
-            SimplexBasis(dimension=0, simplices=(("a",),) * MAX_TOPOLOGY_CHAIN_GROUP),
-        ),
-        boundary_matrices=(
-            SparseBoundaryMatrix(
-                source_dimension=0,
-                target_dimension=-1,
-                rows=0,
-                columns=MAX_TOPOLOGY_CHAIN_GROUP,
-            ),
-        ),
-        boundary_squared_zero=(),
+    labels = tuple(f"v{i}" for i in range(12))
+    facets = tuple((labels[a], labels[b]) for a in range(12) for b in range(a + 1, 12))
+    assert len(facets) > MAX_BASIS_SIZE
+    big = _operation("topology.simplicial_complex.canonicalize").run(
+        SimplicialComplexRequest(vertices=labels, facets=facets)
     )
-    with pytest.raises(ValueError, match="basis bound"):
-        simplicial_chain_complex_value(oversized)
+    with pytest.raises(ValueError, match="faces per chain group"):
+        ChainComplexRequest(
+            complex=big.complex,
+            coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
+            prime=2,
+            convention=HomologyConvention.UNREDUCED,
+        )

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -181,3 +181,24 @@ def test_oversized_simplicial_groups_stay_outside_the_canonical_domain() -> None
             prime=2,
             convention=HomologyConvention.UNREDUCED,
         )
+
+
+def test_aggregate_canonical_cell_bound_is_enforced() -> None:
+    """Ten disjoint tetrahedra pass every per-boundary product but sum to
+    5,200 boundary cells; admission must reject the aggregate so the
+    producer never dies inside canonical value construction."""
+    vertices = tuple(f"v{i}" for i in range(40))
+    facets = tuple(tuple(f"v{4 * k + j}" for j in range(4)) for k in range(10))
+    complex_ = (
+        _operation("topology.simplicial_complex.canonicalize")
+        .run(SimplicialComplexRequest(vertices=vertices, facets=facets))
+        .complex
+    )
+    assert complex_.f_vector == (40, 60, 40, 10)
+    with pytest.raises(ValueError, match="aggregate boundary cells"):
+        ChainComplexRequest(
+            complex=complex_,
+            coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
+            prime=2,
+            convention=HomologyConvention.UNREDUCED,
+        )

--- a/tests/math/topology/test_native.py
+++ b/tests/math/topology/test_native.py
@@ -1,0 +1,162 @@
+"""Native topology surface: the simplicial chain producer composes with
+the canonical chain-complex consumers unchanged."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.models import MathTool
+from jacobian.math.chain_complexes._models import (
+    ComputeHomologyRequest,
+    TensorProductRequest,
+)
+from jacobian.math.chain_complexes.operations import (
+    compute_homology,
+    compute_tensor_product,
+)
+from jacobian.math.chain_complexes.values import CoefficientField
+from jacobian.math.topology._models import (
+    ChainCoefficientRing,
+    ChainComplexRequest,
+    HomologyConvention,
+    SimplicialComplexRequest,
+    SimplicialHomologyRequest,
+)
+from jacobian.math.topology._tools import TOOLS
+from jacobian.math.topology.native import simplicial_chain_complex_value
+
+
+def _operation(operation_id: str) -> MathTool:
+    return next(tool for tool in TOOLS if tool.operation_id == operation_id)
+
+
+def _circle() -> object:
+    request = SimplicialComplexRequest(
+        vertices=("a", "b", "c"),
+        facets=(("a", "b"), ("b", "c"), ("a", "c")),
+    )
+    return _operation("topology.simplicial_complex.canonicalize").run(request).complex
+
+
+def _prime_field_chain(complex_: object, prime: int):
+    return _operation("topology.simplicial_complex.chain_complex.compute").run(
+        ChainComplexRequest(
+            complex=complex_,
+            coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
+            prime=prime,
+            convention=HomologyConvention.UNREDUCED,
+        )
+    )
+
+
+def test_gf_p_chain_result_enters_homology_unchanged() -> None:
+    """A small GF(p) producer output passes through the consumer's typed
+    boundary without caller-side reconstruction."""
+    value = simplicial_chain_complex_value(_prime_field_chain(_circle(), 2))
+    assert value.coefficient_field is CoefficientField.PRIME_FIELD
+    assert value.prime == 2
+    assert value.basis_sizes == (3, 3)
+
+    result = compute_homology(ComputeHomologyRequest(complex=value))
+    assert [(group.degree, group.betti_number) for group in result.homology_groups] == [
+        (0, 1),
+        (1, 1),
+    ]
+
+
+def test_converted_profile_matches_topology_homology_producer() -> None:
+    """The composed profile agrees with the topology domain's own exact
+    homology of the same complex over the same field."""
+    complex_ = _circle()
+    value = simplicial_chain_complex_value(_prime_field_chain(complex_, 3))
+    composed = compute_homology(ComputeHomologyRequest(complex=value))
+    topology = _operation("topology.simplicial_homology.compute").run(
+        SimplicialHomologyRequest(complex=complex_, prime=3)
+    )
+    assert (
+        [group.betti_number for group in composed.homology_groups]
+        == [group.betti_number for group in topology.groups]
+        == [1, 1]
+    )
+
+
+def test_serialized_value_round_trips_into_consumers() -> None:
+    """The converted value survives serialization and keeps composing."""
+    from jacobian.math.chain_complexes.values import ChainComplexValue
+
+    payload = simplicial_chain_complex_value(_prime_field_chain(_circle(), 2))
+    value = ChainComplexValue.model_validate(payload.model_dump())
+    result = compute_homology(ComputeHomologyRequest(complex=value))
+    assert result.homology_groups[1].betti_number == 1
+    tensor = compute_tensor_product(TensorProductRequest(left=value, right=value))
+    assert tensor.value.basis_sizes == (9, 18, 9)
+
+
+def test_point_complex_degenerate_value_keeps_full_context() -> None:
+    request = SimplicialComplexRequest(vertices=("a",), facets=(("a",),))
+    complex_ = (
+        _operation("topology.simplicial_complex.canonicalize").run(request).complex
+    )
+    value = simplicial_chain_complex_value(_prime_field_chain(complex_, 5))
+    assert value.basis_sizes == (1,)
+    assert value.differential_matrices == ()
+    assert (value.degree_min, value.degree_max) == (0, 0)
+    result = compute_homology(ComputeHomologyRequest(complex=value))
+    assert result.homology_groups[0].betti_number == 1
+
+
+def test_integral_ring_is_outside_the_canonical_domain() -> None:
+    integral = _operation("topology.simplicial_complex.chain_complex.compute").run(
+        ChainComplexRequest(
+            complex=_circle(),
+            coefficient_ring=ChainCoefficientRing.INTEGER,
+            convention=HomologyConvention.UNREDUCED,
+        )
+    )
+    with pytest.raises(ValueError, match="prime-field"):
+        simplicial_chain_complex_value(integral)
+
+
+def test_reduced_chains_carry_an_unrepresentable_augmentation() -> None:
+    reduced = _operation("topology.simplicial_complex.chain_complex.compute").run(
+        ChainComplexRequest(
+            complex=_circle(),
+            coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
+            prime=2,
+            convention=HomologyConvention.REDUCED,
+        )
+    )
+    with pytest.raises(ValueError, match="augmentation"):
+        simplicial_chain_complex_value(reduced)
+
+
+def test_oversized_simplicial_groups_stay_outside_the_canonical_domain() -> None:
+    """A producer result whose groups exceed the canonical value's bounds
+    is rejected explicitly instead of failing inside construction."""
+    from jacobian.math.topology._models import (
+        MAX_TOPOLOGY_CHAIN_GROUP,
+        SimplexBasis,
+        SparseBoundaryMatrix,
+    )
+    from jacobian.math.topology._models import HomologyConvention as Convention
+
+    oversized = type(_prime_field_chain(_circle(), 2))(
+        complex_digest="sha256:" + "0" * 64,
+        coefficient_ring=ChainCoefficientRing.PRIME_FIELD,
+        prime=2,
+        convention=Convention.UNREDUCED,
+        simplex_bases=(
+            SimplexBasis(dimension=0, simplices=(("a",),) * MAX_TOPOLOGY_CHAIN_GROUP),
+        ),
+        boundary_matrices=(
+            SparseBoundaryMatrix(
+                source_dimension=0,
+                target_dimension=-1,
+                rows=0,
+                columns=MAX_TOPOLOGY_CHAIN_GROUP,
+            ),
+        ),
+        boundary_squared_zero=(),
+    )
+    with pytest.raises(ValueError, match="basis bound"):
+        simplicial_chain_complex_value(oversized)


### PR DESCRIPTION
## Summary

Add 6 exact operations for finite based chain complexes over exact fields, implementing the core homological algebra layer for Jacobian.

## New operations

| Operation | Description |
|---|---|
| `chain_complex.construct.compute` | Construct a bounded chain complex from differential matrices over QQ or GF(p) |
| `chain_complex.verify_differential.compute` | Verify that d^2 = 0 for a chain complex |
| `chain_complex.verify_chain_map.compute` | Verify that a chain map commutes with differentials |
| `chain_complex.homology.compute` | Compute homology groups (Betti numbers) via exact linear algebra |
| `chain_complex.mapping_cone.compute` | Compute the mapping cone of a chain map f: C → D |
| `chain_complex.tensor_product.compute` | Compute the tensor product (C ⊗ D)_n = ⊕_{i+j=n} C_i ⊗ D_j |

## Design choices

- **Exact rational arithmetic**: All computations use Python's . No floating point.
- **Bounded complexes**: Chain complexes are finite with bounded degree intervals and basis sizes.
- **Independent of topology**: These are general matrix-based chain complexes, not bound to simplicial complexes.
- **Verifiable**: The differential verification independently replays d^2 = 0. The homology computation uses Gaussian elimination over QQ.

## Testing

7 tests cover construction, d^2 verification, homology of circle (Betti 1,1) and point (Betti 1,0), tensor products, and mapping cones. All 34 catalog and chain complex tests pass.

Closes #1824

[Continue this on Linzumi](https://serve.linzumi.com/w/williamlin1327-workspace/thread/general/43b95243-5d01-4634-9139-f8fd635cec03)