### PR TITLE
docs(operations): define implementation selection and evidence plans

### DIFF
--- a/.github/ISSUE_TEMPLATE/math-operation.md
+++ b/.github/ISSUE_TEMPLATE/math-operation.md
@@ -28,7 +28,18 @@ assignees: []
 <!-- Public input, search, output, coefficient, dimension, and time budgets. -->
 
 ## Maintained implementation
-<!-- The backend or bounded native implementation supporting the claim. -->
+<!--
+Identify the implementation class:
+
+- maintained in-process Python backend;
+- thin native binding;
+- bounded Jacobian-owned kernel; or
+- child-process backend.
+
+Explain why its dependency and operational cost are proportionate to the
+admitted mathematical domain. List optional reference implementations
+separately; they are evidence, not runtime dependencies.
+-->
 
 ## Defining invariant
 <!--

--- a/.github/ISSUE_TEMPLATE/math-operation.md
+++ b/.github/ISSUE_TEMPLATE/math-operation.md
@@ -30,6 +30,34 @@ assignees: []
 ## Maintained implementation
 <!-- The backend or bounded native implementation supporting the claim. -->
 
+## Defining invariant
+<!--
+How can an independent validator tell that a returned object is mathematically
+valid? State the reconstruction equation, defining identity, or preservation
+law. Do not use "the backend returned it" as the invariant.
+
+Examples: a factorization reconstructs the input from its unit and factors; an
+inverse satisfies both matrix products; a decomposition satisfies its local
+rules and reconstructs the original object; a Groebner basis generates the
+same ideal and its relevant S-polynomials reduce to zero.
+-->
+
+## Evidence plan
+<!--
+Which tests will establish the invariant and catch plausible weaker or
+incorrect implementations? Include the applicable evidence:
+
+- a known-answer or source-backed reference fixture when conventions matter;
+- boundary, degenerate, and adversarial cases;
+- reconstruction, defining-identity, or preservation tests;
+- a bounded exhaustive check or independent differential oracle when
+  proportionate.
+
+For non-unique results, state the mathematical equivalence to compare instead
+of requiring incidental ordering, temporary identifiers, or a particular
+witness.
+-->
+
 ## Why this is not caller-side composition
 <!-- Which indispensable mathematical postcondition is not already available? -->
 

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -67,6 +67,34 @@ directly. `smt.solve` accepts one bounded QF SMT-LIB query. `lean.check` accepts
 one bounded source snippet and returns elaboration diagnostics after a one-shot
 process invocation.
 
+## Implementation selection
+
+Choose the smallest operational surface that can establish the admitted
+mathematical postcondition within its public bounds. Assess implementation
+options in this order:
+
+1. Use a maintained in-process Python backend when it supports the complete
+   bounded claim.
+2. Use a thin native binding when its build, packaging, platform, and runtime
+   costs are proportionate to the admitted domain.
+3. Use a Jacobian-owned bounded implementation when no lightweight maintained
+   backend fits, the admitted bounds make a simpler published algorithm
+   practical, the result has a complete reconstruction or defining invariant,
+   and ordinary repository tests can establish correctness independently. A
+   mature external implementation may provide additional differential evidence.
+4. Use a child process only for a concrete isolation, killability, or fixed
+   toolchain reason, with the complete process-boundary obligations described in
+   the [mathematical backend contract](mathematical-backends.md).
+5. Narrow or reject the operation when none of these options can support its
+   public claim and work bounds.
+
+Preferring maintained backends does not require importing an entire
+cross-language ecosystem when its build, ABI, installation, runtime, or failure
+surface is disproportionate to the bounded mathematical kernel Jacobian needs.
+The issue or pull request must record why the selected implementation class is
+proportionate; backend convenience alone does not justify a broader public
+contract.
+
 ## Operation preflight
 
 First diagnose the gap: a missing operation is only one of several possible

--- a/docs/reference/mathematical-backends.md
+++ b/docs/reference/mathematical-backends.md
@@ -50,6 +50,21 @@ Child processes use the shared bounded-process supervisor. Backend adapters test
 their codec and outcome projection; the supervisor's owning tests prove
 process-group termination and descendant cleanup.
 
+## External reference oracles
+
+A mathematical implementation used only to compare results during development
+is a differential oracle, not necessarily a Jacobian runtime backend. Heavy or
+native software may remain outside the ordinary installation and required CI
+environment when its installation or runtime cost is disproportionate to the
+bounded operation under test.
+
+Required correctness evidence must remain deterministic and runnable without
+the optional oracle. For a non-unique result, define a canonical normalization
+or mathematical equivalence before comparing implementations; incidental
+ordering, rooting, identifiers, or witness choice are not disagreements.
+Agreement with an oracle supplements but never replaces Jacobian's independent
+reconstruction or defining-invariant validation.
+
 ## Singular
 
 The commutative-algebra domain uses Singular as a private child-process backend
@@ -58,8 +73,7 @@ polynomial ring, collision-proof internal identifiers, a fixed ordering, and a
 strict result encoding. Singular does not define the public request or result
 types.
 
-SageMath is useful during development as an independent differential oracle
-for Singular-backed algorithms. It is not a Jacobian runtime dependency or a
-required CI environment. Required mathematical evidence belongs in bounded,
-repository-owned property tests so that it remains deterministic and locally
-reproducible.
+SageMath is the current development-time differential oracle for selected
+Singular-backed algorithms. It is not a Jacobian runtime dependency or a
+required CI environment; the Singular adapter and bounded repository-owned
+property tests carry the required evidence.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -74,8 +74,8 @@ Before implementing an exact decomposition, certificate, or authoritative
 derived value, state its defining invariant: the reconstruction equation,
 preservation law, or independently checkable property that makes a returned
 value mathematically valid. Then name the smallest set of tests that establishes
-that invariant and distinguishes the intended algorithm from plausible weaker
-ones.
+that invariant and rejects plausible results that satisfy only a weaker
+mathematical claim.
 
 Use a source-backed reference fixture when a standard example helps fix
 terminology, normalization, or another convention-sensitive output. Cite the

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -68,6 +68,27 @@ independent bounded oracle. A factorization needs reconstruction, retained
 unit, and positive-multiplicity properties. Known answers remain useful
 regressions, but they do not replace these defining properties.
 
+### Evidence plans for exact operations
+
+Before implementing an exact decomposition, certificate, or authoritative
+derived value, state its defining invariant: the reconstruction equation,
+preservation law, or independently checkable property that makes a returned
+value mathematically valid. Then name the smallest set of tests that establishes
+that invariant and distinguishes the intended algorithm from plausible weaker
+ones.
+
+Use a source-backed reference fixture when a standard example helps fix
+terminology, normalization, or another convention-sensitive output. Cite the
+specific theorem or example and record the convention the fixture depends on.
+Pair that fixture with the relevant boundary and adversarial cases and with a
+reconstruction, defining-identity, bounded exhaustive, or independent-oracle
+test. A reference fixture is an anchor, not the correctness argument.
+
+When a valid result is not unique, compare its mathematical equivalence class
+or validate its reconstruction. Do not require incidental backend ordering,
+temporary identifiers, tree roots, or one particular witness unless the public
+contract makes that choice canonical.
+
 `lean.check` is the retained external process boundary. Its tests cover request
 bounds, process cleanup, timeout/error projection, and typed diagnostics.
 


### PR DESCRIPTION
## Problem

Operation proposals describe their postcondition and bounds, but the documentation does not give maintainers a proportionate way to choose between a Python backend, native binding, bounded Jacobian-owned kernel, or child process. It also treats development-time differential oracles mainly as a Sage-specific exception and does not ask proposals how exact results will be independently validated.

Without that guidance, “prefer maintained backends” can be read as requiring a large integration even when Jacobian admits a much smaller bounded mathematical domain. Conversely, a custom implementation can be proposed without explaining its reconstruction invariant or evidence.

## Solution

Define an implementation-selection ladder that prefers maintained in-process backends while allowing a bounded Jacobian-owned implementation when no lightweight backend fits, a published algorithm is practical under the admitted bounds, and independent correctness evidence is available. Native bindings and child processes require proportionate operational reasons; unsupported claims must be narrowed or rejected.

Generalize the backend reference to distinguish optional differential oracles from runtime backends. Required evidence remains repository-owned and runnable without the oracle, and non-unique outputs are normalized by mathematical equivalence before comparison.

Expand the mathematical-operation issue template to request:

- the implementation class and proportionality rationale;
- a reconstruction equation, defining identity, or preservation law; and
- an evidence plan covering applicable reference fixtures, boundary and adversarial cases, defining properties, and independent or exhaustive checks.

Clarify that tests target the public mathematical semantics rather than a particular private algorithm. Source-backed examples anchor conventions but do not replace defining-invariant evidence.

## Testing

- `git diff --check` — passed
- `make docs-linkcheck` — passed on the final documentation tree
- `make check` — Ruff, mypy, and 2,337 tests passed
- Specialist validation run: none; this changes documentation and an issue template only

## Public contract impact

None. This does not change operation IDs, schemas, native APIs, MCP contracts, or mathematical semantics.

## Public operation admission

Not applicable; no public operation is added or changed.

## Closure matrix

None.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not present
- [x] Public operation changes are not present
- [x] Result semantics are unchanged
- [x] No shared production abstraction is introduced