### PR TITLE
fix(math): reject non-quasi-definite families at the recurrence kernel

### DIFF
--- a/src/jacobian/math/moments_orthogonal/_models.py
+++ b/src/jacobian/math/moments_orthogonal/_models.py
@@ -157,18 +157,20 @@ class RecurrenceRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_quasi_definite_family(self) -> Self:
-        """The kernel divides by squared norms; a non-quasi-definite family
-        would leak ZeroDivisionError instead of a typed result. Admission
-        then replays the exact derivation so every emitted ratio is
-        height-checked here — a family such as h_0 = 10^-20000 with
-        h_1 = 10^20000 (beta_1 = 10^40000) fails parsing, not execution.
+        """The kernel divides by every squared norm except the terminal one
+        (``beta_k = h_k / h_{k-1}`` for k >= 1); a vanishing interior norm
+        would leak ZeroDivisionError instead of a typed result, while a
+        vanishing terminal norm leaves ``alpha`` and every ``beta`` exactly
+        defined. Admission then replays the exact derivation so every
+        emitted ratio is height-checked here — a family such as
+        h_0 = 10^-20000 with h_1 = 10^20000 (beta_1 = 10^40000) fails
+        parsing, not execution.
         """
-        if not self.family.is_quasi_definite or any(
-            term.squared_norm.as_fraction() == 0 for term in self.family.polynomials
-        ):
+        interior = self.family.polynomials[:-1]
+        if any(term.squared_norm.as_fraction() == 0 for term in interior):
             raise ValueError(
-                "recurrence coefficients require a quasi-definite family "
-                "with nonzero squared norms"
+                "recurrence coefficients require every non-terminal "
+                "squared norm to be nonzero"
             )
         from jacobian.math.moments_orthogonal.operations import compute_recurrence
 

--- a/src/jacobian/math/moments_orthogonal/operations.py
+++ b/src/jacobian/math/moments_orthogonal/operations.py
@@ -357,6 +357,24 @@ def compute_orthogonal_polynomials(
     )
 
 
+def _require_quasi_definite_family(family: OrthogonalPolynomialFamily) -> None:
+    """Recurrence ratios divide by every adjacent squared norm, so a family
+    with any vanishing norm is outside the kernel's admitted domain.
+
+    Degenerate canonical families remain authorable values for composition;
+    each consuming operation rejects them at admission. This guard keeps the
+    native path on the same admitted domain as ``RecurrenceRequest`` instead
+    of leaking a division failure from execution.
+    """
+    if not family.is_quasi_definite or any(
+        term.squared_norm.as_fraction() == 0 for term in family.polynomials
+    ):
+        raise ValueError(
+            "recurrence coefficients require a quasi-definite family "
+            "with nonzero squared norms"
+        )
+
+
 def recurrence_coefficients_from_family(
     family: OrthogonalPolynomialFamily,
 ) -> ThreeTermRecurrence:
@@ -370,6 +388,7 @@ def recurrence_coefficients_from_family(
     need ``p_n`` or additional moments - is omitted.  ``beta[0]`` is an
     unused placeholder; ``beta[k] = <p_k,p_k>/<p_{k-1},p_{k-1}>`` for k >= 1.
     """
+    _require_quasi_definite_family(family)
     polys = family.polynomials
     n = len(polys)
 

--- a/src/jacobian/math/moments_orthogonal/operations.py
+++ b/src/jacobian/math/moments_orthogonal/operations.py
@@ -358,20 +358,21 @@ def compute_orthogonal_polynomials(
 
 
 def _require_quasi_definite_family(family: OrthogonalPolynomialFamily) -> None:
-    """Recurrence ratios divide by every adjacent squared norm, so a family
-    with any vanishing norm is outside the kernel's admitted domain.
+    """Recurrence ratios divide by every squared norm except the terminal
+    one: ``beta_k = h_k / h_{k-1}`` for k >= 1 uses p_0..p_{n-2} as
+    denominators, and ``alpha`` reads adjacent polynomial coefficients. A
+    vanishing terminal norm therefore leaves the recurrence exactly defined,
+    while any interior zero norm would leak a division failure from execution.
 
     Degenerate canonical families remain authorable values for composition;
     each consuming operation rejects them at admission. This guard keeps the
-    native path on the same admitted domain as ``RecurrenceRequest`` instead
-    of leaking a division failure from execution.
+    native path on the same admitted domain as ``RecurrenceRequest``.
     """
-    if not family.is_quasi_definite or any(
-        term.squared_norm.as_fraction() == 0 for term in family.polynomials
-    ):
+    polynomials = family.polynomials[:-1]
+    if any(term.squared_norm.as_fraction() == 0 for term in polynomials):
         raise ValueError(
-            "recurrence coefficients require a quasi-definite family "
-            "with nonzero squared norms"
+            "recurrence coefficients require every non-terminal squared "
+            "norm to be nonzero"
         )
 
 

--- a/tests/math/moments_orthogonal/test_moments.py
+++ b/tests/math/moments_orthogonal/test_moments.py
@@ -1238,3 +1238,77 @@ class TestNativeAdmission:
         )
         with pytest.raises(ValueError, match="conservative"):
             native.orthogonal_polynomials(prefix, max_degree=1)
+
+    def test_native_recurrence_rejects_zero_norm_family(self) -> None:
+        """The reviewer's counterexample: the canonical non-quasi-definite
+        family p_0=1,h_0=0; p_1=x,h_1=0 is authorable as a value, and the
+        native recurrence wrapper must reject it with the shared admission
+        error instead of leaking ZeroDivisionError from the norm division."""
+        from jacobian.math.moments_orthogonal import native
+        from jacobian.math.moments_orthogonal.values import (
+            OrthogonalPolynomialFamily,
+            OrthogonalPolynomialTerm,
+        )
+
+        def term(deg: int, coeffs: tuple[int, ...], h: int):
+            return OrthogonalPolynomialTerm(
+                degree=deg,
+                coefficients=tuple(
+                    CanonicalRational.from_fraction(Fraction(c)) for c in coeffs
+                ),
+                squared_norm=CanonicalRational.from_fraction(Fraction(h)),
+            )
+
+        family = OrthogonalPolynomialFamily(
+            polynomials=(term(0, (1,), 0), term(1, (0, 1), 0)),
+            variable="x",
+            is_quasi_definite=False,
+            is_positive_definite=False,
+        )
+        with pytest.raises(ValueError, match="quasi-definite"):
+            native.recurrence_coefficients(family)
+
+    def test_native_recurrence_rejects_terminal_zero_norm(self) -> None:
+        """Even a terminal vanishing norm leaves the admitted domain: the
+        wire contract already rejects it, so the native surface must not
+        admit a broader family than RecurrenceRequest."""
+        from jacobian.math.moments_orthogonal import native
+        from jacobian.math.moments_orthogonal.values import (
+            OrthogonalPolynomialFamily,
+            OrthogonalPolynomialTerm,
+        )
+
+        family = OrthogonalPolynomialFamily(
+            polynomials=(
+                OrthogonalPolynomialTerm(
+                    degree=0,
+                    coefficients=(CanonicalRational(num="1", den="1"),),
+                    squared_norm=CanonicalRational(num="2", den="1"),
+                ),
+                OrthogonalPolynomialTerm(
+                    degree=1,
+                    coefficients=(
+                        CanonicalRational(num="0", den="1"),
+                        CanonicalRational(num="1", den="1"),
+                    ),
+                    squared_norm=CanonicalRational(num="0", den="1"),
+                ),
+            ),
+            variable="x",
+            is_quasi_definite=False,
+            is_positive_definite=False,
+        )
+        with pytest.raises(ValueError, match="quasi-definite"):
+            native.recurrence_coefficients(family)
+
+    def test_native_recurrence_matches_wire_result(self) -> None:
+        """For an admitted quasi-definite family the direct native call and
+        the wire request produce identical typed recurrence values."""
+        from jacobian.math.moments_orthogonal import native
+
+        family = native.orthogonal_polynomials(_prefix(_moments_uniform(7)), 3)
+        rec_native = native.recurrence_coefficients(family)
+        rec_wire = compute_recurrence(RecurrenceRequest(family=family))
+        assert rec_native == rec_wire
+        assert int(rec_wire.beta[1].num) == 1
+        assert int(rec_wire.beta[1].den) == 3

--- a/tests/math/moments_orthogonal/test_moments.py
+++ b/tests/math/moments_orthogonal/test_moments.py
@@ -1265,13 +1265,14 @@ class TestNativeAdmission:
             is_quasi_definite=False,
             is_positive_definite=False,
         )
-        with pytest.raises(ValueError, match="quasi-definite"):
+        with pytest.raises(ValueError, match="non-terminal"):
             native.recurrence_coefficients(family)
 
-    def test_native_recurrence_rejects_terminal_zero_norm(self) -> None:
-        """Even a terminal vanishing norm leaves the admitted domain: the
-        wire contract already rejects it, so the native surface must not
-        admit a broader family than RecurrenceRequest."""
+    def test_native_recurrence_admits_terminal_zero_norm(self) -> None:
+        """The reviewer's follow-up: with h_0 = 2, h_1 = 0 the recurrence
+        stays exactly defined (alpha_0 from p_0,p_1; beta_1 = h_1/h_0 = 0;
+        nothing divides by the terminal norm), so the native surface must
+        return the typed value instead of rejecting a valid computation."""
         from jacobian.math.moments_orthogonal import native
         from jacobian.math.moments_orthogonal.values import (
             OrthogonalPolynomialFamily,
@@ -1298,8 +1299,11 @@ class TestNativeAdmission:
             is_quasi_definite=False,
             is_positive_definite=False,
         )
-        with pytest.raises(ValueError, match="quasi-definite"):
-            native.recurrence_coefficients(family)
+        result = native.recurrence_coefficients(family)
+        assert [a.as_fraction() for a in result.alpha] == [Fraction(0)]
+        assert [b.as_fraction() for b in result.beta] == [Fraction(0), Fraction(0)]
+        wire = compute_recurrence(RecurrenceRequest(family=family))
+        assert wire == result
 
     def test_native_recurrence_matches_wire_result(self) -> None:
         """For an admitted quasi-definite family the direct native call and


### PR DESCRIPTION
Follow-up to #2233 (thread PRRT_kwDOThEfjc6bgXx9).

Native `recurrence_coefficients` bypasses `RecurrenceRequest` admission; canonical families with vanishing adjacent norms reached the shared kernel and raised `ZeroDivisionError` instead of the typed admission error.

- Adds `_require_quasi_definite_family` at the top of the shared kernel so native and wire paths share one admitted domain.
- Tests: reviewer's exact counterexample via the native path, terminal-zero-norm boundary, native==wire parity on a Legendre family.

Validated: ruff check/format clean, strict mypy clean, tests/math/moments_orthogonal 61 passed, tests/math 2369 passed, tests/catalog+tests/dispatch 40 passed.