### PR TITLE
docs(operations): clarify how mathematical techniques become operations

### DIFF
--- a/.agents/skills/decompose-mathematical-solution-corpora/SKILL.md
+++ b/.agents/skills/decompose-mathematical-solution-corpora/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: decompose-mathematical-solution-corpora
+description: Decompose a bounded corpus of mathematical proofs, formalizations, scripts, and certificates into recurring solution techniques and the smallest reusable Jacobian postconditions. Use for repository- or corpus-level “what can Jacobian learn?” audits; do not use for one operation contract or one agent trajectory.
+---
+
+# Decompose Mathematical Solution Corpora
+
+Extract reusable mathematical moves from a bounded solution corpus without
+turning the result into a file-by-file summary or a catalog of theorem wrappers.
+The unit of analysis is a method family: a recurring local mathematical move,
+its exact carrier, and the global reasoning that lifts it into a proof.
+
+Use `audit-mathematical-vocabulary` for one bounded mathematical slice,
+`learn-from-math-agent-trajectories` for one completed or paused investigation,
+and `audit-public-operation-contracts` when a specific operation needs a deep
+contract review. This skill owns the repository- or corpus-level decomposition
+that precedes those focused audits.
+
+## Freeze the scope
+
+Record the immutable revision of every source repository and the Jacobian
+revision and catalog used for comparison. Define the included directories,
+campaigns, or certificate families and any exclusions. Do not claim corpus
+closure from a partial clone, truncated artifact, generated summary, or
+unreadable dependency.
+
+Inventory artifact types before reading deeply: papers and notes, Lean or other
+formal developments, exact Python or native programs, numerical experiments,
+solver encodings and proofs, prompts and trajectories, certificate bundles,
+test fixtures, and replay or publication metadata. Use the inventory to find
+method families, not to produce a chronological summary of every file.
+
+## Group by solution technique
+
+Cluster sources by mathematical move rather than conjecture name or language.
+Examples include exact finite enumeration, dynamic programming, local-lemma
+witnesses, linear or semidefinite duality, algebraic elimination, interval
+enclosure, canonicalization, dependent rounding, coding-theoretic profiles,
+and finite-state transfer arguments.
+
+Select representative sources from each family. Prefer sources that expose the
+local move, exact hypotheses, boundary behavior, and an independently replayable
+fixture. Continue sampling within a family until another representative no
+longer reveals a new carrier, postcondition, representation regime, or failure
+mode.
+
+## Decompose each representative
+
+Write a compact method record:
+
+```text
+target theorem:
+exact finite carrier:
+local mathematical move:
+theorem-specific lift:
+source representation:
+established technique:
+stable reusable postcondition:
+discovery vocabulary:
+technique disposition:
+evidence and fixture:
+```
+
+The local move is not automatically an operation. Reject boundaries that
+merely expose one loop iteration, solver control, callback, proof bookkeeping,
+or temporary data structure. Also reject the opposite boundary when it bundles
+the motivating theorem, search strategy, interpretation, and stopping rule.
+Look for one postcondition that remains meaningful if the surrounding paper or
+conjecture disappears.
+
+Classify an established technique as a public-operation candidate, native-only
+function, private kernel, invariant or fixture, or caller reasoning. Technique
+names may be discovery vocabulary for a public operation without becoming
+separate operation IDs. Require an independently consumable postcondition
+before making an intermediate technique separately runnable.
+
+Treat representation as mathematical execution evidence. State whether the
+carrier is materialized, succinct, generated, or oracle-backed; what expansion
+the implementation performs; whether that expansion is predictable before
+execution; and whether a compact representation changes the complexity class
+or output obligation.
+
+## Research the method
+
+Trace the local move to primary literature or an authoritative formal/library
+source. Verify the exact hypotheses, conclusion, conventions, algorithmic
+regime, and representation-sensitive complexity. Distinguish neighboring
+methods that share vocabulary but prove different guarantees. Use secondary
+surveys only to discover sources or terminology, then verify the conclusion
+against the primary source.
+
+Research maintained exact backends and standard algorithms in proportion to
+the candidate. The question is whether a bounded, typed Jacobian contract is
+feasible—not whether the corpus's handwritten implementation should be copied.
+Record uncertainty when the literature supports the theorem but not an
+admissible exact kernel at the required scale.
+
+## Compare with Jacobian
+
+Inspect the current catalog, native API, canonical values, request and result
+models, tests, admission decisions, and narrowly related issues. Attempt the
+smallest exact composition before declaring a gap. A manual coordinate change,
+cheap projection, or theorem-specific assembly normally remains caller work;
+incompatible values, detached certificates, or hidden expansion may instead
+identify an interoperability or contract problem.
+
+Give every method family one disposition:
+
+- existing operation or exact composition;
+- representation or interoperability repair;
+- discovery repair;
+- request/result contract repair;
+- scale or backend improvement;
+- new bounded operation candidate;
+- defining, convention, adversarial, metamorphic, producer-consumer, or stress
+  fixture;
+- reasoning, theorem-specific workflow, or certificate infrastructure; or
+- no supported Jacobian action.
+
+For operation candidates, state the semantic domain, stable postcondition,
+source representation, controlling work and output quantities, reconstruction
+or defining invariant, typed incomplete states, and at least one discriminating
+fixture. Separate the existence of a reusable gap from public-catalog admission.
+
+## Route actions without overclaiming
+
+Verify issue ownership narrowly before proposing a new issue. Reinforce the
+canonical owner when the operation, contract, or scale question is already in
+scope. Keep distinct semantics separate even when they share a backend. Do not
+file, comment, edit external systems, or make repository changes without user
+authorization.
+
+Prefer compact in-thread findings and focused repository actions. Do not create
+large durable reports, copied source archives, or generated inventories unless
+the user requests them. Preserve only the small fixtures and evidence needed to
+replay a conclusion.
+
+## Establish closure
+
+Stop when every inventoried method family has a disposition, every proposed
+operation has been compared with exact current composition and issue ownership,
+and additional representative sources yield no new local move, representation
+regime, postcondition, or fixture role. Report the frozen revisions, coverage,
+important exclusions, and unresolved uncertainties. “No gaps remain” means no
+unclassified reusable move within that declared scope, not that the corpus or
+mathematical literature contains nothing else.
+
+Lead the final result with a compact technique-to-disposition matrix, followed
+by the few highest-value operation, contract, scale, and fixture actions. Keep
+the proof workflow separate from the atomic mathematical move throughout.

--- a/.agents/skills/learn-from-math-agent-trajectories/SKILL.md
+++ b/.agents/skills/learn-from-math-agent-trajectories/SKILL.md
@@ -127,6 +127,27 @@ searches or websites. Verify precise hypotheses and dates against primary
 sources. Mark discussion-thread claims, preprints, peer-reviewed results, and
 agent conjectures distinctly.
 
+When a trajectory embeds useful mathematics inside a specialized proof,
+record the method boundary before classifying it:
+
+```text
+mathematical goal:
+local exact move:
+global proof lift:
+source representation:
+stable reusable postcondition:
+literature identity:
+Jacobian disposition:
+```
+
+This record prevents opposite errors: promoting the whole proof workflow into
+one operation, or dismissing a stable operation because its implementation
+appears inside a theorem-specific script. For example, one nullspace update is
+usually too low-level and an entire allocation theorem is too high-level;
+exact rounding that preserves named rows and bounds the monitored-column error
+can be the reusable boundary. Base every field on observable artifacts and
+primary sources rather than inferred hidden reasoning.
+
 ## Attribute the lesson
 
 Classify each important event as one of:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ larger solutions.
 Atomicity is semantic: an operation establishes one stable, reusable
 mathematical postcondition. It need not have a small or simple implementation.
 
+Established mathematical techniques are sources of executable vocabulary, not
+automatic operation IDs. Make a technique discoverable through relevant public
+operations, but admit it separately only when it establishes a distinct stable
+postcondition. Alternative algorithms for the same postcondition remain private
+kernel choices.
+
 It exposes two MCP tools:
 
 | Agent verb | MCP tool | Meaning |

--- a/docs/explanation/executable-mathematical-vocabulary.md
+++ b/docs/explanation/executable-mathematical-vocabulary.md
@@ -52,6 +52,51 @@ Examples:
 Algorithmic complexity is not the test. A sophisticated algorithm may implement
 one atomic operation, while a tiny helper may still be an implementation detail.
 
+### Locate the reusable boundary inside a proof
+
+A specialized proof often contains useful mathematics at several scales. The
+right operation is neither automatically the smallest line of code nor the
+whole theorem workflow.
+
+| Proof fragment | Disposition | Boundary lesson |
+| --- | --- | --- |
+| One floating nullspace step | Too low-level | It exposes an algorithmic move without the preservation and error guarantee callers need. |
+| Hard-constraint rounding | Atomic candidate | Preserving specified linear equations while making bounded progress on fractional coordinates is a stable postcondition; the entire allocation proof remains caller reasoning. |
+| Total variation of materialized finite tables | Atomic candidate | The source and linear comparison work are explicit. Accepting succinct product distributions is a materially broader contract because their support expansion can be exponential and the compact problem can have different complexity. |
+| Weak-design construction | Atomic candidate | A bounded design with stated overlap parameters is reusable; extractor reconstruction and the entropy contradiction are the global proof lift. |
+| Factorial insertion for an arbitrary callback | Reasoning | The identity belongs in a theorem or caller derivation rather than an operation whose behavior is defined by executable caller code. |
+
+State the source representation as part of this boundary. Materialized,
+succinct, generated, and oracle-backed inputs can denote related objects while
+requiring different admission proofs, algorithms, and result bounds.
+
+### Techniques, functions, and operations
+
+An established technique is evidence for executable vocabulary, not an
+automatic public operation. Classify the mathematical result it establishes
+before deciding how Jacobian should expose it:
+
+| Technique role | Jacobian disposition |
+| --- | --- |
+| Computes an independently useful bounded result | Public-operation candidate |
+| Useful exact helper without sufficient catalog leverage | Native-only function |
+| Alternative algorithm for an existing result | Private kernel |
+| Defines or reconstructs an operation's result | Invariant and fixture |
+| Organizes several moves into a proof | Caller reasoning |
+
+Make established terminology searchable through the relevant public operation,
+even when the technique remains its private kernel. Admit a separate operation
+only when the technique returns a distinct reusable result, witness,
+decomposition, or certificate. Multiple algorithms for the same mathematical
+input, output, and defining relation belong behind one canonical operation.
+
+For example, suppose `ramanujan_sum.compute(q, n)` is admitted to return the
+exact integer $c_q(n)$. “Divisor–Möbius formula” should be searchable
+terminology for that operation. A general Möbius transform may be separately
+runnable because it has a different postcondition. A duplicate
+`ramanujan_sum_via_mobius.compute` should not exist when it merely returns the
+same scalar through another algorithm.
+
 ## Discover vocabulary gaps from mathematical work
 
 Grow the vocabulary from observed composition failures rather than from a

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -113,6 +113,10 @@ applicable` with a reason; it must not be omitted.
 
 - Semantic mathematical domain and postcondition:
 - Canonical public value type:
+- Source representation: materialized, succinct, generated, or oracle-backed:
+- Expansion performed by the kernel and its pre-execution bound:
+- Representation-sensitive complexity, including any compact representation
+  that changes the algorithmic problem:
 - Admitted request envelope and its controlling quantities:
 - Producer/consumer closure, or why not applicable:
 - Degenerate inputs:
@@ -308,6 +312,35 @@ too large. If a bound is conservative, name the quantity it bounds, state why
 it is safe for the algorithm, and test both the rejected adversarial case and a
 useful case near the boundary. Do not use a post-hoc output-term cap,
 truncation, sentinel, or host exception as a hidden computational budget.
+
+### Representation-sensitive expansion
+
+Representation is part of the execution envelope, even when two encodings
+denote the same kind of mathematical object. Complete the following review
+before selecting the kernel or request bounds:
+
+- Is the input materialized, succinct, generated, or oracle-backed?
+- What expansion does the kernel perform?
+- Can admission bound that expansion before execution?
+- Does an apparently equivalent compact representation change the complexity
+  class or output obligation?
+
+Name the accepted representation in the public contract and derive every
+expansion budget from its canonical fields. Do not admit a compact value and
+discover only inside the backend that it expands into too many states, terms,
+assignments, or support points. Generated and oracle-backed inputs need the
+same finite, deterministic source and work contract as materialized inputs; if
+that contract cannot be stated and validated before execution, narrow or
+reject the representation.
+
+For example, exact total variation between two materialized finite tables is a
+linear pass over their aligned support. Accepting succinct product
+distributions is not merely a wire-format convenience: expanding their joint
+support can be exponential, and computing the same invariant from the compact
+representation can be a materially harder problem. Those representations
+therefore need separate admission evidence and may require different
+operations or result semantics even though the mathematical formula is the
+same.
 
 ### Choose the controlling quantity
 

--- a/docs/reference/public-operation-admission.md
+++ b/docs/reference/public-operation-admission.md
@@ -46,18 +46,24 @@ applies. Before adopting a small fixed input cap, complete this review:
    factored, modular, symbolic, or implicit values before requiring an expanded
    result, and separate decision, first-witness, and complete-profile contracts
    when their output obligations differ.
-3. Research a maintained specialist backend before writing a custom kernel or
+3. State whether the accepted source is materialized, succinct, generated, or
+   oracle-backed. Identify every expansion the kernel performs, prove that
+   admission can bound it before execution, and check whether an apparently
+   equivalent compact representation changes the complexity class or output
+   obligation. Representation is part of the admitted domain, not an adapter
+   detail.
+4. Research a maintained specialist backend before writing a custom kernel or
    retaining a restrictive pure-Python path. FLINT, GMP, and Arb are relevant
    examples for exact integer, polynomial, matrix, and rigorous ball
    computation; they are not mandatory when another maintained backend better
    fits the operation.
-4. Define preflight admission from the selected algorithm's work,
+5. Define preflight admission from the selected algorithm's work,
    intermediate, memory, and result bounds. Large scalar inputs should remain
    admissible when those derived quantities and the returned value are small.
-5. Document any remaining fixed ceiling as a conservative fallback. State
+6. Document any remaining fixed ceiling as a conservative fallback. State
    whether it is a mathematical, representation, backend, or currently
    uninvestigated limit, and identify the evidence needed to raise it.
-6. Test accepted and rejected boundaries, algorithm or representation
+7. Test accepted and rejected boundaries, algorithm or representation
    crossover points, and realistic source-backed cases. Use defining
    invariants or an independent oracle to show that every selected regime has
    the same public semantics.
@@ -90,6 +96,15 @@ A public operation must satisfy every gate:
    or frozen research workflow.
 9. It has a distinct discovery intent and does not create a near-duplicate
    result that degrades retrieval.
+10. Its admitted representation does not hide an unbounded expansion or a
+    materially different computational problem. The request and preflight name
+    and bound any expansion before execution.
+
+A named technique does not justify a second operation when it has the same
+mathematical input, output, and defining relation as an existing operation.
+Record the technique as discovery vocabulary or a private kernel. Require a
+distinct reusable result, witness, decomposition, or certificate for separate
+admission.
 
 Passing schema validation, having tests, or wrapping a maintained library does
 not by itself satisfy these gates.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -77,6 +77,27 @@ value mathematically valid. Then name the smallest set of tests that establishes
 that invariant and rejects plausible results that satisfy only a weaker
 mathematical claim.
 
+Classify each fixture by the evidence it contributes:
+
+| Fixture role | What it establishes |
+| --- | --- |
+| Defining-invariant | Replays the reconstruction equation, preservation law, or certificate relation owned by the result. |
+| Convention/known-answer | Fixes terminology, normalization, indexing, signs, or another convention-sensitive value. |
+| Adversarial weaker-semantics | Rejects a tempting result that has the right shape or satisfies only a weaker claim. |
+| Metamorphic or equivalence | Checks invariance under a meaning-preserving transformation or compares noncanonical outputs by mathematical equivalence. |
+| Producer-consumer | Supplies one operation's serialized result unchanged to a downstream operation and checks the composed meaning. |
+| Scale/stress | Exercises a source-backed size or representation regime near a justified admission boundary. |
+
+A fixture may fill more than one role, but the evidence plan should name those
+roles rather than treating fixture count as coverage. A large certificate
+should normally yield a small discriminating CI fixture, with the full
+source-scale case retained only as an optional stress or benchmark fixture when
+it remains reproducible and useful. Agreement on a scalar summary is
+insufficient when correctness concerns a set, partition, or family of canonical
+representatives: compare the exact objects or their declared equivalence class.
+For example, two tree generators can return the same count while duplicating
+one representative and omitting another.
+
 Use a source-backed reference fixture when a standard example helps fix
 terminology, normalization, or another convention-sensitive output. Cite the
 specific theorem or example and record the convention the fixture depends on.


### PR DESCRIPTION
## Problem

Jacobian defines operations by stable mathematical postconditions, but the documentation did not make two related review boundaries explicit:

- an established technique may be useful discovery vocabulary, a native helper, a private kernel, or caller reasoning without deserving a separate operation ID; and
- mathematically equivalent materialized and succinct inputs can have very different expansion and complexity, so representation must be part of preflight admission.

The repository also lacked one workflow for decomposing a corpus of papers, formalizations, scripts, and certificates by recurring mathematical method rather than summarizing it file by file.

## Solution

- Clarify that technique names can make an operation discoverable while separate admission requires a distinct reusable result, witness, decomposition, or certificate. An illustrative Ramanujan-sum example distinguishes a canonical operation from its divisor–Möbius kernel and from a general Möbius transform.
- Add representation-sensitive preflight questions for materialized, succinct, generated, and oracle-backed inputs, including pre-execution expansion bounds.
- Add a corpus-decomposition skill that freezes source revisions, groups artifacts by method family, separates local exact moves from theorem-specific lifts, researches primary literature, compares current Jacobian composition, and stops only after each family has a disposition.
- Extend the trajectory-review skill with a compact method-decomposition record.
- Add fixture roles for defining invariants, known answers, adversarial semantics, equivalence, producer-consumer composition, and scale.

This changes guidance only. It does not add operation IDs, schemas, runtime abstractions, or a technique registry.

## Testing

- Corpus-decomposition skill quick validation — skill is valid
- `make docs-linkcheck` — documentation commands and links pass
- `make check` — Ruff, formatting, complexity, mypy, and 2,628 tests pass

- Specialist validation run: none required; this change is documentation and repo-local skill guidance.

## Public contract impact

No operation ID, request/result schema, native API, MCP contract, or mathematical result semantics change. The PR clarifies how future operation admission and corpus-derived evidence should be reviewed.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Public operation admission is unchanged at runtime; no owner-local decision is required
- [x] Documentation link validation passes
