### PR TITLE
feat(math): add exact finite-algebra homomorphism profiles

### DIFF
--- a/src/jacobian/math/universal_algebra/__init__.py
+++ b/src/jacobian/math/universal_algebra/__init__.py
@@ -5,11 +5,14 @@ from jacobian.math.universal_algebra.operations import (
     equation_profile,
     evaluate_term,
     generated_subalgebra,
+    homomorphism_profile,
     quotient,
 )
 from jacobian.math.universal_algebra.values import (
     ApplicationTerm,
     FiniteAlgebra,
+    FiniteAlgebraCarrierMap,
+    FiniteAlgebraHomomorphism,
     FlatTerm,
     OperationSymbol,
     Term,
@@ -19,6 +22,8 @@ from jacobian.math.universal_algebra.values import (
 __all__ = [
     "ApplicationTerm",
     "FiniteAlgebra",
+    "FiniteAlgebraCarrierMap",
+    "FiniteAlgebraHomomorphism",
     "FlatTerm",
     "OperationSymbol",
     "Term",
@@ -27,5 +32,6 @@ __all__ = [
     "equation_profile",
     "evaluate_term",
     "generated_subalgebra",
+    "homomorphism_profile",
     "quotient",
 ]

--- a/src/jacobian/math/universal_algebra/_admission.py
+++ b/src/jacobian/math/universal_algebra/_admission.py
@@ -26,6 +26,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         "exact least subalgebra by finite closure under all basic operations and nullary constants",
     ),
     OperationAdmission(
+        "universal_algebra.map.homomorphism_profile.compute",
+        AdmissionDecision.KEEP,
+        "exact supplied-map operation preservation with a reusable checked homomorphism or first source-bound countertuple",
+    ),
+    OperationAdmission(
         "universal_algebra.congruence.check.compute",
         AdmissionDecision.KEEP,
         "exact compatibility check of a carrier partition against all basic operations",

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -4,17 +4,34 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+)
 from jacobian.math.universal_algebra.values import (
+    MAX_ARITY,
     MAX_CARRIER_SIZE,
+    MAX_SIGNATURE_SIZE,
     FiniteAlgebra,
+    FiniteAlgebraCarrierMap,
+    FiniteAlgebraHomomorphism,
     FlatTerm,
+    _first_homomorphism_failure,
+    _homomorphism_kernel_and_image,
     require_term_for_algebra,
 )
 
 MAX_ENUMERATION_WORK = 1_000_000
+_HOMOMORPHISM_REPLAY_PASSES = 2
+# The result adds at most 32 source indices in kernel blocks, 32 image indices,
+# six flags/scalars, or one obstruction with two arity-at-most-four tuples and a
+# 64-byte operation ID.  Four KiB conservatively bounds that JSON wrapper over
+# the exactly measured retained carrier-map bytes.
+_HOMOMORPHISM_RESULT_RESERVE_BYTES = 4_096
 CarrierBlock = Annotated[
     tuple[int, ...],
     Field(min_length=1, max_length=MAX_CARRIER_SIZE),
@@ -129,6 +146,168 @@ class SubalgebraResult(StrictModel):
     is_closed: bool
 
 
+def _require_homomorphism_output_headroom(
+    carrier_map: FiniteAlgebraCarrierMap,
+) -> None:
+    try:
+        retained_source_bytes = len(
+            encode_strict_json(carrier_map.model_dump(mode="json"))
+        )
+    except CanonicalizationError as exc:
+        raise ValueError(
+            "finite algebra carrier map exceeds the canonical output limit"
+        ) from exc
+    output_limit = CanonicalLimits().max_output_bytes
+    if retained_source_bytes + _HOMOMORPHISM_RESULT_RESERVE_BYTES > output_limit:
+        raise ValueError(
+            "homomorphism profile retains the carrier map and would exceed the "
+            f"{output_limit}-byte canonical output limit"
+        )
+
+
+class HomomorphismProfileRequest(StrictModel):
+    """Check one total finite-algebra carrier map for operation preservation."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Check a complete carrier map between finite algebras with exactly "
+                "matching ordered operation identifiers and arities. Every source "
+                "operation-table cell is checked; the retained-map result is "
+                "rejected before execution when replay work or canonical output "
+                "would exceed its bound."
+            )
+        }
+    )
+
+    carrier_map: FiniteAlgebraCarrierMap = Field(
+        description=(
+            "Total source-to-target carrier map. Source and target signatures must "
+            "match exactly; carrier sizes may differ."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_complete_scan(self) -> Self:
+        preservation_cells = sum(len(table) for table in self.carrier_map.source.tables)
+        if preservation_cells * _HOMOMORPHISM_REPLAY_PASSES > MAX_ENUMERATION_WORK:
+            raise ValueError(
+                "homomorphism operation-and-replay work exceeds the enumeration budget"
+            )
+        _require_homomorphism_output_headroom(self.carrier_map)
+        return self
+
+
+class HomomorphismObstruction(StrictModel):
+    """The first exact operation-preservation failure in canonical scan order."""
+
+    operation: int = Field(ge=0, le=MAX_SIGNATURE_SIZE - 1)
+    operation_id: str = Field(min_length=1, max_length=64)
+    source_arguments: tuple[int, ...] = Field(max_length=MAX_ARITY)
+    target_arguments: tuple[int, ...] = Field(max_length=MAX_ARITY)
+    source_output: int = Field(ge=0, le=MAX_CARRIER_SIZE - 1)
+    mapped_source_output: int = Field(ge=0, le=MAX_CARRIER_SIZE - 1)
+    target_output: int = Field(ge=0, le=MAX_CARRIER_SIZE - 1)
+
+
+class HomomorphismProfileResult(StrictModel):
+    """A checked homomorphism or the first exact preservation obstruction.
+
+    The positive branch carries a reusable :class:`FiniteAlgebraHomomorphism`;
+    the negative branch retains the supplied carrier map. Validation replays
+    preservation and reconstructs every positive kernel/image field or every
+    negative obstruction from that retained source.
+    """
+
+    status: Literal["HOMOMORPHISM", "NOT_A_HOMOMORPHISM"]
+    homomorphism: FiniteAlgebraHomomorphism | None = None
+    carrier_map: FiniteAlgebraCarrierMap | None = None
+    kernel_partition: tuple[CarrierBlock, ...] = Field(
+        default=(), max_length=MAX_CARRIER_SIZE
+    )
+    image: tuple[int, ...] = Field(default=(), max_length=MAX_CARRIER_SIZE)
+    injective: bool | None = None
+    surjective: bool | None = None
+    isomorphism: bool | None = None
+    obstruction: HomomorphismObstruction | None = None
+    method: Literal["DENSE_TABLE_SCAN"] = "DENSE_TABLE_SCAN"
+
+    @model_validator(mode="after")
+    def require_source_bound_profile(self) -> Self:
+        if self.status == "HOMOMORPHISM":
+            if self.homomorphism is None:
+                raise ValueError("HOMOMORPHISM must carry a checked homomorphism")
+            if self.carrier_map is not None or self.obstruction is not None:
+                raise ValueError(
+                    "HOMOMORPHISM cannot carry a failed map or obstruction"
+                )
+            if None in (self.injective, self.surjective, self.isomorphism):
+                raise ValueError("HOMOMORPHISM must carry all map-property flags")
+            _require_homomorphism_output_headroom(self.homomorphism)
+            expected_kernel, expected_image = _homomorphism_kernel_and_image(
+                self.homomorphism.mapping
+            )
+            if self.kernel_partition != expected_kernel:
+                raise ValueError(
+                    "kernel_partition must be the canonical fibers of the carrier map"
+                )
+            if self.image != expected_image:
+                raise ValueError("image must be the sorted carrier-map image")
+            expected_injective = len(expected_image) == len(
+                self.homomorphism.source.carrier
+            )
+            expected_surjective = len(expected_image) == len(
+                self.homomorphism.target.carrier
+            )
+            if self.injective is not expected_injective:
+                raise ValueError("injective must be reconstructed from the kernel")
+            if self.surjective is not expected_surjective:
+                raise ValueError("surjective must be reconstructed from the image")
+            if self.isomorphism is not (expected_injective and expected_surjective):
+                raise ValueError(
+                    "isomorphism must be reconstructed from injectivity and surjectivity"
+                )
+            return self
+
+        if self.carrier_map is None or self.obstruction is None:
+            raise ValueError(
+                "NOT_A_HOMOMORPHISM must retain the carrier map and obstruction"
+            )
+        if self.homomorphism is not None:
+            raise ValueError("NOT_A_HOMOMORPHISM cannot carry a homomorphism")
+        if (
+            self.kernel_partition
+            or self.image
+            or any(
+                flag is not None
+                for flag in (self.injective, self.surjective, self.isomorphism)
+            )
+        ):
+            raise ValueError(
+                "NOT_A_HOMOMORPHISM cannot carry positive map-property data"
+            )
+        _require_homomorphism_output_headroom(self.carrier_map)
+        expected = _first_homomorphism_failure(self.carrier_map)
+        if expected is None:
+            raise ValueError(
+                "NOT_A_HOMOMORPHISM source map preserves every basic operation"
+            )
+        expected_obstruction = HomomorphismObstruction(
+            operation=expected.operation,
+            operation_id=self.carrier_map.source.operations[
+                expected.operation
+            ].operation_id,
+            source_arguments=expected.source_arguments,
+            target_arguments=expected.target_arguments,
+            source_output=expected.source_output,
+            mapped_source_output=expected.mapped_source_output,
+            target_output=expected.target_output,
+        )
+        if self.obstruction != expected_obstruction:
+            raise ValueError("obstruction must be the first exact preservation failure")
+        return self
+
+
 class _PartitionRequest(StrictModel):
     algebra: FiniteAlgebra
     partition: tuple[CarrierBlock, ...] = Field(
@@ -183,6 +362,9 @@ __all__ = [
     "EquationProfileResult",
     "EvaluateRequest",
     "EvaluateResult",
+    "HomomorphismObstruction",
+    "HomomorphismProfileRequest",
+    "HomomorphismProfileResult",
     "QuotientRequest",
     "QuotientResult",
     "SubalgebraRequest",

--- a/src/jacobian/math/universal_algebra/_models.py
+++ b/src/jacobian/math/universal_algebra/_models.py
@@ -335,22 +335,59 @@ class CongruenceResult(StrictModel):
 class QuotientRequest(_PartitionRequest):
     """Construct ``A/theta`` for an admitted congruence partition."""
 
-
-class QuotientResult(StrictModel):
-    """A directly composable quotient algebra and its carrier map."""
-
-    algebra: FiniteAlgebra
-    quotient_map: tuple[int, ...] = Field(
-        min_length=1,
-        max_length=MAX_CARRIER_SIZE,
-    )
-
     @model_validator(mode="after")
-    def require_map_into_quotient(self) -> Self:
-        if any(
-            not 0 <= value < len(self.algebra.carrier) for value in self.quotient_map
-        ):
-            raise ValueError("quotient map value is outside the quotient carrier")
+    def require_source_bound_result_headroom(self) -> Self:
+        """Bound the retained source, quotient tables, and carrier map."""
+
+        quotient_size = len(self.partition)
+        quotient_table_cells = sum(
+            quotient_size**operation.arity for operation in self.algebra.operations
+        )
+        quotient_work = (
+            _congruence_work(self.algebra)
+            + sum(len(table) for table in self.algebra.tables)
+            + quotient_table_cells
+        )
+        if quotient_work > MAX_ENUMERATION_WORK:
+            raise ValueError(
+                "quotient construction and homomorphism replay exceed the "
+                "operation work budget"
+            )
+        try:
+            source_bytes = len(encode_strict_json(self.algebra.model_dump(mode="json")))
+            operation_bytes = len(
+                encode_strict_json(
+                    [
+                        operation.model_dump(mode="json")
+                        for operation in self.algebra.operations
+                    ]
+                )
+            )
+            quotient_carrier_bytes = sum(
+                len(encode_strict_json(f"B{index}")) + 1
+                for index in range(quotient_size)
+            )
+        except CanonicalizationError as exc:
+            raise ValueError(
+                "quotient source exceeds the canonical output limit"
+            ) from exc
+        quotient_index_bytes = len(str(quotient_size - 1)) + 1
+        quotient_table_bytes = quotient_table_cells * quotient_index_bytes
+        mapping_bytes = len(self.algebra.carrier) * quotient_index_bytes
+        predicted_bytes = (
+            source_bytes
+            + operation_bytes
+            + quotient_carrier_bytes
+            + quotient_table_bytes
+            + mapping_bytes
+            + _HOMOMORPHISM_RESULT_RESERVE_BYTES
+        )
+        output_limit = CanonicalLimits().max_output_bytes
+        if predicted_bytes > output_limit:
+            raise ValueError(
+                "canonical quotient homomorphism would exceed the "
+                f"{output_limit}-byte output limit"
+            )
         return self
 
 
@@ -366,7 +403,6 @@ __all__ = [
     "HomomorphismProfileRequest",
     "HomomorphismProfileResult",
     "QuotientRequest",
-    "QuotientResult",
     "SubalgebraRequest",
     "SubalgebraResult",
 ]

--- a/src/jacobian/math/universal_algebra/_operations.py
+++ b/src/jacobian/math/universal_algebra/_operations.py
@@ -10,6 +10,8 @@ from jacobian.math.universal_algebra._models import (
     EquationProfileResult,
     EvaluateRequest,
     EvaluateResult,
+    HomomorphismProfileRequest,
+    HomomorphismProfileResult,
     QuotientRequest,
     QuotientResult,
     SubalgebraRequest,
@@ -20,6 +22,7 @@ from jacobian.math.universal_algebra.operations import (
     equation_profile,
     evaluate_term,
     generated_subalgebra,
+    homomorphism_profile,
     quotient,
 )
 
@@ -28,6 +31,7 @@ __all__ = [
     "compute_equation_profile",
     "compute_evaluate",
     "compute_generated_subalgebra",
+    "compute_homomorphism_profile",
     "compute_quotient",
 ]
 
@@ -62,6 +66,14 @@ def compute_generated_subalgebra(request: SubalgebraRequest) -> SubalgebraResult
         generated_carrier=result["generated_carrier"],  # type: ignore[arg-type]
         rounds=result["rounds"],  # type: ignore[arg-type]
         is_closed=result["is_closed"],  # type: ignore[arg-type]
+    )
+
+
+def compute_homomorphism_profile(
+    request: HomomorphismProfileRequest,
+) -> HomomorphismProfileResult:
+    return HomomorphismProfileResult.model_validate(
+        homomorphism_profile(request.carrier_map)
     )
 
 

--- a/src/jacobian/math/universal_algebra/_operations.py
+++ b/src/jacobian/math/universal_algebra/_operations.py
@@ -13,7 +13,6 @@ from jacobian.math.universal_algebra._models import (
     HomomorphismProfileRequest,
     HomomorphismProfileResult,
     QuotientRequest,
-    QuotientResult,
     SubalgebraRequest,
     SubalgebraResult,
 )
@@ -25,6 +24,7 @@ from jacobian.math.universal_algebra.operations import (
     homomorphism_profile,
     quotient,
 )
+from jacobian.math.universal_algebra.values import FiniteAlgebraHomomorphism
 
 __all__ = [
     "compute_congruence",
@@ -85,9 +85,5 @@ def compute_congruence(request: CongruenceRequest) -> CongruenceResult:
     )
 
 
-def compute_quotient(request: QuotientRequest) -> QuotientResult:
-    algebra, quotient_map = quotient(request.algebra, request.partition)
-    return QuotientResult(
-        algebra=algebra,
-        quotient_map=quotient_map,
-    )
+def compute_quotient(request: QuotientRequest) -> FiniteAlgebraHomomorphism:
+    return quotient(request.algebra, request.partition)

--- a/src/jacobian/math/universal_algebra/_tools.py
+++ b/src/jacobian/math/universal_algebra/_tools.py
@@ -13,6 +13,8 @@ from jacobian.math.universal_algebra._models import (
     EquationProfileResult,
     EvaluateRequest,
     EvaluateResult,
+    HomomorphismProfileRequest,
+    HomomorphismProfileResult,
     QuotientRequest,
     QuotientResult,
     SubalgebraRequest,
@@ -23,6 +25,7 @@ from jacobian.math.universal_algebra._operations import (
     compute_equation_profile,
     compute_evaluate,
     compute_generated_subalgebra,
+    compute_homomorphism_profile,
     compute_quotient,
 )
 
@@ -164,6 +167,37 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             ),
         ),
         version="2",
+    ),
+    _op(
+        "universal_algebra.map.homomorphism_profile.compute",
+        "Profile a supplied finite-algebra carrier map",
+        "Check every basic-operation table cell under one total carrier map. "
+        "Return a reusable checked homomorphism with canonical kernel and image, "
+        "or the first exact preservation obstruction in deterministic signature "
+        "and source-tuple order.",
+        HomomorphismProfileRequest,
+        HomomorphismProfileResult,
+        compute_homomorphism_profile,
+        "universal-algebra",
+        "homomorphism",
+        "carrier-map",
+        "exact",
+        examples=(
+            example(
+                "boolean_identity_map",
+                "Check the identity carrier map between two copies of the "
+                "2-element Boolean algebra; source and target operation "
+                "identifiers and arities must match exactly and the map must "
+                "cover every source carrier position.",
+                {
+                    "carrier_map": {
+                        "source": _ALGEBRA,
+                        "target": _ALGEBRA,
+                        "mapping": [0, 1],
+                    }
+                },
+            ),
+        ),
     ),
     _op(
         "universal_algebra.congruence.check.compute",

--- a/src/jacobian/math/universal_algebra/_tools.py
+++ b/src/jacobian/math/universal_algebra/_tools.py
@@ -16,7 +16,6 @@ from jacobian.math.universal_algebra._models import (
     HomomorphismProfileRequest,
     HomomorphismProfileResult,
     QuotientRequest,
-    QuotientResult,
     SubalgebraRequest,
     SubalgebraResult,
 )
@@ -28,6 +27,7 @@ from jacobian.math.universal_algebra._operations import (
     compute_homomorphism_profile,
     compute_quotient,
 )
+from jacobian.math.universal_algebra.values import FiniteAlgebraHomomorphism
 
 
 def _op[
@@ -224,11 +224,12 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "universal_algebra.quotient.compute",
         "Compute the quotient algebra A/theta",
-        "Return the quotient algebra induced by a congruence. The quotient "
-        "carrier is the set of blocks; return a directly composable "
-        "FiniteAlgebra together with the quotient map.",
+        "Return the canonical checked homomorphism from a finite algebra onto "
+        "the quotient induced by a congruence. The target carrier is the set "
+        "of blocks, and the retained source, target, and mapping pass directly "
+        "to homomorphism-profile consumers.",
         QuotientRequest,
-        QuotientResult,
+        FiniteAlgebraHomomorphism,
         compute_quotient,
         "universal-algebra",
         "quotient",
@@ -240,7 +241,7 @@ UNIVERSAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"algebra": _ALGEBRA, "partition": [[0, 1]]},
             ),
         ),
-        version="2",
+        version="3",
     ),
 )
 

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -261,8 +261,8 @@ def congruence_check(
 
 def quotient(
     algebra: FiniteAlgebra, partition: tuple[tuple[int, ...], ...]
-) -> tuple[FiniteAlgebra, tuple[int, ...]]:
-    """Return the quotient algebra ``A/theta`` induced by a congruence."""
+) -> FiniteAlgebraHomomorphism:
+    """Return the canonical quotient homomorphism ``A -> A/theta``."""
     check = congruence_check(algebra, partition)
     if not check["is_congruence"]:
         raise ValueError("partition is not a congruence")
@@ -295,5 +295,8 @@ def quotient(
         operations=algebra.operations,
         tables=tuple(quotient_tables),
     )
-    quotient_map = tuple(block_of[element] for element in range(n))
-    return quotient_algebra, quotient_map
+    return FiniteAlgebraHomomorphism(
+        source=algebra,
+        target=quotient_algebra,
+        mapping=tuple(block_of[element] for element in range(n)),
+    )

--- a/src/jacobian/math/universal_algebra/operations.py
+++ b/src/jacobian/math/universal_algebra/operations.py
@@ -7,9 +7,13 @@ from itertools import product as iproduct
 from .values import (
     ApplicationTerm,
     FiniteAlgebra,
+    FiniteAlgebraCarrierMap,
+    FiniteAlgebraHomomorphism,
     FlatTerm,
     OperationSymbol,
     VariableTerm,
+    _first_homomorphism_failure,
+    _homomorphism_kernel_and_image,
     require_term_for_algebra,
 )
 
@@ -18,6 +22,7 @@ __all__ = [
     "equation_profile",
     "evaluate_term",
     "generated_subalgebra",
+    "homomorphism_profile",
     "quotient",
 ]
 
@@ -126,6 +131,50 @@ def generated_subalgebra(
         "generated_carrier": tuple(sorted_carrier),
         "rounds": rounds,
         "is_closed": set(generators) == carrier_set if generators else True,
+    }
+
+
+def homomorphism_profile(carrier_map: FiniteAlgebraCarrierMap) -> dict[str, object]:
+    """Check one total map for preservation of every basic operation.
+
+    Operations are checked in signature order and argument tuples in
+    lexicographic carrier-position order.  A failure returns that first exact
+    obstruction.  A successful result returns a checked homomorphism together
+    with its canonical kernel fibers and image.
+    """
+
+    failure = _first_homomorphism_failure(carrier_map)
+    if failure is not None:
+        return {
+            "status": "NOT_A_HOMOMORPHISM",
+            "carrier_map": carrier_map,
+            "obstruction": {
+                "operation": failure.operation,
+                "operation_id": carrier_map.source.operations[
+                    failure.operation
+                ].operation_id,
+                "source_arguments": failure.source_arguments,
+                "target_arguments": failure.target_arguments,
+                "source_output": failure.source_output,
+                "mapped_source_output": failure.mapped_source_output,
+                "target_output": failure.target_output,
+            },
+        }
+
+    homomorphism = FiniteAlgebraHomomorphism.model_validate(
+        carrier_map.model_dump(mode="python")
+    )
+    kernel_partition, image = _homomorphism_kernel_and_image(carrier_map.mapping)
+    injective = len(image) == len(carrier_map.source.carrier)
+    surjective = len(image) == len(carrier_map.target.carrier)
+    return {
+        "status": "HOMOMORPHISM",
+        "homomorphism": homomorphism,
+        "kernel_partition": kernel_partition,
+        "image": image,
+        "injective": injective,
+        "surjective": surjective,
+        "isomorphism": injective and surjective,
     }
 
 

--- a/src/jacobian/math/universal_algebra/values.py
+++ b/src/jacobian/math/universal_algebra/values.py
@@ -9,7 +9,8 @@ is introduced.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from itertools import product as iproduct
+from typing import Annotated, Literal, NamedTuple, Self
 
 from pydantic import Field, model_validator
 
@@ -67,6 +68,120 @@ class FiniteAlgebra(StrictModel):
             for output in table:
                 if not 0 <= output < len(self.carrier):
                     raise ValueError("table output out of carrier range")
+        return self
+
+
+class FiniteAlgebraCarrierMap(StrictModel):
+    """One total carrier map between finite algebras with the same signature.
+
+    ``mapping[a]`` is the target carrier index assigned to source carrier
+    index ``a``.  This value establishes only totality and exact signature
+    binding; :class:`FiniteAlgebraHomomorphism` additionally establishes
+    preservation of every basic operation.
+    """
+
+    source: FiniteAlgebra = Field(
+        description="Source finite algebra whose carrier positions index the map."
+    )
+    target: FiniteAlgebra = Field(
+        description=(
+            "Target finite algebra with exactly the source operation identifiers "
+            "and arities in the same order."
+        )
+    )
+    mapping: tuple[int, ...] = Field(
+        min_length=1,
+        max_length=MAX_CARRIER_SIZE,
+        description=(
+            "Complete target carrier index for each source carrier position, in "
+            "source carrier order."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_total_signature_bound_map(self) -> Self:
+        if self.source.operations != self.target.operations:
+            raise ValueError(
+                "source and target operation identifiers and arities must match exactly"
+            )
+        if len(self.mapping) != len(self.source.carrier):
+            raise ValueError("mapping must contain one target index per source element")
+        if any(not 0 <= image < len(self.target.carrier) for image in self.mapping):
+            raise ValueError("mapping image is outside the target carrier")
+        return self
+
+
+class _PreservationFailure(NamedTuple):
+    operation: int
+    source_arguments: tuple[int, ...]
+    target_arguments: tuple[int, ...]
+    source_output: int
+    mapped_source_output: int
+    target_output: int
+
+
+def _dense_table_index(arguments: tuple[int, ...], carrier_size: int) -> int:
+    index = 0
+    for argument in arguments:
+        index = index * carrier_size + argument
+    return index
+
+
+def _first_homomorphism_failure(
+    carrier_map: FiniteAlgebraCarrierMap,
+) -> _PreservationFailure | None:
+    """Return the first operation-preservation failure in canonical order."""
+
+    source_size = len(carrier_map.source.carrier)
+    target_size = len(carrier_map.target.carrier)
+    for operation, symbol in enumerate(carrier_map.source.operations):
+        for source_arguments in iproduct(range(source_size), repeat=symbol.arity):
+            target_arguments = tuple(
+                carrier_map.mapping[argument] for argument in source_arguments
+            )
+            source_output = carrier_map.source.tables[operation][
+                _dense_table_index(source_arguments, source_size)
+            ]
+            mapped_source_output = carrier_map.mapping[source_output]
+            target_output = carrier_map.target.tables[operation][
+                _dense_table_index(target_arguments, target_size)
+            ]
+            if mapped_source_output != target_output:
+                return _PreservationFailure(
+                    operation=operation,
+                    source_arguments=source_arguments,
+                    target_arguments=target_arguments,
+                    source_output=source_output,
+                    mapped_source_output=mapped_source_output,
+                    target_output=target_output,
+                )
+    return None
+
+
+def _homomorphism_kernel_and_image(
+    mapping: tuple[int, ...],
+) -> tuple[tuple[tuple[int, ...], ...], tuple[int, ...]]:
+    """Return kernel fibers and image in canonical carrier-position order."""
+
+    fibers: dict[int, list[int]] = {}
+    for source_element, target_element in enumerate(mapping):
+        fibers.setdefault(target_element, []).append(source_element)
+    return tuple(tuple(block) for block in fibers.values()), tuple(sorted(fibers))
+
+
+class FiniteAlgebraHomomorphism(FiniteAlgebraCarrierMap):
+    """A checked carrier map preserving every basic operation exactly."""
+
+    @model_validator(mode="after")
+    def require_operation_preservation(self) -> Self:
+        failure = _first_homomorphism_failure(self)
+        if failure is not None:
+            operation_id = self.source.operations[failure.operation].operation_id
+            raise ValueError(
+                "carrier map does not preserve operation "
+                f"{operation_id!r} at source arguments "
+                f"{failure.source_arguments}"
+            )
         return self
 
 
@@ -157,6 +272,8 @@ __all__ = [
     "MAX_SIGNATURE_SIZE",
     "ApplicationTerm",
     "FiniteAlgebra",
+    "FiniteAlgebraCarrierMap",
+    "FiniteAlgebraHomomorphism",
     "FlatTerm",
     "OperationSymbol",
     "Term",

--- a/tests/math/universal_algebra/test_public_api.py
+++ b/tests/math/universal_algebra/test_public_api.py
@@ -9,6 +9,8 @@ def test_exact_public_api_symbols() -> None:
     expected = (
         "ApplicationTerm",
         "FiniteAlgebra",
+        "FiniteAlgebraCarrierMap",
+        "FiniteAlgebraHomomorphism",
         "FlatTerm",
         "OperationSymbol",
         "Term",
@@ -17,6 +19,7 @@ def test_exact_public_api_symbols() -> None:
         "equation_profile",
         "evaluate_term",
         "generated_subalgebra",
+        "homomorphism_profile",
         "quotient",
     )
     assert tuple(universal_algebra.__all__) == expected

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -8,6 +8,8 @@ from pydantic import ValidationError
 from jacobian.math.universal_algebra import (
     ApplicationTerm,
     FiniteAlgebra,
+    FiniteAlgebraCarrierMap,
+    FiniteAlgebraHomomorphism,
     FlatTerm,
     OperationSymbol,
     VariableTerm,
@@ -16,6 +18,8 @@ from jacobian.math.universal_algebra._models import (
     CongruenceRequest,
     EquationProfileRequest,
     EvaluateRequest,
+    HomomorphismProfileRequest,
+    HomomorphismProfileResult,
     QuotientRequest,
     SubalgebraRequest,
 )
@@ -24,6 +28,7 @@ from jacobian.math.universal_algebra._operations import (
     compute_equation_profile,
     compute_evaluate,
     compute_generated_subalgebra,
+    compute_homomorphism_profile,
     compute_quotient,
 )
 from jacobian.math.universal_algebra._tools import TOOLS
@@ -61,6 +66,28 @@ def _and_term() -> FlatTerm:
     )
 
 
+def _cyclic_addition_algebra(order: int) -> FiniteAlgebra:
+    return FiniteAlgebra(
+        carrier=tuple(str(index) for index in range(order)),
+        operations=(OperationSymbol(operation_id="add", arity=2),),
+        tables=(
+            tuple(
+                (left + right) % order
+                for left in range(order)
+                for right in range(order)
+            ),
+        ),
+    )
+
+
+def _empty_signature_algebra(size: int, prefix: str) -> FiniteAlgebra:
+    return FiniteAlgebra(
+        carrier=tuple(f"{prefix}{index}" for index in range(size)),
+        operations=(),
+        tables=(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Catalog
 # ---------------------------------------------------------------------------
@@ -71,6 +98,7 @@ def test_catalog_contains_only_audited_agent_outcomes() -> None:
         "universal_algebra.term.evaluate.compute",
         "universal_algebra.equation.profile.compute",
         "universal_algebra.subalgebra.generated.compute",
+        "universal_algebra.map.homomorphism_profile.compute",
         "universal_algebra.congruence.check.compute",
         "universal_algebra.quotient.compute",
     }
@@ -157,6 +185,242 @@ class TestGeneratedSubalgebra:
             SubalgebraRequest(algebra=_boolean_algebra(), generators=(0, 1))
         )
         assert result.generated_carrier == (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# Supplied-map homomorphism profile
+# ---------------------------------------------------------------------------
+
+
+class TestHomomorphismProfile:
+    def test_identity_is_a_reusable_checked_isomorphism(self) -> None:
+        algebra = _boolean_algebra()
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=algebra,
+                    target=algebra,
+                    mapping=(0, 1),
+                )
+            )
+        )
+
+        assert result.status == "HOMOMORPHISM"
+        assert isinstance(result.homomorphism, FiniteAlgebraHomomorphism)
+        assert result.kernel_partition == ((0,), (1,))
+        assert result.image == (0, 1)
+        assert result.injective is True
+        assert result.surjective is True
+        assert result.isomorphism is True
+
+    def test_quotient_map_has_canonical_kernel_and_image(self) -> None:
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_cyclic_addition_algebra(4),
+                    target=_cyclic_addition_algebra(2),
+                    mapping=(0, 1, 0, 1),
+                )
+            )
+        )
+
+        assert result.status == "HOMOMORPHISM"
+        assert result.kernel_partition == ((0, 2), (1, 3))
+        assert result.image == (0, 1)
+        assert result.injective is False
+        assert result.surjective is True
+        assert result.isomorphism is False
+
+    def test_injective_nonsurjective_map(self) -> None:
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_empty_signature_algebra(2, "s"),
+                    target=_empty_signature_algebra(3, "t"),
+                    mapping=(0, 2),
+                )
+            )
+        )
+
+        assert result.status == "HOMOMORPHISM"
+        assert result.image == (0, 2)
+        assert result.injective is True
+        assert result.surjective is False
+        assert result.isomorphism is False
+
+    def test_first_unary_obstruction_is_complete_and_deterministic(self) -> None:
+        symbol = (OperationSymbol(operation_id="flip", arity=1),)
+        carrier_map = FiniteAlgebraCarrierMap(
+            source=FiniteAlgebra(
+                carrier=("0", "1"), operations=symbol, tables=((1, 0),)
+            ),
+            target=FiniteAlgebra(
+                carrier=("a", "b"), operations=symbol, tables=((0, 1),)
+            ),
+            mapping=(0, 1),
+        )
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(carrier_map=carrier_map)
+        )
+
+        assert result.status == "NOT_A_HOMOMORPHISM"
+        assert result.carrier_map == carrier_map
+        assert result.obstruction is not None
+        assert result.obstruction.operation == 0
+        assert result.obstruction.operation_id == "flip"
+        assert result.obstruction.source_arguments == (0,)
+        assert result.obstruction.target_arguments == (0,)
+        assert result.obstruction.source_output == 1
+        assert result.obstruction.mapped_source_output == 1
+        assert result.obstruction.target_output == 0
+
+    def test_higher_arity_obstruction_uses_lexicographic_tuple_order(self) -> None:
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_boolean_algebra(),
+                    target=_boolean_algebra(),
+                    mapping=(1, 0),
+                )
+            )
+        )
+
+        assert result.status == "NOT_A_HOMOMORPHISM"
+        assert result.obstruction is not None
+        assert result.obstruction.operation_id == "and"
+        assert result.obstruction.source_arguments == (0, 1)
+        assert result.obstruction.target_arguments == (1, 0)
+
+    def test_nullary_constants_are_checked(self) -> None:
+        symbol = (OperationSymbol(operation_id="zero", arity=0),)
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=FiniteAlgebra(
+                        carrier=("0", "1"), operations=symbol, tables=((0,),)
+                    ),
+                    target=FiniteAlgebra(
+                        carrier=("a", "b"), operations=symbol, tables=((1,),)
+                    ),
+                    mapping=(0, 1),
+                )
+            )
+        )
+
+        assert result.status == "NOT_A_HOMOMORPHISM"
+        assert result.obstruction is not None
+        assert result.obstruction.source_arguments == ()
+        assert result.obstruction.target_arguments == ()
+        assert result.obstruction.source_output == 0
+        assert result.obstruction.mapped_source_output == 0
+        assert result.obstruction.target_output == 1
+
+    def test_result_validation_rejects_forged_positive_and_negative_data(
+        self,
+    ) -> None:
+        positive = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_cyclic_addition_algebra(4),
+                    target=_cyclic_addition_algebra(2),
+                    mapping=(0, 1, 0, 1),
+                )
+            )
+        ).model_dump(mode="json")
+        positive["kernel_partition"] = [[0, 1], [2, 3]]
+        with pytest.raises(ValidationError, match="canonical fibers"):
+            HomomorphismProfileResult.model_validate(positive)
+
+        symbol = (OperationSymbol(operation_id="flip", arity=1),)
+        negative = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=FiniteAlgebra(
+                        carrier=("0", "1"), operations=symbol, tables=((1, 0),)
+                    ),
+                    target=FiniteAlgebra(
+                        carrier=("a", "b"), operations=symbol, tables=((0, 1),)
+                    ),
+                    mapping=(0, 1),
+                )
+            )
+        ).model_dump(mode="json")
+        negative["obstruction"]["target_output"] = 1
+        with pytest.raises(ValidationError, match="first exact"):
+            HomomorphismProfileResult.model_validate(negative)
+
+    def test_source_mutation_invalidates_negative_conclusion(self) -> None:
+        symbol = (OperationSymbol(operation_id="flip", arity=1),)
+        payload = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=FiniteAlgebra(
+                        carrier=("0", "1"), operations=symbol, tables=((1, 0),)
+                    ),
+                    target=FiniteAlgebra(
+                        carrier=("a", "b"), operations=symbol, tables=((0, 1),)
+                    ),
+                    mapping=(0, 1),
+                )
+            )
+        ).model_dump(mode="json")
+        payload["carrier_map"]["target"]["tables"] = [[1, 0]]
+        with pytest.raises(ValidationError, match="preserves every"):
+            HomomorphismProfileResult.model_validate(payload)
+
+    def test_source_mutation_invalidates_positive_homomorphism(self) -> None:
+        payload = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=_cyclic_addition_algebra(4),
+                    target=_cyclic_addition_algebra(2),
+                    mapping=(0, 1, 0, 1),
+                )
+            )
+        ).model_dump(mode="json")
+        payload["homomorphism"]["target"]["tables"][0][0] = 1
+        with pytest.raises(ValidationError, match="does not preserve"):
+            HomomorphismProfileResult.model_validate(payload)
+
+    def test_maximum_source_table_budget_is_scanned_completely(self) -> None:
+        size = 16
+        source = FiniteAlgebra(
+            carrier=tuple(str(index) for index in range(size)),
+            operations=(OperationSymbol(operation_id="f", arity=4),),
+            tables=((0,) * (size**4),),
+        )
+        target = FiniteAlgebra(
+            carrier=tuple(str(index) for index in range(size)),
+            operations=(OperationSymbol(operation_id="f", arity=4),),
+            tables=((0,) * (size**4 - 1) + (1,),),
+        )
+        result = compute_homomorphism_profile(
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=source,
+                    target=target,
+                    mapping=tuple(range(size)),
+                )
+            )
+        )
+        assert result.status == "NOT_A_HOMOMORPHISM"
+        assert result.obstruction is not None
+        assert result.obstruction.source_arguments == (15, 15, 15, 15)
+
+    def test_retained_source_must_fit_the_canonical_output(self) -> None:
+        oversized_label = "x" * (5 * 1024 * 1024)
+        source = FiniteAlgebra(carrier=(oversized_label,), operations=(), tables=())
+        target = FiniteAlgebra(
+            carrier=(oversized_label + "y",), operations=(), tables=()
+        )
+        with pytest.raises(ValidationError, match="canonical output limit"):
+            HomomorphismProfileRequest(
+                carrier_map=FiniteAlgebraCarrierMap(
+                    source=source,
+                    target=target,
+                    mapping=(0,),
+                )
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -285,4 +549,36 @@ class TestValidation:
                 left=term,
                 right=term,
                 variable_count=7,
+            )
+
+    def test_carrier_map_rejects_incomplete_or_wrong_signature_input(self) -> None:
+        source = _boolean_algebra()
+        with pytest.raises(ValidationError, match="one target index"):
+            FiniteAlgebraCarrierMap(
+                source=source,
+                target=source,
+                mapping=(0,),
+            )
+        wrong_signature = FiniteAlgebra(
+            carrier=("0", "1"),
+            operations=(OperationSymbol(operation_id="and", arity=1),),
+            tables=((0, 1),),
+        )
+        with pytest.raises(ValidationError, match="must match exactly"):
+            FiniteAlgebraCarrierMap(
+                source=source,
+                target=wrong_signature,
+                mapping=(0, 1),
+            )
+
+    def test_table_budget_rejects_immediately_above_boundary(self) -> None:
+        size = 16
+        with pytest.raises(ValidationError, match="cell budget"):
+            FiniteAlgebra(
+                carrier=tuple(str(index) for index in range(size)),
+                operations=(
+                    OperationSymbol(operation_id="f", arity=4),
+                    OperationSymbol(operation_id="c", arity=0),
+                ),
+                tables=((0,) * (size**4), (0,)),
             )

--- a/tests/math/universal_algebra/test_universal_algebra.py
+++ b/tests/math/universal_algebra/test_universal_algebra.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.canonical import CanonicalLimits
 from jacobian.math.universal_algebra import (
     ApplicationTerm,
     FiniteAlgebra,
@@ -449,13 +450,66 @@ class TestCongruence:
 
 class TestQuotient:
     def test_trivial_quotient(self) -> None:
-        result = compute_quotient(
+        source = _boolean_algebra()
+        result = compute_quotient(QuotientRequest(algebra=source, partition=((0, 1),)))
+        assert isinstance(result, FiniteAlgebraHomomorphism)
+        assert result.source == source
+        assert result.target.carrier == ("B0",)
+        assert len(result.target.operations) == 2
+        assert result.mapping == (0, 0)
+        SubalgebraRequest(algebra=result.target, generators=(0,))
+
+    def test_quotient_homomorphism_composes_with_profile_unchanged(self) -> None:
+        quotient_map = compute_quotient(
             QuotientRequest(algebra=_boolean_algebra(), partition=((0, 1),))
         )
-        assert result.algebra.carrier == ("B0",)
-        assert len(result.algebra.operations) == 2
-        assert result.quotient_map == (0, 0)
-        SubalgebraRequest(algebra=result.algebra, generators=(0,))
+
+        native_profile = compute_homomorphism_profile(
+            HomomorphismProfileRequest(carrier_map=quotient_map)
+        )
+        wire_profile = compute_homomorphism_profile(
+            HomomorphismProfileRequest.model_validate(
+                {"carrier_map": quotient_map.model_dump(mode="json")}
+            )
+        )
+
+        assert native_profile.status == "HOMOMORPHISM"
+        assert native_profile.homomorphism == quotient_map
+        assert wire_profile == native_profile
+
+    def test_quotient_rejects_when_retained_source_has_no_output_headroom(
+        self,
+    ) -> None:
+        source = FiniteAlgebra(
+            carrier=("x" * (CanonicalLimits().max_output_bytes - 1_024),),
+            operations=(),
+            tables=(),
+        )
+
+        with pytest.raises(ValidationError, match="canonical quotient homomorphism"):
+            QuotientRequest(algebra=source, partition=((0,),))
+
+    def test_quotient_charges_construction_and_map_replay_work(self) -> None:
+        def constant_ternary_algebra(size: int) -> FiniteAlgebra:
+            return FiniteAlgebra(
+                carrier=tuple(f"a{index}" for index in range(size)),
+                operations=(OperationSymbol(operation_id="f", arity=3),),
+                tables=((0,) * size**3,),
+            )
+
+        accepted_size = 23
+        accepted = QuotientRequest(
+            algebra=constant_ternary_algebra(accepted_size),
+            partition=tuple((index,) for index in range(accepted_size)),
+        )
+        assert len(accepted.partition) == accepted_size
+
+        rejected_size = 24
+        with pytest.raises(ValidationError, match="construction and homomorphism"):
+            QuotientRequest(
+                algebra=constant_ternary_algebra(rejected_size),
+                partition=tuple((index,) for index in range(rejected_size)),
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Jacobian can evaluate terms, profile equations, check congruences, and build quotients for one finite algebra, but it cannot establish that a supplied map between two finite algebras preserves their basic operations. Callers would have to align signatures, reproduce dense operation-table indexing, scan every source tuple, and invent positive and counterexample contracts.

The existing quotient producer also returns a parallel raw index tuple without its source algebra, so quotient maps cannot pass unchanged into a canonical map consumer.

Closes #2263.

## Solution

Add `universal_algebra.map.homomorphism_profile.compute`, an exact operation for one complete carrier map between finite algebras with the same ordered signature.

The operation checks symbols in signature order and source tuples in lexicographic carrier-index order. A preserving map returns a reusable checked `FiniteAlgebraHomomorphism`, its canonical kernel fibers and image, and exact injective, surjective, and isomorphism flags. A failing map retains the supplied `FiniteAlgebraCarrierMap` and returns the first preservation obstruction, including both argument tuples and both sides of `h(f_A(a_1, ..., a_r)) = f_B(h(a_1), ..., h(a_r))`. Nullary operations are included through their unique empty argument tuple.

The result model replays preservation from the retained source and reconstructs all derived fields, so neither a positive claim nor a counterexample can drift from the map it describes. This PR intentionally checks only a supplied map; it does not search for homomorphisms, enumerate them, or add composition workflows.

The quotient producer now returns that same canonical checked homomorphism value directly: source algebra, quotient target, and total map remain one reusable value. The quotient operation moves to version 3 because its pre-stable result schema no longer exposes a separate target plus raw tuple. Its request preflights congruence checking, quotient-table construction, homomorphism replay, retained-source bytes, predicted target tables, mapping, and wrapper headroom before construction.

The private kernel is a direct scan over the domain's existing dense finite operation tables. SymPy, python-flint, NetworkX, and Z3 do not provide a more appropriate finite-algebra homomorphism primitive, and adding a solver or a new backend would obscure a deterministic complete table check without widening the mathematical domain.

Suggested review order:

1. Canonical map values and dense preservation kernel in `values.py` and `operations.py`.
2. Request admission and source-bound result validation in `_models.py`.
3. Quotient producer/consumer composition and its version-3 declaration.
4. Native API, owner-local admission, and defining-invariant, mutation, boundary, and catalog tests.

## Testing

- `make check` — Ruff and mypy passed; 2,665 tests passed.
- `make test-math TESTS=tests/math/universal_algebra` — 39 passed.
- `uv run pytest -q tests/catalog/test_admission.py tests/catalog/test_catalog.py` — 18 passed.
- `uv run pytest -q tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py -k 'universal_algebra.quotient.compute or universal_algebra.map.homomorphism_profile.compute'` — 4 passed, 963 deselected.

- Specialist validation run: public catalog examples, accepted-request mutation conformance, and owner-local catalog admission, as listed above.

Coverage includes positive and negative maps, nullary operations, canonical first obstructions, kernel/image/property replay, maximum table-work and retained-source output boundaries, quotient-to-profile native and serialized composition, quotient construction/replay work accounting, and quotient retained-source output headroom.

## Public contract impact

Adds `universal_algebra.map.homomorphism_profile.compute`, the native `homomorphism_profile` function, and canonical `FiniteAlgebraCarrierMap` and `FiniteAlgebraHomomorphism` values. The request accepts source and target `FiniteAlgebra` values with the same exact ordered operation IDs and arities, plus one in-range target index for every source carrier position. Results are closed exact `HOMOMORPHISM` or `NOT_A_HOMOMORPHISM` profiles.

`universal_algebra.quotient.compute` moves from version 2 to version 3 and now returns `FiniteAlgebraHomomorphism` directly. This intentionally replaces the pre-stable parallel `{algebra, quotient_map}` result with the canonical source/target/mapping value accepted by the new profiler.

## Public operation admission

- Concrete gap: no operation compared two finite algebras or checked that a supplied total carrier map preserves all basic operations.
- Why existing operations or typed values are insufficient: term and equation operations stay inside one algebra, while the old congruence and quotient results neither aligned two arbitrary signatures nor supplied one canonical source-bound map value.
- Stable mathematical result: a reusable checked homomorphism with canonical kernel, image, and bijectivity properties, or the first exact preservation obstruction in a documented deterministic order.
- Semantic domain and admitted execution envelope: immutable single-sorted finite algebras with exactly matching ordered signatures; total in-range maps; carriers of at most 32 elements, at most 16 operations of arity at most four, complete tables, two charged preservation passes, and an exact retained-source output-headroom check.
- Controlling work, intermediate, memory, and output quantities: the sum of source operation-table cells, multiplied by execution/validation passes, remains within `MAX_ENUMERATION_WORK`; tuple and table access are bounded by existing carrier/signature/arity limits; kernel and image use linear carrier storage; encoded retained-map bytes plus a conservative 4 KiB wrapper reserve fit the canonical 10 MiB limit. Quotient requests additionally charge congruence work, target-table cells, checked-map replay, and predicted source-bound result bytes before construction.
- Exact representation, algorithm regimes, and maintained backend: canonical carrier indices and complete dense operation tables; one exhaustive row-major scan with no approximation, solver, subprocess, or backend expression. The direct domain kernel is the complete algorithm for this admitted finite representation.
- Remaining fixed caps and their classification: the existing 32-element carrier, 16-symbol signature, arity-four, and 65,536-table-cell caps are conservative canonical finite-algebra representation bounds; the one-million replay-work and 10 MiB output limits are execution and transport safety bounds. There is no algorithm crossover in this single exhaustive scan.
- Admission decision: `KEEP` — the operation establishes one reusable exact postcondition that callers cannot obtain by composing the prior public operations.

## Closure matrix

None. Issue #2263 requests this single admitted operation and leaves homomorphism search, enumeration, and composition outside its scope.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] Results are complete exact positive values or exact first obstructions; approximation, incompleteness, unknown, and unavailable outcomes are not applicable
- [x] New bounds include defining work and output boundary tests; there is one algorithm regime and no crossover
- [x] The canonical carrier-map values replace the quotient producer's parallel raw-map representation
