### PR TITLE
feat(math): add exact bounded friable counting

### DIFF
--- a/src/jacobian/math/number_theory/__init__.py
+++ b/src/jacobian/math/number_theory/__init__.py
@@ -1,3 +1,6 @@
 """Number-theory operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.number_theory._friable_operations import count_friable
+from jacobian.math.number_theory._models import FriableCountResult
+
+__all__ = ["FriableCountResult", "count_friable"]

--- a/src/jacobian/math/number_theory/_admission.py
+++ b/src/jacobian/math/number_theory/_admission.py
@@ -230,6 +230,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
     ),
+    OperationAdmission(
+        "number_theory.friable.count.compute",
+        AdmissionDecision.KEEP,
+        "complete exact friable count with result-sensitive materialized and generated regimes, avoiding caller-side factorization of every source integer",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/number_theory/_friable.py
+++ b/src/jacobian/math/number_theory/_friable.py
@@ -1,0 +1,42 @@
+"""Public declaration for the exact bounded friable-count operation."""
+
+from jacobian.catalog._examples import example
+from jacobian.math.number_theory._friable_operations import compute_friable_count
+from jacobian.math.number_theory._models import (
+    FriableCountRequest,
+    FriableCountResult,
+)
+from jacobian.math.number_theory._support import number_theory_operation
+
+FRIABLE_COUNT_OPERATION = number_theory_operation(
+    "number_theory.friable.count.compute",
+    "Count friable integers exactly",
+    (
+        "Return the exact number Psi(x, y) of positive integers at most x whose "
+        "prime factors are all at most the inclusive cutoff y. The result retains "
+        "x and y and replays the count inside the admitted materialized or "
+        "generated-search envelope."
+    ),
+    FriableCountRequest,
+    FriableCountResult,
+    compute_friable_count,
+    "number-theory",
+    "friable",
+    "smooth-number",
+    "counting",
+    "exact",
+    version="1",
+    examples=(
+        example(
+            "five_friable_through_100",
+            (
+                "Count the positive 5-friable integers at most 100; x and y "
+                "must be canonical nonnegative decimals and the selected exact "
+                "counting regime must fit its work budget."
+            ),
+            {"x": "100", "y": "5"},
+        ),
+    ),
+)
+
+__all__ = ["FRIABLE_COUNT_OPERATION"]

--- a/src/jacobian/math/number_theory/_friable_operations.py
+++ b/src/jacobian/math/number_theory/_friable_operations.py
@@ -1,0 +1,88 @@
+"""Exact bounded friable-count kernel and typed operation adapter."""
+
+from __future__ import annotations
+
+from math import isqrt
+
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.number_theory._models import (
+    FriableCountRequest,
+    FriableCountResult,
+    _plan_friable_count,
+)
+
+
+def _count_materialized(x: int, y: int) -> int:
+    """Count integers with no prime factor above ``y`` using local sieves."""
+
+    is_prime = bytearray(b"\x01") * (x + 1)
+    is_prime[0:2] = b"\x00\x00"
+    is_friable = bytearray(b"\x01") * (x + 1)
+    is_friable[0] = 0
+    square_root = isqrt(x)
+
+    for prime in range(2, x + 1):
+        if not is_prime[prime]:
+            continue
+        if prime <= square_root:
+            first_composite = prime * prime
+            composite_count = (x - first_composite) // prime + 1
+            is_prime[first_composite : x + 1 : prime] = b"\x00" * composite_count
+        if prime > y:
+            is_friable[prime : x + 1 : prime] = b"\x00" * (x // prime)
+
+    return sum(is_friable)
+
+
+def _count_generated(x: int, primes: tuple[int, ...]) -> int:
+    """Count bounded prime-exponent tuples without materializing ``1..x``."""
+
+    def visit(prime_index: int, remaining: int) -> int:
+        if prime_index == len(primes):
+            return 1
+        prime = primes[prime_index]
+        total = 0
+        while True:
+            total += visit(prime_index + 1, remaining)
+            if remaining < prime:
+                return total
+            remaining //= prime
+
+    return visit(0, x)
+
+
+def count_friable(x: int, y: int) -> int:
+    """Return ``Psi(x, y)``, the number of positive y-friable integers <= x.
+
+    The cutoff is inclusive. By convention ``Psi(0, y) = 0`` and, for
+    positive ``x``, ``Psi(x, 0) = Psi(x, 1) = 1``. The function accepts the
+    same result-sensitive execution envelope as the public operation.
+    """
+
+    if type(x) is not int or type(y) is not int:
+        raise TypeError("friable-count inputs must be integers")
+    regime, primes = _plan_friable_count(x, y)
+    if regime == "DIRECT":
+        if x == 0:
+            return 0
+        if y <= 1:
+            return 1
+        return x
+    if regime == "MATERIALIZED":
+        return _count_materialized(x, y)
+    return _count_generated(x, primes)
+
+
+def compute_friable_count(request: FriableCountRequest) -> FriableCountResult:
+    """Compute one exact source-bound friable count."""
+
+    x = parse_canonical_integer(request.x)
+    y = parse_canonical_integer(request.y)
+    return FriableCountResult(
+        x=request.x,
+        y=request.y,
+        count=format_canonical_integer(count_friable(x, y)),
+    )
+
+
+__all__ = ["compute_friable_count", "count_friable"]

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -2,7 +2,7 @@
 
 These contracts cover gcd/lcm, Bezout coefficients, divisors, prime
 factorization, p-adic valuation, multiplicative arithmetic functions,
-primality, modular arithmetic, and integer predicates (coprimality,
+primality, friable counting, modular arithmetic, and integer predicates (coprimality,
 divisibility, perfect/abundant/deficient, square, squarefree).  They are
 owned by the number-theory domain and intentionally exclude arithmetic-owned
 operations (absolute value, sign, decimal digit sum/count, base expansion,
@@ -51,6 +51,18 @@ _MAX_RESIDUE_EXPONENT = 32
 _MAX_RESIDUE_ASSIGNMENTS = 4_096
 _MAX_POLYNOMIAL_RESIDUE_MODULUS = 1_000_000
 
+# Friable counting has two exact, result-sensitive execution regimes. The
+# materialized regime uses one bytearray for primality and one for friability;
+# its work bound covers both the operation and result-validation replay. The
+# generated regime enumerates prime-exponent prefixes only when a conservative
+# prefix-box bound covers both passes.
+MAX_FRIABLE_MATERIALIZED_X = 1_000_000
+MAX_FRIABLE_GENERATED_CUTOFF = 10_000
+_MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS = 82_000_000
+_MAX_FRIABLE_MATERIALIZED_BYTES = 3_000_000
+_MAX_FRIABLE_GENERATED_TOTAL_NODES = 1_000_000
+_MAX_FRIABLE_SOURCE_ABS = 10**256
+
 BoundedInteger = Annotated[
     str,
     StringConstraints(
@@ -95,6 +107,72 @@ CanonicalResidue = Annotated[
     StrictInt,
     Field(ge=0, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS),
 ]
+
+type _FriableRegime = Literal["DIRECT", "MATERIALIZED", "GENERATED"]
+
+
+def _primes_through(limit: int) -> tuple[int, ...]:
+    """Return the primes at most a small admitted cutoff."""
+
+    if limit < 2:
+        return ()
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    for candidate in range(2, math.isqrt(limit) + 1):
+        if not sieve[candidate]:
+            continue
+        first_composite = candidate * candidate
+        composite_count = (limit - first_composite) // candidate + 1
+        sieve[first_composite : limit + 1 : candidate] = b"\x00" * composite_count
+    return tuple(index for index, is_prime in enumerate(sieve) if is_prime)
+
+
+def _maximum_exponent(x: int, prime: int) -> int:
+    """Return the largest ``exponent`` with ``prime**exponent <= x``."""
+
+    exponent = 0
+    remaining = x
+    while remaining >= prime:
+        remaining //= prime
+        exponent += 1
+    return exponent
+
+
+def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]]:
+    """Validate and select one exact friable-count execution regime."""
+
+    if x < 0 or y < 0:
+        raise ValueError("friable-count sources must be nonnegative")
+    if x >= _MAX_FRIABLE_SOURCE_ABS or y >= _MAX_FRIABLE_SOURCE_ABS:
+        raise ValueError("friable-count sources must have at most 256 decimal digits")
+    if x == 0 or y <= 1 or y >= x:
+        return "DIRECT", ()
+
+    # Each materialized pass marks at most two harmonic series of multiples,
+    # plus one scan. Result validation replays the full exact computation.
+    per_pass_steps = x * (2 * x.bit_length() + 1)
+    materialized_bytes = 2 * (x + 1) + x // 2
+    if (
+        x <= MAX_FRIABLE_MATERIALIZED_X
+        and 2 * per_pass_steps <= _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS
+        and materialized_bytes <= _MAX_FRIABLE_MATERIALIZED_BYTES
+    ):
+        return "MATERIALIZED", ()
+
+    if y > MAX_FRIABLE_GENERATED_CUTOFF:
+        raise ValueError("generated friable counting exceeds the admitted prime cutoff")
+
+    primes = _primes_through(y)
+    nodes_per_pass = 1
+    prefix_box = 1
+    for prime in primes:
+        prefix_box *= _maximum_exponent(x, prime) + 1
+        nodes_per_pass += prefix_box
+        if 2 * nodes_per_pass > _MAX_FRIABLE_GENERATED_TOTAL_NODES:
+            raise ValueError(
+                "generated friable counting exceeds the search-node budget"
+            )
+    return "GENERATED", primes
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +320,58 @@ class FactorialValuationResult(StrictModel):
     n: StrictInt = Field(ge=0, le=100_000)
     base: StrictInt = Field(ge=2, le=1_000_000)
     valuation: StrictInt = Field(ge=0)
+
+
+class FriableCountRequest(StrictModel):
+    """One exact bounded count of positive ``y``-friable integers through ``x``."""
+
+    x: BoundedInteger = Field(
+        description=(
+            "Canonical nonnegative inclusive source bound. Easy boundary cases may "
+            "use up to 256 decimal digits; other cases must fit an exact counting "
+            "regime selected from the source-sensitive work bounds."
+        ),
+        examples=["100"],
+    )
+    y: BoundedInteger = Field(
+        description=(
+            "Canonical nonnegative inclusive prime-factor cutoff. Values zero and "
+            "one use the convention that only 1 is friable when x is positive."
+        ),
+        examples=["5"],
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_exact_count(self) -> Self:
+        from jacobian.canonical import parse_canonical_integer
+
+        _plan_friable_count(
+            parse_canonical_integer(self.x),
+            parse_canonical_integer(self.y),
+        )
+        return self
+
+
+class FriableCountResult(StrictModel):
+    """An exact friable count bound to its complete source pair."""
+
+    x: BoundedInteger
+    y: BoundedInteger
+    count: BoundedInteger
+
+    @model_validator(mode="after")
+    def bind_exact_count_to_sources(self) -> Self:
+        from jacobian.canonical import parse_canonical_integer
+        from jacobian.math.number_theory._friable_operations import count_friable
+
+        x = parse_canonical_integer(self.x)
+        y = parse_canonical_integer(self.y)
+        count = parse_canonical_integer(self.count)
+        if count < 0:
+            raise ValueError("friable count must be nonnegative")
+        if count != count_friable(x, y):
+            raise ValueError("friable count does not match the retained sources")
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/number_theory/_tools.py
+++ b/src/jacobian/math/number_theory/_tools.py
@@ -6,6 +6,7 @@ from jacobian.math.number_theory._divisibility import DIVISIBILITY_OPERATIONS
 from jacobian.math.number_theory._finite_abelian_groups import (
     FINITE_ABELIAN_GROUP_FACTORIZATION_OPERATION,
 )
+from jacobian.math.number_theory._friable import FRIABLE_COUNT_OPERATION
 from jacobian.math.number_theory._modular import MODULAR_OPERATIONS
 from jacobian.math.number_theory._modular_identity import MODULAR_IDENTITY_OPERATIONS
 from jacobian.math.number_theory._primes import PRIME_OPERATIONS
@@ -19,4 +20,5 @@ TOOLS: MathTools = (
     *MODULAR_IDENTITY_OPERATIONS,
     *DERIVED_NUMBER_THEORY_OPERATIONS,
     FINITE_ABELIAN_GROUP_FACTORIZATION_OPERATION,
+    FRIABLE_COUNT_OPERATION,
 )

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -1,0 +1,176 @@
+"""Exact bounded friable-count operation tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.number_theory import FriableCountResult, count_friable
+from jacobian.math.number_theory._friable_operations import compute_friable_count
+from jacobian.math.number_theory._models import (
+    MAX_FRIABLE_GENERATED_CUTOFF,
+    MAX_FRIABLE_MATERIALIZED_X,
+    FriableCountRequest,
+)
+
+
+def _prime_factors(value: int) -> Iterator[int]:
+    """Yield the distinct prime factors of one positive integer."""
+
+    divisor = 2
+    while divisor * divisor <= value:
+        if value % divisor:
+            divisor += 1
+            continue
+        yield divisor
+        while value % divisor == 0:
+            value //= divisor
+        divisor += 1
+    if value > 1:
+        yield value
+
+
+def _direct_count(x: int, y: int) -> int:
+    return sum(
+        1
+        for value in range(1, x + 1)
+        if all(prime <= y for prime in _prime_factors(value))
+    )
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "expected"),
+    [
+        (0, 0, 0),
+        (0, 17, 0),
+        (1, 0, 1),
+        (25, 0, 1),
+        (25, 1, 1),
+        (10, 2, 4),
+        (10, 3, 7),
+        (100, 5, 34),
+        (100, 100, 100),
+    ],
+)
+def test_known_counts_and_boundary_conventions(x: int, y: int, expected: int) -> None:
+    assert count_friable(x, y) == expected
+
+
+def test_matches_independent_factorization_oracle_on_small_domain() -> None:
+    for x in range(41):
+        for y in range(13):
+            assert count_friable(x, y) == _direct_count(x, y)
+
+
+def test_prime_step_recurrence_and_composite_cutoff_invariance() -> None:
+    primes = (2, 3, 5, 7, 11)
+    for x in range(1, 81):
+        assert count_friable(x, 4) == count_friable(x, 3)
+        previous = 1
+        for prime in primes:
+            assert count_friable(x, prime) == count_friable(
+                x, previous
+            ) + count_friable(x // prime, prime)
+            previous = prime
+
+
+def test_largest_prime_factor_recurrence_from_the_source() -> None:
+    for x in range(1, 41):
+        for y in range(13):
+            primes = (
+                candidate
+                for candidate in range(2, y + 1)
+                if tuple(_prime_factors(candidate)) == (candidate,)
+            )
+            assert count_friable(x, y) == 1 + sum(
+                count_friable(x // prime, prime) for prime in primes
+            )
+
+
+def test_is_monotone_in_source_bound_and_cutoff() -> None:
+    assert [count_friable(x, 5) for x in range(30)] == sorted(
+        count_friable(x, 5) for x in range(30)
+    )
+    assert [count_friable(100, y) for y in range(20)] == sorted(
+        count_friable(100, y) for y in range(20)
+    )
+
+
+def test_generated_regime_admits_large_sources_when_work_is_small() -> None:
+    assert count_friable(10**12, 2) == 40
+    assert count_friable(10**30, 5) == 48_207
+
+
+def test_materialized_regime_reaches_its_cell_boundary() -> None:
+    assert (
+        count_friable(MAX_FRIABLE_MATERIALIZED_X, 999_999) == MAX_FRIABLE_MATERIALIZED_X
+    )
+
+
+def test_large_direct_cases_do_not_inherit_the_materialized_cap() -> None:
+    huge = 10**255
+    assert count_friable(huge, 1) == 1
+    assert count_friable(huge, huge) == huge
+
+
+def test_native_api_enforces_the_source_digit_bound_before_work() -> None:
+    with pytest.raises(ValueError, match="256 decimal digits"):
+        count_friable(10**256, 1)
+
+
+def test_request_rejects_negative_and_noncanonical_sources() -> None:
+    with pytest.raises(ValidationError, match="nonnegative"):
+        FriableCountRequest(x="-1", y="2")
+    with pytest.raises(ValidationError):
+        FriableCountRequest(x="01", y="2")
+
+
+def test_request_rejects_unbounded_generated_prime_cutoff() -> None:
+    with pytest.raises(ValidationError, match="prime cutoff"):
+        FriableCountRequest(
+            x=str(MAX_FRIABLE_MATERIALIZED_X + 1),
+            y=str(MAX_FRIABLE_GENERATED_CUTOFF + 1),
+        )
+
+
+def test_request_rejects_generated_search_above_node_budget() -> None:
+    with pytest.raises(ValidationError, match="search-node budget"):
+        FriableCountRequest(x="1" + "0" * 255, y="5")
+
+
+def test_result_rejects_a_nearby_estimate_presented_as_exact() -> None:
+    with pytest.raises(ValidationError, match="does not match"):
+        FriableCountResult(x="100", y="5", count="35")
+
+
+def test_result_replays_count_and_binds_both_source_fields() -> None:
+    result = compute_friable_count(FriableCountRequest(x="100", y="5"))
+    assert result == FriableCountResult(x="100", y="5", count="34")
+
+    with pytest.raises(ValidationError, match="does not match"):
+        FriableCountResult(x="125", y="5", count=result.count)
+    with pytest.raises(ValidationError, match="does not match"):
+        FriableCountResult(x="100", y="3", count=result.count)
+
+
+def test_operation_is_discoverable_with_one_executable_example() -> None:
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+
+    operation = next(
+        tool
+        for tool in BUILTIN_TOOLS
+        if tool.operation_id == "number_theory.friable.count.compute"
+    )
+    assert len(operation.examples) == 1
+    example = operation.examples[0]
+    request = operation.request_type.model_validate(example.input)
+    assert operation.run(request).count == "34"
+
+
+def test_number_theory_native_api_is_explicit() -> None:
+    from jacobian.math import number_theory
+
+    assert tuple(number_theory.__all__) == ("FriableCountResult", "count_friable")
+    assert all(hasattr(number_theory, name) for name in number_theory.__all__)


### PR DESCRIPTION
## Problem

The number-theory catalog cannot compute the exact friable-count function
`Psi(x, y)`: the number of positive integers at most `x` whose prime factors
are at most the inclusive cutoff `y`. Factoring every integer independently
throws away the function's recurrence structure, while published fast
estimators cannot satisfy an exact result contract.

Fixes #2307.

## Solution

Add `number_theory.friable.count.compute` and the native `count_friable(x, y)`
function. The operation returns a source-bound `FriableCountResult` containing
canonical decimal `x`, `y`, and the exact count. Result construction replays
the full count, so a nearby estimate cannot be presented as exact.

The kernel chooses among three deterministic regimes after complete preflight:

- direct identities for `x = 0`, `y <= 1`, and `y >= x`;
- a request-local bytearray sieve through one million source cells;
- prime-exponent tuple generation for larger `x` when a conservative prefix-box
  bound fits the search-node budget.

The current SymPy 1.14 and python-flint 0.9 documentation was checked before
choosing the kernel. Their documented number-theory APIs provide prime and
factorization building blocks, but not an exact bounded `Psi(x, y)` operation.
The small request-local sieve and tuple traversal therefore keep the public
semantics exact without adding a backend dependency or using a process-global
prime cache.

Tests use an independent small factorization oracle and replay the prime-step,
composite-cutoff, and largest-prime recurrences from the pinned source
formalization.

## Testing

- `make test-math TESTS=tests/math/number_theory/test_friable_count.py PYTEST_ARGS='-q'` — 24 passed
- `make test-catalog TESTS='tests/catalog/test_catalog.py tests/catalog/test_admission.py tests/catalog/test_catalog_invariants.py' PYTEST_ARGS='-q'` — 21 passed
- `make test-integration TESTS='tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py' PYTEST_ARGS='-q'` — 967 passed
- `make check` — Ruff, format, mypy, and 2,673 tests passed

- Specialist validation run: built-in example execution and public-operation
  boundary mutation conformance, as listed above.

## Public contract impact

Adds operation ID `number_theory.friable.count.compute`, request/result schemas
`FriableCountRequest` and `FriableCountResult`, and native number-theory exports
`count_friable` and `FriableCountResult`. The operation is exact-only: requests
outside its admitted envelope fail validation before counting. No MCP transport
contract changes.

## Public operation admission

- Concrete gap: no operation returned the exact bounded friable count.
- Why existing operations or typed values are insufficient: independent integer
  factorization calls do not expose the standard exact count or its reusable
  recurrence structure; asymptotic estimators establish a different result.
- Stable mathematical result: complete `Psi(x, y)` with inclusive cutoff and
  explicit `Psi(0, y) = 0`, `Psi(x, 0) = Psi(x, 1) = 1` conventions.
- Semantic domain and admitted execution envelope: canonical nonnegative
  integers of at most 256 decimal digits; direct identities remain available
  across that representation bound, while nontrivial requests must fit either
  the materialized or generated regime.
- Controlling work, intermediate, memory, and output quantities: two full count
  passes are charged for operation plus result replay; each materialized count
  is bounded by two harmonic marking sums plus one scan, with at most 3 MB of
  bytearray storage; generated work is bounded by one million prime-exponent
  prefix nodes across both passes. The count is at most `x`, so it remains
  within 256 output digits.
- Exact representation, algorithm regimes, and maintained backend: canonical
  decimal wire integers, Python exact integers, direct identities, a local
  Eratosthenes-style sieve, and exact prime-exponent tuple generation. No
  maintained dependency currently documents the required exact count surface.
- Remaining fixed caps and their classification: 256 digits is the canonical
  representation/output bound; one million materialized cells, 82 million
  charged marking steps, 3 MB of materialized storage, a 10,000 prime-table
  cutoff, and one million charged prefix nodes are conservative execution
  bounds. The cell threshold is an algorithm crossover, not the mathematical
  domain boundary.
- Admission decision: `KEEP` — one exact reusable arithmetic value with
  material computational leverage over caller-side factorization.

## Suggested review order

1. `_models.py` for the public envelope and replay invariant.
2. `_friable_operations.py` for the two exact counting kernels.
3. `test_friable_count.py`, then the declaration/admission wiring.

## Closure matrix

None. This PR admits the single requested exact operation; approximation,
enumeration, sampling, progressions, and weighted variants remain explicitly
deferred by #2307.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, backend, Harbor/Oracle)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; no shared abstraction added)
