### PR TITLE
feat(matrices): add exact rational spectrum claim checks for symmetric matrices

### DIFF
--- a/src/jacobian/math/matrices/analysis/_admission.py
+++ b/src/jacobian/math/matrices/analysis/_admission.py
@@ -20,6 +20,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
     ),
+    OperationAdmission(
+        "matrix.symmetric.rational_spectrum_claim.check",
+        AdmissionDecision.KEEP,
+        "one source-bound exact predicate that replays every rational eigenspace multiplicity and completeness from a canonical symmetric QQ matrix",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/matrices/analysis/_models.py
+++ b/src/jacobian/math/matrices/analysis/_models.py
@@ -2,12 +2,216 @@
 
 from __future__ import annotations
 
-from typing import Self
+from math import factorial
+from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math.matrices.values import RationalMatrix, require_matrix_scalar_digits
+
+MAX_RATIONAL_SPECTRUM_ORDER = 32
+MAX_RATIONAL_SPECTRUM_CLAIMS = 32
+MAX_RATIONAL_SPECTRUM_INPUT_DIGITS = 64
+MAX_RATIONAL_SPECTRUM_NONZERO_ENTRIES = 1_024
+MAX_RATIONAL_SPECTRUM_SHIFTED_DIGITS = 129
+MAX_RATIONAL_SPECTRUM_RANK_WORK = 1_048_576
+MAX_RATIONAL_SPECTRUM_MINOR_DIGITS = 132_256
+MAX_RATIONAL_SPECTRUM_RESULT_BYTES = 384 * 1024
+
+
+def _component_digits(value: CanonicalRational) -> int:
+    return max(len(value.num.lstrip("-")), len(value.den))
+
+
+class RationalSpectrumMultiplicityClaim(StrictModel):
+    """One distinct rational eigenvalue and its claimed positive multiplicity."""
+
+    eigenvalue: CanonicalRational
+    multiplicity: StrictInt = Field(ge=1, le=MAX_RATIONAL_SPECTRUM_ORDER)
+
+
+class RationalSpectrumClaimRequest(StrictModel):
+    """A complete rational spectrum claim for one symmetric matrix over QQ.
+
+    ``matrix`` is the canonical materialized rational-matrix value. It must be
+    square, symmetric, and have order at most 32. ``claimed_profile`` contains
+    1..32 pairwise-distinct rational eigenvalues with positive multiplicities.
+    Matrix and claim rational components are limited to 64 decimal digits.
+    """
+
+    matrix: RationalMatrix = Field(
+        description=(
+            "Canonical materialized square symmetric matrix over QQ, of order "
+            "at most 32, with rational components of at most 64 decimal digits."
+        )
+    )
+    claimed_profile: tuple[RationalSpectrumMultiplicityClaim, ...] = Field(
+        min_length=1,
+        max_length=MAX_RATIONAL_SPECTRUM_CLAIMS,
+        description=(
+            "Nonempty list of at most 32 pairwise-distinct rational eigenvalues "
+            "and positive claimed multiplicities."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_complete_claim(self) -> Self:
+        order = len(self.matrix.entries)
+        if order != len(self.matrix.entries[0]):
+            raise ValueError("rational spectrum claims require a square matrix")
+        if order > MAX_RATIONAL_SPECTRUM_ORDER:
+            raise ValueError(
+                "rational spectrum claims support matrix order at most "
+                f"{MAX_RATIONAL_SPECTRUM_ORDER}"
+            )
+        if any(
+            self.matrix.entries[row][column] != self.matrix.entries[column][row]
+            for row in range(order)
+            for column in range(row + 1, order)
+        ):
+            raise ValueError("rational spectrum claims require a symmetric matrix")
+
+        require_matrix_scalar_digits(
+            self.matrix.entries,
+            maximum=MAX_RATIONAL_SPECTRUM_INPUT_DIGITS,
+            label="rational spectrum matrix",
+        )
+        nonzero_entries = sum(
+            entry.num != "0" for row in self.matrix.entries for entry in row
+        )
+        if nonzero_entries > MAX_RATIONAL_SPECTRUM_NONZERO_ENTRIES:
+            raise ValueError(
+                "rational spectrum matrix exceeds the nonzero-entry budget"
+            )
+        eigenvalues = tuple(claim.eigenvalue for claim in self.claimed_profile)
+        for eigenvalue in eigenvalues:
+            require_bounded_rational(
+                eigenvalue,
+                max_digits=MAX_RATIONAL_SPECTRUM_INPUT_DIGITS,
+                label="claimed eigenvalue",
+            )
+        if len(set(eigenvalues)) != len(eigenvalues):
+            raise ValueError("claimed rational eigenvalues must be pairwise distinct")
+
+        shifted_digits = max(
+            _component_digits(
+                CanonicalRational.from_fraction(
+                    self.matrix.entries[index][index].as_fraction()
+                    - eigenvalue.as_fraction()
+                )
+            )
+            for eigenvalue in eigenvalues
+            for index in range(order)
+        )
+        if shifted_digits > MAX_RATIONAL_SPECTRUM_SHIFTED_DIGITS:
+            raise ValueError(
+                "shifted diagonal entries exceed the rational spectrum digit budget"
+            )
+
+        rank_work = len(eigenvalues) * order**3
+        if rank_work > MAX_RATIONAL_SPECTRUM_RANK_WORK:
+            raise ValueError(
+                "shifted-rank computations exceed the aggregate work budget"
+            )
+
+        # Clearing each row's denominators gives integer entries with at most
+        # order * shifted_digits digits. Every square minor then has at most
+        # order! terms, each a product of at most order such entries.
+        minor_digits = order * order * shifted_digits + len(str(factorial(order))) + 1
+        if minor_digits > MAX_RATIONAL_SPECTRUM_MINOR_DIGITS:
+            raise ValueError("exact shifted-rank minors exceed the digit budget")
+
+        source_cells = order * order
+        result_bytes = (
+            2_048
+            + source_cells * (2 * MAX_RATIONAL_SPECTRUM_INPUT_DIGITS + 96)
+            + len(eigenvalues) * (4 * MAX_RATIONAL_SPECTRUM_INPUT_DIGITS + 256)
+        )
+        if result_bytes > MAX_RATIONAL_SPECTRUM_RESULT_BYTES:
+            raise ValueError("rational spectrum ledger exceeds the result-size budget")
+        return self
+
+
+class RationalSpectrumNullityLedgerEntry(StrictModel):
+    """Exact shifted nullity and multiplicity comparison for one claim."""
+
+    eigenvalue: CanonicalRational
+    claimed_multiplicity: StrictInt = Field(ge=1, le=MAX_RATIONAL_SPECTRUM_ORDER)
+    exact_nullity: StrictInt = Field(ge=0, le=MAX_RATIONAL_SPECTRUM_ORDER)
+    multiplicity_matches: bool
+
+
+RationalSpectrumFailure = Literal[
+    "MULTIPLICITY_MISMATCH",
+    "CLAIMED_MULTIPLICITY_SUM_DOES_NOT_EQUAL_MATRIX_ORDER",
+]
+
+
+class RationalSpectrumClaimResult(StrictModel):
+    """An exact complete-spectrum decision bound to its source and claim."""
+
+    matrix: RationalMatrix
+    claimed_profile: tuple[RationalSpectrumMultiplicityClaim, ...] = Field(
+        min_length=1, max_length=MAX_RATIONAL_SPECTRUM_CLAIMS
+    )
+    nullity_ledger: tuple[RationalSpectrumNullityLedgerEntry, ...] = Field(
+        min_length=1, max_length=MAX_RATIONAL_SPECTRUM_CLAIMS
+    )
+    matrix_order: StrictInt = Field(ge=1, le=MAX_RATIONAL_SPECTRUM_ORDER)
+    claimed_multiplicity_sum: StrictInt = Field(
+        ge=1,
+        le=MAX_RATIONAL_SPECTRUM_CLAIMS * MAX_RATIONAL_SPECTRUM_ORDER,
+    )
+    established_multiplicity_sum: StrictInt = Field(
+        ge=0, le=MAX_RATIONAL_SPECTRUM_ORDER
+    )
+    outcome: Literal["VALID", "INVALID"]
+    valid_complete_rational_spectrum: bool
+    first_failed_condition: RationalSpectrumFailure | None = None
+    first_failed_claim_index: StrictInt | None = Field(
+        default=None, ge=0, lt=MAX_RATIONAL_SPECTRUM_CLAIMS
+    )
+    method: Literal["PYTHON_FLINT_EXACT_RANK_AFTER_ROW_DENOMINATOR_CLEARING"] = (
+        "PYTHON_FLINT_EXACT_RANK_AFTER_ROW_DENOMINATOR_CLEARING"
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_claim_to_source(self) -> Self:
+        request = RationalSpectrumClaimRequest(
+            matrix=self.matrix,
+            claimed_profile=self.claimed_profile,
+        )
+        from jacobian.math.matrices.analysis._operations import (
+            _replay_rational_spectrum_claim,
+        )
+
+        (
+            expected_ledger,
+            claimed_sum,
+            established_sum,
+            mismatch,
+            failure,
+        ) = _replay_rational_spectrum_claim(request)
+        valid = failure is None
+
+        expected = (
+            self.nullity_ledger == expected_ledger
+            and self.matrix_order == len(request.matrix.entries)
+            and self.claimed_multiplicity_sum == claimed_sum
+            and self.established_multiplicity_sum == established_sum
+            and self.outcome == ("VALID" if valid else "INVALID")
+            and self.valid_complete_rational_spectrum is valid
+            and self.first_failed_condition == failure
+            and self.first_failed_claim_index == mismatch
+        )
+        if not expected:
+            raise ValueError(
+                "rational spectrum result does not match exact replay from the "
+                "retained source and claim"
+            )
+        return self
 
 
 class MatrixEntry(StrictModel):
@@ -98,5 +302,9 @@ __all__ = [
     "FarkasCertificateResult",
     "InertiaResult",
     "MatrixEntry",
+    "RationalSpectrumClaimRequest",
+    "RationalSpectrumClaimResult",
+    "RationalSpectrumMultiplicityClaim",
+    "RationalSpectrumNullityLedgerEntry",
     "SymmetricMatrixRequest",
 ]

--- a/src/jacobian/math/matrices/analysis/_operations.py
+++ b/src/jacobian/math/matrices/analysis/_operations.py
@@ -3,14 +3,116 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from math import lcm
 
+from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.matrices.analysis._models import (
     FarkasCertificateRequest,
     FarkasCertificateResult,
     InertiaResult,
+    RationalSpectrumClaimRequest,
+    RationalSpectrumClaimResult,
+    RationalSpectrumFailure,
+    RationalSpectrumNullityLedgerEntry,
     SymmetricMatrixRequest,
 )
+from jacobian.math.matrices.values import RationalMatrix
+
+
+def _exact_shifted_nullities(
+    matrix: RationalMatrix,
+    eigenvalues: tuple[CanonicalRational, ...],
+) -> tuple[int, ...]:
+    """Return nullities of ``matrix - eigenvalue * I`` over QQ.
+
+    Each rational row is scaled by the least common multiple of its
+    denominators. This preserves rank and gives FLINT an exact integer matrix;
+    no floating-point or symbolic expression crosses the adapter boundary.
+    """
+    from flint import fmpz_mat
+
+    source = tuple(
+        tuple(entry.as_fraction() for entry in row) for row in matrix.entries
+    )
+    order = len(source)
+    nullities: list[int] = []
+    for canonical_eigenvalue in eigenvalues:
+        eigenvalue = canonical_eigenvalue.as_fraction()
+        integer_rows: list[list[int]] = []
+        for row_index, source_row in enumerate(source):
+            shifted_row = [
+                entry - eigenvalue if row_index == column_index else entry
+                for column_index, entry in enumerate(source_row)
+            ]
+            row_denominator = lcm(*(entry.denominator for entry in shifted_row))
+            integer_rows.append(
+                [
+                    entry.numerator * (row_denominator // entry.denominator)
+                    for entry in shifted_row
+                ]
+            )
+        nullities.append(order - int(fmpz_mat(integer_rows).rank()))
+    return tuple(nullities)
+
+
+def check_rational_spectrum_claim(
+    request: RationalSpectrumClaimRequest,
+) -> RationalSpectrumClaimResult:
+    """Check a claimed complete rational spectrum of a symmetric QQ matrix."""
+    ledger, claimed_sum, established_sum, mismatch, failure = (
+        _replay_rational_spectrum_claim(request)
+    )
+    valid = failure is None
+    return RationalSpectrumClaimResult(
+        matrix=request.matrix,
+        claimed_profile=request.claimed_profile,
+        nullity_ledger=ledger,
+        matrix_order=len(request.matrix.entries),
+        claimed_multiplicity_sum=claimed_sum,
+        established_multiplicity_sum=established_sum,
+        outcome="VALID" if valid else "INVALID",
+        valid_complete_rational_spectrum=valid,
+        first_failed_condition=failure,
+        first_failed_claim_index=mismatch,
+    )
+
+
+def _replay_rational_spectrum_claim(
+    request: RationalSpectrumClaimRequest,
+) -> tuple[
+    tuple[RationalSpectrumNullityLedgerEntry, ...],
+    int,
+    int,
+    int | None,
+    RationalSpectrumFailure | None,
+]:
+    """Recompute the complete source-bound claim ledger."""
+    nullities = _exact_shifted_nullities(
+        request.matrix,
+        tuple(claim.eigenvalue for claim in request.claimed_profile),
+    )
+    ledger = tuple(
+        RationalSpectrumNullityLedgerEntry(
+            eigenvalue=claim.eigenvalue,
+            claimed_multiplicity=claim.multiplicity,
+            exact_nullity=nullity,
+            multiplicity_matches=nullity == claim.multiplicity,
+        )
+        for claim, nullity in zip(request.claimed_profile, nullities, strict=True)
+    )
+    claimed_sum = sum(claim.multiplicity for claim in request.claimed_profile)
+    mismatch = next(
+        (index for index, entry in enumerate(ledger) if not entry.multiplicity_matches),
+        None,
+    )
+    if mismatch is not None:
+        failure: RationalSpectrumFailure | None = "MULTIPLICITY_MISMATCH"
+    elif claimed_sum != len(request.matrix.entries):
+        failure = "CLAIMED_MULTIPLICITY_SUM_DOES_NOT_EQUAL_MATRIX_ORDER"
+    else:
+        failure = None
+    return ledger, claimed_sum, sum(nullities), mismatch, failure
 
 
 def _build_matrix(request: SymmetricMatrixRequest) -> list[list[Fraction]]:
@@ -217,4 +319,8 @@ def check_farkas_certificate(
     )
 
 
-__all__ = ["check_farkas_certificate", "compute_inertia"]
+__all__ = [
+    "check_farkas_certificate",
+    "check_rational_spectrum_claim",
+    "compute_inertia",
+]

--- a/src/jacobian/math/matrices/analysis/_tools.py
+++ b/src/jacobian/math/matrices/analysis/_tools.py
@@ -10,10 +10,13 @@ from jacobian.math.matrices.analysis._models import (
     FarkasCertificateRequest,
     FarkasCertificateResult,
     InertiaResult,
+    RationalSpectrumClaimRequest,
+    RationalSpectrumClaimResult,
     SymmetricMatrixRequest,
 )
 from jacobian.math.matrices.analysis._operations import (
     check_farkas_certificate,
+    check_rational_spectrum_claim,
     compute_inertia,
 )
 
@@ -46,6 +49,63 @@ def _op[
 
 
 MATRIX_ANALYSIS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "matrix.symmetric.rational_spectrum_claim.check",
+        "Check a complete rational spectrum claim for a symmetric matrix",
+        "For a bounded symmetric matrix over QQ and pairwise-distinct rational "
+        "eigenvalue claims, return the retained source and exact shifted-nullity "
+        "ledger, and decide whether the claimed multiplicities give the complete "
+        "spectrum. A claim is complete exactly when every multiplicity equals its "
+        "nullity and the multiplicities sum to the matrix order.",
+        RationalSpectrumClaimRequest,
+        RationalSpectrumClaimResult,
+        check_rational_spectrum_claim,
+        "matrix",
+        "symmetric",
+        "spectrum",
+        "eigenvalue",
+        "multiplicity",
+        "exact",
+        "check",
+        examples=(
+            example(
+                "repeated_diagonal_rational_spectrum",
+                "Check that diag(2, 2, -1) has complete spectrum 2^2, (-1)^1; "
+                "the matrix must be symmetric and claimed eigenvalues distinct.",
+                {
+                    "matrix": {
+                        "entries": [
+                            [
+                                {"num": "2", "den": "1"},
+                                {"num": "0", "den": "1"},
+                                {"num": "0", "den": "1"},
+                            ],
+                            [
+                                {"num": "0", "den": "1"},
+                                {"num": "2", "den": "1"},
+                                {"num": "0", "den": "1"},
+                            ],
+                            [
+                                {"num": "0", "den": "1"},
+                                {"num": "0", "den": "1"},
+                                {"num": "-1", "den": "1"},
+                            ],
+                        ]
+                    },
+                    "claimed_profile": [
+                        {
+                            "eigenvalue": {"num": "2", "den": "1"},
+                            "multiplicity": 2,
+                        },
+                        {
+                            "eigenvalue": {"num": "-1", "den": "1"},
+                            "multiplicity": 1,
+                        },
+                    ],
+                },
+            ),
+        ),
+    ),
     _op(
         "matrix.inertia.compute",
         "Compute Sylvester inertia of a symmetric rational matrix",

--- a/tests/math/matrices/test_rational_spectrum_claim.py
+++ b/tests/math/matrices/test_rational_spectrum_claim.py
@@ -1,0 +1,287 @@
+"""Exact complete rational spectrum-claim tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any, cast
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.matrices.analysis._models import (
+    MAX_RATIONAL_SPECTRUM_INPUT_DIGITS,
+    MAX_RATIONAL_SPECTRUM_RESULT_BYTES,
+    RationalSpectrumClaimRequest,
+    RationalSpectrumClaimResult,
+)
+from jacobian.math.matrices.analysis._operations import (
+    check_rational_spectrum_claim,
+)
+
+
+def _rational(value: int, denominator: int = 1) -> dict[str, str]:
+    return {"num": str(value), "den": str(denominator)}
+
+
+def _matrix(entries: list[list[dict[str, str]]]) -> dict[str, object]:
+    return {"entries": entries}
+
+
+def _claim(
+    eigenvalue: int,
+    multiplicity: int,
+    denominator: int = 1,
+) -> dict[str, object]:
+    return {
+        "eigenvalue": _rational(eigenvalue, denominator),
+        "multiplicity": multiplicity,
+    }
+
+
+def _request(
+    entries: list[list[dict[str, str]]],
+    claims: list[dict[str, object]],
+) -> RationalSpectrumClaimRequest:
+    return RationalSpectrumClaimRequest.model_validate(
+        {
+            "matrix": _matrix(entries),
+            "claimed_profile": claims,
+        }
+    )
+
+
+def _mutate_source_matrix(data: dict[str, Any]) -> None:
+    matrix = cast(dict[str, Any], data["matrix"])
+    entries = cast(list[list[Any]], matrix["entries"])
+    entries[0][0] = _rational(3)
+
+
+def _mutate_claim(data: dict[str, Any]) -> None:
+    profile = cast(list[dict[str, Any]], data["claimed_profile"])
+    profile[0]["multiplicity"] = 2
+
+
+def _mutate_nullity(data: dict[str, Any]) -> None:
+    ledger = cast(list[dict[str, Any]], data["nullity_ledger"])
+    ledger[0]["exact_nullity"] = 0
+
+
+def _mutate_validity(data: dict[str, Any]) -> None:
+    data["valid_complete_rational_spectrum"] = False
+
+
+def _mutate_outcome(data: dict[str, Any]) -> None:
+    data["outcome"] = "INVALID"
+
+
+def test_complete_repeated_rational_spectrum_binds_exact_nullities() -> None:
+    request = _request(
+        [
+            [_rational(2), _rational(0), _rational(0)],
+            [_rational(0), _rational(2), _rational(0)],
+            [_rational(0), _rational(0), _rational(-1)],
+        ],
+        [_claim(2, 2), _claim(-1, 1)],
+    )
+
+    result = check_rational_spectrum_claim(request)
+
+    assert result.outcome == "VALID"
+    assert result.valid_complete_rational_spectrum is True
+    assert result.first_failed_condition is None
+    assert result.first_failed_claim_index is None
+    assert [entry.exact_nullity for entry in result.nullity_ledger] == [2, 1]
+    assert result.claimed_multiplicity_sum == 3
+    assert result.established_multiplicity_sum == 3
+    assert (
+        RationalSpectrumClaimResult.model_validate(result.model_dump(mode="json"))
+        == result
+    )
+
+
+def test_zero_matrix_and_nonintegral_rational_spectrum() -> None:
+    zero = check_rational_spectrum_claim(
+        _request(
+            [
+                [_rational(0), _rational(0), _rational(0)],
+                [_rational(0), _rational(0), _rational(0)],
+                [_rational(0), _rational(0), _rational(0)],
+            ],
+            [_claim(0, 3)],
+        )
+    )
+    assert zero.valid_complete_rational_spectrum is True
+    assert zero.nullity_ledger[0].exact_nullity == 3
+
+    rational = check_rational_spectrum_claim(
+        _request(
+            [
+                [_rational(1, 2), _rational(0)],
+                [_rational(0), _rational(-2, 3)],
+            ],
+            [_claim(1, 1, 2), _claim(-2, 1, 3)],
+        )
+    )
+    assert rational.valid_complete_rational_spectrum is True
+    assert [entry.exact_nullity for entry in rational.nullity_ledger] == [1, 1]
+
+
+def test_irrational_spectrum_is_an_exact_invalid_claim() -> None:
+    # [[0, 1], [1, 1]] has characteristic polynomial x^2 - x - 1.
+    result = check_rational_spectrum_claim(
+        _request(
+            [[_rational(0), _rational(1)], [_rational(1), _rational(1)]],
+            [_claim(0, 2)],
+        )
+    )
+
+    assert result.outcome == "INVALID"
+    assert result.valid_complete_rational_spectrum is False
+    assert result.nullity_ledger[0].exact_nullity == 0
+    assert result.established_multiplicity_sum == 0
+    assert result.first_failed_condition == "MULTIPLICITY_MISMATCH"
+    assert result.first_failed_claim_index == 0
+
+
+def test_correct_subset_fails_only_the_completeness_sum() -> None:
+    result = check_rational_spectrum_claim(
+        _request(
+            [
+                [_rational(1), _rational(0), _rational(0)],
+                [_rational(0), _rational(1), _rational(0)],
+                [_rational(0), _rational(0), _rational(2)],
+            ],
+            [_claim(1, 2)],
+        )
+    )
+
+    assert result.nullity_ledger[0].multiplicity_matches is True
+    assert result.first_failed_condition == (
+        "CLAIMED_MULTIPLICITY_SUM_DOES_NOT_EQUAL_MATRIX_ORDER"
+    )
+    assert result.first_failed_claim_index is None
+    assert result.established_multiplicity_sum == 2
+
+
+def test_first_wrong_multiplicity_is_reported_in_submission_order() -> None:
+    result = check_rational_spectrum_claim(
+        _request(
+            [
+                [_rational(1), _rational(0), _rational(0)],
+                [_rational(0), _rational(1), _rational(0)],
+                [_rational(0), _rational(0), _rational(2)],
+            ],
+            [_claim(1, 1), _claim(2, 2)],
+        )
+    )
+
+    assert [entry.exact_nullity for entry in result.nullity_ledger] == [2, 1]
+    assert [entry.multiplicity_matches for entry in result.nullity_ledger] == [
+        False,
+        False,
+    ]
+    assert result.first_failed_condition == "MULTIPLICITY_MISMATCH"
+    assert result.first_failed_claim_index == 0
+
+
+@pytest.mark.parametrize(
+    ("entries", "claims", "message"),
+    [
+        (
+            [[_rational(1), _rational(1)], [_rational(0), _rational(1)]],
+            [_claim(1, 2)],
+            "symmetric",
+        ),
+        (
+            [[_rational(1), _rational(0)], [_rational(0), _rational(2)]],
+            [_claim(1, 1), _claim(1, 1)],
+            "pairwise distinct",
+        ),
+        (
+            [[_rational(1)]],
+            [_claim(1, 0)],
+            "greater than or equal to 1",
+        ),
+    ],
+)
+def test_invalid_request_domain_is_rejected_before_backend(
+    entries: list[list[dict[str, str]]],
+    claims: list[dict[str, object]],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        _request(entries, claims)
+
+
+def test_source_claim_ledger_and_conclusion_mutations_cannot_revalidate() -> None:
+    result = check_rational_spectrum_claim(
+        _request(
+            [[_rational(1), _rational(0)], [_rational(0), _rational(2)]],
+            [_claim(1, 1), _claim(2, 1)],
+        )
+    )
+
+    mutations: tuple[Callable[[dict[str, Any]], None], ...] = (
+        _mutate_source_matrix,
+        _mutate_claim,
+        _mutate_nullity,
+        _mutate_validity,
+        _mutate_outcome,
+    )
+    for mutate in mutations:
+        forged = deepcopy(result.model_dump(mode="json"))
+        mutate(forged)
+        with pytest.raises(ValidationError, match="does not match exact replay"):
+            RationalSpectrumClaimResult.model_validate(forged)
+
+
+def test_simultaneous_row_column_permutation_preserves_claim() -> None:
+    entries = [
+        [_rational(2), _rational(1), _rational(0)],
+        [_rational(1), _rational(2), _rational(0)],
+        [_rational(0), _rational(0), _rational(4)],
+    ]
+    claims = [_claim(1, 1), _claim(3, 1), _claim(4, 1)]
+    original = check_rational_spectrum_claim(_request(entries, claims))
+    permutation = (2, 0, 1)
+    permuted_entries = [
+        [entries[row][column] for column in permutation] for row in permutation
+    ]
+    permuted = check_rational_spectrum_claim(_request(permuted_entries, claims))
+
+    assert original.valid_complete_rational_spectrum is True
+    assert permuted.valid_complete_rational_spectrum is True
+    assert permuted.nullity_ledger == original.nullity_ledger
+
+
+def test_order_claim_count_digit_and_result_boundaries() -> None:
+    order = 32
+    diagonal = [
+        [_rational(row if row == column else 0) for column in range(order)]
+        for row in range(order)
+    ]
+    claims = [_claim(index, 1) for index in range(order)]
+    boundary = check_rational_spectrum_claim(_request(diagonal, claims))
+    assert boundary.valid_complete_rational_spectrum is True
+    assert len(boundary.model_dump_json()) < MAX_RATIONAL_SPECTRUM_RESULT_BYTES
+
+    dense = [[_rational(1) for _ in range(order)] for _ in range(order)]
+    dense_boundary = check_rational_spectrum_claim(
+        _request(dense, [_claim(order, 1), _claim(0, order - 1)])
+    )
+    assert dense_boundary.valid_complete_rational_spectrum is True
+
+    too_many_claims = [*claims, _claim(order, 1)]
+    with pytest.raises(ValidationError, match="at most 32 items"):
+        _request(diagonal, too_many_claims)
+
+    max_scalar = int("9" * MAX_RATIONAL_SPECTRUM_INPUT_DIGITS)
+    scalar_boundary = check_rational_spectrum_claim(
+        _request([[_rational(max_scalar)]], [_claim(max_scalar, 1)])
+    )
+    assert scalar_boundary.valid_complete_rational_spectrum is True
+
+    over_scalar = int("1" + "0" * MAX_RATIONAL_SPECTRUM_INPUT_DIGITS)
+    with pytest.raises(ValidationError, match="limited to 64 decimal digits"):
+        _request([[_rational(over_scalar)]], [_claim(0, 1)])


### PR DESCRIPTION
Closes #2283.

## Problem

The catalog can compute rational matrix rank and symmetric inertia, but neither operation binds a submitted list of rational eigenvalues and multiplicities to one source matrix or decides whether that list is the complete spectrum. Repeating shifted-rank calls leaves the caller responsible for distinct-value validation, source association, multiplicity matching, and the symmetric-matrix completeness inference.

## Solution

Add `matrix.symmetric.rational_spectrum_claim.check`. The request accepts the canonical materialized `RationalMatrix` plus a nonempty profile of distinct rational eigenvalues and positive multiplicities. It rejects nonsquare or nonsymmetric matrices, duplicate values, and requests outside the digit, work, intermediate-height, or result-size envelope before calling the backend.

For each claim, the operation clears the denominators of every row of `A - λI` and calls python-flint's exact integer-matrix rank. Row scaling preserves rank over `QQ`, so `nullity(A - λI) = n - rank(A - λI)` exactly. Since rational symmetric matrices are diagonalizable over `RR`, the profile is complete exactly when every claimed multiplicity equals its shifted nullity and the claimed multiplicities sum to the matrix order.

The result retains the matrix and submitted profile, reports every exact nullity and comparison, records claimed and established multiplicity sums, and returns a deterministic first failure. Result validation recomputes the complete ledger from the retained source, so authored source, claim, ledger, or conclusion mutations cannot revalidate. Operational failures are not converted into mathematical `INVALID` results.

Suggested review order: request/result invariants in `_models.py`, exact row-cleared rank replay in `_operations.py`, then the adversarial and boundary tests.

## Testing

- `make test-math TESTS=tests/math/matrices/test_rational_spectrum_claim.py` — 11 passed.
- `uv run --locked pytest -q tests/catalog/test_admission.py tests/catalog/test_catalog.py tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py` — 985 passed.
- `make check` — Ruff and formatting clean, mypy clean, 2,660 tests passed.
- Boundary measurement on CPython 3.12.13 with python-flint 0.9.0: one dense symmetric order-32 request with 64-digit rational entries and 32 claims, including source-bound result replay, completed in 1.042184 seconds and returned an exact `INVALID` result. The fixture was generated deterministically with `Random(2283)`.

## Public contract impact

Adds operation ID `matrix.symmetric.rational_spectrum_claim.check` with new request and source-bound result schemas. Existing operation IDs, schemas, and native APIs are unchanged.

## Public operation admission

- **Concrete gap:** no existing operation checks a complete rational spectrum claim while binding all shifted nullities and multiplicities to the canonical source matrix.
- **Why existing operations or typed values are insufficient:** `matrix.rank.compute` and `matrix.inertia.compute` return independent computations; they do not retain the source/profile relation or own completeness replay.
- **Semantic mathematical domain and postcondition:** decide exactly whether distinct rational eigenvalue/multiplicity claims form the complete spectrum of a symmetric matrix over `QQ`.
- **Canonical public value type:** `RationalMatrix`; claims and ledger eigenvalues use `CanonicalRational`.
- **Source representation:** materialized dense canonical rational matrix.
- **Expansion performed by the kernel and its pre-execution bound:** one shifted matrix and one row-cleared integer matrix per claim; order and claim count are each at most 32.
- **Representation-sensitive complexity:** no succinct or generated matrix representation is admitted; the kernel performs no hidden matrix expansion.
- **Admitted request envelope and controlling quantities:** order ≤ 32, nonzero entries ≤ 1,024, claims ≤ 32, source components ≤ 64 digits, shifted components ≤ 129 digits, per-replay shifted-rank work ≤ 1,048,576 `claim_count * order^3` units, and predicted result ≤ 384 KiB. Construction performs two bounded replay passes: computation and source-bound result validation.
- **Producer/consumer closure:** the request consumes `RationalMatrix` unchanged. The output is a source-bound decision, not a new canonical matrix producer.
- **Degenerate inputs:** the nonempty zero matrix is admitted; its zero eigenvalue has nullity equal to the matrix order. Empty matrices are outside the canonical matrix domain.
- **Parent/ring/field identity:** the matrix and claims remain over exact `QQ`; row denominator clearing is an explicit rank-preserving map to an integer matrix used only by the private backend.
- **Deterministic work bound:** each replay performs at most 32 exact rank calls on order-32 matrices; the public result is deterministic in submitted claim order.
- **Maximum intermediate growth:** row clearing gives integer entries with at most `order * shifted_digits` digits; every relevant minor is bounded by `order^2 * shifted_digits + digits(order!) + 1`, capped at 132,256 decimal digits.
- **Exact result-size bound:** one retained matrix, one retained profile, and at most 32 constant-shape ledger entries, conservatively bounded to 384 KiB.
- **Backend and supported version:** pinned python-flint 0.9.0, using `fmpz_mat.rank()`.
- **Backend input domain:** nonempty square integer matrices produced only after complete symmetric-`QQ` request admission and exact row denominator clearing.
- **Conversion/coercion behavior:** canonical rationals become Python `Fraction` values; each shifted row is multiplied by a positive common denominator. No floating-point conversion or implicit field change occurs.
- **Result type:** `RationalSpectrumClaimResult`, a source-bound exact `VALID`/`INVALID` decision with nullity and completeness ledgers.
- **Reconstruction or defining invariant:** every ledger nullity equals `n - rank(A - λI)`; each match flag equals the nullity/multiplicity equality; completeness requires all matches and total multiplicity `n`. Result validation replays these relations.
- **Typed execution failures:** all admitted ordinary executions return the exact result type. Unexpected backend or resource failures remain operational errors and never establish `INVALID`.
- **Property and boundary tests:** repeated and nonintegral rational spectra, zero matrix, irrational spectra, correct incomplete subsets, wrong multiplicities, invalid request classes, independent result-field mutations, simultaneous row/column permutations, and order/claim/digit/nonzero/result boundaries.
- **Remaining fixed caps and classification:** order 32 follows the existing canonical `RationalMatrix` representation and is the measured honest initial envelope. The issue's order-50 source fixture would require a separate evidence-backed widening of that shared canonical value.
- **Admission decision:** `KEEP`.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Complete rational spectrum claim check | delivered | `matrix.symmetric.rational_spectrum_claim.check` |
| Algebraic-number, nonsymmetric/Jordan, approximate, discovery, and eigenvector checks | deferred outside this focused operation | none |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish mathematical invalidity from operational failure
- [x] New bounds include boundary, permutation, adversarial, and measured scale evidence
- [x] No new shared abstraction was introduced