### PR TITLE
feat(math): decide powerful integers without complete factorization (#2317)

### DIFF
--- a/docs/reference/operations/number-theory/integer-powerful-number-decision.md
+++ b/docs/reference/operations/number-theory/integer-powerful-number-decision.md
@@ -2,11 +2,65 @@
 
 [Documentation home](../../../index.md) · [Tool surface](../../tools.md)
 
-Use `integer.compute.prime_factorization` to obtain the complete factor witness,
-then test whether every exponent is at least two in caller-owned Python. The
-powerful-number predicate is a cheap deterministic projection of that retained
-public result and therefore has no separate discovery entry.
+`integer.decide.powerful` decides whether every prime divisor of one positive
+integer has exponent at least two. It accepts canonical decimal integers from
+`1` through the 25-digit execution envelope and returns a source-bound partial
+factor certificate. The operation does not compute a complete factorization.
 
-The integer is the complete request value and the decision is the complete
-response value. The operation runs as a direct bounded computation; it has no
-worker protocol, retained input, or separate checker product.
+## Exact decision
+
+For the source `n`, the operation derives
+
+```text
+B = ceil(n^(1/5)).
+```
+
+It strips prime factors in ascending order through `B`. A stripped exponent of
+one proves immediately that `n` is not powerful. Otherwise the remaining
+cofactor `r` has no prime divisor at most `B`, and `n` is powerful exactly when
+`r` is `1` or a nontrivial perfect power.
+
+For the nontrivial direction, suppose a `B`-rough `r > 1` were powerful but not
+a perfect power. The gcd of all its prime exponents would be one. It therefore
+has at least two prime factors, and the exponent sum is at least five: two
+exponents cannot both be two, while three or more exponents sum to at least
+six. Every prime factor exceeds `B`, so `r > B^5 >= n >= r`, a contradiction.
+
+The result records one of three exact conclusions:
+
+- `EXPONENT_ONE` includes every factor removed through the first exponent-one
+  obstruction. `checked_through` names that prime; the result does not claim
+  that the residual is `B`-rough.
+- `POWERFUL` includes every factor through `B` and either residual `1` or an
+  exact `base^exponent` decomposition of the `B`-rough residual.
+- `ROUGH_NOT_PERFECT_POWER` includes every factor through `B` and a `B`-rough
+  residual whose exact perfect-power classification is negative.
+
+Every result retains the source, derived cutoff, checked range, removed prime
+powers, and residual. Result validation replays the bounded decision, so
+changing the source, cutoff, checked range, exponent, residual, conclusion, or
+perfect-power witness invalidates the result.
+
+## Execution envelope
+
+The 25-digit cap is a conservative release bound, not part of the mathematical
+definition of powerful numbers. It gives `B <= 100000`, hence at most 9,592
+trial primes. The source and every intermediate have at most 84 bits; successful
+factor divisions total at most 83. A positive perfect-power classification
+needs exact roots only for the at most 23 prime exponents through 83. The result
+contains at most 42 stripped-factor rows: before an early exponent-one row,
+every preceding row consumes at least two source bits; complete branches have
+only exponent-at-least-two rows.
+
+Prime generation uses a request-local SymPy 1.14 sieve. Fifth roots, exact roots,
+and residual perfect-power classification use python-flint 0.9 integer kernels.
+The fifth-root cutoff and every power reconstruction use integer arithmetic;
+no floating-point value enters the decision.
+
+The partial-factor criterion and production-scale evidence follow the pinned
+[Erdős #366 certificate](https://github.com/techno-optimist/erdos-frontier-atlas/blob/0394e3d3b249439ffabec7d96a3311aa441651b8/certificates/erdos-366/README.md#the-exact-powerfulness-test).
+Bernstein's
+[perfect-power classification algorithm](https://cr.yp.to/papers/powers-ams.pdf)
+shows that the residual subproblem admits an essentially linear-time algorithm.
+Jacobian delegates its bounded exact classification to FLINT rather than
+porting that algorithm.

--- a/src/jacobian/math/number_theory/_admission.py
+++ b/src/jacobian/math/number_theory/_admission.py
@@ -157,8 +157,8 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     ),
     OperationAdmission(
         "integer.decide.powerful",
-        AdmissionDecision.DROP,
-        "ordinary arithmetic or cheap projection of a retained exact factorization/divisor result",
+        AdmissionDecision.KEEP,
+        "bounded partial-factor and rough-cofactor certificate decides 25-digit inputs without complete factorization",
     ),
     OperationAdmission(
         "integer.decide.prime",

--- a/src/jacobian/math/number_theory/_factorization.py
+++ b/src/jacobian/math/number_theory/_factorization.py
@@ -10,7 +10,6 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.number_theory._factorization_kernels import (
     compute_pratt_certificate,
     compute_radical,
-    decide_powerful,
     decide_squarefree,
     enumerate_divisors,
     enumerate_proper_divisors,
@@ -25,8 +24,6 @@ from jacobian.math.number_theory._models import (
     DivisorListResult,
     IntegerValueResult,
     NonzeroFactorizationRequest,
-    PowerfulNumberRequest,
-    PowerfulNumberResult,
     PrimalityCertificateRequest,
     PrimalityCertificateResult,
     PrimeFactorizationResult,
@@ -61,12 +58,6 @@ def _compute_prime_factorization(
     request: NonzeroFactorizationRequest,
 ) -> PrimeFactorizationResult:
     return factorize_primes(request)
-
-
-def _compute_powerful(
-    request: PowerfulNumberRequest,
-) -> PowerfulNumberResult:
-    return decide_powerful(request)
 
 
 def _compute_squarefree(
@@ -190,26 +181,6 @@ FACTORIZATION_OPERATIONS = (
                 "prime_factorization_360",
                 "Factor 360 into prime powers.",
                 {"value": "360"},
-            ),
-        ),
-    ),
-    _operation(
-        operation_id="integer.decide.powerful",
-        title="Decide powerful-number status",
-        description=(
-            "Decide whether every prime exponent of one positive integer is at "
-            "least two, preserving the complete factor witness and every "
-            "violating prime."
-        ),
-        request_model=PowerfulNumberRequest,
-        result_model=PowerfulNumberResult,
-        implementation=_compute_powerful,
-        tags=("number-theory", "factorization", "predicate"),
-        examples=(
-            example(
-                "powerful_72",
-                "Decide whether 72 is powerful and inspect its factor witness.",
-                {"value": "72"},
             ),
         ),
     ),

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -14,8 +14,6 @@ from jacobian.math.number_theory._models import (
     DivisorListResult,
     FactorizationRequest,
     IntegerValueResult,
-    PowerfulNumberRequest,
-    PowerfulNumberResult,
     PrattCertificateNode,
     PrimalityCertificateRequest,
     PrimalityCertificateResult,
@@ -149,22 +147,6 @@ def factorize_primes(request: FactorizationRequest) -> PrimeFactorizationResult:
             PrimePower(prime=str(prime), power=int(power))
             for prime, power in sorted(factorint(abs(value)).items())
         )
-    )
-
-
-def decide_powerful(request: PowerfulNumberRequest) -> PowerfulNumberResult:
-    from sympy import factorint
-
-    factors = sorted(factorint(int(request.value)).items())
-    return PowerfulNumberResult(
-        semantics_version="powerful-number.prime-exponents-at-least-two.v1",
-        is_powerful=not any(power < 2 for _, power in factors),
-        factors=tuple(
-            PrimePower(prime=str(prime), power=int(power)) for prime, power in factors
-        ),
-        violating_primes=tuple(
-            str(prime) for prime, power in factors if int(power) < 2
-        ),
     )
 
 

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -26,6 +26,10 @@ from jacobian._models import StrictModel
 
 _MAX_INTEGER_LENGTH = 256
 _MAX_FACTORIZATION_LENGTH = 12
+MAX_POWERFUL_INTEGER_DIGITS = 25
+MAX_POWERFUL_CUTOFF = 100_000
+MAX_POWERFUL_FACTOR_ENTRIES = 42
+MAX_POWERFUL_EXPONENT = 83
 # Certified factoring uses SymPy's ``factorint`` (Pollard rho, Pollard p-1,
 # ECM) on the input and recursively on ``p - 1`` for Pratt certificates.
 # The 30-digit bound (~100 bits) is a real work bound: it keeps worst-case
@@ -64,6 +68,14 @@ FactorizationInteger = Annotated[
     StringConstraints(
         pattern=r"^-?(?:0|[1-9][0-9]*)$",
         max_length=_MAX_FACTORIZATION_LENGTH,
+        strict=True,
+    ),
+]
+PowerfulInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[1-9][0-9]*$",
+        max_length=MAX_POWERFUL_INTEGER_DIGITS,
         strict=True,
     ),
 ]
@@ -124,14 +136,16 @@ class NonzeroFactorizationRequest(FactorizationRequest):
         return self
 
 
-class PowerfulNumberRequest(FactorizationRequest):
-    """One positive integer for an exact powerful-number decision."""
+class PowerfulNumberRequest(StrictModel):
+    """One positive canonical integer of at most 25 digits."""
 
-    @model_validator(mode="after")
-    def require_positive_value(self) -> Self:
-        if int(self.value) < 1:
-            raise ValueError("powerful-number input must be positive")
-        return self
+    value: PowerfulInteger = Field(
+        description=(
+            "Positive canonical decimal integer with at most 25 digits. The "
+            "kernel derives B=ceil(value^(1/5)), so B <= 100000."
+        ),
+        examples=["12168"],
+    )
 
 
 class ArithmeticFunctionRequest(StrictModel):
@@ -500,36 +514,80 @@ class PrimeFactorizationResult(StrictModel):
         return self
 
 
-class PowerfulNumberResult(StrictModel):
-    """A powerful-number decision with its complete factor witness."""
+class ResidualPerfectPower(StrictModel):
+    """An exact decomposition of the stripped residual as base**exponent."""
 
-    semantics_version: Literal["powerful-number.prime-exponents-at-least-two.v1"]
+    base: PowerfulInteger
+    exponent: StrictInt = Field(ge=2, le=MAX_POWERFUL_EXPONENT)
+
+
+class PowerfulNumberResult(StrictModel):
+    """A source-bound, replayable exact powerful-number decision."""
+
+    semantics_version: Literal["powerful-number.partial-factor.v2"]
+    value: PowerfulInteger
+    conclusion: Literal[
+        "POWERFUL",
+        "EXPONENT_ONE",
+        "ROUGH_NOT_PERFECT_POWER",
+    ]
     is_powerful: StrictBool
-    factors: tuple[PrimePower, ...] = Field(
-        min_length=0,
-        max_length=_MAX_FACTOR_ENTRIES,
+    cutoff: StrictInt = Field(
+        ge=1,
+        le=MAX_POWERFUL_CUTOFF,
+        description="The canonical cutoff B=ceil(value^(1/5)); B^5 >= value.",
     )
-    violating_primes: tuple[BoundedInteger, ...] = Field(
-        min_length=0,
-        max_length=_MAX_FACTOR_ENTRIES,
+    checked_through: StrictInt = Field(
+        ge=1,
+        le=MAX_POWERFUL_CUTOFF,
+        description=(
+            "All primes at most this bound were tested. It equals cutoff unless "
+            "an exponent-one prime ended the decision early."
+        ),
     )
+    stripped_factors: tuple[PrimePower, ...] = Field(
+        min_length=0,
+        max_length=MAX_POWERFUL_FACTOR_ENTRIES,
+    )
+    residual: PowerfulInteger = Field(
+        description=(
+            "The positive cofactor after the reported prime powers are removed."
+        )
+    )
+    residual_perfect_power: ResidualPerfectPower | None = None
 
     @model_validator(mode="after")
-    def bind_decision_to_canonical_factor_witness(self) -> Self:
-        primes = [int(factor.prime) for factor in self.factors]
-        if any(prime < 2 for prime in primes):
-            raise ValueError("factor bases must be greater than one")
-        if primes != sorted(set(primes)):
-            raise ValueError("factor bases must be strictly increasing")
-        expected_violations = tuple(
-            factor.prime for factor in self.factors if factor.power < 2
+    def bind_decision_to_source_by_exact_replay(self) -> Self:
+        from jacobian.canonical import parse_canonical_integer
+        from jacobian.math.number_theory._powerful_kernels import (
+            decide_powerful_data,
         )
-        if self.violating_primes != expected_violations:
-            raise ValueError(
-                "violating primes must be exactly the factors with exponent below two"
+
+        expected = decide_powerful_data(parse_canonical_integer(self.value))
+        factors = tuple(
+            (parse_canonical_integer(factor.prime), factor.power)
+            for factor in self.stripped_factors
+        )
+        perfect_power = (
+            None
+            if self.residual_perfect_power is None
+            else (
+                parse_canonical_integer(self.residual_perfect_power.base),
+                self.residual_perfect_power.exponent,
             )
-        if self.is_powerful != (not expected_violations):
-            raise ValueError("powerful decision does not match the factor exponents")
+        )
+        if (
+            self.conclusion != expected.conclusion
+            or self.is_powerful != (expected.conclusion == "POWERFUL")
+            or self.cutoff != expected.cutoff
+            or self.checked_through != expected.checked_through
+            or factors != expected.stripped_factors
+            or parse_canonical_integer(self.residual) != expected.residual
+            or perfect_power != expected.perfect_power
+        ):
+            raise ValueError(
+                "powerful-number conclusion or certificate does not match exact replay"
+            )
         return self
 
 

--- a/src/jacobian/math/number_theory/_powerful.py
+++ b/src/jacobian/math/number_theory/_powerful.py
@@ -1,0 +1,70 @@
+"""Exact bounded powerful-number decision and declaration."""
+
+from __future__ import annotations
+
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.catalog._examples import example
+from jacobian.math.number_theory._models import (
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
+    PrimePower,
+    ResidualPerfectPower,
+)
+from jacobian.math.number_theory._powerful_kernels import decide_powerful_data
+from jacobian.math.number_theory._support import number_theory_operation
+
+
+def decide_powerful(request: PowerfulNumberRequest) -> PowerfulNumberResult:
+    """Return the exact source-bound powerful-number decision."""
+
+    data = decide_powerful_data(parse_canonical_integer(request.value))
+    return PowerfulNumberResult(
+        semantics_version="powerful-number.partial-factor.v2",
+        value=request.value,
+        conclusion=data.conclusion,
+        is_powerful=data.conclusion == "POWERFUL",
+        cutoff=data.cutoff,
+        checked_through=data.checked_through,
+        stripped_factors=tuple(
+            PrimePower(prime=format_canonical_integer(prime), power=exponent)
+            for prime, exponent in data.stripped_factors
+        ),
+        residual=format_canonical_integer(data.residual),
+        residual_perfect_power=(
+            None
+            if data.perfect_power is None
+            else ResidualPerfectPower(
+                base=format_canonical_integer(data.perfect_power[0]),
+                exponent=data.perfect_power[1],
+            )
+        ),
+    )
+
+
+POWERFUL_NUMBER_OPERATION = number_theory_operation(
+    "integer.decide.powerful",
+    "Decide powerful-number status",
+    "Decide exactly whether every prime exponent of one positive integer is at "
+    "least two. Trial division through the derived cutoff B=ceil(n^(1/5)) and "
+    "exact perfect-power classification of the B-rough residual avoid complete "
+    "factorization while returning a source-bound replayable certificate.",
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
+    decide_powerful,
+    "number-theory",
+    "2-full",
+    "powerful",
+    "powerful-number",
+    "predicate",
+    "certificate",
+    examples=(
+        example(
+            "powerful_12168",
+            "Decide whether 12168 is powerful from a bounded partial-factor "
+            "certificate; the value must be a positive canonical integer with "
+            "at most 25 digits.",
+            {"value": "12168"},
+        ),
+    ),
+    version="3",
+)

--- a/src/jacobian/math/number_theory/_powerful_kernels.py
+++ b/src/jacobian/math/number_theory/_powerful_kernels.py
@@ -1,0 +1,112 @@
+"""Bounded exact kernel for powerful-number decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from flint import fmpz
+from sympy.ntheory.generate import Sieve, primerange
+
+from jacobian.math.number_theory._models import (
+    MAX_POWERFUL_CUTOFF,
+    MAX_POWERFUL_INTEGER_DIGITS,
+)
+
+PowerfulConclusion = Literal[
+    "POWERFUL",
+    "EXPONENT_ONE",
+    "ROUGH_NOT_PERFECT_POWER",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PowerfulDecisionData:
+    """Private canonical data returned by the exact decision kernel."""
+
+    conclusion: PowerfulConclusion
+    cutoff: int
+    checked_through: int
+    stripped_factors: tuple[tuple[int, int], ...]
+    residual: int
+    perfect_power: tuple[int, int] | None = None
+
+
+def _ceil_fifth_root(value: int) -> int:
+    root = int(fmpz(value).root(5))
+    return root if root**5 == value else root + 1
+
+
+def _perfect_power_witness(value: int) -> tuple[int, int] | None:
+    """Return the least-prime-exponent witness for a positive integer > 1."""
+
+    integer = fmpz(value)
+    if not integer.is_perfect_power():
+        return None
+
+    # Every nontrivial power exponent has a prime divisor, and an exponent for
+    # value is at most floor(log_2(value)).  FLINT supplies each exact floor
+    # root; integer reconstruction decides exactness without floating point.
+    for raw_exponent in primerange(2, value.bit_length() + 1):
+        exponent = int(raw_exponent)
+        base = int(integer.root(exponent))
+        if base**exponent == value:
+            return base, exponent
+    raise AssertionError("FLINT perfect-power result has no exact prime exponent")
+
+
+def decide_powerful_data(value: int) -> PowerfulDecisionData:
+    """Decide whether every prime divisor of ``value`` has exponent at least 2.
+
+    Let ``B = ceil(value**(1/5))``.  Small primes are stripped in ascending
+    order.  An exponent-one factor is an immediate obstruction.  Otherwise the
+    remaining B-rough cofactor is powerful exactly when it is 1 or a perfect
+    power: a powerful non-perfect-power B-rough cofactor would have exponent
+    sum at least five and therefore exceed B**5 >= value.
+    """
+
+    if not 1 <= value < 10**MAX_POWERFUL_INTEGER_DIGITS:
+        raise ValueError("powerful-number value must have at most 25 digits")
+    cutoff = _ceil_fifth_root(value)
+    assert cutoff <= MAX_POWERFUL_CUTOFF
+    residual = value
+    stripped: list[tuple[int, int]] = []
+
+    # A fresh sieve keeps prime generation request-scoped.  At the admitted
+    # maximum B=100000 this enumerates exactly 9592 primes.
+    for raw_prime in Sieve().primerange(2, cutoff + 1):
+        prime = int(raw_prime)
+        if residual % prime != 0:
+            continue
+        exponent = 0
+        while residual % prime == 0:
+            residual //= prime
+            exponent += 1
+        stripped.append((prime, exponent))
+        if exponent == 1:
+            return PowerfulDecisionData(
+                conclusion="EXPONENT_ONE",
+                cutoff=cutoff,
+                checked_through=prime,
+                stripped_factors=tuple(stripped),
+                residual=residual,
+            )
+
+    if residual == 1:
+        return PowerfulDecisionData(
+            conclusion="POWERFUL",
+            cutoff=cutoff,
+            checked_through=cutoff,
+            stripped_factors=tuple(stripped),
+            residual=1,
+        )
+
+    witness = _perfect_power_witness(residual)
+    return PowerfulDecisionData(
+        conclusion=("POWERFUL" if witness is not None else "ROUGH_NOT_PERFECT_POWER"),
+        cutoff=cutoff,
+        checked_through=cutoff,
+        stripped_factors=tuple(stripped),
+        residual=residual,
+        perfect_power=witness,
+    )

--- a/src/jacobian/math/number_theory/_tools.py
+++ b/src/jacobian/math/number_theory/_tools.py
@@ -1,4 +1,4 @@
-"""Exact SymPy-backed integer number-theory operations."""
+"""Exact integer number-theory operations."""
 
 from jacobian.catalog.models import MathTools
 from jacobian.math.number_theory._derived import DERIVED_NUMBER_THEORY_OPERATIONS
@@ -8,6 +8,7 @@ from jacobian.math.number_theory._finite_abelian_groups import (
 )
 from jacobian.math.number_theory._modular import MODULAR_OPERATIONS
 from jacobian.math.number_theory._modular_identity import MODULAR_IDENTITY_OPERATIONS
+from jacobian.math.number_theory._powerful import POWERFUL_NUMBER_OPERATION
 from jacobian.math.number_theory._primes import PRIME_OPERATIONS
 
 __all__ = ["TOOLS"]
@@ -15,6 +16,7 @@ __all__ = ["TOOLS"]
 TOOLS: MathTools = (
     *DIVISIBILITY_OPERATIONS,
     *PRIME_OPERATIONS,
+    POWERFUL_NUMBER_OPERATION,
     *MODULAR_OPERATIONS,
     *MODULAR_IDENTITY_OPERATIONS,
     *DERIVED_NUMBER_THEORY_OPERATIONS,

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -148,6 +148,36 @@ def test_natural_prime_power_query_ranks_factorization_before_prime_navigation()
     )
 
 
+def test_natural_powerful_number_query_finds_bounded_decision() -> None:
+    catalog = Catalog.open()
+
+    result = catalog.search(
+        OperationDiscoveryRequest(
+            query="decide whether an integer is 2-full or powerful",
+            limit=5,
+        )
+    )
+
+    assert "integer.decide.powerful" in {match.operation_id for match in result.matches}
+
+
+def test_catalog_runs_source_bound_powerful_decision() -> None:
+    catalog = Catalog.open()
+    operation = catalog.operation("integer.decide.powerful")
+    assert operation is not None
+    assert operation.version == "3"
+
+    result = invoke_operation(
+        "integer.decide.powerful",
+        {"value": "12168"},
+        catalog,
+    )
+
+    assert result.output is not None
+    assert result.output["is_powerful"] is True
+    assert result.output["value"] == "12168"
+
+
 def test_search_finds_lattice_hnf_in_matrix_domain() -> None:
     catalog = Catalog.open()
 

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -10,7 +10,6 @@ from jacobian.math.number_theory._models import (
     ModularValueRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
-    PowerfulNumberResult,
 )
 
 
@@ -34,39 +33,6 @@ def test_chinese_remainder_rejects_invalid_system_bounds(
 ) -> None:
     with pytest.raises(ValidationError, match=message):
         ChineseRemainderRequest.model_validate(payload)
-
-
-@pytest.mark.parametrize(
-    "payload",
-    (
-        {
-            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
-            "is_powerful": False,
-            "factors": [{"prime": "2", "power": 3}],
-            "violating_primes": [],
-        },
-        {
-            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
-            "is_powerful": True,
-            "factors": [{"prime": "2", "power": 1}],
-            "violating_primes": ["2"],
-        },
-        {
-            "semantics_version": "powerful-number.prime-exponents-at-least-two.v1",
-            "is_powerful": False,
-            "factors": [
-                {"prime": "3", "power": 1},
-                {"prime": "2", "power": 2},
-            ],
-            "violating_primes": ["3"],
-        },
-    ),
-)
-def test_powerful_number_result_rejects_inconsistent_or_noncanonical_witnesses(
-    payload: dict[str, object],
-) -> None:
-    with pytest.raises(ValidationError, match=r"powerful|factor"):
-        PowerfulNumberResult.model_validate(payload)
 
 
 def test_in_process_factorization_dependencies_have_small_input_bounds() -> None:

--- a/tests/math/number_theory/test_powerful.py
+++ b/tests/math/number_theory/test_powerful.py
@@ -1,0 +1,230 @@
+"""Exactness and boundary evidence for the powerful-number decision."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from math import gcd
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from sympy import factorint, isprime
+
+from jacobian.math.number_theory._models import (
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
+)
+from jacobian.math.number_theory._powerful import decide_powerful
+from jacobian.math.number_theory._powerful_kernels import (
+    _perfect_power_witness,
+    decide_powerful_data,
+)
+
+PayloadMutation = Callable[[dict[str, Any]], None]
+
+
+def _full_factorization_oracle(value: int) -> bool:
+    return all(exponent >= 2 for exponent in factorint(value).values())
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, True),
+        (36, True),
+        (2**6 * 3**4, True),
+        (12167, True),
+        (12168, True),
+        (180, False),
+        (2**6 * 3**4 * 7, False),
+        (7, False),
+        (10, False),
+        (12166, False),
+    ],
+)
+def test_powerful_known_answers(value: int, expected: bool) -> None:
+    result = decide_powerful(PowerfulNumberRequest(value=str(value)))
+
+    assert result.is_powerful is expected
+    assert result.conclusion == (
+        "POWERFUL"
+        if expected
+        else (
+            "EXPONENT_ONE"
+            if any(factor.power == 1 for factor in result.stripped_factors)
+            else "ROUGH_NOT_PERFECT_POWER"
+        )
+    )
+
+
+def test_one_is_vacuously_powerful_with_empty_reconstruction() -> None:
+    result = decide_powerful(PowerfulNumberRequest(value="1"))
+
+    assert result.cutoff == 1
+    assert result.checked_through == 1
+    assert result.stripped_factors == ()
+    assert result.residual == "1"
+    assert result.residual_perfect_power is None
+
+
+def test_partial_factor_certificate_reconstructs_12168() -> None:
+    result = decide_powerful(PowerfulNumberRequest(value="12168"))
+
+    stripped_product = 1
+    for factor in result.stripped_factors:
+        stripped_product *= int(factor.prime) ** factor.power
+    assert stripped_product * int(result.residual) == 12168
+    assert result.residual_perfect_power is not None
+    assert int(
+        result.residual_perfect_power.base
+    ) ** result.residual_perfect_power.exponent == int(result.residual)
+
+
+def test_exponent_one_obstruction_records_only_the_processed_range() -> None:
+    result = decide_powerful(PowerfulNumberRequest(value=str(2**6 * 3**4 * 7)))
+
+    assert result.conclusion == "EXPONENT_ONE"
+    assert result.checked_through == 7
+    assert result.checked_through < result.cutoff
+    assert result.stripped_factors[-1].prime == "7"
+    assert result.stripped_factors[-1].power == 1
+
+
+def test_rough_non_power_residual_is_an_exact_negative_branch() -> None:
+    result = decide_powerful(PowerfulNumberRequest(value="10403"))
+
+    assert result.conclusion == "ROUGH_NOT_PERFECT_POWER"
+    assert result.checked_through == result.cutoff
+    assert result.residual == "10403"
+    assert result.residual_perfect_power is None
+
+
+def test_p_squared_q_cubed_uses_residual_power_witness() -> None:
+    value = 67**2 * 71**3
+    result = decide_powerful(PowerfulNumberRequest(value=str(value)))
+
+    assert result.is_powerful is True
+    assert [factor.model_dump() for factor in result.stripped_factors] == [
+        {"prime": "67", "power": 2}
+    ]
+    assert result.residual == str(71**3)
+    assert result.residual_perfect_power is not None
+    assert result.residual_perfect_power.base == "71"
+    assert result.residual_perfect_power.exponent == 3
+
+
+def test_pairwise_gcd_exponents_do_not_fake_a_joint_perfect_power() -> None:
+    exponents = (6, 10, 15)
+    assert all(
+        gcd(left, right) > 1
+        for left in exponents
+        for right in exponents
+        if left != right
+    )
+    assert gcd(*exponents) == 1
+    assert _perfect_power_witness(2**6 * 3**10 * 5**15) is None
+
+
+def test_source_scale_positive_and_planted_exponent_one_failure() -> None:
+    smaller_prime = 60_013
+    larger_prime = 60_017
+    assert isprime(smaller_prime) and isprime(larger_prime)
+    powerful = smaller_prime**2 * larger_prime**3
+    spoiled = 3 * powerful
+
+    positive = decide_powerful(PowerfulNumberRequest(value=str(powerful)))
+    negative = decide_powerful(PowerfulNumberRequest(value=str(spoiled)))
+
+    assert len(str(powerful)) == 24
+    assert len(str(spoiled)) == 25
+    assert positive.is_powerful is True
+    assert positive.residual_perfect_power is not None
+    assert negative.conclusion == "EXPONENT_ONE"
+    assert negative.is_powerful is False
+
+
+def test_near_limit_25_digit_positive_uses_rough_residual_witness() -> None:
+    smaller_prime = 99_971
+    larger_prime = 99_989
+    assert isprime(smaller_prime) and isprime(larger_prime)
+    value = smaller_prime**2 * larger_prime**3
+
+    result = decide_powerful(PowerfulNumberRequest(value=str(value)))
+
+    assert len(str(value)) == 25
+    assert result.is_powerful is True
+    assert result.cutoff == 99_982
+    assert result.stripped_factors[0].prime == str(smaller_prime)
+    assert result.residual_perfect_power is not None
+    assert result.residual_perfect_power.base == str(larger_prime)
+    assert result.residual_perfect_power.exponent == 3
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_cutoff"),
+    [(31**5 - 1, 31), (31**5, 31), (31**5 + 1, 32)],
+)
+def test_cutoff_boundary(value: int, expected_cutoff: int) -> None:
+    result = decide_powerful(PowerfulNumberRequest(value=str(value)))
+
+    assert result.cutoff == expected_cutoff
+    assert result.cutoff**5 >= value
+    if result.cutoff > 1:
+        assert (result.cutoff - 1) ** 5 < value
+
+
+def test_25_digit_boundary_is_admitted_and_26_digits_are_rejected() -> None:
+    request = PowerfulNumberRequest(value="9999999999999999999999999")
+    result = decide_powerful(request)
+
+    assert result.cutoff == 100_000
+    with pytest.raises(ValidationError, match="at most 25 characters"):
+        PowerfulNumberRequest(value="10000000000000000000000000")
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "01", 1])
+def test_request_rejects_nonpositive_noncanonical_or_nonstring_values(
+    value: object,
+) -> None:
+    with pytest.raises(ValidationError):
+        PowerfulNumberRequest.model_validate({"value": value})
+
+
+@pytest.mark.parametrize(
+    ("value", "mutation"),
+    [
+        (12168, lambda payload: payload.update(value="12167")),
+        (12168, lambda payload: payload.update(cutoff=payload["cutoff"] + 1)),
+        (
+            12168,
+            lambda payload: payload["stripped_factors"][0].update(power=2),
+        ),
+        (12168, lambda payload: payload.update(residual="168")),
+        (
+            12168,
+            lambda payload: payload["residual_perfect_power"].update(exponent=3),
+        ),
+        (
+            2**6 * 3**4 * 7,
+            lambda payload: payload.update(checked_through=payload["cutoff"]),
+        ),
+    ],
+)
+def test_result_rejects_mutated_source_or_certificate(
+    value: int,
+    mutation: PayloadMutation,
+) -> None:
+    genuine = decide_powerful(PowerfulNumberRequest(value=str(value)))
+    payload = deepcopy(genuine.model_dump(mode="json"))
+    mutation(payload)
+
+    with pytest.raises(ValidationError, match="does not match exact replay"):
+        PowerfulNumberResult.model_validate(payload)
+
+
+@pytest.mark.exhaustive
+def test_exhaustive_differential_against_complete_factorization() -> None:
+    for value in range(1, 200_001):
+        result = decide_powerful_data(value)
+        assert (result.conclusion == "POWERFUL") is _full_factorization_oracle(value)


### PR DESCRIPTION
## Problem

Closes #2317.

`integer.decide.powerful` was excluded from the catalog because its 12-digit implementation was only a projection of complete factorization. That contract does not cover the useful 24–25 digit regime where powerfulness has a smaller exact certificate than full factorization.

## Solution

Re-admit the existing operation ID as version 3 with a source-bound partial-factor result:

1. Derive `B = ceil(n^(1/5))`.
2. Strip primes through `B` in ascending order, returning immediately on an exponent-one obstruction.
3. If every stripped exponent is at least two, classify the `B`-rough residual as `1`, a perfect power, or not a perfect power.

The residual rule is exact. A powerful, non-perfect-power residual has joint exponent gcd one and exponent sum at least five. Since every residual prime exceeds `B`, that would imply `r > B^5 >= n >= r`.

The result distinguishes `EXPONENT_ONE`, `POWERFUL`, and `ROUGH_NOT_PERFECT_POWER`. It retains the source, derived cutoff, actual checked range, stripped prime powers, residual, and any exact residual power witness. Model validation replays the bounded decision, so early exits do not claim full `B`-roughness and independently mutated certificate fields are rejected.

Prime generation uses a request-local SymPy 1.14 sieve. python-flint 0.9 supplies exact fifth roots, integer roots, and perfect-power classification. This keeps the integer kernels in maintained libraries without using `factorint(limit=...)`, whose limit does not define a pure trial-division envelope and may still discover larger factors.

Suggested review order:

1. `_powerful_kernels.py` for the cutoff proof and three decision branches.
2. `_models.py` and `_powerful.py` for source binding and catalog projection.
3. `test_powerful.py`, admission, discovery, and reference documentation.

## Testing

- `make check` — Ruff and mypy passed; 2,675 non-exhaustive owner/catalog/dispatch/CLI/tooling tests passed.
- Focused number-theory and catalog tests — 52 passed, 1 exhaustive test deselected.
- `uv run --locked pytest -q tests/math/number_theory/test_powerful.py::test_exhaustive_differential_against_complete_factorization` — all integers from 1 through 200,000 matched complete SymPy factorization.
- Independent deterministic differential — 2,000 sampled integers below `10^12` matched complete SymPy factorization.
- `make docs-linkcheck` — passed.

## Public contract impact

`integer.decide.powerful` changes from an excluded 12-digit complete-factor witness candidate to an admitted 25-digit partial-factor certificate (operation version 3, result semantics `powerful-number.partial-factor.v2`). This is intentionally a pre-stable contract replacement; no compatibility wrapper is retained.

## Public operation admission

- Concrete gap: exact powerful-number decisions at source-backed 24–25 digit scale without complete factorization.
- Why existing operations or typed values are insufficient: complete prime factorization has a stronger and input-dependent work obligation; the retained perfect-power profile also factors its full source rather than classifying only the bounded rough residual.
- Stable mathematical result: whether every prime exponent of one positive integer is at least two, with a source-bound replayable certificate.
- Semantic domain and admitted execution envelope: all positive integers semantically; canonical materialized decimal integers `1 <= n < 10^25` in this release.
- Controlling work, intermediate, memory, and output quantities: `B = ceil(n^(1/5)) <= 100000`; at most 9,592 trial primes, 83 successful factor divisions, 84-bit intermediates, 23 candidate prime exponents, and 42 stripped-factor rows.
- Exact representation, algorithm regimes, and maintained backend: materialized canonical integer; request-local SymPy sieve plus FLINT exact roots and perfect-power classification.
- Remaining fixed caps and their classification: the 25-digit ceiling is a conservative implementation/work envelope. Raising it needs boundary evidence for prime enumeration, FLINT classification/root replay, memory, and result size at the wider cutoff.
- Admission decision: `KEEP` for the existing `integer.decide.powerful` ID because the partial certificate provides independent computational leverage over complete factorization.

### Operation preflight

- Semantic mathematical domain and postcondition: positive integers; return true exactly when every prime divisor has exponent at least two.
- Canonical public value type: source-bound `PowerfulNumberResult` with `PrimePower` rows and an optional `ResidualPerfectPower` witness.
- Source representation: one materialized canonical decimal integer.
- Expansion performed by the kernel and its pre-execution bound: enumerate primes through the derived cutoff; at most 9,592 primes.
- Representation-sensitive complexity: no succinct, generated, or oracle-backed representation is admitted.
- Admitted request envelope and controlling quantities: at most 25 digits, hence cutoff at most 100,000 and source bit length at most 84.
- Producer/consumer closure: the result is a decision relation rather than a standalone canonical integer; it retains its source and exact replay inputs. No downstream operation currently consumes the certificate.
- Degenerate inputs: `1` is vacuously powerful with an empty factor list and residual `1`; zero and negative integers are rejected.
- Parent/ring/field identity: positive elements of `ZZ`; no parent change or coercion.
- Deterministic work bound: at most 9,592 modular tests, 83 divisions, one FLINT perfect-power classification, and at most 23 exact root/reconstruction checks.
- Maximum intermediate growth: source, residual, roots, and reconstructed powers remain at most 84 bits; the request-local sieve is bounded by 100,000.
- Exact result-size bound: source/residual/base have at most 25 digits and the result has at most 42 factor rows.
- Backend and supported version: SymPy 1.14.0 and python-flint 0.9.0, both pinned.
- Backend input domain: prime generation through 100,000; positive FLINT integers at most 84 bits; root exponents from 2 through 83.
- Conversion/coercion behavior: canonical decimal parsing to Python integers, explicit `fmpz` construction, and canonical decimal formatting; no implicit coercion or floating point.
- Result type: exact `POWERFUL`, `EXPONENT_ONE`, or `ROUGH_NOT_PERFECT_POWER`.
- Reconstruction or defining invariant: `n = product(p_i^e_i) * residual`, derived `B^5 >= n`, exact checked range, and `residual = base^exponent` when a power witness is present.
- Typed execution failures: malformed, nonpositive, or over-25-digit requests are rejected before backend work; admitted requests have no incomplete or unknown result.
- Property and boundary tests: known answers, unit, all three conclusion branches, `p^2 q^3`, joint-gcd exponents `(6,10,15)`, 24–25 digit constructed values, cutoff transitions around `B^5`, request limits, source/certificate mutations, catalog invocation, and exhaustive differential comparison.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Powerful-number decision with a partial-factor certificate | delivered | `integer.decide.powerful` |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact conclusion branches
- [x] New bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence
