### PR TITLE
feat(math): add complete indexed subset-sum multiplicity profiles

### DIFF
--- a/src/jacobian/math/__init__.py
+++ b/src/jacobian/math/__init__.py
@@ -1,6 +1,7 @@
 """Native-value mathematical APIs supported by Jacobian."""
 
 from jacobian.math import (
+    additive_combinatorics,
     algebraic_combinatorics,
     arithmetic,
     arithmetic_dynamics,
@@ -34,6 +35,7 @@ from jacobian.math import (
 )
 
 __all__ = [
+    "additive_combinatorics",
     "algebraic_combinatorics",
     "arithmetic",
     "arithmetic_dynamics",

--- a/src/jacobian/math/additive_combinatorics/__init__.py
+++ b/src/jacobian/math/additive_combinatorics/__init__.py
@@ -1,3 +1,15 @@
-"""Additive-combinatorics operation ownership."""
+"""Supported native additive-combinatorics API."""
 
-__all__: list[str] = []
+from jacobian.math.additive_combinatorics.operations import subset_sum_profile
+from jacobian.math.additive_combinatorics.values import (
+    IndexedIntegerSequence,
+    SubsetSumProfile,
+    SubsetSumProfileEntry,
+)
+
+__all__ = [
+    "IndexedIntegerSequence",
+    "SubsetSumProfile",
+    "SubsetSumProfileEntry",
+    "subset_sum_profile",
+]

--- a/src/jacobian/math/additive_combinatorics/_admission.py
+++ b/src/jacobian/math/additive_combinatorics/_admission.py
@@ -35,6 +35,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.DROP,
         "cheap deterministic projection of additive.representation_profile.compute",
     ),
+    OperationAdmission(
+        "additive.subset_sum.profile.compute",
+        AdmissionDecision.KEEP,
+        "one complete source-bound profile of sums and multiplicities over indexed at-most-once selections, which pair-sum composition cannot retain",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -11,6 +11,15 @@ from pydantic import Field, StringConstraints, model_validator
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.additive_combinatorics.operations import (
+    MAX_SUBSET_SUM_DP_TRANSITIONS,
+    MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
+    _subset_sum_profile_envelope,
+)
+from jacobian.math.additive_combinatorics.values import (
+    MAX_SUBSET_SUM_PROFILE_ENTRIES,
+    IndexedIntegerSequence,
+)
 
 _MAX_SET_SIZE = 256
 _MAX_RESULT_SIZE = _MAX_SET_SIZE * _MAX_SET_SIZE
@@ -310,6 +319,39 @@ class RepresentationProfileResult(StrictModel):
 
 
 # ---------------------------------------------------------------------------
+# Complete indexed subset-sum profile
+# ---------------------------------------------------------------------------
+
+
+class SubsetSumProfileRequest(StrictModel):
+    """Compute every indexed subset-sum multiplicity, including the empty set.
+
+    Admission is result-sensitive: it bounds the exact sum span, the number of
+    source-selection vectors, sparse-DP transitions, multiplicity digits, and
+    worst-case serialized profile before the dynamic program begins.
+    """
+
+    source: IndexedIntegerSequence = Field(
+        description=(
+            "The ordered indexed integer sequence. Each position is selectable "
+            "at most once; repeated values and zeros remain distinct positions. "
+            "Before execution, S=min(2^n, positive_sum-negative_sum+1, "
+            "product(m_v+1) over distinct nonzero values v) must fit "
+            f"{MAX_SUBSET_SUM_PROFILE_ENTRIES:,} "
+            f"rows, 4*n*S must not exceed {MAX_SUBSET_SUM_DP_TRANSITIONS:,} "
+            "dictionary transitions across construction and validation replay, "
+            "and the conservative serialized-result estimate must not exceed "
+            f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:,} bytes."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_profile_envelope(self) -> Self:
+        _subset_sum_profile_envelope(self.source)
+        return self
+
+
+# ---------------------------------------------------------------------------
 # Additive energy
 # ---------------------------------------------------------------------------
 
@@ -416,6 +458,7 @@ __all__ = [
     "RepresentationProfileEntry",
     "RepresentationProfileRequest",
     "RepresentationProfileResult",
+    "SubsetSumProfileRequest",
     "SumsetCardinalityRequest",
     "SumsetCardinalityResult",
 ]

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -19,10 +19,13 @@ from jacobian.math.additive_combinatorics._models import (
     RepresentationProfileEntry,
     RepresentationProfileRequest,
     RepresentationProfileResult,
+    SubsetSumProfileRequest,
     SumsetCardinalityRequest,
     SumsetCardinalityResult,
     _vector_from_ints,
 )
+from jacobian.math.additive_combinatorics.operations import subset_sum_profile
+from jacobian.math.additive_combinatorics.values import SubsetSumProfile
 
 
 def _parse_set(spec: FiniteIntegerSet) -> frozenset[int]:
@@ -62,6 +65,14 @@ def compute_representation_profile(
         for count in (counts[value],)
     )
     return RepresentationProfileResult(entries=entries)
+
+
+def compute_subset_sum_profile(
+    request: SubsetSumProfileRequest,
+) -> SubsetSumProfile:
+    """Compute the complete exact indexed-subset sum profile."""
+
+    return subset_sum_profile(request.source)
 
 
 def compute_additive_energy(
@@ -155,6 +166,7 @@ __all__ = [
     "compute_additive_energy",
     "compute_ordered_difference_profile",
     "compute_representation_profile",
+    "compute_subset_sum_profile",
     "compute_sumset_cardinality",
     "decide_direct_sum_predicate",
 ]

--- a/src/jacobian/math/additive_combinatorics/_tools.py
+++ b/src/jacobian/math/additive_combinatorics/_tools.py
@@ -16,6 +16,7 @@ from jacobian.math.additive_combinatorics._models import (
     OrderedDifferenceProfileResult,
     RepresentationProfileRequest,
     RepresentationProfileResult,
+    SubsetSumProfileRequest,
     SumsetCardinalityRequest,
     SumsetCardinalityResult,
 )
@@ -23,8 +24,17 @@ from jacobian.math.additive_combinatorics._operations import (
     compute_additive_energy,
     compute_ordered_difference_profile,
     compute_representation_profile,
+    compute_subset_sum_profile,
     compute_sumset_cardinality,
     decide_direct_sum_predicate,
+)
+from jacobian.math.additive_combinatorics.operations import (
+    MAX_SUBSET_SUM_DP_TRANSITIONS,
+    MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
+)
+from jacobian.math.additive_combinatorics.values import (
+    MAX_SUBSET_SUM_PROFILE_ENTRIES,
+    SubsetSumProfile,
 )
 
 
@@ -60,6 +70,10 @@ def additive_combinatorics_operation[
 _REPRESENTATION_PROFILE_EXAMPLE: dict[str, Any] = {
     "left": {"elements": ["1", "2"]},
     "right": {"elements": ["3", "4"]},
+}
+
+_SUBSET_SUM_PROFILE_EXAMPLE: dict[str, Any] = {
+    "source": {"items": ["1", "1"]},
 }
 
 _ADDITIVE_ENERGY_EXAMPLE: dict[str, Any] = {
@@ -107,6 +121,41 @@ ADDITIVE_COMBINATORICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     "E(A,B)=6 is derivable from this profile."
                 ),
                 _REPRESENTATION_PROFILE_EXAMPLE,
+            ),
+        ),
+    ),
+    additive_combinatorics_operation(
+        "additive.subset_sum.profile.compute",
+        "Compute a complete indexed subset-sum multiplicity profile",
+        "Given one finite indexed integer sequence, return the exact number of "
+        "index subsets attaining every integer sum. Each position is selectable "
+        "at most once, equal values remain distinct positions, and the empty "
+        "subset is included. Before execution, result-sensitive admission bounds "
+        f"support by {MAX_SUBSET_SUM_PROFILE_ENTRIES:,} rows, two complete sparse-DP "
+        f"passes by {MAX_SUBSET_SUM_DP_TRANSITIONS:,} dictionary transitions, and "
+        "the conservative serialized result by 4 MiB; "
+        "every accepted result is complete.",
+        SubsetSumProfileRequest,
+        SubsetSumProfile,
+        compute_subset_sum_profile,
+        "additive-combinatorics",
+        "subset-sum",
+        "representation-profile",
+        "indexed",
+        "exact",
+        examples=(
+            example(
+                "repeated_indexed_values",
+                (
+                    "Compute all subset sums of the two indexed values [1,1], "
+                    "giving multiplicities 1,2,1 at sums 0,1,2; input items must "
+                    "be canonical integers inside the schema-visible 256-item, "
+                    f"256-digit, {MAX_SUBSET_SUM_PROFILE_ENTRIES:,}-row, "
+                    f"{MAX_SUBSET_SUM_DP_TRANSITIONS:,}-transition, and "
+                    f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES // (1024 * 1024)} MiB "
+                    "profile bounds."
+                ),
+                _SUBSET_SUM_PROFILE_EXAMPLE,
             ),
         ),
     ),

--- a/src/jacobian/math/additive_combinatorics/operations.py
+++ b/src/jacobian/math/additive_combinatorics/operations.py
@@ -1,0 +1,126 @@
+"""Native exact kernels for additive combinatorics."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.additive_combinatorics.values import (
+    MAX_SUBSET_SUM_PROFILE_ENTRIES,
+    IndexedIntegerSequence,
+    SubsetSumProfile,
+)
+
+MAX_SUBSET_SUM_DP_TRANSITIONS = 4_000_000
+MAX_SUBSET_SUM_PROFILE_RESULT_BYTES = 4 * 1024 * 1024
+_SUBSET_SUM_DP_PASSES = 2
+
+
+@dataclass(frozen=True)
+class _SubsetSumProfileEnvelope:
+    """Conservative pre-execution bounds for one complete profile."""
+
+    support_bound: int
+    transition_bound: int
+    maximum_sum_characters: int
+    maximum_multiplicity_digits: int
+    result_byte_bound: int
+
+
+def _subset_sum_profile_envelope(
+    source: IndexedIntegerSequence,
+) -> _SubsetSumProfileEnvelope:
+    """Derive complete-profile work, intermediate, and output bounds.
+
+    For values grouped by equality, a subset is determined numerically by how
+    many copies of each nonzero value it selects. Thus the support is bounded
+    simultaneously by ``2^n``, the integral sum span, and the product of one
+    plus each nonzero value's multiplicity. Every intermediate DP support is a
+    subset of the final support because the exclude branch retains old sums.
+    """
+
+    values = source.as_int_tuple()
+    item_count = len(values)
+    total_subsets = 1 << item_count
+
+    negative_sum = sum(value for value in values if value < 0)
+    positive_sum = sum(value for value in values if value > 0)
+    span_bound = positive_sum - negative_sum + 1
+
+    grouped = Counter(value for value in values if value != 0)
+    selection_vector_bound = math.prod(
+        multiplicity + 1 for multiplicity in grouped.values()
+    )
+    support_bound = min(total_subsets, span_bound, selection_vector_bound)
+    # The public result validator independently replays the DP so a forged or
+    # truncated exact profile cannot revalidate. Charge both the construction
+    # and validation passes, with two dictionary updates per retained state.
+    transition_bound = _SUBSET_SUM_DP_PASSES * 2 * item_count * support_bound
+
+    maximum_sum_characters = max(
+        len(format_canonical_integer(negative_sum)),
+        len(format_canonical_integer(positive_sum)),
+    )
+    maximum_multiplicity_digits = len(format_canonical_integer(total_subsets))
+
+    source_wire_bound = 64 + sum(len(item) + 3 for item in source.items)
+    entry_wire_bound = 96 + maximum_sum_characters + maximum_multiplicity_digits
+    result_byte_bound = 1024 + source_wire_bound + support_bound * entry_wire_bound
+
+    if support_bound > MAX_SUBSET_SUM_PROFILE_ENTRIES:
+        raise ValueError(
+            "predicted subset-sum support exceeds the "
+            f"{MAX_SUBSET_SUM_PROFILE_ENTRIES}-entry profile bound"
+        )
+    if transition_bound > MAX_SUBSET_SUM_DP_TRANSITIONS:
+        raise ValueError(
+            "predicted subset-sum DP transitions exceed the "
+            f"{MAX_SUBSET_SUM_DP_TRANSITIONS}-transition work bound"
+        )
+    if result_byte_bound > MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:
+        raise ValueError(
+            "predicted subset-sum result exceeds the "
+            f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES}-byte result bound"
+        )
+
+    return _SubsetSumProfileEnvelope(
+        support_bound=support_bound,
+        transition_bound=transition_bound,
+        maximum_sum_characters=maximum_sum_characters,
+        maximum_multiplicity_digits=maximum_multiplicity_digits,
+        result_byte_bound=result_byte_bound,
+    )
+
+
+def _subset_sum_profile_counts(source: IndexedIntegerSequence) -> dict[int, int]:
+    """Return exact counts for every indexed subset sum, including empty."""
+
+    counts: dict[int, int] = {0: 1}
+    for value in source.as_int_tuple():
+        next_counts: dict[int, int] = {}
+        for subtotal, multiplicity in counts.items():
+            next_counts[subtotal] = next_counts.get(subtotal, 0) + multiplicity
+            included = subtotal + value
+            next_counts[included] = next_counts.get(included, 0) + multiplicity
+        counts = next_counts
+    return counts
+
+
+def subset_sum_profile(source: IndexedIntegerSequence) -> SubsetSumProfile:
+    """Return the complete indexed-subset multiplicity profile of ``source``.
+
+    Every position is independently selected at most once. Equal values and
+    zeros therefore contribute separate multiplicity even though they may not
+    enlarge the numeric support. The empty subset is included by definition.
+    """
+
+    envelope = _subset_sum_profile_envelope(source)
+    counts = _subset_sum_profile_counts(source)
+    if len(counts) > envelope.support_bound:
+        raise RuntimeError("subset-sum support exceeded its admitted bound")
+    return SubsetSumProfile.from_counts(source, counts)
+
+
+__all__ = ["subset_sum_profile"]

--- a/src/jacobian/math/additive_combinatorics/values.py
+++ b/src/jacobian/math/additive_combinatorics/values.py
@@ -1,0 +1,170 @@
+"""Canonical values for bounded exact additive combinatorics."""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+
+from pydantic import Field, StrictInt, StringConstraints, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+
+MAX_SUBSET_SUM_ITEMS = 256
+MAX_SUBSET_SUM_ITEM_DIGITS = 256
+MAX_SUBSET_SUM_SUM_DIGITS = MAX_SUBSET_SUM_ITEM_DIGITS + len(str(MAX_SUBSET_SUM_ITEMS))
+MAX_SUBSET_SUM_MULTIPLICITY_DIGITS = len(str(1 << MAX_SUBSET_SUM_ITEMS))
+MAX_SUBSET_SUM_PROFILE_ENTRIES = 50_000
+
+_CANONICAL_INTEGER_PATTERN = r"^(?:0|-?[1-9][0-9]*)$"
+
+IndexedInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=_CANONICAL_INTEGER_PATTERN,
+        max_length=MAX_SUBSET_SUM_ITEM_DIGITS + 1,
+        strict=True,
+    ),
+]
+SubsetSumInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=_CANONICAL_INTEGER_PATTERN,
+        max_length=MAX_SUBSET_SUM_SUM_DIGITS + 1,
+        strict=True,
+    ),
+]
+SubsetSumMultiplicity = Annotated[
+    str,
+    StringConstraints(
+        pattern=_CANONICAL_INTEGER_PATTERN,
+        max_length=MAX_SUBSET_SUM_MULTIPLICITY_DIGITS,
+        strict=True,
+    ),
+]
+
+
+class IndexedIntegerSequence(StrictModel):
+    """A finite integer sequence whose positions are distinct selectable items.
+
+    Equal values and zeros are intentionally retained as separate positions.
+    The listed order is the stable index axis used by subset witnesses and
+    other downstream indexed operations.
+    """
+
+    items: tuple[IndexedInteger, ...] = Field(
+        max_length=MAX_SUBSET_SUM_ITEMS,
+        description=(
+            "An ordered tuple of at most 256 canonical integers. Repeated values "
+            "and zeros remain distinct indexed items; each integer has at most "
+            "256 decimal digits, excluding its optional sign."
+        ),
+        examples=[("1", "1", "3")],
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_items(self) -> Self:
+        for item in self.items:
+            if len(item.lstrip("-")) > MAX_SUBSET_SUM_ITEM_DIGITS:
+                raise ValueError(
+                    "indexed integer exceeds the 256-digit source-item bound"
+                )
+        return self
+
+    def as_int_tuple(self) -> tuple[int, ...]:
+        """Return the indexed values as exact Python integers."""
+
+        return tuple(parse_canonical_integer(item) for item in self.items)
+
+
+class SubsetSumProfileEntry(StrictModel):
+    """One attainable sum and its positive indexed-subset multiplicity."""
+
+    sum: SubsetSumInteger
+    multiplicity: SubsetSumMultiplicity
+
+    @model_validator(mode="after")
+    def require_positive_multiplicity(self) -> Self:
+        if len(self.sum.lstrip("-")) > MAX_SUBSET_SUM_SUM_DIGITS:
+            raise ValueError("subset sum exceeds the derived source-sum digit bound")
+        if parse_canonical_integer(self.multiplicity) <= 0:
+            raise ValueError("subset-sum multiplicity must be positive")
+        return self
+
+
+class SubsetSumProfile(StrictModel):
+    """The complete exact multiplicity profile of one indexed sequence.
+
+    The empty subset is always included. Validation replays the complete
+    bounded dynamic program, binding every row and multiplicity to ``source``.
+    """
+
+    source: IndexedIntegerSequence
+    entries: tuple[SubsetSumProfileEntry, ...] = Field(
+        min_length=1,
+        max_length=MAX_SUBSET_SUM_PROFILE_ENTRIES,
+    )
+    support_size: StrictInt = Field(ge=1, le=MAX_SUBSET_SUM_PROFILE_ENTRIES)
+    total_subsets: SubsetSumMultiplicity
+
+    @model_validator(mode="after")
+    def bind_complete_profile(self) -> Self:
+        sums = tuple(parse_canonical_integer(entry.sum) for entry in self.entries)
+        if sums != tuple(sorted(sums)) or len(sums) != len(set(sums)):
+            raise ValueError("subset-sum profile entries must have unique sorted sums")
+        if self.support_size != len(self.entries):
+            raise ValueError("support_size must equal the number of profile entries")
+
+        expected_total = 1 << len(self.source.items)
+        if parse_canonical_integer(self.total_subsets) != expected_total:
+            raise ValueError("total_subsets must equal 2^len(source.items)")
+
+        from jacobian.math.additive_combinatorics.operations import (
+            _subset_sum_profile_counts,
+            _subset_sum_profile_envelope,
+        )
+
+        _subset_sum_profile_envelope(self.source)
+        expected = tuple(sorted(_subset_sum_profile_counts(self.source).items()))
+        actual = tuple(
+            (
+                parse_canonical_integer(entry.sum),
+                parse_canonical_integer(entry.multiplicity),
+            )
+            for entry in self.entries
+        )
+        if actual != expected:
+            raise ValueError(
+                "entries must be the complete exact subset-sum profile of source"
+            )
+        if sum(multiplicity for _, multiplicity in actual) != expected_total:
+            raise ValueError("profile multiplicities must sum to total_subsets")
+        return self
+
+    @classmethod
+    def from_counts(
+        cls,
+        source: IndexedIntegerSequence,
+        counts: dict[int, int],
+    ) -> SubsetSumProfile:
+        """Construct the canonical source-bound profile from exact counts."""
+
+        entries = tuple(
+            SubsetSumProfileEntry(
+                sum=format_canonical_integer(subtotal),
+                multiplicity=format_canonical_integer(count),
+            )
+            for subtotal, count in sorted(counts.items())
+        )
+        return cls(
+            source=source,
+            entries=entries,
+            support_size=len(entries),
+            total_subsets=format_canonical_integer(1 << len(source.items)),
+        )
+
+
+__all__ = [
+    "IndexedIntegerSequence",
+    "SubsetSumProfile",
+    "SubsetSumProfileEntry",
+]

--- a/tests/math/additive_combinatorics/test_public_api.py
+++ b/tests/math/additive_combinatorics/test_public_api.py
@@ -1,0 +1,24 @@
+"""Exact public API contract for ``jacobian.math.additive_combinatorics``."""
+
+from __future__ import annotations
+
+from jacobian.math import additive_combinatorics
+
+
+def test_exact_public_api_symbols() -> None:
+    """Keep canonical additive-combinatorics values and kernels explicit."""
+
+    expected = (
+        "IndexedIntegerSequence",
+        "SubsetSumProfile",
+        "SubsetSumProfileEntry",
+        "subset_sum_profile",
+    )
+    assert tuple(additive_combinatorics.__all__) == expected
+    assert len(additive_combinatorics.__all__) == len(
+        set(additive_combinatorics.__all__)
+    )
+    assert all(not name.startswith("_") for name in additive_combinatorics.__all__)
+    assert all(
+        hasattr(additive_combinatorics, name) for name in additive_combinatorics.__all__
+    )

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -1,0 +1,234 @@
+"""Tests for complete indexed subset-sum multiplicity profiles."""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.math.additive_combinatorics import (
+    IndexedIntegerSequence,
+    SubsetSumProfile,
+    SubsetSumProfileEntry,
+    subset_sum_profile,
+)
+from jacobian.math.additive_combinatorics._models import SubsetSumProfileRequest
+from jacobian.math.additive_combinatorics._operations import (
+    compute_subset_sum_profile,
+)
+from jacobian.math.additive_combinatorics.operations import (
+    MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
+)
+from jacobian.math.additive_combinatorics.values import (
+    MAX_SUBSET_SUM_ITEM_DIGITS,
+    MAX_SUBSET_SUM_ITEMS,
+    MAX_SUBSET_SUM_SUM_DIGITS,
+)
+
+
+def _request(*items: int) -> SubsetSumProfileRequest:
+    return SubsetSumProfileRequest(
+        source={"items": [str(item) for item in items]},
+    )
+
+
+def _numeric_profile(result: SubsetSumProfile) -> dict[int, int]:
+    return {int(entry.sum): int(entry.multiplicity) for entry in result.entries}
+
+
+def _bitmask_oracle(items: tuple[int, ...]) -> Counter[int]:
+    return Counter(
+        sum(item for index, item in enumerate(items) if mask & (1 << index))
+        for mask in range(1 << len(items))
+    )
+
+
+def test_repeated_values_remain_distinct_indexed_items() -> None:
+    result = compute_subset_sum_profile(_request(1, 1))
+
+    assert _numeric_profile(result) == {0: 1, 1: 2, 2: 1}
+    assert result.total_subsets == "4"
+    assert result.support_size == 3
+
+
+def test_empty_source_contains_exactly_the_empty_subset() -> None:
+    result = compute_subset_sum_profile(_request())
+
+    assert _numeric_profile(result) == {0: 1}
+    assert result.source.items == ()
+    assert result.total_subsets == "1"
+
+
+def test_zeros_change_multiplicity_without_changing_support() -> None:
+    result = compute_subset_sum_profile(_request(0, 0, 2))
+
+    assert _numeric_profile(result) == {0: 4, 2: 4}
+    assert result.total_subsets == "8"
+
+
+def test_mixed_sign_profile_is_sorted_and_complete() -> None:
+    result = compute_subset_sum_profile(_request(-1, 2))
+
+    assert tuple(int(entry.sum) for entry in result.entries) == (-1, 0, 1, 2)
+    assert all(entry.multiplicity == "1" for entry in result.entries)
+
+
+def test_small_profiles_match_independent_bitmask_enumeration() -> None:
+    for length in range(5):
+        for items in product(range(-2, 3), repeat=length):
+            result = compute_subset_sum_profile(_request(*items))
+            assert _numeric_profile(result) == _bitmask_oracle(items)
+
+
+def test_permuting_source_preserves_numeric_profile() -> None:
+    forward = compute_subset_sum_profile(_request(-3, 1, 1, 4))
+    permuted = compute_subset_sum_profile(_request(1, 4, -3, 1))
+
+    assert _numeric_profile(forward) == _numeric_profile(permuted)
+    assert forward.source != permuted.source
+
+
+def test_conway_guy_eleven_set_has_2048_distinct_subset_sums() -> None:
+    # Source-backed convention fixture: the Conway-Guy upper witness recorded
+    # in erdos-frontier-atlas P1 at revision 0394e3d3b249439ffabec7d96a3311aa441651b8.
+    source = (285, 433, 510, 550, 570, 581, 587, 590, 592, 593, 594)
+
+    result = compute_subset_sum_profile(_request(*source))
+
+    assert result.support_size == 2048
+    assert result.total_subsets == "2048"
+    assert all(entry.multiplicity == "1" for entry in result.entries)
+
+
+def test_result_round_trip_replays_complete_profile() -> None:
+    result = compute_subset_sum_profile(_request(-2, 0, 3, 3))
+
+    assert SubsetSumProfile.model_validate(result.model_dump()) == result
+
+
+def test_result_rejects_mutated_source() -> None:
+    result = compute_subset_sum_profile(_request(1, 1))
+    payload = result.model_dump(mode="json")
+    payload["source"]["items"] = ["1", "2"]
+
+    with pytest.raises(ValidationError, match="complete exact subset-sum profile"):
+        SubsetSumProfile.model_validate(payload)
+
+
+def test_result_rejects_mutated_multiplicity() -> None:
+    result = compute_subset_sum_profile(_request(1, 1))
+    payload = result.model_dump(mode="json")
+    payload["entries"][1]["multiplicity"] = "3"
+
+    with pytest.raises(ValidationError, match="complete exact subset-sum profile"):
+        SubsetSumProfile.model_validate(payload)
+
+
+def test_result_rejects_mutated_profile_sum() -> None:
+    result = compute_subset_sum_profile(_request(1, 1))
+    payload = result.model_dump(mode="json")
+    payload["entries"][-1]["sum"] = "3"
+
+    with pytest.raises(ValidationError, match="complete exact subset-sum profile"):
+        SubsetSumProfile.model_validate(payload)
+
+
+def test_result_rejects_mutated_total() -> None:
+    result = compute_subset_sum_profile(_request(1, 1))
+    payload = result.model_dump(mode="json")
+    payload["total_subsets"] = "3"
+
+    with pytest.raises(ValidationError, match=r"2\^len"):
+        SubsetSumProfile.model_validate(payload)
+
+
+def test_result_sensitive_admission_accepts_many_repeated_zeros() -> None:
+    source = IndexedIntegerSequence(items=("0",) * MAX_SUBSET_SUM_ITEMS)
+
+    result = subset_sum_profile(source)
+
+    assert _numeric_profile(result) == {0: 1 << MAX_SUBSET_SUM_ITEMS}
+    assert result.total_subsets == str(1 << MAX_SUBSET_SUM_ITEMS)
+
+
+def test_profile_work_above_bound_is_rejected_before_execution() -> None:
+    items = tuple(1 << exponent for exponent in range(14)) + (0,) * (
+        MAX_SUBSET_SUM_ITEMS - 14
+    )
+
+    with pytest.raises(ValidationError, match="DP transitions"):
+        _request(*items)
+
+
+def test_profile_result_above_bound_is_rejected_before_execution() -> None:
+    offset = 10 ** (MAX_SUBSET_SUM_ITEM_DIGITS - 1)
+    items = tuple(offset + (1 << exponent) for exponent in range(15))
+
+    with pytest.raises(ValidationError, match="byte result bound"):
+        _request(*items)
+
+
+def test_large_accepted_profile_stays_inside_declared_result_budget() -> None:
+    offset = 10 ** (MAX_SUBSET_SUM_ITEM_DIGITS - 1)
+    source = tuple(offset + (1 << exponent) for exponent in range(13))
+    result = compute_subset_sum_profile(_request(*source))
+
+    encoded = canonicalize_json(
+        result.model_dump(mode="json"),
+        limits=CanonicalLimits(
+            max_output_bytes=MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
+        ),
+    )
+
+    assert result.support_size == 1 << 13
+    assert len(encoded) <= MAX_SUBSET_SUM_PROFILE_RESULT_BYTES
+
+
+def test_source_digit_bound_is_enforced_before_integer_conversion() -> None:
+    with pytest.raises(ValidationError, match="256-digit"):
+        SubsetSumProfileRequest(
+            source={"items": ["9" * (MAX_SUBSET_SUM_ITEM_DIGITS + 1)]},
+        )
+
+    with pytest.raises(ValidationError) as error:
+        SubsetSumProfileRequest(source={"items": ["9" * 100_000]})
+    assert error.value.errors()[0]["type"] == "string_too_long"
+
+
+def test_source_item_count_bound_is_enforced_by_schema() -> None:
+    with pytest.raises(ValidationError, match="at most 256 items"):
+        IndexedIntegerSequence(items=("0",) * (MAX_SUBSET_SUM_ITEMS + 1))
+
+
+@pytest.mark.parametrize(
+    ("prefix", "message"),
+    [
+        ("", "source-sum digit bound"),
+        ("-", f"at most {MAX_SUBSET_SUM_SUM_DIGITS + 1} characters"),
+    ],
+)
+def test_profile_entry_sum_digit_bound_applies_to_either_sign(
+    prefix: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        SubsetSumProfileEntry(
+            sum=prefix + "9" * (MAX_SUBSET_SUM_SUM_DIGITS + 1),
+            multiplicity="1",
+        )
+
+
+def test_request_schema_exposes_source_shape_and_character_bounds() -> None:
+    schema = SubsetSumProfileRequest.model_json_schema()
+    source_schema = schema["$defs"]["IndexedIntegerSequence"]
+    items_schema = source_schema["properties"]["items"]
+    source_description = schema["properties"]["source"]["description"]
+
+    assert items_schema["maxItems"] == MAX_SUBSET_SUM_ITEMS
+    assert items_schema["items"]["maxLength"] == MAX_SUBSET_SUM_ITEM_DIGITS + 1
+    assert "4*n*S" in source_description
+    assert "4,000,000" in source_description
+    assert "4,194,304 bytes" in source_description

--- a/tests/math/public_api/test_namespace.py
+++ b/tests/math/public_api/test_namespace.py
@@ -16,6 +16,7 @@ import importlib
 import jacobian
 
 ROOT_MATH_DOMAINS = (
+    "additive_combinatorics",
     "algebraic_combinatorics",
     "arithmetic",
     "arithmetic_dynamics",


### PR DESCRIPTION
## Problem

The additive-combinatorics catalog can count ordered sums from two supplied
sets, but it cannot represent selecting each position of one integer sequence
at most once. Repeated values, zeros, and exact indexed-subset multiplicities
therefore cannot be recovered by composing the existing pair-sum profile.

Closes #2287.

## Solution

Add `additive.subset_sum.profile.compute`, which accepts a canonical
`IndexedIntegerSequence` and returns the complete sorted map from each attainable
integer sum to its positive exact multiplicity. The empty subset is included;
equal values and zeros remain distinct selectable positions. The source,
`support_size`, and `total_subsets` are retained, and result validation replays
the bounded computation so mutated sources, rows, multiplicities, and totals do
not revalidate.

The same canonical sequence, profile values, and `subset_sum_profile` kernel are
available through `jacobian.math.additive_combinatorics` for direct typed
composition. Target-only solving, modular profiles, witnesses, and optimization
remain separate contracts.

### Library choice

This uses an exact sparse integer DP rather than adding a dependency. SymPy's
documented combinatorial enumerators do not expose this indexed, at-most-once,
all-sums multiplicity postcondition; adapting them would still require custom
counting and work accounting. The local kernel preserves positional
multiplicity directly and bounds the quantities it expands before execution.

## Testing

- `make check` — Ruff and strict mypy pass; 2,671 Lean-free owner tests pass.
- `make test-math TESTS='tests/math/additive_combinatorics tests/math/public_api/test_namespace.py'` — 67 passed.
- `uv run --locked pytest -q tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py tests/catalog/test_admission.py` — 976 passed.
- The operation-specific tests compare every tuple of length 0 through 4 over `[-2, 2]` with an independent bitmask oracle. They also cover empty input, repeats, zeros, mixed signs, permutation invariance, forged results, admission boundaries, an 8,192-row result over 256-digit source values, 256 zeros, and the Conway–Guy 11-set's 2,048 distinct subset sums.

## Public contract impact

Adds public operation `additive.subset_sum.profile.compute`, its strict request
and source-bound result schema, and the native
`jacobian.math.additive_combinatorics` value/function surface. Existing
operation IDs and request/result semantics are unchanged.

## Public operation admission

- Concrete gap: no operation returns complete exact subset-sum multiplicities for one indexed source.
- Why existing operations or typed values are insufficient: repeated binary sumsets lose the per-position exclusion constraint and indexed multiplicity; `additive.representation_profile.compute` counts pairs from two sets.
- Stable mathematical result: the complete function `m(s) = #{I subseteq {0,...,n-1} : sum(i in I) a_i = s}`, represented as unique sum-sorted rows with `sum_s m(s) = 2^n`.
- Semantic domain and admitted execution envelope: an ordered tuple of at most 256 canonical integers, each at most 256 decimal digits excluding its optional sign. For `S = min(2^n, positive_sum-negative_sum+1, product(m_v+1) over distinct nonzero values v)`, admission requires `S <= 50,000`, `4*n*S <= 4,000,000`, and a conservative serialized result estimate at most 4 MiB.
- Controlling work, intermediate, memory, and output quantities: two sparse-DP passes (construction and validation replay), at most `S` live sums per pass, bounded integer/sum and multiplicity digits, at most 50,000 result rows, and a 4 MiB result envelope.
- Exact representation, algorithm regimes, and maintained backend: canonical decimal integers and a deterministic Jacobian-owned sparse DP over `Z`; no backend coercion, ambient context, approximation, truncation, or fallback regime.
- Remaining fixed caps and their classification: 256 items and 256 digits conservatively bound input/bigint work; 4,000,000 transitions bound execution; 50,000 rows and 4 MiB bound the complete exact output. Result-sensitive admission still accepts large low-support inputs such as 256 zeros.
- Admission decision: `KEEP` — this is a reusable complete profile that cannot be projected from the existing pair-sum operation.

### Suggested review order

Start with the canonical values and source-binding validator, then check the
support/work/output envelope beside the sparse DP. The request, catalog wiring,
and admission row are thin projections of that contract; the focused tests
exercise the defining invariant and each bound.

## Closure matrix

None. This issue requests one operation; target-only, modular, witness, and optimization variants remain explicitly deferred by the issue.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant catalog and domain validation is listed above
- [x] Harbor task or verifier validation is not applicable; neither changed
- [x] Public operation changes include an owner-local admission decision
- [x] The result is exact and complete; over-envelope requests are rejected before computation
- [x] New bounds include boundary and realistic source-backed scale evidence
- [x] Shared-abstraction replacement is not applicable; the new types are domain-owned canonical mathematical values
