### PR TITLE
feat(math): add exact hard-constraint rounding

### DIFF
--- a/src/jacobian/math/discrepancy_theory/_admission.py
+++ b/src/jacobian/math/discrepancy_theory/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.discrepancy_theory._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "discrepancy.hard_constraint_round.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact source-bound binary rounding that jointly preserves disjoint integral cardinality constraints and certifies the theorem-backed 4d monitored-column error bound",
+    ),
+    OperationAdmission(
         "discrepancy.theory.eval.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -2,14 +2,313 @@
 
 from __future__ import annotations
 
-from typing import Self
+import itertools
+from fractions import Fraction
+from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
+from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 
 MAX_GROUND_SET = 20
 MAX_SETS = 100
+
+MAX_ROUNDING_COORDINATES = 512
+MAX_ROUNDING_ROWS = 512
+MAX_MONITORED_COLUMNS = 512
+MAX_COLUMN_INCIDENCES = 32_768
+MAX_ROUNDING_RATIONAL_DIGITS = 256
+MAX_ROUNDING_WORK = 8_000_000
+MAX_ROUNDING_INTERMEDIATE_DIGITS = 8_192
+MAX_ROUNDING_RESULT_RATIONAL_DIGITS = 100_000
+
+RoundingIndexLabel = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=64, strict=True),
+]
+RoundingCoordinateIndex = Annotated[int, Field(ge=0, strict=True)]
+RoundedBit = Annotated[int, Field(ge=0, le=1, strict=True)]
+
+
+def _fraction_wire_size(value: Fraction) -> int:
+    return len(str(abs(value.numerator))) + len(str(value.denominator))
+
+
+def _as_canonical_rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(value)
+
+
+def _require_canonical_subset(
+    elements: tuple[int, ...], *, coordinate_count: int, owner: str
+) -> None:
+    if any(type(index) is not int for index in elements):
+        raise ValueError(f"{owner} coordinate indices must be strict integers")
+    if any(not 0 <= index < coordinate_count for index in elements):
+        raise ValueError(f"{owner} coordinate indices must be in 0..coordinate_count-1")
+    if any(left >= right for left, right in itertools.pairwise(elements)):
+        raise ValueError(f"{owner} coordinate indices must be strictly increasing")
+
+
+class HardConstraintRow(StrictModel):
+    """One named nonempty block of the hard row partition."""
+
+    label: RoundingIndexLabel
+    coordinates: tuple[RoundingCoordinateIndex, ...] = Field(
+        min_length=1,
+        max_length=MAX_ROUNDING_COORDINATES,
+    )
+
+
+class MonitoredColumn(StrictModel):
+    """One named monitored zero-one column, represented by its support."""
+
+    label: RoundingIndexLabel
+    coordinates: tuple[RoundingCoordinateIndex, ...] = Field(
+        max_length=MAX_ROUNDING_COORDINATES
+    )
+
+
+class HardConstraintRoundingSource(StrictModel):
+    """A materialized rational vector, hard row partition, and monitored columns.
+
+    ``coordinate_labels`` is the ordered coordinate axis. Every row is a
+    nonempty, strictly increasing tuple of coordinate indices, and the rows
+    partition that axis exactly. Monitored columns are strictly increasing
+    index tuples; distinct column labels may have identical supports.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "A materialized exact vector with an ordered coordinate axis, a "
+                "named nonempty-row partition of that axis, and named monitored "
+                "zero-one columns. Row and column supports use strictly increasing "
+                "zero-based coordinate indices. Rows must partition every "
+                "coordinate exactly once; duplicate monitored supports are allowed."
+            )
+        }
+    )
+
+    coordinate_labels: tuple[RoundingIndexLabel, ...] = Field(
+        max_length=MAX_ROUNDING_COORDINATES,
+    )
+    values: tuple[CanonicalRational, ...] = Field(
+        max_length=MAX_ROUNDING_COORDINATES,
+    )
+    rows: tuple[HardConstraintRow, ...] = Field(max_length=MAX_ROUNDING_ROWS)
+    columns: tuple[MonitoredColumn, ...] = Field(max_length=MAX_MONITORED_COLUMNS)
+
+    @model_validator(mode="after")
+    def require_admitted_source(self) -> Self:
+        coordinate_count = len(self.coordinate_labels)
+        if len(set(self.coordinate_labels)) != coordinate_count:
+            raise ValueError("coordinate labels must be unique")
+        if len(self.values) != coordinate_count:
+            raise ValueError("values must align with the coordinate axis")
+        if len({row.label for row in self.rows}) != len(self.rows):
+            raise ValueError("row labels must be unique")
+        if len({column.label for column in self.columns}) != len(self.columns):
+            raise ValueError("column labels must be unique")
+
+        fractions: list[Fraction] = []
+        for value in self.values:
+            require_bounded_rational(
+                value,
+                max_digits=MAX_ROUNDING_RATIONAL_DIGITS,
+                label="rounding source rational",
+            )
+            fraction = value.as_fraction()
+            if not 0 <= fraction <= 1:
+                raise ValueError("rounding source values must lie in [0, 1]")
+            fractions.append(fraction)
+
+        partition: list[int] = []
+        for row in self.rows:
+            _require_canonical_subset(
+                row.coordinates,
+                coordinate_count=coordinate_count,
+                owner="row",
+            )
+            partition.extend(row.coordinates)
+            row_sum = sum((fractions[index] for index in row.coordinates), Fraction())
+            if row_sum.denominator != 1:
+                raise ValueError("every hard row must have an integral source sum")
+        if sorted(partition) != list(range(coordinate_count)):
+            raise ValueError("hard rows must partition every coordinate exactly once")
+
+        total_incidences = 0
+        column_sums: list[Fraction] = []
+        for column in self.columns:
+            _require_canonical_subset(
+                column.coordinates,
+                coordinate_count=coordinate_count,
+                owner="column",
+            )
+            total_incidences += len(column.coordinates)
+            column_sums.append(
+                sum(
+                    (fractions[index] for index in column.coordinates),
+                    Fraction(),
+                )
+            )
+        if total_incidences > MAX_COLUMN_INCIDENCES:
+            raise ValueError(
+                f"monitored column incidences exceed {MAX_COLUMN_INCIDENCES}"
+            )
+
+        fractional_count = sum(0 < value < 1 for value in fractions)
+        scan_work = fractional_count * (coordinate_count + total_incidences)
+        elimination_work = (fractional_count * (fractional_count + 1) // 2) ** 2
+        if scan_work + elimination_work > MAX_ROUNDING_WORK:
+            raise ValueError(
+                "rounding work bound exceeded by fractional support and incidences"
+            )
+
+        common_denominator_digits = 1 + sum(
+            len(value.den) for value in self.values if value.den != "1"
+        )
+        # For an f-column zero-one retained system, fraction-free nullspace
+        # coordinates are minors. Hadamard bounds each minor by f^(f/2);
+        # f*digits(f)+1 is a simple conservative decimal bound. A common
+        # denominator therefore grows by at most this factor per endpoint move.
+        direction_growth_digits = sum(
+            support * len(str(support)) + 1
+            for support in range(2, fractional_count + 1)
+        )
+        if (
+            common_denominator_digits + direction_growth_digits
+            > MAX_ROUNDING_INTERMEDIATE_DIGITS
+        ):
+            raise ValueError("rounding intermediate rational-height bound exceeded")
+
+        input_rational_digits = sum(
+            len(value.num.lstrip("-")) + len(value.den) for value in self.values
+        )
+        row_digits = sum(
+            _fraction_wire_size(
+                sum((fractions[index] for index in row.coordinates), Fraction())
+            )
+            for row in self.rows
+        )
+        coordinate_digits = len(str(max(1, coordinate_count)))
+        column_digits = sum(
+            3 * (_fraction_wire_size(value) + coordinate_digits + 1)
+            for value in column_sums
+        )
+        if (
+            input_rational_digits + row_digits + column_digits
+            > MAX_ROUNDING_RESULT_RATIONAL_DIGITS
+        ):
+            raise ValueError("rounding exact result-size bound exceeded")
+        return self
+
+
+class HardConstraintRoundingRequest(StrictModel):
+    """Compute one exact binary rounding of an admitted materialized source."""
+
+    source: HardConstraintRoundingSource
+
+
+class HardConstraintRowLedger(StrictModel):
+    """Exact source and rounded sums for one hard row."""
+
+    row_label: RoundingIndexLabel
+    source_sum: CanonicalRational
+    rounded_sum: int = Field(ge=0, strict=True)
+
+
+class MonitoredColumnLedger(StrictModel):
+    """Exact source sum and rounded-minus-source error for one column."""
+
+    column_label: RoundingIndexLabel
+    source_sum: CanonicalRational
+    rounded_sum: int = Field(ge=0, strict=True)
+    signed_error: CanonicalRational
+    absolute_error: CanonicalRational
+
+
+class HardConstraintRoundingResult(StrictModel):
+    """A source-bound binary rounding with replayable hard-row and error ledgers."""
+
+    source: HardConstraintRoundingSource
+    rounded_values: tuple[RoundedBit, ...] = Field(max_length=MAX_ROUNDING_COORDINATES)
+    maximum_column_incidence: int = Field(ge=0, strict=True)
+    column_error_bound: int = Field(ge=0, strict=True)
+    row_ledger: tuple[HardConstraintRowLedger, ...] = Field(
+        max_length=MAX_ROUNDING_ROWS
+    )
+    column_ledger: tuple[MonitoredColumnLedger, ...] = Field(
+        max_length=MAX_MONITORED_COLUMNS
+    )
+
+    @model_validator(mode="after")
+    def replay_rounding_invariants(self) -> Self:
+        coordinate_count = len(self.source.coordinate_labels)
+        if len(self.rounded_values) != coordinate_count:
+            raise ValueError("rounded values must align with the coordinate axis")
+        if any(
+            type(value) is not int or value not in (0, 1)
+            for value in self.rounded_values
+        ):
+            raise ValueError("rounded values must be strict binary integers")
+
+        source_values = tuple(value.as_fraction() for value in self.source.values)
+        expected_rows: list[HardConstraintRowLedger] = []
+        for row in self.source.rows:
+            source_sum = sum(
+                (source_values[index] for index in row.coordinates), Fraction()
+            )
+            rounded_sum = sum(self.rounded_values[index] for index in row.coordinates)
+            if source_sum != rounded_sum:
+                raise ValueError("rounded values must preserve every hard row sum")
+            expected_rows.append(
+                HardConstraintRowLedger(
+                    row_label=row.label,
+                    source_sum=_as_canonical_rational(source_sum),
+                    rounded_sum=rounded_sum,
+                )
+            )
+        if tuple(expected_rows) != self.row_ledger:
+            raise ValueError("row ledger must replay exactly from source and rounding")
+
+        incidences = [0] * coordinate_count
+        for column in self.source.columns:
+            for index in column.coordinates:
+                incidences[index] += 1
+        expected_incidence = max(incidences, default=0)
+        expected_bound = 4 * expected_incidence
+        if self.maximum_column_incidence != expected_incidence:
+            raise ValueError("maximum column incidence must be derived from the source")
+        if self.column_error_bound != expected_bound:
+            raise ValueError("column error bound must equal four times the incidence")
+
+        expected_columns: list[MonitoredColumnLedger] = []
+        for column in self.source.columns:
+            source_sum = sum(
+                (source_values[index] for index in column.coordinates), Fraction()
+            )
+            rounded_sum = sum(
+                self.rounded_values[index] for index in column.coordinates
+            )
+            signed_error = Fraction(rounded_sum) - source_sum
+            absolute_error = abs(signed_error)
+            if absolute_error > expected_bound:
+                raise ValueError("monitored column error exceeds the derived 4d bound")
+            expected_columns.append(
+                MonitoredColumnLedger(
+                    column_label=column.label,
+                    source_sum=_as_canonical_rational(source_sum),
+                    rounded_sum=rounded_sum,
+                    signed_error=_as_canonical_rational(signed_error),
+                    absolute_error=_as_canonical_rational(absolute_error),
+                )
+            )
+        if tuple(expected_columns) != self.column_ledger:
+            raise ValueError(
+                "column ledger must replay exactly from source and rounding"
+            )
+        return self
 
 
 class FiniteSetSystem(StrictModel):
@@ -76,11 +375,26 @@ class DiscrepancyOptimumResult(StrictModel):
 
 
 __all__ = [
+    "MAX_COLUMN_INCIDENCES",
     "MAX_GROUND_SET",
+    "MAX_MONITORED_COLUMNS",
+    "MAX_ROUNDING_COORDINATES",
+    "MAX_ROUNDING_INTERMEDIATE_DIGITS",
+    "MAX_ROUNDING_RATIONAL_DIGITS",
+    "MAX_ROUNDING_RESULT_RATIONAL_DIGITS",
+    "MAX_ROUNDING_ROWS",
+    "MAX_ROUNDING_WORK",
     "MAX_SETS",
     "DiscrepancyEvalRequest",
     "DiscrepancyEvalResult",
     "DiscrepancyOptimumRequest",
     "DiscrepancyOptimumResult",
     "FiniteSetSystem",
+    "HardConstraintRoundingRequest",
+    "HardConstraintRoundingResult",
+    "HardConstraintRoundingSource",
+    "HardConstraintRow",
+    "HardConstraintRowLedger",
+    "MonitoredColumn",
+    "MonitoredColumnLedger",
 ]

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -35,6 +35,14 @@ def _fraction_wire_size(value: Fraction) -> int:
     return len(str(abs(value.numerator))) + len(str(value.denominator))
 
 
+def _sum_selected_fractions(
+    values: list[Fraction], coordinates: tuple[int, ...]
+) -> Fraction:
+    """Aggregate one admitted row or column after cheap source preflight."""
+
+    return sum((values[index] for index in coordinates), Fraction())
+
+
 def _as_canonical_rational(value: Fraction) -> CanonicalRational:
     return CanonicalRational.from_fraction(value)
 
@@ -131,14 +139,10 @@ class HardConstraintRoundingSource(StrictModel):
                 owner="row",
             )
             partition.extend(row.coordinates)
-            row_sum = sum((fractions[index] for index in row.coordinates), Fraction())
-            if row_sum.denominator != 1:
-                raise ValueError("every hard row must have an integral source sum")
         if sorted(partition) != list(range(coordinate_count)):
             raise ValueError("hard rows must partition every coordinate exactly once")
 
         total_incidences = 0
-        column_sums: list[Fraction] = []
         for column in self.columns:
             _require_canonical_subset(
                 column.coordinates,
@@ -146,16 +150,10 @@ class HardConstraintRoundingSource(StrictModel):
                 owner="column",
             )
             total_incidences += len(column.coordinates)
-            column_sums.append(
-                sum(
-                    (fractions[index] for index in column.coordinates),
-                    Fraction(),
+            if total_incidences > MAX_COLUMN_INCIDENCES:
+                raise ValueError(
+                    f"monitored column incidences exceed {MAX_COLUMN_INCIDENCES}"
                 )
-            )
-        if total_incidences > MAX_COLUMN_INCIDENCES:
-            raise ValueError(
-                f"monitored column incidences exceed {MAX_COLUMN_INCIDENCES}"
-            )
 
         fractional_count = sum(0 < value < 1 for value in fractions)
         scan_work = fractional_count * (coordinate_count + total_incidences)
@@ -182,15 +180,20 @@ class HardConstraintRoundingSource(StrictModel):
         ):
             raise ValueError("rounding intermediate rational-height bound exceeded")
 
+        row_sums = [
+            _sum_selected_fractions(fractions, row.coordinates) for row in self.rows
+        ]
+        if any(row_sum.denominator != 1 for row_sum in row_sums):
+            raise ValueError("every hard row must have an integral source sum")
+        column_sums = [
+            _sum_selected_fractions(fractions, column.coordinates)
+            for column in self.columns
+        ]
+
         input_rational_digits = sum(
             len(value.num.lstrip("-")) + len(value.den) for value in self.values
         )
-        row_digits = sum(
-            _fraction_wire_size(
-                sum((fractions[index] for index in row.coordinates), Fraction())
-            )
-            for row in self.rows
-        )
+        row_digits = sum(_fraction_wire_size(row_sum) for row_sum in row_sums)
         coordinate_digits = len(str(max(1, coordinate_count)))
         column_digits = sum(
             3 * (_fraction_wire_size(value) + coordinate_digits + 1)

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -3,13 +3,190 @@
 from __future__ import annotations
 
 import itertools
+import math
+from fractions import Fraction
 
+from sympy import ZZ
+from sympy.polys.matrices import DomainMatrix
+
+from jacobian._exact import CanonicalRational
 from jacobian.math.discrepancy_theory._models import (
+    MAX_ROUNDING_INTERMEDIATE_DIGITS,
     DiscrepancyEvalRequest,
     DiscrepancyEvalResult,
     DiscrepancyOptimumRequest,
     DiscrepancyOptimumResult,
+    HardConstraintRoundingRequest,
+    HardConstraintRoundingResult,
+    HardConstraintRowLedger,
+    MonitoredColumnLedger,
 )
+
+
+def _primitive_nullspace_direction(
+    rows: list[list[int]], variable_count: int
+) -> tuple[int, ...]:
+    """Return the first primitive fraction-free right-nullspace direction.
+
+    SymPy's exact ``DomainMatrix.nullspace`` orders basis rows by non-pivot
+    columns. We fix the remaining scale ambiguity by dividing out the gcd and
+    making the first nonzero coordinate positive.
+    """
+
+    if not rows:
+        return (1,) + (0,) * (variable_count - 1)
+    basis = DomainMatrix.from_list(rows, ZZ).nullspace().to_list()
+    if not basis:
+        raise RuntimeError("admitted retained system unexpectedly has trivial kernel")
+    direction = tuple(int(value) for value in basis[0])
+    divisor = math.gcd(*(abs(value) for value in direction))
+    direction = tuple(value // divisor for value in direction)
+    first_nonzero = next(value for value in direction if value)
+    if first_nonzero < 0:
+        direction = tuple(-value for value in direction)
+    return direction
+
+
+def _require_admitted_step_height(
+    common_denominator_digits: int, direction: tuple[int, ...]
+) -> int:
+    """Admit the next common-denominator factor before an endpoint update."""
+
+    direction_digits = max(
+        (len(str(abs(value))) for value in direction if value),
+        default=1,
+    )
+    admitted_direction_digits = len(direction) * len(str(len(direction))) + 1
+    if direction_digits > admitted_direction_digits:
+        raise RuntimeError("nullspace direction exceeds the admitted minor bound")
+    next_digits = common_denominator_digits + direction_digits
+    if next_digits > MAX_ROUNDING_INTERMEDIATE_DIGITS:
+        raise RuntimeError("admitted rounding step exceeds the rational-height bound")
+    return next_digits
+
+
+def _floating_round(
+    source_values: list[Fraction], request: HardConstraintRoundingRequest
+) -> tuple[int, ...]:
+    """Run the deterministic exact floating-variable algorithm."""
+
+    source = request.source
+    values = list(source_values)
+    common_denominator_digits = 1 + sum(
+        len(value.den) for value in source.values if value.den != "1"
+    )
+    coordinate_count = len(values)
+    column_supports = tuple(set(column.coordinates) for column in source.columns)
+    incidences = [0] * coordinate_count
+    for support in column_supports:
+        for index in support:
+            incidences[index] += 1
+    maximum_incidence = max(incidences, default=0)
+    retention_threshold = 4 * maximum_incidence
+
+    while True:
+        fractional = tuple(index for index, value in enumerate(values) if 0 < value < 1)
+        if not fractional:
+            return tuple(int(value) for value in values)
+        fractional_set = set(fractional)
+
+        retained_rows: list[list[int]] = []
+        for row in source.rows:
+            active = fractional_set.intersection(row.coordinates)
+            if active:
+                if len(active) < 2:
+                    raise RuntimeError(
+                        "admitted integral row has one fractional coordinate"
+                    )
+                retained_rows.append([int(index in active) for index in fractional])
+        for support in column_supports:
+            active = fractional_set.intersection(support)
+            if len(active) > retention_threshold:
+                retained_rows.append([int(index in active) for index in fractional])
+        if len(retained_rows) >= len(fractional):
+            raise RuntimeError("admitted retained system is not rank deficient")
+
+        direction = _primitive_nullspace_direction(retained_rows, len(fractional))
+        common_denominator_digits = _require_admitted_step_height(
+            common_denominator_digits, direction
+        )
+        endpoint_candidates = tuple(
+            (Fraction(1) - values[index]) / coefficient
+            if coefficient > 0
+            else values[index] / (-coefficient)
+            for index, coefficient in zip(fractional, direction, strict=True)
+            if coefficient != 0
+        )
+        step = min(endpoint_candidates)
+        if step <= 0:
+            raise RuntimeError("floating endpoint step must be positive")
+        for index, coefficient in zip(fractional, direction, strict=True):
+            values[index] += step * coefficient
+            if not 0 <= values[index] <= 1:
+                raise RuntimeError("floating endpoint left the unit cube")
+
+
+def compute_hard_constraint_rounding(
+    request: HardConstraintRoundingRequest,
+) -> HardConstraintRoundingResult:
+    """Round exactly while preserving hard rows and bounding column errors.
+
+    At each step every active hard row and every monitored column with more
+    than ``4d`` fractional coordinates is retained. The retained zero-one
+    system has fewer equations than fractional coordinates, so a nonzero exact
+    nullspace direction reaches a cube endpoint. This is the floating-rounding
+    argument used in the cited Erdős 390 proof and terminates after at most one
+    step per initially fractional coordinate.
+    """
+
+    source = request.source
+    source_values = [value.as_fraction() for value in source.values]
+    rounded_values = _floating_round(source_values, request)
+
+    incidences = [0] * len(source_values)
+    for column in source.columns:
+        for index in column.coordinates:
+            incidences[index] += 1
+    maximum_incidence = max(incidences, default=0)
+    column_error_bound = 4 * maximum_incidence
+
+    row_ledger = tuple(
+        HardConstraintRowLedger(
+            row_label=row.label,
+            source_sum=CanonicalRational.from_fraction(
+                sum(
+                    (source_values[index] for index in row.coordinates),
+                    Fraction(),
+                )
+            ),
+            rounded_sum=sum(rounded_values[index] for index in row.coordinates),
+        )
+        for row in source.rows
+    )
+    column_ledger: list[MonitoredColumnLedger] = []
+    for column in source.columns:
+        source_sum = sum(
+            (source_values[index] for index in column.coordinates), Fraction()
+        )
+        rounded_sum = sum(rounded_values[index] for index in column.coordinates)
+        signed_error = Fraction(rounded_sum) - source_sum
+        column_ledger.append(
+            MonitoredColumnLedger(
+                column_label=column.label,
+                source_sum=CanonicalRational.from_fraction(source_sum),
+                rounded_sum=rounded_sum,
+                signed_error=CanonicalRational.from_fraction(signed_error),
+                absolute_error=CanonicalRational.from_fraction(abs(signed_error)),
+            )
+        )
+    return HardConstraintRoundingResult(
+        source=source,
+        rounded_values=rounded_values,
+        maximum_column_incidence=maximum_incidence,
+        column_error_bound=column_error_bound,
+        row_ledger=row_ledger,
+        column_ledger=tuple(column_ledger),
+    )
 
 
 def _max_absolute_imbalance(

--- a/src/jacobian/math/discrepancy_theory/_tools.py
+++ b/src/jacobian/math/discrepancy_theory/_tools.py
@@ -11,9 +11,12 @@ from jacobian.math.discrepancy_theory._models import (
     DiscrepancyEvalResult,
     DiscrepancyOptimumRequest,
     DiscrepancyOptimumResult,
+    HardConstraintRoundingRequest,
+    HardConstraintRoundingResult,
 )
 from jacobian.math.discrepancy_theory._operations import (
     compute_discrepancy,
+    compute_hard_constraint_rounding,
     compute_optimal_discrepancy,
 )
 
@@ -46,6 +49,49 @@ def discrepancy_theory_operation[
 
 
 DISCREPANCY_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    discrepancy_theory_operation(
+        "discrepancy.hard_constraint_round.compute",
+        "Round a rational vector under hard cardinality constraints",
+        "Compute a deterministic exact binary rounding that preserves every "
+        "disjoint integral hard-row sum and bounds every monitored zero-one "
+        "column's rounded-minus-source error by 4d, where d is the maximum "
+        "source column incidence of one coordinate.",
+        HardConstraintRoundingRequest,
+        HardConstraintRoundingResult,
+        compute_hard_constraint_rounding,
+        "discrepancy",
+        "rounding",
+        "set-system",
+        "hard-constraint",
+        "exact",
+        examples=(
+            example(
+                "two_hard_rows",
+                "Round four half-integral coordinates while preserving two "
+                "row sums and ledgering two monitored-column errors; rows must "
+                "partition the coordinate axis and have integral source sums.",
+                {
+                    "source": {
+                        "coordinate_labels": ["a", "b", "c", "d"],
+                        "values": [
+                            {"num": "1", "den": "2"},
+                            {"num": "1", "den": "2"},
+                            {"num": "1", "den": "2"},
+                            {"num": "1", "den": "2"},
+                        ],
+                        "rows": [
+                            {"label": "left", "coordinates": [0, 1]},
+                            {"label": "right", "coordinates": [2, 3]},
+                        ],
+                        "columns": [
+                            {"label": "diagonal", "coordinates": [0, 2]},
+                            {"label": "off_diagonal", "coordinates": [1, 3]},
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
     discrepancy_theory_operation(
         "discrepancy.theory.eval.compute",
         "Evaluate the discrepancy of a coloring on a finite set system",

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -356,7 +356,11 @@ class TestHardConstraintRounding:
 
         with pytest.raises(ValidationError, match="incidences exceed"):
             _rounding_request(
-                values=(Fraction(1, denominator),) * coordinate_count,
+                values=(
+                    Fraction(1, denominator),
+                    Fraction(denominator - 1, denominator),
+                )
+                * (coordinate_count // 2),
                 rows=({"label": "all", "coordinates": support},),
                 columns=columns,
             )

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -1,14 +1,449 @@
 """Tests for discrepancy theory operations."""
 
+from __future__ import annotations
+
+import itertools
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
 from jacobian.math.discrepancy_theory._models import (
+    MAX_COLUMN_INCIDENCES,
+    MAX_MONITORED_COLUMNS,
+    MAX_ROUNDING_COORDINATES,
+    MAX_ROUNDING_INTERMEDIATE_DIGITS,
+    MAX_ROUNDING_RATIONAL_DIGITS,
+    MAX_ROUNDING_RESULT_RATIONAL_DIGITS,
+    MAX_ROUNDING_WORK,
     DiscrepancyEvalRequest,
     DiscrepancyOptimumRequest,
     FiniteSetSystem,
+    HardConstraintRoundingRequest,
+    HardConstraintRoundingResult,
 )
 from jacobian.math.discrepancy_theory._operations import (
     compute_discrepancy,
+    compute_hard_constraint_rounding,
     compute_optimal_discrepancy,
 )
+
+
+def _rational(value: Fraction | int) -> dict[str, str]:
+    fraction = Fraction(value)
+    return {"num": str(fraction.numerator), "den": str(fraction.denominator)}
+
+
+def _rounding_request(
+    *,
+    values: tuple[Fraction | int, ...] = (
+        Fraction(1, 2),
+        Fraction(1, 2),
+        Fraction(1, 2),
+        Fraction(1, 2),
+    ),
+    rows: tuple[dict[str, object], ...] = (
+        {"label": "left", "coordinates": (0, 1)},
+        {"label": "right", "coordinates": (2, 3)},
+    ),
+    columns: tuple[dict[str, object], ...] = (
+        {"label": "diagonal", "coordinates": (0, 2)},
+        {"label": "off_diagonal", "coordinates": (1, 3)},
+    ),
+    coordinate_labels: tuple[str, ...] | None = None,
+) -> HardConstraintRoundingRequest:
+    labels = coordinate_labels or tuple(f"a{index}" for index in range(len(values)))
+    return HardConstraintRoundingRequest.model_validate(
+        {
+            "source": {
+                "coordinate_labels": labels,
+                "values": tuple(_rational(value) for value in values),
+                "rows": rows,
+                "columns": columns,
+            }
+        }
+    )
+
+
+class TestHardConstraintRounding:
+    def test_known_answer_preserves_rows_and_returns_complete_ledgers(self) -> None:
+        request = _rounding_request()
+
+        first = compute_hard_constraint_rounding(request)
+        second = compute_hard_constraint_rounding(request)
+
+        assert first == second
+        assert first.rounded_values == (1, 0, 1, 0)
+        assert tuple(item.rounded_sum for item in first.row_ledger) == (1, 1)
+        assert first.maximum_column_incidence == 1
+        assert first.column_error_bound == 4
+        assert tuple(
+            item.signed_error.as_fraction() for item in first.column_ledger
+        ) == (
+            Fraction(1),
+            Fraction(-1),
+        )
+        assert HardConstraintRoundingResult.model_validate(first.model_dump()) == first
+
+    def test_large_active_column_distinguishes_row_only_rounding(self) -> None:
+        request = _rounding_request(
+            values=(Fraction(1, 2),) * 20,
+            rows=({"label": "quota", "coordinates": tuple(range(20))},),
+            columns=({"label": "first_half", "coordinates": tuple(range(10))},),
+        )
+
+        row_only_rounding = (1,) * 10 + (0,) * 10
+        row_only_error = abs(
+            sum(row_only_rounding[:10])
+            - sum(value.as_fraction() for value in request.source.values[:10])
+        )
+        assert sum(row_only_rounding) == 10
+        assert row_only_error == 5
+        assert row_only_error > 4
+
+        result = compute_hard_constraint_rounding(request)
+
+        assert result.row_ledger[0].rounded_sum == 10
+        assert result.column_ledger[0].source_sum.as_fraction() == 5
+        assert result.column_ledger[0].signed_error.as_fraction() == 0
+        assert result.column_ledger[0].absolute_error.as_fraction() <= 4
+
+    def test_integral_singletons_empty_columns_and_unmonitored_coordinates(
+        self,
+    ) -> None:
+        request = _rounding_request(
+            values=(0, 1, 0),
+            rows=(
+                {"label": "zero", "coordinates": (0,)},
+                {"label": "one", "coordinates": (1,)},
+                {"label": "other", "coordinates": (2,)},
+            ),
+            columns=(),
+        )
+
+        result = compute_hard_constraint_rounding(request)
+
+        assert result.rounded_values == (0, 1, 0)
+        assert result.maximum_column_incidence == 0
+        assert result.column_error_bound == 0
+        assert result.column_ledger == ()
+
+    def test_duplicate_indexed_columns_remain_distinct_ledger_entries(self) -> None:
+        request = _rounding_request(
+            columns=(
+                {"label": "first", "coordinates": (0, 2)},
+                {"label": "duplicate", "coordinates": (0, 2)},
+            )
+        )
+
+        result = compute_hard_constraint_rounding(request)
+
+        assert tuple(item.column_label for item in result.column_ledger) == (
+            "first",
+            "duplicate",
+        )
+        assert (
+            result.column_ledger[0].signed_error == result.column_ledger[1].signed_error
+        )
+        assert result.maximum_column_incidence == 2
+
+    def test_coherent_axis_and_family_relabeling_preserves_guarantees(self) -> None:
+        original = compute_hard_constraint_rounding(_rounding_request())
+        relabeled = compute_hard_constraint_rounding(
+            _rounding_request(
+                coordinate_labels=("w", "x", "y", "z"),
+                rows=(
+                    {"label": "r0", "coordinates": (0, 1)},
+                    {"label": "r1", "coordinates": (2, 3)},
+                ),
+                columns=(
+                    {"label": "c0", "coordinates": (0, 2)},
+                    {"label": "c1", "coordinates": (1, 3)},
+                ),
+            )
+        )
+
+        assert relabeled.rounded_values == original.rounded_values
+        assert tuple(item.source_sum for item in relabeled.row_ledger) == tuple(
+            item.source_sum for item in original.row_ledger
+        )
+        assert tuple(item.signed_error for item in relabeled.column_ledger) == tuple(
+            item.signed_error for item in original.column_ledger
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "replacement", "message"),
+        [
+            ("values", (_rational(Fraction(-1, 2)),) * 4, r"lie in \[0, 1\]"),
+            (
+                "values",
+                (_rational(Fraction(1, 3)),) + (_rational(Fraction(1, 2)),) * 3,
+                "integral source sum",
+            ),
+            (
+                "rows",
+                ({"label": "only", "coordinates": (0, 1)},),
+                "partition every coordinate",
+            ),
+            (
+                "rows",
+                (
+                    {"label": "left", "coordinates": (0, 1)},
+                    {"label": "right", "coordinates": (0, 1, 2, 3)},
+                ),
+                "partition every coordinate",
+            ),
+            (
+                "columns",
+                ({"label": "bad", "coordinates": (2, 0)},),
+                "strictly increasing",
+            ),
+            (
+                "columns",
+                ({"label": "bad", "coordinates": (4,)},),
+                "coordinate_count",
+            ),
+        ],
+    )
+    def test_malformed_sources_are_rejected_before_the_kernel(
+        self, field: str, replacement: object, message: str
+    ) -> None:
+        payload = _rounding_request().model_dump()
+        payload["source"][field] = replacement
+        with pytest.raises(ValidationError, match=message):
+            HardConstraintRoundingRequest.model_validate(payload)
+
+    @pytest.mark.parametrize(
+        ("mutation", "message"),
+        [
+            ("bit", "preserve every hard row"),
+            ("row", "row ledger"),
+            ("column", "column ledger"),
+            ("source", "column ledger"),
+        ],
+    )
+    def test_source_bound_result_rejects_authored_mutations(
+        self, mutation: str, message: str
+    ) -> None:
+        payload = compute_hard_constraint_rounding(_rounding_request()).model_dump()
+        if mutation == "bit":
+            payload["rounded_values"] = (0, 0, 1, 0)
+        elif mutation == "row":
+            payload["row_ledger"][0]["rounded_sum"] = 0
+        elif mutation == "column":
+            payload["column_ledger"][0]["signed_error"] = _rational(0)
+        else:
+            payload["source"]["values"] = (
+                _rational(Fraction(1, 3)),
+                _rational(Fraction(2, 3)),
+                *payload["source"]["values"][2:],
+            )
+        with pytest.raises(ValidationError, match=message):
+            HardConstraintRoundingResult.model_validate(payload)
+
+    def test_exhaustive_small_half_integral_sources_satisfy_defining_invariants(
+        self,
+    ) -> None:
+        choices = (Fraction(0), Fraction(1, 2), Fraction(1))
+        for coordinate_count in range(6):
+            columns = tuple(
+                {
+                    "label": f"c{mask}",
+                    "coordinates": tuple(
+                        index
+                        for index in range(coordinate_count)
+                        if mask & (1 << index)
+                    ),
+                }
+                for mask in range(1 << coordinate_count)
+            )
+            rows = (
+                ({"label": "all", "coordinates": tuple(range(coordinate_count))},)
+                if coordinate_count
+                else ()
+            )
+            for values in itertools.product(choices, repeat=coordinate_count):
+                if sum(values).denominator != 1:
+                    continue
+                result = compute_hard_constraint_rounding(
+                    _rounding_request(values=values, rows=rows, columns=columns)
+                )
+                assert all(value in (0, 1) for value in result.rounded_values)
+                if coordinate_count:
+                    assert result.row_ledger[0].rounded_sum == sum(values)
+                else:
+                    assert result.row_ledger == ()
+                assert all(
+                    item.absolute_error.as_fraction() <= result.column_error_bound
+                    for item in result.column_ledger
+                )
+
+    def test_coordinate_column_and_incidence_boundaries(self) -> None:
+        coordinate_values = (0,) * MAX_ROUNDING_COORDINATES
+        _rounding_request(
+            values=coordinate_values,
+            rows=(
+                {
+                    "label": "all",
+                    "coordinates": tuple(range(MAX_ROUNDING_COORDINATES)),
+                },
+            ),
+            columns=(),
+        )
+        with pytest.raises(ValidationError, match="at most 512 items"):
+            _rounding_request(
+                values=(*coordinate_values, 0),
+                rows=(
+                    {
+                        "label": "all",
+                        "coordinates": tuple(range(MAX_ROUNDING_COORDINATES + 1)),
+                    },
+                ),
+                columns=(),
+            )
+
+        empty_columns = tuple(
+            {"label": f"c{index}", "coordinates": ()}
+            for index in range(MAX_MONITORED_COLUMNS)
+        )
+        _rounding_request(
+            values=(0,),
+            rows=({"label": "r", "coordinates": (0,)},),
+            columns=empty_columns,
+        )
+        with pytest.raises(ValidationError, match="at most 512 items"):
+            _rounding_request(
+                values=(0,),
+                rows=({"label": "r", "coordinates": (0,)},),
+                columns=(*empty_columns, {"label": "above", "coordinates": ()}),
+            )
+
+        support = tuple(range(MAX_COLUMN_INCIDENCES // MAX_MONITORED_COLUMNS))
+        incidence_columns = tuple(
+            {"label": f"i{index}", "coordinates": support}
+            for index in range(MAX_MONITORED_COLUMNS)
+        )
+        values = (0,) * (len(support) + 1)
+        rows = ({"label": "r", "coordinates": tuple(range(len(values)))},)
+        _rounding_request(values=values, rows=rows, columns=incidence_columns)
+        above = list(incidence_columns)
+        above[-1] = {"label": "i511", "coordinates": (*support, len(support))}
+        with pytest.raises(ValidationError, match="incidences exceed"):
+            _rounding_request(values=values, rows=rows, columns=tuple(above))
+
+    def test_rational_digit_and_work_boundaries(self) -> None:
+        denominator = 10 ** (MAX_ROUNDING_RATIONAL_DIGITS - 1) + 1
+        _rounding_request(
+            values=(Fraction(1, denominator), Fraction(denominator - 1, denominator)),
+            rows=({"label": "r", "coordinates": (0, 1)},),
+            columns=(),
+        )
+        above_denominator = 10**MAX_ROUNDING_RATIONAL_DIGITS + 1
+        with pytest.raises(ValidationError, match="256-digit bound"):
+            _rounding_request(
+                values=(
+                    Fraction(1, above_denominator),
+                    Fraction(above_denominator - 1, above_denominator),
+                ),
+                rows=({"label": "r", "coordinates": (0, 1)},),
+                columns=(),
+            )
+
+        accepted_fractional = max(
+            count
+            for count in range(2, MAX_ROUNDING_COORDINATES + 1, 2)
+            if (count * (count + 1) // 2) ** 2 + count**2 <= MAX_ROUNDING_WORK
+        )
+        _rounding_request(
+            values=(Fraction(1, 2),) * accepted_fractional,
+            rows=({"label": "r", "coordinates": tuple(range(accepted_fractional))},),
+            columns=(),
+        )
+        rejected_fractional = accepted_fractional + 2
+        with pytest.raises(ValidationError, match="work bound exceeded"):
+            _rounding_request(
+                values=(Fraction(1, 2),) * rejected_fractional,
+                rows=(
+                    {
+                        "label": "r",
+                        "coordinates": tuple(range(rejected_fractional)),
+                    },
+                ),
+                columns=(),
+            )
+
+    def test_intermediate_height_boundary(self) -> None:
+        fractional_count = 74
+        direction_growth = sum(
+            support * len(str(support)) + 1
+            for support in range(2, fractional_count + 1)
+        )
+        required_denominator_digits = (
+            MAX_ROUNDING_INTERMEDIATE_DIGITS - direction_growth - 1
+        )
+        pair_extra_digits = required_denominator_digits // 2 - fractional_count // 2
+        denominator_lengths = [1] * (fractional_count // 2)
+        for index in range(pair_extra_digits):
+            denominator_lengths[index % len(denominator_lengths)] += 1
+
+        def source(
+            lengths: list[int],
+        ) -> tuple[tuple[Fraction, ...], tuple[dict[str, object], ...]]:
+            values: list[Fraction] = []
+            rows: list[dict[str, object]] = []
+            for index, length in enumerate(lengths):
+                denominator = 10 ** (length - 1) + 1
+                values.extend(
+                    (
+                        Fraction(1, denominator),
+                        Fraction(denominator - 1, denominator),
+                    )
+                )
+                rows.append(
+                    {"label": f"r{index}", "coordinates": (2 * index, 2 * index + 1)}
+                )
+            return tuple(values), tuple(rows)
+
+        values, rows = source(denominator_lengths)
+        _rounding_request(values=values, rows=rows, columns=())
+        denominator_lengths[-1] += 1
+        values, rows = source(denominator_lengths)
+        with pytest.raises(ValidationError, match="intermediate rational-height"):
+            _rounding_request(values=values, rows=rows, columns=())
+
+    def test_exact_result_size_boundary(self) -> None:
+        denominator = 10 ** (MAX_ROUNDING_RATIONAL_DIGITS - 1) + 1
+        values = (Fraction(1, denominator), Fraction(denominator - 1, denominator))
+        base_digits = (
+            sum(
+                len(str(abs(value.numerator))) + len(str(value.denominator))
+                for value in values
+            )
+            + 2
+        )
+        per_column_digits = 3 * (
+            len(str(1)) + len(str(denominator)) + len(str(len(values))) + 1
+        )
+        accepted_columns = (
+            MAX_ROUNDING_RESULT_RATIONAL_DIGITS - base_digits
+        ) // per_column_digits
+
+        def columns(count: int) -> tuple[dict[str, object], ...]:
+            return tuple(
+                {"label": f"c{index}", "coordinates": (0,)} for index in range(count)
+            )
+
+        _rounding_request(
+            values=values,
+            rows=({"label": "r", "coordinates": (0, 1)},),
+            columns=columns(accepted_columns),
+        )
+        with pytest.raises(ValidationError, match="result-size bound"):
+            _rounding_request(
+                values=values,
+                rows=({"label": "r", "coordinates": (0, 1)},),
+                columns=columns(accepted_columns + 1),
+            )
 
 
 class TestDiscrepancyEval:

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -8,6 +8,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
+import jacobian.math.discrepancy_theory._models as discrepancy_models
 from jacobian.math.discrepancy_theory._models import (
     MAX_COLUMN_INCIDENCES,
     MAX_MONITORED_COLUMNS,
@@ -330,6 +331,35 @@ class TestHardConstraintRounding:
         above[-1] = {"label": "i511", "coordinates": (*support, len(support))}
         with pytest.raises(ValidationError, match="incidences exceed"):
             _rounding_request(values=values, rows=rows, columns=tuple(above))
+
+    def test_over_incidence_rejects_before_exact_aggregation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fail_if_aggregated(
+            _values: list[Fraction], _coordinates: tuple[int, ...]
+        ) -> Fraction:
+            raise AssertionError("exact aggregation reached before cheap preflight")
+
+        monkeypatch.setattr(
+            discrepancy_models,
+            "_sum_selected_fractions",
+            fail_if_aggregated,
+        )
+        denominator = 10 ** (MAX_ROUNDING_RATIONAL_DIGITS - 1) + 1
+        coordinate_count = MAX_ROUNDING_COORDINATES
+        support = tuple(range(coordinate_count))
+        column_count = MAX_COLUMN_INCIDENCES // coordinate_count + 1
+        columns = tuple(
+            {"label": f"c{index}", "coordinates": support}
+            for index in range(column_count)
+        )
+
+        with pytest.raises(ValidationError, match="incidences exceed"):
+            _rounding_request(
+                values=(Fraction(1, denominator),) * coordinate_count,
+                rows=({"label": "all", "coordinates": support},),
+                columns=columns,
+            )
 
     def test_rational_digit_and_work_boundaries(self) -> None:
         denominator = 10 ** (MAX_ROUNDING_RATIONAL_DIGITS - 1) + 1


### PR DESCRIPTION
Closes #2318.

## Problem

Jacobian can evaluate or optimize unrestricted `+1/-1` discrepancy and can compute exact rational nullspaces, but neither operation establishes the joint postcondition needed by the cited floating-variable argument: round a rational vector to bits, preserve every disjoint integral row sum exactly, and bound every monitored column error by `4d`.

Leaving the iteration to callers would require each caller to choose retained equations, move to exact endpoints, and reconstruct the global error proof. A mixed-integer solver would return feasibility without the source-derived guarantee.

## Solution

This adds `discrepancy.hard_constraint_round.compute`. Its typed source carries an ordered rational coordinate vector, a named row partition, and named monitored zero-one columns. The result retains that source and returns the binary vector, derived incidence `d`, the `4d` bound, and complete exact row and column ledgers.

The private kernel follows the pinned Erdős construction. At each iteration it retains every active hard row and every monitored column with more than `4d` fractional coordinates, chooses a canonical nonzero direction in the exact nullspace, fixes its primitive sign convention, and takes the first positive cube endpoint. Each step makes at least one coordinate integral. The result validator replays every row sum, column sum, signed error, absolute error, and derived bound.

SymPy 1.14 `DomainMatrix` over `ZZ` is the maintained private nullspace backend. The retained matrices are zero-one integer matrices, and `DomainMatrix.nullspace()` provides an exact fraction-free basis; Jacobian fixes the remaining basis-row, scale, sign, and endpoint conventions for deterministic output. Public rationals and endpoint arithmetic remain canonical `Fraction` values, so backend objects do not leak into the contract.

The public guarantee remains `4d`, matching the pinned proof and this kernel. Doerr proves a sharper general `2d` result, but adopting that theorem would broaden the admitted claim and require a separately justified algorithm and evidence; this PR does not present `4d` as optimal.

The execution envelope is deliberately conservative. It admits at most 512 coordinates, rows, and monitored columns, 32,768 column incidences, 256 digits per input rational, an 8,000,000-unit scan/elimination proxy, 8,192 intermediate rational digits, and a 100,000-digit exact-result budget. Admission derives work from fractional support and incidences and derives height from common denominators plus Hadamard bounds on retained-matrix minors. The kernel checks the admitted direction and height before every endpoint update. These are safe fallback caps, not claims about the largest feasible instance.

The cited source does not publish a materialized allocation fixture in this generic request shape, so the suite does not claim a source-scale reproduction. It instead exercises the defining invariants, an adversarial retained-column case, exhaustive small half-integral systems, exact admission boundaries, authored-result mutations, and coherent relabeling.

Suggested review order:

1. Read `_models.py` for source canonicalization, preflight bounds, and result replay.
2. Read `_operations.py` for the rank count, canonical direction, endpoint step, and termination invariant.
3. Check the adversarial, exhaustive, mutation, and boundary cases in `test_discrepancy_theory.py`.
4. Confirm catalog declaration and owner-local admission in `_tools.py` and `_admission.py`.

## Testing

- `make test-math TESTS=tests/math/discrepancy_theory/test_discrepancy_theory.py` — 26 passed.
- `make test-integration TESTS="tests/integration/catalog/test_builtin_examples.py::test_advertised_invocation_example_executes_successfully[discrepancy.hard_constraint_round.compute] tests/integration/catalog/test_public_operation_contract_conformance.py::test_every_accepted_boundary_mutation_returns_the_declared_result[discrepancy.hard_constraint_round.compute]"` — 2 passed.
- `make check` — Ruff, formatting, and mypy passed; 2,669 bounded-owner tests passed.
- `git diff --check` — passed.
- Deterministic randomized replay — 1,000 exact rational partitioned sources preserved every row and satisfied every monitored-column ledger and bound.
- Boundary measurements — the 74-fractional-coordinate work boundary completed in 0.70 s at 79,628 KiB peak RSS; a retained-column boundary case completed in 0.63 s at 79,712 KiB peak RSS.

- Specialist validation run: the owning discrepancy theory test and the two catalog contract nodes listed above.

## Public contract impact

Adds operation ID `discrepancy.hard_constraint_round.compute`, its request/result schemas, the native typed computation, one executable catalog example, and exact `4d` mathematical semantics. Existing operation contracts are unchanged.

## Public operation admission

- Concrete gap: exact source-bound binary rounding that jointly preserves disjoint integral cardinality constraints and certifies a column-sparse error bound.
- Why existing operations or typed values are insufficient: discrepancy coloring lacks a fractional target and hard rows; rational nullspace returns only one algebraic substep and no global rounding guarantee.
- Stable mathematical result: a retained source, deterministic bit vector, derived `d` and `4d`, and complete exact row/column replay ledgers.
- Semantic domain and admitted execution envelope: rational values in `[0,1]`, an exact named row partition with integral sums, and finite named zero-one columns, under the coordinate, incidence, rational-height, work, intermediate, and result budgets above.
- Controlling work, intermediate, memory, and output quantities: fractional support, coordinate and incidence scans, cumulative exact elimination, common-denominator growth, minor height, and serialized ledger size.
- Exact representation, algorithm regimes, and maintained backend: canonical rationals and bits publicly; one exact floating-variable regime using pinned SymPy 1.14 `DomainMatrix` over `ZZ` privately.
- Remaining fixed caps and their classification: 512-element structural caps and conservative 256/8,192/100,000-digit plus 8,000,000-work safety envelopes; widening them needs stronger analysis or measurements, not another operation.
- Admission decision: `KEEP` in the discrepancy theory owner because this establishes a distinct reusable source-bound rounding postcondition.

## Closure matrix

None. Issue #2318 requests this single admitted operation and leaves no residual public surface.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] The result is exact and source-bound; incomplete, unknown, and unavailable outcomes are not part of this accepted domain
- [x] New bounds include exact boundary tests, adversarial retained-column coverage, and measured boundary cases; the source-scale fixture limitation is stated above
- [x] No shared abstraction was introduced; this operation remains domain-owned