### PR TITLE
feat(math): add exact rational Hermite interpolation

### DIFF
--- a/src/jacobian/math/polynomial_interpolation_ops/__init__.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/__init__.py
@@ -1,3 +1,21 @@
-"""Polynomial interpolation operations."""
+"""Supported exact polynomial-interpolation API."""
 
-__all__: list[str] = []
+from jacobian.math.polynomial_interpolation_ops._models import (
+    HermiteConstraintReplay,
+    HermiteInterpolationResult,
+    OrdinaryDerivativeJet,
+    OrdinaryDerivativeJetTable,
+    OrdinaryDerivativeValue,
+)
+from jacobian.math.polynomial_interpolation_ops._operations import (
+    hermite_interpolation,
+)
+
+__all__ = [
+    "HermiteConstraintReplay",
+    "HermiteInterpolationResult",
+    "OrdinaryDerivativeJet",
+    "OrdinaryDerivativeJetTable",
+    "OrdinaryDerivativeValue",
+    "hermite_interpolation",
+]

--- a/src/jacobian/math/polynomial_interpolation_ops/_admission.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_admission.py
@@ -11,6 +11,13 @@ from jacobian.math.polynomial_interpolation_ops._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "polynomial.interpolation.hermite.compute",
+        AdmissionDecision.KEEP,
+        "unique exact QQ polynomial construction from complete ordinary-derivative "
+        "jets, returning the canonical polynomial and a complete source-bound "
+        "constraint replay unavailable from distinct-node interpolation",
+    ),
+    OperationAdmission(
         "polynomial.interpolation.divided_differences.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/polynomial_interpolation_ops/_kernel.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_kernel.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 from fractions import Fraction
+from math import prod
+from typing import TYPE_CHECKING
 
 from jacobian._exact import CanonicalRational
+
+if TYPE_CHECKING:
+    from jacobian.math.polynomial_interpolation_ops._models import (
+        OrdinaryDerivativeJetTable,
+    )
 
 
 def divided_difference_coefficients(
@@ -42,4 +49,76 @@ def evaluate_newton_form(
     return result
 
 
-__all__ = ["divided_difference_coefficients", "evaluate_newton_form"]
+def ordinary_derivative_value(
+    coefficients: tuple[Fraction, ...],
+    node: Fraction,
+    derivative_order: int,
+) -> Fraction:
+    """Evaluate one ordinary derivative of an ascending coefficient tuple."""
+
+    return sum(
+        (
+            coefficients[degree]
+            * prod(range(degree - derivative_order + 1, degree + 1))
+            * node ** (degree - derivative_order)
+            for degree in range(derivative_order, len(coefficients))
+        ),
+        start=Fraction(0),
+    )
+
+
+def hermite_interpolation_coefficients(
+    table: OrdinaryDerivativeJetTable,
+) -> tuple[Fraction, ...]:
+    """Solve one admitted ordinary-derivative Hermite system exactly.
+
+    python-flint 0.9 has no derivative-jet interpolation entry point, but its
+    maintained ``fmpq_mat.solve`` kernel provides exact fraction-free linear
+    algebra. Each row is scaled to integers using the same formula proved by
+    request preflight; FLINT therefore expands only the already-admitted
+    ``M``-square system and fraction-free minors.
+    """
+
+    from flint import fmpq_mat
+
+    multiplicity = sum(len(jet.derivatives) for jet in table.jets)
+    matrix_entries: list[int] = []
+    right_hand_side: list[int] = []
+    ordered_jets = sorted(table.jets, key=lambda item: item.node.as_fraction())
+    for jet in ordered_jets:
+        node_numerator, node_denominator = jet.node.as_integer_ratio()
+        for derivative in jet.derivatives:
+            order = derivative.derivative_order
+            target_numerator, target_denominator = derivative.value.as_integer_ratio()
+            for degree in range(multiplicity):
+                if degree < order:
+                    matrix_entries.append(0)
+                    continue
+                falling = prod(range(degree - order + 1, degree + 1))
+                matrix_entries.append(
+                    falling
+                    * node_numerator ** (degree - order)
+                    * node_denominator ** (multiplicity - 1 - degree)
+                    * target_denominator
+                )
+            right_hand_side.append(
+                target_numerator * node_denominator ** (multiplicity - 1 - order)
+            )
+
+    matrix = fmpq_mat(multiplicity, multiplicity, matrix_entries)
+    target = fmpq_mat(multiplicity, 1, right_hand_side)
+    # python-flint 0.9 documents and accepts the algorithm keyword, while its
+    # bundled type stub has not yet added that optional argument.
+    solution = matrix.solve(target, algorithm="fflu")  # type: ignore[call-arg]
+    return tuple(
+        Fraction(int(solution[index, 0].p), int(solution[index, 0].q))
+        for index in range(multiplicity)
+    )
+
+
+__all__ = [
+    "divided_difference_coefficients",
+    "evaluate_newton_form",
+    "hermite_interpolation_coefficients",
+    "ordinary_derivative_value",
+]

--- a/src/jacobian/math/polynomial_interpolation_ops/_models.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_models.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Self
+from fractions import Fraction
+from math import prod
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -12,13 +14,33 @@ from jacobian._exact import (
     require_bounded_rational,
 )
 from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
 from jacobian.math.polynomial_interpolation_ops._kernel import (
     divided_difference_coefficients,
     evaluate_newton_form,
+    ordinary_derivative_value,
+)
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalPolynomial,
 )
 
 MAX_POINTS = 32
 _MAX_RATIONAL_DIGITS = 256
+MAX_HERMITE_SYSTEM_CELLS = MAX_POINTS * (MAX_POINTS + 1)
+"""Largest admitted Hermite matrix plus right-hand-side allocation."""
+
+MAX_HERMITE_CUBIC_WORK_CELLS = MAX_POINTS**3
+"""Conservative scalar-update count for exact fraction-free elimination."""
+
+MAX_HERMITE_SCALED_ENTRY_DIGITS = MAX_POINTS * _MAX_RATIONAL_DIGITS + 64
+"""Digit envelope for a row-scaled integer Hermite-system entry."""
+
+MAX_HERMITE_INTERMEDIATE_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
+"""Hadamard envelope for fraction-free minors in the maintained backend."""
+
+MAX_HERMITE_RESULT_BYTES = 2 * 1024 * 1024
+"""Aggregate canonical-result envelope for polynomial, source, and replay."""
 
 
 def _require_distinct(nodes: tuple[CanonicalRational, ...]) -> None:
@@ -33,6 +55,449 @@ def _require_bounded(values: tuple[CanonicalRational, ...], label: str) -> None:
             max_digits=_MAX_RATIONAL_DIGITS,
             label=label,
         )
+
+
+class OrdinaryDerivativeValue(StrictModel):
+    """One explicitly indexed ordinary derivative in a complete node jet."""
+
+    derivative_order: int = Field(
+        ge=0,
+        lt=MAX_POINTS,
+        description=(
+            "Ordinary derivative order. Within one jet these orders must be "
+            "exactly 0, 1, ..., m-1 in sequence."
+        ),
+    )
+    value: CanonicalRational = Field(
+        description=(
+            "Canonical exact rational derivative value whose numerator and "
+            "denominator each have at most 256 digits."
+        )
+    )
+
+
+class OrdinaryDerivativeJet(StrictModel):
+    """A nonempty complete prefix of ordinary derivatives at one node."""
+
+    node: CanonicalRational = Field(
+        description=(
+            "Canonical exact rational node whose numerator and denominator "
+            "each have at most 256 digits."
+        )
+    )
+    derivatives: tuple[OrdinaryDerivativeValue, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+        description=(
+            "Nonempty complete prefix f(node), f'(node), ..., "
+            "f^(m-1)(node), represented by derivative orders 0 through m-1."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_complete_prefix_and_bounds(self) -> Self:
+        orders = tuple(item.derivative_order for item in self.derivatives)
+        if orders != tuple(range(len(self.derivatives))):
+            raise ValueError(
+                "ordinary derivative orders must form the complete prefix "
+                "0, 1, ..., m-1 in sequence"
+            )
+        _require_bounded((self.node,), "Hermite interpolation node")
+        _require_bounded(
+            tuple(item.value for item in self.derivatives),
+            "Hermite derivative value",
+        )
+        return self
+
+
+def _raw_derivative_count(value: object) -> int:
+    if isinstance(value, OrdinaryDerivativeJet):
+        return len(value.derivatives)
+    if isinstance(value, dict):
+        derivatives = value.get("derivatives")
+        if isinstance(derivatives, (list, tuple)):
+            return len(derivatives)
+    return 0
+
+
+class OrdinaryDerivativeJetTable(StrictModel):
+    """One bounded materialized ordinary-derivative jet table over ``QQ``.
+
+    Rows may be supplied in any order. Nodes must be pairwise distinct, every
+    row must contain a complete derivative prefix, and the aggregate
+    multiplicity ``M`` may not exceed 32.
+    """
+
+    variable: PolynomialVariable = Field(
+        description=(
+            "The single polynomial variable identifier for the resulting QQ polynomial."
+        )
+    )
+    jets: tuple[OrdinaryDerivativeJet, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+        description=(
+            "Nonempty derivative jets at pairwise-distinct rational nodes; row "
+            "order does not affect the canonical interpolating polynomial. The "
+            "sum of all derivative-prefix lengths is at most 32."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def require_raw_aggregate_bound(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+        jets = data.get("jets")
+        if not isinstance(jets, (list, tuple)):
+            return data
+        if len(jets) > MAX_POINTS:
+            raise ValueError(
+                f"ordinary derivative table exceeds the {MAX_POINTS}-node bound"
+            )
+        total = 0
+        normalized_jets: list[object] = []
+        for jet in jets:
+            total += _raw_derivative_count(jet)
+            if total > MAX_POINTS:
+                raise ValueError(
+                    "total ordinary derivative multiplicity exceeds the "
+                    f"{MAX_POINTS}-constraint bound"
+                )
+            if isinstance(jet, dict):
+                # A before-validator sees JSON arrays as Python lists. Preserve
+                # the strict tuple contract after doing the aggregate count.
+                normalized_jet = dict(jet)
+                derivatives = normalized_jet.get("derivatives")
+                if isinstance(derivatives, list):
+                    normalized_jet["derivatives"] = tuple(derivatives)
+                normalized_jets.append(normalized_jet)
+            else:
+                normalized_jets.append(jet)
+        normalized = dict(data)
+        normalized["jets"] = tuple(normalized_jets)
+        return normalized
+
+    @model_validator(mode="after")
+    def require_distinct_bounded_jets(self) -> Self:
+        _require_distinct(tuple(jet.node for jet in self.jets))
+        total = _total_multiplicity(self)
+        if total > MAX_POINTS:
+            raise ValueError(
+                "total ordinary derivative multiplicity exceeds the "
+                f"{MAX_POINTS}-constraint bound"
+            )
+        _require_hermite_preflight(self)
+        return self
+
+
+def _total_multiplicity(table: OrdinaryDerivativeJetTable) -> int:
+    return sum(len(jet.derivatives) for jet in table.jets)
+
+
+def _factor_digits(value: int, *, exponent: int = 1) -> int:
+    if exponent == 0 or abs(value) == 1:
+        return 0
+    return exponent * len(str(abs(value)))
+
+
+def _scaled_system_row_digit_bounds(
+    table: OrdinaryDerivativeJetTable,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Bound row-scaled Hermite matrix and augmented-row integer heights.
+
+    For the derivative-``r`` row at ``a=p/q`` with target ``s/t``, multiply
+    the equation by ``q^(M-1-r) t``. Its monomial-``k`` entry becomes
+
+    ``(k)_r p^(k-r) q^(M-1-k) t``
+
+    and its right-hand side becomes ``s q^(M-1-r)``. These formulas bound every
+    integer cell before any large power or matrix entry is materialized.
+    """
+
+    multiplicity = _total_multiplicity(table)
+    matrix_rows: list[int] = []
+    augmented_rows: list[int] = []
+    for jet in table.jets:
+        node_numerator, node_denominator = jet.node.as_integer_ratio()
+        for derivative in jet.derivatives:
+            order = derivative.derivative_order
+            target_numerator, target_denominator = derivative.value.as_integer_ratio()
+            entry_bounds: list[int] = []
+            for degree in range(order, multiplicity):
+                node_exponent = degree - order
+                if node_numerator == 0 and node_exponent > 0:
+                    entry_bounds.append(1)
+                    continue
+                falling = prod(range(degree - order + 1, degree + 1))
+                bound = (
+                    _factor_digits(falling)
+                    + _factor_digits(node_numerator, exponent=node_exponent)
+                    + _factor_digits(
+                        node_denominator,
+                        exponent=multiplicity - 1 - degree,
+                    )
+                    + _factor_digits(target_denominator)
+                )
+                entry_bounds.append(max(1, bound))
+            matrix_bound = max(entry_bounds)
+            if target_numerator == 0:
+                target_bound = 1
+            else:
+                target_bound = max(
+                    1,
+                    _factor_digits(target_numerator)
+                    + _factor_digits(
+                        node_denominator,
+                        exponent=multiplicity - 1 - order,
+                    ),
+                )
+            matrix_rows.append(matrix_bound)
+            augmented_rows.append(max(matrix_bound, target_bound))
+    return tuple(matrix_rows), tuple(augmented_rows)
+
+
+def _hadamard_determinant_digits(row_digits: tuple[int, ...]) -> int:
+    dimension = len(row_digits)
+    euclidean_norm_digits = len(str(dimension ** ((dimension + 1) // 2)))
+    return sum(row_digits) + euclidean_norm_digits + 1
+
+
+def _predicted_hermite_result_bytes(
+    table: OrdinaryDerivativeJetTable,
+    coefficient_digits: int,
+) -> int:
+    multiplicity = _total_multiplicity(table)
+    source_bytes = len(encode_strict_json(table.model_dump(mode="json")))
+    replay_bytes = sum(
+        len(encode_strict_json(jet.node.model_dump(mode="json")))
+        + 2 * len(encode_strict_json(derivative.value.model_dump(mode="json")))
+        + 160
+        for jet in table.jets
+        for derivative in jet.derivatives
+    )
+    polynomial_bytes = multiplicity * (2 * coefficient_digits + 192)
+    leading_coefficient_bytes = 2 * coefficient_digits + 192
+    return (
+        source_bytes
+        + replay_bytes
+        + polynomial_bytes
+        + leading_coefficient_bytes
+        + 4_096
+    )
+
+
+def _require_hermite_preflight(
+    table: OrdinaryDerivativeJetTable,
+) -> tuple[int, int]:
+    """Validate allocation, exact-work, intermediate, and result envelopes."""
+
+    multiplicity = _total_multiplicity(table)
+    system_cells = multiplicity * (multiplicity + 1)
+    if system_cells > MAX_HERMITE_SYSTEM_CELLS:
+        raise ValueError(
+            "Hermite linear system exceeds the "
+            f"{MAX_HERMITE_SYSTEM_CELLS}-cell allocation bound"
+        )
+    cubic_work_cells = multiplicity**3
+    if cubic_work_cells > MAX_HERMITE_CUBIC_WORK_CELLS:
+        raise ValueError(
+            "Hermite fraction-free elimination exceeds the "
+            f"{MAX_HERMITE_CUBIC_WORK_CELLS}-cell work bound"
+        )
+
+    matrix_rows, augmented_rows = _scaled_system_row_digit_bounds(table)
+    maximum_entry_digits = max(augmented_rows)
+    if maximum_entry_digits > MAX_HERMITE_SCALED_ENTRY_DIGITS:
+        raise ValueError(
+            "a row-scaled Hermite system entry exceeds the "
+            f"{MAX_HERMITE_SCALED_ENTRY_DIGITS}-digit bound"
+        )
+
+    intermediate_digits = _hadamard_determinant_digits(matrix_rows)
+    if intermediate_digits > MAX_HERMITE_INTERMEDIATE_DIGITS:
+        raise ValueError(
+            "Hermite fraction-free intermediate growth exceeds the "
+            f"{MAX_HERMITE_INTERMEDIATE_DIGITS}-digit bound"
+        )
+
+    all_zero = all(
+        derivative.value.as_fraction() == 0
+        for jet in table.jets
+        for derivative in jet.derivatives
+    )
+    coefficient_digits = (
+        1
+        if all_zero
+        else max(
+            intermediate_digits,
+            _hadamard_determinant_digits(augmented_rows),
+        )
+    )
+    if coefficient_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise ValueError(
+            "Hermite coefficient growth exceeds the canonical "
+            f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit bound"
+        )
+    predicted_result_bytes = _predicted_hermite_result_bytes(table, coefficient_digits)
+    if predicted_result_bytes > MAX_HERMITE_RESULT_BYTES:
+        raise ValueError(
+            "the complete Hermite result exceeds the "
+            f"{MAX_HERMITE_RESULT_BYTES}-byte aggregate result bound"
+        )
+    return coefficient_digits, predicted_result_bytes
+
+
+class HermiteInterpolationRequest(StrictModel):
+    table: OrdinaryDerivativeJetTable = Field(
+        description=(
+            "Materialized ordinary-derivative jet table whose total "
+            "multiplicity determines the unique degree bound."
+        )
+    )
+
+
+class HermiteConstraintReplay(StrictModel):
+    """One exact replay row for an ordinary-derivative constraint."""
+
+    node: CanonicalRational
+    derivative_order: int = Field(ge=0, lt=MAX_POINTS)
+    expected: CanonicalRational
+    computed: CanonicalRational
+
+
+def _polynomial_coefficients(
+    polynomial: RationalPolynomial,
+    multiplicity: int,
+) -> tuple[Fraction, ...]:
+    coefficients = [Fraction(0)] * multiplicity
+    for term in polynomial.polynomial.terms:
+        exponent = term.exponents[0]
+        if exponent >= multiplicity:
+            raise ValueError("Hermite polynomial degree must be less than M")
+        coefficients[exponent] = term.coefficient.as_fraction()
+    return tuple(coefficients)
+
+
+class HermiteInterpolationResult(StrictModel):
+    """Unique degree-``< M`` interpolant with complete source-bound replay."""
+
+    source: OrdinaryDerivativeJetTable = Field(
+        description="Retained source table that binds the polynomial and replay."
+    )
+    polynomial: RationalPolynomial = Field(
+        description=(
+            "Canonical sparse polynomial in QQ[source.variable] of degree less "
+            "than total_multiplicity."
+        )
+    )
+    total_multiplicity: int = Field(
+        ge=1,
+        le=MAX_POINTS,
+        description="Sum of all retained derivative-prefix lengths.",
+    )
+    degree: int | None = Field(
+        default=None,
+        ge=0,
+        lt=MAX_POINTS,
+        description=(
+            "Exact polynomial degree, or null for the zero polynomial whose "
+            "sparse term family is empty."
+        ),
+    )
+    leading_coefficient: CanonicalRational = Field(
+        description=(
+            "Exact leading coefficient; canonical zero 0/1 for the zero polynomial."
+        )
+    )
+    replay: tuple[HermiteConstraintReplay, ...] = Field(
+        min_length=1,
+        max_length=MAX_POINTS,
+        description=(
+            "Every retained derivative constraint exactly once, sorted by "
+            "rational node and then derivative order."
+        ),
+    )
+    method: Literal["FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"] = (
+        "FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"
+    )
+
+    @model_validator(mode="after")
+    def require_unique_source_bound_interpolant(self) -> Self:
+        multiplicity = _total_multiplicity(self.source)
+        if self.total_multiplicity != multiplicity:
+            raise ValueError("total_multiplicity must equal the source jet length")
+        if self.polynomial.variables != (self.source.variable,):
+            raise ValueError(
+                "Hermite polynomial must use exactly the source table variable"
+            )
+        coefficient_bound, _ = _require_hermite_preflight(self.source)
+        for term in self.polynomial.polynomial.terms:
+            require_bounded_rational(
+                term.coefficient,
+                max_digits=coefficient_bound,
+                label="Hermite polynomial coefficient",
+            )
+        coefficients = _polynomial_coefficients(self.polynomial, multiplicity)
+        nonzero_degrees = tuple(
+            degree for degree, coefficient in enumerate(coefficients) if coefficient
+        )
+        expected_degree = max(nonzero_degrees) if nonzero_degrees else None
+        if self.degree != expected_degree:
+            raise ValueError("degree must equal the exact polynomial degree")
+        expected_leading = (
+            Fraction(0) if expected_degree is None else coefficients[expected_degree]
+        )
+        if self.leading_coefficient.as_fraction() != expected_leading:
+            raise ValueError("leading_coefficient must match the canonical polynomial")
+
+        expected_rows = tuple(
+            (
+                jet.node.as_fraction(),
+                derivative.derivative_order,
+                derivative.value.as_fraction(),
+            )
+            for jet in sorted(
+                self.source.jets, key=lambda item: item.node.as_fraction()
+            )
+            for derivative in jet.derivatives
+        )
+        actual_rows = tuple(
+            (
+                item.node.as_fraction(),
+                item.derivative_order,
+                item.expected.as_fraction(),
+            )
+            for item in self.replay
+        )
+        if actual_rows != expected_rows:
+            raise ValueError(
+                "replay must cover every source derivative constraint in "
+                "canonical node/order order"
+            )
+        for item in self.replay:
+            computed = ordinary_derivative_value(
+                coefficients,
+                item.node.as_fraction(),
+                item.derivative_order,
+            )
+            if item.computed.as_fraction() != computed:
+                raise ValueError(
+                    "replay computed value does not match the returned polynomial"
+                )
+            if item.computed.as_fraction() != item.expected.as_fraction():
+                raise ValueError(
+                    "returned polynomial does not satisfy a source derivative "
+                    "constraint"
+                )
+        if (
+            len(encode_strict_json(self.model_dump(mode="json")))
+            > MAX_HERMITE_RESULT_BYTES
+        ):
+            raise ValueError(
+                "complete Hermite result exceeds the aggregate result bound"
+            )
+        return self
 
 
 class InterpolationSamples(StrictModel):
@@ -134,12 +599,23 @@ class NewtonEvaluateResult(StrictModel):
 
 
 __all__ = [
+    "MAX_HERMITE_CUBIC_WORK_CELLS",
+    "MAX_HERMITE_INTERMEDIATE_DIGITS",
+    "MAX_HERMITE_RESULT_BYTES",
+    "MAX_HERMITE_SCALED_ENTRY_DIGITS",
+    "MAX_HERMITE_SYSTEM_CELLS",
     "DividedDifferencesRequest",
     "DividedDifferencesResult",
+    "HermiteConstraintReplay",
+    "HermiteInterpolationRequest",
+    "HermiteInterpolationResult",
     "InterpolationSamples",
     "NewtonEvaluateRequest",
     "NewtonEvaluateResult",
     "NewtonForm",
     "NewtonFormRequest",
     "NewtonFormResult",
+    "OrdinaryDerivativeJet",
+    "OrdinaryDerivativeJetTable",
+    "OrdinaryDerivativeValue",
 ]

--- a/src/jacobian/math/polynomial_interpolation_ops/_operations.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_operations.py
@@ -8,14 +8,25 @@ from jacobian._exact import CanonicalRational
 from jacobian.math.polynomial_interpolation_ops._kernel import (
     divided_difference_coefficients,
     evaluate_newton_form,
+    hermite_interpolation_coefficients,
+    ordinary_derivative_value,
 )
 from jacobian.math.polynomial_interpolation_ops._models import (
     DividedDifferencesRequest,
     DividedDifferencesResult,
+    HermiteConstraintReplay,
+    HermiteInterpolationRequest,
+    HermiteInterpolationResult,
     NewtonEvaluateRequest,
     NewtonEvaluateResult,
     NewtonForm,
     NewtonFormRequest,
+    OrdinaryDerivativeJetTable,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
 )
 
 
@@ -56,8 +67,70 @@ def compute_newton_evaluate(request: NewtonEvaluateRequest) -> NewtonEvaluateRes
     )
 
 
+def hermite_interpolation(
+    table: OrdinaryDerivativeJetTable,
+) -> HermiteInterpolationResult:
+    """Return the unique degree-``< M`` polynomial matching one jet table."""
+
+    coefficients = hermite_interpolation_coefficients(table)
+    nonzero_degrees = tuple(
+        degree for degree, coefficient in enumerate(coefficients) if coefficient
+    )
+    degree = max(nonzero_degrees) if nonzero_degrees else None
+    polynomial = RationalPolynomial(
+        variables=(table.variable,),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(
+                        coefficients[term_degree]
+                    ),
+                    exponents=(term_degree,),
+                )
+                for term_degree in reversed(nonzero_degrees)
+            )
+        ),
+    )
+    replay = tuple(
+        HermiteConstraintReplay(
+            node=CanonicalRational.from_integer_ratio(*jet.node.as_integer_ratio()),
+            derivative_order=derivative.derivative_order,
+            expected=CanonicalRational.from_integer_ratio(
+                *derivative.value.as_integer_ratio()
+            ),
+            computed=CanonicalRational.from_fraction(
+                ordinary_derivative_value(
+                    coefficients,
+                    jet.node.as_fraction(),
+                    derivative.derivative_order,
+                )
+            ),
+        )
+        for jet in sorted(table.jets, key=lambda item: item.node.as_fraction())
+        for derivative in jet.derivatives
+    )
+    return HermiteInterpolationResult(
+        source=table,
+        polynomial=polynomial,
+        total_multiplicity=len(coefficients),
+        degree=degree,
+        leading_coefficient=CanonicalRational.from_fraction(
+            Fraction(0) if degree is None else coefficients[degree]
+        ),
+        replay=replay,
+    )
+
+
+def compute_hermite_interpolation(
+    request: HermiteInterpolationRequest,
+) -> HermiteInterpolationResult:
+    return hermite_interpolation(request.table)
+
+
 __all__ = [
     "compute_divided_differences",
+    "compute_hermite_interpolation",
     "compute_newton_evaluate",
     "compute_newton_form",
+    "hermite_interpolation",
 ]

--- a/src/jacobian/math/polynomial_interpolation_ops/_tools.py
+++ b/src/jacobian/math/polynomial_interpolation_ops/_tools.py
@@ -9,6 +9,8 @@ from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.polynomial_interpolation_ops._models import (
     DividedDifferencesRequest,
     DividedDifferencesResult,
+    HermiteInterpolationRequest,
+    HermiteInterpolationResult,
     NewtonEvaluateRequest,
     NewtonEvaluateResult,
     NewtonFormRequest,
@@ -16,6 +18,7 @@ from jacobian.math.polynomial_interpolation_ops._models import (
 )
 from jacobian.math.polynomial_interpolation_ops._operations import (
     compute_divided_differences,
+    compute_hermite_interpolation,
     compute_newton_evaluate,
     compute_newton_form,
 )
@@ -56,7 +59,56 @@ def _samples() -> dict[str, list[dict[str, str]]]:
     }
 
 
+def _hermite_table() -> dict[str, object]:
+    return {
+        "variable": "x",
+        "jets": [
+            {
+                "node": _rational(0),
+                "derivatives": [
+                    {"derivative_order": 0, "value": _rational(0)},
+                    {"derivative_order": 1, "value": _rational(0)},
+                ],
+            },
+            {
+                "node": _rational(1),
+                "derivatives": [
+                    {"derivative_order": 0, "value": _rational(1)},
+                    {"derivative_order": 1, "value": _rational(2)},
+                ],
+            },
+        ],
+    }
+
+
 TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "polynomial.interpolation.hermite.compute",
+        "Compute an exact rational Hermite interpolant",
+        "Return the unique degree-<M polynomial in QQ[x] whose ordinary "
+        "derivatives match a complete table of rational derivative jets, with "
+        "a complete exact source-bound replay ledger. Uses a preflighted exact "
+        "Hermite-Vandermonde solve; rows require distinct nodes and derivative "
+        "orders 0 through m-1.",
+        HermiteInterpolationRequest,
+        HermiteInterpolationResult,
+        compute_hermite_interpolation,
+        "polynomial",
+        "interpolation",
+        "hermite",
+        "derivative-jet",
+        "confluent-interpolation",
+        "exact",
+        examples=(
+            example(
+                "quadratic_from_two_first_order_jets",
+                "Compute the exact polynomial matching value and first derivative "
+                "jets of x^2 at 0 and 1; nodes must be distinct and each jet must "
+                "list the complete derivative-order prefix starting at zero.",
+                {"table": _hermite_table()},
+            ),
+        ),
+    ),
     _op(
         "polynomial.interpolation.divided_differences.compute",
         "Compute Newton divided differences",

--- a/tests/math/polynomial_interpolation_ops/test_hermite_interpolation.py
+++ b/tests/math/polynomial_interpolation_ops/test_hermite_interpolation.py
@@ -1,0 +1,424 @@
+"""Exact contract, replay, and boundary tests for Hermite interpolation."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import prod
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import encode_strict_json
+from jacobian.math import polynomial_interpolation_ops
+from jacobian.math.polynomial_interpolation_ops import (
+    HermiteInterpolationResult,
+    OrdinaryDerivativeJet,
+    OrdinaryDerivativeJetTable,
+    OrdinaryDerivativeValue,
+    hermite_interpolation,
+)
+from jacobian.math.polynomial_interpolation_ops._models import (
+    MAX_HERMITE_CUBIC_WORK_CELLS,
+    MAX_HERMITE_RESULT_BYTES,
+    MAX_HERMITE_SYSTEM_CELLS,
+    HermiteInterpolationRequest,
+)
+from jacobian.math.polynomial_interpolation_ops._operations import (
+    compute_hermite_interpolation,
+)
+from jacobian.math.polynomials._elementary_operations import (
+    rational_polynomial_evaluate,
+)
+from jacobian.math.polynomials._models import RationalPolynomialEvaluationRequest
+
+
+def _q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    value = Fraction(numerator, denominator)
+    return CanonicalRational(
+        num=str(value.numerator),
+        den=str(value.denominator),
+    )
+
+
+def _derivative(
+    derivative_order: int,
+    numerator: int,
+    denominator: int = 1,
+) -> OrdinaryDerivativeValue:
+    return OrdinaryDerivativeValue(
+        derivative_order=derivative_order,
+        value=_q(numerator, denominator),
+    )
+
+
+def _jet(
+    node_numerator: int,
+    *values: tuple[int, int],
+    node_denominator: int = 1,
+) -> OrdinaryDerivativeJet:
+    return OrdinaryDerivativeJet(
+        node=_q(node_numerator, node_denominator),
+        derivatives=tuple(
+            _derivative(order, numerator, denominator)
+            for order, (numerator, denominator) in enumerate(values)
+        ),
+    )
+
+
+def _table(*jets: OrdinaryDerivativeJet) -> OrdinaryDerivativeJetTable:
+    return OrdinaryDerivativeJetTable(variable="x", jets=jets)
+
+
+def _full_multiplicity_payload(
+    node_digits: int,
+    *,
+    last_value_digits: int | None = None,
+) -> dict[str, object]:
+    return {
+        "variable": "x",
+        "jets": [
+            {
+                "node": {"num": "9" * node_digits, "den": "1"},
+                "derivatives": [
+                    {
+                        "derivative_order": order,
+                        "value": {
+                            "num": (
+                                "9" * last_value_digits
+                                if order == 31 and last_value_digits is not None
+                                else "0"
+                            ),
+                            "den": "1",
+                        },
+                    }
+                    for order in range(32)
+                ],
+            }
+        ],
+    }
+
+
+def _coefficient_map(result: HermiteInterpolationResult) -> dict[int, Fraction]:
+    return {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in result.polynomial.polynomial.terms
+    }
+
+
+def _ordinary_derivative(
+    coefficients: tuple[Fraction, ...], node: Fraction, order: int
+) -> Fraction:
+    return sum(
+        (
+            coefficients[degree]
+            * prod(range(degree - order + 1, degree + 1))
+            * node ** (degree - order)
+            for degree in range(order, len(coefficients))
+        ),
+        start=Fraction(0),
+    )
+
+
+def test_native_api_exports_the_typed_hermite_operation() -> None:
+    assert tuple(polynomial_interpolation_ops.__all__) == (
+        "HermiteConstraintReplay",
+        "HermiteInterpolationResult",
+        "OrdinaryDerivativeJet",
+        "OrdinaryDerivativeJetTable",
+        "OrdinaryDerivativeValue",
+        "hermite_interpolation",
+    )
+    assert polynomial_interpolation_ops.hermite_interpolation is hermite_interpolation
+
+
+def test_constant_jet_returns_a_canonical_constant_polynomial() -> None:
+    result = hermite_interpolation(_table(_jet(3, (5, 1))))
+
+    assert _coefficient_map(result) == {0: Fraction(5)}
+    assert result.total_multiplicity == 1
+    assert result.degree == 0
+    assert result.leading_coefficient.as_fraction() == 5
+    assert result.method == "FLINT_FMPQ_HERMITE_VANDERMONDE_FFLU"
+
+
+def test_higher_jet_uses_ordinary_not_hasse_derivatives() -> None:
+    result = hermite_interpolation(_table(_jet(2, (8, 1), (12, 1), (12, 1), (6, 1))))
+
+    assert _coefficient_map(result) == {3: Fraction(1)}
+    assert result.degree == 3
+    assert tuple(item.computed.as_fraction() for item in result.replay) == (
+        Fraction(8),
+        Fraction(12),
+        Fraction(12),
+        Fraction(6),
+    )
+
+
+def test_known_polynomial_is_reconstructed_from_several_nodes() -> None:
+    # p(x) = 2*x^5 - 3/2*x^3 + 7*x - 4, with M = 2 + 3 + 1 = 6.
+    table = _table(
+        _jet(-1, (-23, 2), (25, 2)),
+        _jet(0, (-4, 1), (7, 1), (0, 1)),
+        _jet(2, (62, 1)),
+    )
+
+    result = compute_hermite_interpolation(HermiteInterpolationRequest(table=table))
+
+    assert _coefficient_map(result) == {
+        5: Fraction(2),
+        3: Fraction(-3, 2),
+        1: Fraction(7),
+        0: Fraction(-4),
+    }
+    assert result.degree == 5
+    assert result.leading_coefficient.as_fraction() == 2
+    assert len(result.replay) == result.total_multiplicity == 6
+
+
+def test_rational_nodes_follow_the_same_exact_contract() -> None:
+    result = hermite_interpolation(
+        _table(
+            _jet(1, (1, 4), (1, 1), node_denominator=2),
+            _jet(-1, (1, 1)),
+        )
+    )
+
+    assert _coefficient_map(result) == {2: Fraction(1)}
+    assert tuple(item.computed.as_fraction() for item in result.replay) == (
+        Fraction(1),
+        Fraction(1, 4),
+        Fraction(1),
+    )
+
+
+def test_replay_establishes_every_defining_derivative_constraint() -> None:
+    coefficients = (
+        Fraction(-4),
+        Fraction(7),
+        Fraction(0),
+        Fraction(-3, 2),
+        Fraction(0),
+        Fraction(2),
+    )
+    table = _table(
+        _jet(-1, (-23, 2), (25, 2)),
+        _jet(0, (-4, 1), (7, 1), (0, 1)),
+        _jet(2, (62, 1)),
+    )
+    result = hermite_interpolation(table)
+
+    for replay in result.replay:
+        assert replay.computed.as_fraction() == _ordinary_derivative(
+            coefficients,
+            replay.node.as_fraction(),
+            replay.derivative_order,
+        )
+        assert replay.computed.as_fraction() == replay.expected.as_fraction()
+
+
+def test_zero_polynomial_retains_ring_and_zero_conventions() -> None:
+    result = hermite_interpolation(
+        _table(
+            _jet(-2, (0, 1), (0, 1)),
+            _jet(3, (0, 1), (0, 1), (0, 1)),
+        )
+    )
+
+    assert result.polynomial.variables == ("x",)
+    assert result.polynomial.polynomial.terms == ()
+    assert result.degree is None
+    assert result.leading_coefficient.as_fraction() == 0
+    assert all(item.computed.as_fraction() == 0 for item in result.replay)
+
+
+def test_node_row_permutation_preserves_polynomial_and_replay_order() -> None:
+    jets = (
+        _jet(-1, (-23, 2), (25, 2)),
+        _jet(0, (-4, 1), (7, 1), (0, 1)),
+        _jet(2, (62, 1)),
+    )
+
+    forward = hermite_interpolation(_table(*jets))
+    reversed_rows = hermite_interpolation(_table(*reversed(jets)))
+
+    assert forward.polynomial == reversed_rows.polynomial
+    assert forward.degree == reversed_rows.degree
+    assert forward.leading_coefficient == reversed_rows.leading_coefficient
+    assert forward.replay == reversed_rows.replay
+
+
+def test_native_polynomial_value_composes_with_existing_evaluation() -> None:
+    result = hermite_interpolation(
+        _table(_jet(0, (0, 1), (0, 1)), _jet(1, (1, 1), (2, 1)))
+    )
+    serialized_polynomial = result.polynomial.model_dump(mode="json")
+    request = RationalPolynomialEvaluationRequest.model_validate(
+        {"polynomial": serialized_polynomial, "point": {"num": "3", "den": "1"}}
+    )
+
+    evaluated = rational_polynomial_evaluate(request)
+
+    assert evaluated.value.as_fraction() == 9
+
+
+def test_duplicate_nodes_and_incomplete_prefixes_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="pairwise distinct"):
+        _table(_jet(1, (1, 1)), _jet(1, (2, 1)))
+
+    with pytest.raises(ValidationError, match="complete prefix"):
+        OrdinaryDerivativeJet(
+            node=_q(0),
+            derivatives=(_derivative(0, 1), _derivative(2, 3)),
+        )
+
+    with pytest.raises(ValidationError, match="complete prefix"):
+        OrdinaryDerivativeJet(
+            node=_q(0),
+            derivatives=(_derivative(1, 1),),
+        )
+
+
+def test_forged_replay_and_retained_source_are_rejected() -> None:
+    result = hermite_interpolation(
+        _table(_jet(0, (0, 1), (0, 1)), _jet(1, (1, 1), (2, 1)))
+    )
+
+    forged_replay = result.model_dump(mode="json")
+    forged_replay["replay"][0]["computed"] = {"num": "1", "den": "1"}
+    with pytest.raises(ValidationError, match="computed value"):
+        HermiteInterpolationResult.model_validate(forged_replay)
+
+    forged_source = result.model_dump(mode="json")
+    forged_source["source"]["jets"][0]["derivatives"][0]["value"] = {
+        "num": "1",
+        "den": "1",
+    }
+    with pytest.raises(ValidationError, match="replay must cover"):
+        HermiteInterpolationResult.model_validate(forged_source)
+
+
+def test_forged_polynomial_degree_and_leading_coefficient_are_rejected() -> None:
+    result = hermite_interpolation(_table(_jet(0, (1, 1), (1, 1))))
+
+    forged_polynomial = result.model_dump(mode="json")
+    forged_polynomial["polynomial"]["polynomial"]["terms"][1]["coefficient"] = {
+        "num": "2",
+        "den": "1",
+    }
+    with pytest.raises(ValidationError, match="computed value"):
+        HermiteInterpolationResult.model_validate(forged_polynomial)
+
+    forged_summary = result.model_dump(mode="json")
+    forged_summary["leading_coefficient"] = {"num": "2", "den": "1"}
+    with pytest.raises(ValidationError, match="leading_coefficient"):
+        HermiteInterpolationResult.model_validate(forged_summary)
+
+
+def test_total_multiplicity_and_linear_work_boundaries() -> None:
+    assert MAX_HERMITE_SYSTEM_CELLS == 32 * 33
+    assert MAX_HERMITE_CUBIC_WORK_CELLS == 32**3
+    boundary = OrdinaryDerivativeJetTable.model_validate(
+        {
+            "variable": "x",
+            "jets": [
+                {
+                    "node": {"num": "0", "den": "1"},
+                    "derivatives": [
+                        {
+                            "derivative_order": order,
+                            "value": {"num": "0", "den": "1"},
+                        }
+                        for order in range(32)
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert sum(len(jet.derivatives) for jet in boundary.jets) == 32
+    assert hermite_interpolation(boundary).polynomial.polynomial.terms == ()
+
+    above = boundary.model_dump(mode="json")
+    above["jets"][0]["derivatives"].append(
+        {"derivative_order": 31, "value": {"num": "0", "den": "1"}}
+    )
+    with pytest.raises(ValidationError, match="total ordinary derivative"):
+        OrdinaryDerivativeJetTable.model_validate(above)
+
+
+def test_input_rational_digit_boundary_is_documented_and_enforced() -> None:
+    at_limit = "9" * 256
+    denominator_at_limit = "1" + "0" * 255
+    table = OrdinaryDerivativeJetTable.model_validate(
+        {
+            "variable": "x",
+            "jets": [
+                {
+                    "node": {"num": "1", "den": denominator_at_limit},
+                    "derivatives": [
+                        {
+                            "derivative_order": 0,
+                            "value": {"num": at_limit, "den": "1"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    assert hermite_interpolation(table).leading_coefficient.num == at_limit
+
+    above_limit = table.model_dump(mode="json")
+    above_limit["jets"][0]["derivatives"][0]["value"]["num"] = "9" * 257
+    with pytest.raises(ValidationError):
+        OrdinaryDerivativeJetTable.model_validate(above_limit)
+
+    above_denominator = table.model_dump(mode="json")
+    above_denominator["jets"][0]["node"]["den"] = "1" + "0" * 256
+    with pytest.raises(ValidationError):
+        OrdinaryDerivativeJetTable.model_validate(above_denominator)
+
+    schema = OrdinaryDerivativeJetTable.model_json_schema()
+    jet_properties = schema["$defs"]["OrdinaryDerivativeJet"]["properties"]
+    value_properties = schema["$defs"]["OrdinaryDerivativeValue"]["properties"]
+    assert "at most 256 digits" in jet_properties["node"]["description"]
+    assert "at most 256 digits" in value_properties["value"]["description"]
+
+
+def test_intermediate_growth_boundary_rejects_before_matrix_construction() -> None:
+    # At M=32 these adjacent node heights straddle the 32,768-digit
+    # fraction-free-minor envelope while every raw rational remains admissible.
+    accepted = OrdinaryDerivativeJetTable.model_validate(_full_multiplicity_payload(64))
+    assert hermite_interpolation(accepted).polynomial.polynomial.terms == ()
+    with pytest.raises(ValidationError, match="intermediate growth"):
+        OrdinaryDerivativeJetTable.model_validate(_full_multiplicity_payload(65))
+
+
+def test_aggregate_result_boundary_is_checked_during_request_preflight() -> None:
+    # A 256-digit final derivative keeps the minor estimate admissible, while
+    # these adjacent node heights straddle the complete 2 MiB result envelope.
+    accepted = OrdinaryDerivativeJetTable.model_validate(
+        _full_multiplicity_payload(61, last_value_digits=256)
+    )
+    result = hermite_interpolation(accepted)
+    assert (
+        len(encode_strict_json(result.model_dump(mode="json")))
+        < MAX_HERMITE_RESULT_BYTES
+    )
+    with pytest.raises(ValidationError, match="complete Hermite result"):
+        OrdinaryDerivativeJetTable.model_validate(
+            _full_multiplicity_payload(62, last_value_digits=256)
+        )
+
+
+def test_result_size_is_bounded_and_round_trips() -> None:
+    result = hermite_interpolation(
+        _table(_jet(0, (0, 1), (0, 1)), _jet(1, (1, 1), (2, 1)))
+    )
+    serialized = result.model_dump(mode="json")
+
+    assert (
+        len(encode_strict_json(result.model_dump(mode="json")))
+        < MAX_HERMITE_RESULT_BYTES
+    )
+    assert HermiteInterpolationResult.model_validate(serialized) == result

--- a/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
+++ b/tests/math/polynomial_interpolation_ops/test_polynomial_interpolation.py
@@ -32,6 +32,7 @@ def _samples(
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "polynomial.interpolation.divided_differences.compute",
+        "polynomial.interpolation.hermite.compute",
         "polynomial.interpolation.newton_form.compute",
         "polynomial.interpolation.newton_evaluate.compute",
     }


### PR DESCRIPTION
## Problem

The existing interpolation operations accept only values at pairwise-distinct nodes. They cannot represent ordinary derivative jets, so callers cannot construct the unique rational polynomial determined by repeated-node derivative constraints.

Closes #2262.

## Solution

Add `polynomial.interpolation.hermite.compute` and a native `hermite_interpolation` function. The request is a typed table of pairwise-distinct rational nodes with a nonempty complete prefix of ordinary derivatives at each node. The result returns the existing canonical `RationalPolynomial`, exact degree and leading coefficient, the retained source table, and a deterministic replay row for every constraint.

The private kernel row-scales the confluent Vandermonde system to integers and uses the repository's pinned python-flint 0.9 `fmpq_mat.solve(..., algorithm="fflu")` exact linear-algebra backend. This keeps Jacobian's public values independent of FLINT while avoiding a new interpolation kernel. SymPy and python-flint provide the required exact polynomial and matrix primitives, but neither documented API provides this complete ordinary-derivative-jet postcondition directly.

Request validation bounds the system before FLINT constructs it. Result validation independently checks the degree bound, canonical coefficient envelope, source/replay correspondence, and every ordinary derivative equality. No parser, evaluator, approximation, truncation, or unknown branch is involved.

Suggested review order:

1. Request, work, growth, and result bounds in `_models.py`.
2. The row-scaled FLINT adapter and typed operation in `_kernel.py` and `_operations.py`.
3. Contract, adversarial, and boundary tests.

## Testing

```text
make test-math TESTS=tests/math/polynomial_interpolation_ops
# 28 passed

uv run pytest -q tests/catalog/test_admission.py tests/catalog/test_catalog.py
# 18 passed

uv run pytest -q tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py -k 'polynomial.interpolation.hermite.compute'
# 2 passed, 965 deselected

make check
# 2666 passed; Ruff, format, and mypy passed
```

- Specialist validation run: `make test-math TESTS=tests/math/polynomial_interpolation_ops`

## Public contract impact

Adds operation ID `polynomial.interpolation.hermite.compute`, its typed request/result schema, one catalog example, and the native `hermite_interpolation` API. Existing interpolation contracts and operation versions are unchanged.

## Public operation admission

- Concrete gap: exact interpolation from complete ordinary derivative jets is not expressible through the distinct-node sample table.
- Why existing operations or typed values are insufficient: divided differences and Newton form reject repeated nodes and carry no derivative-order structure; differentiation can check a known polynomial but cannot construct this unique interpolant.
- Stable mathematical result: the unique polynomial in `QQ[x]` of degree `< M`, plus complete exact replay of all source constraints.
- Semantic domain and admitted execution envelope: pairwise-distinct rational nodes, complete ordinary derivative prefixes, `M <= 32`, and at most 256 digits in each input rational component.
- Controlling work, intermediate, memory, and output quantities: at most 1,056 allocated system cells, 32,768 cubic elimination updates, 8,256 digits per row-scaled integer entry, 32,768 digits under the Hadamard minor envelope, 32 canonical polynomial terms, 32 replay rows, and a 2 MiB complete-result envelope.
- Exact representation, algorithm regimes, and maintained backend: canonical Jacobian rationals and rational polynomials around one exact, integer-row-scaled FLINT fraction-free LU solve; the returned polynomial and replay are revalidated directly.
- Remaining fixed caps and their classification: `M = 32`, 256-digit inputs, and 2 MiB results are conservative execution-envelope caps, not restrictions on the mathematical Hermite interpolation postcondition. There is one admitted algorithm regime.
- Admission decision: `KEEP`.

## Closure matrix

None. This issue requests one admitted operation and leaves Hasse derivatives, other coefficient fields, multivariate interpolation, and incremental workflows explicitly deferred.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics are complete and exact; approximation, incompleteness, unknown, and unavailable results are not applicable
- [x] New bounds have defining boundary tests; there is one algorithm regime and no crossover
- [x] No shared abstraction was added
