### PR TITLE
feat(graphs): add exact independence polynomials for bounded trees

### DIFF
--- a/src/jacobian/math/graphs/polynomials/__init__.py
+++ b/src/jacobian/math/graphs/polynomials/__init__.py
@@ -1,3 +1,11 @@
 """Graph-polynomial operation ownership."""
 
-__all__: list[str] = []
+from jacobian.math.graphs.polynomials.operations import (
+    independence_polynomial,
+    independence_polynomial_coefficients,
+)
+
+__all__ = [
+    "independence_polynomial",
+    "independence_polynomial_coefficients",
+]

--- a/src/jacobian/math/graphs/polynomials/_admission.py
+++ b/src/jacobian/math/graphs/polynomials/_admission.py
@@ -23,7 +23,7 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "graph.polynomial.independence.compute",
         AdmissionDecision.KEEP,
-        "exact independent-set cardinality generating function of a bounded tree, source-bound and returned as the canonical polynomial value for unchanged downstream composition",
+        "exact independent-set cardinality generating function of a bounded tree, source-bound with its dense coefficients and canonical polynomial for unchanged downstream composition",
     ),
     OperationAdmission(
         "graph.polynomial.matching.compute",

--- a/src/jacobian/math/graphs/polynomials/_admission.py
+++ b/src/jacobian/math/graphs/polynomials/_admission.py
@@ -21,6 +21,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
     ),
     OperationAdmission(
+        "graph.polynomial.independence.compute",
+        AdmissionDecision.KEEP,
+        "exact independent-set cardinality generating function of a bounded tree, source-bound and returned as the canonical polynomial value for unchanged downstream composition",
+    ),
+    OperationAdmission(
         "graph.polynomial.matching.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/graphs/polynomials/_models.py
+++ b/src/jacobian/math/graphs/polynomials/_models.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, StrictInt, model_validator
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+)
 from jacobian.math.graphs.polynomials.operations import (
     MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
     MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
@@ -105,11 +110,12 @@ def _maximum_independence_result_bytes(
     graph: SimpleUndirectedGraph,
     degree: int,
 ) -> int:
-    """Bound the echoed graph plus a maximum-size canonical polynomial."""
+    """Bound the complete source-bound result at one admitted degree."""
 
     maximum_coefficient = "9" * MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
     payload = {
         "graph": graph.model_dump(mode="json"),
+        "coefficients": [maximum_coefficient] * (degree + 1),
         "polynomial": {
             "polynomial_schema_version": "1",
             "domain": "QQ",
@@ -127,6 +133,8 @@ def _maximum_independence_result_bytes(
                 ]
             },
         },
+        "independence_number": degree,
+        "independent_set_count": maximum_coefficient,
     }
     output_limit = CanonicalLimits().max_output_bytes
     measurement_limits = CanonicalLimits(max_output_bytes=2 * output_limit)
@@ -183,13 +191,29 @@ class TreeIndependencePolynomialRequest(StrictModel):
 
 
 class TreeIndependencePolynomialResult(StrictModel):
-    """One source-bound exact independence polynomial in ``QQ[x]``."""
+    """One source-bound exact independence polynomial and its defining values."""
 
     graph: SimpleUndirectedGraph
+    coefficients: tuple[CanonicalInteger, ...] = Field(
+        min_length=2,
+        max_length=MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
+        description=(
+            "Dense coefficients i_0, ..., i_alpha as canonical decimal "
+            "nonnegative integers."
+        ),
+    )
     polynomial: RationalPolynomial
+    independence_number: StrictInt = Field(
+        ge=1,
+        le=MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+        description="The tree independence number alpha(T).",
+    )
+    independent_set_count: CanonicalInteger = Field(
+        description="The total I_T(1) as a canonical decimal integer."
+    )
 
     @model_validator(mode="after")
-    def require_polynomial_bound_to_source(self) -> Self:
+    def require_values_bound_to_source(self) -> Self:
         if self.polynomial.variables != ("x",):
             raise ValueError("independence polynomial must belong to QQ[x]")
         require_polynomial_budget(
@@ -199,14 +223,45 @@ class TreeIndependencePolynomialResult(StrictModel):
             maximum_coefficient_digits=MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
             label="independence polynomial",
         )
+        if any(
+            len(coefficient.lstrip("-"))
+            > MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
+            for coefficient in self.coefficients
+        ):
+            raise ValueError(
+                "independence coefficient exceeds the "
+                f"{MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS}-digit bound"
+            )
+        if (
+            len(self.independent_set_count.lstrip("-"))
+            > MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
+        ):
+            raise ValueError(
+                "independent-set count exceeds the "
+                f"{MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS}-digit bound"
+            )
         TreeIndependencePolynomialRequest(graph=self.graph)
 
         from jacobian.math.graphs.polynomials.operations import (
-            independence_polynomial,
+            _polynomial_from_coefficients,
+            independence_polynomial_coefficients,
         )
 
-        if self.polynomial != independence_polynomial(self.graph):
+        expected_coefficients = independence_polynomial_coefficients(self.graph)
+        expected_wire_coefficients = tuple(
+            format_canonical_integer(coefficient)
+            for coefficient in expected_coefficients
+        )
+        if self.polynomial != _polynomial_from_coefficients(expected_coefficients):
             raise ValueError("independence polynomial does not match the source tree")
+        if self.coefficients != expected_wire_coefficients:
+            raise ValueError("independence coefficients do not match the source tree")
+        if self.independence_number != len(expected_coefficients) - 1:
+            raise ValueError("independence number does not match the source tree")
+        if self.independent_set_count != format_canonical_integer(
+            sum(expected_coefficients)
+        ):
+            raise ValueError("independent-set count does not match the source tree")
         return self
 
 

--- a/src/jacobian/math/graphs/polynomials/_models.py
+++ b/src/jacobian/math/graphs/polynomials/_models.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.math.graphs.polynomials.operations import (
+    MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
+    MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+    MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
+    MAX_INDEPENDENCE_POLYNOMIAL_VERTICES,
+    _admitted_tree_profile,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    require_polynomial_budget,
+)
 
 
 class GraphEdge(StrictModel):
@@ -88,6 +101,115 @@ class MatchingPolynomialRequest(StrictModel):
         return self
 
 
+def _maximum_independence_result_bytes(
+    graph: SimpleUndirectedGraph,
+    degree: int,
+) -> int:
+    """Bound the echoed graph plus a maximum-size canonical polynomial."""
+
+    maximum_coefficient = "9" * MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
+    payload = {
+        "graph": graph.model_dump(mode="json"),
+        "polynomial": {
+            "polynomial_schema_version": "1",
+            "domain": "QQ",
+            "variables": ["x"],
+            "polynomial": {
+                "terms": [
+                    {
+                        "coefficient": {
+                            "num": maximum_coefficient,
+                            "den": "1",
+                        },
+                        "exponents": [exponent],
+                    }
+                    for exponent in range(degree, -1, -1)
+                ]
+            },
+        },
+    }
+    output_limit = CanonicalLimits().max_output_bytes
+    measurement_limits = CanonicalLimits(max_output_bytes=2 * output_limit)
+    return len(encode_strict_json(payload, limits=measurement_limits))
+
+
+class TreeIndependencePolynomialRequest(StrictModel):
+    """Request the exact independence polynomial of one admitted tree.
+
+    The materialized canonical graph must be nonempty, connected, and acyclic.
+    A scalar tree dynamic program admits only results of degree at most 127
+    before the coefficient recurrence expands; this keeps the returned value
+    inside the current exact univariate-polynomial consumer envelope.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Compute the exact independence polynomial of one materialized "
+                "canonical tree. The graph must be nonempty, connected, and "
+                "acyclic; its independence number, hence polynomial degree, "
+                "must be at most 127. Admission bounds rooted convolution work "
+                "and reserves canonical-output space for the echoed source."
+            )
+        }
+    )
+
+    graph: SimpleUndirectedGraph = Field(
+        description=(
+            "Canonical finite simple undirected graph. It may contain at most "
+            f"{MAX_INDEPENDENCE_POLYNOMIAL_VERTICES} vertices and must be a "
+            "nonempty tree whose independence polynomial has degree at most "
+            f"{MAX_INDEPENDENCE_POLYNOMIAL_DEGREE}."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_tree_and_output(self) -> Self:
+        profile = _admitted_tree_profile(self.graph)
+        output_limit = CanonicalLimits().max_output_bytes
+        if (
+            _maximum_independence_result_bytes(
+                self.graph,
+                profile.independence_degree,
+            )
+            > output_limit
+        ):
+            raise ValueError(
+                "tree independence polynomial would exceed the "
+                f"{output_limit}-byte canonical output limit after retaining "
+                "its source; shorten vertex labels"
+            )
+        return self
+
+
+class TreeIndependencePolynomialResult(StrictModel):
+    """One source-bound exact independence polynomial in ``QQ[x]``."""
+
+    graph: SimpleUndirectedGraph
+    polynomial: RationalPolynomial
+
+    @model_validator(mode="after")
+    def require_polynomial_bound_to_source(self) -> Self:
+        if self.polynomial.variables != ("x",):
+            raise ValueError("independence polynomial must belong to QQ[x]")
+        require_polynomial_budget(
+            self.polynomial,
+            maximum_terms=MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
+            maximum_exponent=MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+            maximum_coefficient_digits=MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
+            label="independence polynomial",
+        )
+        TreeIndependencePolynomialRequest(graph=self.graph)
+
+        from jacobian.math.graphs.polynomials.operations import (
+            independence_polynomial,
+        )
+
+        if self.polynomial != independence_polynomial(self.graph):
+            raise ValueError("independence polynomial does not match the source tree")
+        return self
+
+
 class PolynomialTerm(StrictModel):
     """One monomial term: coefficient times x^degree."""
 
@@ -152,4 +274,6 @@ __all__ = [
     "MultivariatePolynomialTerm",
     "PolynomialTerm",
     "SparseMultivariatePolynomial",
+    "TreeIndependencePolynomialRequest",
+    "TreeIndependencePolynomialResult",
 ]

--- a/src/jacobian/math/graphs/polynomials/_models.py
+++ b/src/jacobian/math/graphs/polynomials/_models.py
@@ -14,7 +14,7 @@ from jacobian.canonical import (
 )
 from jacobian.math.graphs.polynomials.operations import (
     MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
-    MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+    MAX_INDEPENDENCE_POLYNOMIAL_EXPONENT,
     MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
     MAX_INDEPENDENCE_POLYNOMIAL_VERTICES,
     _admitted_tree_profile,
@@ -149,9 +149,11 @@ class TreeIndependencePolynomialRequest(StrictModel):
     """Request the exact independence polynomial of one admitted tree.
 
     The materialized canonical graph must be nonempty, connected, and acyclic.
-    A scalar tree dynamic program admits only results of degree at most 127
-    before the coefficient recurrence expands; this keeps the returned value
-    inside the current exact univariate-polynomial consumer envelope.
+    Admission derives every budget from this operation's own work and result
+    envelope: at most 256 vertices, a scalar preflight whose exact
+    coefficient-convolution count stays inside the kernel pass budget, and a
+    serialized-result reservation that keeps the echoed source plus dense
+    coefficients inside the canonical output limit.
     """
 
     model_config = ConfigDict(
@@ -159,9 +161,9 @@ class TreeIndependencePolynomialRequest(StrictModel):
             "description": (
                 "Compute the exact independence polynomial of one materialized "
                 "canonical tree. The graph must be nonempty, connected, and "
-                "acyclic; its independence number, hence polynomial degree, "
-                "must be at most 127. Admission bounds rooted convolution work "
-                "and reserves canonical-output space for the echoed source."
+                "acyclic. Admission bounds rooted convolution work by an exact "
+                "scalar preflight and reserves canonical-output space for the "
+                "echoed source and dense coefficients."
             )
         }
     )
@@ -170,8 +172,8 @@ class TreeIndependencePolynomialRequest(StrictModel):
         description=(
             "Canonical finite simple undirected graph. It may contain at most "
             f"{MAX_INDEPENDENCE_POLYNOMIAL_VERTICES} vertices and must be a "
-            "nonempty tree whose independence polynomial has degree at most "
-            f"{MAX_INDEPENDENCE_POLYNOMIAL_DEGREE}."
+            "nonempty tree whose independence polynomial fits this "
+            "operation's convolution-work and serialized-output budgets."
         )
     )
 
@@ -209,7 +211,7 @@ class TreeIndependencePolynomialResult(StrictModel):
     polynomial: RationalPolynomial
     independence_number: StrictInt = Field(
         ge=1,
-        le=MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+        le=MAX_INDEPENDENCE_POLYNOMIAL_EXPONENT,
         description="The tree independence number alpha(T).",
     )
     independent_set_count: _NonnegativeCanonicalInteger = Field(
@@ -223,7 +225,7 @@ class TreeIndependencePolynomialResult(StrictModel):
         require_polynomial_budget(
             self.polynomial,
             maximum_terms=MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
-            maximum_exponent=MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
+            maximum_exponent=MAX_INDEPENDENCE_POLYNOMIAL_EXPONENT,
             maximum_coefficient_digits=MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS,
             label="independence polynomial",
         )

--- a/src/jacobian/math/graphs/polynomials/_models.py
+++ b/src/jacobian/math/graphs/polynomials/_models.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import ConfigDict, Field, StrictInt, model_validator
+from pydantic import ConfigDict, Field, StrictInt, StringConstraints, model_validator
 
-from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import (
     CanonicalLimits,
@@ -25,6 +24,11 @@ from jacobian.math.polynomials.values import (
     RationalPolynomial,
     require_polynomial_budget,
 )
+
+_NonnegativeCanonicalInteger = Annotated[
+    str,
+    StringConstraints(pattern=r"^(?:0|[1-9][0-9]*)$", strict=True),
+]
 
 
 class GraphEdge(StrictModel):
@@ -194,7 +198,7 @@ class TreeIndependencePolynomialResult(StrictModel):
     """One source-bound exact independence polynomial and its defining values."""
 
     graph: SimpleUndirectedGraph
-    coefficients: tuple[CanonicalInteger, ...] = Field(
+    coefficients: tuple[_NonnegativeCanonicalInteger, ...] = Field(
         min_length=2,
         max_length=MAX_INDEPENDENCE_POLYNOMIAL_TERMS,
         description=(
@@ -208,7 +212,7 @@ class TreeIndependencePolynomialResult(StrictModel):
         le=MAX_INDEPENDENCE_POLYNOMIAL_DEGREE,
         description="The tree independence number alpha(T).",
     )
-    independent_set_count: CanonicalInteger = Field(
+    independent_set_count: _NonnegativeCanonicalInteger = Field(
         description="The total I_T(1) as a canonical decimal integer."
     )
 

--- a/src/jacobian/math/graphs/polynomials/_operations.py
+++ b/src/jacobian/math/graphs/polynomials/_operations.py
@@ -8,6 +8,7 @@ import networkx as nx
 import sympy
 from sympy import Poly, Symbol, expand
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.polynomials._models import (
     GraphPolynomialRequest,
     GraphPolynomialResult,
@@ -18,7 +19,10 @@ from jacobian.math.graphs.polynomials._models import (
     TreeIndependencePolynomialRequest,
     TreeIndependencePolynomialResult,
 )
-from jacobian.math.graphs.polynomials.operations import independence_polynomial
+from jacobian.math.graphs.polynomials.operations import (
+    _polynomial_from_coefficients,
+    independence_polynomial_coefficients,
+)
 
 
 def _build_graph(
@@ -143,9 +147,15 @@ def compute_independence_polynomial(
 ) -> TreeIndependencePolynomialResult:
     """Compute the exact independence polynomial of an admitted finite tree."""
 
+    coefficients = independence_polynomial_coefficients(request.graph)
     return TreeIndependencePolynomialResult(
         graph=request.graph,
-        polynomial=independence_polynomial(request.graph),
+        coefficients=tuple(
+            format_canonical_integer(coefficient) for coefficient in coefficients
+        ),
+        polynomial=_polynomial_from_coefficients(coefficients),
+        independence_number=len(coefficients) - 1,
+        independent_set_count=format_canonical_integer(sum(coefficients)),
     )
 
 

--- a/src/jacobian/math/graphs/polynomials/_operations.py
+++ b/src/jacobian/math/graphs/polynomials/_operations.py
@@ -15,7 +15,10 @@ from jacobian.math.graphs.polynomials._models import (
     MultivariatePolynomialTerm,
     PolynomialTerm,
     SparseMultivariatePolynomial,
+    TreeIndependencePolynomialRequest,
+    TreeIndependencePolynomialResult,
 )
+from jacobian.math.graphs.polynomials.operations import independence_polynomial
 
 
 def _build_graph(
@@ -135,9 +138,21 @@ def compute_matching_polynomial(
     return GraphPolynomialResult(terms=terms)
 
 
+def compute_independence_polynomial(
+    request: TreeIndependencePolynomialRequest,
+) -> TreeIndependencePolynomialResult:
+    """Compute the exact independence polynomial of an admitted finite tree."""
+
+    return TreeIndependencePolynomialResult(
+        graph=request.graph,
+        polynomial=independence_polynomial(request.graph),
+    )
+
+
 __all__ = [
     "compute_chromatic_polynomial",
     "compute_flow_polynomial",
+    "compute_independence_polynomial",
     "compute_matching_polynomial",
     "compute_tutte_polynomial",
 ]

--- a/src/jacobian/math/graphs/polynomials/_tools.py
+++ b/src/jacobian/math/graphs/polynomials/_tools.py
@@ -148,8 +148,10 @@ GRAPH_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Compute a tree independence polynomial",
         "Compute the exact independence polynomial whose degree-k coefficient "
         "counts independent vertex sets of cardinality k in one nonempty "
-        "finite tree. Return a source-bound canonical sparse RationalPolynomial "
-        "in QQ[x] after a scalar preflight bounds degree and convolution work.",
+        "finite tree. Return its source-bound dense coefficients, independence "
+        "number, total independent-set count, and canonical sparse "
+        "RationalPolynomial in QQ[x] after a scalar preflight bounds degree "
+        "and convolution work.",
         TreeIndependencePolynomialRequest,
         TreeIndependencePolynomialResult,
         compute_independence_polynomial,

--- a/src/jacobian/math/graphs/polynomials/_tools.py
+++ b/src/jacobian/math/graphs/polynomials/_tools.py
@@ -150,8 +150,8 @@ GRAPH_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "counts independent vertex sets of cardinality k in one nonempty "
         "finite tree. Return its source-bound dense coefficients, independence "
         "number, total independent-set count, and canonical sparse "
-        "RationalPolynomial in QQ[x] after a scalar preflight bounds degree "
-        "and convolution work.",
+        "RationalPolynomial in QQ[x] after a scalar preflight bounds "
+        "convolution work and serialized-result size.",
         TreeIndependencePolynomialRequest,
         TreeIndependencePolynomialResult,
         compute_independence_polynomial,
@@ -167,8 +167,8 @@ GRAPH_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "path_tree_p4",
                 (
                     "Compute the exact independence polynomial of P4; the graph "
-                    "must be a nonempty tree whose independence number is at "
-                    "most 127."
+                    "must be a nonempty tree within this operation's bounded "
+                    "convolution-work and serialized-output envelope."
                 ),
                 _PATH_TREE_EXAMPLE,
             ),

--- a/src/jacobian/math/graphs/polynomials/_tools.py
+++ b/src/jacobian/math/graphs/polynomials/_tools.py
@@ -11,10 +11,13 @@ from jacobian.math.graphs.polynomials._models import (
     GraphPolynomialResult,
     MatchingPolynomialRequest,
     SparseMultivariatePolynomial,
+    TreeIndependencePolynomialRequest,
+    TreeIndependencePolynomialResult,
 )
 from jacobian.math.graphs.polynomials._operations import (
     compute_chromatic_polynomial,
     compute_flow_polynomial,
+    compute_independence_polynomial,
     compute_matching_polynomial,
     compute_tutte_polynomial,
 )
@@ -67,6 +70,14 @@ _PATH_GRAPH_EXAMPLE: dict[str, Any] = {
             {"u": 1, "v": 2},
         ],
     },
+}
+
+_PATH_TREE_EXAMPLE: dict[str, Any] = {
+    "graph": {
+        "graph_schema_version": "1",
+        "vertices": ["a", "b", "c", "d"],
+        "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+    }
 }
 
 
@@ -129,6 +140,35 @@ GRAPH_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 "cycle_graph_c4_flow",
                 "Flow polynomial of the 4-cycle C4.",
                 _CYCLE_GRAPH_EXAMPLE,
+            ),
+        ),
+    ),
+    graph_polynomial_operation(
+        "graph.polynomial.independence.compute",
+        "Compute a tree independence polynomial",
+        "Compute the exact independence polynomial whose degree-k coefficient "
+        "counts independent vertex sets of cardinality k in one nonempty "
+        "finite tree. Return a source-bound canonical sparse RationalPolynomial "
+        "in QQ[x] after a scalar preflight bounds degree and convolution work.",
+        TreeIndependencePolynomialRequest,
+        TreeIndependencePolynomialResult,
+        compute_independence_polynomial,
+        "graph",
+        "polynomial",
+        "independence",
+        "independent-sets",
+        "cardinality-count",
+        "tree",
+        "exact",
+        examples=(
+            example(
+                "path_tree_p4",
+                (
+                    "Compute the exact independence polynomial of P4; the graph "
+                    "must be a nonempty tree whose independence number is at "
+                    "most 127."
+                ),
+                _PATH_TREE_EXAMPLE,
             ),
         ),
     ),

--- a/src/jacobian/math/graphs/polynomials/operations.py
+++ b/src/jacobian/math/graphs/polynomials/operations.py
@@ -139,8 +139,8 @@ def independence_polynomial_coefficients(
 ) -> tuple[int, ...]:
     """Return ``i_0, ..., i_alpha`` for one admitted finite tree.
 
-    This dense coefficient view is a native-only projection.  The catalog
-    operation returns the canonical sparse ``RationalPolynomial`` instead.
+    This native projection matches the dense coefficients returned alongside
+    the canonical sparse ``RationalPolynomial`` by the catalog operation.
     """
 
     profile = _admitted_tree_profile(graph)

--- a/src/jacobian/math/graphs/polynomials/operations.py
+++ b/src/jacobian/math/graphs/polynomials/operations.py
@@ -1,0 +1,197 @@
+"""Exact native graph-polynomial operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+MAX_INDEPENDENCE_POLYNOMIAL_VERTICES = 256
+MAX_INDEPENDENCE_POLYNOMIAL_DEGREE = 127
+MAX_INDEPENDENCE_POLYNOMIAL_TERMS = MAX_INDEPENDENCE_POLYNOMIAL_DEGREE + 1
+# Every tree is bipartite, so one color class witnesses
+# alpha(T) >= ceil(|V(T)| / 2).  The degree limit therefore implies this
+# sharper bound for every admitted result, even though the canonical graph
+# representation itself accepts 256 vertices.
+MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES = 2 * MAX_INDEPENDENCE_POLYNOMIAL_DEGREE
+MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS = len(
+    format_canonical_integer(1 << MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES)
+)
+
+# Each of the n - 1 rooted edges causes two dense convolutions.  Every factor
+# has at most degree + 1 coefficients, so this bounds one complete kernel pass
+# before any coefficient expansion.  The public result validator performs one
+# additional bounded replay against the retained source tree.
+MAX_INDEPENDENCE_CONVOLUTION_PRODUCTS_PER_PASS = (
+    2
+    * (MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES - 1)
+    * MAX_INDEPENDENCE_POLYNOMIAL_TERMS**2
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _TreeProfile:
+    root: str
+    children: dict[str, tuple[str, ...]]
+    postorder: tuple[str, ...]
+    independence_degree: int
+    convolution_products: int
+
+
+def _admitted_tree_profile(graph: SimpleUndirectedGraph) -> _TreeProfile:
+    """Validate the native tree/work domain before expanding coefficients."""
+
+    import networkx as nx
+
+    from jacobian.math.graphs._networkx import graph_from_value
+
+    vertex_count = len(graph.vertices)
+    if vertex_count == 0:
+        raise ValueError("independence polynomial requires a nonempty tree")
+    if vertex_count > MAX_INDEPENDENCE_POLYNOMIAL_VERTICES:
+        raise ValueError(
+            "independence polynomial supports at most "
+            f"{MAX_INDEPENDENCE_POLYNOMIAL_VERTICES} vertices"
+        )
+
+    transient = graph_from_value(graph)
+    if not nx.is_tree(transient):
+        raise ValueError("independence polynomial requires a connected acyclic graph")
+
+    root = graph.vertices[0]
+    child_lists: dict[str, list[str]] = {vertex: [] for vertex in graph.vertices}
+    order = [root]
+    for parent, child in nx.bfs_edges(
+        transient,
+        source=root,
+        sort_neighbors=sorted,
+    ):
+        child_lists[parent].append(child)
+        order.append(child)
+    children = {vertex: tuple(child_lists[vertex]) for vertex in graph.vertices}
+    postorder = tuple(reversed(order))
+
+    excluded_degree: dict[str, int] = {}
+    included_degree: dict[str, int] = {}
+    convolution_products = 0
+    for vertex in postorder:
+        excluded = 0
+        included = 1
+        for child in children[vertex]:
+            child_total = max(excluded_degree[child], included_degree[child])
+            convolution_products += (excluded + 1) * (child_total + 1)
+            convolution_products += (included + 1) * (excluded_degree[child] + 1)
+            excluded += child_total
+            included += excluded_degree[child]
+        excluded_degree[vertex] = excluded
+        included_degree[vertex] = included
+
+    independence_degree = max(excluded_degree[root], included_degree[root])
+    if independence_degree > MAX_INDEPENDENCE_POLYNOMIAL_DEGREE:
+        raise ValueError(
+            "tree independence polynomial must have degree at most "
+            f"{MAX_INDEPENDENCE_POLYNOMIAL_DEGREE}"
+        )
+    if convolution_products > MAX_INDEPENDENCE_CONVOLUTION_PRODUCTS_PER_PASS:
+        raise ValueError(
+            "tree independence polynomial exceeds the "
+            f"{MAX_INDEPENDENCE_CONVOLUTION_PRODUCTS_PER_PASS}-product "
+            "coefficient-convolution budget"
+        )
+
+    return _TreeProfile(
+        root=root,
+        children=children,
+        postorder=postorder,
+        independence_degree=independence_degree,
+        convolution_products=convolution_products,
+    )
+
+
+def _add_coefficients(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[int, ...]:
+    size = max(len(left), len(right))
+    return tuple(
+        (left[index] if index < len(left) else 0)
+        + (right[index] if index < len(right) else 0)
+        for index in range(size)
+    )
+
+
+def _convolve_coefficients(
+    left: tuple[int, ...], right: tuple[int, ...]
+) -> tuple[int, ...]:
+    result = [0] * (len(left) + len(right) - 1)
+    for left_degree, left_coefficient in enumerate(left):
+        for right_degree, right_coefficient in enumerate(right):
+            result[left_degree + right_degree] += left_coefficient * right_coefficient
+    return tuple(result)
+
+
+def independence_polynomial_coefficients(
+    graph: SimpleUndirectedGraph,
+) -> tuple[int, ...]:
+    """Return ``i_0, ..., i_alpha`` for one admitted finite tree.
+
+    This dense coefficient view is a native-only projection.  The catalog
+    operation returns the canonical sparse ``RationalPolynomial`` instead.
+    """
+
+    profile = _admitted_tree_profile(graph)
+    states: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {}
+    for vertex in profile.postorder:
+        excluded: tuple[int, ...] = (1,)
+        included: tuple[int, ...] = (0, 1)
+        for child in profile.children[vertex]:
+            child_excluded, child_included = states.pop(child)
+            excluded = _convolve_coefficients(
+                excluded,
+                _add_coefficients(child_excluded, child_included),
+            )
+            included = _convolve_coefficients(included, child_excluded)
+        states[vertex] = (excluded, included)
+
+    root_excluded, root_included = states[profile.root]
+    coefficients = _add_coefficients(root_excluded, root_included)
+    if len(coefficients) != profile.independence_degree + 1:
+        raise ValueError("independence polynomial degree invariant failed")
+    return coefficients
+
+
+def _polynomial_from_coefficients(
+    coefficients: tuple[int, ...],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=("x",),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(
+                        num=format_canonical_integer(coefficient),
+                        den="1",
+                    ),
+                    exponents=(degree,),
+                )
+                for degree, coefficient in reversed(list(enumerate(coefficients)))
+                if coefficient != 0
+            )
+        ),
+    )
+
+
+def independence_polynomial(graph: SimpleUndirectedGraph) -> RationalPolynomial:
+    """Return the exact independence polynomial of one admitted finite tree."""
+
+    return _polynomial_from_coefficients(independence_polynomial_coefficients(graph))
+
+
+__all__ = [
+    "independence_polynomial",
+    "independence_polynomial_coefficients",
+]

--- a/src/jacobian/math/graphs/polynomials/operations.py
+++ b/src/jacobian/math/graphs/polynomials/operations.py
@@ -14,24 +14,23 @@ from jacobian.math.polynomials.values import (
 )
 
 MAX_INDEPENDENCE_POLYNOMIAL_VERTICES = 256
-MAX_INDEPENDENCE_POLYNOMIAL_DEGREE = 127
-MAX_INDEPENDENCE_POLYNOMIAL_TERMS = MAX_INDEPENDENCE_POLYNOMIAL_DEGREE + 1
-# Every tree is bipartite, so one color class witnesses
-# alpha(T) >= ceil(|V(T)| / 2).  The degree limit therefore implies this
-# sharper bound for every admitted result, even though the canonical graph
-# representation itself accepts 256 vertices.
-MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES = 2 * MAX_INDEPENDENCE_POLYNOMIAL_DEGREE
+# The canonical graph representation accepts at most 256 vertices, and every
+# budget below derives from that input envelope rather than from any other
+# operation's consumer limit:
+#   - a tree on n vertices has independence number at most n - 1, so its
+#     dense coefficient profile carries at most n terms;
+#   - each coefficient counts independent k-element vertex sets, hence is at
+#     most 2^n, and the total independent-set count sums those coefficients;
+#   - the kernel performs exactly two dense convolutions per rooted edge and
+#     each factor carries at most one coefficient per term.
+MAX_INDEPENDENCE_POLYNOMIAL_TERMS = MAX_INDEPENDENCE_POLYNOMIAL_VERTICES
+MAX_INDEPENDENCE_POLYNOMIAL_EXPONENT = MAX_INDEPENDENCE_POLYNOMIAL_TERMS - 1
 MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS = len(
-    format_canonical_integer(1 << MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES)
+    format_canonical_integer(1 << MAX_INDEPENDENCE_POLYNOMIAL_VERTICES)
 )
-
-# Each of the n - 1 rooted edges causes two dense convolutions.  Every factor
-# has at most degree + 1 coefficients, so this bounds one complete kernel pass
-# before any coefficient expansion.  The public result validator performs one
-# additional bounded replay against the retained source tree.
 MAX_INDEPENDENCE_CONVOLUTION_PRODUCTS_PER_PASS = (
     2
-    * (MAX_INDEPENDENCE_POLYNOMIAL_ADMITTED_VERTICES - 1)
+    * (MAX_INDEPENDENCE_POLYNOMIAL_VERTICES - 1)
     * MAX_INDEPENDENCE_POLYNOMIAL_TERMS**2
 )
 
@@ -94,11 +93,6 @@ def _admitted_tree_profile(graph: SimpleUndirectedGraph) -> _TreeProfile:
         included_degree[vertex] = included
 
     independence_degree = max(excluded_degree[root], included_degree[root])
-    if independence_degree > MAX_INDEPENDENCE_POLYNOMIAL_DEGREE:
-        raise ValueError(
-            "tree independence polynomial must have degree at most "
-            f"{MAX_INDEPENDENCE_POLYNOMIAL_DEGREE}"
-        )
     if convolution_products > MAX_INDEPENDENCE_CONVOLUTION_PRODUCTS_PER_PASS:
         raise ValueError(
             "tree independence polynomial exceeds the "

--- a/tests/catalog/test_graph_independence_polynomial.py
+++ b/tests/catalog/test_graph_independence_polynomial.py
@@ -5,7 +5,7 @@ from jacobian.catalog.models import OperationDiscoveryRequest
 from jacobian.dispatch import invoke_operation
 
 
-def test_catalog_example_executes_as_a_source_bound_canonical_polynomial() -> None:
+def test_catalog_example_executes_as_a_source_bound_polynomial_profile() -> None:
     catalog = Catalog.open()
     operation = catalog.operation("graph.polynomial.independence.compute")
     assert operation is not None
@@ -16,6 +16,9 @@ def test_catalog_example_executes_as_a_source_bound_canonical_polynomial() -> No
 
     assert example.name == "path_tree_p4"
     assert result.output["graph"] == example.input["graph"]
+    assert result.output["coefficients"] == ["1", "4", "3"]
+    assert result.output["independence_number"] == 2
+    assert result.output["independent_set_count"] == "8"
     assert result.output["polynomial"]["variables"] == ["x"]
     assert result.output["polynomial"]["polynomial"]["terms"] == [
         {

--- a/tests/catalog/test_graph_independence_polynomial.py
+++ b/tests/catalog/test_graph_independence_polynomial.py
@@ -1,0 +1,47 @@
+"""Catalog conformance for the tree independence-polynomial operation."""
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationDiscoveryRequest
+from jacobian.dispatch import invoke_operation
+
+
+def test_catalog_example_executes_as_a_source_bound_canonical_polynomial() -> None:
+    catalog = Catalog.open()
+    operation = catalog.operation("graph.polynomial.independence.compute")
+    assert operation is not None
+    assert len(operation.examples) == 1
+
+    example = operation.examples[0]
+    result = invoke_operation(operation.operation_id, example.input, catalog)
+
+    assert example.name == "path_tree_p4"
+    assert result.output["graph"] == example.input["graph"]
+    assert result.output["polynomial"]["variables"] == ["x"]
+    assert result.output["polynomial"]["polynomial"]["terms"] == [
+        {
+            "coefficient": {"num": "3", "den": "1"},
+            "exponents": [2],
+        },
+        {
+            "coefficient": {"num": "4", "den": "1"},
+            "exponents": [1],
+        },
+        {
+            "coefficient": {"num": "1", "den": "1"},
+            "exponents": [0],
+        },
+    ]
+
+
+def test_catalog_search_discovers_independent_set_cardinality_distribution() -> None:
+    result = Catalog.open().search(
+        OperationDiscoveryRequest(
+            query="count independent vertex sets by cardinality in a tree",
+            domain="graph",
+            limit=10,
+        )
+    )
+
+    assert "graph.polynomial.independence.compute" in {
+        match.operation_id for match in result.matches
+    }

--- a/tests/math/graphs/test_graph_independence_polynomial.py
+++ b/tests/math/graphs/test_graph_independence_polynomial.py
@@ -347,6 +347,36 @@ def test_result_rejects_overbudget_derived_values_before_replay(
         TreeIndependencePolynomialResult.model_validate(valid)
 
 
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("coefficients", ["1", "-4", "3"]),
+        ("independent_set_count", "-8"),
+    ],
+)
+def test_result_rejects_negative_derived_values_before_replay(
+    field: str,
+    replacement: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=_path(4))
+    ).model_dump(mode="json")
+    valid[field] = replacement
+
+    def fail_replay(_graph: SimpleUndirectedGraph) -> tuple[int, ...]:
+        raise AssertionError("negative cardinalities must fail before replay")
+
+    monkeypatch.setattr(
+        polynomial_operations,
+        "independence_polynomial_coefficients",
+        fail_replay,
+    )
+
+    with pytest.raises(ValidationError):
+        TreeIndependencePolynomialResult.model_validate(valid)
+
+
 def test_native_module_exports_canonical_value_and_dense_projection() -> None:
     from jacobian.math.graphs import polynomials
 

--- a/tests/math/graphs/test_graph_independence_polynomial.py
+++ b/tests/math/graphs/test_graph_independence_polynomial.py
@@ -97,6 +97,15 @@ def test_known_independence_polynomials(
     assert independence_polynomial_coefficients(graph) == expected
     assert _dense_coefficients(independence_polynomial(graph)) == expected
 
+    result = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=graph)
+    )
+    assert result.coefficients == tuple(
+        format_canonical_integer(coefficient) for coefficient in expected
+    )
+    assert result.independence_number == len(expected) - 1
+    assert result.independent_set_count == format_canonical_integer(sum(expected))
+
 
 def test_all_free_trees_through_order_eight_match_subset_enumeration() -> None:
     trees = [explicit_graph(("v",), ())]
@@ -164,9 +173,7 @@ def test_serialized_polynomial_feeds_exact_evaluation_unchanged(
 
     evaluation = rational_polynomial_evaluate(evaluation_request)
 
-    assert evaluation.value.num == format_canonical_integer(
-        sum(independence_polynomial_coefficients(graph))
-    )
+    assert evaluation.value.num == result.independent_set_count
     assert evaluation.value.den == "1"
 
 
@@ -194,6 +201,11 @@ def test_result_sensitive_degree_boundary_accepts_p254_and_rejects_p255() -> Non
 
     result = compute_independence_polynomial(request)
 
+    assert len(result.coefficients) == 128
+    assert result.independence_number == 127
+    assert result.independent_set_count == format_canonical_integer(
+        sum(independence_polynomial_coefficients(accepted))
+    )
     assert len(result.polynomial.polynomial.terms) == 128
     assert result.polynomial.polynomial.terms[0].exponents == (127,)
     with pytest.raises(ValidationError, match="degree at most 127"):
@@ -252,6 +264,28 @@ def test_result_rejects_a_weaker_polynomial_and_a_changed_source() -> None:
         TreeIndependencePolynomialResult.model_validate(changed_source)
 
 
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("coefficients", ["1", "4", "2"], "coefficients do not match"),
+        ("independence_number", 1, "independence number does not match"),
+        ("independent_set_count", "7", "independent-set count does not match"),
+    ],
+)
+def test_result_rejects_mutated_derived_values(
+    field: str,
+    replacement: object,
+    message: str,
+) -> None:
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=_path(4))
+    ).model_dump(mode="json")
+    valid[field] = replacement
+
+    with pytest.raises(ValidationError, match=message):
+        TreeIndependencePolynomialResult.model_validate(valid)
+
+
 def test_result_rejects_a_polynomial_outside_qq_x() -> None:
     valid = compute_independence_polynomial(
         TreeIndependencePolynomialRequest(graph=_path(4))
@@ -270,12 +304,42 @@ def test_result_rejects_overbudget_coefficients_before_replay(
     ).model_dump(mode="json")
     valid["polynomial"]["polynomial"]["terms"][0]["coefficient"]["num"] = "9" * 78
 
-    def fail_replay(_graph: SimpleUndirectedGraph) -> RationalPolynomial:
+    def fail_replay(_graph: SimpleUndirectedGraph) -> tuple[int, ...]:
         raise AssertionError("overbudget polynomial must fail before replay")
 
     monkeypatch.setattr(
         polynomial_operations,
-        "independence_polynomial",
+        "independence_polynomial_coefficients",
+        fail_replay,
+    )
+
+    with pytest.raises(ValidationError, match="77-digit bound"):
+        TreeIndependencePolynomialResult.model_validate(valid)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("coefficients", ["9" * 78, "1", "3"]),
+        ("independent_set_count", "9" * 78),
+    ],
+)
+def test_result_rejects_overbudget_derived_values_before_replay(
+    field: str,
+    replacement: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=_path(4))
+    ).model_dump(mode="json")
+    valid[field] = replacement
+
+    def fail_replay(_graph: SimpleUndirectedGraph) -> tuple[int, ...]:
+        raise AssertionError("overbudget derived value must fail before replay")
+
+    monkeypatch.setattr(
+        polynomial_operations,
+        "independence_polynomial_coefficients",
         fail_replay,
     )
 

--- a/tests/math/graphs/test_graph_independence_polynomial.py
+++ b/tests/math/graphs/test_graph_independence_polynomial.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import cast
 
 import networkx as nx
@@ -195,21 +196,38 @@ def test_request_rejects_empty_disconnected_and_cyclic_graphs(
         TreeIndependencePolynomialRequest(graph=graph)
 
 
-def test_result_sensitive_degree_boundary_accepts_p254_and_rejects_p255() -> None:
-    accepted = _path(254)
-    request = TreeIndependencePolynomialRequest(graph=accepted)
+def test_star_beyond_the_old_consumer_degree_cap_is_admitted_exactly() -> None:
+    leaves = 128
+    star = _star(leaves)
+    binomials = tuple(math.comb(leaves, k) for k in range(leaves + 1))
+    expected = (binomials[0], binomials[1] + 1, *binomials[2:])
+
+    request = TreeIndependencePolynomialRequest(graph=star)
+    result = compute_independence_polynomial(request)
+
+    assert result.coefficients == tuple(
+        format_canonical_integer(coefficient) for coefficient in expected
+    )
+    assert result.independence_number == leaves
+    assert result.independent_set_count == format_canonical_integer(sum(expected))
+    assert result.independent_set_count == format_canonical_integer((1 << leaves) + 1)
+    assert len(result.polynomial.polynomial.terms) == leaves + 1
+    assert _dense_coefficients(independence_polynomial(star)) == expected
+
+
+def test_full_vertex_envelope_path_is_admitted_and_over_envelope_is_rejected() -> None:
+    admitted = _path(256)
+    request = TreeIndependencePolynomialRequest(graph=admitted)
 
     result = compute_independence_polynomial(request)
 
-    assert len(result.coefficients) == 128
-    assert result.independence_number == 127
-    assert result.independent_set_count == format_canonical_integer(
-        sum(independence_polynomial_coefficients(accepted))
+    assert result.independence_number == 128
+    assert len(result.coefficients) == 129
+    assert result.coefficients[-1] == format_canonical_integer(
+        math.comb(256 - 128 + 1, 128)
     )
-    assert len(result.polynomial.polynomial.terms) == 128
-    assert result.polynomial.polynomial.terms[0].exponents == (127,)
-    with pytest.raises(ValidationError, match="degree at most 127"):
-        TreeIndependencePolynomialRequest(graph=_path(255))
+    with pytest.raises(ValidationError, match="at most 256"):
+        TreeIndependencePolynomialRequest(graph=_path(257))
 
 
 def test_request_reserves_output_headroom_for_the_retained_source() -> None:
@@ -222,12 +240,12 @@ def test_request_reserves_output_headroom_for_the_retained_source() -> None:
         TreeIndependencePolynomialRequest(graph=graph)
 
 
-def test_request_schema_exposes_tree_and_degree_preconditions() -> None:
+def test_request_schema_exposes_tree_and_work_preconditions() -> None:
     schema = TreeIndependencePolynomialRequest.model_json_schema()
 
     assert "nonempty" in schema["description"]
-    assert "degree" in schema["description"]
-    assert "at most 127" in schema["properties"]["graph"]["description"]
+    assert "acyclic" in schema["description"]
+    assert "convolution-work" in schema["properties"]["graph"]["description"]
     graph_schema = schema["$defs"]["SimpleUndirectedGraph"]
     assert graph_schema["properties"]["vertices"]["maxItems"] == 256
 
@@ -302,7 +320,10 @@ def test_result_rejects_overbudget_coefficients_before_replay(
     valid = compute_independence_polynomial(
         TreeIndependencePolynomialRequest(graph=_path(4))
     ).model_dump(mode="json")
-    valid["polynomial"]["polynomial"]["terms"][0]["coefficient"]["num"] = "9" * 78
+    digits = polynomial_operations.MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS
+    valid["polynomial"]["polynomial"]["terms"][0]["coefficient"]["num"] = "9" * (
+        digits + 1
+    )
 
     def fail_replay(_graph: SimpleUndirectedGraph) -> tuple[int, ...]:
         raise AssertionError("overbudget polynomial must fail before replay")
@@ -313,15 +334,20 @@ def test_result_rejects_overbudget_coefficients_before_replay(
         fail_replay,
     )
 
-    with pytest.raises(ValidationError, match="77-digit bound"):
+    with pytest.raises(ValidationError, match=f"{digits}-digit bound"):
         TreeIndependencePolynomialResult.model_validate(valid)
+
+
+_OVERBUDGET_DIGITS = (
+    polynomial_operations.MAX_INDEPENDENCE_POLYNOMIAL_COEFFICIENT_DIGITS + 1
+)
 
 
 @pytest.mark.parametrize(
     ("field", "replacement"),
     [
-        ("coefficients", ["9" * 78, "1", "3"]),
-        ("independent_set_count", "9" * 78),
+        ("coefficients", ["9" * _OVERBUDGET_DIGITS, "1", "3"]),
+        ("independent_set_count", "9" * _OVERBUDGET_DIGITS),
     ],
 )
 def test_result_rejects_overbudget_derived_values_before_replay(
@@ -343,7 +369,7 @@ def test_result_rejects_overbudget_derived_values_before_replay(
         fail_replay,
     )
 
-    with pytest.raises(ValidationError, match="77-digit bound"):
+    with pytest.raises(ValidationError, match=f"{_OVERBUDGET_DIGITS - 1}-digit bound"):
         TreeIndependencePolynomialResult.model_validate(valid)
 
 

--- a/tests/math/graphs/test_graph_independence_polynomial.py
+++ b/tests/math/graphs/test_graph_independence_polynomial.py
@@ -1,0 +1,295 @@
+"""Defining evidence for exact independence polynomials of bounded trees."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import networkx as nx
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+)
+from jacobian.math.graphs.operations import explicit_graph
+from jacobian.math.graphs.polynomials import (
+    independence_polynomial,
+    independence_polynomial_coefficients,
+)
+from jacobian.math.graphs.polynomials import operations as polynomial_operations
+from jacobian.math.graphs.polynomials._models import (
+    TreeIndependencePolynomialRequest,
+    TreeIndependencePolynomialResult,
+)
+from jacobian.math.graphs.polynomials._operations import (
+    compute_independence_polynomial,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.polynomials._elementary_operations import (
+    rational_polynomial_evaluate,
+)
+from jacobian.math.polynomials._models import RationalPolynomialEvaluationRequest
+from jacobian.math.polynomials.values import RationalPolynomial
+
+
+def _path(order: int) -> SimpleUndirectedGraph:
+    vertices = tuple(f"v{index:03d}" for index in range(order))
+    edges = tuple((vertices[index], vertices[index + 1]) for index in range(order - 1))
+    return explicit_graph(vertices, edges)
+
+
+def _star(leaves: int) -> SimpleUndirectedGraph:
+    vertices = ("center", *(f"leaf-{index:03d}" for index in range(leaves)))
+    edges = tuple(("center", leaf) for leaf in vertices[1:])
+    return explicit_graph(vertices, edges)
+
+
+def _from_networkx(graph: nx.Graph[int]) -> SimpleUndirectedGraph:
+    labels = {vertex: f"v{vertex:03d}" for vertex in graph.nodes}
+    return explicit_graph(
+        tuple(labels.values()),
+        tuple((labels[left], labels[right]) for left, right in graph.edges),
+    )
+
+
+def _brute_force_coefficients(graph: SimpleUndirectedGraph) -> tuple[int, ...]:
+    indices = {vertex: index for index, vertex in enumerate(graph.vertices)}
+    edge_masks = tuple(
+        (1 << indices[left]) | (1 << indices[right]) for left, right in graph.edges
+    )
+    counts = [0] * (len(graph.vertices) + 1)
+    for mask in range(1 << len(graph.vertices)):
+        if all(mask & edge_mask != edge_mask for edge_mask in edge_masks):
+            counts[mask.bit_count()] += 1
+    while len(counts) > 1 and counts[-1] == 0:
+        counts.pop()
+    return tuple(counts)
+
+
+def _dense_coefficients(polynomial: RationalPolynomial) -> tuple[int, ...]:
+    degree = max(
+        (term.exponents[0] for term in polynomial.polynomial.terms),
+        default=0,
+    )
+    coefficients = [0] * (degree + 1)
+    for term in polynomial.polynomial.terms:
+        numerator, denominator = term.coefficient.as_integer_ratio()
+        assert denominator == 1
+        coefficients[term.exponents[0]] = numerator
+    return tuple(coefficients)
+
+
+@pytest.mark.parametrize(
+    ("graph", "expected"),
+    [
+        (explicit_graph(("v",), ()), (1, 1)),
+        (_path(2), (1, 2)),
+        (_path(5), (1, 5, 6, 1)),
+        (_star(4), (1, 5, 6, 4, 1)),
+    ],
+)
+def test_known_independence_polynomials(
+    graph: SimpleUndirectedGraph,
+    expected: tuple[int, ...],
+) -> None:
+    assert independence_polynomial_coefficients(graph) == expected
+    assert _dense_coefficients(independence_polynomial(graph)) == expected
+
+
+def test_all_free_trees_through_order_eight_match_subset_enumeration() -> None:
+    trees = [explicit_graph(("v",), ())]
+    for order in range(2, 9):
+        trees.extend(
+            _from_networkx(cast("nx.Graph[int]", tree))
+            for tree in nx.nonisomorphic_trees(order)
+        )
+
+    assert len(trees) == 48
+    for graph in trees:
+        expected = _brute_force_coefficients(graph)
+        coefficients = independence_polynomial_coefficients(graph)
+        polynomial = independence_polynomial(graph)
+
+        assert coefficients == expected
+        assert _dense_coefficients(polynomial) == expected
+        assert coefficients[0] == 1
+        assert coefficients[1] == len(graph.vertices)
+        assert all(coefficient > 0 for coefficient in coefficients)
+        assert len(coefficients) - 1 == len(expected) - 1
+        assert sum(coefficients) == sum(expected)
+
+
+def test_root_choice_and_vertex_relabeling_do_not_change_polynomial() -> None:
+    graph = _path(8)
+    different_root = SimpleUndirectedGraph(
+        vertices=tuple(reversed(graph.vertices)),
+        edges=graph.edges,
+    )
+    relabeling = {
+        vertex: f"renamed-{len(graph.vertices) - index:03d}"
+        for index, vertex in enumerate(graph.vertices)
+    }
+    relabeled = explicit_graph(
+        tuple(relabeling.values()),
+        tuple((relabeling[left], relabeling[right]) for left, right in graph.edges),
+    )
+
+    expected = independence_polynomial(graph)
+    assert independence_polynomial(different_root) == expected
+    assert independence_polynomial(relabeled) == expected
+
+
+@pytest.mark.parametrize(
+    "graph",
+    [
+        explicit_graph(("v",), ()),
+        _path(4),
+    ],
+)
+def test_serialized_polynomial_feeds_exact_evaluation_unchanged(
+    graph: SimpleUndirectedGraph,
+) -> None:
+    result = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=graph)
+    )
+    serialized = result.model_dump(mode="json")["polynomial"]
+    evaluation_request = RationalPolynomialEvaluationRequest.model_validate(
+        {
+            "polynomial": serialized,
+            "point": {"num": "1", "den": "1"},
+        }
+    )
+
+    evaluation = rational_polynomial_evaluate(evaluation_request)
+
+    assert evaluation.value.num == format_canonical_integer(
+        sum(independence_polynomial_coefficients(graph))
+    )
+    assert evaluation.value.den == "1"
+
+
+@pytest.mark.parametrize(
+    "graph",
+    [
+        explicit_graph((), ()),
+        explicit_graph(("a", "b", "c"), (("a", "b"),)),
+        explicit_graph(
+            ("a", "b", "c"),
+            (("a", "b"), ("a", "c"), ("b", "c")),
+        ),
+    ],
+)
+def test_request_rejects_empty_disconnected_and_cyclic_graphs(
+    graph: SimpleUndirectedGraph,
+) -> None:
+    with pytest.raises(ValidationError, match=r"nonempty|connected acyclic"):
+        TreeIndependencePolynomialRequest(graph=graph)
+
+
+def test_result_sensitive_degree_boundary_accepts_p254_and_rejects_p255() -> None:
+    accepted = _path(254)
+    request = TreeIndependencePolynomialRequest(graph=accepted)
+
+    result = compute_independence_polynomial(request)
+
+    assert len(result.polynomial.polynomial.terms) == 128
+    assert result.polynomial.polynomial.terms[0].exponents == (127,)
+    with pytest.raises(ValidationError, match="degree at most 127"):
+        TreeIndependencePolynomialRequest(graph=_path(255))
+
+
+def test_request_reserves_output_headroom_for_the_retained_source() -> None:
+    output_limit = CanonicalLimits().max_output_bytes
+    graph = explicit_graph(("v" * (output_limit - 300),), ())
+    encoded_request = encode_strict_json({"graph": graph.model_dump(mode="json")})
+
+    assert len(encoded_request) <= output_limit
+    with pytest.raises(ValidationError, match="canonical output limit"):
+        TreeIndependencePolynomialRequest(graph=graph)
+
+
+def test_request_schema_exposes_tree_and_degree_preconditions() -> None:
+    schema = TreeIndependencePolynomialRequest.model_json_schema()
+
+    assert "nonempty" in schema["description"]
+    assert "degree" in schema["description"]
+    assert "at most 127" in schema["properties"]["graph"]["description"]
+    graph_schema = schema["$defs"]["SimpleUndirectedGraph"]
+    assert graph_schema["properties"]["vertices"]["maxItems"] == 256
+
+
+def test_result_rejects_a_weaker_polynomial_and_a_changed_source() -> None:
+    graph = _path(4)
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=graph)
+    ).model_dump(mode="json")
+    weaker = valid.copy()
+    weaker["polynomial"] = {
+        "polynomial_schema_version": "1",
+        "domain": "QQ",
+        "variables": ["x"],
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": "4", "den": "1"},
+                    "exponents": [1],
+                },
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [0],
+                },
+            ]
+        },
+    }
+    changed_source = valid.copy()
+    changed_source["graph"] = _path(5).model_dump(mode="json")
+
+    with pytest.raises(ValidationError, match="does not match the source tree"):
+        TreeIndependencePolynomialResult.model_validate(weaker)
+    with pytest.raises(ValidationError, match="does not match the source tree"):
+        TreeIndependencePolynomialResult.model_validate(changed_source)
+
+
+def test_result_rejects_a_polynomial_outside_qq_x() -> None:
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=_path(4))
+    ).model_dump(mode="json")
+    valid["polynomial"]["variables"] = ["y"]
+
+    with pytest.raises(ValidationError, match=r"belong to QQ\[x\]"):
+        TreeIndependencePolynomialResult.model_validate(valid)
+
+
+def test_result_rejects_overbudget_coefficients_before_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid = compute_independence_polynomial(
+        TreeIndependencePolynomialRequest(graph=_path(4))
+    ).model_dump(mode="json")
+    valid["polynomial"]["polynomial"]["terms"][0]["coefficient"]["num"] = "9" * 78
+
+    def fail_replay(_graph: SimpleUndirectedGraph) -> RationalPolynomial:
+        raise AssertionError("overbudget polynomial must fail before replay")
+
+    monkeypatch.setattr(
+        polynomial_operations,
+        "independence_polynomial",
+        fail_replay,
+    )
+
+    with pytest.raises(ValidationError, match="77-digit bound"):
+        TreeIndependencePolynomialResult.model_validate(valid)
+
+
+def test_native_module_exports_canonical_value_and_dense_projection() -> None:
+    from jacobian.math.graphs import polynomials
+
+    assert polynomials.__all__ == [
+        "independence_polynomial",
+        "independence_polynomial_coefficients",
+    ]
+    assert all(hasattr(polynomials, name) for name in polynomials.__all__)
+    assert type(independence_polynomial(_path(2))) is RationalPolynomial
+    assert independence_polynomial_coefficients(_path(2)) == (1, 2)


### PR DESCRIPTION
## Problem

Jacobian can return a tree's independence number, but not the coefficient distribution that counts independent sets at every cardinality. The Erdős 993 certificate needs that reusable polynomial before applying its caller-owned unimodality analysis.

Closes #2281.

## Solution

Add `graph.polynomial.independence.compute` for nonempty finite trees. The source-bound result contains the dense coefficient tuple, the equivalent canonical `RationalPolynomial` in `QQ[x]`, the independence number, and the total number of independent sets. The native graph-polynomial API exposes both the canonical polynomial and its dense integer coefficients.

The kernel roots the tree and computes

```text
A_v = product(A_c + B_c)
B_v = x product(A_c)
```

with exact Python integers. The result validator repeats the computation from the retained source and binds all four public conclusions to the same coefficient tuple.

NetworkX 3.6.1 remains the maintained structure backend for tree recognition and deterministic traversal; it does not provide this independence-polynomial computation. The small rooted recurrence is therefore domain-owned, while the returned sparse polynomial reuses Jacobian's existing canonical polynomial value.

Suggested review order: the scalar admission and recurrence in `operations.py`, the complete result contract in `_models.py`, then the catalog declaration/admission and brute-force/boundary tests.

## Testing

- `make test-math TESTS='tests/math/graphs/test_graph_independence_polynomial.py' PYTEST_ARGS='-q'` — 25 passed
- `make test-catalog TESTS='tests/catalog/test_graph_independence_polynomial.py' PYTEST_ARGS='-q'` — 2 passed
- `make test-integration TESTS='tests/integration/catalog/test_public_operation_contract_conformance.py::test_every_accepted_boundary_mutation_returns_the_declared_result[graph.polynomial.independence.compute]' PYTEST_ARGS='-q'` — 1 passed
- `make check` — Ruff, formatting, mypy, and 2,676 tests passed

The mathematical tests compare every free tree through order eight with direct subset enumeration, check known paths and stars, exercise root/relabeling invariance, and test the exact degree/output boundaries.

- Specialist validation run (if any): exact catalog boundary-mutation conformance command listed above

## Public contract impact

Adds public operation ID `graph.polynomial.independence.compute`, its tree-only request and complete source-bound result schema, and native `independence_polynomial` and `independence_polynomial_coefficients` functions under `jacobian.math.graphs.polynomials`.

Dense coefficients and the total count use canonical nonnegative decimal strings so values beyond JSON's safe integer range remain exact. The canonical polynomial passes unchanged to existing rational-polynomial consumers.

## Public operation admission

- Concrete gap: the exact cardinality generating function of independent vertex subsets of one supplied tree.
- Why existing operations or typed values are insufficient: the independence-number operation returns only the largest cardinality; it cannot reconstruct intermediate coefficients or the total count.
- Stable mathematical result: `I_T(x) = sum i_k x^k`, together with its dense coefficients, degree `alpha(T)`, and evaluation `I_T(1)`.
- Semantic domain and admitted execution envelope: nonempty connected acyclic canonical graphs whose exact scalar preflight proves independence degree at most 127. The graph representation permits 256 vertices; bipartiteness implies the admitted tree has at most 254.
- Controlling work, intermediate, memory, and output quantities: at most 128 coefficients, 77 decimal digits per coefficient, 8,290,304 dense coefficient products per construction/replay pass, and the canonical 10 MiB output budget including the retained graph and all result projections.
- Exact representation, algorithm regimes, and maintained backend: exact integer dense convolution in one rooted-tree dynamic-programming regime; NetworkX handles only tree structure and traversal; output uses the existing `RationalPolynomial` value.
- Remaining fixed caps and their classification: degree/term and coefficient-digit caps are exact-result/output limits; the convolution-product cap is a conservative execution limit; the byte preflight reserves output space for source labels and every returned field.
- Admission decision: KEEP — one supplied tree maps to one exact reusable generating function, without adding census generation or a theorem-specific predicate.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Dense coefficient tuple | delivered in the catalog result and native projection | `graph.polynomial.independence.compute` |
| Canonical sparse polynomial | delivered | `graph.polynomial.independence.compute` |
| Independence number | delivered in the source-bound result | `graph.polynomial.independence.compute` |
| Total independent-set count | delivered in the source-bound result | `graph.polynomial.independence.compute` |

Cyclic graphs, graph census generation, unimodality/log-concavity predicates, and weighted or multivariate variants remain outside this issue.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, backend, Harbor/Oracle)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable; this operation has one complete exact result branch
- [x] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence; the operation has one exact recurrence regime and a path on the degree boundary
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; existing graph and polynomial values are reused)
