### PR TITLE
feat(math): add bounded generalized exact cover

### DIFF
--- a/src/jacobian/math/combinatorics/__init__.py
+++ b/src/jacobian/math/combinatorics/__init__.py
@@ -1,5 +1,14 @@
 """Provider-independent exact combinatorics values and functions."""
 
+from jacobian.math.combinatorics.exact_cover import (
+    ExactCoverItemMultiplicity,
+    ExactCoverRow,
+    ExactCoverSearchStatus,
+    GeneralizedExactCoverInstance,
+    GeneralizedExactCoverRequest,
+    GeneralizedExactCoverResult,
+    find_generalized_exact_cover,
+)
 from jacobian.math.combinatorics.operations import (
     bell_number,
     bernoulli_number,
@@ -22,6 +31,12 @@ from jacobian.math.combinatorics.recurrence_tables import (
 )
 
 __all__ = [
+    "ExactCoverItemMultiplicity",
+    "ExactCoverRow",
+    "ExactCoverSearchStatus",
+    "GeneralizedExactCoverInstance",
+    "GeneralizedExactCoverRequest",
+    "GeneralizedExactCoverResult",
     "IndexedRecurrenceResidual",
     "PolynomialCoefficientRecurrenceTableRequest",
     "PolynomialCoefficientRecurrenceTableResult",
@@ -31,6 +46,7 @@ __all__ = [
     "derangement_number",
     "double_factorial",
     "fibonacci_number",
+    "find_generalized_exact_cover",
     "integer_partitions",
     "lucas_number",
     "motzkin_number",

--- a/src/jacobian/math/combinatorics/_admission.py
+++ b/src/jacobian/math/combinatorics/_admission.py
@@ -128,6 +128,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         native_symbol="jacobian.math.combinatorics.integer_partitions",
     ),
     OperationAdmission(
+        "combinatorics.generalized_exact_cover.find",
+        AdmissionDecision.KEEP,
+        "one checked primary/secondary exact-cover witness or exact bounded nonexistence over materialized incidence rows",
+    ),
+    OperationAdmission(
         "combinatorics.generating_function.coefficients.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/combinatorics/_exact_cover.py
+++ b/src/jacobian/math/combinatorics/_exact_cover.py
@@ -1,0 +1,62 @@
+"""Public declaration for bounded generalized exact cover."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.combinatorics.exact_cover import (
+    GeneralizedExactCoverRequest,
+    GeneralizedExactCoverResult,
+    find_generalized_exact_cover,
+)
+
+GENERALIZED_EXACT_COVER_OPERATION = MathTool(
+    operation_id="combinatorics.generalized_exact_cover.find",
+    version="1",
+    title="Find a generalized exact cover",
+    description=(
+        "Find one row family that covers every primary item exactly once and "
+        "every secondary item at most once. Return FOUND with a checked "
+        "selected-row family, NO_COVER only after complete bounded search, or "
+        "UNKNOWN when the deterministic search-node limit is reached."
+    ),
+    request_type=GeneralizedExactCoverRequest,
+    result_type=GeneralizedExactCoverResult,
+    run=find_generalized_exact_cover,
+    tags=(
+        "combinatorics",
+        "exact-cover",
+        "generalized-exact-cover",
+        "primary-items",
+        "secondary-items",
+        "incidence",
+        "algorithm-x",
+        "bounded-search",
+        "deterministic",
+    ),
+    examples=(
+        example(
+            "two_constraints_one_resource",
+            "Select one row for each of two primary constraints while using "
+            "the optional resource at most once; item and row labels must be "
+            "declared in sorted canonical order.",
+            {
+                "instance": {
+                    "primary_items": ["constraint:a", "constraint:b"],
+                    "secondary_items": ["resource:x"],
+                    "rows": [
+                        {
+                            "row_id": "a-use-x",
+                            "items": ["constraint:a", "resource:x"],
+                        },
+                        {
+                            "row_id": "b-free",
+                            "items": ["constraint:b"],
+                        },
+                    ],
+                },
+                "search_node_limit": 100,
+            },
+        ),
+    ),
+)
+
+__all__ = ["GENERALIZED_EXACT_COVER_OPERATION"]

--- a/src/jacobian/math/combinatorics/_exact_cover_kernel.py
+++ b/src/jacobian/math/combinatorics/_exact_cover_kernel.py
@@ -1,0 +1,127 @@
+"""Deterministic bounded Algorithm X kernel for generalized exact cover."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jacobian.math.combinatorics.exact_cover import GeneralizedExactCoverInstance
+
+
+@dataclass(frozen=True, slots=True)
+class ExactCoverKernelResult:
+    status: Literal["FOUND", "NO_COVER", "UNKNOWN"]
+    selected_rows: tuple[int, ...] = ()
+
+
+def search_generalized_exact_cover(
+    instance: GeneralizedExactCoverInstance,
+    search_node_limit: int,
+) -> ExactCoverKernelResult:
+    """Search one materialized primary/secondary incidence matrix.
+
+    A node is one conflict-free partial selected-row family, represented by
+    its uncovered-primary and available-row bitsets. The root and terminal
+    states count as nodes. Branching chooses the uncovered primary item with
+    the fewest available rows, ties by canonical item order, and tries rows in
+    canonical row-ID order. Thus the same canonical input and node limit always
+    produce the same status and witness.
+
+    Write P for primary items, M for all items, R for rows, I for incidences,
+    and N for the node allowance. Index construction materializes I item
+    indices, M R-bit item-to-row masks, R P-bit row-to-primary masks, and R
+    R-bit conflict masks using at most 2I mask updates. The logical bitset
+    payload is therefore M*R + R*P + R*R bits plus I bounded item indices.
+
+    Each node uses at most P intersections and population counts on R-bit
+    masks to choose a primary item, followed by constant-many P- or R-bit mask
+    operations for each child. At most N nodes and N-1 child edges are visited.
+    Recursion depth is at most P, so its logical mask payload is bounded by
+    (P+1)*(P+R) bits plus P selected row indices. The public P <= 256 and
+    R <= 4096 bounds keep this below Python's recursion limit and make every
+    intermediate integer width explicit.
+    """
+
+    if search_node_limit < 1:
+        raise ValueError("search_node_limit must be positive")
+
+    items = (*instance.primary_items, *instance.secondary_items)
+    item_index = {item: index for index, item in enumerate(items)}
+    primary_count = len(instance.primary_items)
+    row_count = len(instance.rows)
+
+    item_rows = [0] * len(items)
+    row_item_indices: list[tuple[int, ...]] = []
+    row_primary_masks: list[int] = []
+    for row_index, row in enumerate(instance.rows):
+        indices = tuple(item_index[item] for item in row.items)
+        row_item_indices.append(indices)
+        primary_mask = 0
+        for index in indices:
+            item_rows[index] |= 1 << row_index
+            if index < primary_count:
+                primary_mask |= 1 << index
+        row_primary_masks.append(primary_mask)
+
+    # Selecting a row removes every row sharing any primary or secondary item.
+    # At most MAX_INCIDENCES bounded big-integer ORs construct this index.
+    row_conflicts: list[int] = []
+    for indices in row_item_indices:
+        conflicts = 0
+        for index in indices:
+            conflicts |= item_rows[index]
+        row_conflicts.append(conflicts)
+
+    all_primary = (1 << primary_count) - 1
+    all_rows = (1 << row_count) - 1
+    visited_nodes = 0
+    selected_rows: list[int] = []
+
+    def visit(
+        uncovered_primary: int,
+        available_rows: int,
+    ) -> ExactCoverKernelResult:
+        nonlocal visited_nodes
+        if visited_nodes >= search_node_limit:
+            return ExactCoverKernelResult(status="UNKNOWN")
+        visited_nodes += 1
+
+        if uncovered_primary == 0:
+            return ExactCoverKernelResult(
+                status="FOUND", selected_rows=tuple(selected_rows)
+            )
+
+        chosen_rows = 0
+        fewest_candidates = row_count + 1
+        remaining_items = uncovered_primary
+        while remaining_items:
+            item_bit = remaining_items & -remaining_items
+            item = item_bit.bit_length() - 1
+            candidates = item_rows[item] & available_rows
+            candidate_count = candidates.bit_count()
+            if candidate_count < fewest_candidates:
+                chosen_rows = candidates
+                fewest_candidates = candidate_count
+                if candidate_count == 0:
+                    return ExactCoverKernelResult(status="NO_COVER")
+            remaining_items ^= item_bit
+
+        candidates = chosen_rows
+        while candidates:
+            row_bit = candidates & -candidates
+            row = row_bit.bit_length() - 1
+            selected_rows.append(row)
+            result = visit(
+                uncovered_primary & ~row_primary_masks[row],
+                available_rows & ~row_conflicts[row],
+            )
+            selected_rows.pop()
+            if result.status != "NO_COVER":
+                return result
+            candidates ^= row_bit
+        return ExactCoverKernelResult(status="NO_COVER")
+
+    return visit(all_primary, all_rows)
+
+
+__all__ = ["ExactCoverKernelResult", "search_generalized_exact_cover"]

--- a/src/jacobian/math/combinatorics/_tools.py
+++ b/src/jacobian/math/combinatorics/_tools.py
@@ -3,6 +3,7 @@
 from jacobian.catalog.models import MathTools
 from jacobian.math.combinatorics._counting import COUNTING_OPERATIONS
 from jacobian.math.combinatorics._difference_sets import DIFFERENCE_SET_OPERATIONS
+from jacobian.math.combinatorics._exact_cover import GENERALIZED_EXACT_COVER_OPERATION
 from jacobian.math.combinatorics._partitions import PARTITION_OPERATIONS
 from jacobian.math.combinatorics._recurrence import RECURRENCE_OPERATIONS
 
@@ -13,4 +14,5 @@ TOOLS: MathTools = (
     *PARTITION_OPERATIONS,
     *RECURRENCE_OPERATIONS,
     *DIFFERENCE_SET_OPERATIONS,
+    GENERALIZED_EXACT_COVER_OPERATION,
 )

--- a/src/jacobian/math/combinatorics/exact_cover.py
+++ b/src/jacobian/math/combinatorics/exact_cover.py
@@ -1,0 +1,400 @@
+"""Canonical values and results for bounded generalized exact cover."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Literal, Self
+
+from pydantic import ConfigDict, Field, StrictInt, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.canonical import (
+    CanonicalizationError,
+    encode_strict_json,
+)
+from jacobian.math._labels import OpaqueLabel
+
+MAX_EXACT_COVER_ITEMS = 256
+MAX_EXACT_COVER_PRIMARY_ITEMS = MAX_EXACT_COVER_ITEMS
+MAX_EXACT_COVER_SECONDARY_ITEMS = MAX_EXACT_COVER_ITEMS
+MAX_EXACT_COVER_ROWS = 4_096
+MAX_EXACT_COVER_INCIDENCES = 65_536
+
+# NO_COVER is replayed by its result validator, so a negative public call makes
+# at most two passes. A million-node adversarial pass is too slow to repeat at
+# the public boundary; 100,000 nodes per pass is a measured conservative
+# execution fallback, independent of the broader 256-item representation bound.
+MAX_EXACT_COVER_SEARCH_NODES_PER_PASS = 100_000
+MAX_EXACT_COVER_SEARCH_NODES = 2 * MAX_EXACT_COVER_SEARCH_NODES_PER_PASS
+
+ExactCoverSearchStatus = Literal["FOUND", "NO_COVER", "UNKNOWN"]
+
+
+def _require_canonical_labels(labels: tuple[str, ...], role: str) -> None:
+    if any(not unicodedata.is_normalized("NFC", label) for label in labels):
+        raise ValueError(f"{role} must use Unicode NFC")
+    if labels != tuple(sorted(set(labels))):
+        raise ValueError(f"{role} must be sorted and unique")
+
+
+class ExactCoverRow(StrictModel):
+    """One identified finite row in a generalized exact-cover instance."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "One materialized incidence row. `row_id` is an opaque unique "
+                "identifier; `items` must be sorted, unique Unicode-NFC labels. "
+                "Every item is declared by the enclosing instance. Duplicate "
+                "incidences are rejected rather than normalized."
+            )
+        }
+    )
+
+    row_id: OpaqueLabel
+    items: tuple[OpaqueLabel, ...] = Field(max_length=MAX_EXACT_COVER_ITEMS)
+
+    @model_validator(mode="after")
+    def require_canonical_row(self) -> Self:
+        if not unicodedata.is_normalized("NFC", self.row_id):
+            raise ValueError("row IDs must use Unicode NFC")
+        _require_canonical_labels(self.items, "row items")
+        return self
+
+
+class GeneralizedExactCoverInstance(StrictModel):
+    """A materialized finite primary/secondary exact-cover instance.
+
+    A selected row family must cover every primary item exactly once and every
+    secondary item at most once. Rows that contain no primary item are valid
+    incidence data but are irrelevant to feasibility and are never selected by
+    the canonical search.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Canonical materialized generalized exact cover. Primary and "
+                "secondary item labels are disjoint, sorted, unique, and use "
+                "Unicode NFC. Rows are sorted by unique row ID; each row's item "
+                "labels are sorted and unique and must be declared. Rows with "
+                "different IDs remain distinct candidates even when their item "
+                "sets agree. At most "
+                f"{MAX_EXACT_COVER_ITEMS} total items, {MAX_EXACT_COVER_ROWS} "
+                f"rows, and {MAX_EXACT_COVER_INCIDENCES} incidences are admitted."
+            )
+        }
+    )
+
+    instance_schema_version: Literal["1"] = "1"
+    primary_items: tuple[OpaqueLabel, ...] = Field(
+        max_length=MAX_EXACT_COVER_PRIMARY_ITEMS,
+        description=(
+            "Items that a solution covers exactly once, in sorted unique "
+            "Unicode-NFC order. The empty tuple is allowed."
+        ),
+    )
+    secondary_items: tuple[OpaqueLabel, ...] = Field(
+        max_length=MAX_EXACT_COVER_SECONDARY_ITEMS,
+        description=(
+            "Items that a solution covers at most once, in sorted unique "
+            "Unicode-NFC order."
+        ),
+    )
+    rows: tuple[ExactCoverRow, ...] = Field(
+        max_length=MAX_EXACT_COVER_ROWS,
+        description="Materialized rows in increasing row-ID order.",
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_instance(self) -> Self:
+        _require_canonical_labels(self.primary_items, "primary items")
+        _require_canonical_labels(self.secondary_items, "secondary items")
+        if set(self.primary_items) & set(self.secondary_items):
+            raise ValueError("primary and secondary items must be disjoint")
+        if len(self.primary_items) + len(self.secondary_items) > MAX_EXACT_COVER_ITEMS:
+            raise ValueError(
+                f"an exact-cover instance has at most {MAX_EXACT_COVER_ITEMS} items"
+            )
+
+        row_ids = tuple(row.row_id for row in self.rows)
+        _require_canonical_labels(row_ids, "row IDs")
+        declared = set(self.primary_items) | set(self.secondary_items)
+        incidence_count = 0
+        for row in self.rows:
+            if not set(row.items) <= declared:
+                raise ValueError("every row item must be declared by the instance")
+            incidence_count += len(row.items)
+        if incidence_count > MAX_EXACT_COVER_INCIDENCES:
+            raise ValueError(
+                "exact-cover incidence count exceeds the "
+                f"{MAX_EXACT_COVER_INCIDENCES}-incidence bound"
+            )
+        return self
+
+
+def _coverage_wire_value(
+    instance: GeneralizedExactCoverInstance,
+) -> list[dict[str, object]]:
+    return [
+        {"item_id": item, "kind": "PRIMARY", "multiplicity": 1}
+        for item in instance.primary_items
+    ] + [
+        {"item_id": item, "kind": "SECONDARY", "multiplicity": 1}
+        for item in instance.secondary_items
+    ]
+
+
+def _require_output_headroom(instance: GeneralizedExactCoverInstance) -> None:
+    """Prove that every result shape fits before the search begins.
+
+    A witness contains at most one selected row per primary item. The coverage
+    ledger contains one bounded record per declared item. The exact source is
+    retained once so conclusions remain replayable. Materializing the largest
+    possible FOUND wire value and both non-positive wire values gives the exact
+    serialized upper bound for this source; it does not rely on label lengths
+    or a fixed structural reserve.
+    """
+
+    try:
+        source = instance.model_dump(mode="json")
+        selected_count = min(len(instance.primary_items), len(instance.rows))
+        selected_row_ids = sorted(
+            instance.rows,
+            key=lambda row: len(encode_strict_json(row.row_id)),
+            reverse=True,
+        )[:selected_count]
+        common = {
+            "result_schema_version": "1",
+            "instance": source,
+            "search_node_limit": MAX_EXACT_COVER_SEARCH_NODES_PER_PASS,
+        }
+        found_wire = {
+            **common,
+            "status": "FOUND",
+            "selected_row_ids": sorted(row.row_id for row in selected_row_ids),
+            "item_multiplicities": _coverage_wire_value(instance),
+        }
+        no_cover_wire = {
+            **common,
+            "status": "NO_COVER",
+            "selected_row_ids": None,
+            "item_multiplicities": None,
+        }
+        unknown_wire = {
+            **common,
+            "status": "UNKNOWN",
+            "selected_row_ids": None,
+            "item_multiplicities": None,
+        }
+        for wire in (found_wire, no_cover_wire, unknown_wire):
+            encode_strict_json(wire)
+    except CanonicalizationError as exc:
+        raise ValueError(
+            "the exact-cover result retains its source and would exceed the "
+            "canonical output limit; shorten labels or shrink the incidence data"
+        ) from exc
+
+
+class GeneralizedExactCoverRequest(StrictModel):
+    """Find one generalized exact cover under a deterministic node limit."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Find one row family covering each primary item exactly once "
+                "and each secondary item at most once. The bitset Algorithm X "
+                "search visits at most `search_node_limit` partial row families "
+                "per pass. It returns NO_COVER only after exhaustive search; a "
+                "node-limit stop returns UNKNOWN. An exact NO_COVER result is "
+                "replayed during validation, so total negative-case work is at "
+                f"most {MAX_EXACT_COVER_SEARCH_NODES} node visits. UNKNOWN is "
+                "a source-bound non-conclusion and is not replayed."
+            )
+        }
+    )
+
+    instance: GeneralizedExactCoverInstance
+    search_node_limit: StrictInt = Field(
+        default=100_000,
+        ge=1,
+        le=MAX_EXACT_COVER_SEARCH_NODES_PER_PASS,
+        description=(
+            "Maximum partial selected-row families visited in one deterministic "
+            "search pass, including the root and terminal states."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def reserve_result_space(self) -> Self:
+        _require_output_headroom(self.instance)
+        return self
+
+
+class ExactCoverItemMultiplicity(StrictModel):
+    """One item's reconstructed multiplicity in a selected-row family."""
+
+    item_id: OpaqueLabel
+    kind: Literal["PRIMARY", "SECONDARY"]
+    multiplicity: StrictInt = Field(ge=0, le=1)
+
+    @model_validator(mode="after")
+    def require_canonical_item_id(self) -> Self:
+        if not unicodedata.is_normalized("NFC", self.item_id):
+            raise ValueError("item multiplicity IDs must use Unicode NFC")
+        return self
+
+
+def _expected_coverage(
+    instance: GeneralizedExactCoverInstance,
+    selected_row_ids: tuple[str, ...],
+) -> tuple[ExactCoverItemMultiplicity, ...]:
+    if selected_row_ids != tuple(sorted(set(selected_row_ids))):
+        raise ValueError("selected row IDs must be sorted and unique")
+    rows_by_id = {row.row_id: row for row in instance.rows}
+    if any(row_id not in rows_by_id for row_id in selected_row_ids):
+        raise ValueError("every selected row ID must be declared by the instance")
+
+    primary = set(instance.primary_items)
+    counts = dict.fromkeys((*instance.primary_items, *instance.secondary_items), 0)
+    for row_id in selected_row_ids:
+        row = rows_by_id[row_id]
+        if not primary.intersection(row.items):
+            raise ValueError("a canonical witness omits rows with no primary item")
+        for item in row.items:
+            counts[item] += 1
+
+    if any(counts[item] != 1 for item in instance.primary_items):
+        raise ValueError("a FOUND witness must cover every primary item exactly once")
+    if any(counts[item] > 1 for item in instance.secondary_items):
+        raise ValueError("a FOUND witness must cover every secondary item at most once")
+
+    return tuple(
+        ExactCoverItemMultiplicity(
+            item_id=item,
+            kind="PRIMARY",
+            multiplicity=counts[item],
+        )
+        for item in instance.primary_items
+    ) + tuple(
+        ExactCoverItemMultiplicity(
+            item_id=item,
+            kind="SECONDARY",
+            multiplicity=counts[item],
+        )
+        for item in instance.secondary_items
+    )
+
+
+class GeneralizedExactCoverResult(StrictModel):
+    """One checked cover, exact nonexistence, or an honest non-conclusion."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Source-bound generalized exact-cover result. FOUND carries a "
+                "canonical selected-row family and every declared item's "
+                "reconstructed multiplicity. NO_COVER is accepted only after "
+                "the retained instance replays to exhaustive failure. UNKNOWN "
+                "records only that this execution made no mathematical "
+                "conclusion within the retained node limit; it is intentionally "
+                "not tied to a private search-kernel revision."
+            )
+        }
+    )
+
+    result_schema_version: Literal["1"] = "1"
+    instance: GeneralizedExactCoverInstance
+    search_node_limit: StrictInt = Field(ge=1, le=MAX_EXACT_COVER_SEARCH_NODES_PER_PASS)
+    status: ExactCoverSearchStatus
+    selected_row_ids: tuple[OpaqueLabel, ...] | None = Field(
+        default=None,
+        max_length=MAX_EXACT_COVER_PRIMARY_ITEMS,
+        description=(
+            "Canonical selected row IDs for FOUND; absent for NO_COVER and UNKNOWN."
+        ),
+    )
+    item_multiplicities: tuple[ExactCoverItemMultiplicity, ...] | None = Field(
+        default=None,
+        max_length=MAX_EXACT_COVER_ITEMS,
+        description=(
+            "One reconstructed multiplicity for every declared item in primary-"
+            "then-secondary order for FOUND; absent otherwise."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_source_bound_result(self) -> Self:
+        _require_output_headroom(self.instance)
+        if self.status == "FOUND":
+            if self.selected_row_ids is None or self.item_multiplicities is None:
+                raise ValueError(
+                    "a FOUND result must carry selected rows and item multiplicities"
+                )
+            expected = _expected_coverage(self.instance, self.selected_row_ids)
+            if self.item_multiplicities != expected:
+                raise ValueError(
+                    "item multiplicities must reconstruct the selected-row family"
+                )
+            return self
+
+        if self.selected_row_ids is not None or self.item_multiplicities is not None:
+            raise ValueError("only a FOUND result may carry a selected-row family")
+
+        # UNKNOWN carries no mathematical claim. Replaying it would turn a
+        # private branching/kernel choice into durable public semantics and
+        # repeat bounded work merely to validate a non-conclusion.
+        if self.status == "UNKNOWN":
+            return self
+
+        from jacobian.math.combinatorics._exact_cover_kernel import (
+            search_generalized_exact_cover,
+        )
+
+        replay = search_generalized_exact_cover(self.instance, self.search_node_limit)
+        if replay.status != "NO_COVER":
+            raise ValueError(
+                f"NO_COVER contradicts deterministic replay, which returned "
+                f"{replay.status}"
+            )
+        return self
+
+
+def find_generalized_exact_cover(
+    request: GeneralizedExactCoverRequest,
+) -> GeneralizedExactCoverResult:
+    """Return one cover, exact nonexistence, or UNKNOWN at the node limit."""
+
+    from jacobian.math.combinatorics._exact_cover_kernel import (
+        search_generalized_exact_cover,
+    )
+
+    search = search_generalized_exact_cover(request.instance, request.search_node_limit)
+    if search.status != "FOUND":
+        return GeneralizedExactCoverResult(
+            instance=request.instance,
+            search_node_limit=request.search_node_limit,
+            status=search.status,
+        )
+
+    selected_row_ids = tuple(
+        sorted(request.instance.rows[index].row_id for index in search.selected_rows)
+    )
+    return GeneralizedExactCoverResult(
+        instance=request.instance,
+        search_node_limit=request.search_node_limit,
+        status="FOUND",
+        selected_row_ids=selected_row_ids,
+        item_multiplicities=_expected_coverage(request.instance, selected_row_ids),
+    )
+
+
+__all__ = [
+    "ExactCoverItemMultiplicity",
+    "ExactCoverRow",
+    "ExactCoverSearchStatus",
+    "GeneralizedExactCoverInstance",
+    "GeneralizedExactCoverRequest",
+    "GeneralizedExactCoverResult",
+    "find_generalized_exact_cover",
+]

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -164,6 +164,18 @@ def test_search_finds_lattice_hnf_in_matrix_domain() -> None:
     }
 
 
+def test_search_finds_generalized_exact_cover() -> None:
+    catalog = Catalog.open()
+
+    result = catalog.search(
+        OperationDiscoveryRequest(query="generalized exact cover", limit=5)
+    )
+
+    assert result.matches[0].operation_id == (
+        "combinatorics.generalized_exact_cover.find"
+    )
+
+
 def test_browse_includes_lattice_hnf_in_matrix_domain() -> None:
     catalog = Catalog.open()
 

--- a/tests/math/combinatorics/test_exact_cover.py
+++ b/tests/math/combinatorics/test_exact_cover.py
@@ -1,0 +1,473 @@
+"""Contract tests for bounded generalized exact cover."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.combinatorics.exact_cover import (
+    MAX_EXACT_COVER_INCIDENCES,
+    MAX_EXACT_COVER_PRIMARY_ITEMS,
+    MAX_EXACT_COVER_ROWS,
+    MAX_EXACT_COVER_SEARCH_NODES_PER_PASS,
+    ExactCoverRow,
+    GeneralizedExactCoverInstance,
+    GeneralizedExactCoverRequest,
+    GeneralizedExactCoverResult,
+    find_generalized_exact_cover,
+)
+
+
+def _instance(
+    *,
+    primary: tuple[str, ...],
+    secondary: tuple[str, ...] = (),
+    rows: tuple[tuple[str, tuple[str, ...]], ...] = (),
+) -> GeneralizedExactCoverInstance:
+    return GeneralizedExactCoverInstance(
+        primary_items=primary,
+        secondary_items=secondary,
+        rows=tuple(ExactCoverRow(row_id=row_id, items=items) for row_id, items in rows),
+    )
+
+
+def _solve(
+    instance: GeneralizedExactCoverInstance,
+    *,
+    search_node_limit: int = 100_000,
+) -> GeneralizedExactCoverResult:
+    return find_generalized_exact_cover(
+        GeneralizedExactCoverRequest(
+            instance=instance,
+            search_node_limit=search_node_limit,
+        )
+    )
+
+
+def _multiplicities(result: GeneralizedExactCoverResult) -> dict[str, int]:
+    assert result.item_multiplicities is not None
+    return {item.item_id: item.multiplicity for item in result.item_multiplicities}
+
+
+def test_knuth_exact_cover_known_answer_is_deterministic() -> None:
+    # The six-row example from Knuth's Algorithm X has the unique cover B,D,F.
+    instance = _instance(
+        primary=("1", "2", "3", "4", "5", "6", "7"),
+        rows=(
+            ("A", ("1", "4", "7")),
+            ("B", ("1", "4")),
+            ("C", ("4", "5", "7")),
+            ("D", ("3", "5", "6")),
+            ("E", ("2", "3", "6", "7")),
+            ("F", ("2", "7")),
+        ),
+    )
+
+    first = _solve(instance)
+    second = _solve(instance)
+
+    assert first.status == "FOUND"
+    assert first.selected_row_ids == ("B", "D", "F")
+    assert _multiplicities(first) == dict.fromkeys(instance.primary_items, 1)
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+
+
+def test_secondary_items_are_optional_but_never_reusable() -> None:
+    found = _solve(
+        _instance(
+            primary=("p", "q"),
+            secondary=("s", "t"),
+            rows=(
+                ("r1", ("p", "s")),
+                ("r2", ("q", "t")),
+            ),
+        )
+    )
+    assert found.status == "FOUND"
+    assert _multiplicities(found) == {"p": 1, "q": 1, "s": 1, "t": 1}
+
+    optional = _solve(
+        _instance(
+            primary=("p",),
+            secondary=("s",),
+            rows=(("r", ("p",)),),
+        )
+    )
+    assert optional.status == "FOUND"
+    assert _multiplicities(optional) == {"p": 1, "s": 0}
+
+    conflict = _solve(
+        _instance(
+            primary=("p", "q"),
+            secondary=("s",),
+            rows=(
+                ("r1", ("p", "s")),
+                ("r2", ("q", "s")),
+            ),
+        )
+    )
+    assert conflict.status == "NO_COVER"
+    assert conflict.selected_row_ids is None
+    assert conflict.item_multiplicities is None
+
+
+def test_node_limit_returns_unknown_not_no_cover() -> None:
+    instance = _instance(
+        primary=("p", "q"),
+        secondary=("s",),
+        rows=(
+            ("r1", ("p", "s")),
+            ("r2", ("q", "s")),
+        ),
+    )
+
+    limited = _solve(instance, search_node_limit=1)
+    complete = _solve(instance, search_node_limit=2)
+
+    assert limited.status == "UNKNOWN"
+    assert limited.selected_row_ids is None
+    assert complete.status == "NO_COVER"
+    # UNKNOWN is an operational outcome bound to this deterministic limit.
+    assert type(limited).model_validate(limited.model_dump()) == limited
+
+
+def test_empty_primary_domain_has_the_empty_cover() -> None:
+    instance = _instance(
+        primary=(),
+        secondary=("resource",),
+        rows=(("irrelevant", ("resource",)),),
+    )
+
+    result = _solve(instance, search_node_limit=1)
+
+    assert result.status == "FOUND"
+    assert result.selected_row_ids == ()
+    assert _multiplicities(result) == {"resource": 0}
+
+
+def test_uncovered_primary_item_proves_no_cover_at_the_root() -> None:
+    result = _solve(_instance(primary=("required",)), search_node_limit=1)
+
+    assert result.status == "NO_COVER"
+
+
+def _brute_force_feasible(instance: GeneralizedExactCoverInstance) -> bool:
+    items = (*instance.primary_items, *instance.secondary_items)
+    for chosen_count in range(len(instance.rows) + 1):
+        for chosen in combinations(instance.rows, chosen_count):
+            counts = dict.fromkeys(items, 0)
+            for row in chosen:
+                for item in row.items:
+                    counts[item] += 1
+            if all(counts[item] == 1 for item in instance.primary_items) and all(
+                counts[item] <= 1 for item in instance.secondary_items
+            ):
+                return True
+    return False
+
+
+def test_small_incidence_families_match_independent_exhaustive_oracle() -> None:
+    item_subsets = tuple(
+        tuple(item for bit, item in enumerate(("p", "q", "s")) if mask >> bit & 1)
+        for mask in range(1, 8)
+    )
+    all_rows = tuple(
+        (f"r{index}", items) for index, items in enumerate(item_subsets, start=1)
+    )
+
+    # Exhaust every family of the seven possible nonempty rows on two primary
+    # items and one secondary item. This oracle does not share Algorithm X.
+    for family_mask in range(1 << len(all_rows)):
+        instance = _instance(
+            primary=("p", "q"),
+            secondary=("s",),
+            rows=tuple(
+                row for index, row in enumerate(all_rows) if family_mask >> index & 1
+            ),
+        )
+        result = _solve(instance, search_node_limit=1_000)
+        expected_status = "FOUND" if _brute_force_feasible(instance) else "NO_COVER"
+        assert result.status == expected_status
+
+
+def test_item_and_row_relabelling_preserves_feasibility() -> None:
+    original = _instance(
+        primary=("p", "q"),
+        secondary=("s",),
+        rows=(
+            ("r1", ("p", "s")),
+            ("r2", ("q",)),
+        ),
+    )
+    relabelled = _instance(
+        primary=("alpha", "omega"),
+        secondary=("middle",),
+        rows=(
+            ("left", ("alpha", "middle")),
+            ("right", ("omega",)),
+        ),
+    )
+
+    original_result = _solve(original)
+    relabelled_result = _solve(relabelled)
+
+    assert original_result.status == relabelled_result.status == "FOUND"
+    assert sorted(_multiplicities(original_result).values()) == sorted(
+        _multiplicities(relabelled_result).values()
+    )
+
+
+def test_erdos_743_k3_packing_fixture_and_planted_overfull_mutation() -> None:
+    """Replay the compact K3 controls from the pinned Erdős 743 certificate.
+
+    Source: techno-optimist/erdos-frontier-atlas, commit
+    0394e3d3b249439ffabec7d96a3311aa441651b8,
+    certificates/erdos-743/pack.c selftest. The positive instance selects one
+    embedding of T2 and T3 with edge-disjoint supports; the planted mutation
+    asks for two three-vertex tree supports, whose four edge incidences cannot
+    fit in the three edges of K3.
+    """
+
+    packing = _instance(
+        primary=("tree:2", "tree:3"),
+        secondary=("edge:01", "edge:02", "edge:12"),
+        rows=(
+            ("t2:01", ("edge:01", "tree:2")),
+            ("t2:02", ("edge:02", "tree:2")),
+            ("t2:12", ("edge:12", "tree:2")),
+            ("t3:center0", ("edge:01", "edge:02", "tree:3")),
+            ("t3:center1", ("edge:01", "edge:12", "tree:3")),
+            ("t3:center2", ("edge:02", "edge:12", "tree:3")),
+        ),
+    )
+    packed = _solve(packing)
+    assert packed.status == "FOUND"
+    assert _multiplicities(packed) == dict.fromkeys(
+        (*packing.primary_items, *packing.secondary_items), 1
+    )
+
+    overfull = _instance(
+        primary=("tree:3:a", "tree:3:b"),
+        secondary=("edge:01", "edge:02", "edge:12"),
+        rows=tuple(
+            (f"{tree}:{center}", (*edges, f"tree:3:{tree}"))
+            for tree in ("a", "b")
+            for center, edges in (
+                ("center0", ("edge:01", "edge:02")),
+                ("center1", ("edge:01", "edge:12")),
+                ("center2", ("edge:02", "edge:12")),
+            )
+        ),
+    )
+    assert _solve(overfull).status == "NO_COVER"
+
+
+def test_result_validation_reconstructs_witness_and_replays_exact_negative() -> None:
+    cover = _instance(
+        primary=("p", "q"),
+        secondary=("s",),
+        rows=(
+            ("r1", ("p", "s")),
+            ("r2", ("q",)),
+        ),
+    )
+    found = _solve(cover)
+    payload = found.model_dump(mode="json")
+    payload["item_multiplicities"][-1]["multiplicity"] = 0
+    with pytest.raises(ValidationError, match="reconstruct"):
+        GeneralizedExactCoverResult.model_validate(payload)
+
+    mutated_source = found.model_dump(mode="json")
+    mutated_source["instance"]["rows"][0]["items"] = ["p"]
+    with pytest.raises(ValidationError, match="reconstruct"):
+        GeneralizedExactCoverResult.model_validate(mutated_source)
+
+    with pytest.raises(ValidationError, match="deterministic replay"):
+        GeneralizedExactCoverResult(
+            instance=cover,
+            search_node_limit=100,
+            status="NO_COVER",
+        )
+
+    no_cover = _instance(
+        primary=("p", "q"),
+        secondary=("s",),
+        rows=(
+            ("r1", ("p", "s")),
+            ("r2", ("q", "s")),
+        ),
+    )
+    # UNKNOWN is a durable non-conclusion, not a claim that validation must
+    # reproduce with one private branching implementation.
+    unknown = GeneralizedExactCoverResult(
+        instance=no_cover,
+        search_node_limit=1,
+        status="UNKNOWN",
+    )
+    assert type(unknown).model_validate(unknown.model_dump()) == unknown
+
+
+def test_contract_rejects_duplicate_undeclared_and_noncanonical_incidences() -> None:
+    with pytest.raises(ValidationError, match="sorted and unique"):
+        ExactCoverRow(row_id="r", items=("p", "p"))
+    with pytest.raises(ValidationError, match="sorted and unique"):
+        ExactCoverRow(row_id="r", items=("q", "p"))
+    with pytest.raises(ValidationError, match="must be declared"):
+        _instance(primary=("p",), rows=(("r", ("q",)),))
+    with pytest.raises(ValidationError, match="must be disjoint"):
+        _instance(primary=("p",), secondary=("p",))
+    with pytest.raises(ValidationError, match="sorted and unique"):
+        _instance(
+            primary=("p",),
+            rows=(
+                ("same", ("p",)),
+                ("same", ("p",)),
+            ),
+        )
+    with pytest.raises(ValidationError, match="row IDs must be sorted"):
+        _instance(
+            primary=("p",),
+            rows=(
+                ("z", ("p",)),
+                ("a", ("p",)),
+            ),
+        )
+
+    # Equal item sets are distinct candidate rows when their explicit IDs differ.
+    repeated_item_set = _solve(
+        _instance(
+            primary=("p",),
+            rows=(
+                ("first", ("p",)),
+                ("second", ("p",)),
+            ),
+        )
+    )
+    assert repeated_item_set.selected_row_ids == ("first",)
+
+
+def test_row_and_incidence_boundaries_are_admitted_before_search() -> None:
+    maximum_rows = tuple(
+        ExactCoverRow(row_id=f"r{index:04d}", items=("p",))
+        for index in range(MAX_EXACT_COVER_ROWS)
+    )
+    row_boundary = GeneralizedExactCoverInstance(
+        primary_items=("p",), secondary_items=(), rows=maximum_rows
+    )
+    assert _solve(row_boundary, search_node_limit=2).status == "FOUND"
+    with pytest.raises(ValidationError, match="at most 4096 items"):
+        GeneralizedExactCoverInstance(
+            primary_items=("p",),
+            secondary_items=(),
+            rows=(
+                *maximum_rows,
+                ExactCoverRow(row_id="r4096", items=("p",)),
+            ),
+        )
+
+    primary = tuple(f"p{index:03d}" for index in range(128))
+    secondary = tuple(f"s{index:03d}" for index in range(128))
+    all_items = (*primary, *secondary)
+    incidence_rows = tuple(
+        ExactCoverRow(row_id=f"r{index:03d}", items=all_items)
+        for index in range(MAX_EXACT_COVER_INCIDENCES // len(all_items))
+    )
+    incidence_boundary = GeneralizedExactCoverInstance(
+        primary_items=primary,
+        secondary_items=secondary,
+        rows=incidence_rows,
+    )
+    assert sum(len(row.items) for row in incidence_boundary.rows) == (
+        MAX_EXACT_COVER_INCIDENCES
+    )
+    assert _solve(incidence_boundary, search_node_limit=2).status == "FOUND"
+    with pytest.raises(ValidationError, match="incidence count"):
+        GeneralizedExactCoverInstance(
+            primary_items=primary,
+            secondary_items=secondary,
+            rows=(
+                *incidence_rows,
+                ExactCoverRow(row_id="r256", items=("p000",)),
+            ),
+        )
+
+
+def test_combined_item_bound_is_not_hidden_by_per_field_limits() -> None:
+    primary = tuple(f"p{index:03d}" for index in range(MAX_EXACT_COVER_PRIMARY_ITEMS))
+    secondary = tuple(f"s{index:03d}" for index in range(129))
+
+    with pytest.raises(ValidationError, match="at most 256 items"):
+        GeneralizedExactCoverInstance(
+            primary_items=primary,
+            secondary_items=secondary,
+            rows=(),
+        )
+
+
+def test_129_primary_one_row_instance_uses_the_aggregate_item_envelope() -> None:
+    primary = tuple(f"p{index:03d}" for index in range(129))
+    instance = _instance(primary=primary, rows=(("all", primary),))
+
+    result = _solve(instance, search_node_limit=2)
+
+    assert result.status == "FOUND"
+    assert result.selected_row_ids == ("all",)
+    assert _multiplicities(result) == dict.fromkeys(primary, 1)
+
+
+def test_selected_row_output_reaches_the_256_primary_boundary() -> None:
+    primary = tuple(f"p{index:03d}" for index in range(256))
+    rows = tuple((f"r{index:03d}", (item,)) for index, item in enumerate(primary))
+
+    result = _solve(_instance(primary=primary, rows=rows), search_node_limit=257)
+
+    assert result.status == "FOUND"
+    assert result.selected_row_ids == tuple(row_id for row_id, _items in rows)
+    assert len(result.item_multiplicities or ()) == 256
+
+
+def test_search_and_retained_output_boundaries_are_preflighted() -> None:
+    small = _instance(primary=("p",), rows=(("r", ("p",)),))
+    assert GeneralizedExactCoverRequest(
+        instance=small,
+        search_node_limit=MAX_EXACT_COVER_SEARCH_NODES_PER_PASS,
+    )
+    with pytest.raises(ValidationError, match="less than or equal to 100000"):
+        GeneralizedExactCoverRequest(
+            instance=small,
+            search_node_limit=MAX_EXACT_COVER_SEARCH_NODES_PER_PASS + 1,
+        )
+
+    # The item/row/incidence counts alone do not bound UTF-8 source bytes.
+    # This canonical instance fits every combinatorial count but its retained
+    # source would exceed the transport's identical output limit.
+    prefix = "🟦" * 60
+    primary = tuple(f"{prefix}p{index:03d}" for index in range(128))
+    secondary = tuple(f"{prefix}s{index:03d}" for index in range(128))
+    all_items = (*primary, *secondary)
+    large_source = GeneralizedExactCoverInstance(
+        primary_items=primary,
+        secondary_items=secondary,
+        rows=tuple(
+            ExactCoverRow(row_id=f"r{index:03d}", items=all_items)
+            for index in range(MAX_EXACT_COVER_INCIDENCES // len(all_items))
+        ),
+    )
+    with pytest.raises(ValidationError, match="canonical output limit"):
+        GeneralizedExactCoverRequest(instance=large_source)
+
+
+def test_schema_publishes_the_exact_cover_contract() -> None:
+    schema = GeneralizedExactCoverRequest.model_json_schema()
+    instance_schema = schema["$defs"]["GeneralizedExactCoverInstance"]
+    result_schema = GeneralizedExactCoverResult.model_json_schema()
+    assert instance_schema["properties"]["primary_items"]["maxItems"] == 256
+    assert instance_schema["properties"]["rows"]["maxItems"] == 4_096
+    assert schema["properties"]["search_node_limit"]["maximum"] == 100_000
+    assert (
+        result_schema["properties"]["selected_row_ids"]["anyOf"][0]["maxItems"] == 256
+    )
+    assert "NO_COVER" in schema["description"]
+    assert "UNKNOWN" in schema["description"]

--- a/tests/math/combinatorics/test_public_api.py
+++ b/tests/math/combinatorics/test_public_api.py
@@ -8,6 +8,12 @@ from jacobian.math import combinatorics
 def test_exact_public_api_symbols() -> None:
     """Exact owner-local contract for the combinatorics public API."""
     expected = (
+        "ExactCoverItemMultiplicity",
+        "ExactCoverRow",
+        "ExactCoverSearchStatus",
+        "GeneralizedExactCoverInstance",
+        "GeneralizedExactCoverRequest",
+        "GeneralizedExactCoverResult",
         "IndexedRecurrenceResidual",
         "PolynomialCoefficientRecurrenceTableRequest",
         "PolynomialCoefficientRecurrenceTableResult",
@@ -17,6 +23,7 @@ def test_exact_public_api_symbols() -> None:
         "derangement_number",
         "double_factorial",
         "fibonacci_number",
+        "find_generalized_exact_cover",
         "integer_partitions",
         "lucas_number",
         "motzkin_number",


### PR DESCRIPTION
## Problem

Agents that need to choose one compatible witness for each required constraint currently have to encode generalized exact cover as SAT, maintain a separate row-to-variable map, decode an arbitrary model, and reconstruct coverage multiplicities. That obscures the primary/exactly-once and secondary/at-most-once semantics, and makes it easy to treat a bounded search stop as nonexistence.

Closes #2256.

## Solution

Add `combinatorics.generalized_exact_cover.find` over a canonical materialized incidence value. Primary items must be covered exactly once, secondary items at most once, and distinct row IDs remain distinct candidates even when their incidences agree.

The operation uses a request-scoped bitset implementation of Algorithm X. It chooses the uncovered primary item with the fewest available rows, breaks ties by canonical item order, and visits rows in canonical row-ID order. The result is therefore deterministic for a canonical input and node allowance:

- `FOUND` carries selected row IDs and a reconstructed multiplicity for every declared item;
- `NO_COVER` is returned only after exhaustive search and is checked by source-bound replay; and
- `UNKNOWN` is an explicit non-conclusion at the node allowance. It is source-bound but intentionally not replayed, so a private kernel improvement cannot invalidate an old non-conclusion.

The public surface stays at exact-one/at-most-one feasibility. It does not add weighted set cover, optimization, generated candidate families, checkpoints, or durable search state.

## Testing

- `make check` — 2,666 passed; Ruff and mypy passed.
- `uv run --locked pytest -q tests/math/combinatorics/test_exact_cover.py tests/math/combinatorics/test_public_api.py tests/catalog/test_catalog.py tests/tooling/test_pytest_collection_ownership.py tests/integration/catalog/test_public_operation_contract_conformance.py` — 515 passed.
- Specialist validation run: catalog public-operation mutation conformance is included in the focused command above.

The tests include Knuth's known-answer example, all 128 subfamilies of the seven nonempty rows over two primary and one secondary item against an independent exhaustive oracle, the pinned Erdős 743 K3 packing control and an overfull mutation, relabelling, source mutations, empty and uncovered-primary degeneracies, exact count/output boundaries, and `UNKNOWN` versus `NO_COVER` behavior. The exhaustive oracle now requires infeasible families to return `NO_COVER`; `UNKNOWN` fails the test.

Indicative single-run measurements used `time.perf_counter` around request construction plus the public function on CPython 3.12.13, Linux x86-64, and an Intel i7-10875H. They establish usefulness, not the work proof:

| Instance | Bound/result | Elapsed |
| --- | --- | ---: |
| 129 primary items, one row containing all of them | 2 nodes / `FOUND` | 0.007405 s |
| 1 primary item, 4,096 candidate rows | 2 nodes / `FOUND` | 0.191453 s |
| 83 pigeons, 48 secondary holes, all 3,984 assignment rows | 100,000 nodes / `UNKNOWN` | 1.545194 s |

The last case exercises the maximum-node fallback with nearly the maximum row-bitset width. A previous 1,000,000-node adversarial pass was too costly to repeat during exact-negative validation, so the public ceiling is 100,000 nodes per pass; `NO_COVER` construction plus replay is bounded to 200,000 visits.

## Public contract impact

Adds operation version 1, the native `find_generalized_exact_cover` function, and these canonical/source-bound types under `jacobian.math.combinatorics`:

- `ExactCoverRow`
- `GeneralizedExactCoverInstance`
- `GeneralizedExactCoverRequest`
- `GeneralizedExactCoverResult`
- `ExactCoverItemMultiplicity`
- `ExactCoverSearchStatus`

## Public operation admission

- Concrete gap: generalized exact cover is a reusable incidence postcondition. The existing `sat.solve` route leaves Boolean encoding, row identity, model decoding, multiplicity reconstruction, and incomplete-search interpretation to every caller.
- Why existing operations or typed values are insufficient: finite-set exact-cover checks validate one supplied family; they do not search primary/secondary incidence rows. SAT accepts clauses rather than this mathematical value and does not return selected ordinary rows.
- Stable mathematical result: one row family covering each primary item exactly once and each secondary item at most once, exact nonexistence after exhaustive bounded search, or an explicit non-conclusion.
- Semantic mathematical domain and postcondition: finite materialized generalized exact-cover instances with explicit item and row identities. Duplicate incidences, undeclared items, overlapping primary/secondary declarations, and noncanonical ordering are rejected.
- Canonical public value type: `GeneralizedExactCoverInstance` owns the ordered primary items, secondary items, and identified `ExactCoverRow` values. Results retain that instance unchanged.
- Source representation: materialized. The kernel does not expand a succinct generator or query an oracle.
- Expansion performed by the kernel and its pre-execution bound: for `P` primary items, `M` total items, `R` rows, and `I` incidences, index construction materializes `I` item indices, `M` row masks, `R` primary masks, and `R` conflict masks using at most `2I` mask updates.
- Representation-sensitive complexity: row IDs distinguish candidates; equal incidence sets are not normalized together. Generated or symmetry-reduced row families remain caller-owned because their completeness proof is outside this operation.
- Semantic domain and admitted execution envelope: `M <= 256`, `R <= 4,096`, `I <= 65,536`, at most 256 selected rows, and at most 100,000 search nodes per pass. Opaque-label and canonical JSON limits also apply. The prior independent 128-primary ceiling was removed; a 129-primary one-row instance and the 256-primary/256-selected-row boundary execute successfully.
- Producer/consumer closure: no existing operation produces this incidence value. Its canonical serialization can be supplied unchanged to the request, and the result retains the full source plus ordinary row IDs and multiplicities for caller-side composition. Empty-primary instances retain their secondary axis and return the empty selected family.
- Degenerate inputs: an empty primary family has the empty cover; required items with no candidate row prove `NO_COVER` at the root; rows containing no primary item are valid source data but never appear in the canonical witness.
- Parent/ring/field identity: not applicable. Opaque item and row IDs define one finite incidence instance; no coercion or ambient algebraic parent exists.
- Deterministic work bound: index construction uses at most `2I` mask updates. Each node performs at most `P` intersections/population counts on `R`-bit masks plus constant-many child-mask operations, with at most `N-1` child edges for `N <= 100,000`. Exact-negative result replay makes at most two passes.
- Maximum intermediate growth: the logical index payload is `M*R + R*P + R^2` bits plus `I` bounded item indices, at most 18,874,368 mask bits under the public envelope. Recursion depth is at most `P <= 256`; frame mask payload is bounded by `(P+1)*(P+R)` bits plus `P` selected-row indices. Python object overhead is additionally bounded by the same item, row, incidence, and depth counts.
- Exact result-size bound: a witness has at most `min(P, R)` selected IDs and exactly `M` multiplicity records. Admission materializes and canonically encodes the worst `FOUND` shape using the longest possible selected row IDs, plus both non-positive shapes, each retaining the source. Search starts only if every shape fits the shared 10 MiB output limit.
- Exact representation, algorithm regimes, and maintained backend: one Jacobian-owned bitset Algorithm X regime over canonical ordinal indices. The installed Z3 backend can encode these Boolean constraints and distinguish `sat`, `unsat`, and `unknown`, but it returns an arbitrary model rather than the canonical row witness and its resource units follow solver internals. Canonicalizing that model would require repeated solver calls or optimization and a second row-variable protocol. No maintained exact-cover dependency already in the stack supplies the complete typed postcondition; adding a larger solver package is disproportionate to this bounded 127-line kernel.
- Backend and supported version: no external runtime backend. The kernel is ordinary supported Python and uses arbitrary-precision integer bitsets.
- Backend input domain: the already-validated canonical instance; no backend-specific domain is discovered during execution.
- Conversion/coercion behavior: item and row labels map bijectively to their canonical tuple positions. No label is parsed or evaluated, no duplicate is normalized away, and output maps selected positions back to the original row IDs.
- Result type: source-bound `GeneralizedExactCoverResult` with `FOUND`, `NO_COVER`, or `UNKNOWN` status.
- Reconstruction or defining invariant: `FOUND` validation recomputes every primary and secondary multiplicity from the retained rows. `NO_COVER` validation repeats the bounded exhaustive search and rejects a contradictory replay. `UNKNOWN` carries no mathematical conclusion and therefore does not turn a private search convention into durable public semantics.
- Typed execution failures: malformed or over-envelope instances fail request validation; reaching the admitted node allowance returns `UNKNOWN`; every accepted request returns the declared result type.
- Property and boundary tests: known answers, independent exhaustive feasible/infeasible classification, primary/secondary conflict cases, relabelling, empty inputs, source and witness mutations, 4,096-row and 65,536-incidence boundaries, 129- and 256-primary execution, exact retained-output preflight, catalog discovery, and public mutation conformance.
- Remaining fixed caps and their classification: the 256-item, 4,096-row, and 65,536-incidence ceilings are conservative materialization/memory fallbacks and can be raised after larger logical-mask and canonical-output measurements. The 100,000-node ceiling is an execution-safety fallback and can be raised if a faster maintained backend or a compact independently checked negative certificate removes replay cost. Opaque-label and 10 MiB JSON limits are shared transport bounds, not mathematical restrictions.
- Admission decision: `KEEP`, recorded in the combinatorics owner.

## Closure matrix

None. This PR admits the single focused operation from #2256; weighted or at-least-one covering remains outside its semantics.

## Suggested review order

1. Public value, result, and bound contract in `exact_cover.py`.
2. Bitset work/intermediate proof and search in `_exact_cover_kernel.py`.
3. Known-answer, exhaustive-oracle, mutation, and boundary tests.
4. Catalog declaration and owner-local admission.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes ran their dedicated validation (not applicable; no Harbor files changed)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact and unknown outcomes
- [x] New bounds include boundary and realistic source-backed scale evidence
- [x] New shared abstractions replace duplication in at least two production paths (not applicable; no shared abstraction was added)
