### PR TITLE
feat(automata): compute exact transition-Parikh profiles

### DIFF
--- a/src/jacobian/math/regular_languages/__init__.py
+++ b/src/jacobian/math/regular_languages/__init__.py
@@ -4,13 +4,28 @@ from jacobian.math.regular_languages.operations import (
     count_accepted_words,
     dfa_complement,
     dfa_run,
+    dfa_transition_carrier,
+    transition_parikh_profile,
 )
-from jacobian.math.regular_languages.values import DFA, DFATransition
+from jacobian.math.regular_languages.values import (
+    DFA,
+    AutomatonTransition,
+    DFATransition,
+    FiniteLabeledAutomaton,
+    TransitionParikhCell,
+    TransitionParikhProfile,
+)
 
 __all__ = [
     "DFA",
+    "AutomatonTransition",
     "DFATransition",
+    "FiniteLabeledAutomaton",
+    "TransitionParikhCell",
+    "TransitionParikhProfile",
     "count_accepted_words",
     "dfa_complement",
     "dfa_run",
+    "dfa_transition_carrier",
+    "transition_parikh_profile",
 ]

--- a/src/jacobian/math/regular_languages/_admission.py
+++ b/src/jacobian/math/regular_languages/_admission.py
@@ -11,6 +11,13 @@ from jacobian.math.regular_languages._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "automaton.path.transition_parikh_profile.compute",
+        AdmissionDecision.KEEP,
+        "complete endpoint-bound histogram of transition-use vectors retains "
+        "information lost by scalar path counting and supplies an exact reusable "
+        "profile under derived work and output bounds",
+    ),
+    OperationAdmission(
         "regular_language.complement.compute",
         AdmissionDecision.NATIVE_ONLY,
         "cheap deterministic accepting-state projection of a supplied complete DFA",

--- a/src/jacobian/math/regular_languages/_models.py
+++ b/src/jacobian/math/regular_languages/_models.py
@@ -12,7 +12,10 @@ from jacobian.math.regular_languages.values import (
     DFA,
     MAX_COUNT_WORD_LENGTH,
     MAX_DFA_STATES,
+    MAX_LABELED_AUTOMATON_STATES,
+    MAX_TRANSITION_PROFILE_PATH_LENGTH,
     MAX_WORD_LENGTH,
+    FiniteLabeledAutomaton,
 )
 
 
@@ -41,6 +44,51 @@ class ComplementRequest(StrictModel):
     """Compute the complement of a DFA's language."""
 
     dfa: DFA
+
+
+class TransitionParikhProfileRequest(StrictModel):
+    """Compute a complete transition-use profile for exact automaton paths.
+
+    The automaton's ordered ``transition_id`` axis is authoritative. Admission
+    derives path-extension, sparse-DP-cell, vector-coordinate, multiplicity,
+    profile-cell, and serialized-result bounds before running the recurrence.
+    """
+
+    automaton: FiniteLabeledAutomaton = Field(
+        description=(
+            "Finite labeled transition carrier whose contiguous transition_id "
+            "order is the complete profile coordinate axis."
+        )
+    )
+    source_state: int = Field(
+        ge=0,
+        le=MAX_LABELED_AUTOMATON_STATES - 1,
+        description="Path source on the automaton's zero-based state axis.",
+    )
+    target_state: int = Field(
+        ge=0,
+        le=MAX_LABELED_AUTOMATON_STATES - 1,
+        description="Path target on the automaton's zero-based state axis.",
+    )
+    path_length: int = Field(
+        ge=0,
+        le=MAX_TRANSITION_PROFILE_PATH_LENGTH,
+        description="Exact nonnegative number of transitions in every path.",
+    )
+
+    @model_validator(mode="after")
+    def require_complete_bounded_profile(self) -> Self:
+        from jacobian.math.regular_languages.operations import (
+            _require_transition_profile_envelope,
+        )
+
+        _require_transition_profile_envelope(
+            self.automaton,
+            self.source_state,
+            self.target_state,
+            self.path_length,
+        )
+        return self
 
 
 class RunResult(RunRequest):
@@ -96,4 +144,5 @@ __all__ = [
     "CountResult",
     "RunRequest",
     "RunResult",
+    "TransitionParikhProfileRequest",
 ]

--- a/src/jacobian/math/regular_languages/_operations.py
+++ b/src/jacobian/math/regular_languages/_operations.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.regular_languages import (
+    TransitionParikhProfile,
     count_accepted_words,
     dfa_complement,
     dfa_run,
+    transition_parikh_profile,
 )
 from jacobian.math.regular_languages._models import (
     ComplementRequest,
@@ -15,6 +17,7 @@ from jacobian.math.regular_languages._models import (
     CountResult,
     RunRequest,
     RunResult,
+    TransitionParikhProfileRequest,
 )
 
 
@@ -46,4 +49,20 @@ def compute_complement(request: ComplementRequest) -> ComplementResult:
     return ComplementResult(dfa=dfa_complement(request.dfa))
 
 
-__all__ = ["compute_complement", "compute_count", "compute_run"]
+def compute_transition_parikh_profile(
+    request: TransitionParikhProfileRequest,
+) -> TransitionParikhProfile:
+    return transition_parikh_profile(
+        request.automaton,
+        request.source_state,
+        request.target_state,
+        request.path_length,
+    )
+
+
+__all__ = [
+    "compute_complement",
+    "compute_count",
+    "compute_run",
+    "compute_transition_parikh_profile",
+]

--- a/src/jacobian/math/regular_languages/_tools.py
+++ b/src/jacobian/math/regular_languages/_tools.py
@@ -13,12 +13,15 @@ from jacobian.math.regular_languages._models import (
     CountResult,
     RunRequest,
     RunResult,
+    TransitionParikhProfileRequest,
 )
 from jacobian.math.regular_languages._operations import (
     compute_complement,
     compute_count,
     compute_run,
+    compute_transition_parikh_profile,
 )
+from jacobian.math.regular_languages.values import TransitionParikhProfile
 
 
 def rl_operation[RequestT: StrictModel, ResultT: StrictModel](
@@ -60,8 +63,46 @@ _DFA_EXAMPLE = {
     },
 }
 
+_TRANSITION_PROFILE_EXAMPLE = {
+    "automaton": {
+        "state_count": 1,
+        "alphabet_size": 2,
+        "transitions": [
+            {"transition_id": 0, "source": 0, "symbol": 0, "target": 0},
+            {"transition_id": 1, "source": 0, "symbol": 1, "target": 0},
+        ],
+    },
+    "source_state": 0,
+    "target_state": 0,
+    "path_length": 2,
+}
+
 
 REGULAR_LANGUAGE_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    rl_operation(
+        "automaton.path.transition_parikh_profile.compute",
+        "Compute a transition-Parikh profile for fixed-length automaton paths",
+        "Return the complete exact histogram from transition-use vectors to path "
+        "multiplicities for one source, target, and exact length. Coordinates use "
+        "the automaton's stable transition-ID axis; requests above the derived "
+        "work or result envelope are rejected before the sparse recurrence runs.",
+        TransitionParikhProfileRequest,
+        TransitionParikhProfile,
+        compute_transition_parikh_profile,
+        "automata",
+        "paths",
+        "parikh",
+        "exact",
+        "complete",
+        examples=(
+            example(
+                "two_loop_transition_histogram",
+                "Compute all length-two loop paths and group them by transition "
+                "counts; transition IDs must be the contiguous ordered axis.",
+                _TRANSITION_PROFILE_EXAMPLE,
+            ),
+        ),
+    ),
     rl_operation(
         "regular_language.run.check",
         "Check if a word is accepted by a DFA",

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -1,10 +1,46 @@
-"""Exact regular language kernels backed by SymPy matrix powering."""
+"""Exact finite-automaton and regular-language kernels."""
 
 from __future__ import annotations
 
-from jacobian.math.regular_languages.values import DFA
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.regular_languages.values import (
+    DFA,
+    MAX_TRANSITION_PROFILE_COUNT_DIGITS,
+    MAX_TRANSITION_PROFILE_ENTRIES,
+    MAX_TRANSITION_PROFILE_PATH_LENGTH,
+    AutomatonTransition,
+    FiniteLabeledAutomaton,
+    TransitionParikhCell,
+    TransitionParikhProfile,
+)
 
-__all__ = ["count_accepted_words", "dfa_complement", "dfa_run"]
+__all__ = [
+    "count_accepted_words",
+    "dfa_complement",
+    "dfa_run",
+    "dfa_transition_carrier",
+    "transition_parikh_profile",
+]
+
+# The catalog path performs at most three bounded state preflights (request,
+# computation, and result binding) and two sparse profile recurrences
+# (computation and source-binding replay). These per-pass limits therefore also
+# give a fixed deterministic bound on the complete public call.
+_MAX_TRANSITION_PROFILE_DP_UPDATES = 2_000_000
+_MAX_TRANSITION_PROFILE_VECTOR_UPDATE_WORK = 20_000_000
+_MAX_TRANSITION_PROFILE_VECTOR_COORDINATES = 4_000_000
+_MAX_TRANSITION_PROFILE_RESULT_BYTES = 4 * 1024 * 1024
+_MAX_TRANSITION_PROFILE_PREFLIGHT_SCANS = 4_000_000
+_MAX_TRANSITION_PROFILE_COMPOSITION_CELLS = 20_000_000
+
+# Conservative canonical-wire allowances. One source transition has four
+# bounded integer fields; one profile entry adds its keys, brackets, separators,
+# dense coordinate vector, and exact multiplicity string. The estimates stay
+# above the compact RFC 8785 encoding used at the transport boundary.
+_AUTOMATON_BASE_WIRE_BYTES = 256
+_AUTOMATON_TRANSITION_WIRE_BYTES = 128
+_PROFILE_BASE_WIRE_BYTES = 256
+_PROFILE_ENTRY_BASE_WIRE_BYTES = 96
 
 
 def _transition_map(dfa: DFA) -> dict[tuple[int, int], int]:
@@ -49,4 +85,302 @@ def dfa_complement(dfa: DFA) -> DFA:
         transitions=dfa.transitions,
         initial_state=dfa.initial_state,
         accepting_states=tuple(sorted(set(range(dfa.state_count)) - accepting)),
+    )
+
+
+def dfa_transition_carrier(dfa: DFA) -> FiniteLabeledAutomaton:
+    """Project a DFA onto a labeled carrier with a stable transition axis.
+
+    The unique DFA transitions are ordered by ``(source, symbol)`` before
+    receiving contiguous transition IDs. Initial and accepting-state data are
+    intentionally absent from the path carrier.
+    """
+
+    ordered = sorted(dfa.transitions, key=lambda item: (item.source, item.symbol))
+    return FiniteLabeledAutomaton(
+        state_count=dfa.state_count,
+        alphabet_size=dfa.alphabet_size,
+        transitions=tuple(
+            AutomatonTransition(
+                transition_id=transition_id,
+                source=transition.source,
+                symbol=transition.symbol,
+                target=transition.target,
+            )
+            for transition_id, transition in enumerate(ordered)
+        ),
+    )
+
+
+def _outgoing_transitions(
+    automaton: FiniteLabeledAutomaton,
+) -> tuple[tuple[AutomatonTransition, ...], ...]:
+    outgoing: list[list[AutomatonTransition]] = [
+        [] for _ in range(automaton.state_count)
+    ]
+    for transition in automaton.transitions:
+        outgoing[transition.source].append(transition)
+    return tuple(tuple(transitions) for transitions in outgoing)
+
+
+def _path_count_and_walk_update_bound(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+    composition_update_bound: int,
+) -> tuple[int, int, int]:
+    """Return target path count, path-extension count, and peak layer paths."""
+
+    outgoing = _outgoing_transitions(automaton)
+
+    counts = [0] * automaton.state_count
+    counts[source_state] = 1
+    walk_updates = 0
+    max_layer_paths = 1
+    preflight_scans = 0
+    for _ in range(path_length):
+        next_counts = [0] * automaton.state_count
+        for state, multiplicity in enumerate(counts):
+            if not multiplicity:
+                continue
+            preflight_scans += len(outgoing[state])
+            if preflight_scans > _MAX_TRANSITION_PROFILE_PREFLIGHT_SCANS:
+                raise ValueError(
+                    "transition-Parikh preflight reachable-state scan bound exceeded; "
+                    "reduce the path length or reachable transition carrier"
+                )
+            for transition in outgoing[state]:
+                walk_updates = min(
+                    _MAX_TRANSITION_PROFILE_DP_UPDATES + 1,
+                    walk_updates + multiplicity,
+                )
+                next_counts[transition.target] += multiplicity
+        if (
+            walk_updates > _MAX_TRANSITION_PROFILE_DP_UPDATES
+            and composition_update_bound > _MAX_TRANSITION_PROFILE_DP_UPDATES
+        ):
+            raise ValueError(
+                "transition-Parikh DP transition-update bound exceeded; reduce the "
+                "path length or transition branching"
+            )
+        counts = next_counts
+        max_layer_paths = max(max_layer_paths, sum(counts))
+        if not any(counts):
+            break
+    return counts[target_state], walk_updates, max_layer_paths
+
+
+def _capped_combination(n: int, k: int, cap: int) -> int:
+    """Return ``min(comb(n, k), cap + 1)`` without materializing huge values."""
+
+    if k < 0 or k > n:
+        return 0
+    k = min(k, n - k)
+    result = 1
+    for factor in range(1, k + 1):
+        result = result * (n - k + factor) // factor
+        if result > cap:
+            return cap + 1
+    return result
+
+
+def _transition_profile_composition_bounds(
+    transition_count: int, path_length: int
+) -> tuple[int, int]:
+    """Return dense-vector support and DP-update bounds from stars and bars."""
+
+    if path_length == 0:
+        return 1, 0
+    if transition_count == 0:
+        return 0, 0
+    profile_cells = _capped_combination(
+        path_length + transition_count - 1,
+        transition_count - 1,
+        _MAX_TRANSITION_PROFILE_COMPOSITION_CELLS,
+    )
+    # At layer k, each transition can extend at most C(k+m-1,m-1)
+    # transition-count vectors. Summing k=0..L-1 gives m*C(L+m-1,m).
+    per_transition_cap = _MAX_TRANSITION_PROFILE_DP_UPDATES // transition_count
+    per_transition_updates = _capped_combination(
+        path_length + transition_count - 1,
+        transition_count,
+        per_transition_cap,
+    )
+    dp_updates = min(
+        _MAX_TRANSITION_PROFILE_DP_UPDATES + 1,
+        transition_count * per_transition_updates,
+    )
+    return profile_cells, dp_updates
+
+
+def _require_transition_profile_envelope(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> int:
+    """Preflight exact work, intermediate, count-digit, and result bounds."""
+
+    if not 0 <= source_state < automaton.state_count:
+        raise ValueError("source_state must be in 0..state_count-1")
+    if not 0 <= target_state < automaton.state_count:
+        raise ValueError("target_state must be in 0..state_count-1")
+    if path_length < 0:
+        raise ValueError("path_length must be nonnegative")
+    if path_length > MAX_TRANSITION_PROFILE_PATH_LENGTH:
+        raise ValueError(
+            "path_length exceeds the transition-Parikh preflight length bound"
+        )
+
+    transition_count = len(automaton.transitions)
+    profile_composition_bound, composition_update_bound = (
+        _transition_profile_composition_bounds(transition_count, path_length)
+    )
+    target_path_count, walk_update_bound, max_layer_paths = (
+        _path_count_and_walk_update_bound(
+            automaton,
+            source_state,
+            target_state,
+            path_length,
+            composition_update_bound,
+        )
+    )
+
+    dp_update_bound = min(walk_update_bound, composition_update_bound)
+    if dp_update_bound > _MAX_TRANSITION_PROFILE_DP_UPDATES:
+        raise ValueError(
+            "transition-Parikh DP transition-update bound exceeded; reduce the "
+            "path length or transition branching"
+        )
+
+    profile_cell_bound = min(target_path_count, profile_composition_bound)
+    if profile_cell_bound > MAX_TRANSITION_PROFILE_ENTRIES:
+        raise ValueError(
+            "transition-Parikh profile-cell bound exceeded; reduce the path length "
+            "or transition dimension"
+        )
+
+    vector_update_work = dp_update_bound * transition_count
+    if vector_update_work > _MAX_TRANSITION_PROFILE_VECTOR_UPDATE_WORK:
+        raise ValueError(
+            "transition-Parikh dense-vector update-work bound exceeded; reduce "
+            "the transition axis or path branching"
+        )
+
+    layer_cell_bound = min(
+        max_layer_paths,
+        automaton.state_count * profile_composition_bound,
+        dp_update_bound + 1,
+    )
+    vector_coordinate_bound = layer_cell_bound * transition_count
+    if vector_coordinate_bound > _MAX_TRANSITION_PROFILE_VECTOR_COORDINATES:
+        raise ValueError(
+            "transition-Parikh intermediate vector-coordinate bound exceeded; "
+            "reduce the transition axis or path branching"
+        )
+
+    count_digits = len(format_canonical_integer(max(1, target_path_count)))
+    if count_digits > MAX_TRANSITION_PROFILE_COUNT_DIGITS:
+        raise ValueError(
+            "transition-Parikh multiplicity digit bound exceeded; reduce the path "
+            "length or transition branching"
+        )
+    coordinate_digits = len(str(max(1, path_length)))
+    estimated_entry_bytes = (
+        _PROFILE_ENTRY_BASE_WIRE_BYTES
+        + transition_count * (coordinate_digits + 2)
+        + count_digits
+    )
+    estimated_result_bytes = (
+        _AUTOMATON_BASE_WIRE_BYTES
+        + transition_count * _AUTOMATON_TRANSITION_WIRE_BYTES
+        + _PROFILE_BASE_WIRE_BYTES
+        + profile_cell_bound * estimated_entry_bytes
+    )
+    if estimated_result_bytes > _MAX_TRANSITION_PROFILE_RESULT_BYTES:
+        raise ValueError(
+            "transition-Parikh serialized-result bound exceeded; reduce the "
+            "transition axis or profile support"
+        )
+    return target_path_count
+
+
+def _transition_parikh_profile_data(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> tuple[tuple[tuple[tuple[int, ...], int], ...], int]:
+    """Compute canonical profile entries and their independent total count.
+
+    The sparse dynamic program obeys
+
+    ``P[k+1, target, v+e_i] += P[k, source, v]``
+
+    for every identified transition ``i: source -> target``. Dense vectors are
+    returned on the automaton's complete transition-ID axis.
+    """
+
+    expected_path_count = _require_transition_profile_envelope(
+        automaton, source_state, target_state, path_length
+    )
+    transition_count = len(automaton.transitions)
+    outgoing = _outgoing_transitions(automaton)
+
+    zero_vector = tuple(0 for _ in range(transition_count))
+    layer: dict[tuple[int, tuple[int, ...]], int] = {(source_state, zero_vector): 1}
+    for _ in range(path_length):
+        if not layer:
+            break
+        next_layer: dict[tuple[int, tuple[int, ...]], int] = {}
+        for (state, vector), multiplicity in layer.items():
+            for transition in outgoing[state]:
+                transition_id = transition.transition_id
+                updated = (
+                    *vector[:transition_id],
+                    vector[transition_id] + 1,
+                    *vector[transition_id + 1 :],
+                )
+                key = (transition.target, updated)
+                next_layer[key] = next_layer.get(key, 0) + multiplicity
+        layer = next_layer
+
+    target_entries = sorted(
+        (vector, multiplicity)
+        for (state, vector), multiplicity in layer.items()
+        if state == target_state
+    )
+    total_path_count = sum(multiplicity for _, multiplicity in target_entries)
+    if total_path_count != expected_path_count:
+        raise RuntimeError(
+            "transition-Parikh recurrence disagrees with independent path counting"
+        )
+    return tuple(target_entries), total_path_count
+
+
+def transition_parikh_profile(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> TransitionParikhProfile:
+    """Return the exact transition-use histogram for fixed-endpoint paths."""
+
+    target_entries, total_path_count = _transition_parikh_profile_data(
+        automaton, source_state, target_state, path_length
+    )
+    return TransitionParikhProfile(
+        automaton=automaton,
+        source_state=source_state,
+        target_state=target_state,
+        path_length=path_length,
+        entries=tuple(
+            TransitionParikhCell(
+                transition_counts=vector,
+                multiplicity=format_canonical_integer(multiplicity),
+            )
+            for vector, multiplicity in target_entries
+        ),
+        total_path_count=format_canonical_integer(total_path_count),
     )

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -30,7 +30,6 @@ _MAX_TRANSITION_PROFILE_DP_UPDATES = 2_000_000
 _MAX_TRANSITION_PROFILE_VECTOR_UPDATE_WORK = 20_000_000
 _MAX_TRANSITION_PROFILE_VECTOR_COORDINATES = 4_000_000
 _MAX_TRANSITION_PROFILE_RESULT_BYTES = 4 * 1024 * 1024
-_MAX_TRANSITION_PROFILE_PREFLIGHT_SCANS = 4_000_000
 _MAX_TRANSITION_PROFILE_COMPOSITION_CELLS = 20_000_000
 
 # Conservative canonical-wire allowances. One source transition has four
@@ -130,7 +129,7 @@ def _path_count_and_walk_update_bound(
     path_length: int,
     composition_update_bound: int,
 ) -> tuple[int, int, int]:
-    """Return target path count, path-extension count, and peak layer paths."""
+    """Return target path count, capped path extensions, and peak layer paths."""
 
     outgoing = _outgoing_transitions(automaton)
 
@@ -138,19 +137,14 @@ def _path_count_and_walk_update_bound(
     counts[source_state] = 1
     walk_updates = 0
     max_layer_paths = 1
-    preflight_scans = 0
     for _ in range(path_length):
         next_counts = [0] * automaton.state_count
         for state, multiplicity in enumerate(counts):
             if not multiplicity:
                 continue
-            preflight_scans += len(outgoing[state])
-            if preflight_scans > _MAX_TRANSITION_PROFILE_PREFLIGHT_SCANS:
-                raise ValueError(
-                    "transition-Parikh preflight reachable-state scan bound exceeded; "
-                    "reduce the path length or reachable transition carrier"
-                )
             for transition in outgoing[state]:
+                # Every reachable-state scan extends at least one path, so this
+                # capped count also bounds the state preflight's transition work.
                 walk_updates = min(
                     _MAX_TRANSITION_PROFILE_DP_UPDATES + 1,
                     walk_updates + multiplicity,

--- a/src/jacobian/math/regular_languages/operations.py
+++ b/src/jacobian/math/regular_languages/operations.py
@@ -133,15 +133,12 @@ def _path_count_and_walk_update_bound(
 
     outgoing = _outgoing_transitions(automaton)
 
-    counts = [0] * automaton.state_count
-    counts[source_state] = 1
+    counts = {source_state: 1}
     walk_updates = 0
     max_layer_paths = 1
     for _ in range(path_length):
-        next_counts = [0] * automaton.state_count
-        for state, multiplicity in enumerate(counts):
-            if not multiplicity:
-                continue
+        next_counts: dict[int, int] = {}
+        for state, multiplicity in counts.items():
             for transition in outgoing[state]:
                 # Every reachable-state scan extends at least one path, so this
                 # capped count also bounds the state preflight's transition work.
@@ -149,7 +146,9 @@ def _path_count_and_walk_update_bound(
                     _MAX_TRANSITION_PROFILE_DP_UPDATES + 1,
                     walk_updates + multiplicity,
                 )
-                next_counts[transition.target] += multiplicity
+                next_counts[transition.target] = (
+                    next_counts.get(transition.target, 0) + multiplicity
+                )
         if (
             walk_updates > _MAX_TRANSITION_PROFILE_DP_UPDATES
             and composition_update_bound > _MAX_TRANSITION_PROFILE_DP_UPDATES
@@ -159,10 +158,10 @@ def _path_count_and_walk_update_bound(
                 "path length or transition branching"
             )
         counts = next_counts
-        max_layer_paths = max(max_layer_paths, sum(counts))
-        if not any(counts):
+        max_layer_paths = max(max_layer_paths, sum(counts.values()))
+        if not counts:
             break
-    return counts[target_state], walk_updates, max_layer_paths
+    return counts.get(target_state, 0), walk_updates, max_layer_paths
 
 
 def _capped_combination(n: int, k: int, cap: int) -> int:

--- a/src/jacobian/math/regular_languages/values.py
+++ b/src/jacobian/math/regular_languages/values.py
@@ -1,18 +1,37 @@
-"""Provider-independent values for exact regular languages over finite DFAs."""
+"""Provider-independent values for finite automata and regular languages."""
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
 
 MAX_DFA_STATES = 64
 MAX_DFA_ALPHABET = 32
 MAX_DFA_TRANSITIONS = 4096
 MAX_WORD_LENGTH = 1000
 MAX_COUNT_WORD_LENGTH = 200
+
+MAX_LABELED_AUTOMATON_STATES = 64
+MAX_LABELED_AUTOMATON_ALPHABET = 32
+MAX_LABELED_AUTOMATON_TRANSITIONS = 4096
+# Conservative layer-iteration fallback for the pure-Python recurrence. Derived
+# path, DP, intermediate, and output budgets normally reject branching profiles
+# much earlier, while deterministic or quickly dead carriers remain useful far
+# beyond the ordinary DFA word bound. A future cycle-accelerated kernel could
+# raise this ceiling without changing the public postcondition.
+MAX_TRANSITION_PROFILE_PATH_LENGTH = 1_000_000
+MAX_TRANSITION_PROFILE_ENTRIES = 43_000
+MAX_TRANSITION_PROFILE_COUNT_DIGITS = 32_768
+
+TransitionUseCount = Annotated[
+    int,
+    Field(ge=0, le=MAX_TRANSITION_PROFILE_PATH_LENGTH),
+]
 
 
 class DFATransition(StrictModel):
@@ -73,4 +92,173 @@ class DFA(StrictModel):
         return self
 
 
-__all__ = ["DFA", "DFATransition"]
+class AutomatonTransition(StrictModel):
+    """One identified edge of a finite labeled transition system.
+
+    ``transition_id`` is its stable coordinate on the automaton's ordered
+    transition axis. Parallel transitions remain distinct mathematical edges.
+    """
+
+    transition_id: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_TRANSITIONS - 1)
+    source: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_STATES - 1)
+    symbol: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_ALPHABET - 1)
+    target: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_STATES - 1)
+
+
+class FiniteLabeledAutomaton(StrictModel):
+    """A finite labeled transition carrier with an explicit edge axis.
+
+    States and symbols use the declared zero-based axes. Transitions are the
+    complete ordered transition axis: their identifiers must be exactly
+    ``0, ..., len(transitions)-1`` in tuple order. The carrier may be partial,
+    nondeterministic, have parallel identified transitions, or have no
+    transitions. Path endpoints belong to the operation using the carrier
+    rather than being baked into this reusable value.
+    """
+
+    state_count: int = Field(ge=1, le=MAX_LABELED_AUTOMATON_STATES)
+    alphabet_size: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_ALPHABET)
+    transitions: tuple[AutomatonTransition, ...] = Field(
+        max_length=MAX_LABELED_AUTOMATON_TRANSITIONS,
+        description=(
+            "Complete transition axis in transition_id order; IDs must be the "
+            "contiguous zero-based positions. Parallel transitions are distinct."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_transition_axis(self) -> Self:
+        if tuple(transition.transition_id for transition in self.transitions) != tuple(
+            range(len(self.transitions))
+        ):
+            raise ValueError(
+                "transition_id values must be the contiguous zero-based axis in "
+                "tuple order"
+            )
+        for transition in self.transitions:
+            if not 0 <= transition.source < self.state_count:
+                raise ValueError("transition source must be in 0..state_count-1")
+            if not 0 <= transition.target < self.state_count:
+                raise ValueError("transition target must be in 0..state_count-1")
+            if not 0 <= transition.symbol < self.alphabet_size:
+                raise ValueError("transition symbol must be in 0..alphabet_size-1")
+        return self
+
+
+class TransitionParikhCell(StrictModel):
+    """One transition-count vector and its positive exact path multiplicity."""
+
+    transition_counts: tuple[TransitionUseCount, ...] = Field(
+        max_length=MAX_LABELED_AUTOMATON_TRANSITIONS,
+        description=(
+            "Nonnegative transition uses on the source automaton's transition_id "
+            "axis; the coordinate sum equals the exact path length."
+        ),
+    )
+    multiplicity: CanonicalInteger = Field(
+        max_length=MAX_TRANSITION_PROFILE_COUNT_DIGITS,
+        description="Positive exact number of paths with this transition ledger.",
+    )
+
+    @model_validator(mode="after")
+    def require_positive_multiplicity(self) -> Self:
+        if parse_canonical_integer(self.multiplicity) <= 0:
+            raise ValueError("path multiplicity must be positive")
+        return self
+
+
+class TransitionParikhProfile(StrictModel):
+    """Complete transition-use histogram for one exact endpoint-bound path set."""
+
+    automaton: FiniteLabeledAutomaton
+    source_state: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_STATES - 1)
+    target_state: int = Field(ge=0, le=MAX_LABELED_AUTOMATON_STATES - 1)
+    path_length: int = Field(ge=0, le=MAX_TRANSITION_PROFILE_PATH_LENGTH)
+    entries: tuple[TransitionParikhCell, ...] = Field(
+        max_length=MAX_TRANSITION_PROFILE_ENTRIES,
+        description=(
+            "Complete lexicographically ordered map entries from dense transition "
+            "count vectors to exact path multiplicities."
+        ),
+    )
+    total_path_count: CanonicalInteger = Field(
+        max_length=MAX_TRANSITION_PROFILE_COUNT_DIGITS
+    )
+    complete: Literal[True] = True
+
+    @model_validator(mode="after")
+    def require_source_and_canonical_complete_profile(self) -> Self:
+        if not 0 <= self.source_state < self.automaton.state_count:
+            raise ValueError("source_state must be in 0..state_count-1")
+        if not 0 <= self.target_state < self.automaton.state_count:
+            raise ValueError("target_state must be in 0..state_count-1")
+
+        transition_count = len(self.automaton.transitions)
+        vectors = tuple(entry.transition_counts for entry in self.entries)
+        if vectors != tuple(sorted(set(vectors))):
+            raise ValueError(
+                "profile transition-count vectors must be lexicographically sorted "
+                "and unique"
+            )
+        for vector in vectors:
+            if len(vector) != transition_count:
+                raise ValueError(
+                    "every transition-count vector must use the automaton's complete "
+                    "transition axis"
+                )
+            if sum(vector) != self.path_length:
+                raise ValueError(
+                    "every transition-count vector must sum to path_length"
+                )
+
+        total = sum(
+            parse_canonical_integer(entry.multiplicity) for entry in self.entries
+        )
+        if parse_canonical_integer(self.total_path_count) != total:
+            raise ValueError(
+                "total_path_count must equal the sum of profile multiplicities"
+            )
+
+        if self.path_length == 0:
+            expected_vectors = (
+                (tuple(0 for _ in self.automaton.transitions),)
+                if self.source_state == self.target_state
+                else ()
+            )
+            if vectors != expected_vectors or total != len(expected_vectors):
+                raise ValueError(
+                    "length-zero profile must contain the zero vector once exactly "
+                    "when source_state equals target_state"
+                )
+
+        # Replay the bounded recurrence so a serialized value cannot preserve
+        # local shape invariants while changing its automaton or path scope.
+        from jacobian.math.regular_languages.operations import (
+            _transition_parikh_profile_data,
+        )
+
+        expected_entries, expected_total = _transition_parikh_profile_data(
+            self.automaton,
+            self.source_state,
+            self.target_state,
+            self.path_length,
+        )
+        actual_entries = tuple(
+            (entry.transition_counts, parse_canonical_integer(entry.multiplicity))
+            for entry in self.entries
+        )
+        if actual_entries != expected_entries or total != expected_total:
+            raise ValueError(
+                "transition-Parikh profile is not bound to its automaton and path scope"
+            )
+        return self
+
+
+__all__ = [
+    "DFA",
+    "AutomatonTransition",
+    "DFATransition",
+    "FiniteLabeledAutomaton",
+    "TransitionParikhCell",
+    "TransitionParikhProfile",
+]

--- a/src/jacobian/math/regular_languages/values.py
+++ b/src/jacobian/math/regular_languages/values.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
 from pydantic import Field, model_validator
 
@@ -16,7 +16,9 @@ MAX_DFA_TRANSITIONS = 4096
 MAX_WORD_LENGTH = 1000
 MAX_COUNT_WORD_LENGTH = 200
 
-MAX_LABELED_AUTOMATON_STATES = 64
+# A materialized state axis is cheap relative to the transition/profile data;
+# operation-owned reachable-work bounds decide which path requests are admitted.
+MAX_LABELED_AUTOMATON_STATES = 4_096
 MAX_LABELED_AUTOMATON_ALPHABET = 32
 MAX_LABELED_AUTOMATON_TRANSITIONS = 4096
 # Conservative layer-iteration fallback for the pure-Python recurrence. Derived
@@ -184,7 +186,6 @@ class TransitionParikhProfile(StrictModel):
     total_path_count: CanonicalInteger = Field(
         max_length=MAX_TRANSITION_PROFILE_COUNT_DIGITS
     )
-    complete: Literal[True] = True
 
     @model_validator(mode="after")
     def require_source_and_canonical_complete_profile(self) -> Self:

--- a/tests/math/regular_languages/test_public_api.py
+++ b/tests/math/regular_languages/test_public_api.py
@@ -9,10 +9,16 @@ def test_exact_public_api_symbols() -> None:
     """Exact owner-local contract for the regular_languages public API."""
     expected = (
         "DFA",
+        "AutomatonTransition",
         "DFATransition",
+        "FiniteLabeledAutomaton",
+        "TransitionParikhCell",
+        "TransitionParikhProfile",
         "count_accepted_words",
         "dfa_complement",
         "dfa_run",
+        "dfa_transition_carrier",
+        "transition_parikh_profile",
     )
     assert tuple(regular_languages.__all__) == expected
     assert len(regular_languages.__all__) == len(set(regular_languages.__all__))

--- a/tests/math/regular_languages/test_transition_parikh_profile.py
+++ b/tests/math/regular_languages/test_transition_parikh_profile.py
@@ -23,6 +23,7 @@ from jacobian.math.regular_languages.operations import (
 )
 from jacobian.math.regular_languages.values import (
     DFA,
+    MAX_LABELED_AUTOMATON_STATES,
     MAX_LABELED_AUTOMATON_TRANSITIONS,
     MAX_TRANSITION_PROFILE_PATH_LENGTH,
     AutomatonTransition,
@@ -113,7 +114,6 @@ def test_two_loop_paths_form_a_histogram_not_a_set() -> None:
         }
     )
     assert profile.total_path_count == "4"
-    assert profile.complete is True
 
 
 def test_length_zero_and_empty_transition_conventions_retain_the_carrier() -> None:
@@ -562,32 +562,61 @@ def test_length_bound_keeps_large_degenerate_cases_typed() -> None:
         )
 
 
-def _atlas_carry_product_automaton() -> FiniteLabeledAutomaton:
-    """Atlas's three digit roles crossed with its carry state for one clock state."""
+def _atlas_clock_carry_product_automaton() -> tuple[FiniteLabeledAutomaton, int]:
+    """Atlas's three clock states in each role, crossed with carry."""
 
+    delta = ((0, 0, 1), (0, 0, 2), (0, 0, 0))
     carries = (-1, 0, 1)
+    states = tuple(
+        (*clock_states, carry)
+        for clock_states in product(range(3), repeat=3)
+        for carry in carries
+    )
+    state_index = {state: index for index, state in enumerate(states)}
     rows: list[tuple[int, int, int]] = []
-    for source_state, carry in enumerate(carries):
+    for source_state, (left_state, middle_state, right_state, carry) in enumerate(
+        states
+    ):
         for symbol, (a, b, c) in enumerate(product(range(3), repeat=3)):
             value = a + c - 2 * b + carry
             if value % 3 == 0 and value // 3 in carries:
-                rows.append((source_state, symbol, carries.index(value // 3)))
-    return _automaton(3, 27, tuple(rows))
+                target = (
+                    delta[left_state][a],
+                    delta[middle_state][b],
+                    delta[right_state][c],
+                    value // 3,
+                )
+                rows.append((source_state, symbol, state_index[target]))
+    start = state_index[(0, 0, 0, 0)]
+    return _automaton(len(states), 27, tuple(rows)), start
 
 
-def test_atlas_length_three_carry_product_profile_is_complete() -> None:
+def test_atlas_length_three_clock_cubed_carry_profile_is_complete() -> None:
     # Source: route_enum.py and macro_engine.py at Atlas revision
     # 0394e3d3b249439ffabec7d96a3311aa441651b8. The source script enumerates
-    # this digit-triple/carry product exactly only through length four.
-    automaton = _atlas_carry_product_automaton()
+    # the full clock^3/carry product exactly only through length four.
+    automaton, start = _atlas_clock_carry_product_automaton()
 
-    profile = transition_parikh_profile(automaton, 1, 1, 3)
+    profile = transition_parikh_profile(automaton, start, start, 3)
 
-    assert len(automaton.transitions) == 27
-    assert len(profile.entries) == 195
-    assert profile.total_path_count == "365"
-    assert max(_profile_map(profile).values()) == 6
-    assert _profile_map(profile) == _brute_profile(automaton, 1, 1, 3)
+    assert automaton.state_count == 81
+    assert len(automaton.transitions) == 729
+    assert profile.total_path_count != "0"
+    assert _profile_map(profile) == _brute_profile(automaton, start, start, 3)
+
+
+def test_labeled_automaton_state_materialization_boundary() -> None:
+    FiniteLabeledAutomaton(
+        state_count=MAX_LABELED_AUTOMATON_STATES,
+        alphabet_size=0,
+        transitions=(),
+    )
+    with pytest.raises(ValidationError, match="less than or equal"):
+        FiniteLabeledAutomaton(
+            state_count=MAX_LABELED_AUTOMATON_STATES + 1,
+            alphabet_size=0,
+            transitions=(),
+        )
 
 
 def _clock_automaton(delta: tuple[tuple[int, int, int], ...]) -> FiniteLabeledAutomaton:

--- a/tests/math/regular_languages/test_transition_parikh_profile.py
+++ b/tests/math/regular_languages/test_transition_parikh_profile.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+from itertools import product
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from jacobian.canonical import encode_strict_json, parse_canonical_integer
+from jacobian.math.regular_languages._models import (
+    TransitionParikhProfileRequest,
+)
+from jacobian.math.regular_languages._operations import (
+    compute_transition_parikh_profile,
+)
+from jacobian.math.regular_languages.operations import (
+    _MAX_TRANSITION_PROFILE_RESULT_BYTES,
+    dfa_transition_carrier,
+    transition_parikh_profile,
+)
+from jacobian.math.regular_languages.values import (
+    DFA,
+    MAX_LABELED_AUTOMATON_TRANSITIONS,
+    MAX_TRANSITION_PROFILE_PATH_LENGTH,
+    AutomatonTransition,
+    DFATransition,
+    FiniteLabeledAutomaton,
+    TransitionParikhProfile,
+)
+
+
+def _automaton(
+    state_count: int,
+    alphabet_size: int,
+    rows: tuple[tuple[int, int, int], ...],
+) -> FiniteLabeledAutomaton:
+    return FiniteLabeledAutomaton(
+        state_count=state_count,
+        alphabet_size=alphabet_size,
+        transitions=tuple(
+            AutomatonTransition(
+                transition_id=transition_id,
+                source=source,
+                symbol=symbol,
+                target=target,
+            )
+            for transition_id, (source, symbol, target) in enumerate(rows)
+        ),
+    )
+
+
+def _profile_map(profile: TransitionParikhProfile) -> Counter[tuple[int, ...]]:
+    return Counter(
+        {
+            entry.transition_counts: parse_canonical_integer(entry.multiplicity)
+            for entry in profile.entries
+        }
+    )
+
+
+def _path_id_sequences(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> tuple[tuple[int, ...], ...]:
+    layer = ((source_state, ()),)
+    for _ in range(path_length):
+        layer = tuple(
+            (transition.target, (*path, transition.transition_id))
+            for state, path in layer
+            for transition in automaton.transitions
+            if transition.source == state
+        )
+    return tuple(path for state, path in layer if state == target_state)
+
+
+def _brute_profile(
+    automaton: FiniteLabeledAutomaton,
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> Counter[tuple[int, ...]]:
+    histogram: Counter[tuple[int, ...]] = Counter()
+    for path in _path_id_sequences(automaton, source_state, target_state, path_length):
+        counts = [0] * len(automaton.transitions)
+        for transition_id in path:
+            counts[transition_id] += 1
+        histogram[tuple(counts)] += 1
+    return histogram
+
+
+def test_two_loop_paths_form_a_histogram_not_a_set() -> None:
+    automaton = _automaton(
+        1,
+        2,
+        (
+            (0, 0, 0),
+            (0, 1, 0),
+        ),
+    )
+
+    profile = transition_parikh_profile(automaton, 0, 0, 2)
+
+    assert _profile_map(profile) == Counter(
+        {
+            (0, 2): 1,
+            (1, 1): 2,
+            (2, 0): 1,
+        }
+    )
+    assert profile.total_path_count == "4"
+    assert profile.complete is True
+
+
+def test_length_zero_and_empty_transition_conventions_retain_the_carrier() -> None:
+    automaton = _automaton(2, 0, ())
+
+    identity = transition_parikh_profile(automaton, 0, 0, 0)
+    distinct = transition_parikh_profile(automaton, 0, 1, 0)
+    positive_length = transition_parikh_profile(automaton, 0, 0, 1)
+
+    assert identity.automaton == automaton
+    assert _profile_map(identity) == Counter({(): 1})
+    assert identity.total_path_count == "1"
+    assert distinct.entries == ()
+    assert distinct.total_path_count == "0"
+    assert positive_length.entries == ()
+    assert positive_length.total_path_count == "0"
+
+
+def test_profile_multiplicities_sum_to_independent_state_path_count() -> None:
+    automaton = _automaton(
+        3,
+        2,
+        (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 1, 2),
+            (2, 0, 2),
+        ),
+    )
+    path_length = 5
+    state_counts = [0] * automaton.state_count
+    state_counts[0] = 1
+    for _ in range(path_length):
+        next_counts = [0] * automaton.state_count
+        for transition in automaton.transitions:
+            next_counts[transition.target] += state_counts[transition.source]
+        state_counts = next_counts
+
+    profile = transition_parikh_profile(automaton, 0, 2, path_length)
+
+    assert sum(_profile_map(profile).values()) == state_counts[2]
+    assert parse_canonical_integer(profile.total_path_count) == state_counts[2]
+
+
+def test_profile_satisfies_the_transition_recurrence() -> None:
+    automaton = _automaton(
+        2,
+        2,
+        (
+            (0, 0, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 1, 1),
+        ),
+    )
+    path_length = 4
+    expected: Counter[tuple[int, ...]] = Counter()
+    for transition in automaton.transitions:
+        if transition.target != 1:
+            continue
+        prefix = transition_parikh_profile(
+            automaton, 0, transition.source, path_length - 1
+        )
+        for vector, multiplicity in _profile_map(prefix).items():
+            extended = list(vector)
+            extended[transition.transition_id] += 1
+            expected[tuple(extended)] += multiplicity
+
+    assert _profile_map(transition_parikh_profile(automaton, 0, 1, path_length)) == (
+        expected
+    )
+
+
+def test_transition_counts_project_to_symbol_parikh_counts() -> None:
+    automaton = _automaton(
+        2,
+        2,
+        (
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 1, 1),
+        ),
+    )
+    profile = transition_parikh_profile(automaton, 0, 1, 3)
+    projected: Counter[tuple[int, ...]] = Counter()
+    for vector, multiplicity in _profile_map(profile).items():
+        symbol_counts = tuple(
+            sum(
+                vector[transition.transition_id]
+                for transition in automaton.transitions
+                if transition.symbol == symbol
+            )
+            for symbol in range(automaton.alphabet_size)
+        )
+        projected[symbol_counts] += multiplicity
+
+    brute: Counter[tuple[int, ...]] = Counter()
+    for path in _path_id_sequences(automaton, 0, 1, 3):
+        symbols = [
+            automaton.transitions[transition_id].symbol for transition_id in path
+        ]
+        brute[tuple(symbols.count(symbol) for symbol in range(2))] += 1
+
+    assert projected == brute
+
+
+def test_state_relabeling_transports_the_profile_without_changing_its_axis() -> None:
+    automaton = _automaton(
+        3,
+        2,
+        (
+            (0, 0, 1),
+            (0, 1, 2),
+            (1, 0, 2),
+            (2, 1, 0),
+        ),
+    )
+    relabel = (2, 0, 1)
+    transported = _automaton(
+        3,
+        2,
+        tuple(
+            (relabel[transition.source], transition.symbol, relabel[transition.target])
+            for transition in automaton.transitions
+        ),
+    )
+
+    original_profile = transition_parikh_profile(automaton, 0, 2, 4)
+    transported_profile = transition_parikh_profile(
+        transported, relabel[0], relabel[2], 4
+    )
+
+    assert original_profile.entries == transported_profile.entries
+    assert original_profile.total_path_count == transported_profile.total_path_count
+
+
+def test_transition_relabeling_permutes_profile_coordinates_canonically() -> None:
+    automaton = _automaton(
+        2,
+        2,
+        (
+            (0, 0, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 1, 1),
+        ),
+    )
+    permutation = (2, 0, 3, 1)
+    relabeled = _automaton(
+        automaton.state_count,
+        automaton.alphabet_size,
+        tuple(
+            (
+                automaton.transitions[old_id].source,
+                automaton.transitions[old_id].symbol,
+                automaton.transitions[old_id].target,
+            )
+            for old_id in permutation
+        ),
+    )
+
+    original = _profile_map(transition_parikh_profile(automaton, 0, 1, 4))
+    transported = _profile_map(transition_parikh_profile(relabeled, 0, 1, 4))
+
+    assert transported == Counter(
+        {
+            tuple(vector[old_id] for old_id in permutation): multiplicity
+            for vector, multiplicity in original.items()
+        }
+    )
+
+
+def test_dfa_projection_supplies_the_canonical_carrier_unchanged() -> None:
+    dfa = DFA(
+        state_count=2,
+        alphabet_size=2,
+        transitions=(
+            DFATransition(source=1, symbol=1, target=1),
+            DFATransition(source=0, symbol=1, target=1),
+            DFATransition(source=1, symbol=0, target=0),
+            DFATransition(source=0, symbol=0, target=0),
+        ),
+        initial_state=0,
+        accepting_states=(1,),
+    )
+
+    carrier = dfa_transition_carrier(dfa)
+    profile = transition_parikh_profile(carrier, 0, 1, 2)
+
+    assert tuple(
+        (transition.transition_id, transition.source, transition.symbol)
+        for transition in carrier.transitions
+    ) == ((0, 0, 0), (1, 0, 1), (2, 1, 0), (3, 1, 1))
+    assert profile.automaton == carrier
+
+
+@pytest.mark.property
+@settings(max_examples=80, deadline=None)
+@given(
+    rows=st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=2),
+            st.integers(min_value=0, max_value=1),
+            st.integers(min_value=0, max_value=2),
+        ),
+        max_size=4,
+    ),
+    source_state=st.integers(min_value=0, max_value=2),
+    target_state=st.integers(min_value=0, max_value=2),
+    path_length=st.integers(min_value=0, max_value=4),
+)
+def test_sparse_dp_matches_bounded_brute_force(
+    rows: list[tuple[int, int, int]],
+    source_state: int,
+    target_state: int,
+    path_length: int,
+) -> None:
+    automaton = _automaton(3, 2, tuple(rows))
+
+    profile = transition_parikh_profile(
+        automaton, source_state, target_state, path_length
+    )
+
+    assert _profile_map(profile) == _brute_profile(
+        automaton, source_state, target_state, path_length
+    )
+
+
+def test_wire_result_rejects_source_and_conclusion_forgeries() -> None:
+    automaton = _automaton(
+        2,
+        2,
+        (
+            (0, 0, 0),
+            (0, 1, 1),
+            (1, 0, 1),
+        ),
+    )
+    result = compute_transition_parikh_profile(
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=1,
+            path_length=1,
+        )
+    )
+    payload = result.model_dump(mode="json")
+    forgeries: list[dict[str, object]] = []
+
+    wrong_vector = deepcopy(payload)
+    wrong_vector["entries"][0]["transition_counts"] = [1, 0, 0]  # type: ignore[index]
+    forgeries.append(wrong_vector)
+
+    wrong_multiplicity = deepcopy(payload)
+    wrong_multiplicity["entries"][0]["multiplicity"] = "2"  # type: ignore[index]
+    wrong_multiplicity["total_path_count"] = "2"
+    forgeries.append(wrong_multiplicity)
+
+    wrong_source = deepcopy(payload)
+    wrong_source["source_state"] = 1
+    forgeries.append(wrong_source)
+
+    wrong_target = deepcopy(payload)
+    wrong_target["target_state"] = 0
+    forgeries.append(wrong_target)
+
+    wrong_length = deepcopy(payload)
+    wrong_length["path_length"] = 2
+    forgeries.append(wrong_length)
+
+    wrong_transition = deepcopy(payload)
+    wrong_transition["automaton"]["transitions"][1]["target"] = 0  # type: ignore[index]
+    forgeries.append(wrong_transition)
+
+    for forged in forgeries:
+        with pytest.raises(ValidationError):
+            TransitionParikhProfile.model_validate(forged)
+
+
+def test_transition_axis_requires_contiguous_stable_identifiers() -> None:
+    with pytest.raises(ValidationError, match="contiguous zero-based axis"):
+        FiniteLabeledAutomaton(
+            state_count=1,
+            alphabet_size=1,
+            transitions=(
+                AutomatonTransition(
+                    transition_id=1,
+                    source=0,
+                    symbol=0,
+                    target=0,
+                ),
+            ),
+        )
+
+    parallel = _automaton(1, 1, ((0, 0, 0), (0, 0, 0)))
+    assert _profile_map(transition_parikh_profile(parallel, 0, 0, 1)) == Counter(
+        {(0, 1): 1, (1, 0): 1}
+    )
+
+
+def test_request_rejects_out_of_range_endpoint_before_execution() -> None:
+    with pytest.raises(ValidationError, match="source_state"):
+        TransitionParikhProfileRequest(
+            automaton=_automaton(1, 0, ()),
+            source_state=1,
+            target_state=0,
+            path_length=0,
+        )
+
+
+def _loop_automaton(
+    transition_count: int, *, state_count: int = 1
+) -> FiniteLabeledAutomaton:
+    return _automaton(
+        state_count,
+        1,
+        tuple((0, 0, 0) for _ in range(transition_count)),
+    )
+
+
+def test_request_rejects_excessive_dp_work_even_when_target_is_unreachable() -> None:
+    automaton = _loop_automaton(3, state_count=2)
+    TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=157,
+    )
+    with pytest.raises(ValidationError, match="DP transition-update bound"):
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=1,
+            path_length=158,
+        )
+
+
+def test_request_preflight_scans_only_reachable_outgoing_transitions() -> None:
+    transition_count = MAX_LABELED_AUTOMATON_TRANSITIONS
+    automaton = _automaton(
+        2,
+        1,
+        ((0, 0, 0), *((1, 0, 1) for _ in range(transition_count - 1))),
+    )
+
+    TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=0,
+        path_length=1_000,
+    )
+
+
+def test_request_rejects_excessive_dense_vector_update_work() -> None:
+    automaton = _loop_automaton(11, state_count=2)
+    TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=9,
+    )
+    with pytest.raises(ValidationError, match="dense-vector update-work bound"):
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=1,
+            path_length=10,
+        )
+
+
+def test_request_rejects_excessive_profile_cell_count() -> None:
+    automaton = _loop_automaton(9)
+    TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=0,
+        path_length=9,
+    )
+    with pytest.raises(ValidationError, match="profile-cell bound"):
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=0,
+            path_length=10,
+        )
+
+
+def test_request_rejects_excessive_intermediate_vector_coordinates() -> None:
+    automaton = _loop_automaton(159, state_count=2)
+    with pytest.raises(ValidationError, match="intermediate vector-coordinate bound"):
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=1,
+            path_length=2,
+        )
+    TransitionParikhProfileRequest(
+        automaton=_loop_automaton(158, state_count=2),
+        source_state=0,
+        target_state=1,
+        path_length=2,
+    )
+
+
+def test_request_rejects_excessive_serialized_result() -> None:
+    accepted = TransitionParikhProfileRequest(
+        automaton=_loop_automaton(129),
+        source_state=0,
+        target_state=0,
+        path_length=2,
+    )
+    encoded = encode_strict_json(
+        compute_transition_parikh_profile(accepted).model_dump(mode="json")
+    )
+    assert len(encoded) <= _MAX_TRANSITION_PROFILE_RESULT_BYTES
+
+    with pytest.raises(ValidationError, match="serialized-result bound"):
+        TransitionParikhProfileRequest(
+            automaton=_loop_automaton(130),
+            source_state=0,
+            target_state=0,
+            path_length=2,
+        )
+
+
+def test_length_bound_keeps_large_degenerate_cases_typed() -> None:
+    automaton = _automaton(2, 0, ())
+    request = TransitionParikhProfileRequest(
+        automaton=automaton,
+        source_state=0,
+        target_state=1,
+        path_length=MAX_TRANSITION_PROFILE_PATH_LENGTH,
+    )
+    assert compute_transition_parikh_profile(request).entries == ()
+
+    with pytest.raises(ValidationError, match="less than or equal"):
+        TransitionParikhProfileRequest(
+            automaton=automaton,
+            source_state=0,
+            target_state=1,
+            path_length=MAX_TRANSITION_PROFILE_PATH_LENGTH + 1,
+        )
+
+
+def _atlas_carry_product_automaton() -> FiniteLabeledAutomaton:
+    """Atlas's three digit roles crossed with its carry state for one clock state."""
+
+    carries = (-1, 0, 1)
+    rows: list[tuple[int, int, int]] = []
+    for source_state, carry in enumerate(carries):
+        for symbol, (a, b, c) in enumerate(product(range(3), repeat=3)):
+            value = a + c - 2 * b + carry
+            if value % 3 == 0 and value // 3 in carries:
+                rows.append((source_state, symbol, carries.index(value // 3)))
+    return _automaton(3, 27, tuple(rows))
+
+
+def test_atlas_length_three_carry_product_profile_is_complete() -> None:
+    # Source: route_enum.py and macro_engine.py at Atlas revision
+    # 0394e3d3b249439ffabec7d96a3311aa441651b8. The source script enumerates
+    # this digit-triple/carry product exactly only through length four.
+    automaton = _atlas_carry_product_automaton()
+
+    profile = transition_parikh_profile(automaton, 1, 1, 3)
+
+    assert len(automaton.transitions) == 27
+    assert len(profile.entries) == 195
+    assert profile.total_path_count == "365"
+    assert max(_profile_map(profile).values()) == 6
+    assert _profile_map(profile) == _brute_profile(automaton, 1, 1, 3)
+
+
+def _clock_automaton(delta: tuple[tuple[int, int, int], ...]) -> FiniteLabeledAutomaton:
+    return _automaton(
+        3,
+        3,
+        tuple(
+            (state, symbol, delta[state][symbol])
+            for state in range(3)
+            for symbol in range(3)
+        ),
+    )
+
+
+def _states_reachable_through_length_three(
+    automaton: FiniteLabeledAutomaton,
+) -> set[int]:
+    return {
+        target
+        for target in range(automaton.state_count)
+        for length in range(4)
+        if transition_parikh_profile(automaton, 0, target, length).total_path_count
+        != "0"
+    }
+
+
+def test_atlas_nine_port_clock_is_unreachable_while_seven_port_clock_is_reachable() -> (
+    None
+):
+    # PORT_CAPACITY_S3.json at the pinned Atlas revision records maxima 9 over
+    # all ternary clocks and 7 after requiring every state reachable by L=3.
+    nine_port_clock = _clock_automaton(((0, 0, 0), (0, 0, 0), (0, 0, 0)))
+    seven_port_clock = _clock_automaton(((0, 0, 1), (0, 0, 2), (0, 0, 0)))
+
+    assert (
+        sum(transition.target == 0 for transition in nine_port_clock.transitions) == 9
+    )
+    assert _states_reachable_through_length_three(nine_port_clock) == {0}
+    assert (
+        sum(transition.target == 0 for transition in seven_port_clock.transitions) == 7
+    )
+    assert _states_reachable_through_length_three(seven_port_clock) == {0, 1, 2}


### PR DESCRIPTION
## Problem

Closes #2301.

The existing regular-language operations can count fixed-length words, but a scalar count loses how often each identified transition is used. Word-level Parikh vectors also merge distinct transitions that carry the same symbol. That leaves callers unable to transport the exact transition ledger needed by downstream optimization, and the motivating Atlas script falls back to sampling beyond its small exact range.

## Solution

Add `automaton.path.transition_parikh_profile.compute`. For one finite labeled automaton, source, target, and exact length, it returns the complete lexicographically ordered histogram

```text
transition-count vector -> exact path multiplicity
```

The new canonical `FiniteLabeledAutomaton` gives every edge a stable coordinate, including parallel edges. The result retains that carrier and the complete path scope, and its model validator replays the bounded recurrence so a serialized result cannot change a transition, endpoint, length, vector, or multiplicity while preserving only local shape checks. A native `transition_parikh_profile` function and deterministic DFA-to-carrier projection expose the same mathematical values without transport-specific types.

Admission combines two independent bounds: reachable path-extension counting on the supplied carrier and a stars-and-bars bound on possible transition-count vectors. Their sharper bound controls sparse-DP updates, dense-vector work, peak live coordinates, profile cells, multiplicity digits, and projected wire bytes before expansion. Accepted requests always return the complete profile; requests outside that envelope reject rather than sample.

No dependency is added. The kernel is the defining sparse recurrence over exact integers, keyed by `(state, transition-count vector)`. Existing DFA backends do not own the required stable parallel-edge axis or source-bound transition histogram, so an adapter would add machinery without replacing the bounded mathematical kernel.

## Testing

- `make test-math TESTS=tests/math/regular_languages` — 43 passed
- `uv run --locked pytest -q tests/integration/catalog/test_public_operation_contract_conformance.py` — 484 passed
- `make check` — Ruff, formatting, mypy over 764 source files, and 2,671 tests passed

The owner lane includes brute-force and property comparisons, recurrence and projection invariants, source/result mutation rejection, and boundary cases for every derived budget. The pinned Atlas fixture exercises the actual `clock^3 × carry` carrier: 81 states, 729 identified transitions, 141 result cells, and a 253,124-byte exact result.

## Public contract impact

Adds the public operation `automaton.path.transition_parikh_profile.compute`, its request/result schemas, the canonical `FiniteLabeledAutomaton`, `AutomatonTransition`, `TransitionParikhCell`, and `TransitionParikhProfile` values, plus native `transition_parikh_profile` and `dfa_transition_carrier` functions.

The operation has exact-only semantics. Its result is the complete endpoint-bound profile for every accepted request; there is no partial or unknown result shape.

## Public operation admission

- Concrete gap: fixed-length path counts and word Parikh data do not retain the complete distribution on identified transitions.
- Why existing operations or typed values are insufficient: `regular_language.count.compute` returns one scalar, while `DFA` cannot represent partial, nondeterministic, or parallel identified transitions as a reusable coordinate carrier.
- Stable mathematical result: the complete exact map from dense transition-use vectors to positive path multiplicities for one source, target, and exact path length.
- Semantic domain and admitted execution envelope: finite partial or nondeterministic labeled automata with a contiguous transition-ID axis; requests are admitted only when complete recurrence work, intermediates, integer digits, and output fit the declared envelope.
- Controlling work, intermediate, memory, and output quantities: reachable path extensions, composition-cell bounds, sparse DP updates, transition-vector update work, peak live vector coordinates, target profile cells, multiplicity digits, and projected canonical-wire bytes.
- Exact representation, algorithm regimes, and maintained backend: dense nonnegative transition vectors and canonical integer multiplicities, computed by one bounded sparse exact recurrence. Reachability-sensitive and composition-sensitive preflights use whichever proof gives the sharper safe bound. No external backend is needed for this direct finite recurrence.
- Remaining fixed caps and their classification: 4,096 states and transitions and 32 symbols are conservative carrier-materialization bounds; length 1,000,000 is a pure-Python layer fallback. Separate operational limits cap two million DP updates, twenty million vector-coordinate updates, four million live vector coordinates, 43,000 result cells, 32,768 count digits, and a four MiB projected result. Derived work and result bounds normally decide admission before the coarse fallbacks.
- Admission decision: `KEEP` in the regular-language owner.

## Closure matrix

None. This PR admits one operation. Caller-defined transition weights, optimization, sampling, witnesses, and asymptotic analysis remain outside its postcondition.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (catalog conformance and the regular-language owner lane)
- [x] Harbor task or verifier changes ran the required validation (not applicable; no Harbor files changed)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable (exact-only; out-of-envelope requests reject)
- [x] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; the new canonical carrier is shared by the native operation and DFA projection without replacing an existing duplicate)
