### PR TITLE
feat(graphs): count induced vertex-subset graph patterns exactly

### DIFF
--- a/src/jacobian/math/graphs/patterns/__init__.py
+++ b/src/jacobian/math/graphs/patterns/__init__.py
@@ -1,0 +1,3 @@
+"""Induced graph-pattern count operation ownership."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/graphs/patterns/_admission.py
+++ b/src/jacobian/math/graphs/patterns/_admission.py
@@ -1,0 +1,18 @@
+"""Owner-local admission for induced graph-pattern counts."""
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.graphs.patterns._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "graph.induced_vertex_subset_pattern.count",
+        AdmissionDecision.KEEP,
+        "distinct exact source-bound count of induced vertex subsets; it is not recoverable from one ordinary embedding without complete automorphism quotienting and search bookkeeping",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/graphs/patterns/_models.py
+++ b/src/jacobian/math/graphs/patterns/_models.py
@@ -23,7 +23,7 @@ from jacobian.math.graphs.values import SimpleUndirectedGraph
 # either graph.
 COUNT_AND_VALIDATION_PASSES = 2
 
-# The subset count separately bounds induced-subgraph view construction. The
+# The subset count separately bounds explicit candidate construction. The
 # total work budget below additionally charges exact isomorphism search. These
 # are conservative limits for the current pure-Python NetworkX envelope, not
 # restrictions on the mathematical definition; widening requires sharper
@@ -55,12 +55,14 @@ def _partial_injection_state_bound(order: int) -> int:
 def _per_candidate_work(pattern_order: int) -> int:
     if pattern_order == 0:
         return 0
-    # Creating the subset tuple and graph view visits every chosen vertex.
-    # NetworkX's edge-count and degree filters can each scan both directions
-    # of every possible induced edge, and sorting the degrees is bounded by a
-    # quadratic comparison budget.
-    subset_and_view_construction = pattern_order
-    induced_edge_and_degree_checks = 4 * max(1, comb(pattern_order, 2))
+    # Creating the subset tuple and the explicit local graph each visits every
+    # selected vertex. Every possible local edge incurs one O(1) host-edge
+    # probe and, in the dense case, one O(1) insertion in the candidate graph.
+    subset_and_vertex_construction = 2 * pattern_order
+    pair_probes_and_edge_insertions = 2 * max(1, comb(pattern_order, 2))
+    # Edge-count and degree iteration visit the local vertices, while sorting
+    # the degree sequence is conservatively bounded by order^2 comparisons.
+    local_edge_and_degree_checks = 2 * pattern_order
     degree_sort_checks = max(1, pattern_order * pattern_order)
     # VF2++ explores a subset of the partial injective maps. Candidate
     # generation and feasibility inspect at most order^2 adjacency relations
@@ -69,8 +71,9 @@ def _per_candidate_work(pattern_order: int) -> int:
         1, pattern_order * pattern_order
     )
     return (
-        subset_and_view_construction
-        + induced_edge_and_degree_checks
+        subset_and_vertex_construction
+        + pair_probes_and_edge_insertions
+        + local_edge_and_degree_checks
         + degree_sort_checks
         + isomorphism_checks
     )
@@ -155,8 +158,8 @@ def _require_bounded_request(
         raise ValueError(
             f"induced-pattern exact count requires {total_work:,} work units, "
             f"exceeding the {MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,}-unit bound "
-            "for graph construction, induced-edge comparison, VF2++ search, "
-            "and result-validation replay"
+            "for graph construction, direct host-edge probes, explicit candidate "
+            "scans, VF2++ search, and result-validation replay"
         )
 
 
@@ -171,10 +174,11 @@ class InducedVertexSubsetPatternCountRequest(StrictModel):
                 "SimpleUndirectedGraph bounds (at most 256 vertices and 32,640 "
                 "edges). Admission preflights the exact candidate count "
                 "C(|V(host)|, |V(pattern)|), encoded request and retained-result "
-                "bytes, graph records, induced-view construction and adjacency "
-                "scans, and a worst-case VF2++ partial-injection state bound for "
-                "every subset. It permits at most 5,000 subsets per pass and "
-                "64,000,000 total work units across both counting and source-bound "
+                "bytes, graph records, explicit candidate construction from "
+                "C(|V(pattern)|, 2) direct host-edge probes per subset, local "
+                "candidate scans, and a worst-case VF2++ partial-injection state "
+                "bound for every subset. It permits at most 5,000 subsets per pass "
+                "and 64,000,000 total work units across both counting and source-bound "
                 "result-validation passes. The retained result must fit the "
                 "10,485,760-byte canonical output bound. These are conservative "
                 "current-backend limits, not restrictions on the mathematical "

--- a/src/jacobian/math/graphs/patterns/_models.py
+++ b/src/jacobian/math/graphs/patterns/_models.py
@@ -1,0 +1,244 @@
+"""Typed contracts and admission for induced vertex-subset pattern counts."""
+
+from __future__ import annotations
+
+from math import comb
+from typing import Self
+
+from pydantic import ConfigDict, Field, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.canonical import (
+    CanonicalizationError,
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+# One accepted request performs the exact count once and the source-bound result
+# validator replays it once.  Admission charges both passes before NetworkX sees
+# either graph.
+COUNT_AND_VALIDATION_PASSES = 2
+
+# The subset count separately bounds induced-subgraph view construction. The
+# total work budget below additionally charges exact isomorphism search. These
+# are conservative limits for the current pure-Python NetworkX envelope, not
+# restrictions on the mathematical definition; widening requires sharper
+# backend-specific search bounds and representative boundary measurements.
+MAX_INDUCED_PATTERN_SUBSETS_PER_PASS = 5_000
+MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS = 64_000_000
+
+# Every returned count is at most the admitted number of candidate subsets.
+MAX_INDUCED_PATTERN_COUNT_DIGITS = len(
+    format_canonical_integer(MAX_INDUCED_PATTERN_SUBSETS_PER_PASS)
+)
+
+
+def _candidate_subset_count(host_order: int, pattern_order: int) -> int:
+    return 0 if pattern_order > host_order else comb(host_order, pattern_order)
+
+
+def _partial_injection_state_bound(order: int) -> int:
+    """Bound every partial bijection state an exact isomorphism search can visit."""
+
+    states = 1
+    falling_factorial = 1
+    for depth in range(1, order + 1):
+        falling_factorial *= order - depth + 1
+        states += falling_factorial
+    return states
+
+
+def _per_candidate_work(pattern_order: int) -> int:
+    if pattern_order == 0:
+        return 0
+    # Creating the subset tuple and graph view visits every chosen vertex.
+    # NetworkX's edge-count and degree filters can each scan both directions
+    # of every possible induced edge, and sorting the degrees is bounded by a
+    # quadratic comparison budget.
+    subset_and_view_construction = pattern_order
+    induced_edge_and_degree_checks = 4 * max(1, comb(pattern_order, 2))
+    degree_sort_checks = max(1, pattern_order * pattern_order)
+    # VF2++ explores a subset of the partial injective maps. Candidate
+    # generation and feasibility inspect at most order^2 adjacency relations
+    # at each such state, including its preprocessing and degree checks.
+    isomorphism_checks = _partial_injection_state_bound(pattern_order) * max(
+        1, pattern_order * pattern_order
+    )
+    return (
+        subset_and_view_construction
+        + induced_edge_and_degree_checks
+        + degree_sort_checks
+        + isomorphism_checks
+    )
+
+
+def _encode_with_bound(
+    payload: object,
+    *,
+    limit: int,
+    error: str,
+) -> int:
+    try:
+        encoded = encode_strict_json(
+            payload,
+            limits=CanonicalLimits(max_output_bytes=limit),
+        )
+    except CanonicalizationError as exc:
+        raise ValueError(error) from exc
+    return len(encoded)
+
+
+def _require_bounded_request(
+    host: SimpleUndirectedGraph,
+    pattern: SimpleUndirectedGraph,
+) -> None:
+    limits = CanonicalLimits()
+    host_payload = host.model_dump(mode="json")
+    pattern_payload = pattern.model_dump(mode="json")
+    source_payload = {
+        "host": host_payload,
+        "pattern": pattern_payload,
+    }
+    source_bytes = _encode_with_bound(
+        source_payload,
+        limit=limits.max_input_bytes,
+        error=(
+            "host and pattern exceed the canonical "
+            f"{limits.max_input_bytes}-byte input bound"
+        ),
+    )
+
+    host_order = len(host.vertices)
+    pattern_order = len(pattern.vertices)
+    candidate_count = _candidate_subset_count(host_order, pattern_order)
+    if candidate_count > MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:
+        raise ValueError(
+            f"induced-pattern subset count {candidate_count:,} exceeds the "
+            f"{MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,}-candidate per-pass bound "
+            f"({COUNT_AND_VALIDATION_PASSES * MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,} "
+            "including result-validation replay)"
+        )
+
+    maximum_count = format_canonical_integer(candidate_count)
+    result_payload = {
+        "host": host_payload,
+        "pattern": pattern_payload,
+        "occurrence_count": maximum_count,
+    }
+    result_bytes = _encode_with_bound(
+        result_payload,
+        limit=limits.max_output_bytes,
+        error=(
+            "the induced-pattern count result retains host and pattern and exceeds "
+            f"the canonical {limits.max_output_bytes}-byte output bound"
+        ),
+    )
+
+    graph_records = (
+        len(host.vertices)
+        + len(host.edges)
+        + len(pattern.vertices)
+        + len(pattern.edges)
+    )
+    total_work = COUNT_AND_VALIDATION_PASSES * (
+        source_bytes
+        + result_bytes
+        + graph_records
+        + max(1, pattern_order * pattern_order)
+        + candidate_count * _per_candidate_work(pattern_order)
+    )
+    if total_work > MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:
+        raise ValueError(
+            f"induced-pattern exact count requires {total_work:,} work units, "
+            f"exceeding the {MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,}-unit bound "
+            "for graph construction, induced-edge comparison, VF2++ search, "
+            "and result-validation replay"
+        )
+
+
+class InducedVertexSubsetPatternCountRequest(StrictModel):
+    """Count vertex subsets whose induced graph is isomorphic to a pattern."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Count vertex subsets S of the canonical host for which host[S] "
+                "is isomorphic to the canonical pattern. Graphs use the shared "
+                "SimpleUndirectedGraph bounds (at most 256 vertices and 32,640 "
+                "edges). Admission preflights the exact candidate count "
+                "C(|V(host)|, |V(pattern)|), encoded request and retained-result "
+                "bytes, graph records, induced-view construction and adjacency "
+                "scans, and a worst-case VF2++ partial-injection state bound for "
+                "every subset. It permits at most 5,000 subsets per pass and "
+                "64,000,000 total work units across both counting and source-bound "
+                "result-validation passes. The retained result must fit the "
+                "10,485,760-byte canonical output bound. These are conservative "
+                "current-backend limits, not restrictions on the mathematical "
+                "definition."
+            )
+        }
+    )
+
+    host: SimpleUndirectedGraph = Field(
+        description=(
+            "Canonical finite simple undirected host graph; vertex labels are "
+            "transport and do not constrain isomorphism. Output from "
+            "explicit_graph or compose_graphs is accepted unchanged."
+        )
+    )
+    pattern: SimpleUndirectedGraph = Field(
+        description=(
+            "Canonical finite simple undirected pattern graph. An empty pattern "
+            "has one occurrence; a pattern larger than the host has zero. Output "
+            "from explicit_graph or compose_graphs is accepted unchanged."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_complete_exact_count_bounded(self) -> Self:
+        _require_bounded_request(self.host, self.pattern)
+        return self
+
+
+class InducedVertexSubsetPatternCountResult(StrictModel):
+    """Exact induced-pattern subset count bound to both source graphs."""
+
+    host: SimpleUndirectedGraph
+    pattern: SimpleUndirectedGraph
+    occurrence_count: CanonicalInteger = Field(
+        min_length=1,
+        max_length=MAX_INDUCED_PATTERN_COUNT_DIGITS,
+        description=(
+            "Canonical nonnegative decimal count of host vertex subsets inducing "
+            "a graph isomorphic to pattern; subsets, not labelled maps, are counted."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def bind_count_to_retained_sources(self) -> Self:
+        _require_bounded_request(self.host, self.pattern)
+        claimed = parse_canonical_integer(self.occurrence_count)
+        if claimed < 0:
+            raise ValueError("occurrence_count must be nonnegative")
+
+        from jacobian.math.graphs.patterns._operations import (
+            count_induced_vertex_subset_patterns,
+        )
+
+        expected = count_induced_vertex_subset_patterns(self.host, self.pattern)
+        if claimed != expected:
+            raise ValueError(
+                "occurrence_count does not equal the number of retained host "
+                "vertex subsets inducing the retained pattern"
+            )
+        return self
+
+
+__all__ = [
+    "InducedVertexSubsetPatternCountRequest",
+    "InducedVertexSubsetPatternCountResult",
+]

--- a/src/jacobian/math/graphs/patterns/_operations.py
+++ b/src/jacobian/math/graphs/patterns/_operations.py
@@ -1,0 +1,73 @@
+"""Exact induced vertex-subset counting with the pinned NetworkX 3.6.1 backend."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+import networkx as nx
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.graphs.patterns._models import (
+    InducedVertexSubsetPatternCountRequest,
+    InducedVertexSubsetPatternCountResult,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _integer_graph(value: SimpleUndirectedGraph) -> nx.Graph[int]:
+    """Convert canonical labels once so enumeration work uses bounded integers."""
+
+    indices = {vertex: index for index, vertex in enumerate(value.vertices)}
+    graph: nx.Graph[int] = nx.Graph()
+    graph.add_nodes_from(range(len(value.vertices)))
+    graph.add_edges_from((indices[left], indices[right]) for left, right in value.edges)
+    return graph
+
+
+def count_induced_vertex_subset_patterns(
+    host: SimpleUndirectedGraph,
+    pattern: SimpleUndirectedGraph,
+) -> int:
+    """Return the exact number of host vertex subsets inducing ``pattern``."""
+
+    host_order = len(host.vertices)
+    pattern_order = len(pattern.vertices)
+    if pattern_order > host_order:
+        return 0
+    if pattern_order == 0:
+        return 1
+
+    host_graph = _integer_graph(host)
+    pattern_graph = _integer_graph(pattern)
+    pattern_edge_count = pattern_graph.number_of_edges()
+    pattern_degrees = tuple(sorted(degree for _, degree in pattern_graph.degree()))
+
+    occurrence_count = 0
+    for subset in combinations(range(host_order), pattern_order):
+        induced = host_graph.subgraph(subset)
+        if induced.number_of_edges() != pattern_edge_count:
+            continue
+        if tuple(sorted(degree for _, degree in induced.degree())) != pattern_degrees:
+            continue
+        if nx.vf2pp_is_isomorphic(induced, pattern_graph):
+            occurrence_count += 1
+    return occurrence_count
+
+
+def compute_induced_vertex_subset_pattern_count(
+    request: InducedVertexSubsetPatternCountRequest,
+) -> InducedVertexSubsetPatternCountResult:
+    """Count induced pattern occurrences once per host vertex subset."""
+
+    occurrence_count = count_induced_vertex_subset_patterns(
+        request.host,
+        request.pattern,
+    )
+    return InducedVertexSubsetPatternCountResult(
+        host=request.host,
+        pattern=request.pattern,
+        occurrence_count=format_canonical_integer(occurrence_count),
+    )
+
+
+__all__ = ["compute_induced_vertex_subset_pattern_count"]

--- a/src/jacobian/math/graphs/patterns/_operations.py
+++ b/src/jacobian/math/graphs/patterns/_operations.py
@@ -24,6 +24,22 @@ def _integer_graph(value: SimpleUndirectedGraph) -> nx.Graph[int]:
     return graph
 
 
+def _explicit_induced_candidate(
+    host: nx.Graph[int],
+    subset: tuple[int, ...],
+) -> nx.Graph[int]:
+    """Materialize one induced candidate with work depending only on its order."""
+
+    candidate: nx.Graph[int] = nx.Graph()
+    candidate.add_nodes_from(range(len(subset)))
+    candidate.add_edges_from(
+        (left_index, right_index)
+        for left_index, right_index in combinations(range(len(subset)), 2)
+        if host.has_edge(subset[left_index], subset[right_index])
+    )
+    return candidate
+
+
 def count_induced_vertex_subset_patterns(
     host: SimpleUndirectedGraph,
     pattern: SimpleUndirectedGraph,
@@ -44,7 +60,7 @@ def count_induced_vertex_subset_patterns(
 
     occurrence_count = 0
     for subset in combinations(range(host_order), pattern_order):
-        induced = host_graph.subgraph(subset)
+        induced = _explicit_induced_candidate(host_graph, subset)
         if induced.number_of_edges() != pattern_edge_count:
             continue
         if tuple(sorted(degree for _, degree in induced.degree())) != pattern_degrees:

--- a/src/jacobian/math/graphs/patterns/_tools.py
+++ b/src/jacobian/math/graphs/patterns/_tools.py
@@ -19,9 +19,10 @@ TOOLS: MathTools = (
             "Count host vertex subsets whose induced simple graph is isomorphic "
             "to a supplied pattern, once per subset rather than per embedding. "
             "Admission preflights C(|V(host)|, |V(pattern)|), encoded source and "
-            "retained-result bytes, graph construction, induced adjacency scans, "
-            "and worst-case NetworkX VF2++ partial-map work for every subset. It "
-            "admits at most 5,000 subsets per pass and 64,000,000 work units "
+            "retained-result bytes, C(|V(pattern)|, 2) direct host-edge probes "
+            "and explicit local-graph construction per subset, and worst-case "
+            "NetworkX VF2++ partial-map work for every subset. It admits at most "
+            "5,000 subsets per pass and 64,000,000 work units "
             "across counting and source-bound result replay; these are "
             "conservative current-backend limits."
         ),
@@ -40,7 +41,10 @@ TOOLS: MathTools = (
         examples=(
             example(
                 "two_induced_p4_in_p5",
-                "Count the two four-vertex subsets of P5 inducing P4. Admission preflights C(5, 4)=5 subsets plus construction, adjacency scans, and per-subset VF2++ work in both passes; limits are 5,000 subsets per pass and 64,000,000 total work units.",
+                "Count two P4 subsets in P5. Admission preflights 5 subsets, 6 "
+                "direct host-edge probes and one local graph per subset, plus "
+                "per-subset VF2++ work across two passes; limits are 5,000 subsets "
+                "per pass and 64,000,000 work units.",
                 {
                     "host": {
                         "vertices": ["a", "b", "c", "d", "e"],

--- a/src/jacobian/math/graphs/patterns/_tools.py
+++ b/src/jacobian/math/graphs/patterns/_tools.py
@@ -17,14 +17,12 @@ TOOLS: MathTools = (
         title="Count induced vertex-subset copies of a graph pattern",
         description=(
             "Count host vertex subsets whose induced simple graph is isomorphic "
-            "to a supplied pattern, once per subset rather than per embedding. "
-            "Admission preflights C(|V(host)|, |V(pattern)|), encoded source and "
-            "retained-result bytes, C(|V(pattern)|, 2) direct host-edge probes "
-            "and explicit local-graph construction per subset, and worst-case "
-            "NetworkX VF2++ partial-map work for every subset. It admits at most "
-            "5,000 subsets per pass and 64,000,000 work units "
-            "across counting and source-bound result replay; these are "
-            "conservative current-backend limits."
+            "to a pattern, once per subset, not per embedding. Admission preflights "
+            "C(|V(host)|, |V(pattern)|), exact source/result bytes, "
+            "C(|V(pattern)|, 2) direct host-edge probes, explicit local-graph "
+            "construction, and a worst-case NetworkX VF2++ partial-map bound. "
+            "Limits are 5,000 subsets per pass and 64,000,000 work units across "
+            "counting and source-bound replay; this is a conservative backend envelope."
         ),
         request_type=InducedVertexSubsetPatternCountRequest,
         result_type=InducedVertexSubsetPatternCountResult,

--- a/src/jacobian/math/graphs/patterns/_tools.py
+++ b/src/jacobian/math/graphs/patterns/_tools.py
@@ -1,0 +1,87 @@
+"""Induced graph-pattern count operation declaration."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.graphs.patterns._models import (
+    InducedVertexSubsetPatternCountRequest,
+    InducedVertexSubsetPatternCountResult,
+)
+from jacobian.math.graphs.patterns._operations import (
+    compute_induced_vertex_subset_pattern_count,
+)
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="graph.induced_vertex_subset_pattern.count",
+        version="1",
+        title="Count induced vertex-subset copies of a graph pattern",
+        description=(
+            "Count host vertex subsets whose induced simple graph is isomorphic "
+            "to a supplied pattern, once per subset rather than per embedding. "
+            "Admission preflights C(|V(host)|, |V(pattern)|), encoded source and "
+            "retained-result bytes, graph construction, induced adjacency scans, "
+            "and worst-case NetworkX VF2++ partial-map work for every subset. It "
+            "admits at most 5,000 subsets per pass and 64,000,000 work units "
+            "across counting and source-bound result replay; these are "
+            "conservative current-backend limits."
+        ),
+        request_type=InducedVertexSubsetPatternCountRequest,
+        result_type=InducedVertexSubsetPatternCountResult,
+        run=compute_induced_vertex_subset_pattern_count,
+        tags=(
+            "graph",
+            "induced-subgraph",
+            "pattern",
+            "count",
+            "isomorphism",
+            "exact",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "two_induced_p4_in_p5",
+                "Count the two four-vertex subsets of P5 inducing P4. Admission preflights C(5, 4)=5 subsets plus construction, adjacency scans, and per-subset VF2++ work in both passes; limits are 5,000 subsets per pass and 64,000,000 total work units.",
+                {
+                    "host": {
+                        "vertices": ["a", "b", "c", "d", "e"],
+                        "edges": [["a", "b"], ["b", "c"], ["c", "d"], ["d", "e"]],
+                    },
+                    "pattern": {
+                        "vertices": ["w", "x", "y", "z"],
+                        "edges": [["w", "x"], ["x", "y"], ["y", "z"]],
+                    },
+                },
+            ),
+            example(
+                "c4_does_not_induce_p4",
+                "Count zero P4 subsets in C4 because its closing edge is retained; both inputs must be canonical finite simple undirected graphs.",
+                {
+                    "host": {
+                        "vertices": ["a", "b", "c", "d"],
+                        "edges": [["a", "b"], ["a", "d"], ["b", "c"], ["c", "d"]],
+                    },
+                    "pattern": {
+                        "vertices": ["w", "x", "y", "z"],
+                        "edges": [["w", "x"], ["x", "y"], ["y", "z"]],
+                    },
+                },
+            ),
+            example(
+                "one_induced_two_edge_matching",
+                "Count the single full vertex subset of 2K2 inducing 2K2; each subset contributes once regardless of pattern automorphisms.",
+                {
+                    "host": {
+                        "vertices": ["a", "b", "c", "d"],
+                        "edges": [["a", "b"], ["c", "d"]],
+                    },
+                    "pattern": {
+                        "vertices": ["w", "x", "y", "z"],
+                        "edges": [["w", "x"], ["y", "z"]],
+                    },
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/tests/math/graphs/test_induced_pattern_counts.py
+++ b/tests/math/graphs/test_induced_pattern_counts.py
@@ -11,7 +11,6 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.canonical import CanonicalLimits, encode_strict_json
-from jacobian.catalog.catalog import Catalog
 from jacobian.math.graphs import explicit_graph
 from jacobian.math.graphs.patterns._models import (
     InducedVertexSubsetPatternCountRequest,
@@ -22,8 +21,6 @@ from jacobian.math.graphs.patterns._operations import (
 )
 from jacobian.math.graphs.patterns._tools import TOOLS
 from jacobian.math.graphs.values import SimpleUndirectedGraph
-
-OPERATION_ID = "graph.induced_vertex_subset_pattern.count"
 
 
 def _graph(
@@ -343,10 +340,3 @@ def test_numeric_admission_caps_are_visible_in_schema_and_tool_description() -> 
     assert "5,000 subsets per pass" in TOOLS[0].description
     assert "64,000,000 work units" in TOOLS[0].description
     assert "per-subset VF2++ work" in TOOLS[0].examples[0].description
-
-
-def test_operation_is_admitted_to_the_public_catalog() -> None:
-    operation = Catalog.open().operation(OPERATION_ID)
-    assert operation is not None
-    assert operation.request_type is InducedVertexSubsetPatternCountRequest
-    assert operation.result_type is InducedVertexSubsetPatternCountResult

--- a/tests/math/graphs/test_induced_pattern_counts.py
+++ b/tests/math/graphs/test_induced_pattern_counts.py
@@ -1,0 +1,352 @@
+"""Defining-invariant tests for induced vertex-subset pattern counts."""
+
+from __future__ import annotations
+
+import json
+import random
+from itertools import combinations, pairwise, permutations
+
+import networkx as nx
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.catalog import Catalog
+from jacobian.math.graphs import explicit_graph
+from jacobian.math.graphs.patterns._models import (
+    InducedVertexSubsetPatternCountRequest,
+    InducedVertexSubsetPatternCountResult,
+)
+from jacobian.math.graphs.patterns._operations import (
+    compute_induced_vertex_subset_pattern_count,
+)
+from jacobian.math.graphs.patterns._tools import TOOLS
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+OPERATION_ID = "graph.induced_vertex_subset_pattern.count"
+
+
+def _graph(
+    vertices: tuple[str, ...] | list[str],
+    edges: tuple[tuple[str, str], ...] | list[tuple[str, str]],
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(
+        vertices=tuple(vertices),
+        edges=tuple(
+            sorted(
+                (left, right) if left < right else (right, left)
+                for left, right in edges
+            )
+        ),
+    )
+
+
+def _path(order: int, prefix: str) -> SimpleUndirectedGraph:
+    vertices = tuple(f"{prefix}{index:02d}" for index in range(order))
+    return _graph(vertices, list(pairwise(vertices)))
+
+
+def _cycle(order: int, prefix: str) -> SimpleUndirectedGraph:
+    path = _path(order, prefix)
+    if order < 3:
+        raise ValueError("a simple cycle requires at least three vertices")
+    return _graph(path.vertices, [*path.edges, (path.vertices[0], path.vertices[-1])])
+
+
+def _complete(order: int, prefix: str) -> SimpleUndirectedGraph:
+    vertices = tuple(f"{prefix}{index:02d}" for index in range(order))
+    return _graph(vertices, list(combinations(vertices, 2)))
+
+
+def _empty(order: int, prefix: str) -> SimpleUndirectedGraph:
+    return _graph(tuple(f"{prefix}{index:02d}" for index in range(order)), [])
+
+
+def _count(host: SimpleUndirectedGraph, pattern: SimpleUndirectedGraph) -> str:
+    request = InducedVertexSubsetPatternCountRequest(host=host, pattern=pattern)
+    return compute_induced_vertex_subset_pattern_count(request).occurrence_count
+
+
+def _edge_key(left: str, right: str) -> tuple[str, str]:
+    return (left, right) if left < right else (right, left)
+
+
+def _brute_force_count(
+    host: SimpleUndirectedGraph,
+    pattern: SimpleUndirectedGraph,
+) -> int:
+    """Replay the definition directly, without the production VF2++ backend."""
+
+    if len(pattern.vertices) > len(host.vertices):
+        return 0
+    host_edges = set(host.edges)
+    pattern_edges = set(pattern.edges)
+    count = 0
+    for subset in combinations(host.vertices, len(pattern.vertices)):
+        for image in permutations(subset):
+            mapping = dict(zip(pattern.vertices, image, strict=True))
+            if all(
+                (_edge_key(left, right) in pattern_edges)
+                == (_edge_key(mapping[left], mapping[right]) in host_edges)
+                for left, right in combinations(pattern.vertices, 2)
+            ):
+                count += 1
+                break
+    return count
+
+
+@pytest.mark.parametrize(
+    ("example_name", "expected"),
+    (
+        ("two_induced_p4_in_p5", "2"),
+        ("c4_does_not_induce_p4", "0"),
+        ("one_induced_two_edge_matching", "1"),
+    ),
+)
+def test_public_known_answer_examples(example_name: str, expected: str) -> None:
+    """The motivating P4, C4, and 2K2 cases stay public and executable."""
+
+    operation = TOOLS[0]
+    invocation = next(item for item in operation.examples if item.name == example_name)
+    request = operation.request_type.model_validate(invocation.input)
+    result = operation.run(request)
+
+    assert result.occurrence_count == expected
+    assert result.host == request.host
+    assert result.pattern == request.pattern
+
+
+def test_k4_contains_four_triangle_subsets_not_twenty_four_maps() -> None:
+    assert _count(_complete(4, "h"), _complete(3, "p")) == "4"
+
+
+def test_c4_contains_one_full_induced_c4_copy() -> None:
+    assert _count(_cycle(4, "h"), _cycle(4, "p")) == "1"
+
+
+@pytest.mark.parametrize(
+    ("host", "pattern", "expected"),
+    (
+        (_complete(5, "h"), _complete(2, "p"), "10"),
+        (_empty(5, "h"), _empty(2, "p"), "10"),
+        (_complete(5, "h"), _empty(2, "p"), "0"),
+        (_empty(5, "h"), _complete(2, "p"), "0"),
+    ),
+)
+def test_complete_and_empty_hosts_distinguish_complement_patterns(
+    host: SimpleUndirectedGraph,
+    pattern: SimpleUndirectedGraph,
+    expected: str,
+) -> None:
+    assert _count(host, pattern) == expected
+
+
+def test_isolated_pattern_vertex_is_semantically_significant() -> None:
+    host = _path(4, "h")
+    pattern = _graph(
+        ("p0", "p1", "p2"),
+        [("p0", "p1")],
+    )
+
+    assert _count(host, pattern) == "2"
+
+
+def test_empty_pattern_has_one_occurrence_without_backend_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_isomorphism(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("empty-pattern count must not invoke NetworkX")
+
+    monkeypatch.setattr(nx, "vf2pp_is_isomorphic", fail_isomorphism)
+    assert _count(_empty(0, "h"), _empty(0, "p")) == "1"
+    assert _count(_path(5, "h"), _empty(0, "p")) == "1"
+
+
+def test_pattern_larger_than_host_returns_zero_without_backend_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_isomorphism(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("pattern-larger-than-host must not invoke NetworkX")
+
+    monkeypatch.setattr(nx, "vf2pp_is_isomorphic", fail_isomorphism)
+    assert _count(_path(3, "h"), _path(4, "p")) == "0"
+
+
+def test_host_and_pattern_relabelling_and_row_order_preserve_count() -> None:
+    original = _count(_path(5, "h"), _path(4, "p"))
+    host = SimpleUndirectedGraph(
+        vertices=("z", "v", "x", "u", "y"),
+        edges=(("u", "v"), ("v", "x"), ("x", "y"), ("y", "z")),
+    )
+    pattern = SimpleUndirectedGraph(
+        vertices=("delta", "alpha", "gamma", "beta"),
+        edges=(("alpha", "beta"), ("beta", "gamma"), ("delta", "gamma")),
+    )
+
+    assert original == "2"
+    assert _count(host, pattern) == original
+
+
+def test_canonical_graph_producer_output_enters_request_unchanged() -> None:
+    host = explicit_graph(
+        ("e", "c", "a", "d", "b"),
+        (("a", "b"), ("b", "c"), ("c", "d"), ("d", "e")),
+    )
+    pattern = explicit_graph(
+        ("z", "x", "w", "y"),
+        (("w", "x"), ("x", "y"), ("y", "z")),
+    )
+    request = InducedVertexSubsetPatternCountRequest.model_validate(
+        {
+            "host": host.model_dump(mode="json"),
+            "pattern": pattern.model_dump(mode="json"),
+        }
+    )
+
+    assert request.host == host
+    assert request.pattern == pattern
+    assert compute_induced_vertex_subset_pattern_count(request).occurrence_count == "2"
+
+
+def test_small_random_graphs_match_independent_subset_and_permutation_oracle() -> None:
+    rng = random.Random(2275)
+    for host_order in range(7):
+        host_vertices = tuple(f"h{index}" for index in range(host_order))
+        for case in range(3):
+            host = _graph(
+                host_vertices,
+                [
+                    edge
+                    for edge in combinations(host_vertices, 2)
+                    if rng.random() < 0.45
+                ],
+            )
+            pattern_order = rng.randrange(0, min(4, host_order + 1) + 1)
+            pattern_vertices = tuple(
+                f"p{case}_{index}" for index in range(pattern_order)
+            )
+            pattern = _graph(
+                pattern_vertices,
+                [
+                    edge
+                    for edge in combinations(pattern_vertices, 2)
+                    if rng.random() < 0.45
+                ],
+            )
+
+            assert int(_count(host, pattern)) == _brute_force_count(host, pattern)
+
+
+def test_result_rejects_forged_zero_and_source_mutations() -> None:
+    host = _path(5, "h")
+    pattern = _path(4, "p")
+
+    with pytest.raises(ValidationError, match="does not equal"):
+        InducedVertexSubsetPatternCountResult(
+            host=host,
+            pattern=pattern,
+            occurrence_count="0",
+        )
+    with pytest.raises(ValidationError, match="does not equal"):
+        InducedVertexSubsetPatternCountResult(
+            host=host,
+            pattern=pattern,
+            occurrence_count="3",
+        )
+    with pytest.raises(ValidationError, match="does not equal"):
+        InducedVertexSubsetPatternCountResult(
+            host=_cycle(4, "c"),
+            pattern=pattern,
+            occurrence_count="2",
+        )
+    with pytest.raises(ValidationError, match="does not equal"):
+        InducedVertexSubsetPatternCountResult(
+            host=host,
+            pattern=_cycle(4, "q"),
+            occurrence_count="2",
+        )
+
+
+def test_request_accepts_useful_case_near_subset_bound() -> None:
+    # C(20, 4) = 4,845, just below the 5,000-subset per-pass limit.
+    request = InducedVertexSubsetPatternCountRequest(
+        host=_empty(20, "h"),
+        pattern=_complete(4, "p"),
+    )
+    assert compute_induced_vertex_subset_pattern_count(request).occurrence_count == "0"
+
+
+def test_request_rejects_next_graph_order_above_subset_bound() -> None:
+    # C(21, 4) = 5,985, so rejection happens before enumeration.
+    with pytest.raises(ValidationError, match="5,000-candidate per-pass bound"):
+        InducedVertexSubsetPatternCountRequest(
+            host=_empty(21, "h"),
+            pattern=_complete(4, "p"),
+        )
+
+
+def test_request_bounds_per_subset_isomorphism_work() -> None:
+    # A single order-eight comparison fits; the next order still has one
+    # subset but exceeds the conservative VF2++ partial-injection work bound.
+    assert _count(_empty(8, "h"), _empty(8, "p")) == "1"
+    with pytest.raises(ValidationError, match="64,000,000-unit bound"):
+        InducedVertexSubsetPatternCountRequest(
+            host=_empty(9, "h"),
+            pattern=_empty(9, "p"),
+        )
+
+
+def test_canonical_graph_size_bound_rejects_257_vertices() -> None:
+    with pytest.raises(ValidationError, match="at most 256 items"):
+        InducedVertexSubsetPatternCountRequest.model_validate(
+            {
+                "host": {
+                    "vertices": [f"h{index:03d}" for index in range(257)],
+                    "edges": [],
+                },
+                "pattern": {"vertices": [], "edges": []},
+            }
+        )
+
+
+def test_request_reserves_exact_output_headroom_for_retained_sources() -> None:
+    limits = CanonicalLimits()
+    pattern = _empty(0, "p")
+    base_host = _graph(("x",), [])
+    base_payload = {
+        "host": base_host.model_dump(mode="json"),
+        "pattern": pattern.model_dump(mode="json"),
+    }
+    base_size = len(encode_strict_json(base_payload))
+    label_length = limits.max_input_bytes - base_size + 1
+    host = _graph(("x" * label_length,), [])
+    request_payload = {
+        "host": host.model_dump(mode="json"),
+        "pattern": pattern.model_dump(mode="json"),
+    }
+    assert len(encode_strict_json(request_payload)) == limits.max_input_bytes
+
+    with pytest.raises(ValidationError, match="retains host and pattern"):
+        InducedVertexSubsetPatternCountRequest(host=host, pattern=pattern)
+
+
+def test_numeric_admission_caps_are_visible_in_schema_and_tool_description() -> None:
+    schema = json.dumps(
+        InducedVertexSubsetPatternCountRequest.model_json_schema(),
+        sort_keys=True,
+    )
+    assert "5,000 subsets per pass" in schema
+    assert "64,000,000 total work units" in schema
+    assert "10,485,760-byte canonical output bound" in schema
+    assert "C(|V(host)|, |V(pattern)|)" in schema
+    assert "partial-injection state bound" in schema
+    assert "5,000 subsets per pass" in TOOLS[0].description
+    assert "64,000,000 work units" in TOOLS[0].description
+    assert "per-subset VF2++ work" in TOOLS[0].examples[0].description
+
+
+def test_operation_is_admitted_to_the_public_catalog() -> None:
+    operation = Catalog.open().operation(OPERATION_ID)
+    assert operation is not None
+    assert operation.request_type is InducedVertexSubsetPatternCountRequest
+    assert operation.result_type is InducedVertexSubsetPatternCountResult

--- a/tests/math/graphs/test_induced_pattern_counts.py
+++ b/tests/math/graphs/test_induced_pattern_counts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import random
 from itertools import combinations, pairwise, permutations
+from math import comb
 
 import networkx as nx
 import pytest
@@ -273,6 +274,30 @@ def test_request_accepts_useful_case_near_subset_bound() -> None:
     assert compute_induced_vertex_subset_pattern_count(request).occurrence_count == "0"
 
 
+def test_dense_host_at_subset_bound_avoids_host_filtered_views(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_has_edge = nx.Graph.has_edge
+    host_pair_probes = 0
+
+    def fail_subgraph(*_args: object, **_kwargs: object) -> nx.Graph[object]:
+        raise AssertionError("candidate construction must not scan a host graph view")
+
+    def count_host_pair_probe(graph: nx.Graph[int], left: int, right: int) -> bool:
+        nonlocal host_pair_probes
+        if graph.number_of_nodes() == 100:
+            host_pair_probes += 1
+        return original_has_edge(graph, left, right)
+
+    monkeypatch.setattr(nx.Graph, "subgraph", fail_subgraph)
+    monkeypatch.setattr(nx.Graph, "has_edge", count_host_pair_probe)
+
+    # C(100, 2) = 4,950, so this dense case exercises the useful candidate
+    # boundary without allowing work to depend on the host vertices' degrees.
+    assert _count(_complete(100, "h"), _complete(2, "p")) == "4950"
+    assert host_pair_probes == 2 * comb(100, 2)
+
+
 def test_request_rejects_next_graph_order_above_subset_bound() -> None:
     # C(21, 4) = 5,985, so rejection happens before enumeration.
     with pytest.raises(ValidationError, match="5,000-candidate per-pass bound"):
@@ -336,7 +361,10 @@ def test_numeric_admission_caps_are_visible_in_schema_and_tool_description() -> 
     assert "64,000,000 total work units" in schema
     assert "10,485,760-byte canonical output bound" in schema
     assert "C(|V(host)|, |V(pattern)|)" in schema
+    assert "C(|V(pattern)|, 2) direct host-edge probes" in schema
     assert "partial-injection state bound" in schema
     assert "5,000 subsets per pass" in TOOLS[0].description
     assert "64,000,000 work units" in TOOLS[0].description
+    assert "direct host-edge probes" in TOOLS[0].description
+    assert "one local graph per subset" in TOOLS[0].examples[0].description
     assert "per-subset VF2++ work" in TOOLS[0].examples[0].description


### PR DESCRIPTION
Closes #2275.

## Problem

The existing graph-pattern surface can find one ordinary edge-preserving embedding. It cannot return the exact number of vertex subsets whose **induced** graph is isomorphic to a supplied pattern. Repeated witness search would also leave callers responsible for nonedge preservation, automorphism quotienting, exclusions, and completeness.

That distinction changes the answer for basic patterns: `P5` has two induced `P4` subsets, `C4` has no full-vertex induced `P4`, and `K4` has four induced `K3` subsets rather than 24 labelled embeddings.

## Solution

This adds `graph.induced_vertex_subset_pattern.count`. It consumes the existing canonical `SimpleUndirectedGraph` value for both host and pattern and returns the exact nonnegative subset count while retaining both sources.

The kernel enumerates each host subset of pattern order once. For each subset it materializes an independent local graph using exactly one host-edge probe for every possible local pair, filters by edge count and degree sequence, and delegates exact isomorphism to the pinned NetworkX 3.6.1 VF2++ implementation. NetworkX remains the private maintained isomorphism backend; Jacobian owns the subset semantics, deterministic enumeration, and public bounds.

Explicit materialization is important to the admitted work claim. A NetworkX induced-subgraph view can make later degree scans depend on the host vertices' full adjacency. Building the local graph directly keeps candidate construction at `C(|V(pattern)|, 2)` host probes and prevents hidden host-degree-dependent rescans.

The result validator replays the defining count from the retained graphs. Empty patterns return one, patterns larger than the host return zero, isolated pattern vertices remain significant, and coherent relabelling does not change the scalar result.

## Testing

- `make check` — Ruff and formatting passed; mypy passed for 769 source files; 2,672 bounded-owner tests passed.
- `make test-math TESTS=tests/math/graphs/test_induced_pattern_counts.py` — 23 passed.
- `make test-integration TESTS='tests/integration/catalog/test_builtin_examples.py::test_advertised_invocation_example_executes_successfully[graph.induced_vertex_subset_pattern.count] tests/integration/catalog/test_public_operation_contract_conformance.py::test_every_accepted_boundary_mutation_returns_the_declared_result[graph.induced_vertex_subset_pattern.count]'` — 2 passed.
- `git diff --check origin/main...HEAD` — passed.
- An independent small-graph oracle enumerates subsets and all pattern permutations; randomized cases agree with VF2++.
- The dense boundary regression counts `K2` in `K100` as 4,950, forbids lazy `Graph.subgraph` use, and observes exactly 9,900 host-edge probes across computation and result replay.

- Specialist validation run: the owning graph-pattern test module and the two catalog contract nodes listed above.

## Public contract impact

Adds operation ID `graph.induced_vertex_subset_pattern.count` version 1, its typed request/result schemas, three executable catalog examples, and exact induced-subset counting semantics. Existing operation contracts and native APIs are unchanged.

## Public operation admission

- Concrete gap: the exact number of host vertex subsets inducing a graph isomorphic to a supplied pattern.
- Why existing operations or typed values are insufficient: ordinary one-witness subgraph containment neither preserves nonedges nor establishes a subset count; iterating it would require caller-owned exclusion, automorphism, and completeness machinery.
- Stable mathematical result: `|{S subseteq V(G) : |S| = |V(H)| and G[S] isomorphic to H}|`, with both canonical source graphs retained and replayed.
- Semantic domain and admitted execution envelope: finite simple undirected host and pattern graphs under the shared 256-vertex/32,640-edge representation; at most 5,000 candidate subsets per pass and 64,000,000 work units across computation and validation replay.
- Controlling work, intermediate, memory, and output quantities: exact binomial subset count, graph records and encoded bytes, explicit local vertices, every possible local edge probe and insertion, degree scans and sorting, a worst-case partial-injection VF2++ state bound, exact count digits, and the 10,485,760-byte retained-source result ceiling.
- Exact representation, algorithm regimes, and maintained backend: canonical `SimpleUndirectedGraph` values and canonical decimal counts publicly; one exhaustive subset regime using materialized NetworkX graphs and pinned NetworkX 3.6.1 VF2++ privately.
- Remaining fixed caps and their classification: the shared graph representation limit and conservative 5,000-subset/64,000,000-work current-backend safety envelope. Widening these is a scale or backend investigation, not a new operation.
- Admission decision: `KEEP` in the graph-pattern owner because induced subset count is one distinct, reusable, exact scalar postcondition.

## Closure matrix

None. Issue #2275 requests this single operation and leaves occurrence enumeration, mapping counts, packing, multi-pattern census, and theorem-specific workflows out of scope.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] The result is exact; timeout, incomplete search, and backend failure cannot become a count
- [x] Bounds have exact-at/over-bound, dense-host, output-headroom, known-answer, and randomized differential coverage
- [x] A shared abstraction is not introduced; the operation remains in its graph-pattern owner
