### PR TITLE
feat(math): add exact rational conic parametrization

### DIFF
--- a/src/jacobian/math/plane_algebraic_curves/_admission.py
+++ b/src/jacobian/math/plane_algebraic_curves/_admission.py
@@ -21,6 +21,13 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
     ),
     OperationAdmission(
+        "algebraic_geometry.conic.rational_parametrization.compute",
+        AdmissionDecision.KEEP,
+        "constructs one reusable birational conic chart with canonical rational "
+        "functions, an inverse, and explicit exceptional loci that polynomial "
+        "substitution alone cannot recover",
+    ),
+    OperationAdmission(
         "algebraic_geometry.projective_curve.affine_chart.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/plane_algebraic_curves/_conic.py
+++ b/src/jacobian/math/plane_algebraic_curves/_conic.py
@@ -344,26 +344,40 @@ def _require_smooth_conic_and_point(
     polynomial: RationalPolynomial,
     point: VariablePoint,
 ) -> None:
-    source, point_values, gradient, quadratic = _source_data(polynomial, point)
-    if source.total_degree() != 2:
+    # Exact preflight on the already bounded canonical coefficients; the
+    # backend is entered only after every admission check has passed.
+    coefficients = _source_coefficients(polynomial)
+    zero = Fraction(0)
+    a = coefficients.get((2, 0), zero)
+    b = coefficients.get((1, 1), zero)
+    c = coefficients.get((0, 2), zero)
+    d = coefficients.get((1, 0), zero)
+    e = coefficients.get((0, 1), zero)
+    constant = coefficients.get((0, 0), zero)
+    total_degree = max(
+        (sum(term.exponents) for term in polynomial.polynomial.terms),
+        default=0,
+    )
+    if total_degree != 2:
         raise ValueError("rational conic polynomial must have total degree exactly two")
-    if source.eval(dict(zip(source.gens, point_values, strict=True))) != 0:
+    px, py = (value.as_fraction() for value in point.values)
+    if a * px * px + b * px * py + c * py * py + d * px + e * py + constant != 0:
         raise ValueError("supplied rational point must lie on the conic")
 
-    a, b, c = quadratic
-    d = _coefficient(source, (1, 0))
-    e = _coefficient(source, (0, 1))
-    constant = _coefficient(source, (0, 0))
-    twice_projective_matrix = sympy.Matrix(
-        (
-            (2 * a, b, d),
-            (b, 2 * c, e),
-            (d, e, 2 * constant),
-        )
+    gradient = (2 * a * px + b * py + d, b * px + 2 * c * py + e)
+    # Closed-form determinant of the twice-projective symmetric matrix
+    # ((2a, b, d), (b, 2c, e), (d, e, 2*constant)); nonzero exactly for a
+    # smooth irreducible projective conic.
+    determinant = (
+        8 * a * c * constant
+        + 2 * b * d * e
+        - 2 * c * d * d
+        - 2 * b * b * constant
+        - 2 * a * e * e
     )
-    if twice_projective_matrix.det() == 0:
+    if determinant == 0:
         raise ValueError("projective closure must be a smooth irreducible conic")
-    if gradient == (0, 0):
+    if gradient == (zero, zero):
         raise ValueError("supplied point must be smooth on the affine conic")
 
 

--- a/src/jacobian/math/plane_algebraic_curves/_conic.py
+++ b/src/jacobian/math/plane_algebraic_curves/_conic.py
@@ -1,0 +1,663 @@
+"""Exact kernel and replay helpers for smooth rational conics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from math import gcd, lcm
+from typing import Any
+
+import sympy
+
+from jacobian._exact import require_bounded_rational
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_function_to_sympy,
+    rational_polynomial_from_sympy,
+    rational_polynomial_to_sympy,
+)
+from jacobian.math.polynomials.maps._models import VariablePoint
+from jacobian.math.polynomials.values import (
+    PolynomialVariable,
+    RationalFunction,
+    RationalPolynomial,
+    require_polynomial_budget,
+)
+
+MAX_CONIC_TERMS = 6
+MAX_CONIC_INPUT_DIGITS = 128
+MAX_CONIC_INTERMEDIATE_DIGITS = 16_384
+MAX_CONIC_RESULT_DIGITS = 128
+MAX_CONIC_RESULT_TERMS = 3
+
+# A factor of a primitive integer polynomial of degree at most two has
+# coefficient norm at most 2**2 times the source 2-norm. With at most three
+# coefficients, one extra decimal digit bounds 4*sqrt(3).
+_QUADRATIC_FACTOR_DIGIT_SLACK = 1
+_LOG10_2_UPPER_NUMERATOR = 30_103
+_LOG10_2_UPPER_DENOMINATOR = 100_000
+
+
+@dataclass(frozen=True, slots=True)
+class ConicParametrizationData:
+    """Canonical values produced by the gradient-normalized line pencil."""
+
+    coordinates: tuple[RationalFunction, RationalFunction]
+    inverse_parameter: RationalFunction
+    finite_parameter_denominator: RationalPolynomial
+
+
+@dataclass(frozen=True, slots=True)
+class _IntegerPolynomialHeight:
+    primitive_coefficient_digits: int
+    cleared_coefficient_digits: int
+    rational_content: Fraction
+
+
+@dataclass(frozen=True, slots=True)
+class _ParametrizationHeightBounds:
+    intermediate_digits: int
+    result_coefficient_digits: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ConicParametrizationDerivation:
+    data: ConicParametrizationData
+    projective_coordinates: tuple[Any, Any, Any]
+
+
+def _coefficient(polynomial: Any, exponents: tuple[int, int]) -> Any:
+    return polynomial.coeff_monomial(exponents)
+
+
+def _point_values(point: VariablePoint) -> tuple[Any, Any]:
+    first, second = point.values
+    return (
+        sympy.Rational(*first.as_integer_ratio()),
+        sympy.Rational(*second.as_integer_ratio()),
+    )
+
+
+def _source_data(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+) -> tuple[Any, tuple[Any, Any], tuple[Any, Any], tuple[Any, Any, Any]]:
+    source = rational_polynomial_to_sympy(polynomial)
+    point_values = _point_values(point)
+    substitutions = dict(zip(source.gens, point_values, strict=True))
+    gradient = tuple(
+        source.diff(variable).eval(substitutions) for variable in source.gens
+    )
+    quadratic = (
+        _coefficient(source, (2, 0)),
+        _coefficient(source, (1, 1)),
+        _coefficient(source, (0, 2)),
+    )
+    return source, point_values, gradient, quadratic
+
+
+def _source_coefficients(
+    polynomial: RationalPolynomial,
+) -> dict[tuple[int, ...], Fraction]:
+    return {
+        term.exponents: term.coefficient.as_fraction()
+        for term in polynomial.polynomial.terms
+    }
+
+
+def _digits(value: int) -> int:
+    bit_length = abs(value).bit_length()
+    if bit_length == 0:
+        return 1
+    return (
+        bit_length * _LOG10_2_UPPER_NUMERATOR + _LOG10_2_UPPER_DENOMINATOR - 1
+    ) // _LOG10_2_UPPER_DENOMINATOR
+
+
+def _rational_digits(value: Fraction) -> int:
+    return max(_digits(value.numerator), _digits(value.denominator))
+
+
+def _integer_polynomial_height(
+    coefficients: tuple[Fraction, ...],
+) -> _IntegerPolynomialHeight:
+    """Measure the primitive integer associate after bounded denominator clearing."""
+
+    nonzero = tuple(coefficient for coefficient in coefficients if coefficient)
+    if not nonzero:
+        raise ValueError("parametrization polynomial cannot be zero")
+    clearing_denominator = lcm(*(coefficient.denominator for coefficient in nonzero))
+    integer_coefficients = tuple(
+        coefficient.numerator * (clearing_denominator // coefficient.denominator)
+        for coefficient in nonzero
+    )
+    content = gcd(*(abs(coefficient) for coefficient in integer_coefficients))
+    primitive_coefficients = tuple(
+        coefficient // content for coefficient in integer_coefficients
+    )
+    return _IntegerPolynomialHeight(
+        primitive_coefficient_digits=max(map(_digits, primitive_coefficients)),
+        cleared_coefficient_digits=max(map(_digits, integer_coefficients)),
+        rational_content=Fraction(content, clearing_denominator),
+    )
+
+
+def _rational_function_height_bounds(
+    numerator: tuple[Fraction, ...],
+    denominator: tuple[Fraction, ...],
+) -> tuple[int, int]:
+    """Bound reduced coefficients and degree-two cancellation intermediates."""
+
+    numerator_integer = _integer_polynomial_height(numerator)
+    denominator_integer = _integer_polynomial_height(denominator)
+    factor_slack = _QUADRATIC_FACTOR_DIGIT_SLACK
+    content_ratio = numerator_integer.rational_content / (
+        denominator_integer.rational_content
+    )
+    numerator_factor_digits = (
+        numerator_integer.primitive_coefficient_digits + factor_slack
+    )
+    denominator_factor_digits = (
+        denominator_integer.primitive_coefficient_digits + factor_slack
+    )
+
+    # Write each rational polynomial as rational content times a primitive
+    # integer polynomial. Mignotte's degree-two factor bound controls the
+    # quotients after gcd cancellation. Dividing by the remaining denominator
+    # leading coefficient accounts for canonical monic normalization.
+    result_digits = max(
+        _digits(content_ratio.numerator) + numerator_factor_digits,
+        _digits(content_ratio.denominator) + denominator_factor_digits,
+        denominator_factor_digits,
+    )
+
+    # For degrees at most two, gcd subresultants are minors of a Sylvester
+    # matrix of order at most four. Four coefficient products plus two decimal
+    # digits for the at-most 4! determinant terms conservatively bound them.
+    cancellation_digits = (
+        4
+        * max(
+            numerator_integer.cleared_coefficient_digits,
+            denominator_integer.cleared_coefficient_digits,
+        )
+        + 2
+    )
+    return result_digits, cancellation_digits
+
+
+def _coprime_linear_function_height_bounds(
+    numerator: tuple[Fraction, ...],
+    denominator: tuple[Fraction, ...],
+) -> tuple[int, int]:
+    """Bound the inverse chart, whose two affine linear forms are coprime."""
+
+    leading = next(coefficient for coefficient in denominator if coefficient)
+    result_digits = max(
+        _rational_digits(coefficient / leading)
+        for coefficient in (*numerator, *denominator)
+    )
+    numerator_integer = _integer_polynomial_height(numerator)
+    denominator_integer = _integer_polynomial_height(denominator)
+    # The only possible nonconstant gcd of two affine linear forms is detected
+    # by their 2x2 coefficient minors. Each minor has two products.
+    cancellation_digits = (
+        2
+        * max(
+            numerator_integer.cleared_coefficient_digits,
+            denominator_integer.cleared_coefficient_digits,
+        )
+        + 1
+    )
+    return result_digits, cancellation_digits
+
+
+def _monic_polynomial_result_digits(
+    coefficients: tuple[Fraction, ...],
+) -> int:
+    leading = coefficients[-1]
+    return max(_rational_digits(coefficient / leading) for coefficient in coefficients)
+
+
+def _parametrization_height_bounds(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+) -> _ParametrizationHeightBounds:
+    """Bound raw work and every normalized materialized coefficient."""
+
+    coefficients = _source_coefficients(polynomial)
+    zero = Fraction(0)
+    a = coefficients.get((2, 0), zero)
+    b = coefficients.get((1, 1), zero)
+    c = coefficients.get((0, 2), zero)
+    d = coefficients.get((1, 0), zero)
+    e = coefficients.get((0, 1), zero)
+    constant = coefficients.get((0, 0), zero)
+    px, py = (value.as_fraction() for value in point.values)
+    fx = 2 * a * px + b * py + d
+    fy = b * px + 2 * c * py + e
+    gradient_square = fx * fx + fy * fy
+
+    denominator = (
+        a * fx * fx + b * fx * fy + c * fy * fy,
+        -2 * a * fx * fy + b * (fx * fx - fy * fy) + 2 * c * fx * fy,
+        a * fy * fy - b * fx * fy + c * fx * fx,
+    )
+    coordinate_x_numerator = (
+        px * denominator[0] - gradient_square * fx,
+        px * denominator[1] + gradient_square * fy,
+        px * denominator[2],
+    )
+    coordinate_y_numerator = (
+        py * denominator[0] - gradient_square * fy,
+        py * denominator[1] - gradient_square * fx,
+        py * denominator[2],
+    )
+    inverse_numerator = (
+        -fy,
+        fx,
+        fy * px - fx * py,
+    )
+    inverse_denominator = (
+        fx,
+        fy,
+        -fx * px - fy * py,
+    )
+
+    rational_function_bounds = (
+        _rational_function_height_bounds(coordinate_x_numerator, denominator),
+        _rational_function_height_bounds(coordinate_y_numerator, denominator),
+        _coprime_linear_function_height_bounds(inverse_numerator, inverse_denominator),
+    )
+    result_digits = max(
+        *(result for result, _intermediate in rational_function_bounds),
+        _monic_polynomial_result_digits(denominator),
+    )
+
+    determinant = (
+        8 * a * c * constant
+        + 2 * b * d * e
+        - 2 * c * d * d
+        - 2 * b * b * constant
+        - 2 * a * e * e
+    )
+    raw_values = (
+        fx,
+        fy,
+        gradient_square,
+        determinant,
+        *denominator,
+        *coordinate_x_numerator,
+        *coordinate_y_numerator,
+        *inverse_numerator,
+        *inverse_denominator,
+    )
+    # Canonical RationalFunction validation performs one more gcd on at most
+    # three result coefficients. The same degree-two determinant bound is
+    # 12*result_digits + 2 after clearing their denominators.
+    intermediate_digits = max(
+        *(_rational_digits(value) for value in raw_values),
+        *(intermediate for _result, intermediate in rational_function_bounds),
+        12 * result_digits + 2,
+    )
+    return _ParametrizationHeightBounds(
+        intermediate_digits=intermediate_digits,
+        result_coefficient_digits=result_digits,
+    )
+
+
+def _require_source_bounds(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+) -> None:
+    require_polynomial_budget(
+        polynomial,
+        maximum_terms=MAX_CONIC_TERMS,
+        maximum_exponent=2,
+        maximum_coefficient_digits=MAX_CONIC_INPUT_DIGITS,
+        label="conic polynomial",
+    )
+    for coordinate in point.values:
+        require_bounded_rational(
+            coordinate,
+            max_digits=MAX_CONIC_INPUT_DIGITS,
+            label="conic point coordinate",
+        )
+
+
+def _require_work_and_result_bounds(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+) -> None:
+    bounds = _parametrization_height_bounds(polynomial, point)
+    if bounds.result_coefficient_digits > MAX_CONIC_RESULT_DIGITS:
+        raise ValueError(
+            "conic parametrization normalized output exceeds the conservative "
+            "128-digit coefficient bound"
+        )
+    if bounds.intermediate_digits > MAX_CONIC_INTERMEDIATE_DIGITS:
+        raise ValueError(
+            "conic parametrization exceeds the 16,384-digit intermediate bound"
+        )
+
+
+def _require_smooth_conic_and_point(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+) -> None:
+    source, point_values, gradient, quadratic = _source_data(polynomial, point)
+    if source.total_degree() != 2:
+        raise ValueError("rational conic polynomial must have total degree exactly two")
+    if source.eval(dict(zip(source.gens, point_values, strict=True))) != 0:
+        raise ValueError("supplied rational point must lie on the conic")
+
+    a, b, c = quadratic
+    d = _coefficient(source, (1, 0))
+    e = _coefficient(source, (0, 1))
+    constant = _coefficient(source, (0, 0))
+    twice_projective_matrix = sympy.Matrix(
+        (
+            (2 * a, b, d),
+            (b, 2 * c, e),
+            (d, e, 2 * constant),
+        )
+    )
+    if twice_projective_matrix.det() == 0:
+        raise ValueError("projective closure must be a smooth irreducible conic")
+    if gradient == (0, 0):
+        raise ValueError("supplied point must be smooth on the affine conic")
+
+
+def validate_rational_conic_request(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+    parameter: PolynomialVariable,
+) -> None:
+    """Admit one smooth conic-with-point before constructing its chart."""
+
+    if len(polynomial.variables) != 2:
+        raise ValueError(
+            "rational conic parametrization requires exactly two variables"
+        )
+    if point.variables != polynomial.variables:
+        raise ValueError("conic point must use the polynomial's complete ordered axis")
+    if parameter in polynomial.variables:
+        raise ValueError("parameter must be distinct from both conic variables")
+    _require_source_bounds(polynomial, point)
+    _require_smooth_conic_and_point(polynomial, point)
+    _require_work_and_result_bounds(polynomial, point)
+
+
+def _derive_rational_conic_parametrization(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+    parameter: PolynomialVariable,
+) -> _ConicParametrizationDerivation:
+    source, point_values, gradient, (a, b, c) = _source_data(polynomial, point)
+    px, py = point_values
+    fx, fy = gradient
+    t = sympy.Symbol(parameter)
+    direction_x = fx - fy * t
+    direction_y = fy + fx * t
+    gradient_square = fx**2 + fy**2
+    denominator_expression = sympy.expand(
+        a * direction_x**2 + b * direction_x * direction_y + c * direction_y**2
+    )
+    denominator = sympy.Poly(denominator_expression, t, domain=sympy.QQ)
+    if denominator.degree() != 2:
+        raise ValueError("smooth conic pencil must have a quadratic denominator")
+
+    projective_x = sympy.Poly(
+        sympy.expand(px * denominator_expression - gradient_square * direction_x),
+        t,
+        domain=sympy.QQ,
+    )
+    projective_y = sympy.Poly(
+        sympy.expand(py * denominator_expression - gradient_square * direction_y),
+        t,
+        domain=sympy.QQ,
+    )
+    coordinate_x = rational_function_from_sympy(
+        projective_x.as_expr() / denominator_expression,
+        (parameter,),
+        maximum_terms=MAX_CONIC_RESULT_TERMS,
+    )
+    coordinate_y = rational_function_from_sympy(
+        projective_y.as_expr() / denominator_expression,
+        (parameter,),
+        maximum_terms=MAX_CONIC_RESULT_TERMS,
+    )
+
+    x, y = source.gens
+    inverse_expression = (-fy * (x - px) + fx * (y - py)) / (
+        fx * (x - px) + fy * (y - py)
+    )
+    inverse = rational_function_from_sympy(
+        inverse_expression,
+        polynomial.variables,
+        maximum_terms=MAX_CONIC_RESULT_TERMS,
+    )
+    denominator_value = rational_polynomial_from_sympy(
+        denominator.monic(),
+        (parameter,),
+        maximum_terms=MAX_CONIC_RESULT_TERMS,
+    )
+    require_polynomial_budget(
+        denominator_value,
+        maximum_terms=MAX_CONIC_RESULT_TERMS,
+        maximum_exponent=2,
+        maximum_coefficient_digits=MAX_CONIC_RESULT_DIGITS,
+        label="finite-parameter denominator",
+    )
+    return _ConicParametrizationDerivation(
+        data=ConicParametrizationData(
+            coordinates=(coordinate_x, coordinate_y),
+            inverse_parameter=inverse,
+            finite_parameter_denominator=denominator_value,
+        ),
+        projective_coordinates=(projective_x, projective_y, denominator),
+    )
+
+
+def derive_rational_conic_parametrization(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+    parameter: PolynomialVariable,
+) -> ConicParametrizationData:
+    """Construct the second intersection of a normalized line pencil."""
+
+    return _derive_rational_conic_parametrization(polynomial, point, parameter).data
+
+
+def _require_identity_mod_source(expression: Any, source: Any, *, label: str) -> None:
+    numerator_expression, _denominator_expression = sympy.fraction(
+        sympy.cancel(expression)
+    )
+    numerator = sympy.Poly(numerator_expression, *source.gens, domain=sympy.QQ)
+    _quotient, remainder = numerator.div(source)
+    if not remainder.is_zero:
+        raise ValueError(f"{label} must hold modulo the source conic")
+
+
+def _validate_inverse_chart(
+    source: Any,
+    point: VariablePoint,
+    parameter: PolynomialVariable,
+    data: ConicParametrizationData,
+) -> None:
+    source_symbols = source.gens
+    parameter_symbol = sympy.Symbol(parameter)
+    coordinate_expressions = tuple(
+        rational_function_to_sympy(coordinate) for coordinate in data.coordinates
+    )
+    inverse_expression = rational_function_to_sympy(data.inverse_parameter)
+    substitutions = dict(zip(source_symbols, coordinate_expressions, strict=True))
+    if (
+        sympy.cancel(
+            inverse_expression.subs(substitutions, simultaneous=True) - parameter_symbol
+        )
+        != 0
+    ):
+        raise ValueError("inverse chart does not recover the finite parameter")
+
+    for coordinate_expression, source_symbol in zip(
+        coordinate_expressions, source_symbols, strict=True
+    ):
+        _require_identity_mod_source(
+            coordinate_expression.subs(parameter_symbol, inverse_expression)
+            - source_symbol,
+            source,
+            label="parametrization after inverse",
+        )
+
+    px, py = _point_values(point)
+    substitutions_at_point = dict(zip(source_symbols, (px, py), strict=True))
+    fx, fy = (
+        source.diff(variable).eval(substitutions_at_point)
+        for variable in source_symbols
+    )
+    tangent = sympy.Poly(
+        fx * (source_symbols[0] - px) + fy * (source_symbols[1] - py),
+        *source_symbols,
+        domain=sympy.QQ,
+    )
+    _inverse_numerator, inverse_denominator_expression = sympy.fraction(
+        sympy.cancel(inverse_expression)
+    )
+    inverse_denominator = sympy.Poly(
+        inverse_denominator_expression, *source_symbols, domain=sympy.QQ
+    )
+    if inverse_denominator.monic() != tangent.monic():
+        raise ValueError("inverse denominator must be the tangent line at the point")
+
+    line_parameter = sympy.Dummy("line_parameter")
+    tangent_restriction = sympy.Poly(
+        sympy.expand(
+            source.as_expr().subs(
+                {
+                    source_symbols[0]: px - fy * line_parameter,
+                    source_symbols[1]: py + fx * line_parameter,
+                },
+                simultaneous=True,
+            )
+        ),
+        line_parameter,
+        domain=sympy.QQ,
+    )
+    if (
+        tangent_restriction.degree() != 2
+        or tangent_restriction.nth(0) != 0
+        or tangent_restriction.nth(1) != 0
+        or tangent_restriction.nth(2) == 0
+    ):
+        raise ValueError(
+            "inverse denominator must vanish on the conic only at the exceptional point"
+        )
+
+
+def _validate_projective_denominator_locus(
+    source: Any,
+    parameter: PolynomialVariable,
+    data: ConicParametrizationData,
+    projective_coordinates: tuple[Any, Any, Any],
+) -> None:
+    projective_x, projective_y, projective_z = projective_coordinates
+    reported_denominator = rational_polynomial_to_sympy(
+        data.finite_parameter_denominator
+    )
+    if reported_denominator != projective_z.monic():
+        raise ValueError(
+            "finite-parameter denominator must be the projective chart coordinate"
+        )
+
+    common_factor = projective_x.gcd(projective_y).gcd(projective_z)
+    if common_factor.degree() > 0:
+        raise ValueError("projective parametrization must have no finite base point")
+
+    projective_axis = sympy.Dummy("projective_axis")
+    projective_source = source.homogenize(projective_axis)
+    projective_substitution = {
+        source.gens[0]: projective_x.as_expr(),
+        source.gens[1]: projective_y.as_expr(),
+        projective_axis: projective_z.as_expr(),
+    }
+    if (
+        sympy.expand(
+            projective_source.as_expr().subs(projective_substitution, simultaneous=True)
+        )
+        != 0
+    ):
+        raise ValueError("projective parametrization must satisfy the source closure")
+
+    if tuple(str(generator) for generator in projective_z.gens) != (parameter,):
+        raise ValueError("projective chart coordinate must use the parameter axis")
+
+
+def validate_rational_conic_result_identities(
+    polynomial: RationalPolynomial,
+    point: VariablePoint,
+    parameter: PolynomialVariable,
+    data: ConicParametrizationData,
+) -> None:
+    """Replay the canonical chart and its defining birational identities."""
+
+    derivation = _derive_rational_conic_parametrization(polynomial, point, parameter)
+    if data != derivation.data:
+        raise ValueError(
+            "parametrization must match the gradient-normalized line pencil"
+        )
+
+    source = rational_polynomial_to_sympy(polynomial)
+    source_symbols = source.gens
+    parameter_symbol = sympy.Symbol(parameter)
+    coordinate_expressions = tuple(
+        rational_function_to_sympy(coordinate) for coordinate in data.coordinates
+    )
+    substituted = sympy.cancel(
+        source.as_expr().subs(
+            dict(zip(source_symbols, coordinate_expressions, strict=True)),
+            simultaneous=True,
+        )
+    )
+    if substituted != 0:
+        raise ValueError("parametrization does not satisfy the source conic identity")
+
+    _validate_inverse_chart(source, point, parameter, data)
+    _validate_projective_denominator_locus(
+        source,
+        parameter,
+        data,
+        derivation.projective_coordinates,
+    )
+
+    for coordinate_expression, exceptional_coordinate in zip(
+        coordinate_expressions,
+        _point_values(point),
+        strict=True,
+    ):
+        difference = sympy.cancel(coordinate_expression - exceptional_coordinate)
+        numerator, denominator = sympy.fraction(difference)
+        if numerator == 0:
+            continue
+        numerator_degree = sympy.Poly(
+            numerator, parameter_symbol, domain=sympy.QQ
+        ).degree()
+        denominator_degree = sympy.Poly(
+            denominator, parameter_symbol, domain=sympy.QQ
+        ).degree()
+        if numerator_degree >= denominator_degree:
+            raise ValueError(
+                "projective parameter infinity must map to the exceptional point"
+            )
+
+
+__all__ = [
+    "MAX_CONIC_INPUT_DIGITS",
+    "MAX_CONIC_INTERMEDIATE_DIGITS",
+    "MAX_CONIC_RESULT_DIGITS",
+    "MAX_CONIC_RESULT_TERMS",
+    "MAX_CONIC_TERMS",
+    "ConicParametrizationData",
+    "derive_rational_conic_parametrization",
+    "validate_rational_conic_request",
+    "validate_rational_conic_result_identities",
+]

--- a/src/jacobian/math/plane_algebraic_curves/_models.py
+++ b/src/jacobian/math/plane_algebraic_curves/_models.py
@@ -7,9 +7,16 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math.plane_algebraic_curves._conic import (
+    ConicParametrizationData,
+    validate_rational_conic_request,
+    validate_rational_conic_result_identities,
+)
 from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.maps._models import VariablePoint
 from jacobian.math.polynomials.values import (
     PolynomialVariable,
+    RationalFunction,
     RationalPolynomial,
     require_polynomial_budget,
 )
@@ -82,6 +89,47 @@ class AffineChartRequest(StrictModel):
         return self
 
 
+class RationalConicParametrizationRequest(StrictModel):
+    """A smooth affine rational conic with one supplied rational point."""
+
+    polynomial: RationalPolynomial = Field(
+        description=(
+            "A total-degree-two polynomial in exactly two ordered variables over "
+            "QQ whose projective closure is smooth. Coefficients have at most "
+            "128 digits."
+        )
+    )
+    point: VariablePoint = Field(
+        description=(
+            "A checked rational point on the conic whose complete ordered axis "
+            "must exactly match the polynomial variables; each component has at "
+            "most 128 digits."
+        ),
+        examples=[
+            {
+                "variables": ["x", "y"],
+                "values": [
+                    {"num": "1", "den": "1"},
+                    {"num": "0", "den": "1"},
+                ],
+            }
+        ],
+    )
+    parameter: PolynomialVariable = Field(
+        default="t",
+        description=(
+            "The rational-function parameter variable; it must differ from both "
+            "source variables."
+        ),
+        examples=["t"],
+    )
+
+    @model_validator(mode="after")
+    def require_smooth_conic_with_admitted_output(self) -> Self:
+        validate_rational_conic_request(self.polynomial, self.point, self.parameter)
+        return self
+
+
 class AffineCurveResult(StrictModel):
     is_valid: bool
     degree: int = Field(ge=0, le=_MAX_EXPONENT)
@@ -98,6 +146,61 @@ class AffineChartResult(StrictModel):
     method: Literal["DEHOMOGENIZATION"] = "DEHOMOGENIZATION"
 
 
+class RationalConicParametrizationResult(StrictModel):
+    """A source-bound affine chart of a smooth projective rational conic."""
+
+    source_polynomial: RationalPolynomial
+    exceptional_point: VariablePoint = Field(
+        description=(
+            "The supplied source point, omitted by the finite affine parameter "
+            "chart and attained at projective parameter infinity."
+        )
+    )
+    parameter: PolynomialVariable
+    coordinates: tuple[RationalFunction, RationalFunction] = Field(
+        description=(
+            "Canonical coordinate functions in source-variable order. For every "
+            "finite parameter outside finite_parameter_denominator=0 they give "
+            "an affine point on the source conic."
+        )
+    )
+    inverse_parameter: RationalFunction = Field(
+        description=(
+            "The inverse rational parameter in the two source variables. Its "
+            "denominator-nonzero chart is the conic minus exceptional_point."
+        )
+    )
+    finite_parameter_denominator: RationalPolynomial = Field(
+        description=(
+            "The monic quadratic whose finite zeros map to points of the "
+            "projective closure outside the source affine chart."
+        )
+    )
+    exceptional_parameter: Literal["PROJECTIVE_INFINITY"] = "PROJECTIVE_INFINITY"
+    normalization: Literal["GRADIENT_ORTHOGONAL_LINE_PENCIL"] = (
+        "GRADIENT_ORTHOGONAL_LINE_PENCIL"
+    )
+
+    @model_validator(mode="after")
+    def replay_defining_identities(self) -> Self:
+        validate_rational_conic_request(
+            self.source_polynomial,
+            self.exceptional_point,
+            self.parameter,
+        )
+        validate_rational_conic_result_identities(
+            self.source_polynomial,
+            self.exceptional_point,
+            self.parameter,
+            ConicParametrizationData(
+                coordinates=self.coordinates,
+                inverse_parameter=self.inverse_parameter,
+                finite_parameter_denominator=self.finite_parameter_denominator,
+            ),
+        )
+        return self
+
+
 __all__ = [
     "MAX_VARS",
     "AffineChartRequest",
@@ -106,4 +209,6 @@ __all__ = [
     "AffineCurveResult",
     "ProjectiveClosureRequest",
     "ProjectiveClosureResult",
+    "RationalConicParametrizationRequest",
+    "RationalConicParametrizationResult",
 ]

--- a/src/jacobian/math/plane_algebraic_curves/_operations.py
+++ b/src/jacobian/math/plane_algebraic_curves/_operations.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import sympy
 
+from jacobian.math.plane_algebraic_curves._conic import (
+    derive_rational_conic_parametrization,
+)
 from jacobian.math.plane_algebraic_curves._models import (
     HOMOGENIZING_COORDINATE,
     AffineChartRequest,
@@ -12,6 +15,8 @@ from jacobian.math.plane_algebraic_curves._models import (
     AffineCurveResult,
     ProjectiveClosureRequest,
     ProjectiveClosureResult,
+    RationalConicParametrizationRequest,
+    RationalConicParametrizationResult,
 )
 from jacobian.math.polynomials._conversions import (
     rational_polynomial_from_sympy,
@@ -97,8 +102,29 @@ def compute_affine_chart(request: AffineChartRequest) -> AffineChartResult:
     )
 
 
+def compute_rational_conic_parametrization(
+    request: RationalConicParametrizationRequest,
+) -> RationalConicParametrizationResult:
+    """Parametrize a smooth rational conic by its normalized line pencil."""
+
+    data = derive_rational_conic_parametrization(
+        request.polynomial,
+        request.point,
+        request.parameter,
+    )
+    return RationalConicParametrizationResult(
+        source_polynomial=request.polynomial,
+        exceptional_point=request.point,
+        parameter=request.parameter,
+        coordinates=data.coordinates,
+        inverse_parameter=data.inverse_parameter,
+        finite_parameter_denominator=data.finite_parameter_denominator,
+    )
+
+
 __all__ = [
     "compute_affine_chart",
     "compute_affine_curve_check",
     "compute_projective_closure",
+    "compute_rational_conic_parametrization",
 ]

--- a/src/jacobian/math/plane_algebraic_curves/_tools.py
+++ b/src/jacobian/math/plane_algebraic_curves/_tools.py
@@ -13,11 +13,14 @@ from jacobian.math.plane_algebraic_curves._models import (
     AffineCurveResult,
     ProjectiveClosureRequest,
     ProjectiveClosureResult,
+    RationalConicParametrizationRequest,
+    RationalConicParametrizationResult,
 )
 from jacobian.math.plane_algebraic_curves._operations import (
     compute_affine_chart,
     compute_affine_curve_check,
     compute_projective_closure,
+    compute_rational_conic_parametrization,
 )
 
 
@@ -115,6 +118,45 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                         (1, (0, 2)),
                         (-1, (0, 0)),
                     ),
+                },
+            ),
+        ),
+    ),
+    _op(
+        "algebraic_geometry.conic.rational_parametrization.compute",
+        "Parametrize a smooth rational conic",
+        "Construct canonical rational coordinate functions, their inverse chart, "
+        "the finite affine-denominator locus, and the exceptional source point "
+        "from a smooth rational affine conic with a supplied rational point.",
+        RationalConicParametrizationRequest,
+        RationalConicParametrizationResult,
+        compute_rational_conic_parametrization,
+        "algebraic-geometry",
+        "conic",
+        "rational-parametrization",
+        "exact",
+        examples=(
+            example(
+                "smooth_conic_from_point",
+                "Parametrize x^2 + x*y - y^2 - 1 = 0 from (1,0); the "
+                "polynomial must have smooth projective closure and the checked "
+                "point must lie on it.",
+                {
+                    "polynomial": _polynomial(
+                        ("x", "y"),
+                        (1, (2, 0)),
+                        (1, (1, 1)),
+                        (-1, (0, 2)),
+                        (-1, (0, 0)),
+                    ),
+                    "point": {
+                        "variables": ["x", "y"],
+                        "values": [
+                            {"num": "1", "den": "1"},
+                            {"num": "0", "den": "1"},
+                        ],
+                    },
+                    "parameter": "t",
                 },
             ),
         ),

--- a/tests/integration/algebra/test_conic_parametrization_composition.py
+++ b/tests/integration/algebra/test_conic_parametrization_composition.py
@@ -1,0 +1,95 @@
+"""Cross-owner composition for rational conic coordinate functions."""
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.matrices.symbolic._models import (
+    SymbolicDeterminantRequest,
+)
+from jacobian.math.matrices.symbolic._operations import compute_symbolic_determinant
+from jacobian.math.plane_algebraic_curves._models import (
+    RationalConicParametrizationRequest,
+)
+from jacobian.math.plane_algebraic_curves._operations import (
+    compute_rational_conic_parametrization,
+)
+from jacobian.math.polynomials.maps._models import EvalRequest, VariablePoint
+from jacobian.math.polynomials.maps._operations import evaluate_polynomial
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _integer(value: int) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(value, 1)
+
+
+def test_conic_coordinate_serialization_is_a_symbolic_matrix_entry() -> None:
+    source = RationalPolynomial(
+        variables=("x", "y"),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=_integer(1), exponents=(2, 0)),
+                RationalPolynomialTerm(coefficient=_integer(1), exponents=(0, 2)),
+                RationalPolynomialTerm(coefficient=_integer(-1), exponents=(0, 0)),
+            )
+        ),
+    )
+    parametrization = compute_rational_conic_parametrization(
+        RationalConicParametrizationRequest(
+            polynomial=source,
+            point=VariablePoint(
+                variables=source.variables,
+                values=(_integer(1), _integer(0)),
+            ),
+            parameter="t",
+        )
+    )
+    coordinate_payload = parametrization.model_dump(mode="json")["coordinates"][0]
+    determinant_request = SymbolicDeterminantRequest.model_validate(
+        {
+            "matrix": {
+                "variables": ["t"],
+                "entries": [[coordinate_payload]],
+            }
+        }
+    )
+
+    assert determinant_request.matrix.entries[0][0] == parametrization.coordinates[0]
+    determinant = compute_symbolic_determinant(determinant_request)
+    assert determinant.determinant == parametrization.coordinates[0]
+
+
+def test_exceptional_point_serialization_evaluates_on_its_source_conic() -> None:
+    source = RationalPolynomial(
+        variables=("x", "y"),
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(coefficient=_integer(1), exponents=(2, 0)),
+                RationalPolynomialTerm(coefficient=_integer(1), exponents=(0, 2)),
+                RationalPolynomialTerm(coefficient=_integer(-1), exponents=(0, 0)),
+            )
+        ),
+    )
+    point = VariablePoint(
+        variables=source.variables,
+        values=(_integer(1), _integer(0)),
+    )
+    request_payload = {
+        "polynomial": source.model_dump(mode="json"),
+        "point": point.model_dump(mode="json"),
+        "parameter": "t",
+    }
+    request = RationalConicParametrizationRequest.model_validate(request_payload)
+    assert request.point == point
+
+    parametrization = compute_rational_conic_parametrization(request)
+    exceptional_payload = parametrization.model_dump(mode="json")["exceptional_point"]
+    evaluation_request = EvalRequest.model_validate(
+        {
+            "polynomial": source.model_dump(mode="json"),
+            "point": exceptional_payload,
+        }
+    )
+    assert evaluation_request.point == parametrization.exceptional_point
+    assert evaluate_polynomial(evaluation_request).value == _integer(0)

--- a/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
@@ -7,6 +7,7 @@ import sympy
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.plane_algebraic_curves import _conic
 from jacobian.math.plane_algebraic_curves._conic import MAX_CONIC_INPUT_DIGITS
 from jacobian.math.plane_algebraic_curves._models import (
     AffineChartRequest,
@@ -422,6 +423,59 @@ def test_normalized_result_height_boundary_is_accepted_then_rejected() -> None:
                 (_rational(rejected_x), _rational(rejected_x**2)),
             ),
         )
+
+
+def test_request_admission_completes_before_any_backend_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ForbiddenSympy:
+        def __getattr__(self, name: str) -> object:
+            raise AssertionError("request admission must not enter SymPy")
+
+    monkeypatch.setattr(_conic, "sympy", _ForbiddenSympy())
+    source = _polynomial(("x", "y"), (-1, (2, 0)), (1, (0, 1)))
+
+    accepted_x = 10**31
+    request = RationalConicParametrizationRequest(
+        polynomial=source,
+        point=_point(("x", "y"), (_rational(accepted_x), _rational(accepted_x**2))),
+    )
+    assert request.parameter == "t"
+
+    rejected_x = 10**32
+    with pytest.raises(ValidationError, match=r"output exceeds.*128-digit"):
+        RationalConicParametrizationRequest(
+            polynomial=source,
+            point=_point(
+                ("x", "y"),
+                (_rational(rejected_x), _rational(rejected_x**2)),
+            ),
+        )
+
+
+def test_exact_preflight_admits_rational_point_on_hyperbola() -> None:
+    source = _polynomial(("x", "y"), (1, (1, 1)), (-1, (0, 0)))
+    point = (_rational(1, 3), _rational(3))
+    result = _parametrize(source, point)
+    coordinate_expressions = tuple(
+        rational_function_to_sympy(coordinate) for coordinate in result.coordinates
+    )
+    substitutions = dict(
+        zip(
+            symbols_for_variables(result.source_polynomial.variables),
+            coordinate_expressions,
+            strict=True,
+        )
+    )
+
+    assert (
+        sympy.cancel(
+            rational_polynomial_to_sympy(source)
+            .as_expr()
+            .subs(substitutions, simultaneous=True)
+        )
+        == 0
+    )
 
 
 def test_result_rejects_independently_forged_source_point_and_coordinates() -> None:

--- a/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
+++ b/tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py
@@ -1,25 +1,42 @@
 """Tests for plane algebraic curve operations."""
 
+from copy import deepcopy
+
 import pytest
+import sympy
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.math.plane_algebraic_curves._conic import MAX_CONIC_INPUT_DIGITS
 from jacobian.math.plane_algebraic_curves._models import (
     AffineChartRequest,
     AffineCurveRequest,
     ProjectiveClosureRequest,
+    RationalConicParametrizationRequest,
+    RationalConicParametrizationResult,
 )
 from jacobian.math.plane_algebraic_curves._operations import (
     compute_affine_chart,
     compute_affine_curve_check,
     compute_projective_closure,
+    compute_rational_conic_parametrization,
 )
 from jacobian.math.plane_algebraic_curves._tools import TOOLS
+from jacobian.math.polynomials._conversions import (
+    rational_function_to_sympy,
+    rational_polynomial_to_sympy,
+    symbols_for_variables,
+)
+from jacobian.math.polynomials.maps._models import VariablePoint
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
+
+
+def _rational(numerator: str | int, denominator: str | int = 1) -> CanonicalRational:
+    return CanonicalRational(num=str(numerator), den=str(denominator))
 
 
 def _polynomial(
@@ -40,12 +57,436 @@ def _polynomial(
     )
 
 
+def _rational_polynomial(
+    variables: tuple[str, ...],
+    *terms: tuple[tuple[str, str], tuple[int, ...]],
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(*coefficient),
+                    exponents=exponents,
+                )
+                for coefficient, exponents in terms
+            )
+        ),
+    )
+
+
+def _parametrize(
+    polynomial: RationalPolynomial,
+    point: tuple[CanonicalRational, CanonicalRational],
+    parameter: str = "t",
+) -> RationalConicParametrizationResult:
+    return compute_rational_conic_parametrization(
+        RationalConicParametrizationRequest(
+            polynomial=polynomial,
+            point=_point(polynomial.variables, point),
+            parameter=parameter,
+        )
+    )
+
+
+def _point(
+    variables: tuple[str, ...],
+    values: tuple[CanonicalRational, CanonicalRational],
+) -> VariablePoint:
+    return VariablePoint(variables=variables, values=values)
+
+
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
         "algebraic_geometry.affine_plane_curve.check",
+        "algebraic_geometry.conic.rational_parametrization.compute",
         "algebraic_geometry.plane_curve.projective_closure.compute",
         "algebraic_geometry.projective_curve.affine_chart.compute",
     }
+
+
+def test_rational_conic_parametrization_has_canonical_known_answer() -> None:
+    source = _polynomial(
+        ("x", "y"),
+        (1, (2, 0)),
+        (1, (1, 1)),
+        (-1, (0, 2)),
+        (-1, (0, 0)),
+    )
+    point = (_rational(1), _rational(0))
+    result = _parametrize(source, point)
+    t, x, y = sympy.symbols("t x y")
+
+    assert rational_function_to_sympy(result.coordinates[0]) == (t**2 + 1) / (
+        t**2 + t - 1
+    )
+    assert rational_function_to_sympy(result.coordinates[1]) == (2 * t + 1) / (
+        t**2 + t - 1
+    )
+    assert rational_function_to_sympy(result.inverse_parameter) == (
+        -x / 2 + y + sympy.Rational(1, 2)
+    ) / (x + y / 2 - 1)
+    assert (
+        rational_polynomial_to_sympy(result.finite_parameter_denominator).as_expr()
+        == t**2 + t - 1
+    )
+    assert result.exceptional_point == _point(source.variables, point)
+    assert result.exceptional_parameter == "PROJECTIVE_INFINITY"
+    assert result.normalization == "GRADIENT_ORTHOGONAL_LINE_PENCIL"
+
+
+@pytest.mark.parametrize(
+    ("source", "point"),
+    [
+        (
+            _polynomial(
+                ("x", "y"),
+                (1, (2, 0)),
+                (1, (0, 2)),
+                (-1, (0, 0)),
+            ),
+            (_rational(1), _rational(0)),
+        ),
+        (
+            _polynomial(("x", "y"), (1, (1, 1)), (-1, (0, 0))),
+            (_rational(1), _rational(1)),
+        ),
+        (
+            _polynomial(("x", "y"), (-1, (2, 0)), (1, (0, 1))),
+            (_rational(0), _rational(0)),
+        ),
+        (
+            _polynomial(
+                ("u", "v"),
+                (2, (2, 0)),
+                (-3, (1, 1)),
+                (-1, (0, 2)),
+                (-2, (0, 0)),
+            ),
+            (_rational(1), _rational(0)),
+        ),
+    ],
+)
+def test_parametrization_replays_substitution_and_inverse_identities(
+    source: RationalPolynomial,
+    point: tuple[CanonicalRational, CanonicalRational],
+) -> None:
+    result = _parametrize(source, point)
+    coordinate_expressions = tuple(
+        rational_function_to_sympy(coordinate) for coordinate in result.coordinates
+    )
+    variables = symbols_for_variables(source.variables)
+    parameter = sympy.Symbol(result.parameter)
+    substitutions = dict(zip(variables, coordinate_expressions, strict=True))
+
+    assert (
+        sympy.cancel(
+            rational_polynomial_to_sympy(source)
+            .as_expr()
+            .subs(
+                substitutions,
+                simultaneous=True,
+            )
+        )
+        == 0
+    )
+    assert (
+        sympy.cancel(
+            rational_function_to_sympy(result.inverse_parameter).subs(
+                substitutions,
+                simultaneous=True,
+            )
+            - parameter
+        )
+        == 0
+    )
+    inverse = rational_function_to_sympy(result.inverse_parameter)
+    source_polynomial = rational_polynomial_to_sympy(source)
+    for coordinate, variable in zip(coordinate_expressions, variables, strict=True):
+        numerator, _denominator = sympy.fraction(
+            sympy.cancel(coordinate.subs(parameter, inverse) - variable)
+        )
+        _quotient, remainder = sympy.Poly(numerator, *variables, domain=sympy.QQ).div(
+            source_polynomial
+        )
+        assert remainder.is_zero
+    assert tuple(
+        sympy.limit(coordinate, parameter, sympy.oo)
+        for coordinate in coordinate_expressions
+    ) == tuple(sympy.Rational(*coordinate.as_integer_ratio()) for coordinate in point)
+
+
+def test_parabola_retains_common_denominator_locus_after_coordinate_cancellation() -> (
+    None
+):
+    result = _parametrize(
+        _polynomial(("x", "y"), (-1, (2, 0)), (1, (0, 1))),
+        (_rational(0), _rational(0)),
+    )
+    t = sympy.Symbol("t")
+
+    assert rational_function_to_sympy(result.coordinates[0]) == -1 / t
+    assert rational_function_to_sympy(result.coordinates[1]) == 1 / t**2
+    assert (
+        rational_polynomial_to_sympy(result.finite_parameter_denominator).as_expr()
+        == t**2
+    )
+    source = rational_polynomial_to_sympy(result.source_polynomial)
+    projective_x = sympy.Poly(
+        sympy.cancel(rational_function_to_sympy(result.coordinates[0]) * t**2),
+        t,
+        domain=sympy.QQ,
+    )
+    projective_y = sympy.Poly(
+        sympy.cancel(rational_function_to_sympy(result.coordinates[1]) * t**2),
+        t,
+        domain=sympy.QQ,
+    )
+    projective_z = sympy.Poly(t**2, t, domain=sympy.QQ)
+    assert projective_x.gcd(projective_y).gcd(projective_z).degree() == 0
+    z = sympy.Symbol("z")
+    assert (
+        sympy.expand(
+            source.homogenize(z)
+            .as_expr()
+            .subs(
+                {
+                    source.gens[0]: projective_x.as_expr(),
+                    source.gens[1]: projective_y.as_expr(),
+                    z: projective_z.as_expr(),
+                },
+                simultaneous=True,
+            )
+        )
+        == 0
+    )
+
+
+def test_hyperbola_denominator_locus_is_not_inferred_from_one_coordinate() -> None:
+    result = _parametrize(
+        _polynomial(("x", "y"), (1, (1, 1)), (-1, (0, 0))),
+        (_rational(1), _rational(1)),
+    )
+    t = sympy.Symbol("t")
+
+    assert rational_function_to_sympy(result.coordinates[0]) == (t - 1) / (t + 1)
+    assert rational_function_to_sympy(result.coordinates[1]) == (t + 1) / (t - 1)
+    assert (
+        rational_polynomial_to_sympy(result.finite_parameter_denominator).as_expr()
+        == t**2 - 1
+    )
+
+
+def test_nonzero_equation_rescaling_preserves_normalized_parametrization() -> None:
+    source = _polynomial(
+        ("x", "y"),
+        (1, (2, 0)),
+        (1, (1, 1)),
+        (-1, (0, 2)),
+        (-1, (0, 0)),
+    )
+    rescaled = _polynomial(
+        ("x", "y"),
+        (-7, (2, 0)),
+        (-7, (1, 1)),
+        (7, (0, 2)),
+        (7, (0, 0)),
+    )
+    point = (_rational(1), _rational(0))
+
+    original = _parametrize(source, point)
+    scaled = _parametrize(rescaled, point)
+    assert scaled.coordinates == original.coordinates
+    assert scaled.inverse_parameter == original.inverse_parameter
+    assert scaled.finite_parameter_denominator == original.finite_parameter_denominator
+
+
+def test_request_rejects_point_outside_conic() -> None:
+    with pytest.raises(ValidationError, match="point must lie"):
+        RationalConicParametrizationRequest(
+            polynomial=_polynomial(
+                ("x", "y"),
+                (1, (2, 0)),
+                (1, (0, 2)),
+                (-1, (0, 0)),
+            ),
+            point=_point(("x", "y"), (_rational(0), _rational(0))),
+        )
+
+
+@pytest.mark.parametrize(
+    ("source", "point"),
+    [
+        (
+            _polynomial(("x", "y"), (1, (1, 1))),
+            (_rational(0), _rational(0)),
+        ),
+        (
+            _polynomial(("x", "y"), (1, (2, 0)), (1, (0, 2))),
+            (_rational(0), _rational(0)),
+        ),
+        (
+            _polynomial(("x", "y"), (1, (2, 0)), (-1, (0, 0))),
+            (_rational(1), _rational(0)),
+        ),
+    ],
+)
+def test_request_rejects_singular_or_reducible_quadratics(
+    source: RationalPolynomial,
+    point: tuple[CanonicalRational, CanonicalRational],
+) -> None:
+    with pytest.raises(ValidationError, match="smooth irreducible"):
+        RationalConicParametrizationRequest(
+            polynomial=source,
+            point=_point(source.variables, point),
+        )
+
+
+def test_request_rejects_wrong_degree_axis_and_parameter_collision() -> None:
+    point = (_rational(0), _rational(0))
+    with pytest.raises(ValidationError, match="degree exactly two"):
+        RationalConicParametrizationRequest(
+            polynomial=_polynomial(("x", "y"), (1, (1, 0))),
+            point=_point(("x", "y"), point),
+        )
+    with pytest.raises(ValidationError, match="exactly two variables"):
+        RationalConicParametrizationRequest(
+            polynomial=_polynomial(("x",), (1, (2,))),
+            point=_point(("x", "y"), point),
+        )
+    with pytest.raises(ValidationError, match="parameter must be distinct"):
+        RationalConicParametrizationRequest(
+            polynomial=_polynomial(
+                ("x", "y"),
+                (1, (2, 0)),
+                (1, (0, 2)),
+                (-1, (0, 0)),
+            ),
+            point=_point(("x", "y"), (_rational(1), _rational(0))),
+            parameter="x",
+        )
+
+
+@pytest.mark.parametrize("variables", [("x", "z"), ("y", "x")])
+def test_request_rejects_mismatched_or_reordered_point_axis(
+    variables: tuple[str, str],
+) -> None:
+    source = _polynomial(("x", "y"), (1, (2, 0)), (1, (0, 2)), (-1, (0, 0)))
+    with pytest.raises(ValidationError, match="complete ordered axis"):
+        RationalConicParametrizationRequest(
+            polynomial=source,
+            point=_point(variables, (_rational(1), _rational(0))),
+        )
+
+
+def test_input_coefficient_boundary_is_accepted_then_rejected() -> None:
+    accepted_denominator = "1" + "0" * (MAX_CONIC_INPUT_DIGITS - 1)
+    accepted = _rational_polynomial(
+        ("x", "y"),
+        (("1", accepted_denominator), (2, 0)),
+        (("1", accepted_denominator), (0, 2)),
+        (("-1", accepted_denominator), (0, 0)),
+    )
+    result = _parametrize(accepted, (_rational(1), _rational(0)))
+    assert result.coordinates
+
+    rejected_denominator = "1" + "0" * MAX_CONIC_INPUT_DIGITS
+    rejected = _rational_polynomial(
+        ("x", "y"),
+        (("1", rejected_denominator), (2, 0)),
+        (("1", rejected_denominator), (0, 2)),
+        (("-1", rejected_denominator), (0, 0)),
+    )
+    with pytest.raises(ValidationError, match="128-digit"):
+        RationalConicParametrizationRequest(
+            polynomial=rejected,
+            point=_point(("x", "y"), (_rational(1), _rational(0))),
+        )
+
+
+def test_normalized_result_height_boundary_is_accepted_then_rejected() -> None:
+    source = _polynomial(("x", "y"), (-1, (2, 0)), (1, (0, 1)))
+    accepted_x = 10**31
+    accepted = _parametrize(
+        source,
+        (_rational(accepted_x), _rational(accepted_x**2)),
+    )
+    assert accepted.coordinates
+
+    rejected_x = 10**32
+    with pytest.raises(ValidationError, match=r"output exceeds.*128-digit"):
+        RationalConicParametrizationRequest(
+            polynomial=source,
+            point=_point(
+                ("x", "y"),
+                (_rational(rejected_x), _rational(rejected_x**2)),
+            ),
+        )
+
+
+def test_result_rejects_independently_forged_source_point_and_coordinates() -> None:
+    source = _polynomial(
+        ("x", "y"),
+        (1, (2, 0)),
+        (1, (1, 1)),
+        (-1, (0, 2)),
+        (-1, (0, 0)),
+    )
+    result = _parametrize(source, (_rational(1), _rational(0)))
+    payload = result.model_dump(mode="json")
+
+    forged_coordinates = deepcopy(payload)
+    forged_coordinates["coordinates"][0] = payload["coordinates"][1]
+    with pytest.raises(ValidationError, match="gradient-normalized"):
+        RationalConicParametrizationResult.model_validate(forged_coordinates)
+
+    forged_source = deepcopy(payload)
+    forged_source["source_polynomial"] = _polynomial(
+        ("x", "y"),
+        (1, (2, 0)),
+        (1, (0, 2)),
+        (-1, (0, 0)),
+    ).model_dump(mode="json")
+    with pytest.raises(ValidationError, match="gradient-normalized"):
+        RationalConicParametrizationResult.model_validate(forged_source)
+
+    forged_point = deepcopy(payload)
+    forged_point["exceptional_point"] = _point(
+        source.variables, (_rational(-1), _rational(0))
+    ).model_dump(mode="json")
+    with pytest.raises(ValidationError, match="gradient-normalized"):
+        RationalConicParametrizationResult.model_validate(forged_point)
+
+    forged_inverse = deepcopy(payload)
+    forged_inverse["inverse_parameter"] = payload["coordinates"][0]
+    with pytest.raises(ValidationError, match="gradient-normalized"):
+        RationalConicParametrizationResult.model_validate(forged_inverse)
+
+    forged_denominator = deepcopy(payload)
+    denominator_terms = forged_denominator["finite_parameter_denominator"][
+        "polynomial"
+    ]["terms"]
+    denominator_terms[-1]["coefficient"]["num"] = "-2"
+    with pytest.raises(ValidationError, match="gradient-normalized"):
+        RationalConicParametrizationResult.model_validate(forged_denominator)
+
+
+def test_parametrization_schema_guides_cross_field_contract() -> None:
+    schema = RationalConicParametrizationRequest.model_json_schema()
+    assert "smooth" in schema["properties"]["polynomial"]["description"]
+    assert "ordered" in schema["properties"]["point"]["description"]
+    assert schema["properties"]["point"]["examples"]
+    assert schema["properties"]["parameter"]["examples"] == ["t"]
+
+    tool = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id
+        == "algebraic_geometry.conic.rational_parametrization.compute"
+    )
+    request = tool.request_type.model_validate(tool.examples[0].input)
+    output = tool.run(request)
+    assert tool.result_type.model_validate(output.model_dump(mode="json")) == output
 
 
 def test_affine_curve_check_circle() -> None:


### PR DESCRIPTION
## Problem

Closes #2257.

Jacobian could verify or substitute a supplied polynomial map, but it could not construct the standard birational chart of a smooth rational conic from a known rational point. Callers therefore had to derive the line pencil, normalize its rational functions, and reason separately about the inverse and exceptional loci. A sign or chart error in that derivation would then propagate into downstream polynomial computations.

## Solution

Add `algebraic_geometry.conic.rational_parametrization.compute`. The request accepts a degree-two `RationalPolynomial` and the existing axis-bearing `VariablePoint`; the point axis must exactly match the polynomial axis. Admission checks the point, projective smoothness, parameter separation, fixed-degree work, intermediate growth, and the complete normalized output bound before constructing the result.

The operation uses the pinned SymPy 1.14 exact `QQ` polynomial backend for the gradient-normalized line pencil and returns:

- two canonical `RationalFunction` coordinates in source-variable order;
- the inverse rational parameter on its declared chart;
- the source-bound exceptional point and projective-infinity parameter; and
- the common monic finite-parameter denominator, including factors cancelled from an individual coordinate.

Result validation replays the canonical construction and checks the source substitution, both directions of the birational inverse, the tangent-line complement of the exceptional point, and a base-point-free projective parametrization whose `Z` coordinate is the reported finite denominator. Nonzero rational rescaling of the source equation preserves the normalized chart.

Admission does not construct the result. It computes the fixed set of raw scalar coefficients with exact `Fraction` arithmetic, clears their actual denominator LCMs, separates rational content from primitive degree-two polynomials, applies the degree-two factor bound to cancellation quotients, and includes the final leading-coefficient division. The accepted 127-digit result boundary returns normally; the adjacent 131-digit bound is rejected before SymPy result construction.

Suggested review order: request/result contracts, coefficient admission and kernel in `_conic.py`, defining-invariant tests, then catalog declaration and admission.

## Testing

- `make test-math TESTS=tests/math/plane_algebraic_curves/test_plane_algebraic_curves.py` — 31 passed
- `make test-integration TESTS=tests/integration/algebra/test_conic_parametrization_composition.py` — 2 passed
- `make test-integration TESTS=tests/integration/catalog/test_public_operation_contract_conformance.py` — 484 passed
- `make test-catalog` — 27 passed
- `make lint typecheck` — Ruff and mypy passed
- `make check` — 2,668 passed; Ruff and mypy passed
- Specialist validation run: focused cross-owner composition and public-operation conformance commands listed above

## Public contract impact

Adds operation ID `algebraic_geometry.conic.rational_parametrization.compute` with new request/result schemas. The request and exceptional-point result reuse `VariablePoint` unchanged, so the serialized exceptional point can pass directly to `polynomial.map.evaluate`. Existing operation IDs and schemas are unchanged.

## Public operation admission

- Concrete gap: construct an exact source-bound rational parametrization of a smooth conic from a rational point.
- Why existing operations or typed values are insufficient: polynomial substitution can check a proposed map but cannot construct the chart, inverse, or exceptional loci.
- Stable mathematical result: one canonical birational conic chart normalized by the gradient-orthogonal line pencil.
- Semantic domain and admitted execution envelope: smooth projective degree-two conics over `QQ` with an affine rational point; source, point, normalized coefficient, and intermediate digit bounds are checked before execution.
- Controlling work, intermediate, memory, and output quantities: six possible conic terms, fixed degree two, exact coefficient heights after denominator clearing, degree-two cancellation minors, three terms per returned numerator or denominator, 128 result-coefficient digits, and a 16,384-digit intermediate ceiling.
- Exact representation, algorithm regimes, and maintained backend: canonical Jacobian polynomial, rational-function, and point values; one exact `QQ` line-pencil construction using pinned SymPy 1.14.
- Remaining fixed caps and their classification: the 128-digit input/output limits and 16,384-digit intermediate limit are conservative release-envelope caps; degree two and six source terms are semantic consequences of the conic domain.
- Admission decision: `KEEP` as a distinct reusable birational construction.

## Closure matrix

None — this issue requests one admitted operation and leaves no residual surface.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics are exact; incomplete or unavailable outcomes are not exposed
- [x] New bounds include accepted/rejected boundaries and a 128-digit rescaling case
- [x] No new shared abstraction is introduced
