### PR TITLE
feat(math): add exact Artin–Mazur zeta functions for edge shifts

### DIFF
--- a/src/jacobian/math/symbolic_dynamics/__init__.py
+++ b/src/jacobian/math/symbolic_dynamics/__init__.py
@@ -2,6 +2,7 @@
 
 from jacobian.math.symbolic_dynamics.operations import (
     adjacency_shift,
+    artin_mazur_zeta,
     block_language,
     finite_type_presentation,
     higher_block_presentation,
@@ -21,6 +22,7 @@ __all__ = [
     "ForbiddenBlockShift",
     "LabeledTransition",
     "adjacency_shift",
+    "artin_mazur_zeta",
     "block_language",
     "finite_type_presentation",
     "higher_block_presentation",

--- a/src/jacobian/math/symbolic_dynamics/_admission.py
+++ b/src/jacobian/math/symbolic_dynamics/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.symbolic_dynamics._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "symbolic_dynamics.artin_mazur_zeta.compute",
+        AdmissionDecision.KEEP,
+        "exact rational dynamical invariant with periodic-point replay",
+    ),
+    OperationAdmission(
         "symbolic_dynamics.block_language.compute",
         AdmissionDecision.KEEP,
         "complete occurring-block language of a bounded shift presentation",

--- a/src/jacobian/math/symbolic_dynamics/_models.py
+++ b/src/jacobian/math/symbolic_dynamics/_models.py
@@ -9,10 +9,14 @@ from pydantic import Field, model_validator
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer
+from jacobian.math.polynomials.values import RationalFunction, RationalPolynomial
 from jacobian.math.symbolic_dynamics.operations import (
+    MAX_ZETA_REPLAY_PERIOD,
     _presentation_memory,
     _require_bounded_presentation,
     _require_bounded_support,
+    _require_zeta_budget,
+    artin_mazur_zeta,
     block_language,
     enumeration_size,
     finite_type_presentation,
@@ -161,7 +165,63 @@ class HigherBlockResult(HigherBlockRequest):
         return self
 
 
+class ArtinMazurZetaRequest(StrictModel):
+    """Request the exact Artin--Mazur zeta function of one edge shift."""
+
+    shift: AdjacencyShift
+    replay_period: int = Field(ge=1, le=MAX_ZETA_REPLAY_PERIOD)
+
+    @model_validator(mode="after")
+    def require_bounded_exact_zeta(self) -> Self:
+        _require_zeta_budget(self.shift, self.replay_period)
+        return self
+
+
+class ArtinMazurZetaReplayRow(StrictModel):
+    period: int = Field(ge=1, le=MAX_ZETA_REPLAY_PERIOD)
+    trace_fixed_points: CanonicalInteger
+    logarithmic_derivative_coefficient: CanonicalInteger
+
+
+class ArtinMazurZetaResult(ArtinMazurZetaRequest):
+    determinant_polynomial: RationalPolynomial
+    zeta_function: RationalFunction
+    replay: tuple[ArtinMazurZetaReplayRow, ...] = Field(
+        min_length=1, max_length=MAX_ZETA_REPLAY_PERIOD
+    )
+    convention: Literal["EDGE_SHIFT_ARTIN_MAZUR_ZETA"] = "EDGE_SHIFT_ARTIN_MAZUR_ZETA"
+    method: Literal["SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL"] = (
+        "SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL"
+    )
+
+    @model_validator(mode="after")
+    def bind_zeta_and_periodic_replay(self) -> Self:
+        determinant, zeta, coefficients = artin_mazur_zeta(
+            self.shift, self.replay_period
+        )
+        expected_replay = tuple(
+            ArtinMazurZetaReplayRow(
+                period=period,
+                trace_fixed_points=format_canonical_integer(coefficient),
+                logarithmic_derivative_coefficient=format_canonical_integer(
+                    coefficient
+                ),
+            )
+            for period, coefficient in enumerate(coefficients, 1)
+        )
+        if (
+            self.determinant_polynomial != determinant
+            or self.zeta_function != zeta
+            or self.replay != expected_replay
+        ):
+            raise ValueError("Artin--Mazur zeta result is not bound to the request")
+        return self
+
+
 __all__ = [
+    "ArtinMazurZetaReplayRow",
+    "ArtinMazurZetaRequest",
+    "ArtinMazurZetaResult",
     "BlockLanguageRequest",
     "BlockLanguageResult",
     "FiniteTypeShiftRequest",

--- a/src/jacobian/math/symbolic_dynamics/_operations.py
+++ b/src/jacobian/math/symbolic_dynamics/_operations.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.symbolic_dynamics._models import (
+    ArtinMazurZetaReplayRow,
+    ArtinMazurZetaRequest,
+    ArtinMazurZetaResult,
     BlockLanguageRequest,
     BlockLanguageResult,
     FiniteTypeShiftRequest,
@@ -14,12 +17,36 @@ from jacobian.math.symbolic_dynamics._models import (
     PeriodicPointProfileResult,
 )
 from jacobian.math.symbolic_dynamics.operations import (
+    artin_mazur_zeta,
     block_language,
     finite_type_presentation,
     higher_block_presentation,
     normalize_forbidden_blocks,
     periodic_point_profile,
 )
+
+
+def compute_artin_mazur_zeta(
+    request: ArtinMazurZetaRequest,
+) -> ArtinMazurZetaResult:
+    determinant, zeta, coefficients = artin_mazur_zeta(
+        request.shift, request.replay_period
+    )
+    return ArtinMazurZetaResult(
+        **request.model_dump(),
+        determinant_polynomial=determinant,
+        zeta_function=zeta,
+        replay=tuple(
+            ArtinMazurZetaReplayRow(
+                period=period,
+                trace_fixed_points=format_canonical_integer(coefficient),
+                logarithmic_derivative_coefficient=format_canonical_integer(
+                    coefficient
+                ),
+            )
+            for period, coefficient in enumerate(coefficients, 1)
+        ),
+    )
 
 
 def construct_finite_type_shift(
@@ -65,6 +92,7 @@ def compute_higher_block(request: HigherBlockRequest) -> HigherBlockResult:
 
 
 __all__ = [
+    "compute_artin_mazur_zeta",
     "compute_block_language",
     "compute_higher_block",
     "compute_periodic_point_profile",

--- a/src/jacobian/math/symbolic_dynamics/_tools.py
+++ b/src/jacobian/math/symbolic_dynamics/_tools.py
@@ -5,6 +5,8 @@ from typing import Any
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.symbolic_dynamics._models import (
+    ArtinMazurZetaRequest,
+    ArtinMazurZetaResult,
     BlockLanguageRequest,
     BlockLanguageResult,
     FiniteTypeShiftRequest,
@@ -15,6 +17,7 @@ from jacobian.math.symbolic_dynamics._models import (
     PeriodicPointProfileResult,
 )
 from jacobian.math.symbolic_dynamics._operations import (
+    compute_artin_mazur_zeta,
     compute_block_language,
     compute_higher_block,
     compute_periodic_point_profile,
@@ -88,6 +91,30 @@ SYMBOLIC_DYNAMICS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {
                     "shift": {"matrix": [[1, 1], [1, 0]], "two_sided": True},
                     "max_period": 5,
+                },
+            ),
+        ),
+    ),
+    MathTool(
+        operation_id="symbolic_dynamics.artin_mazur_zeta.compute",
+        version="1",
+        title="Compute an Artin-Mazur zeta function",
+        description=(
+            "Compute the exact edge-shift zeta function 1/det(I-tA) as a "
+            "canonical rational function, retaining det(I-tA) with constant "
+            "term one and replaying -tD'(t)/D(t) against periodic-point traces."
+        ),
+        request_type=ArtinMazurZetaRequest,
+        result_type=ArtinMazurZetaResult,
+        run=compute_artin_mazur_zeta,
+        tags=("symbolic-dynamics", "artin-mazur-zeta", "periodic-points", "exact"),
+        examples=(
+            example(
+                "golden_mean_zeta",
+                "Compute the Golden Mean shift zeta function through five replay coefficients.",
+                {
+                    "shift": {"matrix": [[1, 1], [1, 0]], "two_sided": True},
+                    "replay_period": 5,
                 },
             ),
         ),

--- a/src/jacobian/math/symbolic_dynamics/operations.py
+++ b/src/jacobian/math/symbolic_dynamics/operations.py
@@ -8,14 +8,27 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import networkx as nx
 
+from jacobian.math.polynomials._conversions import (
+    rational_function_from_sympy,
+    rational_polynomial_from_sympy,
+)
+from jacobian.math.polynomials.values import RationalFunction, RationalPolynomial
 from jacobian.math.symbolic_dynamics.values import (
+    MAX_ADJACENCY_STATES,
     MAX_ENUMERATED_BLOCKS,
+    MAX_PERIOD,
     MAX_PRESENTATION_CELLS,
     AdjacencyShift,
     BlockPresentation,
     ForbiddenBlockShift,
     LabeledTransition,
 )
+
+MAX_ZETA_REPLAY_PERIOD = MAX_PERIOD
+MAX_ZETA_COEFFICIENT_DIGITS = 128
+MAX_ZETA_RESULT_DIGITS = 100_000
+MAX_ZETA_RESULT_BYTES = 512_000
+MAX_ZETA_WORK = 13_000_000
 
 
 def _contains(word: tuple[str, ...], factor: tuple[str, ...]) -> bool:
@@ -298,8 +311,103 @@ def periodic_point_profile(
     return tuple(fixed), exact, orbits
 
 
+def _determinant_coefficients(shift: AdjacencyShift) -> tuple[int, ...]:
+    """Return ascending coefficients of ``det(I - t A)``."""
+
+    from sympy import Matrix
+
+    characteristic = Matrix(shift.matrix).charpoly()
+    # det(lambda I - A) = sum(c_k lambda^(n-k)), so the same coefficient
+    # sequence in ascending powers of t is det(I - t A).
+    return tuple(int(coefficient) for coefficient in characteristic.all_coeffs())
+
+
+def _require_zeta_budget(shift: AdjacencyShift, replay_period: int) -> None:
+    if not 1 <= replay_period <= MAX_ZETA_REPLAY_PERIOD:
+        raise ValueError("replay period is outside the supported bounds")
+    states = len(shift.matrix)
+    maximum_entry = max(entry for row in shift.matrix for entry in row)
+    # The degree-k coefficient is a sum of principal k-minors. Its absolute
+    # value is at most C(states,k) k! M^k <= (states M)^k.
+    coefficient_digits = states * len(str(states * max(1, maximum_entry))) + 1
+    if coefficient_digits > MAX_ZETA_COEFFICIENT_DIGITS:
+        raise ValueError("zeta polynomial exceeds the coefficient digit bound")
+    work = states**4 + states**3 * replay_period
+    if work > MAX_ZETA_WORK:
+        raise ValueError("zeta determinant and replay exceed the work bound")
+    maximum_row_sum = max(sum(row) for row in shift.matrix)
+    count_bound = states * max(1, maximum_row_sum) ** replay_period
+    count_digits = len(str(count_bound))
+    result_digits = (
+        2 * (states + 1) * coefficient_digits + 2 * replay_period * count_digits
+    )
+    if result_digits > MAX_ZETA_RESULT_DIGITS:
+        raise ValueError("zeta result exceeds the aggregate digit bound")
+    source_bytes = 4096 + states**2 * (len(str(maximum_entry)) + 3)
+    polynomial_bytes = 2 * (states + 1) * (2 * coefficient_digits + 160)
+    replay_bytes = replay_period * (2 * count_digits + 160)
+    if source_bytes + polynomial_bytes + replay_bytes > MAX_ZETA_RESULT_BYTES:
+        raise ValueError("zeta result exceeds the byte bound")
+
+
+def _logarithmic_derivative_coefficients(
+    determinant_coefficients: tuple[int, ...], period_count: int
+) -> tuple[int, ...]:
+    """Return coefficients of ``-t D'(t) / D(t)`` through ``period_count``."""
+
+    result: list[int] = []
+    degree = len(determinant_coefficients) - 1
+    for period in range(1, period_count + 1):
+        derivative_term = (
+            -period * determinant_coefficients[period] if period <= degree else 0
+        )
+        convolution = sum(
+            determinant_coefficients[offset] * result[period - offset - 1]
+            for offset in range(1, min(degree, period - 1) + 1)
+        )
+        result.append(derivative_term - convolution)
+    return tuple(result)
+
+
+def artin_mazur_zeta(
+    shift: AdjacencyShift, replay_period: int
+) -> tuple[RationalPolynomial, RationalFunction, tuple[int, ...]]:
+    """Return ``det(I-tA)``, ``1/det(I-tA)``, and its fixed-point replay."""
+
+    _require_zeta_budget(shift, replay_period)
+    from sympy import QQ, Poly, Symbol
+
+    variable = Symbol("t")
+    coefficients = _determinant_coefficients(shift)
+    determinant = Poly.from_dict(
+        {(exponent,): coefficient for exponent, coefficient in enumerate(coefficients)},
+        variable,
+        domain=QQ,
+    )
+    logarithmic_derivative = _logarithmic_derivative_coefficients(
+        coefficients, replay_period
+    )
+    fixed_points, _, _ = periodic_point_profile(shift, replay_period)
+    if logarithmic_derivative != fixed_points:
+        raise RuntimeError(
+            "zeta logarithmic derivative disagrees with periodic-point traces"
+        )
+    return (
+        rational_polynomial_from_sympy(
+            determinant, ("t",), maximum_terms=MAX_ADJACENCY_STATES + 1
+        ),
+        rational_function_from_sympy(
+            1 / determinant.as_expr(),
+            ("t",),
+            maximum_terms=MAX_ADJACENCY_STATES + 1,
+        ),
+        logarithmic_derivative,
+    )
+
+
 __all__ = [
     "adjacency_shift",
+    "artin_mazur_zeta",
     "block_language",
     "enumeration_size",
     "finite_type_presentation",

--- a/tests/math/symbolic_dynamics/test_public_api.py
+++ b/tests/math/symbolic_dynamics/test_public_api.py
@@ -13,6 +13,7 @@ def test_exact_public_api_symbols() -> None:
         "ForbiddenBlockShift",
         "LabeledTransition",
         "adjacency_shift",
+        "artin_mazur_zeta",
         "block_language",
         "finite_type_presentation",
         "higher_block_presentation",

--- a/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
+++ b/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import random
+from fractions import Fraction
 
 import pytest
 from pydantic import ValidationError
@@ -12,12 +13,15 @@ from jacobian.math.symbolic_dynamics import (
     AdjacencyShift,
     ForbiddenBlockShift,
     adjacency_shift,
+    artin_mazur_zeta,
     block_language,
     finite_type_presentation,
     normalize_forbidden_blocks,
     periodic_point_profile,
 )
 from jacobian.math.symbolic_dynamics._models import (
+    ArtinMazurZetaRequest,
+    ArtinMazurZetaResult,
     BlockLanguageRequest,
     BlockLanguageResult,
     FiniteTypeShiftRequest,
@@ -28,6 +32,7 @@ from jacobian.math.symbolic_dynamics._models import (
     PeriodicPointProfileResult,
 )
 from jacobian.math.symbolic_dynamics._operations import (
+    compute_artin_mazur_zeta,
     compute_block_language,
     compute_higher_block,
     compute_periodic_point_profile,
@@ -40,11 +45,142 @@ def _golden_mean() -> ForbiddenBlockShift:
     return ForbiddenBlockShift(alphabet=("0", "1"), forbidden_blocks=(("1", "1"),))
 
 
+def test_golden_mean_artin_mazur_zeta_is_bound_to_periodic_traces() -> None:
+    request = ArtinMazurZetaRequest(
+        shift=AdjacencyShift(matrix=((1, 1), (1, 0))),
+        replay_period=5,
+    )
+
+    result = compute_artin_mazur_zeta(request)
+
+    assert tuple(
+        (term.coefficient.as_fraction(), term.exponents)
+        for term in result.determinant_polynomial.polynomial.terms
+    ) == ((-1, (2,)), (-1, (1,)), (1, (0,)))
+    assert tuple(
+        (term.coefficient.as_fraction(), term.exponents)
+        for term in result.zeta_function.denominator.terms
+    ) == ((1, (2,)), (1, (1,)), (-1, (0,)))
+    assert result.zeta_function.numerator.terms[0].coefficient.as_fraction() == -1
+    assert tuple(row.trace_fixed_points for row in result.replay) == (
+        "1",
+        "3",
+        "4",
+        "7",
+        "11",
+    )
+    assert tuple(row.logarithmic_derivative_coefficient for row in result.replay) == (
+        "1",
+        "3",
+        "4",
+        "7",
+        "11",
+    )
+
+    payload = result.model_dump()
+    payload["replay"][2]["logarithmic_derivative_coefficient"] = "5"
+    with pytest.raises(ValidationError, match="not bound"):
+        ArtinMazurZetaResult.model_validate(payload)
+
+    payload = result.model_dump()
+    payload["determinant_polynomial"]["polynomial"]["terms"][0]["coefficient"][
+        "num"
+    ] = "-2"
+    with pytest.raises(ValidationError, match="not bound"):
+        ArtinMazurZetaResult.model_validate(payload)
+
+
+def test_zeta_distinguishes_full_shift_cycle_and_disjoint_components() -> None:
+    empty = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(shift=AdjacencyShift(matrix=((0,),)), replay_period=4)
+    )
+    full_shift = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(shift=AdjacencyShift(matrix=((2,),)), replay_period=4)
+    )
+    cycle = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(
+            shift=AdjacencyShift(matrix=((0, 1), (1, 0))), replay_period=4
+        )
+    )
+    disjoint = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(
+            shift=AdjacencyShift(matrix=((2, 0), (0, 3))), replay_period=4
+        )
+    )
+
+    assert tuple(row.trace_fixed_points for row in empty.replay) == (
+        "0",
+        "0",
+        "0",
+        "0",
+    )
+    assert (
+        empty.determinant_polynomial.polynomial.terms[0].coefficient.as_fraction() == 1
+    )
+    assert empty.zeta_function.numerator == empty.zeta_function.denominator
+    assert tuple(row.trace_fixed_points for row in full_shift.replay) == (
+        "2",
+        "4",
+        "8",
+        "16",
+    )
+    assert tuple(row.trace_fixed_points for row in cycle.replay) == (
+        "0",
+        "2",
+        "0",
+        "2",
+    )
+    assert tuple(
+        (term.coefficient.as_fraction(), term.exponents)
+        for term in disjoint.determinant_polynomial.polynomial.terms
+    ) == ((6, (2,)), (-5, (1,)), (1, (0,)))
+    assert disjoint.zeta_function.numerator.terms[0].coefficient.as_fraction() == (
+        Fraction(1, 6)
+    )
+
+
+def test_zeta_is_invariant_under_state_relabeling() -> None:
+    original = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(
+            shift=AdjacencyShift(matrix=((1, 2, 0), (0, 1, 1), (1, 0, 0))),
+            replay_period=6,
+        )
+    )
+    relabeled = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(
+            shift=AdjacencyShift(matrix=((0, 1, 0), (0, 1, 2), (1, 0, 1))),
+            replay_period=6,
+        )
+    )
+
+    assert relabeled.determinant_polynomial == original.determinant_polynomial
+    assert relabeled.zeta_function == original.zeta_function
+    assert relabeled.replay == original.replay
+
+
+def test_zeta_admission_bounds_coefficient_growth_before_backend() -> None:
+    identity = tuple(
+        tuple(1 if row == column else 0 for column in range(50)) for row in range(50)
+    )
+    boundary = compute_artin_mazur_zeta(
+        ArtinMazurZetaRequest(shift=AdjacencyShift(matrix=identity), replay_period=50)
+    )
+    assert len(boundary.determinant_polynomial.polynomial.terms) == 51
+    assert len(boundary.replay) == 50
+
+    dense_large = (tuple((1_000_000,) * 50),) * 50
+    with pytest.raises(ValidationError, match="coefficient digit bound"):
+        ArtinMazurZetaRequest(shift=AdjacencyShift(matrix=dense_large), replay_period=1)
+    with pytest.raises(ValueError, match="coefficient digit bound"):
+        artin_mazur_zeta(AdjacencyShift(matrix=dense_large), 1)
+
+
 def test_public_surface_excludes_adjacency_carrier_invariants() -> None:
     assert tuple(tool.operation_id for tool in TOOLS) == (
         "symbolic_dynamics.finite_type_shift.construct",
         "symbolic_dynamics.block_language.compute",
         "symbolic_dynamics.periodic_point_profile.compute",
+        "symbolic_dynamics.artin_mazur_zeta.compute",
         "symbolic_dynamics.higher_block.compute",
     )
     carrier = adjacency_shift(((1, 1), (1, 0)))


### PR DESCRIPTION
## Problem

#1910 identifies the Artin–Mazur zeta function as a missing global invariant for bounded shifts of finite type. The existing symbolic-dynamics operations can already return periodic-point profiles, but callers cannot obtain the exact rational generating function or replay its coefficients against those traces.

This PR delivers that focused zeta-function slice. It does not close #1910: sofic presentations still depend on a canonical directed edge-ID multigraph, and full sliding-block/conjugacy work still depends on active alphabet/carrier design.

## Solution

Add `symbolic_dynamics.artin_mazur_zeta.compute` for an existing `AdjacencyShift`. It returns:

- the canonical rational polynomial `D(t) = det(I - tA)`;
- the canonical rational function `1 / D(t)`; and
- exact replay rows proving that the coefficients of `-tD'(t) / D(t)` agree with `trace(A^n)` through the requested period.

SymPy 1.14's exact characteristic-polynomial implementation is the private determinant kernel. Jacobian retains the public semantics, the existing 50-state adjacency carrier, exact polynomial/function values, admission bounds, and source-bound replay. The implementation deliberately does not migrate the carrier to `IntegerMatrix`, whose current 32-state nonempty contract would narrow existing symbolic-dynamics behavior.

## Testing

- `make check`
- focused owner, public-API, admission, and catalog tests (31 passed)
- independent differential checks: 960 random matrices against direct `det(I-tA)` and 400 random matrices against matrix-power traces and an independent SymPy series expansion
- deterministic 50×50 binary boundary: 1.60 s and 82,548 KiB in the implementation run; 2.40 s and about 84 MB in independent review

- Specialist validation run (if any): none

## Public contract impact

Adds public operation `symbolic_dynamics.artin_mazur_zeta.compute`, request/result schemas, and native `artin_mazur_zeta`. Existing operation IDs, carriers, and semantics are unchanged.

## Public operation admission

- Concrete gap: exact Artin–Mazur zeta data was not available from the existing periodic-point profile.
- Why existing operations or typed values are insufficient: traces through a finite period do not themselves provide the canonical rational invariant `1/det(I-tA)`.
- Stable mathematical result: a source-bound determinant polynomial, reciprocal rational function, and exact logarithmic-derivative replay.
- Semantic domain and admitted execution envelope: nonnegative integer adjacency shifts using the existing 1–50 state carrier, with replay periods 1–50 and result-sensitive coefficient, work, digit, and byte bounds.
- Controlling work, intermediate, memory, and output quantities: state count, maximum edge multiplicity, characteristic-polynomial coefficient height, `n^4 + n^3 p` work, periodic-count digits, polynomial terms, replay rows, and conservative serialized bytes.
- Exact representation, algorithm regimes, and maintained backend: canonical Jacobian `RationalPolynomial`/`RationalFunction` values; SymPy 1.14 exact characteristic polynomial; integer recurrence and matrix traces for replay.
- Remaining fixed caps and their classification: the existing 50-state/50-period carrier limits and the 13,000,000-work ceiling are conservative execution limits, not mathematical-domain restrictions.
- Admission decision: KEEP — this is a distinct exact dynamical invariant with direct periodic-point replay.

## Closure matrix

Not closing the broad parent issue. This PR delivers only `symbolic_dynamics.artin_mazur_zeta.compute`; the sofic and sliding-block/conjugacy candidates remain deferred on their named canonical-carrier dependencies.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, Lean, backend, Harbor/Oracle)
- [x] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] New or changed bounds include boundary and realistic scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable)
