### PR TITLE
feat(game-theory): solve exact deterministic terminal games

### DIFF
--- a/src/jacobian/math/finite_game_theory/__init__.py
+++ b/src/jacobian/math/finite_game_theory/__init__.py
@@ -1,3 +1,21 @@
-"""Finite-game-theory operation ownership."""
+"""Exact native APIs for finite deterministic games."""
 
-__all__: list[str] = []
+from jacobian.math.finite_game_theory.operations import solve_terminal_game
+from jacobian.math.finite_game_theory.values import (
+    DeterministicGameMove,
+    DeterministicGamePosition,
+    DeterministicTerminalGame,
+    DeterministicTerminalGameSolution,
+    StationaryChoice,
+    TerminalGameValueClass,
+)
+
+__all__ = [
+    "DeterministicGameMove",
+    "DeterministicGamePosition",
+    "DeterministicTerminalGame",
+    "DeterministicTerminalGameSolution",
+    "StationaryChoice",
+    "TerminalGameValueClass",
+    "solve_terminal_game",
+]

--- a/src/jacobian/math/finite_game_theory/_admission.py
+++ b/src/jacobian/math/finite_game_theory/_admission.py
@@ -20,6 +20,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "exact primal-dual linear programming returns a complete equilibrium witness for every bounded finite zero-sum game",
     ),
+    OperationAdmission(
+        "game.deterministic_terminal.solve",
+        AdmissionDecision.KEEP,
+        "exact threshold attractors return the complete all-position minimax profile and bound optimal stationary witnesses for a bounded owned arena",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/finite_game_theory/_models.py
+++ b/src/jacobian/math/finite_game_theory/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math.finite_game_theory.values import DeterministicTerminalGame
 
 MAX_PLAYERS = 10
 MAX_STRATEGIES = 8
@@ -62,8 +63,20 @@ class NashEquilibriumResult(StrictModel):
     value: CanonicalRational
 
 
+class DeterministicTerminalGameRequest(StrictModel):
+    """Solve every position of one complete deterministic terminal game."""
+
+    game: DeterministicTerminalGame = Field(
+        description=(
+            "Materialized owned arena with exact terminal and infinite-play "
+            "payoffs; every nonterminal must have an outgoing move."
+        )
+    )
+
+
 __all__ = [
     "BestResponseResult",
+    "DeterministicTerminalGameRequest",
     "NashEquilibriumResult",
     "PayoffMatrix",
     "ZeroSumGameRequest",

--- a/src/jacobian/math/finite_game_theory/_operations.py
+++ b/src/jacobian/math/finite_game_theory/_operations.py
@@ -8,9 +8,12 @@ from math import lcm
 from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
     BestResponseResult,
+    DeterministicTerminalGameRequest,
     NashEquilibriumResult,
     ZeroSumGameRequest,
 )
+from jacobian.math.finite_game_theory.operations import solve_terminal_game
+from jacobian.math.finite_game_theory.values import DeterministicTerminalGameSolution
 
 
 def _wire_rational(value: Fraction) -> CanonicalRational:
@@ -114,4 +117,16 @@ def compute_nash_equilibrium(request: ZeroSumGameRequest) -> NashEquilibriumResu
     )
 
 
-__all__ = ["compute_best_response", "compute_nash_equilibrium"]
+def compute_deterministic_terminal_game(
+    request: DeterministicTerminalGameRequest,
+) -> DeterministicTerminalGameSolution:
+    """Compute every value and canonical optimal stationary strategy pair."""
+
+    return solve_terminal_game(request.game)
+
+
+__all__ = [
+    "compute_best_response",
+    "compute_deterministic_terminal_game",
+    "compute_nash_equilibrium",
+]

--- a/src/jacobian/math/finite_game_theory/_tools.py
+++ b/src/jacobian/math/finite_game_theory/_tools.py
@@ -8,13 +8,16 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.finite_game_theory._models import (
     BestResponseResult,
+    DeterministicTerminalGameRequest,
     NashEquilibriumResult,
     ZeroSumGameRequest,
 )
 from jacobian.math.finite_game_theory._operations import (
     compute_best_response,
+    compute_deterministic_terminal_game,
     compute_nash_equilibrium,
 )
+from jacobian.math.finite_game_theory.values import DeterministicTerminalGameSolution
 
 
 def _op[
@@ -55,6 +58,34 @@ GAME_EXAMPLE = {
             {"num": "2", "den": "1"},
         ],
     },
+}
+
+DETERMINISTIC_TERMINAL_GAME_EXAMPLE = {
+    "game": {
+        "positions": [
+            {"label": "s", "owner": "MIN"},
+            {"label": "u", "owner": "MAX"},
+            {"label": "v", "owner": "MIN"},
+            {
+                "label": "t1",
+                "owner": "TERMINAL",
+                "payoff": {"num": "1", "den": "1"},
+            },
+            {
+                "label": "t2",
+                "owner": "TERMINAL",
+                "payoff": {"num": "2", "den": "1"},
+            },
+        ],
+        "moves": [
+            {"source": "s", "target": "u"},
+            {"source": "s", "target": "v"},
+            {"source": "u", "target": "u"},
+            {"source": "u", "target": "t1"},
+            {"source": "v", "target": "t2"},
+        ],
+        "draw_payoff": {"num": "0", "den": "1"},
+    }
 }
 
 
@@ -100,6 +131,31 @@ FINITE_GAME_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
             ),
         ),
         version="2",
+    ),
+    _op(
+        "game.deterministic_terminal.solve",
+        "Solve a finite deterministic terminal-payoff game",
+        "Compute every position's exact minimax payoff and one canonical "
+        "optimal stationary strategy for each player in a materialized finite "
+        "turn-based arena. Terminal positions carry exact rational payoffs to "
+        "MAX, and every infinite play has the declared draw payoff.",
+        DeterministicTerminalGameRequest,
+        DeterministicTerminalGameSolution,
+        compute_deterministic_terminal_game,
+        "game-theory",
+        "deterministic-game",
+        "terminal-payoff",
+        "stationary-strategy",
+        "exact",
+        examples=(
+            example(
+                "owned_cycle_and_two_terminals",
+                "Solve every position of an owned cyclic arena; positions must "
+                "partition into MAX, MIN, and terminal owners, every nonterminal "
+                "must have a move, and moves must use declared-position order.",
+                DETERMINISTIC_TERMINAL_GAME_EXAMPLE,
+            ),
+        ),
     ),
 )
 

--- a/src/jacobian/math/finite_game_theory/operations.py
+++ b/src/jacobian/math/finite_game_theory/operations.py
@@ -1,0 +1,243 @@
+"""Exact native operations for finite deterministic terminal-payoff games."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.finite_game_theory.values import (
+    DeterministicTerminalGame,
+    DeterministicTerminalGameSolution,
+    PositionOwner,
+    StationaryChoice,
+    TerminalGameValueClass,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Arena:
+    labels: tuple[str, ...]
+    owners: tuple[PositionOwner, ...]
+    successors: tuple[tuple[int, ...], ...]
+    predecessors: tuple[tuple[int, ...], ...]
+    terminal_payoffs: tuple[Fraction | None, ...]
+    draw_payoff: Fraction
+
+
+@dataclass(frozen=True, slots=True)
+class _ThresholdRegion:
+    max_winning: frozenset[int]
+    attractor: frozenset[int]
+    ranks: tuple[int | None, ...]
+
+
+def _arena(game: DeterministicTerminalGame) -> _Arena:
+    labels = tuple(position.label for position in game.positions)
+    index = {label: offset for offset, label in enumerate(labels)}
+    successors: list[list[int]] = [[] for _ in labels]
+    predecessors: list[list[int]] = [[] for _ in labels]
+    for move in game.moves:
+        source = index[move.source]
+        target = index[move.target]
+        successors[source].append(target)
+        predecessors[target].append(source)
+    return _Arena(
+        labels=labels,
+        owners=tuple(position.owner for position in game.positions),
+        successors=tuple(tuple(targets) for targets in successors),
+        predecessors=tuple(tuple(sources) for sources in predecessors),
+        terminal_payoffs=tuple(
+            position.payoff.as_fraction() if position.payoff is not None else None
+            for position in game.positions
+        ),
+        draw_payoff=game.draw_payoff.as_fraction(),
+    )
+
+
+def _attractor(
+    arena: _Arena,
+    targets: frozenset[int],
+    existential_owner: PositionOwner,
+) -> tuple[frozenset[int], tuple[int | None, ...]]:
+    """Return one reachability attractor and its strict progress ranks."""
+
+    attracted = set(targets)
+    ranks: list[int | None] = [None] * len(arena.labels)
+    for target in targets:
+        ranks[target] = 0
+
+    remaining = [len(options) for options in arena.successors]
+    maximum_seen_rank = [-1] * len(arena.labels)
+    pending = deque(sorted(targets))
+    while pending:
+        target = pending.popleft()
+        target_rank = ranks[target]
+        if target_rank is None:  # pragma: no cover - construction invariant
+            raise RuntimeError("attractor queue contains an unranked position")
+        for source in arena.predecessors[target]:
+            if source in attracted or arena.owners[source] == "TERMINAL":
+                continue
+            if arena.owners[source] == existential_owner:
+                attracted.add(source)
+                ranks[source] = target_rank + 1
+                pending.append(source)
+                continue
+            remaining[source] -= 1
+            maximum_seen_rank[source] = max(maximum_seen_rank[source], target_rank)
+            if remaining[source] == 0:
+                attracted.add(source)
+                ranks[source] = maximum_seen_rank[source] + 1
+                pending.append(source)
+    return frozenset(attracted), tuple(ranks)
+
+
+def _threshold_region(arena: _Arena, threshold: Fraction) -> _ThresholdRegion:
+    vertices = frozenset(range(len(arena.labels)))
+    if threshold > arena.draw_payoff:
+        good_terminals = frozenset(
+            index
+            for index, payoff in enumerate(arena.terminal_payoffs)
+            if payoff is not None and payoff >= threshold
+        )
+        attractor, ranks = _attractor(arena, good_terminals, "MAX")
+        return _ThresholdRegion(
+            max_winning=attractor,
+            attractor=attractor,
+            ranks=ranks,
+        )
+
+    bad_terminals = frozenset(
+        index
+        for index, payoff in enumerate(arena.terminal_payoffs)
+        if payoff is not None and payoff < threshold
+    )
+    attractor, ranks = _attractor(arena, bad_terminals, "MIN")
+    return _ThresholdRegion(
+        max_winning=vertices - attractor,
+        attractor=attractor,
+        ranks=ranks,
+    )
+
+
+def _progress_successor(
+    successors: tuple[int, ...],
+    ranks: tuple[int | None, ...],
+    source: int,
+) -> int:
+    source_rank = ranks[source]
+    if source_rank is None:  # pragma: no cover - construction invariant
+        raise RuntimeError("an attracted player position must have a rank")
+    candidates: list[int] = []
+    for target in successors:
+        target_rank = ranks[target]
+        if target_rank is not None and target_rank < source_rank:
+            candidates.append(target)
+    if not candidates:  # pragma: no cover - attractor invariant
+        raise RuntimeError("an attracted player position must have a progress move")
+    return min(candidates)
+
+
+def _safe_successor(successors: tuple[int, ...], unsafe: frozenset[int]) -> int:
+    candidates = tuple(target for target in successors if target not in unsafe)
+    if not candidates:  # pragma: no cover - complement-attractor invariant
+        raise RuntimeError("a safety-winning player position must have a safe move")
+    return min(candidates)
+
+
+def _solve_terminal_game_data(
+    game: DeterministicTerminalGame,
+) -> tuple[
+    tuple[TerminalGameValueClass, ...],
+    tuple[StationaryChoice, ...],
+    tuple[StationaryChoice, ...],
+]:
+    """Return the canonical all-position value profile and optimal strategies.
+
+    For a threshold above the infinite-play payoff, MAX must reach a terminal
+    at or above that threshold. At or below the infinite-play payoff, MAX must
+    avoid terminals below the threshold. Standard reachability attractors solve
+    both objectives, and the greatest won threshold is the exact game value.
+    """
+
+    arena = _arena(game)
+    levels = tuple(
+        sorted(
+            {
+                arena.draw_payoff,
+                *(payoff for payoff in arena.terminal_payoffs if payoff is not None),
+            }
+        )
+    )
+    regions = {level: _threshold_region(arena, level) for level in levels}
+    values = [levels[0]] * len(arena.labels)
+    for level in levels:
+        for vertex in regions[level].max_winning:
+            values[vertex] = level
+
+    level_indices = {level: index for index, level in enumerate(levels)}
+    max_choices: list[StationaryChoice] = []
+    min_choices: list[StationaryChoice] = []
+    for vertex, owner in enumerate(arena.owners):
+        if owner == "TERMINAL":
+            continue
+        value = values[vertex]
+        if owner == "MAX":
+            region = regions[value]
+            target = (
+                _progress_successor(arena.successors[vertex], region.ranks, vertex)
+                if value > arena.draw_payoff
+                else _safe_successor(arena.successors[vertex], region.attractor)
+            )
+            max_choices.append(
+                StationaryChoice(
+                    position=arena.labels[vertex], target=arena.labels[target]
+                )
+            )
+            continue
+
+        level_index = level_indices[value]
+        if value < arena.draw_payoff:
+            next_region = regions[levels[level_index + 1]]
+            target = _progress_successor(
+                arena.successors[vertex], next_region.ranks, vertex
+            )
+        elif level_index + 1 < len(levels):
+            next_region = regions[levels[level_index + 1]]
+            target = _safe_successor(arena.successors[vertex], next_region.attractor)
+        else:
+            target = min(arena.successors[vertex])
+        min_choices.append(
+            StationaryChoice(position=arena.labels[vertex], target=arena.labels[target])
+        )
+
+    class_members: dict[Fraction, list[str]] = {level: [] for level in levels}
+    for label, value in zip(arena.labels, values, strict=True):
+        class_members[value].append(label)
+    value_classes = tuple(
+        TerminalGameValueClass(
+            payoff=CanonicalRational.from_fraction(level),
+            positions=tuple(class_members[level]),
+        )
+        for level in levels
+        if class_members[level]
+    )
+    return value_classes, tuple(max_choices), tuple(min_choices)
+
+
+def solve_terminal_game(
+    game: DeterministicTerminalGame,
+) -> DeterministicTerminalGameSolution:
+    """Solve one exact finite deterministic terminal-payoff game."""
+
+    value_classes, max_strategy, min_strategy = _solve_terminal_game_data(game)
+    return DeterministicTerminalGameSolution(
+        game=game,
+        value_classes=value_classes,
+        max_strategy=max_strategy,
+        min_strategy=min_strategy,
+    )
+
+
+__all__ = ["solve_terminal_game"]

--- a/src/jacobian/math/finite_game_theory/operations.py
+++ b/src/jacobian/math/finite_game_theory/operations.py
@@ -58,7 +58,7 @@ def _arena(game: DeterministicTerminalGame) -> _Arena:
 
 def _attractor(
     arena: _Arena,
-    targets: frozenset[int],
+    targets: tuple[int, ...],
     existential_owner: PositionOwner,
 ) -> tuple[frozenset[int], tuple[int | None, ...]]:
     """Return one reachability attractor and its strict progress ranks."""
@@ -70,7 +70,7 @@ def _attractor(
 
     remaining = [len(options) for options in arena.successors]
     maximum_seen_rank = [-1] * len(arena.labels)
-    pending = deque(sorted(targets))
+    pending = deque(targets)
     while pending:
         target = pending.popleft()
         target_rank = ranks[target]
@@ -96,7 +96,7 @@ def _attractor(
 def _threshold_region(arena: _Arena, threshold: Fraction) -> _ThresholdRegion:
     vertices = frozenset(range(len(arena.labels)))
     if threshold > arena.draw_payoff:
-        good_terminals = frozenset(
+        good_terminals = tuple(
             index
             for index, payoff in enumerate(arena.terminal_payoffs)
             if payoff is not None and payoff >= threshold
@@ -108,7 +108,7 @@ def _threshold_region(arena: _Arena, threshold: Fraction) -> _ThresholdRegion:
             ranks=ranks,
         )
 
-    bad_terminals = frozenset(
+    bad_terminals = tuple(
         index
         for index, payoff in enumerate(arena.terminal_payoffs)
         if payoff is not None and payoff < threshold

--- a/src/jacobian/math/finite_game_theory/values.py
+++ b/src/jacobian/math/finite_game_theory/values.py
@@ -1,0 +1,276 @@
+"""Canonical values for finite deterministic terminal-payoff games."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.math._labels import OpaqueLabel
+
+MAX_TERMINAL_GAME_POSITIONS = 4_096
+MAX_TERMINAL_GAME_MOVES = 65_536
+MAX_TERMINAL_GAME_WORK_UNITS = 3_000_000
+MAX_TERMINAL_GAME_RESULT_BYTES = 4 * 1024 * 1024
+
+PositionOwner = Literal["MAX", "MIN", "TERMINAL"]
+
+
+class DeterministicGamePosition(StrictModel):
+    """One position, its controller, and its payoff when terminal."""
+
+    label: OpaqueLabel
+    owner: PositionOwner
+    payoff: CanonicalRational | None = Field(
+        default=None,
+        description=(
+            "Exact payoff to MAX when owner is TERMINAL; omit it for MAX and "
+            "MIN positions."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_payoff_exactly_at_terminals(self) -> Self:
+        if self.owner == "TERMINAL" and self.payoff is None:
+            raise ValueError("terminal positions require an exact payoff")
+        if self.owner != "TERMINAL" and self.payoff is not None:
+            raise ValueError("nonterminal positions must not carry a payoff")
+        return self
+
+
+class DeterministicGameMove(StrictModel):
+    """One directed move in a deterministic turn-based arena."""
+
+    source: OpaqueLabel
+    target: OpaqueLabel
+
+
+class DeterministicTerminalGame(StrictModel):
+    """A complete finite deterministic two-player terminal-payoff game.
+
+    MAX maximizes and MIN minimizes the exact payoff. A play stops on first
+    reaching a terminal position. A play that never reaches a terminal has
+    ``draw_payoff``. Position order is the public axis for values and strategy
+    tie-breaking; moves must be sorted by their endpoint indices on that axis.
+    """
+
+    positions: tuple[DeterministicGamePosition, ...] = Field(
+        min_length=1,
+        max_length=MAX_TERMINAL_GAME_POSITIONS,
+        description=(
+            "Distinct NFC-normalized labeled positions in the declared order "
+            "used by every returned profile."
+        ),
+    )
+    moves: tuple[DeterministicGameMove, ...] = Field(
+        max_length=MAX_TERMINAL_GAME_MOVES,
+        description=(
+            "Distinct directed moves in lexicographic (source index, target "
+            "index) order relative to positions; self-loops are allowed only "
+            "at nonterminal positions."
+        ),
+    )
+    draw_payoff: CanonicalRational = Field(
+        description="Exact payoff to MAX for every infinite play."
+    )
+
+    @model_validator(mode="after")
+    def require_complete_bounded_arena(self) -> Self:
+        labels = tuple(position.label for position in self.positions)
+        if any(not unicodedata.is_normalized("NFC", label) for label in labels):
+            raise ValueError("position labels must use Unicode NFC")
+        if len(set(labels)) != len(labels):
+            raise ValueError("position labels must be distinct")
+
+        index = {label: offset for offset, label in enumerate(labels)}
+        edge_pairs = tuple((move.source, move.target) for move in self.moves)
+        if any(
+            source not in index or target not in index for source, target in edge_pairs
+        ):
+            raise ValueError("every move endpoint must be a declared position")
+        if len(set(edge_pairs)) != len(edge_pairs):
+            raise ValueError("game moves must be distinct")
+        canonical_edges = tuple(
+            sorted(edge_pairs, key=lambda edge: (index[edge[0]], index[edge[1]]))
+        )
+        if edge_pairs != canonical_edges:
+            raise ValueError("game moves must use canonical declared-position order")
+
+        outgoing = dict.fromkeys(labels, 0)
+        for source, _ in edge_pairs:
+            outgoing[source] += 1
+        for position in self.positions:
+            if position.owner == "TERMINAL":
+                if outgoing[position.label] != 0:
+                    raise ValueError("terminal positions must have no outgoing moves")
+            elif outgoing[position.label] == 0:
+                raise ValueError(
+                    "every nonterminal position must have an outgoing move"
+                )
+
+        _require_terminal_game_envelope(self)
+        return self
+
+
+class TerminalGameValueClass(StrictModel):
+    """Every declared position having one exact minimax payoff."""
+
+    payoff: CanonicalRational
+    positions: tuple[OpaqueLabel, ...] = Field(
+        min_length=1,
+        max_length=MAX_TERMINAL_GAME_POSITIONS,
+        description="Positions in their declared game order.",
+    )
+
+
+class StationaryChoice(StrictModel):
+    """The successor selected at one player-owned position."""
+
+    position: OpaqueLabel
+    target: OpaqueLabel
+
+
+class DeterministicTerminalGameSolution(StrictModel):
+    """All position values and one canonical optimal stationary strategy pair.
+
+    The source game is retained so validation can replay the exact threshold
+    games. Value classes are ordered by payoff and list members in declared
+    position order. Strategy choices follow the corresponding player's declared
+    positions and break equivalent choices by declared target order.
+    """
+
+    game: DeterministicTerminalGame
+    value_classes: tuple[TerminalGameValueClass, ...] = Field(
+        min_length=1,
+        max_length=MAX_TERMINAL_GAME_POSITIONS,
+        description="Nonempty payoff classes in strictly increasing payoff order.",
+    )
+    max_strategy: tuple[StationaryChoice, ...] = Field(
+        max_length=MAX_TERMINAL_GAME_POSITIONS,
+        description="One optimal move for every MAX position in declared order.",
+    )
+    min_strategy: tuple[StationaryChoice, ...] = Field(
+        max_length=MAX_TERMINAL_GAME_POSITIONS,
+        description="One optimal move for every MIN position in declared order.",
+    )
+
+    @model_validator(mode="after")
+    def bind_exact_solution_to_source(self) -> Self:
+        from jacobian.math.finite_game_theory.operations import (
+            _solve_terminal_game_data,
+        )
+
+        value_classes, max_strategy, min_strategy = _solve_terminal_game_data(self.game)
+        if self.value_classes != value_classes:
+            raise ValueError("value_classes must be the exact minimax partition")
+        if self.max_strategy != max_strategy:
+            raise ValueError("max_strategy must be the canonical optimal strategy")
+        if self.min_strategy != min_strategy:
+            raise ValueError("min_strategy must be the canonical optimal strategy")
+        return self
+
+
+def _require_terminal_game_envelope(game: DeterministicTerminalGame) -> None:
+    """Preflight threshold work and a conservative exact-result wire bound."""
+
+    payoffs = [game.draw_payoff]
+    payoffs.extend(
+        position.payoff for position in game.positions if position.payoff is not None
+    )
+    threshold_count = len({(payoff.num, payoff.den) for payoff in payoffs})
+    terminal_count = len(payoffs) - 1
+    max_digits = max(
+        max(len(payoff.num.lstrip("-")), len(payoff.den)) for payoff in payoffs
+    )
+    position_count = len(game.positions)
+    move_count = len(game.moves)
+
+    # Each threshold performs at most four full vertex passes (target choice,
+    # attractor setup, safety complement, and value update), one edge pass, and
+    # the solve performs one final O(V+E) strategy pass. Result construction
+    # replays the same kernel.
+    # Forming threshold targets compares every terminal payoff with every
+    # threshold. Sorting k exact rationals uses at most k*ceil(log2(k)) more
+    # comparisons. Each comparison is conservatively charged quadratically in
+    # the largest scalar digit count, while parsing/hashing every supplied
+    # scalar is charged linearly.
+    comparison_levels = (threshold_count - 1).bit_length()
+    rational_work = (
+        len(payoffs) * max_digits
+        + (threshold_count * terminal_count + threshold_count * comparison_levels)
+        * max_digits
+        * max_digits
+    )
+    work_units = 2 * (
+        threshold_count * (4 * position_count + move_count)
+        + position_count
+        + move_count
+        + rational_work
+    )
+    if work_units > MAX_TERMINAL_GAME_WORK_UNITS:
+        raise ValueError(
+            "terminal-game threshold work exceeds the exact work bound "
+            f"({work_units} > {MAX_TERMINAL_GAME_WORK_UNITS}); reduce distinct "
+            "payoff levels, arena size, or payoff digit length"
+        )
+
+    labels = tuple(position.label for position in game.positions)
+    longest_label = max(labels, key=lambda label: len(canonicalize_json([label])))
+    widest_payoff = max(
+        payoffs,
+        key=lambda payoff: len(payoff.num) + len(payoff.den),
+    )
+    max_positions = tuple(
+        position for position in game.positions if position.owner == "MAX"
+    )
+    min_positions = tuple(
+        position for position in game.positions if position.owner == "MIN"
+    )
+    result_upper_bound = {
+        "game": game.model_dump(mode="json"),
+        "value_classes": [
+            {
+                "payoff": widest_payoff.model_dump(mode="json"),
+                "positions": [position.label],
+            }
+            for position in game.positions
+        ],
+        "max_strategy": [
+            {"position": position.label, "target": longest_label}
+            for position in max_positions
+        ],
+        "min_strategy": [
+            {"position": position.label, "target": longest_label}
+            for position in min_positions
+        ],
+    }
+    try:
+        canonicalize_json(
+            result_upper_bound,
+            limits=CanonicalLimits(
+                max_output_bytes=MAX_TERMINAL_GAME_RESULT_BYTES,
+            ),
+        )
+    except ValueError as exc:
+        raise ValueError(
+            "terminal-game solution exceeds the exact result-size bound"
+        ) from exc
+
+
+__all__ = [
+    "MAX_TERMINAL_GAME_MOVES",
+    "MAX_TERMINAL_GAME_POSITIONS",
+    "MAX_TERMINAL_GAME_RESULT_BYTES",
+    "MAX_TERMINAL_GAME_WORK_UNITS",
+    "DeterministicGameMove",
+    "DeterministicGamePosition",
+    "DeterministicTerminalGame",
+    "DeterministicTerminalGameSolution",
+    "PositionOwner",
+    "StationaryChoice",
+    "TerminalGameValueClass",
+]

--- a/src/jacobian/math/finite_game_theory/values.py
+++ b/src/jacobian/math/finite_game_theory/values.py
@@ -140,7 +140,10 @@ class DeterministicTerminalGameSolution(StrictModel):
     The source game is retained so validation can replay the exact threshold
     games. Value classes are ordered by payoff and list members in declared
     position order. Strategy choices follow the corresponding player's declared
-    positions and break equivalent choices by declared target order.
+    positions. Reachability choices use the first declared successor of strictly
+    smaller canonical threshold-attractor rank; safety choices use the first
+    declared safe successor. Where no stricter threshold exists, the first
+    declared successor is used.
     """
 
     game: DeterministicTerminalGame

--- a/tests/math/finite_game_theory/test_deterministic_terminal_game.py
+++ b/tests/math/finite_game_theory/test_deterministic_terminal_game.py
@@ -1,0 +1,423 @@
+"""Exact contract tests for deterministic terminal-payoff games."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import product
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math import finite_game_theory
+from jacobian.math.finite_game_theory import (
+    DeterministicGameMove,
+    DeterministicGamePosition,
+    DeterministicTerminalGame,
+    DeterministicTerminalGameSolution,
+    StationaryChoice,
+    TerminalGameValueClass,
+    solve_terminal_game,
+)
+from jacobian.math.finite_game_theory._models import (
+    DeterministicTerminalGameRequest,
+)
+from jacobian.math.finite_game_theory._operations import (
+    compute_deterministic_terminal_game,
+)
+from jacobian.math.finite_game_theory._tools import TOOLS
+
+
+def _r(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(numerator, denominator)
+
+
+def _paper_game() -> DeterministicTerminalGame:
+    return DeterministicTerminalGame(
+        positions=(
+            DeterministicGamePosition(label="s", owner="MIN"),
+            DeterministicGamePosition(label="u", owner="MAX"),
+            DeterministicGamePosition(label="v", owner="MIN"),
+            DeterministicGamePosition(label="t1", owner="TERMINAL", payoff=_r(1)),
+            DeterministicGamePosition(label="t2", owner="TERMINAL", payoff=_r(2)),
+        ),
+        moves=(
+            DeterministicGameMove(source="s", target="u"),
+            DeterministicGameMove(source="s", target="v"),
+            DeterministicGameMove(source="u", target="u"),
+            DeterministicGameMove(source="u", target="t1"),
+            DeterministicGameMove(source="v", target="t2"),
+        ),
+        draw_payoff=_r(0),
+    )
+
+
+def _all_stationary_strategies(
+    game: DeterministicTerminalGame, owner: str
+) -> tuple[dict[str, str], ...]:
+    successors: dict[str, list[str]] = {
+        position.label: [] for position in game.positions
+    }
+    for move in game.moves:
+        successors[move.source].append(move.target)
+    controlled = tuple(
+        position.label for position in game.positions if position.owner == owner
+    )
+    return tuple(
+        dict(zip(controlled, choices, strict=True))
+        for choices in product(*(successors[position] for position in controlled))
+    )
+
+
+def _play_payoff(
+    game: DeterministicTerminalGame,
+    start: str,
+    max_strategy: dict[str, str],
+    min_strategy: dict[str, str],
+) -> Fraction:
+    positions = {position.label: position for position in game.positions}
+    current = start
+    seen: set[str] = set()
+    while True:
+        position = positions[current]
+        if position.owner == "TERMINAL":
+            assert position.payoff is not None
+            return position.payoff.as_fraction()
+        if current in seen:
+            return game.draw_payoff.as_fraction()
+        seen.add(current)
+        current = (
+            max_strategy[current] if position.owner == "MAX" else min_strategy[current]
+        )
+
+
+def _profile(
+    game: DeterministicTerminalGame,
+    max_strategy: dict[str, str],
+    min_strategy: dict[str, str],
+) -> tuple[Fraction, ...]:
+    return tuple(
+        _play_payoff(game, position.label, max_strategy, min_strategy)
+        for position in game.positions
+    )
+
+
+def test_source_example_returns_values_and_stationary_witnesses() -> None:
+    game = _paper_game()
+    result = solve_terminal_game(game)
+
+    assert tuple(
+        (entry.payoff.as_fraction(), entry.positions) for entry in result.value_classes
+    ) == (
+        (Fraction(1), ("s", "u", "t1")),
+        (Fraction(2), ("v", "t2")),
+    )
+    assert result.max_strategy == (StationaryChoice(position="u", target="t1"),)
+    assert result.min_strategy == (
+        StationaryChoice(position="s", target="u"),
+        StationaryChoice(position="v", target="t2"),
+    )
+
+
+def test_all_four_source_strategy_outcomes_are_reproduced() -> None:
+    game = _paper_game()
+
+    outcomes = tuple(
+        _profile(game, max_strategy, min_strategy)
+        for max_strategy in _all_stationary_strategies(game, "MAX")
+        for min_strategy in _all_stationary_strategies(game, "MIN")
+    )
+
+    assert outcomes == (
+        tuple(map(Fraction, (0, 0, 2, 1, 2))),
+        tuple(map(Fraction, (2, 0, 2, 1, 2))),
+        tuple(map(Fraction, (1, 1, 2, 1, 2))),
+        tuple(map(Fraction, (2, 1, 2, 1, 2))),
+    )
+
+
+def test_solution_matches_independent_stationary_strategy_enumeration() -> None:
+    game = _paper_game()
+    result = solve_terminal_game(game)
+    max_strategies = _all_stationary_strategies(game, "MAX")
+    min_strategies = _all_stationary_strategies(game, "MIN")
+    result_max = {choice.position: choice.target for choice in result.max_strategy}
+    result_min = {choice.position: choice.target for choice in result.min_strategy}
+
+    expected_values = {
+        position: value_class.payoff.as_fraction()
+        for value_class in result.value_classes
+        for position in value_class.positions
+    }
+    for start in (position.label for position in game.positions):
+        maximin = max(
+            min(
+                _play_payoff(game, start, max_strategy, min_strategy)
+                for min_strategy in min_strategies
+            )
+            for max_strategy in max_strategies
+        )
+        minimax = min(
+            max(
+                _play_payoff(game, start, max_strategy, min_strategy)
+                for max_strategy in max_strategies
+            )
+            for min_strategy in min_strategies
+        )
+        witnessed_lower = min(
+            _play_payoff(game, start, result_max, min_strategy)
+            for min_strategy in min_strategies
+        )
+        witnessed_upper = max(
+            _play_payoff(game, start, max_strategy, result_min)
+            for max_strategy in max_strategies
+        )
+
+        assert maximin == minimax == expected_values[start]
+        assert witnessed_lower == witnessed_upper == expected_values[start]
+
+
+def test_infinite_play_is_an_exact_value_not_a_missing_witness() -> None:
+    game = DeterministicTerminalGame(
+        positions=(
+            DeterministicGamePosition(label="x", owner="MAX"),
+            DeterministicGamePosition(label="y", owner="MIN"),
+        ),
+        moves=(
+            DeterministicGameMove(source="x", target="x"),
+            DeterministicGameMove(source="x", target="y"),
+            DeterministicGameMove(source="y", target="x"),
+        ),
+        draw_payoff=_r(3, 2),
+    )
+
+    result = solve_terminal_game(game)
+
+    assert result.value_classes == (
+        TerminalGameValueClass(payoff=_r(3, 2), positions=("x", "y")),
+    )
+    assert result.max_strategy == (StationaryChoice(position="x", target="x"),)
+    assert result.min_strategy == (StationaryChoice(position="y", target="x"),)
+
+
+def test_exact_fractional_thresholds_choose_reachability_over_draw() -> None:
+    game = DeterministicTerminalGame(
+        positions=(
+            DeterministicGamePosition(label="x", owner="MAX"),
+            DeterministicGamePosition(label="high", owner="TERMINAL", payoff=_r(2, 3)),
+        ),
+        moves=(
+            DeterministicGameMove(source="x", target="x"),
+            DeterministicGameMove(source="x", target="high"),
+        ),
+        draw_payoff=_r(1, 2),
+    )
+
+    result = solve_terminal_game(game)
+
+    assert result.value_classes[-1].payoff.as_fraction() == Fraction(2, 3)
+    assert result.max_strategy == (StationaryChoice(position="x", target="high"),)
+
+
+def test_below_draw_reachability_and_at_draw_safety_choose_progress() -> None:
+    game = DeterministicTerminalGame(
+        positions=(
+            DeterministicGamePosition(label="m", owner="MIN"),
+            DeterministicGamePosition(label="x", owner="MAX"),
+            DeterministicGamePosition(label="low", owner="TERMINAL", payoff=_r(-1)),
+        ),
+        moves=(
+            DeterministicGameMove(source="m", target="m"),
+            DeterministicGameMove(source="m", target="low"),
+            DeterministicGameMove(source="x", target="x"),
+            DeterministicGameMove(source="x", target="low"),
+        ),
+        draw_payoff=_r(0),
+    )
+
+    result = solve_terminal_game(game)
+
+    assert result.value_classes == (
+        TerminalGameValueClass(payoff=_r(-1), positions=("m", "low")),
+        TerminalGameValueClass(payoff=_r(0), positions=("x",)),
+    )
+    assert result.max_strategy == (StationaryChoice(position="x", target="x"),)
+    assert result.min_strategy == (StationaryChoice(position="m", target="low"),)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (
+            {
+                "positions": [{"label": "t", "owner": "TERMINAL"}],
+                "moves": [],
+                "draw_payoff": {"num": "0", "den": "1"},
+            },
+            "terminal positions require",
+        ),
+        (
+            {
+                "positions": [{"label": "x", "owner": "MAX"}],
+                "moves": [],
+                "draw_payoff": {"num": "0", "den": "1"},
+            },
+            "nonterminal position",
+        ),
+        (
+            {
+                "positions": [
+                    {
+                        "label": "t",
+                        "owner": "TERMINAL",
+                        "payoff": {"num": "0", "den": "1"},
+                    }
+                ],
+                "moves": [{"source": "t", "target": "t"}],
+                "draw_payoff": {"num": "0", "den": "1"},
+            },
+            "terminal positions must have no outgoing",
+        ),
+        (
+            {
+                "positions": [{"label": "x", "owner": "MAX"}],
+                "moves": [{"source": "x", "target": "missing"}],
+                "draw_payoff": {"num": "0", "den": "1"},
+            },
+            "endpoint",
+        ),
+        (
+            {
+                "positions": [
+                    {"label": "x", "owner": "MAX"},
+                    {"label": "y", "owner": "MIN"},
+                ],
+                "moves": [
+                    {"source": "y", "target": "x"},
+                    {"source": "x", "target": "y"},
+                ],
+                "draw_payoff": {"num": "0", "den": "1"},
+            },
+            "canonical declared-position order",
+        ),
+    ],
+)
+def test_malformed_arenas_fail_at_the_typed_boundary(
+    payload: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        DeterministicTerminalGame.model_validate(payload)
+
+
+def test_threshold_work_is_admitted_and_rejected_before_solving() -> None:
+    def terminal_game(size: int) -> dict[str, object]:
+        return {
+            "positions": [
+                {
+                    "label": f"t{index}",
+                    "owner": "TERMINAL",
+                    "payoff": {"num": str(index), "den": "1"},
+                }
+                for index in range(size)
+            ],
+            "moves": [],
+            "draw_payoff": {"num": "0", "den": "1"},
+        }
+
+    DeterministicTerminalGame.model_validate(terminal_game(256))
+    with pytest.raises(ValidationError, match="threshold work"):
+        DeterministicTerminalGame.model_validate(terminal_game(400))
+
+
+def test_result_size_is_rejected_independently_of_threshold_work() -> None:
+    size = 170
+    labels = tuple(f"v{index:04d}" + "x" * 59 for index in range(size))
+    payload = {
+        "positions": [{"label": label, "owner": "MAX"} for label in labels],
+        "moves": [
+            {"source": source, "target": target}
+            for source in labels
+            for target in labels
+        ],
+        "draw_payoff": {"num": "0", "den": "1"},
+    }
+
+    with pytest.raises(ValidationError, match="result-size bound"):
+        DeterministicTerminalGame.model_validate(payload)
+
+
+def test_solution_rejects_value_strategy_and_source_mutations() -> None:
+    result = solve_terminal_game(_paper_game())
+
+    bad_classes = (
+        TerminalGameValueClass(payoff=_r(0), positions=("s", "u", "t1")),
+        *result.value_classes[1:],
+    )
+    with pytest.raises(ValidationError, match="exact minimax partition"):
+        DeterministicTerminalGameSolution(
+            game=result.game,
+            value_classes=bad_classes,
+            max_strategy=result.max_strategy,
+            min_strategy=result.min_strategy,
+        )
+
+    with pytest.raises(ValidationError, match="canonical optimal strategy"):
+        DeterministicTerminalGameSolution(
+            game=result.game,
+            value_classes=result.value_classes,
+            max_strategy=(StationaryChoice(position="u", target="u"),),
+            min_strategy=result.min_strategy,
+        )
+
+    source_mutations = []
+    draw_mutation = result.game.model_dump(mode="json")
+    draw_mutation["draw_payoff"] = {"num": "3", "den": "1"}
+    source_mutations.append(draw_mutation)
+    owner_mutation = result.game.model_dump(mode="json")
+    owner_mutation["positions"][1]["owner"] = "MIN"
+    source_mutations.append(owner_mutation)
+    graph_mutation = result.game.model_dump(mode="json")
+    graph_mutation["moves"] = [
+        move
+        for move in graph_mutation["moves"]
+        if move != {"source": "u", "target": "t1"}
+    ]
+    source_mutations.append(graph_mutation)
+
+    for mutated_game in source_mutations:
+        with pytest.raises(ValidationError, match="exact minimax partition"):
+            DeterministicTerminalGameSolution(
+                game=DeterministicTerminalGame.model_validate(mutated_game),
+                value_classes=result.value_classes,
+                max_strategy=result.max_strategy,
+                min_strategy=result.min_strategy,
+            )
+
+
+def test_public_request_and_example_return_the_declared_result() -> None:
+    operation = next(
+        tool
+        for tool in TOOLS
+        if tool.operation_id == "game.deterministic_terminal.solve"
+    )
+    request = DeterministicTerminalGameRequest.model_validate(
+        operation.examples[0].input
+    )
+
+    result = compute_deterministic_terminal_game(request)
+
+    assert isinstance(result, DeterministicTerminalGameSolution)
+    assert result.value_classes[0].payoff.as_fraction() == 1
+
+
+def test_native_api_is_explicit() -> None:
+    assert tuple(finite_game_theory.__all__) == (
+        "DeterministicGameMove",
+        "DeterministicGamePosition",
+        "DeterministicTerminalGame",
+        "DeterministicTerminalGameSolution",
+        "StationaryChoice",
+        "TerminalGameValueClass",
+        "solve_terminal_game",
+    )
+    assert all(hasattr(finite_game_theory, name) for name in finite_game_theory.__all__)

--- a/tests/math/finite_game_theory/test_deterministic_terminal_game.py
+++ b/tests/math/finite_game_theory/test_deterministic_terminal_game.py
@@ -219,6 +219,32 @@ def test_exact_fractional_thresholds_choose_reachability_over_draw() -> None:
     assert result.max_strategy == (StationaryChoice(position="x", target="high"),)
 
 
+def test_reachability_strategy_uses_canonical_strict_progress_rank() -> None:
+    game = DeterministicTerminalGame(
+        positions=(
+            DeterministicGamePosition(label="x", owner="MAX"),
+            DeterministicGamePosition(label="y", owner="MAX"),
+            DeterministicGamePosition(label="t", owner="TERMINAL", payoff=_r(1)),
+        ),
+        moves=(
+            DeterministicGameMove(source="x", target="y"),
+            DeterministicGameMove(source="x", target="t"),
+            DeterministicGameMove(source="y", target="t"),
+        ),
+        draw_payoff=_r(0),
+    )
+
+    result = solve_terminal_game(game)
+
+    assert result.value_classes == (
+        TerminalGameValueClass(payoff=_r(1), positions=("x", "y", "t")),
+    )
+    assert result.max_strategy == (
+        StationaryChoice(position="x", target="t"),
+        StationaryChoice(position="y", target="t"),
+    )
+
+
 def test_below_draw_reachability_and_at_draw_safety_choose_progress() -> None:
     game = DeterministicTerminalGame(
         positions=(


### PR DESCRIPTION
## Problem

Issue #977 needs an exact operation for finite deterministic two-player games with terminal payoffs and a declared infinite-play payoff. The existing finite-game operations accept normal-form payoff matrices; they cannot represent an owned cyclic arena, terminal stopping semantics, or an all-position value profile with stationary strategy witnesses.

The issue's current scope explicitly excludes making one paper's mutable backward-search trace part of the game-value contract.

Closes #977.

## Solution

Add `game.deterministic_terminal.solve` and a native `solve_terminal_game` API. The canonical game value contains an ordered position axis, explicit `MAX`/`MIN`/`TERMINAL` ownership, canonical directed moves, exact rational terminal payoffs, and one exact rational payoff for infinite play. Malformed partitions, outgoing terminal moves, nonterminal dead ends, duplicate moves, and noncanonical move order fail at the typed boundary.

The operation returns the complete payoff partition for every position and one source-bound canonical optimal stationary strategy for each player. For each payoff threshold above the draw payoff, a standard reachability attractor identifies where MAX can force a sufficiently valuable terminal. At or below the draw payoff, the complement of MIN's attractor to lower terminals solves the corresponding safety game. The greatest won threshold is the exact value. Strict attractor ranks provide finite progress choices; safety regions provide invariant-preserving choices.

This direct threshold kernel uses exact `Fraction` arithmetic and adjacency lists. NetworkX does not provide the required game solver, while Gambit and OpenSpiel model substantially broader game workflows without supplying this exact source-bound, all-position terminal-arena result. Adding either dependency would leave the threshold-game semantics and canonical witnesses as custom adapter logic, so the bounded reachability/safety kernel stays owner-local.

The implementation does not add the paper-specific attractor-trace replay, an algorithm verifier, durable state, or a generic game framework.

## Testing

- `uv run pytest -q tests/math/finite_game_theory/test_deterministic_terminal_game.py tests/math/finite_game_theory/test_finite_game_theory.py` (25 passed)
- `uv run pytest -q tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py` (967 passed)
- `uv run ruff check src/jacobian/math/finite_game_theory tests/math/finite_game_theory`
- `uv run mypy src/jacobian/math/finite_game_theory`
- `make check` (Ruff, format, mypy, and 2,666 tests passed)
- An independent exhaustive stationary-strategy differential over 20,000 generated arenas with one to seven positions matched every returned value and verified both global strategy witnesses from every start.
- Manual admitted-scale runs solved 256 distinct terminal payoff levels in 0.16 s (31,905 canonical bytes) and a 4,096-position owned cycle in 0.30 s (524,457 canonical bytes).

- Specialist validation run (if any): catalog and public-operation contract-conformance lanes listed above

## Public contract impact

- Adds `game.deterministic_terminal.solve` version 1 with exact request/result schemas.
- Exposes the canonical arena, position, move, solution, value-class, strategy-choice values, and `solve_terminal_game` through `jacobian.math.finite_game_theory`.
- Existing normal-form game operation IDs, schemas, and semantics are unchanged.

## Public operation admission

- Concrete gap: no operation computes exact all-position values and stationary witnesses for an owned cyclic terminal-payoff arena.
- Why existing operations or typed values are insufficient: a normal-form payoff matrix has no position graph, owner partition, terminal stopping rule, infinite-play payoff, or position-indexed strategy witness.
- Stable mathematical result: the complete exact minimax payoff partition and one canonical globally optimal stationary strategy per player.
- Semantic domain and admitted execution envelope: finite deterministic turn-based zero-sum arenas with exact rational terminal and infinite-play payoffs; every nonterminal has a move and terminals have none. Requests admit at most 4,096 positions and 65,536 moves when the complete threshold solve and source replay fit 3,000,000 derived work units and the exact retained result fits 4 MiB.
- Controlling work, intermediate, memory, and output quantities: distinct payoff thresholds, positions, moves, exact-rational digit lengths and comparisons, two complete kernel passes, retained arena bytes, value-class membership, and one choice per owned position.
- Exact representation, algorithm regimes, and maintained backend: canonical rational values backed by `Fraction`, with one adjacency-list reachability/safety-attractor regime over the full admitted domain. No maintained library supplies the narrower exact game postcondition or its canonical global witnesses.
- Remaining fixed caps and their classification: the 4,096-position and 65,536-move materialization caps are conservative structural safety limits; the derived threshold-work and 4 MiB result bounds are the effective admission envelope. There is no algorithm crossover.
- Admission decision: KEEP — exact terminal-game values with bound stationary strategies are a reusable game-theoretic postcondition, independent of any one attractor implementation or source paper.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Finite deterministic terminal-payoff game solution | delivered | `game.deterministic_terminal.solve` |
| Separate solution verifier | not separately admitted; the source-bound result replays the same exact mathematical postcondition | none |
| Mutable attractor/backward-search trace replay | not admitted without users beyond the source paper, as requested in the owner comment | none |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics are exact and complete for every admitted request
- [x] New bounds include boundary and realistic source-backed scale evidence; there is no algorithm crossover
- [x] No new shared abstraction is introduced
