### PR TITLE
feat(graphs): compute bounded exact maximum cuts

### DIFF
--- a/src/jacobian/math/graphs/optimization/_admission.py
+++ b/src/jacobian/math/graphs/optimization/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.graphs.optimization._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "graph.cut.maximum.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact source-bound maximum bipartition cut with a reusable partition and crossing-edge witness",
+    ),
+    OperationAdmission(
         "graph.distance_matrix.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -225,7 +225,6 @@ def _projected_result_bytes(graph: SimpleUndirectedGraph) -> int:
     worst_case = {
         "result_schema_version": "1",
         "graph": graph_value,
-        "status": "EXACT",
         # A valid partition contains every source vertex exactly once across
         # both sides. Putting every vertex on one side maximizes list separators
         # and is therefore a conservative exact bound for the partition fields.
@@ -235,7 +234,6 @@ def _projected_result_bytes(graph: SimpleUndirectedGraph) -> int:
         "cut_value": len(graph.edges),
         "lower_bound": len(graph.edges),
         "upper_bound": len(graph.edges),
-        "completion": "COMPLETE",
     }
     return len(
         encode_strict_json(
@@ -304,14 +302,12 @@ class GraphMaximumCutResult(StrictModel):
 
     result_schema_version: Literal["1"] = "1"
     graph: SimpleUndirectedGraph
-    status: Literal["EXACT"] = "EXACT"
     left_vertices: tuple[str, ...] = Field(max_length=256)
     right_vertices: tuple[str, ...] = Field(max_length=256)
     crossing_edges: tuple[tuple[str, str], ...] = Field(max_length=32_640)
     cut_value: StrictInt = Field(ge=0, le=32_640)
     lower_bound: StrictInt = Field(ge=0, le=32_640)
     upper_bound: StrictInt = Field(ge=0, le=32_640)
-    completion: Literal["COMPLETE"] = "COMPLETE"
 
     @model_validator(mode="after")
     def bind_cut_to_source_and_replay_optimality(self) -> Self:
@@ -502,42 +498,58 @@ def _solve_analysis(
     return _combine_component_solutions(analysis, tuple(solutions))
 
 
+def _partition_from_class_sides(
+    graph: SimpleUndirectedGraph,
+    analysis: _MaximumCutAnalysis,
+    class_sides: tuple[bool, ...],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[tuple[str, str], ...]]:
+    vertex_sides = tuple(class_sides[class_id] for class_id in analysis.class_of_vertex)
+    left_vertices = tuple(
+        vertex
+        for vertex, side in zip(graph.vertices, vertex_sides, strict=True)
+        if not side
+    )
+    right_vertices = tuple(
+        vertex
+        for vertex, side in zip(graph.vertices, vertex_sides, strict=True)
+        if side
+    )
+    right = set(right_vertices)
+    crossing_edges = tuple(
+        edge for edge in graph.edges if (edge[0] in right) != (edge[1] in right)
+    )
+    return left_vertices, right_vertices, crossing_edges
+
+
 def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResult:
     """Compute one deterministic exact maximum cut and source-edge ledger."""
 
     analysis = _analyze_graph(request.graph)
     cut_value, class_sides = _solve_analysis(analysis)
-    vertex_sides = tuple(class_sides[class_id] for class_id in analysis.class_of_vertex)
-    left_vertices = tuple(
-        vertex
-        for vertex, side in zip(request.graph.vertices, vertex_sides, strict=True)
-        if not side
-    )
-    right_vertices = tuple(
-        vertex
-        for vertex, side in zip(request.graph.vertices, vertex_sides, strict=True)
-        if side
-    )
-    right = set(right_vertices)
-    crossing_edges = tuple(
-        edge for edge in request.graph.edges if (edge[0] in right) != (edge[1] in right)
+    left_vertices, right_vertices, crossing_edges = _partition_from_class_sides(
+        request.graph,
+        analysis,
+        class_sides,
     )
     if len(crossing_edges) != cut_value:
-        raise RuntimeError("maximum-cut backend returned an inconsistent objective")
+        cut_value, class_sides = _solve_analysis_by_enumeration(analysis)
+        left_vertices, right_vertices, crossing_edges = _partition_from_class_sides(
+            request.graph,
+            analysis,
+            class_sides,
+        )
 
     # The producer already has coincident exact backend bounds. Avoid paying a
     # second complete search inside this call; independently supplied or
     # deserialized results always execute the exhaustive source-bound replay.
     return GraphMaximumCutResult.model_construct(
         graph=request.graph,
-        status="EXACT",
         left_vertices=left_vertices,
         right_vertices=right_vertices,
         crossing_edges=crossing_edges,
         cut_value=cut_value,
         lower_bound=cut_value,
         upper_bound=cut_value,
-        completion="COMPLETE",
     )
 
 

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -1,0 +1,686 @@
+"""Bounded exact maximum cut on canonical simple undirected graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictInt, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
+
+from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+MAXIMUM_CUT_CANDIDATE_PARTITIONS = 1_048_576
+"""Maximum reduced component assignments admitted by one exact request."""
+
+MAXIMUM_CUT_EDGE_UPDATES = 5_000_000
+"""Maximum weighted adjacency updates in one complete result replay."""
+
+MAXIMUM_CUT_RESULT_BYTES = CanonicalLimits().max_output_bytes
+"""Maximum projected canonical JSON bytes for one exact result."""
+
+MAXIMUM_CUT_Z3_RLIMIT = 100_000
+"""Per-component Z3 resource limit before the exact fallback takes over."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ReducedEdge:
+    left: int
+    right: int
+    weight: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ReducedComponent:
+    class_ids: tuple[int, ...]
+    edges: tuple[_ReducedEdge, ...]
+    bipartite_sides: tuple[bool, ...] | None
+    root: int
+    variable_order: tuple[int, ...]
+    candidate_partitions: int
+
+
+@dataclass(frozen=True, slots=True)
+class _MaximumCutAnalysis:
+    twin_classes: tuple[tuple[int, ...], ...]
+    class_of_vertex: tuple[int, ...]
+    components: tuple[_ReducedComponent, ...]
+    source_component_count: int
+    candidate_partitions: int
+    edge_updates: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ComponentSolution:
+    value: int
+    sides: tuple[bool, ...]
+
+
+def _component_count(adjacency: tuple[tuple[int, ...], ...]) -> int:
+    unseen = set(range(len(adjacency)))
+    count = 0
+    while unseen:
+        count += 1
+        stack = [min(unseen)]
+        unseen.remove(stack[0])
+        while stack:
+            vertex = stack.pop()
+            for neighbor in adjacency[vertex]:
+                if neighbor in unseen:
+                    unseen.remove(neighbor)
+                    stack.append(neighbor)
+    return count
+
+
+def _connected_components(
+    adjacency: tuple[tuple[tuple[int, int], ...], ...],
+) -> tuple[tuple[int, ...], ...]:
+    unseen = set(range(len(adjacency)))
+    components: list[tuple[int, ...]] = []
+    while unseen:
+        start = min(unseen)
+        unseen.remove(start)
+        stack = [start]
+        component: list[int] = []
+        while stack:
+            vertex = stack.pop()
+            component.append(vertex)
+            for neighbor, _weight in adjacency[vertex]:
+                if neighbor in unseen:
+                    unseen.remove(neighbor)
+                    stack.append(neighbor)
+        components.append(tuple(sorted(component)))
+    return tuple(components)
+
+
+def _bipartite_sides(
+    class_ids: tuple[int, ...],
+    adjacency: tuple[tuple[tuple[int, int], ...], ...],
+) -> tuple[bool, ...] | None:
+    colors: dict[int, bool] = {class_ids[0]: False}
+    queue = [class_ids[0]]
+    for vertex in queue:
+        for neighbor, _weight in adjacency[vertex]:
+            expected = not colors[vertex]
+            if neighbor not in colors:
+                colors[neighbor] = expected
+                queue.append(neighbor)
+            elif colors[neighbor] != expected:
+                return None
+    return tuple(colors[class_id] for class_id in class_ids)
+
+
+def _analyze_graph(graph: SimpleUndirectedGraph) -> _MaximumCutAnalysis:
+    """Derive the exact false-twin quotient and exhaustive replay budget.
+
+    Vertices with equal open neighborhoods are nonadjacent false twins. For a
+    fixed assignment of every other vertex, their incident cut contributions
+    are independent and identical, so homogenizing the class on whichever side
+    is no worse preserves an optimum. Aggregating source edges between classes
+    as integer weights therefore preserves the exact maximum-cut value.
+    """
+
+    vertex_index = {vertex: index for index, vertex in enumerate(graph.vertices)}
+    source_adjacency: list[set[int]] = [set() for _vertex in graph.vertices]
+    indexed_edges: list[tuple[int, int]] = []
+    for left_label, right_label in graph.edges:
+        left_index = vertex_index[left_label]
+        right_index = vertex_index[right_label]
+        indexed_edges.append((left_index, right_index))
+        source_adjacency[left_index].add(right_index)
+        source_adjacency[right_index].add(left_index)
+    source_adjacency_value = tuple(
+        tuple(sorted(neighbors)) for neighbors in source_adjacency
+    )
+    source_component_count = _component_count(source_adjacency_value)
+
+    classes_by_neighborhood: dict[tuple[int, ...], list[int]] = {}
+    for vertex, neighbors in enumerate(source_adjacency_value):
+        classes_by_neighborhood.setdefault(neighbors, []).append(vertex)
+    twin_classes = tuple(
+        tuple(vertices) for vertices in classes_by_neighborhood.values()
+    )
+    class_of_vertex = [0] * len(graph.vertices)
+    for class_id, vertices in enumerate(twin_classes):
+        for vertex in vertices:
+            class_of_vertex[vertex] = class_id
+
+    reduced_weights: dict[tuple[int, int], int] = {}
+    for left_index, right_index in indexed_edges:
+        left_class = class_of_vertex[left_index]
+        right_class = class_of_vertex[right_index]
+        if left_class == right_class:
+            raise RuntimeError("false-twin reduction produced an internal edge")
+        endpoints = (
+            (left_class, right_class)
+            if left_class < right_class
+            else (right_class, left_class)
+        )
+        reduced_weights[endpoints] = reduced_weights.get(endpoints, 0) + 1
+
+    adjacency_lists: list[list[tuple[int, int]]] = [[] for _class in twin_classes]
+    reduced_edges = tuple(
+        _ReducedEdge(left, right, weight)
+        for (left, right), weight in sorted(reduced_weights.items())
+    )
+    for edge in reduced_edges:
+        adjacency_lists[edge.left].append((edge.right, edge.weight))
+        adjacency_lists[edge.right].append((edge.left, edge.weight))
+    adjacency = tuple(tuple(sorted(neighbors)) for neighbors in adjacency_lists)
+
+    component_ids = _connected_components(adjacency)
+    component_of_class = {
+        class_id: component_index
+        for component_index, class_ids in enumerate(component_ids)
+        for class_id in class_ids
+    }
+    component_edges: list[list[_ReducedEdge]] = [[] for _component in component_ids]
+    for edge in reduced_edges:
+        component_edges[component_of_class[edge.left]].append(edge)
+
+    components: list[_ReducedComponent] = []
+    candidate_partitions = 0
+    edge_updates = 0
+    for component_index, class_ids in enumerate(component_ids):
+        coloring = _bipartite_sides(class_ids, adjacency)
+        if coloring is not None:
+            components.append(
+                _ReducedComponent(
+                    class_ids=class_ids,
+                    edges=tuple(component_edges[component_index]),
+                    bipartite_sides=coloring,
+                    root=class_ids[0],
+                    variable_order=(),
+                    candidate_partitions=0,
+                )
+            )
+            continue
+
+        root = max(
+            class_ids, key=lambda class_id: (len(adjacency[class_id]), -class_id)
+        )
+        variable_order = tuple(
+            sorted(
+                (class_id for class_id in class_ids if class_id != root),
+                key=lambda class_id: (len(adjacency[class_id]), class_id),
+            )
+        )
+        component_candidates = 1 << len(variable_order)
+        component_updates = sum(
+            len(adjacency[class_id]) * (1 << (len(variable_order) - position - 1))
+            for position, class_id in enumerate(variable_order)
+        )
+        candidate_partitions += component_candidates
+        edge_updates += component_updates
+        components.append(
+            _ReducedComponent(
+                class_ids=class_ids,
+                edges=tuple(component_edges[component_index]),
+                bipartite_sides=None,
+                root=root,
+                variable_order=variable_order,
+                candidate_partitions=component_candidates,
+            )
+        )
+
+    return _MaximumCutAnalysis(
+        twin_classes=twin_classes,
+        class_of_vertex=tuple(class_of_vertex),
+        components=tuple(components),
+        source_component_count=source_component_count,
+        candidate_partitions=candidate_partitions,
+        edge_updates=edge_updates,
+    )
+
+
+def _projected_result_bytes(
+    graph: SimpleUndirectedGraph,
+    analysis: _MaximumCutAnalysis,
+) -> int:
+    """Return a conservative exact-result JSON size before search."""
+
+    graph_value = graph.model_dump(mode="json")
+    worst_case = {
+        "result_schema_version": "1",
+        "graph": graph_value,
+        "status": "EXACT",
+        # A valid partition contains every source vertex once. Repeating every
+        # vertex on both sides keeps this a simple conservative upper bound.
+        "left_vertices": list(graph.vertices),
+        "right_vertices": list(graph.vertices),
+        "crossing_edges": [list(edge) for edge in graph.edges],
+        "cut_value": len(graph.edges),
+        "lower_bound": len(graph.edges),
+        "upper_bound": len(graph.edges),
+        "optimality_certificate": {
+            "certificate_schema_version": "1",
+            "method": "EXACT_FALSE_TWIN_QUOTIENT_SEARCH",
+            "source_component_count": analysis.source_component_count,
+            "reduced_vertex_count": len(analysis.twin_classes),
+            "candidate_partitions": analysis.candidate_partitions,
+            "edge_updates": analysis.edge_updates,
+            "required_checks": [
+                "SOURCE_PARTITION",
+                "CROSSING_EDGE_LEDGER",
+                "CUT_VALUE",
+                "COMPLETE_OPTIMALITY_REPLAY",
+            ],
+        },
+        "completion": "COMPLETE",
+    }
+    return len(
+        encode_strict_json(
+            worst_case,
+            limits=CanonicalLimits(max_output_bytes=4 * MAXIMUM_CUT_RESULT_BYTES),
+        )
+    )
+
+
+def _require_graph_envelope(graph: SimpleUndirectedGraph) -> _MaximumCutAnalysis:
+    analysis = _analyze_graph(graph)
+    if analysis.candidate_partitions > MAXIMUM_CUT_CANDIDATE_PARTITIONS:
+        raise ValueError(
+            "maximum-cut false-twin quotient requires "
+            f"{analysis.candidate_partitions} candidate partitions; at most "
+            f"{MAXIMUM_CUT_CANDIDATE_PARTITIONS} are admitted"
+        )
+    if analysis.edge_updates > MAXIMUM_CUT_EDGE_UPDATES:
+        raise ValueError(
+            "maximum-cut complete replay requires "
+            f"{analysis.edge_updates} weighted edge updates; at most "
+            f"{MAXIMUM_CUT_EDGE_UPDATES} are admitted"
+        )
+    projected_bytes = _projected_result_bytes(graph, analysis)
+    if projected_bytes > MAXIMUM_CUT_RESULT_BYTES:
+        raise ValueError(
+            "maximum-cut projected exact result requires at most "
+            f"{projected_bytes} bytes; the admitted result bound is "
+            f"{MAXIMUM_CUT_RESULT_BYTES} bytes"
+        )
+    return analysis
+
+
+def _maximum_cut_graph_schema() -> JsonSchemaValue:
+    schema = SimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "Canonical materialized SimpleUndirectedGraph for an exact-only maximum-cut "
+        "request. Admission uses connected components and the exact false-twin quotient, "
+        f"then permits at most {MAXIMUM_CUT_CANDIDATE_PARTITIONS} candidate partitions, "
+        f"{MAXIMUM_CUT_EDGE_UPDATES} weighted replay edge updates, and a projected exact "
+        f"result of at most {MAXIMUM_CUT_RESULT_BYTES} bytes. Bipartite reduced components "
+        "use a complete linear two-coloring check and do not consume candidate partitions."
+    )
+    return schema
+
+
+MaximumCutGraph = Annotated[
+    SimpleUndirectedGraph,
+    WithJsonSchema(_maximum_cut_graph_schema()),
+]
+
+
+class GraphMaximumCutRequest(StrictModel):
+    """One materialized graph inside the complete exact search envelope."""
+
+    graph: MaximumCutGraph
+
+    @model_validator(mode="after")
+    def require_complete_search_envelope(self) -> Self:
+        _require_graph_envelope(self.graph)
+        return self
+
+
+class GraphMaximumCutOptimalityCertificate(StrictModel):
+    """Replay metadata for one source-bound exact maximum-cut claim."""
+
+    certificate_schema_version: Literal["1"] = "1"
+    method: Literal["EXACT_FALSE_TWIN_QUOTIENT_SEARCH"] = (
+        "EXACT_FALSE_TWIN_QUOTIENT_SEARCH"
+    )
+    source_component_count: StrictInt = Field(ge=0, le=256)
+    reduced_vertex_count: StrictInt = Field(ge=0, le=256)
+    candidate_partitions: StrictInt = Field(
+        ge=0,
+        le=MAXIMUM_CUT_CANDIDATE_PARTITIONS,
+    )
+    edge_updates: StrictInt = Field(ge=0, le=MAXIMUM_CUT_EDGE_UPDATES)
+    required_checks: tuple[
+        Literal[
+            "SOURCE_PARTITION",
+            "CROSSING_EDGE_LEDGER",
+            "CUT_VALUE",
+            "COMPLETE_OPTIMALITY_REPLAY",
+        ],
+        ...,
+    ] = (
+        "SOURCE_PARTITION",
+        "CROSSING_EDGE_LEDGER",
+        "CUT_VALUE",
+        "COMPLETE_OPTIMALITY_REPLAY",
+    )
+
+
+def _expected_certificate(
+    analysis: _MaximumCutAnalysis,
+) -> GraphMaximumCutOptimalityCertificate:
+    return GraphMaximumCutOptimalityCertificate(
+        source_component_count=analysis.source_component_count,
+        reduced_vertex_count=len(analysis.twin_classes),
+        candidate_partitions=analysis.candidate_partitions,
+        edge_updates=analysis.edge_updates,
+    )
+
+
+class GraphMaximumCutResult(StrictModel):
+    """An exact maximum cut bound to its complete canonical source graph."""
+
+    result_schema_version: Literal["1"] = "1"
+    graph: SimpleUndirectedGraph
+    status: Literal["EXACT"] = "EXACT"
+    left_vertices: tuple[str, ...] = Field(max_length=256)
+    right_vertices: tuple[str, ...] = Field(max_length=256)
+    crossing_edges: tuple[tuple[str, str], ...] = Field(max_length=32_640)
+    cut_value: StrictInt = Field(ge=0, le=32_640)
+    lower_bound: StrictInt = Field(ge=0, le=32_640)
+    upper_bound: StrictInt = Field(ge=0, le=32_640)
+    optimality_certificate: GraphMaximumCutOptimalityCertificate
+    completion: Literal["COMPLETE"] = "COMPLETE"
+
+    @model_validator(mode="after")
+    def bind_cut_to_source_and_replay_optimality(self) -> Self:
+        analysis = _require_graph_envelope(self.graph)
+        graph_vertices = set(self.graph.vertices)
+        left = set(self.left_vertices)
+        right = set(self.right_vertices)
+        if (
+            len(left) != len(self.left_vertices)
+            or len(right) != len(self.right_vertices)
+            or left & right
+            or left | right != graph_vertices
+            or self.left_vertices
+            != tuple(vertex for vertex in self.graph.vertices if vertex in left)
+            or self.right_vertices
+            != tuple(vertex for vertex in self.graph.vertices if vertex in right)
+        ):
+            raise ValueError(
+                "bipartition sides must partition the source graph vertices in "
+                "source-axis order"
+            )
+
+        expected_crossing = tuple(
+            edge for edge in self.graph.edges if (edge[0] in left) != (edge[1] in left)
+        )
+        if self.crossing_edges != expected_crossing:
+            raise ValueError(
+                "crossing-edge ledger must equal the source graph edges crossing "
+                "the submitted partition in source-edge order"
+            )
+        if self.cut_value != len(expected_crossing):
+            raise ValueError(
+                "cut value must equal the crossing-edge ledger cardinality"
+            )
+        if self.lower_bound != self.cut_value or self.upper_bound != self.cut_value:
+            raise ValueError("an exact result requires exact bounds equal to cut value")
+        if self.optimality_certificate != _expected_certificate(analysis):
+            raise ValueError(
+                "optimality certificate does not match the retained source graph"
+            )
+
+        replayed_value, _sides = _solve_analysis_by_enumeration(analysis)
+        if self.cut_value != replayed_value:
+            raise ValueError(
+                "cut value is feasible but not maximum for the retained source graph"
+            )
+        return self
+
+
+def _solve_component_by_enumeration(
+    analysis: _MaximumCutAnalysis,
+    component_index: int,
+) -> _ComponentSolution:
+    component = analysis.components[component_index]
+    if component.bipartite_sides is not None:
+        return _ComponentSolution(
+            value=sum(edge.weight for edge in component.edges),
+            sides=component.bipartite_sides,
+        )
+
+    local_index = {
+        class_id: position for position, class_id in enumerate(component.class_ids)
+    }
+    local_adjacency: list[list[tuple[int, int]]] = [
+        [] for _class_id in component.class_ids
+    ]
+    for edge in component.edges:
+        left = local_index[edge.left]
+        right = local_index[edge.right]
+        local_adjacency[left].append((right, edge.weight))
+        local_adjacency[right].append((left, edge.weight))
+
+    sides = [False] * len(component.class_ids)
+    best_sides = tuple(sides)
+    current_value = 0
+    best_value = 0
+    for step in range(1, component.candidate_partitions):
+        changed_position = (step & -step).bit_length() - 1
+        changed_class = component.variable_order[changed_position]
+        changed = local_index[changed_class]
+        old_side = sides[changed]
+        for neighbor, weight in local_adjacency[changed]:
+            current_value += weight if sides[neighbor] == old_side else -weight
+        sides[changed] = not old_side
+        side_value = tuple(sides)
+        if current_value > best_value or (
+            current_value == best_value and side_value < best_sides
+        ):
+            best_value = current_value
+            best_sides = side_value
+    return _ComponentSolution(value=best_value, sides=best_sides)
+
+
+def _solve_component_with_z3(
+    analysis: _MaximumCutAnalysis,
+    component_index: int,
+) -> _ComponentSolution | None:
+    """Return an exact deterministic Z3 optimum, or defer to the fallback."""
+
+    component = analysis.components[component_index]
+    if component.bipartite_sides is not None:
+        return _ComponentSolution(
+            value=sum(edge.weight for edge in component.edges),
+            sides=component.bipartite_sides,
+        )
+
+    import z3  # type: ignore[import-untyped]
+
+    try:
+        optimizer = z3.Optimize()
+        optimizer.set(priority="lex", rlimit=MAXIMUM_CUT_Z3_RLIMIT)
+        variables = {
+            class_id: z3.Bool(f"maximum_cut_{component_index}_{position}")
+            for position, class_id in enumerate(component.class_ids)
+        }
+        optimizer.add(variables[component.root] == z3.BoolVal(False))
+        objective = z3.Sum(
+            [
+                edge.weight * z3.If(variables[edge.left] != variables[edge.right], 1, 0)
+                for edge in component.edges
+            ]
+        )
+        objective_handle = optimizer.maximize(objective)
+        tie_break = z3.Sum(
+            [
+                z3.If(
+                    variables[class_id],
+                    1 << (len(component.class_ids) - position - 1),
+                    0,
+                )
+                for position, class_id in enumerate(component.class_ids)
+            ]
+        )
+        optimizer.minimize(tie_break)
+        if optimizer.check() != z3.sat:
+            return None
+        lower = objective_handle.lower()
+        upper = objective_handle.upper()
+        if not (z3.is_int_value(lower) and z3.is_int_value(upper)):
+            return None
+        lower_value = lower.as_long()
+        upper_value = upper.as_long()
+        if lower_value != upper_value:
+            return None
+        model = optimizer.model()
+        model_value = model.eval(objective, model_completion=True)
+        if not z3.is_int_value(model_value) or model_value.as_long() != lower_value:
+            return None
+        sides = tuple(
+            z3.is_true(model.eval(variables[class_id], model_completion=True))
+            for class_id in component.class_ids
+        )
+        return _ComponentSolution(value=lower_value, sides=sides)
+    except z3.Z3Exception:
+        return None
+
+
+def _combine_component_solutions(
+    analysis: _MaximumCutAnalysis,
+    solutions: tuple[_ComponentSolution, ...],
+) -> tuple[int, tuple[bool, ...]]:
+    class_sides = [False] * len(analysis.twin_classes)
+    value = 0
+    for component, solution in zip(analysis.components, solutions, strict=True):
+        value += solution.value
+        for class_id, side in zip(component.class_ids, solution.sides, strict=True):
+            class_sides[class_id] = side
+    return value, tuple(class_sides)
+
+
+def _solve_analysis_by_enumeration(
+    analysis: _MaximumCutAnalysis,
+) -> tuple[int, tuple[bool, ...]]:
+    return _combine_component_solutions(
+        analysis,
+        tuple(
+            _solve_component_by_enumeration(analysis, component_index)
+            for component_index in range(len(analysis.components))
+        ),
+    )
+
+
+def _solve_analysis(
+    analysis: _MaximumCutAnalysis,
+) -> tuple[int, tuple[bool, ...]]:
+    solutions: list[_ComponentSolution] = []
+    for component_index in range(len(analysis.components)):
+        solution = _solve_component_with_z3(analysis, component_index)
+        if solution is None:
+            solution = _solve_component_by_enumeration(analysis, component_index)
+        solutions.append(solution)
+    return _combine_component_solutions(analysis, tuple(solutions))
+
+
+def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResult:
+    """Compute one deterministic exact maximum cut and source-edge ledger."""
+
+    analysis = _analyze_graph(request.graph)
+    cut_value, class_sides = _solve_analysis(analysis)
+    vertex_sides = tuple(class_sides[class_id] for class_id in analysis.class_of_vertex)
+    left_vertices = tuple(
+        vertex
+        for vertex, side in zip(request.graph.vertices, vertex_sides, strict=True)
+        if not side
+    )
+    right_vertices = tuple(
+        vertex
+        for vertex, side in zip(request.graph.vertices, vertex_sides, strict=True)
+        if side
+    )
+    right = set(right_vertices)
+    crossing_edges = tuple(
+        edge for edge in request.graph.edges if (edge[0] in right) != (edge[1] in right)
+    )
+    if len(crossing_edges) != cut_value:
+        raise RuntimeError("maximum-cut backend returned an inconsistent objective")
+
+    # The producer already has coincident exact backend bounds. Avoid paying a
+    # second complete search inside this call; independently supplied or
+    # deserialized results always execute the exhaustive source-bound replay.
+    return GraphMaximumCutResult.model_construct(
+        graph=request.graph,
+        status="EXACT",
+        left_vertices=left_vertices,
+        right_vertices=right_vertices,
+        crossing_edges=crossing_edges,
+        cut_value=cut_value,
+        lower_bound=cut_value,
+        upper_bound=cut_value,
+        optimality_certificate=_expected_certificate(analysis),
+        completion="COMPLETE",
+    )
+
+
+MAXIMUM_CUT_OPERATION: MathTool[
+    GraphMaximumCutRequest,
+    GraphMaximumCutResult,
+] = MathTool(
+    operation_id="graph.cut.maximum.compute",
+    version="1",
+    title="Exact maximum cut",
+    description=(
+        "Compute one exact maximum-cardinality bipartition cut of a bounded "
+        "canonical simple undirected graph. Return both partition sides, the source-"
+        "ordered crossing-edge ledger, coincident lower and upper bounds, and bounded "
+        "optimality-replay metadata; requests outside the complete exact envelope are "
+        "rejected before search."
+    ),
+    request_type=GraphMaximumCutRequest,
+    result_type=GraphMaximumCutResult,
+    run=compute_maximum_cut,
+    tags=(
+        "graph",
+        "cut",
+        "max-cut",
+        "maximum-bipartition",
+        "exact",
+        "bounded",
+        "z3",
+    ),
+    examples=(
+        example(
+            "cycle_five",
+            (
+                "Compute an exact maximum cut of the five-cycle; the materialized "
+                "simple graph must satisfy the published quotient-search and result "
+                "bounds."
+            ),
+            {
+                "graph": {
+                    "vertices": ["0", "1", "2", "3", "4"],
+                    "edges": [
+                        ["0", "1"],
+                        ["0", "4"],
+                        ["1", "2"],
+                        ["2", "3"],
+                        ["3", "4"],
+                    ],
+                }
+            },
+        ),
+    ),
+)
+
+
+__all__ = [
+    "MAXIMUM_CUT_CANDIDATE_PARTITIONS",
+    "MAXIMUM_CUT_EDGE_UPDATES",
+    "MAXIMUM_CUT_OPERATION",
+    "MAXIMUM_CUT_RESULT_BYTES",
+    "GraphMaximumCutOptimalityCertificate",
+    "GraphMaximumCutRequest",
+    "GraphMaximumCutResult",
+    "compute_maximum_cut",
+]

--- a/src/jacobian/math/graphs/optimization/_maximum_cut.py
+++ b/src/jacobian/math/graphs/optimization/_maximum_cut.py
@@ -49,7 +49,6 @@ class _MaximumCutAnalysis:
     twin_classes: tuple[tuple[int, ...], ...]
     class_of_vertex: tuple[int, ...]
     components: tuple[_ReducedComponent, ...]
-    source_component_count: int
     candidate_partitions: int
     edge_updates: int
 
@@ -58,22 +57,6 @@ class _MaximumCutAnalysis:
 class _ComponentSolution:
     value: int
     sides: tuple[bool, ...]
-
-
-def _component_count(adjacency: tuple[tuple[int, ...], ...]) -> int:
-    unseen = set(range(len(adjacency)))
-    count = 0
-    while unseen:
-        count += 1
-        stack = [min(unseen)]
-        unseen.remove(stack[0])
-        while stack:
-            vertex = stack.pop()
-            for neighbor in adjacency[vertex]:
-                if neighbor in unseen:
-                    unseen.remove(neighbor)
-                    stack.append(neighbor)
-    return count
 
 
 def _connected_components(
@@ -136,7 +119,6 @@ def _analyze_graph(graph: SimpleUndirectedGraph) -> _MaximumCutAnalysis:
     source_adjacency_value = tuple(
         tuple(sorted(neighbors)) for neighbors in source_adjacency
     )
-    source_component_count = _component_count(source_adjacency_value)
 
     classes_by_neighborhood: dict[tuple[int, ...], list[int]] = {}
     for vertex, neighbors in enumerate(source_adjacency_value):
@@ -231,16 +213,12 @@ def _analyze_graph(graph: SimpleUndirectedGraph) -> _MaximumCutAnalysis:
         twin_classes=twin_classes,
         class_of_vertex=tuple(class_of_vertex),
         components=tuple(components),
-        source_component_count=source_component_count,
         candidate_partitions=candidate_partitions,
         edge_updates=edge_updates,
     )
 
 
-def _projected_result_bytes(
-    graph: SimpleUndirectedGraph,
-    analysis: _MaximumCutAnalysis,
-) -> int:
+def _projected_result_bytes(graph: SimpleUndirectedGraph) -> int:
     """Return a conservative exact-result JSON size before search."""
 
     graph_value = graph.model_dump(mode="json")
@@ -248,28 +226,15 @@ def _projected_result_bytes(
         "result_schema_version": "1",
         "graph": graph_value,
         "status": "EXACT",
-        # A valid partition contains every source vertex once. Repeating every
-        # vertex on both sides keeps this a simple conservative upper bound.
+        # A valid partition contains every source vertex exactly once across
+        # both sides. Putting every vertex on one side maximizes list separators
+        # and is therefore a conservative exact bound for the partition fields.
         "left_vertices": list(graph.vertices),
-        "right_vertices": list(graph.vertices),
+        "right_vertices": [],
         "crossing_edges": [list(edge) for edge in graph.edges],
         "cut_value": len(graph.edges),
         "lower_bound": len(graph.edges),
         "upper_bound": len(graph.edges),
-        "optimality_certificate": {
-            "certificate_schema_version": "1",
-            "method": "EXACT_FALSE_TWIN_QUOTIENT_SEARCH",
-            "source_component_count": analysis.source_component_count,
-            "reduced_vertex_count": len(analysis.twin_classes),
-            "candidate_partitions": analysis.candidate_partitions,
-            "edge_updates": analysis.edge_updates,
-            "required_checks": [
-                "SOURCE_PARTITION",
-                "CROSSING_EDGE_LEDGER",
-                "CUT_VALUE",
-                "COMPLETE_OPTIMALITY_REPLAY",
-            ],
-        },
         "completion": "COMPLETE",
     }
     return len(
@@ -284,17 +249,17 @@ def _require_graph_envelope(graph: SimpleUndirectedGraph) -> _MaximumCutAnalysis
     analysis = _analyze_graph(graph)
     if analysis.candidate_partitions > MAXIMUM_CUT_CANDIDATE_PARTITIONS:
         raise ValueError(
-            "maximum-cut false-twin quotient requires "
+            "maximum-cut exact preflight requires "
             f"{analysis.candidate_partitions} candidate partitions; at most "
             f"{MAXIMUM_CUT_CANDIDATE_PARTITIONS} are admitted"
         )
     if analysis.edge_updates > MAXIMUM_CUT_EDGE_UPDATES:
         raise ValueError(
-            "maximum-cut complete replay requires "
-            f"{analysis.edge_updates} weighted edge updates; at most "
+            "maximum-cut exact preflight requires "
+            f"{analysis.edge_updates} incremental weighted edge contributions; at most "
             f"{MAXIMUM_CUT_EDGE_UPDATES} are admitted"
         )
-    projected_bytes = _projected_result_bytes(graph, analysis)
+    projected_bytes = _projected_result_bytes(graph)
     if projected_bytes > MAXIMUM_CUT_RESULT_BYTES:
         raise ValueError(
             "maximum-cut projected exact result requires at most "
@@ -308,11 +273,11 @@ def _maximum_cut_graph_schema() -> JsonSchemaValue:
     schema = SimpleUndirectedGraph.model_json_schema()
     schema["description"] = (
         "Canonical materialized SimpleUndirectedGraph for an exact-only maximum-cut "
-        "request. Admission uses connected components and the exact false-twin quotient, "
-        f"then permits at most {MAXIMUM_CUT_CANDIDATE_PARTITIONS} candidate partitions, "
-        f"{MAXIMUM_CUT_EDGE_UPDATES} weighted replay edge updates, and a projected exact "
-        f"result of at most {MAXIMUM_CUT_RESULT_BYTES} bytes. Bipartite reduced components "
-        "use a complete linear two-coloring check and do not consume candidate partitions."
+        "request. Admission preflights a complete exact proof with at most "
+        f"{MAXIMUM_CUT_CANDIDATE_PARTITIONS} internally derived candidate partitions, "
+        f"{MAXIMUM_CUT_EDGE_UPDATES} incremental weighted edge contributions, and a "
+        f"projected exact result of at most {MAXIMUM_CUT_RESULT_BYTES} bytes. Requests "
+        "outside any bound are rejected before search."
     )
     return schema
 
@@ -334,47 +299,6 @@ class GraphMaximumCutRequest(StrictModel):
         return self
 
 
-class GraphMaximumCutOptimalityCertificate(StrictModel):
-    """Replay metadata for one source-bound exact maximum-cut claim."""
-
-    certificate_schema_version: Literal["1"] = "1"
-    method: Literal["EXACT_FALSE_TWIN_QUOTIENT_SEARCH"] = (
-        "EXACT_FALSE_TWIN_QUOTIENT_SEARCH"
-    )
-    source_component_count: StrictInt = Field(ge=0, le=256)
-    reduced_vertex_count: StrictInt = Field(ge=0, le=256)
-    candidate_partitions: StrictInt = Field(
-        ge=0,
-        le=MAXIMUM_CUT_CANDIDATE_PARTITIONS,
-    )
-    edge_updates: StrictInt = Field(ge=0, le=MAXIMUM_CUT_EDGE_UPDATES)
-    required_checks: tuple[
-        Literal[
-            "SOURCE_PARTITION",
-            "CROSSING_EDGE_LEDGER",
-            "CUT_VALUE",
-            "COMPLETE_OPTIMALITY_REPLAY",
-        ],
-        ...,
-    ] = (
-        "SOURCE_PARTITION",
-        "CROSSING_EDGE_LEDGER",
-        "CUT_VALUE",
-        "COMPLETE_OPTIMALITY_REPLAY",
-    )
-
-
-def _expected_certificate(
-    analysis: _MaximumCutAnalysis,
-) -> GraphMaximumCutOptimalityCertificate:
-    return GraphMaximumCutOptimalityCertificate(
-        source_component_count=analysis.source_component_count,
-        reduced_vertex_count=len(analysis.twin_classes),
-        candidate_partitions=analysis.candidate_partitions,
-        edge_updates=analysis.edge_updates,
-    )
-
-
 class GraphMaximumCutResult(StrictModel):
     """An exact maximum cut bound to its complete canonical source graph."""
 
@@ -387,7 +311,6 @@ class GraphMaximumCutResult(StrictModel):
     cut_value: StrictInt = Field(ge=0, le=32_640)
     lower_bound: StrictInt = Field(ge=0, le=32_640)
     upper_bound: StrictInt = Field(ge=0, le=32_640)
-    optimality_certificate: GraphMaximumCutOptimalityCertificate
     completion: Literal["COMPLETE"] = "COMPLETE"
 
     @model_validator(mode="after")
@@ -425,10 +348,6 @@ class GraphMaximumCutResult(StrictModel):
             )
         if self.lower_bound != self.cut_value or self.upper_bound != self.cut_value:
             raise ValueError("an exact result requires exact bounds equal to cut value")
-        if self.optimality_certificate != _expected_certificate(analysis):
-            raise ValueError(
-                "optimality certificate does not match the retained source graph"
-            )
 
         replayed_value, _sides = _solve_analysis_by_enumeration(analysis)
         if self.cut_value != replayed_value:
@@ -618,7 +537,6 @@ def compute_maximum_cut(request: GraphMaximumCutRequest) -> GraphMaximumCutResul
         cut_value=cut_value,
         lower_bound=cut_value,
         upper_bound=cut_value,
-        optimality_certificate=_expected_certificate(analysis),
         completion="COMPLETE",
     )
 
@@ -633,9 +551,8 @@ MAXIMUM_CUT_OPERATION: MathTool[
     description=(
         "Compute one exact maximum-cardinality bipartition cut of a bounded "
         "canonical simple undirected graph. Return both partition sides, the source-"
-        "ordered crossing-edge ledger, coincident lower and upper bounds, and bounded "
-        "optimality-replay metadata; requests outside the complete exact envelope are "
-        "rejected before search."
+        "ordered crossing-edge ledger, and coincident lower and upper bounds; requests "
+        "outside the complete exact envelope are rejected before search."
     ),
     request_type=GraphMaximumCutRequest,
     result_type=GraphMaximumCutResult,
@@ -647,15 +564,13 @@ MAXIMUM_CUT_OPERATION: MathTool[
         "maximum-bipartition",
         "exact",
         "bounded",
-        "z3",
     ),
     examples=(
         example(
             "cycle_five",
             (
                 "Compute an exact maximum cut of the five-cycle; the materialized "
-                "simple graph must satisfy the published quotient-search and result "
-                "bounds."
+                "simple graph must satisfy the published exact work and result bounds."
             ),
             {
                 "graph": {
@@ -679,7 +594,6 @@ __all__ = [
     "MAXIMUM_CUT_EDGE_UPDATES",
     "MAXIMUM_CUT_OPERATION",
     "MAXIMUM_CUT_RESULT_BYTES",
-    "GraphMaximumCutOptimalityCertificate",
     "GraphMaximumCutRequest",
     "GraphMaximumCutResult",
     "compute_maximum_cut",

--- a/src/jacobian/math/graphs/optimization/_tools.py
+++ b/src/jacobian/math/graphs/optimization/_tools.py
@@ -20,6 +20,7 @@ from jacobian.math.graphs.optimization._invariants import (
     CLIQUE_NUMBER_OPERATION,
     EXACT_GRAPH_INVARIANT_OPERATIONS,
 )
+from jacobian.math.graphs.optimization._maximum_cut import MAXIMUM_CUT_OPERATION
 from jacobian.math.graphs.optimization._minimum_spanning_tree import (
     MINIMUM_SPANNING_TREE_OPERATION,
 )
@@ -28,6 +29,7 @@ __all__ = ["TOOLS"]
 
 TOOLS: MathTools = (
     CHROMATIC_NUMBER_OPERATION,
+    MAXIMUM_CUT_OPERATION,
     *FINITE_GRAPH_OPTIMIZATION_OPERATIONS,
     HAMILTONIAN_PATH_OPERATION,
     MINIMUM_SPANNING_TREE_OPERATION,

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -10,9 +10,11 @@ import networkx as nx
 import pytest
 from pydantic import ValidationError
 
+from jacobian.canonical import encode_strict_json
 from jacobian.math.graphs.optimization import _maximum_cut
 from jacobian.math.graphs.optimization._maximum_cut import (
     MAXIMUM_CUT_CANDIDATE_PARTITIONS,
+    MAXIMUM_CUT_RESULT_BYTES,
     GraphMaximumCutRequest,
     GraphMaximumCutResult,
     compute_maximum_cut,
@@ -108,7 +110,6 @@ def test_empty_graph_retains_its_source_and_exact_zero_cut() -> None:
     assert result.right_vertices == ()
     assert result.crossing_edges == ()
     assert result.cut_value == 0
-    assert result.optimality_certificate.source_component_count == 0
 
 
 def test_bipartite_graph_cuts_every_edge_and_preserves_source_axes() -> None:
@@ -147,18 +148,14 @@ def test_known_exact_maximum_cut_values(
     _assert_cut_invariant(result)
 
 
-def test_false_twin_reduction_admits_the_atlas_scale_blow_up() -> None:
+def test_exact_envelope_admits_the_atlas_scale_blow_up() -> None:
     graph = _c5_blow_up((5, 5, 5, 5, 5))
 
     result = _validated_result(graph)
 
     assert len(graph.vertices) == 25
     assert len(graph.edges) == 125
-    assert result.optimality_certificate.reduced_vertex_count == 5
-    assert result.optimality_certificate.candidate_partitions == 16
-    assert result.optimality_certificate.candidate_partitions < (
-        MAXIMUM_CUT_CANDIDATE_PARTITIONS
-    )
+    assert result.cut_value == 100
 
 
 def test_maximum_cut_is_additive_over_connected_components() -> None:
@@ -170,7 +167,6 @@ def test_maximum_cut_is_additive_over_connected_components() -> None:
     result = _validated_result(graph)
 
     assert result.cut_value == 4 + 4
-    assert result.optimality_certificate.source_component_count == 2
     _assert_cut_invariant(result)
 
 
@@ -231,16 +227,9 @@ def test_complementary_side_orientation_revalidates() -> None:
             ),
             "exact bounds",
         ),
-        (
-            lambda payload: payload["optimality_certificate"].__setitem__(
-                "candidate_partitions",
-                payload["optimality_certificate"]["candidate_partitions"] + 1,
-            ),
-            "certificate",
-        ),
     ],
 )
-def test_result_rejects_forged_ledger_values_bounds_and_certificate(
+def test_result_rejects_forged_ledger_values_and_bounds(
     mutate: Callable[[dict[str, Any]], object], message: str
 ) -> None:
     payload = _validated_result(_cycle(5)).model_dump(mode="json")
@@ -279,12 +268,22 @@ def test_approximate_upper_bound_and_lower_valued_cut_cannot_claim_exactness() -
         GraphMaximumCutResult.model_validate(honest)
 
 
+def test_feasible_suboptimal_cut_with_forged_exact_bounds_fails_replay() -> None:
+    forged = _validated_result(_cycle(5)).model_dump(mode="json")
+    forged["left_vertices"] = ["00"]
+    forged["right_vertices"] = ["01", "02", "03", "04"]
+    forged["crossing_edges"] = [["00", "01"], ["00", "04"]]
+    forged["cut_value"] = 2
+    forged["lower_bound"] = 2
+    forged["upper_bound"] = 2
+
+    with pytest.raises(ValidationError, match="feasible but not maximum"):
+        GraphMaximumCutResult.model_validate(forged)
+
+
 def test_candidate_boundary_accepts_c21_and_rejects_c23_before_backend() -> None:
     accepted = _validated_result(_cycle(21))
-    assert (
-        accepted.optimality_certificate.candidate_partitions
-        == MAXIMUM_CUT_CANDIDATE_PARTITIONS
-    )
+    assert accepted.cut_value == 20
 
     with pytest.raises(ValidationError, match="candidate partitions"):
         GraphMaximumCutRequest(graph=_cycle(23))
@@ -293,7 +292,7 @@ def test_candidate_boundary_accepts_c21_and_rejects_c23_before_backend() -> None
 def test_edge_update_boundary_accepts_k19_and_rejects_k20_before_backend() -> None:
     GraphMaximumCutRequest(graph=_complete(19))
 
-    with pytest.raises(ValidationError, match="weighted edge updates"):
+    with pytest.raises(ValidationError, match="weighted edge contributions"):
         GraphMaximumCutRequest(graph=_complete(20))
 
 
@@ -307,7 +306,6 @@ def test_large_bipartite_graph_is_not_rejected_by_a_coarse_order_cap() -> None:
     result = _validated_result(graph)
 
     assert result.cut_value == 255
-    assert result.optimality_certificate.candidate_partitions == 0
 
 
 def test_projected_result_bytes_are_rejected_before_search() -> None:
@@ -319,12 +317,50 @@ def test_projected_result_bytes_are_rejected_before_search() -> None:
         GraphMaximumCutRequest(graph=graph)
 
 
-def test_schema_explains_the_non_schema_representable_work_bounds() -> None:
-    graph_schema = GraphMaximumCutRequest.model_json_schema()["properties"]["graph"]
+def test_result_size_boundary_accepts_the_largest_fit_and_rejects_the_next() -> None:
+    probe = _validated_result(_graph(("a", "b"), ()))
+    fixed_result_bytes = len(encode_strict_json(probe.model_dump(mode="json"))) - 4
+    accepted_label_length = (MAXIMUM_CUT_RESULT_BYTES - fixed_result_bytes) // 4
+    accepted_graph = _graph(
+        ("a" * accepted_label_length, "b" * accepted_label_length),
+        (),
+    )
 
-    assert "false-twin quotient" in graph_schema["description"]
-    assert str(MAXIMUM_CUT_CANDIDATE_PARTITIONS) in graph_schema["description"]
-    assert "exact-only" in graph_schema["description"]
+    accepted = _validated_result(accepted_graph)
+    accepted_bytes = len(encode_strict_json(accepted.model_dump(mode="json")))
+
+    assert accepted_bytes > MAXIMUM_CUT_RESULT_BYTES - 4
+    assert accepted_bytes <= MAXIMUM_CUT_RESULT_BYTES
+    with pytest.raises(ValidationError, match="projected exact result"):
+        GraphMaximumCutRequest(
+            graph=_graph(
+                (
+                    "a" * (accepted_label_length + 1),
+                    "b" * (accepted_label_length + 1),
+                ),
+                (),
+            )
+        )
+
+
+def test_public_contract_explains_bounds_without_private_kernel_details() -> None:
+    graph_schema = GraphMaximumCutRequest.model_json_schema()["properties"]["graph"]
+    description = graph_schema["description"]
+
+    assert str(MAXIMUM_CUT_CANDIDATE_PARTITIONS) in description
+    assert "exact-only" in description
+    assert "false-twin" not in description
+    assert "quotient" not in description
+    assert (
+        "optimality_certificate"
+        not in GraphMaximumCutResult.model_json_schema()["properties"]
+    )
+    assert "z3" not in _maximum_cut.MAXIMUM_CUT_OPERATION.tags
+    assert "quotient" not in _maximum_cut.MAXIMUM_CUT_OPERATION.description
+    assert all(
+        "quotient" not in invocation.description
+        for invocation in _maximum_cut.MAXIMUM_CUT_OPERATION.examples
+    )
 
 
 def test_bounded_exhaustive_fallback_preserves_an_exact_result(

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -346,15 +346,15 @@ def test_result_size_boundary_accepts_the_largest_fit_and_rejects_the_next() -> 
 def test_public_contract_explains_bounds_without_private_kernel_details() -> None:
     graph_schema = GraphMaximumCutRequest.model_json_schema()["properties"]["graph"]
     description = graph_schema["description"]
+    result_properties = GraphMaximumCutResult.model_json_schema()["properties"]
 
     assert str(MAXIMUM_CUT_CANDIDATE_PARTITIONS) in description
     assert "exact-only" in description
     assert "false-twin" not in description
     assert "quotient" not in description
-    assert (
-        "optimality_certificate"
-        not in GraphMaximumCutResult.model_json_schema()["properties"]
-    )
+    assert "optimality_certificate" not in result_properties
+    assert "status" not in result_properties
+    assert "completion" not in result_properties
     assert "z3" not in _maximum_cut.MAXIMUM_CUT_OPERATION.tags
     assert "quotient" not in _maximum_cut.MAXIMUM_CUT_OPERATION.description
     assert all(
@@ -371,6 +371,23 @@ def test_bounded_exhaustive_fallback_preserves_an_exact_result(
     result = _validated_result(_complete(7))
 
     assert result.cut_value == 12
+
+
+def test_inconsistent_private_objective_falls_back_to_exhaustive_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _cycle(5)
+
+    monkeypatch.setattr(
+        _maximum_cut,
+        "_solve_analysis",
+        lambda analysis: (1, tuple(False for _ in analysis.twin_classes)),
+    )
+
+    result = compute_maximum_cut(GraphMaximumCutRequest(graph=graph))
+
+    assert result.cut_value == 4
+    _assert_cut_invariant(result)
 
 
 def test_operation_is_deterministic_on_a_nonunique_optimum() -> None:

--- a/tests/math/graphs/test_graph_maximum_cut.py
+++ b/tests/math/graphs/test_graph_maximum_cut.py
@@ -1,0 +1,346 @@
+"""Contract tests for bounded exact maximum cut."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import combinations
+from typing import Any
+
+import networkx as nx
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.optimization import _maximum_cut
+from jacobian.math.graphs.optimization._maximum_cut import (
+    MAXIMUM_CUT_CANDIDATE_PARTITIONS,
+    GraphMaximumCutRequest,
+    GraphMaximumCutResult,
+    compute_maximum_cut,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
+
+
+def _graph(
+    vertices: tuple[str, ...], edges: tuple[tuple[str, str], ...]
+) -> SimpleUndirectedGraph:
+    return SimpleUndirectedGraph(vertices=vertices, edges=edges)
+
+
+def _cycle(order: int) -> SimpleUndirectedGraph:
+    vertices = tuple(f"{index:02d}" for index in range(order))
+    edges = tuple(
+        sorted(
+            {
+                tuple(sorted((vertices[index], vertices[(index + 1) % order])))
+                for index in range(order)
+            }
+        )
+    )
+    return _graph(vertices, edges)
+
+
+def _complete(order: int) -> SimpleUndirectedGraph:
+    vertices = tuple(f"{index:02d}" for index in range(order))
+    return _graph(vertices, tuple(combinations(vertices, 2)))
+
+
+def _c5_blow_up(class_sizes: tuple[int, int, int, int, int]) -> SimpleUndirectedGraph:
+    classes = tuple(
+        tuple(f"{class_index}:{offset}" for offset in range(size))
+        for class_index, size in enumerate(class_sizes)
+    )
+    vertices = tuple(vertex for class_ in classes for vertex in class_)
+    edges = tuple(
+        sorted(
+            {
+                tuple(sorted((left, right)))
+                for class_index, class_ in enumerate(classes)
+                for left in class_
+                for right in classes[(class_index + 1) % 5]
+            }
+        )
+    )
+    return _graph(vertices, edges)
+
+
+def _validated_result(graph: SimpleUndirectedGraph) -> GraphMaximumCutResult:
+    produced = compute_maximum_cut(GraphMaximumCutRequest(graph=graph))
+    return GraphMaximumCutResult.model_validate(produced.model_dump(mode="json"))
+
+
+def _brute_force_value(graph: SimpleUndirectedGraph) -> int:
+    if not graph.vertices:
+        return 0
+    vertex_index = {vertex: index for index, vertex in enumerate(graph.vertices)}
+    indexed_edges = tuple(
+        (vertex_index[left], vertex_index[right]) for left, right in graph.edges
+    )
+    best = 0
+    for mask in range(1 << (len(graph.vertices) - 1)):
+        sides = (
+            False,
+            *(bool(mask & (1 << index)) for index in range(len(graph.vertices) - 1)),
+        )
+        best = max(
+            best,
+            sum(sides[left] != sides[right] for left, right in indexed_edges),
+        )
+    return best
+
+
+def _assert_cut_invariant(result: GraphMaximumCutResult) -> None:
+    left = set(result.left_vertices)
+    expected = tuple(
+        edge for edge in result.graph.edges if (edge[0] in left) != (edge[1] in left)
+    )
+    assert result.crossing_edges == expected
+    assert result.cut_value == len(expected)
+    assert result.lower_bound == result.cut_value == result.upper_bound
+
+
+def test_empty_graph_retains_its_source_and_exact_zero_cut() -> None:
+    graph = _graph((), ())
+
+    result = _validated_result(graph)
+
+    assert result.graph == graph
+    assert result.left_vertices == ()
+    assert result.right_vertices == ()
+    assert result.crossing_edges == ()
+    assert result.cut_value == 0
+    assert result.optimality_certificate.source_component_count == 0
+
+
+def test_bipartite_graph_cuts_every_edge_and_preserves_source_axes() -> None:
+    graph = _graph(
+        ("z", "a", "m", "b"),
+        (("a", "z"), ("a", "m"), ("b", "m")),
+    )
+
+    result = _validated_result(graph)
+
+    assert result.cut_value == len(graph.edges)
+    assert result.crossing_edges == graph.edges
+    assert tuple(
+        vertex for vertex in graph.vertices if vertex in result.left_vertices
+    ) == (result.left_vertices)
+    assert tuple(
+        vertex for vertex in graph.vertices if vertex in result.right_vertices
+    ) == (result.right_vertices)
+
+
+@pytest.mark.parametrize(
+    ("graph", "expected"),
+    [
+        (_cycle(5), 4),
+        (_complete(6), 9),
+        (_c5_blow_up((5, 5, 5, 5, 5)), 100),
+        (_c5_blow_up((5, 5, 5, 5, 4)), 95),
+    ],
+)
+def test_known_exact_maximum_cut_values(
+    graph: SimpleUndirectedGraph, expected: int
+) -> None:
+    result = _validated_result(graph)
+
+    assert result.cut_value == expected
+    _assert_cut_invariant(result)
+
+
+def test_false_twin_reduction_admits_the_atlas_scale_blow_up() -> None:
+    graph = _c5_blow_up((5, 5, 5, 5, 5))
+
+    result = _validated_result(graph)
+
+    assert len(graph.vertices) == 25
+    assert len(graph.edges) == 125
+    assert result.optimality_certificate.reduced_vertex_count == 5
+    assert result.optimality_certificate.candidate_partitions == 16
+    assert result.optimality_certificate.candidate_partitions < (
+        MAXIMUM_CUT_CANDIDATE_PARTITIONS
+    )
+
+
+def test_maximum_cut_is_additive_over_connected_components() -> None:
+    first = _cycle(5)
+    second_vertices = ("k0", "k1", "k2", "k3")
+    second_edges = tuple(combinations(second_vertices, 2))
+    graph = _graph(first.vertices + second_vertices, first.edges + second_edges)
+
+    result = _validated_result(graph)
+
+    assert result.cut_value == 4 + 4
+    assert result.optimality_certificate.source_component_count == 2
+    _assert_cut_invariant(result)
+
+
+def test_every_graph_through_order_six_matches_an_independent_oracle() -> None:
+    for atlas_graph in nx.graph_atlas_g():
+        if len(atlas_graph) > 6:
+            continue
+        labels = {vertex: str(vertex) for vertex in atlas_graph}
+        vertices = tuple(sorted(labels.values()))
+        edges = tuple(
+            sorted(
+                tuple(sorted((labels[left], labels[right])))
+                for left, right in atlas_graph.edges
+            )
+        )
+        graph = _graph(vertices, edges)
+
+        result = compute_maximum_cut(GraphMaximumCutRequest(graph=graph))
+
+        assert result.cut_value == _brute_force_value(graph)
+        _assert_cut_invariant(result)
+
+
+def test_complementary_side_orientation_revalidates() -> None:
+    result = _validated_result(_cycle(5))
+    payload = result.model_dump(mode="json")
+    payload["left_vertices"], payload["right_vertices"] = (
+        payload["right_vertices"],
+        payload["left_vertices"],
+    )
+
+    complemented = GraphMaximumCutResult.model_validate(payload)
+
+    assert complemented.cut_value == result.cut_value
+    assert complemented.crossing_edges == result.crossing_edges
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda payload: payload["crossing_edges"].pop(),
+            "crossing-edge ledger",
+        ),
+        (
+            lambda payload: payload.__setitem__("cut_value", payload["cut_value"] + 1),
+            "cut value",
+        ),
+        (
+            lambda payload: payload.__setitem__(
+                "lower_bound", payload["lower_bound"] - 1
+            ),
+            "exact bounds",
+        ),
+        (
+            lambda payload: payload.__setitem__(
+                "upper_bound", payload["upper_bound"] + 1
+            ),
+            "exact bounds",
+        ),
+        (
+            lambda payload: payload["optimality_certificate"].__setitem__(
+                "candidate_partitions",
+                payload["optimality_certificate"]["candidate_partitions"] + 1,
+            ),
+            "certificate",
+        ),
+    ],
+)
+def test_result_rejects_forged_ledger_values_bounds_and_certificate(
+    mutate: Callable[[dict[str, Any]], object], message: str
+) -> None:
+    payload = _validated_result(_cycle(5)).model_dump(mode="json")
+    mutate(payload)
+
+    with pytest.raises(ValidationError, match=message):
+        GraphMaximumCutResult.model_validate(payload)
+
+
+def test_result_rejects_mutated_partition_and_source_graph() -> None:
+    payload = _validated_result(_cycle(5)).model_dump(mode="json")
+    moved = payload["left_vertices"].pop()
+    payload["right_vertices"].append(moved)
+    source_order = payload["graph"]["vertices"]
+    payload["right_vertices"].sort(key=source_order.index)
+    with pytest.raises(ValidationError, match="crossing-edge ledger"):
+        GraphMaximumCutResult.model_validate(payload)
+
+    payload = _validated_result(_cycle(5)).model_dump(mode="json")
+    removed = payload["crossing_edges"][0]
+    payload["graph"]["edges"].remove(removed)
+    with pytest.raises(ValidationError, match="source graph"):
+        GraphMaximumCutResult.model_validate(payload)
+
+
+def test_approximate_upper_bound_and_lower_valued_cut_cannot_claim_exactness() -> None:
+    honest = _validated_result(_cycle(5)).model_dump(mode="json")
+    honest["left_vertices"] = ["00"]
+    honest["right_vertices"] = ["01", "02", "03", "04"]
+    honest["crossing_edges"] = [["00", "01"], ["00", "04"]]
+    honest["cut_value"] = 2
+    honest["lower_bound"] = 2
+    honest["upper_bound"] = 4
+
+    with pytest.raises(ValidationError, match="exact bounds"):
+        GraphMaximumCutResult.model_validate(honest)
+
+
+def test_candidate_boundary_accepts_c21_and_rejects_c23_before_backend() -> None:
+    accepted = _validated_result(_cycle(21))
+    assert (
+        accepted.optimality_certificate.candidate_partitions
+        == MAXIMUM_CUT_CANDIDATE_PARTITIONS
+    )
+
+    with pytest.raises(ValidationError, match="candidate partitions"):
+        GraphMaximumCutRequest(graph=_cycle(23))
+
+
+def test_edge_update_boundary_accepts_k19_and_rejects_k20_before_backend() -> None:
+    GraphMaximumCutRequest(graph=_complete(19))
+
+    with pytest.raises(ValidationError, match="weighted edge updates"):
+        GraphMaximumCutRequest(graph=_complete(20))
+
+
+def test_large_bipartite_graph_is_not_rejected_by_a_coarse_order_cap() -> None:
+    vertices = tuple(f"{index:03d}" for index in range(256))
+    graph = _graph(
+        vertices,
+        tuple((vertices[index], vertices[index + 1]) for index in range(255)),
+    )
+
+    result = _validated_result(graph)
+
+    assert result.cut_value == 255
+    assert result.optimality_certificate.candidate_partitions == 0
+
+
+def test_projected_result_bytes_are_rejected_before_search() -> None:
+    left = "a" * 1_400_000
+    right = "b" * 1_400_000
+    graph = _graph((left, right), ((left, right),))
+
+    with pytest.raises(ValidationError, match="projected exact result"):
+        GraphMaximumCutRequest(graph=graph)
+
+
+def test_schema_explains_the_non_schema_representable_work_bounds() -> None:
+    graph_schema = GraphMaximumCutRequest.model_json_schema()["properties"]["graph"]
+
+    assert "false-twin quotient" in graph_schema["description"]
+    assert str(MAXIMUM_CUT_CANDIDATE_PARTITIONS) in graph_schema["description"]
+    assert "exact-only" in graph_schema["description"]
+
+
+def test_bounded_exhaustive_fallback_preserves_an_exact_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_maximum_cut, "MAXIMUM_CUT_Z3_RLIMIT", 1)
+
+    result = _validated_result(_complete(7))
+
+    assert result.cut_value == 12
+
+
+def test_operation_is_deterministic_on_a_nonunique_optimum() -> None:
+    request = GraphMaximumCutRequest(graph=_cycle(5))
+
+    first = compute_maximum_cut(request)
+    second = compute_maximum_cut(request)
+
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")


### PR DESCRIPTION
## Problem

Closes #2291.

Jacobian has minimum `s-t` cut, but maximum bipartition cut is a different NP-hard invariant. Callers currently cannot obtain an exact graph-owned partition and crossing-edge ledger, and a solver incumbent or relaxation bound alone cannot establish the maximum-cut value needed by the motivating Atlas bipartization calculation.

## Solution

Add the exact-only operation `graph.cut.maximum.compute` for canonical unweighted `SimpleUndirectedGraph` values. The result retains the source graph, both partition sides in source-axis order, the complete crossing-edge ledger, the cut value, and coincident lower and upper bounds. Complementary orientations both validate; the producer chooses one deterministically.

Admission proves that an exhaustive fallback fits before any optimizer call. Privately, equal open-neighborhood vertices are collapsed into weighted false-twin classes, connected components are solved independently, and bipartite components are discharged directly. Non-bipartite reduced components use the existing Z3 optimizer as an accelerator only when it returns coincident integer objective bounds and a matching model value. Any unavailable, resource-limited, exceptional, or inconsistent optimizer result falls back to the admitted Gray-code enumeration. Deserialized results replay that enumeration independently, so backend identity, quotient structure, and search counters are not part of the public contract.

The result projection counts every vertex once across the two partition sides, retains every source edge in the worst-case ledger, and rejects requests whose actual contract cannot fit the canonical output limit. Constant `EXACT` or `COMPLETE` assurance fields are intentionally absent: this result type has only one mathematical postcondition.

## Testing

- `make test-math TESTS=tests/math/graphs` — 277 passed
- `uv run --locked pytest -q tests/integration/catalog/test_public_operation_contract_conformance.py` — 484 passed
- `make check` — Ruff, formatting, mypy over 765 source files, and 2,675 tests passed

The owner tests compare every Graph Atlas graph through order six with independent brute force; cover empty, bipartite, disconnected, complete, odd-cycle, and nonunique-optimum cases; and check the Atlas five-class blow-ups with maximum cuts 100 and 95. They also exercise exact candidate, edge-update, and 10 MiB result boundaries, the optimizer fallback, complementary orientations, and forged partitions, ledgers, bounds, source graphs, and structurally consistent suboptimal cuts.

## Public contract impact

Adds `graph.cut.maximum.compute` with `GraphMaximumCutRequest` and `GraphMaximumCutResult` schemas. Accepted requests return one exact maximum bipartition, its source-ordered crossing ledger, and equal feasible/optimal bounds. Requests above the exhaustive work or output envelope reject before search; there is no approximate or incomplete result shape.

## Public operation admission

- Concrete gap: no current operation computes maximum bipartition cut or returns a graph-owned optimal partition and crossing-edge ledger.
- Why existing operations or typed values are insufficient: minimum `s-t` cut solves a different polynomial-time problem, while generic solver calls do not bind a graph-specific incumbent and optimum claim to canonical source edges.
- Stable mathematical result: one exact maximum-cardinality bipartition cut, represented by both source-ordered sides, exactly the crossing source edges, the value, and coincident lower and upper bounds.
- Semantic domain and admitted execution envelope: canonical finite simple undirected unweighted graphs whose componentwise exact search and projected result fit the declared bounds.
- Controlling work, intermediate, memory, and output quantities: reduced component assignments, incremental weighted adjacency updates across the complete Gray-code traversal, source vertex/edge materialization, crossing-ledger rows, vertex-label bytes, and projected canonical JSON bytes.
- Exact representation, algorithm regimes, and maintained backend: canonical source labels and edges remain authoritative. Bipartite components are linear; other components may use the maintained Z3 optimizer as a private exact accelerator, with a bounded exhaustive enumeration as the source-independent fallback and result replay.
- Remaining fixed caps and their classification: the canonical graph owner permits at most 256 vertices and 32,640 edges. Maximum cut separately admits at most 1,048,576 reduced assignments, 5,000,000 incremental edge updates, and the shared 10 MiB canonical result limit. Z3's 100,000-unit per-component resource limit affects only acceleration, not mathematical admission or exactness.
- Admission decision: `KEEP` in the graph-optimization owner.

## Closure matrix

None. This PR admits one unweighted exact operation. Weighted or signed cuts, SDP relaxations, approximation ratios, editing/bipartization workflows, Ising formulations, and theorem-specific graph enumeration remain separate domains or caller composition.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (graph owner lane and catalog conformance)
- [x] Harbor task or verifier changes ran the required validation (not applicable; no Harbor files changed)
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable (exact-only; out-of-envelope requests reject)
- [x] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable; the implementation stays owner-local)
