### PR TITLE
feat(math): add complete canonical Nim option families

### DIFF
--- a/src/jacobian/math/impartial_games/__init__.py
+++ b/src/jacobian/math/impartial_games/__init__.py
@@ -17,7 +17,6 @@ from jacobian.math.impartial_games.operations import (
 from jacobian.math.impartial_games.values import (
     GameMove,
     ImpartialGame,
-    NimOption,
     NimPosition,
 )
 
@@ -25,7 +24,6 @@ __all__ = [
     "GameMove",
     "GrundyAnalysis",
     "ImpartialGame",
-    "NimOption",
     "NimPosition",
     "SubtractionGrundyAnalysis",
     "birthdays",

--- a/src/jacobian/math/impartial_games/__init__.py
+++ b/src/jacobian/math/impartial_games/__init__.py
@@ -14,12 +14,19 @@ from jacobian.math.impartial_games.operations import (
     subtraction_game,
     subtraction_grundy_prefix,
 )
-from jacobian.math.impartial_games.values import GameMove, ImpartialGame
+from jacobian.math.impartial_games.values import (
+    GameMove,
+    ImpartialGame,
+    NimOption,
+    NimPosition,
+)
 
 __all__ = [
     "GameMove",
     "GrundyAnalysis",
     "ImpartialGame",
+    "NimOption",
+    "NimPosition",
     "SubtractionGrundyAnalysis",
     "birthdays",
     "grundy_classes",

--- a/src/jacobian/math/impartial_games/_admission.py
+++ b/src/jacobian/math/impartial_games/_admission.py
@@ -31,6 +31,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         "exact bitwise xor nim sum determining the P/N outcome of a Nim position",
     ),
     OperationAdmission(
+        "game.nim.options.compute",
+        AdmissionDecision.KEEP,
+        "complete deduplicated one-move relation for a bounded canonical Nim multiset with indexed source transport",
+    ),
+    OperationAdmission(
         "game.impartial.outcome_profile.compute",
         AdmissionDecision.KEEP,
         "complete P/N position partition with Grundy values and terminal positions",

--- a/src/jacobian/math/impartial_games/_models.py
+++ b/src/jacobian/math/impartial_games/_models.py
@@ -4,22 +4,31 @@ from __future__ import annotations
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictBool, StrictInt, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
 from jacobian.math.impartial_games.operations import (
+    _nim_option_plan,
     birthdays,
     grundy_table,
+    nim_options,
+    nim_sum,
     subtraction_grundy_prefix,
 )
 from jacobian.math.impartial_games.values import (
     MAX_HEAP_BOUND,
     MAX_HEAP_SIZE,
     MAX_HEAPS,
+    MAX_NIM_DISTINCT_OPTIONS,
+    MAX_NIM_OPTION_RESULT_BYTES,
+    MAX_NIM_RAW_CANDIDATES,
     MAX_POSITIONS,
     MAX_SUBTRACTION_VALUE,
     MAX_SUBTRACTION_WORK,
     ImpartialGame,
+    NimOption,
+    NimPosition,
 )
 
 MAX_COMPONENT_GRUNDY = MAX_POSITIONS - 1
@@ -140,6 +149,8 @@ __all__ = [
     "GrundyEntry",
     "GrundyTableRequest",
     "GrundyTableResult",
+    "NimOptionsRequest",
+    "NimOptionsResult",
     "SubtractionGrundyPrefixRequest",
     "SubtractionGrundyPrefixResult",
 ]
@@ -151,25 +162,83 @@ __all__ = [
 
 
 class NimSumRequest(StrictModel):
-    """A finite Nim position: a bounded list of nonnegative heap sizes."""
+    """One canonical finite normal-play Nim position."""
 
-    heaps: tuple[int, ...] = Field(min_length=0, max_length=MAX_HEAPS)
+    position: NimPosition
+
+
+class NimSumResult(NimSumRequest):
+    """The exact bitwise xor bound to its canonical source position."""
+
+    nim_sum: StrictInt = Field(ge=0, le=(1 << MAX_HEAP_SIZE.bit_length()) - 1)
+    is_p_position: StrictBool
 
     @model_validator(mode="after")
-    def require_bounded_heaps(self) -> Self:
-        if any(heap < 0 for heap in self.heaps):
-            raise ValueError("heap sizes must be nonnegative")
-        if any(heap > MAX_HEAP_SIZE for heap in self.heaps):
-            raise ValueError(f"heap sizes must be at most {MAX_HEAP_SIZE}")
+    def bind_exact_nim_sum(self) -> Self:
+        expected = nim_sum(self.position)
+        if self.nim_sum != expected:
+            raise ValueError("nim_sum must be the exact xor of the source position")
+        if self.is_p_position != (expected == 0):
+            raise ValueError("is_p_position must report whether the exact xor is zero")
         return self
 
 
-class NimSumResult(StrictModel):
-    """The exact nim sum (bitwise xor) of a Nim position."""
+class NimOptionsRequest(StrictModel):
+    """Enumerate the complete distinct option family of one Nim multiset."""
 
-    nim_sum: int = Field(ge=0)
-    is_p_position: bool
-    heaps: tuple[int, ...]
+    position: NimPosition = Field(
+        description=(
+            "Canonical sorted heap multiset whose one-move option family is requested."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_complete_family(self) -> Self:
+        _nim_option_plan(self.position)
+        return self
+
+
+class NimOptionsResult(NimOptionsRequest):
+    """Every distinct legal one-heap reduction, in option-position order."""
+
+    options: tuple[NimOption, ...] = Field(
+        max_length=MAX_NIM_DISTINCT_OPTIONS,
+        description="Distinct resulting positions in lexicographic heap order.",
+    )
+    raw_candidate_count: int = Field(
+        ge=0,
+        le=MAX_NIM_RAW_CANDIDATES,
+        description=(
+            "Number of indexed (source heap, replacement size) moves before "
+            "canonical multiset deduplication."
+        ),
+    )
+    distinct_option_count: int = Field(
+        ge=0,
+        le=MAX_NIM_DISTINCT_OPTIONS,
+        description="Number of distinct canonical resulting positions.",
+    )
+    complete: Literal[True] = True
+
+    @model_validator(mode="after")
+    def bind_complete_option_family(self) -> Self:
+        expected = nim_options(self.position)
+        plan = _nim_option_plan(self.position)
+        if (
+            self.options != expected
+            or self.raw_candidate_count != plan.raw_candidate_count
+            or self.distinct_option_count != plan.distinct_option_count
+        ):
+            raise ValueError("result must be the exact complete Nim option family")
+        actual_bytes = len(encode_strict_json(self.model_dump(mode="json")))
+        if (
+            actual_bytes != plan.serialized_result_bytes
+            or actual_bytes > MAX_NIM_OPTION_RESULT_BYTES
+        ):
+            raise ValueError(
+                "serialized result must match the request-time Nim option bound"
+            )
+        return self
 
 
 class OutcomeProfileRequest(StrictModel):

--- a/src/jacobian/math/impartial_games/_operations.py
+++ b/src/jacobian/math/impartial_games/_operations.py
@@ -8,6 +8,8 @@ from jacobian.math.impartial_games._models import (
     GrundyEntry,
     GrundyTableRequest,
     GrundyTableResult,
+    NimOptionsRequest,
+    NimOptionsResult,
     NimSumRequest,
     NimSumResult,
     OutcomeProfileRequest,
@@ -16,8 +18,11 @@ from jacobian.math.impartial_games._models import (
     SubtractionGrundyPrefixResult,
 )
 from jacobian.math.impartial_games.operations import (
+    _nim_option_plan,
     birthdays,
     grundy_table,
+    nim_options,
+    nim_sum,
     subtraction_grundy_prefix,
 )
 
@@ -70,6 +75,7 @@ __all__ = [
     "compute_birthday",
     "compute_disjunctive_sum",
     "compute_grundy_table",
+    "compute_nim_options",
     "compute_subtraction_grundy_prefix",
 ]
 
@@ -79,15 +85,26 @@ def compute_nim_sum(
 ) -> NimSumResult:
     """Compute the exact nim sum (bitwise xor) of heap sizes."""
 
-    from functools import reduce
-    from operator import xor
-
-    heaps = request.heaps
-    nim_sum = 0 if not heaps else reduce(xor, heaps)
+    value = nim_sum(request.position)
     return NimSumResult(
-        nim_sum=nim_sum,
-        is_p_position=(nim_sum == 0),
-        heaps=heaps,
+        position=request.position,
+        nim_sum=value,
+        is_p_position=(value == 0),
+    )
+
+
+def compute_nim_options(
+    request: NimOptionsRequest,
+) -> NimOptionsResult:
+    """Enumerate the complete deduplicated option family of a Nim position."""
+
+    options = nim_options(request.position)
+    plan = _nim_option_plan(request.position)
+    return NimOptionsResult(
+        position=request.position,
+        options=options,
+        raw_candidate_count=plan.raw_candidate_count,
+        distinct_option_count=plan.distinct_option_count,
     )
 
 

--- a/src/jacobian/math/impartial_games/_tools.py
+++ b/src/jacobian/math/impartial_games/_tools.py
@@ -13,6 +13,8 @@ from jacobian.math.impartial_games._models import (
     DisjunctiveSumResult,
     GrundyTableRequest,
     GrundyTableResult,
+    NimOptionsRequest,
+    NimOptionsResult,
     NimSumRequest,
     NimSumResult,
     OutcomeProfileRequest,
@@ -24,6 +26,7 @@ from jacobian.math.impartial_games._operations import (
     compute_birthday,
     compute_disjunctive_sum,
     compute_grundy_table,
+    compute_nim_options,
     compute_nim_sum,
     compute_outcome_profile,
     compute_subtraction_grundy_prefix,
@@ -41,11 +44,12 @@ def _op[
     result_model: type[ResultT],
     operation: Callable[[RequestT], ResultT],
     *tags: str,
+    version: str = "1",
     examples: tuple[OperationExample, ...],
 ) -> MathTool[RequestT, ResultT]:
     return MathTool(
         operation_id=operation_id,
-        version="1",
+        version=version,
         title=title,
         description=description,
         request_type=request_model,
@@ -144,20 +148,43 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "game.nim.nim_sum.compute",
         "Compute the nim sum of a Nim position",
-        "Compute the exact bitwise xor of heap sizes, determining "
-        "the P/N outcome of a finite Nim position under normal play.",
+        "Compute the exact bitwise xor of a canonical sorted heap multiset, "
+        "determining the P/N outcome under normal play.",
         NimSumRequest,
         NimSumResult,
         compute_nim_sum,
         "game-theory",
         "nim",
         "exact",
+        version="2",
         examples=(
             example(
                 "nim_sum_1_2_3",
                 "Compute the nim sum of heaps (1, 2, 3); "
-                "heaps must be nonnegative integers.",
-                {"heaps": [1, 2, 3]},
+                "heaps must be nonnegative integers in nondecreasing order.",
+                {"position": {"heaps": [1, 2, 3]}},
+            ),
+        ),
+    ),
+    _op(
+        "game.nim.options.compute",
+        "Enumerate every distinct legal Nim option",
+        "Return the complete canonical one-move option family of a sorted Nim "
+        "heap multiset, retaining every source heap index collapsed by "
+        "multiset deduplication.",
+        NimOptionsRequest,
+        NimOptionsResult,
+        compute_nim_options,
+        "game-theory",
+        "nim",
+        "options",
+        "exact",
+        examples=(
+            example(
+                "deduplicated_equal_heaps",
+                "Enumerate every distinct option of Nim heaps (1,2,2); heaps "
+                "must be nondecreasing, and zero heaps are retained.",
+                {"position": {"heaps": [1, 2, 2]}},
             ),
         ),
     ),

--- a/src/jacobian/math/impartial_games/operations.py
+++ b/src/jacobian/math/impartial_games/operations.py
@@ -9,14 +9,16 @@ from operator import xor
 
 from jacobian.math.impartial_games.values import (
     MAX_HEAP_BOUND,
-    MAX_HEAP_SIZE,
-    MAX_HEAPS,
     MAX_MOVES,
-    MAX_NIM_OPTIONS,
+    MAX_NIM_DISTINCT_OPTIONS,
+    MAX_NIM_OPTION_RESULT_BYTES,
+    MAX_NIM_RAW_CANDIDATES,
     MAX_SUBTRACTION_VALUE,
     MAX_SUBTRACTION_WORK,
     GameMove,
     ImpartialGame,
+    NimOption,
+    NimPosition,
 )
 
 
@@ -33,6 +35,120 @@ class SubtractionGrundyAnalysis:
     max_heap: int
     grundy_values: tuple[int, ...]
     option_value_sets: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _NimOptionPlan:
+    raw_candidate_count: int
+    distinct_option_count: int
+    serialized_result_bytes: int
+
+
+def _json_integer_size(value: int) -> int:
+    return len(str(value))
+
+
+def _json_integer_sequence_size(values: tuple[int, ...]) -> int:
+    count = len(values)
+    return 2 + max(count - 1, 0) + sum(_json_integer_size(value) for value in values)
+
+
+def _json_object_size(fields: tuple[tuple[str, int], ...]) -> int:
+    return (
+        2
+        + max(len(fields) - 1, 0)
+        + sum(len(name) + 3 + value_size for name, value_size in fields)
+    )
+
+
+def _nim_position_json_size(heap_list_size: int) -> int:
+    return _json_object_size((("heaps", heap_list_size),))
+
+
+def _heap_groups(position: NimPosition) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    groups: dict[int, list[int]] = {}
+    for index, heap in enumerate(position.heaps):
+        groups.setdefault(heap, []).append(index)
+    return tuple((heap, tuple(indices)) for heap, indices in groups.items())
+
+
+def _nim_option_result_size(
+    position: NimPosition,
+    groups: tuple[tuple[int, tuple[int, ...]], ...],
+    distinct_option_count: int,
+    raw_candidate_count: int,
+) -> int:
+    source_heap_list_size = _json_integer_sequence_size(position.heaps)
+    row_sizes = 0
+    for source_size, source_indices in groups:
+        if source_size == 0:
+            continue
+        source_index_size = _json_integer_sequence_size(source_indices)
+        for replacement_size in range(source_size):
+            resulting_heap_list_size = (
+                source_heap_list_size
+                - _json_integer_size(source_size)
+                + _json_integer_size(replacement_size)
+            )
+            row_sizes += _json_object_size(
+                (
+                    ("source_heap_indices", source_index_size),
+                    ("source_heap_size", _json_integer_size(source_size)),
+                    (
+                        "replacement_heap_size",
+                        _json_integer_size(replacement_size),
+                    ),
+                    (
+                        "resulting_position",
+                        _nim_position_json_size(resulting_heap_list_size),
+                    ),
+                )
+            )
+    options_size = 2 + max(distinct_option_count - 1, 0) + row_sizes
+    return _json_object_size(
+        (
+            ("position", _nim_position_json_size(source_heap_list_size)),
+            ("options", options_size),
+            ("raw_candidate_count", _json_integer_size(raw_candidate_count)),
+            (
+                "distinct_option_count",
+                _json_integer_size(distinct_option_count),
+            ),
+            ("complete", 4),
+        )
+    )
+
+
+def _nim_option_plan(position: NimPosition) -> _NimOptionPlan:
+    groups = _heap_groups(position)
+    raw_candidate_count = sum(position.heaps)
+    distinct_option_count = sum(heap for heap, _ in groups)
+    if raw_candidate_count > MAX_NIM_RAW_CANDIDATES:
+        raise ValueError(
+            "indexed Nim moves exceed the exact raw-candidate bound of "
+            f"{MAX_NIM_RAW_CANDIDATES}"
+        )
+    if distinct_option_count > MAX_NIM_DISTINCT_OPTIONS:
+        raise ValueError(
+            "distinct Nim options exceed the exact result-count bound of "
+            f"{MAX_NIM_DISTINCT_OPTIONS}"
+        )
+    serialized_result_bytes = _nim_option_result_size(
+        position,
+        groups,
+        distinct_option_count,
+        raw_candidate_count,
+    )
+    if serialized_result_bytes > MAX_NIM_OPTION_RESULT_BYTES:
+        raise ValueError(
+            "canonical serialized result exceeds the Nim option bound of "
+            f"{MAX_NIM_OPTION_RESULT_BYTES} bytes"
+        )
+    return _NimOptionPlan(
+        raw_candidate_count=raw_candidate_count,
+        distinct_option_count=distinct_option_count,
+        serialized_result_bytes=serialized_result_bytes,
+    )
 
 
 def mex(values: tuple[int, ...]) -> int:
@@ -104,20 +220,43 @@ def grundy_classes(game: ImpartialGame) -> tuple[tuple[int, tuple[str, ...]], ..
     )
 
 
-def nim_sum(heaps: tuple[int, ...]) -> int:
-    _validate_heaps(heaps)
-    return reduce(xor, heaps, 0)
+def nim_sum(position: NimPosition) -> int:
+    """Return the exact normal-play Nim sum of one canonical position."""
+
+    return reduce(xor, position.heaps, 0)
 
 
-def nim_options(heaps: tuple[int, ...]) -> tuple[tuple[int, ...], ...]:
-    _validate_heaps(heaps)
-    if sum(heaps) > MAX_NIM_OPTIONS:
-        raise ValueError("nim option enumeration exceeds the output bound")
-    return tuple(
-        (*heaps[:index], new_size, *heaps[index + 1 :])
-        for index, size in enumerate(heaps)
-        for new_size in range(size)
+def nim_options(position: NimPosition) -> tuple[NimOption, ...]:
+    """Return every distinct canonical one-move option and its source indices."""
+
+    plan = _nim_option_plan(position)
+    options: list[NimOption] = []
+    for source_size, source_indices in _heap_groups(position):
+        if source_size == 0:
+            continue
+        for replacement_size in range(source_size):
+            resulting_heaps = list(position.heaps)
+            resulting_heaps[source_indices[0]] = replacement_size
+            options.append(
+                NimOption(
+                    source_heap_indices=source_indices,
+                    source_heap_size=source_size,
+                    replacement_heap_size=replacement_size,
+                    resulting_position=NimPosition(
+                        heaps=tuple(sorted(resulting_heaps))
+                    ),
+                )
+            )
+    canonical_options = tuple(
+        sorted(options, key=lambda option: option.resulting_position.heaps)
     )
+    distinct_results = {option.resulting_position.heaps for option in canonical_options}
+    if (
+        len(canonical_options) != plan.distinct_option_count
+        or len(distinct_results) != plan.distinct_option_count
+    ):
+        raise RuntimeError("Nim option preflight disagrees with exact enumeration")
+    return canonical_options
 
 
 def subtraction_game(subtraction_set: tuple[int, ...], max_heap: int) -> ImpartialGame:
@@ -194,13 +333,6 @@ def _lexicographical_topological_order(
     if len(order) != len(game.positions):
         raise RuntimeError("validated impartial game unexpectedly contains a cycle")
     return tuple(order)
-
-
-def _validate_heaps(heaps: tuple[int, ...]) -> None:
-    if not 1 <= len(heaps) <= MAX_HEAPS:
-        raise ValueError("heap tuple must contain between 1 and 50 heaps")
-    if any(not 0 <= heap <= MAX_HEAP_SIZE for heap in heaps):
-        raise ValueError("heap size is outside the supported bound")
 
 
 def _validate_subtraction_input(

--- a/src/jacobian/math/impartial_games/values.py
+++ b/src/jacobian/math/impartial_games/values.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, StrictInt, model_validator
 
 from jacobian._models import StrictModel
 from jacobian.math._labels import MAX_OPAQUE_LABEL_LENGTH, OpaqueLabel
@@ -15,10 +15,22 @@ MAX_MOVES = 2_000
 MAX_LABEL_LENGTH = MAX_OPAQUE_LABEL_LENGTH
 MAX_HEAPS = 50
 MAX_HEAP_SIZE = 10_000
-MAX_NIM_OPTIONS = 5_000
+MAX_NIM_RAW_CANDIDATES = MAX_HEAPS * MAX_HEAP_SIZE
+MAX_NIM_DISTINCT_OPTIONS = 50_000
+# Keep materialized results below the repository's 10 MiB canonical wire ceiling.
+MAX_NIM_OPTION_RESULT_BYTES = 8 * 1024 * 1024
 MAX_SUBTRACTION_VALUE = 500
 MAX_HEAP_BOUND = 5_000
 MAX_SUBTRACTION_WORK = 250_000
+
+NimHeapSize = Annotated[
+    StrictInt,
+    Field(ge=0, le=MAX_HEAP_SIZE),
+]
+NimHeapIndex = Annotated[
+    StrictInt,
+    Field(ge=0, lt=MAX_HEAPS),
+]
 
 
 class GameMove(StrictModel):
@@ -68,16 +80,67 @@ class ImpartialGame(StrictModel):
         return self
 
 
+class NimPosition(StrictModel):
+    """One canonical multiset presentation of finite normal-play Nim heaps."""
+
+    heaps: tuple[NimHeapSize, ...] = Field(
+        max_length=MAX_HEAPS,
+        description=(
+            "Heap sizes in nondecreasing order. Zero heaps are retained as inert "
+            "components, and duplicate sizes retain their multiplicity."
+        ),
+        examples=[[0, 1, 2, 2]],
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_heaps(self) -> Self:
+        if self.heaps != tuple(sorted(self.heaps)):
+            raise ValueError("Nim heaps must be in nondecreasing order")
+        return self
+
+
+class NimOption(StrictModel):
+    """One distinct canonical option with every indexed source-heap witness."""
+
+    source_heap_indices: tuple[NimHeapIndex, ...] = Field(
+        min_length=1,
+        max_length=MAX_HEAPS,
+        description=(
+            "All indices in the retained canonical source position whose move "
+            "produces this same multiset option."
+        ),
+    )
+    source_heap_size: NimHeapSize
+    replacement_heap_size: NimHeapSize
+    resulting_position: NimPosition
+
+    @model_validator(mode="after")
+    def require_local_move_shape(self) -> Self:
+        if self.source_heap_indices != tuple(sorted(set(self.source_heap_indices))):
+            raise ValueError("source heap indices must be distinct and sorted")
+        if self.source_heap_size == 0:
+            raise ValueError("a zero heap has no legal Nim move")
+        if self.replacement_heap_size >= self.source_heap_size:
+            raise ValueError("a Nim move must strictly reduce one heap")
+        return self
+
+
 __all__ = [
     "MAX_HEAPS",
     "MAX_HEAP_BOUND",
     "MAX_HEAP_SIZE",
     "MAX_LABEL_LENGTH",
     "MAX_MOVES",
-    "MAX_NIM_OPTIONS",
+    "MAX_NIM_DISTINCT_OPTIONS",
+    "MAX_NIM_OPTION_RESULT_BYTES",
+    "MAX_NIM_RAW_CANDIDATES",
     "MAX_POSITIONS",
     "MAX_SUBTRACTION_VALUE",
     "MAX_SUBTRACTION_WORK",
     "GameMove",
     "ImpartialGame",
+    "NimHeapIndex",
+    "NimHeapSize",
+    "NimOption",
+    "NimPosition",
 ]

--- a/src/jacobian/math/impartial_games/values.py
+++ b/src/jacobian/math/impartial_games/values.py
@@ -100,7 +100,13 @@ class NimPosition(StrictModel):
 
 
 class NimOption(StrictModel):
-    """One distinct canonical option with every indexed source-heap witness."""
+    """One distinct one-heap reduction row with every indexed source witness.
+
+    This is a context-dependent row of ``NimOptionsResult``, not a standalone
+    canonical value: each row is validated against the request position by
+    the result's exact reconstruction binding, so callers obtain rows only
+    from that typed result boundary.
+    """
 
     source_heap_indices: tuple[NimHeapIndex, ...] = Field(
         min_length=1,
@@ -141,6 +147,5 @@ __all__ = [
     "ImpartialGame",
     "NimHeapIndex",
     "NimHeapSize",
-    "NimOption",
     "NimPosition",
 ]

--- a/tests/math/impartial_games/test_impartial_games.py
+++ b/tests/math/impartial_games/test_impartial_games.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from jacobian.math.impartial_games import (
     GameMove,
     ImpartialGame,
+    NimPosition,
     birthdays,
     grundy_classes,
     grundy_table,
@@ -172,11 +173,14 @@ class TestNativePortfolio:
 
     def test_nim_helpers_are_exact_and_bounded(self) -> None:
         assert mex((0, 1, 1, 3)) == 2
-        assert nim_sum((3, 4, 5)) == 2
-        assert nim_options((2,)) == ((0,), (1,))
+        assert nim_sum(NimPosition(heaps=(3, 4, 5))) == 2
+        assert tuple(
+            option.resulting_position.heaps
+            for option in nim_options(NimPosition(heaps=(2,)))
+        ) == ((0,), (1,))
 
-        with pytest.raises(ValueError, match="output bound"):
-            nim_options((5001,))
+        with pytest.raises(ValidationError, match="less than or equal to 10000"):
+            NimPosition(heaps=(10_001,))
 
     def test_subtraction_dag_fails_closed_at_move_bound(self) -> None:
         with pytest.raises(ValueError, match="move bound"):
@@ -188,6 +192,7 @@ class TestNativePortfolio:
             "game.impartial.grundy_table.compute",
             "game.subtraction.grundy_prefix.compute",
             "game.nim.nim_sum.compute",
+            "game.nim.options.compute",
             "game.impartial.outcome_profile.compute",
             "game.impartial.disjunctive_sum.compute",
         }

--- a/tests/math/impartial_games/test_nim_options.py
+++ b/tests/math/impartial_games/test_nim_options.py
@@ -1,0 +1,180 @@
+"""Contract tests for complete canonical Nim option families."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from jacobian.canonical import encode_strict_json
+from jacobian.math.impartial_games._models import (
+    NimOptionsRequest,
+    NimOptionsResult,
+    NimSumRequest,
+)
+from jacobian.math.impartial_games._operations import (
+    compute_nim_options,
+    compute_nim_sum,
+)
+from jacobian.math.impartial_games._tools import TOOLS
+from jacobian.math.impartial_games.values import (
+    MAX_NIM_DISTINCT_OPTIONS,
+    MAX_NIM_OPTION_RESULT_BYTES,
+    MAX_NIM_RAW_CANDIDATES,
+    NimPosition,
+)
+
+
+def test_nim_options_deduplicate_equal_heaps_and_retain_all_source_indices() -> None:
+    result = compute_nim_options(
+        NimOptionsRequest(position=NimPosition(heaps=(1, 1, 2)))
+    )
+
+    assert tuple(
+        (
+            option.resulting_position.heaps,
+            option.source_heap_indices,
+            option.source_heap_size,
+            option.replacement_heap_size,
+        )
+        for option in result.options
+    ) == (
+        ((0, 1, 1), (2,), 2, 0),
+        ((0, 1, 2), (0, 1), 1, 0),
+        ((1, 1, 1), (2,), 2, 1),
+    )
+    assert result.raw_candidate_count == 4
+    assert result.distinct_option_count == 3
+    assert result.complete is True
+
+
+@pytest.mark.parametrize("heaps", ((), (0,), (0, 0, 0)))
+def test_terminal_nim_positions_have_one_complete_empty_option_family(
+    heaps: tuple[int, ...],
+) -> None:
+    result = compute_nim_options(NimOptionsRequest(position=NimPosition(heaps=heaps)))
+
+    assert result.options == ()
+    assert result.raw_candidate_count == 0
+    assert result.distinct_option_count == 0
+
+
+@given(
+    st.lists(
+        st.integers(min_value=0, max_value=5),
+        min_size=0,
+        max_size=6,
+    ).map(lambda heaps: tuple(sorted(heaps)))
+)
+def test_nim_options_match_direct_indexed_move_enumeration(
+    heaps: tuple[int, ...],
+) -> None:
+    result = compute_nim_options(NimOptionsRequest(position=NimPosition(heaps=heaps)))
+    indexed_options: dict[tuple[int, ...], set[int]] = {}
+    for index, heap in enumerate(heaps):
+        for replacement in range(heap):
+            option = list(heaps)
+            option[index] = replacement
+            canonical = tuple(sorted(option))
+            indexed_options.setdefault(canonical, set()).add(index)
+
+    expected = tuple(
+        (position, tuple(sorted(indices)))
+        for position, indices in sorted(indexed_options.items())
+    )
+    actual = tuple(
+        (option.resulting_position.heaps, option.source_heap_indices)
+        for option in result.options
+    )
+
+    assert actual == expected
+    assert result.raw_candidate_count == sum(heaps)
+    assert result.distinct_option_count == len(indexed_options)
+
+
+def test_nim_position_contract_is_canonical_strict_and_bounded() -> None:
+    with pytest.raises(ValidationError, match="nondecreasing"):
+        NimPosition(heaps=(2, 1))
+    with pytest.raises(ValidationError):
+        NimPosition(heaps=("1",))
+    with pytest.raises(ValidationError):
+        NimPosition(heaps=(1.0,))
+    with pytest.raises(ValidationError, match=r"less than or equal|heap bits"):
+        NimPosition(heaps=(10_001,))
+    with pytest.raises(ValidationError):
+        NimPosition(heaps=(0,) * 51)
+
+
+def test_nim_options_preflight_distinguishes_raw_and_distinct_counts() -> None:
+    max_raw = NimOptionsRequest(position=NimPosition(heaps=(10_000,) * 50))
+    assert max_raw.position.heaps == (10_000,) * 50
+    assert sum(max_raw.position.heaps) == MAX_NIM_RAW_CANDIDATES
+
+    exact_distinct = (15, 9_995, 9_996, 9_997, 9_998, 9_999)
+    assert sum(set(exact_distinct)) == MAX_NIM_DISTINCT_OPTIONS
+    NimOptionsRequest(position=NimPosition(heaps=exact_distinct))
+
+    with pytest.raises(ValidationError, match="distinct Nim options"):
+        NimOptionsRequest(
+            position=NimPosition(heaps=(16, 9_995, 9_996, 9_997, 9_998, 9_999))
+        )
+
+
+def test_nim_options_reject_result_bytes_before_option_expansion() -> None:
+    with pytest.raises(ValidationError, match="serialized result"):
+        NimOptionsRequest(position=NimPosition(heaps=tuple(range(951, 1_001))))
+
+
+def test_nim_options_result_is_source_bound_and_canonical_json_bounded() -> None:
+    result = compute_nim_options(
+        NimOptionsRequest(position=NimPosition(heaps=(1, 2, 2)))
+    )
+    payload = result.model_dump(mode="json")
+
+    assert len(encode_strict_json(payload)) <= MAX_NIM_OPTION_RESULT_BYTES
+    assert (
+        NimOptionsRequest.model_validate(
+            {"position": result.options[0].resulting_position.model_dump(mode="json")}
+        ).position
+        == result.options[0].resulting_position
+    )
+    downstream_request = NimSumRequest.model_validate(
+        {"position": result.options[0].resulting_position.model_dump(mode="json")}
+    )
+    downstream = compute_nim_sum(downstream_request)
+    assert downstream.position == result.options[0].resulting_position
+
+    source_mutation = deepcopy(payload)
+    source_mutation["position"]["heaps"] = [1, 2, 3]
+    with pytest.raises(ValidationError, match="exact complete Nim option family"):
+        NimOptionsResult.model_validate(source_mutation)
+
+    option_mutation = deepcopy(payload)
+    option_mutation["options"][0]["source_heap_indices"] = [0]
+    with pytest.raises(ValidationError, match="exact complete Nim option family"):
+        NimOptionsResult.model_validate(option_mutation)
+
+    index_bound_mutation = deepcopy(payload)
+    index_bound_mutation["options"][0]["source_heap_indices"] = [50]
+    with pytest.raises(ValidationError, match="less than 50"):
+        NimOptionsResult.model_validate(index_bound_mutation)
+
+    count_mutation = deepcopy(payload)
+    count_mutation["raw_candidate_count"] += 1
+    with pytest.raises(ValidationError, match="exact complete Nim option family"):
+        NimOptionsResult.model_validate(count_mutation)
+
+
+def test_nim_options_is_a_public_exact_operation() -> None:
+    tool = next(
+        tool for tool in TOOLS if tool.operation_id == "game.nim.options.compute"
+    )
+    request = tool.request_type.model_validate(tool.examples[0].input)
+    result = tool.run(request)
+
+    assert isinstance(result, NimOptionsResult)
+    assert result.distinct_option_count == len(result.options)
+    assert {"game-theory", "nim", "options", "exact"} <= set(tool.tags)

--- a/tests/math/impartial_games/test_nim_options.py
+++ b/tests/math/impartial_games/test_nim_options.py
@@ -157,6 +157,19 @@ def test_nim_options_result_is_source_bound_and_canonical_json_bounded() -> None
     with pytest.raises(ValidationError, match="exact complete Nim option family"):
         NimOptionsResult.model_validate(option_mutation)
 
+    witness_mutation = deepcopy(payload)
+    witness_mutation["options"][0]["resulting_position"]["heaps"] = [0, 0, 2]
+    with pytest.raises(ValidationError, match="exact complete Nim option family"):
+        NimOptionsResult.model_validate(witness_mutation)
+
+    order_mutation = deepcopy(payload)
+    order_mutation["options"][0], order_mutation["options"][1] = (
+        order_mutation["options"][1],
+        order_mutation["options"][0],
+    )
+    with pytest.raises(ValidationError, match="exact complete Nim option family"):
+        NimOptionsResult.model_validate(order_mutation)
+
     index_bound_mutation = deepcopy(payload)
     index_bound_mutation["options"][0]["source_heap_indices"] = [50]
     with pytest.raises(ValidationError, match="less than 50"):

--- a/tests/math/impartial_games/test_nim_outcome.py
+++ b/tests/math/impartial_games/test_nim_outcome.py
@@ -8,6 +8,7 @@ from jacobian.math.impartial_games._operations import (
     compute_nim_sum,
     compute_outcome_profile,
 )
+from jacobian.math.impartial_games.values import NimPosition
 
 _GAME = {
     "positions": ["0", "1", "2", "3"],
@@ -23,37 +24,52 @@ _GAME = {
 
 class TestNimSum:
     def test_empty_heaps(self) -> None:
-        result = compute_nim_sum(NimSumRequest(heaps=()))
+        result = compute_nim_sum(NimSumRequest(position=NimPosition(heaps=())))
         assert result.nim_sum == 0
         assert result.is_p_position is True
 
     def test_single_heap(self) -> None:
-        result = compute_nim_sum(NimSumRequest(heaps=(5,)))
+        result = compute_nim_sum(NimSumRequest(position=NimPosition(heaps=(5,))))
         assert result.nim_sum == 5
         assert result.is_p_position is False
 
     def test_xor_identity(self) -> None:
-        result = compute_nim_sum(NimSumRequest(heaps=(5, 5)))
+        result = compute_nim_sum(NimSumRequest(position=NimPosition(heaps=(5, 5))))
         assert result.nim_sum == 0
         assert result.is_p_position is True
 
     def test_1_2_3_is_zero(self) -> None:
-        result = compute_nim_sum(NimSumRequest(heaps=(1, 2, 3)))
+        result = compute_nim_sum(NimSumRequest(position=NimPosition(heaps=(1, 2, 3))))
         assert result.nim_sum == 0
         assert result.is_p_position is True
 
     def test_1_2_3_4_5(self) -> None:
-        result = compute_nim_sum(NimSumRequest(heaps=(1, 2, 3, 4, 5)))
+        result = compute_nim_sum(
+            NimSumRequest(position=NimPosition(heaps=(1, 2, 3, 4, 5)))
+        )
         assert result.nim_sum == 1
 
     def test_negative_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="nonnegative"):
-            NimSumRequest(heaps=(-1,))
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            NimSumRequest(position=NimPosition(heaps=(-1,)))
 
     def test_heaps_preserved(self) -> None:
-        heaps = (7, 3, 11)
-        result = compute_nim_sum(NimSumRequest(heaps=heaps))
-        assert result.heaps == heaps
+        position = NimPosition(heaps=(3, 7, 11))
+        result = compute_nim_sum(NimSumRequest(position=position))
+        assert result.position == position
+
+    def test_result_rejects_source_and_decision_mutations(self) -> None:
+        result = compute_nim_sum(NimSumRequest(position=NimPosition(heaps=(1, 2, 4))))
+
+        payload = result.model_dump(mode="json")
+        payload["position"]["heaps"] = [1, 2, 5]
+        with pytest.raises(ValidationError, match="exact xor"):
+            type(result).model_validate(payload)
+
+        payload = result.model_dump(mode="json")
+        payload["is_p_position"] = True
+        with pytest.raises(ValidationError, match="is_p_position"):
+            type(result).model_validate(payload)
 
 
 class TestOutcomeProfile:

--- a/tests/math/impartial_games/test_public_api.py
+++ b/tests/math/impartial_games/test_public_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from jacobian.math import impartial_games
+from jacobian.math.impartial_games import values
 
 
 def test_exact_public_api_symbols() -> None:
@@ -11,7 +12,6 @@ def test_exact_public_api_symbols() -> None:
         "GameMove",
         "GrundyAnalysis",
         "ImpartialGame",
-        "NimOption",
         "NimPosition",
         "SubtractionGrundyAnalysis",
         "birthdays",
@@ -29,3 +29,9 @@ def test_exact_public_api_symbols() -> None:
     assert len(impartial_games.__all__) == len(set(impartial_games.__all__))
     assert all(not name.startswith("_") for name in impartial_games.__all__)
     assert all(hasattr(impartial_games, name) for name in impartial_games.__all__)
+
+
+def test_nim_option_rows_are_not_public_canonical_values() -> None:
+    """Option rows are context-dependent and stay behind the result boundary."""
+    assert "NimOption" not in values.__all__
+    assert "NimOption" not in impartial_games.__all__

--- a/tests/math/impartial_games/test_public_api.py
+++ b/tests/math/impartial_games/test_public_api.py
@@ -11,6 +11,8 @@ def test_exact_public_api_symbols() -> None:
         "GameMove",
         "GrundyAnalysis",
         "ImpartialGame",
+        "NimOption",
+        "NimPosition",
         "SubtractionGrundyAnalysis",
         "birthdays",
         "grundy_classes",


### PR DESCRIPTION
## Problem

Jacobian already computes Grundy tables, birthdays, outcome partitions, subtraction-game prefixes, disjunctive sums, and Nim xor, but the remaining Nim option surface is not a reusable public operation. The native helper emits one tuple per indexed move, keeps duplicate multiset outcomes, and uses a coarse 5,000-move ceiling. It does not retain which equal source heaps collapse to one mathematical option.

The existing nim-sum operation also accepts a parallel unordered heap tuple instead of a canonical Nim value, so an option result cannot feed it unchanged.

Closes #1907.

## Solution

Add `game.nim.options.compute`, the complete distinct one-move relation for one canonical finite Nim position.

`NimPosition` represents the declared heap multiset in nondecreasing order, retaining zero heaps as inert indexed components. Each `NimOption` replaces one positive heap by a smaller nonnegative size, re-canonicalizes the multiset, and carries every source index of an equal-sized heap that produces that same result. Rows are ordered lexicographically by their resulting positions.

The result retains its source, reports both the indexed move count and distinct result count, declares completeness, and replays the entire option family during validation. Every resulting `NimPosition` is accepted unchanged by another options request and by nim sum.

To preserve that producer-consumer boundary, `game.nim.nim_sum.compute` moves to version 2. It now consumes the same canonical `NimPosition` and returns a source-bound xor and exact P-position decision. The native `nim_sum` and `nim_options` functions use the same domain value; no parallel analysis wrapper remains.

The kernel is the defining finite integer/multiset enumeration: group equal heaps, enumerate each smaller replacement once per distinct positive heap size, and sort the resulting canonical positions. No installed graph, CAS, or optimization library owns a more suitable kernel, and introducing one would not widen this mathematical domain. Mathlib's Nim development supplies the normal-play move and xor semantics referenced by the issue, while the runtime stays on exact standard-library integer operations.

Admission runs before option-row allocation. It computes the exact indexed count `sum(heaps)`, the exact distinct count `sum(distinct positive heap sizes)`, and the exact canonical JSON size from heap/index digit lengths. Accepted requests have at most 500,000 indexed moves, 50,000 distinct rows, and an 8 MiB retained result.

Suggested review order:

1. `NimPosition` and `NimOption` in `values.py`.
2. Count/output planning and enumeration in `operations.py`.
3. Source-bound request/result contracts and the nim-sum version-2 migration.
4. Catalog declaration, admission, property, mutation, composition, and boundary tests.

## Testing

- `make check` — Ruff, formatting, and mypy passed; 2,660 tests passed.
- `make test-math TESTS=tests/math/impartial_games` — 56 passed.
- `uv run pytest -q tests/catalog/test_admission.py tests/catalog/test_catalog.py` — 18 passed.
- `uv run pytest -q tests/integration/catalog/test_builtin_examples.py tests/integration/catalog/test_public_operation_contract_conformance.py -k 'game.nim.options.compute or game.nim.nim_sum.compute'` — 4 passed, 963 deselected.
- Final-tree boundary replay — the 50,000-distinct-option case serialized to 7,088,958 bytes; the 500,000-indexed-move case deduplicated to 10,000 rows and serialized to 5,518,191 bytes.

Coverage includes equal-heap deduplication and complete source-index transport, terminal empty/zero positions, a bounded exhaustive property comparison with direct indexed enumeration, strict canonical heap inputs, raw-count/distinct-count/output-byte boundaries, exact size-plan agreement, source/option/count/decision mutations, and option-to-options plus option-to-nim-sum composition.

## Public contract impact

Adds canonical `NimPosition` and `NimOption` values, `game.nim.options.compute` version 1, and a typed native `nim_options` function returning canonical option rows.

`game.nim.nim_sum.compute` moves from version 1 to version 2. Its pre-stable `{heaps: [...]}` request and parallel result source are replaced by `{position: {heaps: [...]}}`; the result retains that exact position and validates the xor and P-position decision. The native `nim_sum` function likewise accepts `NimPosition`.

## Public operation admission

- Concrete gap: no public operation returns the complete deduplicated legal option relation of a finite Nim position.
- Why existing operations or typed values are insufficient: xor determines the outcome class but cannot reconstruct legal moves or their source-index transport; the old native helper loses multiset deduplication and uses a coarse ordered-move cap.
- Stable mathematical result: every distinct multiset obtainable by exactly one legal heap reduction, with all corresponding indices in the retained canonical source.
- Semantic domain and admitted execution envelope: 0–50 heaps, each a strict integer from 0 through 10,000, in nondecreasing order; zero heaps are retained but have no moves.
- Controlling work, intermediate, memory, and output quantities: at most 500,000 raw indexed moves, 50,000 materialized distinct rows, 50 heap entries per canonicalization, and exactly predicted retained JSON below 8 MiB. Source-bound validation performs one complete replay within the same envelope.
- Exact representation, algorithm regimes, and maintained backend: canonical integer tuples and one complete standard-library enumeration; grouping equal heaps is the result-sensitive regime that avoids materializing duplicate indexed moves.
- Remaining fixed caps and their classification: heap count and size are the existing Nim representation bounds; distinct-row and JSON limits are output/memory bounds. Larger xor-only positions remain the responsibility of the separate direct nim-sum postcondition rather than option enumeration.
- Admission decision: `KEEP` — the complete legal relation is reusable game data and cannot be recovered from the existing scalar xor.

## Closure matrix

| Requested family | Disposition |
| --- | --- |
| Grundy table, birthdays, P/N profile, disjunctive sum, subtraction prefix, Nim xor | Already public on current main; this change makes Nim xor consume the canonical position value. |
| Complete Nim options | Added here as the remaining public operation gap. |
| Position Grundy, Grundy classes, mex, subtraction DAG | Existing native projections or constructors compose from the authoritative table/prefix values; duplicate catalog leaves are not needed. |
| Nim-equivalent heap and direct Nim Grundy | The installed Grundy scalar or xor is already the canonical heap size; a wrapper would add no postcondition. |
| Full Nim/product DAG cross-checks | Existing DAG, Grundy, and xor operations compose for admitted small cases; a dedicated cross-check operation would be a workflow. |
| Period search and misère play | Intentionally deferred by the issue because a finite repeated prefix is not a global theorem and misère semantics are distinct. |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes are not applicable
- [x] Public operation changes include an owner-local admission decision
- [x] Every accepted request returns the complete exact option family; omitted, partial, unknown, and unavailable results are not admitted
- [x] Work, candidate rows, canonicalization width, replay, and exact serialized result bytes are bounded before allocation
- [x] The new producer and existing consumer share one canonical Nim value
