### PR TITLE
fix(math): charge multigraph flow-search replay to one request budget

### DIFF
--- a/src/jacobian/math/graphs/multigraph/_models.py
+++ b/src/jacobian/math/graphs/multigraph/_models.py
@@ -453,9 +453,9 @@ class MultigraphFlowFindRequest(StrictModel):
 class _FlowSearchOutcome(StrictModel):
     """Private unbound search outcome used inside the bounded search kernel.
 
-    Carries no retained search domain so source-binding validators can
-    replay it without recursion; the public result type adds the required
-    ``graph``/``group``/``resource_budget`` binding.
+    Carries no retained search domain so the public result type can add the
+    required ``graph``/``group``/``resource_budget`` binding without
+    recursion.
     """
 
     result_schema_version: Literal["1"] = "1"
@@ -493,38 +493,80 @@ class MultigraphFlowFindResult(StrictModel):
 
     @model_validator(mode="after")
     def require_consistent_status(self) -> Self:
+        # The bounded search runs exactly once per request, inside the
+        # operation; validation -- including deserialized re-validation --
+        # must never repeat it, so the declared budget bounds the total
+        # visited states.  Each outcome is therefore checked structurally
+        # and arithmetically against the retained source: shape, budget,
+        # witness validity, and the exact charged-state totals that only
+        # the kernel's termination modes can produce.
         _require_status_shape(self.status, self.flow, self.termination_reason)
         if self.states_explored > self.resource_budget.max_states:
             raise ValueError("states_explored exceeds resource budget")
-        # Every outcome is replayed against the retained search domain and
-        # budget: the deterministic bounded search must reproduce the same
-        # status, state count, and (for FOUND) the same witness.
-        from jacobian.math.graphs.multigraph._operations import (
-            _search_flow_unbound,
-        )
-
-        replay = _search_flow_unbound(self.graph, self.group, self.resource_budget)
-        if (
-            replay.status != self.status
-            or replay.states_explored != self.states_explored
-            or replay.termination_reason != self.termination_reason
-        ):
-            raise ValueError(
-                f"{self.status} outcome does not match the deterministic "
-                f"search replay over the retained domain "
-                f"(replay reported {replay.status} after "
-                f"{replay.states_explored} states)"
-            )
-        if self.status == "FOUND" and self.flow is not None:
+        if self.status == "FOUND":
+            if self.termination_reason == "SPECIAL_CASE":
+                # SPECIAL_CASE is reserved for the edgeless empty-flow
+                # shortcut; the DFS itself never emits it.
+                if self.graph.edges or self.flow != ():
+                    raise ValueError(
+                        "SPECIAL_CASE termination requires an edgeless "
+                        "graph with the empty flow"
+                    )
+            elif not self.graph.edges:
+                raise ValueError(
+                    "an edgeless graph terminates as SPECIAL_CASE, not "
+                    f"{self.termination_reason}"
+                )
+            assert self.flow is not None  # guaranteed by _require_status_shape
             _verify_found_witness(
                 self.graph, self.group, self.resource_budget, self.flow
             )
-            if replay.flow != self.flow:
+        elif self.status == "EXHAUSTED":
+            if not self.graph.edges:
+                raise ValueError("EXHAUSTED status requires a nonempty search domain")
+            expected = _complete_enumeration_state_count(
+                self.graph,
+                self.group,
+                self.resource_budget.require_nowhere_zero,
+            )
+            if self.states_explored != expected:
                 raise ValueError(
-                    "FOUND witness does not match the deterministic "
-                    "search replay over the retained domain"
+                    f"EXHAUSTED outcome reports {self.states_explored} "
+                    f"explored states; a completed enumeration of the "
+                    f"retained domain charges exactly {expected}"
+                )
+        else:
+            # UNKNOWN is emitted only at the moment the budget is exceeded,
+            # reporting exactly max_states charged states.
+            if self.states_explored != self.resource_budget.max_states:
+                raise ValueError(
+                    f"UNKNOWN outcome reports {self.states_explored} "
+                    "explored states; a budget-exceeded search reports "
+                    f"exactly {self.resource_budget.max_states}"
                 )
         return self
+
+
+def _complete_enumeration_state_count(
+    graph: LooplessMultigraph,
+    group: FiniteAbelianGroup,
+    require_nowhere_zero: bool,
+) -> int:
+    """Exact charged-state total of a completed exhaustive flow search.
+
+    The bounded DFS charges one state per pushed partial assignment, so a
+    completed enumeration over ``d = len(graph.edges)`` edges with ``b``
+    choices per edge visits exactly ``b + b^2 + ... + b^d`` states, where
+    ``b`` is twice the number of admissible per-edge values (one term per
+    orientation).  Deriving this closed form from the retained source lets
+    validators authenticate EXHAUSTED outcomes without repeating the
+    bounded search.
+    """
+    depth = len(graph.edges)
+    values = group.cardinality - 1 if require_nowhere_zero else group.cardinality
+    branching = 2 * values
+    growth: int = branching**depth
+    return branching * (growth - 1) // (branching - 1)
 
 
 def _require_status_shape(

--- a/tests/math/graphs_multigraph/test_multigraph.py
+++ b/tests/math/graphs_multigraph/test_multigraph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.graphs.multigraph import _operations as multigraph_operations
 from jacobian.math.graphs.multigraph._models import (
     MAX_GROUP_CARDINALITY,
     MAX_GROUP_MODULUS,
@@ -460,6 +461,8 @@ class TestFlowSearchUnknown:
         assert result.status == "UNKNOWN"
         assert result.termination_reason == "STATE_BUDGET_EXCEEDED"
         assert result.flow is None
+        # A budget-exceeded search reports exactly max_states charged states.
+        assert result.states_explored == 1
 
 
 # ---------------------------------------------------------------------------
@@ -655,11 +658,11 @@ class TestZeroEdgeIdentification:
 
 
 # ---------------------------------------------------------------------------
-# Source-binding replay of non-witness outcomes
+# Source binding of non-witness outcomes (validated without re-searching)
 # ---------------------------------------------------------------------------
 
 
-class TestSourceBindingReplay:
+class TestSourceBinding:
     def test_forged_exhausted_on_flow_admitting_graph_rejected(self):
         """A triangle admits a nowhere-zero Z/3 flow; EXHAUSTED must not validate."""
         payload = {
@@ -671,7 +674,7 @@ class TestSourceBindingReplay:
             "states_explored": 0,
             "termination_reason": "SEARCH_EXHAUSTED",
         }
-        with pytest.raises(ValidationError, match="search replay"):
+        with pytest.raises(ValidationError, match="completed enumeration"):
             MultigraphFlowFindResult.model_validate(payload)
 
     def test_genuine_exhausted_roundtrips(self):
@@ -707,7 +710,7 @@ class TestSourceBindingReplay:
         payload = unknown.model_dump()
         payload["status"] = "EXHAUSTED"
         payload["termination_reason"] = "SEARCH_EXHAUSTED"
-        with pytest.raises(ValidationError, match="search replay"):
+        with pytest.raises(ValidationError, match="completed enumeration"):
             MultigraphFlowFindResult.model_validate(payload)
 
     def test_unbound_results_are_rejected(self):
@@ -753,7 +756,7 @@ class TestSourceBindingReplay:
             "states_explored": 0,
             "termination_reason": "SPECIAL_CASE",
         }
-        with pytest.raises(ValidationError, match="search replay"):
+        with pytest.raises(ValidationError, match="SPECIAL_CASE"):
             MultigraphFlowFindResult.model_validate(payload)
 
     def test_genuine_found_roundtrips(self):
@@ -933,7 +936,81 @@ class TestLeafWorkBoundedBySearchBudget:
         assert result.flow is not None
 
 
-class TestReplayTerminationReasonBinding:
+class TestAggregateSearchBudgetAcrossValidation:
+    """One request performs exactly one charged search: result construction
+    and serialized re-validation must not repeat the bounded search, so the
+    total visited states stay within resource_budget.max_states (review
+    thread: PR #2223, 19-edge Z/2 bridge case previously charged 3x)."""
+
+    @staticmethod
+    def _bridge19_graph() -> LooplessMultigraph:
+        edges = []
+        for i in range(9):
+            edges.append(MultigraphEdge(edge_id=f"a{i}", left=i, right=(i + 1) % 9))
+        for i in range(9):
+            edges.append(
+                MultigraphEdge(edge_id=f"b{i}", left=9 + i, right=9 + (i + 1) % 9)
+            )
+        edges.append(MultigraphEdge(edge_id="br", left=0, right=9))
+        return LooplessMultigraph(vertex_count=18, edges=tuple(edges))
+
+    def test_construction_and_revalidation_charge_one_search(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"count": 0}
+        real_search = multigraph_operations._search_flow_unbound
+
+        def counting_search(graph: object, group: object, budget: object) -> object:
+            calls["count"] += 1
+            return real_search(graph, group, budget)
+
+        monkeypatch.setattr(
+            multigraph_operations, "_search_flow_unbound", counting_search
+        )
+        result = _flow_find(
+            self._bridge19_graph(),
+            Z2,
+            resource_budget={"require_nowhere_zero": True},
+        )
+        payload = result.model_dump()
+        MultigraphFlowFindResult.model_validate(payload)
+        MultigraphFlowFindResult.model_validate(payload)
+        assert calls["count"] == 1
+        assert result.status == "EXHAUSTED"
+        assert result.states_explored <= result.resource_budget.max_states
+
+    def test_exhausted_state_counts_match_closed_form(self) -> None:
+        # b = 2 * admissible per-edge values; a completed enumeration charges
+        # b + b^2 + ... + b^d states.  These hand-computed totals guard the
+        # validator's arithmetic against drift from the kernel's charging.
+        single_edge = LooplessMultigraph(
+            vertex_count=2,
+            edges=(MultigraphEdge(edge_id="e", left=0, right=1),),
+        )
+        star = LooplessMultigraph(
+            vertex_count=4,
+            edges=(
+                MultigraphEdge(edge_id="s1", left=0, right=1),
+                MultigraphEdge(edge_id="s2", left=0, right=2),
+                MultigraphEdge(edge_id="s3", left=0, right=3),
+            ),
+        )
+        cases = [
+            (BRIDGE_GRAPH, Z3, 21_844),  # b=4, d=7: (4^8 - 4) / 3
+            (single_edge, Z2, 2),  # b=2, d=1
+            (star, Z2, 14),  # b=2, d=3: 2 + 4 + 8
+        ]
+        for graph, group, expected in cases:
+            result = _flow_find(
+                graph,
+                group,
+                resource_budget={"max_states": 1_000_000, "require_nowhere_zero": True},
+            )
+            assert result.status == "EXHAUSTED"
+            assert result.states_explored == expected
+
+
+class TestTerminationReasonBinding:
     def test_found_reason_relabeled_special_case_rejected(self) -> None:
         result = _flow_find(
             TRIANGLE, Z3, resource_budget={"require_nowhere_zero": True}
@@ -941,7 +1018,7 @@ class TestReplayTerminationReasonBinding:
         assert result.status == "FOUND"
         payload = result.model_dump()
         payload["termination_reason"] = "SPECIAL_CASE"
-        with pytest.raises(ValidationError, match="search replay"):
+        with pytest.raises(ValidationError, match="requires an edgeless"):
             MultigraphFlowFindResult.model_validate(payload)
 
     def test_empty_graph_special_case_relabeled_witness_rejected(self) -> None:
@@ -949,7 +1026,7 @@ class TestReplayTerminationReasonBinding:
         result = _flow_find(empty_graph, Z3)
         payload = result.model_dump()
         payload["termination_reason"] = "WITNESS_FOUND"
-        with pytest.raises(ValidationError, match="search replay"):
+        with pytest.raises(ValidationError, match="edgeless graph terminates"):
             MultigraphFlowFindResult.model_validate(payload)
 
 


### PR DESCRIPTION
Follow-up to #2223 (merged with an unresolved review thread).

**Problem:** after the merge, constructing `find_multigraph_flow` results re-ran the full bounded search (`_search_flow_unbound`) inside the result validator, and validating the serialized result ran it a third time. For the 19-edge nowhere-zero Z/2 bridge case the request visited **3,145,722 charged states against a declared 1,048,576-state budget** — the resource budget undercounted execution work and tripled worst-case latency.

**Fix:** the validator no longer repeats the search (kernel stays stateless; the single charged pass happens once in `find_multigraph_flow`). Each decoded outcome is authenticated against the retained source without searching:
- FOUND: witness coverage/rank/nowhere-zero/conservation verified locally
- EXHAUSTED: must match the exact closed-form enumeration total `b + b² + … + b^d`
- UNKNOWN: must report exactly `max_states`

Measured after fix: exactly one search invocation across construction + two re-validations; 1,048,574 states ≤ budget (1.00×).

**Validation:** lint ✓ typecheck ✓ multigraph suite 68 passed, sibling graphs lane 252 passed. New `TestAggregateSearchBudgetAcrossValidation` asserts a single kernel call and aggregate ≤ budget.