### PR TITLE
fix(tests): enforce coalgebra scan-work rejection without enumeration

### DIFF
--- a/tests/math/coalgebras/test_coalgebras.py
+++ b/tests/math/coalgebras/test_coalgebras.py
@@ -456,17 +456,26 @@ class TestScanWorkBoundary:
         with pytest.raises(ValidationError, match="scan work exceeds"):
             GroupLikeElementsRequest(coalgebra=ca)
 
-    def test_reported_sixteen_dim_request_typed_rejected(self):
+    def test_reported_sixteen_dim_request_typed_rejected(self, monkeypatch):
         """The originally reported 16-dim GF(2) direct-sum request pays
         roughly 152M reconstruction units per pass (kernel plus replay),
         far above the budget, so it fails admission without enumerating.
 
         Rejection is proven structurally: the predicted scan work exceeds
         the budget, and the typed admission error (not a completed scan)
-        is what fires. No wall-clock bound: construction legitimately pays
-        the O(dimension^4) coalgebra-axiom verification, which varies
-        several fold on loaded CI runners.
+        is what fires. The group-like kernel is patched to fail if
+        admission ever triggers enumeration. No wall-clock bound:
+        construction legitimately pays the O(dimension^4) coalgebra-axiom
+        verification, which varies several fold on loaded CI runners.
         """
+        import jacobian.math.coalgebras._operations as coalgebra_operations
+
+        def forbid_enumeration(coalgebra):
+            raise AssertionError("admission must reject before enumeration")
+
+        monkeypatch.setattr(
+            coalgebra_operations, "_group_like_coefficients", forbid_enumeration
+        )
         ca = _direct_sum_group_like_coalgebra(16)
         assert (
             group_like_scan_work(ca.prime, ca.dimension) > GROUP_LIKE_SCAN_WORK_BUDGET


### PR DESCRIPTION
## Problem

#2354 removed the flaky wall-clock bound from
`TestScanWorkBoundary::test_reported_sixteen_dim_request_typed_rejected` and
now documents the contract structurally: the 16-dim GF(2) direct-sum request
(paying roughly 152M reconstruction units per pass) must fail admission
**without enumerating**. But nothing enforces the second half of that claim. If
a future change makes request admission run a scan first and raise the typed
error afterwards, the test stays green while every rejected request pays the
full enumeration.

## Solution

Patch `_group_like_coefficients` (the kernel behind both the scan and the
replay) for the duration of the construction with a stub that raises
`AssertionError`. Any regression that enumerates inside admission surfaces as
an assertion failure wrapped by pydantic, which no longer matches the
documented "scan work exceeds" error, so the test fails loudly and
deterministically.

The guard is machine independent. A wall-clock bound cannot separate rejection
from accidental enumeration on untraced local runs, where a full scan costs
only a few seconds against a ~0.4s guard-only baseline; the patched-kernel
assertion holds everywhere regardless of load or coverage tracing. Admitted
paths never call the kernel during request construction (verified by
profiling), so the stub cannot produce false failures.

## Testing

- `make check` — Ruff, mypy, and all Lean-free owner lanes pass (3486 tests).
- Owning file: `uv run pytest tests/math/coalgebras/test_coalgebras.py` — 36 passed.
- Negative-path verification: patching the kernel and validating a
  `GroupLikeElementsResult` confirms the late import resolves the patched
  attribute, so interception is real; admitted request construction never
  triggers it.
- `make lint typecheck` pass.

Specialist validation run: none — ordinary domain-test change only.

## Public contract impact

None. Test-only change; operation IDs, schemas, native API, MCP contract, and
mathematical semantics are unchanged.

## Closure matrix

None.

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [ ] Harbor task or verifier changes ran `make harbor-prepare-task` then `make harbor-validate-task` (not applicable)
- [ ] Public operation changes include an owner-local admission decision (not applicable)
- [ ] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [ ] New or changed bounds include boundary, algorithm-crossover, and realistic source-backed scale evidence (not applicable)
- [ ] New shared abstractions replace duplication in at least two surviving production paths (not applicable)