### PR TITLE
fix(math): bind min-cost-flow results to source and repair rational scaling

### DIFF
--- a/src/jacobian/math/graphs/flow/_models.py
+++ b/src/jacobian/math/graphs/flow/_models.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
+from math import lcm
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+
+# Derived integer scales that make rational capacities and costs exact
+# integers are intermediate growth, not input size: each denominator is
+# already bounded by the canonical rational limit, but the least common
+# multiple of up to 1,024 such denominators can grow far beyond what the
+# integer backend can expand. Requests whose derived scale exceeds this
+# documented conservative digit budget are rejected before any backend graph
+# is constructed.
+MAX_MIN_COST_FLOW_DERIVED_SCALE_DIGITS = 4096
+
+
+def _bounded_denominator_scale(denominators: tuple[int, ...], kind: str) -> int:
+    """Return the LCM of ``denominators`` under the derived-scale digit budget."""
+    scale = 1
+    for denominator in denominators:
+        scale = lcm(scale, abs(denominator))
+        if len(str(scale)) > MAX_MIN_COST_FLOW_DERIVED_SCALE_DIGITS:
+            raise ValueError(
+                f"the least common multiple of {kind} denominators exceeds the "
+                f"{MAX_MIN_COST_FLOW_DERIVED_SCALE_DIGITS}-digit derived-scale limit"
+            )
+    return scale
 
 
 class CapacitatedEdge(StrictModel):
@@ -187,6 +210,14 @@ class MinCostFlowRequest(StrictModel):
             raise ValueError("demands length must match vertex_count")
         if sum(self.demands) != 0:
             raise ValueError("demands must sum to zero")
+        capacity_denominators = tuple(
+            edge.capacity.as_integer_ratio()[1] for edge in self.graph.edges
+        )
+        cost_denominators = tuple(
+            edge.cost.as_integer_ratio()[1] for edge in self.graph.edges
+        )
+        _bounded_denominator_scale(capacity_denominators, "capacity")
+        _bounded_denominator_scale(cost_denominators, "cost")
         return self
 
 
@@ -199,10 +230,75 @@ class FlowEdgeResult(StrictModel):
 
 
 class MinCostFlowResult(StrictModel):
+    """The exact minimum-cost-flow outcome bound to its complete source network.
+
+    Retains the source graph and demands so validation replays the defining
+    relations instead of trusting an independently authored claim: every edge
+    flow lies between zero and its source capacity, every node balance equals
+    its source demand, and the objective is the exact cost of the returned
+    source-unit flows.  Infeasibility carries no flow or cost data.
+    """
+
+    graph: CostedFlowGraph
+    demands: tuple[int, ...] = Field(default=(), max_length=64)
     total_cost: CanonicalRational
     flow_edges: tuple[FlowEdgeResult, ...] = Field(default=())
     feasible: bool
     convention: Literal["NETWORKX_MIN_COST_FLOW"] = "NETWORKX_MIN_COST_FLOW"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from fractions import Fraction
+
+        if len(self.demands) != self.graph.vertex_count:
+            raise ValueError("demands length must match graph.vertex_count")
+        if sum(self.demands) != 0:
+            raise ValueError("demands must sum to zero")
+        if not self.feasible:
+            if self.flow_edges or self.total_cost.as_fraction() != 0:
+                raise ValueError(
+                    "an infeasible result carries no flow edges or nonzero cost"
+                )
+            return self
+
+        capacities: dict[tuple[int, int], Fraction] = {}
+        costs: dict[tuple[int, int], Fraction] = {}
+        for edge in self.graph.edges:
+            endpoints = (edge.source, edge.target)
+            capacities[endpoints] = edge.capacity.as_fraction()
+            costs[endpoints] = edge.cost.as_fraction()
+        balance = [Fraction(0)] * self.graph.vertex_count
+        objective = Fraction(0)
+        seen: set[tuple[int, int]] = set()
+        for flow_edge in self.flow_edges:
+            endpoints = (flow_edge.source, flow_edge.target)
+            if endpoints not in capacities:
+                raise ValueError(
+                    f"flow reported on undeclared edge {endpoints[0]}->{endpoints[1]}"
+                )
+            if endpoints in seen:
+                raise ValueError(
+                    f"edge {endpoints[0]}->{endpoints[1]} reported more than once"
+                )
+            seen.add(endpoints)
+            flow = flow_edge.flow.as_fraction()
+            if not 0 <= flow <= capacities[endpoints]:
+                raise ValueError(
+                    f"flow {flow} on edge {endpoints[0]}->{endpoints[1]} "
+                    f"violates the source capacity {capacities[endpoints]}"
+                )
+            balance[flow_edge.source] -= flow
+            balance[flow_edge.target] += flow
+            objective += costs[endpoints] * flow
+        for node, demand in enumerate(self.demands):
+            if balance[node] != demand:
+                raise ValueError(
+                    f"node {node} balance {balance[node]} does not equal "
+                    f"its source demand {demand}"
+                )
+        if objective != self.total_cost.as_fraction():
+            raise ValueError("total cost does not equal the cost of the returned flows")
+        return self
 
 
 class CirculationResult(StrictModel):

--- a/src/jacobian/math/graphs/flow/_operations.py
+++ b/src/jacobian/math/graphs/flow/_operations.py
@@ -115,38 +115,46 @@ def compute_edge_disjoint_paths(
 def compute_min_cost_flow(request: MinCostFlowRequest) -> MinCostFlowResult:
     """Compute minimum-cost flow with demands using exact integer arithmetic.
 
-    All rational capacities and costs are scaled to integers by a common
-    denominator before calling NetworkX's network simplex.  The integer
-    results are then divided back to exact rationals.
+    Rational capacities, demands, and costs are scaled to integers by two
+    derived scales before calling NetworkX's network simplex: the flow scale
+    ``F`` (the LCM of the capacity denominators) makes every capacity and
+    demand an exact integer, and the cost scale ``C`` (the LCM of the cost
+    denominators) makes every per-unit cost an exact integer.  A backend flow
+    of ``f'`` is therefore ``f'/F`` units of source flow and a backend
+    objective of ``o'`` satisfies ``o' = F * C * total_cost``, so both are
+    divided back exactly.  The request model bounds the derived scales before
+    any backend graph is built.
     """
     edges = request.graph.edges
-    capacities = [e.capacity.as_fraction() for e in edges]
-    costs = [e.cost.as_fraction() for e in edges]
 
-    # Compute the least common multiple of all denominators so that
-    # scaling produces integers.
-    from math import lcm
+    from jacobian.math.graphs.flow._models import _bounded_denominator_scale
 
-    scale = 1
-    for frac in capacities + costs:
-        scale = lcm(scale, frac.denominator)
+    flow_scale = _bounded_denominator_scale(
+        tuple(edge.capacity.as_integer_ratio()[1] for edge in edges), "capacity"
+    )
+    cost_scale = _bounded_denominator_scale(
+        tuple(edge.cost.as_integer_ratio()[1] for edge in edges), "cost"
+    )
 
-    # Build graph with integer capacities and costs.
     g: nx.DiGraph[Any] = nx.DiGraph()
     g.add_nodes_from(range(request.graph.vertex_count))
     for node in range(request.graph.vertex_count):
-        g.nodes[node]["demand"] = request.demands[node]
-    for edge, cap, cost in zip(edges, capacities, costs, strict=True):
+        g.nodes[node]["demand"] = request.demands[node] * flow_scale
+    for edge in edges:
+        capacity_num, capacity_den = edge.capacity.as_integer_ratio()
+        cost_num, cost_den = edge.cost.as_integer_ratio()
         g.add_edge(
             edge.source,
             edge.target,
-            capacity=int(cap * scale),
-            weight=int(cost * scale),
+            capacity=capacity_num * (flow_scale // capacity_den),
+            weight=cost_num * (cost_scale // cost_den),
         )
     try:
         flow_cost_int, flow_dict = nx.network_simplex(g)
     except (nx.NetworkXUnfeasible, nx.NetworkXError):
         return MinCostFlowResult(
+            graph=request.graph,
+            demands=request.demands,
             total_cost=_rational(0),
             feasible=False,
             flow_edges=(),
@@ -160,14 +168,16 @@ def compute_min_cost_flow(request: MinCostFlowRequest) -> MinCostFlowResult:
                     FlowEdgeResult(
                         source=source_node,
                         target=target_node,
-                        flow=_rational(int(flow_amount)),
+                        flow=_rational(Fraction(int(flow_amount), flow_scale)),
                     )
                 )
-    # The integer flow cost is sum(scaled_weight * flow) = sum((cost * scale) * flow)
-    # = scale * sum(cost * flow) = scale * total_cost.
-    # Therefore total_cost = flow_cost_int / scale.
-    total_cost = Fraction(int(flow_cost_int), scale)
+    # A backend objective is sum(cost * cost_scale * flow * flow_scale)
+    # over the returned source-unit flows, so the exact public objective
+    # divides it by both scales.
+    total_cost = Fraction(int(flow_cost_int), flow_scale * cost_scale)
     return MinCostFlowResult(
+        graph=request.graph,
+        demands=request.demands,
         total_cost=_rational(total_cost),
         feasible=True,
         flow_edges=tuple(flow_edges),

--- a/tests/math/graph_flow/test_network_ops.py
+++ b/tests/math/graph_flow/test_network_ops.py
@@ -1,12 +1,17 @@
 """Tests for network optimization operations."""
 
+import copy
 from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.flow._models import (
     CostedFlowEdge,
     CostedFlowGraph,
     MinCostFlowRequest,
+    MinCostFlowResult,
 )
 from jacobian.math.graphs.flow._operations import (
     compute_min_cost_flow,
@@ -185,3 +190,172 @@ def test_min_cost_flow_infeasible() -> None:
     request = MinCostFlowRequest(graph=graph, demands=(-10, 0, 10))
     result = compute_min_cost_flow(request)
     assert result.feasible is False
+    assert result.flow_edges == ()
+    assert result.total_cost.as_fraction() == 0
+
+
+def test_min_cost_flow_fractional_capacity_below_demand_is_infeasible() -> None:
+    """Issue #2292: demand 1 cannot cross a capacity-1/2 edge.
+
+    The scaling bug admitted this request and returned flow 1 across the
+    half-unit edge; the source problem is infeasible.
+    """
+    graph = CostedFlowGraph(
+        vertex_count=2,
+        edges=(
+            CostedFlowEdge(
+                source=0,
+                target=1,
+                capacity=CanonicalRational(num="1", den="2"),
+                cost=CanonicalRational(num="1", den="3"),
+            ),
+        ),
+    )
+    result = compute_min_cost_flow(MinCostFlowRequest(graph=graph, demands=(-1, 1)))
+    assert result.feasible is False
+    assert result.flow_edges == ()
+    assert result.total_cost.as_fraction() == 0
+
+
+def test_min_cost_flow_rational_flow_and_objective_use_distinct_scales() -> None:
+    """A feasible fractional flow is divided back through the flow scale."""
+    graph = CostedFlowGraph(
+        vertex_count=2,
+        edges=(
+            CostedFlowEdge(
+                source=0,
+                target=1,
+                capacity=CanonicalRational(num="3", den="2"),
+                cost=CanonicalRational(num="2", den="3"),
+            ),
+        ),
+    )
+    result = compute_min_cost_flow(MinCostFlowRequest(graph=graph, demands=(-1, 1)))
+    assert result.feasible is True
+    assert [(e.source, e.target, e.flow.as_fraction()) for e in result.flow_edges] == [
+        (0, 1, Fraction(1, 1))
+    ]
+    assert result.total_cost.as_fraction() == Fraction(2, 3)
+
+
+def test_min_cost_flow_mixed_capacity_and_cost_denominators() -> None:
+    """Distinct flow and cost scales compose exactly across edges."""
+    graph = CostedFlowGraph(
+        vertex_count=3,
+        edges=(
+            CostedFlowEdge(
+                source=0,
+                target=1,
+                capacity=CanonicalRational(num="3", den="2"),
+                cost=CanonicalRational(num="2", den="3"),
+            ),
+            CostedFlowEdge(
+                source=1,
+                target=2,
+                capacity=CanonicalRational(num="5", den="3"),
+                cost=CanonicalRational(num="4", den="5"),
+            ),
+        ),
+    )
+    result = compute_min_cost_flow(MinCostFlowRequest(graph=graph, demands=(-1, 0, 1)))
+    assert result.feasible is True
+    assert result.total_cost.as_fraction() == Fraction(2, 3) + Fraction(4, 5)
+    # The retained source network replays balances, capacities, and objective.
+    balance = [Fraction(0)] * 3
+    for fe in result.flow_edges:
+        balance[fe.source] -= fe.flow.as_fraction()
+        balance[fe.target] += fe.flow.as_fraction()
+    assert balance == [Fraction(-1), Fraction(0), Fraction(1)]
+    assert result.graph == graph
+    assert result.demands == (-1, 0, 1)
+
+
+def _two_path_graph() -> CostedFlowGraph:
+    return CostedFlowGraph(
+        vertex_count=3,
+        edges=(
+            CostedFlowEdge(
+                source=0,
+                target=1,
+                capacity=CanonicalRational(num="5", den="2"),
+                cost=CanonicalRational(num="1", den="3"),
+            ),
+            CostedFlowEdge(
+                source=0,
+                target=2,
+                capacity=CanonicalRational(num="5", den="1"),
+                cost=CanonicalRational(num="4", den="1"),
+            ),
+            CostedFlowEdge(
+                source=2,
+                target=1,
+                capacity=CanonicalRational(num="5", den="1"),
+                cost=CanonicalRational(num="1", den="1"),
+            ),
+        ),
+    )
+
+
+def test_min_cost_flow_serialized_result_replays_against_source() -> None:
+    """Serialization round-trips and mutations of any field are rejected."""
+    request = MinCostFlowRequest(graph=_two_path_graph(), demands=(-2, 2, 0))
+    result = compute_min_cost_flow(request)
+    assert result.feasible is True
+    dumped = result.model_dump()
+    assert MinCostFlowResult.model_validate(dumped) == result
+
+    shrunk = copy.deepcopy(dumped)
+    shrunk["graph"]["edges"][0]["capacity"] = {"num": "1", "den": "1"}
+    with pytest.raises(ValidationError, match="violates the source capacity"):
+        MinCostFlowResult.model_validate(shrunk)
+
+    undeclared = copy.deepcopy(dumped)
+    undeclared["flow_edges"] = (
+        *undeclared["flow_edges"],
+        {"source": 1, "target": 0, "flow": {"num": "1", "den": "1"}},
+    )
+    with pytest.raises(ValidationError, match="undeclared edge"):
+        MinCostFlowResult.model_validate(undeclared)
+
+    rebalanced = copy.deepcopy(dumped)
+    rebalanced["demands"] = [1, -2, 1]
+    with pytest.raises(ValidationError, match="source demand"):
+        MinCostFlowResult.model_validate(rebalanced)
+
+    recompensed = copy.deepcopy(dumped)
+    recompensed["total_cost"] = {"num": "9999", "den": "1"}
+    with pytest.raises(ValidationError, match="does not equal the cost"):
+        MinCostFlowResult.model_validate(recompensed)
+
+
+def test_min_cost_flow_infeasible_result_carries_no_claim() -> None:
+    with pytest.raises(ValidationError, match="carries no flow edges or nonzero cost"):
+        MinCostFlowResult(
+            graph=_two_path_graph(),
+            demands=(-2, 2, 0),
+            total_cost=CanonicalRational(num="7", den="1"),
+            feasible=False,
+        )
+
+
+def test_min_cost_flow_derived_scale_admission_fails_closed() -> None:
+    """Oversized derived LCMs are rejected before backend construction."""
+    primes = []
+    candidate = 2
+    while len(primes) < 500:
+        if all(candidate % p for p in primes if p * p <= candidate):
+            primes.append(candidate)
+        candidate += 1
+    pairs = [(i, j) for i in range(64) for j in range(64) if i != j][: len(primes)]
+    edges = tuple(
+        CostedFlowEdge(
+            source=source,
+            target=target,
+            capacity=CanonicalRational(num="1", den=str(prime**3)),
+            cost=CanonicalRational(num="1", den="1"),
+        )
+        for (source, target), prime in zip(pairs, primes, strict=True)
+    )
+    graph = CostedFlowGraph(vertex_count=64, edges=edges)
+    with pytest.raises(ValidationError, match="derived-scale limit"):
+        MinCostFlowRequest(graph=graph, demands=tuple([0] * 63 + [0]))


### PR DESCRIPTION
## Problem

`network.min_cost_flow.compute` reported infeasible rational networks as feasible with capacity-violating flows (#2292, P0).

**Root cause:** the producer scaled capacities and costs by one common denominator but left integer demands unscaled, returned backend integer flows without dividing by the flow scale, and divided the objective by only that common scale. With `capacity=1/2, cost=1/3, demands=(-1,1)` the backend saw demand 1 against scaled capacity 3 and returned `feasible=true, flow(0,1)=1` — violating the source capacity of one half.

## Fix

- Distinct derived scales: flow scale `F` (LCM of capacity denominators) scales capacities **and demands**; cost scale `C` (LCM of cost denominators) scales costs.
- Public flow = backend flow / `F`; public objective = backend objective / (`F*C`) — exact for mixed denominators.
- `MinCostFlowRequest` rejects requests whose derived LCM exceeds a documented 4096-digit budget before any backend graph is constructed (intermediate-growth admission, not an input-size cap).
- `MinCostFlowResult` retains the complete source network and replays its defining relations: flows lie within source capacities, node balances equal source demands, and the objective equals the exact cost of returned flows. Infeasible outcomes carry no flow or cost data, keeping infeasibility distinct from forged claims.

## Validation

- `make check` green (3523 passed) plus `tests/math/graph_flow`.
- New regressions: the issue's infeasible reproduction; feasible fractional flow/cost through distinct scales; mixed capacity/cost denominators; serialized-result replay with capacity/undeclared-edge/demand/objective mutations rejected; infeasible-no-claim; oversized derived-LCM fail-closed admission.

Fixes #2292