### PR TITLE
fix(math): admit constant resultant inputs and restore Sylvester orientation

### DIFF
--- a/src/jacobian/math/polynomials/multivariate/_models.py
+++ b/src/jacobian/math/polynomials/multivariate/_models.py
@@ -148,8 +148,14 @@ class MultivariateDivisionResult(StrictModel):
 class MultivariateResultantRequest(StrictModel):
     """Compute a bounded resultant with respect to one variable.
 
-    The request rejects inputs whose degree envelope can produce more terms
-    than the exact sparse result contract can represent.
+    The eliminated-variable domain follows the Sylvester determinant exactly,
+    including its degenerate rows: an input that is a nonzero constant in the
+    elimination variable contributes the standard power rule
+    ``Res_x(f, c) = c ^ deg_x(f)`` (and symmetrically ``Res_x(c, g) =
+    c ^ deg_x(g)``), two inputs both constant in the eliminated variable give
+    the empty-determinant value 1, and a zero input gives 0.  The request
+    rejects inputs whose degree envelope can produce more terms than the
+    exact sparse result contract can represent.
     """
 
     left: RationalPolynomial
@@ -171,18 +177,6 @@ class MultivariateResultantRequest(StrictModel):
                 maximum_coefficient_digits=_MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
             )
         variable_index = self.left.variables.index(self.elimination_variable)
-        for polynomial, label in ((self.left, "left"), (self.right, "right")):
-            degree_in_variable = max(
-                (
-                    term.exponents[variable_index]
-                    for term in polynomial.polynomial.terms
-                ),
-                default=0,
-            )
-            if degree_in_variable == 0:
-                raise ValueError(
-                    f"{label} polynomial has zero degree in the elimination variable"
-                )
         degree_sum = max(
             (term.exponents[variable_index] for term in self.left.polynomial.terms),
             default=0,
@@ -217,9 +211,37 @@ MultivariateInvariantValue = Annotated[
 
 
 class MultivariateResultantResult(StrictModel):
+    """The exact resultant bound to its source pair.
+
+    Retains both source polynomials and the eliminated variable so
+    validation replays the exact Sylvester determinant instead of trusting
+    an independently authored value.  The replay runs inside the same
+    admitted degree envelope as the producer.
+    """
+
+    left: RationalPolynomial
+    right: RationalPolynomial
     elimination_variable: PolynomialVariable
     resultant: MultivariateInvariantValue
     convention: Literal["SYLVESTER_DETERMINANT"] = "SYLVESTER_DETERMINANT"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.polynomials.multivariate._operations import (
+            _sylvester_resultant_value,
+        )
+
+        request = MultivariateResultantRequest(
+            left=self.left,
+            right=self.right,
+            elimination_variable=self.elimination_variable,
+        )
+        if self.resultant != _sylvester_resultant_value(request):
+            raise ValueError(
+                "resultant must equal the Sylvester determinant of the "
+                "retained source polynomials"
+            )
+        return self
 
 
 class MultivariateFactorRequest(StrictModel):

--- a/src/jacobian/math/polynomials/multivariate/_operations.py
+++ b/src/jacobian/math/polynomials/multivariate/_operations.py
@@ -115,11 +115,18 @@ def compute_multivariate_division(
     )
 
 
-def compute_multivariate_resultant(
+def _sylvester_resultant_value(
     request: MultivariateResultantRequest,
-) -> MultivariateResultantResult:
-    """Compute the resultant of two multivariate polynomials w.r.t. one variable."""
+) -> MultivariateScalarValue | MultivariatePolynomialValue:
+    """Compute the exact resultant value of an admitted request.
 
+    Returns the classical Sylvester-determinant orientation.  SymPy's
+    subresultant PRS canonicalizes ``deg(left) >= deg(right)`` internally
+    without compensating the swap sign (upstream sympy/sympy#10666), so
+    whenever the left elimination degree is the smaller one the backend
+    value carries an extra ``(-1)^(m*n)`` factor relative to the declared
+    convention; this adapter restores the standard orientation.
+    """
     from sympy import QQ, Poly
     from sympy import resultant as sympy_resultant
 
@@ -131,6 +138,20 @@ def compute_multivariate_resultant(
     right = rational_polynomial_to_sympy(request.right)
     value = sympy_resultant(left.as_expr(), right.as_expr(), generator)
 
+    left_elimination_degree = max(
+        (term.exponents[elimination_index] for term in request.left.polynomial.terms),
+        default=0,
+    )
+    right_elimination_degree = max(
+        (term.exponents[elimination_index] for term in request.right.polynomial.terms),
+        default=0,
+    )
+    if (
+        left_elimination_degree < right_elimination_degree
+        and (left_elimination_degree * right_elimination_degree) % 2
+    ):
+        value = -value
+
     remaining_variables = tuple(
         variable for variable in variables if variable != request.elimination_variable
     )
@@ -138,18 +159,24 @@ def compute_multivariate_resultant(
         # The resultant is a rational scalar.
         from jacobian.math.polynomials._conversions import rational_from_sympy
 
-        return MultivariateResultantResult(
-            elimination_variable=request.elimination_variable,
-            resultant=MultivariateScalarValue(
-                value=rational_from_sympy(value),
-            ),
+        return MultivariateScalarValue(
+            value=rational_from_sympy(value),
         )
     resultant_poly = Poly(value, *symbols_for_variables(remaining_variables), domain=QQ)
+    return MultivariatePolynomialValue(
+        value=_result_polynomial(resultant_poly, remaining_variables),
+    )
+
+
+def compute_multivariate_resultant(
+    request: MultivariateResultantRequest,
+) -> MultivariateResultantResult:
+    """Compute the resultant of two multivariate polynomials w.r.t. one variable."""
     return MultivariateResultantResult(
+        left=request.left,
+        right=request.right,
         elimination_variable=request.elimination_variable,
-        resultant=MultivariatePolynomialValue(
-            value=_result_polynomial(resultant_poly, remaining_variables),
-        ),
+        resultant=_sylvester_resultant_value(request),
     )
 
 

--- a/src/jacobian/math/polynomials/multivariate/_tools.py
+++ b/src/jacobian/math/polynomials/multivariate/_tools.py
@@ -217,7 +217,11 @@ MULTIVARIATE_POLYNOMIAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         (
             "Compute the exact resultant of two multivariate polynomials with "
             "respect to one declared variable over QQ[x_1, ..., x_n].  The "
-            "resultant lives in the ring over the remaining variables.  Backed "
+            "resultant lives in the ring over the remaining variables.  "
+            "Nonzero inputs that are constant in the eliminated variable "
+            "follow the Sylvester power rule Res_x(f, c) = c^deg_x(f) "
+            "(symmetrically for the right input), two such constants give "
+            "the empty-determinant value 1, and a zero input gives 0.  Backed "
             "by SymPy's resultant."
         ),
         MultivariateResultantRequest,

--- a/tests/math/polynomials/test_multivariate_polynomial.py
+++ b/tests/math/polynomials/test_multivariate_polynomial.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import copy
+from fractions import Fraction
+
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.polynomials.multivariate._models import (
     MultivariateDivisionRequest,
     MultivariateGcdRequest,
     MultivariateResultantRequest,
+    MultivariateResultantResult,
 )
 from jacobian.math.polynomials.multivariate._operations import (
     compute_multivariate_division,
@@ -37,6 +42,19 @@ def _poly(
             },
         }
     )
+
+
+def _poly_from_sympy(expr) -> RationalPolynomial:
+    """Convert a small two-variable SymPy expression to a ``RationalPolynomial``."""
+
+    from sympy import Poly, symbols
+
+    x_symbol, y_symbol = symbols("x y")
+    poly = Poly(expr, x_symbol, y_symbol)
+    terms = []
+    for monomials, coefficient in sorted(poly.terms(), reverse=True):
+        terms.append((f"{coefficient.p}/{coefficient.q}", tuple(monomials)))
+    return _poly(("x", "y"), tuple(terms))
 
 
 def _scalar(
@@ -312,16 +330,207 @@ class TestMultivariateResultant:
         value = result.resultant.value
         assert value.variables == ("y", "z")
 
-    def test_resultant_rejects_zero_degree(self) -> None:
-        """The elimination variable must appear in both polynomials."""
+    def test_resultant_nonzero_constant_right_input(self) -> None:
+        """Atlas elimination case: res_x(x + y^2 - u, y - v) = y - v."""
 
-        # left has zero degree in x; right has zero degree in x
-        left = _poly(("x", "y"), (("1/1", (0, 1)),))
-        right = _poly(("x", "y"), (("1/1", (0, 1)),))
-        with pytest.raises(ValueError, match="zero degree in the elimination variable"):
+        left = _poly(
+            ("x", "y", "u", "v"),
+            (("1/1", (1, 0, 0, 0)), ("1/1", (0, 2, 0, 0)), ("-1/1", (0, 0, 1, 0))),
+        )
+        right = _poly(
+            ("x", "y", "u", "v"), (("1/1", (0, 1, 0, 0)), ("-1/1", (0, 0, 0, 1)))
+        )
+        result = compute_multivariate_resultant(
             MultivariateResultantRequest(
                 left=left, right=right, elimination_variable="x"
             )
+        )
+        assert result.resultant.kind == "POLYNOMIAL"
+        terms = {
+            t.exponents: t.coefficient.as_fraction()
+            for t in result.resultant.value.polynomial.terms
+        }
+        assert terms == {(1, 0, 0): Fraction(1), (0, 0, 1): Fraction(-1)}
+
+    def test_resultant_power_rule_over_constant_inputs(self) -> None:
+        """Res_x(f, c) = c^deg_x(f) and Res_x(c, g) = c^deg_x(g)."""
+
+        f = _poly(("x", "y"), (("3/1", (3, 0)), ("1/2", (0, 1))))
+        five = _poly(("x", "y"), (("5/1", (0, 0)),))
+        left_as_eliminated = compute_multivariate_resultant(
+            MultivariateResultantRequest(left=f, right=five, elimination_variable="x")
+        )
+        right_as_eliminated = compute_multivariate_resultant(
+            MultivariateResultantRequest(left=five, right=f, elimination_variable="x")
+        )
+        for record in (left_as_eliminated, right_as_eliminated):
+            assert record.resultant.kind == "POLYNOMIAL"
+            terms = {
+                t.exponents: t.coefficient.as_fraction()
+                for t in record.resultant.value.polynomial.terms
+            }
+            assert terms == {(0,): Fraction(125)}
+
+    def test_resultant_both_constant_gives_empty_determinant_value(self) -> None:
+        """Two inputs constant in the eliminated variable give exactly 1."""
+
+        left = _poly(("x", "y", "z"), (("1/2", (0, 1, 0)), ("5/1", (0, 0, 0))))
+        right = _poly(("x", "y", "z"), (("1/3", (0, 0, 1)), ("-7/1", (0, 0, 0))))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+        )
+        assert result.resultant.kind == "POLYNOMIAL"
+        terms = {
+            t.exponents: t.coefficient.as_fraction()
+            for t in result.resultant.value.polynomial.terms
+        }
+        assert terms == {(0, 0): Fraction(1)}
+
+    def test_resultant_zero_input_gives_zero(self) -> None:
+        """Either zero input gives the zero resultant."""
+
+        zero = _poly(("x", "y"), ())
+        g = _poly(("x", "y"), (("1/1", (2, 0)), ("-4/1", (0, 1))))
+        for left, right in ((zero, g), (g, zero), (zero, zero)):
+            result = compute_multivariate_resultant(
+                MultivariateResultantRequest(
+                    left=left, right=right, elimination_variable="x"
+                )
+            )
+            assert result.resultant.kind == "POLYNOMIAL"
+            assert len(result.resultant.value.polynomial.terms) == 0
+
+    def test_resultant_swap_law_with_degenerate_rows(self) -> None:
+        """Res(f, g) = (-1)^{mn} Res(g, f) across admitted degree profiles."""
+
+        cases = (
+            (
+                _poly(("x", "y"), (("1/1", (2, 0)), ("-3/1", (0, 0)))),
+                _poly(("x", "y"), (("1/1", (1, 1)), ("2/1", (0, 0)))),
+            ),
+            (
+                _poly(("x", "y"), (("1/1", (1, 0)),)),
+                _poly(("x", "y"), (("7/1", (0, 0)),)),
+            ),
+            (
+                _poly(("x", "y"), (("1/1", (0, 1)),)),
+                _poly(("x", "y"), (("1/1", (3, 0)), ("-1/1", (0, 0)))),
+            ),
+            (
+                _poly(("x", "y"), (("1/1", (1, 0)), ("5/1", (0, 0)))),
+                _poly(("x", "y"), (("1/1", (3, 0)), ("-4/1", (0, 0)))),
+            ),
+        )
+        for left, right in cases:
+            first = compute_multivariate_resultant(
+                MultivariateResultantRequest(
+                    left=left, right=right, elimination_variable="x"
+                )
+            )
+            second = compute_multivariate_resultant(
+                MultivariateResultantRequest(
+                    left=right, right=left, elimination_variable="x"
+                )
+            )
+            m = max((t.exponents[0] for t in left.polynomial.terms), default=0)
+            n = max((t.exponents[0] for t in right.polynomial.terms), default=0)
+            sign = -1 if (m * n) % 2 else 1
+            first_terms = {
+                t.exponents: sign * t.coefficient.as_fraction()
+                for t in first.resultant.value.polynomial.terms
+            }
+            second_terms = {
+                t.exponents: t.coefficient.as_fraction()
+                for t in second.resultant.value.polynomial.terms
+            }
+            assert first_terms == second_terms
+
+    def test_resultant_sign_matches_sylvester_orientation(self) -> None:
+        """deg(left) < deg(right) keeps the standard Sylvester orientation.
+
+        SymPy's PRS canonicalizes the degree order without compensating the
+        swap sign (upstream sympy/sympy#10666); these fixed cases flip under
+        the uncorrected backend value.
+        """
+
+        left = _poly(("x", "y"), (("1/1", (1, 0)), ("5/1", (0, 0))))
+        right = _poly(("x", "y"), (("1/1", (3, 0)),))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=left, right=right, elimination_variable="x"
+            )
+        )
+        terms = {
+            t.exponents: t.coefficient.as_fraction()
+            for t in result.resultant.value.polynomial.terms
+        }
+        assert terms == {(0,): Fraction(-125)}
+
+        symbolic_left = _poly(("x", "y"), (("1/1", (1, 1)),))
+        symbolic_right = _poly(("x", "y"), (("1/1", (3, 0)), ("-1/1", (0, 3))))
+        result = compute_multivariate_resultant(
+            MultivariateResultantRequest(
+                left=symbolic_left, right=symbolic_right, elimination_variable="x"
+            )
+        )
+        terms = {
+            t.exponents: t.coefficient.as_fraction()
+            for t in result.resultant.value.polynomial.terms
+        }
+        assert terms == {(6,): Fraction(-1)}
+
+    def test_resultant_matches_sylvester_determinant_oracle(self) -> None:
+        """Differential oracle: the sparse value equals the Sylvester determinant."""
+
+        from sympy import Matrix, symbols, together
+        from sympy.polys.subresultants_qq_zz import sylvester as sympy_sylvester
+
+        x, y = symbols("x y")
+        cases = (
+            (x**2 + y * x + 1, 3 * x - y**2),
+            (x + 5, x**3 + y),
+            (2 * x**2 - 7, y * x + 3),
+            (y**2 + 1, x - 4),
+        )
+        for f_expr, g_expr in cases:
+            f = _poly_from_sympy(f_expr)
+            g = _poly_from_sympy(g_expr)
+            result = compute_multivariate_resultant(
+                MultivariateResultantRequest(left=f, right=g, elimination_variable="x")
+            )
+            expected = together(Matrix(sympy_sylvester(f_expr, g_expr, x)).det())
+            claimed = sum(
+                Fraction(int(t.coefficient.num), int(t.coefficient.den))
+                * y ** t.exponents[0]
+                for t in result.resultant.value.polynomial.terms
+            )
+            assert together(expected - claimed) == 0
+
+    def test_resultant_source_bound_replay_rejects_mutations(self) -> None:
+        """Serialized results replay against their retained source pair."""
+
+        left = _poly(("x", "y"), (("1/1", (1, 1)), ("-1/1", (0, 0))))
+        right = _poly(("x", "y"), (("1/1", (2, 0)), ("-1/1", (0, 0))))
+        request = MultivariateResultantRequest(
+            left=left, right=right, elimination_variable="x"
+        )
+        result = compute_multivariate_resultant(request)
+        dumped = result.model_dump()
+        assert MultivariateResultantResult.model_validate(dumped) == result
+
+        forged = copy.deepcopy(dumped)
+        forged["resultant"]["value"]["polynomial"]["terms"] = [
+            {"coefficient": {"num": "9999", "den": "1"}, "exponents": [0]}
+        ]
+        with pytest.raises(ValidationError, match="Sylvester determinant"):
+            MultivariateResultantResult.model_validate(forged)
+
+        swapped = copy.deepcopy(dumped)
+        swapped["left"] = dumped["right"]
+        with pytest.raises(ValidationError, match="Sylvester determinant"):
+            MultivariateResultantResult.model_validate(swapped)
 
     def test_resultant_rejects_univariate(self) -> None:
         """Univariate polynomials are rejected for multivariate operations."""


### PR DESCRIPTION
## Problem

Two defects in `polynomial.multivariate.resultant.compute`:

1. **#2293 (contract too narrow):** the request model rejected any input with zero degree in the elimination variable, blocking standard elimination cases like the Atlas certificate `Res_x(x + y^2 - u, y - v) = y - v` where one equation does not involve the eliminated variable.
2. **Backend sign defect (found during investigation):** SymPy's subresultant PRS canonicalizes `deg(left) >= deg(right)` internally without compensating the swap sign — long-standing upstream issue [sympy/sympy#10666](https://github.com/sympy/sympy/issues/10666), still present in 1.14. Whenever `deg_x(left) < deg_x(right)` and both degrees are odd, the shipped operation returned `(−1)^{mn}` times the true Sylvester determinant (e.g. `Res(x+5, x³)` = +125 instead of −125, confirmed against the classical Sylvester determinant and root-product formulas on a 30-case sweep).

## Fix

- **Widened admission** to the exact Sylvester semantics: nonzero inputs constant in the eliminated variable follow `Res_x(f, c) = c^{deg_x(f)}` (symmetrically), two such constants give the empty-determinant value 1, and zero inputs give 0. Degree-sum and output-term budgets unchanged.
- **Restored standard orientation:** the adapter negates the backend value when `deg_x(left) < deg_x(right)` and `m·n` is odd, matching the declared SYLVESTER_DETERMINANT convention.
- **Source-bound results:** `MultivariateResultantResult` retains both source polynomials and replays the exact determinant, so authored or mutated values are rejected.

## Validation

- `make check` green (3524 passed).
- New regressions: the Atlas known answer; power rule over rational constants; both-constant → 1; zero input → 0; swap law including unequal odd degrees; differential oracle vs an independently constructed Sylvester determinant; sign-orientation fixtures (`Res(x+5,x³) = −125`, symbolic `−y⁶`); serialized-result replay rejecting forged/swapped payloads; request mutation tests retained.

Fixes #2293