### PR TITLE
fix(math): source-bind rational RREF, rank, and nullspace results

### DIFF
--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -198,11 +198,47 @@ class RationalLinearSolveRequest(StrictModel):
 
 
 class RrefResult(StrictModel):
+    """The unique reduced row echelon form bound to its source matrix.
+
+    Retains the source matrix so validation replays the defining relation:
+    the claimed form is the unique RREF over QQ of the retained source, the
+    rank equals the pivot count, and the pivot and free columns partition the
+    source column axis.  The rational matrix domain admits at least one row
+    and column, so zero-row shapes are rejected by request admission rather
+    than silently dropped.
+    """
+
+    matrix: RationalMatrix
     reduced_matrix: RationalMatrix
     rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     pivot_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
     free_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
     convention: Literal["UNIQUE_RREF_OVER_QQ"] = "UNIQUE_RREF_OVER_QQ"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        column_count = len(self.matrix.entries[0])
+        if (
+            len(self.reduced_matrix.entries) != len(self.matrix.entries)
+            or len(self.reduced_matrix.entries[0]) != column_count
+        ):
+            raise ValueError("reduced matrix must have the source shape")
+        if self.rank != len(self.pivot_columns):
+            raise ValueError("rank must equal the pivot column count")
+        if sorted((*self.pivot_columns, *self.free_columns)) != list(
+            range(column_count)
+        ):
+            raise ValueError("pivot and free columns must partition the source columns")
+        from jacobian.math.matrices import _conversions as conversions
+        from jacobian.math.matrices._operations import _rref_replay
+
+        expected_reduced, pivots = _rref_replay(self.matrix)
+        if tuple(int(pivot) for pivot in pivots) != self.pivot_columns or (
+            conversions.rational_matrix_to_sympy(self.reduced_matrix)
+            != expected_reduced
+        ):
+            raise ValueError("reduced matrix must be the unique RREF of the source")
+        return self
 
 
 class MatrixDeterminantResult(StrictModel):
@@ -213,14 +249,38 @@ class MatrixDeterminantResult(StrictModel):
 
 
 class MatrixRankResult(StrictModel):
-    """One exact rank with the canonical RREF pivot columns."""
+    """One exact rank with the canonical RREF pivot columns, bound to its source."""
 
+    matrix: RationalMatrix
     rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     pivot_columns: tuple[int, ...] = Field(max_length=MAX_MATRIX_DIMENSION)
     method: Literal["EXACT_RATIONAL_ROW_REDUCTION"] = "EXACT_RATIONAL_ROW_REDUCTION"
 
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        if self.rank != len(self.pivot_columns):
+            raise ValueError("rank must equal the pivot column count")
+        from jacobian.math.matrices._operations import _rank_replay
+
+        expected_rank, pivots = _rank_replay(self.matrix)
+        if expected_rank != self.rank or tuple(int(p) for p in pivots) != (
+            self.pivot_columns
+        ):
+            raise ValueError("rank and pivot columns must replay against the source")
+        return self
+
 
 class NullspaceResult(StrictModel):
+    """The RREF fundamental nullspace basis bound to its source matrix.
+
+    Retains the source matrix so validation replays the defining relations:
+    every basis vector satisfies ``A v = 0`` exactly, each vector carries a
+    one in its own free column and zeros in the other free columns (which
+    also establishes independence), and the claimed rank equals the exact
+    rank of the retained source.
+    """
+
+    matrix: RationalMatrix
     ambient_dimension: int = Field(ge=1, le=MAX_MATRIX_DIMENSION)
     rank: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
     nullity: int = Field(ge=0, le=MAX_MATRIX_DIMENSION)
@@ -232,14 +292,43 @@ class NullspaceResult(StrictModel):
 
     @model_validator(mode="after")
     def require_basis_shape(self) -> Self:
+        if self.ambient_dimension != len(self.matrix.entries[0]):
+            raise ValueError("ambient dimension must equal the source column count")
         if self.rank + self.nullity != self.ambient_dimension:
             raise ValueError("rank plus nullity must equal the ambient dimension")
         if len(self.basis_vectors) != self.nullity:
             raise ValueError("basis vector count must equal nullity")
         if any(len(vector) != self.ambient_dimension for vector in self.basis_vectors):
             raise ValueError("each basis vector must have the ambient dimension")
-        if len(self.free_columns) != self.nullity:
-            raise ValueError("free column count must equal nullity")
+        if len(self.free_columns) != self.nullity or self.free_columns != tuple(
+            sorted(self.free_columns)
+        ):
+            raise ValueError("free column count must equal nullity in ascending order")
+
+        entries = [
+            [value.as_fraction() for value in row] for row in self.matrix.entries
+        ]
+        for index, vector in enumerate(self.basis_vectors):
+            components = [value.as_fraction() for value in vector]
+            for row in entries:
+                if sum(a * b for a, b in zip(row, components, strict=True)) != 0:
+                    raise ValueError(
+                        f"basis vector {index} does not satisfy A v = 0 exactly"
+                    )
+            own = self.free_columns[index]
+            if components[own] != 1 or any(
+                components[other] != 0 for other in self.free_columns if other != own
+            ):
+                raise ValueError(
+                    f"basis vector {index} is not the fundamental basis vector "
+                    "of its free column"
+                )
+
+        from jacobian.math.matrices._operations import _rank_replay
+
+        expected_rank, _pivots = _rank_replay(self.matrix)
+        if expected_rank != self.rank:
+            raise ValueError("claimed rank must equal the exact rank of the source")
         return self
 
 

--- a/src/jacobian/math/matrices/_operations.py
+++ b/src/jacobian/math/matrices/_operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.math import matrices
@@ -32,7 +34,7 @@ from jacobian.math.matrices._operation_models import (
     SquareIntegerMatrixRequest,
     SquareRationalMatrixRequest,
 )
-from jacobian.math.matrices.values import SmithNormalForm
+from jacobian.math.matrices.values import RationalMatrix, SmithNormalForm
 
 
 def compute_determinant(
@@ -46,11 +48,27 @@ def compute_determinant(
     )
 
 
+def _rref_replay(matrix: RationalMatrix) -> tuple[Any, tuple[int, ...]]:
+    """Return the exact RREF and pivot columns of a retained source matrix."""
+    reduced, pivots = matrices.rref(conversions.rational_matrix_to_sympy(matrix))
+    return reduced, tuple(int(pivot) for pivot in pivots)
+
+
+def _rank_replay(matrix: RationalMatrix) -> tuple[int, tuple[int, ...]]:
+    """Return the exact rank and RREF pivot columns of a retained source matrix."""
+    rank, pivots = matrices.rank(conversions.rational_matrix_to_sympy(matrix))
+    return int(rank), tuple(int(pivot) for pivot in pivots)
+
+
 def compute_rank(request: MatrixRankRequest) -> MatrixRankResult:
     rank, pivot_columns = matrices.rank(
         conversions.rational_matrix_to_sympy(request.matrix)
     )
-    return MatrixRankResult(rank=rank, pivot_columns=pivot_columns)
+    return MatrixRankResult(
+        matrix=request.matrix,
+        rank=rank,
+        pivot_columns=tuple(int(column) for column in pivot_columns),
+    )
 
 
 def compute_rref(request: RationalMatrixRequest) -> RrefResult:
@@ -60,6 +78,7 @@ def compute_rref(request: RationalMatrixRequest) -> RrefResult:
     columns = reduced.cols
     pivot_columns = tuple(int(column) for column in pivots)
     return RrefResult(
+        matrix=request.matrix,
         reduced_matrix=conversions.rational_matrix_from_sympy(reduced),
         rank=len(pivot_columns),
         pivot_columns=pivot_columns,
@@ -89,6 +108,7 @@ def compute_nullspace(request: RationalMatrixRequest) -> NullspaceResult:
             vector[pivot_column] = -reduced[row, free_column]
         basis.append(tuple(conversions.rational_from_sympy(value) for value in vector))
     return NullspaceResult(
+        matrix=request.matrix,
         ambient_dimension=matrix.cols,
         rank=len(pivot_columns),
         nullity=len(basis),

--- a/tests/math/matrices/test_result_source_binding.py
+++ b/tests/math/matrices/test_result_source_binding.py
@@ -1,0 +1,211 @@
+"""Regression tests binding rational RREF, rank, and nullspace to their source."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.matrices._operation_models import (
+    MatrixRankRequest,
+    MatrixRankResult,
+    NullspaceResult,
+    RationalMatrixRequest,
+    RrefResult,
+)
+from jacobian.math.matrices._operations import (
+    compute_nullspace,
+    compute_rank,
+    compute_rref,
+)
+from jacobian.math.matrices.values import RationalMatrix
+
+
+def _matrix(rows: list[list[str]]) -> RationalMatrix:
+    return RationalMatrix.model_validate(
+        {
+            "matrix_schema_version": "1",
+            "domain": "QQ",
+            "entries": [
+                [
+                    {
+                        "num": value.split("/")[0],
+                        "den": value.split("/")[1] if "/" in value else "1",
+                    }
+                    for value in row
+                ]
+                for row in rows
+            ],
+        }
+    )
+
+
+def test_producer_results_replay_across_shapes() -> None:
+    """Zero, rectangular, rank-deficient, and full-rank sources stay bound."""
+
+    shapes = (
+        _matrix([["0", "0"], ["0", "0"]]),
+        _matrix([["1", "2", "3"], ["4", "5", "6"]]),
+        _matrix([["1", "2"], ["2", "4"], ["3", "6"]]),
+        _matrix([["1/2", "0"], ["0", "1/3"]]),
+    )
+    for matrix in shapes:
+        request = RationalMatrixRequest(matrix=matrix)
+        rref = compute_rref(request)
+        assert rref.matrix == matrix
+        assert (
+            rref.reduced_matrix.entries
+            == compute_rref(RationalMatrixRequest(matrix=matrix)).reduced_matrix.entries
+        )
+
+        rank_request = MatrixRankRequest(matrix=matrix)
+        rank = compute_rank(rank_request)
+        assert rank.matrix == matrix
+        assert rank.rank == len(rank.pivot_columns)
+
+        nullspace = compute_nullspace(request)
+        assert nullspace.matrix == matrix
+        assert nullspace.rank + nullspace.nullity == nullspace.ambient_dimension
+        assert len(nullspace.basis_vectors) == nullspace.nullity
+
+
+@pytest.mark.parametrize(
+    "rows",
+    (
+        [["1", "2", "3"], ["4", "5", "6"]],
+        [["0", "0", "0"], ["1", "0", "0"]],
+        [["1/2", "1/3"], ["1/5", "1/7"], ["1", "1"]],
+    ),
+)
+def test_serialized_results_round_trip(rows: list[list[str]]) -> None:
+    matrix = _matrix(rows)
+    dumped_rref = compute_rref(RationalMatrixRequest(matrix=matrix)).model_dump()
+    assert (
+        RrefResult.model_validate(dumped_rref).reduced_matrix
+        == compute_rref(RationalMatrixRequest(matrix=matrix)).reduced_matrix
+    )
+    dumped_rank = compute_rank(MatrixRankRequest(matrix=matrix)).model_dump()
+    assert (
+        MatrixRankResult.model_validate(dumped_rank).rank
+        == compute_rank(MatrixRankRequest(matrix=matrix)).rank
+    )
+    dumped_null = compute_nullspace(RationalMatrixRequest(matrix=matrix)).model_dump()
+    assert (
+        NullspaceResult.model_validate(dumped_null).nullity
+        == compute_nullspace(RationalMatrixRequest(matrix=matrix)).nullity
+    )
+
+
+def _mutable(dumped: dict) -> dict:
+    """JSON round-trip so nested tuple payloads become mutable lists."""
+    import json
+
+    return json.loads(json.dumps(dumped))
+
+
+def test_rref_result_rejects_mutations() -> None:
+    matrix = _matrix([["1", "2"], ["2", "4"]])
+    result = compute_rref(RationalMatrixRequest(matrix=matrix))
+    dumped = result.model_dump()
+
+    foreign_source = copy.deepcopy(_mutable(dumped))
+    foreign_source["matrix"]["entries"] = [
+        [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}],
+        [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+    ]
+    with pytest.raises(ValidationError):
+        RrefResult.model_validate(foreign_source)
+
+    forged_form = copy.deepcopy(_mutable(dumped))
+    forged_form["reduced_matrix"]["entries"][0][1] = {"num": "9", "den": "1"}
+    with pytest.raises(ValidationError, match="unique RREF"):
+        RrefResult.model_validate(forged_form)
+
+    forged_pivots = copy.deepcopy(_mutable(dumped))
+    forged_pivots["pivot_columns"] = [1]
+    forged_pivots["free_columns"] = [0]
+    with pytest.raises(ValidationError, match="unique RREF"):
+        RrefResult.model_validate(forged_pivots)
+
+    broken_partition = copy.deepcopy(_mutable(dumped))
+    broken_partition["free_columns"] = []
+    with pytest.raises(ValidationError, match="partition"):
+        RrefResult.model_validate(broken_partition)
+
+
+def test_rank_result_rejects_mutations() -> None:
+    matrix = _matrix([["1", "2"], ["2", "4"]])
+    result = compute_rank(MatrixRankRequest(matrix=matrix))
+    dumped = result.model_dump()
+
+    forged_rank = copy.deepcopy(_mutable(dumped))
+    forged_rank["rank"] = 32
+    with pytest.raises(ValidationError, match="pivot column count"):
+        MatrixRankResult.model_validate(forged_rank)
+
+    forged_pivots = copy.deepcopy(_mutable(dumped))
+    forged_pivots["pivot_columns"] = [1]
+    with pytest.raises(ValidationError, match="replay against the source"):
+        MatrixRankResult.model_validate(forged_pivots)
+
+    foreign_source = copy.deepcopy(_mutable(dumped))
+    foreign_source["matrix"]["entries"] = [
+        [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}],
+        [{"num": "0", "den": "1"}, {"num": "1", "den": "1"}],
+    ]
+    with pytest.raises(ValidationError, match="replay against the source"):
+        MatrixRankResult.model_validate(foreign_source)
+
+
+def test_nullspace_result_rejects_mutations() -> None:
+    matrix = _matrix([["1", "2"], ["2", "4"]])
+    result = compute_nullspace(RationalMatrixRequest(matrix=matrix))
+    dumped = result.model_dump()
+    assert result.nullity == 1
+    assert result.basis_vectors[0][-2:] == (
+        __import__("jacobian")._exact.CanonicalRational(num="-2", den="1"),
+        __import__("jacobian")._exact.CanonicalRational(num="1", den="1"),
+    )
+
+    outside_vector = copy.deepcopy(_mutable(dumped))
+    outside_vector["basis_vectors"] = [
+        [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}]
+    ]
+    with pytest.raises(ValidationError, match="A v = 0"):
+        NullspaceResult.model_validate(outside_vector)
+
+    non_fundamental = copy.deepcopy(_mutable(dumped))
+    scaled = copy.deepcopy(non_fundamental["basis_vectors"][0])
+    scaled[1] = {"num": "2", "den": "1"}
+    scaled[0] = {"num": "-4", "den": "1"}
+    non_fundamental["basis_vectors"] = [scaled]
+    with pytest.raises(ValidationError, match="fundamental basis vector"):
+        NullspaceResult.model_validate(non_fundamental)
+
+    forged_dimension = copy.deepcopy(_mutable(dumped))
+    forged_dimension["ambient_dimension"] = 3
+    with pytest.raises(ValidationError, match="ambient dimension must equal"):
+        NullspaceResult.model_validate(forged_dimension)
+
+    forged_rank = copy.deepcopy(_mutable(dumped))
+    forged_rank["rank"] = 2
+    forged_rank["nullity"] = 0
+    forged_rank["basis_vectors"] = []
+    forged_rank["free_columns"] = []
+    with pytest.raises(ValidationError, match="exact rank of the source"):
+        NullspaceResult.model_validate(forged_rank)
+
+
+def test_producer_to_serialized_interoperability() -> None:
+    """Serialized RREF agrees with independently produced rank and nullspace."""
+
+    matrix = _matrix([["1", "2", "3"], ["4", "5", "6"], ["7", "8", "9"]])
+    rref = RrefResult.model_validate(
+        compute_rref(RationalMatrixRequest(matrix=matrix)).model_dump()
+    )
+    rank = compute_rank(MatrixRankRequest(matrix=matrix))
+    nullspace = compute_nullspace(RationalMatrixRequest(matrix=matrix))
+    assert rref.rank == rank.rank == nullspace.rank == 2
+    assert list(rref.pivot_columns) == list(rank.pivot_columns)
+    assert list(rref.free_columns) == list(nullspace.free_columns)


### PR DESCRIPTION
## Problem

`RrefResult`, `MatrixRankResult`, and `NullspaceResult` omitted the source matrix (\#2310): `MatrixRankResult(rank=32, pivot_columns=())` validated, arbitrary vectors satisfied the nullspace model's shape-only checks without ever verifying `A v = 0` or independence, and serialized results carried no matrix against which the exact claim could be checked. The producers received the source matrix and discarded it.

## Fix

All three results retain the canonical rational source matrix and replay their defining invariants in model validation:

- **RREF**: claimed form is the unique RREF over QQ of the retained source (replayed through the same exact row reduction), pivot/free columns partition the column axis, rank equals the pivot count.
- **Rank**: rank equals pivot count, and both replay exactly against the retained source.
- **Nullspace**: every basis vector satisfies `A v = 0` exactly; each vector carries the fundamental-basis unit pattern on its own free column (one in its own free column, zeros in other free columns — establishing independence); free columns ascend; ambient dimension matches the source column count; claimed rank equals the exact source rank.

Zero-row shapes: the rational matrix domain admits at least one row/column, so `0 x n` inputs are rejected by request admission rather than silently dropping the ambient dimension (documented on the result contracts).

## Validation

- `make check` green (3525 passed) plus new `tests/math/matrices/test_result_source_binding.py`.
- New regressions per the issue: zero/rectangular/rank-deficient/full-rank sources; serialization round-trips; forged source/RREF/pivots/basis/dimension mutations rejected; producer→serialized-RREF→rank/nullspace interoperability with consistent pivots.

Fixes #2310