### PR TITLE
Add exact visibility kernels for rational polygons

### DIFF
--- a/src/jacobian/math/geometry/polygon_kernel/__init__.py
+++ b/src/jacobian/math/geometry/polygon_kernel/__init__.py
@@ -1,23 +1,3 @@
-"""Exact visibility kernels of simple rational polygons."""
+"""Polygon visibility-kernel operation ownership."""
 
-from jacobian.math.geometry.polygon_kernel._models import (
-    KernelBoundaryIntersection,
-    KernelPolygon,
-    OrientedEdgeHalfPlane,
-    PolygonKernelRequest,
-    PolygonKernelResult,
-    PolygonVertexTurn,
-)
-from jacobian.math.geometry.polygon_kernel._operations import (
-    compute_visibility_kernel,
-)
-
-__all__ = [
-    "KernelBoundaryIntersection",
-    "KernelPolygon",
-    "OrientedEdgeHalfPlane",
-    "PolygonKernelRequest",
-    "PolygonKernelResult",
-    "PolygonVertexTurn",
-    "compute_visibility_kernel",
-]
+__all__: list[str] = []

--- a/src/jacobian/math/geometry/polygon_kernel/__init__.py
+++ b/src/jacobian/math/geometry/polygon_kernel/__init__.py
@@ -1,0 +1,23 @@
+"""Exact visibility kernels of simple rational polygons."""
+
+from jacobian.math.geometry.polygon_kernel._models import (
+    KernelBoundaryIntersection,
+    KernelPolygon,
+    OrientedEdgeHalfPlane,
+    PolygonKernelRequest,
+    PolygonKernelResult,
+    PolygonVertexTurn,
+)
+from jacobian.math.geometry.polygon_kernel._operations import (
+    compute_visibility_kernel,
+)
+
+__all__ = [
+    "KernelBoundaryIntersection",
+    "KernelPolygon",
+    "OrientedEdgeHalfPlane",
+    "PolygonKernelRequest",
+    "PolygonKernelResult",
+    "PolygonVertexTurn",
+    "compute_visibility_kernel",
+]

--- a/src/jacobian/math/geometry/polygon_kernel/_admission.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_admission.py
@@ -1,0 +1,18 @@
+"""Owner-local admission for the polygon visibility-kernel operation."""
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.geometry.polygon_kernel._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "geometry.polygon.visibility_kernel.compute",
+        AdmissionDecision.KEEP,
+        "complete exact source-bound intersection of all oriented polygon-edge half-planes, including lower-dimensional kernels and rational area measures",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/geometry/polygon_kernel/_kernel.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_kernel.py
@@ -1,0 +1,231 @@
+"""Bounded exact half-plane kernel for simple counterclockwise polygons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Literal
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.geometry._models import (
+    GeometryConvexHullResult,
+    PointSetRequest,
+    RationalPoint2D,
+)
+from jacobian.math.geometry._operations import convex_hull_points
+from jacobian.math.geometry.polygon_kernel._models import (
+    KernelBoundaryIntersection,
+    KernelPolygon,
+    OrientedEdgeHalfPlane,
+    PolygonVertexTurn,
+)
+
+
+def _fraction_point(point: RationalPoint2D) -> tuple[Fraction, Fraction]:
+    return point.x.as_fraction(), point.y.as_fraction()
+
+
+def _wire_point(point: tuple[Fraction, Fraction]) -> RationalPoint2D:
+    return RationalPoint2D(
+        x=CanonicalRational.from_fraction(point[0]),
+        y=CanonicalRational.from_fraction(point[1]),
+    )
+
+
+def oriented_half_planes(
+    polygon: KernelPolygon,
+) -> tuple[OrientedEdgeHalfPlane, ...]:
+    """Return edge-derived inequalities whose nonnegative side is interior."""
+
+    result: list[OrientedEdgeHalfPlane] = []
+    points = tuple(_fraction_point(point) for point in polygon.points)
+    for edge_index, ((x1, y1), (x2, y2)) in enumerate(
+        zip(points, points[1:] + points[:1], strict=True)
+    ):
+        a, b, c = y1 - y2, x2 - x1, x1 * y2 - x2 * y1
+        result.append(
+            OrientedEdgeHalfPlane(
+                edge_index=edge_index,
+                a=CanonicalRational.from_fraction(a),
+                b=CanonicalRational.from_fraction(b),
+                c=CanonicalRational.from_fraction(c),
+            )
+        )
+    return tuple(result)
+
+
+def _fraction_half_plane(
+    half_plane: OrientedEdgeHalfPlane,
+) -> tuple[Fraction, Fraction, Fraction]:
+    return (
+        half_plane.a.as_fraction(),
+        half_plane.b.as_fraction(),
+        half_plane.c.as_fraction(),
+    )
+
+
+def _evaluate(
+    half_plane: tuple[Fraction, Fraction, Fraction],
+    point: tuple[Fraction, Fraction],
+) -> Fraction:
+    a, b, c = half_plane
+    return a * point[0] + b * point[1] + c
+
+
+def _feasible_boundary_intersections(
+    half_planes: tuple[OrientedEdgeHalfPlane, ...],
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    coefficients = tuple(_fraction_half_plane(item) for item in half_planes)
+    candidates: set[tuple[Fraction, Fraction]] = set()
+    for first_index, (a, b, c) in enumerate(coefficients):
+        for d, e, f in coefficients[first_index + 1 :]:
+            determinant = a * e - d * b
+            if determinant == 0:
+                continue
+            point = (
+                (b * f - e * c) / determinant,
+                (c * d - f * a) / determinant,
+            )
+            if all(_evaluate(half_plane, point) >= 0 for half_plane in coefficients):
+                candidates.add(point)
+    return tuple(sorted(candidates))
+
+
+def _canonical_hull(
+    points: tuple[tuple[Fraction, Fraction], ...],
+) -> tuple[RationalPoint2D, ...]:
+    wire_points = tuple(_wire_point(point) for point in points)
+    if len(wire_points) <= 1:
+        return wire_points
+    return convex_hull_points(PointSetRequest(points=wire_points)).points
+
+
+def polygon_signed_area(points: tuple[RationalPoint2D, ...]) -> Fraction:
+    """Return the exact signed shoelace area of one cyclic boundary."""
+
+    if len(points) < 3:
+        return Fraction()
+    total = Fraction()
+    for index, point in enumerate(points):
+        following = points[(index + 1) % len(points)]
+        total += (
+            point.x.as_fraction() * following.y.as_fraction()
+            - point.y.as_fraction() * following.x.as_fraction()
+        )
+    return total / 2
+
+
+def _turns(polygon: KernelPolygon) -> tuple[PolygonVertexTurn, ...]:
+    points = tuple(_fraction_point(point) for point in polygon.points)
+    rows: list[PolygonVertexTurn] = []
+    for vertex_index, current in enumerate(points):
+        previous = points[vertex_index - 1]
+        following = points[(vertex_index + 1) % len(points)]
+        cross = (current[0] - previous[0]) * (following[1] - current[1]) - (
+            current[1] - previous[1]
+        ) * (following[0] - current[0])
+        rows.append(
+            PolygonVertexTurn(
+                vertex_index=vertex_index,
+                cross=CanonicalRational.from_fraction(cross),
+                kind=(
+                    "CONVEX" if cross > 0 else "REFLEX" if cross < 0 else "COLLINEAR"
+                ),
+            )
+        )
+    return tuple(rows)
+
+
+def _boundary_rows(
+    points: tuple[RationalPoint2D, ...],
+    half_planes: tuple[OrientedEdgeHalfPlane, ...],
+) -> tuple[KernelBoundaryIntersection, ...]:
+    coefficients = tuple(_fraction_half_plane(item) for item in half_planes)
+    return tuple(
+        KernelBoundaryIntersection(
+            point=point,
+            active_edge_indices=tuple(
+                edge_index
+                for edge_index, half_plane in enumerate(coefficients)
+                if _evaluate(half_plane, _fraction_point(point)) == 0
+            ),
+        )
+        for point in points
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class KernelData:
+    convention: Literal["a*x+b*y+c>=0"]
+    half_planes: tuple[OrientedEdgeHalfPlane, ...]
+    vertex_turns: tuple[PolygonVertexTurn, ...]
+    reflex_vertex_indices: tuple[int, ...]
+    dimension: Literal["EMPTY", "POINT", "SEGMENT", "POLYGON"]
+    boundary: tuple[KernelBoundaryIntersection, ...]
+    convex_hull: GeometryConvexHullResult
+    polygon_area: CanonicalRational
+    kernel_area: CanonicalRational
+    convex_hull_area: CanonicalRational
+    kernel_to_polygon_area_ratio: CanonicalRational
+    polygon_to_hull_area_ratio: CanonicalRational
+
+    def as_tuple(self) -> tuple[object, ...]:
+        return (
+            self.convention,
+            self.half_planes,
+            self.vertex_turns,
+            self.reflex_vertex_indices,
+            self.dimension,
+            self.boundary,
+            self.convex_hull,
+            self.polygon_area,
+            self.kernel_area,
+            self.convex_hull_area,
+            self.kernel_to_polygon_area_ratio,
+            self.polygon_to_hull_area_ratio,
+        )
+
+
+def compute_kernel_data(polygon: KernelPolygon) -> KernelData:
+    """Compute the complete canonical kernel data used by producer and replay."""
+
+    half_planes = oriented_half_planes(polygon)
+    candidates = _feasible_boundary_intersections(half_planes)
+    kernel_points = _canonical_hull(candidates)
+    dimension: Literal["EMPTY", "POINT", "SEGMENT", "POLYGON"] = (
+        "EMPTY"
+        if not kernel_points
+        else "POINT"
+        if len(kernel_points) == 1
+        else "SEGMENT"
+        if len(kernel_points) == 2
+        else "POLYGON"
+    )
+    turns = _turns(polygon)
+    source_hull = convex_hull_points(PointSetRequest(points=polygon.points))
+    polygon_area = polygon_signed_area(polygon.points)
+    kernel_area = polygon_signed_area(kernel_points)
+    hull_area = polygon_signed_area(source_hull.points)
+    return KernelData(
+        convention="a*x+b*y+c>=0",
+        half_planes=half_planes,
+        vertex_turns=turns,
+        reflex_vertex_indices=tuple(
+            row.vertex_index for row in turns if row.kind == "REFLEX"
+        ),
+        dimension=dimension,
+        boundary=_boundary_rows(kernel_points, half_planes),
+        convex_hull=source_hull,
+        polygon_area=CanonicalRational.from_fraction(polygon_area),
+        kernel_area=CanonicalRational.from_fraction(kernel_area),
+        convex_hull_area=CanonicalRational.from_fraction(hull_area),
+        kernel_to_polygon_area_ratio=CanonicalRational.from_fraction(
+            kernel_area / polygon_area
+        ),
+        polygon_to_hull_area_ratio=CanonicalRational.from_fraction(
+            polygon_area / hull_area
+        ),
+    )
+
+
+__all__ = ["KernelData", "compute_kernel_data", "oriented_half_planes"]

--- a/src/jacobian/math/geometry/polygon_kernel/_models.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_models.py
@@ -1,0 +1,275 @@
+"""Typed contracts for exact rational polygon visibility kernels."""
+
+from __future__ import annotations
+
+from math import comb
+from typing import Literal, Self
+
+from pydantic import ConfigDict, Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.geometry._models import (
+    GeometryConvexHullResult,
+    PolygonRequest,
+    RationalPoint2D,
+    _is_simple_ring,
+)
+
+MAX_KERNEL_SOURCE_VERTICES = 64
+MAX_KERNEL_COORDINATE_DIGITS = 64
+MAX_HALF_PLANE_COEFFICIENT_DIGITS = 1_024
+MAX_INTERSECTION_COMPONENT_DIGITS = 2_056
+MAX_KERNEL_FEASIBILITY_WORK = 500_000_000
+MAX_KERNEL_RESULT_CHARS = 500_000
+
+
+def _component_digits(value: CanonicalRational) -> int:
+    return max(len(value.num.lstrip("-")), len(value.den))
+
+
+class KernelPolygon(PolygonRequest):
+    """Operation-local bounded view of one simple CCW rational polygon.
+
+    The wire shape is exactly ``PolygonRequest``. The additional validation is
+    the visibility-kernel operation's execution envelope, not a second polygon
+    representation.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    points: tuple[RationalPoint2D, ...] = Field(
+        min_length=3,
+        max_length=MAX_KERNEL_SOURCE_VERTICES,
+        description=(
+            "Distinct cyclic vertices of one simple counterclockwise rational "
+            f"polygon; coordinate components have at most "
+            f"{MAX_KERNEL_COORDINATE_DIGITS} digits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_simple_counterclockwise_polygon(self) -> Self:
+        max_coordinate_digits = max(
+            _component_digits(component)
+            for point in self.points
+            for component in (point.x, point.y)
+        )
+        if max_coordinate_digits > MAX_KERNEL_COORDINATE_DIGITS:
+            raise ValueError(
+                "polygon coordinates exceed the "
+                f"{MAX_KERNEL_COORDINATE_DIGITS}-digit visibility-kernel bound"
+            )
+
+        # Constructing the n oriented edge equations is the only arithmetic
+        # done before the pairwise expansion. Their actual normalized height
+        # makes the following work/output admission representation-sensitive.
+        from jacobian.math.geometry.polygon_kernel._kernel import (
+            oriented_half_planes,
+            polygon_signed_area,
+        )
+
+        half_planes = oriented_half_planes(self)
+        coefficient_digits = max(
+            _component_digits(value)
+            for half_plane in half_planes
+            for value in (half_plane.a, half_plane.b, half_plane.c)
+        )
+        if coefficient_digits > MAX_HALF_PLANE_COEFFICIENT_DIGITS:
+            raise ValueError(
+                "oriented half-plane coefficients exceed the "
+                f"{MAX_HALF_PLANE_COEFFICIENT_DIGITS}-digit bound"
+            )
+        # A 2x2 boundary intersection forms products and differences of
+        # rational coefficients, then divides two such rationals. Eight input
+        # component heights plus constant sign/carry slack bounds either
+        # reduced output component.
+        intersection_digits = 8 * coefficient_digits + 8
+        if intersection_digits > MAX_INTERSECTION_COMPONENT_DIGITS:
+            raise ValueError(
+                "a boundary-line intersection can exceed the "
+                f"{MAX_INTERSECTION_COMPONENT_DIGITS}-digit component bound"
+            )
+
+        vertex_count = len(self.points)
+        # The result retains the source once, n half-planes and turns, and at
+        # most n hull/kernel vertices. The formula charges four rational
+        # components per retained point plus JSON/index overhead.
+        estimated_result_chars = vertex_count * (
+            16 * max_coordinate_digits
+            + 6 * coefficient_digits
+            + 8 * intersection_digits
+            + 4 * vertex_count
+            + 400
+        )
+        if estimated_result_chars > MAX_KERNEL_RESULT_CHARS:
+            raise ValueError(
+                "visibility-kernel result can require "
+                f"{estimated_result_chars} characters, exceeding the "
+                f"{MAX_KERNEL_RESULT_CHARS}-character bound"
+            )
+
+        pair_count = comb(vertex_count, 2)
+        # Every boundary-line pair may produce one exact point which is checked
+        # against every half-plane. Integer/Fraction multiplication at height h
+        # is conservatively charged h^2 units.
+        feasibility_work = (
+            pair_count * vertex_count * coefficient_digits * coefficient_digits
+        )
+        if feasibility_work > MAX_KERNEL_FEASIBILITY_WORK:
+            raise ValueError(
+                "visibility-kernel feasibility work "
+                f"C({vertex_count},2)*{vertex_count}*"
+                f"{coefficient_digits}^2={feasibility_work} exceeds "
+                f"{MAX_KERNEL_FEASIBILITY_WORK}"
+            )
+
+        if not _is_simple_ring(self.points):
+            raise ValueError("visibility-kernel input must be a simple polygon")
+        if polygon_signed_area(self.points) <= 0:
+            raise ValueError(
+                "visibility-kernel vertices must use counterclockwise cyclic order"
+            )
+        return self
+
+
+class PolygonKernelRequest(StrictModel):
+    """Reconstruct one simple CCW polygon's exact visibility kernel."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Exact visibility-kernel reconstruction for a simple CCW "
+                "rational polygon. Admission bounds C(n,2)*n boundary-point "
+                "feasibility checks, coefficient/intersection digit growth, "
+                f"and a {MAX_KERNEL_RESULT_CHARS}-character result estimate "
+                "before pairwise boundary expansion."
+            ),
+            "feasibility_work_bound": MAX_KERNEL_FEASIBILITY_WORK,
+            "result_character_bound": MAX_KERNEL_RESULT_CHARS,
+        }
+    )
+
+    polygon: KernelPolygon = Field(
+        description=(
+            "One simple counterclockwise polygon. Edge i is directed from "
+            "vertex i to vertex i+1 cyclically, and its closed interior side "
+            "is the left half-plane a*x+b*y+c >= 0."
+        )
+    )
+
+
+class OrientedEdgeHalfPlane(StrictModel):
+    """Exact edge-derived coefficients for one closed interior half-plane."""
+
+    edge_index: StrictInt = Field(ge=0, lt=MAX_KERNEL_SOURCE_VERTICES)
+    a: CanonicalRational
+    b: CanonicalRational
+    c: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_nonzero_normal(self) -> Self:
+        if self.a.as_fraction() == 0 and self.b.as_fraction() == 0:
+            raise ValueError("an oriented half-plane must have a nonzero normal")
+        return self
+
+
+class PolygonVertexTurn(StrictModel):
+    """The exact centered orientation cross at one source vertex."""
+
+    vertex_index: StrictInt = Field(ge=0, lt=MAX_KERNEL_SOURCE_VERTICES)
+    cross: CanonicalRational
+    kind: Literal["CONVEX", "COLLINEAR", "REFLEX"]
+
+    @model_validator(mode="after")
+    def bind_turn_kind(self) -> Self:
+        value = self.cross.as_fraction()
+        expected = "CONVEX" if value > 0 else "REFLEX" if value < 0 else "COLLINEAR"
+        if self.kind != expected:
+            raise ValueError("turn kind must match the sign of its exact cross")
+        return self
+
+
+class KernelBoundaryIntersection(StrictModel):
+    """One canonical kernel boundary point and all tight source edges there."""
+
+    point: RationalPoint2D
+    active_edge_indices: tuple[StrictInt, ...] = Field(
+        min_length=2,
+        max_length=MAX_KERNEL_SOURCE_VERTICES,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_active_edges(self) -> Self:
+        if self.active_edge_indices != tuple(sorted(set(self.active_edge_indices))):
+            raise ValueError("active edge indices must be distinct and sorted")
+        return self
+
+
+class PolygonKernelResult(StrictModel):
+    """Source-bound exact half-plane reconstruction and rational area profile."""
+
+    polygon: KernelPolygon
+    interior_half_plane_convention: Literal["a*x+b*y+c>=0"]
+    half_planes: tuple[OrientedEdgeHalfPlane, ...] = Field(
+        min_length=3,
+        max_length=MAX_KERNEL_SOURCE_VERTICES,
+    )
+    vertex_turns: tuple[PolygonVertexTurn, ...] = Field(
+        min_length=3,
+        max_length=MAX_KERNEL_SOURCE_VERTICES,
+    )
+    reflex_vertex_indices: tuple[StrictInt, ...] = Field(
+        max_length=MAX_KERNEL_SOURCE_VERTICES
+    )
+    kernel_dimension: Literal["EMPTY", "POINT", "SEGMENT", "POLYGON"]
+    kernel_boundary: tuple[KernelBoundaryIntersection, ...] = Field(
+        max_length=MAX_KERNEL_SOURCE_VERTICES
+    )
+    convex_hull: GeometryConvexHullResult
+    polygon_area: CanonicalRational
+    kernel_area: CanonicalRational
+    convex_hull_area: CanonicalRational
+    kernel_to_polygon_area_ratio: CanonicalRational
+    polygon_to_hull_area_ratio: CanonicalRational
+
+    @model_validator(mode="after")
+    def bind_result_to_source_polygon(self) -> Self:
+        from jacobian.math.geometry.polygon_kernel._kernel import compute_kernel_data
+
+        expected = compute_kernel_data(self.polygon)
+        actual = (
+            self.interior_half_plane_convention,
+            self.half_planes,
+            self.vertex_turns,
+            self.reflex_vertex_indices,
+            self.kernel_dimension,
+            self.kernel_boundary,
+            self.convex_hull,
+            self.polygon_area,
+            self.kernel_area,
+            self.convex_hull_area,
+            self.kernel_to_polygon_area_ratio,
+            self.polygon_to_hull_area_ratio,
+        )
+        if actual != expected.as_tuple():
+            raise ValueError(
+                "visibility-kernel result does not match the retained source polygon"
+            )
+        return self
+
+
+__all__ = [
+    "MAX_HALF_PLANE_COEFFICIENT_DIGITS",
+    "MAX_INTERSECTION_COMPONENT_DIGITS",
+    "MAX_KERNEL_COORDINATE_DIGITS",
+    "MAX_KERNEL_FEASIBILITY_WORK",
+    "MAX_KERNEL_RESULT_CHARS",
+    "MAX_KERNEL_SOURCE_VERTICES",
+    "KernelBoundaryIntersection",
+    "KernelPolygon",
+    "OrientedEdgeHalfPlane",
+    "PolygonKernelRequest",
+    "PolygonKernelResult",
+    "PolygonVertexTurn",
+]

--- a/src/jacobian/math/geometry/polygon_kernel/_operations.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_operations.py
@@ -1,0 +1,34 @@
+"""Native exact visibility-kernel operation."""
+
+from jacobian.math.geometry.polygon_kernel._kernel import compute_kernel_data
+from jacobian.math.geometry.polygon_kernel._models import (
+    PolygonKernelRequest,
+    PolygonKernelResult,
+)
+
+
+def compute_visibility_kernel(request: PolygonKernelRequest) -> PolygonKernelResult:
+    """Reconstruct a simple CCW polygon's closed visibility kernel exactly."""
+
+    data = compute_kernel_data(request.polygon)
+    # ``compute_kernel_data`` is the same deterministic replay used by the
+    # result model. Avoid paying the O(n^3) replay twice in the trusted producer;
+    # serialized/authored results still run the complete source-binding check.
+    return PolygonKernelResult.model_construct(
+        polygon=request.polygon,
+        interior_half_plane_convention=data.convention,
+        half_planes=data.half_planes,
+        vertex_turns=data.vertex_turns,
+        reflex_vertex_indices=data.reflex_vertex_indices,
+        kernel_dimension=data.dimension,
+        kernel_boundary=data.boundary,
+        convex_hull=data.convex_hull,
+        polygon_area=data.polygon_area,
+        kernel_area=data.kernel_area,
+        convex_hull_area=data.convex_hull_area,
+        kernel_to_polygon_area_ratio=data.kernel_to_polygon_area_ratio,
+        polygon_to_hull_area_ratio=data.polygon_to_hull_area_ratio,
+    )
+
+
+__all__ = ["compute_visibility_kernel"]

--- a/src/jacobian/math/geometry/polygon_kernel/_tools.py
+++ b/src/jacobian/math/geometry/polygon_kernel/_tools.py
@@ -1,0 +1,55 @@
+"""Public declaration for exact rational polygon visibility kernels."""
+
+from jacobian.catalog._examples import example
+from jacobian.math.geometry._support import geometry_operation
+from jacobian.math.geometry.polygon_kernel._models import (
+    PolygonKernelRequest,
+    PolygonKernelResult,
+)
+from jacobian.math.geometry.polygon_kernel._operations import (
+    compute_visibility_kernel,
+)
+
+_NAKANO_PENTAGON = [
+    {"x": {"num": "0", "den": "1"}, "y": {"num": "4620", "den": "1"}},
+    {"x": {"num": "0", "den": "1"}, "y": {"num": "-4620", "den": "1"}},
+    {"x": {"num": "23100", "den": "1"}, "y": {"num": "-385", "den": "1"}},
+    {"x": {"num": "22176", "den": "1"}, "y": {"num": "0", "den": "1"}},
+    {"x": {"num": "23100", "den": "1"}, "y": {"num": "385", "den": "1"}},
+]
+
+TOOLS = (
+    geometry_operation(
+        "geometry.polygon.visibility_kernel.compute",
+        "Reconstruct an exact polygon visibility kernel",
+        (
+            "Intersect the closed left half-plane of each edge of one bounded "
+            "simple CCW rational polygon. Return source-bound oriented inequalities "
+            "and vertex turns; the canonical empty, point, segment, or polygon "
+            "kernel; the polygon convex hull; exact polygon, kernel, and hull "
+            "areas; and rational area ratios. Admission allows 64 vertices and 64 "
+            "digits per coordinate component, then bounds pairwise feasibility "
+            "work, coefficient/intersection growth, and output before expansion. "
+            "No perimeter or theorem-level claim."
+        ),
+        PolygonKernelRequest,
+        PolygonKernelResult,
+        compute_visibility_kernel,
+        "geometry",
+        "polygon",
+        "visibility-kernel",
+        "exact",
+        examples=(
+            example(
+                "published_pentagon_kernel",
+                (
+                    "Reconstruct the exact five-vertex kernel and rational area "
+                    "profile of Nakano's counterclockwise pentagon."
+                ),
+                {"polygon": {"points": _NAKANO_PENTAGON}},
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/tests/math/geometry/polygon_kernel/test_tools.py
+++ b/tests/math/geometry/polygon_kernel/test_tools.py
@@ -1,0 +1,362 @@
+"""Exact contract tests for rational polygon visibility kernels."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from copy import deepcopy
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.geometry.polygon_kernel import (
+    KernelPolygon,
+    PolygonKernelRequest,
+    PolygonKernelResult,
+    compute_visibility_kernel,
+)
+from jacobian.math.geometry.polygon_kernel._models import (
+    MAX_KERNEL_COORDINATE_DIGITS,
+    MAX_KERNEL_SOURCE_VERTICES,
+)
+
+
+def _point(x: int | Fraction, y: int | Fraction) -> dict[str, object]:
+    x_value, y_value = Fraction(x), Fraction(y)
+    return {
+        "x": {"num": str(x_value.numerator), "den": str(x_value.denominator)},
+        "y": {"num": str(y_value.numerator), "den": str(y_value.denominator)},
+    }
+
+
+def _request(
+    points: Sequence[tuple[int | Fraction, int | Fraction]],
+) -> PolygonKernelRequest:
+    return PolygonKernelRequest(
+        polygon=KernelPolygon.model_validate(
+            {"points": [_point(x, y) for x, y in points]}
+        )
+    )
+
+
+def _kernel_points(
+    result: PolygonKernelResult,
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    return tuple(
+        (row.point.x.as_fraction(), row.point.y.as_fraction())
+        for row in result.kernel_boundary
+    )
+
+
+PUBLISHED_PENTAGON = [
+    (0, 4620),
+    (0, -4620),
+    (23100, -385),
+    (22176, 0),
+    (23100, 385),
+]
+
+
+def _cross(
+    origin: tuple[Fraction, Fraction],
+    first: tuple[Fraction, Fraction],
+    second: tuple[Fraction, Fraction],
+) -> Fraction:
+    return (first[0] - origin[0]) * (second[1] - origin[1]) - (first[1] - origin[1]) * (
+        second[0] - origin[0]
+    )
+
+
+def _canonical_hull(
+    points: list[tuple[Fraction, Fraction]],
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    ordered = sorted(set(points))
+    if len(ordered) <= 1:
+        return tuple(ordered)
+    lower: list[tuple[Fraction, Fraction]] = []
+    for point in ordered:
+        while len(lower) >= 2 and _cross(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper: list[tuple[Fraction, Fraction]] = []
+    for point in reversed(ordered):
+        while len(upper) >= 2 and _cross(upper[-2], upper[-1], point) <= 0:
+            upper.pop()
+        upper.append(point)
+    return tuple(lower[:-1] + upper[:-1])
+
+
+def _half_plane_value(
+    coefficients: tuple[Fraction, Fraction, Fraction],
+    point: tuple[Fraction, Fraction],
+) -> Fraction:
+    a, b, c = coefficients
+    return a * point[0] + b * point[1] + c
+
+
+def _clip_kernel_oracle(
+    source: Sequence[tuple[int, int]],
+) -> tuple[tuple[Fraction, Fraction], ...]:
+    """Independent exact sequential half-plane clipping oracle for tests."""
+
+    points = [(Fraction(x), Fraction(y)) for x, y in source]
+    xs, ys = [point[0] for point in points], [point[1] for point in points]
+    clipped = [
+        (min(xs), min(ys)),
+        (max(xs), min(ys)),
+        (max(xs), max(ys)),
+        (min(xs), max(ys)),
+    ]
+    for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1], strict=True):
+        coefficients = y1 - y2, x2 - x1, x1 * y2 - x2 * y1
+
+        output: list[tuple[Fraction, Fraction]] = []
+        for previous, current in zip(clipped[-1:] + clipped[:-1], clipped, strict=True):
+            previous_value = _half_plane_value(coefficients, previous)
+            current_value = _half_plane_value(coefficients, current)
+            if current_value >= 0:
+                if previous_value < 0:
+                    parameter = previous_value / (previous_value - current_value)
+                    output.append(
+                        (
+                            previous[0] + parameter * (current[0] - previous[0]),
+                            previous[1] + parameter * (current[1] - previous[1]),
+                        )
+                    )
+                output.append(current)
+            elif previous_value >= 0:
+                parameter = previous_value / (previous_value - current_value)
+                output.append(
+                    (
+                        previous[0] + parameter * (current[0] - previous[0]),
+                        previous[1] + parameter * (current[1] - previous[1]),
+                    )
+                )
+        clipped = output
+        if not clipped:
+            break
+    return _canonical_hull(clipped)
+
+
+def test_published_pentagon_reconstructs_kernel_and_exact_area_profile() -> None:
+    # Nakano, arXiv:2606.05052v2, Section 4 and Appendix B.
+    result = compute_visibility_kernel(_request(PUBLISHED_PENTAGON))
+
+    # For the downward first edge, the CCW interior is to its left: x >= 0.
+    # Keeping the edge-derived scale makes the orientation trap explicit.
+    first = result.half_planes[0]
+    assert (
+        first.a.as_fraction(),
+        first.b.as_fraction(),
+        first.c.as_fraction(),
+    ) == (Fraction(9240), Fraction(0), Fraction(0))
+    assert result.interior_half_plane_convention == "a*x+b*y+c>=0"
+
+    assert tuple(row.cross.as_fraction() for row in result.vertex_turns) == (
+        Fraction(213444000),
+        Fraction(213444000),
+        Fraction(12806640),
+        Fraction(-711480),
+        Fraction(12806640),
+    )
+    assert result.reflex_vertex_indices == (3,)
+    assert result.kernel_dimension == "POLYGON"
+    assert _kernel_points(result) == (
+        (Fraction(0), Fraction(-4620)),
+        (Fraction(19800), Fraction(-990)),
+        (Fraction(22176), Fraction(0)),
+        (Fraction(19800), Fraction(990)),
+        (Fraction(0), Fraction(4620)),
+    )
+    assert result.polygon_area.as_fraction() == 115259760
+    assert result.kernel_area.as_fraction() == 113430240
+    assert result.convex_hull_area.as_fraction() == 115615500
+    assert result.kernel_to_polygon_area_ratio.as_fraction() == Fraction(62, 63)
+    assert result.polygon_to_hull_area_ratio.as_fraction() == Fraction(324, 325)
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        PUBLISHED_PENTAGON,
+        [(0, 0), (6, 0), (6, 5), (4, 3), (2, 5), (0, 5)],
+        [(0, 0), (4, 0), (4, 4), (0, 4)],
+    ],
+)
+def test_pairwise_kernel_matches_independent_sequential_clipping_oracle(
+    points: list[tuple[int, int]],
+) -> None:
+    result = compute_visibility_kernel(_request(points))
+    assert _kernel_points(result) == _clip_kernel_oracle(points)
+
+
+@pytest.mark.parametrize(
+    ("dimension", "points", "expected_boundary"),
+    [
+        (
+            "EMPTY",
+            [(0, 0), (4, 0), (4, 4), (3, 4), (3, 1), (1, 1), (1, 4), (0, 4)],
+            (),
+        ),
+        (
+            "POINT",
+            [
+                (-5, -5),
+                (-4, -5),
+                (-3, -4),
+                (-2, -5),
+                (5, -5),
+                (5, 5),
+                (-1, 5),
+                (-2, -3),
+                (-4, 5),
+                (-5, 5),
+            ],
+            ((Fraction(-2), Fraction(-3)),),
+        ),
+        (
+            "SEGMENT",
+            [
+                (-5, -5),
+                (-4, -5),
+                (-3, -3),
+                (-2, -5),
+                (5, -5),
+                (5, 5),
+                (1, 5),
+                (-2, -1),
+                (-4, 5),
+                (-5, 5),
+            ],
+            (
+                (Fraction(-3), Fraction(-3)),
+                (Fraction(-2), Fraction(-1)),
+            ),
+        ),
+        (
+            "POLYGON",
+            [(0, 0), (4, 0), (4, 4), (0, 4)],
+            (
+                (Fraction(0), Fraction(0)),
+                (Fraction(4), Fraction(0)),
+                (Fraction(4), Fraction(4)),
+                (Fraction(0), Fraction(4)),
+            ),
+        ),
+    ],
+)
+def test_all_kernel_dimensions_are_distinct_and_complete(
+    dimension: str,
+    points: list[tuple[int, int]],
+    expected_boundary: tuple[tuple[Fraction, Fraction], ...],
+) -> None:
+    result = compute_visibility_kernel(_request(points))
+    assert result.kernel_dimension == dimension
+    assert _kernel_points(result) == expected_boundary
+    assert result.kernel_area.as_fraction() == (
+        Fraction(16) if dimension == "POLYGON" else Fraction(0)
+    )
+
+
+def test_clockwise_orientation_trap_is_rejected_before_kernel_work() -> None:
+    clockwise = [PUBLISHED_PENTAGON[0], *reversed(PUBLISHED_PENTAGON[1:])]
+    with pytest.raises(ValidationError, match="counterclockwise cyclic order"):
+        _request(clockwise)
+
+
+def test_non_simple_ring_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="simple polygon"):
+        _request([(0, 0), (2, 2), (0, 2), (2, 0)])
+
+
+def test_cyclic_rotation_preserves_kernel_and_scalar_measures() -> None:
+    first = compute_visibility_kernel(_request(PUBLISHED_PENTAGON))
+    rotated_points = PUBLISHED_PENTAGON[2:] + PUBLISHED_PENTAGON[:2]
+    rotated = compute_visibility_kernel(_request(rotated_points))
+    assert _kernel_points(rotated) == _kernel_points(first)
+    assert rotated.convex_hull == first.convex_hull
+    assert rotated.polygon_area == first.polygon_area
+    assert rotated.kernel_area == first.kernel_area
+    assert rotated.kernel_to_polygon_area_ratio == first.kernel_to_polygon_area_ratio
+
+
+def test_fractional_polygon_round_trips_through_source_bound_validation() -> None:
+    result = compute_visibility_kernel(
+        _request(
+            [
+                (Fraction(1, 3), Fraction(1, 5)),
+                (Fraction(7, 3), Fraction(1, 5)),
+                (Fraction(7, 3), Fraction(11, 5)),
+                (Fraction(1, 3), Fraction(11, 5)),
+            ]
+        )
+    )
+    replayed = PolygonKernelResult.model_validate_json(result.model_dump_json())
+    assert replayed == result
+    assert replayed.polygon_area.as_fraction() == 4
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["source", "half_plane", "kernel", "area", "dimension"],
+)
+def test_result_validation_rejects_independent_mutations(mutation: str) -> None:
+    result = compute_visibility_kernel(_request(PUBLISHED_PENTAGON))
+    payload = deepcopy(result.model_dump(mode="json"))
+    if mutation == "source":
+        payload["polygon"]["points"][3]["x"] = {"num": "22175", "den": "1"}
+    elif mutation == "half_plane":
+        payload["half_planes"][0]["a"] = {"num": "9239", "den": "1"}
+    elif mutation == "kernel":
+        payload["kernel_boundary"][1]["point"]["x"] = {
+            "num": "19799",
+            "den": "1",
+        }
+    elif mutation == "area":
+        payload["kernel_area"] = {"num": "113430241", "den": "1"}
+    else:
+        payload["kernel_dimension"] = "SEGMENT"
+    with pytest.raises(ValidationError, match="does not match the retained source"):
+        PolygonKernelResult.model_validate(payload)
+
+
+def _parabola_polygon(scale: int = 1) -> list[tuple[int, int]]:
+    return [
+        (x * scale, x * x * scale)
+        for x in range(
+            -(MAX_KERNEL_SOURCE_VERTICES // 2),
+            MAX_KERNEL_SOURCE_VERTICES // 2,
+        )
+    ]
+
+
+def test_accepts_vertex_and_coordinate_boundaries() -> None:
+    polygon = _request(_parabola_polygon())
+    assert len(polygon.polygon.points) == MAX_KERNEL_SOURCE_VERTICES
+    result = compute_visibility_kernel(polygon)
+    assert result.kernel_dimension == "POLYGON"
+    assert len(result.kernel_boundary) == MAX_KERNEL_SOURCE_VERTICES
+
+    magnitude = 10 ** (MAX_KERNEL_COORDINATE_DIGITS - 1)
+    coordinate_boundary = _request([(0, 0), (magnitude, 0), (0, 1)])
+    assert coordinate_boundary.polygon.points[1].x.num == str(magnitude)
+
+
+def test_rejects_immediately_above_structural_boundaries() -> None:
+    too_many = [*_parabola_polygon(), (MAX_KERNEL_SOURCE_VERTICES, 0)]
+    with pytest.raises(ValidationError, match="at most 64 items"):
+        _request(too_many)
+
+    magnitude = 10**MAX_KERNEL_COORDINATE_DIGITS
+    with pytest.raises(ValidationError, match="64-digit visibility-kernel bound"):
+        _request([(0, 0), (magnitude, 0), (0, 1)])
+
+
+def test_rejects_derived_work_before_pairwise_expansion() -> None:
+    with pytest.raises(ValidationError, match="feasibility work"):
+        _request(_parabola_polygon(10**30))
+
+
+def test_rejects_derived_result_size_before_pairwise_expansion() -> None:
+    with pytest.raises(ValidationError, match="character bound"):
+        _request(_parabola_polygon(10**45))

--- a/tests/math/geometry/polygon_kernel/test_tools.py
+++ b/tests/math/geometry/polygon_kernel/test_tools.py
@@ -9,15 +9,15 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
-from jacobian.math.geometry.polygon_kernel import (
-    KernelPolygon,
-    PolygonKernelRequest,
-    PolygonKernelResult,
-    compute_visibility_kernel,
-)
 from jacobian.math.geometry.polygon_kernel._models import (
     MAX_KERNEL_COORDINATE_DIGITS,
     MAX_KERNEL_SOURCE_VERTICES,
+    KernelPolygon,
+    PolygonKernelRequest,
+    PolygonKernelResult,
+)
+from jacobian.math.geometry.polygon_kernel._operations import (
+    compute_visibility_kernel,
 )
 
 


### PR DESCRIPTION
## Problem

Part of #974. Jacobian could compute individual rational-polygon predicates, but it had no source-bound operation for the visibility kernel of one simple counter-clockwise polygon. Callers therefore had to assemble oriented half-planes, enumerate the lower-dimensional cases, and recompute areas themselves.

## Solution

Add `geometry.polygon.visibility_kernel.compute`. It accepts a bounded simple counter-clockwise rational polygon and returns its oriented-edge half-planes, turns/reflex vertices, exact kernel as `EMPTY`, `POINT`, `SEGMENT`, or `POLYGON`, active source edges, convex hull, exact areas, and the kernel/polygon and kernel/hull area ratios.

The kernel uses exact `Fraction` arithmetic: pairwise half-plane boundary intersections plus the polygon vertices are the complete candidate set in two dimensions. The result replays source binding, every half-plane inequality, active-edge membership, canonical cyclic order, and area/ratio identities. No generic verifier or durable certificate surface is introduced.

Perimeters and the `G-P` comparison remain out of scope because the current canonical values have no exact finite radical-sum carrier.

## Testing

- `make check` — 2,670 passed.
- Polygon-kernel and namespace tests — 28 passed.
- Catalog examples and public-operation conformance — 2 passed.
- Independent exact clipping oracle — 850 generated simple polygons matched, covering 456 empty, 1 point, and 393 polygon kernels; 250 additional cases matched area and ratio calculations.

## Public contract impact

Adds `geometry.polygon.visibility_kernel.compute` with its bounded request/result schema. Geometry remains catalog-owned: no MCP request or result model is exposed as a native-value API.

## Public operation admission

- Concrete gap: compute the complete visibility kernel and bound measures of one typed rational polygon.
- Why existing operations or typed values are insufficient: the existing primitives do not return the composed half-plane intersection, its complete dimension classification, source-edge binding, and exact measures.
- Stable mathematical result: the exact kernel of a simple counter-clockwise polygon, with its defining half-plane representation and exact area projections.
- Semantic domain and admitted execution envelope: simple counter-clockwise rational polygons with at most 64 vertices and operation-owned coordinate bounds.
- Controlling work, intermediate, memory, and output quantities: at most 64 source vertices and 4,096 boundary pairs; every candidate, active edge, serialized result, and exact coordinate is bounded before construction.
- Exact representation, algorithm regimes, and maintained backend: domain-owned exact `Fraction` arithmetic and existing canonical geometry values; this finite two-dimensional enumeration has no dependency requiring a new backend.
- Remaining fixed caps and their classification: the 64-vertex and coordinate/result limits are conservative execution-envelope caps, not a restriction on the mathematical definition.
- Admission decision: keep.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Exact polygon visibility kernel and area measures | delivered | `geometry.polygon.visibility_kernel.compute` |
| Exact perimeters and `G-P` comparison | deferred: no finite radical-sum carrier | #974 |

## Checklist

- [x] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] Public operation changes include an owner-local admission decision
- [x] Result semantics distinguish exact kernel dimensions without incomplete or unavailable states
- [x] New bounds include boundary and independent scale evidence
