### PR TITLE
fix(math): canonicalize and source-bind rational continued fractions

### DIFF
--- a/src/jacobian/math/arithmetic/_operations.py
+++ b/src/jacobian/math/arithmetic/_operations.py
@@ -193,7 +193,8 @@ def continued_fraction(
     value = _fraction(request.value)
     terms = sympy_continued_fraction(SympyRational(value.numerator, value.denominator))
     return RationalContinuedFractionResult(
-        terms=tuple(format_canonical_integer(int(term)) for term in terms)
+        value=request.value,
+        terms=tuple(format_canonical_integer(int(term)) for term in terms),
     )
 
 

--- a/src/jacobian/math/arithmetic/_rational_models.py
+++ b/src/jacobian/math/arithmetic/_rational_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -79,9 +80,47 @@ class RationalComparisonResult(StrictModel):
 
 
 class RationalContinuedFractionResult(StrictModel):
-    """The finite simple continued fraction expansion of one rational."""
+    """The canonical finite simple continued fraction of one rational.
 
+    Retains the source rational so validation replays the exact continuant
+    reconstruction and enforces the one canonical representation: every
+    partial quotient after the first is positive, and a multi-term
+    expansion never ends in ``1`` (the two-representation ambiguity is
+    resolved by merging a trailing ``[... , x, 1]`` into ``[..., x + 1]``).
+    The sign convention follows floor-based expansion, so the first term
+    carries the sign and every later term is positive; integers expand to a
+    single term.
+    """
+
+    value: CanonicalRational
     terms: tuple[CanonicalInteger, ...] = Field(
         min_length=1,
         max_length=_MAX_CONTINUED_FRACTION_TERMS,
     )
+
+    @model_validator(mode="after")
+    def require_canonical_reconstruction(self) -> Self:
+        from jacobian.canonical import parse_canonical_integer
+
+        quotients = [parse_canonical_integer(term) for term in self.terms]
+        if any(quotient < 1 for quotient in quotients[1:]):
+            raise ValueError("every partial quotient after the first must be positive")
+        if len(quotients) > 1 and quotients[-1] == 1:
+            raise ValueError("a multi-term simple continued fraction must not end in 1")
+        numerator_minus_2, numerator_minus_1 = 1, quotients[0]
+        denominator_minus_2, denominator_minus_1 = 0, 1
+        for quotient in quotients[1:]:
+            numerator_minus_2, numerator_minus_1 = (
+                numerator_minus_1,
+                quotient * numerator_minus_1 + numerator_minus_2,
+            )
+            denominator_minus_2, denominator_minus_1 = (
+                denominator_minus_1,
+                quotient * denominator_minus_1 + denominator_minus_2,
+            )
+        if Fraction(numerator_minus_1, denominator_minus_1) != self.value.as_fraction():
+            raise ValueError(
+                "terms must reconstruct the retained rational through the "
+                "continuant recurrence"
+            )
+        return self

--- a/tests/math/arithmetic/test_rational_continued_fraction.py
+++ b/tests/math/arithmetic/test_rational_continued_fraction.py
@@ -1,0 +1,73 @@
+"""Regression tests for canonical rational continued fractions (#2312)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.arithmetic._operations import continued_fraction
+from jacobian.math.arithmetic._rational_models import (
+    RationalContinuedFractionResult,
+    RationalValueRequest,
+)
+
+
+def _request(num: str, den: str) -> RationalValueRequest:
+    return RationalValueRequest(value=CanonicalRational(num=num, den=den))
+
+
+@pytest.mark.parametrize(
+    ("num", "den", "expected"),
+    (
+        ("7", "3", ("2", "3")),
+        ("-7", "3", ("-3", "1", "2")),
+        ("5", "1", ("5",)),
+        ("0", "1", ("0",)),
+        ("1", "2", ("0", "2")),
+        ("-1", "2", ("-1", "2")),
+        ("3", "1", ("3",)),
+    ),
+)
+def test_producer_emits_canonical_expansions(
+    num: str, den: str, expected: tuple[str, ...]
+) -> None:
+    result = continued_fraction(_request(num, den))
+    assert result.terms == expected
+    assert result.value == CanonicalRational(num=num, den=den)
+    assert RationalContinuedFractionResult.model_validate(result.model_dump()) == result
+
+
+def test_two_representation_boundary_is_canonical() -> None:
+    """The expansion never ends in 1; the merged form is the accepted one."""
+
+    result = continued_fraction(_request("7", "3"))
+    assert result.terms[-1] != "1"
+    with pytest.raises(ValidationError, match="must not end in 1"):
+        RationalContinuedFractionResult(
+            value=CanonicalRational(num="7", den="3"),
+            terms=("2", "2", "1"),
+        )
+
+
+def test_result_rejects_mutations() -> None:
+    with pytest.raises(ValidationError, match="must be positive"):
+        RationalContinuedFractionResult(
+            value=CanonicalRational(num="7", den="3"),
+            terms=("0", "0"),
+        )
+    with pytest.raises(ValidationError, match="continuant recurrence"):
+        RationalContinuedFractionResult(
+            value=CanonicalRational(num="7", den="3"),
+            terms=("2", "4"),
+        )
+    with pytest.raises(ValidationError, match="continuant recurrence"):
+        RationalContinuedFractionResult(
+            value=CanonicalRational(num="-7", den="3"),
+            terms=("2", "3"),
+        )
+    with pytest.raises(ValidationError, match="continuant recurrence"):
+        RationalContinuedFractionResult(
+            value=CanonicalRational(num="5", den="1"),
+            terms=("6",),
+        )


### PR DESCRIPTION
## Problem

`RationalContinuedFractionResult` accepted any nonempty integer tuple without retaining the source rational (#2312): `(0, 0)` validated although a terminal zero is noncanonical, and serialized results carried no rational to reconstruct.

## Fix

- The result retains `value`, the exact source rational.
- Validation enforces the unique canonical finite simple-CF representation:
  - every partial quotient after the first is positive;
  - a multi-term expansion never ends in 1 (resolving the two-representation ambiguity);
  - integers expand to a single term; the first term carries the sign.
- Terms must reconstruct the retained rational exactly through the continuant recurrence (replayed with pure integer arithmetic).

## Validation

- `make check` green.
- New regressions: positive/negative/zero/integer rationals; the two-representation boundary (trailing-1 rejected); source/term mutations rejected; producer→serialized-result reconstruction round-trips.

Fixes #2312