### PR TITLE
feat(logic): add bounded source-indexed SMT UNSAT cores

### DIFF
--- a/src/jacobian/math/logic/_admission.py
+++ b/src/jacobian/math/logic/_admission.py
@@ -35,6 +35,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         AdmissionDecision.KEEP,
         "distinct exact or explicitly bounded search outcome with material computational leverage",
     ),
+    OperationAdmission(
+        "smt.unsat_core",
+        AdmissionDecision.KEEP,
+        "replayable source-bound contradiction certificate with distinct proof-extraction leverage",
+    ),
 )
 
 REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/logic/_tools.py
+++ b/src/jacobian/math/logic/_tools.py
@@ -2,7 +2,8 @@
 
 from jacobian.catalog.models import MathTools
 from jacobian.math.logic._operations import LOGIC_OPERATIONS
+from jacobian.math.logic._unsat_core import SMT_UNSAT_CORE_OPERATION
 
 __all__ = ["TOOLS"]
 
-TOOLS: MathTools = LOGIC_OPERATIONS
+TOOLS: MathTools = (*LOGIC_OPERATIONS, SMT_UNSAT_CORE_OPERATION)

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from fractions import Fraction
 from typing import Any, Literal, Self
 
 from pydantic import ConfigDict, Field, StrictInt, ValidationError, model_validator
@@ -11,6 +12,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.logic._operations import (
+    SmtLogic,
     SmtSolveRequest,
     _tokenize_smtlib,
     _top_level_smtlib_commands,
@@ -22,21 +24,28 @@ _MAX_CORE_NESTING_DEPTH = 256
 _MAX_CORE_NUMERAL_DIGITS = 256
 _MAX_CORE_AST_NODES = 4_096
 _MAX_CORE_RLIMIT = 10_000_000
-_MAX_CORE_MEMORY_MB = 512
-_NUMERAL = re.compile(r"(?:[0-9]+(?:\.[0-9]+)?|#x[0-9a-fA-F]+|#b[01]+)")
+_NUMERAL = re.compile(r"(?:-?[0-9]+(?:\.[0-9]+)?|#x[0-9a-fA-F]+|#b[01]+)")
 
 
 class SmtUnsatCoreRequest(SmtSolveRequest):
     """One bounded SMT-LIB query whose top-level assertions are indexed from zero.
 
     The source uses the SMT-LIB 2 command and term grammar admitted by ``smt.solve``.
+    Terms must stay inside the selected quantifier-free fragment: QF_UF admits
+    Boolean-sorted constants and uninterpreted functions, while QF_LIA and QF_LRA
+    admit pure linear integer and real arithmetic respectively, together with
+    Boolean structure.
     Its inherited 128,000-byte ASCII envelope is further limited to 32,768 tokens,
     nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
-    nodes, and 256 digits per numeral. Assertion source order is the public
-    zero-based index. Parsing constructs Z3 syntax trees only; it does not evaluate
-    the source as Python or as a host command. Execution performs one tracked check
-    and at most one direct result-validation replay, each under the supplied timeout,
-    rlimit, and memory bound.
+    nodes, 256 digits per numeral, and 256 digits in the numerator or denominator
+    of a normalized closed arithmetic coefficient. Assertion source order is the
+    public zero-based index. Parsing constructs Z3 syntax trees only; it does not
+    evaluate the source as Python or as a host command. Execution performs one
+    tracked check and at most one direct result-validation replay, each under the
+    supplied deterministic rlimit and timeout safety net.
+    Z3 5.0 exposes only a process-global memory threshold, so this in-process
+    operation does not claim a hard request-local byte limit; fixed source, AST,
+    coefficient, and resource-unit bounds control its admitted memory envelope.
     """
 
     model_config = ConfigDict(
@@ -53,23 +62,23 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
                     ),
                     "timeout_ms": 1_000,
                     "rlimit": 100_000,
-                    "max_memory_mb": 128,
                 }
             ]
         }
     )
 
+    logic: SmtLogic = Field(
+        description=(
+            "Declared quantifier-free fragment. QF_UF is Boolean-sorted "
+            "uninterpreted functions; QF_LIA and QF_LRA are pure linear integer "
+            "and real arithmetic respectively, with Boolean structure."
+        )
+    )
     rlimit: StrictInt = Field(
         default=100_000,
         ge=1,
         le=_MAX_CORE_RLIMIT,
         description="Z3 deterministic resource-unit limit for each solver check.",
-    )
-    max_memory_mb: StrictInt = Field(
-        default=128,
-        ge=16,
-        le=_MAX_CORE_MEMORY_MB,
-        description="Z3 memory limit in megabytes for each solver check.",
     )
 
     @property
@@ -92,16 +101,13 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
             raise ValueError(
                 f"SMT core source may contain at most {_MAX_CORE_ASSERTIONS} source assertions"
             )
-        assertions = _parse_assertions(self.smtlib)
-        if len(assertions) != self.assertion_count:
-            raise ValueError(
-                "SMT-LIB parser output must preserve one term per source assertion"
-            )
-        node_count, _boolean_constants = _ast_facts(assertions)
-        if node_count > _MAX_CORE_AST_NODES:
-            raise ValueError(
-                f"SMT core source may contain at most {_MAX_CORE_AST_NODES} distinct AST nodes"
-            )
+        parsed_error = _parsed_request_error(
+            self.smtlib,
+            assertion_count=self.assertion_count,
+            logic=self.logic,
+        )
+        if parsed_error is not None:
+            raise ValueError(parsed_error)
         return self
 
 
@@ -115,7 +121,8 @@ class SmtUnsatCoreResult(StrictModel):
         max_length=_MAX_CORE_ASSERTIONS,
         description=(
             "Strictly increasing zero-based source-assertion indices. Present only "
-            "for UNSAT, when the selected assertions independently replay as UNSAT."
+            "for UNSAT, when the selected assertions independently replay as UNSAT; "
+            "the core is not promised to be minimum or inclusion-minimal."
         ),
     )
     detail: str | None = Field(default=None, max_length=1_024)
@@ -194,18 +201,39 @@ def _validate_numerals(tokens: tuple[str, ...]) -> None:
 def _parse_assertions(smtlib: str, *, context: Any | None = None) -> tuple[Any, ...]:
     import z3  # type: ignore[import-untyped]
 
-    ctx = context if context is not None else z3.Context()
     try:
+        ctx = context if context is not None else z3.Context()
         return tuple(z3.parse_smt2_string(smtlib, ctx=ctx))
     except z3.Z3Exception as exc:
         raise ValueError("SMT core source could not be parsed as SMT-LIB") from exc
 
 
-def _ast_facts(assertions: tuple[Any, ...]) -> tuple[int, frozenset[int]]:
-    import z3
+def _parsed_request_error(
+    smtlib: str,
+    *,
+    assertion_count: int,
+    logic: SmtLogic,
+) -> str | None:
+    """Inspect parsed terms without attaching Z3 objects to validation errors."""
 
+    try:
+        assertions = _parse_assertions(smtlib)
+        if len(assertions) != assertion_count:
+            return "SMT-LIB parser output must preserve one term per source assertion"
+        node_count = _ast_node_count(assertions)
+        if node_count > _MAX_CORE_AST_NODES:
+            return (
+                "SMT core source may contain at most "
+                f"{_MAX_CORE_AST_NODES} distinct AST nodes"
+            )
+        _require_declared_logic(assertions, logic)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _ast_node_count(assertions: tuple[Any, ...]) -> int:
     seen: set[int] = set()
-    boolean_constants: set[int] = set()
     stack = list(assertions)
     while stack:
         expression = stack.pop()
@@ -213,27 +241,241 @@ def _ast_facts(assertions: tuple[Any, ...]) -> tuple[int, frozenset[int]]:
         if expression_id in seen:
             continue
         seen.add(expression_id)
-        if z3.is_const(expression) and z3.is_bool(expression):
-            boolean_constants.add(expression_id)
         if len(seen) > _MAX_CORE_AST_NODES:
-            return len(seen), frozenset(boolean_constants)
+            return len(seen)
         stack.extend(expression.children())
-    return len(seen), frozenset(boolean_constants)
+    return len(seen)
 
 
-def _tracking_literals(assertions: tuple[Any, ...], *, context: Any) -> tuple[Any, ...]:
+def _require_declared_logic(
+    assertions: tuple[Any, ...],
+    logic: SmtLogic,
+) -> None:
+    """Reject parsed terms outside the request's advertised QF fragment."""
+
+    if not assertions:
+        return
+
     import z3
 
-    _node_count, used_boolean_constants = _ast_facts(assertions)
-    trackers: list[Any] = []
-    for index in range(len(assertions)):
-        name = f"jacobian_unsat_core_{index}"
-        tracker = z3.Bool(name, ctx=context)
-        while tracker.get_id() in used_boolean_constants:
-            name += "_"
-            tracker = z3.Bool(name, ctx=context)
-        trackers.append(tracker)
-    return tuple(trackers)
+    try:
+        if logic is SmtLogic.QF_UF:
+            if not _is_boolean_uninterpreted_fragment(assertions):
+                raise ValueError(
+                    "SMT core terms must belong to the declared QF_UF fragment"
+                )
+            return
+
+        classified_assertions = _normalize_closed_coefficients(assertions)
+        goal = z3.Goal(ctx=assertions[0].ctx)
+        goal.add(*classified_assertions)
+        probe_name = "is-lia" if logic is SmtLogic.QF_LIA else "is-lra"
+        has_quantifiers = float(
+            z3.Probe("has-quantifiers", ctx=assertions[0].ctx)(goal)
+        )
+        belongs_to_fragment = float(z3.Probe(probe_name, ctx=assertions[0].ctx)(goal))
+        if has_quantifiers != 0.0 or belongs_to_fragment != 1.0:
+            raise ValueError(
+                f"SMT core terms must belong to the declared {logic.value} fragment"
+            )
+    except z3.Z3Exception as exc:
+        raise ValueError(
+            f"SMT core terms could not be classified as {logic.value}"
+        ) from exc
+
+
+def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ...]:
+    """Normalize only bounded exact arithmetic subterms with no variables."""
+
+    normalized_by_id: dict[int, Any] = {}
+    closed_value_by_id: dict[int, Fraction | None] = {}
+    return tuple(
+        _normalize_closed_expression(
+            assertion,
+            normalized_by_id=normalized_by_id,
+            closed_value_by_id=closed_value_by_id,
+        )
+        for assertion in assertions
+    )
+
+
+def _normalize_closed_expression(
+    expression: Any,
+    *,
+    normalized_by_id: dict[int, Any],
+    closed_value_by_id: dict[int, Fraction | None],
+) -> Any:
+    """Normalize one expression without retaining a recursive closure over its AST."""
+
+    import z3
+
+    expression_id = expression.get_id()
+    if expression_id in normalized_by_id:
+        return normalized_by_id[expression_id]
+    if z3.is_int_value(expression):
+        normalized_by_id[expression_id] = expression
+        closed_value_by_id[expression_id] = Fraction(expression.as_long())
+        return expression
+    if z3.is_rational_value(expression):
+        normalized_by_id[expression_id] = expression
+        closed_value_by_id[expression_id] = expression.as_fraction()
+        return expression
+    if not z3.is_app(expression):
+        normalized_by_id[expression_id] = expression
+        closed_value_by_id[expression_id] = None
+        return expression
+
+    children = expression.children()
+    normalized_children = tuple(
+        _normalize_closed_expression(
+            child,
+            normalized_by_id=normalized_by_id,
+            closed_value_by_id=closed_value_by_id,
+        )
+        for child in children
+    )
+    if any(
+        not original.eq(normalized)
+        for original, normalized in zip(children, normalized_children, strict=True)
+    ):
+        candidate = expression.decl()(*normalized_children)
+    else:
+        candidate = expression
+
+    child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
+    if candidate.decl().kind() == z3.Z3_OP_MUL:
+        dependent_children = tuple(
+            normalized_child
+            for normalized_child, value in zip(
+                normalized_children, child_values, strict=True
+            )
+            if value is None
+        )
+        closed_factors = tuple(value for value in child_values if value is not None)
+        if len(dependent_children) == 1 and closed_factors:
+            coefficient = _bounded_fraction_product(closed_factors)
+            candidate = candidate.decl()(
+                _exact_arithmetic_value(coefficient, template=candidate),
+                dependent_children[0],
+            )
+
+    closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
+    if closed_value is not None:
+        candidate = _exact_arithmetic_value(closed_value, template=candidate)
+
+    normalized_by_id[expression_id] = candidate
+    closed_value_by_id[expression_id] = closed_value
+    return candidate
+
+
+def _evaluate_closed_arithmetic(
+    kind: int,
+    values: tuple[Fraction | None, ...],
+) -> Fraction | None:
+    import z3
+
+    if not values or any(value is None for value in values):
+        return None
+    exact_values = tuple(value for value in values if value is not None)
+    if kind == z3.Z3_OP_ADD:
+        total = Fraction()
+        for value in exact_values:
+            total += value
+            _require_bounded_normalized_coefficient(total)
+        return total
+    if kind == z3.Z3_OP_SUB:
+        difference = exact_values[0]
+        for value in exact_values[1:]:
+            difference -= value
+            _require_bounded_normalized_coefficient(difference)
+        return difference
+    if kind == z3.Z3_OP_UMINUS:
+        return -exact_values[0]
+    if kind == z3.Z3_OP_MUL:
+        return _bounded_fraction_product(exact_values)
+    if kind == z3.Z3_OP_DIV and len(exact_values) == 2 and exact_values[1]:
+        return exact_values[0] / exact_values[1]
+    return None
+
+
+def _bounded_fraction_product(values: tuple[Fraction, ...]) -> Fraction:
+    product = Fraction(1)
+    for value in values:
+        product *= value
+        _require_bounded_normalized_coefficient(product)
+    return product
+
+
+def _exact_arithmetic_value(value: Fraction, *, template: Any) -> Any:
+    import z3
+
+    _require_bounded_normalized_coefficient(value)
+    if template.sort().kind() == z3.Z3_INT_SORT:
+        if value.denominator != 1:
+            raise ValueError("normalized integer coefficient must remain integral")
+        return z3.IntVal(value.numerator, ctx=template.ctx)
+    if template.sort().kind() == z3.Z3_REAL_SORT:
+        return z3.RealVal(
+            f"{value.numerator}/{value.denominator}",
+            ctx=template.ctx,
+        )
+    raise ValueError("normalized coefficient must have an arithmetic sort")
+
+
+def _require_bounded_normalized_coefficient(value: Fraction) -> None:
+    if any(
+        len(str(abs(component))) > _MAX_CORE_NUMERAL_DIGITS
+        for component in (value.numerator, value.denominator)
+    ):
+        raise ValueError(
+            "normalized SMT coefficient numerator and denominator may contain at "
+            f"most {_MAX_CORE_NUMERAL_DIGITS} digits"
+        )
+
+
+def _is_boolean_uninterpreted_fragment(assertions: tuple[Any, ...]) -> bool:
+    import z3
+
+    allowed_kinds = frozenset(
+        {
+            z3.Z3_OP_TRUE,
+            z3.Z3_OP_FALSE,
+            z3.Z3_OP_EQ,
+            z3.Z3_OP_DISTINCT,
+            z3.Z3_OP_ITE,
+            z3.Z3_OP_AND,
+            z3.Z3_OP_OR,
+            z3.Z3_OP_XOR,
+            z3.Z3_OP_NOT,
+            z3.Z3_OP_IMPLIES,
+            z3.Z3_OP_UNINTERPRETED,
+        }
+    )
+    seen: set[int] = set()
+    stack = list(assertions)
+    while stack:
+        expression = stack.pop()
+        expression_id = expression.get_id()
+        if expression_id in seen:
+            continue
+        seen.add(expression_id)
+        if (
+            not z3.is_app(expression)
+            or not z3.is_bool(expression)
+            or expression.decl().kind() not in allowed_kinds
+        ):
+            return False
+        stack.extend(expression.children())
+    return True
+
+
+def _tracking_literals(assertion_count: int, *, context: Any) -> tuple[Any, ...]:
+    import z3
+
+    return tuple(
+        z3.FreshBool(f"jacobian_unsat_core_{index}", ctx=context)
+        for index in range(assertion_count)
+    )
 
 
 def _configured_solver(source: SmtUnsatCoreRequest, *, context: Any) -> Any:
@@ -243,7 +485,6 @@ def _configured_solver(source: SmtUnsatCoreRequest, *, context: Any) -> Any:
     solver.set(
         timeout=source.timeout_ms,
         rlimit=source.rlimit,
-        max_memory=source.max_memory_mb,
         random_seed=0,
         unsat_core=True,
     )
@@ -269,28 +510,29 @@ def _extract_source_core(
 ) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], tuple[int, ...], str | None]:
     import z3
 
-    context = z3.Context()
     try:
+        context = z3.Context()
         assertions = _parse_assertions(source.smtlib, context=context)
         solver = _configured_solver(source, context=context)
-        trackers = _tracking_literals(assertions, context=context)
+        trackers = _tracking_literals(len(assertions), context=context)
         for assertion, tracker in zip(assertions, trackers, strict=True):
             solver.assert_and_track(assertion, tracker)
         outcome, detail = _bounded_outcome(solver)
+        if outcome != "UNSAT":
+            return outcome, (), detail
+
+        core_ids = {literal.get_id() for literal in solver.unsat_core()}
+        tracker_ids = {tracker.get_id() for tracker in trackers}
+        if not core_ids or not core_ids <= tracker_ids:
+            return "UNKNOWN", (), "Z3 returned an unusable UNSAT core."
+        core_indices = tuple(
+            index
+            for index, tracker in enumerate(trackers)
+            if tracker.get_id() in core_ids
+        )
+        return "UNSAT", core_indices, None
     except (ValueError, z3.Z3Exception):
         return "UNKNOWN", (), "Z3 could not complete the bounded source check."
-
-    if outcome != "UNSAT":
-        return outcome, (), detail
-
-    core_ids = {literal.get_id() for literal in solver.unsat_core()}
-    tracker_ids = {tracker.get_id() for tracker in trackers}
-    if not core_ids or not core_ids <= tracker_ids:
-        return "UNKNOWN", (), "Z3 returned an unusable UNSAT core."
-    core_indices = tuple(
-        index for index, tracker in enumerate(trackers) if tracker.get_id() in core_ids
-    )
-    return "UNSAT", core_indices, None
 
 
 def _replay_source(
@@ -299,8 +541,8 @@ def _replay_source(
 ) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], str | None]:
     import z3
 
-    context = z3.Context()
     try:
+        context = z3.Context()
         assertions = _parse_assertions(source.smtlib, context=context)
         selected = (
             tuple(range(len(assertions)))
@@ -338,8 +580,9 @@ SMT_UNSAT_CORE_OPERATION = MathTool(
     version="1",
     title="Extract a bounded indexed SMT UNSAT core",
     description=(
-        "Return SAT, UNKNOWN, or source-order indices of assertions whose exact "
-        "subsystem replays as UNSAT through the maintained Z3 Python binding."
+        "Return SAT, UNKNOWN, or a deterministic backend-selected set of source-order "
+        "assertion indices whose exact subsystem replays as UNSAT through the "
+        "maintained Z3 Python binding. The core need not be minimal."
     ),
     request_type=SmtUnsatCoreRequest,
     result_type=SmtUnsatCoreResult,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -38,7 +38,8 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     Its inherited 128,000-byte ASCII envelope is further limited to 32,768 tokens,
     nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
     nodes, 256 digits per numeral, and 256 digits in the numerator or denominator
-    of a normalized closed arithmetic coefficient. Assertion source order is the
+    of any closed arithmetic coefficient, including the complete scalar coefficient
+    obtained by flattening nested products. Assertion source order is the
     public zero-based index. Parsing constructs Z3 syntax trees only; it does not
     evaluate the source as Python or as a host command. Execution performs one
     tracked check and at most one direct result-validation replay, each under the
@@ -289,11 +290,15 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
 
     normalized_by_id: dict[int, Any] = {}
     closed_value_by_id: dict[int, Fraction | None] = {}
+    scalar_by_id: dict[int, Fraction | None] = {}
+    residual_by_id: dict[int, Any] = {}
     return tuple(
         _normalize_closed_expression(
             assertion,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
+            scalar_by_id=scalar_by_id,
+            residual_by_id=residual_by_id,
         )
         for assertion in assertions
     )
@@ -304,6 +309,8 @@ def _normalize_closed_expression(
     *,
     normalized_by_id: dict[int, Any],
     closed_value_by_id: dict[int, Fraction | None],
+    scalar_by_id: dict[int, Fraction | None],
+    residual_by_id: dict[int, Any],
 ) -> Any:
     """Normalize one expression without retaining a recursive closure over its AST."""
 
@@ -313,16 +320,21 @@ def _normalize_closed_expression(
     if expression_id in normalized_by_id:
         return normalized_by_id[expression_id]
     if z3.is_int_value(expression):
+        value = Fraction(expression.as_long())
         normalized_by_id[expression_id] = expression
-        closed_value_by_id[expression_id] = Fraction(expression.as_long())
+        closed_value_by_id[expression_id] = value
+        scalar_by_id[expression_id] = value
         return expression
     if z3.is_rational_value(expression):
+        value = expression.as_fraction()
         normalized_by_id[expression_id] = expression
-        closed_value_by_id[expression_id] = expression.as_fraction()
+        closed_value_by_id[expression_id] = value
+        scalar_by_id[expression_id] = value
         return expression
     if not z3.is_app(expression):
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
+        scalar_by_id[expression_id] = None
         return expression
 
     children = expression.children()
@@ -331,6 +343,8 @@ def _normalize_closed_expression(
             child,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
+            scalar_by_id=scalar_by_id,
+            residual_by_id=residual_by_id,
         )
         for child in children
     )
@@ -343,6 +357,8 @@ def _normalize_closed_expression(
         candidate = expression
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
+    folded_coefficient: Fraction | None = None
+    folded_dependent: Any | None = None
     if candidate.decl().kind() == z3.Z3_OP_MUL:
         dependent_children = tuple(
             normalized_child
@@ -352,12 +368,27 @@ def _normalize_closed_expression(
             if value is None
         )
         closed_factors = tuple(value for value in child_values if value is not None)
+        dependent_scalar: Fraction | None = None
+        for child, child_value in zip(children, child_values, strict=True):
+            if child_value is None:
+                dependent_scalar = scalar_by_id[child.get_id()]
+                break
         if len(dependent_children) == 1 and closed_factors:
-            coefficient = _bounded_fraction_product(closed_factors)
+            factors = (
+                (*closed_factors, dependent_scalar)
+                if dependent_scalar is not None
+                else closed_factors
+            )
+            coefficient = _bounded_fraction_product(factors)
+            dependent = dependent_children[0]
+            while (residual := residual_by_id.get(dependent.get_id())) is not None:
+                dependent = residual
             candidate = candidate.decl()(
                 _exact_arithmetic_value(coefficient, template=candidate),
-                dependent_children[0],
+                dependent,
             )
+            folded_coefficient = coefficient
+            folded_dependent = dependent
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
     if closed_value is not None:
@@ -365,6 +396,12 @@ def _normalize_closed_expression(
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
+    scalar_by_id[expression_id] = (
+        closed_value if closed_value is not None else folded_coefficient
+    )
+    if folded_dependent is not None:
+        residual_by_id[expression_id] = folded_dependent
+        residual_by_id[candidate.get_id()] = folded_dependent
     return candidate
 
 

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -739,6 +739,10 @@ def _signed_sum_envelope(
     numerator_digits = widest_numerator + len(str(len(envelopes)))
     if shared is not None:
         denominator_digits = min(denominator_digits, len(str(shared)))
+        merged_numerator = (
+            sum(10**envelope.numerator_digits for envelope in envelopes) * shared
+        )
+        numerator_digits = min(numerator_digits, len(str(merged_numerator)))
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -474,17 +474,27 @@ def _normalize_closed_expression(
         )
     if closed_value is not None:
         envelope = _closed_value_envelope(closed_value)
+    elif scaled_envelope is not None:
+        envelope = scaled_envelope
+    elif form is not None:
+        envelope = _affine_form_envelope(
+            form,
+            height=_coefficient_height(
+                candidate.decl().kind(),
+                children,
+                child_values,
+                envelope_by_id=envelope_by_id,
+                enforce_digit_budget=False,
+            ).height,
+        )
     else:
         envelope = _coefficient_height(
             candidate.decl().kind(),
             children,
             child_values,
             envelope_by_id=envelope_by_id,
+            enforce_digit_budget=True,
         )
-        if scaled_envelope is not None:
-            envelope = scaled_envelope
-        elif form is not None:
-            envelope = _affine_form_envelope(form, height=envelope.height)
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
@@ -556,6 +566,7 @@ def _coefficient_height(
     child_values: tuple[Fraction | None, ...],
     *,
     envelope_by_id: dict[int, _CoefficientEnvelope],
+    enforce_digit_budget: bool,
 ) -> _CoefficientEnvelope:
     """Bound every coefficient reachable in one expression's linear reading.
 
@@ -564,7 +575,9 @@ def _coefficient_height(
     numerator and denominator digit budget, so a numerically smaller reciprocal
     branch cannot hide denominator growth from later scaling. Products multiply
     envelopes and signed sums merge them, matching every scalar the preserving
-    wrappers can derive downstream.
+    wrappers can derive downstream. Divisions by closed constants compose their
+    budgets into one coefficient, so they validate those budgets unless an
+    exact flattened form already validates every quotient.
     """
 
     import z3
@@ -588,7 +601,10 @@ def _coefficient_height(
         and child_values[1] != 0
     ):
         return _divided_envelope(
-            child_envelopes[0], child_values[1], exact=kind == z3.Z3_OP_DIV
+            child_envelopes[0],
+            child_values[1],
+            exact=kind == z3.Z3_OP_DIV,
+            validate_budget=enforce_digit_budget,
         )
     if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
         return _signed_sum_envelope(child_envelopes)
@@ -619,6 +635,7 @@ def _divided_envelope(
     divisor: Fraction,
     *,
     exact: bool,
+    validate_budget: bool,
 ) -> _CoefficientEnvelope:
     """Divide one envelope by a closed nonzero constant, SMT-LIB div included."""
 
@@ -629,6 +646,11 @@ def _divided_envelope(
         scaled += 1
         numerator_digits += 1
     _require_bounded_normalized_coefficient(scaled)
+    if validate_budget:
+        _require_bounded_coefficient_digit_budget(
+            numerator_digits,
+            denominator_digits,
+        )
     return _CoefficientEnvelope(scaled, numerator_digits, denominator_digits)
 
 

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -343,9 +343,7 @@ def _fold_scaled_product(
 
     if candidate.decl().kind() != z3.Z3_OP_MUL:
         return candidate, None
-    open_indices = [
-        index for index, value in enumerate(child_values) if value is None
-    ]
+    open_indices = [index for index, value in enumerate(child_values) if value is None]
     if len(open_indices) != 1:
         return candidate, None
     dependent = children[open_indices[0]]

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -631,6 +631,18 @@ def _coefficient_height(
             child_envelopes,
             validate_budget=enforce_digit_budget,
         )
+    if kind in (
+        z3.Z3_OP_EQ,
+        z3.Z3_OP_DISTINCT,
+        z3.Z3_OP_LE,
+        z3.Z3_OP_LT,
+        z3.Z3_OP_GE,
+        z3.Z3_OP_GT,
+    ):
+        return _compared_envelope(
+            child_envelopes,
+            validate_budget=enforce_digit_budget,
+        )
     height = Fraction(0)
     for envelope in child_envelopes:
         height += envelope.height
@@ -743,6 +755,35 @@ def _signed_sum_envelope(
             sum(10**envelope.numerator_digits for envelope in envelopes) * shared
         )
         numerator_digits = min(numerator_digits, len(str(merged_numerator)))
+    if validate_budget:
+        _require_bounded_coefficient_digit_budget(
+            numerator_digits,
+            denominator_digits,
+        )
+    return _CoefficientEnvelope(height, numerator_digits, denominator_digits, shared)
+
+
+def _compared_envelope(
+    envelopes: tuple[_CoefficientEnvelope, ...],
+    *,
+    validate_budget: bool,
+) -> _CoefficientEnvelope:
+    """Bound the difference an arithmetic comparison forms between its sides."""
+
+    height = Fraction(0)
+    for envelope in envelopes:
+        height += envelope.height
+        _require_bounded_normalized_coefficient(height)
+    shared = _shared_common_denominator(
+        tuple(envelope.common_denominator for envelope in envelopes)
+    )
+    denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
+    numerator_digits = max(
+        (envelope.numerator_digits for envelope in envelopes), default=0
+    )
+    if shared is not None:
+        denominator_digits = min(denominator_digits, len(str(shared)))
+        numerator_digits = min(numerator_digits, len(str(shared)) + numerator_digits)
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -1,0 +1,375 @@
+"""Bounded source-indexed SMT unsatisfiable cores."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, Self
+
+from pydantic import ConfigDict, Field, StrictInt, ValidationError, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.logic._operations import (
+    SmtSolveRequest,
+    _tokenize_smtlib,
+    _top_level_smtlib_commands,
+)
+
+_MAX_CORE_ASSERTIONS = 512
+_MAX_CORE_TOKENS = 32_768
+_MAX_CORE_NESTING_DEPTH = 256
+_MAX_CORE_NUMERAL_DIGITS = 256
+_MAX_CORE_AST_NODES = 4_096
+_MAX_CORE_RLIMIT = 10_000_000
+_MAX_CORE_MEMORY_MB = 512
+_NUMERAL = re.compile(r"(?:[0-9]+(?:\.[0-9]+)?|#x[0-9a-fA-F]+|#b[01]+)")
+
+
+class SmtUnsatCoreRequest(SmtSolveRequest):
+    """One bounded SMT-LIB query whose top-level assertions are indexed from zero.
+
+    The source uses the SMT-LIB 2 command and term grammar admitted by ``smt.solve``.
+    Its inherited 128,000-byte ASCII envelope is further limited to 32,768 tokens,
+    nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
+    nodes, and 256 digits per numeral. Assertion source order is the public
+    zero-based index. Parsing constructs Z3 syntax trees only; it does not evaluate
+    the source as Python or as a host command. Execution performs one tracked check
+    and at most one direct result-validation replay, each under the supplied timeout,
+    rlimit, and memory bound.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "logic": "QF_LIA",
+                    "smtlib": (
+                        "(set-logic QF_LIA)\n"
+                        "(declare-const x Int)\n"
+                        "(assert (>= x 1))\n"
+                        "(assert (<= x 0))\n"
+                        "(check-sat)"
+                    ),
+                    "timeout_ms": 1_000,
+                    "rlimit": 100_000,
+                    "max_memory_mb": 128,
+                }
+            ]
+        }
+    )
+
+    rlimit: StrictInt = Field(
+        default=100_000,
+        ge=1,
+        le=_MAX_CORE_RLIMIT,
+        description="Z3 deterministic resource-unit limit for each solver check.",
+    )
+    max_memory_mb: StrictInt = Field(
+        default=128,
+        ge=16,
+        le=_MAX_CORE_MEMORY_MB,
+        description="Z3 memory limit in megabytes for each solver check.",
+    )
+
+    @property
+    def assertion_count(self) -> int:
+        return sum(
+            command[:1] == ("assert",)
+            for command in _top_level_smtlib_commands(self.smtlib)
+        )
+
+    @model_validator(mode="after")
+    def require_bounded_indexed_assertions(self) -> Self:
+        tokens = _tokenize_smtlib(self.smtlib)
+        if len(tokens) > _MAX_CORE_TOKENS:
+            raise ValueError(
+                f"SMT core source may contain at most {_MAX_CORE_TOKENS} tokens"
+            )
+        _validate_nesting(tokens)
+        _validate_numerals(tokens)
+        if self.assertion_count > _MAX_CORE_ASSERTIONS:
+            raise ValueError(
+                f"SMT core source may contain at most {_MAX_CORE_ASSERTIONS} source assertions"
+            )
+        assertions = _parse_assertions(self.smtlib)
+        if len(assertions) != self.assertion_count:
+            raise ValueError(
+                "SMT-LIB parser output must preserve one term per source assertion"
+            )
+        node_count, _boolean_constants = _ast_facts(assertions)
+        if node_count > _MAX_CORE_AST_NODES:
+            raise ValueError(
+                f"SMT core source may contain at most {_MAX_CORE_AST_NODES} distinct AST nodes"
+            )
+        return self
+
+
+class SmtUnsatCoreResult(StrictModel):
+    """A source-bound satisfiability outcome and replayable UNSAT core."""
+
+    source: SmtUnsatCoreRequest
+    outcome: Literal["SAT", "UNSAT", "UNKNOWN"]
+    core_indices: tuple[StrictInt, ...] = Field(
+        default=(),
+        max_length=_MAX_CORE_ASSERTIONS,
+        description=(
+            "Strictly increasing zero-based source-assertion indices. Present only "
+            "for UNSAT, when the selected assertions independently replay as UNSAT."
+        ),
+    )
+    detail: str | None = Field(default=None, max_length=1_024)
+
+    @model_validator(mode="after")
+    def bind_outcome_to_source(self) -> Self:
+        if self.core_indices != tuple(sorted(set(self.core_indices))):
+            raise ValueError("core indices must be distinct and strictly increasing")
+        if any(
+            index < 0 or index >= self.source.assertion_count
+            for index in self.core_indices
+        ):
+            raise ValueError("core index does not refer to a source assertion")
+
+        if self.outcome == "UNSAT":
+            if not self.core_indices:
+                raise ValueError(
+                    "UNSAT requires a nonempty core because the source has no untracked assertions"
+                )
+            replay, _detail = _replay_source(self.source, self.core_indices)
+            if replay != "UNSAT":
+                raise ValueError(
+                    "selected source assertions must independently replay as UNSAT"
+                )
+        elif self.outcome == "SAT":
+            if self.core_indices:
+                raise ValueError("SAT cannot carry core indices")
+            replay, _detail = _replay_source(self.source, None)
+            if replay != "SAT":
+                raise ValueError(
+                    "complete source assertions must independently replay as SAT"
+                )
+        else:
+            if self.core_indices:
+                raise ValueError("UNKNOWN cannot carry core indices")
+            if not self.detail:
+                raise ValueError("UNKNOWN must explain the bounded execution outcome")
+
+        if self.outcome != "UNKNOWN" and self.detail is not None:
+            raise ValueError("only UNKNOWN may carry execution detail")
+        return self
+
+
+def _validate_nesting(tokens: tuple[str, ...]) -> None:
+    depth = 0
+    for token in tokens:
+        if token == "(":
+            depth += 1
+            if depth > _MAX_CORE_NESTING_DEPTH:
+                raise ValueError(
+                    f"SMT core source nesting may not exceed {_MAX_CORE_NESTING_DEPTH}"
+                )
+        elif token == ")":
+            depth -= 1
+            if depth < 0:
+                raise ValueError("SMT core source parentheses must be balanced")
+    if depth:
+        raise ValueError("SMT core source parentheses must be balanced")
+
+
+def _validate_numerals(tokens: tuple[str, ...]) -> None:
+    for token in tokens:
+        if _NUMERAL.fullmatch(token) is None:
+            continue
+        digits = (
+            len(token[2:])
+            if token.startswith(("#x", "#b"))
+            else sum(character.isdigit() for character in token)
+        )
+        if digits > _MAX_CORE_NUMERAL_DIGITS:
+            raise ValueError(
+                f"SMT numeral may contain at most {_MAX_CORE_NUMERAL_DIGITS} digits"
+            )
+
+
+def _parse_assertions(smtlib: str, *, context: Any | None = None) -> tuple[Any, ...]:
+    import z3  # type: ignore[import-untyped]
+
+    ctx = context if context is not None else z3.Context()
+    try:
+        return tuple(z3.parse_smt2_string(smtlib, ctx=ctx))
+    except z3.Z3Exception as exc:
+        raise ValueError("SMT core source could not be parsed as SMT-LIB") from exc
+
+
+def _ast_facts(assertions: tuple[Any, ...]) -> tuple[int, frozenset[int]]:
+    import z3
+
+    seen: set[int] = set()
+    boolean_constants: set[int] = set()
+    stack = list(assertions)
+    while stack:
+        expression = stack.pop()
+        expression_id = expression.get_id()
+        if expression_id in seen:
+            continue
+        seen.add(expression_id)
+        if z3.is_const(expression) and z3.is_bool(expression):
+            boolean_constants.add(expression_id)
+        if len(seen) > _MAX_CORE_AST_NODES:
+            return len(seen), frozenset(boolean_constants)
+        stack.extend(expression.children())
+    return len(seen), frozenset(boolean_constants)
+
+
+def _tracking_literals(assertions: tuple[Any, ...], *, context: Any) -> tuple[Any, ...]:
+    import z3
+
+    _node_count, used_boolean_constants = _ast_facts(assertions)
+    trackers: list[Any] = []
+    for index in range(len(assertions)):
+        name = f"jacobian_unsat_core_{index}"
+        tracker = z3.Bool(name, ctx=context)
+        while tracker.get_id() in used_boolean_constants:
+            name += "_"
+            tracker = z3.Bool(name, ctx=context)
+        trackers.append(tracker)
+    return tuple(trackers)
+
+
+def _configured_solver(source: SmtUnsatCoreRequest, *, context: Any) -> Any:
+    import z3
+
+    solver = z3.SolverFor(source.logic.value, ctx=context)
+    solver.set(
+        timeout=source.timeout_ms,
+        rlimit=source.rlimit,
+        max_memory=source.max_memory_mb,
+        random_seed=0,
+        unsat_core=True,
+    )
+    return solver
+
+
+def _bounded_outcome(
+    solver: Any,
+) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], str | None]:
+    import z3
+
+    outcome = solver.check()
+    if outcome == z3.sat:
+        return "SAT", None
+    if outcome == z3.unsat:
+        return "UNSAT", None
+    detail = solver.reason_unknown().strip() or "Z3 returned UNKNOWN."
+    return "UNKNOWN", detail[:1_024]
+
+
+def _extract_source_core(
+    source: SmtUnsatCoreRequest,
+) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], tuple[int, ...], str | None]:
+    import z3
+
+    context = z3.Context()
+    try:
+        assertions = _parse_assertions(source.smtlib, context=context)
+        solver = _configured_solver(source, context=context)
+        trackers = _tracking_literals(assertions, context=context)
+        for assertion, tracker in zip(assertions, trackers, strict=True):
+            solver.assert_and_track(assertion, tracker)
+        outcome, detail = _bounded_outcome(solver)
+    except (ValueError, z3.Z3Exception):
+        return "UNKNOWN", (), "Z3 could not complete the bounded source check."
+
+    if outcome != "UNSAT":
+        return outcome, (), detail
+
+    core_ids = {literal.get_id() for literal in solver.unsat_core()}
+    tracker_ids = {tracker.get_id() for tracker in trackers}
+    if not core_ids or not core_ids <= tracker_ids:
+        return "UNKNOWN", (), "Z3 returned an unusable UNSAT core."
+    core_indices = tuple(
+        index for index, tracker in enumerate(trackers) if tracker.get_id() in core_ids
+    )
+    return "UNSAT", core_indices, None
+
+
+def _replay_source(
+    source: SmtUnsatCoreRequest,
+    selected_indices: tuple[int, ...] | None,
+) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], str | None]:
+    import z3
+
+    context = z3.Context()
+    try:
+        assertions = _parse_assertions(source.smtlib, context=context)
+        selected = (
+            tuple(range(len(assertions)))
+            if selected_indices is None
+            else selected_indices
+        )
+        solver = _configured_solver(source, context=context)
+        solver.add(*(assertions[index] for index in selected))
+        return _bounded_outcome(solver)
+    except (ValueError, z3.Z3Exception):
+        return "UNKNOWN", "Z3 could not complete the bounded source replay."
+
+
+def compute_smt_unsat_core(request: SmtUnsatCoreRequest) -> SmtUnsatCoreResult:
+    """Return a bounded core of source-assertion indices when Z3 proves UNSAT."""
+
+    outcome, core_indices, detail = _extract_source_core(request)
+    try:
+        return SmtUnsatCoreResult(
+            source=request,
+            outcome=outcome,
+            core_indices=core_indices,
+            detail=detail,
+        )
+    except ValidationError:
+        return SmtUnsatCoreResult(
+            source=request,
+            outcome="UNKNOWN",
+            detail="The bounded result-validation replay did not establish the conclusion.",
+        )
+
+
+SMT_UNSAT_CORE_OPERATION = MathTool(
+    operation_id="smt.unsat_core",
+    version="1",
+    title="Extract a bounded indexed SMT UNSAT core",
+    description=(
+        "Return SAT, UNKNOWN, or source-order indices of assertions whose exact "
+        "subsystem replays as UNSAT through the maintained Z3 Python binding."
+    ),
+    request_type=SmtUnsatCoreRequest,
+    result_type=SmtUnsatCoreResult,
+    run=compute_smt_unsat_core,
+    tags=("smt", "unsat", "core", "constraints", "z3"),
+    examples=(
+        example(
+            "contradictory_integer_bounds",
+            (
+                "Extract an indexed core from contradictory integer bounds; the "
+                "SMT-LIB source must end in one check-sat and uses zero-based assertion indices."
+            ),
+            {
+                "logic": "QF_LIA",
+                "smtlib": (
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    "(assert (>= x 1))\n"
+                    "(assert (<= x 0))\n"
+                    "(assert (<= x 10))\n"
+                    "(check-sat)"
+                ),
+            },
+        ),
+    ),
+)
+
+__all__ = [
+    "SMT_UNSAT_CORE_OPERATION",
+    "SmtUnsatCoreRequest",
+    "SmtUnsatCoreResult",
+    "compute_smt_unsat_core",
+]

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -69,17 +69,16 @@ def _capped_pairs(
 def _merged_pairs(
     *pair_lists: tuple[tuple[int, int], ...] | None,
 ) -> tuple[tuple[int, int], ...] | None:
-    """Union reachable coefficient pairs, keeping the widest per denominator."""
+    """Union reachable coefficient pairs without collapsing any of them."""
 
-    numerators_by_denominator: dict[int, int] = {}
+    merged: set[tuple[int, int]] = set()
     for pair_list in pair_lists:
         if pair_list is None:
             return None
-        for numerator, denominator in pair_list:
-            numerators_by_denominator[denominator] = max(
-                numerators_by_denominator.get(denominator, 0), numerator
-            )
-    return _capped_pairs(numerators_by_denominator)
+        merged.update(pair_list)
+    if len(merged) > _MAX_ENVELOPE_PAIRS:
+        return None
+    return tuple(sorted(merged))
 
 
 def _pairs_common_denominator(
@@ -856,7 +855,7 @@ def _compared_envelope(
         _require_bounded_normalized_coefficient(height)
     shared = _shared_denominator_of_pairs(envelopes)
     if shared is None:
-        fallback = _signed_sum_envelope(envelopes, validate_budget=False)
+        fallback = _signed_sum_envelope(envelopes, validate_budget=validate_budget)
         return _CoefficientEnvelope(
             height,
             fallback.numerator_digits,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -39,7 +39,9 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
     nodes, 256 digits per numeral, and 256 digits in the numerator or denominator
     of any closed arithmetic coefficient, including the complete scalar coefficient
-    obtained by flattening nested products. Assertion source order is the
+    obtained by flattening nested products and coefficient-preserving wrappers
+    (negation, unary addition, and exact division by closed constants).
+    Assertion source order is the
     public zero-based index. Parsing constructs Z3 syntax trees only; it does not
     evaluate the source as Python or as a host command. Execution performs one
     tracked check and at most one direct result-validation replay, each under the
@@ -394,15 +396,69 @@ def _normalize_closed_expression(
     if closed_value is not None:
         candidate = _exact_arithmetic_value(closed_value, template=candidate)
 
+    scalar = closed_value if closed_value is not None else folded_coefficient
+    if scalar is None:
+        scalar = _wrapped_linear_scalar(
+            candidate,
+            children,
+            child_values,
+            scalar_by_id=scalar_by_id,
+            residual_by_id=residual_by_id,
+        )
+
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
-    scalar_by_id[expression_id] = (
-        closed_value if closed_value is not None else folded_coefficient
-    )
+    scalar_by_id[expression_id] = scalar
     if folded_dependent is not None:
         residual_by_id[expression_id] = folded_dependent
         residual_by_id[candidate.get_id()] = folded_dependent
     return candidate
+
+
+def _chased_residual(dependent: Any, residual_by_id: dict[int, Any]) -> Any:
+    core = dependent
+    while (residual := residual_by_id.get(core.get_id())) is not None:
+        core = residual
+    return core
+
+
+def _wrapped_linear_scalar(
+    candidate: Any,
+    children: tuple[Any, ...],
+    child_values: tuple[Fraction | None, ...],
+    *,
+    scalar_by_id: dict[int, Fraction | None],
+    residual_by_id: dict[int, Any],
+) -> Fraction | None:
+    """Carry one child's folded linear scalar through coefficient-preserving wrappers."""
+
+    import z3
+
+    kind = candidate.decl().kind()
+    if len(children) == 1 and kind in (z3.Z3_OP_UMINUS, z3.Z3_OP_ADD):
+        child_scalar = scalar_by_id[children[0].get_id()]
+        if child_scalar is None:
+            return None
+        scalar = -child_scalar if kind == z3.Z3_OP_UMINUS else child_scalar
+        residual = _chased_residual(children[0], residual_by_id)
+    elif (
+        len(children) == 2
+        and kind == z3.Z3_OP_DIV
+        and child_values[0] is None
+        and child_values[1] is not None
+        and child_values[1] != 0
+    ):
+        dividend_scalar = scalar_by_id[children[0].get_id()]
+        if dividend_scalar is None:
+            return None
+        scalar = dividend_scalar / child_values[1]
+        _require_bounded_normalized_coefficient(scalar)
+        residual = _chased_residual(children[0], residual_by_id)
+    else:
+        return None
+    residual_by_id[children[0].get_id()] = residual
+    residual_by_id[candidate.get_id()] = residual
+    return scalar
 
 
 def _evaluate_closed_arithmetic(

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -36,27 +36,74 @@ class _CoefficientEnvelope(NamedTuple):
     Every coefficient reachable while reading the expression linearly has
     magnitude at most ``height``, numerator digit count at most
     ``numerator_digits``, and denominator digit count at most
-    ``denominator_digits``. ``common_denominator`` is an upper bound that the
-    denominator of every reachable coefficient divides, or ``None`` when no
-    such shared bound is tracked; sums use it to keep shared denominators from
-    compounding.
+    ``denominator_digits``. ``pairs`` is the exact closure of reachable
+    ``(numerator bound, denominator)`` pairs, or ``None`` when only the
+    marginal digit budgets are tracked; sums and comparisons use it to keep
+    shared denominators from compounding while still bounding merged
+    numerators soundly.
     """
 
     height: Fraction
     numerator_digits: int
     denominator_digits: int
-    common_denominator: int | None
+    pairs: tuple[tuple[int, int], ...] | None
 
 
-_UNIT_COEFFICIENT_ENVELOPE = _CoefficientEnvelope(Fraction(1), 1, 1, 1)
+_UNIT_COEFFICIENT_ENVELOPE = _CoefficientEnvelope(Fraction(1), 1, 1, ((1, 1),))
+_MAX_ENVELOPE_PAIRS = 16
 
 
-def _shared_common_denominator(
-    common_denominators: tuple[int | None, ...],
-) -> int | None:
-    if any(value is None for value in common_denominators):
+def _capped_pairs(
+    numerators_by_denominator: dict[int, int],
+) -> tuple[tuple[int, int], ...] | None:
+    if len(numerators_by_denominator) > _MAX_ENVELOPE_PAIRS:
         return None
-    return lcm(*(value for value in common_denominators if value is not None))
+    return tuple(
+        sorted(
+            (numerator, denominator)
+            for denominator, numerator in numerators_by_denominator.items()
+        )
+    )
+
+
+def _merged_pairs(
+    *pair_lists: tuple[tuple[int, int], ...] | None,
+) -> tuple[tuple[int, int], ...] | None:
+    """Union reachable coefficient pairs, keeping the widest per denominator."""
+
+    numerators_by_denominator: dict[int, int] = {}
+    for pair_list in pair_lists:
+        if pair_list is None:
+            return None
+        for numerator, denominator in pair_list:
+            numerators_by_denominator[denominator] = max(
+                numerators_by_denominator.get(denominator, 0), numerator
+            )
+    return _capped_pairs(numerators_by_denominator)
+
+
+def _pairs_common_denominator(
+    pairs: tuple[tuple[int, int], ...] | None,
+) -> int | None:
+    if pairs is None:
+        return None
+    return lcm(*(denominator for _numerator, denominator in pairs))
+
+
+def _scaled_pairs(
+    scalar: Fraction,
+    pairs: tuple[tuple[int, int], ...] | None,
+) -> tuple[tuple[int, int], ...] | None:
+    if pairs is None:
+        return None
+    numerators_by_denominator: dict[int, int] = {}
+    for numerator, denominator in pairs:
+        scaled = Fraction(numerator, denominator) * scalar
+        numerators_by_denominator[scaled.denominator] = max(
+            numerators_by_denominator.get(scaled.denominator, 0),
+            abs(scaled.numerator),
+        )
+    return _capped_pairs(numerators_by_denominator)
 
 
 class SmtUnsatCoreRequest(SmtSolveRequest):
@@ -603,9 +650,7 @@ def _coefficient_height(
             max(left.height, right.height),
             max(left.numerator_digits, right.numerator_digits),
             max(left.denominator_digits, right.denominator_digits),
-            _shared_common_denominator(
-                (left.common_denominator, right.common_denominator)
-            ),
+            _merged_pairs(left.pairs, right.pairs),
         )
     if kind == z3.Z3_OP_UMINUS:
         return child_envelopes[0]
@@ -623,7 +668,7 @@ def _coefficient_height(
         return _divided_envelope(
             child_envelopes[0],
             child_values[1],
-            exact=kind == z3.Z3_OP_DIV,
+            exact=kind == z3.Z3_OP_DIV or abs(child_values[1]) == 1,
             validate_budget=enforce_digit_budget,
         )
     if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
@@ -668,13 +713,8 @@ def _multiplied_envelope(
 
     numerator_digits = sum(envelope.numerator_digits for envelope in envelopes)
     denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
-    product = 1
-    for envelope in envelopes:
-        if envelope.common_denominator is None:
-            product = 0
-            break
-        product *= envelope.common_denominator
-    common_denominator: int | None = product or None
+    pairs = _product_pairs(tuple(envelope.pairs for envelope in envelopes))
+    common_denominator = _pairs_common_denominator(pairs)
     if common_denominator is not None:
         denominator_digits = min(denominator_digits, len(str(common_denominator)))
     if validate_budget:
@@ -686,7 +726,32 @@ def _multiplied_envelope(
         _bounded_fraction_product(tuple(envelope.height for envelope in envelopes)),
         numerator_digits,
         denominator_digits,
-        common_denominator,
+        pairs,
+    )
+
+
+def _product_pairs(
+    pair_lists: tuple[tuple[tuple[int, int], ...] | None, ...],
+) -> tuple[tuple[int, int], ...] | None:
+    result: dict[int, int] = {1: 1}
+    for pair_list in pair_lists:
+        if pair_list is None:
+            return None
+        combined: dict[int, int] = {}
+        for numerator, denominator in pair_list:
+            left = Fraction(numerator, denominator)
+            for shared_denominator, shared_numerator in result.items():
+                right = Fraction(shared_numerator, shared_denominator)
+                product = left * right
+                combined[product.denominator] = max(
+                    combined.get(product.denominator, 0),
+                    abs(product.numerator),
+                )
+        result = combined
+        if len(result) > _MAX_ENVELOPE_PAIRS:
+            return None
+    return tuple(
+        sorted((numerator, denominator) for denominator, numerator in result.items())
     )
 
 
@@ -705,11 +770,8 @@ def _divided_envelope(
     if not exact:
         scaled += 1
         numerator_digits += 1
-    common_denominator = (
-        None
-        if dividend.common_denominator is None
-        else dividend.common_denominator * abs(divisor.numerator)
-    )
+    pairs = _scaled_pairs(Fraction(1) / divisor, dividend.pairs) if exact else None
+    common_denominator = _pairs_common_denominator(pairs)
     if common_denominator is not None:
         denominator_digits = min(denominator_digits, len(str(common_denominator)))
     _require_bounded_normalized_coefficient(scaled)
@@ -718,12 +780,7 @@ def _divided_envelope(
             numerator_digits,
             denominator_digits,
         )
-    return _CoefficientEnvelope(
-        scaled,
-        numerator_digits,
-        denominator_digits,
-        common_denominator,
-    )
+    return _CoefficientEnvelope(scaled, numerator_digits, denominator_digits, pairs)
 
 
 def _signed_sum_envelope(
@@ -737,9 +794,6 @@ def _signed_sum_envelope(
     for envelope in envelopes:
         height += envelope.height
         _require_bounded_normalized_coefficient(height)
-    shared = _shared_common_denominator(
-        tuple(envelope.common_denominator for envelope in envelopes)
-    )
     denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
     widest_numerator = max(
         (
@@ -749,18 +803,39 @@ def _signed_sum_envelope(
         default=0,
     )
     numerator_digits = widest_numerator + len(str(len(envelopes)))
+    shared = _shared_denominator_of_pairs(envelopes)
     if shared is not None:
+        merged_numerator = 0
+        for envelope in envelopes:
+            merged_numerator += max(
+                (
+                    numerator * (shared // denominator)
+                    for numerator, denominator in envelope.pairs or ()
+                ),
+                default=0,
+            )
         denominator_digits = min(denominator_digits, len(str(shared)))
-        merged_numerator = (
-            sum(10**envelope.numerator_digits for envelope in envelopes) * shared
-        )
         numerator_digits = min(numerator_digits, len(str(merged_numerator)))
+        pairs: tuple[tuple[int, int], ...] | None = ((merged_numerator, shared),)
+    else:
+        pairs = None
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,
             denominator_digits,
         )
-    return _CoefficientEnvelope(height, numerator_digits, denominator_digits, shared)
+    return _CoefficientEnvelope(height, numerator_digits, denominator_digits, pairs)
+
+
+def _shared_denominator_of_pairs(
+    envelopes: tuple[_CoefficientEnvelope, ...],
+) -> int | None:
+    denominators: list[int] = []
+    for envelope in envelopes:
+        if envelope.pairs is None:
+            return None
+        denominators.extend(denominator for _numerator, denominator in envelope.pairs)
+    return lcm(*denominators)
 
 
 def _compared_envelope(
@@ -768,28 +843,52 @@ def _compared_envelope(
     *,
     validate_budget: bool,
 ) -> _CoefficientEnvelope:
-    """Bound the difference an arithmetic comparison forms between its sides."""
+    """Bound the difference an arithmetic comparison forms between its sides.
+
+    The difference of two nonnegative quantities never exceeds the larger one,
+    so each side is lifted to the shared denominator and only the widest lifted
+    numerator bounds the merged coefficient.
+    """
 
     height = Fraction(0)
     for envelope in envelopes:
         height += envelope.height
         _require_bounded_normalized_coefficient(height)
-    shared = _shared_common_denominator(
-        tuple(envelope.common_denominator for envelope in envelopes)
+    shared = _shared_denominator_of_pairs(envelopes)
+    if shared is None:
+        fallback = _signed_sum_envelope(envelopes, validate_budget=False)
+        return _CoefficientEnvelope(
+            height,
+            fallback.numerator_digits,
+            fallback.denominator_digits,
+            None,
+        )
+    denominator_digits = min(
+        sum(envelope.denominator_digits for envelope in envelopes),
+        len(str(shared)),
     )
-    denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
-    numerator_digits = max(
-        (envelope.numerator_digits for envelope in envelopes), default=0
-    )
-    if shared is not None:
-        denominator_digits = min(denominator_digits, len(str(shared)))
-        numerator_digits = min(numerator_digits, len(str(shared)) + numerator_digits)
+    lifted_numerator = 0
+    for left_index, left in enumerate(envelopes):
+        for right in envelopes[left_index + 1 :]:
+            for left_numerator, left_denominator in left.pairs or ():
+                for right_numerator, right_denominator in right.pairs or ():
+                    difference = abs(
+                        Fraction(left_numerator, left_denominator)
+                        - Fraction(right_numerator, right_denominator)
+                    )
+                    lifted_numerator = max(lifted_numerator, difference.numerator)
+    numerator_digits = len(str(lifted_numerator))
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,
             denominator_digits,
         )
-    return _CoefficientEnvelope(height, numerator_digits, denominator_digits, shared)
+    return _CoefficientEnvelope(
+        height,
+        numerator_digits,
+        denominator_digits,
+        ((lifted_numerator, shared),),
+    )
 
 
 def _maximal_digit_envelope(
@@ -812,7 +911,7 @@ def _closed_value_envelope(value: Fraction) -> _CoefficientEnvelope:
         abs(value),
         len(str(abs(value.numerator))),
         len(str(value.denominator)),
-        value.denominator,
+        ((abs(value.numerator), value.denominator),),
     )
 
 
@@ -822,11 +921,17 @@ def _affine_form_envelope(
     """Read exact digit budgets off the flattened coefficients of one form."""
 
     coefficients = (form[1], *(coefficient for coefficient, _core in form[0]))
+    numerators_by_denominator: dict[int, int] = {}
+    for value in coefficients:
+        key = value.denominator
+        numerators_by_denominator[key] = max(
+            numerators_by_denominator.get(key, 0), abs(value.numerator)
+        )
     return _CoefficientEnvelope(
         height,
         max(len(str(abs(value.numerator))) for value in coefficients),
         max(len(str(value.denominator)) for value in coefficients),
-        lcm(*(value.denominator for value in coefficients)),
+        _capped_pairs(numerators_by_denominator),
     )
 
 
@@ -838,12 +943,8 @@ def _scaled_coefficient_envelope(
 
     numerator_digits = len(str(abs(coefficient.numerator))) + envelope.numerator_digits
     denominator_digits = len(str(coefficient.denominator)) + envelope.denominator_digits
-    if coefficient.denominator == 1:
-        common_denominator = envelope.common_denominator
-    elif envelope.common_denominator is not None:
-        common_denominator = coefficient.denominator * envelope.common_denominator
-    else:
-        common_denominator = None
+    pairs = _scaled_pairs(coefficient, envelope.pairs)
+    common_denominator = _pairs_common_denominator(pairs)
     if common_denominator is not None:
         denominator_digits = min(denominator_digits, len(str(common_denominator)))
     _require_bounded_coefficient_digit_budget(numerator_digits, denominator_digits)
@@ -851,7 +952,7 @@ def _scaled_coefficient_envelope(
         coefficient * envelope.height,
         numerator_digits,
         denominator_digits,
-        common_denominator,
+        pairs,
     )
 
 

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -575,9 +575,10 @@ def _coefficient_height(
     numerator and denominator digit budget, so a numerically smaller reciprocal
     branch cannot hide denominator growth from later scaling. Products multiply
     envelopes and signed sums merge them, matching every scalar the preserving
-    wrappers can derive downstream. Divisions by closed constants compose their
-    budgets into one coefficient, so they validate those budgets unless an
-    exact flattened form already validates every quotient.
+    wrappers can derive downstream. Divisions by closed constants and
+    composed signed sums merge branch budgets into one coefficient, so they
+    validate those budgets unless an exact flattened form already validates
+    every coefficient of the node.
     """
 
     import z3
@@ -593,7 +594,10 @@ def _coefficient_height(
     if kind == z3.Z3_OP_UMINUS:
         return child_envelopes[0]
     if kind == z3.Z3_OP_MUL:
-        return _multiplied_envelope(child_envelopes)
+        return _multiplied_envelope(
+            child_envelopes,
+            validate_budget=enforce_digit_budget,
+        )
     if (
         len(children) == 2
         and kind in (z3.Z3_OP_DIV, z3.Z3_OP_IDIV)
@@ -607,26 +611,44 @@ def _coefficient_height(
             validate_budget=enforce_digit_budget,
         )
     if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
-        return _signed_sum_envelope(child_envelopes)
+        return _signed_sum_envelope(
+            child_envelopes,
+            validate_budget=enforce_digit_budget,
+        )
     height = Fraction(0)
     for envelope in child_envelopes:
         height += envelope.height
         _require_bounded_normalized_coefficient(height)
-    return _maximal_digit_envelope(
+    envelope = _maximal_digit_envelope(
         child_envelopes,
         height=height,
     )
+    if enforce_digit_budget:
+        _require_bounded_coefficient_digit_budget(
+            envelope.numerator_digits,
+            envelope.denominator_digits,
+        )
+    return envelope
 
 
 def _multiplied_envelope(
     envelopes: tuple[_CoefficientEnvelope, ...],
+    *,
+    validate_budget: bool,
 ) -> _CoefficientEnvelope:
     """Scale one envelope by every remaining envelope, as products do."""
 
+    numerator_digits = sum(envelope.numerator_digits for envelope in envelopes)
+    denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
+    if validate_budget:
+        _require_bounded_coefficient_digit_budget(
+            numerator_digits,
+            denominator_digits,
+        )
     return _CoefficientEnvelope(
         _bounded_fraction_product(tuple(envelope.height for envelope in envelopes)),
-        sum(envelope.numerator_digits for envelope in envelopes),
-        sum(envelope.denominator_digits for envelope in envelopes),
+        numerator_digits,
+        denominator_digits,
     )
 
 
@@ -656,6 +678,8 @@ def _divided_envelope(
 
 def _signed_sum_envelope(
     envelopes: tuple[_CoefficientEnvelope, ...],
+    *,
+    validate_budget: bool,
 ) -> _CoefficientEnvelope:
     """Merge child readings the way signed sums combine their coefficients."""
 
@@ -671,11 +695,13 @@ def _signed_sum_envelope(
         ),
         default=0,
     )
-    return _CoefficientEnvelope(
-        height,
-        widest_numerator + len(str(len(envelopes))),
-        denominator_digits,
-    )
+    numerator_digits = widest_numerator + len(str(len(envelopes)))
+    if validate_budget:
+        _require_bounded_coefficient_digit_budget(
+            numerator_digits,
+            denominator_digits,
+        )
+    return _CoefficientEnvelope(height, numerator_digits, denominator_digits)
 
 
 def _maximal_digit_envelope(

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from fractions import Fraction
+from math import lcm
 from typing import Any, Literal, NamedTuple, Self
 
 from pydantic import ConfigDict, Field, StrictInt, ValidationError, model_validator
@@ -35,15 +36,27 @@ class _CoefficientEnvelope(NamedTuple):
     Every coefficient reachable while reading the expression linearly has
     magnitude at most ``height``, numerator digit count at most
     ``numerator_digits``, and denominator digit count at most
-    ``denominator_digits``.
+    ``denominator_digits``. ``common_denominator`` is an upper bound that the
+    denominator of every reachable coefficient divides, or ``None`` when no
+    such shared bound is tracked; sums use it to keep shared denominators from
+    compounding.
     """
 
     height: Fraction
     numerator_digits: int
     denominator_digits: int
+    common_denominator: int | None
 
 
-_UNIT_COEFFICIENT_ENVELOPE = _CoefficientEnvelope(Fraction(1), 1, 1)
+_UNIT_COEFFICIENT_ENVELOPE = _CoefficientEnvelope(Fraction(1), 1, 1, 1)
+
+
+def _shared_common_denominator(
+    common_denominators: tuple[int | None, ...],
+) -> int | None:
+    if any(value is None for value in common_denominators):
+        return None
+    return lcm(*(value for value in common_denominators if value is not None))
 
 
 class SmtUnsatCoreRequest(SmtSolveRequest):
@@ -590,6 +603,9 @@ def _coefficient_height(
             max(left.height, right.height),
             max(left.numerator_digits, right.numerator_digits),
             max(left.denominator_digits, right.denominator_digits),
+            _shared_common_denominator(
+                (left.common_denominator, right.common_denominator)
+            ),
         )
     if kind == z3.Z3_OP_UMINUS:
         return child_envelopes[0]
@@ -640,6 +656,15 @@ def _multiplied_envelope(
 
     numerator_digits = sum(envelope.numerator_digits for envelope in envelopes)
     denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
+    product = 1
+    for envelope in envelopes:
+        if envelope.common_denominator is None:
+            product = 0
+            break
+        product *= envelope.common_denominator
+    common_denominator: int | None = product or None
+    if common_denominator is not None:
+        denominator_digits = min(denominator_digits, len(str(common_denominator)))
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,
@@ -649,6 +674,7 @@ def _multiplied_envelope(
         _bounded_fraction_product(tuple(envelope.height for envelope in envelopes)),
         numerator_digits,
         denominator_digits,
+        common_denominator,
     )
 
 
@@ -667,13 +693,25 @@ def _divided_envelope(
     if not exact:
         scaled += 1
         numerator_digits += 1
+    common_denominator = (
+        None
+        if dividend.common_denominator is None
+        else dividend.common_denominator * abs(divisor.numerator)
+    )
+    if common_denominator is not None:
+        denominator_digits = min(denominator_digits, len(str(common_denominator)))
     _require_bounded_normalized_coefficient(scaled)
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,
             denominator_digits,
         )
-    return _CoefficientEnvelope(scaled, numerator_digits, denominator_digits)
+    return _CoefficientEnvelope(
+        scaled,
+        numerator_digits,
+        denominator_digits,
+        common_denominator,
+    )
 
 
 def _signed_sum_envelope(
@@ -687,6 +725,8 @@ def _signed_sum_envelope(
     for envelope in envelopes:
         height += envelope.height
         _require_bounded_normalized_coefficient(height)
+    common_denominators = tuple(envelope.common_denominator for envelope in envelopes)
+    shared = _shared_common_denominator(common_denominators)
     denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
     widest_numerator = max(
         (
@@ -696,12 +736,20 @@ def _signed_sum_envelope(
         default=0,
     )
     numerator_digits = widest_numerator + len(str(len(envelopes)))
+    if shared is not None:
+        denominator_digits = min(denominator_digits, len(str(shared)))
+        merged_numerator = sum(
+            10**envelope.numerator_digits
+            * (shared // (envelope.common_denominator or 1))
+            for envelope in envelopes
+        )
+        numerator_digits = min(numerator_digits, len(str(merged_numerator)))
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,
             denominator_digits,
         )
-    return _CoefficientEnvelope(height, numerator_digits, denominator_digits)
+    return _CoefficientEnvelope(height, numerator_digits, denominator_digits, shared)
 
 
 def _maximal_digit_envelope(
@@ -715,6 +763,7 @@ def _maximal_digit_envelope(
         height,
         max((envelope.numerator_digits for envelope in envelopes), default=0),
         max((envelope.denominator_digits for envelope in envelopes), default=0),
+        None,
     )
 
 
@@ -723,6 +772,7 @@ def _closed_value_envelope(value: Fraction) -> _CoefficientEnvelope:
         abs(value),
         len(str(abs(value.numerator))),
         len(str(value.denominator)),
+        value.denominator,
     )
 
 
@@ -736,6 +786,7 @@ def _affine_form_envelope(
         height,
         max(len(str(abs(value.numerator))) for value in coefficients),
         max(len(str(value.denominator)) for value in coefficients),
+        lcm(*(value.denominator for value in coefficients)),
     )
 
 
@@ -747,11 +798,20 @@ def _scaled_coefficient_envelope(
 
     numerator_digits = len(str(abs(coefficient.numerator))) + envelope.numerator_digits
     denominator_digits = len(str(coefficient.denominator)) + envelope.denominator_digits
+    if coefficient.denominator == 1:
+        common_denominator = envelope.common_denominator
+    elif envelope.common_denominator is not None:
+        common_denominator = coefficient.denominator * envelope.common_denominator
+    else:
+        common_denominator = None
+    if common_denominator is not None:
+        denominator_digits = min(denominator_digits, len(str(common_denominator)))
     _require_bounded_coefficient_digit_budget(numerator_digits, denominator_digits)
     return _CoefficientEnvelope(
         coefficient * envelope.height,
         numerator_digits,
         denominator_digits,
+        common_denominator,
     )
 
 

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -791,6 +791,7 @@ def _signed_sum_envelope(
         default=0,
     )
     numerator_digits = widest_numerator + len(str(len(envelopes)))
+    pairs = None
     shared = _shared_denominator_of_pairs(envelopes)
     if shared is not None:
         lifted: list[set[Fraction]] = []
@@ -808,14 +809,20 @@ def _signed_sum_envelope(
                 break
         else:
             pairs = _capped_pairs(
-                {(abs(value.numerator), value.denominator) for value in totals}
+                {
+                    (
+                        abs((total / shared).numerator),
+                        (total / shared).denominator,
+                    )
+                    for total in totals
+                }
             )
             common_denominator = _pairs_common_denominator(pairs)
             if common_denominator is not None:
                 denominator_digits = min(
                     denominator_digits, len(str(common_denominator))
                 )
-            widest_merged = max(abs(value.numerator) for value in totals)
+            widest_merged = max(abs((total / shared).numerator) for total in totals)
             numerator_digits = min(numerator_digits, len(str(widest_merged)))
     else:
         pairs = None

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from fractions import Fraction
-from typing import Any, Literal, Self
+from typing import Any, Literal, NamedTuple, Self
 
 from pydantic import ConfigDict, Field, StrictInt, ValidationError, model_validator
 
@@ -29,6 +29,23 @@ _AffineTerms = tuple[tuple[Fraction, Any], ...]
 _AffineForm = tuple[_AffineTerms, Fraction]
 
 
+class _CoefficientEnvelope(NamedTuple):
+    """Numeric height plus reachable coefficient digit budgets for one expression.
+
+    Every coefficient reachable while reading the expression linearly has
+    magnitude at most ``height``, numerator digit count at most
+    ``numerator_digits``, and denominator digit count at most
+    ``denominator_digits``.
+    """
+
+    height: Fraction
+    numerator_digits: int
+    denominator_digits: int
+
+
+_UNIT_COEFFICIENT_ENVELOPE = _CoefficientEnvelope(Fraction(1), 1, 1)
+
+
 class SmtUnsatCoreRequest(SmtSolveRequest):
     """One bounded SMT-LIB query whose top-level assertions are indexed from zero.
 
@@ -46,8 +63,9 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     subtractions over closed and variable-carrying operands, exact division
     by closed nonzero constants, integer division included when every divided
     coefficient remains exactly divisible, and arithmetic if-then-else
-    selections, where scaling is bounded by the largest coefficient reachable
-    through any branch).
+    selections, where scaling is validated against every branch's reachable
+    coefficient digits, so a numerically smaller branch cannot hide reciprocal
+    growth beyond the digit budget).
     Assertion source order is the public zero-based index. Parsing constructs Z3
     syntax trees only; it does not evaluate the source as Python or as a host
     command. Execution performs one tracked check and at most one direct
@@ -300,14 +318,14 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
     normalized_by_id: dict[int, Any] = {}
     closed_value_by_id: dict[int, Fraction | None] = {}
     form_by_id: dict[int, _AffineForm | None] = {}
-    height_by_id: dict[int, Fraction] = {}
+    envelope_by_id: dict[int, _CoefficientEnvelope] = {}
     return tuple(
         _normalize_closed_expression(
             assertion,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             form_by_id=form_by_id,
-            height_by_id=height_by_id,
+            envelope_by_id=envelope_by_id,
         )
         for assertion in assertions
     )
@@ -340,25 +358,29 @@ def _fold_scaled_product(
     child_values: tuple[Fraction | None, ...],
     *,
     form_by_id: dict[int, _AffineForm | None],
-    height_by_id: dict[int, Fraction],
-) -> tuple[Any, _AffineForm | None]:
+    envelope_by_id: dict[int, _CoefficientEnvelope],
+) -> tuple[Any, _AffineForm | None, _CoefficientEnvelope | None]:
     """Flatten one product with a single variable-carrying affine child."""
 
     import z3
 
     if candidate.decl().kind() != z3.Z3_OP_MUL:
-        return candidate, None
+        return candidate, None, None
     open_indices = [index for index, value in enumerate(child_values) if value is None]
     if len(open_indices) != 1:
-        return candidate, None
+        return candidate, None, None
     dependent = children[open_indices[0]]
     coefficient = _bounded_fraction_product(
         tuple(value for value in child_values if value is not None)
     )
+    scaled_envelope = None
     child_form = form_by_id.get(dependent.get_id())
     if child_form is None:
-        scaled_height = coefficient * height_by_id.get(dependent.get_id(), Fraction(1))
-        _require_bounded_normalized_coefficient(scaled_height)
+        scaled_envelope = _scaled_coefficient_envelope(
+            coefficient,
+            envelope_by_id.get(dependent.get_id(), _UNIT_COEFFICIENT_ENVELOPE),
+        )
+        _require_bounded_normalized_coefficient(scaled_envelope.height)
         child_form = (((Fraction(1), dependent),), Fraction(0))
     terms, offset = child_form
     scaled_terms: list[tuple[Fraction, Any]] = []
@@ -372,7 +394,7 @@ def _fold_scaled_product(
         _require_bounded_normalized_coefficient(scaled_offset)
     folded_terms = tuple(scaled_terms)
     folded = _affine_expression(folded_terms, scaled_offset, template=candidate)
-    return folded, (folded_terms, scaled_offset)
+    return folded, (folded_terms, scaled_offset), scaled_envelope
 
 
 def _normalize_closed_expression(
@@ -381,7 +403,7 @@ def _normalize_closed_expression(
     normalized_by_id: dict[int, Any],
     closed_value_by_id: dict[int, Fraction | None],
     form_by_id: dict[int, _AffineForm | None],
-    height_by_id: dict[int, Fraction],
+    envelope_by_id: dict[int, _CoefficientEnvelope],
 ) -> Any:
     """Normalize one expression without retaining a recursive closure over its AST."""
 
@@ -399,19 +421,19 @@ def _normalize_closed_expression(
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = value
         form_by_id[expression_id] = ((), value)
-        height_by_id[expression_id] = abs(value)
+        envelope_by_id[expression_id] = _closed_value_envelope(value)
         return expression
     if not z3.is_app(expression):
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
         form_by_id[expression_id] = None
-        height_by_id[expression_id] = Fraction(1)
+        envelope_by_id[expression_id] = _UNIT_COEFFICIENT_ENVELOPE
         return expression
     if z3.is_arith(expression) and not expression.children():
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
         form_by_id[expression_id] = (((Fraction(1), expression),), Fraction(0))
-        height_by_id[expression_id] = Fraction(1)
+        envelope_by_id[expression_id] = _UNIT_COEFFICIENT_ENVELOPE
         return expression
 
     children = expression.children()
@@ -421,7 +443,7 @@ def _normalize_closed_expression(
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             form_by_id=form_by_id,
-            height_by_id=height_by_id,
+            envelope_by_id=envelope_by_id,
         )
         for child in children
     )
@@ -434,12 +456,12 @@ def _normalize_closed_expression(
         candidate = expression
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
-    candidate, form = _fold_scaled_product(
+    candidate, form, scaled_envelope = _fold_scaled_product(
         candidate,
         children,
         child_values,
         form_by_id=form_by_id,
-        height_by_id=height_by_id,
+        envelope_by_id=envelope_by_id,
     )
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
@@ -450,21 +472,27 @@ def _normalize_closed_expression(
         form = _wrapped_linear_form(
             candidate, children, child_values, form_by_id=form_by_id
         )
-    height = (
-        abs(closed_value)
-        if closed_value is not None
-        else _coefficient_height(
-            candidate.decl().kind(), children, child_values, height_by_id=height_by_id
+    if closed_value is not None:
+        envelope = _closed_value_envelope(closed_value)
+    else:
+        envelope = _coefficient_height(
+            candidate.decl().kind(),
+            children,
+            child_values,
+            envelope_by_id=envelope_by_id,
         )
-    )
+        if scaled_envelope is not None:
+            envelope = scaled_envelope
+        elif form is not None:
+            envelope = _affine_form_envelope(form, height=envelope.height)
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
     form_by_id[expression_id] = form
-    height_by_id[expression_id] = height
+    envelope_by_id[expression_id] = envelope
     if not candidate.eq(expression):
         form_by_id[candidate.get_id()] = form
-        height_by_id[candidate.get_id()] = height
+        envelope_by_id[candidate.get_id()] = envelope
     return candidate
 
 
@@ -527,49 +555,156 @@ def _coefficient_height(
     children: tuple[Any, ...],
     child_values: tuple[Fraction | None, ...],
     *,
-    height_by_id: dict[int, Fraction],
-) -> Fraction:
+    envelope_by_id: dict[int, _CoefficientEnvelope],
+) -> _CoefficientEnvelope:
     """Bound every coefficient reachable in one expression's linear reading.
 
     Arithmetic if-then-else selects exactly one branch, so its envelope is the
-    largest branch envelope; products multiply envelopes and signed sums merge
-    them, matching every scalar the preserving wrappers can derive downstream.
+    componentwise maximum of the branch envelopes: each branch keeps its own
+    numerator and denominator digit budget, so a numerically smaller reciprocal
+    branch cannot hide denominator growth from later scaling. Products multiply
+    envelopes and signed sums merge them, matching every scalar the preserving
+    wrappers can derive downstream.
     """
 
     import z3
 
-    child_heights = tuple(height_by_id[child.get_id()] for child in children)
-    if kind == z3.Z3_OP_ITE and len(child_heights) == 3:
-        return max(child_heights[1], child_heights[2])
+    child_envelopes = tuple(envelope_by_id[child.get_id()] for child in children)
+    if kind == z3.Z3_OP_ITE and len(child_envelopes) == 3:
+        left, right = child_envelopes[1], child_envelopes[2]
+        return _CoefficientEnvelope(
+            max(left.height, right.height),
+            max(left.numerator_digits, right.numerator_digits),
+            max(left.denominator_digits, right.denominator_digits),
+        )
     if kind == z3.Z3_OP_UMINUS:
-        return child_heights[0]
-    total = Fraction(0)
-    if kind == z3.Z3_OP_SUB:
-        total += child_heights[0]
-        _require_bounded_normalized_coefficient(total)
-        child_heights = child_heights[1:]
-    if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
-        for height in child_heights:
-            total += height
-            _require_bounded_normalized_coefficient(total)
-        return total
+        return child_envelopes[0]
     if kind == z3.Z3_OP_MUL:
-        return _bounded_fraction_product(child_heights)
+        return _multiplied_envelope(child_envelopes)
     if (
         len(children) == 2
         and kind in (z3.Z3_OP_DIV, z3.Z3_OP_IDIV)
         and child_values[1] is not None
         and child_values[1] != 0
     ):
-        scaled = child_heights[0] / abs(child_values[1])
-        if kind == z3.Z3_OP_IDIV:
-            scaled += 1
-        _require_bounded_normalized_coefficient(scaled)
-        return scaled
-    for height in child_heights:
-        total += height
-        _require_bounded_normalized_coefficient(total)
-    return total
+        return _divided_envelope(
+            child_envelopes[0], child_values[1], exact=kind == z3.Z3_OP_DIV
+        )
+    if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
+        return _signed_sum_envelope(child_envelopes)
+    height = Fraction(0)
+    for envelope in child_envelopes:
+        height += envelope.height
+        _require_bounded_normalized_coefficient(height)
+    return _maximal_digit_envelope(
+        child_envelopes,
+        height=height,
+    )
+
+
+def _multiplied_envelope(
+    envelopes: tuple[_CoefficientEnvelope, ...],
+) -> _CoefficientEnvelope:
+    """Scale one envelope by every remaining envelope, as products do."""
+
+    return _CoefficientEnvelope(
+        _bounded_fraction_product(tuple(envelope.height for envelope in envelopes)),
+        sum(envelope.numerator_digits for envelope in envelopes),
+        sum(envelope.denominator_digits for envelope in envelopes),
+    )
+
+
+def _divided_envelope(
+    dividend: _CoefficientEnvelope,
+    divisor: Fraction,
+    *,
+    exact: bool,
+) -> _CoefficientEnvelope:
+    """Divide one envelope by a closed nonzero constant, SMT-LIB div included."""
+
+    scaled = dividend.height / abs(divisor)
+    numerator_digits = dividend.numerator_digits + len(str(divisor.denominator))
+    denominator_digits = dividend.denominator_digits + len(str(abs(divisor.numerator)))
+    if not exact:
+        scaled += 1
+        numerator_digits += 1
+    _require_bounded_normalized_coefficient(scaled)
+    return _CoefficientEnvelope(scaled, numerator_digits, denominator_digits)
+
+
+def _signed_sum_envelope(
+    envelopes: tuple[_CoefficientEnvelope, ...],
+) -> _CoefficientEnvelope:
+    """Merge child readings the way signed sums combine their coefficients."""
+
+    height = Fraction(0)
+    for envelope in envelopes:
+        height += envelope.height
+        _require_bounded_normalized_coefficient(height)
+    denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
+    widest_numerator = max(
+        (
+            envelope.numerator_digits + denominator_digits - envelope.denominator_digits
+            for envelope in envelopes
+        ),
+        default=0,
+    )
+    return _CoefficientEnvelope(
+        height,
+        widest_numerator + len(str(len(envelopes))),
+        denominator_digits,
+    )
+
+
+def _maximal_digit_envelope(
+    envelopes: tuple[_CoefficientEnvelope, ...],
+    *,
+    height: Fraction,
+) -> _CoefficientEnvelope:
+    """Carry the widest child digit budgets without compounding them."""
+
+    return _CoefficientEnvelope(
+        height,
+        max((envelope.numerator_digits for envelope in envelopes), default=0),
+        max((envelope.denominator_digits for envelope in envelopes), default=0),
+    )
+
+
+def _closed_value_envelope(value: Fraction) -> _CoefficientEnvelope:
+    return _CoefficientEnvelope(
+        abs(value),
+        len(str(abs(value.numerator))),
+        len(str(value.denominator)),
+    )
+
+
+def _affine_form_envelope(
+    form: _AffineForm, *, height: Fraction
+) -> _CoefficientEnvelope:
+    """Read exact digit budgets off the flattened coefficients of one form."""
+
+    coefficients = (form[1], *(coefficient for coefficient, _core in form[0]))
+    return _CoefficientEnvelope(
+        height,
+        max(len(str(abs(value.numerator))) for value in coefficients),
+        max(len(str(value.denominator)) for value in coefficients),
+    )
+
+
+def _scaled_coefficient_envelope(
+    coefficient: Fraction,
+    envelope: _CoefficientEnvelope,
+) -> _CoefficientEnvelope:
+    """Validate a scalar against a dependent's budget before scaling it."""
+
+    numerator_digits = len(str(abs(coefficient.numerator))) + envelope.numerator_digits
+    denominator_digits = len(str(coefficient.denominator)) + envelope.denominator_digits
+    _require_bounded_coefficient_digit_budget(numerator_digits, denominator_digits)
+    return _CoefficientEnvelope(
+        coefficient * envelope.height,
+        numerator_digits,
+        denominator_digits,
+    )
 
 
 def _combined_signed_form(
@@ -687,6 +822,20 @@ def _exact_arithmetic_value(value: Fraction, *, template: Any) -> Any:
             ctx=template.ctx,
         )
     raise ValueError("normalized coefficient must have an arithmetic sort")
+
+
+def _require_bounded_coefficient_digit_budget(
+    numerator_digits: int,
+    denominator_digits: int,
+) -> None:
+    if (
+        numerator_digits > _MAX_CORE_NUMERAL_DIGITS
+        or denominator_digits > _MAX_CORE_NUMERAL_DIGITS
+    ):
+        raise ValueError(
+            "normalized SMT coefficient numerator and denominator may contain at "
+            f"most {_MAX_CORE_NUMERAL_DIGITS} digits"
+        )
 
 
 def _require_bounded_normalized_coefficient(value: Fraction) -> None:

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -38,12 +38,13 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     Its inherited 128,000-byte ASCII envelope is further limited to 32,768 tokens,
     nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
     nodes, 256 digits per numeral, and 256 digits in the numerator or denominator
-    of any closed arithmetic coefficient, including the complete scalar coefficient
-    obtained by flattening nested products and coefficient-preserving wrappers
-    (negation, unary addition, and exact division by closed constants).
-    Assertion source order is the
-    public zero-based index. Parsing constructs Z3 syntax trees only; it does not
-    evaluate the source as Python or as a host command. Execution performs one
+    of any closed arithmetic coefficient, including every scalar coefficient and
+    translated constant obtained by flattening nested products through
+    coefficient-preserving wrappers (negation, additions and subtractions whose
+    remaining operands are closed, and exact division by closed constants).
+    Assertion source order is the public zero-based index. Parsing constructs Z3
+    syntax trees only; it does not evaluate the source as Python or as a host
+    command. Execution performs one tracked check and at most one direct
     tracked check and at most one direct result-validation replay, each under the
     supplied deterministic rlimit and timeout safety net.
     Z3 5.0 exposes only a process-global memory threshold, so this in-process
@@ -293,6 +294,7 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
     normalized_by_id: dict[int, Any] = {}
     closed_value_by_id: dict[int, Fraction | None] = {}
     scalar_by_id: dict[int, Fraction | None] = {}
+    offset_by_id: dict[int, Fraction] = {}
     residual_by_id: dict[int, Any] = {}
     return tuple(
         _normalize_closed_expression(
@@ -300,10 +302,71 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             scalar_by_id=scalar_by_id,
+            offset_by_id=offset_by_id,
             residual_by_id=residual_by_id,
         )
         for assertion in assertions
     )
+
+
+def _fold_scaled_product(
+    candidate: Any,
+    children: tuple[Any, ...],
+    normalized_children: tuple[Any, ...],
+    child_values: tuple[Fraction | None, ...],
+    *,
+    scalar_by_id: dict[int, Fraction | None],
+    offset_by_id: dict[int, Fraction],
+    residual_by_id: dict[int, Any],
+) -> tuple[Any, Fraction | None, Any | None, Fraction]:
+    """Flatten one product with a single variable-carrying affine child."""
+
+    import z3
+
+    if candidate.decl().kind() != z3.Z3_OP_MUL:
+        return candidate, None, None, Fraction(0)
+    dependent_children = tuple(
+        normalized_child
+        for normalized_child, value in zip(
+            normalized_children, child_values, strict=True
+        )
+        if value is None
+    )
+    closed_factors = tuple(value for value in child_values if value is not None)
+    dependent_scalar: Fraction | None = None
+    dependent_offset = Fraction(0)
+    for child, child_value in zip(children, child_values, strict=True):
+        if child_value is None:
+            dependent_scalar = scalar_by_id[child.get_id()]
+            if dependent_scalar is not None:
+                dependent_offset = offset_by_id[child.get_id()]
+            break
+    if len(dependent_children) != 1 or not closed_factors:
+        return candidate, None, None, Fraction(0)
+    factors = (
+        (*closed_factors, dependent_scalar)
+        if dependent_scalar is not None
+        else closed_factors
+    )
+    coefficient = _bounded_fraction_product(factors)
+    scaled_offset = Fraction(0)
+    if dependent_offset:
+        scaled_offset = _bounded_fraction_product((*closed_factors, dependent_offset))
+    dependent = dependent_children[0]
+    while (residual := residual_by_id.get(dependent.get_id())) is not None:
+        dependent = residual
+    folded_term = candidate.decl()(
+        _exact_arithmetic_value(coefficient, template=candidate),
+        dependent,
+    )
+    folded_offset = Fraction(0)
+    folded_candidate: Any = folded_term
+    if dependent_offset:
+        folded_candidate = folded_term + _exact_arithmetic_value(
+            scaled_offset, template=folded_term
+        )
+        folded_offset = scaled_offset
+    return folded_candidate, coefficient, dependent, folded_offset
 
 
 def _normalize_closed_expression(
@@ -312,6 +375,7 @@ def _normalize_closed_expression(
     normalized_by_id: dict[int, Any],
     closed_value_by_id: dict[int, Fraction | None],
     scalar_by_id: dict[int, Fraction | None],
+    offset_by_id: dict[int, Fraction],
     residual_by_id: dict[int, Any],
 ) -> Any:
     """Normalize one expression without retaining a recursive closure over its AST."""
@@ -326,12 +390,14 @@ def _normalize_closed_expression(
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = value
         scalar_by_id[expression_id] = value
+        offset_by_id[expression_id] = Fraction(0)
         return expression
     if z3.is_rational_value(expression):
         value = expression.as_fraction()
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = value
         scalar_by_id[expression_id] = value
+        offset_by_id[expression_id] = Fraction(0)
         return expression
     if not z3.is_app(expression):
         normalized_by_id[expression_id] = expression
@@ -346,6 +412,7 @@ def _normalize_closed_expression(
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             scalar_by_id=scalar_by_id,
+            offset_by_id=offset_by_id,
             residual_by_id=residual_by_id,
         )
         for child in children
@@ -359,59 +426,43 @@ def _normalize_closed_expression(
         candidate = expression
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
-    folded_coefficient: Fraction | None = None
-    folded_dependent: Any | None = None
-    if candidate.decl().kind() == z3.Z3_OP_MUL:
-        dependent_children = tuple(
-            normalized_child
-            for normalized_child, value in zip(
-                normalized_children, child_values, strict=True
-            )
-            if value is None
-        )
-        closed_factors = tuple(value for value in child_values if value is not None)
-        dependent_scalar: Fraction | None = None
-        for child, child_value in zip(children, child_values, strict=True):
-            if child_value is None:
-                dependent_scalar = scalar_by_id[child.get_id()]
-                break
-        if len(dependent_children) == 1 and closed_factors:
-            factors = (
-                (*closed_factors, dependent_scalar)
-                if dependent_scalar is not None
-                else closed_factors
-            )
-            coefficient = _bounded_fraction_product(factors)
-            dependent = dependent_children[0]
-            while (residual := residual_by_id.get(dependent.get_id())) is not None:
-                dependent = residual
-            candidate = candidate.decl()(
-                _exact_arithmetic_value(coefficient, template=candidate),
-                dependent,
-            )
-            folded_coefficient = coefficient
-            folded_dependent = dependent
+    candidate, folded_coefficient, folded_dependent, folded_offset = _fold_scaled_product(
+        candidate,
+        children,
+        normalized_children,
+        child_values,
+        scalar_by_id=scalar_by_id,
+        offset_by_id=offset_by_id,
+        residual_by_id=residual_by_id,
+    )
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
     if closed_value is not None:
         candidate = _exact_arithmetic_value(closed_value, template=candidate)
 
     scalar = closed_value if closed_value is not None else folded_coefficient
+    offset: Fraction | None = (
+        Fraction(0) if closed_value is not None else folded_offset
+    )
     if scalar is None:
-        scalar = _wrapped_linear_scalar(
+        scalar, offset = _wrapped_linear_scalar(
             candidate,
             children,
             child_values,
             scalar_by_id=scalar_by_id,
+            offset_by_id=offset_by_id,
             residual_by_id=residual_by_id,
         )
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
     scalar_by_id[expression_id] = scalar
+    if offset is not None:
+        offset_by_id[expression_id] = offset
     if folded_dependent is not None:
         residual_by_id[expression_id] = folded_dependent
         residual_by_id[candidate.get_id()] = folded_dependent
+        offset_by_id[candidate.get_id()] = folded_offset
     return candidate
 
 
@@ -422,25 +473,59 @@ def _chased_residual(dependent: Any, residual_by_id: dict[int, Any]) -> Any:
     return core
 
 
+def _folded_offset(offset_by_id: dict[int, Fraction], child: Any) -> Fraction:
+    """Return the recorded translated constant of a scalar-bearing child."""
+
+    return offset_by_id.get(child.get_id(), Fraction(0))
+
+
 def _wrapped_linear_scalar(
     candidate: Any,
     children: tuple[Any, ...],
     child_values: tuple[Fraction | None, ...],
     *,
     scalar_by_id: dict[int, Fraction | None],
+    offset_by_id: dict[int, Fraction],
     residual_by_id: dict[int, Any],
-) -> Fraction | None:
+) -> tuple[Fraction | None, Fraction | None]:
     """Carry one child's folded linear scalar through coefficient-preserving wrappers."""
 
     import z3
 
     kind = candidate.decl().kind()
+    if kind == z3.Z3_OP_ADD and len(children) >= 2:
+        signs: tuple[int, ...] = (1,) * len(children)
+    elif kind == z3.Z3_OP_SUB and len(children) >= 2:
+        signs = (1,) + (-1,) * (len(children) - 1)
+    else:
+        signs = ()
     if len(children) == 1 and kind in (z3.Z3_OP_UMINUS, z3.Z3_OP_ADD):
         child_scalar = scalar_by_id[children[0].get_id()]
         if child_scalar is None:
-            return None
+            return None, None
         scalar = -child_scalar if kind == z3.Z3_OP_UMINUS else child_scalar
+        child_offset = _folded_offset(offset_by_id, children[0])
+        offset = -child_offset if kind == z3.Z3_OP_UMINUS else child_offset
         residual = _chased_residual(children[0], residual_by_id)
+    elif signs:
+        open_indices = [
+            index for index, value in enumerate(child_values) if value is None
+        ]
+        if len(open_indices) != 1:
+            return None, None
+        open_index = open_indices[0]
+        child_scalar = scalar_by_id[children[open_index].get_id()]
+        if child_scalar is None:
+            return None, None
+        sign = signs[open_index]
+        scalar = sign * child_scalar
+        total: Fraction = sign * _folded_offset(offset_by_id, children[open_index])
+        for index, value in enumerate(child_values):
+            if value is not None:
+                total += signs[index] * value
+        _require_bounded_normalized_coefficient(total)
+        offset = total
+        residual = _chased_residual(children[open_index], residual_by_id)
     elif (
         len(children) == 2
         and kind == z3.Z3_OP_DIV
@@ -450,15 +535,17 @@ def _wrapped_linear_scalar(
     ):
         dividend_scalar = scalar_by_id[children[0].get_id()]
         if dividend_scalar is None:
-            return None
-        scalar = dividend_scalar / child_values[1]
+            return None, None
+        divisor = child_values[1]
+        scalar = dividend_scalar / divisor
         _require_bounded_normalized_coefficient(scalar)
+        offset = _folded_offset(offset_by_id, children[0]) / divisor
+        _require_bounded_normalized_coefficient(offset)
         residual = _chased_residual(children[0], residual_by_id)
     else:
-        return None
-    residual_by_id[children[0].get_id()] = residual
+        return None, None
     residual_by_id[candidate.get_id()] = residual
-    return scalar
+    return scalar, offset
 
 
 def _evaluate_closed_arithmetic(

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -426,14 +426,16 @@ def _normalize_closed_expression(
         candidate = expression
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
-    candidate, folded_coefficient, folded_dependent, folded_offset = _fold_scaled_product(
-        candidate,
-        children,
-        normalized_children,
-        child_values,
-        scalar_by_id=scalar_by_id,
-        offset_by_id=offset_by_id,
-        residual_by_id=residual_by_id,
+    candidate, folded_coefficient, folded_dependent, folded_offset = (
+        _fold_scaled_product(
+            candidate,
+            children,
+            normalized_children,
+            child_values,
+            scalar_by_id=scalar_by_id,
+            offset_by_id=offset_by_id,
+            residual_by_id=residual_by_id,
+        )
     )
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
@@ -441,9 +443,7 @@ def _normalize_closed_expression(
         candidate = _exact_arithmetic_value(closed_value, template=candidate)
 
     scalar = closed_value if closed_value is not None else folded_coefficient
-    offset: Fraction | None = (
-        Fraction(0) if closed_value is not None else folded_offset
-    )
+    offset: Fraction | None = Fraction(0) if closed_value is not None else folded_offset
     if scalar is None:
         scalar, offset = _wrapped_linear_scalar(
             candidate,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -43,9 +43,11 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     of any closed arithmetic coefficient, including every scalar coefficient and
     translated constant obtained by flattening nested products and signed affine
     sums through coefficient-preserving wrappers (negation, additions and
-    subtractions over closed and variable-carrying operands, and exact division
+    subtractions over closed and variable-carrying operands, exact division
     by closed nonzero constants, integer division included when every divided
-    coefficient remains exactly divisible).
+    coefficient remains exactly divisible, and arithmetic if-then-else
+    selections, where scaling is bounded by the largest coefficient reachable
+    through any branch).
     Assertion source order is the public zero-based index. Parsing constructs Z3
     syntax trees only; it does not evaluate the source as Python or as a host
     command. Execution performs one tracked check and at most one direct
@@ -298,12 +300,14 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
     normalized_by_id: dict[int, Any] = {}
     closed_value_by_id: dict[int, Fraction | None] = {}
     form_by_id: dict[int, _AffineForm | None] = {}
+    height_by_id: dict[int, Fraction] = {}
     return tuple(
         _normalize_closed_expression(
             assertion,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             form_by_id=form_by_id,
+            height_by_id=height_by_id,
         )
         for assertion in assertions
     )
@@ -336,6 +340,7 @@ def _fold_scaled_product(
     child_values: tuple[Fraction | None, ...],
     *,
     form_by_id: dict[int, _AffineForm | None],
+    height_by_id: dict[int, Fraction],
 ) -> tuple[Any, _AffineForm | None]:
     """Flatten one product with a single variable-carrying affine child."""
 
@@ -347,12 +352,14 @@ def _fold_scaled_product(
     if len(open_indices) != 1:
         return candidate, None
     dependent = children[open_indices[0]]
-    child_form = form_by_id.get(dependent.get_id())
-    if child_form is None:
-        child_form = (((Fraction(1), dependent),), Fraction(0))
     coefficient = _bounded_fraction_product(
         tuple(value for value in child_values if value is not None)
     )
+    child_form = form_by_id.get(dependent.get_id())
+    if child_form is None:
+        scaled_height = coefficient * height_by_id.get(dependent.get_id(), Fraction(1))
+        _require_bounded_normalized_coefficient(scaled_height)
+        child_form = (((Fraction(1), dependent),), Fraction(0))
     terms, offset = child_form
     scaled_terms: list[tuple[Fraction, Any]] = []
     for term_coefficient, core in terms:
@@ -374,6 +381,7 @@ def _normalize_closed_expression(
     normalized_by_id: dict[int, Any],
     closed_value_by_id: dict[int, Fraction | None],
     form_by_id: dict[int, _AffineForm | None],
+    height_by_id: dict[int, Fraction],
 ) -> Any:
     """Normalize one expression without retaining a recursive closure over its AST."""
 
@@ -391,16 +399,19 @@ def _normalize_closed_expression(
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = value
         form_by_id[expression_id] = ((), value)
+        height_by_id[expression_id] = abs(value)
         return expression
     if not z3.is_app(expression):
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
         form_by_id[expression_id] = None
+        height_by_id[expression_id] = Fraction(1)
         return expression
     if z3.is_arith(expression) and not expression.children():
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
         form_by_id[expression_id] = (((Fraction(1), expression),), Fraction(0))
+        height_by_id[expression_id] = Fraction(1)
         return expression
 
     children = expression.children()
@@ -410,6 +421,7 @@ def _normalize_closed_expression(
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
             form_by_id=form_by_id,
+            height_by_id=height_by_id,
         )
         for child in children
     )
@@ -423,7 +435,11 @@ def _normalize_closed_expression(
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
     candidate, form = _fold_scaled_product(
-        candidate, children, child_values, form_by_id=form_by_id
+        candidate,
+        children,
+        child_values,
+        form_by_id=form_by_id,
+        height_by_id=height_by_id,
     )
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
@@ -434,12 +450,21 @@ def _normalize_closed_expression(
         form = _wrapped_linear_form(
             candidate, children, child_values, form_by_id=form_by_id
         )
+    height = (
+        abs(closed_value)
+        if closed_value is not None
+        else _coefficient_height(
+            candidate.decl().kind(), children, child_values, height_by_id=height_by_id
+        )
+    )
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
     form_by_id[expression_id] = form
+    height_by_id[expression_id] = height
     if not candidate.eq(expression):
         form_by_id[candidate.get_id()] = form
+        height_by_id[candidate.get_id()] = height
     return candidate
 
 
@@ -495,6 +520,56 @@ def _wrapped_linear_form(
         _require_bounded_normalized_coefficient(scaled_offset)
         return (tuple(scaled_terms), scaled_offset)
     return None
+
+
+def _coefficient_height(
+    kind: int,
+    children: tuple[Any, ...],
+    child_values: tuple[Fraction | None, ...],
+    *,
+    height_by_id: dict[int, Fraction],
+) -> Fraction:
+    """Bound every coefficient reachable in one expression's linear reading.
+
+    Arithmetic if-then-else selects exactly one branch, so its envelope is the
+    largest branch envelope; products multiply envelopes and signed sums merge
+    them, matching every scalar the preserving wrappers can derive downstream.
+    """
+
+    import z3
+
+    child_heights = tuple(height_by_id[child.get_id()] for child in children)
+    if kind == z3.Z3_OP_ITE and len(child_heights) == 3:
+        return max(child_heights[1], child_heights[2])
+    if kind == z3.Z3_OP_UMINUS:
+        return child_heights[0]
+    total = Fraction(0)
+    if kind == z3.Z3_OP_SUB:
+        total += child_heights[0]
+        _require_bounded_normalized_coefficient(total)
+        child_heights = child_heights[1:]
+    if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
+        for height in child_heights:
+            total += height
+            _require_bounded_normalized_coefficient(total)
+        return total
+    if kind == z3.Z3_OP_MUL:
+        return _bounded_fraction_product(child_heights)
+    if (
+        len(children) == 2
+        and kind in (z3.Z3_OP_DIV, z3.Z3_OP_IDIV)
+        and child_values[1] is not None
+        and child_values[1] != 0
+    ):
+        scaled = child_heights[0] / abs(child_values[1])
+        if kind == z3.Z3_OP_IDIV:
+            scaled += 1
+        _require_bounded_normalized_coefficient(scaled)
+        return scaled
+    for height in child_heights:
+        total += height
+        _require_bounded_normalized_coefficient(total)
+    return total
 
 
 def _combined_signed_form(

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -725,8 +725,9 @@ def _signed_sum_envelope(
     for envelope in envelopes:
         height += envelope.height
         _require_bounded_normalized_coefficient(height)
-    common_denominators = tuple(envelope.common_denominator for envelope in envelopes)
-    shared = _shared_common_denominator(common_denominators)
+    shared = _shared_common_denominator(
+        tuple(envelope.common_denominator for envelope in envelopes)
+    )
     denominator_digits = sum(envelope.denominator_digits for envelope in envelopes)
     widest_numerator = max(
         (
@@ -738,12 +739,6 @@ def _signed_sum_envelope(
     numerator_digits = widest_numerator + len(str(len(envelopes)))
     if shared is not None:
         denominator_digits = min(denominator_digits, len(str(shared)))
-        merged_numerator = sum(
-            10**envelope.numerator_digits
-            * (shared // (envelope.common_denominator or 1))
-            for envelope in envelopes
-        )
-        numerator_digits = min(numerator_digits, len(str(merged_numerator)))
     if validate_budget:
         _require_bounded_coefficient_digit_budget(
             numerator_digits,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -54,16 +54,11 @@ _MAX_ENVELOPE_PAIRS = 16
 
 
 def _capped_pairs(
-    numerators_by_denominator: dict[int, int],
+    pairs: set[tuple[int, int]],
 ) -> tuple[tuple[int, int], ...] | None:
-    if len(numerators_by_denominator) > _MAX_ENVELOPE_PAIRS:
+    if len(pairs) > _MAX_ENVELOPE_PAIRS:
         return None
-    return tuple(
-        sorted(
-            (numerator, denominator)
-            for denominator, numerator in numerators_by_denominator.items()
-        )
-    )
+    return tuple(sorted(pairs))
 
 
 def _merged_pairs(
@@ -76,9 +71,7 @@ def _merged_pairs(
         if pair_list is None:
             return None
         merged.update(pair_list)
-    if len(merged) > _MAX_ENVELOPE_PAIRS:
-        return None
-    return tuple(sorted(merged))
+    return _capped_pairs(merged)
 
 
 def _pairs_common_denominator(
@@ -95,14 +88,15 @@ def _scaled_pairs(
 ) -> tuple[tuple[int, int], ...] | None:
     if pairs is None:
         return None
-    numerators_by_denominator: dict[int, int] = {}
-    for numerator, denominator in pairs:
-        scaled = Fraction(numerator, denominator) * scalar
-        numerators_by_denominator[scaled.denominator] = max(
-            numerators_by_denominator.get(scaled.denominator, 0),
-            abs(scaled.numerator),
-        )
-    return _capped_pairs(numerators_by_denominator)
+    return _capped_pairs(
+        {
+            (
+                abs((Fraction(numerator, denominator) * scalar).numerator),
+                (Fraction(numerator, denominator) * scalar).denominator,
+            )
+            for numerator, denominator in pairs
+        }
+    )
 
 
 class SmtUnsatCoreRequest(SmtSolveRequest):
@@ -732,26 +726,21 @@ def _multiplied_envelope(
 def _product_pairs(
     pair_lists: tuple[tuple[tuple[int, int], ...] | None, ...],
 ) -> tuple[tuple[int, int], ...] | None:
-    result: dict[int, int] = {1: 1}
+    result: set[tuple[int, int]] = {(1, 1)}
     for pair_list in pair_lists:
         if pair_list is None:
             return None
-        combined: dict[int, int] = {}
+        combined: set[tuple[int, int]] = set()
         for numerator, denominator in pair_list:
             left = Fraction(numerator, denominator)
-            for shared_denominator, shared_numerator in result.items():
+            for shared_numerator, shared_denominator in result:
                 right = Fraction(shared_numerator, shared_denominator)
                 product = left * right
-                combined[product.denominator] = max(
-                    combined.get(product.denominator, 0),
-                    abs(product.numerator),
-                )
+                combined.add((abs(product.numerator), product.denominator))
         result = combined
         if len(result) > _MAX_ENVELOPE_PAIRS:
             return None
-    return tuple(
-        sorted((numerator, denominator) for denominator, numerator in result.items())
-    )
+    return _capped_pairs(result)
 
 
 def _divided_envelope(
@@ -804,18 +793,30 @@ def _signed_sum_envelope(
     numerator_digits = widest_numerator + len(str(len(envelopes)))
     shared = _shared_denominator_of_pairs(envelopes)
     if shared is not None:
-        merged_numerator = 0
+        lifted: list[set[Fraction]] = []
         for envelope in envelopes:
-            merged_numerator += max(
-                (
-                    numerator * (shared // denominator)
+            lifted.append(
+                {
+                    Fraction(numerator, denominator) * shared
                     for numerator, denominator in envelope.pairs or ()
-                ),
-                default=0,
+                }
             )
-        denominator_digits = min(denominator_digits, len(str(shared)))
-        numerator_digits = min(numerator_digits, len(str(merged_numerator)))
-        pairs: tuple[tuple[int, int], ...] | None = ((merged_numerator, shared),)
+        totals: set[Fraction] = {Fraction(0)}
+        for values in lifted:
+            totals = {total + value for total in totals for value in values}
+            if len(totals) > _MAX_ENVELOPE_PAIRS:
+                break
+        else:
+            pairs = _capped_pairs(
+                {(abs(value.numerator), value.denominator) for value in totals}
+            )
+            common_denominator = _pairs_common_denominator(pairs)
+            if common_denominator is not None:
+                denominator_digits = min(
+                    denominator_digits, len(str(common_denominator))
+                )
+            widest_merged = max(abs(value.numerator) for value in totals)
+            numerator_digits = min(numerator_digits, len(str(widest_merged)))
     else:
         pairs = None
     if validate_budget:
@@ -920,17 +921,13 @@ def _affine_form_envelope(
     """Read exact digit budgets off the flattened coefficients of one form."""
 
     coefficients = (form[1], *(coefficient for coefficient, _core in form[0]))
-    numerators_by_denominator: dict[int, int] = {}
-    for value in coefficients:
-        key = value.denominator
-        numerators_by_denominator[key] = max(
-            numerators_by_denominator.get(key, 0), abs(value.numerator)
-        )
     return _CoefficientEnvelope(
         height,
         max(len(str(abs(value.numerator))) for value in coefficients),
         max(len(str(value.denominator)) for value in coefficients),
-        _capped_pairs(numerators_by_denominator),
+        _capped_pairs(
+            {(abs(value.numerator), value.denominator) for value in coefficients}
+        ),
     )
 
 

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -25,6 +25,8 @@ _MAX_CORE_NUMERAL_DIGITS = 256
 _MAX_CORE_AST_NODES = 4_096
 _MAX_CORE_RLIMIT = 10_000_000
 _NUMERAL = re.compile(r"(?:-?[0-9]+(?:\.[0-9]+)?|#x[0-9a-fA-F]+|#b[01]+)")
+_AffineTerms = tuple[tuple[Fraction, Any], ...]
+_AffineForm = tuple[_AffineTerms, Fraction]
 
 
 class SmtUnsatCoreRequest(SmtSolveRequest):
@@ -39,9 +41,11 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
     nesting depth 256, 512 top-level ``assert`` commands, 4,096 distinct parsed AST
     nodes, 256 digits per numeral, and 256 digits in the numerator or denominator
     of any closed arithmetic coefficient, including every scalar coefficient and
-    translated constant obtained by flattening nested products through
-    coefficient-preserving wrappers (negation, additions and subtractions whose
-    remaining operands are closed, and exact division by closed constants).
+    translated constant obtained by flattening nested products and signed affine
+    sums through coefficient-preserving wrappers (negation, additions and
+    subtractions over closed and variable-carrying operands, and exact division
+    by closed nonzero constants, integer division included when every divided
+    coefficient remains exactly divisible).
     Assertion source order is the public zero-based index. Parsing constructs Z3
     syntax trees only; it does not evaluate the source as Python or as a host
     command. Execution performs one tracked check and at most one direct
@@ -293,80 +297,77 @@ def _normalize_closed_coefficients(assertions: tuple[Any, ...]) -> tuple[Any, ..
 
     normalized_by_id: dict[int, Any] = {}
     closed_value_by_id: dict[int, Fraction | None] = {}
-    scalar_by_id: dict[int, Fraction | None] = {}
-    offset_by_id: dict[int, Fraction] = {}
-    residual_by_id: dict[int, Any] = {}
+    form_by_id: dict[int, _AffineForm | None] = {}
     return tuple(
         _normalize_closed_expression(
             assertion,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
-            scalar_by_id=scalar_by_id,
-            offset_by_id=offset_by_id,
-            residual_by_id=residual_by_id,
+            form_by_id=form_by_id,
         )
         for assertion in assertions
     )
 
 
+def _affine_expression(
+    terms: _AffineTerms,
+    offset: Fraction,
+    *,
+    template: Any,
+) -> Any:
+    """Rebuild one bounded flat affine sum, or its constant when it has no terms."""
+
+    if not terms:
+        return _exact_arithmetic_value(offset, template=template)
+    lead_coefficient, lead_core = terms[0]
+    total: Any = (
+        _exact_arithmetic_value(lead_coefficient, template=lead_core) * lead_core
+    )
+    for coefficient, core in terms[1:]:
+        total = total + _exact_arithmetic_value(coefficient, template=core) * core
+    if offset:
+        total = total + _exact_arithmetic_value(offset, template=template)
+    return total
+
+
 def _fold_scaled_product(
     candidate: Any,
     children: tuple[Any, ...],
-    normalized_children: tuple[Any, ...],
     child_values: tuple[Fraction | None, ...],
     *,
-    scalar_by_id: dict[int, Fraction | None],
-    offset_by_id: dict[int, Fraction],
-    residual_by_id: dict[int, Any],
-) -> tuple[Any, Fraction | None, Any | None, Fraction]:
+    form_by_id: dict[int, _AffineForm | None],
+) -> tuple[Any, _AffineForm | None]:
     """Flatten one product with a single variable-carrying affine child."""
 
     import z3
 
     if candidate.decl().kind() != z3.Z3_OP_MUL:
-        return candidate, None, None, Fraction(0)
-    dependent_children = tuple(
-        normalized_child
-        for normalized_child, value in zip(
-            normalized_children, child_values, strict=True
-        )
-        if value is None
+        return candidate, None
+    open_indices = [
+        index for index, value in enumerate(child_values) if value is None
+    ]
+    if len(open_indices) != 1:
+        return candidate, None
+    dependent = children[open_indices[0]]
+    child_form = form_by_id.get(dependent.get_id())
+    if child_form is None:
+        child_form = (((Fraction(1), dependent),), Fraction(0))
+    coefficient = _bounded_fraction_product(
+        tuple(value for value in child_values if value is not None)
     )
-    closed_factors = tuple(value for value in child_values if value is not None)
-    dependent_scalar: Fraction | None = None
-    dependent_offset = Fraction(0)
-    for child, child_value in zip(children, child_values, strict=True):
-        if child_value is None:
-            dependent_scalar = scalar_by_id[child.get_id()]
-            if dependent_scalar is not None:
-                dependent_offset = offset_by_id[child.get_id()]
-            break
-    if len(dependent_children) != 1 or not closed_factors:
-        return candidate, None, None, Fraction(0)
-    factors = (
-        (*closed_factors, dependent_scalar)
-        if dependent_scalar is not None
-        else closed_factors
-    )
-    coefficient = _bounded_fraction_product(factors)
+    terms, offset = child_form
+    scaled_terms: list[tuple[Fraction, Any]] = []
+    for term_coefficient, core in terms:
+        scaled = coefficient * term_coefficient
+        _require_bounded_normalized_coefficient(scaled)
+        scaled_terms.append((scaled, core))
     scaled_offset = Fraction(0)
-    if dependent_offset:
-        scaled_offset = _bounded_fraction_product((*closed_factors, dependent_offset))
-    dependent = dependent_children[0]
-    while (residual := residual_by_id.get(dependent.get_id())) is not None:
-        dependent = residual
-    folded_term = candidate.decl()(
-        _exact_arithmetic_value(coefficient, template=candidate),
-        dependent,
-    )
-    folded_offset = Fraction(0)
-    folded_candidate: Any = folded_term
-    if dependent_offset:
-        folded_candidate = folded_term + _exact_arithmetic_value(
-            scaled_offset, template=folded_term
-        )
-        folded_offset = scaled_offset
-    return folded_candidate, coefficient, dependent, folded_offset
+    if offset:
+        scaled_offset = coefficient * offset
+        _require_bounded_normalized_coefficient(scaled_offset)
+    folded_terms = tuple(scaled_terms)
+    folded = _affine_expression(folded_terms, scaled_offset, template=candidate)
+    return folded, (folded_terms, scaled_offset)
 
 
 def _normalize_closed_expression(
@@ -374,9 +375,7 @@ def _normalize_closed_expression(
     *,
     normalized_by_id: dict[int, Any],
     closed_value_by_id: dict[int, Fraction | None],
-    scalar_by_id: dict[int, Fraction | None],
-    offset_by_id: dict[int, Fraction],
-    residual_by_id: dict[int, Any],
+    form_by_id: dict[int, _AffineForm | None],
 ) -> Any:
     """Normalize one expression without retaining a recursive closure over its AST."""
 
@@ -385,24 +384,25 @@ def _normalize_closed_expression(
     expression_id = expression.get_id()
     if expression_id in normalized_by_id:
         return normalized_by_id[expression_id]
-    if z3.is_int_value(expression):
-        value = Fraction(expression.as_long())
+    if z3.is_int_value(expression) or z3.is_rational_value(expression):
+        value = (
+            Fraction(expression.as_long())
+            if z3.is_int_value(expression)
+            else expression.as_fraction()
+        )
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = value
-        scalar_by_id[expression_id] = value
-        offset_by_id[expression_id] = Fraction(0)
-        return expression
-    if z3.is_rational_value(expression):
-        value = expression.as_fraction()
-        normalized_by_id[expression_id] = expression
-        closed_value_by_id[expression_id] = value
-        scalar_by_id[expression_id] = value
-        offset_by_id[expression_id] = Fraction(0)
+        form_by_id[expression_id] = ((), value)
         return expression
     if not z3.is_app(expression):
         normalized_by_id[expression_id] = expression
         closed_value_by_id[expression_id] = None
-        scalar_by_id[expression_id] = None
+        form_by_id[expression_id] = None
+        return expression
+    if z3.is_arith(expression) and not expression.children():
+        normalized_by_id[expression_id] = expression
+        closed_value_by_id[expression_id] = None
+        form_by_id[expression_id] = (((Fraction(1), expression),), Fraction(0))
         return expression
 
     children = expression.children()
@@ -411,9 +411,7 @@ def _normalize_closed_expression(
             child,
             normalized_by_id=normalized_by_id,
             closed_value_by_id=closed_value_by_id,
-            scalar_by_id=scalar_by_id,
-            offset_by_id=offset_by_id,
-            residual_by_id=residual_by_id,
+            form_by_id=form_by_id,
         )
         for child in children
     )
@@ -426,126 +424,142 @@ def _normalize_closed_expression(
         candidate = expression
 
     child_values = tuple(closed_value_by_id[child.get_id()] for child in children)
-    candidate, folded_coefficient, folded_dependent, folded_offset = (
-        _fold_scaled_product(
-            candidate,
-            children,
-            normalized_children,
-            child_values,
-            scalar_by_id=scalar_by_id,
-            offset_by_id=offset_by_id,
-            residual_by_id=residual_by_id,
-        )
+    candidate, form = _fold_scaled_product(
+        candidate, children, child_values, form_by_id=form_by_id
     )
 
     closed_value = _evaluate_closed_arithmetic(candidate.decl().kind(), child_values)
     if closed_value is not None:
         candidate = _exact_arithmetic_value(closed_value, template=candidate)
-
-    scalar = closed_value if closed_value is not None else folded_coefficient
-    offset: Fraction | None = Fraction(0) if closed_value is not None else folded_offset
-    if scalar is None:
-        scalar, offset = _wrapped_linear_scalar(
-            candidate,
-            children,
-            child_values,
-            scalar_by_id=scalar_by_id,
-            offset_by_id=offset_by_id,
-            residual_by_id=residual_by_id,
+        form = ((), closed_value)
+    elif form is None:
+        form = _wrapped_linear_form(
+            candidate, children, child_values, form_by_id=form_by_id
         )
 
     normalized_by_id[expression_id] = candidate
     closed_value_by_id[expression_id] = closed_value
-    scalar_by_id[expression_id] = scalar
-    if offset is not None:
-        offset_by_id[expression_id] = offset
-    if folded_dependent is not None:
-        residual_by_id[expression_id] = folded_dependent
-        residual_by_id[candidate.get_id()] = folded_dependent
-        offset_by_id[candidate.get_id()] = folded_offset
+    form_by_id[expression_id] = form
+    if not candidate.eq(expression):
+        form_by_id[candidate.get_id()] = form
     return candidate
 
 
-def _chased_residual(dependent: Any, residual_by_id: dict[int, Any]) -> Any:
-    core = dependent
-    while (residual := residual_by_id.get(core.get_id())) is not None:
-        core = residual
-    return core
-
-
-def _folded_offset(offset_by_id: dict[int, Fraction], child: Any) -> Fraction:
-    """Return the recorded translated constant of a scalar-bearing child."""
-
-    return offset_by_id.get(child.get_id(), Fraction(0))
-
-
-def _wrapped_linear_scalar(
+def _wrapped_linear_form(
     candidate: Any,
     children: tuple[Any, ...],
     child_values: tuple[Fraction | None, ...],
     *,
-    scalar_by_id: dict[int, Fraction | None],
-    offset_by_id: dict[int, Fraction],
-    residual_by_id: dict[int, Any],
-) -> tuple[Fraction | None, Fraction | None]:
-    """Carry one child's folded linear scalar through coefficient-preserving wrappers."""
+    form_by_id: dict[int, _AffineForm | None],
+) -> _AffineForm | None:
+    """Combine children's affine forms through coefficient-preserving wrappers."""
 
     import z3
 
     kind = candidate.decl().kind()
-    if kind == z3.Z3_OP_ADD and len(children) >= 2:
+    if len(children) == 1 and kind == z3.Z3_OP_UMINUS:
+        child_form = form_by_id.get(children[0].get_id())
+        if child_form is None:
+            return None
+        terms, offset = child_form
+        return (
+            tuple((-coefficient, core) for coefficient, core in terms),
+            -offset,
+        )
+    if kind == z3.Z3_OP_ADD and children:
         signs: tuple[int, ...] = (1,) * len(children)
     elif kind == z3.Z3_OP_SUB and len(children) >= 2:
         signs = (1,) + (-1,) * (len(children) - 1)
     else:
         signs = ()
-    if len(children) == 1 and kind in (z3.Z3_OP_UMINUS, z3.Z3_OP_ADD):
-        child_scalar = scalar_by_id[children[0].get_id()]
-        if child_scalar is None:
-            return None, None
-        scalar = -child_scalar if kind == z3.Z3_OP_UMINUS else child_scalar
-        child_offset = _folded_offset(offset_by_id, children[0])
-        offset = -child_offset if kind == z3.Z3_OP_UMINUS else child_offset
-        residual = _chased_residual(children[0], residual_by_id)
-    elif signs:
-        open_indices = [
-            index for index, value in enumerate(child_values) if value is None
-        ]
-        if len(open_indices) != 1:
-            return None, None
-        open_index = open_indices[0]
-        child_scalar = scalar_by_id[children[open_index].get_id()]
-        if child_scalar is None:
-            return None, None
-        sign = signs[open_index]
-        scalar = sign * child_scalar
-        total: Fraction = sign * _folded_offset(offset_by_id, children[open_index])
-        for index, value in enumerate(child_values):
-            if value is not None:
-                total += signs[index] * value
-        _require_bounded_normalized_coefficient(total)
-        offset = total
-        residual = _chased_residual(children[open_index], residual_by_id)
-    elif (
+    if signs:
+        return _combined_signed_form(children, signs, form_by_id=form_by_id)
+    if (
         len(children) == 2
-        and kind == z3.Z3_OP_DIV
+        and kind in (z3.Z3_OP_DIV, z3.Z3_OP_IDIV)
         and child_values[0] is None
         and child_values[1] is not None
         and child_values[1] != 0
     ):
-        dividend_scalar = scalar_by_id[children[0].get_id()]
-        if dividend_scalar is None:
-            return None, None
+        dividend_form = form_by_id.get(children[0].get_id())
+        if dividend_form is None:
+            return None
         divisor = child_values[1]
-        scalar = dividend_scalar / divisor
-        _require_bounded_normalized_coefficient(scalar)
-        offset = _folded_offset(offset_by_id, children[0]) / divisor
-        _require_bounded_normalized_coefficient(offset)
-        residual = _chased_residual(children[0], residual_by_id)
-    else:
-        return None, None
-    residual_by_id[candidate.get_id()] = residual
-    return scalar, offset
+        if kind == z3.Z3_OP_IDIV:
+            return _exact_integer_division_form(dividend_form, divisor)
+        terms, offset = dividend_form
+        scaled_terms: list[tuple[Fraction, Any]] = []
+        for coefficient, core in terms:
+            scaled = coefficient / divisor
+            _require_bounded_normalized_coefficient(scaled)
+            scaled_terms.append((scaled, core))
+        scaled_offset = offset / divisor
+        _require_bounded_normalized_coefficient(scaled_offset)
+        return (tuple(scaled_terms), scaled_offset)
+    return None
+
+
+def _combined_signed_form(
+    children: tuple[Any, ...],
+    signs: tuple[int, ...],
+    *,
+    form_by_id: dict[int, _AffineForm | None],
+) -> _AffineForm | None:
+    """Add signed affine forms, bounding every merged coefficient and constant."""
+
+    merged: dict[int, list[Any]] = {}
+    total = Fraction(0)
+    for child, sign in zip(children, signs, strict=True):
+        child_form = form_by_id.get(child.get_id())
+        if child_form is None:
+            return None
+        terms, offset = child_form
+        for coefficient, core in terms:
+            entry = merged.setdefault(core.get_id(), [Fraction(0), core])
+            entry[0] += sign * coefficient
+            _require_bounded_normalized_coefficient(entry[0])
+        total += sign * offset
+        _require_bounded_normalized_coefficient(total)
+    return (
+        tuple((entry[0], entry[1]) for entry in merged.values() if entry[0] != 0),
+        total,
+    )
+
+
+def _exact_integer_division_form(
+    form: _AffineForm,
+    divisor: Fraction,
+) -> _AffineForm | None:
+    """Divide an affine form by an integer constant under SMT-LIB div semantics.
+
+    Exact whenever the divisor divides every coefficient: for integers s, o, d
+    with d dividing s, ``(div (+ (* s x) o) d)`` equals ``(* (/ s d) x)``
+    plus the Euclidean quotient of ``o`` by ``d``, since the constant remainder
+    ``o mod d`` already satisfies the Euclidean range on its own.
+    """
+
+    if divisor.denominator != 1:
+        return None
+    terms, offset = form
+    if offset.denominator != 1:
+        return None
+    divided_terms: list[tuple[Fraction, Any]] = []
+    for coefficient, core in terms:
+        if coefficient.denominator != 1 or coefficient.numerator % divisor.numerator:
+            return None
+        quotient = coefficient / divisor
+        _require_bounded_normalized_coefficient(quotient)
+        divided_terms.append((quotient, core))
+    quotient_offset = _euclidean_quotient(offset, divisor)
+    _require_bounded_normalized_coefficient(quotient_offset)
+    return (tuple(divided_terms), quotient_offset)
+
+
+def _euclidean_quotient(value: Fraction, divisor: Fraction) -> Fraction:
+    quotient = Fraction(value // divisor)
+    if value - divisor * quotient < 0:
+        quotient += 1
+    return quotient
 
 
 def _evaluate_closed_arithmetic(

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -30,6 +30,7 @@ def test_logic_bundle_exposes_only_atomic_inline_operations() -> None:
         "sat.solve",
         "smt.solve",
         "lean.check",
+        "smt.unsat_core",
     )
 
 

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -679,9 +679,7 @@ def test_request_bounds_integer_division_translated_constant_digits() -> None:
         logic="QF_LIA", smtlib=template.format(constant=constant)
     )
     with pytest.raises(ValidationError, match="normalized SMT coefficient"):
-        SmtUnsatCoreRequest(
-            logic="QF_LIA", smtlib=template.format(constant="9" * 256)
-        )
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=template.format(constant="9" * 256))
 
 
 def test_translated_nested_coefficients_flatten_and_still_solve() -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -923,6 +923,67 @@ def test_request_bounds_shared_denominator_comparison_numerator_digits() -> None
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_nested_division_of_formless_ite_denominator_digits() -> None:
+    outer = "9" * 200
+    inner = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (/ (/ (ite p (* {outer} x) x) {outer}) {inner}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_nested_division_of_formless_ite_still_admitted() -> None:
+    outer = "9" * 60
+    inner = "3" * 60
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (/ (/ (ite p (* {outer} x) x) {outer}) {inner}) 0))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_request_bounds_compared_pairless_chain_denominator_digits() -> None:
+    constants = [str(10**199 + offset) for offset in range(5)]
+
+    def chain(prefix: str) -> str:
+        term = "x"
+        for index in range(5):
+            term = f"(ite {prefix}{index} (* (/ 1 {constants[index]}) x) {term})"
+        return term
+
+    declarations = "".join(
+        f"(declare-const left{index} Bool)\n(declare-const right{index} Bool)\n"
+        for index in range(5)
+    )
+    source = (
+        "(set-logic QF_LRA)\n"
+        f"{declarations}"
+        "(declare-const x Real)\n"
+        f"(assert (= {chain('left')} {chain('right')}))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -485,9 +485,7 @@ def test_request_bounds_nested_coefficients_through_preserving_wrappers(
 ) -> None:
     outer = "9" * 200
     inner = "9" * 200
-    declaration = (
-        "(declare-const x Int)" if logic == "QF_LIA" else ""
-    )
+    declaration = "(declare-const x Int)" if logic == "QF_LIA" else ""
     source = (
         f"(set-logic {logic})\n"
         f"{declaration}\n"

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1068,6 +1068,68 @@ def test_bounded_sum_division_of_formless_ite_still_admitted() -> None:
     assert result.core_indices == (0, 1)
 
 
+def test_request_keeps_oversized_sum_cross_sums_typed_and_admitted() -> None:
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (+ (ite p x (ite q (* 2 x) (ite p (* 4 x) (ite q (* 8 x) "
+        "(* 16 x)))))) (ite p (* 16 x) (ite q (* 8 x) (ite p (* 4 x) "
+        "(ite q (* 2 x) x))))))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
+def test_request_bounds_shared_denominator_sum_division_digits() -> None:
+    inner = "9" * 130
+    outer = "9" * 130
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ "
+        f"(+ (ite p (/ x {inner}) x) (ite q (/ x {inner}) x)) "
+        f"(* 2 {inner})) {outer}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_shared_denominator_sum_division_still_admitted() -> None:
+    inner = "9" * 60
+    outer = "3" * 60
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ "
+        f"(+ (ite p (/ x {inner}) x) (ite q (/ x {inner}) x)) "
+        f"(* 2 {inner})) {outer}) 0))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -811,6 +811,38 @@ def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
+    odd = "9" * 200
+    scalar = "9" * 100
+    ite_template = "(ite {p} (* (/ 9 2) x) (* (/ 1 {odd}) x))"
+    sum_term = (
+        f"(+ {ite_template.format(p='p', odd=odd)} "
+        f"{ite_template.format(p='q', odd=odd)})"
+    )
+    scaled_source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* {scalar} {sum_term}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=scaled_source)
+
+    unscaled_source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= {sum_term} 0))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=unscaled_source)
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -510,6 +510,83 @@ def test_request_bounds_nested_real_coefficient_digits() -> None:
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+@pytest.mark.parametrize(
+    ("logic", "declaration", "assertion_template"),
+    (
+        (
+            "QF_LIA",
+            "(declare-const x Int)",
+            "(assert (= (* {outer} (+ (* {inner} x) 1)) 0))",
+        ),
+        (
+            "QF_LIA",
+            "(declare-const x Int)",
+            "(assert (= (* {outer} (- (* {inner} x) 1)) 0))",
+        ),
+        (
+            "QF_LIA",
+            "(declare-const x Int)",
+            "(assert (= (* {outer} (+ 1 (- (* {inner} x)) 2)) 0))",
+        ),
+        (
+            "QF_LRA",
+            "(declare-const y Real)",
+            "(assert (= (* {outer}.0 (+ (* {inner}.0 y) (/ 1.0 3.0))) 0.0))",
+        ),
+    ),
+)
+def test_request_bounds_translated_product_coefficient_digits(
+    logic: str,
+    declaration: str,
+    assertion_template: str,
+) -> None:
+    outer = "9" * 200
+    inner = "9" * 200
+    source = (
+        f"(set-logic {logic})\n"
+        f"{declaration}\n"
+        f"{assertion_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+
+
+def test_request_bounds_translated_constant_digits() -> None:
+    boundary_constant = "9" * 255
+    over_constant = "9" * 256
+    template = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (= (* 2 (+ (* 2 x) {constant})) 0))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(
+        logic="QF_LIA", smtlib=template.format(constant=boundary_constant)
+    )
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(
+            logic="QF_LIA", smtlib=template.format(constant=over_constant)
+        )
+
+
+def test_translated_nested_coefficients_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (* 2 (+ (* 2 x) 1)) 10))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
 def test_nested_closed_coefficients_flatten_and_still_solve() -> None:
     source = (
         "(set-logic QF_LIA)\n"

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -741,6 +741,46 @@ def test_request_bounds_deeply_nested_ite_branch_coefficients(nesting: int) -> N
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
 
 
+@pytest.mark.parametrize(
+    "assertion_template",
+    (
+        "(assert (= (* {outer} (ite p (* {inner} x) x)) 0))",
+        "(assert (= (* {outer} (ite p x (* {inner} x))) 0))",
+        "(assert (= (* {outer} (ite p (* {inner} x) (* {inner} x))) 0))",
+    ),
+)
+def test_request_bounds_reciprocal_ite_branch_denominator_digits(
+    assertion_template: str,
+) -> None:
+    outer = "0." + "9" * 150
+    inner = "0." + "9" * 150
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"{assertion_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_request_bounds_ite_branch_digits_when_scalars_cancel_the_height() -> None:
+    larger = "9" * 150
+    smaller = "0." + "9" * 150
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* {smaller} (ite p (* {larger} x) (* {smaller} x))) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
 def test_translated_nested_coefficients_flatten_and_still_solve() -> None:
     source = (
         "(set-logic QF_LIA)\n"
@@ -889,6 +929,39 @@ def test_small_ite_branch_scalars_remain_admitted_and_satisfiable() -> None:
     )
 
     result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
+def test_bounded_reciprocal_ite_branches_flatten_and_still_solve() -> None:
+    larger = "9" * 100
+    smaller = "0." + "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* {smaller} (ite p (* {larger} x) (* {smaller} x))) 0))\n"
+        "(assert (distinct x 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_small_reciprocal_ite_scalars_remain_admitted_and_satisfiable() -> None:
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (>= (* 0.5 (ite p (* 0.25 x) x)) 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
     assert result.outcome == "SAT"
     assert result.core_indices == ()

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -781,6 +781,45 @@ def test_request_bounds_ite_branch_digits_when_scalars_cancel_the_height() -> No
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_division_of_formless_ite_branch_denominator_digits() -> None:
+    digits = "9" * 200
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (/ (ite p (/ x {digits}) x) {digits}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_division_of_formless_ite_branches_still_admitted() -> None:
+    digits = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (/ (ite p (/ x {digits}) x) {digits}) 0))\n"
+        f"(assert (= (/ x {digits}) 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_request_keeps_exact_division_by_boundary_digit_divisor() -> None:
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (/ x {'9' * 256}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
 def test_translated_nested_coefficients_flatten_and_still_solve() -> None:
     source = (
         "(set-logic QF_LIA)\n"

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -796,18 +796,45 @@ def test_request_bounds_division_of_formless_ite_branch_denominator_digits() -> 
 
 
 def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
-    digits = "9" * 200
+    odd = "9" * 200
+    even = "1" + "0" * 200
     source = (
         "(set-logic QF_LRA)\n"
         "(declare-const p Bool)\n"
         "(declare-const q Bool)\n"
         "(declare-const x Real)\n"
-        f"(assert (= (+ (ite p (/ x {digits}) x) (ite q (/ x {digits}) x)) 0))\n"
+        f"(assert (= (+ (ite p (/ x {odd}) x) (ite q (/ x {even}) x)) 0))\n"
         "(check-sat)\n"
     )
 
     with pytest.raises(ValidationError, match="normalized SMT coefficient"):
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
+    digits = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const r Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (+ "
+        f"(ite p (/ x {digits}) x) "
+        f"(ite q (/ x {digits}) x) "
+        f"(ite r (/ x {digits}) x)"
+        ") 3))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
 
 
 def test_bounded_formless_ite_sums_flatten_and_still_solve() -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -871,6 +871,43 @@ def test_request_bounds_four_shared_denominator_formless_ite_terms() -> None:
     assert result.core_indices == ()
 
 
+def test_request_bounds_comparison_of_formless_ite_branch_denominator_digits() -> None:
+    odd = "9" * 200
+    even = "1" + "0" * 200
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (ite p (/ x {odd}) x) (ite q (/ x {even}) x)))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_comparison_of_formless_ite_branches_still_admitted() -> None:
+    digits = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (ite p (/ x {digits}) x) (ite q (/ x {digits}) x)))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from weakref import ReferenceType, ref
 
 import pytest
 import z3
@@ -33,7 +34,6 @@ def _request(
         smtlib=smtlib,
         timeout_ms=1_000,
         rlimit=rlimit,
-        max_memory_mb=128,
     )
 
 
@@ -47,6 +47,13 @@ def test_unsat_core_is_an_indexed_replayable_source_subset() -> None:
     replay = z3.SolverFor(result.source.logic.value)
     replay.add(*(assertions[index] for index in result.core_indices))
     assert replay.check() == z3.unsat
+
+
+def test_repeated_calls_have_a_stable_exact_outcome() -> None:
+    results = tuple(compute_smt_unsat_core(_request()) for _ in range(16))
+
+    assert tuple(result.outcome for result in results) == ("UNSAT",) * 16
+    assert tuple(result.core_indices for result in results) == ((0, 1),) * 16
 
 
 def test_unsat_core_result_rejects_a_core_detached_from_its_source() -> None:
@@ -91,6 +98,19 @@ def test_resource_exhaustion_is_unknown_not_unsat() -> None:
     assert result.outcome == "UNKNOWN"
     assert result.core_indices == ()
     assert result.detail
+
+
+def test_core_extraction_failure_is_a_typed_unknown(monkeypatch) -> None:
+    def fail_core_extraction(_solver: z3.Solver) -> None:
+        raise z3.Z3Exception("core extraction failed")
+
+    monkeypatch.setattr(z3.Solver, "unsat_core", fail_core_extraction)
+
+    result = compute_smt_unsat_core(_request())
+
+    assert result.outcome == "UNKNOWN"
+    assert result.core_indices == ()
+    assert result.detail == "Z3 could not complete the bounded source check."
 
 
 def test_replay_resource_exhaustion_is_a_typed_unknown(monkeypatch) -> None:
@@ -151,6 +171,128 @@ def test_unsat_core_supports_each_admitted_smt_fragment(
     assert result.core_indices == (0, 1)
 
 
+def test_qf_uf_accepts_boolean_uninterpreted_functions() -> None:
+    source = """\
+(set-logic QF_UF)
+(declare-fun f (Bool) Bool)
+(declare-const p Bool)
+(assert (f p))
+(assert (not (f p)))
+(check-sat)
+"""
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_UF", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+@pytest.mark.parametrize(
+    ("logic", "source"),
+    (
+        (
+            "QF_LIA",
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (>= (* (- 2) x) 2))\n"
+            "(assert (>= x 0))\n"
+            "(check-sat)\n",
+        ),
+        (
+            "QF_LRA",
+            "(set-logic QF_LRA)\n"
+            "(declare-const x Real)\n"
+            "(assert (= (* (/ 1 3) x) 2.0))\n"
+            "(assert (= x 0.0))\n"
+            "(check-sat)\n",
+        ),
+        (
+            "QF_LIA",
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (= (* 2 3 x) 6))\n"
+            "(assert (= x 0))\n"
+            "(check-sat)\n",
+        ),
+        (
+            "QF_LRA",
+            "(set-logic QF_LRA)\n"
+            "(declare-const x Real)\n"
+            "(assert (= (* (/ 1 2) (/ 2 3) x) 1.0))\n"
+            "(assert (= x 0.0))\n"
+            "(check-sat)\n",
+        ),
+    ),
+)
+def test_linear_closed_coefficients_are_admitted(logic: str, source: str) -> None:
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic=logic, smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+@pytest.mark.parametrize(
+    ("logic", "declarations", "assertion"),
+    (
+        ("QF_LIA", "(declare-const x Int)", "(assert (= (* x x) 2))"),
+        ("QF_LIA", "(declare-const x Int)", "(assert (= (* 0 x x) 0))"),
+        ("QF_LIA", "(declare-const x Real)", "(assert (> x 0.0))"),
+        (
+            "QF_LIA",
+            "",
+            "(assert (forall ((x Int)) (= x x)))",
+        ),
+        (
+            "QF_LRA",
+            "(declare-const x (_ BitVec 8))",
+            "(assert (= x (_ bv0 8)))",
+        ),
+        ("QF_UF", "(declare-const x Int)", "(assert (= x x))"),
+    ),
+)
+def test_request_rejects_terms_outside_the_declared_fragment(
+    logic: str,
+    declarations: str,
+    assertion: str,
+) -> None:
+    source = "\n".join((f"(set-logic {logic})", declarations, assertion, "(check-sat)"))
+
+    with pytest.raises(ValidationError, match=f"declared {logic} fragment"):
+        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+
+
+def test_retained_validation_error_does_not_retain_a_z3_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_refs: list[ReferenceType[z3.Context]] = []
+    parse_assertions = unsat_core._parse_assertions
+
+    def track_context(
+        smtlib: str,
+        *,
+        context: z3.Context | None = None,
+    ) -> tuple[object, ...]:
+        owned_context = z3.Context() if context is None else context
+        context_refs.append(ref(owned_context))
+        return parse_assertions(smtlib, context=owned_context)
+
+    monkeypatch.setattr(unsat_core, "_parse_assertions", track_context)
+    with pytest.raises(ValidationError) as retained_error:
+        SmtUnsatCoreRequest(
+            logic="QF_LIA",
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                "(assert (= (* x x) 2))\n"
+                "(check-sat)\n"
+            ),
+        )
+
+    assert retained_error.value
+    assert context_refs
+    assert all(context_ref() is None for context_ref in context_refs)
+
+
 def test_comments_cannot_impersonate_indexed_assertions_or_execute_text(
     tmp_path: Path,
 ) -> None:
@@ -206,6 +348,31 @@ def test_request_bounds_the_number_of_indexed_assertions() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=rejected)
 
 
+def test_request_bounds_source_tokens() -> None:
+    def source(term_count: int) -> str:
+        terms = " ".join("x" for _ in range(term_count))
+        return (
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Bool)\n"
+            f"(assert (and {terms}))\n"
+            "(check-sat)\n"
+        )
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(32_750))
+    with pytest.raises(ValidationError, match="at most 32768 tokens"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(32_751))
+
+
+def test_request_bounds_source_nesting() -> None:
+    def source(negation_count: int) -> str:
+        term = "(not " * negation_count + "true" + ")" * negation_count
+        return f"(set-logic QF_LIA)\n(assert {term})\n(check-sat)\n"
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(255))
+    with pytest.raises(ValidationError, match="nesting may not exceed 256"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(256))
+
+
 def test_request_bounds_numeric_coefficient_digits() -> None:
     accepted_number = "1" * 256
     accepted = (
@@ -218,6 +385,22 @@ def test_request_bounds_numeric_coefficient_digits() -> None:
     assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=accepted)
     with pytest.raises(ValidationError, match="numeral may contain at most 256 digits"):
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=rejected)
+
+
+def test_request_bounds_negative_numeric_atom_digits() -> None:
+    rejected_number = "-" + "1" * 257
+    source = f"(set-logic QF_LIA)\n(assert (= {rejected_number} 0))\n(check-sat)\n"
+
+    with pytest.raises(ValidationError, match="numeral may contain at most 256 digits"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
+def test_request_bounds_normalized_closed_coefficient_digits() -> None:
+    factor = "9" * 256
+    source = f"(set-logic QF_LIA)\n(assert (= (* {factor} {factor}) 0))\n(check-sat)\n"
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
 
 
 def test_request_bounds_parsed_ast_nodes() -> None:
@@ -252,4 +435,6 @@ def test_request_schema_explains_validator_owned_indexing() -> None:
     schema = SmtUnsatCoreRequest.model_json_schema()
 
     assert "zero-based index" in schema["description"]
+    assert "does not claim a hard request-local byte limit" in schema["description"]
+    assert "Boolean-sorted" in schema["properties"]["logic"]["description"]
     assert schema["examples"]

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -984,6 +984,90 @@ def test_request_bounds_compared_pairless_chain_denominator_digits() -> None:
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_scaled_formless_ite_nested_division_digits() -> None:
+    scalar = "9" * 150
+    outer = "9" * 150
+    inner = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ (/ "
+        f"(ite p (* {scalar} {outer} x) (* {outer} x)) "
+        f"{outer}) {scalar}) {inner}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_scaled_formless_ite_nested_division_still_admitted() -> None:
+    scalar = "9" * 60
+    outer = "7" * 60
+    inner = "3" * 60
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ (/ "
+        f"(ite p (* {scalar} {outer} x) (* {outer} x)) "
+        f"{outer}) {scalar}) {inner}) 0))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_request_bounds_sum_division_of_formless_ite_denominator_digits() -> None:
+    inner = "9" * 200
+    outer = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ "
+        f"(+ (ite p (* {inner} x) x) (ite q (* {inner} x) x)) "
+        f"(* 2 {inner})) {outer}) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_sum_division_of_formless_ite_still_admitted() -> None:
+    inner = "3" * 60
+    outer = "9" * 60
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (/ (/ "
+        f"(+ (ite p (* {inner} x) x) (ite q (* {inner} x) x)) "
+        f"(* 2 {inner})) {outer}) 0))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import z3
+from pydantic import ValidationError
+
+from jacobian.math.logic import _unsat_core as unsat_core
+from jacobian.math.logic._unsat_core import (
+    SmtUnsatCoreRequest,
+    SmtUnsatCoreResult,
+    compute_smt_unsat_core,
+)
+
+CONTRADICTORY_LIA = """\
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (>= x 1))
+(assert (<= x 0))
+(assert (<= x 10))
+(check-sat)
+"""
+
+
+def _request(
+    smtlib: str = CONTRADICTORY_LIA,
+    *,
+    rlimit: int = 100_000,
+) -> SmtUnsatCoreRequest:
+    return SmtUnsatCoreRequest(
+        logic="QF_LIA",
+        smtlib=smtlib,
+        timeout_ms=1_000,
+        rlimit=rlimit,
+        max_memory_mb=128,
+    )
+
+
+def test_unsat_core_is_an_indexed_replayable_source_subset() -> None:
+    result = compute_smt_unsat_core(_request())
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == tuple(sorted(result.core_indices))
+    assert result.core_indices == (0, 1)
+    assertions = tuple(z3.parse_smt2_string(result.source.smtlib))
+    replay = z3.SolverFor(result.source.logic.value)
+    replay.add(*(assertions[index] for index in result.core_indices))
+    assert replay.check() == z3.unsat
+
+
+def test_unsat_core_result_rejects_a_core_detached_from_its_source() -> None:
+    result = compute_smt_unsat_core(_request())
+    payload = result.model_dump(mode="json")
+    payload["source"]["smtlib"] = CONTRADICTORY_LIA.replace("(>= x 1)", "(>= x -1)")
+
+    with pytest.raises(ValidationError, match="selected source assertions"):
+        SmtUnsatCoreResult.model_validate(payload)
+
+
+def test_unsat_core_result_rejects_a_forged_proper_subset() -> None:
+    result = compute_smt_unsat_core(_request())
+    payload = result.model_dump(mode="json")
+    payload["core_indices"] = [0]
+
+    with pytest.raises(ValidationError, match="selected source assertions"):
+        SmtUnsatCoreResult.model_validate(payload)
+
+
+def test_unsat_core_result_rejects_a_forged_sat_conclusion() -> None:
+    result = compute_smt_unsat_core(_request())
+    payload = result.model_dump(mode="json")
+    payload["outcome"] = "SAT"
+    payload["core_indices"] = []
+
+    with pytest.raises(ValidationError, match="complete source assertions"):
+        SmtUnsatCoreResult.model_validate(payload)
+
+
+def test_empty_assertion_collection_is_satisfiable() -> None:
+    result = compute_smt_unsat_core(_request("(set-logic QF_LIA)\n(check-sat)\n"))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+    assert result.detail is None
+
+
+def test_resource_exhaustion_is_unknown_not_unsat() -> None:
+    result = compute_smt_unsat_core(_request(rlimit=1))
+
+    assert result.outcome == "UNKNOWN"
+    assert result.core_indices == ()
+    assert result.detail
+
+
+def test_replay_resource_exhaustion_is_a_typed_unknown(monkeypatch) -> None:
+    monkeypatch.setattr(
+        unsat_core,
+        "_extract_source_core",
+        lambda _source: ("UNSAT", (0, 1), None),
+    )
+    monkeypatch.setattr(
+        unsat_core,
+        "_replay_source",
+        lambda _source, _indices: ("UNKNOWN", "canceled"),
+    )
+
+    result = compute_smt_unsat_core(_request())
+
+    assert result.outcome == "UNKNOWN"
+    assert result.core_indices == ()
+    assert result.detail is not None
+    assert "result-validation replay" in result.detail
+
+
+@pytest.mark.parametrize(
+    ("logic", "smtlib"),
+    (
+        (
+            "QF_UF",
+            "(set-logic QF_UF)\n"
+            "(declare-const p Bool)\n"
+            "(assert p)\n"
+            "(assert (not p))\n"
+            "(check-sat)\n",
+        ),
+        (
+            "QF_LIA",
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (> x 0))\n"
+            "(assert (< x 0))\n"
+            "(check-sat)\n",
+        ),
+        (
+            "QF_LRA",
+            "(set-logic QF_LRA)\n"
+            "(declare-const x Real)\n"
+            "(assert (> x 0))\n"
+            "(assert (< x 0))\n"
+            "(check-sat)\n",
+        ),
+    ),
+)
+def test_unsat_core_supports_each_admitted_smt_fragment(
+    logic: str, smtlib: str
+) -> None:
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic=logic, smtlib=smtlib))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_comments_cannot_impersonate_indexed_assertions_or_execute_text(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "executed"
+    source = f"""\
+(set-logic QF_LIA)
+(declare-const x Int)
+; (assert false) __import__('pathlib').Path({str(marker)!r}).write_text('x')
+(assert (> x 0))
+(assert (< x 0))
+(check-sat)
+"""
+
+    result = compute_smt_unsat_core(_request(source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+    assert not marker.exists()
+
+
+def test_tracking_symbols_do_not_alias_caller_boolean_constants() -> None:
+    source = """\
+(set-logic QF_LIA)
+(declare-const jacobian_unsat_core_0 Bool)
+(declare-const x Int)
+(assert (not jacobian_unsat_core_0))
+(assert (> x 0))
+(assert (< x 0))
+(check-sat)
+"""
+
+    result = compute_smt_unsat_core(_request(source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (1, 2)
+
+
+def test_request_validates_smtlib_syntax_before_execution() -> None:
+    with pytest.raises(ValidationError, match="could not be parsed"):
+        _request(
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (+ 1 2))\n(check-sat)\n"
+        )
+
+
+def test_request_bounds_the_number_of_indexed_assertions() -> None:
+    accepted = "\n".join(
+        ["(set-logic QF_LIA)", *("(assert true)" for _ in range(512)), "(check-sat)"]
+    )
+    rejected = accepted.replace("(check-sat)", "(assert true)\n(check-sat)")
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=accepted).assertion_count == 512
+    with pytest.raises(ValidationError, match="at most 512 source assertions"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=rejected)
+
+
+def test_request_bounds_numeric_coefficient_digits() -> None:
+    accepted_number = "1" * 256
+    accepted = (
+        "(set-logic QF_LIA)\n"
+        f"(assert (= {accepted_number} {accepted_number}))\n"
+        "(check-sat)\n"
+    )
+    rejected = accepted.replace(accepted_number, "1" * 257, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=accepted)
+    with pytest.raises(ValidationError, match="numeral may contain at most 256 digits"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=rejected)
+
+
+def test_request_bounds_parsed_ast_nodes() -> None:
+    def source(term_count: int) -> str:
+        equalities = " ".join(f"(= x {value})" for value in range(term_count))
+        return (
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            f"(assert (and {equalities}))\n"
+            "(check-sat)\n"
+        )
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_047))
+    with pytest.raises(ValidationError, match="at most 4096 distinct AST nodes"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(2_048))
+
+
+def test_unsat_result_requires_a_nonempty_canonical_core() -> None:
+    result = compute_smt_unsat_core(_request())
+    payload = result.model_dump(mode="json")
+    payload["core_indices"] = []
+
+    with pytest.raises(ValidationError, match="nonempty core"):
+        SmtUnsatCoreResult.model_validate(payload)
+
+    payload["core_indices"] = [1, 0]
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        SmtUnsatCoreResult.model_validate(payload)
+
+
+def test_request_schema_explains_validator_owned_indexing() -> None:
+    schema = SmtUnsatCoreRequest.model_json_schema()
+
+    assert "zero-based index" in schema["description"]
+    assert schema["examples"]

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -843,6 +843,34 @@ def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
     assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=unscaled_source)
 
 
+def test_request_bounds_four_shared_denominator_formless_ite_terms() -> None:
+    digits = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const r Bool)\n"
+        "(declare-const s Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (+ "
+        f"(ite p (/ x {digits}) x) "
+        f"(ite q (/ x {digits}) x) "
+        f"(ite r (/ x {digits}) x) "
+        f"(ite s (/ x {digits}) x)"
+        ") 4))\n"
+        "(assert (>= x 1))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -795,6 +795,39 @@ def test_request_bounds_division_of_formless_ite_branch_denominator_digits() -> 
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
+    digits = "9" * 200
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (+ (ite p (/ x {digits}) x) (ite q (/ x {digits}) x)) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_formless_ite_sums_flatten_and_still_solve() -> None:
+    digits = "9" * 100
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (+ (ite p (/ x {digits}) x) (ite q (/ x {digits}) x)) 0))\n"
+        "(assert (>= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
 def test_bounded_division_of_formless_ite_branches_still_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -572,6 +572,118 @@ def test_request_bounds_translated_constant_digits() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("logic", "declarations", "assertion_template"),
+    (
+        (
+            "QF_LIA",
+            "(declare-const x Int)\n(declare-const y Int)",
+            "(assert (= (* {outer} (+ (* {inner} x) (* {inner} y))) 0))",
+        ),
+        (
+            "QF_LIA",
+            "(declare-const x Int)\n(declare-const y Int)\n(declare-const z Int)",
+            "(assert (= (* {outer} (+ (* {inner} x) (- (* {inner} y)) (* {inner} z))) 0))",
+        ),
+        (
+            "QF_LRA",
+            "(declare-const x Real)\n(declare-const y Real)",
+            "(assert (= (* {outer}.0 (+ (* {inner}.0 x) (* {inner}.0 y))) 0.0))",
+        ),
+    ),
+)
+def test_request_bounds_multi_term_affine_sum_coefficient_digits(
+    logic: str,
+    declarations: str,
+    assertion_template: str,
+) -> None:
+    outer = "9" * 200
+    inner = "9" * 200
+    source = (
+        f"(set-logic {logic})\n"
+        f"{declarations}\n"
+        f"{assertion_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+
+
+def test_request_bounds_multi_term_boundary_coefficients() -> None:
+    factor = "9" * 128
+    boundary = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(declare-const y Int)\n"
+        f"(assert (= (* {factor} (+ (* {factor} x) (* {factor} y))) 0))\n"
+        "(check-sat)\n"
+    )
+    over = boundary.replace(factor, "9" * 129, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+
+
+def test_request_bounds_merged_duplicate_summand_coefficients() -> None:
+    summand = "9" * 128
+    outer = "9" * 127
+    boundary = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= (* {outer} (+ (* {summand} x) (* {summand} x))) 0))\n"
+        "(check-sat)\n"
+    )
+    over = boundary.replace(outer, "9" * 128, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+
+
+@pytest.mark.parametrize(
+    "assertion_template",
+    (
+        "(assert (= (* {outer} (div (* {inner} x) 1)) 0))",
+        "(assert (= (* {outer} (div (+ (* {inner} x) 7) 1)) 0))",
+        "(assert (= (* {outer} (div (* {inner} x) (- 1))) 0))",
+    ),
+)
+def test_request_bounds_exact_integer_division_coefficient_digits(
+    assertion_template: str,
+) -> None:
+    outer = "9" * 200
+    inner = "9" * 200
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"{assertion_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
+def test_request_bounds_integer_division_translated_constant_digits() -> None:
+    constant = "9" * 255
+    template = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (= (* 4 (div (+ (* 2 x) {constant}) 1)) 0))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(
+        logic="QF_LIA", smtlib=template.format(constant=constant)
+    )
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(
+            logic="QF_LIA", smtlib=template.format(constant="9" * 256)
+        )
+
+
 def test_translated_nested_coefficients_flatten_and_still_solve() -> None:
     source = (
         "(set-logic QF_LIA)\n"
@@ -627,6 +739,68 @@ def test_wrapped_lra_coefficients_flatten_and_still_solve() -> None:
     )
 
     result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_multi_term_affine_sums_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(declare-const y Int)\n"
+        "(assert (>= (* 2 (+ (* 2 x) (* 3 y))) 13))\n"
+        "(assert (<= x 1))\n"
+        "(assert (<= y 1))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1, 2)
+
+
+def test_cancelled_affine_sums_normalize_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (* 2 (+ (* 3 x) (- (* 3 x)))) 0))\n"
+        "(assert (> x 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
+def test_exact_integer_division_flattens_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (= (div (+ (* 6 x) 7) 2) 10))\n"
+        "(assert (= x 2))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_non_exact_integer_division_remains_admitted() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (div (* 3 x) 2) 2))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
 
     assert result.outcome == "UNSAT"
     assert result.core_indices == (0, 1)

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -908,6 +908,21 @@ def test_bounded_comparison_of_formless_ite_branches_still_admitted() -> None:
     assert result.core_indices == ()
 
 
+def test_request_bounds_shared_denominator_comparison_numerator_digits() -> None:
+    odd = "9" * 255
+    small = "9" * 50
+    power = "3" * 170
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* (/ {odd} 2) x) (* (/ {small} {power}) x)))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
 def test_request_keeps_shared_denominator_formless_ite_sums_admitted() -> None:
     digits = "9" * 100
     source = (

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -682,6 +682,65 @@ def test_request_bounds_integer_division_translated_constant_digits() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=template.format(constant="9" * 256))
 
 
+def test_request_bounds_arithmetic_ite_branch_coefficient_digits() -> None:
+    factor = "9" * 128
+    boundary = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= (* {factor} (ite p (* {factor} x) 0)) 0))\n"
+        "(check-sat)\n"
+    )
+    over = boundary.replace(factor, "9" * 129, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+
+
+@pytest.mark.parametrize(
+    "assertion_template",
+    (
+        "(assert (= (* {outer} (ite p (* {inner} x) 0)) 0))",
+        "(assert (= (* {outer} (ite p x (* {inner} x))) 0))",
+        "(assert (= (* {outer} (- (ite p (* {inner} x) 0))) 0))",
+        "(assert (= (* {outer} (- (- (ite p (* {inner} x) 0)))) 0))",
+        "(assert (= (* {outer} (+ (ite p (* {inner} x) 0) 1)) 0))",
+    ),
+)
+def test_request_bounds_scaled_ite_branch_coefficient_digits(
+    assertion_template: str,
+) -> None:
+    outer = "9" * 200
+    inner = "9" * 200
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Int)\n"
+        f"{assertion_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
+@pytest.mark.parametrize("nesting", (2, 3))
+def test_request_bounds_deeply_nested_ite_branch_coefficients(nesting: int) -> None:
+    factor = "9" * 128
+    term = f"(* {factor} " * nesting + f"(ite p (* {factor} x) 0)" + ")" * nesting
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= {term} 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
 def test_translated_nested_coefficients_flatten_and_still_solve() -> None:
     source = (
         "(set-logic QF_LIA)\n"
@@ -802,6 +861,37 @@ def test_non_exact_integer_division_remains_admitted() -> None:
 
     assert result.outcome == "UNSAT"
     assert result.core_indices == (0, 1)
+
+
+def test_bounded_ite_branch_coefficients_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (* 2 (ite p (* 2 x) 0)) 8))\n"
+        "(assert (<= x 1))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_small_ite_branch_scalars_remain_admitted_and_satisfiable() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (* 2 (ite p x 0)) 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
 
 
 def test_request_bounds_parsed_ast_nodes() -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -403,6 +403,78 @@ def test_request_bounds_normalized_closed_coefficient_digits() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
 
 
+def test_request_bounds_nested_product_coefficient_digits() -> None:
+    factor = "9" * 128
+    boundary = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= (* {factor} (* {factor} x)) 0))\n"
+        "(check-sat)\n"
+    )
+    over = boundary.replace(factor, "9" * 129, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+
+
+@pytest.mark.parametrize("nesting", (2, 3, 4))
+def test_request_bounds_deeply_nested_coefficient_products(nesting: int) -> None:
+    factor = "1" * 256
+    term = f"(* {factor} " * nesting + "x" + ")" * nesting
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= {term} 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
+def test_request_bounds_outer_factor_against_folded_inner_coefficient() -> None:
+    inner = "9" * 200
+    outer = "9" * 57
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= (* {outer} (* {inner} x)) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
+
+
+def test_request_bounds_nested_real_coefficient_digits() -> None:
+    numerator = "9" * 200
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* (/ {numerator} 3) (* (/ {numerator} 3) x)) 0.0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_nested_closed_coefficients_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (* 2 (* 2 x)) 8))\n"
+        "(assert (<= x 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
 def test_request_bounds_parsed_ast_nodes() -> None:
     def source(term_count: int) -> str:
         equalities = " ".join(f"(= x {value})" for value in range(term_count))

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -447,6 +447,58 @@ def test_request_bounds_outer_factor_against_folded_inner_coefficient() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source)
 
 
+def test_request_bounds_negated_nested_product_coefficient_digits() -> None:
+    factor = "9" * 128
+    boundary = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        f"(assert (= (* {factor} (- (* {factor} x))) 0))\n"
+        "(check-sat)\n"
+    )
+    over = boundary.replace(factor, "9" * 129, 1)
+
+    assert SmtUnsatCoreRequest(logic="QF_LIA", smtlib=boundary)
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=over)
+
+
+@pytest.mark.parametrize(
+    ("logic", "source_template"),
+    (
+        (
+            "QF_LIA",
+            "(assert (= (* {outer} (- (- (* {inner} x)))) 0))",
+        ),
+        (
+            "QF_LIA",
+            "(assert (= (* {outer} (+ (* {inner} x))) 0))",
+        ),
+        (
+            "QF_LRA",
+            "(declare-const x Real)\n(assert (= (* {outer}.0 (/ (* {inner} x) 7.0)) 0.0))",
+        ),
+    ),
+)
+def test_request_bounds_nested_coefficients_through_preserving_wrappers(
+    logic: str,
+    source_template: str,
+) -> None:
+    outer = "9" * 200
+    inner = "9" * 200
+    declaration = (
+        "(declare-const x Int)" if logic == "QF_LIA" else ""
+    )
+    source = (
+        f"(set-logic {logic})\n"
+        f"{declaration}\n"
+        f"{source_template.format(outer=outer, inner=inner)}\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic=logic, smtlib=source)
+
+
 def test_request_bounds_nested_real_coefficient_digits() -> None:
     numerator = "9" * 200
     source = (
@@ -470,6 +522,36 @@ def test_nested_closed_coefficients_flatten_and_still_solve() -> None:
     )
 
     result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_negated_nested_coefficients_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LIA)\n"
+        "(declare-const x Int)\n"
+        "(assert (>= (- (* 2 (- (* 2 x)))) 8))\n"
+        "(assert (<= x 0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source))
+
+    assert result.outcome == "UNSAT"
+    assert result.core_indices == (0, 1)
+
+
+def test_wrapped_lra_coefficients_flatten_and_still_solve() -> None:
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const y Real)\n"
+        "(assert (>= (* 2.0 (/ (* 2.0 y) 4.0)) 3.0))\n"
+        "(assert (<= y 1.0))\n"
+        "(check-sat)\n"
+    )
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
 
     assert result.outcome == "UNSAT"
     assert result.core_indices == (0, 1)


### PR DESCRIPTION
Closes #2273

## Motivation

A solver-wide UNSAT answer leaves callers to rebuild and solve subsets when they need the contradictory source assertions. This adds one bounded operation that returns source-order assertion indices whose selected subsystem is independently replayed as UNSAT.

## Design

The operation uses Z3 5.0’s direct `assert_and_track` and `unsat_core` APIs in a fresh context. Its public result is source-bound: each index refers to the original ordered `assert` commands, and result construction replays the selected subset before returning `UNSAT`. The returned core is deterministic for the pinned backend and fixed solver seed, but is intentionally not claimed to be minimum or inclusion-minimal.

The request admits explicit QF_UF Boolean-uninterpreted terms, QF_LIA, and QF_LRA only after parsing and fragment classification. It bounds SMT-LIB bytes, tokens, nesting, source assertions, parsed AST nodes, numeral and normalized-coefficient digits, and deterministic Z3 resource units. The existing timeout remains an execution safety net. Z3’s 5.0 memory limit is process-global rather than request-local, so this operation deliberately does not expose a misleading per-request memory limit.

No core minimization, all-core enumeration, proofs, MUS search, durable state, or generic verification layer is introduced.

## Validation

- `uv run --locked ruff check src/jacobian/math/logic/_unsat_core.py tests/math/logic/test_unsat_core.py`
- `uv run --locked mypy src/jacobian/math/logic/_unsat_core.py`
- `uv run --locked pytest -q tests/math/logic/test_unsat_core.py tests/math/logic/test_tools.py` (47 passed)
- `make check`
- `make test-integration`

The tests cover source binding and replay, SAT/UNSAT/UNKNOWN behavior, extraction and replay failures, each admitted fragment, nonlinear/cross-theory/quantified rejection, exact boundary limits, parser safety, tracker collisions, and repeated deterministic results.