### PR TITLE
Measure strict polynomial sublevels exactly

### DIFF
--- a/src/jacobian/math/polynomials/real_algebra/_admission.py
+++ b/src/jacobian/math/polynomials/real_algebra/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.polynomials.real_algebra._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "polynomial.real.strict_sublevel_measure.compute",
+        AdmissionDecision.KEEP,
+        "complete exact measure and source-bound component decomposition of a strict polynomial sublevel set",
+    ),
+    OperationAdmission(
         "polynomial.root_count.compute",
         AdmissionDecision.KEEP,
         "distinct exact or explicitly bounded search outcome with material computational leverage",

--- a/src/jacobian/math/polynomials/real_algebra/_operations.py
+++ b/src/jacobian/math/polynomials/real_algebra/_operations.py
@@ -14,6 +14,13 @@ from jacobian.math.polynomials.real_algebra._models import (
     SturmChainResult,
     UnivariatePolynomial,
 )
+from jacobian.math.polynomials.real_algebra._strict_sublevel import (
+    compute_strict_sublevel_payload,
+)
+from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
+    StrictSublevelMeasureRequest,
+    StrictSublevelMeasureResult,
+)
 
 
 def _poly_to_terms(poly: UnivariatePolynomial) -> list[tuple[Fraction, int]]:
@@ -53,4 +60,22 @@ def compute_root_count(request: RootCountRequest) -> RootCountResult:
         root_count=count,
         lower=request.lower,
         upper=request.upper,
+    )
+
+
+def compute_strict_sublevel_measure(
+    request: StrictSublevelMeasureRequest,
+) -> StrictSublevelMeasureResult:
+    payload = compute_strict_sublevel_payload(request)
+    # The payload is built entirely from the already validated request and the
+    # exact kernel. External result validation still replays the source once;
+    # the trusted producer must not repeat root isolation merely to accept its
+    # own derived fields.
+    return StrictSublevelMeasureResult.model_construct(
+        source_polynomial=request.polynomial,
+        threshold=request.threshold,
+        lower=request.lower,
+        upper=request.upper,
+        components=payload.components,
+        measure=payload.measure,
     )

--- a/src/jacobian/math/polynomials/real_algebra/_strict_sublevel.py
+++ b/src/jacobian/math/polynomials/real_algebra/_strict_sublevel.py
@@ -1,0 +1,245 @@
+"""Exact strict polynomial sublevel decomposition backed by SymPy roots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from functools import cmp_to_key
+from typing import Any, Literal, cast
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
+    AlgebraicMeasureRootTerm,
+    LevelEquation,
+    LevelRootEndpoint,
+    LevelRootReference,
+    ScopeEndpoint,
+    SourceBoundAlgebraicMeasure,
+    StrictSublevelComponent,
+    StrictSublevelEndpoint,
+    StrictSublevelMeasureRequest,
+)
+
+
+@dataclass(frozen=True)
+class StrictSublevelPayload:
+    components: tuple[StrictSublevelComponent, ...]
+    measure: SourceBoundAlgebraicMeasure
+
+
+@dataclass(frozen=True)
+class _RealLevelRoot:
+    value: Any
+    reference: LevelRootReference
+
+
+def _sympy_rational(value: CanonicalRational) -> Any:
+    from sympy import Rational
+
+    return Rational(*value.as_integer_ratio())
+
+
+def _compare_level_roots(left: _RealLevelRoot, right: _RealLevelRoot) -> int:
+    if bool(left.value < right.value):
+        return -1
+    if bool(left.value > right.value):
+        return 1
+    raise RuntimeError("distinct positive-threshold level equations shared a root")
+
+
+def _real_level_roots(polynomial: Any, equation: LevelEquation) -> list[_RealLevelRoot]:
+    return [
+        _RealLevelRoot(
+            value=root,
+            reference=LevelRootReference(
+                equation=equation,
+                root_index=index,
+                multiplicity=int(multiplicity),
+            ),
+        )
+        for index, (root, multiplicity) in enumerate(
+            polynomial.real_roots(multiple=False, radicals=False)
+        )
+    ]
+
+
+def _root_endpoint(root: _RealLevelRoot) -> LevelRootEndpoint:
+    return LevelRootEndpoint(root=root.reference)
+
+
+def _strict_at(polynomial: Any, threshold: Any, point: Any) -> bool:
+    return bool(abs(polynomial.eval(point)) < threshold)
+
+
+def _whole_scope_payload(
+    request: StrictSublevelMeasureRequest,
+) -> StrictSublevelPayload:
+    lower = ScopeEndpoint(value=request.lower)
+    upper = ScopeEndpoint(value=request.upper)
+    component = StrictSublevelComponent(
+        left=lower,
+        right=upper,
+        left_included=True,
+        right_included=True,
+    )
+    measure = SourceBoundAlgebraicMeasure(
+        rational_part=CanonicalRational.from_fraction(
+            request.upper.as_fraction() - request.lower.as_fraction()
+        )
+    )
+    return StrictSublevelPayload(components=(component,), measure=measure)
+
+
+def _empty_payload() -> StrictSublevelPayload:
+    return StrictSublevelPayload(
+        components=(),
+        measure=SourceBoundAlgebraicMeasure(
+            rational_part=CanonicalRational(num="0", den="1")
+        ),
+    )
+
+
+def _measure_from_components(
+    components: tuple[StrictSublevelComponent, ...],
+    roots: tuple[_RealLevelRoot, ...],
+) -> SourceBoundAlgebraicMeasure:
+    from sympy import Rational
+
+    roots_by_key = {
+        (root.reference.equation, root.reference.root_index): root for root in roots
+    }
+    rational_part = Fraction(0)
+    coefficients: dict[tuple[LevelEquation, int], int] = {}
+
+    def add_endpoint(endpoint: StrictSublevelEndpoint, sign: int) -> None:
+        nonlocal rational_part
+        if isinstance(endpoint, ScopeEndpoint):
+            rational_part += sign * endpoint.value.as_fraction()
+            return
+        key = (endpoint.root.equation, endpoint.root.root_index)
+        root = roots_by_key[key]
+        if isinstance(root.value, Rational):
+            rational_part += sign * Fraction(int(root.value.p), int(root.value.q))
+            return
+        coefficients[key] = coefficients.get(key, 0) + sign
+
+    for component in components:
+        add_endpoint(component.left, -1)
+        add_endpoint(component.right, 1)
+
+    terms = []
+    for key in sorted(coefficients):
+        coefficient = coefficients[key]
+        if coefficient == 0:
+            continue
+        if coefficient not in (-1, 1):
+            raise RuntimeError("a level boundary had non-canonical measure incidence")
+        terms.append(
+            AlgebraicMeasureRootTerm(
+                root=roots_by_key[key].reference,
+                coefficient=cast(Literal[-1, 1], coefficient),
+            )
+        )
+    return SourceBoundAlgebraicMeasure(
+        rational_part=CanonicalRational.from_fraction(rational_part),
+        root_terms=tuple(terms),
+    )
+
+
+def compute_strict_sublevel_payload(
+    request: StrictSublevelMeasureRequest,
+) -> StrictSublevelPayload:
+    """Return every contributing cell and its exact endpoint-difference sum.
+
+    SymPy supplies the sorted exact real roots of ``f-t`` and ``f+t``.  Since
+    their product has positive leading coefficient and even degree, its sign is
+    positive at negative infinity and flips exactly at odd-multiplicity level
+    roots.  This yields the complete sign chart without numerical samples or a
+    custom isolation kernel.
+    """
+
+    if request.threshold.as_fraction() == 0:
+        return _empty_payload()
+
+    polynomial = rational_polynomial_to_sympy(request.polynomial)
+    threshold = _sympy_rational(request.threshold)
+    lower_value = _sympy_rational(request.lower)
+    upper_value = _sympy_rational(request.upper)
+
+    if request.lower == request.upper:
+        if _strict_at(polynomial, threshold, lower_value):
+            return _whole_scope_payload(request)
+        return _empty_payload()
+
+    if polynomial.degree() <= 0:
+        if _strict_at(polynomial, threshold, lower_value):
+            return _whole_scope_payload(request)
+        return _empty_payload()
+
+    roots = tuple(
+        sorted(
+            (
+                *_real_level_roots(
+                    polynomial - threshold,
+                    "F_MINUS_THRESHOLD",
+                ),
+                *_real_level_roots(
+                    polynomial + threshold,
+                    "F_PLUS_THRESHOLD",
+                ),
+            ),
+            key=cmp_to_key(_compare_level_roots),
+        )
+    )
+
+    # The level-product sign is positive on the leftmost unbounded cell.
+    negative = False
+    for root in roots:
+        if bool(root.value <= lower_value):
+            if root.reference.multiplicity % 2:
+                negative = not negative
+        else:
+            break
+
+    components: list[StrictSublevelComponent] = []
+    left_endpoint: StrictSublevelEndpoint = ScopeEndpoint(value=request.lower)
+    left_included = _strict_at(polynomial, threshold, lower_value)
+    for root in roots:
+        if bool(root.value <= lower_value):
+            continue
+        if bool(root.value >= upper_value):
+            break
+        endpoint = _root_endpoint(root)
+        if negative:
+            components.append(
+                StrictSublevelComponent(
+                    left=left_endpoint,
+                    right=endpoint,
+                    left_included=left_included,
+                    right_included=False,
+                )
+            )
+        if root.reference.multiplicity % 2:
+            negative = not negative
+        left_endpoint = endpoint
+        left_included = False
+
+    if negative:
+        components.append(
+            StrictSublevelComponent(
+                left=left_endpoint,
+                right=ScopeEndpoint(value=request.upper),
+                left_included=left_included,
+                right_included=_strict_at(polynomial, threshold, upper_value),
+            )
+        )
+
+    component_tuple = tuple(components)
+    return StrictSublevelPayload(
+        components=component_tuple,
+        measure=_measure_from_components(component_tuple, roots),
+    )
+
+
+__all__ = ["StrictSublevelPayload", "compute_strict_sublevel_payload"]

--- a/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
@@ -1,0 +1,511 @@
+"""Typed source-bound contracts for exact strict polynomial sublevel measure."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import gcd, lcm
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictBool, field_validator, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    require_polynomial_budget,
+)
+
+# SymPy clears QQ denominators before its Vincent-Akritas-Strzebonski exact
+# real-root isolation.  The controlling height is therefore the primitive
+# integer height of f-t and f+t, not one input coefficient in isolation.  These
+# degree and height caps form a conservative fixed backend envelope while the
+# backend exposes no exact step counter.  Exact root comparisons are likewise
+# bounded by two lists of at most degree roots in these same number fields.
+MAX_STRICT_SUBLEVEL_DEGREE = 16
+MAX_STRICT_SUBLEVEL_TERMS = MAX_STRICT_SUBLEVEL_DEGREE + 1
+MAX_STRICT_SUBLEVEL_INPUT_DIGITS = 64
+MAX_STRICT_SUBLEVEL_BOUNDARY_HEIGHT_DIGITS = 256
+MAX_STRICT_SUBLEVEL_BOUNDARIES = 2 * MAX_STRICT_SUBLEVEL_DEGREE
+MAX_STRICT_SUBLEVEL_COMPONENTS = MAX_STRICT_SUBLEVEL_BOUNDARIES + 1
+
+# Joint isolation-work admission for the two level polynomials.  VAS isolation
+# is strongly degree- and height-sensitive; ``degree**5 * sum(height_digits)``
+# is a deliberately conservative measured proxy over the fixed exact backend.
+# A degree-10 polynomial with twenty nearby level boundaries costs 1.6M units
+# and about 2.5 seconds including source-binding replay; a close-root degree-8,
+# 41-digit case costs 2.69M units and about 9 seconds, so it is rejected.  The
+# envelope still admits degree 16 at unit height and progressively taller
+# inputs at lower degree.
+MAX_STRICT_SUBLEVEL_ISOLATION_WORK = 2_100_000
+
+# By the rational-root theorem, every rational level root has numerator and
+# denominator bounded by the primitive level-polynomial height.  A sum of all
+# 2d possible rational boundaries and both rational scope endpoints therefore
+# fits this conservative digit budget.  Irrational roots stay as source-bound
+# references and do not expand the rational part or serialized result.
+MAX_STRICT_SUBLEVEL_MEASURE_DIGITS = (
+    MAX_STRICT_SUBLEVEL_BOUNDARIES * MAX_STRICT_SUBLEVEL_BOUNDARY_HEIGHT_DIGITS
+    + 2 * MAX_STRICT_SUBLEVEL_INPUT_DIGITS
+    + 2
+)
+
+LevelEquation = Literal["F_MINUS_THRESHOLD", "F_PLUS_THRESHOLD"]
+
+
+def _bound_raw_rational(
+    value: object,
+    *,
+    max_digits: int,
+    label: str,
+) -> None:
+    """Reject oversized decimal components before canonical-rational parsing."""
+
+    if isinstance(value, CanonicalRational):
+        components: tuple[object, object] = (value.num, value.den)
+    elif isinstance(value, Mapping):
+        components = (value.get("num"), value.get("den"))
+    else:
+        return
+    for component in components:
+        if (
+            isinstance(component, str)
+            and len(component) - component.startswith("-") > max_digits
+        ):
+            raise ValueError(f"{label} exceeds the {max_digits}-digit bound")
+
+
+def _bound_raw_terms(terms: tuple[object, ...] | list[object]) -> None:
+    """Bound univariate raw terms before nested polynomial parsing."""
+
+    for term in terms:
+        coefficient: object
+        if isinstance(term, RationalPolynomialTerm):
+            coefficient = term.coefficient
+        elif isinstance(term, Mapping):
+            coefficient = term.get("coefficient")
+            exponents = term.get("exponents")
+            if isinstance(exponents, (list, tuple)) and len(exponents) != 1:
+                raise ValueError(
+                    "strict sublevel measure requires exactly one exponent per term"
+                )
+        else:
+            continue
+        _bound_raw_rational(
+            coefficient,
+            max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+            label="strict sublevel polynomial coefficient",
+        )
+
+
+def _prepare_raw_polynomial(value: object) -> object:
+    """Bound and normalize one JSON polynomial before nested construction."""
+
+    if isinstance(value, RationalPolynomial):
+        variables: object = value.variables
+        terms: object = value.polynomial.terms
+    elif isinstance(value, Mapping):
+        variables = value.get("variables")
+        sparse = value.get("polynomial")
+        terms = sparse.get("terms") if isinstance(sparse, Mapping) else None
+    else:
+        return value
+
+    if isinstance(variables, (list, tuple)) and len(variables) > 1:
+        raise ValueError("strict sublevel measure requires one polynomial variable")
+    if not isinstance(terms, (list, tuple)):
+        return value
+    if len(terms) > MAX_STRICT_SUBLEVEL_TERMS:
+        raise ValueError(
+            "strict sublevel polynomial exceeds the "
+            f"{MAX_STRICT_SUBLEVEL_TERMS}-term operation budget"
+        )
+    _bound_raw_terms(terms)
+
+    if not isinstance(value, Mapping):
+        return value
+    prepared = dict(value)
+    if isinstance(variables, list):
+        prepared["variables"] = tuple(variables)
+    if isinstance(sparse, Mapping):
+        prepared_sparse = dict(sparse)
+        prepared_terms: list[object] = []
+        for term in terms:
+            if isinstance(term, Mapping):
+                prepared_term = dict(term)
+                exponents = prepared_term.get("exponents")
+                if isinstance(exponents, list):
+                    prepared_term["exponents"] = tuple(exponents)
+                prepared_terms.append(prepared_term)
+            else:
+                prepared_terms.append(term)
+        prepared_sparse["terms"] = tuple(prepared_terms)
+        prepared["polynomial"] = prepared_sparse
+    return prepared
+
+
+def _polynomial_degree(polynomial: RationalPolynomial) -> int:
+    return max(
+        (term.exponents[0] for term in polynomial.polynomial.terms),
+        default=0,
+    )
+
+
+def _level_polynomial_height_digits(
+    polynomial: RationalPolynomial,
+    threshold: CanonicalRational,
+    *,
+    subtract_threshold: bool,
+) -> int:
+    """Return primitive integer height digits of ``f-t`` or ``f+t``.
+
+    This bounded Fraction-only preflight mirrors denominator clearing without
+    asking the root backend to expand anything.  The polynomial is known to be
+    univariate before this helper is called.
+    """
+
+    coefficients = {
+        term.exponents[0]: term.coefficient.as_fraction()
+        for term in polynomial.polynomial.terms
+    }
+    signed_threshold = threshold.as_fraction()
+    if subtract_threshold:
+        signed_threshold = -signed_threshold
+    coefficients[0] = coefficients.get(0, 0) + signed_threshold
+    nonzero = tuple(value for value in coefficients.values() if value)
+    if not nonzero:
+        return 1
+
+    common_denominator = 1
+    for coefficient in nonzero:
+        common_denominator = lcm(common_denominator, coefficient.denominator)
+    integer_coefficients = tuple(
+        coefficient.numerator * (common_denominator // coefficient.denominator)
+        for coefficient in nonzero
+    )
+    content = 0
+    for integer_coefficient in integer_coefficients:
+        content = gcd(content, abs(integer_coefficient))
+    return max(
+        len(str(abs(integer_coefficient // content)))
+        for integer_coefficient in integer_coefficients
+    )
+
+
+class StrictSublevelMeasureRequest(StrictModel):
+    """Exact strict ``|f(x)| < threshold`` measure on a rational scope."""
+
+    polynomial: RationalPolynomial
+    threshold: CanonicalRational
+    lower: CanonicalRational
+    upper: CanonicalRational
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_request(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        prepared: dict[str, object] = dict(value)
+        prepared["polynomial"] = _prepare_raw_polynomial(prepared.get("polynomial"))
+        for field, label in (
+            ("threshold", "strict sublevel threshold"),
+            ("lower", "strict sublevel lower scope endpoint"),
+            ("upper", "strict sublevel upper scope endpoint"),
+        ):
+            _bound_raw_rational(
+                prepared.get(field),
+                max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+                label=label,
+            )
+        return prepared
+
+    @model_validator(mode="after")
+    def require_complete_root_isolation_budget(self) -> Self:
+        if len(self.polynomial.variables) != 1:
+            raise ValueError("strict sublevel measure requires one polynomial variable")
+        require_polynomial_budget(
+            self.polynomial,
+            maximum_terms=MAX_STRICT_SUBLEVEL_TERMS,
+            maximum_exponent=MAX_STRICT_SUBLEVEL_DEGREE,
+            maximum_coefficient_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+            label="strict sublevel polynomial",
+        )
+        for value, label in (
+            (self.threshold, "strict sublevel threshold"),
+            (self.lower, "strict sublevel lower scope endpoint"),
+            (self.upper, "strict sublevel upper scope endpoint"),
+        ):
+            require_bounded_rational(
+                value,
+                max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+                label=label,
+            )
+        if self.threshold.as_fraction() < 0:
+            raise ValueError("strict sublevel threshold must be nonnegative")
+        if self.lower.as_fraction() > self.upper.as_fraction():
+            raise ValueError("strict sublevel lower endpoint must not exceed upper")
+
+        # These cases require no root isolation: t=0 is empty, constants are
+        # decided by one exact comparison, and a singleton scope has zero
+        # measure with membership decided by one exact evaluation.
+        if (
+            self.threshold.as_fraction() == 0
+            or _polynomial_degree(self.polynomial) == 0
+            or self.lower == self.upper
+        ):
+            return self
+
+        boundary_heights = []
+        for subtract_threshold, label in (
+            (True, "f-threshold"),
+            (False, "f+threshold"),
+        ):
+            height_digits = _level_polynomial_height_digits(
+                self.polynomial,
+                self.threshold,
+                subtract_threshold=subtract_threshold,
+            )
+            if height_digits > MAX_STRICT_SUBLEVEL_BOUNDARY_HEIGHT_DIGITS:
+                raise ValueError(
+                    f"primitive {label} height exceeds the "
+                    f"{MAX_STRICT_SUBLEVEL_BOUNDARY_HEIGHT_DIGITS}-digit "
+                    "root-isolation bound"
+                )
+            boundary_heights.append(height_digits)
+        degree = _polynomial_degree(self.polynomial)
+        isolation_work = degree**5 * sum(boundary_heights)
+        if isolation_work > MAX_STRICT_SUBLEVEL_ISOLATION_WORK:
+            raise ValueError(
+                "strict sublevel exact-root isolation exceeds the work bound "
+                f"(degree^5*level-height-sum={isolation_work} > "
+                f"{MAX_STRICT_SUBLEVEL_ISOLATION_WORK}); reduce degree or "
+                "coefficient/threshold height"
+            )
+        return self
+
+
+class LevelRootReference(StrictModel):
+    """One distinct real root of a retained level polynomial.
+
+    ``root_index`` is zero-based in the increasing list of distinct real roots
+    of the named equation.  Together with the result's source polynomial and
+    threshold, it is an exact real-algebraic number definition.
+    """
+
+    equation: LevelEquation
+    root_index: int = Field(
+        ge=0,
+        lt=MAX_STRICT_SUBLEVEL_DEGREE,
+        strict=True,
+    )
+    multiplicity: int = Field(
+        ge=1,
+        le=MAX_STRICT_SUBLEVEL_DEGREE,
+        strict=True,
+    )
+
+
+class ScopeEndpoint(StrictModel):
+    kind: Literal["SCOPE_ENDPOINT"] = "SCOPE_ENDPOINT"
+    value: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_scope_value(self) -> Self:
+        require_bounded_rational(
+            self.value,
+            max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+            label="strict sublevel scope endpoint",
+        )
+        return self
+
+
+class LevelRootEndpoint(StrictModel):
+    kind: Literal["LEVEL_ROOT"] = "LEVEL_ROOT"
+    root: LevelRootReference
+
+
+StrictSublevelEndpoint = Annotated[
+    ScopeEndpoint | LevelRootEndpoint,
+    Field(discriminator="kind"),
+]
+
+
+class StrictSublevelComponent(StrictModel):
+    """One connected component with explicit strict/scope endpoint membership."""
+
+    left: StrictSublevelEndpoint
+    right: StrictSublevelEndpoint
+    left_included: StrictBool
+    right_included: StrictBool
+
+
+class AlgebraicMeasureRootTerm(StrictModel):
+    """An integer multiple of one retained-source irrational level root."""
+
+    root: LevelRootReference
+    coefficient: Literal[-1, 1]
+
+    @field_validator("coefficient", mode="before")
+    @classmethod
+    def require_strict_incidence_coefficient(cls, value: object) -> object:
+        if type(value) is not int:
+            raise ValueError("measure root coefficient must be the integer -1 or 1")
+        return value
+
+
+class SourceBoundAlgebraicMeasure(StrictModel):
+    """The exact value ``rational_part + sum(coefficient * root)``.
+
+    Root terms are consolidated and sorted in the retained level-root
+    coordinates.  This is the canonical endpoint-incidence ledger for the
+    decomposition, rather than a potentially exponential primitive-element
+    expansion.
+    """
+
+    rational_part: CanonicalRational
+    root_terms: tuple[AlgebraicMeasureRootTerm, ...] = Field(
+        default=(),
+        max_length=MAX_STRICT_SUBLEVEL_BOUNDARIES,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_root_ledger(self) -> Self:
+        require_bounded_rational(
+            self.rational_part,
+            max_digits=MAX_STRICT_SUBLEVEL_MEASURE_DIGITS,
+            label="strict sublevel rational measure part",
+        )
+        keys = tuple(
+            (term.root.equation, term.root.root_index) for term in self.root_terms
+        )
+        if len(set(keys)) != len(keys):
+            raise ValueError("measure root terms must identify distinct roots")
+        if keys != tuple(sorted(keys)):
+            raise ValueError(
+                "measure root terms must use canonical equation/index order"
+            )
+        return self
+
+
+class StrictSublevelMeasureResult(StrictModel):
+    """Complete source-bound strict sublevel decomposition and exact measure."""
+
+    semantics_version: Literal["strict-polynomial-sublevel-measure.v1"] = (
+        "strict-polynomial-sublevel-measure.v1"
+    )
+    source_polynomial: RationalPolynomial
+    threshold: CanonicalRational
+    lower: CanonicalRational
+    upper: CanonicalRational
+    components: tuple[StrictSublevelComponent, ...] = Field(
+        default=(),
+        max_length=MAX_STRICT_SUBLEVEL_COMPONENTS,
+    )
+    measure: SourceBoundAlgebraicMeasure
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_result(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        prepared: dict[str, object] = dict(value)
+        prepared["source_polynomial"] = _prepare_raw_polynomial(
+            prepared.get("source_polynomial")
+        )
+        for field, label in (
+            ("threshold", "strict sublevel threshold"),
+            ("lower", "strict sublevel lower scope endpoint"),
+            ("upper", "strict sublevel upper scope endpoint"),
+        ):
+            _bound_raw_rational(
+                prepared.get(field),
+                max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+                label=label,
+            )
+
+        raw_components = prepared.get("components")
+        if isinstance(raw_components, (list, tuple)):
+            if len(raw_components) > MAX_STRICT_SUBLEVEL_COMPONENTS:
+                raise ValueError(
+                    "strict sublevel result exceeds the "
+                    f"{MAX_STRICT_SUBLEVEL_COMPONENTS}-component bound"
+                )
+            for component in raw_components:
+                if not isinstance(component, Mapping):
+                    continue
+                for side in ("left", "right"):
+                    endpoint = component.get(side)
+                    if isinstance(endpoint, Mapping) and endpoint.get("kind") == (
+                        "SCOPE_ENDPOINT"
+                    ):
+                        _bound_raw_rational(
+                            endpoint.get("value"),
+                            max_digits=MAX_STRICT_SUBLEVEL_INPUT_DIGITS,
+                            label="strict sublevel scope endpoint",
+                        )
+            if isinstance(raw_components, list):
+                prepared["components"] = tuple(raw_components)
+
+        raw_measure = prepared.get("measure")
+        if isinstance(raw_measure, SourceBoundAlgebraicMeasure):
+            rational_part: object = raw_measure.rational_part
+            root_terms: object = raw_measure.root_terms
+        elif isinstance(raw_measure, Mapping):
+            measure = dict(raw_measure)
+            rational_part = measure.get("rational_part")
+            root_terms = measure.get("root_terms")
+            if isinstance(root_terms, list):
+                measure["root_terms"] = tuple(root_terms)
+                root_terms = measure["root_terms"]
+            prepared["measure"] = measure
+        else:
+            return prepared
+        _bound_raw_rational(
+            rational_part,
+            max_digits=MAX_STRICT_SUBLEVEL_MEASURE_DIGITS,
+            label="strict sublevel rational measure part",
+        )
+        if isinstance(root_terms, (list, tuple)) and (
+            len(root_terms) > MAX_STRICT_SUBLEVEL_BOUNDARIES
+        ):
+            raise ValueError(
+                "strict sublevel measure exceeds the "
+                f"{MAX_STRICT_SUBLEVEL_BOUNDARIES}-root-term bound"
+            )
+        return prepared
+
+    @model_validator(mode="after")
+    def require_source_bound_reconstruction(self) -> Self:
+        request = StrictSublevelMeasureRequest(
+            polynomial=self.source_polynomial,
+            threshold=self.threshold,
+            lower=self.lower,
+            upper=self.upper,
+        )
+        from jacobian.math.polynomials.real_algebra._strict_sublevel import (
+            compute_strict_sublevel_payload,
+        )
+
+        expected = compute_strict_sublevel_payload(request)
+        if self.components != expected.components:
+            raise ValueError(
+                "strict sublevel components must be the complete source-derived cells"
+            )
+        if self.measure != expected.measure:
+            raise ValueError(
+                "strict sublevel measure must reconstruct from the returned components"
+            )
+        return self
+
+
+__all__ = [
+    "AlgebraicMeasureRootTerm",
+    "LevelRootEndpoint",
+    "LevelRootReference",
+    "ScopeEndpoint",
+    "SourceBoundAlgebraicMeasure",
+    "StrictSublevelComponent",
+    "StrictSublevelEndpoint",
+    "StrictSublevelMeasureRequest",
+    "StrictSublevelMeasureResult",
+]

--- a/src/jacobian/math/polynomials/real_algebra/_tools.py
+++ b/src/jacobian/math/polynomials/real_algebra/_tools.py
@@ -14,7 +14,12 @@ from jacobian.math.polynomials.real_algebra._models import (
 )
 from jacobian.math.polynomials.real_algebra._operations import (
     compute_root_count,
+    compute_strict_sublevel_measure,
     compute_sturm_chain,
+)
+from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
+    StrictSublevelMeasureRequest,
+    StrictSublevelMeasureResult,
 )
 
 
@@ -97,6 +102,43 @@ REAL_ALGEBRA_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                     },
                     "lower": {"num": "-10", "den": "1"},
                     "upper": {"num": "10", "den": "1"},
+                },
+            ),
+        ),
+    ),
+    ra_operation(
+        "polynomial.real.strict_sublevel_measure.compute",
+        "Compute an exact strict polynomial sublevel measure",
+        "Return the complete component decomposition and source-bound exact "
+        "real-algebraic measure of {x in [lower, upper] : |f(x)| < threshold} "
+        "for a canonical univariate polynomial over QQ.",
+        StrictSublevelMeasureRequest,
+        StrictSublevelMeasureResult,
+        compute_strict_sublevel_measure,
+        "polynomial",
+        "real-algebra",
+        "sublevel-set",
+        "measure",
+        "exact",
+        examples=(
+            example(
+                "quadratic_irrational_length",
+                "Measure |x^2| < 2 on [-2, 2], with endpoints at ±sqrt(2).",
+                {
+                    "polynomial": {
+                        "variables": ["x"],
+                        "polynomial": {
+                            "terms": [
+                                {
+                                    "coefficient": {"num": "1", "den": "1"},
+                                    "exponents": [2],
+                                }
+                            ]
+                        },
+                    },
+                    "threshold": {"num": "2", "den": "1"},
+                    "lower": {"num": "-2", "den": "1"},
+                    "upper": {"num": "2", "den": "1"},
                 },
             ),
         ),

--- a/tests/math/polynomials/test_strict_sublevel_measure.py
+++ b/tests/math/polynomials/test_strict_sublevel_measure.py
@@ -1,0 +1,496 @@
+"""Exact contract and invariant tests for strict polynomial sublevel measure."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from fractions import Fraction
+from itertools import product
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+from jacobian.math.polynomials.real_algebra._operations import (
+    compute_strict_sublevel_measure,
+)
+from jacobian.math.polynomials.real_algebra._strict_sublevel_models import (
+    LevelRootEndpoint,
+    ScopeEndpoint,
+    StrictSublevelMeasureRequest,
+    StrictSublevelMeasureResult,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _rational(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def _polynomial(
+    *terms: tuple[int | Fraction, int],
+    variables: tuple[str, ...] = ("x",),
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(Fraction(coefficient)),
+                    exponents=(exponent,) + (0,) * (len(variables) - 1),
+                )
+                for coefficient, exponent in sorted(
+                    terms,
+                    key=lambda item: item[1],
+                    reverse=True,
+                )
+                if coefficient
+            )
+        ),
+    )
+
+
+def _request(
+    polynomial: RationalPolynomial,
+    *,
+    threshold: int = 1,
+    lower: int = -2,
+    upper: int = 2,
+) -> StrictSublevelMeasureRequest:
+    return StrictSublevelMeasureRequest(
+        polynomial=polynomial,
+        threshold=_rational(threshold),
+        lower=_rational(lower),
+        upper=_rational(upper),
+    )
+
+
+def _resolve_endpoint(result: StrictSublevelMeasureResult, endpoint: object) -> Any:
+    from sympy import Rational
+
+    if isinstance(endpoint, ScopeEndpoint):
+        return Rational(*endpoint.value.as_integer_ratio())
+    assert isinstance(endpoint, LevelRootEndpoint)
+    polynomial = rational_polynomial_to_sympy(result.source_polynomial)
+    threshold = Rational(*result.threshold.as_integer_ratio())
+    level = (
+        polynomial - threshold
+        if endpoint.root.equation == "F_MINUS_THRESHOLD"
+        else polynomial + threshold
+    )
+    return level.real_roots(multiple=False, radicals=False)[endpoint.root.root_index][0]
+
+
+def _resolve_measure(result: StrictSublevelMeasureResult) -> Any:
+    from sympy import Rational
+
+    polynomial = rational_polynomial_to_sympy(result.source_polynomial)
+    threshold = Rational(*result.threshold.as_integer_ratio())
+    value = Rational(*result.measure.rational_part.as_integer_ratio())
+    for term in result.measure.root_terms:
+        level = (
+            polynomial - threshold
+            if term.root.equation == "F_MINUS_THRESHOLD"
+            else polynomial + threshold
+        )
+        root = level.real_roots(multiple=False, radicals=False)[term.root.root_index][0]
+        value += term.coefficient * root
+    return value
+
+
+def test_quadratic_measure_retains_exact_irrational_boundary_sum() -> None:
+    result = compute_strict_sublevel_measure(_request(_polynomial((1, 2)), threshold=2))
+
+    assert len(result.components) == 1
+    component = result.components[0]
+    assert isinstance(component.left, LevelRootEndpoint)
+    assert isinstance(component.right, LevelRootEndpoint)
+    assert component.left.root.equation == "F_MINUS_THRESHOLD"
+    assert component.left.root.root_index == 0
+    assert component.right.root.root_index == 1
+    assert not component.left_included
+    assert not component.right_included
+    assert result.measure.rational_part == _rational(0)
+    assert tuple(term.coefficient for term in result.measure.root_terms) == (-1, 1)
+
+    reconstructed_length = sum(
+        _resolve_endpoint(result, item.right) - _resolve_endpoint(result, item.left)
+        for item in result.components
+    )
+    assert _resolve_measure(result) - reconstructed_length == 0
+
+
+def test_producer_isolates_once_and_external_validation_replays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian.math.polynomials.real_algebra._operations as operations
+    import jacobian.math.polynomials.real_algebra._strict_sublevel as kernel
+
+    calls = 0
+    original = kernel.compute_strict_sublevel_payload
+
+    def counting(request: StrictSublevelMeasureRequest) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(request)
+
+    monkeypatch.setattr(operations, "compute_strict_sublevel_payload", counting)
+    monkeypatch.setattr(kernel, "compute_strict_sublevel_payload", counting)
+    result = operations.compute_strict_sublevel_measure(
+        _request(_polynomial((1, 2)), threshold=2)
+    )
+    assert calls == 1
+
+    StrictSublevelMeasureResult.model_validate(result.model_dump(mode="json"))
+    assert calls == 2
+
+
+def test_request_and_result_compose_through_strict_json_transport() -> None:
+    request = _request(_polynomial((1, 2)), threshold=2)
+    parsed_request = StrictSublevelMeasureRequest.model_validate_json(
+        request.model_dump_json(), strict=True
+    )
+    result = compute_strict_sublevel_measure(parsed_request)
+
+    assert parsed_request == request
+    assert (
+        StrictSublevelMeasureResult.model_validate_json(
+            result.model_dump_json(), strict=True
+        )
+        == result
+    )
+
+
+def test_rational_level_roots_collapse_into_the_rational_measure_part() -> None:
+    result = compute_strict_sublevel_measure(
+        StrictSublevelMeasureRequest(
+            polynomial=_polynomial((Fraction(1, 2), 1)),
+            threshold=_rational(1, 2),
+            lower=_rational(-3, 2),
+            upper=_rational(3, 2),
+        )
+    )
+
+    assert len(result.components) == 1
+    component = result.components[0]
+    assert isinstance(component.left, LevelRootEndpoint)
+    assert component.left.root.equation == "F_PLUS_THRESHOLD"
+    assert isinstance(component.right, LevelRootEndpoint)
+    assert component.right.root.equation == "F_MINUS_THRESHOLD"
+    assert result.measure.rational_part == _rational(2)
+    assert result.measure.root_terms == ()
+
+
+@pytest.mark.parametrize(
+    ("polynomial", "threshold", "component_count", "measure"),
+    [
+        (_polynomial(), 1, 1, 4),
+        (_polynomial(), 0, 0, 0),
+        (_polynomial((1, 0)), 2, 1, 4),
+        (_polynomial((2, 0)), 2, 0, 0),
+        (_polynomial((3, 0)), 2, 0, 0),
+    ],
+)
+def test_zero_and_constant_polynomial_conventions(
+    polynomial: RationalPolynomial,
+    threshold: int,
+    component_count: int,
+    measure: int,
+) -> None:
+    result = compute_strict_sublevel_measure(_request(polynomial, threshold=threshold))
+
+    assert len(result.components) == component_count
+    assert result.measure.rational_part == _rational(measure)
+    assert result.measure.root_terms == ()
+    if result.components:
+        component = result.components[0]
+        assert isinstance(component.left, ScopeEndpoint)
+        assert isinstance(component.right, ScopeEndpoint)
+        assert component.left_included and component.right_included
+
+
+def test_even_root_splits_strict_components_without_sign_change() -> None:
+    # |x^2-1| < 1 is (-sqrt(2), 0) union (0, sqrt(2)).  The root x=0 of
+    # f+1 has multiplicity two: the product sign stays negative, but strict
+    # equality removes the point and therefore separates the components.
+    result = compute_strict_sublevel_measure(_request(_polynomial((1, 2), (-1, 0))))
+
+    assert len(result.components) == 2
+    tangent_right = result.components[0].right
+    tangent_left = result.components[1].left
+    assert tangent_right == tangent_left
+    assert isinstance(tangent_right, LevelRootEndpoint)
+    assert tangent_right.root.equation == "F_PLUS_THRESHOLD"
+    assert tangent_right.root.multiplicity == 2
+    assert not result.components[0].right_included
+    assert not result.components[1].left_included
+    assert all(
+        term.root.equation == "F_MINUS_THRESHOLD" for term in result.measure.root_terms
+    )
+
+
+def test_roots_at_scope_endpoints_remain_excluded_under_strict_semantics() -> None:
+    result = compute_strict_sublevel_measure(
+        _request(_polynomial((1, 1)), lower=-1, upper=1)
+    )
+
+    assert len(result.components) == 1
+    component = result.components[0]
+    assert isinstance(component.left, ScopeEndpoint)
+    assert isinstance(component.right, ScopeEndpoint)
+    assert not component.left_included
+    assert not component.right_included
+    assert result.measure.rational_part == _rational(2)
+
+
+def test_singleton_scope_preserves_membership_while_measure_stays_zero() -> None:
+    inside = compute_strict_sublevel_measure(
+        _request(_polynomial((1, 1)), lower=0, upper=0)
+    )
+    equality = compute_strict_sublevel_measure(
+        _request(_polynomial((1, 1)), lower=1, upper=1)
+    )
+
+    assert len(inside.components) == 1
+    assert inside.components[0].left == inside.components[0].right
+    assert inside.components[0].left_included
+    assert inside.components[0].right_included
+    assert inside.measure.rational_part == _rational(0)
+    assert equality.components == ()
+    assert equality.measure.rational_part == _rational(0)
+
+
+def test_request_rejects_outside_domain_and_work_bounds() -> None:
+    with pytest.raises(ValidationError, match="one polynomial variable"):
+        _request(_polynomial((1, 1), variables=("x", "y")))
+    with pytest.raises(ValidationError, match="nonnegative"):
+        StrictSublevelMeasureRequest(
+            polynomial=_polynomial((1, 1)),
+            threshold=_rational(-1),
+            lower=_rational(-1),
+            upper=_rational(1),
+        )
+    with pytest.raises(ValidationError, match="must not exceed"):
+        _request(_polynomial((1, 1)), lower=2, upper=-2)
+    with pytest.raises(ValidationError, match="16-degree operation budget"):
+        _request(_polynomial((1, 17)))
+    _request(_polynomial((1, 16)))
+
+    oversized_coefficient = Fraction(int("9" * 65), 1)
+    with pytest.raises(ValidationError, match="64-digit bound"):
+        _request(_polynomial((oversized_coefficient, 1)))
+
+
+def test_request_bounds_raw_polynomial_before_nested_parsing() -> None:
+    raw_term = {
+        "coefficient": {"num": "not-an-integer", "den": "1"},
+        "exponents": [0],
+    }
+    with pytest.raises(ValidationError, match="17-term operation budget"):
+        StrictSublevelMeasureRequest.model_validate(
+            {
+                "polynomial": {
+                    "variables": ["x"],
+                    "polynomial": {"terms": [raw_term] * 18},
+                },
+                "threshold": {"num": "1", "den": "1"},
+                "lower": {"num": "-2", "den": "1"},
+                "upper": {"num": "2", "den": "1"},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="64-digit bound"):
+        StrictSublevelMeasureRequest.model_validate(
+            {
+                "polynomial": {
+                    "variables": ["x"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": "x" * 65, "den": "1"},
+                                "exponents": [1],
+                            }
+                        ]
+                    },
+                },
+                "threshold": {"num": "1", "den": "1"},
+                "lower": {"num": "-2", "den": "1"},
+                "upper": {"num": "2", "den": "1"},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="exactly one exponent per term"):
+        StrictSublevelMeasureRequest.model_validate(
+            {
+                "polynomial": {
+                    "variables": ["x"],
+                    "polynomial": {
+                        "terms": [
+                            {
+                                "coefficient": {"num": "not-an-integer", "den": "1"},
+                                "exponents": [0] * 65,
+                            }
+                        ]
+                    },
+                },
+                "threshold": {"num": "1", "den": "1"},
+                "lower": {"num": "-2", "den": "1"},
+                "upper": {"num": "2", "den": "1"},
+            }
+        )
+
+
+def test_request_preflights_cleared_level_polynomial_height() -> None:
+    pairwise_coprime_denominators = (
+        2**210,
+        3**130,
+        5**90,
+        7**74,
+        11**60,
+    )
+    polynomial = _polynomial(
+        *(
+            (Fraction(1, denominator), exponent)
+            for exponent, denominator in enumerate(pairwise_coprime_denominators)
+        )
+    )
+
+    with pytest.raises(ValidationError, match="root-isolation bound"):
+        _request(polynomial)
+
+    # No root work is needed for the strict t=0 set, so result-sensitive
+    # admission accepts the same source and returns the exact empty set.
+    request = _request(polynomial, threshold=0)
+    assert compute_strict_sublevel_measure(request).components == ()
+
+
+def test_request_jointly_bounds_level_root_isolation_degree_and_height() -> None:
+    scale = 10**20
+    close_root_polynomial = _polynomial(
+        (1, 8),
+        (-2 * scale**2, 2),
+        (4 * scale, 1),
+        (-1, 0),
+    )
+
+    with pytest.raises(ValidationError, match="exact-root isolation exceeds"):
+        _request(close_root_polynomial)
+
+
+def test_small_integer_polynomials_match_sympy_inequality_sets_exhaustively() -> None:
+    """Differentially compare every degree-one/two polynomial in {-1,0,1}[x]."""
+
+    from sympy import Abs, Interval, S, Symbol, Union, simplify
+    from sympy.solvers.inequalities import solve_univariate_inequality
+
+    x = Symbol("x", real=True)
+    for degree in (1, 2):
+        for lower_coefficients in product((-1, 0, 1), repeat=degree):
+            for leading_coefficient in (-1, 1):
+                coefficients = (leading_coefficient, *lower_coefficients)
+                polynomial = _polynomial(
+                    *(
+                        (coefficient, degree - index)
+                        for index, coefficient in enumerate(coefficients)
+                    )
+                )
+                result = compute_strict_sublevel_measure(_request(polynomial))
+                actual_intervals = tuple(
+                    Interval(
+                        _resolve_endpoint(result, component.left),
+                        _resolve_endpoint(result, component.right),
+                        left_open=not component.left_included,
+                        right_open=not component.right_included,
+                    )
+                    for component in result.components
+                )
+
+                expression = sum(
+                    coefficient * x ** (degree - index)
+                    for index, coefficient in enumerate(coefficients)
+                )
+                expected_set = solve_univariate_inequality(
+                    Abs(expression) < 1,
+                    x,
+                    relational=False,
+                ).intersect(Interval(-2, 2))
+                if expected_set is S.EmptySet:
+                    expected_intervals: tuple[Interval, ...] = ()
+                elif isinstance(expected_set, Interval):
+                    expected_intervals = (expected_set,)
+                else:
+                    assert isinstance(expected_set, Union)
+                    expected_intervals = tuple(expected_set.args)
+
+                assert len(actual_intervals) == len(expected_intervals), expression
+                for actual, expected in zip(
+                    actual_intervals,
+                    expected_intervals,
+                    strict=True,
+                ):
+                    assert actual.left_open == expected.left_open, expression
+                    assert actual.right_open == expected.right_open, expression
+                    assert actual.start.equals(expected.start), expression
+                    assert actual.end.equals(expected.end), expression
+                assert simplify(_resolve_measure(result) - expected_set.measure) == 0
+
+
+def test_source_bound_result_rejects_independent_forged_fields() -> None:
+    result = compute_strict_sublevel_measure(_request(_polynomial((1, 2)), threshold=2))
+    payload = result.model_dump(mode="json")
+    mutations = []
+
+    changed_source = deepcopy(payload)
+    changed_source["source_polynomial"]["polynomial"]["terms"].append(
+        {
+            "coefficient": {"num": "3", "den": "1"},
+            "exponents": (0,),
+        }
+    )
+    mutations.append(changed_source)
+
+    changed_threshold = deepcopy(payload)
+    changed_threshold["threshold"] = {"num": "0", "den": "1"}
+    mutations.append(changed_threshold)
+
+    changed_scope = deepcopy(payload)
+    changed_scope["upper"] = {"num": "0", "den": "1"}
+    mutations.append(changed_scope)
+
+    changed_endpoint = deepcopy(payload)
+    changed_endpoint["components"][0]["left"]["root"]["root_index"] = 1
+    mutations.append(changed_endpoint)
+
+    changed_measure = deepcopy(payload)
+    changed_measure["measure"]["root_terms"][0]["coefficient"] = 1
+    mutations.append(changed_measure)
+
+    for mutation in mutations:
+        with pytest.raises(ValidationError):
+            StrictSublevelMeasureResult.model_validate(mutation)
+
+
+def test_measure_root_incidence_rejects_boolean_coefficient() -> None:
+    result = compute_strict_sublevel_measure(_request(_polynomial((1, 2)), threshold=2))
+    payload = result.model_dump(mode="json")
+    payload["measure"]["root_terms"][0]["coefficient"] = True
+
+    with pytest.raises(ValidationError, match="integer -1 or 1"):
+        StrictSublevelMeasureResult.model_validate(payload)
+
+
+def test_result_bounds_raw_measure_before_source_replay() -> None:
+    result = compute_strict_sublevel_measure(_request(_polynomial((1, 2)), threshold=2))
+    payload = result.model_dump(mode="json")
+    payload["measure"]["rational_part"] = {
+        "num": "x" * 8_323,
+        "den": "1",
+    }
+
+    with pytest.raises(ValidationError, match="8322-digit bound"):
+        StrictSublevelMeasureResult.model_validate(payload)


### PR DESCRIPTION
## Summary

Adds `polynomial.real.strict_sublevel_measure.compute`: the complete connected-component decomposition and exact measure of

```text
{ x in [lower, upper] : |f(x)| < threshold }
```

for a bounded canonical univariate polynomial over `QQ`.

SymPy's exact `Poly.real_roots(..., radicals=False)` is the private root-isolation backend. Jacobian combines the roots of `f - threshold` and `f + threshold` into the deterministic strict sign chart, retains every endpoint by equation/index/multiplicity, and replays the source on externally supplied results.

The measure is represented as a rational part plus a canonical signed incidence ledger of retained irrational level roots. This stays exact and composable without forcing a potentially expensive primitive-element expansion. Rational roots are folded into the rational part.

The operation intentionally does not solve a more general semialgebraic measure problem: it is the narrow reusable strict univariate sublevel primitive. Admission bounds degree, input/cleared-level height, root-isolation work, result size, and raw JSON structures before nested normalization.

## Validation

- `make check` (2,669 passed)
- `make test-integration` (1,026 passed)
- Exhaustive degree-one/two differential comparison against SymPy inequalities
- Exact source-replay, strict-JSON transport, rational/irrational boundary, repeated-root, singleton/constant, and adversarial raw-input tests

An independent exact-diff review found and verified the raw exponent-vector admission guard added before JSON normalization.

Closes #2308
