### PR TITLE
feat(number-theory): add bounded prime affine tuple operations

### DIFF
--- a/src/jacobian/math/affine_forms/__init__.py
+++ b/src/jacobian/math/affine_forms/__init__.py
@@ -1,0 +1,5 @@
+"""Canonical values shared by integer-affine mathematical domains."""
+
+from jacobian.math.affine_forms.values import AffineFormId, IntegerAffineForm
+
+__all__ = ["AffineFormId", "IntegerAffineForm"]

--- a/src/jacobian/math/affine_forms/values.py
+++ b/src/jacobian/math/affine_forms/values.py
@@ -1,0 +1,87 @@
+"""Canonical passive values for labelled integer affine forms."""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+
+from pydantic import Field, StringConstraints, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+
+MAX_AFFINE_COMPONENT_DIGITS = 256
+MAX_FORM_ID_LENGTH = 32
+
+AffineComponentInteger = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=MAX_AFFINE_COMPONENT_DIGITS + 1, strict=True),
+]
+
+AffineFormId = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[A-Za-z][A-Za-z0-9_.-]{0,31}$",
+        max_length=MAX_FORM_ID_LENGTH,
+        strict=True,
+    ),
+]
+
+
+def _component_digits(value: str) -> int:
+    return len(value.lstrip("-"))
+
+
+class IntegerAffineForm(StrictModel):
+    """One labelled nonzero integer affine expression ``a*n+b``."""
+
+    form_id: AffineFormId = Field(
+        description=(
+            "Stable form label using the grammar [A-Za-z][A-Za-z0-9_.-]{0,31}."
+        )
+    )
+    coefficient: AffineComponentInteger = Field(
+        description=(
+            "Canonical decimal coefficient a in L(n)=a*n+b, with at most 256 "
+            "digits excluding an optional minus sign."
+        )
+    )
+    constant: AffineComponentInteger = Field(
+        description=(
+            "Canonical decimal constant b in L(n)=a*n+b, with at most 256 "
+            "digits excluding an optional minus sign."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_nonzero_expression(self) -> Self:
+        if (
+            _component_digits(self.coefficient) > MAX_AFFINE_COMPONENT_DIGITS
+            or _component_digits(self.constant) > MAX_AFFINE_COMPONENT_DIGITS
+        ):
+            raise ValueError(
+                "affine coefficient and constant must each have at most "
+                f"{MAX_AFFINE_COMPONENT_DIGITS} digits"
+            )
+        if (
+            parse_canonical_integer(self.coefficient) == 0
+            and parse_canonical_integer(self.constant) == 0
+        ):
+            raise ValueError("integer affine form must not be identically zero")
+        return self
+
+    def evaluate(self, parameter: int) -> int:
+        """Evaluate the form exactly at one integer parameter."""
+
+        return parse_canonical_integer(
+            self.coefficient
+        ) * parameter + parse_canonical_integer(self.constant)
+
+
+__all__ = [
+    "MAX_AFFINE_COMPONENT_DIGITS",
+    "MAX_FORM_ID_LENGTH",
+    "AffineComponentInteger",
+    "AffineFormId",
+    "IntegerAffineForm",
+]

--- a/src/jacobian/math/prime_affine_forms/__init__.py
+++ b/src/jacobian/math/prime_affine_forms/__init__.py
@@ -1,0 +1,13 @@
+"""Canonical public values for prime-affine local arithmetic."""
+
+from jacobian.math.prime_affine_forms._models import PrimeTupleResidueWheel
+from jacobian.math.prime_affine_forms.values import (
+    PrimeAffineTuple,
+    PrimitiveIntegerAffineForm,
+)
+
+__all__ = [
+    "PrimeAffineTuple",
+    "PrimeTupleResidueWheel",
+    "PrimitiveIntegerAffineForm",
+]

--- a/src/jacobian/math/prime_affine_forms/__init__.py
+++ b/src/jacobian/math/prime_affine_forms/__init__.py
@@ -1,6 +1,18 @@
-"""Canonical public values for prime-affine local arithmetic."""
+"""Canonical public values and native operations for prime-affine arithmetic."""
 
 from jacobian.math.prime_affine_forms._models import PrimeTupleResidueWheel
+from jacobian.math.prime_affine_forms.operations import (
+    enumerate_residue_wheel,
+    interval_count,
+    interval_enumerate,
+    interval_residue_profile,
+    local_admissibility,
+    local_factor,
+    local_factors,
+    residue_wheel,
+    translate_tuple,
+    wheel_membership,
+)
 from jacobian.math.prime_affine_forms.values import (
     PrimeAffineTuple,
     PrimitiveIntegerAffineForm,
@@ -10,4 +22,14 @@ __all__ = [
     "PrimeAffineTuple",
     "PrimeTupleResidueWheel",
     "PrimitiveIntegerAffineForm",
+    "enumerate_residue_wheel",
+    "interval_count",
+    "interval_enumerate",
+    "interval_residue_profile",
+    "local_admissibility",
+    "local_factor",
+    "local_factors",
+    "residue_wheel",
+    "translate_tuple",
+    "wheel_membership",
 ]

--- a/src/jacobian/math/prime_affine_forms/_admission.py
+++ b/src/jacobian/math/prime_affine_forms/_admission.py
@@ -1,0 +1,65 @@
+"""Owner-local admission decisions for prime-affine operations."""
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.prime_affine_forms._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "number_theory.prime_affine_forms.interval_count.compute",
+        AdmissionDecision.KEEP,
+        "exact count of a complete bounded positive-prime affine pattern",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.interval_enumerate.compute",
+        AdmissionDecision.KEEP,
+        "complete bounded family of positive-prime affine matches and values",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.interval_residue_profile.compute",
+        AdmissionDecision.KEEP,
+        "complete bounded interval profile for a supplied exact CRT wheel",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.local_admissibility.compute",
+        AdmissionDecision.KEEP,
+        "closed local-admissibility decision from the primitive-form finite cutoff theorem",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.local_factor.compute",
+        AdmissionDecision.KEEP,
+        "complete one-prime residue partition and exact Hardy-Littlewood local factor",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.local_factors.compute",
+        AdmissionDecision.KEEP,
+        "exact finite local-factor family and explicitly finite rational product",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.residue_wheel.compute",
+        AdmissionDecision.KEEP,
+        "compact exact CRT product with source-bound local residue factors and count",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.residue_wheel.enumerate.compute",
+        AdmissionDecision.KEEP,
+        "separately bounded complete CRT residue materialization with component transport",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.translation.compute",
+        AdmissionDecision.KEEP,
+        "typed affine-variable translation preserving stable form identity",
+    ),
+    OperationAdmission(
+        "number_theory.prime_affine_forms.wheel_membership.compute",
+        AdmissionDecision.KEEP,
+        "exact modular membership with a replayable first local exclusion",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)
+
+__all__ = ["ADMISSIONS", "REGISTRATION"]

--- a/src/jacobian/math/prime_affine_forms/_kernel.py
+++ b/src/jacobian/math/prime_affine_forms/_kernel.py
@@ -1,0 +1,176 @@
+"""Exact finite kernels for prime-affine local arithmetic."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from itertools import product
+from math import prod
+from typing import TYPE_CHECKING
+
+from sympy import isprime, primerange
+from sympy.ntheory.modular import crt
+
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
+
+MAX_DETERMINISTIC_PRIME_INPUT = 2**64 - 1
+
+
+def local_bad_residues(
+    source: PrimeAffineTuple, prime: int
+) -> tuple[tuple[int, tuple[str, ...]], ...]:
+    """Return nonempty residue/form incidence rows in canonical residue order."""
+
+    by_residue: dict[int, list[str]] = {}
+    for form in source.forms:
+        coefficient = parse_canonical_integer(form.coefficient)
+        constant = parse_canonical_integer(form.constant)
+        if coefficient % prime == 0:
+            continue
+        residue = (-constant * pow(coefficient, -1, prime)) % prime
+        by_residue.setdefault(residue, []).append(form.form_id)
+    return tuple(
+        (residue, tuple(sorted(form_ids)))
+        for residue, form_ids in sorted(by_residue.items())
+    )
+
+
+def local_counts(source: PrimeAffineTuple, prime: int) -> tuple[int, int]:
+    bad_count = len(local_bad_residues(source, prime))
+    return bad_count, prime - bad_count
+
+
+def local_factor_from_bad_count(
+    form_count: int, prime: int, bad_count: int
+) -> Fraction:
+    if bad_count == prime:
+        return Fraction(0, 1)
+    return Fraction(
+        (prime - bad_count) * pow(prime, form_count - 1),
+        pow(prime - 1, form_count),
+    )
+
+
+def valid_residues(source: PrimeAffineTuple, prime: int) -> tuple[int, ...]:
+    bad = {residue for residue, _ in local_bad_residues(source, prime)}
+    return tuple(residue for residue in range(prime) if residue not in bad)
+
+
+def primes_through(bound: int) -> tuple[int, ...]:
+    """Enumerate exactly the primes through the admitted finite cutoff."""
+
+    return tuple(int(prime) for prime in primerange(2, bound + 1))
+
+
+def wheel_modulus(primes: tuple[int, ...]) -> int:
+    return prod(primes, start=1)
+
+
+def wheel_rows(
+    source: PrimeAffineTuple, primes: tuple[int, ...]
+) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    """Enumerate CRT rows after distinct-prime and output preflight."""
+
+    if not primes:
+        return ((0, ()),)
+    expected_modulus = wheel_modulus(primes)
+    local_sets = tuple(valid_residues(source, prime) for prime in primes)
+    if any(not residues for residues in local_sets):
+        return ()
+    rows: list[tuple[int, tuple[int, ...]]] = []
+    for components in product(*local_sets):
+        combined = crt(primes, components, symmetric=False, check=False)
+        if combined is None:  # Pairwise-distinct primes make this unreachable.
+            raise RuntimeError("CRT failed for pairwise-distinct prime moduli")
+        residue, modulus = (int(combined[0]), int(combined[1]))
+        if (
+            modulus != expected_modulus
+            or not 0 <= residue < expected_modulus
+            or any(
+                residue % prime != component
+                for prime, component in zip(primes, components, strict=True)
+            )
+        ):
+            raise RuntimeError("CRT result failed its defining congruence invariant")
+        rows.append((residue, tuple(components)))
+    return tuple(sorted(rows))
+
+
+def iter_interval_values(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> Iterator[tuple[int, tuple[int, ...]]]:
+    for parameter in range(lower, upper + 1):
+        yield parameter, tuple(form.evaluate(parameter) for form in source.forms)
+
+
+def is_positive_prime(value: int) -> bool:
+    """Return exact ordinary-prime status in the admitted deterministic range."""
+
+    return value > 1 and bool(isprime(value))
+
+
+def interval_matches(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> tuple[tuple[int, tuple[int, ...]], ...]:
+    return tuple(
+        (parameter, values)
+        for parameter, values in iter_interval_values(source, lower, upper)
+        if all(is_positive_prime(value) for value in values)
+    )
+
+
+def interval_match_summary(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> tuple[int, int | None, int | None]:
+    count = 0
+    first: int | None = None
+    last: int | None = None
+    for parameter, values in iter_interval_values(source, lower, upper):
+        if all(is_positive_prime(value) for value in values):
+            count += 1
+            if first is None:
+                first = parameter
+            last = parameter
+    return count, first, last
+
+
+def translated_tuple(source: PrimeAffineTuple, shift: int) -> PrimeAffineTuple:
+    from jacobian.math.prime_affine_forms.values import (
+        PrimeAffineTuple,
+        PrimitiveIntegerAffineForm,
+    )
+
+    return PrimeAffineTuple(
+        forms=tuple(
+            PrimitiveIntegerAffineForm(
+                form_id=form.form_id,
+                coefficient=form.coefficient,
+                constant=format_canonical_integer(
+                    parse_canonical_integer(form.constant)
+                    + parse_canonical_integer(form.coefficient) * shift
+                ),
+            )
+            for form in source.forms
+        )
+    )
+
+
+__all__ = [
+    "MAX_DETERMINISTIC_PRIME_INPUT",
+    "interval_match_summary",
+    "interval_matches",
+    "is_positive_prime",
+    "iter_interval_values",
+    "local_bad_residues",
+    "local_counts",
+    "local_factor_from_bad_count",
+    "primes_through",
+    "translated_tuple",
+    "valid_residues",
+    "wheel_modulus",
+    "wheel_rows",
+]

--- a/src/jacobian/math/prime_affine_forms/_models.py
+++ b/src/jacobian/math/prime_affine_forms/_models.py
@@ -1,0 +1,1024 @@
+"""Typed contracts for exact prime-affine local arithmetic."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import prod
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+from sympy import isprime, primepi
+
+from jacobian._exact import CanonicalInteger, CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.affine_forms.values import (
+    MAX_AFFINE_COMPONENT_DIGITS,
+    MAX_FORM_ID_LENGTH,
+    AffineComponentInteger,
+    AffineFormId,
+)
+from jacobian.math.prime_affine_forms._kernel import (
+    MAX_DETERMINISTIC_PRIME_INPUT,
+    interval_match_summary,
+    interval_matches,
+    local_bad_residues,
+    local_counts,
+    local_factor_from_bad_count,
+    primes_through,
+    translated_tuple,
+    wheel_modulus,
+)
+from jacobian.math.prime_affine_forms.values import (
+    MAX_AFFINE_FORMS,
+    PrimeAffineTuple,
+)
+
+MAX_LOCAL_PROFILE_PRIME = 8_191
+MAX_LOCAL_PROFILE_WORK = 20_000
+MAX_BATCH_PRIME = (1 << 53) - 1
+MAX_PRIME_BATCH = 64
+MAX_BATCH_ROOT_WORK = 250_000
+MAX_FACTOR_COMPONENT_DIGITS = 4_096
+MAX_FACTOR_PRODUCT_DIGITS = 8_192
+MAX_ADMISSIBILITY_CUTOFF = MAX_AFFINE_FORMS
+MAX_ADMISSIBILITY_PRIME_ROWS = 128
+MAX_ADMISSIBILITY_ROOT_CELLS = 200_000
+MAX_WHEEL_PRIMES = 64
+MAX_WHEEL_LOCAL_RESIDUES = 32_768
+MAX_WHEEL_RESIDUES = 8_192
+MAX_WHEEL_RESULT_CELLS = 65_536
+MAX_WHEEL_ENUMERATION_WORK = 300_000
+MAX_COMPACT_WHEEL_ROOT_WORK = 250_000
+MAX_COMPACT_WHEEL_SCALAR_DIGITS = 4_096
+MAX_RESULT_CHARACTER_BUDGET = 2_000_000
+MAX_INTERVAL_ENDPOINT_DIGITS = 64
+MAX_INTERVAL_REPLAY_EVALUATIONS = 200_000
+MAX_INTERVAL_ENUMERATION_CELLS = 65_536
+MAX_WHEEL_INTERVAL_LENGTH = 8_192
+
+CompactPrime = Annotated[
+    StrictInt,
+    Field(
+        ge=2,
+        le=MAX_BATCH_PRIME,
+        description=(
+            "Prime in the interoperable JSON-integer range 2 through "
+            f"{MAX_BATCH_PRIME}."
+        ),
+    ),
+]
+CompactWheelScalar = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=MAX_COMPACT_WHEEL_SCALAR_DIGITS, strict=True),
+]
+IntervalEndpointInteger = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=MAX_INTERVAL_ENDPOINT_DIGITS + 1, strict=True),
+]
+DeterministicPrimeInteger = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=20, strict=True),
+]
+
+
+def _digits(value: int | str) -> int:
+    return len(str(value).lstrip("-"))
+
+
+def _source_character_upper_bound(source: PrimeAffineTuple) -> int:
+    """Conservatively bound the source tuple's compact JSON representation."""
+
+    return 16 + sum(
+        64 + len(form.form_id) + len(form.coefficient) + len(form.constant)
+        for form in source.forms
+    )
+
+
+def _summary_character_upper_bound(source: PrimeAffineTuple, prime: int) -> int:
+    """Bound one compact local summary after its root-work preflight."""
+
+    bad = local_bad_residues(source, prime)
+    return (
+        72
+        + 4 * _digits(prime)
+        + sum(
+            32 + _digits(residue) + sum(len(form_id) + 4 for form_id in form_ids)
+            for residue, form_ids in bad
+        )
+    )
+
+
+def _require_prime(prime: int, *, maximum: int) -> None:
+    """Require a prime inside SymPy's deterministic sub-2^64 domain."""
+
+    if prime > maximum:
+        raise ValueError(f"prime must be at most {maximum}")
+    if not isprime(prime):
+        raise ValueError("modulus must be prime")
+
+
+def _require_prime_set(primes: tuple[int, ...], *, maximum: int) -> None:
+    if primes != tuple(sorted(set(primes))):
+        raise ValueError("primes must be distinct and strictly increasing")
+    for prime in primes:
+        _require_prime(prime, maximum=maximum)
+
+
+def _factor_digit_upper_bound(source: PrimeAffineTuple, prime: int) -> int:
+    bad_count, _ = local_counts(source, prime)
+    if bad_count == prime:
+        return 1
+    numerator = _digits(prime - bad_count) + (source.form_count - 1) * _digits(prime)
+    denominator = source.form_count * _digits(prime - 1)
+    return max(numerator, denominator)
+
+
+def _require_factor_output(source: PrimeAffineTuple, prime: int) -> None:
+    bound = _factor_digit_upper_bound(source, prime)
+    if bound > MAX_FACTOR_COMPONENT_DIGITS:
+        raise ValueError(
+            "local-factor numerator or denominator may require "
+            f"{bound} digits, exceeding the bound {MAX_FACTOR_COMPONENT_DIGITS}"
+        )
+
+
+def _expected_summary(
+    source: PrimeAffineTuple, prime: int
+) -> tuple[tuple[tuple[int, tuple[str, ...]], ...], int, int]:
+    bad = local_bad_residues(source, prime)
+    return bad, len(bad), prime - len(bad)
+
+
+def _require_summary(source: PrimeAffineTuple, summary: PrimeTupleLocalSummary) -> None:
+    bad, bad_count, valid_count = _expected_summary(source, summary.prime)
+    actual = tuple((row.residue, row.form_ids) for row in summary.bad_residues)
+    if actual != bad:
+        raise ValueError("bad-residue rows do not match the source affine tuple")
+    if summary.bad_count != bad_count or summary.valid_count != valid_count:
+        raise ValueError("local residue counts do not match the source tuple")
+
+
+def _parse_interval(lower: str, upper: str) -> tuple[int, int, int]:
+    if (
+        _digits(lower) > MAX_INTERVAL_ENDPOINT_DIGITS
+        or _digits(upper) > MAX_INTERVAL_ENDPOINT_DIGITS
+    ):
+        raise ValueError(
+            "interval endpoints must each have at most "
+            f"{MAX_INTERVAL_ENDPOINT_DIGITS} digits"
+        )
+    lower_value = parse_canonical_integer(lower)
+    upper_value = parse_canonical_integer(upper)
+    if lower_value > upper_value:
+        raise ValueError("interval lower endpoint must not exceed upper endpoint")
+    return lower_value, upper_value, upper_value - lower_value + 1
+
+
+def _interval_value_digit_bound(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> int:
+    maximum_digits = 1
+    for form in source.forms:
+        values = (form.evaluate(lower), form.evaluate(upper))
+        maximum_digits = max(maximum_digits, *(_digits(value) for value in values))
+        if max(values) > MAX_DETERMINISTIC_PRIME_INPUT:
+            raise ValueError(
+                "a positive affine value exceeds SymPy's deterministic primality "
+                f"range 0..{MAX_DETERMINISTIC_PRIME_INPUT}"
+            )
+    return maximum_digits
+
+
+class PrimeTupleBadResidueRow(StrictModel):
+    """One residue excluded by the labelled forms that vanish there."""
+
+    residue: StrictInt = Field(ge=0, le=MAX_BATCH_PRIME)
+    form_ids: tuple[AffineFormId, ...] = Field(
+        min_length=1, max_length=MAX_AFFINE_FORMS
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_ids(self) -> Self:
+        if self.form_ids != tuple(sorted(set(self.form_ids))):
+            raise ValueError("vanishing form IDs must be distinct and sorted")
+        return self
+
+
+class PrimeTupleResidueRow(StrictModel):
+    """One residue and every source form that vanishes there."""
+
+    residue: StrictInt = Field(ge=0, le=MAX_LOCAL_PROFILE_PRIME)
+    vanishing_form_ids: tuple[AffineFormId, ...] = Field(max_length=MAX_AFFINE_FORMS)
+
+    @model_validator(mode="after")
+    def require_canonical_ids(self) -> Self:
+        if self.vanishing_form_ids != tuple(sorted(set(self.vanishing_form_ids))):
+            raise ValueError("vanishing form IDs must be distinct and sorted")
+        return self
+
+
+class PrimeTupleLocalSummary(StrictModel):
+    """Compact exact local obstruction data for one prime."""
+
+    prime: StrictInt = Field(ge=2, le=MAX_BATCH_PRIME)
+    bad_residues: tuple[PrimeTupleBadResidueRow, ...] = Field(
+        max_length=MAX_AFFINE_FORMS
+    )
+    bad_count: StrictInt = Field(ge=0)
+    valid_count: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def require_internal_partition_counts(self) -> Self:
+        _require_prime(self.prime, maximum=MAX_BATCH_PRIME)
+        residues = tuple(row.residue for row in self.bad_residues)
+        if residues != tuple(sorted(set(residues))):
+            raise ValueError("bad residues must be distinct and sorted")
+        if any(residue >= self.prime for residue in residues):
+            raise ValueError("bad residues must be canonical modulo the prime")
+        if self.bad_count != len(self.bad_residues):
+            raise ValueError("bad_count must equal the number of bad residue rows")
+        if self.bad_count + self.valid_count != self.prime:
+            raise ValueError("bad and valid counts must partition every residue")
+        if sum(len(row.form_ids) for row in self.bad_residues) > MAX_AFFINE_FORMS:
+            raise ValueError(
+                "bad-residue incidence count exceeds the affine-form bound"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorRequest(StrictModel):
+    """Compute one complete local residue profile and exact local factor."""
+
+    source: PrimeAffineTuple
+    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
+
+    @model_validator(mode="after")
+    def require_bounded_complete_profile(self) -> Self:
+        _require_prime(self.prime, maximum=MAX_LOCAL_PROFILE_PRIME)
+        _require_factor_output(self.source, self.prime)
+        work = 6 * self.source.form_count + 2 * self.prime
+        if work > MAX_LOCAL_PROFILE_WORK:
+            raise ValueError(
+                f"local profile and validation need {work} bounded steps, "
+                f"exceeding {MAX_LOCAL_PROFILE_WORK}"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorResult(StrictModel):
+    """Source-bound complete partition modulo one prime and its local factor."""
+
+    source: PrimeAffineTuple
+    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
+    residue_rows: tuple[PrimeTupleResidueRow, ...] = Field(
+        min_length=2, max_length=MAX_LOCAL_PROFILE_PRIME
+    )
+    bad_count: StrictInt = Field(ge=0)
+    valid_count: StrictInt = Field(ge=0)
+    locally_obstructed: StrictBool
+    factor: CanonicalRational
+
+    @model_validator(mode="after")
+    def bind_complete_local_factor(self) -> Self:
+        if (
+            sum(len(row.vanishing_form_ids) for row in self.residue_rows)
+            > self.source.form_count
+        ):
+            raise ValueError(
+                "residue incidence count exceeds the source affine-form count"
+            )
+        PrimeTupleLocalFactorRequest(source=self.source, prime=self.prime)
+        bad = dict(local_bad_residues(self.source, self.prime))
+        expected_rows = tuple(
+            (residue, bad.get(residue, ())) for residue in range(self.prime)
+        )
+        actual_rows = tuple(
+            (row.residue, row.vanishing_form_ids) for row in self.residue_rows
+        )
+        if actual_rows != expected_rows:
+            raise ValueError("residue rows must be the complete source-bound partition")
+        expected_bad = len(bad)
+        expected_valid = self.prime - expected_bad
+        if self.bad_count != expected_bad or self.valid_count != expected_valid:
+            raise ValueError("local counts do not match the complete residue rows")
+        if self.locally_obstructed != (expected_valid == 0):
+            raise ValueError("local obstruction status must equal valid_count == 0")
+        if self.factor.as_fraction() != local_factor_from_bad_count(
+            self.source.form_count, self.prime, expected_bad
+        ):
+            raise ValueError("local factor does not satisfy its defining formula")
+        return self
+
+
+class PrimeTupleLocalFactorsRequest(StrictModel):
+    """Compute compact local factors for a canonical finite prime set."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(
+        min_length=1,
+        max_length=MAX_PRIME_BATCH,
+        description=(
+            "Distinct primes in strictly increasing order. The aggregate form/root "
+            "and exact rational-output bounds are validated before computation."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_factor_batch(self) -> Self:
+        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
+        root_cells = self.source.form_count * len(self.primes)
+        root_work = 6 * root_cells
+        if root_work > MAX_BATCH_ROOT_WORK:
+            raise ValueError(
+                f"local-factor computation and validation need {root_work} root "
+                f"steps, exceeding {MAX_BATCH_ROOT_WORK}"
+            )
+        digit_bounds = tuple(
+            _factor_digit_upper_bound(self.source, prime) for prime in self.primes
+        )
+        if any(bound > MAX_FACTOR_COMPONENT_DIGITS for bound in digit_bounds):
+            raise ValueError(
+                "one local factor exceeds the exact rational component-digit bound"
+            )
+        if sum(digit_bounds) > MAX_FACTOR_PRODUCT_DIGITS:
+            raise ValueError(
+                "finite factor product exceeds the conservative exact rational "
+                f"digit bound {MAX_FACTOR_PRODUCT_DIGITS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in self.primes
+            )
+            + 128 * len(self.primes)
+            + 4 * sum(digit_bounds)
+            + 256
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "finite factor result exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorRow(StrictModel):
+    summary: PrimeTupleLocalSummary
+    factor: CanonicalRational
+
+
+class FinitePrimeTupleFactorProduct(StrictModel):
+    """Exact finite local-factor product, explicitly not an infinite series."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(min_length=1, max_length=MAX_PRIME_BATCH)
+    rows: tuple[PrimeTupleLocalFactorRow, ...] = Field(
+        min_length=1, max_length=MAX_PRIME_BATCH
+    )
+    product: CanonicalRational
+    first_obstructing_prime: StrictInt | None = None
+
+    @model_validator(mode="after")
+    def bind_finite_factor_product(self) -> Self:
+        PrimeTupleLocalFactorsRequest(source=self.source, primes=self.primes)
+        if tuple(row.summary.prime for row in self.rows) != self.primes:
+            raise ValueError(
+                "local-factor rows must align with the canonical prime set"
+            )
+        expected_product = Fraction(1, 1)
+        expected_first: int | None = None
+        for row in self.rows:
+            _require_summary(self.source, row.summary)
+            expected_factor = local_factor_from_bad_count(
+                self.source.form_count,
+                row.summary.prime,
+                row.summary.bad_count,
+            )
+            if row.factor.as_fraction() != expected_factor:
+                raise ValueError(
+                    "local factor row does not satisfy its defining formula"
+                )
+            expected_product *= expected_factor
+            if expected_first is None and row.summary.valid_count == 0:
+                expected_first = row.summary.prime
+        if self.product.as_fraction() != expected_product:
+            raise ValueError("finite product must equal the product of every local row")
+        if self.first_obstructing_prime != expected_first:
+            raise ValueError("first obstructing prime does not match the local rows")
+        return self
+
+
+class PrimeTupleAdmissibilityRequest(StrictModel):
+    """Decide local admissibility by checking exactly the primes at most k."""
+
+    source: PrimeAffineTuple
+
+    @model_validator(mode="after")
+    def require_bounded_cutoff_profile(self) -> Self:
+        cutoff = self.source.form_count
+        prime_rows = int(primepi(cutoff))
+        if prime_rows > MAX_ADMISSIBILITY_PRIME_ROWS:
+            raise ValueError(
+                f"admissibility needs {prime_rows} prime rows, exceeding "
+                f"{MAX_ADMISSIBILITY_PRIME_ROWS}"
+            )
+        root_cells = self.source.form_count * prime_rows
+        total_root_cells = 4 * root_cells
+        if total_root_cells > MAX_ADMISSIBILITY_ROOT_CELLS:
+            raise ValueError(
+                "admissibility computation and validation may require "
+                f"{total_root_cells} root cells, "
+                f"exceeding {MAX_ADMISSIBILITY_ROOT_CELLS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in primes_through(cutoff)
+            )
+            + 16 * prime_rows
+            + 256
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "admissibility profile exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleAdmissibilityResult(StrictModel):
+    """Closed decision: every p<=k is checked and every p>k has nu_p<=k<p."""
+
+    source: PrimeAffineTuple
+    cutoff: StrictInt = Field(ge=1, le=MAX_ADMISSIBILITY_CUTOFF)
+    checked_primes: tuple[StrictInt, ...] = Field(
+        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
+    )
+    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(
+        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
+    )
+    status: Literal["LOCALLY_ADMISSIBLE", "LOCALLY_OBSTRUCTED"]
+    least_obstructing_prime: StrictInt | None = None
+    large_prime_lower_bound: StrictInt = Field(ge=2)
+    maximum_large_prime_bad_residues: StrictInt = Field(ge=1)
+
+    @model_validator(mode="after")
+    def bind_cutoff_decision(self) -> Self:
+        PrimeTupleAdmissibilityRequest(source=self.source)
+        expected_cutoff = self.source.form_count
+        expected_primes = primes_through(expected_cutoff)
+        if self.cutoff != expected_cutoff or self.checked_primes != expected_primes:
+            raise ValueError(
+                "checked primes must be exactly every prime through the cutoff"
+            )
+        if tuple(row.prime for row in self.local_rows) != expected_primes:
+            raise ValueError("local rows must align with every checked prime")
+        for row in self.local_rows:
+            _require_summary(self.source, row)
+        obstructing = tuple(
+            row.prime for row in self.local_rows if row.valid_count == 0
+        )
+        expected_status = "LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE"
+        if self.status != expected_status:
+            raise ValueError("admissibility status does not match the local rows")
+        expected_first = obstructing[0] if obstructing else None
+        if self.least_obstructing_prime != expected_first:
+            raise ValueError("least obstructing prime does not match the local rows")
+        if (
+            self.large_prime_lower_bound != expected_cutoff + 1
+            or self.maximum_large_prime_bad_residues != self.source.form_count
+        ):
+            raise ValueError("large-prime cutoff evidence does not match the source")
+        return self
+
+
+class PrimeTupleResidueWheelRequest(StrictModel):
+    """Construct a compact exact CRT wheel for a canonical finite prime set."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(
+        max_length=MAX_WHEEL_PRIMES,
+        description=(
+            "Possibly empty tuple of distinct primes in strictly increasing order; "
+            "the empty set returns the modulus-one identity wheel. This compact "
+            "operation does not enumerate all combined residues."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_compact_wheel(self) -> Self:
+        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
+        root_cells = self.source.form_count * len(self.primes)
+        root_work = 6 * root_cells
+        if root_work > MAX_COMPACT_WHEEL_ROOT_WORK:
+            raise ValueError(
+                f"compact wheel computation and validation need {root_work} root "
+                f"steps, exceeding {MAX_COMPACT_WHEEL_ROOT_WORK}"
+            )
+        modulus_digits = sum(_digits(prime) for prime in self.primes) or 1
+        if modulus_digits > MAX_COMPACT_WHEEL_SCALAR_DIGITS:
+            raise ValueError(
+                "compact wheel modulus exceeds the conservative exact scalar "
+                f"digit bound {MAX_COMPACT_WHEEL_SCALAR_DIGITS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in self.primes
+            )
+            + 2 * modulus_digits
+            + 128
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError("compact wheel exceeds the conservative serialized bound")
+        return self
+
+
+class PrimeTupleWheelResidueRow(StrictModel):
+    residue: CompactWheelScalar
+    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+
+
+class PrimeTupleResidueWheel(StrictModel):
+    """Compact source-bound CRT wheel as a product of valid local residue sets."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    modulus: CompactWheelScalar
+    valid_count: CompactWheelScalar
+
+    @model_validator(mode="after")
+    def bind_compact_crt_wheel(self) -> Self:
+        PrimeTupleResidueWheelRequest(source=self.source, primes=self.primes)
+        if tuple(row.prime for row in self.local_rows) != self.primes:
+            raise ValueError("wheel local rows must align with its canonical primes")
+        for row in self.local_rows:
+            _require_summary(self.source, row)
+        expected_modulus = wheel_modulus(self.primes)
+        if parse_canonical_integer(self.modulus) != expected_modulus:
+            raise ValueError("wheel modulus must equal the product of its primes")
+        expected_count = prod((row.valid_count for row in self.local_rows), start=1)
+        if parse_canonical_integer(self.valid_count) != expected_count:
+            raise ValueError("wheel valid_count must equal the product of local counts")
+        return self
+
+
+class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
+    """Materialize every residue of a supplied compact wheel under strict bounds."""
+
+    wheel: PrimeTupleResidueWheel
+
+    @model_validator(mode="after")
+    def require_bounded_wheel_enumeration(self) -> Self:
+        local_residue_rows = sum(self.wheel.primes)
+        if local_residue_rows > MAX_WHEEL_LOCAL_RESIDUES:
+            raise ValueError(
+                f"wheel local residue enumeration {local_residue_rows} exceeds "
+                f"{MAX_WHEEL_LOCAL_RESIDUES}"
+            )
+        result_count = parse_canonical_integer(self.wheel.valid_count)
+        if result_count > MAX_WHEEL_RESIDUES:
+            raise ValueError(
+                f"wheel has {result_count} valid residues, exceeding "
+                f"{MAX_WHEEL_RESIDUES}"
+            )
+        result_cells = result_count * (len(self.wheel.primes) + 1)
+        if result_cells > MAX_WHEEL_RESULT_CELLS:
+            raise ValueError(
+                f"wheel result needs {result_cells} cells, exceeding "
+                f"{MAX_WHEEL_RESULT_CELLS}"
+            )
+        root_cells = self.wheel.source.form_count * len(self.wheel.primes)
+        replay_work = 2 * (
+            result_count * len(self.wheel.primes) + local_residue_rows + root_cells
+        )
+        if replay_work > MAX_WHEEL_ENUMERATION_WORK:
+            raise ValueError(
+                f"wheel enumeration and validation need {replay_work} bounded "
+                f"steps, exceeding {MAX_WHEEL_ENUMERATION_WORK}"
+            )
+        modulus_digits = _digits(self.wheel.modulus)
+        component_digits = sum(_digits(prime) for prime in self.wheel.primes)
+        serialized_characters = (
+            len(self.wheel.model_dump_json())
+            + result_count
+            * (modulus_digits + component_digits + 4 * len(self.wheel.primes) + 64)
+            + 128
+        )
+        if serialized_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "wheel enumeration exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleResidueWheelEnumeration(StrictModel):
+    """Complete explicit residue realization of one compact CRT wheel."""
+
+    wheel: PrimeTupleResidueWheel
+    residues: tuple[PrimeTupleWheelResidueRow, ...] = Field(
+        max_length=MAX_WHEEL_RESIDUES
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_crt_enumeration(self) -> Self:
+        result_cells = len(self.residues) + sum(
+            len(row.components) for row in self.residues
+        )
+        if result_cells > MAX_WHEEL_RESULT_CELLS:
+            raise ValueError("wheel rows exceed the explicit result-cell bound")
+        PrimeTupleResidueWheelEnumerationRequest(wheel=self.wheel)
+        expected_count = parse_canonical_integer(self.wheel.valid_count)
+        if len(self.residues) != expected_count:
+            raise ValueError(
+                "wheel rows do not satisfy the complete CRT reconstruction invariant"
+            )
+        residues = tuple(parse_canonical_integer(row.residue) for row in self.residues)
+        if residues != tuple(sorted(set(residues))):
+            raise ValueError(
+                "wheel rows do not satisfy the complete CRT reconstruction invariant"
+            )
+        modulus = parse_canonical_integer(self.wheel.modulus)
+        for row, residue in zip(self.residues, residues, strict=True):
+            if not 0 <= residue < modulus or len(row.components) != len(
+                self.wheel.primes
+            ):
+                raise ValueError(
+                    "wheel rows do not satisfy the complete CRT reconstruction invariant"
+                )
+            for prime, summary, component in zip(
+                self.wheel.primes,
+                self.wheel.local_rows,
+                row.components,
+                strict=True,
+            ):
+                bad = {item.residue for item in summary.bad_residues}
+                if (
+                    not 0 <= component < prime
+                    or residue % prime != component
+                    or component in bad
+                ):
+                    raise ValueError(
+                        "wheel rows do not satisfy the complete CRT reconstruction "
+                        "invariant"
+                    )
+        return self
+
+
+class PrimeTupleWheelMembershipRequest(StrictModel):
+    """Check one integer against an exact residue wheel supplied unchanged."""
+
+    wheel: PrimeTupleResidueWheel
+    value: AffineComponentInteger
+
+    @model_validator(mode="after")
+    def require_bounded_value(self) -> Self:
+        if _digits(self.value) > MAX_AFFINE_COMPONENT_DIGITS:
+            raise ValueError(
+                f"membership value must have at most {MAX_AFFINE_COMPONENT_DIGITS} digits"
+            )
+        result_characters = (
+            len(self.wheel.model_dump_json())
+            + len(self.value)
+            + _digits(self.wheel.modulus)
+            + sum(_digits(prime) for prime in self.wheel.primes)
+            + MAX_FORM_ID_LENGTH * self.wheel.source.form_count
+            + 256
+        )
+        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "wheel membership result exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleWheelMembershipResult(StrictModel):
+    wheel: PrimeTupleResidueWheel
+    value: AffineComponentInteger
+    canonical_residue: CompactWheelScalar
+    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    is_permitted: StrictBool
+    first_excluded_prime: StrictInt | None = None
+    vanishing_form_ids: tuple[AffineFormId, ...] = Field(max_length=MAX_AFFINE_FORMS)
+
+    @model_validator(mode="after")
+    def bind_wheel_membership(self) -> Self:
+        PrimeTupleWheelMembershipRequest(wheel=self.wheel, value=self.value)
+        value = parse_canonical_integer(self.value)
+        modulus = parse_canonical_integer(self.wheel.modulus)
+        expected_residue = value % modulus
+        expected_components = tuple(value % prime for prime in self.wheel.primes)
+        expected_prime: int | None = None
+        expected_form_ids: tuple[str, ...] = ()
+        for summary, component in zip(
+            self.wheel.local_rows, expected_components, strict=True
+        ):
+            bad = {row.residue: row.form_ids for row in summary.bad_residues}
+            if component in bad:
+                expected_prime = summary.prime
+                expected_form_ids = bad[component]
+                break
+        expected_permitted = expected_prime is None
+        if parse_canonical_integer(self.canonical_residue) != expected_residue:
+            raise ValueError("canonical residue does not match the wheel modulus")
+        if self.components != expected_components:
+            raise ValueError("prime components do not match the supplied integer")
+        if self.is_permitted != expected_permitted:
+            raise ValueError("wheel membership does not match the complete residue set")
+        if (
+            self.first_excluded_prime != expected_prime
+            or self.vanishing_form_ids != expected_form_ids
+        ):
+            raise ValueError("first local exclusion does not match the source forms")
+        return self
+
+
+class PrimeAffineIntervalCountRequest(StrictModel):
+    """Count all positive-prime affine tuples on one closed integer interval."""
+
+    source: PrimeAffineTuple
+    lower: IntervalEndpointInteger = Field(
+        description="Canonical lower endpoint of a nonempty closed integer interval."
+    )
+    upper: IntervalEndpointInteger = Field(
+        description="Canonical upper endpoint, required to be at least lower."
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_complete_count(self) -> Self:
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        _interval_value_digit_bound(self.source, lower, upper)
+        replay_evaluations = 2 * interval_size * self.source.form_count
+        if replay_evaluations > MAX_INTERVAL_REPLAY_EVALUATIONS:
+            raise ValueError(
+                f"interval result and validation need {replay_evaluations} affine "
+                f"evaluations, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
+            )
+        return self
+
+
+class PrimeAffineIntervalEnumerateRequest(PrimeAffineIntervalCountRequest):
+    """Enumerate all positive-prime affine tuples on a stricter output envelope."""
+
+    @model_validator(mode="after")
+    def require_bounded_complete_enumeration(self) -> Self:
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        value_digits = _interval_value_digit_bound(self.source, lower, upper)
+        result_cells = interval_size * (self.source.form_count + 1)
+        if result_cells > MAX_INTERVAL_ENUMERATION_CELLS:
+            raise ValueError(
+                f"interval enumeration may need {result_cells} result cells, "
+                f"exceeding {MAX_INTERVAL_ENUMERATION_CELLS}"
+            )
+        parameter_digits = max(_digits(lower), _digits(upper))
+        serialized_characters = (
+            _source_character_upper_bound(self.source)
+            + interval_size
+            * (40 + parameter_digits + self.source.form_count * (value_digits + 4))
+            + 256
+        )
+        if serialized_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "interval enumeration exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimePatternMatch(StrictModel):
+    parameter: IntervalEndpointInteger
+    prime_values: tuple[DeterministicPrimeInteger, ...] = Field(
+        min_length=1, max_length=MAX_AFFINE_FORMS
+    )
+
+
+class PrimePatternIntervalCountResult(StrictModel):
+    source: PrimeAffineTuple
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+    interval_size: StrictInt = Field(ge=1)
+    affine_values_examined: StrictInt = Field(ge=1)
+    match_count: StrictInt = Field(ge=0)
+    first_match: IntervalEndpointInteger | None = None
+    last_match: IntervalEndpointInteger | None = None
+
+    @model_validator(mode="after")
+    def bind_exact_interval_count(self) -> Self:
+        PrimeAffineIntervalCountRequest(
+            source=self.source, lower=self.lower, upper=self.upper
+        )
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        expected_count, expected_first, expected_last = interval_match_summary(
+            self.source, lower, upper
+        )
+        if self.interval_size != interval_size:
+            raise ValueError("interval_size must equal upper-lower+1")
+        if self.affine_values_examined != interval_size * self.source.form_count:
+            raise ValueError(
+                "affine_values_examined does not match the complete interval"
+            )
+        if self.match_count != expected_count:
+            raise ValueError("match_count does not match exact interval primality")
+        if (
+            None
+            if self.first_match is None
+            else parse_canonical_integer(self.first_match)
+        ) != expected_first or (
+            None
+            if self.last_match is None
+            else parse_canonical_integer(self.last_match)
+        ) != expected_last:
+            raise ValueError(
+                "first or last match does not match exact interval primality"
+            )
+        return self
+
+
+class PrimePatternIntervalEnumerateResult(StrictModel):
+    source: PrimeAffineTuple
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+    interval_size: StrictInt = Field(ge=1)
+    affine_values_examined: StrictInt = Field(ge=1)
+    matches: tuple[PrimePatternMatch, ...] = Field(
+        max_length=MAX_INTERVAL_ENUMERATION_CELLS
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_interval_enumeration(self) -> Self:
+        result_cells = len(self.matches) + sum(
+            len(match.prime_values) for match in self.matches
+        )
+        if result_cells > MAX_INTERVAL_ENUMERATION_CELLS:
+            raise ValueError("matches exceed the interval result-cell bound")
+        PrimeAffineIntervalEnumerateRequest(
+            source=self.source, lower=self.lower, upper=self.upper
+        )
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        expected = interval_matches(self.source, lower, upper)
+        actual = tuple(
+            (
+                parse_canonical_integer(match.parameter),
+                tuple(parse_canonical_integer(value) for value in match.prime_values),
+            )
+            for match in self.matches
+        )
+        if actual != expected:
+            raise ValueError(
+                "matches must be every and only positive-prime affine tuple"
+            )
+        if self.interval_size != interval_size:
+            raise ValueError("interval_size must equal upper-lower+1")
+        if self.affine_values_examined != interval_size * self.source.form_count:
+            raise ValueError(
+                "affine_values_examined does not match the complete interval"
+            )
+        return self
+
+
+class PrimeTupleIntervalResidueProfileRequest(StrictModel):
+    """Enumerate local-wheel survivors on one bounded closed integer interval."""
+
+    wheel: PrimeTupleResidueWheel
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+
+    @model_validator(mode="after")
+    def require_bounded_survivor_profile(self) -> Self:
+        _, _, interval_size = _parse_interval(self.lower, self.upper)
+        if interval_size > MAX_WHEEL_INTERVAL_LENGTH:
+            raise ValueError(
+                f"wheel interval length {interval_size} exceeds "
+                f"{MAX_WHEEL_INTERVAL_LENGTH}"
+            )
+        replay_work = 2 * interval_size * max(1, len(self.wheel.primes))
+        if replay_work > MAX_INTERVAL_REPLAY_EVALUATIONS:
+            raise ValueError(
+                f"wheel interval profile and validation need {replay_work} "
+                f"modular checks, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
+            )
+        endpoint_digits = max(_digits(self.lower), _digits(self.upper))
+        result_characters = (
+            len(self.wheel.model_dump_json())
+            + interval_size * (endpoint_digits + 4)
+            + 192
+        )
+        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise ValueError(
+                "wheel interval profile exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleIntervalResidueProfileResult(StrictModel):
+    """Exact local survivors; this value does not assert actual primality."""
+
+    wheel: PrimeTupleResidueWheel
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+    interval_size: StrictInt = Field(ge=1, le=MAX_WHEEL_INTERVAL_LENGTH)
+    survivors: tuple[IntervalEndpointInteger, ...] = Field(
+        max_length=MAX_WHEEL_INTERVAL_LENGTH
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_survivor_family(self) -> Self:
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=self.wheel, lower=self.lower, upper=self.upper
+        )
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        bad_by_prime = tuple(
+            {row.residue for row in summary.bad_residues}
+            for summary in self.wheel.local_rows
+        )
+        expected = tuple(
+            value
+            for value in range(lower, upper + 1)
+            if all(
+                value % prime not in bad
+                for prime, bad in zip(self.wheel.primes, bad_by_prime, strict=True)
+            )
+        )
+        actual = tuple(parse_canonical_integer(value) for value in self.survivors)
+        if actual != expected:
+            raise ValueError("survivors must be the complete local wheel profile")
+        if self.interval_size != interval_size:
+            raise ValueError("interval_size must equal upper-lower+1")
+        return self
+
+
+class PrimeAffineTranslationRequest(StrictModel):
+    """Translate every source form by the variable substitution n -> n+shift."""
+
+    source: PrimeAffineTuple
+    shift: IntervalEndpointInteger
+
+    @model_validator(mode="after")
+    def require_bounded_translated_tuple(self) -> Self:
+        if _digits(self.shift) > MAX_INTERVAL_ENDPOINT_DIGITS:
+            raise ValueError(
+                f"translation shift must have at most {MAX_INTERVAL_ENDPOINT_DIGITS} digits"
+            )
+        shift = parse_canonical_integer(self.shift)
+        for form in self.source.forms:
+            translated_constant = form.evaluate(shift)
+            if _digits(translated_constant) > MAX_AFFINE_COMPONENT_DIGITS:
+                raise ValueError(
+                    "translated constant exceeds the canonical affine component bound"
+                )
+        return self
+
+
+class PrimeAffineTranslationResult(StrictModel):
+    source: PrimeAffineTuple
+    shift: IntervalEndpointInteger
+    translated: PrimeAffineTuple
+
+    @model_validator(mode="after")
+    def bind_exact_translation(self) -> Self:
+        PrimeAffineTranslationRequest(source=self.source, shift=self.shift)
+        expected = translated_tuple(self.source, parse_canonical_integer(self.shift))
+        if self.translated != expected:
+            raise ValueError("translated tuple must equal L_i(n+shift) for every form")
+        return self
+
+
+__all__ = [
+    "MAX_ADMISSIBILITY_CUTOFF",
+    "MAX_BATCH_PRIME",
+    "MAX_INTERVAL_ENUMERATION_CELLS",
+    "MAX_INTERVAL_REPLAY_EVALUATIONS",
+    "MAX_LOCAL_PROFILE_PRIME",
+    "MAX_PRIME_BATCH",
+    "MAX_WHEEL_INTERVAL_LENGTH",
+    "MAX_WHEEL_PRIMES",
+    "MAX_WHEEL_RESIDUES",
+    "FinitePrimeTupleFactorProduct",
+    "PrimeAffineIntervalCountRequest",
+    "PrimeAffineIntervalEnumerateRequest",
+    "PrimeAffineTranslationRequest",
+    "PrimeAffineTranslationResult",
+    "PrimePatternIntervalCountResult",
+    "PrimePatternIntervalEnumerateResult",
+    "PrimePatternMatch",
+    "PrimeTupleAdmissibilityRequest",
+    "PrimeTupleAdmissibilityResult",
+    "PrimeTupleBadResidueRow",
+    "PrimeTupleIntervalResidueProfileRequest",
+    "PrimeTupleIntervalResidueProfileResult",
+    "PrimeTupleLocalFactorRequest",
+    "PrimeTupleLocalFactorResult",
+    "PrimeTupleLocalFactorRow",
+    "PrimeTupleLocalFactorsRequest",
+    "PrimeTupleLocalSummary",
+    "PrimeTupleResidueRow",
+    "PrimeTupleResidueWheel",
+    "PrimeTupleResidueWheelEnumeration",
+    "PrimeTupleResidueWheelEnumerationRequest",
+    "PrimeTupleResidueWheelRequest",
+    "PrimeTupleWheelMembershipRequest",
+    "PrimeTupleWheelMembershipResult",
+    "PrimeTupleWheelResidueRow",
+]

--- a/src/jacobian/math/prime_affine_forms/_models.py
+++ b/src/jacobian/math/prime_affine_forms/_models.py
@@ -30,6 +30,7 @@ from jacobian.math.prime_affine_forms._kernel import (
     wheel_modulus,
 )
 from jacobian.math.prime_affine_forms.values import (
+    MAX_AFFINE_AGGREGATE_DIGITS,
     MAX_AFFINE_FORMS,
     PrimeAffineTuple,
 )
@@ -962,12 +963,19 @@ class PrimeAffineTranslationRequest(StrictModel):
                 f"translation shift must have at most {MAX_INTERVAL_ENDPOINT_DIGITS} digits"
             )
         shift = parse_canonical_integer(self.shift)
+        aggregate_digits = 0
         for form in self.source.forms:
             translated_constant = form.evaluate(shift)
             if _digits(translated_constant) > MAX_AFFINE_COMPONENT_DIGITS:
                 raise ValueError(
                     "translated constant exceeds the canonical affine component bound"
                 )
+            aggregate_digits += _digits(form.coefficient) + _digits(translated_constant)
+        if aggregate_digits > MAX_AFFINE_AGGREGATE_DIGITS:
+            raise ValueError(
+                "translated affine tuple exceeds the aggregate coefficient-digit "
+                f"bound {MAX_AFFINE_AGGREGATE_DIGITS}"
+            )
         return self
 
 

--- a/src/jacobian/math/prime_affine_forms/_operations.py
+++ b/src/jacobian/math/prime_affine_forms/_operations.py
@@ -1,0 +1,285 @@
+"""Domain operations for exact prime-affine local arithmetic."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from math import prod
+
+from jacobian._exact import CanonicalRational
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math.prime_affine_forms._kernel import (
+    interval_match_summary,
+    interval_matches,
+    local_bad_residues,
+    local_factor_from_bad_count,
+    primes_through,
+    translated_tuple,
+    wheel_modulus,
+    wheel_rows,
+)
+from jacobian.math.prime_affine_forms._models import (
+    FinitePrimeTupleFactorProduct,
+    PrimeAffineIntervalCountRequest,
+    PrimeAffineIntervalEnumerateRequest,
+    PrimeAffineTranslationRequest,
+    PrimeAffineTranslationResult,
+    PrimePatternIntervalCountResult,
+    PrimePatternIntervalEnumerateResult,
+    PrimePatternMatch,
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleAdmissibilityResult,
+    PrimeTupleBadResidueRow,
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleIntervalResidueProfileResult,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorRow,
+    PrimeTupleLocalFactorsRequest,
+    PrimeTupleLocalSummary,
+    PrimeTupleResidueRow,
+    PrimeTupleResidueWheel,
+    PrimeTupleResidueWheelEnumeration,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
+    PrimeTupleWheelMembershipResult,
+    PrimeTupleWheelResidueRow,
+)
+from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
+
+
+def _summary(source: PrimeAffineTuple, prime: int) -> PrimeTupleLocalSummary:
+    bad = local_bad_residues(source, prime)
+    return PrimeTupleLocalSummary(
+        prime=prime,
+        bad_residues=tuple(
+            PrimeTupleBadResidueRow(residue=residue, form_ids=form_ids)
+            for residue, form_ids in bad
+        ),
+        bad_count=len(bad),
+        valid_count=prime - len(bad),
+    )
+
+
+def compute_local_factor(
+    request: PrimeTupleLocalFactorRequest,
+) -> PrimeTupleLocalFactorResult:
+    bad = dict(local_bad_residues(request.source, request.prime))
+    return PrimeTupleLocalFactorResult(
+        source=request.source,
+        prime=request.prime,
+        residue_rows=tuple(
+            PrimeTupleResidueRow(
+                residue=residue,
+                vanishing_form_ids=bad.get(residue, ()),
+            )
+            for residue in range(request.prime)
+        ),
+        bad_count=len(bad),
+        valid_count=request.prime - len(bad),
+        locally_obstructed=len(bad) == request.prime,
+        factor=CanonicalRational.from_fraction(
+            local_factor_from_bad_count(
+                request.source.form_count, request.prime, len(bad)
+            )
+        ),
+    )
+
+
+def compute_local_factors(
+    request: PrimeTupleLocalFactorsRequest,
+) -> FinitePrimeTupleFactorProduct:
+    product = Fraction(1, 1)
+    rows: list[PrimeTupleLocalFactorRow] = []
+    first_obstruction: int | None = None
+    for prime in request.primes:
+        summary = _summary(request.source, prime)
+        factor = local_factor_from_bad_count(
+            request.source.form_count, prime, summary.bad_count
+        )
+        rows.append(
+            PrimeTupleLocalFactorRow(
+                summary=summary,
+                factor=CanonicalRational.from_fraction(factor),
+            )
+        )
+        product *= factor
+        if first_obstruction is None and summary.valid_count == 0:
+            first_obstruction = prime
+    return FinitePrimeTupleFactorProduct(
+        source=request.source,
+        primes=request.primes,
+        rows=tuple(rows),
+        product=CanonicalRational.from_fraction(product),
+        first_obstructing_prime=first_obstruction,
+    )
+
+
+def compute_local_admissibility(
+    request: PrimeTupleAdmissibilityRequest,
+) -> PrimeTupleAdmissibilityResult:
+    cutoff = request.source.form_count
+    checked_primes = primes_through(cutoff)
+    rows = tuple(_summary(request.source, prime) for prime in checked_primes)
+    obstructing = tuple(row.prime for row in rows if row.valid_count == 0)
+    return PrimeTupleAdmissibilityResult(
+        source=request.source,
+        cutoff=cutoff,
+        checked_primes=checked_primes,
+        local_rows=rows,
+        status="LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE",
+        least_obstructing_prime=obstructing[0] if obstructing else None,
+        large_prime_lower_bound=cutoff + 1,
+        maximum_large_prime_bad_residues=request.source.form_count,
+    )
+
+
+def compute_residue_wheel(
+    request: PrimeTupleResidueWheelRequest,
+) -> PrimeTupleResidueWheel:
+    local_rows = tuple(_summary(request.source, prime) for prime in request.primes)
+    return PrimeTupleResidueWheel(
+        source=request.source,
+        primes=request.primes,
+        local_rows=local_rows,
+        modulus=format_canonical_integer(wheel_modulus(request.primes)),
+        valid_count=format_canonical_integer(
+            prod((row.valid_count for row in local_rows), start=1)
+        ),
+    )
+
+
+def compute_residue_wheel_enumeration(
+    request: PrimeTupleResidueWheelEnumerationRequest,
+) -> PrimeTupleResidueWheelEnumeration:
+    rows = wheel_rows(request.wheel.source, request.wheel.primes)
+    return PrimeTupleResidueWheelEnumeration(
+        wheel=request.wheel,
+        residues=tuple(
+            PrimeTupleWheelResidueRow(
+                residue=format_canonical_integer(residue),
+                components=components,
+            )
+            for residue, components in rows
+        ),
+    )
+
+
+def compute_wheel_membership(
+    request: PrimeTupleWheelMembershipRequest,
+) -> PrimeTupleWheelMembershipResult:
+    value = parse_canonical_integer(request.value)
+    modulus = parse_canonical_integer(request.wheel.modulus)
+    residue = value % modulus
+    components = tuple(value % prime for prime in request.wheel.primes)
+    first_prime: int | None = None
+    form_ids: tuple[str, ...] = ()
+    for summary, component in zip(request.wheel.local_rows, components, strict=True):
+        bad = {row.residue: row.form_ids for row in summary.bad_residues}
+        if component in bad:
+            first_prime = summary.prime
+            form_ids = bad[component]
+            break
+    return PrimeTupleWheelMembershipResult(
+        wheel=request.wheel,
+        value=request.value,
+        canonical_residue=format_canonical_integer(residue),
+        components=components,
+        is_permitted=first_prime is None,
+        first_excluded_prime=first_prime,
+        vanishing_form_ids=form_ids,
+    )
+
+
+def compute_interval_count(
+    request: PrimeAffineIntervalCountRequest,
+) -> PrimePatternIntervalCountResult:
+    lower = parse_canonical_integer(request.lower)
+    upper = parse_canonical_integer(request.upper)
+    interval_size = upper - lower + 1
+    count, first, last = interval_match_summary(request.source, lower, upper)
+    return PrimePatternIntervalCountResult(
+        source=request.source,
+        lower=request.lower,
+        upper=request.upper,
+        interval_size=interval_size,
+        affine_values_examined=interval_size * request.source.form_count,
+        match_count=count,
+        first_match=None if first is None else format_canonical_integer(first),
+        last_match=None if last is None else format_canonical_integer(last),
+    )
+
+
+def compute_interval_enumerate(
+    request: PrimeAffineIntervalEnumerateRequest,
+) -> PrimePatternIntervalEnumerateResult:
+    lower = parse_canonical_integer(request.lower)
+    upper = parse_canonical_integer(request.upper)
+    interval_size = upper - lower + 1
+    matches = interval_matches(request.source, lower, upper)
+    return PrimePatternIntervalEnumerateResult(
+        source=request.source,
+        lower=request.lower,
+        upper=request.upper,
+        interval_size=interval_size,
+        affine_values_examined=interval_size * request.source.form_count,
+        matches=tuple(
+            PrimePatternMatch(
+                parameter=format_canonical_integer(parameter),
+                prime_values=tuple(format_canonical_integer(value) for value in values),
+            )
+            for parameter, values in matches
+        ),
+    )
+
+
+def compute_interval_residue_profile(
+    request: PrimeTupleIntervalResidueProfileRequest,
+) -> PrimeTupleIntervalResidueProfileResult:
+    lower = parse_canonical_integer(request.lower)
+    upper = parse_canonical_integer(request.upper)
+    bad_by_prime = tuple(
+        {row.residue for row in summary.bad_residues}
+        for summary in request.wheel.local_rows
+    )
+    survivors = tuple(
+        value
+        for value in range(lower, upper + 1)
+        if all(
+            value % prime not in bad
+            for prime, bad in zip(request.wheel.primes, bad_by_prime, strict=True)
+        )
+    )
+    return PrimeTupleIntervalResidueProfileResult(
+        wheel=request.wheel,
+        lower=request.lower,
+        upper=request.upper,
+        interval_size=upper - lower + 1,
+        survivors=tuple(format_canonical_integer(value) for value in survivors),
+    )
+
+
+def compute_translation(
+    request: PrimeAffineTranslationRequest,
+) -> PrimeAffineTranslationResult:
+    return PrimeAffineTranslationResult(
+        source=request.source,
+        shift=request.shift,
+        translated=translated_tuple(
+            request.source, parse_canonical_integer(request.shift)
+        ),
+    )
+
+
+__all__ = [
+    "compute_interval_count",
+    "compute_interval_enumerate",
+    "compute_interval_residue_profile",
+    "compute_local_admissibility",
+    "compute_local_factor",
+    "compute_local_factors",
+    "compute_residue_wheel",
+    "compute_residue_wheel_enumeration",
+    "compute_translation",
+    "compute_wheel_membership",
+]

--- a/src/jacobian/math/prime_affine_forms/_tools.py
+++ b/src/jacobian/math/prime_affine_forms/_tools.py
@@ -103,15 +103,15 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     _operation(
         "number_theory.prime_affine_forms.local_factor.compute",
         "Compute one prime-affine local factor",
-        "For a finite tuple of primitive integer affine forms and one bounded "
-        "prime p, return the complete residue partition modulo p and the exact "
-        "Hardy-Littlewood local factor (1-nu_p/p)/(1-1/p)^k.",
+        "For a finite tuple of primitive affine forms and one bounded modulus "
+        "p, return the complete residue partition and the exact Hardy-Littlewood "
+        "density term (1-nu_p/p)/(1-1/p)^k.",
         PrimeTupleLocalFactorRequest,
         PrimeTupleLocalFactorResult,
         compute_local_factor,
         "number-theory",
-        "prime-tuple",
-        "local-factor",
+        "local-obstruction",
+        "hardy-littlewood",
         "exact",
         examples=(
             example(

--- a/src/jacobian/math/prime_affine_forms/_tools.py
+++ b/src/jacobian/math/prime_affine_forms/_tools.py
@@ -1,0 +1,330 @@
+"""Public operation declarations for prime-affine local arithmetic."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.prime_affine_forms._models import (
+    FinitePrimeTupleFactorProduct,
+    PrimeAffineIntervalCountRequest,
+    PrimeAffineIntervalEnumerateRequest,
+    PrimeAffineTranslationRequest,
+    PrimeAffineTranslationResult,
+    PrimePatternIntervalCountResult,
+    PrimePatternIntervalEnumerateResult,
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleAdmissibilityResult,
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleIntervalResidueProfileResult,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    PrimeTupleResidueWheel,
+    PrimeTupleResidueWheelEnumeration,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
+    PrimeTupleWheelMembershipResult,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_local_admissibility,
+    compute_local_factor,
+    compute_local_factors,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+
+
+def _operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...],
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version="1",
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+_TWIN_PRIME_SOURCE = {
+    "forms": [
+        {"form_id": "n", "coefficient": "1", "constant": "0"},
+        {"form_id": "n_plus_2", "coefficient": "1", "constant": "2"},
+    ]
+}
+
+_TWIN_PRIME_WHEEL = {
+    "source": _TWIN_PRIME_SOURCE,
+    "primes": [2, 3],
+    "local_rows": [
+        {
+            "prime": 2,
+            "bad_residues": [
+                {"residue": 0, "form_ids": ["n", "n_plus_2"]},
+            ],
+            "bad_count": 1,
+            "valid_count": 1,
+        },
+        {
+            "prime": 3,
+            "bad_residues": [
+                {"residue": 0, "form_ids": ["n"]},
+                {"residue": 1, "form_ids": ["n_plus_2"]},
+            ],
+            "bad_count": 2,
+            "valid_count": 1,
+        },
+    ],
+    "modulus": "6",
+    "valid_count": "1",
+}
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _operation(
+        "number_theory.prime_affine_forms.local_factor.compute",
+        "Compute one prime-affine local factor",
+        "For a finite tuple of primitive integer affine forms and one bounded "
+        "prime p, return the complete residue partition modulo p and the exact "
+        "Hardy-Littlewood local factor (1-nu_p/p)/(1-1/p)^k.",
+        PrimeTupleLocalFactorRequest,
+        PrimeTupleLocalFactorResult,
+        compute_local_factor,
+        "number-theory",
+        "prime-tuple",
+        "local-factor",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_local_factor_mod_3",
+                "Compute the complete modulo-3 local profile of n and n+2; "
+                "the forms must be distinct, primitive, and nonconstant.",
+                {"source": _TWIN_PRIME_SOURCE, "prime": 3},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.local_factors.compute",
+        "Compute a finite prime-affine factor product",
+        "Compute compact exact local-factor rows for a finite canonical prime "
+        "set and their exact finite product. The result makes no infinite "
+        "singular-series or asymptotic claim.",
+        PrimeTupleLocalFactorsRequest,
+        FinitePrimeTupleFactorProduct,
+        compute_local_factors,
+        "number-theory",
+        "prime-tuple",
+        "finite-product",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_factors_2_3",
+                "Compute the finite local-factor product for p=2 and p=3; "
+                "the prime tuple must be strictly increasing and duplicate-free.",
+                {"source": _TWIN_PRIME_SOURCE, "primes": [2, 3]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.local_admissibility.compute",
+        "Decide local admissibility of primitive affine forms",
+        "Check every prime through the form count k, then use primitivity to "
+        "prove that each form excludes at most one residue and every p>k has "
+        "a permitted class. This does not assert simultaneous primality.",
+        PrimeTupleAdmissibilityRequest,
+        PrimeTupleAdmissibilityResult,
+        compute_local_admissibility,
+        "number-theory",
+        "prime-tuple",
+        "admissibility",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_admissibility",
+                "Decide local admissibility of n and n+2; every supplied form "
+                "must be primitive and have a nonzero coefficient.",
+                {"source": _TWIN_PRIME_SOURCE},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.residue_wheel.compute",
+        "Construct a compact exact prime-affine residue wheel",
+        "Return a source-bound product of valid local residue sets, its CRT "
+        "modulus, and exact valid count without expanding every combined residue.",
+        PrimeTupleResidueWheelRequest,
+        PrimeTupleResidueWheel,
+        compute_residue_wheel,
+        "number-theory",
+        "prime-tuple",
+        "crt",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_wheel_6",
+                "Construct the compact modulo-6 wheel of n and n+2 from primes "
+                "2 and 3; primes must be distinct and strictly increasing.",
+                {"source": _TWIN_PRIME_SOURCE, "primes": [2, 3]},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.residue_wheel.enumerate.compute",
+        "Enumerate every residue of a compact prime-affine wheel",
+        "Materialize every permitted CRT residue and its aligned prime components "
+        "from a supplied compact wheel under separate residue, work, and output "
+        "bounds.",
+        PrimeTupleResidueWheelEnumerationRequest,
+        PrimeTupleResidueWheelEnumeration,
+        compute_residue_wheel_enumeration,
+        "number-theory",
+        "prime-tuple",
+        "crt",
+        "enumeration",
+        "exact",
+        examples=(
+            example(
+                "enumerate_twin_prime_wheel_6",
+                "Enumerate the sole permitted residue of the compact modulo-6 "
+                "twin-prime wheel; the supplied wheel must be complete and "
+                "source-bound.",
+                {"wheel": _TWIN_PRIME_WHEEL},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.wheel_membership.compute",
+        "Check membership in a prime-affine residue wheel",
+        "Reduce one exact integer through a source-bound residue wheel and "
+        "return its CRT components plus the first excluded prime and vanishing "
+        "forms when it is not locally permitted.",
+        PrimeTupleWheelMembershipRequest,
+        PrimeTupleWheelMembershipResult,
+        compute_wheel_membership,
+        "number-theory",
+        "prime-tuple",
+        "crt",
+        "membership",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_wheel_member",
+                "Check that 5 is permitted by the exact modulo-6 twin-prime "
+                "wheel; the wheel must be a complete source-bound result.",
+                {"wheel": _TWIN_PRIME_WHEEL, "value": "5"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.interval_count.compute",
+        "Count exact prime-affine matches on an interval",
+        "Count every integer n in a bounded closed interval for which all source "
+        "forms have ordinary positive-prime values. Every positive candidate "
+        "is admitted below SymPy's deterministic 2^64 primality boundary.",
+        PrimeAffineIntervalCountRequest,
+        PrimePatternIntervalCountResult,
+        compute_interval_count,
+        "number-theory",
+        "prime-tuple",
+        "interval",
+        "exact",
+        examples=(
+            example(
+                "twin_primes_through_10_count",
+                "Count twin-prime starts from 0 through 10 exactly; lower and "
+                "upper must form a nonempty canonical integer interval.",
+                {"source": _TWIN_PRIME_SOURCE, "lower": "0", "upper": "10"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.interval_enumerate.compute",
+        "Enumerate exact prime-affine matches on an interval",
+        "Return every integer n and aligned affine-value tuple for which all "
+        "forms are ordinary positive primes on a bounded closed interval. The "
+        "complete match output has a stricter bound than count-only execution.",
+        PrimeAffineIntervalEnumerateRequest,
+        PrimePatternIntervalEnumerateResult,
+        compute_interval_enumerate,
+        "number-theory",
+        "prime-tuple",
+        "interval",
+        "enumeration",
+        "exact",
+        examples=(
+            example(
+                "twin_primes_through_10",
+                "Enumerate twin-prime starts from 0 through 10 exactly; lower "
+                "and upper must form a nonempty canonical integer interval.",
+                {"source": _TWIN_PRIME_SOURCE, "lower": "0", "upper": "10"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.interval_residue_profile.compute",
+        "Enumerate interval survivors of a prime-affine wheel",
+        "Return every integer in a bounded closed interval whose residue is "
+        "permitted by the supplied exact wheel. Wheel survival is only local "
+        "divisibility data and does not assert primality.",
+        PrimeTupleIntervalResidueProfileRequest,
+        PrimeTupleIntervalResidueProfileResult,
+        compute_interval_residue_profile,
+        "number-theory",
+        "prime-tuple",
+        "crt",
+        "interval",
+        "exact",
+        examples=(
+            example(
+                "twin_prime_wheel_survivors",
+                "Enumerate modulo-6 twin-prime wheel survivors from 0 through "
+                "12; the supplied wheel must be complete and source-bound.",
+                {"wheel": _TWIN_PRIME_WHEEL, "lower": "0", "upper": "12"},
+            ),
+        ),
+    ),
+    _operation(
+        "number_theory.prime_affine_forms.translation.compute",
+        "Translate a primitive affine-form tuple",
+        "Apply n -> n+c exactly to every labelled primitive affine form, "
+        "preserving form IDs and producing a canonical tuple whose local factors "
+        "are transported by residue translation.",
+        PrimeAffineTranslationRequest,
+        PrimeAffineTranslationResult,
+        compute_translation,
+        "number-theory",
+        "prime-tuple",
+        "translation",
+        "exact",
+        examples=(
+            example(
+                "translate_twin_prime_tuple",
+                "Translate n and n+2 by one to obtain n+1 and n+3; the resulting "
+                "constants must remain within the canonical component bound.",
+                {"source": _TWIN_PRIME_SOURCE, "shift": "1"},
+            ),
+        ),
+    ),
+)
+
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/prime_affine_forms/operations.py
+++ b/src/jacobian/math/prime_affine_forms/operations.py
@@ -1,0 +1,164 @@
+"""Value-based native operations on canonical prime-affine tuple values."""
+
+from __future__ import annotations
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.prime_affine_forms._models import (
+    FinitePrimeTupleFactorProduct,
+    PrimeAffineIntervalCountRequest,
+    PrimeAffineIntervalEnumerateRequest,
+    PrimeAffineTranslationRequest,
+    PrimeAffineTranslationResult,
+    PrimePatternIntervalCountResult,
+    PrimePatternIntervalEnumerateResult,
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleAdmissibilityResult,
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleIntervalResidueProfileResult,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    PrimeTupleResidueWheel,
+    PrimeTupleResidueWheelEnumeration,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
+    PrimeTupleWheelMembershipResult,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_local_admissibility,
+    compute_local_factor,
+    compute_local_factors,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
+
+
+def local_factor(source: PrimeAffineTuple, prime: int) -> PrimeTupleLocalFactorResult:
+    """Return the complete modulo-``prime`` residue partition and local factor."""
+
+    return compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=source, prime=prime)
+    )
+
+
+def local_factors(
+    source: PrimeAffineTuple, primes: tuple[int, ...]
+) -> FinitePrimeTupleFactorProduct:
+    """Return exact compact local factors over one finite prime set."""
+
+    return compute_local_factors(
+        PrimeTupleLocalFactorsRequest(source=source, primes=primes)
+    )
+
+
+def local_admissibility(source: PrimeAffineTuple) -> PrimeTupleAdmissibilityResult:
+    """Decide local admissibility by checking exactly every prime at most k."""
+
+    return compute_local_admissibility(PrimeTupleAdmissibilityRequest(source=source))
+
+
+def residue_wheel(
+    source: PrimeAffineTuple, primes: tuple[int, ...]
+) -> PrimeTupleResidueWheel:
+    """Construct the compact source-bound CRT wheel of one finite prime set."""
+
+    return compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=source, primes=primes)
+    )
+
+
+def enumerate_residue_wheel(
+    wheel: PrimeTupleResidueWheel,
+) -> PrimeTupleResidueWheelEnumeration:
+    """Materialize every permitted CRT residue of a supplied compact wheel."""
+
+    return compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
+    )
+
+
+def wheel_membership(
+    wheel: PrimeTupleResidueWheel, value: int
+) -> PrimeTupleWheelMembershipResult:
+    """Reduce one exact integer through a source-bound residue wheel."""
+
+    return compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(
+            wheel=wheel, value=format_canonical_integer(value)
+        )
+    )
+
+
+def interval_count(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> PrimePatternIntervalCountResult:
+    """Count every n in [lower, upper] whose affine values are all positive primes."""
+
+    return compute_interval_count(
+        PrimeAffineIntervalCountRequest(
+            source=source,
+            lower=format_canonical_integer(lower),
+            upper=format_canonical_integer(upper),
+        )
+    )
+
+
+def interval_enumerate(
+    source: PrimeAffineTuple, lower: int, upper: int
+) -> PrimePatternIntervalEnumerateResult:
+    """Enumerate every n in [lower, upper] whose affine values are all positive primes."""
+
+    return compute_interval_enumerate(
+        PrimeAffineIntervalEnumerateRequest(
+            source=source,
+            lower=format_canonical_integer(lower),
+            upper=format_canonical_integer(upper),
+        )
+    )
+
+
+def interval_residue_profile(
+    wheel: PrimeTupleResidueWheel, lower: int, upper: int
+) -> PrimeTupleIntervalResidueProfileResult:
+    """Enumerate wheel-permitted integers on one bounded closed interval."""
+
+    return compute_interval_residue_profile(
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=wheel,
+            lower=format_canonical_integer(lower),
+            upper=format_canonical_integer(upper),
+        )
+    )
+
+
+def translate_tuple(
+    source: PrimeAffineTuple, shift: int
+) -> PrimeAffineTranslationResult:
+    """Apply the substitution n -> n+shift to every labelled form."""
+
+    return compute_translation(
+        PrimeAffineTranslationRequest(
+            source=source, shift=format_canonical_integer(shift)
+        )
+    )
+
+
+__all__ = [
+    "enumerate_residue_wheel",
+    "interval_count",
+    "interval_enumerate",
+    "interval_residue_profile",
+    "local_admissibility",
+    "local_factor",
+    "local_factors",
+    "residue_wheel",
+    "translate_tuple",
+    "wheel_membership",
+]

--- a/src/jacobian/math/prime_affine_forms/values.py
+++ b/src/jacobian/math/prime_affine_forms/values.py
@@ -1,0 +1,87 @@
+"""Canonical values for finite families of primitive integer affine forms."""
+
+from __future__ import annotations
+
+from math import gcd
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.affine_forms.values import IntegerAffineForm
+
+MAX_AFFINE_FORMS = 512
+MAX_AFFINE_AGGREGATE_DIGITS = 131_072
+
+
+def _component_digits(value: str) -> int:
+    return len(value.lstrip("-"))
+
+
+class PrimitiveIntegerAffineForm(IntegerAffineForm):
+    """One labelled primitive nonconstant form ``a*n+b`` over the integers."""
+
+    @model_validator(mode="after")
+    def require_primitive_nonconstant_form(self) -> Self:
+        coefficient = parse_canonical_integer(self.coefficient)
+        constant = parse_canonical_integer(self.constant)
+        if coefficient == 0:
+            raise ValueError("primitive affine form coefficient must be nonzero")
+        if gcd(abs(coefficient), abs(constant)) != 1:
+            raise ValueError("affine coefficient and constant must be coprime")
+        return self
+
+
+class PrimeAffineTuple(StrictModel):
+    """A canonical finite set of distinct primitive integer affine forms."""
+
+    forms: tuple[PrimitiveIntegerAffineForm, ...] = Field(
+        min_length=1,
+        max_length=MAX_AFFINE_FORMS,
+        description=(
+            "Nonempty primitive affine-form family. Form IDs and coefficient/constant "
+            "pairs must be unique; rows are normalized by form_id. Across all forms, "
+            "coefficient and constant magnitudes contain at most 131072 decimal digits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_distinct_canonical_forms(self) -> Self:
+        if (
+            sum(
+                _component_digits(form.coefficient) + _component_digits(form.constant)
+                for form in self.forms
+            )
+            > MAX_AFFINE_AGGREGATE_DIGITS
+        ):
+            raise ValueError(
+                "affine tuple exceeds the aggregate coefficient-digit bound "
+                f"{MAX_AFFINE_AGGREGATE_DIGITS}"
+            )
+        form_ids = tuple(form.form_id for form in self.forms)
+        if len(set(form_ids)) != len(form_ids):
+            raise ValueError("affine form IDs must be unique")
+        coefficient_pairs = tuple(
+            (form.coefficient, form.constant) for form in self.forms
+        )
+        if len(set(coefficient_pairs)) != len(coefficient_pairs):
+            raise ValueError("affine forms must be pairwise distinct")
+        object.__setattr__(
+            self,
+            "forms",
+            tuple(sorted(self.forms, key=lambda form: form.form_id)),
+        )
+        return self
+
+    @property
+    def form_count(self) -> int:
+        return len(self.forms)
+
+
+__all__ = [
+    "MAX_AFFINE_AGGREGATE_DIGITS",
+    "MAX_AFFINE_FORMS",
+    "PrimeAffineTuple",
+    "PrimitiveIntegerAffineForm",
+]

--- a/tests/math/prime_affine_forms/test_native_api.py
+++ b/tests/math/prime_affine_forms/test_native_api.py
@@ -1,0 +1,165 @@
+"""Native public surface of prime-affine tuple operations."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.prime_affine_forms import (
+    PrimeAffineTuple,
+    PrimitiveIntegerAffineForm,
+    enumerate_residue_wheel,
+    interval_count,
+    interval_enumerate,
+    interval_residue_profile,
+    local_admissibility,
+    local_factor,
+    local_factors,
+    residue_wheel,
+    translate_tuple,
+    wheel_membership,
+)
+from jacobian.math.prime_affine_forms._models import (
+    PrimeAffineIntervalCountRequest,
+    PrimeAffineIntervalEnumerateRequest,
+    PrimeAffineTranslationRequest,
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorsRequest,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_local_admissibility,
+    compute_local_factor,
+    compute_local_factors,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+
+
+def _form(form_id: str, coefficient: int, constant: int) -> PrimitiveIntegerAffineForm:
+    return PrimitiveIntegerAffineForm(
+        form_id=form_id,
+        coefficient=str(coefficient),
+        constant=str(constant),
+    )
+
+
+TWIN_PRIMES = PrimeAffineTuple(forms=(_form("n", 1, 0), _form("n_plus_2", 1, 2)))
+
+
+def test_native_surface_composes_without_private_imports() -> None:
+    factor = local_factor(TWIN_PRIMES, 3)
+    assert factor.factor.as_integer_ratio() == (3, 4)
+    assert not factor.locally_obstructed
+
+    product = local_factors(TWIN_PRIMES, (2, 3))
+    assert product.product.as_integer_ratio() == (3, 2)
+    assert product.first_obstructing_prime is None
+
+    admissibility = local_admissibility(TWIN_PRIMES)
+    assert admissibility.status == "LOCALLY_ADMISSIBLE"
+    assert admissibility.cutoff == 2
+    assert admissibility.checked_primes == (2,)
+
+    wheel = residue_wheel(TWIN_PRIMES, (2, 3))
+    assert wheel.modulus == "6"
+    assert wheel.valid_count == "1"
+
+    enumeration = enumerate_residue_wheel(wheel)
+    assert tuple((row.residue, row.components) for row in enumeration.residues) == (
+        ("5", (1, 2)),
+    )
+
+    member = wheel_membership(wheel, 5)
+    excluded = wheel_membership(wheel, 1)
+    assert member.is_permitted and member.canonical_residue == "5"
+    assert not excluded.is_permitted
+    assert (excluded.first_excluded_prime, excluded.vanishing_form_ids) == (
+        3,
+        ("n_plus_2",),
+    )
+
+    count = interval_count(TWIN_PRIMES, 0, 12)
+    matches = interval_enumerate(TWIN_PRIMES, 0, 12)
+    assert count.match_count == 3
+    assert (count.first_match, count.last_match) == ("3", "11")
+    assert tuple(
+        (match.parameter, match.prime_values) for match in matches.matches
+    ) == (("3", ("3", "5")), ("5", ("5", "7")), ("11", ("11", "13")))
+
+    identity_wheel = residue_wheel(PrimeAffineTuple(forms=(_form("n", 1, 0),)), (2,))
+    profile = interval_residue_profile(identity_wheel, 24, 26)
+    assert profile.survivors == ("25",)
+
+    translated = translate_tuple(TWIN_PRIMES, 1)
+    assert tuple(form.constant for form in translated.translated.forms) == ("1", "3")
+
+
+def test_native_results_equal_the_wire_request_path() -> None:
+    wheel = residue_wheel(TWIN_PRIMES, (2, 3))
+
+    expected = (
+        local_factor(TWIN_PRIMES, 3),
+        compute_local_factor(PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=3)),
+    )
+    assert expected[0] == expected[1]
+
+    assert local_factors(TWIN_PRIMES, (2, 3)) == compute_local_factors(
+        PrimeTupleLocalFactorsRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    assert local_admissibility(TWIN_PRIMES) == compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=TWIN_PRIMES)
+    )
+    assert wheel == compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    assert enumerate_residue_wheel(wheel) == compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
+    )
+    assert wheel_membership(wheel, -7) == compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(wheel=wheel, value="-7")
+    )
+    assert interval_count(TWIN_PRIMES, 4, 8) == compute_interval_count(
+        PrimeAffineIntervalCountRequest(source=TWIN_PRIMES, lower="4", upper="8")
+    )
+    assert interval_enumerate(TWIN_PRIMES, 4, 8) == compute_interval_enumerate(
+        PrimeAffineIntervalEnumerateRequest(source=TWIN_PRIMES, lower="4", upper="8")
+    )
+    assert interval_residue_profile(wheel, 0, 6) == compute_interval_residue_profile(
+        PrimeTupleIntervalResidueProfileRequest(wheel=wheel, lower="0", upper="6")
+    )
+    assert translate_tuple(TWIN_PRIMES, -5) == compute_translation(
+        PrimeAffineTranslationRequest(source=TWIN_PRIMES, shift="-5")
+    )
+
+
+def test_native_calls_reject_out_of_envelope_requests() -> None:
+    with pytest.raises(ValidationError):
+        local_factor(TWIN_PRIMES, 8_209)
+    with pytest.raises(ValidationError, match="must be prime"):
+        local_factor(TWIN_PRIMES, 15)
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        local_factors(TWIN_PRIMES, (3, 2))
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        residue_wheel(TWIN_PRIMES, (2, 2))
+    with pytest.raises(ValidationError, match="affine evaluations"):
+        interval_count(PrimeAffineTuple(forms=(_form("n", 1, 0),)), 0, 100_000)
+    with pytest.raises(ValidationError, match="deterministic primality"):
+        interval_enumerate(PrimeAffineTuple(forms=(_form("n", 1, 0),)), 2**64, 2**64)
+    with pytest.raises(ValidationError, match="at most 65 characters"):
+        translate_tuple(
+            PrimeAffineTuple(forms=(_form("large", 1, int("9" * 256)),)),
+            10**65 + 1,
+        )
+    large_wheel = residue_wheel(PrimeAffineTuple(forms=(_form("n", 1, 0),)), (8_209,))
+    with pytest.raises(ValidationError, match="valid residues"):
+        enumerate_residue_wheel(large_wheel)

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -301,6 +301,26 @@ def test_translation_preserves_local_factors_and_form_ids() -> None:
         PrimeAffineTranslationResult.model_validate(payload)
 
 
+def test_translation_rejects_translated_tuple_exceeding_aggregate_digit_bound() -> None:
+    source = _tuple(
+        *(_form(f"f{index:03d}", 10**127 + index, 1) for index in range(512))
+    )
+    with pytest.raises(ValidationError, match="aggregate coefficient-digit bound"):
+        PrimeAffineTranslationRequest(source=source, shift=str(10**63))
+
+
+def test_translation_admits_translated_tuple_at_the_aggregate_digit_bound() -> None:
+    source = _tuple(
+        *(_form(f"f{index:03d}", 10**127 + index, 1) for index in range(512))
+    )
+    result = compute_translation(
+        PrimeAffineTranslationRequest(source=source, shift="1")
+    )
+    assert result.translated.form_count == 512
+    assert result.translated.forms[0].form_id == "f000"
+    assert all(len(form.constant) == 128 for form in result.translated.forms)
+
+
 def test_residue_wheel_and_membership_compose_without_reconstruction() -> None:
     wheel = compute_residue_wheel(
         PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from fractions import Fraction
+from math import prod
+
+import pytest
+from pydantic import ValidationError
+from sympy import primerange
+
+from jacobian.math.affine_forms import IntegerAffineForm
+from jacobian.math.prime_affine_forms import (
+    PrimeAffineTuple,
+    PrimitiveIntegerAffineForm,
+)
+from jacobian.math.prime_affine_forms._models import (
+    FinitePrimeTupleFactorProduct,
+    PrimeAffineIntervalCountRequest,
+    PrimeAffineIntervalEnumerateRequest,
+    PrimeAffineTranslationRequest,
+    PrimeAffineTranslationResult,
+    PrimePatternIntervalCountResult,
+    PrimePatternIntervalEnumerateResult,
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    PrimeTupleLocalSummary,
+    PrimeTupleResidueWheel,
+    PrimeTupleResidueWheelEnumeration,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_local_admissibility,
+    compute_local_factor,
+    compute_local_factors,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms._tools import TOOLS
+
+
+def _form(form_id: str, coefficient: int, constant: int) -> PrimitiveIntegerAffineForm:
+    return PrimitiveIntegerAffineForm(
+        form_id=form_id,
+        coefficient=str(coefficient),
+        constant=str(constant),
+    )
+
+
+def _tuple(*forms: PrimitiveIntegerAffineForm) -> PrimeAffineTuple:
+    return PrimeAffineTuple(forms=forms)
+
+
+TWIN_PRIMES = _tuple(_form("n_plus_2", 1, 2), _form("n", 1, 0))
+
+
+def test_affine_tuple_is_canonical_and_closed() -> None:
+    constant_form = IntegerAffineForm(
+        form_id="constant",
+        coefficient="0",
+        constant="-4",
+    )
+    assert constant_form.evaluate(999) == -4
+    with pytest.raises(ValidationError, match="identically zero"):
+        IntegerAffineForm(form_id="zero", coefficient="0", constant="0")
+
+    assert tuple(form.form_id for form in TWIN_PRIMES.forms) == ("n", "n_plus_2")
+    assert TWIN_PRIMES.forms[1].evaluate(7) == 9
+
+    with pytest.raises(ValidationError, match="coefficient must be nonzero"):
+        _form("constant", 0, 1)
+    with pytest.raises(ValidationError, match="must be coprime"):
+        _form("nonprimitive", 2, 2)
+    with pytest.raises(ValidationError, match="IDs must be unique"):
+        _tuple(_form("same", 1, 0), _form("same", 1, 2))
+    with pytest.raises(ValidationError, match="pairwise distinct"):
+        _tuple(_form("first", 1, 0), _form("second", 1, 0))
+
+    _form("f" * 32, 1, int("9" * 256))
+    with pytest.raises(ValidationError):
+        _form("f" * 33, 1, 0)
+    with pytest.raises(ValidationError, match="at most 256 digits"):
+        _form("too_many_digits", 1, int("9" * 257))
+
+    _tuple(*(_form(f"f{index:03d}", 1, index) for index in range(512)))
+    with pytest.raises(ValidationError):
+        _tuple(*(_form(f"f{index:03d}", 1, index) for index in range(513)))
+
+
+def test_local_factor_returns_complete_residue_partition() -> None:
+    result = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=3)
+    )
+
+    assert tuple(
+        (row.residue, row.vanishing_form_ids) for row in result.residue_rows
+    ) == ((0, ("n",)), (1, ("n_plus_2",)), (2, ()))
+    assert (result.bad_count, result.valid_count, result.locally_obstructed) == (
+        2,
+        1,
+        False,
+    )
+    assert result.factor.as_integer_ratio() == (3, 4)
+
+
+def test_local_factor_handles_divisible_coefficients_and_overlaps() -> None:
+    no_root = compute_local_factor(
+        PrimeTupleLocalFactorRequest(
+            source=_tuple(_form("two_n_plus_1", 2, 1)),
+            prime=2,
+        )
+    )
+    assert no_root.bad_count == 0
+    assert no_root.factor.as_integer_ratio() == (2, 1)
+
+    overlap = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=2)
+    )
+    assert overlap.residue_rows[0].vanishing_form_ids == ("n", "n_plus_2")
+    assert overlap.bad_count == 1
+    assert overlap.factor.as_integer_ratio() == (2, 1)
+
+
+@pytest.mark.parametrize("prime", [2, 3, 5, 7])
+def test_local_factor_agrees_with_direct_residue_oracle(prime: int) -> None:
+    source = _tuple(
+        _form("two_n_plus_1", 2, 1),
+        _form("three_n_plus_2", 3, 2),
+        _form("five_n_minus_1", 5, -1),
+    )
+    result = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=source, prime=prime)
+    )
+
+    expected_rows = tuple(
+        (
+            residue,
+            tuple(
+                form.form_id
+                for form in source.forms
+                if form.evaluate(residue) % prime == 0
+            ),
+        )
+        for residue in range(prime)
+    )
+    bad_count = sum(bool(form_ids) for _, form_ids in expected_rows)
+    expected_factor = (
+        Fraction(prime - bad_count, prime)
+        / Fraction(prime - 1, prime) ** source.form_count
+    )
+
+    assert (
+        tuple((row.residue, row.vanishing_form_ids) for row in result.residue_rows)
+        == expected_rows
+    )
+    assert result.factor.as_fraction() == expected_factor
+
+
+def test_local_factor_result_rejects_source_and_conclusion_mutations() -> None:
+    result = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=3)
+    )
+    payload = result.model_dump(mode="json")
+
+    wrong_factor = deepcopy(payload)
+    wrong_factor["factor"] = {"num": "1", "den": "1"}
+    with pytest.raises(ValidationError, match="defining formula"):
+        PrimeTupleLocalFactorResult.model_validate(wrong_factor)
+
+    wrong_source = deepcopy(payload)
+    wrong_source["source"]["forms"][1]["constant"] = "4"
+    with pytest.raises(ValidationError, match="source-bound partition"):
+        PrimeTupleLocalFactorResult.model_validate(wrong_source)
+
+    wrong_row = deepcopy(payload)
+    wrong_row["residue_rows"][1]["vanishing_form_ids"] = []
+    with pytest.raises(ValidationError, match="source-bound partition"):
+        PrimeTupleLocalFactorResult.model_validate(wrong_row)
+
+
+def test_finite_local_factor_product_and_obstruction() -> None:
+    result = compute_local_factors(
+        PrimeTupleLocalFactorsRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    assert result.product.as_integer_ratio() == (3, 2)
+    assert result.first_obstructing_prime is None
+
+    obstructed = _tuple(
+        _form("n", 1, 0),
+        _form("n_plus_2", 1, 2),
+        _form("n_plus_4", 1, 4),
+    )
+    zero = compute_local_factors(
+        PrimeTupleLocalFactorsRequest(source=obstructed, primes=(2, 3, 5))
+    )
+    assert zero.product.as_integer_ratio() == (0, 1)
+    assert zero.first_obstructing_prime == 3
+
+    payload = zero.model_dump(mode="json")
+    payload["first_obstructing_prime"] = 2
+    with pytest.raises(ValidationError, match="first obstructing prime"):
+        FinitePrimeTupleFactorProduct.model_validate(payload)
+
+
+def test_local_admissibility_uses_complete_finite_cutoff() -> None:
+    admissible = compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=TWIN_PRIMES)
+    )
+    assert admissible.status == "LOCALLY_ADMISSIBLE"
+    assert admissible.cutoff == 2
+    assert admissible.checked_primes == (2,)
+    assert admissible.large_prime_lower_bound == 3
+    assert admissible.maximum_large_prime_bad_residues == 2
+
+    consecutive = _tuple(_form("n", 1, 0), _form("n_plus_1", 1, 1))
+    obstructed = compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=consecutive)
+    )
+    assert obstructed.status == "LOCALLY_OBSTRUCTED"
+    assert obstructed.least_obstructing_prime == 2
+    assert obstructed.local_rows[0].valid_count == 0
+
+    admissible_triple = _tuple(
+        _form("n", 1, 0),
+        _form("n_plus_2", 1, 2),
+        _form("n_plus_6", 1, 6),
+    )
+    triple_result = compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=admissible_triple)
+    )
+    assert triple_result.status == "LOCALLY_ADMISSIBLE"
+
+    planted_obstruction = _tuple(
+        _form("n", 1, 0),
+        _form("n_plus_2", 1, 2),
+        _form("n_plus_4", 1, 4),
+    )
+    planted_result = compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=planted_obstruction)
+    )
+    assert planted_result.status == "LOCALLY_OBSTRUCTED"
+    assert planted_result.least_obstructing_prime == 3
+
+    huge_coefficient = _tuple(_form("huge_coefficient", int("9" * 256), 1))
+    huge_result = compute_local_admissibility(
+        PrimeTupleAdmissibilityRequest(source=huge_coefficient)
+    )
+    assert huge_result.status == "LOCALLY_ADMISSIBLE"
+    assert huge_result.cutoff == 1
+    assert huge_result.checked_primes == ()
+
+
+def test_local_admissibility_supports_the_343_form_demand_scale() -> None:
+    small_primorial = prod(int(prime) for prime in primerange(2, 344))
+    source = _tuple(
+        *(_form(f"h{index:03d}", 1, index * small_primorial) for index in range(343))
+    )
+
+    result = compute_local_admissibility(PrimeTupleAdmissibilityRequest(source=source))
+
+    assert result.status == "LOCALLY_ADMISSIBLE"
+    assert result.cutoff == 343
+    assert result.checked_primes == tuple(int(p) for p in primerange(2, 344))
+    assert all(row.bad_count == 1 for row in result.local_rows)
+
+
+def test_translation_preserves_local_factors_and_form_ids() -> None:
+    translated = compute_translation(
+        PrimeAffineTranslationRequest(source=TWIN_PRIMES, shift="1")
+    )
+    assert tuple(form.form_id for form in translated.translated.forms) == (
+        "n",
+        "n_plus_2",
+    )
+    assert tuple(form.constant for form in translated.translated.forms) == ("1", "3")
+
+    before = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=TWIN_PRIMES, prime=5)
+    )
+    after = compute_local_factor(
+        PrimeTupleLocalFactorRequest(source=translated.translated, prime=5)
+    )
+    assert (before.bad_count, before.valid_count, before.factor) == (
+        after.bad_count,
+        after.valid_count,
+        after.factor,
+    )
+
+    payload = translated.model_dump(mode="json")
+    payload["translated"]["forms"][0]["constant"] = "2"
+    with pytest.raises(ValidationError, match=r"L_i\(n\+shift\)"):
+        PrimeAffineTranslationResult.model_validate(payload)
+
+
+def test_residue_wheel_and_membership_compose_without_reconstruction() -> None:
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    assert wheel.modulus == "6"
+    assert wheel.valid_count == "1"
+    enumeration = compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
+    )
+    assert tuple((row.residue, row.components) for row in enumeration.residues) == (
+        ("5", (1, 2)),
+    )
+    assert tuple(
+        residue
+        for residue in range(6)
+        if all(
+            form.evaluate(residue) % prime != 0
+            for prime in (2, 3)
+            for form in TWIN_PRIMES.forms
+        )
+    ) == (5,)
+
+    serialized = wheel.model_dump(mode="json")
+    request = PrimeTupleWheelMembershipRequest.model_validate(
+        {"wheel": serialized, "value": "5"}
+    )
+    member = compute_wheel_membership(request)
+    assert member.is_permitted
+    assert member.canonical_residue == "5"
+
+    excluded = compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(wheel=wheel, value="1")
+    )
+    assert not excluded.is_permitted
+    assert excluded.first_excluded_prime == 3
+    assert excluded.vanishing_form_ids == ("n_plus_2",)
+
+    first_excluded = compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(wheel=wheel, value="0")
+    )
+    assert first_excluded.first_excluded_prime == 2
+    assert first_excluded.vanishing_form_ids == ("n", "n_plus_2")
+
+
+def test_empty_prime_wheel_is_the_modulus_one_identity() -> None:
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=())
+    )
+    assert wheel.modulus == "1"
+    assert wheel.valid_count == "1"
+    enumeration = compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
+    )
+    assert tuple((row.residue, row.components) for row in enumeration.residues) == (
+        ("0", ()),
+    )
+    result = compute_wheel_membership(
+        PrimeTupleWheelMembershipRequest(wheel=wheel, value="-123")
+    )
+    assert result.is_permitted
+    assert result.canonical_residue == "0"
+    assert result.first_excluded_prime is None
+
+
+def test_wheel_result_rejects_component_and_source_mutations() -> None:
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    payload = wheel.model_dump(mode="json")
+
+    wrong_source = deepcopy(payload)
+    wrong_source["source"]["forms"][1]["constant"] = "4"
+    with pytest.raises(ValidationError, match="source affine tuple"):
+        PrimeTupleResidueWheel.model_validate(wrong_source)
+
+    enumeration = compute_residue_wheel_enumeration(
+        PrimeTupleResidueWheelEnumerationRequest(wheel=wheel)
+    )
+    wrong_component = enumeration.model_dump(mode="json")
+    wrong_component["residues"][0]["components"] = [0, 2]
+    with pytest.raises(ValidationError, match="complete CRT reconstruction"):
+        PrimeTupleResidueWheelEnumeration.model_validate(wrong_component)
+
+    oversized_scalar = deepcopy(payload)
+    oversized_scalar["modulus"] = "9" * 4_097
+    with pytest.raises(ValidationError, match="at most 4096 characters"):
+        PrimeTupleWheelMembershipRequest.model_validate(
+            {"wheel": oversized_scalar, "value": "1"}
+        )
+
+
+def test_interval_count_and_enumeration_are_exact_and_aligned() -> None:
+    count = compute_interval_count(
+        PrimeAffineIntervalCountRequest(
+            source=TWIN_PRIMES,
+            lower="0",
+            upper="12",
+        )
+    )
+    enumeration = compute_interval_enumerate(
+        PrimeAffineIntervalEnumerateRequest(
+            source=TWIN_PRIMES,
+            lower="0",
+            upper="12",
+        )
+    )
+
+    assert count.match_count == 3
+    assert (count.first_match, count.last_match) == ("3", "11")
+    assert tuple(
+        (match.parameter, match.prime_values) for match in enumeration.matches
+    ) == (("3", ("3", "5")), ("5", ("5", "7")), ("11", ("11", "13")))
+    assert count.match_count == len(enumeration.matches)
+
+    payload = enumeration.model_dump(mode="json")
+    payload["matches"][0]["prime_values"][1] = "7"
+    with pytest.raises(ValidationError, match="every and only"):
+        PrimePatternIntervalEnumerateResult.model_validate(payload)
+
+
+def test_wheel_survival_is_not_mislabelled_as_primality() -> None:
+    identity_form = _tuple(_form("n", 1, 0))
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=identity_form, primes=(2,))
+    )
+    profile = compute_interval_residue_profile(
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=wheel,
+            lower="2",
+            upper="3",
+        )
+    )
+    primes = compute_interval_enumerate(
+        PrimeAffineIntervalEnumerateRequest(
+            source=identity_form,
+            lower="2",
+            upper="3",
+        )
+    )
+
+    assert profile.survivors == ("3",)
+    assert tuple(match.parameter for match in primes.matches) == ("2", "3")
+
+    composite_survivor = compute_interval_residue_profile(
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=wheel,
+            lower="25",
+            upper="25",
+        )
+    )
+    composite_matches = compute_interval_enumerate(
+        PrimeAffineIntervalEnumerateRequest(
+            source=identity_form,
+            lower="25",
+            upper="25",
+        )
+    )
+    assert composite_survivor.survivors == ("25",)
+    assert composite_matches.matches == ()
+
+
+def test_request_boundaries_reject_before_expansion() -> None:
+    identity_form = _tuple(_form("n", 1, 0))
+
+    PrimeTupleLocalFactorRequest(source=identity_form, prime=8_191)
+    with pytest.raises(ValidationError):
+        PrimeTupleLocalFactorRequest(source=identity_form, prime=8_209)
+    with pytest.raises(ValidationError, match="must be prime"):
+        PrimeTupleLocalFactorRequest(source=identity_form, prime=15)
+    with pytest.raises(ValidationError, match="must be prime"):
+        PrimeTupleLocalSummary(
+            prime=15,
+            bad_residues=(),
+            bad_count=0,
+            valid_count=15,
+        )
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        PrimeTupleLocalFactorsRequest(source=identity_form, primes=(3, 2))
+    with pytest.raises(ValidationError, match="strictly increasing"):
+        PrimeTupleLocalFactorsRequest(source=identity_form, primes=(2, 2))
+
+    PrimeAffineIntervalCountRequest(source=identity_form, lower="0", upper="99999")
+    with pytest.raises(ValidationError, match="affine evaluations"):
+        PrimeAffineIntervalCountRequest(source=identity_form, lower="0", upper="100000")
+
+    PrimeAffineIntervalEnumerateRequest(source=identity_form, lower="0", upper="32767")
+    with pytest.raises(ValidationError, match="result cells"):
+        PrimeAffineIntervalEnumerateRequest(
+            source=identity_form, lower="0", upper="32768"
+        )
+
+    cancellation_source = _tuple(_form("shifted_n", 1, -(10**63)))
+    with pytest.raises(ValidationError, match="serialized bound"):
+        PrimeAffineIntervalEnumerateRequest(
+            source=cancellation_source,
+            lower=str(10**63),
+            upper=str(10**63 + 20_000),
+        )
+
+    PrimeAffineIntervalCountRequest(
+        source=identity_form,
+        lower=str(2**64 - 1),
+        upper=str(2**64 - 1),
+    )
+    with pytest.raises(ValidationError, match="deterministic primality"):
+        PrimeAffineIntervalCountRequest(
+            source=identity_form,
+            lower=str(2**64),
+            upper=str(2**64),
+        )
+
+    large_machine_prime = 4_294_967_291
+    PrimeTupleLocalFactorsRequest(
+        source=identity_form,
+        primes=(large_machine_prime,),
+    )
+    machine_prime_wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(
+            source=identity_form,
+            primes=(large_machine_prime,),
+        )
+    )
+    assert machine_prime_wheel.modulus == str(large_machine_prime)
+    assert machine_prime_wheel.valid_count == str(large_machine_prime - 1)
+
+    PrimeTupleResidueWheelRequest(source=identity_form, primes=(8_209,))
+    large_compact_wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=identity_form, primes=(8_209,))
+    )
+    assert large_compact_wheel.valid_count == "8208"
+    with pytest.raises(ValidationError, match="valid residues"):
+        PrimeTupleResidueWheelEnumerationRequest(wheel=large_compact_wheel)
+
+    with pytest.raises(ValidationError, match="translated constant"):
+        PrimeAffineTranslationRequest(
+            source=_tuple(_form("large", 1, int("9" * 256))),
+            shift="1",
+        )
+
+
+def test_result_validation_reapplies_request_bounds_before_replay() -> None:
+    count = compute_interval_count(
+        PrimeAffineIntervalCountRequest(
+            source=_tuple(_form("n", 1, 0)), lower="0", upper="10"
+        )
+    )
+    overbound_count = count.model_dump(mode="json")
+    overbound_count["upper"] = "100000"
+    with pytest.raises(ValidationError, match="affine evaluations"):
+        PrimePatternIntervalCountResult.model_validate(overbound_count)
+
+    wheel = compute_residue_wheel(
+        PrimeTupleResidueWheelRequest(source=TWIN_PRIMES, primes=(2, 3))
+    )
+    overbound_wheel = wheel.model_dump(mode="json")
+    overbound_wheel["primes"] = [9_007_199_254_740_993]
+    with pytest.raises(ValidationError):
+        PrimeTupleResidueWheel.model_validate(overbound_wheel)
+
+
+def test_prime_sets_and_interval_relations_are_schema_visible() -> None:
+    factor_schema = PrimeTupleLocalFactorsRequest.model_json_schema()
+    assert "strictly increasing" in factor_schema["properties"]["primes"]["description"]
+    assert factor_schema["properties"]["primes"]["items"]["maximum"] == ((1 << 53) - 1)
+    source_schema = factor_schema["$defs"]["PrimeAffineTuple"]
+    assert "131072" in source_schema["properties"]["forms"]["description"]
+    form_schema = factor_schema["$defs"]["PrimitiveIntegerAffineForm"]
+    assert form_schema["properties"]["coefficient"]["maxLength"] == 257
+    assert (
+        "at most 256 digits" in form_schema["properties"]["coefficient"]["description"]
+    )
+    interval_schema = PrimeAffineIntervalCountRequest.model_json_schema()
+    assert "at least lower" in interval_schema["properties"]["upper"]["description"]
+
+
+def test_every_prime_affine_tool_has_an_executable_example() -> None:
+    expected_ids = {
+        "number_theory.prime_affine_forms.interval_count.compute",
+        "number_theory.prime_affine_forms.interval_enumerate.compute",
+        "number_theory.prime_affine_forms.interval_residue_profile.compute",
+        "number_theory.prime_affine_forms.local_admissibility.compute",
+        "number_theory.prime_affine_forms.local_factor.compute",
+        "number_theory.prime_affine_forms.local_factors.compute",
+        "number_theory.prime_affine_forms.residue_wheel.compute",
+        "number_theory.prime_affine_forms.residue_wheel.enumerate.compute",
+        "number_theory.prime_affine_forms.translation.compute",
+        "number_theory.prime_affine_forms.wheel_membership.compute",
+    }
+    assert {tool.operation_id for tool in TOOLS} == expected_ids
+    assert all(tool.examples for tool in TOOLS)
+
+    for tool in TOOLS:
+        for operation_example in tool.examples:
+            request = tool.request_type.model_validate(operation_example.input)
+            result = tool.run(request)
+            tool.result_type.model_validate(result.model_dump(mode="json"))


### PR DESCRIPTION
Closes #1911

## Motivation

Finite prime-tuple work repeatedly needs exact local obstruction data, finite CRT wheels, and bounded interval matches for a supplied family of affine forms. Existing integer primality and modular operations do not retain the family identity, complete residue partitions, or the distinction between local admissibility and a prime-tuple theorem.

## Public operation contract

The PR introduces a shared passive `IntegerAffineForm` carrier and a prime-specific `PrimeAffineTuple` of distinct primitive nonconstant forms. It adds direct typed operations for one-prime and finite local factors, complete local-admissibility, compact wheel construction, wheel enumeration and membership, count/enumerate interval work, wheel-survivor profiles, and variable translation. The wheel is a canonical reusable value consumed unchanged by its enumeration, membership, and interval-profile operations.

For a tuple of (k) primitive forms, every prime (p>k) leaves at least one residue class: a form either has one root modulo (p), or none when (p\mid a) (then primitivity makes (b
otquiv0\pmod p)). The admissibility operation checks every prime through (k), preserves the local rows, and records this finite-cutoff relation. `LOCALLY_ADMISSIBLE` is never presented as simultaneous primality, density, or infinitude.

Each leaf preflights its own materialized work and exact output: residue rows, root checks, rational digits, CRT components, interval evaluations, match/survivor cells, and serialized result size. Complete results replay their source-bound defining relation. Intervals use the existing pinned SymPy 1.14.0 integer `isprime`, with positive affine values limited to its deterministic sub-²⁶⁴ domain; `primerange` and CRT are the maintained private kernels for the finite prime and wheel computations.

No sieve framework, singular-series tail, global prime-tuple claim, optimization/search workflow, persistent state, or verifier protocol is introduced. The neighboring square-free affine-form work can reuse the shared carrier but retains its distinct modulo-​p² local mathematics.

## Validation

- `uv run --locked ruff check src/jacobian/math/affine_forms src/jacobian/math/prime_affine_forms tests/math/prime_affine_forms/test_prime_affine_forms.py`
- `uv run --locked mypy src/jacobian/math/affine_forms src/jacobian/math/prime_affine_forms`
- `uv run --locked pytest -q tests/math/prime_affine_forms/test_prime_affine_forms.py` (21 passed)
- `make check`
- `make test-integration`

The domain tests cover local residue partitions and overlaps, finite products, the complete (p>k) admissibility cutoff including the 343-form demand scale, translation invariance, compact-to-enumerated wheel composition, membership, exact interval count/enumeration, the wheel-prime equality exception, composite survivors, mutation rejection, request boundaries, and executable catalog examples.

Suggested review order: `affine_forms/values.py`, `prime_affine_forms/values.py`, `_models.py` and `_kernel.py`, then declarations and tests.