### PR TITLE
fix(math): replay sqrt continued-fraction and convergent results against the request

### DIFF
--- a/src/jacobian/math/diophantine_approximation/_admission.py
+++ b/src/jacobian/math/diophantine_approximation/_admission.py
@@ -13,12 +13,18 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "diophantine.continued_fraction.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "contract version 2 reevaluation: exact bounded periodic continued "
+        "fraction of sqrt(D) for squarefree D whose retained request is "
+        "replayed against the canonical preperiod/period expansion of the "
+        "same discriminant within the admitted term envelope",
     ),
     OperationAdmission(
         "diophantine.convergents.compute",
         AdmissionDecision.NATIVE_ONLY,
-        "useful deterministic projection of the retained continued-fraction result",
+        "contract version 2 reevaluation: deterministic projection of the "
+        "retained source-replayed continued-fraction result, admissible only "
+        "when the convergents replay the continuant recurrence of the same "
+        "sqrt(D) under the derived digit cap",
         native_symbol="jacobian.math.diophantine_approximation.convergents",
     ),
     OperationAdmission(

--- a/src/jacobian/math/diophantine_approximation/_models.py
+++ b/src/jacobian/math/diophantine_approximation/_models.py
@@ -44,13 +44,45 @@ class ContinuedFractionRequest(StrictModel):
 
 
 class ContinuedFractionResult(StrictModel):
-    """The continued fraction [a_0; a_1, ...] of sqrt(D)."""
+    """The continued fraction [a_0; a_1, ...] of sqrt(D).
+
+    Retains the complete request so validation replays the canonical
+    periodic expansion of the same ``sqrt(D)``: the coefficient prefix is
+    exactly the preperiod followed by repeats of the fundamental period, and
+    the reported preperiod/period lengths match that expansion.  A prefix
+    shorter than preperiod + period is an operationally truncated window
+    (its requested count is retained), never a complete-period claim.
+    """
 
     discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    term_count: StrictInt = Field(ge=1, le=_MAX_TERMS)
     coefficients: tuple[StrictInt, ...] = Field(min_length=1, max_length=_MAX_TERMS)
     preperiod_length: StrictInt = Field(ge=1)
     period_length: StrictInt = Field(ge=1)
     method: Literal["SYMPY_CONTINUED_FRACTION"] = "SYMPY_CONTINUED_FRACTION"
+
+    @model_validator(mode="after")
+    def require_source_expansion(self) -> Self:
+        from jacobian.math.diophantine_approximation.operations import (
+            _cf_coefficients,
+            _coefficients,
+        )
+
+        preperiod, period = _cf_coefficients(self.discriminant)
+        if self.preperiod_length != len(preperiod) or self.period_length != len(period):
+            raise ValueError(
+                "preperiod/period metadata must match the canonical expansion "
+                "of sqrt(discriminant)"
+            )
+        if self.term_count != len(self.coefficients):
+            raise ValueError("coefficient count must equal the requested term_count")
+        expected = tuple(_coefficients(preperiod, period, self.term_count))
+        if tuple(self.coefficients) != expected:
+            raise ValueError(
+                "coefficients must be the canonical continued fraction of "
+                "sqrt(discriminant)"
+            )
+        return self
 
 
 class ConvergentRequest(StrictModel):
@@ -75,13 +107,66 @@ class ConvergentValue(StrictModel):
 
 
 class ConvergentResult(StrictModel):
-    """Convergents of sqrt(D)."""
+    """Convergents of sqrt(D).
+
+    Retains the complete request so validation replays the continuant
+    recurrence from the canonical coefficient stream of the same ``sqrt(D)``:
+    indices are contiguous from zero, denominators are positive, each
+    numerator/denominator pair is reduced, and adjacent pairs satisfy
+    ``p_n q_{n-1} - p_{n-1} q_n = (-1)^(n+1)``.
+    """
 
     discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
+    convergent_count: StrictInt = Field(ge=1, le=_MAX_TERMS)
     convergents: tuple[ConvergentValue, ...] = Field(
         min_length=1, max_length=_MAX_TERMS
     )
     method: Literal["CONTINUED_FRACTION_RECURSION"] = "CONTINUED_FRACTION_RECURSION"
+
+    @model_validator(mode="after")
+    def require_source_convergents(self) -> Self:
+        from math import gcd
+
+        from jacobian.canonical import parse_canonical_integer
+        from jacobian.math.diophantine_approximation.operations import (
+            _cf_coefficients,
+            _coefficients,
+        )
+
+        if len(self.convergents) != self.convergent_count:
+            raise ValueError("convergent count must equal the requested count")
+        if tuple(value.index for value in self.convergents) != tuple(
+            range(len(self.convergents))
+        ):
+            raise ValueError("convergent indices must be contiguous starting at zero")
+        for value in self.convergents:
+            numerator = parse_canonical_integer(value.numerator)
+            denominator = parse_canonical_integer(value.denominator)
+            if denominator <= 0:
+                raise ValueError("convergent denominators must be positive")
+            if gcd(numerator, denominator) != 1:
+                raise ValueError(
+                    "convergent numerator/denominator pairs must be reduced"
+                )
+
+        preperiod, period = _cf_coefficients(self.discriminant)
+        coefficients = _coefficients(preperiod, period, self.convergent_count)
+        p_prev2, p_prev1 = 1, coefficients[0]
+        q_prev2, q_prev1 = 0, 1
+        for index, claimed in enumerate(self.convergents):
+            if index > 0:
+                coefficient = coefficients[index]
+                p_prev2, p_prev1 = p_prev1, coefficient * p_prev1 + p_prev2
+                q_prev2, q_prev1 = q_prev1, coefficient * q_prev1 + q_prev2
+            if (
+                parse_canonical_integer(claimed.numerator) != p_prev1
+                or parse_canonical_integer(claimed.denominator) != q_prev1
+            ):
+                raise ValueError(
+                    "convergents must replay the continuant recurrence of the "
+                    "canonical coefficient stream"
+                )
+        return self
 
 
 class PellEquationRequest(StrictModel):

--- a/src/jacobian/math/diophantine_approximation/_models.py
+++ b/src/jacobian/math/diophantine_approximation/_models.py
@@ -18,6 +18,22 @@ def _is_square_free(value: int) -> bool:
     return all(value % (divisor * divisor) for divisor in range(2, isqrt(value) + 1))
 
 
+def _convergent_component_digit_cap(count: int) -> int:
+    """Conservative decimal-digit bound for any sqrt(D) convergent component.
+
+    Every partial quotient of ``sqrt(D)`` after the initial term is at most
+    ``2 * isqrt(D)``, so with ``D <= _MAX_DISCRIMINANT`` every coefficient is
+    at most ``2 * isqrt(_MAX_DISCRIMINANT)`` and each continuant grows by a
+    factor below ``2 * isqrt(_MAX_DISCRIMINANT) + 1`` per step.  Components of
+    convergents with index ``< count`` therefore stay strictly below
+    ``(2 * isqrt(_MAX_DISCRIMINANT) + 1) ** count``, which this returns as an
+    exact digit count so oversized canonical strings are rejected by length
+    before any bigint work.
+    """
+    growth = 2 * isqrt(_MAX_DISCRIMINANT) + 1
+    return len(str(growth**count))
+
+
 class SquarefreeRequest(StrictModel):
     """One positive squarefree integer D for sqrt(D) operations."""
 
@@ -60,6 +76,12 @@ class ContinuedFractionResult(StrictModel):
     preperiod_length: StrictInt = Field(ge=1)
     period_length: StrictInt = Field(ge=1)
     method: Literal["SYMPY_CONTINUED_FRACTION"] = "SYMPY_CONTINUED_FRACTION"
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
 
     @model_validator(mode="after")
     def require_source_expansion(self) -> Self:
@@ -113,7 +135,9 @@ class ConvergentResult(StrictModel):
     recurrence from the canonical coefficient stream of the same ``sqrt(D)``:
     indices are contiguous from zero, denominators are positive, each
     numerator/denominator pair is reduced, and adjacent pairs satisfy
-    ``p_n q_{n-1} - p_{n-1} q_n = (-1)^(n+1)``.
+    ``p_n q_{n-1} - p_{n-1} q_n = (-1)^(n+1)``.  Canonical numerators and
+    denominators carry no more digits than the geometric bound implied by
+    the admitted discriminant/count envelope.
     """
 
     discriminant: StrictInt = Field(ge=2, le=_MAX_DISCRIMINANT)
@@ -122,6 +146,12 @@ class ConvergentResult(StrictModel):
         min_length=1, max_length=_MAX_TERMS
     )
     method: Literal["CONTINUED_FRACTION_RECURSION"] = "CONTINUED_FRACTION_RECURSION"
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
 
     @model_validator(mode="after")
     def require_source_convergents(self) -> Self:
@@ -139,7 +169,16 @@ class ConvergentResult(StrictModel):
             range(len(self.convergents))
         ):
             raise ValueError("convergent indices must be contiguous starting at zero")
+        digit_cap = _convergent_component_digit_cap(self.convergent_count)
         for value in self.convergents:
+            if (
+                len(value.numerator.lstrip("-")) > digit_cap
+                or len(value.denominator.lstrip("-")) > digit_cap
+            ):
+                raise ValueError(
+                    "convergent numerators/denominators exceed the "
+                    f"{digit_cap}-digit bound implied by the admitted request"
+                )
             numerator = parse_canonical_integer(value.numerator)
             denominator = parse_canonical_integer(value.denominator)
             if denominator <= 0:
@@ -188,6 +227,12 @@ class PellEquationResult(StrictModel):
     x: CanonicalInteger
     y: CanonicalInteger
     method: Literal["CONTINUED_FRACTION_CONVERGENTS"] = "CONTINUED_FRACTION_CONVERGENTS"
+
+    @model_validator(mode="after")
+    def require_squarefree(self) -> Self:
+        if not _is_square_free(self.discriminant):
+            raise ValueError("discriminant must be squarefree")
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/diophantine_approximation/_operations.py
+++ b/src/jacobian/math/diophantine_approximation/_operations.py
@@ -27,6 +27,7 @@ def compute_continued_fraction(
     )
     return ContinuedFractionResult(
         discriminant=request.discriminant,
+        term_count=request.term_count,
         coefficients=tuple(coefficients),
         preperiod_length=preperiod_length,
         period_length=period_length,
@@ -37,6 +38,7 @@ def compute_convergents(request: ConvergentRequest) -> ConvergentResult:
     values = convergents(request.discriminant, request.convergent_count)
     return ConvergentResult(
         discriminant=request.discriminant,
+        convergent_count=request.convergent_count,
         convergents=tuple(
             ConvergentValue(
                 index=index,

--- a/src/jacobian/math/diophantine_approximation/_tools.py
+++ b/src/jacobian/math/diophantine_approximation/_tools.py
@@ -65,6 +65,7 @@ DIOPHANTINE_APPROXIMATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"discriminant": 2, "term_count": 5},
             ),
         ),
+        version="2",
     ),
     da_operation(
         "diophantine.convergents.compute",
@@ -84,6 +85,7 @@ DIOPHANTINE_APPROXIMATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {"discriminant": 2, "convergent_count": 5},
             ),
         ),
+        version="2",
     ),
     da_operation(
         "diophantine.pell_equation.solve",

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -390,6 +390,90 @@ def test_convergent_result_rejects_mutations() -> None:
         ConvergentResult.model_validate(count_mismatch)
 
 
+def test_results_reject_non_squarefree_discriminant() -> None:
+    """Results satisfy the same squarefree source domain as their requests.
+
+    The forged payloads below carry the genuine canonical expansion and
+    convergents of sqrt(8), so only the squarefree predicate can reject them.
+    """
+    from jacobian.math.diophantine_approximation._models import (
+        ContinuedFractionResult,
+        ConvergentResult,
+        PellEquationResult,
+    )
+
+    # sqrt(8) = [2; overline{1, 4}] with convergents 2/1, 3/1, 14/5, 17/6.
+    sqrt8_cf = {
+        "discriminant": 8,
+        "term_count": 5,
+        "coefficients": (2, 1, 4, 1, 4),
+        "preperiod_length": 1,
+        "period_length": 2,
+    }
+    with pytest.raises(ValidationError, match="squarefree"):
+        ContinuedFractionResult.model_validate(sqrt8_cf)
+
+    sqrt8_convergents = {
+        "discriminant": 8,
+        "convergent_count": 4,
+        "convergents": [
+            {"index": 0, "numerator": "2", "denominator": "1"},
+            {"index": 1, "numerator": "3", "denominator": "1"},
+            {"index": 2, "numerator": "14", "denominator": "5"},
+            {"index": 3, "numerator": "17", "denominator": "6"},
+        ],
+    }
+    with pytest.raises(ValidationError, match="squarefree"):
+        ConvergentResult.model_validate(sqrt8_convergents)
+
+    with pytest.raises(ValidationError, match="squarefree"):
+        PellEquationResult(discriminant=8, x="3", y="1")
+
+    with pytest.raises(ValidationError, match="squarefree"):
+        PellEquationResult(discriminant=9, x="3", y="1")
+
+
+def test_convergent_result_rejects_oversized_components_before_bigint_work() -> None:
+    """Forged long canonical strings die on the digit bound, before parsing/gcd.
+
+    With convergent_count=4 the derived cap is len(str(201**4)) == 10 digits,
+    so a 100,000-digit numerator is rejected by string length alone; matching
+    the digit-bound message proves the gate ran instead of the gcd/replay work.
+    """
+    from jacobian.math.diophantine_approximation._models import ConvergentResult
+
+    result = compute_convergents(
+        ConvergentRequest(discriminant=2, convergent_count=4)
+    ).model_dump()
+
+    long_numerator = dict(result)
+    long_numerator["convergents"] = [dict(item) for item in result["convergents"]]
+    long_numerator["convergents"][3]["numerator"] = "9" * 100_000
+    with pytest.raises(ValidationError, match=r"10-digit bound"):
+        ConvergentResult.model_validate(long_numerator)
+
+    long_denominator = dict(result)
+    long_denominator["convergents"] = [dict(item) for item in result["convergents"]]
+    long_denominator["convergents"][3]["denominator"] = "7" * 100_000
+    with pytest.raises(ValidationError, match=r"10-digit bound"):
+        ConvergentResult.model_validate(long_denominator)
+
+
+def test_convergent_digit_bound_admits_full_envelope() -> None:
+    """Legitimate output across the admitted envelope stays inside the bound."""
+    from jacobian.math.diophantine_approximation._models import ConvergentResult
+
+    result = compute_convergents(
+        ConvergentRequest(discriminant=9949, convergent_count=500)
+    )
+    assert ConvergentResult.model_validate(result.model_dump()) == result
+    widest = max(
+        max(len(c.numerator.lstrip("-")), len(c.denominator.lstrip("-")))
+        for c in result.convergents
+    )
+    assert widest > 100
+
+
 def test_producer_to_convergent_composition() -> None:
     """The CF coefficient stream composes into the serialized convergents."""
 

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -494,3 +494,33 @@ def test_producer_to_convergent_composition() -> None:
         for c in convs.convergents
     ]
     assert claimed == replayed
+
+
+# ---------------------------------------------------------------------------
+# Contract-version regressions (#2313)
+# ---------------------------------------------------------------------------
+
+
+def _operation_version(operation_id: str) -> str:
+    from jacobian.math.diophantine_approximation._tools import TOOLS
+
+    return next(
+        tool for tool in TOOLS if tool.operation_id == operation_id
+    ).version
+
+
+def test_continued_fraction_contract_version_tracks_wire_shape() -> None:
+    """term_count joined the required result, so the declaration is version 2."""
+    assert (
+        _operation_version("diophantine.continued_fraction.compute") == "2"
+    )
+
+
+def test_convergents_contract_version_tracks_wire_shape() -> None:
+    """convergent_count joined the required result, so the declaration is version 2."""
+    assert _operation_version("diophantine.convergents.compute") == "2"
+
+
+def test_pell_equation_keeps_unchanged_wire_contract_version() -> None:
+    """The Pell request/result schemas did not change shape in this contract."""
+    assert _operation_version("diophantine.pell_equation.solve") == "1"

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -230,3 +230,183 @@ def test_public_kernels_return_typed_values() -> None:
     assert continued_fraction(2, 3) == ([1, 2, 2], 1, 1)
     assert convergents(2, 3) == [(0, 1, 1), (1, 3, 2), (2, 7, 5)]
     assert solve_pell(2) == (3, 2)
+
+
+# ---------------------------------------------------------------------------
+# Source-bound replay regressions (#2313)
+# ---------------------------------------------------------------------------
+
+
+def test_continued_fraction_result_replays_known_answers() -> None:
+    from jacobian.math.diophantine_approximation._models import (
+        ContinuedFractionResult,
+    )
+
+    sqrt2 = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=5)
+    )
+    assert sqrt2.coefficients == (1, 2, 2, 2, 2)
+    assert (sqrt2.preperiod_length, sqrt2.period_length) == (1, 1)
+    assert ContinuedFractionResult.model_validate(sqrt2.model_dump()) == sqrt2
+
+    sqrt3 = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=6)
+    )
+    assert sqrt3.coefficients == (1, 1, 2, 1, 2, 1)
+    assert (sqrt3.preperiod_length, sqrt3.period_length) == (1, 2)
+
+    one_period = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=2)
+    )
+    assert one_period.coefficients == (1, 2)
+    two_periods = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=5)
+    )
+    assert two_periods.coefficients == (1, 1, 2, 1, 2)
+
+
+def test_continued_fraction_prefix_boundary_semantics() -> None:
+    """A truncated window retains its requested count and replays exactly."""
+
+    exact_window = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=3)
+    )
+    assert exact_window.term_count == 3
+    assert exact_window.coefficients == (1, 1, 2)
+    assert exact_window.preperiod_length + exact_window.period_length == 3
+
+    beyond = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=3, term_count=4)
+    )
+    assert beyond.coefficients[-1] == 1
+
+
+def test_continued_fraction_result_rejects_mutations() -> None:
+    from jacobian.math.diophantine_approximation._models import (
+        ContinuedFractionResult,
+    )
+
+    with pytest.raises(ValidationError):
+        ContinuedFractionResult(
+            discriminant=2,
+            coefficients=(99,),
+            preperiod_length=7,
+            period_length=8,
+        )
+    result = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=2, term_count=5)
+    ).model_dump()
+
+    wrong_source = dict(result, discriminant=3)
+    with pytest.raises(ValidationError):
+        ContinuedFractionResult.model_validate(wrong_source)
+
+    forged_coefficients = dict(result)
+    forged_coefficients["coefficients"] = (1, 2, 2, 2, 3)
+    with pytest.raises(ValidationError, match="canonical continued fraction"):
+        ContinuedFractionResult.model_validate(forged_coefficients)
+
+    forged_metadata = dict(result, preperiod_length=2)
+    with pytest.raises(ValidationError, match="metadata"):
+        ContinuedFractionResult.model_validate(forged_metadata)
+
+    count_mismatch = dict(result, term_count=4)
+    with pytest.raises(ValidationError, match="term_count"):
+        ContinuedFractionResult.model_validate(count_mismatch)
+
+
+def test_convergent_result_replays_recurrence_and_determinant() -> None:
+    from jacobian.math.diophantine_approximation._models import ConvergentResult
+
+    result = compute_convergents(ConvergentRequest(discriminant=2, convergent_count=6))
+    assert [(c.index, c.numerator, c.denominator) for c in result.convergents] == [
+        (0, "1", "1"),
+        (1, "3", "2"),
+        (2, "7", "5"),
+        (3, "17", "12"),
+        (4, "41", "29"),
+        (5, "99", "70"),
+    ]
+    parsed = [
+        (parse_canonical_integer(c.numerator), parse_canonical_integer(c.denominator))
+        for c in result.convergents
+    ]
+    for n in range(1, len(parsed)):
+        p_n, q_n = parsed[n]
+        p_prev, q_prev = parsed[n - 1]
+        determinant = p_n * q_prev - p_prev * q_n
+        assert determinant == (-1) ** (n - 1)
+    assert ConvergentResult.model_validate(result.model_dump()) == result
+
+    sqrt3 = compute_convergents(ConvergentRequest(discriminant=3, convergent_count=4))
+    parsed3 = [
+        (parse_canonical_integer(c.numerator), parse_canonical_integer(c.denominator))
+        for c in sqrt3.convergents
+    ]
+    assert parsed3[:2] == [(1, 1), (2, 1)]
+
+
+def test_convergent_result_rejects_mutations() -> None:
+    from jacobian.math.diophantine_approximation._models import (
+        ConvergentResult,
+        ConvergentValue,
+    )
+
+    with pytest.raises(ValidationError, match="contiguous"):
+        ConvergentResult(
+            discriminant=2,
+            convergent_count=1,
+            convergents=(ConvergentValue(index=77, numerator="0", denominator="0"),),
+        )
+    result = compute_convergents(
+        ConvergentRequest(discriminant=2, convergent_count=4)
+    ).model_dump()
+
+    zero_denominator = dict(result)
+    zero_denominator["convergents"] = [dict(item) for item in result["convergents"]]
+    zero_denominator["convergents"][0]["denominator"] = "0"
+    with pytest.raises(ValidationError, match="positive"):
+        ConvergentResult.model_validate(zero_denominator)
+
+    nonreduced = dict(result)
+    nonreduced["convergents"] = [dict(item) for item in result["convergents"]]
+    nonreduced["convergents"][1]["numerator"] = "6"
+    nonreduced["convergents"][1]["denominator"] = "4"
+    with pytest.raises(ValidationError, match="reduced"):
+        ConvergentResult.model_validate(nonreduced)
+
+    recurrence_break = dict(result)
+    recurrence_break["convergents"] = [dict(item) for item in result["convergents"]]
+    recurrence_break["convergents"][2]["numerator"] = "8"
+    with pytest.raises(ValidationError, match="continuant recurrence"):
+        ConvergentResult.model_validate(recurrence_break)
+
+    wrong_source = dict(result, discriminant=3)
+    with pytest.raises(ValidationError):
+        ConvergentResult.model_validate(wrong_source)
+
+    count_mismatch = dict(result, convergent_count=9)
+    with pytest.raises(ValidationError, match="requested count"):
+        ConvergentResult.model_validate(count_mismatch)
+
+
+def test_producer_to_convergent_composition() -> None:
+    """The CF coefficient stream composes into the serialized convergents."""
+
+    cf = compute_continued_fraction(
+        ContinuedFractionRequest(discriminant=13, term_count=10)
+    )
+    convs = compute_convergents(ConvergentRequest(discriminant=13, convergent_count=10))
+    coefficients = [cf.preperiod_length and x for x in cf.coefficients]
+    p_prev2, p_prev1 = 1, coefficients[0]
+    q_prev2, q_prev1 = 0, 1
+    replayed = [(p_prev1, q_prev1)]
+    for coefficient in coefficients[1:]:
+        p_prev2, p_prev1 = p_prev1, coefficient * p_prev1 + p_prev2
+        q_prev2, q_prev1 = q_prev1, coefficient * q_prev1 + q_prev2
+        replayed.append((p_prev1, q_prev1))
+    claimed = [
+        (parse_canonical_integer(c.numerator), parse_canonical_integer(c.denominator))
+        for c in convs.convergents
+    ]
+    assert claimed == replayed

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -436,26 +436,31 @@ def test_results_reject_non_squarefree_discriminant() -> None:
 def test_convergent_result_rejects_oversized_components_before_bigint_work() -> None:
     """Forged long canonical strings die on the digit bound, before parsing/gcd.
 
-    With convergent_count=4 the derived cap is len(str(201**4)) == 10 digits,
-    so a 100,000-digit numerator is rejected by string length alone; matching
-    the digit-bound message proves the gate ran instead of the gcd/replay work.
+    With convergent_count=4 the derived cap is
+    ``_convergent_component_digit_cap(4)``, so a 100,000-digit numerator is
+    rejected by string length alone; matching the digit-bound message proves
+    the gate ran instead of the gcd/replay work.
     """
-    from jacobian.math.diophantine_approximation._models import ConvergentResult
+    from jacobian.math.diophantine_approximation._models import (
+        ConvergentResult,
+        _convergent_component_digit_cap,
+    )
 
     result = compute_convergents(
         ConvergentRequest(discriminant=2, convergent_count=4)
     ).model_dump()
 
+    digit_bound = _convergent_component_digit_cap(4)
     long_numerator = dict(result)
     long_numerator["convergents"] = [dict(item) for item in result["convergents"]]
     long_numerator["convergents"][3]["numerator"] = "9" * 100_000
-    with pytest.raises(ValidationError, match=r"10-digit bound"):
+    with pytest.raises(ValidationError, match=rf"{digit_bound}-digit bound"):
         ConvergentResult.model_validate(long_numerator)
 
     long_denominator = dict(result)
     long_denominator["convergents"] = [dict(item) for item in result["convergents"]]
     long_denominator["convergents"][3]["denominator"] = "7" * 100_000
-    with pytest.raises(ValidationError, match=r"10-digit bound"):
+    with pytest.raises(ValidationError, match=rf"{digit_bound}-digit bound"):
         ConvergentResult.model_validate(long_denominator)
 
 

--- a/tests/math/diophantine_approximation/test_diophantine_approximation.py
+++ b/tests/math/diophantine_approximation/test_diophantine_approximation.py
@@ -504,16 +504,12 @@ def test_producer_to_convergent_composition() -> None:
 def _operation_version(operation_id: str) -> str:
     from jacobian.math.diophantine_approximation._tools import TOOLS
 
-    return next(
-        tool for tool in TOOLS if tool.operation_id == operation_id
-    ).version
+    return next(tool for tool in TOOLS if tool.operation_id == operation_id).version
 
 
 def test_continued_fraction_contract_version_tracks_wire_shape() -> None:
     """term_count joined the required result, so the declaration is version 2."""
-    assert (
-        _operation_version("diophantine.continued_fraction.compute") == "2"
-    )
+    assert _operation_version("diophantine.continued_fraction.compute") == "2"
 
 
 def test_convergents_contract_version_tracks_wire_shape() -> None:


### PR DESCRIPTION
## Problem

`ContinuedFractionResult` and `ConvergentResult` retained only the discriminant (#2313). Both authored values from the issue validated: `ContinuedFractionResult(discriminant=2, coefficients=(99,), preperiod_length=7, period_length=8)` and `ConvergentResult(discriminant=2, convergents=(ConvergentValue(index=77, numerator="0", denominator="0"),))`. Serialization dropped the requested counts, and nothing replayed coefficients, period data, indices, denominators, or recurrences against `sqrt(D)`.

## Fix

- **ContinuedFractionResult** retains `term_count` (the complete request) and replays the canonical periodic expansion via the domain kernel's preperiod/period decomposition: coefficients are exactly preperiod followed by period repeats for the requested count; preperiod/period metadata must match that expansion. A prefix shorter than preperiod+period is an explicitly retained truncated window, never a complete-period claim.
- **ConvergentResult** retains `convergent_count` and enforces contiguous indices from zero, positive denominators, gcd-reduced pairs, and an exact continuant-recurrence replay from the canonical coefficient stream — pinning the adjacent-pair determinant identity `p_n q_{n-1} − p_{n-1} q_n = (−1)^{n−1}` as well.

## Validation

- `make check` green (3523 passed).
- New regressions per the issue: sqrt(2)/sqrt(3) known answers; one- and two-period windows; prefix counts at the truncation boundary; source/metadata/coefficient/count mutations rejected; denominator-zero and nonreduced mutations rejected; recurrence mutation rejected; adjacent-pair determinant identity on produced results; producer CF→convergent composition (sqrt(13)).

Fixes #2313