### PR TITLE
Bind rational LP outcomes to their source

### DIFF
--- a/src/jacobian/math/optimization/_admission.py
+++ b/src/jacobian/math/optimization/_admission.py
@@ -13,7 +13,7 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "optimization.linear.rational_optimum.compute",
         AdmissionDecision.KEEP,
-        "distinct exact or explicitly bounded search outcome with material computational leverage",
+        "distinct exact source-bound standard-form LP outcome with replayable optimality, Farkas, or recession witnesses",
     ),
 )
 

--- a/src/jacobian/math/optimization/_models.py
+++ b/src/jacobian/math/optimization/_models.py
@@ -2,32 +2,388 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from fractions import Fraction
+from math import comb, factorial
 from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
-from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian._models import StrictModel
 
 MAX_RATIONAL_DIGITS = 128
+MAX_LINEAR_PROGRAM_RESULT_BYTES = 10 * 1024 * 1024
+MAX_LINEAR_PROGRAM_SIMPLEX_BASES = 1_000_000
+MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES = 50_000_000
 type RationalLinearProgramStatus = Literal[
     "OPTIMAL",
     "PRIMAL_FEASIBLE",
     "INFEASIBLE",
     "UNBOUNDED",
+    "UNKNOWN",
 ]
 
 
+def _bound_raw_rational(
+    value: object,
+    *,
+    maximum_digits: int = MAX_RATIONAL_DIGITS,
+    label: str,
+) -> None:
+    """Apply the LP scalar limit before generic rational construction."""
+
+    if isinstance(value, CanonicalRational):
+        components: tuple[object, object] = (value.num, value.den)
+    elif isinstance(value, Mapping):
+        components = (value.get("num"), value.get("den"))
+    else:
+        return
+    for component in components:
+        if (
+            isinstance(component, str)
+            and len(component) - component.startswith("-") > maximum_digits
+        ):
+            raise ValueError(f"{label} exceeds the {maximum_digits}-digit bound")
+
+
+def _bound_raw_rational_vector(
+    value: object,
+    *,
+    maximum_length: int,
+    maximum_digits: int = MAX_RATIONAL_DIGITS,
+    label: str,
+) -> None:
+    """Bound one raw LP vector before recursive model construction."""
+
+    if not isinstance(value, (list, tuple)):
+        return
+    if len(value) > maximum_length:
+        raise ValueError(f"{label} exceeds the {maximum_length}-entry bound")
+    for item in value:
+        _bound_raw_rational(item, maximum_digits=maximum_digits, label=label)
+
+
+def _prepare_raw_rational_vector(
+    value: object,
+    *,
+    maximum_length: int,
+    maximum_digits: int = MAX_RATIONAL_DIGITS,
+    label: str,
+) -> object:
+    """Bound and normalize one raw LP vector before nested parsing."""
+
+    _bound_raw_rational_vector(
+        value,
+        maximum_length=maximum_length,
+        maximum_digits=maximum_digits,
+        label=label,
+    )
+    return tuple(value) if isinstance(value, list) else value
+
+
+def _prepare_raw_program(value: object) -> object:
+    """Bound and normalize an LP source before nested model construction."""
+
+    if not isinstance(value, Mapping):
+        return value
+    variables = value.get("variables")
+    if isinstance(variables, (list, tuple)):
+        if len(variables) > 32:
+            raise ValueError("linear-program variables exceed the 32-entry bound")
+        if any(isinstance(name, str) and len(name) > 64 for name in variables):
+            raise ValueError(
+                "linear-program variable name exceeds the 64-character bound"
+            )
+    objective = _prepare_raw_rational_vector(
+        value.get("objective"),
+        maximum_length=32,
+        label="rational linear-program objective",
+    )
+    rhs = _prepare_raw_rational_vector(
+        value.get("rhs"),
+        maximum_length=64,
+        label="rational linear-program rhs",
+    )
+    rows = value.get("coefficients")
+    if not isinstance(rows, (list, tuple)):
+        return value
+    if len(rows) > 64:
+        raise ValueError("linear-program coefficient rows exceed the 64-row bound")
+    prepared_rows = tuple(
+        _prepare_raw_rational_vector(
+            row,
+            maximum_length=32,
+            label="rational linear-program coefficient row",
+        )
+        for row in rows
+    )
+    prepared = dict(value)
+    if isinstance(variables, list):
+        prepared["variables"] = tuple(variables)
+    prepared["objective"] = objective
+    prepared["coefficients"] = prepared_rows
+    prepared["rhs"] = rhs
+    return prepared
+
+
+def _cleared_row_digit_bound(
+    values: tuple[CanonicalRational, ...],
+) -> int:
+    """Bound one integer row after clearing every rational denominator."""
+
+    if not values:
+        return 1
+    denominator_digits = sum(
+        len(denominator) for denominator in {v.den for v in values}
+    )
+    return max(
+        len(value.num.lstrip("-")) + denominator_digits - len(value.den)
+        for value in values
+    )
+
+
+def _determinant_digit_bound(
+    row_bounds: tuple[int, ...],
+    *,
+    variable_columns: int,
+) -> int:
+    """Leibniz-bound every basis minor and one diagnostic row."""
+
+    order = min(variable_columns + 1, len(row_bounds))
+    if order == 0:
+        return 1
+    largest_rows = sorted(row_bounds, reverse=True)[:order]
+    return sum(largest_rows) + len(str(factorial(order))) + 2
+
+
+def _active_equations(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[tuple[tuple[CanonicalRational, ...], CanonicalRational], ...]:
+    return tuple(
+        (row, rhs)
+        for row, rhs in zip(program.coefficients, program.rhs, strict=True)
+        if any(value.num != "0" for value in row) or rhs.num != "0"
+    )
+
+
+def _has_trivial_inconsistent_row(
+    program: StandardFormRationalLinearProgram,
+) -> bool:
+    return any(
+        not any(value.num != "0" for value in row) and rhs.num != "0"
+        for row, rhs in zip(program.coefficients, program.rhs, strict=True)
+    )
+
+
+def _result_digit_bound(program: StandardFormRationalLinearProgram) -> int:
+    """Bound simplex tableaux, witnesses, and source-derived diagnostics.
+
+    Clearing denominators row by row turns each exact LP used by the operation
+    into an integer tableau. Every basic coordinate, reduced cost, objective,
+    and normalized Farkas or recession coordinate is a ratio of minors. The
+    Leibniz bounds below include one additional row for a derived diagnostic.
+    Free dual/Farkas variables are represented as a difference of two
+    nonnegative basic variables; the final two digits cover that subtraction.
+    """
+
+    if _has_trivial_inconsistent_row(program):
+        return max(
+            (
+                max(len(value.num.lstrip("-")), len(value.den))
+                for value in (
+                    *program.objective,
+                    *program.rhs,
+                    *(value for row in program.coefficients for value in row),
+                )
+            ),
+            default=1,
+        )
+
+    active_equations = _active_equations(program)
+    active_coefficients = tuple(row for row, _ in active_equations)
+    active_rhs = tuple(rhs for _, rhs in active_equations)
+    zero = CanonicalRational(num="0", den="1")
+    one = CanonicalRational(num="1", den="1")
+    objective_row = _cleared_row_digit_bound((*program.objective, zero))
+    unit_primal_objective = _cleared_row_digit_bound(
+        (*(one for _ in program.variables), zero)
+    )
+    primal_rows = tuple(
+        _cleared_row_digit_bound((*row, rhs)) for row, rhs in active_equations
+    )
+    dual_rows = tuple(
+        _cleared_row_digit_bound(
+            (
+                *(row[column] for row in active_coefficients),
+                program.objective[column],
+            )
+        )
+        for column in range(len(program.variables))
+    )
+    dual_objective_row = _cleared_row_digit_bound((*active_rhs, zero))
+    farkas_rows = tuple(
+        _cleared_row_digit_bound((*(row[column] for row in active_coefficients), zero))
+        for column in range(len(program.variables))
+    )
+    farkas_normalization = _cleared_row_digit_bound((*active_rhs, one))
+    ray_rows = tuple(
+        _cleared_row_digit_bound((*row, zero)) for row in active_coefficients
+    )
+    ray_normalization = _cleared_row_digit_bound((*program.objective, one))
+
+    variables = len(program.variables)
+    equations = len(active_equations)
+    return max(
+        _determinant_digit_bound(
+            (*primal_rows, *primal_rows, objective_row, unit_primal_objective),
+            variable_columns=2 * variables,
+        ),
+        _determinant_digit_bound(
+            (*dual_rows, dual_objective_row),
+            variable_columns=2 * equations,
+        ),
+        _determinant_digit_bound(
+            (*farkas_rows, farkas_normalization, farkas_normalization, 1),
+            variable_columns=2 * equations,
+        ),
+        _determinant_digit_bound(
+            (
+                *ray_rows,
+                *ray_rows,
+                ray_normalization,
+                ray_normalization,
+                unit_primal_objective,
+            ),
+            variable_columns=2 * variables,
+        ),
+    )
+
+
+def _simplex_candidate_and_update_bounds(
+    *,
+    variables: int,
+    equations: int,
+) -> tuple[int, int]:
+    """Bound Bland pivots by all possible bases in both simplex phases."""
+
+    def solve(rows: int, columns: int) -> tuple[int, int]:
+        # SymPy's pinned exact simplex uses Bland's rule. Each phase therefore
+        # visits no basis twice; the factor two covers feasibility and optimum.
+        candidates = 2 * comb(rows + columns, rows)
+        scalar_updates = candidates * (rows + 2) * (columns + 2)
+        return candidates, scalar_updates
+
+    # ``lpmin`` may introduce one shifted nonnegative auxiliary for each
+    # source variable whose univariate constraints form a finite interval.
+    primal = solve(2 * equations, 2 * variables)
+    dual = solve(variables, 2 * equations)
+    farkas = solve(variables + 2, 2 * equations)
+    feasible_point = primal
+    recession = solve(2 * (equations + 1), 2 * variables)
+    branches = (
+        (primal, dual),
+        (primal, farkas),
+        (primal, feasible_point, recession),
+    )
+    return (
+        max(sum(item[0] for item in branch) for branch in branches),
+        max(sum(item[1] for item in branch) for branch in branches),
+    )
+
+
+def _source_wire_bytes(program: StandardFormRationalLinearProgram) -> int:
+    rationals = (
+        *program.objective,
+        *program.rhs,
+        *(value for row in program.coefficients for value in row),
+    )
+    return (
+        2_048
+        + sum(len(value.num) + len(value.den) + 32 for value in rationals)
+        + sum(len(variable) + 4 for variable in program.variables)
+    )
+
+
+def _dot(left: tuple[Fraction, ...], right: tuple[Fraction, ...]) -> Fraction:
+    return sum((a * b for a, b in zip(left, right, strict=True)), Fraction())
+
+
+def _program_fractions(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[
+    tuple[Fraction, ...],
+    tuple[tuple[Fraction, ...], ...],
+    tuple[Fraction, ...],
+]:
+    return (
+        tuple(value.as_fraction() for value in program.objective),
+        tuple(
+            tuple(value.as_fraction() for value in row) for row in program.coefficients
+        ),
+        tuple(value.as_fraction() for value in program.rhs),
+    )
+
+
+def _primal_diagnostics(
+    program: StandardFormRationalLinearProgram,
+    candidate: tuple[Fraction, ...],
+) -> tuple[Fraction, tuple[Fraction, ...]]:
+    objective, coefficients, rhs = _program_fractions(program)
+    return _dot(objective, candidate), tuple(
+        _dot(row, candidate) - expected
+        for row, expected in zip(coefficients, rhs, strict=True)
+    )
+
+
+def _recession_diagnostics(
+    program: StandardFormRationalLinearProgram,
+    direction: tuple[Fraction, ...],
+) -> tuple[Fraction, tuple[Fraction, ...]]:
+    objective, coefficients, _ = _program_fractions(program)
+    return _dot(objective, direction), tuple(
+        _dot(row, direction) for row in coefficients
+    )
+
+
+def _dual_diagnostics(
+    program: StandardFormRationalLinearProgram,
+    candidate: tuple[Fraction, ...],
+) -> tuple[Fraction, tuple[Fraction, ...]]:
+    objective, coefficients, rhs = _program_fractions(program)
+    slacks = tuple(
+        objective[column]
+        - sum(
+            (
+                coefficients[row][column] * candidate[row]
+                for row in range(len(coefficients))
+            ),
+            Fraction(),
+        )
+        for column in range(len(objective))
+    )
+    return _dot(rhs, candidate), slacks
+
+
 class StandardFormRationalLinearProgram(StrictModel):
-    """Minimize ``cᵀx`` subject to ``Ax=b`` and ``x>=0``."""
+    """Minimize ``cᵀx`` subject to ``Ax=b`` and ``x>=0``.
+
+    An empty coefficient/RHS family is the unconstrained nonnegative orthant.
+    """
 
     variables: tuple[str, ...] = Field(min_length=1, max_length=32)
     objective: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=32)
-    coefficients: tuple[tuple[CanonicalRational, ...], ...] = Field(
-        min_length=1,
-        max_length=64,
-    )
-    rhs: tuple[CanonicalRational, ...] = Field(min_length=1, max_length=64)
+    coefficients: tuple[tuple[CanonicalRational, ...], ...] = Field(max_length=64)
+    rhs: tuple[CanonicalRational, ...] = Field(max_length=64)
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_program(cls, value: object) -> object:
+        return _prepare_raw_program(value)
 
     @model_validator(mode="after")
     def require_canonical_dimensions(self) -> Self:
@@ -56,7 +412,43 @@ class StandardFormRationalLinearProgram(StrictModel):
             require_bounded_rational(
                 value,
                 max_digits=MAX_RATIONAL_DIGITS,
-                label="validated-analysis rational",
+                label="rational linear-program input",
+            )
+
+        result_digits = _result_digit_bound(self)
+        if result_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+            raise ValueError(
+                "linear-program rational height can exceed the exact "
+                f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit result bound"
+            )
+        direct_certificate = _has_trivial_inconsistent_row(self)
+        active_equations = 0 if direct_certificate else len(_active_equations(self))
+        candidates, scalar_updates = (0, 0)
+        if not direct_certificate:
+            candidates, scalar_updates = _simplex_candidate_and_update_bounds(
+                variables=len(self.variables),
+                equations=active_equations,
+            )
+        if candidates > MAX_LINEAR_PROGRAM_SIMPLEX_BASES:
+            raise ValueError(
+                "linear-program possible simplex bases exceed the "
+                f"{MAX_LINEAR_PROGRAM_SIMPLEX_BASES}-candidate bound"
+            )
+        if scalar_updates > MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES:
+            raise ValueError(
+                "linear-program exact simplex pivot work exceeds the "
+                f"{MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES}-scalar-update bound"
+            )
+        derived_rationals = 2 * len(self.variables) + 2 * len(self.rhs) + 2
+        estimated_result_bytes = (
+            _source_wire_bytes(self)
+            + derived_rationals * (2 * result_digits + 32)
+            + 4_096
+        )
+        if estimated_result_bytes > MAX_LINEAR_PROGRAM_RESULT_BYTES:
+            raise ValueError(
+                "linear-program exact result can exceed the "
+                f"{MAX_LINEAR_PROGRAM_RESULT_BYTES}-byte result bound"
             )
         return self
 
@@ -66,46 +458,240 @@ class RationalLinearProgramRequest(StrictModel):
 
 
 class RationalLinearProgramResult(StrictModel):
-    """The direct mathematical outcome of one rational linear program."""
+    """A source-bound outcome for one standard-form rational LP.
 
+    ``INFEASIBLE`` uses the Farkas convention ``Aᵀy>=0, bᵀy<0``.
+    ``UNBOUNDED`` carries feasible ``x0`` and nonnegative ``d`` satisfying
+    ``Ad=0, cᵀd<0``. ``UNKNOWN`` makes no mathematical claim.
+    """
+
+    program: StandardFormRationalLinearProgram
     status: RationalLinearProgramStatus
-    primal_candidate: tuple[CanonicalRational, ...] | None = None
-    dual_candidate: tuple[CanonicalRational, ...] | None = None
+    primal_candidate: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=32
+    )
+    dual_candidate: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=64
+    )
     primal_objective: CanonicalRational | None = None
     dual_objective: CanonicalRational | None = None
-    primal_residuals: tuple[CanonicalRational, ...] | None = None
-    dual_slacks: tuple[CanonicalRational, ...] | None = None
+    primal_residuals: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=64
+    )
+    dual_slacks: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=32
+    )
+    farkas_candidate: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=64
+    )
+    recession_direction: tuple[CanonicalRational, ...] | None = Field(
+        default=None, max_length=32
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_result(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        prepared: dict[str, object] = dict(value)
+        prepared["program"] = _prepare_raw_program(prepared.get("program"))
+        prepared["primal_candidate"] = _prepare_raw_rational_vector(
+            prepared.get("primal_candidate"),
+            maximum_length=32,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program primal candidate",
+        )
+        prepared["dual_candidate"] = _prepare_raw_rational_vector(
+            prepared.get("dual_candidate"),
+            maximum_length=64,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program dual candidate",
+        )
+        prepared["primal_residuals"] = _prepare_raw_rational_vector(
+            prepared.get("primal_residuals"),
+            maximum_length=64,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program primal residuals",
+        )
+        prepared["dual_slacks"] = _prepare_raw_rational_vector(
+            prepared.get("dual_slacks"),
+            maximum_length=32,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program dual slacks",
+        )
+        prepared["farkas_candidate"] = _prepare_raw_rational_vector(
+            prepared.get("farkas_candidate"),
+            maximum_length=64,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program Farkas candidate",
+        )
+        prepared["recession_direction"] = _prepare_raw_rational_vector(
+            prepared.get("recession_direction"),
+            maximum_length=32,
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program recession direction",
+        )
+        _bound_raw_rational(
+            prepared.get("primal_objective"),
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program primal objective",
+        )
+        _bound_raw_rational(
+            prepared.get("dual_objective"),
+            maximum_digits=MAX_CANONICAL_RATIONAL_DIGITS,
+            label="rational linear-program dual objective",
+        )
+        return prepared
 
     @model_validator(mode="after")
-    def bind_result_fields(self) -> Self:
-        optimal = self.status == "OPTIMAL"
-        primal_fields = (
-            self.primal_candidate,
-            self.primal_objective,
-            self.primal_residuals,
-        )
-        dual_fields = (
-            self.dual_candidate,
-            self.dual_objective,
-            self.dual_slacks,
-        )
-        has_primal = self.status in {"OPTIMAL", "PRIMAL_FEASIBLE"}
-        if has_primal and not all(value is not None for value in primal_fields):
-            raise ValueError(
-                "a primal result requires a candidate, objective, and residuals"
-            )
-        if not has_primal and any(value is not None for value in primal_fields):
-            raise ValueError("an infeasible or unbounded result cannot carry a point")
-        if optimal and not all(value is not None for value in dual_fields):
-            raise ValueError(
-                "an optimal result requires a dual candidate, objective, and slacks"
-            )
-        if not optimal and any(value is not None for value in dual_fields):
-            raise ValueError("only an optimal result can carry dual data")
+    def bind_result_to_source(self) -> Self:
+        _require_result_shape(self)
+        _require_result_heights(self)
+        primal_objective = _replay_primal(self)
+        _replay_dual(self, primal_objective)
+        _replay_farkas(self)
+        _replay_recession(self)
         return self
 
 
+def _require_result_shape(result: RationalLinearProgramResult) -> None:
+    primal_fields = (
+        result.primal_candidate,
+        result.primal_objective,
+        result.primal_residuals,
+    )
+    dual_fields = (
+        result.dual_candidate,
+        result.dual_objective,
+        result.dual_slacks,
+    )
+    has_primal = result.status in {"OPTIMAL", "PRIMAL_FEASIBLE", "UNBOUNDED"}
+    if has_primal and not all(value is not None for value in primal_fields):
+        raise ValueError(
+            "optimal, primal-feasible, and unbounded results require exactly "
+            "one feasible primal point with its source-derived diagnostics"
+        )
+    if not has_primal and any(value is not None for value in primal_fields):
+        raise ValueError("infeasible and unknown results cannot carry primal data")
+    if result.status == "OPTIMAL" and not all(
+        value is not None for value in dual_fields
+    ):
+        raise ValueError(
+            "an optimal result requires exactly one dual point with its "
+            "source-derived diagnostics"
+        )
+    if result.status != "OPTIMAL" and any(value is not None for value in dual_fields):
+        raise ValueError("only an optimal result can carry dual data")
+    if (result.status == "INFEASIBLE") != (result.farkas_candidate is not None):
+        raise ValueError("an infeasible result requires exactly one Farkas candidate")
+    if (result.status == "UNBOUNDED") != (result.recession_direction is not None):
+        raise ValueError("an unbounded result requires exactly one recession direction")
+
+
+def _require_result_heights(result: RationalLinearProgramResult) -> None:
+    result_bound = _result_digit_bound(result.program)
+    vector_fields = (
+        result.primal_candidate,
+        result.dual_candidate,
+        result.primal_residuals,
+        result.dual_slacks,
+        result.farkas_candidate,
+        result.recession_direction,
+    )
+    scalar_fields = (result.primal_objective, result.dual_objective)
+    values = tuple(
+        value for field in vector_fields if field is not None for value in field
+    ) + tuple(value for value in scalar_fields if value is not None)
+    for value in values:
+        require_bounded_rational(
+            value,
+            max_digits=result_bound,
+            label="rational linear-program result",
+        )
+
+
+def _replay_primal(result: RationalLinearProgramResult) -> Fraction | None:
+    if result.primal_candidate is None:
+        return None
+    if len(result.primal_candidate) != len(result.program.variables):
+        raise ValueError("primal candidate length must match the source")
+    primal = tuple(value.as_fraction() for value in result.primal_candidate)
+    if any(value < 0 for value in primal):
+        raise ValueError("primal candidate must be nonnegative")
+    objective, residuals = _primal_diagnostics(result.program, primal)
+    assert result.primal_objective is not None
+    assert result.primal_residuals is not None
+    if result.primal_objective.as_fraction() != objective:
+        raise ValueError("primal objective must be recomputed from the source")
+    if tuple(value.as_fraction() for value in result.primal_residuals) != residuals:
+        raise ValueError("primal residuals must be recomputed from the source")
+    if len(residuals) != len(result.program.rhs) or any(residuals):
+        raise ValueError("primal candidate must satisfy the source equalities")
+    return objective
+
+
+def _replay_dual(
+    result: RationalLinearProgramResult,
+    primal_objective: Fraction | None,
+) -> None:
+    if result.dual_candidate is None:
+        return
+    if len(result.dual_candidate) != len(result.program.rhs):
+        raise ValueError("dual candidate length must match the source")
+    dual = tuple(value.as_fraction() for value in result.dual_candidate)
+    objective, slacks = _dual_diagnostics(result.program, dual)
+    assert result.dual_objective is not None
+    assert result.dual_slacks is not None
+    if result.dual_objective.as_fraction() != objective:
+        raise ValueError("dual objective must be recomputed from the source")
+    if tuple(value.as_fraction() for value in result.dual_slacks) != slacks:
+        raise ValueError("dual slacks must be recomputed from the source")
+    if len(slacks) != len(result.program.variables) or any(
+        value < 0 for value in slacks
+    ):
+        raise ValueError("dual candidate must satisfy the source inequalities")
+    if primal_objective != objective:
+        raise ValueError("optimal primal and dual objectives must agree")
+
+
+def _replay_farkas(result: RationalLinearProgramResult) -> None:
+    if result.farkas_candidate is None:
+        return
+    if len(result.farkas_candidate) != len(result.program.rhs):
+        raise ValueError("Farkas candidate length must match the source")
+    farkas = tuple(value.as_fraction() for value in result.farkas_candidate)
+    _, slacks = _dual_diagnostics(result.program, farkas)
+    # _dual_diagnostics returns c-Aᵀy; remove c to recover Aᵀy.
+    objective = tuple(value.as_fraction() for value in result.program.objective)
+    pairings = tuple(
+        objective[column] - slacks[column] for column in range(len(objective))
+    )
+    rhs = tuple(value.as_fraction() for value in result.program.rhs)
+    if any(value < 0 for value in pairings) or _dot(rhs, farkas) >= 0:
+        raise ValueError(
+            "Farkas candidate must satisfy Aᵀy>=0 and bᵀy<0 for the source"
+        )
+
+
+def _replay_recession(result: RationalLinearProgramResult) -> None:
+    if result.recession_direction is None:
+        return
+    if len(result.recession_direction) != len(result.program.variables):
+        raise ValueError("recession direction length must match the source")
+    direction = tuple(value.as_fraction() for value in result.recession_direction)
+    if any(value < 0 for value in direction):
+        raise ValueError("recession direction must be nonnegative")
+    objective, residuals = _recession_diagnostics(result.program, direction)
+    if any(residuals) or objective >= 0:
+        raise ValueError(
+            "recession direction must satisfy Ad=0 and cᵀd<0 for the source"
+        )
+
+
 __all__ = [
+    "MAX_LINEAR_PROGRAM_RESULT_BYTES",
+    "MAX_LINEAR_PROGRAM_SIMPLEX_BASES",
+    "MAX_LINEAR_PROGRAM_SIMPLEX_SCALAR_UPDATES",
     "RationalLinearProgramRequest",
     "RationalLinearProgramResult",
     "RationalLinearProgramStatus",

--- a/src/jacobian/math/optimization/_operations.py
+++ b/src/jacobian/math/optimization/_operations.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Any
 
+from pydantic import ValidationError
+
 from jacobian._exact import CanonicalRational
-from jacobian.canonical import format_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
 from jacobian.math.optimization._models import (
     RationalLinearProgramRequest,
     RationalLinearProgramResult,
+    StandardFormRationalLinearProgram,
+    _active_equations,
+    _dual_diagnostics,
+    _primal_diagnostics,
+    _result_digit_bound,
 )
 
 
@@ -20,105 +27,533 @@ def _rational(value: CanonicalRational) -> Any:
     return sympy.Rational(value.as_fraction())
 
 
-def _wire(value: Any) -> CanonicalRational:
+def _linear(coefficients: tuple[Any, ...], symbols: tuple[Any, ...]) -> Any:
     import sympy
 
-    rational = sympy.Rational(value)
-    return CanonicalRational(
-        num=format_canonical_integer(int(rational.p)),
-        den=format_canonical_integer(int(rational.q)),
+    return sum(
+        (
+            coefficient * symbol
+            for coefficient, symbol in zip(coefficients, symbols, strict=True)
+        ),
+        sympy.S.Zero,
     )
+
+
+def _wire(value: Any, *, max_digits: int) -> CanonicalRational | None:
+    import sympy
+
+    try:
+        rational = sympy.Rational(value)
+        numerator = int(rational.p)
+        denominator = int(rational.q)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    if len(str(abs(numerator))) > max_digits or len(str(denominator)) > max_digits:
+        return None
+    return CanonicalRational.from_integer_ratio(numerator, denominator)
+
+
+def _wire_fraction(
+    value: Fraction,
+    *,
+    max_digits: int,
+) -> CanonicalRational | None:
+    if (
+        len(str(abs(value.numerator))) > max_digits
+        or len(str(value.denominator)) > max_digits
+    ):
+        return None
+    return CanonicalRational.from_fraction(value)
+
+
+def _wire_solution(
+    solution: dict[Any, Any],
+    symbols: tuple[Any, ...],
+    *,
+    max_digits: int,
+) -> tuple[CanonicalRational, ...] | None:
+    import sympy
+
+    values: list[CanonicalRational] = []
+    for symbol in symbols:
+        value = _wire(solution.get(symbol, sympy.S.Zero), max_digits=max_digits)
+        if value is None:
+            return None
+        values.append(value)
+    return tuple(values)
+
+
+def _wire_difference_solution(
+    solution: dict[Any, Any],
+    positive_symbols: tuple[Any, ...],
+    negative_symbols: tuple[Any, ...],
+    *,
+    max_digits: int,
+) -> tuple[CanonicalRational, ...] | None:
+    import sympy
+
+    values: list[CanonicalRational] = []
+    for positive, negative in zip(positive_symbols, negative_symbols, strict=True):
+        value = _wire(
+            solution.get(positive, sympy.S.Zero) - solution.get(negative, sympy.S.Zero),
+            max_digits=max_digits,
+        )
+        if value is None:
+            return None
+        values.append(value)
+    return tuple(values)
+
+
+def _program_arrays(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[tuple[Any, ...], tuple[tuple[Any, ...], ...], tuple[Any, ...]]:
+    return (
+        tuple(_rational(value) for value in program.objective),
+        tuple(tuple(_rational(value) for value in row) for row in program.coefficients),
+        tuple(_rational(value) for value in program.rhs),
+    )
+
+
+def _active_row_indices(program: StandardFormRationalLinearProgram) -> tuple[int, ...]:
+    """Return source rows that impose a nontrivial equality."""
+
+    return tuple(
+        index
+        for index, (row, rhs) in enumerate(
+            zip(program.coefficients, program.rhs, strict=True)
+        )
+        if any(value.num != "0" for value in row) or rhs.num != "0"
+    )
+
+
+def _expand_active_row_values(
+    values: tuple[CanonicalRational, ...],
+    indices: tuple[int, ...],
+    *,
+    source_rows: int,
+) -> tuple[CanonicalRational, ...]:
+    """Embed an auxiliary-row vector back into the source row coordinates."""
+
+    zero = CanonicalRational.from_integer_ratio(0, 1)
+    expanded = [zero] * source_rows
+    for index, value in zip(indices, values, strict=True):
+        expanded[index] = value
+    return tuple(expanded)
+
+
+def _solve_primal(
+    program: StandardFormRationalLinearProgram,
+    objective: tuple[Any, ...],
+    *,
+    symbol_prefix: str,
+) -> tuple[tuple[Any, ...], dict[Any, Any]]:
+    import sympy
+    from sympy.solvers.simplex import InfeasibleLPError, lpmin
+
+    _, coefficients, rhs = _program_arrays(program)
+    symbols = tuple(sympy.symbols(f"{symbol_prefix}0:{len(program.variables)}"))
+    constraints = []
+    for row, expected in zip(coefficients, rhs, strict=True):
+        if any(row):
+            constraints.append(
+                sympy.Eq(_linear(row, symbols), expected, evaluate=False)
+            )
+        elif expected:
+            raise InfeasibleLPError("zero coefficient row has a nonzero rhs")
+    constraints.extend(
+        sympy.Ge(symbol, sympy.S.Zero, evaluate=False) for symbol in symbols
+    )
+    _, solution = lpmin(_linear(objective, symbols), constraints)
+    return symbols, solution
+
+
+def _solve_dual(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[tuple[int, ...], tuple[Any, ...], dict[Any, Any]]:
+    import sympy
+    from sympy.solvers.simplex import lpmax
+
+    objective, all_coefficients, all_rhs = _program_arrays(program)
+    indices = _active_row_indices(program)
+    coefficients = tuple(all_coefficients[index] for index in indices)
+    rhs = tuple(all_rhs[index] for index in indices)
+    symbols = tuple(sympy.symbols(f"_lp_dual0:{len(rhs)}"))
+    constraints = [
+        sympy.Le(
+            _linear(
+                tuple(row[column] for row in coefficients),
+                symbols,
+            ),
+            objective[column],
+            evaluate=False,
+        )
+        for column in range(len(objective))
+    ]
+    _, solution = lpmax(_linear(rhs, symbols), constraints)
+    return indices, symbols, solution
+
+
+def _solve_farkas(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[tuple[int, ...], tuple[Any, ...], tuple[Any, ...], dict[Any, Any]]:
+    import sympy
+    from sympy.solvers.simplex import InfeasibleLPError, lpmin
+
+    _, all_coefficients, all_rhs = _program_arrays(program)
+    indices = _active_row_indices(program)
+    coefficients = tuple(all_coefficients[index] for index in indices)
+    rhs = tuple(all_rhs[index] for index in indices)
+    if not any(rhs):
+        raise InfeasibleLPError("Farkas normalization requires a nonzero rhs")
+    positive = tuple(sympy.symbols(f"_lp_farkas_positive0:{len(rhs)}"))
+    negative = tuple(sympy.symbols(f"_lp_farkas_negative0:{len(rhs)}"))
+    symbols = tuple(
+        positive_value - negative_value
+        for positive_value, negative_value in zip(positive, negative, strict=True)
+    )
+    constraints = [
+        sympy.Ge(
+            _linear(
+                tuple(row[column] for row in coefficients),
+                symbols,
+            ),
+            sympy.S.Zero,
+            evaluate=False,
+        )
+        for column in range(len(program.variables))
+    ]
+    constraints.append(
+        sympy.Eq(
+            _linear(rhs, symbols),
+            -sympy.S.One,
+            evaluate=False,
+        )
+    )
+    constraints.extend(
+        sympy.Ge(symbol, sympy.S.Zero, evaluate=False)
+        for symbol in (*positive, *negative)
+    )
+    _, solution = lpmin(sum((*positive, *negative), sympy.S.Zero), constraints)
+    return indices, positive, negative, solution
+
+
+def _solve_recession_direction(
+    program: StandardFormRationalLinearProgram,
+) -> tuple[tuple[Any, ...], dict[Any, Any]]:
+    import sympy
+    from sympy.solvers.simplex import InfeasibleLPError, lpmin
+
+    objective, coefficients, _ = _program_arrays(program)
+    if not any(objective):
+        raise InfeasibleLPError("a zero objective has no decreasing direction")
+    symbols = tuple(sympy.symbols(f"_lp_ray0:{len(program.variables)}"))
+    constraints = [
+        sympy.Eq(_linear(row, symbols), sympy.S.Zero, evaluate=False)
+        for row in coefficients
+        if any(row)
+    ]
+    constraints.append(
+        sympy.Eq(
+            _linear(objective, symbols),
+            -sympy.S.One,
+            evaluate=False,
+        )
+    )
+    constraints.extend(
+        sympy.Ge(symbol, sympy.S.Zero, evaluate=False) for symbol in symbols
+    )
+    one_objective = tuple(sympy.S.One for _ in symbols)
+    _, solution = lpmin(_linear(one_objective, symbols), constraints)
+    return symbols, solution
+
+
+def _primal_data(
+    program: StandardFormRationalLinearProgram,
+    candidate: tuple[CanonicalRational, ...],
+    *,
+    max_digits: int,
+) -> tuple[CanonicalRational, tuple[CanonicalRational, ...]] | None:
+    values = tuple(value.as_fraction() for value in candidate)
+    objective, residuals = _primal_diagnostics(program, values)
+    wire_objective = _wire_fraction(objective, max_digits=max_digits)
+    wire_residuals = tuple(
+        _wire_fraction(value, max_digits=max_digits) for value in residuals
+    )
+    if wire_objective is None or any(value is None for value in wire_residuals):
+        return None
+    return wire_objective, tuple(value for value in wire_residuals if value is not None)
+
+
+def _dual_data(
+    program: StandardFormRationalLinearProgram,
+    candidate: tuple[CanonicalRational, ...],
+    *,
+    max_digits: int,
+) -> tuple[CanonicalRational, tuple[CanonicalRational, ...]] | None:
+    values = tuple(value.as_fraction() for value in candidate)
+    objective, slacks = _dual_diagnostics(program, values)
+    wire_objective = _wire_fraction(objective, max_digits=max_digits)
+    wire_slacks = tuple(
+        _wire_fraction(value, max_digits=max_digits) for value in slacks
+    )
+    if wire_objective is None or any(value is None for value in wire_slacks):
+        return None
+    return wire_objective, tuple(value for value in wire_slacks if value is not None)
+
+
+def _unknown(
+    program: StandardFormRationalLinearProgram,
+) -> RationalLinearProgramResult:
+    return RationalLinearProgramResult(program=program, status="UNKNOWN")
+
+
+def _trivial_infeasibility(
+    program: StandardFormRationalLinearProgram,
+) -> RationalLinearProgramResult | None:
+    zero = CanonicalRational.from_integer_ratio(0, 1)
+    for row_index, (row, rhs) in enumerate(
+        zip(program.coefficients, program.rhs, strict=True)
+    ):
+        if any(value.num != "0" for value in row) or rhs.num == "0":
+            continue
+        witness = [zero] * len(program.rhs)
+        witness[row_index] = CanonicalRational.from_integer_ratio(
+            1 if rhs.num.startswith("-") else -1,
+            1,
+        )
+        return RationalLinearProgramResult(
+            program=program,
+            status="INFEASIBLE",
+            farkas_candidate=tuple(witness),
+        )
+    return None
+
+
+def _certify_infeasible(
+    program: StandardFormRationalLinearProgram,
+    *,
+    result_digits: int,
+) -> RationalLinearProgramResult:
+    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
+
+    try:
+        active_rows, positive_symbols, negative_symbols, farkas_solution = (
+            _solve_farkas(program)
+        )
+    except (
+        InfeasibleLPError,
+        UnboundedLPError,
+        AttributeError,
+        IndexError,
+        TypeError,
+        ValueError,
+        ZeroDivisionError,
+    ):
+        return _unknown(program)
+    active_farkas = _wire_difference_solution(
+        farkas_solution,
+        positive_symbols,
+        negative_symbols,
+        max_digits=result_digits,
+    )
+    if active_farkas is None:
+        return _unknown(program)
+    farkas = _expand_active_row_values(
+        active_farkas,
+        active_rows,
+        source_rows=len(program.rhs),
+    )
+    try:
+        return RationalLinearProgramResult(
+            program=program,
+            status="INFEASIBLE",
+            farkas_candidate=farkas,
+        )
+    except ValidationError:
+        return _unknown(program)
+
+
+def _certify_unbounded(
+    program: StandardFormRationalLinearProgram,
+    *,
+    result_digits: int,
+) -> RationalLinearProgramResult:
+    import sympy
+    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
+
+    feasibility_objective = tuple(sympy.S.One for _ in program.variables)
+    try:
+        feasible_symbols, feasible_solution = _solve_primal(
+            program,
+            feasibility_objective,
+            symbol_prefix="_lp_feasible",
+        )
+        ray_symbols, ray_solution = _solve_recession_direction(program)
+    except (
+        InfeasibleLPError,
+        UnboundedLPError,
+        AttributeError,
+        IndexError,
+        TypeError,
+        ValueError,
+        ZeroDivisionError,
+    ):
+        return _unknown(program)
+    feasible = _wire_solution(
+        feasible_solution,
+        feasible_symbols,
+        max_digits=result_digits,
+    )
+    ray = _wire_solution(
+        ray_solution,
+        ray_symbols,
+        max_digits=result_digits,
+    )
+    if feasible is None or ray is None:
+        return _unknown(program)
+    primal_data = _primal_data(
+        program,
+        feasible,
+        max_digits=result_digits,
+    )
+    if primal_data is None:
+        return _unknown(program)
+    primal_objective, primal_residuals = primal_data
+    try:
+        return RationalLinearProgramResult(
+            program=program,
+            status="UNBOUNDED",
+            primal_candidate=feasible,
+            primal_objective=primal_objective,
+            primal_residuals=primal_residuals,
+            recession_direction=ray,
+        )
+    except ValidationError:
+        return _unknown(program)
+
+
+def _positive_result(
+    program: StandardFormRationalLinearProgram,
+    primal_symbols: tuple[Any, ...],
+    primal_solution: dict[Any, Any],
+    *,
+    result_digits: int,
+) -> RationalLinearProgramResult:
+    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
+
+    primal = _wire_solution(
+        primal_solution,
+        primal_symbols,
+        max_digits=result_digits,
+    )
+    if primal is None:
+        return _certify_infeasible(program, result_digits=result_digits)
+    primal_data = _primal_data(program, primal, max_digits=result_digits)
+    if primal_data is None:
+        return _certify_infeasible(program, result_digits=result_digits)
+    primal_objective, primal_residuals = primal_data
+    try:
+        primal_result = RationalLinearProgramResult(
+            program=program,
+            status="PRIMAL_FEASIBLE",
+            primal_candidate=primal,
+            primal_objective=primal_objective,
+            primal_residuals=primal_residuals,
+        )
+    except ValidationError:
+        return _certify_infeasible(program, result_digits=result_digits)
+
+    if not _active_equations(program):
+        dual = tuple(CanonicalRational.from_integer_ratio(0, 1) for _ in program.rhs)
+    else:
+        try:
+            active_rows, dual_symbols, dual_solution = _solve_dual(program)
+        except (
+            InfeasibleLPError,
+            UnboundedLPError,
+            AttributeError,
+            IndexError,
+            TypeError,
+            ValueError,
+            ZeroDivisionError,
+        ):
+            return primal_result
+        converted_dual = _wire_solution(
+            dual_solution,
+            dual_symbols,
+            max_digits=result_digits,
+        )
+        if converted_dual is None:
+            return primal_result
+        dual = _expand_active_row_values(
+            converted_dual,
+            active_rows,
+            source_rows=len(program.rhs),
+        )
+    dual_data = _dual_data(program, dual, max_digits=result_digits)
+    if dual_data is None:
+        return primal_result
+    dual_objective, dual_slacks = dual_data
+    try:
+        return RationalLinearProgramResult(
+            program=program,
+            status="OPTIMAL",
+            primal_candidate=primal,
+            primal_objective=primal_objective,
+            primal_residuals=primal_residuals,
+            dual_candidate=dual,
+            dual_objective=dual_objective,
+            dual_slacks=dual_slacks,
+        )
+    except ValidationError:
+        return primal_result
 
 
 def _linear_program(
     request: RationalLinearProgramRequest,
 ) -> RationalLinearProgramResult:
     import sympy
-    from sympy.solvers.simplex import (
-        InfeasibleLPError,
-        UnboundedLPError,
-        linprog,
-        lpmax,
-    )
+    from sympy.solvers.simplex import InfeasibleLPError, UnboundedLPError
 
     program = request.program
-    objective = sympy.Matrix([[_rational(value) for value in program.objective]])
-    coefficients = sympy.Matrix(
-        [[_rational(value) for value in row] for row in program.coefficients]
+    trivial_infeasibility = _trivial_infeasibility(program)
+    if trivial_infeasibility is not None:
+        return trivial_infeasibility
+    result_digits = _result_digit_bound(program)
+    objective, _, _ = _program_arrays(program)
+    backend_objective = (
+        objective if any(objective) else tuple(sympy.S.One for _ in program.variables)
     )
-    rhs = sympy.Matrix([_rational(value) for value in program.rhs])
     try:
-        primal_value, primal_values = linprog(
-            objective,
-            A=coefficients.col_join(-coefficients),
-            b=rhs.col_join(-rhs),
+        primal_symbols, primal_solution = _solve_primal(
+            program,
+            backend_objective,
+            symbol_prefix="_lp_primal",
         )
     except InfeasibleLPError:
-        return RationalLinearProgramResult(
-            status="INFEASIBLE",
-        )
+        return _certify_infeasible(program, result_digits=result_digits)
     except UnboundedLPError:
-        return RationalLinearProgramResult(
-            status="UNBOUNDED",
-        )
-
-    if len(primal_values) != objective.cols:
-        raise RuntimeError("SymPy returned a primal candidate with the wrong dimension")
-    primal = sympy.Matrix(primal_values)
-    residuals = coefficients * primal - rhs
-    if any(value < 0 for value in primal) or any(value != 0 for value in residuals):
-        raise RuntimeError("SymPy returned an infeasible linear-program candidate")
-    primal_candidate = tuple(_wire(value) for value in primal)
-    primal_objective = _wire(primal_value)
-    primal_residuals = tuple(_wire(value) for value in residuals)
-    try:
-        dual_symbols = sympy.symbols(f"_dual0:{rhs.rows}")
-        dual_column = sympy.Matrix(dual_symbols)
-        dual_value, dual_solution = lpmax(
-            (rhs.transpose() * dual_column)[0],
-            [
-                sympy.Le(left, right, evaluate=False)
-                for left, right in zip(
-                    coefficients.transpose() * dual_column,
-                    objective.transpose(),
-                    strict=True,
-                )
-            ],
-        )
-    except (InfeasibleLPError, UnboundedLPError):
-        return RationalLinearProgramResult(
-            status="PRIMAL_FEASIBLE",
-            primal_candidate=primal_candidate,
-            primal_objective=primal_objective,
-            primal_residuals=primal_residuals,
-        )
-
-    dual_values = [dual_solution.get(symbol, sympy.S.Zero) for symbol in dual_symbols]
-    if len(dual_values) != rhs.rows:
-        raise RuntimeError("SymPy returned a dual candidate with the wrong dimension")
-    dual = sympy.Matrix(dual_values)
-    slacks = objective.transpose() - coefficients.transpose() * dual
-    if any(value < 0 for value in slacks) or primal_value != dual_value:
-        raise RuntimeError("SymPy returned inconsistent linear-program candidates")
-    return RationalLinearProgramResult(
-        status="OPTIMAL",
-        primal_candidate=primal_candidate,
-        primal_objective=primal_objective,
-        primal_residuals=primal_residuals,
-        dual_candidate=tuple(_wire(value) for value in dual),
-        dual_objective=_wire(dual_value),
-        dual_slacks=tuple(_wire(value) for value in slacks),
+        return _certify_unbounded(program, result_digits=result_digits)
+    except (AttributeError, IndexError, TypeError, ValueError, ZeroDivisionError):
+        return _unknown(program)
+    return _positive_result(
+        program,
+        primal_symbols,
+        primal_solution,
+        result_digits=result_digits,
     )
 
 
 RATIONAL_LINEAR_OPERATIONS: MathTools = (
     MathTool(
         operation_id="optimization.linear.rational_optimum.compute",
-        version="1",
+        version="2",
         title="Solve a rational linear program",
         description=(
-            "Use exact SymPy simplex calls to return an optimum, feasible point, "
-            "infeasibility, or unboundedness for a standard-form rational LP."
+            "Use exact SymPy simplex calls to return a source-bound standard-form "
+            "rational LP outcome. Optimal and feasible outcomes retain replayed "
+            "points; infeasible outcomes carry a Farkas witness; unbounded outcomes "
+            "carry a feasible point and recession direction; UNKNOWN makes no claim."
         ),
         request_type=RationalLinearProgramRequest,
         result_type=RationalLinearProgramResult,

--- a/tests/integration/linear/test_direct_linear_outcomes.py
+++ b/tests/integration/linear/test_direct_linear_outcomes.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from fractions import Fraction
+
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
 from tests.support.rationals import rational_payload as q
 
 from jacobian.math.matrices.rational_linear._models import (
@@ -11,7 +17,11 @@ from jacobian.math.matrices.rational_linear._operations import (
     compute_rational_inconsistency,
     compute_rational_solution,
 )
-from jacobian.math.optimization._models import RationalLinearProgramRequest
+from jacobian.math.optimization._models import (
+    RationalLinearProgramRequest,
+    RationalLinearProgramResult,
+    StandardFormRationalLinearProgram,
+)
 from jacobian.math.optimization._tools import TOOLS as OPTIMIZATION_TOOLS
 
 pytestmark = pytest.mark.requires_backend("flint")
@@ -23,6 +33,13 @@ def _system(rhs: list[dict[str, str]]) -> dict[str, object]:
         "coefficients": {"entries": [[q(1)] for _ in rhs]},
         "rhs": rhs,
     }
+
+
+def _run_linear_program(program: dict[str, object]) -> RationalLinearProgramResult:
+    request = RationalLinearProgramRequest.model_validate({"program": program})
+    result = OPTIMIZATION_TOOLS[0].run(request)
+    assert isinstance(result, RationalLinearProgramResult)
+    return result
 
 
 def test_rational_linear_operations_return_mathematical_outcomes() -> None:
@@ -53,7 +70,7 @@ def test_rational_linear_operations_return_mathematical_outcomes() -> None:
     assert contradiction.rhs_pairing.model_dump(mode="json") == q(1)
 
 
-def test_rational_linear_program_returns_an_optimum_not_a_certificate() -> None:
+def test_rational_linear_program_returns_a_source_bound_optimum() -> None:
     operation = OPTIMIZATION_TOOLS[0]
     result = operation.run(
         RationalLinearProgramRequest.model_validate(
@@ -69,9 +86,10 @@ def test_rational_linear_program_returns_an_optimum_not_a_certificate() -> None:
     )
 
     assert result.status == "OPTIMAL"
-    # Guard the public wire shape: an optimum carries exactly the primal/dual
-    # fields and no certificate, assurance, or other non-mathematical metadata.
+    # Guard the public wire shape: every conclusion retains the canonical source,
+    # while status-specific witnesses stay direct mathematical values.
     assert set(result.model_dump(mode="json")) == {
+        "program",
         "status",
         "primal_candidate",
         "dual_candidate",
@@ -79,7 +97,22 @@ def test_rational_linear_program_returns_an_optimum_not_a_certificate() -> None:
         "dual_objective",
         "primal_residuals",
         "dual_slacks",
+        "farkas_candidate",
+        "recession_direction",
     }
+    assert (
+        result.program
+        == RationalLinearProgramRequest.model_validate(
+            {
+                "program": {
+                    "variables": ["x"],
+                    "objective": [q(1)],
+                    "coefficients": [[q(1)]],
+                    "rhs": [q(1)],
+                }
+            }
+        ).program
+    )
     assert [v.model_dump(mode="json") for v in result.primal_candidate] == [q(1)]
     assert [v.model_dump(mode="json") for v in result.dual_candidate] == [q(1)]
     assert result.primal_objective.model_dump(mode="json") == q(1)
@@ -106,3 +139,410 @@ def test_rational_linear_program_handles_multiple_equalities() -> None:
     assert result.status == "OPTIMAL"
     assert [v.model_dump(mode="json") for v in result.primal_candidate] == [q(1), q(2)]
     assert [v.model_dump(mode="json") for v in result.primal_residuals] == [q(0), q(0)]
+
+
+def test_rational_linear_program_returns_a_replayable_farkas_witness() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(3), q(-2)],
+            "coefficients": [
+                [q(1), q(0)],
+                [q(0), q(1)],
+                [q(1), q(1)],
+            ],
+            "rhs": [q(0), q(0), q(1)],
+        }
+    )
+
+    assert result.status == "INFEASIBLE"
+    assert result.farkas_candidate is not None
+    witness = tuple(value.as_fraction() for value in result.farkas_candidate)
+    assert witness == (Fraction(1), Fraction(1), Fraction(-1))
+    assert result.primal_candidate is None
+    assert (
+        RationalLinearProgramResult.model_validate_json(result.model_dump_json())
+        == result
+    )
+
+
+def test_zero_coefficient_nonzero_rhs_has_a_direct_farkas_witness() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(0), q(0)],
+            "coefficients": [[q(0), q(0)], [q(1), q(-1)]],
+            "rhs": [q(-3), q(0)],
+        }
+    )
+
+    assert result.status == "INFEASIBLE"
+    assert result.farkas_candidate is not None
+    assert tuple(value.as_fraction() for value in result.farkas_candidate) == (
+        Fraction(1),
+        Fraction(0),
+    )
+
+
+def test_zero_equalities_are_pruned_from_farkas_backend_work() -> None:
+    from jacobian.math.optimization._operations import _solve_farkas
+
+    program = RationalLinearProgramRequest.model_validate(
+        {
+            "program": {
+                "variables": ["x", "y"],
+                "objective": [q(0), q(0)],
+                "coefficients": [[q(1), q(0)], [q(1), q(0)]]
+                + [[q(0), q(0)] for _ in range(62)],
+                "rhs": [q(0), q(1)] + [q(0) for _ in range(62)],
+            }
+        }
+    ).program
+
+    active_rows, positive, negative, _ = _solve_farkas(program)
+    assert active_rows == (0, 1)
+    assert len(positive) == len(negative) == 2
+
+    result = _run_linear_program(program.model_dump(mode="json"))
+    assert result.status == "INFEASIBLE"
+    assert result.farkas_candidate is not None
+    assert len(result.farkas_candidate) == 64
+    assert all(value.as_fraction() == 0 for value in result.farkas_candidate[2:])
+
+
+def test_rational_linear_program_returns_a_feasible_point_and_recession_ray() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(-1), q(0)],
+            "coefficients": [[q(1), q(-1)]],
+            "rhs": [q(1)],
+        }
+    )
+
+    assert result.status == "UNBOUNDED"
+    assert result.primal_candidate is not None
+    assert result.recession_direction is not None
+    point = tuple(value.as_fraction() for value in result.primal_candidate)
+    direction = tuple(value.as_fraction() for value in result.recession_direction)
+    assert point[0] - point[1] == 1
+    assert all(value >= 0 for value in point)
+    assert direction[0] - direction[1] == 0
+    assert all(value >= 0 for value in direction)
+    assert -direction[0] < 0
+
+
+@pytest.mark.parametrize(
+    ("objective", "expected_status"),
+    [
+        ([q(1), q(2)], "OPTIMAL"),
+        ([q(-1), q(2)], "UNBOUNDED"),
+    ],
+)
+def test_rational_linear_program_has_an_explicit_zero_row_convention(
+    objective: list[dict[str, str]],
+    expected_status: str,
+) -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": objective,
+            "coefficients": [],
+            "rhs": [],
+        }
+    )
+
+    assert result.status == expected_status
+    assert result.program.coefficients == ()
+    assert result.program.rhs == ()
+    assert result.primal_candidate is not None
+    assert result.primal_residuals == ()
+
+
+def test_rational_linear_program_handles_redundancy_degeneracy_and_rationals() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(1, 2), q(1, 2)],
+            "coefficients": [
+                [q(1, 3), q(1, 3)],
+                [q(2, 3), q(2, 3)],
+            ],
+            "rhs": [q(1, 3), q(2, 3)],
+        }
+    )
+
+    assert result.status == "OPTIMAL"
+    assert result.primal_objective is not None
+    assert result.dual_objective is not None
+    assert result.primal_objective.as_fraction() == Fraction(1, 2)
+    assert result.dual_objective.as_fraction() == Fraction(1, 2)
+    assert result.primal_residuals is not None
+    assert all(value.as_fraction() == 0 for value in result.primal_residuals)
+
+
+def test_source_derived_result_height_exceeds_input_scalar_limit() -> None:
+    scale = 10**127
+    first_rhs = Fraction(scale + 6, scale + 2)
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(0), q(0)],
+            "coefficients": [
+                [q(1, scale + 1), q(1, scale + 3)],
+                [q(1, scale + 5), q(1, scale + 7)],
+            ],
+            "rhs": [q(first_rhs.numerator, first_rhs.denominator), q(1)],
+        }
+    )
+
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert max(len(value.num.lstrip("-")) for value in result.primal_candidate) > 128
+    assert (
+        RationalLinearProgramResult.model_validate_json(
+            result.model_dump_json(), strict=True
+        )
+        == result
+    )
+
+
+def test_optimal_result_rejects_source_and_diagnostic_mutations() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x"],
+            "objective": [q(1)],
+            "coefficients": [[q(1)]],
+            "rhs": [q(1)],
+        }
+    )
+    payload = result.model_dump(mode="json")
+    mutations: list[tuple[tuple[str, ...], object]] = [
+        (("program", "rhs"), [q(2)]),
+        (("primal_candidate",), [q(2)]),
+        (("primal_objective",), q(2)),
+        (("primal_residuals",), [q(1)]),
+        (("dual_candidate",), [q(0)]),
+        (("dual_objective",), q(0)),
+        (("dual_slacks",), [q(1)]),
+    ]
+
+    for path, replacement in mutations:
+        mutated = deepcopy(payload)
+        target = mutated
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = replacement
+        with pytest.raises(ValidationError):
+            RationalLinearProgramResult.model_validate(mutated)
+
+
+def test_optimal_result_rejects_matrix_objective_and_variable_order_mutations() -> None:
+    result = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(1), q(3)],
+            "coefficients": [[q(1), q(0)], [q(0), q(1)]],
+            "rhs": [q(1), q(2)],
+        }
+    )
+    payload = result.model_dump(mode="json")
+    mutations = []
+
+    coefficient = deepcopy(payload)
+    coefficient["program"]["coefficients"][0][0] = q(2)
+    mutations.append(coefficient)
+    rhs = deepcopy(payload)
+    rhs["program"]["rhs"][0] = q(2)
+    mutations.append(rhs)
+    objective = deepcopy(payload)
+    objective["program"]["objective"][0] = q(2)
+    mutations.append(objective)
+    row = deepcopy(payload)
+    row["program"]["coefficients"] = [[q(0), q(1)], [q(1), q(0)]]
+    mutations.append(row)
+    variable_order = deepcopy(payload)
+    variable_order["program"]["variables"] = ["y", "x"]
+    variable_order["program"]["objective"] = [q(3), q(1)]
+    variable_order["program"]["coefficients"] = [
+        [q(0), q(1)],
+        [q(1), q(0)],
+    ]
+    mutations.append(variable_order)
+
+    for mutation in mutations:
+        with pytest.raises(ValidationError):
+            RationalLinearProgramResult.model_validate(mutation)
+
+
+def test_missing_dual_evidence_remains_primal_feasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sympy.solvers import simplex
+
+    def unavailable_dual(*_args: object, **_kwargs: object) -> None:
+        raise simplex.InfeasibleLPError("dual certificate unavailable")
+
+    monkeypatch.setattr(simplex, "lpmax", unavailable_dual)
+    result = _run_linear_program(
+        {
+            "variables": ["x"],
+            "objective": [q(1)],
+            "coefficients": [[q(1)]],
+            "rhs": [q(1)],
+        }
+    )
+
+    assert result.status == "PRIMAL_FEASIBLE"
+    assert result.primal_candidate is not None
+    assert result.dual_candidate is None
+
+
+def test_missing_negative_certificate_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sympy.solvers import simplex
+
+    def unavailable_simplex(*_args: object, **_kwargs: object) -> None:
+        raise simplex.InfeasibleLPError("certificate unavailable")
+
+    monkeypatch.setattr(simplex, "lpmin", unavailable_simplex)
+    result = _run_linear_program(
+        {
+            "variables": ["x"],
+            "objective": [q(0)],
+            "coefficients": [[q(1)], [q(1)]],
+            "rhs": [q(0), q(1)],
+        }
+    )
+
+    assert result.status == "UNKNOWN"
+    assert result.farkas_candidate is None
+    assert result.recession_direction is None
+
+
+def test_negative_results_reject_bare_or_source_mutated_claims() -> None:
+    infeasible = _run_linear_program(
+        {
+            "variables": ["x"],
+            "objective": [q(0)],
+            "coefficients": [[q(1)], [q(1)]],
+            "rhs": [q(0), q(1)],
+        }
+    ).model_dump(mode="json")
+    unbounded = _run_linear_program(
+        {
+            "variables": ["x", "y"],
+            "objective": [q(-1), q(0)],
+            "coefficients": [[q(1), q(-1)]],
+            "rhs": [q(1)],
+        }
+    ).model_dump(mode="json")
+
+    mutations = []
+    bare_infeasible = deepcopy(infeasible)
+    bare_infeasible["farkas_candidate"] = None
+    mutations.append(bare_infeasible)
+    zero_farkas = deepcopy(infeasible)
+    zero_farkas["farkas_candidate"] = [q(0), q(0)]
+    mutations.append(zero_farkas)
+    feasible_source = deepcopy(infeasible)
+    feasible_source["program"]["rhs"] = [q(0), q(0)]
+    mutations.append(feasible_source)
+    bare_unbounded = deepcopy(unbounded)
+    bare_unbounded["recession_direction"] = None
+    mutations.append(bare_unbounded)
+    flat_direction = deepcopy(unbounded)
+    flat_direction["recession_direction"] = [q(0), q(0)]
+    mutations.append(flat_direction)
+    bounded_source = deepcopy(unbounded)
+    bounded_source["program"]["objective"] = [q(1), q(0)]
+    mutations.append(bounded_source)
+
+    for mutation in mutations:
+        with pytest.raises(ValidationError):
+            RationalLinearProgramResult.model_validate(mutation)
+
+
+@st.composite
+def _diagonal_linear_programs(
+    draw: st.DrawFn,
+) -> tuple[dict[str, object], tuple[Fraction, ...], Fraction]:
+    dimension = draw(st.integers(min_value=1, max_value=4))
+    diagonal = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=9),
+            min_size=dimension,
+            max_size=dimension,
+        )
+    )
+    rhs = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=9),
+            min_size=dimension,
+            max_size=dimension,
+        )
+    )
+    objective = draw(
+        st.lists(
+            st.integers(min_value=-9, max_value=9),
+            min_size=dimension,
+            max_size=dimension,
+        )
+    )
+    point = tuple(Fraction(rhs[index], diagonal[index]) for index in range(dimension))
+    optimum = sum(
+        (Fraction(objective[index]) * point[index] for index in range(dimension)),
+        Fraction(),
+    )
+    coefficients = [
+        [q(diagonal[row]) if row == column else q(0) for column in range(dimension)]
+        for row in range(dimension)
+    ]
+    return (
+        {
+            "variables": [f"x{index}" for index in range(dimension)],
+            "objective": [q(value) for value in objective],
+            "coefficients": coefficients,
+            "rhs": [q(value) for value in rhs],
+        },
+        point,
+        optimum,
+    )
+
+
+@given(_diagonal_linear_programs())
+@settings(max_examples=30, deadline=None)
+def test_diagonal_linear_program_property(
+    case: tuple[dict[str, object], tuple[Fraction, ...], Fraction],
+) -> None:
+    program, expected_point, expected_optimum = case
+    result = _run_linear_program(program)
+
+    assert result.status == "OPTIMAL"
+    assert result.primal_candidate is not None
+    assert (
+        tuple(value.as_fraction() for value in result.primal_candidate)
+        == expected_point
+    )
+    assert result.primal_objective is not None
+    assert result.primal_objective.as_fraction() == expected_optimum
+
+
+def test_linear_program_admission_is_result_sensitive_but_bounds_all_bases() -> None:
+    maximum_shape = {
+        "variables": [f"x{index}" for index in range(32)],
+        "objective": [q(0)] * 32,
+        "coefficients": [[q(0)] * 32 for _ in range(64)],
+        "rhs": [q(0)] * 64,
+    }
+    assert StandardFormRationalLinearProgram.model_validate(maximum_shape)
+
+    excessive_work = {
+        "variables": [f"x{index}" for index in range(8)],
+        "objective": [q(0)] * 8,
+        "coefficients": [[q(1)] * 8 for _ in range(8)],
+        "rhs": [q(0)] * 8,
+    }
+    with pytest.raises(ValidationError, match="possible simplex bases"):
+        StandardFormRationalLinearProgram.model_validate(excessive_work)

--- a/tests/integration/linear/test_models.py
+++ b/tests/integration/linear/test_models.py
@@ -10,7 +10,10 @@ from jacobian.math.matrices.rational_linear._models import (
     LinearRationalSolutionResult,
     LinearRationalSystem,
 )
-from jacobian.math.optimization._models import RationalLinearProgramResult
+from jacobian.math.optimization._models import (
+    RationalLinearProgramResult,
+    StandardFormRationalLinearProgram,
+)
 
 
 def _system() -> dict[str, object]:
@@ -76,17 +79,67 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
         )
 
 
-def test_linear_program_outcomes_only_carry_their_mathematical_data() -> None:
-    with pytest.raises(ValidationError, match="cannot carry a point"):
-        RationalLinearProgramResult(
-            status="INFEASIBLE",
-            primal_candidate=(_q(1),),
+def test_linear_program_outcomes_require_status_specific_source_bound_data() -> None:
+    program = StandardFormRationalLinearProgram.model_validate(
+        {
+            "variables": ["x"],
+            "objective": [_q(1)],
+            "coefficients": [[_q(1)]],
+            "rhs": [_q(1)],
+        }
+    )
+    with pytest.raises(ValidationError, match="cannot carry primal data"):
+        RationalLinearProgramResult.model_validate(
+            {
+                "program": program,
+                "status": "INFEASIBLE",
+                "primal_candidate": [_q(1)],
+            }
         )
     with pytest.raises(ValidationError, match="only an optimal"):
-        RationalLinearProgramResult(
-            status="PRIMAL_FEASIBLE",
-            primal_candidate=(_q(1),),
-            primal_objective=_q(1),
-            primal_residuals=(_q(0),),
-            dual_candidate=(_q(1),),
+        RationalLinearProgramResult.model_validate(
+            {
+                "program": program,
+                "status": "PRIMAL_FEASIBLE",
+                "primal_candidate": [_q(1)],
+                "primal_objective": _q(1),
+                "primal_residuals": [_q(0)],
+                "dual_candidate": [_q(1)],
+            }
+        )
+
+
+def test_linear_program_raw_rational_bounds_precede_canonical_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jacobian._exact as exact
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> int:
+        raise AssertionError("raw LP admission must run before integer parsing")
+
+    monkeypatch.setattr(exact, "parse_canonical_integer", fail_if_called)
+    oversized = "9" * 129
+    with pytest.raises(ValidationError, match="128-digit bound"):
+        StandardFormRationalLinearProgram.model_validate(
+            {
+                "variables": ["x"],
+                "objective": [{"num": oversized, "den": "1"}],
+                "coefficients": [[_q(1)]],
+                "rhs": [_q(1)],
+            }
+        )
+
+    program = StandardFormRationalLinearProgram.model_construct(
+        variables=("x",),
+        objective=(_q(1),),
+        coefficients=((_q(1),),),
+        rhs=(_q(1),),
+    )
+    with pytest.raises(ValidationError, match="32768-digit bound"):
+        RationalLinearProgramResult.model_validate(
+            {
+                "program": program,
+                "status": "UNKNOWN",
+                "farkas_candidate": [{"num": "9" * 32_769, "den": "1"}],
+            }
         )


### PR DESCRIPTION
## Summary

Repairs the public contract of `optimization.linear.rational_optimum.compute` for its existing standard-form domain:

```text
minimize c^T x  subject to A x = b, x >= 0
```

Every mathematical result now retains the exact source program and replays its claim:

- `OPTIMAL` carries exact primal and dual points with derived residuals, slacks, objectives, and strong-duality equality.
- `PRIMAL_FEASIBLE` establishes only a replayed feasible point when no dual proof is available.
- `INFEASIBLE` carries a Farkas witness using `A^T y >= 0, b^T y < 0`.
- `UNBOUNDED` carries a replayed feasible point and nonnegative recession direction with `Ad = 0, c^T d < 0`.
- `UNKNOWN` carries no mathematical conclusion.

SymPy remains a private exact simplex producer. Jacobian owns canonical source binding, certificate types, replay, status semantics, and explicit work/result admission. Redundant `0 = 0` source rows are pruned from auxiliary dual/Farkas tableaux but restored as zero coordinates in public certificates, so the stated tableau envelope matches actual backend work.

Raw source input is limited to 128-digit rationals before generic parsing. Raw result transport uses the generic canonical pre-cap, then the result’s source-derived rational-height bound is replayed; this preserves legitimate large exact coordinates without admitting unbounded caller input.

This deliberately does not add general inequalities, bounds, or free variables; that representation extension remains #2277.

## Validation

- `make check` (2,649 passed)
- `make test-integration` (1,040 passed)
- Source/candidate/objective/matrix/order mutations, primal-only fallback, Farkas and recession negative controls, zero/redundant rows, strict JSON round trips, pre-parse limits, and large source-derived-coordinate regressions

An independent exact-diff review found the zero-row work-accounting and raw-bound gaps; both fixes were followed by focused, full, and integration validation.

Closes #2276
