### PR TITLE
feat(math): check uniform rank-3 chirotopes

### DIFF
--- a/src/jacobian/math/oriented_matroids/__init__.py
+++ b/src/jacobian/math/oriented_matroids/__init__.py
@@ -1,0 +1,3 @@
+"""Bounded exact operations on finite oriented-matroid data."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/oriented_matroids/_admission.py
+++ b/src/jacobian/math/oriented_matroids/_admission.py
@@ -1,0 +1,20 @@
+"""Owner-local admission decision for oriented-matroid operations."""
+
+from __future__ import annotations
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.oriented_matroids._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "oriented_matroid.chirotope.check",
+        AdmissionDecision.KEEP,
+        "exact bounded validity check with a source-bound first axiom obstruction",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/oriented_matroids/_models.py
+++ b/src/jacobian/math/oriented_matroids/_models.py
@@ -1,0 +1,174 @@
+"""Typed contracts for complete uniform rank-3 chirotope checks."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from itertools import combinations
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_GROUND_SIZE = 10
+"""The B2 bound: ``10**6 == 1_000_000`` ordered triple pairs."""
+
+MAX_CHIROTOPE_ENTRIES = 120
+"""``binomial(MAX_GROUND_SIZE, 3)`` materialized increasing triples."""
+
+MAX_B2_EXCHANGE_INSTANCES = MAX_GROUND_SIZE**6
+"""The complete B2 negative-case work bound for one mathematical scan."""
+
+SOURCE_BOUND_REPLAY_PASSES = 2
+"""One producer scan plus mandatory result-validation replay."""
+
+MAX_EXECUTION_B2_EXCHANGE_INSTANCES = (
+    SOURCE_BOUND_REPLAY_PASSES * MAX_B2_EXCHANGE_INSTANCES
+)
+"""The work envelope charged by one public checker invocation."""
+
+
+class Rank3ChirotopeEntry(StrictModel):
+    """One sign of a complete rank-3 table on an increasing triple."""
+
+    triple: tuple[StrictInt, StrictInt, StrictInt] = Field(
+        description=(
+            "An increasing triple 0 <= i < j < k < ground_size. Entries must "
+            "be the complete lexicographic list of such triples; ordered or "
+            "nonalternating presentations are not admitted."
+        )
+    )
+    sign: Literal[-1, 1] = Field(
+        description="The nonzero chirotope sign on this increasing triple."
+    )
+
+
+class UniformRank3Chirotope(StrictModel):
+    """A canonical, complete uniform rank-3 chirotope source table.
+
+    Ground elements are the ordered indices ``0, ..., ground_size - 1``.  The
+    table contains exactly one nonzero sign for each increasing triple, in
+    lexicographic order. Values on all ordered triples are its alternating
+    extension, so nonalternating or zero presentations are rejected at request
+    admission rather than reported as checker results. It is materialized
+    rather than an oracle or a generated table.
+    """
+
+    ground_size: StrictInt = Field(
+        ge=3,
+        le=MAX_GROUND_SIZE,
+        description=(
+            "Number n of indexed ground elements 0..n-1. The checker admits "
+            "n <= 10 because it reserves two B2 scans of n^6 pairs: at most "
+            "2,000,000 pair checks per public invocation."
+        ),
+    )
+    entries: tuple[Rank3ChirotopeEntry, ...] = Field(
+        min_length=1,
+        max_length=MAX_CHIROTOPE_ENTRIES,
+        description=(
+            "The complete lexicographically ordered list of increasing triples; "
+            "its length is exactly binomial(ground_size, 3)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_complete_canonical_table(self) -> Self:
+        if self.ground_size**6 > MAX_B2_EXCHANGE_INSTANCES:
+            raise ValueError(
+                "ground_size exceeds the one-scan B2 exchange work envelope"
+            )
+        expected = tuple(combinations(range(self.ground_size), 3))
+        actual = tuple(entry.triple for entry in self.entries)
+        if actual != expected:
+            raise ValueError(
+                "entries must be the complete lexicographic sequence of increasing "
+                "triples for ground_size"
+            )
+        return self
+
+
+class ChirotopeCheckStatus(StrEnum):
+    VALID = "VALID"
+    B2_OBSTRUCTION = "B2_OBSTRUCTION"
+
+
+class B2Obstruction(StrictModel):
+    """One ordered rank-3 B2 exchange instance whose implication fails."""
+
+    kind: Literal["B2"] = "B2"
+    x: tuple[StrictInt, StrictInt, StrictInt]
+    y: tuple[StrictInt, StrictInt, StrictInt]
+    premise_factors: tuple[
+        tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+        tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+        tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+    ]
+    premise_products: tuple[StrictInt, StrictInt, StrictInt]
+    conclusion_factors: tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]]
+    conclusion_product: StrictInt
+
+    @model_validator(mode="after")
+    def require_recorded_products(self) -> Self:
+        if self.premise_products != tuple(
+            left * right for left, right in self.premise_factors
+        ):
+            raise ValueError("premise_products must match premise_factors")
+        if self.conclusion_product != (
+            self.conclusion_factors[0] * self.conclusion_factors[1]
+        ):
+            raise ValueError("conclusion_product must match conclusion_factors")
+        return self
+
+
+class ChirotopeCheckRequest(StrictModel):
+    """Check the complete rank-3 B2 chirotope axiom of one canonical table."""
+
+    chirotope: UniformRank3Chirotope
+
+
+class ChirotopeCheckResult(StrictModel):
+    """A source-bound exact validity result or deterministic first obstruction."""
+
+    chirotope: UniformRank3Chirotope
+    status: ChirotopeCheckStatus = Field(
+        description=(
+            "VALID after every B2 ordered-triple pair passes, or the first B2 "
+            "obstruction in lexicographic order."
+        )
+    )
+    b2_exchange_instances_checked: StrictInt = Field(
+        ge=0,
+        description=(
+            "Pairs checked in one mathematical producer scan. The mandatory "
+            "source-bound replay performs the same scan again but is not added "
+            "to this mathematical count."
+        ),
+    )
+    obstruction: B2Obstruction | None = None
+
+    @model_validator(mode="after")
+    def replay_complete_check(self) -> Self:
+        from jacobian.math.oriented_matroids._operations import _expected_result
+
+        expected = _expected_result(ChirotopeCheckRequest(chirotope=self.chirotope))
+        if self != expected:
+            raise ValueError(
+                "result must be the exact axiom replay of the retained chirotope"
+            )
+        return self
+
+
+__all__ = [
+    "MAX_B2_EXCHANGE_INSTANCES",
+    "MAX_CHIROTOPE_ENTRIES",
+    "MAX_EXECUTION_B2_EXCHANGE_INSTANCES",
+    "MAX_GROUND_SIZE",
+    "SOURCE_BOUND_REPLAY_PASSES",
+    "B2Obstruction",
+    "ChirotopeCheckRequest",
+    "ChirotopeCheckResult",
+    "ChirotopeCheckStatus",
+    "Rank3ChirotopeEntry",
+    "UniformRank3Chirotope",
+]

--- a/src/jacobian/math/oriented_matroids/_operations.py
+++ b/src/jacobian/math/oriented_matroids/_operations.py
@@ -1,0 +1,144 @@
+"""Exact finite rank-3 chirotope-axiom enumeration."""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Literal, cast
+
+from jacobian.math.oriented_matroids._models import (
+    B2Obstruction,
+    ChirotopeCheckRequest,
+    ChirotopeCheckResult,
+    ChirotopeCheckStatus,
+    UniformRank3Chirotope,
+)
+
+type Triple = tuple[int, int, int]
+
+
+def _permutation_sign(triple: tuple[int, int, int]) -> int:
+    """Return the sign of a distinct triple's sorting permutation."""
+
+    inversions = sum(
+        triple[left] > triple[right]
+        for left in range(3)
+        for right in range(left + 1, 3)
+    )
+    return -1 if inversions % 2 else 1
+
+
+def _alternating_value(
+    table: dict[Triple, int],
+    triple: Triple,
+) -> int:
+    """Evaluate the table's alternating extension without any coercion."""
+
+    if len(set(triple)) != 3:
+        return 0
+    increasing = cast(Triple, tuple(sorted(triple)))
+    return _permutation_sign(triple) * table[increasing]
+
+
+def _table(chirotope: UniformRank3Chirotope) -> dict[Triple, int]:
+    return {entry.triple: entry.sign for entry in chirotope.entries}
+
+
+def _ordered_triples(ground_size: int) -> tuple[Triple, ...]:
+    return tuple(
+        (first, second, third)
+        for first, second, third in product(range(ground_size), repeat=3)
+    )
+
+
+def _result(
+    chirotope: UniformRank3Chirotope,
+    status: ChirotopeCheckStatus,
+    b2_exchange_instances_checked: int,
+    obstruction: B2Obstruction | None,
+) -> ChirotopeCheckResult:
+    return ChirotopeCheckResult.model_construct(
+        chirotope=chirotope,
+        status=status,
+        b2_exchange_instances_checked=b2_exchange_instances_checked,
+        obstruction=obstruction,
+    )
+
+
+def _expected_result(request: ChirotopeCheckRequest) -> ChirotopeCheckResult:
+    """Exhaustively check the complete rank-3 B2 axiom.
+
+    The materialized request pre-bounds the direct enumeration: at most
+    ``10**6`` B2 pairs. The first failed instance is deterministic because the
+    loop is lexicographic. Alternation is structural in the canonical request
+    table.
+    """
+
+    chirotope = request.chirotope
+    table = _table(chirotope)
+    ordered_triples = _ordered_triples(chirotope.ground_size)
+    values = {triple: _alternating_value(table, triple) for triple in ordered_triples}
+
+    b2_checked = 0
+    for x in ordered_triples:
+        x1, x2, x3 = x
+        x_value = values[x]
+        for y in ordered_triples:
+            b2_checked += 1
+            y1, y2, y3 = y
+            premises = (
+                values[(y1, x2, x3)] * values[(x1, y2, y3)],
+                values[(y2, x2, x3)] * values[(y1, x1, y3)],
+                values[(y3, x2, x3)] * values[(y1, y2, x1)],
+            )
+            conclusion = x_value * values[y]
+            if all(value >= 0 for value in premises) and conclusion < 0:
+                premise_factors = (
+                    (values[(y1, x2, x3)], values[(x1, y2, y3)]),
+                    (values[(y2, x2, x3)], values[(y1, x1, y3)]),
+                    (values[(y3, x2, x3)], values[(y1, y2, x1)]),
+                )
+                conclusion_factors = (x_value, values[y])
+                return _result(
+                    chirotope,
+                    ChirotopeCheckStatus.B2_OBSTRUCTION,
+                    b2_checked,
+                    B2Obstruction(
+                        x=x,
+                        y=y,
+                        premise_factors=cast(
+                            tuple[
+                                tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+                                tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+                                tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+                            ],
+                            premise_factors,
+                        ),
+                        premise_products=premises,
+                        conclusion_factors=cast(
+                            tuple[Literal[-1, 0, 1], Literal[-1, 0, 1]],
+                            conclusion_factors,
+                        ),
+                        conclusion_product=conclusion,
+                    ),
+                )
+
+    return _result(
+        chirotope,
+        ChirotopeCheckStatus.VALID,
+        b2_checked,
+        None,
+    )
+
+
+def check_chirotope(request: ChirotopeCheckRequest) -> ChirotopeCheckResult:
+    """Return a result after producer and source-bound replay scans.
+
+    The reported count describes the first mathematical scan. Constructing the
+    result through ``model_validate`` performs the mandatory second replay scan;
+    admission reserves both scans before this function is entered.
+    """
+
+    return ChirotopeCheckResult.model_validate(_expected_result(request).model_dump())
+
+
+__all__ = ["check_chirotope"]

--- a/src/jacobian/math/oriented_matroids/_tools.py
+++ b/src/jacobian/math/oriented_matroids/_tools.py
@@ -1,0 +1,54 @@
+"""Oriented-matroid operation declarations."""
+
+from typing import Any
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.oriented_matroids._models import (
+    ChirotopeCheckRequest,
+    ChirotopeCheckResult,
+)
+from jacobian.math.oriented_matroids._operations import check_chirotope
+
+_ALTERNATING_RANK3_EXAMPLE: dict[str, Any] = {
+    "chirotope": {
+        "ground_size": 4,
+        "entries": [
+            {"triple": [0, 1, 2], "sign": 1},
+            {"triple": [0, 1, 3], "sign": 1},
+            {"triple": [0, 2, 3], "sign": 1},
+            {"triple": [1, 2, 3], "sign": 1},
+        ],
+    }
+}
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    MathTool(
+        operation_id="oriented_matroid.chirotope.check",
+        version="1",
+        title="Check a complete uniform rank-3 chirotope",
+        description=(
+            "Exhaustively validate the complete rank-3 B2 exchange axiom of one "
+            "canonical uniform rank-3 sign table. The source must be the "
+            "lexicographic table on indexed elements 0..n-1 with n <= 10; the "
+            "result gives exact checked counts and the first obstruction, if any. "
+            "Nonalternating or zero presentations are rejected at request "
+            "admission. Each public invocation reserves one producer scan and one "
+            "source-bound replay scan, while the reported count describes one scan."
+        ),
+        request_type=ChirotopeCheckRequest,
+        result_type=ChirotopeCheckResult,
+        run=check_chirotope,
+        tags=("oriented-matroid", "chirotope", "exact"),
+        examples=(
+            example(
+                "alternating_rank3_four_elements",
+                "Check the alternating rank-3 chirotope on four indexed elements; "
+                "the input lists every increasing triple in lexicographic order.",
+                _ALTERNATING_RANK3_EXAMPLE,
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/tests/math/oriented_matroids/__init__.py
+++ b/tests/math/oriented_matroids/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for bounded oriented-matroid operations."""

--- a/tests/math/oriented_matroids/test_chirotope.py
+++ b/tests/math/oriented_matroids/test_chirotope.py
@@ -1,0 +1,296 @@
+"""Contract and exactness tests for rank-3 chirotope validation (#1767)."""
+
+# ruff: noqa: SIM905
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any, cast
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.oriented_matroids._models import (
+    MAX_B2_EXCHANGE_INSTANCES,
+    MAX_EXECUTION_B2_EXCHANGE_INSTANCES,
+    SOURCE_BOUND_REPLAY_PASSES,
+    ChirotopeCheckRequest,
+    ChirotopeCheckResult,
+    ChirotopeCheckStatus,
+    UniformRank3Chirotope,
+)
+from jacobian.math.oriented_matroids._operations import (
+    _alternating_value,
+    check_chirotope,
+)
+from jacobian.math.oriented_matroids._tools import TOOLS
+
+type Triple = tuple[int, int, int]
+
+
+def _increasing_triples(ground_size: int) -> tuple[Triple, ...]:
+    return tuple(combinations(range(ground_size), 3))
+
+
+def _table_from_signs(ground_size: int, signs: dict[Triple, int]) -> dict[str, Any]:
+    return {
+        "ground_size": ground_size,
+        "entries": [
+            {"triple": triple, "sign": signs[triple]}
+            for triple in _increasing_triples(ground_size)
+        ],
+    }
+
+
+def _alternating_table(ground_size: int) -> dict[str, Any]:
+    return _table_from_signs(
+        ground_size,
+        dict.fromkeys(_increasing_triples(ground_size), 1),
+    )
+
+
+def _ringel_table() -> dict[str, Any]:
+    """Independent transcription of Atlas's two-projection Ringel fixture."""
+
+    # Convention/known-answer fixture only: it does not identify the historical
+    # pictured object or assert realizability. Immutable upstream source:
+    # https://raw.githubusercontent.com/techno-optimist/erdos-frontier-atlas/04e44966932bf8093553eb79788652fa6cba71a1/certificates/ringel-nonstretchability/fidelity/chirotope_axioms.py
+    # Revision 04e44966932bf8093553eb79788652fa6cba71a1; SHA-256
+    # 939079eda82bbfb79f0e1a6683408f3579e69420139d4a1205dd3502cd565bc9.
+
+    z_positive = (
+        "127 134 135 136 137 138 145 146 147 148 157 167 168 234 235 236 "
+        "237 238 245 246 247 248 256 257 258 267 268 345 346 347 348 357 367 "
+        "368 567 568"
+    ).split()
+    z_negative = (
+        "123 124 125 126 128 156 158 178 278 356 358 378 456 457 458 467 468 "
+        "478 578 678"
+    ).split()
+    s_positive = (
+        "081 082 083 085 086 084 012 013 015 016 014 023 025 026 024 035 036 "
+        "034 056 812 815 835 135 136 134 235 236 234 256"
+    ).split()
+    s_negative = (
+        "054 064 813 816 814 823 825 826 824 836 834 856 854 864 123 125 126 "
+        "124 156 154 164 254 264 356 354 364 564"
+    ).split()
+
+    def permutation_sign(triple: Triple) -> int:
+        inversions = sum(
+            triple[left] > triple[right]
+            for left in range(3)
+            for right in range(left + 1, 3)
+        )
+        return -1 if inversions % 2 else 1
+
+    def parse(positive: list[str], negative: list[str]) -> dict[Triple, int]:
+        signs: dict[Triple, int] = {}
+        for raw, sign in [(item, 1) for item in positive] + [
+            (item, -1) for item in negative
+        ]:
+            triple = cast(Triple, tuple(int(value) for value in raw))
+            signs[cast(Triple, tuple(sorted(triple)))] = sign * permutation_sign(triple)
+        return signs
+
+    first_projection = parse(z_positive, z_negative)
+    second_projection = {
+        triple: sign * (-1 if 8 in triple else 1)
+        for triple, sign in parse(s_positive, s_negative).items()
+    }
+    signs = first_projection | second_projection
+    for index in (1, 2, 3, 4, 5, 6, 8):
+        signs[cast(Triple, tuple(sorted((0, index, 7))))] = 1
+    assert len(signs) == 84
+    return _table_from_signs(9, signs)
+
+
+def _reorient(table: dict[str, Any], reoriented: set[int]) -> dict[str, Any]:
+    signs = {tuple(entry["triple"]): entry["sign"] for entry in table["entries"]}
+    return _table_from_signs(
+        table["ground_size"],
+        {
+            triple: sign * (-1 if len(set(triple) & reoriented) % 2 else 1)
+            for triple, sign in signs.items()
+        },
+    )
+
+
+def _relabel(table: dict[str, Any], permutation: tuple[int, ...]) -> dict[str, Any]:
+    old_signs = {tuple(entry["triple"]): entry["sign"] for entry in table["entries"]}
+    inverse = {new: old for old, new in enumerate(permutation)}
+    old_values = old_signs
+    return _table_from_signs(
+        table["ground_size"],
+        {
+            triple: _alternating_value(
+                old_values, cast(Triple, tuple(inverse[index] for index in triple))
+            )
+            for triple in _increasing_triples(table["ground_size"])
+        },
+    )
+
+
+class TestCanonicalUniformRank3Table:
+    def test_rejects_zero_sign_before_axiom_enumeration(self) -> None:
+        table = _alternating_table(4)
+        table["entries"][0]["sign"] = 0
+        with pytest.raises(ValidationError, match="Input should be -1 or 1"):
+            ChirotopeCheckRequest.model_validate({"chirotope": table})
+
+    def test_rejects_missing_or_reordered_triples(self) -> None:
+        table = _alternating_table(4)
+        table["entries"][1], table["entries"][2] = (
+            table["entries"][2],
+            table["entries"][1],
+        )
+        with pytest.raises(ValidationError, match="complete lexicographic"):
+            UniformRank3Chirotope.model_validate(table)
+
+    def test_b2_budget_admits_nine_and_ten_but_rejects_eleven(self) -> None:
+        assert (
+            UniformRank3Chirotope.model_validate(_alternating_table(10)).ground_size
+            == 10
+        )
+        oversized = _alternating_table(11)
+        with pytest.raises(ValidationError, match="less than or equal to 10"):
+            UniformRank3Chirotope.model_validate(oversized)
+
+
+class TestChirotopeCheck:
+    def test_alternating_rank3_fixture_has_exact_counts(self) -> None:
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": _alternating_table(4)})
+        )
+        assert result.status is ChirotopeCheckStatus.VALID
+        assert result.b2_exchange_instances_checked == 4**6
+        assert result.obstruction is None
+
+    def test_ringel_fixture_replays_all_cited_b2_instances(self) -> None:
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": _ringel_table()})
+        )
+        assert result.status is ChirotopeCheckStatus.VALID
+        assert result.b2_exchange_instances_checked == 9**6 == 531_441
+        assert ChirotopeCheckResult.model_validate(result.model_dump()) == result
+
+    def test_one_entry_mutation_returns_deterministic_b2_obstruction(self) -> None:
+        table = _ringel_table()
+        table["entries"][0]["sign"] *= -1
+        request = ChirotopeCheckRequest.model_validate({"chirotope": table})
+        first = check_chirotope(request)
+        second = check_chirotope(request)
+        assert first == second
+        assert first.status is ChirotopeCheckStatus.B2_OBSTRUCTION
+        assert first.b2_exchange_instances_checked < 9**6
+        assert first.obstruction is not None
+        assert first.obstruction.kind == "B2"
+        assert all(value >= 0 for value in first.obstruction.premise_products)
+        assert first.obstruction.conclusion_product < 0
+        assert all(
+            left * right == product
+            for (left, right), product in zip(
+                first.obstruction.premise_factors,
+                first.obstruction.premise_products,
+                strict=True,
+            )
+        )
+        assert (
+            first.obstruction.conclusion_factors[0]
+            * first.obstruction.conclusion_factors[1]
+            == first.obstruction.conclusion_product
+        )
+
+    def test_reorientation_and_relabelling_preserve_validity(self) -> None:
+        table = _ringel_table()
+        reoriented = _reorient(table, {1, 4, 8})
+        relabelled = _relabel(reoriented, (8, 4, 7, 0, 5, 2, 1, 3, 6))
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": relabelled})
+        )
+        assert result.status is ChirotopeCheckStatus.VALID
+        assert result.b2_exchange_instances_checked == 531_441
+
+    def test_result_replay_rejects_source_and_conclusion_corruption(self) -> None:
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": _ringel_table()})
+        )
+        source_corruption = result.model_dump(mode="json")
+        source_corruption["chirotope"]["entries"][0]["sign"] *= -1
+        with pytest.raises(ValidationError, match="exact axiom replay"):
+            ChirotopeCheckResult.model_validate(source_corruption)
+
+        conclusion_corruption = result.model_dump(mode="json")
+        conclusion_corruption["b2_exchange_instances_checked"] -= 1
+        with pytest.raises(ValidationError, match="exact axiom replay"):
+            ChirotopeCheckResult.model_validate(conclusion_corruption)
+
+    def test_result_replay_rejects_corrupted_b2_witness(self) -> None:
+        table = _ringel_table()
+        table["entries"][0]["sign"] *= -1
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": table})
+        )
+        witness_corruption = result.model_dump(mode="json")
+        assert witness_corruption["obstruction"] is not None
+        original_x = witness_corruption["obstruction"]["x"]
+        witness_corruption["obstruction"]["x"] = [
+            (original_x[0] + 1) % 9,
+            original_x[1],
+            original_x[2],
+        ]
+        with pytest.raises(ValidationError, match="exact axiom replay"):
+            ChirotopeCheckResult.model_validate(witness_corruption)
+
+    def test_boundary_ten_reserves_two_b2_scans(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from jacobian.math.oriented_matroids import _operations
+
+        calls = 0
+        original = _operations._expected_result
+
+        def count_scan(request: ChirotopeCheckRequest) -> ChirotopeCheckResult:
+            nonlocal calls
+            calls += 1
+            return original(request)
+
+        monkeypatch.setattr(_operations, "_expected_result", count_scan)
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate({"chirotope": _alternating_table(10)})
+        )
+        assert result.status is ChirotopeCheckStatus.VALID
+        assert result.b2_exchange_instances_checked == MAX_B2_EXCHANGE_INSTANCES
+        assert calls == SOURCE_BOUND_REPLAY_PASSES == 2
+        assert MAX_EXECUTION_B2_EXCHANGE_INSTANCES == 2_000_000
+
+
+class TestIndependentOracleAndCatalog:
+    def test_exact_vandermonde_determinant_signs_are_valid(self) -> None:
+        """A direct determinant formula independently supplies chi(i,j,k)."""
+
+        parameters = (-5, -2, 0, 3, 7, 11)
+        signs = {
+            (i, j, k): 1
+            if (parameters[j] - parameters[i])
+            * (parameters[k] - parameters[i])
+            * (parameters[k] - parameters[j])
+            > 0
+            else -1
+            for i, j, k in combinations(range(len(parameters)), 3)
+        }
+        result = check_chirotope(
+            ChirotopeCheckRequest.model_validate(
+                {"chirotope": _table_from_signs(len(parameters), signs)}
+            )
+        )
+        assert result.status is ChirotopeCheckStatus.VALID
+
+    def test_catalog_example_executes_the_published_contract(self) -> None:
+        tool = next(
+            tool
+            for tool in TOOLS
+            if tool.operation_id == "oriented_matroid.chirotope.check"
+        )
+        request = tool.request_type.model_validate(tool.examples[0].input)
+        assert tool.run(request).status is ChirotopeCheckStatus.VALID


### PR DESCRIPTION
## Problem

Closes #1767.

A complete rank-3 chirotope sign table needs a finite, source-bound validity check that can explain the first failed axiom instance. Existing linear-matroid operations do not carry oriented signs, and a realizability solver would be a materially different operation.

## Solution

Add `oriented_matroid.chirotope.check`. It accepts one canonical complete lexicographic table of nonzero signs on increasing triples of `0..n-1`, with `n <= 10`, and returns either `VALID` or the first deterministic B2'' exchange obstruction. Ordered, zero, and nonalternating presentations are rejected while constructing the canonical source; alternation is therefore not an unreachable result branch.

The direct finite kernel enumerates the complete B2'' domain in lexicographic order. The result retains the source, scanned one-pass count, and factor-level obstruction data; validation independently replays the scan. Execution reserves two scans—producer plus source-bound result replay—so the `n=10` ceiling is explicitly 2,000,000 checked instances while the mathematical result reports its 1,000,000-instance complete scan.

The Ringel convention fixture is pinned to an immutable upstream revision and checksum. It is used as a known-answer/convention anchor, alongside a separate exact Vandermonde-determinant oracle; it does not claim realizability or historical object identity.

Suggested review order:

1. Canonical source and replay contract in `_models.py`.
2. B2'' enumeration and deterministic witness construction in `_operations.py`.
3. Catalog/admission declaration.
4. Boundary, source-backed, oracle, and corruption tests.

## Testing

- `make check` — Ruff, mypy, and 3,529 Lean-free owner tests passed.
- `make test-math TESTS=tests/math/oriented_matroids` — 12 passed.
- Focused catalog/admission/example validation — 19 passed.

## Public contract impact

Adds one operation ID with typed request/result models. Its result is exactly `VALID` or a B2 obstruction; the three-term Grassmann--Pluecker check is not exposed as a redundant dead result branch because B2'' is the complete canonical chirotope axiom in this domain.

## Public operation admission

- Concrete gap: no current operation validates a materialized oriented rank-3 sign table or binds an axiom obstruction to it.
- Why existing operations or typed values are insufficient: finite-field linear-matroid closure does not represent oriented signs or chirotope axioms.
- Stable mathematical result: a complete canonical B2'' validity decision with a deterministic failed exchange witness.
- Semantic domain and admitted execution envelope: complete uniform rank-3 sign tables on indexed ground sets of size 3 through 10.
- Controlling work, intermediate, memory, and output quantities: at most 120 retained table entries; one 1,000,000-instance mathematical scan; two charged execution scans; and one constant-size obstruction.
- Exact representation, algorithm regimes, and maintained backend: direct bounded sign arithmetic and lexicographic enumeration; no TOPCOM, polymake, subprocess, parser, or solver dependency.
- Remaining fixed caps and their classification: `n <= 10` is a conservative finite-enumeration cap chosen from the explicit two-pass B2'' envelope.
- Admission decision: KEEP. This is a reusable exact validity primitive for oriented-matroid constructions and counterexamples.

## Closure matrix

None. This PR adds the one bounded checker selected by the issue comments; realizability remains a separate problem.

## Checklist

- [x] `make check` passes
- [x] Relevant domain and catalog/example validation is listed above
- [x] Harbor validation is not applicable
- [x] The public operation has an owner-local admission decision
- [x] The result is exact and source-bound
- [x] Bounds include the `n=10` accepted and `n=11` rejected boundary, plus producer/replay accounting
