### PR TITLE
fix(code): source-bind linear-code invariant results and replay exact claims

### DIFF
--- a/src/jacobian/math/code_theory/_admission.py
+++ b/src/jacobian/math/code_theory/_admission.py
@@ -13,17 +13,23 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "code.covering_radius.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "exact covering radius bound to its retained source code and "
+        "replayed by bounded syndrome-graph BFS within the declared "
+        "state and transition bounds",
     ),
     OperationAdmission(
         "code.minimum_distance.compute",
         AdmissionDecision.KEEP,
-        "distinct exact or explicitly bounded search outcome with material computational leverage",
+        "exact minimum nonzero codeword weight bound to its retained "
+        "source code and replayed by exact enumeration, including the "
+        "documented zero-code length-n empty-code convention",
     ),
     OperationAdmission(
         "code.weight_distribution.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "exact codeword weight profile bound to its retained source "
+        "code and replayed by exact enumeration with strictly ascending "
+        "positive counts summing to q^rank",
     ),
     OperationAdmission(
         "code.dual_code.compute",

--- a/src/jacobian/math/code_theory/_models.py
+++ b/src/jacobian/math/code_theory/_models.py
@@ -89,7 +89,11 @@ class MinimumDistanceResult(StrictModel):
     Retains the canonical source code (prime field order and generator
     matrix) so validation replays the exact enumeration: the claimed
     distance lies in ``[0, n]`` and equals the minimum nonzero Hamming
-    weight over the distinct generated codewords of the retained generator.
+    weight over the distinct generated codewords of the retained
+    generator. For the zero code (rank 0) the generated codeword set is
+    ``{0}``, so no nonzero codeword exists; the claimed distance is then
+    the code length ``n`` by the empty-code convention and is not the
+    weight of any generated word.
     """
 
     request: LinearCodeRequest

--- a/src/jacobian/math/code_theory/_models.py
+++ b/src/jacobian/math/code_theory/_models.py
@@ -84,13 +84,87 @@ class LinearCodeRequest(StrictModel):
 
 
 class MinimumDistanceResult(StrictModel):
-    minimum_distance: int = Field(ge=0, le=10000)
+    """The exact minimum nonzero codeword weight bound to its source code.
+
+    Retains the canonical source code (prime field order and generator
+    matrix) so validation replays the exact enumeration: the claimed
+    distance lies in ``[0, n]`` and equals the minimum nonzero Hamming
+    weight over the distinct generated codewords of the retained generator.
+    """
+
+    request: LinearCodeRequest
+    minimum_distance: int = Field(ge=0, le=256)
     method: Literal["EXACT_ENUMERATION"] = "EXACT_ENUMERATION"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.code_theory.operations import (
+            minimum_distance as replay_minimum_distance,
+        )
+
+        width = len(self.request.generator_matrix[0])
+        if self.minimum_distance > width:
+            raise ValueError("minimum distance must lie in [0, code length]")
+        if (
+            replay_minimum_distance(
+                self.request.generator_matrix, self.request.field_order
+            )
+            != self.minimum_distance
+        ):
+            raise ValueError(
+                "minimum distance must be the exact enumeration of the "
+                "retained source code"
+            )
+        return self
 
 
 class WeightDistributionResult(StrictModel):
+    """The exact weight distribution bound to its source code.
+
+    Retains the canonical source code so validation replays the defining
+    relations: rows are canonically ordered with positive counts and weights
+    in ``[0, n]``, counts sum to the number of distinct generated codewords
+    (``q^rank``), and the profile equals the exact enumeration.
+    """
+
+    request: LinearCodeRequest
     weights: tuple[tuple[int, int], ...] = Field(max_length=10000)
     method: Literal["EXACT_ENUMERATION"] = "EXACT_ENUMERATION"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.code_theory._models import _matrix_rank_mod_prime
+        from jacobian.math.code_theory.operations import (
+            weight_distribution as replay_weight_distribution,
+        )
+
+        width = len(self.request.generator_matrix[0])
+        seen_weights: list[int] = []
+        for weight, count in self.weights:
+            if not 0 <= weight <= width:
+                raise ValueError("weight rows must lie in [0, code length]")
+            if count < 1:
+                raise ValueError("weight counts must be positive")
+            if seen_weights and weight <= seen_weights[-1]:
+                raise ValueError("weight rows must be strictly ascending and unique")
+            seen_weights.append(weight)
+        rank = _matrix_rank_mod_prime(
+            self.request.generator_matrix, self.request.field_order
+        )
+        expected_total = self.request.field_order**rank
+        if sum(count for _weight, count in self.weights) != expected_total:
+            raise ValueError(
+                "weight counts must sum to the distinct generated codeword count"
+            )
+        replayed = replay_weight_distribution(
+            self.request.generator_matrix, self.request.field_order
+        )
+        if tuple((w, c) for w, c in replayed) != self.weights:
+            raise ValueError(
+                "weight distribution must be the exact enumeration of the "
+                "retained source code"
+            )
+        return self
 
 
 class CoveringRadiusRequest(StrictModel):
@@ -120,8 +194,38 @@ class CoveringRadiusRequest(StrictModel):
 
 
 class CoveringRadiusResult(StrictModel):
+    """The exact covering radius bound to its source code.
+
+    Retains the canonical source code (the same bounded syndrome-graph
+    request) so validation replays the exact BFS: the radius lies in
+    ``[0, n]`` and equals the maximum minimum-error weight over the
+    retained source's syndrome graph.
+    """
+
+    request: CoveringRadiusRequest
     covering_radius: int = Field(ge=0, le=256)
     method: Literal["SYNDROME_BFS"] = "SYNDROME_BFS"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.code_theory.operations import (
+            covering_radius as replay_covering_radius,
+        )
+
+        width = len(self.request.generator_matrix[0])
+        if self.covering_radius > width:
+            raise ValueError("covering radius must lie in [0, code length]")
+        if (
+            replay_covering_radius(
+                self.request.generator_matrix, self.request.field_order
+            )
+            != self.covering_radius
+        ):
+            raise ValueError(
+                "covering radius must be the exact syndrome BFS of the "
+                "retained source code"
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/src/jacobian/math/code_theory/_models.py
+++ b/src/jacobian/math/code_theory/_models.py
@@ -8,9 +8,17 @@ from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
 
-MAX_EXACT_CODEWORDS = 65_536
-MAX_COVERING_RADIUS_STATES = 65_536
-MAX_COVERING_RADIUS_TRANSITIONS = 2_000_000
+# One source-bound call performs its exhaustive work twice: the domain
+# function computes the claimed value and the retained-source result
+# validator replays it. The enumeration and transition budgets below are
+# therefore totals charged across both passes per accepted call;
+# MAX_COVERING_RADIUS_STATES_PER_PASS stays a per-pass bound because each
+# BFS allocates its visited set independently.
+EXACT_ENUMERATION_PASSES = 2
+SYNDROME_BFS_PASSES = 2
+MAX_EXACT_CODEWORD_EVALUATIONS = 131_072
+MAX_COVERING_RADIUS_STATES_PER_PASS = 65_536
+MAX_COVERING_RADIUS_TRANSITIONS = 4_000_000
 
 
 def _validate_prime_field_matrix(
@@ -78,7 +86,10 @@ class LinearCodeRequest(StrictModel):
     @model_validator(mode="after")
     def require_bounded_prime_field_matrix(self) -> Self:
         _validate_prime_field_matrix(self.field_order, self.generator_matrix)
-        if self.field_order ** len(self.generator_matrix) > MAX_EXACT_CODEWORDS:
+        if (
+            EXACT_ENUMERATION_PASSES * self.field_order ** len(self.generator_matrix)
+            > MAX_EXACT_CODEWORD_EVALUATIONS
+        ):
             raise ValueError("generator matrix exceeds the exact enumeration bound")
         return self
 
@@ -186,13 +197,16 @@ class CoveringRadiusRequest(StrictModel):
         rank = _matrix_rank_mod_prime(self.generator_matrix, self.field_order)
         syndrome_dimension = width - rank
         state_count = self.field_order**syndrome_dimension
-        if state_count > MAX_COVERING_RADIUS_STATES:
+        if state_count > MAX_COVERING_RADIUS_STATES_PER_PASS:
             raise ValueError("syndrome space exceeds the exact state bound")
         move_count_bound = min(
             width * (self.field_order - 1),
             max(state_count - 1, 0),
         )
-        if state_count * move_count_bound > MAX_COVERING_RADIUS_TRANSITIONS:
+        if (
+            SYNDROME_BFS_PASSES * state_count * move_count_bound
+            > MAX_COVERING_RADIUS_TRANSITIONS
+        ):
             raise ValueError("syndrome graph exceeds the exact transition bound")
         return self
 

--- a/src/jacobian/math/code_theory/_operations.py
+++ b/src/jacobian/math/code_theory/_operations.py
@@ -18,14 +18,16 @@ from jacobian.math.code_theory._models import (
 
 def compute_min_distance(request: LinearCodeRequest) -> MinimumDistanceResult:
     dist = minimum_distance(request.generator_matrix, request.field_order)
-    return MinimumDistanceResult(minimum_distance=dist)
+    return MinimumDistanceResult(request=request, minimum_distance=dist)
 
 
 def compute_weight_dist(request: LinearCodeRequest) -> WeightDistributionResult:
     weights = weight_distribution(request.generator_matrix, request.field_order)
-    return WeightDistributionResult(weights=tuple((w, c) for w, c in weights))
+    return WeightDistributionResult(
+        request=request, weights=tuple((w, c) for w, c in weights)
+    )
 
 
 def compute_covering_radius(request: CoveringRadiusRequest) -> CoveringRadiusResult:
     radius = covering_radius(request.generator_matrix, request.field_order)
-    return CoveringRadiusResult(covering_radius=radius)
+    return CoveringRadiusResult(request=request, covering_radius=radius)

--- a/src/jacobian/math/code_theory/_tools.py
+++ b/src/jacobian/math/code_theory/_tools.py
@@ -63,6 +63,7 @@ CODE_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "code",
         "minimum-distance",
         "exact",
+        version="2",
         examples=(
             example(
                 "binary_repetition_code",
@@ -81,6 +82,7 @@ CODE_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "code",
         "weight-distribution",
         "exact",
+        version="2",
         examples=(
             example(
                 "binary_repetition_code",
@@ -99,6 +101,7 @@ CODE_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "code",
         "covering-radius",
         "exact",
+        version="2",
         examples=(
             example(
                 "binary_repetition_code",

--- a/src/jacobian/math/code_theory/operations.py
+++ b/src/jacobian/math/code_theory/operations.py
@@ -36,6 +36,11 @@ def _codewords(
 
 
 def minimum_distance(generator_matrix: GeneratorMatrix, field_order: int) -> int:
+    """Return the exact minimum nonzero codeword weight.
+
+    For the zero code (rank 0) no nonzero codeword exists; the code
+    length is returned by the empty-code convention.
+    """
     from jacobian.math.code_theory._models import LinearCodeRequest
 
     request = LinearCodeRequest(

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -282,3 +282,64 @@ def test_dependent_generator_rows_rank_cardinality() -> None:
     request = LinearCodeRequest(field_order=2, generator_matrix=((1, 1), (1, 1)))
     profile = compute_weight_dist(request)
     assert sum(count for _weight, count in profile.weights) == 2
+
+
+def test_enumeration_budget_charges_kernel_and_replay_passes() -> None:
+    """Admission charges both exhaustive passes of a source-bound call.
+
+    The kernel pass in ``compute_*`` plus the retained-source replay in
+    result validation must jointly fit ``MAX_EXACT_CODEWORD_EVALUATIONS``,
+    so the per-pass envelope stays at half that total.
+    """
+
+    from jacobian.math.code_theory._models import (
+        EXACT_ENUMERATION_PASSES,
+        MAX_EXACT_CODEWORD_EVALUATIONS,
+    )
+
+    assert EXACT_ENUMERATION_PASSES == 2
+
+    per_pass = MAX_EXACT_CODEWORD_EVALUATIONS // EXACT_ENUMERATION_PASSES
+    boundary = LinearCodeRequest(field_order=251, generator_matrix=((1,), (0,)))
+    tuples_per_pass = boundary.field_order ** len(boundary.generator_matrix)
+    assert tuples_per_pass <= per_pass
+    assert compute_min_distance(boundary).minimum_distance == 1
+    assert compute_weight_dist(boundary).weights == ((0, 1), (1, 250))
+
+    with pytest.raises(ValidationError, match="enumeration"):
+        LinearCodeRequest(field_order=41, generator_matrix=((1,),) * 3)
+
+
+def test_covering_radius_budget_charges_bfs_and_replay_passes() -> None:
+    """Syndrome-graph admission charges both BFS passes' transitions.
+
+    A full-rank width-24 binary code keeps 65,536 syndrome states and
+    1,572,864 transitions per pass, so both passes fit the transition
+    total; one more column doubles the state space past its per-pass cap.
+    """
+
+    from jacobian.math.code_theory._models import (
+        MAX_COVERING_RADIUS_STATES_PER_PASS,
+        MAX_COVERING_RADIUS_TRANSITIONS,
+        SYNDROME_BFS_PASSES,
+    )
+
+    assert SYNDROME_BFS_PASSES == 2
+
+    identity = tuple(
+        tuple(1 if column == row else 0 for column in range(8)) for row in range(8)
+    )
+    boundary_matrix = tuple(row + (1,) * 16 for row in identity)
+    boundary = CoveringRadiusRequest(
+        field_order=2, generator_matrix=boundary_matrix
+    )
+    width = len(boundary.generator_matrix[0])
+    states = 2 ** (width - 8)
+    assert states == MAX_COVERING_RADIUS_STATES_PER_PASS
+    assert states * 24 * SYNDROME_BFS_PASSES <= MAX_COVERING_RADIUS_TRANSITIONS
+
+    with pytest.raises(ValidationError, match="syndrome space"):
+        CoveringRadiusRequest(
+            field_order=2,
+            generator_matrix=tuple(row + (1,) * 17 for row in identity),
+        )

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -153,3 +153,96 @@ def test_covering_radius_contract_rejects_nonprime_field() -> None:
             field_order=4,
             generator_matrix=((1, 1),),
         )
+
+
+# ---------------------------------------------------------------------------
+# Source-bound replay regressions (#2309)
+# ---------------------------------------------------------------------------
+
+
+def _linear_request() -> LinearCodeRequest:
+    return LinearCodeRequest(field_order=3, generator_matrix=((1, 0, 1), (0, 1, 1)))
+
+
+def test_results_retain_source_and_replay() -> None:
+    from jacobian.math.code_theory._models import (
+        CoveringRadiusResult,
+        MinimumDistanceResult,
+        WeightDistributionResult,
+    )
+
+    request = _linear_request()
+    dist = compute_min_distance(request)
+    assert dist.request == request
+    assert dist.minimum_distance == 2
+    assert MinimumDistanceResult.model_validate(dist.model_dump()) == dist
+
+    profile = compute_weight_dist(request)
+    assert profile.request == request
+    # q^rank = 9 distinct codewords over GF(3) with rank-2 generator rows.
+    assert sum(count for _weight, count in profile.weights) == 9
+    assert WeightDistributionResult.model_validate(profile.model_dump()) == profile
+
+    covering = CoveringRadiusRequest(
+        field_order=2, generator_matrix=((1, 0, 1), (0, 1, 1))
+    )
+    radius = compute_covering_radius(covering)
+    assert radius.request == covering
+    assert CoveringRadiusResult.model_validate(radius.model_dump()) == radius
+
+    with pytest.raises(ValidationError):
+        MinimumDistanceResult(
+            request=request,
+            minimum_distance=9999,
+        )
+    with pytest.raises(ValidationError):
+        WeightDistributionResult(
+            request=request,
+            weights=((99, 777), (-4, 123)),
+        )
+    with pytest.raises(ValidationError):
+        CoveringRadiusResult(request=covering, covering_radius=200)
+
+
+def test_forged_profiles_are_rejected() -> None:
+    from jacobian.math.code_theory._models import (
+        MinimumDistanceResult,
+        WeightDistributionResult,
+    )
+
+    request = _linear_request()
+    base = {
+        "request": request.model_dump(),
+        "method": "EXACT_ENUMERATION",
+    }
+
+    wrong_distance = dict(base, minimum_distance=1)
+    with pytest.raises(ValidationError, match="exact enumeration"):
+        MinimumDistanceResult.model_validate(wrong_distance)
+
+    foreign_code = LinearCodeRequest(
+        field_order=2, generator_matrix=((1, 0), (0, 1), (1, 1))
+    )
+    forged_source = dict(base, request=foreign_code.model_dump(), minimum_distance=2)
+    with pytest.raises(ValidationError, match="retained source code"):
+        MinimumDistanceResult.model_validate(forged_source)
+
+    unsorted_profile = dict(base, weights=((1, 6), (0, 1), (2, 2)))
+    with pytest.raises(ValidationError, match="ascending"):
+        WeightDistributionResult.model_validate(unsorted_profile)
+
+    bad_total = dict(base, weights=((0, 1), (2, 2)))
+    with pytest.raises(ValidationError, match="distinct generated codeword"):
+        WeightDistributionResult.model_validate(bad_total)
+
+    forged_profile = dict(base, weights=((0, 1), (1, 5), (2, 3)))
+    with pytest.raises(ValidationError, match="exact enumeration"):
+        WeightDistributionResult.model_validate(forged_profile)
+
+
+def test_dependent_generator_rows_rank_cardinality() -> None:
+    """Dependent rows deduplicate: cardinality is q^rank, not q^rows."""
+
+    request = LinearCodeRequest(field_order=2, generator_matrix=((1, 1), (1, 1)))
+    profile = compute_weight_dist(request)
+    assert sum(count for _weight, count in profile.weights) == 2

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -240,6 +240,16 @@ def test_forged_profiles_are_rejected() -> None:
         WeightDistributionResult.model_validate(forged_profile)
 
 
+def test_source_bound_result_versions_track_wire_shape() -> None:
+    from jacobian.math.code_theory._tools import TOOLS
+
+    versions = {tool.operation_id: tool.version for tool in TOOLS}
+
+    assert versions["code.minimum_distance.compute"] == "2"
+    assert versions["code.weight_distribution.compute"] == "2"
+    assert versions["code.covering_radius.compute"] == "2"
+
+
 def test_dependent_generator_rows_rank_cardinality() -> None:
     """Dependent rows deduplicate: cardinality is q^rank, not q^rows."""
 

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -330,9 +330,7 @@ def test_covering_radius_budget_charges_bfs_and_replay_passes() -> None:
         tuple(1 if column == row else 0 for column in range(8)) for row in range(8)
     )
     boundary_matrix = tuple(row + (1,) * 16 for row in identity)
-    boundary = CoveringRadiusRequest(
-        field_order=2, generator_matrix=boundary_matrix
-    )
+    boundary = CoveringRadiusRequest(field_order=2, generator_matrix=boundary_matrix)
     width = len(boundary.generator_matrix[0])
     states = 2 ** (width - 8)
     assert states == MAX_COVERING_RADIUS_STATES_PER_PASS

--- a/tests/math/code_theory/test_exact_code_enumeration.py
+++ b/tests/math/code_theory/test_exact_code_enumeration.py
@@ -250,6 +250,32 @@ def test_source_bound_result_versions_track_wire_shape() -> None:
     assert versions["code.covering_radius.compute"] == "2"
 
 
+def test_zero_code_result_replays_the_documented_length_convention() -> None:
+    from jacobian.math.code_theory._models import MinimumDistanceResult
+
+    request = LinearCodeRequest(field_order=2, generator_matrix=((0, 0, 0),))
+    result = compute_min_distance(request)
+
+    assert result.minimum_distance == 3
+    assert MinimumDistanceResult.model_validate(result.model_dump()) == result
+    description = MinimumDistanceResult.model_json_schema()["description"]
+    assert "empty-code convention" in description
+
+
+def test_forged_zero_code_distance_is_rejected() -> None:
+    from jacobian.math.code_theory._models import MinimumDistanceResult
+
+    request = LinearCodeRequest(field_order=2, generator_matrix=((0, 0, 0),))
+    forged = {
+        "request": request.model_dump(),
+        "method": "EXACT_ENUMERATION",
+        "minimum_distance": 2,
+    }
+
+    with pytest.raises(ValidationError, match="exact enumeration"):
+        MinimumDistanceResult.model_validate(forged)
+
+
 def test_dependent_generator_rows_rank_cardinality() -> None:
     """Dependent rows deduplicate: cardinality is q^rank, not q^rows."""
 


### PR DESCRIPTION
## Problem

`MinimumDistanceResult`, `WeightDistributionResult`, and `CoveringRadiusResult` retained only a claimed scalar/profile plus a method tag (#2309): `MinimumDistanceResult(minimum_distance=9999)`, `WeightDistributionResult(weights=((99, 777), (-4, 123)))`, and `CoveringRadiusResult(covering_radius=200)` all validated independently of any code. No nonnegative-weight/canonical-order/count checks existed, no field/generator matrix was retained, and serialization produced values indistinguishable from producer output. A method string is not a certificate.

## Fix

Each result retains the canonical source code (field order + generator matrix, as its typed request) and replays its defining relation during validation:

- **Minimum distance** ∈ [0, n] and equals the minimum nonzero codeword weight of the retained generator under the exact enumeration convention.
- **Weight distribution**: rows strictly ascending/unique, weights ∈ [0, n], counts positive, counts sum to the number of distinct generated codewords (`q^rank`, computed via the domain's prime-field rank), and the profile equals the exact enumeration replay.
- **Covering radius** ∈ [0, n] and equals the exact syndrome-graph BFS of the retained source.

Replay cost is bounded by the existing admission envelopes (≤65,536 enumerated codewords; bounded syndrome graph).

## Validation

- `make check` green.
- New regressions per the issue: source retention + round-trip replay for all three results; forged scalars/profiles rejected; foreign source codes rejected; unsorted/negative/zero-count weight rows rejected; wrong total multiplicity rejected; dependent generator rows deduplicate to `q^rank` cardinality.

Fixes #2309