### PR TITLE
fix(math): start formal-concept enumeration at the closure of the empty set

### DIFF
--- a/src/jacobian/math/formal_concept_analysis/operations.py
+++ b/src/jacobian/math/formal_concept_analysis/operations.py
@@ -123,15 +123,17 @@ def enumerate_concepts(ctx: FormalContext) -> list[dict[str, frozenset[int]]]:
     """Return every formal concept exactly once using Ganter's NextClosure
     algorithm over the declared attribute order.
 
-    The algorithm enumerates closed attribute intents in lectic order.
-    Each step requires O(n) derivation operations, so the total cost is
-    proportional to the number of concepts times n, not to 2^n.
+    The algorithm enumerates closed attribute intents in lectic order,
+    starting from ``attribute_closure(ctx, frozenset())`` because in a
+    general context the empty attribute set need not be closed; the least
+    closed intent is ``cl(∅) = ∅''``.  Each step requires O(n) derivation
+    operations, so the total cost is proportional to the number of concepts
+    times n, not to 2^n.
     """
     n = len(ctx.attributes)
     concepts: list[dict[str, frozenset[int]]] = []
 
-    # The empty set is always closed (it is the intent of the top concept).
-    current: frozenset[int] | None = frozenset()
+    current: frozenset[int] | None = attribute_closure(ctx, frozenset())
     while current is not None:
         intent = current
         extent = attribute_derivation(ctx, intent)

--- a/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
+++ b/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
@@ -152,16 +152,82 @@ class TestEnumeration:
         result = compute_enumerate_concepts(
             EnumerateConceptsRequest(context=_cross_context())
         )
-        # Cross context: (�{}, {a0,a1}), ({o0}, {a0}), ({o1}, {a1})
+        # Cross context: ({}, {a0,a1}), ({o0}, {a0}), ({o1}, {a1})
         assert result.count == 4
 
-    def test_diagonal_context_has_three_concepts(self) -> None:
+    def test_diagonal_context_has_two_concepts(self) -> None:
+        """cl(empty) = {a1} here, so the empty intent is not a concept."""
         result = compute_enumerate_concepts(
             EnumerateConceptsRequest(context=_diagonal_context())
         )
         # Diagonal: o0 has both a0 and a1; o1 has a1.
-        # Concepts: ({o0,o1}, {}), ({o0,o1}, {a1}), ({o0}, {a0,a1})
-        assert result.count == 3
+        # Concepts: ({o0,o1}, {a1}), ({o0}, {a0,a1})
+        assert result.count == 2
+
+
+# ---------------------------------------------------------------------------
+# Defining-equation replay (#2266)
+# ---------------------------------------------------------------------------
+
+
+def _assert_defining_equations(context: FormalContext) -> None:
+    from jacobian.math.formal_concept_analysis import (
+        attribute_derivation,
+        object_derivation,
+    )
+
+    for extent_tuple, intent_tuple in compute_enumerate_concepts(
+        EnumerateConceptsRequest(context=context)
+    ).concepts:
+        extent = frozenset(extent_tuple)
+        intent = frozenset(intent_tuple)
+        assert object_derivation(context, extent) == intent
+        assert attribute_derivation(context, intent) == extent
+
+
+@pytest.mark.parametrize(
+    "incidence",
+    (
+        ((0, 0), (0, 1), (1, 1)),
+        ((0, 0), (1, 1)),
+        ((0, 0), (0, 1), (1, 0), (1, 1)),
+        ((0, 1), (1, 0), (1, 1)),
+        ((0, 0),),
+        ((0, 0), (0, 1), (0, 2), (1, 1), (2, 2)),
+    ),
+)
+def test_every_emitted_concept_satisfies_defining_equations(
+    incidence: tuple[tuple[int, int], ...],
+) -> None:
+    object_count = max((o for o, _a in incidence), default=-1) + 1
+    attribute_count = max((a for _o, a in incidence), default=-1) + 1
+    context = FormalContext(
+        objects=tuple(f"o{i}" for i in range(object_count)),
+        attributes=tuple(f"a{j}" for j in range(attribute_count)),
+        incidence=incidence,
+    )
+    _assert_defining_equations(context)
+
+
+def test_lattice_embedded_concepts_replay_defining_equations() -> None:
+    from jacobian.math.formal_concept_analysis import (
+        attribute_derivation,
+        object_derivation,
+    )
+
+    context = _diagonal_context()
+    result = compute_concept_lattice(
+        EnumerateConceptsRequest(context=_diagonal_context())
+    )
+    assert len(result.concepts) == 2
+    for extent_tuple, intent_tuple in result.concepts:
+        extent = frozenset(extent_tuple)
+        intent = frozenset(intent_tuple)
+        assert object_derivation(context, extent) == intent
+        assert attribute_derivation(context, intent) == extent
+    # Extents are pairwise distinct, so no two concepts compare equal.
+    extents = [frozenset(extent_tuple) for extent_tuple, _intent in result.concepts]
+    assert len(set(extents)) == len(extents)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`formal_context.concepts.enumerate.compute` unconditionally started Ganter's NextClosure from the empty attribute set and published it as an intent (#2266). In FCA the least closed intent is `cl(∅) = ∅''`, which need not be empty: for the context `o0={a0,a1}, o1={a1}` it is `{a1}`. The emitted row `(extent {o0,o1}, intent {})` satisfied neither defining equation (`{o0,o1}' = {a1} ≠ {}`) and duplicated the extent of the next concept, so the derived lattice relation could order distinct elements in both directions. The source comment claiming "The empty set is always closed" was false for a general closure operator.

## Fix

- Enumeration starts at `attribute_closure(ctx, frozenset())`; the false comment is gone.
- The issue's example now returns exactly `(\{o0,o1\}, \{a1\})` and `(\{o0\}, \{a0,a1\})`.
- The diagonal-context count expectation is corrected from three to two (the third row was the invalid one).

## Validation

- `make check` green (3524 passed).
- New regressions replay both defining equations `A' = B` and `B' = A` for every enumerated concept across six contexts (including closed-empty and full/cross shapes) and for every concept embedded in a returned concept lattice; extents are pairwise distinct so no two concepts compare equal.

Fixes #2266