### PR TITLE
Generalize graded Jacobian syzygy operations

### DIFF
--- a/src/jacobian/math/polynomials/_admission.py
+++ b/src/jacobian/math/polynomials/_admission.py
@@ -68,12 +68,12 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "polynomial.jacobian_syzygy.coefficients.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "dimension-parametric exact sparse ledger with separately bounded SymPy rank replay and material certificate leverage; labelled projective-line factors remain the compatible three-variable input",
     ),
     OperationAdmission(
         "polynomial.jacobian_syzygy.minimum_degree.compute",
         AdmissionDecision.KEEP,
-        "distinct exact or explicitly bounded search outcome with material computational leverage",
+        "dimension-parametric exact first-kernel search with separately bounded SymPy rank replay and material computational leverage; labelled projective-line factors remain the compatible three-variable input",
     ),
     OperationAdmission(
         "polynomial.rational.compute.derivative",

--- a/src/jacobian/math/polynomials/_jacobian_syzygy.py
+++ b/src/jacobian/math/polynomials/_jacobian_syzygy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from fractions import Fraction
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import canonicalize_json, format_canonical_integer
@@ -24,22 +24,17 @@ from jacobian.math.polynomials._syzygy_models import (
     GradedJacobianKernelWitness,
     GradedJacobianMapEntry,
     GradedJacobianRankMinor,
+    GradedJacobianSyzygyCoefficientRequest,
     GradedJacobianSyzygyRequest,
+    GradedJacobianSyzygyRequestBase,
     GradedJacobianSyzygyResult,
+    _homogeneous_basis,
 )
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
     SparseRationalPolynomial,
 )
-
-
-def _homogeneous_basis(degree: int) -> tuple[tuple[int, int, int], ...]:
-    return tuple(
-        (first, second, degree - first - second)
-        for first in range(degree, -1, -1)
-        for second in range(degree - first, -1, -1)
-    )
 
 
 def _fraction_text(value: Any) -> str:
@@ -53,8 +48,8 @@ def _fraction_text(value: Any) -> str:
 def _matrix_digest(
     *,
     multiplier_degree: int,
-    source_basis: tuple[tuple[int, int, int], ...],
-    target_basis: tuple[tuple[int, int, int], ...],
+    source_basis: tuple[tuple[int, ...], ...],
+    target_basis: tuple[tuple[int, ...], ...],
     entries: tuple[tuple[int, int, Any], ...],
 ) -> str:
     payload = {
@@ -80,8 +75,8 @@ def _primitive_kernel(vector: Any) -> tuple[Fraction, ...]:
 
 def _multiplier_polynomial(
     *,
-    variables: tuple[str, str, str],
-    basis: tuple[tuple[int, int, int], ...],
+    variables: tuple[str, ...],
+    basis: tuple[tuple[int, ...], ...],
     coefficients: tuple[Fraction, ...],
 ) -> RationalPolynomial:
     return RationalPolynomial(
@@ -103,38 +98,36 @@ def _multiplier_polynomial(
 
 
 def _coefficient_matrix(
-    partials: tuple[Any, Any, Any],
+    partials: tuple[Any, ...],
     multiplier_degree: int,
     homogeneous_degree: int,
 ) -> tuple[
-    tuple[tuple[int, int, int], ...],
-    tuple[tuple[int, int, int], ...],
+    tuple[tuple[int, ...], ...],
+    tuple[tuple[int, ...], ...],
     Any,
     tuple[tuple[int, int, Any], ...],
 ]:
     from sympy import Matrix
 
-    source_basis = _homogeneous_basis(multiplier_degree)
+    variable_count = len(partials)
+    source_basis = _homogeneous_basis(variable_count, multiplier_degree)
     target_degree = homogeneous_degree - 1 + multiplier_degree
-    target_basis = _homogeneous_basis(target_degree)
+    target_basis = _homogeneous_basis(variable_count, target_degree)
     row_by_exponent = {exponents: index for index, exponents in enumerate(target_basis)}
-    matrix = Matrix.zeros(len(target_basis), 3 * len(source_basis))
+    matrix = Matrix.zeros(len(target_basis), variable_count * len(source_basis))
     for component, partial in enumerate(partials):
         for basis_index, multiplier_exponents in enumerate(source_basis):
             column = component * len(source_basis) + basis_index
             for partial_exponents, coefficient in partial.terms():
                 if coefficient == 0:
                     continue
-                target_exponents = cast(
-                    tuple[int, int, int],
-                    tuple(
-                        left + right
-                        for left, right in zip(
-                            multiplier_exponents,
-                            partial_exponents,
-                            strict=True,
-                        )
-                    ),
+                target_exponents = tuple(
+                    left + right
+                    for left, right in zip(
+                        multiplier_exponents,
+                        partial_exponents,
+                        strict=True,
+                    )
                 )
                 row = row_by_exponent[target_exponents]
                 matrix[row, column] += coefficient
@@ -150,28 +143,21 @@ def _coefficient_matrix(
 def compute_graded_jacobian_syzygy(
     request: GradedJacobianSyzygyRequest,
 ) -> GradedJacobianSyzygyResult:
-    if request.coefficient_map_detail != "CERTIFICATES":
-        raise ValueError(
-            "full sparse coefficient maps are available through the explicit "
-            "jacobian syzygy coefficient-ledger operation"
-        )
     return _compute_graded_jacobian_syzygy(request)
 
 
 def compute_graded_jacobian_syzygy_coefficients(
-    request: GradedJacobianSyzygyRequest,
+    request: GradedJacobianSyzygyCoefficientRequest,
 ) -> GradedJacobianSyzygyResult:
     """Retain the full sparse coefficient maps as explicit evidence."""
-    return _compute_graded_jacobian_syzygy(
-        request.model_copy(update={"coefficient_map_detail": "SPARSE_ENTRIES"})
-    )
+    return _compute_graded_jacobian_syzygy(request)
 
 
 def _compute_graded_jacobian_syzygy(
-    request: GradedJacobianSyzygyRequest,
+    request: GradedJacobianSyzygyRequestBase,
 ) -> GradedJacobianSyzygyResult:
     if request.polynomial is not None:
-        variables = cast(tuple[str, str, str], request.polynomial.variables)
+        variables = request.polynomial.variables
         source = rational_polynomial_to_sympy(request.polynomial)
         source_kind: Literal[
             "EXPANDED_POLYNOMIAL", "LABELLED_LINEAR_FACTOR_PRODUCT"
@@ -201,10 +187,7 @@ def _compute_graded_jacobian_syzygy(
             )
         source_kind = "LABELLED_LINEAR_FACTOR_PRODUCT"
     source_degree = int(source.total_degree())
-    partials = cast(
-        tuple[Any, Any, Any],
-        tuple(source.diff(variable) for variable in source.gens),
-    )
+    partials = tuple(source.diff(variable) for variable in source.gens)
     maps: list[GradedJacobianCoefficientMap] = []
     kernel_witness: GradedJacobianKernelWitness | None = None
     first_degree: int | None = None
@@ -267,18 +250,15 @@ def _compute_graded_jacobian_syzygy(
             first_degree = multiplier_degree
             vector = _primitive_kernel(matrix.nullspace()[0])
             block_size = len(source_basis)
-            multipliers = cast(
-                tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
-                tuple(
-                    _multiplier_polynomial(
-                        variables=variables,
-                        basis=source_basis,
-                        coefficients=vector[
-                            component * block_size : (component + 1) * block_size
-                        ],
-                    )
-                    for component in range(3)
-                ),
+            multipliers = tuple(
+                _multiplier_polynomial(
+                    variables=variables,
+                    basis=source_basis,
+                    coefficients=vector[
+                        component * block_size : (component + 1) * block_size
+                    ],
+                )
+                for component in range(len(variables))
             )
             kernel_witness = GradedJacobianKernelWitness(
                 multiplier_degree=multiplier_degree,
@@ -301,12 +281,8 @@ def _compute_graded_jacobian_syzygy(
         homogeneous_degree=source_degree,
         searched_through_degree=searched_through,
         coefficient_map_detail=request.coefficient_map_detail,
-        partial_derivatives=cast(
-            tuple[RationalPolynomial, RationalPolynomial, RationalPolynomial],
-            tuple(
-                rational_polynomial_from_sympy(partial, variables)
-                for partial in partials
-            ),
+        partial_derivatives=tuple(
+            rational_polynomial_from_sympy(partial, variables) for partial in partials
         ),
         degree_maps=tuple(maps),
         status="FOUND" if first_degree is not None else "NONE_THROUGH_BOUND",
@@ -319,13 +295,12 @@ GRADED_JACOBIAN_SYZYGY_OPERATION = polynomial_operation(
     "polynomial.jacobian_syzygy.minimum_degree.compute",
     "Compute the first graded Jacobian syzygy degree",
     (
-        "For one bounded homogeneous h in QQ[x,y,z], supplied either sparsely "
-        "or as a labelled product of linear forms, exactly construct every "
-        "graded map (QQ[x,y,z]_q)^3 -> QQ[x,y,z]_(q+deg(h)-1) from q=0, "
-        "report rank certificates, and stop at the first nonzero kernel or the "
-        "declared finite degree bound. Sparse polynomial terms must have "
-        "nonzero coefficients and unique exponent tuples in descending "
-        "lexicographic order. Full sparse maps are optional."
+        "For bounded homogeneous h in QQ[x_1,...,x_n], supplied sparsely or, "
+        "for n=3, as labelled linear forms, construct every graded map "
+        "(QQ[x_1,...,x_n]_q)^n -> QQ[x_1,...,x_n]_(q+deg(h)-1) from q=0 and "
+        "stop at the first nonzero kernel or the finite degree bound. This "
+        "operation returns rank certificates only; use the coefficient ledger "
+        "for sparse map entries."
     ),
     GradedJacobianSyzygyRequest,
     GradedJacobianSyzygyResult,
@@ -338,7 +313,7 @@ GRADED_JACOBIAN_SYZYGY_OPERATION = polynomial_operation(
     "rank",
     "kernel",
     "exact",
-    version="4",
+    version="6",
     examples=(
         OperationExample(
             name="sparse-homogeneous-polynomial",
@@ -416,7 +391,7 @@ JACOBIAN_SYZYGY_COEFFICIENT_LEDGER_OPERATION = polynomial_operation(
         "Compute every sparse entry in the bounded graded Jacobian coefficient "
         "maps, together with the syzygy summary and rank certificates."
     ),
-    GradedJacobianSyzygyRequest,
+    GradedJacobianSyzygyCoefficientRequest,
     GradedJacobianSyzygyResult,
     compute_graded_jacobian_syzygy_coefficients,
     "polynomial",
@@ -424,6 +399,7 @@ JACOBIAN_SYZYGY_COEFFICIENT_LEDGER_OPERATION = polynomial_operation(
     "syzygy",
     "coefficient-ledger",
     "evidence",
+    version="4",
     examples=(
         OperationExample(
             name="sparse-homogeneous-polynomial",

--- a/src/jacobian/math/polynomials/_syzygy_models.py
+++ b/src/jacobian/math/polynomials/_syzygy_models.py
@@ -190,6 +190,66 @@ def _multiply_terms(
     }
 
 
+def _expanded_source_terms(
+    polynomial: RationalPolynomial | None,
+    linear_factors: tuple[RationalProjectiveLine, ...] | None,
+) -> dict[tuple[int, ...], Fraction]:
+    if polynomial is not None:
+        return _polynomial_terms(polynomial)
+    if linear_factors is None:
+        raise ValueError("labelled linear factors are required")
+    terms: dict[tuple[int, ...], Fraction] = {(0, 0, 0): Fraction(1)}
+    for factor in linear_factors:
+        terms = _multiply_terms(
+            terms,
+            {
+                tuple(1 if axis == position else 0 for axis in range(3)): (
+                    coefficient.as_fraction()
+                )
+                for position, coefficient in enumerate(factor.coefficients)
+            },
+        )
+    return terms
+
+
+def _degree_zero_kernel_is_forced(
+    *, variable_count: int, source_terms: dict[tuple[int, ...], Fraction]
+) -> bool:
+    """Decide whether the degree-zero Jacobian map provably has nonzero nullity.
+
+    Every degree-zero column is exactly one partial derivative's coefficient
+    vector, so the map's exact rank follows from the admitted request alone.
+    Rank below the variable count forces the first kernel at degree zero, and
+    execution then breaks before constructing any later map.
+    """
+
+    partials = tuple(
+        _partial_derivative_terms(source_terms, variable)
+        for variable in range(variable_count)
+    )
+    pivot_rows: list[tuple[int, list[Fraction]]] = []
+    for exponents in sorted({key for partial in partials for key in partial}):
+        row = [partial.get(exponents, Fraction(0)) for partial in partials]
+        for leading_column, pivot_row in pivot_rows:
+            factor = row[leading_column]
+            if not factor:
+                continue
+            row = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(row, pivot_row, strict=True)
+            ]
+        new_leading_column = next(
+            (column for column, value in enumerate(row) if value), None
+        )
+        if new_leading_column is None:
+            continue
+        scale = row[new_leading_column]
+        pivot_rows.append((new_leading_column, [value / scale for value in row]))
+        if len(pivot_rows) == variable_count:
+            return False
+    return True
+
+
 class GradedJacobianSyzygyRequestBase(StrictModel):
     """Search the homogeneous Jacobian map through one explicit degree bound."""
 
@@ -259,10 +319,23 @@ class GradedJacobianSyzygyRequestBase(StrictModel):
             + _decimal_log_upper(_basis_size(3, source_degree))
             + _decimal_log_upper(source_degree)
         )
+        # Execution stops at the first non-injective map, so admission charges
+        # only degrees a run can actually reach. The degree-zero rank is exact
+        # and cheap from the request alone; later degrees stay fully budgeted.
+        budgeted_max_degree = (
+            0
+            if _degree_zero_kernel_is_forced(
+                variable_count=len(variables),
+                source_terms=_expanded_source_terms(
+                    self.polynomial, self.linear_factors
+                ),
+            )
+            else self.max_degree
+        )
         _require_coefficient_map_budget(
             variable_count=len(variables),
             source_degree=source_degree,
-            max_degree=self.max_degree,
+            max_degree=budgeted_max_degree,
             coefficient_map_detail=self.coefficient_map_detail,
             entry_coefficient_digits=entry_coefficient_digits,
         )
@@ -468,6 +541,10 @@ def _validate_result_source_and_partials(result: GradedJacobianSyzygyResult) -> 
     variable_count = len(result.variables)
     if len(set(result.variables)) != variable_count:
         raise ValueError("result variable order must be unique")
+    if result.source_kind == "LABELLED_LINEAR_FACTOR_PRODUCT" and variable_count != 3:
+        raise ValueError(
+            "labelled linear-factor provenance requires exactly three variables"
+        )
     if result.expanded_polynomial.variables != result.variables:
         raise ValueError("expanded source must use the declared variable order")
     source_terms = _polynomial_terms(result.expanded_polynomial)

--- a/src/jacobian/math/polynomials/_syzygy_models.py
+++ b/src/jacobian/math/polynomials/_syzygy_models.py
@@ -1,19 +1,61 @@
-"""Bounded exact contracts for graded Jacobian syzygies over QQ[x,y,z]."""
+"""Bounded exact contracts for graded Jacobian syzygies over ``QQ``."""
 
 from __future__ import annotations
 
+import hashlib
+from fractions import Fraction
 from math import comb
 from typing import Literal, Self
 
 from pydantic import Field, StrictInt, model_validator
 
 from jacobian._digest import Sha256Digest
-from jacobian._exact import CanonicalRational
+from jacobian._exact import (
+    MAX_CANONICAL_RATIONAL_DIGITS,
+    CanonicalRational,
+    require_bounded_rational,
+)
 from jacobian._models import StrictModel
+from jacobian.canonical import canonicalize_json
 from jacobian.math.geometry.projective.values import RationalProjectiveLine
-from jacobian.math.polynomials.values import PolynomialVariable, RationalPolynomial
+from jacobian.math.polynomials.values import (
+    MAX_POLYNOMIAL_VARIABLES,
+    PolynomialVariable,
+    RationalPolynomial,
+    require_polynomial_budget,
+)
 
-ExponentTriple = tuple[int, int, int]
+ExponentVector = tuple[StrictInt, ...]
+
+MAX_SOURCE_DEGREE = 16
+MAX_MULTIPLIER_DEGREE = 8
+MAX_MAP_DIMENSION = 512
+MAX_TOTAL_BASIS_MONOMIALS = 2_048
+MAX_AGGREGATE_MATRIX_ENTRIES = 250_000
+MAX_SPARSE_MATRIX_ENTRIES = 50_000
+MAX_LINEAR_ALGEBRA_WORK = 15_000_000
+MAX_SOURCE_COEFFICIENT_DIGITS = 32
+MAX_LINEAR_FACTOR_COEFFICIENT_DIGITS = 12
+
+
+def _basis_size(variable_count: int, degree: int) -> int:
+    return comb(degree + variable_count - 1, variable_count - 1)
+
+
+def _decimal_log_upper(value: int) -> int:
+    """Return ``ceil(log10(value))`` without floating-point arithmetic."""
+
+    return 0 if value <= 1 else len(str(value - 1))
+
+
+def _homogeneous_basis(variable_count: int, degree: int) -> tuple[tuple[int, ...], ...]:
+    if variable_count == 1:
+        return ((degree,),)
+    return tuple(
+        (first, *tail)
+        for first in range(degree, -1, -1)
+        for tail in _homogeneous_basis(variable_count - 1, degree - first)
+    )
 
 
 def _compute_homogeneous_source_degree(
@@ -33,40 +75,138 @@ def _compute_homogeneous_source_degree(
     return len(linear_factors)
 
 
-def _require_coefficient_map_entry_budget(source_degree: int, max_degree: int) -> None:
+def _require_coefficient_map_budget(
+    *,
+    variable_count: int,
+    source_degree: int,
+    max_degree: int,
+    coefficient_map_detail: Literal["CERTIFICATES", "SPARSE_ENTRIES"],
+    entry_coefficient_digits: int,
+) -> None:
+    """Bound rows, columns, dense work, and the materialized result separately."""
+
+    # Exact work is charged before SymPy runs. At each degree we perform a
+    # producer RREF, an RREF to select independent minor rows, a determinant,
+    # a possible nullspace RREF, then validator RREF and determinant replay.
+    # With k=min(rows, columns), their conservative scalar-update bound is
+    # 3*rows*columns*k + k*k*rows + 2*k**3. A fraction-free intermediate is a
+    # ratio of k-minors; each numerator and denominator has at most
+    # k*(entry_digits + ceil(log10(k))) digits. This covers both the rank
+    # certificate and every exact value that can cross the result boundary.
     aggregate_entries = 0
+    total_basis_monomials = 0
+    total_linear_algebra_work = 0
+    maximum_intermediate_digits = 0
     for degree in range(max_degree + 1):
-        columns = 3 * comb(degree + 2, 2)
-        rows = comb(source_degree + degree + 1, 2)
-        aggregate_entries += rows * columns
-    if aggregate_entries > 250_000:
+        source_basis_count = _basis_size(variable_count, degree)
+        target_basis_count = _basis_size(variable_count, source_degree - 1 + degree)
+        column_count = variable_count * source_basis_count
+        if (
+            source_basis_count > MAX_MAP_DIMENSION
+            or target_basis_count > MAX_MAP_DIMENSION
+            or column_count > MAX_MAP_DIMENSION
+        ):
+            raise ValueError(
+                "graded coefficient-map dimensions exceed the 512-monomial or "
+                "512-column exact certificate budget"
+            )
+        aggregate_entries += target_basis_count * column_count
+        total_basis_monomials += source_basis_count + target_basis_count
+        rank_bound = min(target_basis_count, column_count)
+        total_linear_algebra_work += (
+            3 * target_basis_count * column_count * rank_bound
+            + rank_bound * rank_bound * target_basis_count
+            + 2 * rank_bound**3
+        )
+        maximum_intermediate_digits = max(
+            maximum_intermediate_digits,
+            rank_bound * (entry_coefficient_digits + _decimal_log_upper(rank_bound)),
+        )
+    if aggregate_entries > MAX_AGGREGATE_MATRIX_ENTRIES:
         raise ValueError(
             "graded coefficient maps exceed the 250000-entry exact rank budget"
         )
+    if total_basis_monomials > MAX_TOTAL_BASIS_MONOMIALS:
+        raise ValueError(
+            "graded coefficient-map bases exceed the 2048-monomial result budget"
+        )
+    if total_linear_algebra_work > MAX_LINEAR_ALGEBRA_WORK:
+        raise ValueError(
+            "graded coefficient maps exceed the 15000000-update exact linear-algebra budget"
+        )
+    if maximum_intermediate_digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise ValueError(
+            "graded coefficient maps exceed the exact rational intermediate-height budget"
+        )
+    if (
+        coefficient_map_detail == "SPARSE_ENTRIES"
+        and aggregate_entries > MAX_SPARSE_MATRIX_ENTRIES
+    ):
+        raise ValueError(
+            "materialized graded coefficient maps exceed the 50000-entry result budget"
+        )
 
 
-class GradedJacobianSyzygyRequest(StrictModel):
+def _polynomial_terms(
+    polynomial: RationalPolynomial,
+) -> dict[tuple[int, ...], Fraction]:
+    return {
+        tuple(term.exponents): term.coefficient.as_fraction()
+        for term in polynomial.polynomial.terms
+    }
+
+
+def _partial_derivative_terms(
+    terms: dict[tuple[int, ...], Fraction], variable: int
+) -> dict[tuple[int, ...], Fraction]:
+    derivative: dict[tuple[int, ...], Fraction] = {}
+    for exponents, coefficient in terms.items():
+        power = exponents[variable]
+        if power:
+            derived = list(exponents)
+            derived[variable] -= 1
+            derivative[tuple(derived)] = coefficient * power
+    return derivative
+
+
+def _multiply_terms(
+    left: dict[tuple[int, ...], Fraction], right: dict[tuple[int, ...], Fraction]
+) -> dict[tuple[int, ...], Fraction]:
+    product: dict[tuple[int, ...], Fraction] = {}
+    for left_exponents, left_coefficient in left.items():
+        for right_exponents, right_coefficient in right.items():
+            exponents = tuple(
+                first + second
+                for first, second in zip(left_exponents, right_exponents, strict=True)
+            )
+            product[exponents] = (
+                product.get(exponents, Fraction(0))
+                + left_coefficient * right_coefficient
+            )
+    return {
+        exponents: coefficient
+        for exponents, coefficient in product.items()
+        if coefficient
+    }
+
+
+class GradedJacobianSyzygyRequestBase(StrictModel):
     """Search the homogeneous Jacobian map through one explicit degree bound."""
 
     polynomial: RationalPolynomial | None = None
     linear_factors: tuple[RationalProjectiveLine, ...] | None = Field(
         default=None,
         min_length=1,
-        max_length=16,
+        max_length=MAX_SOURCE_DEGREE,
     )
     linear_factor_variables: (
-        tuple[
-            PolynomialVariable,
-            PolynomialVariable,
-            PolynomialVariable,
-        ]
-        | None
+        tuple[PolynomialVariable, PolynomialVariable, PolynomialVariable] | None
     ) = None
-    max_degree: StrictInt = Field(default=6, ge=0, le=8)
-    coefficient_map_detail: Literal["CERTIFICATES", "SPARSE_ENTRIES"] = "CERTIFICATES"
+    max_degree: StrictInt = Field(default=6, ge=0, le=MAX_MULTIPLIER_DEGREE)
+    coefficient_map_detail: Literal["CERTIFICATES", "SPARSE_ENTRIES"]
 
     @model_validator(mode="after")
-    def require_bounded_homogeneous_three_variable_input(self) -> Self:
+    def require_bounded_homogeneous_input(self) -> Self:
         if self.polynomial is not None:
             if self.linear_factors is not None:
                 raise ValueError(
@@ -78,35 +218,72 @@ class GradedJacobianSyzygyRequest(StrictModel):
                 )
             polynomial = self.polynomial
             variables = polynomial.variables
+            require_polynomial_budget(
+                polynomial,
+                maximum_terms=4_096,
+                maximum_exponent=MAX_SOURCE_DEGREE,
+                maximum_coefficient_digits=MAX_SOURCE_COEFFICIENT_DIGITS,
+                label="graded Jacobian source polynomial",
+            )
         elif self.linear_factors is not None:
             if self.linear_factor_variables is None:
                 raise ValueError("linear_factors require an exact three-variable order")
             labels = tuple(factor.label for factor in self.linear_factors)
             if len(labels) != len(set(labels)):
                 raise ValueError("labelled linear-factor names must be unique")
+            for factor in self.linear_factors:
+                for coefficient in factor.coefficients:
+                    require_bounded_rational(
+                        coefficient,
+                        max_digits=MAX_LINEAR_FACTOR_COEFFICIENT_DIGITS,
+                        label="graded Jacobian linear-factor coefficient",
+                    )
             variables = self.linear_factor_variables
         else:
             raise ValueError(
                 "supply exactly one of polynomial or labelled linear_factors"
             )
-        if len(variables) != 3:
-            raise ValueError(
-                "graded Jacobian syzygies currently require exactly three variables"
-            )
+        if not 1 <= len(variables) <= MAX_POLYNOMIAL_VARIABLES:
+            raise ValueError("graded Jacobian syzygies require one to eight variables")
         if len(set(variables)) != len(variables):
             raise ValueError("graded Jacobian syzygy variables must be unique")
         source_degree = _compute_homogeneous_source_degree(
             self.polynomial, self.linear_factors
         )
-        if source_degree < 1 or source_degree > 16:
+        if not 1 <= source_degree <= MAX_SOURCE_DEGREE:
             raise ValueError("the source homogeneous degree must lie between 1 and 16")
-        _require_coefficient_map_entry_budget(source_degree, self.max_degree)
+        entry_coefficient_digits = (
+            MAX_SOURCE_COEFFICIENT_DIGITS + _decimal_log_upper(source_degree)
+            if self.polynomial is not None
+            else source_degree * MAX_LINEAR_FACTOR_COEFFICIENT_DIGITS
+            + _decimal_log_upper(_basis_size(3, source_degree))
+            + _decimal_log_upper(source_degree)
+        )
+        _require_coefficient_map_budget(
+            variable_count=len(variables),
+            source_degree=source_degree,
+            max_degree=self.max_degree,
+            coefficient_map_detail=self.coefficient_map_detail,
+            entry_coefficient_digits=entry_coefficient_digits,
+        )
         return self
 
 
+class GradedJacobianSyzygyRequest(GradedJacobianSyzygyRequestBase):
+    """Minimum-degree request, whose result deliberately omits sparse entries."""
+
+    coefficient_map_detail: Literal["CERTIFICATES"] = "CERTIFICATES"
+
+
+class GradedJacobianSyzygyCoefficientRequest(GradedJacobianSyzygyRequestBase):
+    """Coefficient-ledger request, whose result always materializes sparse entries."""
+
+    coefficient_map_detail: Literal["SPARSE_ENTRIES"] = "SPARSE_ENTRIES"
+
+
 class GradedJacobianMapEntry(StrictModel):
-    row: StrictInt = Field(ge=0, le=1023)
-    column: StrictInt = Field(ge=0, le=1023)
+    row: StrictInt = Field(ge=0, lt=MAX_MAP_DIMENSION)
+    column: StrictInt = Field(ge=0, lt=MAX_MAP_DIMENSION)
     coefficient: CanonicalRational
 
     @model_validator(mode="after")
@@ -117,8 +294,8 @@ class GradedJacobianMapEntry(StrictModel):
 
 
 class GradedJacobianRankMinor(StrictModel):
-    row_indices: tuple[StrictInt, ...] = Field(max_length=512)
-    column_indices: tuple[StrictInt, ...] = Field(max_length=512)
+    row_indices: tuple[StrictInt, ...] = Field(max_length=MAX_MAP_DIMENSION)
+    column_indices: tuple[StrictInt, ...] = Field(max_length=MAX_MAP_DIMENSION)
     determinant: CanonicalRational
 
     @model_validator(mode="after")
@@ -136,23 +313,46 @@ class GradedJacobianRankMinor(StrictModel):
 
 
 class GradedJacobianCoefficientMap(StrictModel):
-    multiplier_degree: StrictInt = Field(ge=0, le=8)
-    source_monomial_basis: tuple[ExponentTriple, ...] = Field(max_length=64)
-    target_monomial_basis: tuple[ExponentTriple, ...] = Field(max_length=512)
-    row_count: StrictInt = Field(ge=1, le=512)
-    column_count: StrictInt = Field(ge=3, le=512)
+    multiplier_degree: StrictInt = Field(ge=0, le=MAX_MULTIPLIER_DEGREE)
+    source_monomial_basis: tuple[ExponentVector, ...] = Field(
+        min_length=1, max_length=MAX_MAP_DIMENSION
+    )
+    target_monomial_basis: tuple[ExponentVector, ...] = Field(
+        max_length=MAX_MAP_DIMENSION
+    )
+    row_count: StrictInt = Field(ge=1, le=MAX_MAP_DIMENSION)
+    column_count: StrictInt = Field(ge=1, le=MAX_MAP_DIMENSION)
     matrix_digest: Sha256Digest
-    sparse_entries: tuple[GradedJacobianMapEntry, ...] = Field(max_length=50_000)
-    rank: StrictInt = Field(ge=0, le=512)
-    nullity: StrictInt = Field(ge=0, le=512)
-    pivot_columns: tuple[StrictInt, ...] = Field(max_length=512)
+    sparse_entries: tuple[GradedJacobianMapEntry, ...] = Field(
+        max_length=MAX_SPARSE_MATRIX_ENTRIES
+    )
+    rank: StrictInt = Field(ge=0, le=MAX_MAP_DIMENSION)
+    nullity: StrictInt = Field(ge=0, le=MAX_MAP_DIMENSION)
+    pivot_columns: tuple[StrictInt, ...] = Field(max_length=MAX_MAP_DIMENSION)
     rank_minor: GradedJacobianRankMinor | None = None
     injective: bool
 
     @model_validator(mode="after")
     def bind_dimensions_rank_and_optional_entries(self) -> Self:
-        if len(self.source_monomial_basis) * 3 != self.column_count:
-            raise ValueError("source basis must induce three multiplier blocks")
+        variable_count = len(self.source_monomial_basis[0])
+        if not 1 <= variable_count <= MAX_POLYNOMIAL_VARIABLES:
+            raise ValueError(
+                "source basis exponent vectors must have one to eight axes"
+            )
+        if self.source_monomial_basis != _homogeneous_basis(
+            variable_count, self.multiplier_degree
+        ):
+            raise ValueError("source basis must be the canonical homogeneous basis")
+        if any(
+            len(exponents) != variable_count
+            or any(exponent < 0 for exponent in exponents)
+            for exponents in self.target_monomial_basis
+        ):
+            raise ValueError("target basis exponent vectors must match variable_count")
+        if len(self.source_monomial_basis) * variable_count != self.column_count:
+            raise ValueError(
+                "source basis must induce one multiplier block per variable"
+            )
         if len(self.target_monomial_basis) != self.row_count:
             raise ValueError("target basis length must equal row_count")
         if self.rank + self.nullity != self.column_count:
@@ -187,85 +387,72 @@ class GradedJacobianCoefficientMap(StrictModel):
 
 
 class GradedJacobianKernelWitness(StrictModel):
-    multiplier_degree: StrictInt = Field(ge=0, le=8)
+    multiplier_degree: StrictInt = Field(ge=0, le=MAX_MULTIPLIER_DEGREE)
     coefficient_vector: tuple[CanonicalRational, ...] = Field(
-        min_length=3,
-        max_length=512,
+        min_length=1,
+        max_length=MAX_MAP_DIMENSION,
     )
-    multipliers: tuple[
-        RationalPolynomial,
-        RationalPolynomial,
-        RationalPolynomial,
-    ]
+    multipliers: tuple[RationalPolynomial, ...] = Field(
+        min_length=1,
+        max_length=MAX_POLYNOMIAL_VARIABLES,
+    )
 
     @model_validator(mode="after")
-    def require_nonzero_vector(self) -> Self:
+    def require_nonzero_homogeneous_vector(self) -> Self:
         if all(value.as_fraction() == 0 for value in self.coefficient_vector):
             raise ValueError("kernel witness coefficient vector must be nonzero")
+        if any(
+            any(
+                sum(term.exponents) != self.multiplier_degree
+                for term in multiplier.polynomial.terms
+            )
+            for multiplier in self.multipliers
+        ):
+            raise ValueError("kernel witness multipliers must be homogeneous")
         return self
 
 
 class GradedJacobianSyzygyResult(StrictModel):
-    """Exact rank ledger and first kernel through the requested finite bound."""
+    """Exact rank ledger and first kernel through the requested finite bound.
+
+    ``result_schema_version='1'`` remains compatible with the prior
+    three-variable result shape: variable count is still carried only by the
+    canonical ``variables`` and exponent vectors. Operation versions, rather
+    than this result value version, distinguish the specialized request modes.
+    """
 
     result_schema_version: Literal["1"] = "1"
-    variables: tuple[str, str, str]
+    variables: tuple[PolynomialVariable, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
     source_kind: Literal["EXPANDED_POLYNOMIAL", "LABELLED_LINEAR_FACTOR_PRODUCT"]
     expanded_polynomial: RationalPolynomial
-    homogeneous_degree: StrictInt = Field(ge=1, le=16)
-    searched_through_degree: StrictInt = Field(ge=0, le=8)
+    homogeneous_degree: StrictInt = Field(ge=1, le=MAX_SOURCE_DEGREE)
+    searched_through_degree: StrictInt = Field(ge=0, le=MAX_MULTIPLIER_DEGREE)
     coefficient_map_detail: Literal["CERTIFICATES", "SPARSE_ENTRIES"]
-    partial_derivatives: tuple[
-        RationalPolynomial,
-        RationalPolynomial,
-        RationalPolynomial,
-    ]
+    partial_derivatives: tuple[RationalPolynomial, ...] = Field(
+        min_length=1, max_length=MAX_POLYNOMIAL_VARIABLES
+    )
     degree_maps: tuple[GradedJacobianCoefficientMap, ...] = Field(
         min_length=1,
-        max_length=9,
+        max_length=MAX_MULTIPLIER_DEGREE + 1,
     )
     status: Literal["FOUND", "NONE_THROUGH_BOUND"]
-    first_syzygy_degree: StrictInt | None = Field(default=None, ge=0, le=8)
+    first_syzygy_degree: StrictInt | None = Field(
+        default=None, ge=0, le=MAX_MULTIPLIER_DEGREE
+    )
     kernel_witness: GradedJacobianKernelWitness | None = None
     completion: Literal["COMPLETE_THROUGH_BOUND"] = "COMPLETE_THROUGH_BOUND"
 
     @model_validator(mode="after")
     def bind_first_kernel_and_finite_scope(self) -> Self:
-        if self.expanded_polynomial.variables != self.variables:
-            raise ValueError("expanded source must use the declared variable order")
-        if not self.expanded_polynomial.polynomial.terms or any(
-            sum(term.exponents) != self.homogeneous_degree
-            for term in self.expanded_polynomial.polynomial.terms
-        ):
-            raise ValueError(
-                "expanded source must be nonzero and homogeneous of the stated degree"
-            )
-        expected_degrees = tuple(range(self.searched_through_degree + 1))
-        actual_degrees = tuple(item.multiplier_degree for item in self.degree_maps)
-        if actual_degrees != expected_degrees:
-            raise ValueError("degree maps must cover every degree from zero in order")
-        if self.coefficient_map_detail == "CERTIFICATES" and any(
-            item.sparse_entries for item in self.degree_maps
-        ):
-            raise ValueError("certificate detail must omit full sparse matrices")
-        if self.coefficient_map_detail == "SPARSE_ENTRIES" and any(
-            not item.sparse_entries and item.rank > 0 for item in self.degree_maps
-        ):
-            raise ValueError("sparse-entry detail must expose every nonzero map")
+        variable_count = _validate_result_source_and_partials(self)
+        _validate_result_maps(self, variable_count)
         noninjective = tuple(
             item.multiplier_degree for item in self.degree_maps if not item.injective
         )
         if self.status == "FOUND":
-            if (
-                not noninjective
-                or self.first_syzygy_degree != noninjective[0]
-                or self.kernel_witness is None
-                or self.kernel_witness.multiplier_degree != noninjective[0]
-                or len(self.kernel_witness.coefficient_vector)
-                != self.degree_maps[noninjective[0]].column_count
-                or self.searched_through_degree != noninjective[0]
-            ):
-                raise ValueError("FOUND must bind the first nonzero graded kernel")
+            _validate_found_witness(self, variable_count, noninjective)
         elif (
             noninjective
             or self.first_syzygy_degree is not None
@@ -277,11 +464,200 @@ class GradedJacobianSyzygyResult(StrictModel):
         return self
 
 
+def _validate_result_source_and_partials(result: GradedJacobianSyzygyResult) -> int:
+    variable_count = len(result.variables)
+    if len(set(result.variables)) != variable_count:
+        raise ValueError("result variable order must be unique")
+    if result.expanded_polynomial.variables != result.variables:
+        raise ValueError("expanded source must use the declared variable order")
+    source_terms = _polynomial_terms(result.expanded_polynomial)
+    if not source_terms or any(
+        sum(exponents) != result.homogeneous_degree for exponents in source_terms
+    ):
+        raise ValueError(
+            "expanded source must be nonzero and homogeneous of the stated degree"
+        )
+    if len(result.partial_derivatives) != variable_count or any(
+        partial.variables != result.variables for partial in result.partial_derivatives
+    ):
+        raise ValueError("partial derivatives must retain the source variable order")
+    expected_partials = tuple(
+        _partial_derivative_terms(source_terms, variable)
+        for variable in range(variable_count)
+    )
+    if any(
+        _polynomial_terms(partial) != expected
+        for partial, expected in zip(
+            result.partial_derivatives, expected_partials, strict=True
+        )
+    ):
+        raise ValueError("partial derivatives must reconstruct from the source")
+    return variable_count
+
+
+def _validate_result_maps(
+    result: GradedJacobianSyzygyResult, variable_count: int
+) -> None:
+    expected_degrees = tuple(range(result.searched_through_degree + 1))
+    actual_degrees = tuple(item.multiplier_degree for item in result.degree_maps)
+    if actual_degrees != expected_degrees:
+        raise ValueError("degree maps must cover every degree from zero in order")
+    for item in result.degree_maps:
+        expected_target_basis = _homogeneous_basis(
+            variable_count, result.homogeneous_degree - 1 + item.multiplier_degree
+        )
+        if item.target_monomial_basis != expected_target_basis:
+            raise ValueError("coefficient maps must use the source ring's exact bases")
+    if result.coefficient_map_detail == "CERTIFICATES" and any(
+        item.sparse_entries for item in result.degree_maps
+    ):
+        raise ValueError("certificate detail must omit full sparse matrices")
+    if result.coefficient_map_detail == "SPARSE_ENTRIES" and any(
+        not item.sparse_entries and item.rank > 0 for item in result.degree_maps
+    ):
+        raise ValueError("sparse-entry detail must expose every nonzero map")
+    for item in result.degree_maps:
+        _replay_coefficient_map(result, item)
+
+
+def _replayed_matrix_digest(
+    *,
+    multiplier_degree: int,
+    source_basis: tuple[tuple[int, ...], ...],
+    target_basis: tuple[tuple[int, ...], ...],
+    entries: tuple[tuple[int, int, Fraction], ...],
+) -> str:
+    payload = {
+        "protocol": "jacobian.graded-jacobian-map.v1",
+        "multiplier_degree": multiplier_degree,
+        "source_monomial_basis": [list(item) for item in source_basis],
+        "target_monomial_basis": [list(item) for item in target_basis],
+        "entries": [
+            [row, column, f"{value.numerator}/{value.denominator}"]
+            for row, column, value in entries
+        ],
+    }
+    return f"sha256:{hashlib.sha256(canonicalize_json(payload)).hexdigest()}"
+
+
+def _replay_coefficient_map(
+    result: GradedJacobianSyzygyResult,
+    item: GradedJacobianCoefficientMap,
+) -> None:
+    """Replay one admitted exact map so rank proves the reported minimum."""
+
+    from sympy import Matrix, Rational
+
+    matrix = Matrix.zeros(item.row_count, item.column_count)
+    row_by_exponent = {
+        exponents: row for row, exponents in enumerate(item.target_monomial_basis)
+    }
+    block_size = len(item.source_monomial_basis)
+    for component, partial in enumerate(result.partial_derivatives):
+        for basis_index, multiplier_exponents in enumerate(item.source_monomial_basis):
+            column = component * block_size + basis_index
+            for partial_exponents, coefficient in _polynomial_terms(partial).items():
+                target_exponents = tuple(
+                    left + right
+                    for left, right in zip(
+                        multiplier_exponents, partial_exponents, strict=True
+                    )
+                )
+                matrix[row_by_exponent[target_exponents], column] += Rational(
+                    coefficient.numerator, coefficient.denominator
+                )
+    entries = tuple(
+        (row, column, Fraction(matrix[row, column]))
+        for row in range(matrix.rows)
+        for column in range(matrix.cols)
+        if matrix[row, column] != 0
+    )
+    if item.matrix_digest != _replayed_matrix_digest(
+        multiplier_degree=item.multiplier_degree,
+        source_basis=item.source_monomial_basis,
+        target_basis=item.target_monomial_basis,
+        entries=entries,
+    ):
+        raise ValueError("coefficient-map digest must bind the reconstructed matrix")
+    if (
+        item.sparse_entries
+        and tuple(
+            (entry.row, entry.column, entry.coefficient.as_fraction())
+            for entry in item.sparse_entries
+        )
+        != entries
+    ):
+        raise ValueError("sparse coefficient-map entries must reconstruct exactly")
+    _, pivot_columns = matrix.rref()
+    rank = len(pivot_columns)
+    if (
+        item.rank != rank
+        or item.pivot_columns != tuple(int(column) for column in pivot_columns)
+        or item.nullity != matrix.cols - rank
+        or item.injective != (rank == matrix.cols)
+    ):
+        raise ValueError("coefficient-map rank certificate must replay exactly")
+    if item.rank_minor is not None:
+        minor = matrix.extract(
+            item.rank_minor.row_indices, item.rank_minor.column_indices
+        ).det()
+        if Fraction(minor) != item.rank_minor.determinant.as_fraction():
+            raise ValueError("rank-minor determinant must replay exactly")
+
+
+def _validate_found_witness(
+    result: GradedJacobianSyzygyResult,
+    variable_count: int,
+    noninjective: tuple[int, ...],
+) -> None:
+    witness = result.kernel_witness
+    if (
+        not noninjective
+        or result.first_syzygy_degree != noninjective[0]
+        or witness is None
+        or witness.multiplier_degree != noninjective[0]
+        or len(witness.multipliers) != variable_count
+        or len(witness.coefficient_vector)
+        != result.degree_maps[noninjective[0]].column_count
+        or result.searched_through_degree != noninjective[0]
+        or any(
+            multiplier.variables != result.variables
+            for multiplier in witness.multipliers
+        )
+    ):
+        raise ValueError("FOUND must bind the first nonzero graded kernel")
+    basis = result.degree_maps[noninjective[0]].source_monomial_basis
+    expected_vector = tuple(
+        _polynomial_terms(multiplier).get(exponents, Fraction(0))
+        for multiplier in witness.multipliers
+        for exponents in basis
+    )
+    if (
+        tuple(value.as_fraction() for value in witness.coefficient_vector)
+        != expected_vector
+    ):
+        raise ValueError("kernel vector must reconstruct its multipliers")
+    reconstructed: dict[tuple[int, ...], Fraction] = {}
+    for multiplier, partial in zip(
+        witness.multipliers, result.partial_derivatives, strict=True
+    ):
+        for exponents, coefficient in _multiply_terms(
+            _polynomial_terms(multiplier), _polynomial_terms(partial)
+        ).items():
+            reconstructed[exponents] = (
+                reconstructed.get(exponents, Fraction(0)) + coefficient
+            )
+    if any(reconstructed.values()):
+        raise ValueError("kernel witness must reconstruct a Jacobian syzygy")
+
+
 __all__ = [
     "GradedJacobianCoefficientMap",
     "GradedJacobianKernelWitness",
     "GradedJacobianMapEntry",
     "GradedJacobianRankMinor",
+    "GradedJacobianSyzygyCoefficientRequest",
     "GradedJacobianSyzygyRequest",
+    "GradedJacobianSyzygyRequestBase",
     "GradedJacobianSyzygyResult",
 ]

--- a/tests/math/polynomials/test_jacobian_syzygy_invariants.py
+++ b/tests/math/polynomials/test_jacobian_syzygy_invariants.py
@@ -280,13 +280,24 @@ def test_result_rejects_a_mutated_witness_or_partial_derivative() -> None:
 def test_dimension_specific_basis_boundary_rejects_before_backend_execution() -> None:
     with pytest.raises(ValidationError, match="512-monomial"):
         GradedJacobianSyzygyRequest(
-            polynomial=_sparse_polynomial(("x", "y", "z", "w"), {(11, 0, 0, 0): 1}),
+            polynomial=_sparse_polynomial(
+                ("x", "y", "z", "w"),
+                {
+                    (11, 0, 0, 0): 1,
+                    (0, 11, 0, 0): 1,
+                    (0, 0, 11, 0): 1,
+                    (0, 0, 0, 11): 1,
+                },
+            ),
             max_degree=3,
         )
 
     with pytest.raises(ValidationError, match="15000000-update"):
         GradedJacobianSyzygyRequest(
-            polynomial=_sparse_polynomial(("x", "y", "z", "w"), {(9, 0, 0, 0): 1}),
+            polynomial=_sparse_polynomial(
+                ("x", "y", "z", "w"),
+                {(9, 0, 0, 0): 1, (0, 9, 0, 0): 1, (0, 0, 9, 0): 1, (0, 0, 0, 9): 1},
+            ),
             max_degree=4,
         )
 
@@ -302,3 +313,78 @@ def test_syzygy_kernel_rejects_an_incomplete_linear_factor_request() -> None:
 
     with pytest.raises(ValueError, match="linear-factor input is incomplete"):
         compute_graded_jacobian_syzygy(request)
+
+
+def test_zero_partial_derivatives_admit_the_forced_degree_zero_kernel() -> None:
+    request = GradedJacobianSyzygyRequest(
+        polynomial=_sparse_polynomial(("a", "b", "c", "d", "e"), {(1, 0, 0, 0, 0): 1}),
+    )
+
+    assert request.max_degree == 6
+    result = compute_graded_jacobian_syzygy(request)
+
+    assert result.status == "FOUND"
+    assert result.first_syzygy_degree == 0
+    assert result.searched_through_degree == 0
+    assert [
+        (item.row_count, item.column_count, item.rank, item.nullity)
+        for item in result.degree_maps
+    ] == [(1, 5, 1, 4)]
+    assert (
+        GradedJacobianSyzygyResult.model_validate(result.model_dump(mode="python"))
+        == result
+    )
+
+
+def test_default_bound_admits_eight_variables_when_the_kernel_is_forced() -> None:
+    request = GradedJacobianSyzygyRequest(
+        polynomial=_sparse_polynomial(
+            ("a", "b", "c", "d", "e", "f", "g", "h"),
+            {(1, 0, 0, 0, 0, 0, 0, 0): 1},
+        ),
+        max_degree=8,
+    )
+    result = compute_graded_jacobian_syzygy(request)
+
+    assert result.first_syzygy_degree == 0
+    assert [item.column_count for item in result.degree_maps] == [8]
+
+
+def test_dependent_gradient_without_zero_partials_stops_at_degree_zero() -> None:
+    result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(
+                ("x", "y", "z"),
+                {(2, 0, 2): 1, (1, 1, 2): -2, (0, 2, 2): 1},
+            ),
+            max_degree=6,
+        )
+    )
+
+    assert result.status == "FOUND"
+    assert result.first_syzygy_degree == 0
+    assert len(result.degree_maps) == 1
+    witness = result.kernel_witness
+    assert witness is not None
+    assert len(witness.multipliers) == 3
+
+
+def test_result_rejects_labelled_provenance_off_three_variables() -> None:
+    for variables in (("x",), ("x", "y"), ("x", "y", "z", "w")):
+        source = _sparse_polynomial(
+            variables,
+            {tuple(1 if index == 0 else 0 for index in range(len(variables))): 1},
+        )
+        produced = compute_graded_jacobian_syzygy_coefficients(
+            GradedJacobianSyzygyCoefficientRequest(
+                polynomial=source,
+                max_degree=1,
+                coefficient_map_detail="SPARSE_ENTRIES",
+            )
+        )
+        payload = json.loads(produced.model_dump_json())
+        assert GradedJacobianSyzygyResult.model_validate(payload) == produced
+
+        payload["source_kind"] = "LABELLED_LINEAR_FACTOR_PRODUCT"
+        with pytest.raises(ValidationError, match="requires exactly three variables"):
+            GradedJacobianSyzygyResult.model_validate(payload)

--- a/tests/math/polynomials/test_jacobian_syzygy_invariants.py
+++ b/tests/math/polynomials/test_jacobian_syzygy_invariants.py
@@ -1,11 +1,294 @@
 from __future__ import annotations
 
-import pytest
+import json
+from fractions import Fraction
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.geometry.projective.values import RationalProjectiveLine
 from jacobian.math.polynomials._jacobian_syzygy import (
     compute_graded_jacobian_syzygy,
+    compute_graded_jacobian_syzygy_coefficients,
 )
-from jacobian.math.polynomials._syzygy_models import GradedJacobianSyzygyRequest
+from jacobian.math.polynomials._syzygy_models import (
+    GradedJacobianSyzygyCoefficientRequest,
+    GradedJacobianSyzygyRequest,
+    GradedJacobianSyzygyResult,
+)
+from jacobian.math.polynomials.values import (
+    RationalPolynomial,
+    RationalPolynomialTerm,
+    SparseRationalPolynomial,
+)
+
+
+def _rational(value: Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(value)
+
+
+def _four_variable_counterexample() -> RationalPolynomial:
+    """Expand the nine specified linear forms without using the producer."""
+
+    factors = (
+        ((1, 0, 0, 0),),
+        ((0, 1, 0, 0),),
+        ((0, 0, 1, 0),),
+        ((0, 0, 0, 1),),
+        ((0, 1, 0, 1),),
+        ((0, 0, 1, 1),),
+        ((-1, 1, 0, 1),),
+        ((-1, 0, 1, 1),),
+        ((-1, 1, 1, 1),),
+    )
+    terms: dict[tuple[int, int, int, int], Fraction] = {(0, 0, 0, 0): Fraction(1)}
+    for factor in factors:
+        product: dict[tuple[int, int, int, int], Fraction] = {}
+        for exponents, coefficient in terms.items():
+            for factor_exponents in factor:
+                # Every listed factor has coefficients in {-1, 0, 1} encoded by
+                # its nonzero variable terms below.
+                for variable, factor_coefficient in enumerate(factor_exponents):
+                    if not factor_coefficient:
+                        continue
+                    target = list(exponents)
+                    target[variable] += 1
+                    target_tuple = tuple(target)
+                    product[target_tuple] = product.get(target_tuple, Fraction(0)) + (
+                        coefficient * factor_coefficient
+                    )
+        terms = {
+            exponents: coefficient
+            for exponents, coefficient in product.items()
+            if coefficient
+        }
+    return RationalPolynomial(
+        variables=("x", "y", "z", "w"),
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=_rational(coefficient), exponents=exponents
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+            )
+        ),
+    )
+
+
+def _sparse_polynomial(
+    variables: tuple[str, ...], terms: dict[tuple[int, ...], int]
+) -> RationalPolynomial:
+    return RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=tuple(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational(num=str(coefficient), den="1"),
+                    exponents=exponents,
+                )
+                for exponents, coefficient in sorted(terms.items(), reverse=True)
+            )
+        ),
+    )
+
+
+LEGACY_THREE_VARIABLE_CERTIFICATE_PAYLOAD = {
+    "polynomial": {
+        "variables": ["x", "y", "z"],
+        "polynomial": {
+            "terms": [
+                {
+                    "coefficient": {"num": "1", "den": "1"},
+                    "exponents": [1, 1, 1],
+                }
+            ]
+        },
+    },
+    "max_degree": 1,
+    "coefficient_map_detail": "CERTIFICATES",
+}
+
+
+def test_four_variable_rank_fixture_has_the_published_first_kernel() -> None:
+    result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            polynomial=_four_variable_counterexample(), max_degree=3
+        )
+    )
+
+    assert result.variables == ("x", "y", "z", "w")
+    assert result.first_syzygy_degree == 3
+    assert result.status == "FOUND"
+    assert result.kernel_witness is not None
+    assert len(result.kernel_witness.multipliers) == 4
+    assert [
+        (item.row_count, item.column_count, item.rank, item.nullity)
+        for item in result.degree_maps
+    ] == [
+        (165, 4, 4, 0),
+        (220, 16, 16, 0),
+        (286, 40, 40, 0),
+        (364, 80, 76, 4),
+    ]
+
+    # Revalidation replays every returned partial and the exact witness equation.
+    assert (
+        GradedJacobianSyzygyResult.model_validate(result.model_dump(mode="python"))
+        == result
+    )
+
+
+def test_three_variable_sparse_and_labelled_inputs_remain_compatible() -> None:
+    sparse_result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(
+                ("x", "y", "z"),
+                {(1, 1, 1): 1},
+            ),
+            max_degree=1,
+        )
+    )
+    labelled_result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            linear_factors=(
+                RationalProjectiveLine(
+                    label="x",
+                    coefficients=(
+                        _rational(Fraction(1)),
+                        _rational(Fraction(0)),
+                        _rational(Fraction(0)),
+                    ),
+                ),
+                RationalProjectiveLine(
+                    label="y",
+                    coefficients=(
+                        _rational(Fraction(0)),
+                        _rational(Fraction(1)),
+                        _rational(Fraction(0)),
+                    ),
+                ),
+                RationalProjectiveLine(
+                    label="z",
+                    coefficients=(
+                        _rational(Fraction(0)),
+                        _rational(Fraction(0)),
+                        _rational(Fraction(1)),
+                    ),
+                ),
+            ),
+            linear_factor_variables=("x", "y", "z"),
+            max_degree=1,
+        )
+    )
+
+    sparse_payload = sparse_result.model_dump()
+    labelled_payload = labelled_result.model_dump()
+    assert sparse_payload.pop("source_kind") == "EXPANDED_POLYNOMIAL"
+    assert labelled_payload.pop("source_kind") == "LABELLED_LINEAR_FACTOR_PRODUCT"
+    assert sparse_payload == labelled_payload
+    assert sparse_result.first_syzygy_degree == 1
+    assert [item.column_count for item in sparse_result.degree_maps] == [3, 9]
+
+
+def test_frozen_legacy_three_variable_certificate_payload_remains_version_one() -> None:
+    result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest.model_validate(
+            LEGACY_THREE_VARIABLE_CERTIFICATE_PAYLOAD
+        )
+    )
+
+    assert result.result_schema_version == "1"
+    assert result.coefficient_map_detail == "CERTIFICATES"
+    assert result.first_syzygy_degree == 1
+    assert [
+        (item.row_count, item.column_count, item.rank, item.nullity)
+        for item in result.degree_maps
+    ] == [(6, 3, 3, 0), (10, 9, 7, 2)]
+
+
+def test_detail_mode_is_part_of_each_operation_request_contract() -> None:
+    sparse_payload = {
+        **LEGACY_THREE_VARIABLE_CERTIFICATE_PAYLOAD,
+        "coefficient_map_detail": "SPARSE_ENTRIES",
+    }
+    with pytest.raises(ValidationError, match="CERTIFICATES"):
+        GradedJacobianSyzygyRequest.model_validate(sparse_payload)
+
+    with pytest.raises(ValidationError, match="SPARSE_ENTRIES"):
+        GradedJacobianSyzygyCoefficientRequest.model_validate(
+            LEGACY_THREE_VARIABLE_CERTIFICATE_PAYLOAD
+        )
+
+
+def test_sparse_coefficient_ledger_uses_four_variable_exponent_vectors() -> None:
+    result = compute_graded_jacobian_syzygy_coefficients(
+        GradedJacobianSyzygyCoefficientRequest(
+            polynomial=_sparse_polynomial(("x", "y", "z", "w"), {(1, 1, 1, 1): 1}),
+            max_degree=0,
+        )
+    )
+
+    coefficient_map = result.degree_maps[0]
+    assert coefficient_map.row_count == 20
+    assert coefficient_map.column_count == 4
+    assert coefficient_map.sparse_entries
+    assert all(
+        len(exponents) == 4
+        for exponents in (
+            *coefficient_map.source_monomial_basis,
+            *coefficient_map.target_monomial_basis,
+        )
+    )
+
+
+def test_result_rejects_a_mutated_witness_or_partial_derivative() -> None:
+    result = compute_graded_jacobian_syzygy(
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(("x", "y", "z"), {(1, 1, 1): 1}),
+            max_degree=1,
+        )
+    )
+    witness = result.kernel_witness
+    assert witness is not None
+    first_nonzero = next(
+        index
+        for index, coefficient in enumerate(witness.coefficient_vector)
+        if coefficient.as_fraction()
+    )
+    corrupted_witness = json.loads(result.model_dump_json())
+    corrupted_witness["kernel_witness"]["coefficient_vector"][first_nonzero] = {
+        "num": "2",
+        "den": "1",
+    }
+    with pytest.raises(ValidationError, match="kernel vector must reconstruct"):
+        GradedJacobianSyzygyResult.model_validate(corrupted_witness)
+
+    corrupted_partial = json.loads(result.model_dump_json())
+    corrupted_partial["partial_derivatives"][0]["polynomial"]["terms"][0][
+        "coefficient"
+    ] = {"num": "2", "den": "1"}
+    with pytest.raises(ValidationError, match="partial derivatives must reconstruct"):
+        GradedJacobianSyzygyResult.model_validate(corrupted_partial)
+
+    corrupted_map = json.loads(result.model_dump_json())
+    corrupted_map["degree_maps"][0]["matrix_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(ValidationError, match="digest must bind"):
+        GradedJacobianSyzygyResult.model_validate(corrupted_map)
+
+
+def test_dimension_specific_basis_boundary_rejects_before_backend_execution() -> None:
+    with pytest.raises(ValidationError, match="512-monomial"):
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(("x", "y", "z", "w"), {(11, 0, 0, 0): 1}),
+            max_degree=3,
+        )
+
+    with pytest.raises(ValidationError, match="15000000-update"):
+        GradedJacobianSyzygyRequest(
+            polynomial=_sparse_polynomial(("x", "y", "z", "w"), {(9, 0, 0, 0): 1}),
+            max_degree=4,
+        )
 
 
 def test_syzygy_kernel_rejects_an_incomplete_linear_factor_request() -> None:


### PR DESCRIPTION
Closes #921

## Why

The graded Jacobian-syzygy operations only accepted homogeneous sources in three variables, even though the coefficient-map construction and its exact linear algebra are defined for a bounded number of variables. The existing labelled-line arrangement path remains intrinsically three-variable and is kept as such.

## What changed

- Accept homogeneous `RationalPolynomial` inputs in one through eight variables and preserve exponent vectors at their actual arity.
- Keep the existing three-variable labelled-factor path, including its `RationalProjectiveLine` contract.
- Split the public requests by executable detail: minimum-degree requests always return rank certificates, while coefficient-ledger requests always return sparse entries. Unsupported modes are rejected at request validation rather than reconstructed during execution.
- Add pass-aware admission for all producer and replay RREF/determinant/nullspace work, exact intermediate rational height, dimensions, sparse result entries, and source coefficient budgets.
- Preserve version-1 three-variable certificate payloads; advance the operation versions for the broader request contract.

SymPy remains the private exact linear-algebra backend. The added admission is deliberately expressed in the dimensions and rational values it will receive, so the public domain is bounded before invoking SymPy.

## Validation

- `make check` — 3,524 passed (one existing unrelated syntax warning)
- `make test-math TESTS=tests/math/polynomials/test_jacobian_syzygy_invariants.py` — 8 passed

Suggested review order: `_syzygy_models.py` establishes the expanded values and admission; `_jacobian_syzygy.py` adapts the coefficient-map kernel; the focused tests cover the four-variable fixture, request detail separation, and legacy payload compatibility.
