### PR TITLE
feat(math): add exact spectra over real quadratic fields

### DIFF
--- a/src/jacobian/math/matrices/quadratic_spectral/__init__.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/__init__.py
@@ -1,0 +1,21 @@
+"""Supported exact matrix API over real quadratic fields."""
+
+from jacobian.math.matrices.quadratic_spectral.operations import (
+    inertia,
+    singular_spectrum,
+    symmetric_spectrum,
+)
+from jacobian.math.matrices.quadratic_spectral.values import (
+    RealAlgebraicMultiplicity,
+    RealQuadraticInertia,
+    RealQuadraticSpectrum,
+)
+
+__all__ = [
+    "RealAlgebraicMultiplicity",
+    "RealQuadraticInertia",
+    "RealQuadraticSpectrum",
+    "inertia",
+    "singular_spectrum",
+    "symmetric_spectrum",
+]

--- a/src/jacobian/math/matrices/quadratic_spectral/_admission.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/_admission.py
@@ -1,0 +1,30 @@
+"""Owner-local admission decisions for exact quadratic matrix operations."""
+
+from __future__ import annotations
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.matrices.quadratic_spectral._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "matrix.real_quadratic.inertia.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
+    OperationAdmission(
+        "matrix.real_quadratic.singular_spectrum.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
+    OperationAdmission(
+        "matrix.real_quadratic.symmetric_spectrum.compute",
+        AdmissionDecision.KEEP,
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/matrices/quadratic_spectral/_models.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/_models.py
@@ -1,0 +1,79 @@
+"""Typed requests for exact real-quadratic matrix spectra."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.matrices.values import RealQuadraticMatrix
+
+
+class RealQuadraticSymmetricSpectrumRequest(StrictModel):
+    """One symmetric 2 by 2 matrix over a shared real quadratic field."""
+
+    matrix: RealQuadraticMatrix = Field(
+        description=(
+            "An exact symmetric 2 by 2 matrix over one shared Q(sqrt(d)); "
+            "the primitive spectral annihilating polynomial may use at most "
+            "996 decimal digits per coefficient."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_matrix(self) -> Self:
+        from jacobian.math.matrices.quadratic_spectral.operations import (
+            require_symmetric_spectrum_matrix,
+        )
+
+        require_symmetric_spectrum_matrix(self.matrix)
+        return self
+
+
+class RealQuadraticSingularSpectrumRequest(StrictModel):
+    """One 2 by 2 matrix over a shared real quadratic field."""
+
+    matrix: RealQuadraticMatrix = Field(
+        description=(
+            "An exact 2 by 2 matrix over one shared Q(sqrt(d)); the primitive "
+            "singular-value annihilating polynomial may use at most 996 "
+            "decimal digits per coefficient."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_matrix(self) -> Self:
+        from jacobian.math.matrices.quadratic_spectral.operations import (
+            require_singular_spectrum_matrix,
+        )
+
+        require_singular_spectrum_matrix(self.matrix)
+        return self
+
+
+class RealQuadraticInertiaRequest(StrictModel):
+    """One symmetric matrix of dimension at most four over a quadratic field."""
+
+    matrix: RealQuadraticMatrix = Field(
+        description=(
+            "An exact symmetric matrix of dimension at most four over one "
+            "shared Q(sqrt(d))."
+        )
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_matrix(self) -> Self:
+        from jacobian.math.matrices.quadratic_spectral.operations import (
+            require_inertia_matrix,
+        )
+
+        require_inertia_matrix(self.matrix)
+        return self
+
+
+__all__ = [
+    "RealQuadraticInertiaRequest",
+    "RealQuadraticSingularSpectrumRequest",
+    "RealQuadraticSymmetricSpectrumRequest",
+]

--- a/src/jacobian/math/matrices/quadratic_spectral/_operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/_operations.py
@@ -1,0 +1,39 @@
+"""Wire adapters for exact real-quadratic matrix spectra."""
+
+from jacobian.math.matrices.quadratic_spectral._models import (
+    RealQuadraticInertiaRequest,
+    RealQuadraticSingularSpectrumRequest,
+    RealQuadraticSymmetricSpectrumRequest,
+)
+from jacobian.math.matrices.quadratic_spectral.operations import (
+    inertia,
+    singular_spectrum,
+    symmetric_spectrum,
+)
+from jacobian.math.matrices.quadratic_spectral.values import (
+    RealQuadraticInertia,
+    RealQuadraticSpectrum,
+)
+
+
+def compute_symmetric_spectrum(
+    request: RealQuadraticSymmetricSpectrumRequest,
+) -> RealQuadraticSpectrum:
+    return symmetric_spectrum(request.matrix)
+
+
+def compute_singular_spectrum(
+    request: RealQuadraticSingularSpectrumRequest,
+) -> RealQuadraticSpectrum:
+    return singular_spectrum(request.matrix)
+
+
+def compute_inertia(request: RealQuadraticInertiaRequest) -> RealQuadraticInertia:
+    return inertia(request.matrix)
+
+
+__all__ = [
+    "compute_inertia",
+    "compute_singular_spectrum",
+    "compute_symmetric_spectrum",
+]

--- a/src/jacobian/math/matrices/quadratic_spectral/_tools.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/_tools.py
@@ -1,0 +1,192 @@
+"""Exact real-quadratic matrix operation declarations."""
+
+from collections.abc import Callable
+from typing import Any
+
+from jacobian._models import StrictModel
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, OperationExample
+from jacobian.math.matrices.quadratic_spectral._models import (
+    RealQuadraticInertiaRequest,
+    RealQuadraticSingularSpectrumRequest,
+    RealQuadraticSymmetricSpectrumRequest,
+)
+from jacobian.math.matrices.quadratic_spectral._operations import (
+    compute_inertia,
+    compute_singular_spectrum,
+    compute_symmetric_spectrum,
+)
+from jacobian.math.matrices.quadratic_spectral.values import (
+    RealQuadraticInertia,
+    RealQuadraticSpectrum,
+)
+
+
+def _op[
+    RequestT: StrictModel,
+    ResultT: StrictModel,
+](
+    operation_id: str,
+    title: str,
+    description: str,
+    request_model: type[RequestT],
+    result_model: type[ResultT],
+    operation: Callable[[RequestT], ResultT],
+    *tags: str,
+    examples: tuple[OperationExample, ...] = (),
+) -> MathTool[RequestT, ResultT]:
+    return MathTool(
+        operation_id=operation_id,
+        version="1",
+        title=title,
+        description=description,
+        request_type=request_model,
+        result_type=result_model,
+        run=operation,
+        tags=tags,
+        examples=examples,
+    )
+
+
+def _quadratic(
+    rational_numerator: int,
+    radical_numerator: int,
+    radicand: int,
+    *,
+    rational_denominator: int = 1,
+    radical_denominator: int = 1,
+) -> dict[str, object]:
+    return {
+        "rational_part": {
+            "num": str(rational_numerator),
+            "den": str(rational_denominator),
+        },
+        "radical_coefficient": {
+            "num": str(radical_numerator),
+            "den": str(radical_denominator),
+        },
+        "radicand": radicand,
+    }
+
+
+TOOLS: tuple[MathTool[Any, Any], ...] = (
+    _op(
+        "matrix.real_quadratic.symmetric_spectrum.compute",
+        "Compute an exact symmetric 2 by 2 spectrum over Q(sqrt(d))",
+        "Return the complete descending eigenvalue spectrum of an exact "
+        "symmetric 2 by 2 matrix over one real quadratic field. Values use "
+        "canonical minimal polynomials and increasing real-root indices. "
+        "The exact annihilating polynomial is limited to 996 decimal digits "
+        "per coefficient.",
+        RealQuadraticSymmetricSpectrumRequest,
+        RealQuadraticSpectrum,
+        compute_symmetric_spectrum,
+        "matrix",
+        "eigenvalue",
+        "spectrum",
+        "quadratic-field",
+        "exact",
+        examples=(
+            example(
+                "pang_weighted_sum_spectrum",
+                "Compute the exact eigenvalues 1/2 +/- sqrt(3)/20 of Pang's "
+                "weighted projection sum.",
+                {
+                    "matrix": {
+                        "entries": [
+                            [
+                                _quadratic(1, 0, 3, rational_denominator=2),
+                                _quadratic(0, 1, 3, radical_denominator=20),
+                            ],
+                            [
+                                _quadratic(0, 1, 3, radical_denominator=20),
+                                _quadratic(1, 0, 3, rational_denominator=2),
+                            ],
+                        ]
+                    }
+                },
+            ),
+        ),
+    ),
+    _op(
+        "matrix.real_quadratic.singular_spectrum.compute",
+        "Compute an exact 2 by 2 singular spectrum over Q(sqrt(d))",
+        "Return the complete descending singular-value spectrum of an exact "
+        "2 by 2 matrix over one real quadratic field. Values use canonical "
+        "minimal polynomials and increasing real-root indices. The exact "
+        "annihilating polynomial is limited to 996 decimal digits per "
+        "coefficient.",
+        RealQuadraticSingularSpectrumRequest,
+        RealQuadraticSpectrum,
+        compute_singular_spectrum,
+        "matrix",
+        "singular-value",
+        "spectrum",
+        "quadratic-field",
+        "exact",
+        examples=(
+            example(
+                "pang_projection_product_spectrum",
+                "Compute the singular values 3*sqrt(3)/8 and 0 of Pang's "
+                "four-projection product.",
+                {
+                    "matrix": {
+                        "entries": [
+                            [
+                                _quadratic(0, 0, 3),
+                                _quadratic(0, 3, 3, radical_denominator=8),
+                            ],
+                            [_quadratic(0, 0, 3), _quadratic(0, 0, 3)],
+                        ]
+                    }
+                },
+            ),
+        ),
+    ),
+    _op(
+        "matrix.real_quadratic.inertia.compute",
+        "Compute exact inertia over Q(sqrt(d))",
+        "Return Sylvester inertia and definiteness for an exact symmetric "
+        "matrix of dimension at most four over one real quadratic field. "
+        "Signs and congruence pivots are computed exactly; no floating "
+        "tolerance is used.",
+        RealQuadraticInertiaRequest,
+        RealQuadraticInertia,
+        compute_inertia,
+        "matrix",
+        "inertia",
+        "definiteness",
+        "quadratic-field",
+        "exact",
+        examples=(
+            example(
+                "maxwell_hessian_inertia",
+                "Compute the exact (+--) inertia of the Maxwell critical-point "
+                "Hessian at (1/3, 0, sqrt(39)/12).",
+                {
+                    "matrix": {
+                        "entries": [
+                            [
+                                _quadratic(19, 0, 39, rational_denominator=8),
+                                _quadratic(0, 0, 39),
+                                _quadratic(0, -1, 39, radical_denominator=2),
+                            ],
+                            [
+                                _quadratic(0, 0, 39),
+                                _quadratic(-45, 0, 39, rational_denominator=8),
+                                _quadratic(0, 0, 39),
+                            ],
+                            [
+                                _quadratic(0, -1, 39, radical_denominator=2),
+                                _quadratic(0, 0, 39),
+                                _quadratic(13, 0, 39, rational_denominator=4),
+                            ],
+                        ]
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -1,0 +1,715 @@
+"""Exact bounded matrix spectra over one real quadratic field."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from math import gcd, lcm
+from typing import Any, Literal
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.matrices.quadratic_spectral.values import (
+    Definiteness,
+    RealAlgebraicMultiplicity,
+    RealQuadraticInertia,
+    RealQuadraticSpectrum,
+    SpectrumKind,
+)
+from jacobian.math.matrices.values import RealQuadraticMatrix
+from jacobian.math.real_algebraic import RealAlgebraicValue
+
+type Quadratic = tuple[Fraction, Fraction]
+type FractionPolynomial = tuple[Fraction, ...]
+Branch = Literal["UPPER", "LOWER", "REPEATED"]
+
+MAX_INERTIA_DIMENSION = 4
+# A degree-eight factor of a degree-eight primitive norm polynomial with
+# 996-digit coefficients has coefficients below 10**999 by the Landau--
+# Mignotte factor bound.  Mignotte's separation bound then places the required
+# isolating and Arb branch-selection precision below 32,768 bits; that fixed
+# precision is therefore part of the admitted exact-kernel envelope, not a
+# fallback for an otherwise unbounded numerical search.
+MAX_SPECTRAL_ANNIHILATING_COEFFICIENT_DIGITS = 996
+_MAX_ARB_PRECISION_BITS = 32_768
+_ZERO: Quadratic = (Fraction(0), Fraction(0))
+_ONE: Quadratic = (Fraction(1), Fraction(0))
+
+
+@dataclass(frozen=True, slots=True)
+class _RootData:
+    value: RealAlgebraicValue
+    lower: Any
+    upper: Any
+
+
+def _entry(value) -> Quadratic:  # type: ignore[no-untyped-def]
+    return (
+        value.rational_part.as_fraction(),
+        value.radical_coefficient.as_fraction(),
+    )
+
+
+def _add(left: Quadratic, right: Quadratic) -> Quadratic:
+    return left[0] + right[0], left[1] + right[1]
+
+
+def _negate(value: Quadratic) -> Quadratic:
+    return -value[0], -value[1]
+
+
+def _subtract(left: Quadratic, right: Quadratic) -> Quadratic:
+    return _add(left, _negate(right))
+
+
+def _multiply(left: Quadratic, right: Quadratic, radicand: int) -> Quadratic:
+    return (
+        left[0] * right[0] + radicand * left[1] * right[1],
+        left[0] * right[1] + left[1] * right[0],
+    )
+
+
+def _scale(value: Quadratic, scalar: Fraction) -> Quadratic:
+    return value[0] * scalar, value[1] * scalar
+
+
+def _is_zero(value: Quadratic) -> bool:
+    return value == _ZERO
+
+
+def _sign(value: Quadratic, radicand: int) -> int:
+    rational, radical = value
+    if radical == 0:
+        return (rational > 0) - (rational < 0)
+    if rational == 0:
+        return (radical > 0) - (radical < 0)
+    if (rational > 0) == (radical > 0):
+        return (rational > 0) - (rational < 0)
+    rational_square = rational * rational
+    radical_square = radical * radical * radicand
+    if rational_square == radical_square:  # impossible for square-free d > 1
+        raise RuntimeError("quadratic-field sign comparison reached an invalid tie")
+    dominant = radical if radical_square > rational_square else rational
+    return (dominant > 0) - (dominant < 0)
+
+
+def _divide(left: Quadratic, right: Quadratic, radicand: int) -> Quadratic:
+    norm = right[0] * right[0] - radicand * right[1] * right[1]
+    if norm == 0:
+        raise ZeroDivisionError("cannot divide by zero in a real quadratic field")
+    inverse = (right[0] / norm, -right[1] / norm)
+    return _multiply(left, inverse, radicand)
+
+
+def _convolve(left: FractionPolynomial, right: FractionPolynomial) -> list[Fraction]:
+    result = [Fraction(0)] * (len(left) + len(right) - 1)
+    for left_index, left_value in enumerate(left):
+        for right_index, right_value in enumerate(right):
+            result[left_index + right_index] += left_value * right_value
+    return result
+
+
+def _primitive_integer_coefficients(
+    coefficients_increasing: list[Fraction] | FractionPolynomial,
+) -> tuple[int, ...]:
+    denominator_lcm = 1
+    for coefficient in coefficients_increasing:
+        denominator_lcm = lcm(denominator_lcm, coefficient.denominator)
+    integers: list[int] = [
+        coefficient.numerator * (denominator_lcm // coefficient.denominator)
+        for coefficient in coefficients_increasing
+    ]
+    while len(integers) > 1 and integers[-1] == 0:
+        integers.pop()
+    content = 0
+    for integer in integers:
+        content = gcd(content, abs(integer))
+    integers = [integer // content for integer in integers]
+    if integers[-1] < 0:
+        integers = [-coefficient for coefficient in integers]
+    return tuple(reversed(integers))
+
+
+def _matrix_entries(matrix: RealQuadraticMatrix) -> list[list[Quadratic]]:
+    return [[_entry(value) for value in row] for row in matrix.entries]
+
+
+def _trace_and_determinant(
+    matrix: RealQuadraticMatrix,
+    spectrum_kind: SpectrumKind,
+) -> tuple[Quadratic, Quadratic]:
+    entries = _matrix_entries(matrix)
+    radicand = matrix.entries[0][0].radicand
+    if spectrum_kind == "SYMMETRIC_EIGENVALUES":
+        a, b = entries[0]
+        _ignored, c = entries[1]
+    else:
+        m00, m01 = entries[0]
+        m10, m11 = entries[1]
+        a = _add(
+            _multiply(m00, m00, radicand),
+            _multiply(m10, m10, radicand),
+        )
+        b = _add(
+            _multiply(m00, m01, radicand),
+            _multiply(m10, m11, radicand),
+        )
+        c = _add(
+            _multiply(m01, m01, radicand),
+            _multiply(m11, m11, radicand),
+        )
+    trace = _add(a, c)
+    determinant = _subtract(
+        _multiply(a, c, radicand),
+        _multiply(b, b, radicand),
+    )
+    return trace, determinant
+
+
+def _polynomial_parts(
+    matrix: RealQuadraticMatrix,
+    spectrum_kind: SpectrumKind,
+) -> tuple[FractionPolynomial, FractionPolynomial, Quadratic, Quadratic]:
+    trace, determinant = _trace_and_determinant(matrix, spectrum_kind)
+    if spectrum_kind == "SYMMETRIC_EIGENVALUES":
+        rational: FractionPolynomial = (determinant[0], -trace[0], Fraction(1))
+        radical: FractionPolynomial = (determinant[1], -trace[1], Fraction(0))
+    else:
+        rational = (
+            determinant[0],
+            Fraction(0),
+            -trace[0],
+            Fraction(0),
+            Fraction(1),
+        )
+        radical = (
+            determinant[1],
+            Fraction(0),
+            -trace[1],
+            Fraction(0),
+            Fraction(0),
+        )
+    return rational, radical, trace, determinant
+
+
+def _annihilating_coefficients(
+    matrix: RealQuadraticMatrix,
+    spectrum_kind: SpectrumKind,
+) -> tuple[int, ...]:
+    rational, radical, _trace, _determinant = _polynomial_parts(matrix, spectrum_kind)
+    radicand = matrix.entries[0][0].radicand
+    norm = [
+        left - radicand * right
+        for left, right in zip(
+            _convolve(rational, rational),
+            _convolve(radical, radical),
+            strict=True,
+        )
+    ]
+    return _primitive_integer_coefficients(norm)
+
+
+def _require_two_by_two(matrix: RealQuadraticMatrix) -> None:
+    if len(matrix.entries) != 2 or len(matrix.entries[0]) != 2:
+        raise ValueError("exact quadratic spectral operations require a 2 by 2 matrix")
+
+
+def _require_symmetric(matrix: RealQuadraticMatrix) -> None:
+    rows = len(matrix.entries)
+    columns = len(matrix.entries[0])
+    if rows != columns:
+        raise ValueError("quadratic inertia and eigenvalues require a square matrix")
+    if any(
+        matrix.entries[row][column] != matrix.entries[column][row]
+        for row in range(rows)
+        for column in range(row + 1, rows)
+    ):
+        raise ValueError("quadratic inertia and eigenvalues require exact symmetry")
+
+
+def _require_spectral_coefficient_bound(
+    matrix: RealQuadraticMatrix,
+    spectrum_kind: SpectrumKind,
+) -> None:
+    coefficients = _annihilating_coefficients(matrix, spectrum_kind)
+    if any(
+        len(format_canonical_integer(coefficient).lstrip("-"))
+        > MAX_SPECTRAL_ANNIHILATING_COEFFICIENT_DIGITS
+        for coefficient in coefficients
+    ):
+        raise ValueError(
+            "exact spectral annihilating polynomial exceeds the "
+            f"{MAX_SPECTRAL_ANNIHILATING_COEFFICIENT_DIGITS}-digit coefficient bound"
+        )
+
+
+def require_symmetric_spectrum_matrix(matrix: RealQuadraticMatrix) -> None:
+    _require_two_by_two(matrix)
+    _require_symmetric(matrix)
+    _require_spectral_coefficient_bound(matrix, "SYMMETRIC_EIGENVALUES")
+
+
+def require_singular_spectrum_matrix(matrix: RealQuadraticMatrix) -> None:
+    _require_two_by_two(matrix)
+    _require_spectral_coefficient_bound(matrix, "SINGULAR_VALUES")
+
+
+def require_inertia_matrix(matrix: RealQuadraticMatrix) -> None:
+    _require_symmetric(matrix)
+    if len(matrix.entries) > MAX_INERTIA_DIMENSION:
+        raise ValueError(
+            f"exact quadratic inertia supports dimension at most {MAX_INERTIA_DIMENSION}"
+        )
+
+
+def _sympy_polynomial(coefficients: tuple[int, ...]):  # type: ignore[no-untyped-def]
+    import sympy
+
+    return sympy.Poly.from_list(coefficients, gens=sympy.Symbol("x"), domain=sympy.ZZ)
+
+
+def _strict_root_count(poly, lower, upper) -> int:  # type: ignore[no-untyped-def]
+    if lower == upper:
+        return int(poly.eval(lower) == 0)
+    count = int(poly.count_roots(lower, upper))
+    if poly.eval(lower) == 0:
+        count -= 1
+    if poly.eval(upper) == 0:
+        count -= 1
+    return count
+
+
+def _canonical_factor(factor) -> tuple[str, ...]:  # type: ignore[no-untyped-def]
+    coefficients = [int(coefficient) for coefficient in factor.all_coeffs()]
+    content = 0
+    for coefficient in coefficients:
+        content = gcd(content, abs(coefficient))
+    coefficients = [coefficient // content for coefficient in coefficients]
+    if coefficients[0] < 0:
+        coefficients = [-coefficient for coefficient in coefficients]
+    return tuple(format_canonical_integer(coefficient) for coefficient in coefficients)
+
+
+def _root_data(polynomial) -> tuple[_RootData, ...]:  # type: ignore[no-untyped-def]
+    factors = polynomial.factor_list()[1]
+    factor_indices = [0] * len(factors)
+    rows: list[_RootData] = []
+    for (lower, upper), _multiplicity in polynomial.intervals():
+        matches = [
+            index
+            for index, (factor, _factor_multiplicity) in enumerate(factors)
+            if _strict_root_count(factor, lower, upper) == 1
+        ]
+        if len(matches) != 1:  # pragma: no cover
+            raise RuntimeError("exact factor isolation did not identify one root")
+        factor_index = matches[0]
+        factor, _factor_multiplicity = factors[factor_index]
+        root_index = factor_indices[factor_index]
+        factor_indices[factor_index] += 1
+        rows.append(
+            _RootData(
+                value=RealAlgebraicValue(
+                    polynomial=_canonical_factor(factor),
+                    real_root_index=root_index,
+                ),
+                lower=lower,
+                upper=upper,
+            )
+        )
+    return tuple(rows)
+
+
+def _evaluate_polynomial(
+    coefficients: FractionPolynomial,
+    value: Fraction,
+) -> Fraction:
+    result = Fraction(0)
+    for coefficient in reversed(coefficients):
+        result = result * value + coefficient
+    return result
+
+
+def _rational_branches(
+    roots: tuple[_RootData, ...],
+    rational: FractionPolynomial,
+    radical: FractionPolynomial,
+    trace: Quadratic,
+    spectrum_kind: SpectrumKind,
+    radicand: int,
+) -> dict[Branch, _RootData]:
+    result: dict[Branch, _RootData] = {}
+    for root in roots:
+        if root.lower != root.upper:
+            continue
+        value = Fraction(int(root.lower.p), int(root.lower.q))
+        if spectrum_kind == "SINGULAR_VALUES" and value < 0:
+            continue
+        if _evaluate_polynomial(rational, value) != 0:
+            continue
+        if _evaluate_polynomial(radical, value) != 0:
+            continue
+        branch_difference = _subtract(
+            (2 * value, Fraction(0))
+            if spectrum_kind == "SYMMETRIC_EIGENVALUES"
+            else (2 * value * value, Fraction(0)),
+            trace,
+        )
+        sign = _sign(branch_difference, radicand)
+        branch: Branch = "UPPER" if sign > 0 else "LOWER" if sign < 0 else "REPEATED"
+        result[branch] = root
+    return result
+
+
+def _arb_fraction(value: Fraction):  # type: ignore[no-untyped-def]
+    from flint import arb
+
+    return arb(value.numerator) / value.denominator
+
+
+def _arb_quadratic(value: Quadratic, radicand: int):  # type: ignore[no-untyped-def]
+    from flint import arb
+
+    return _arb_fraction(value[0]) + _arb_fraction(value[1]) * arb(radicand).sqrt()
+
+
+def _arb_rational(value: Any) -> Any:
+    from flint import arb
+
+    return arb(int(value.p)) / int(value.q)
+
+
+def _strictly_inside(ball, root: _RootData) -> bool:  # type: ignore[no-untyped-def]
+    if root.lower == root.upper:
+        return False
+    return bool(ball > _arb_rational(root.lower) and ball < _arb_rational(root.upper))
+
+
+def _branch_balls(
+    trace: Quadratic,
+    determinant: Quadratic,
+    spectrum_kind: SpectrumKind,
+    radicand: int,
+    precision: int,
+    repeated: bool,
+) -> dict[Branch, Any] | None:
+    from flint import ctx
+
+    with ctx.workprec(precision):
+        trace_ball = _arb_quadratic(trace, radicand)
+        if repeated:
+            repeated_ball = trace_ball / 2
+            if spectrum_kind == "SINGULAR_VALUES":
+                if not repeated_ball > 0:
+                    return None
+                repeated_ball = repeated_ball.sqrt()
+            return {"REPEATED": repeated_ball}
+        determinant_ball = _arb_quadratic(determinant, radicand)
+        discriminant_ball = trace_ball * trace_ball - 4 * determinant_ball
+        if not discriminant_ball > 0:
+            return None
+        root = discriminant_ball.sqrt()
+        upper = (trace_ball + root) / 2
+        lower = (trace_ball - root) / 2
+        if spectrum_kind == "SINGULAR_VALUES":
+            if not upper > 0:
+                return None
+            upper = upper.sqrt()
+            lower = lower.sqrt() if lower > 0 else None
+        result: dict[Branch, Any] = {"UPPER": upper}
+        if lower is not None:
+            result["LOWER"] = lower
+        return result
+
+
+def _select_nonrational_branches(
+    roots: tuple[_RootData, ...],
+    trace: Quadratic,
+    determinant: Quadratic,
+    spectrum_kind: SpectrumKind,
+    radicand: int,
+    missing: tuple[Branch, ...],
+) -> dict[Branch, _RootData]:
+    precision = 128
+    while precision <= _MAX_ARB_PRECISION_BITS:
+        balls = _branch_balls(
+            trace,
+            determinant,
+            spectrum_kind,
+            radicand,
+            precision,
+            repeated=missing == ("REPEATED",),
+        )
+        if balls is not None:
+            selected: dict[Branch, _RootData] = {}
+            for branch in missing:
+                ball = balls.get(branch)
+                if ball is None:
+                    break
+                matches = [root for root in roots if _strictly_inside(ball, root)]
+                if len(matches) != 1:
+                    break
+                selected[branch] = matches[0]
+            else:
+                if len({row.value for row in selected.values()}) == len(selected):
+                    return selected
+        precision *= 2
+    raise RuntimeError("rigorous algebraic-root selection exceeded its precision proof")
+
+
+def spectrum_rows(
+    matrix: RealQuadraticMatrix,
+    spectrum_kind: SpectrumKind,
+) -> tuple[RealAlgebraicMultiplicity, ...]:
+    """Return the complete descending exact spectrum with multiplicities."""
+
+    if spectrum_kind == "SYMMETRIC_EIGENVALUES":
+        require_symmetric_spectrum_matrix(matrix)
+    else:
+        require_singular_spectrum_matrix(matrix)
+    rational, radical, trace, determinant = _polynomial_parts(matrix, spectrum_kind)
+    radicand = matrix.entries[0][0].radicand
+    discriminant = _subtract(
+        _multiply(trace, trace, radicand),
+        _scale(determinant, Fraction(4)),
+    )
+    discriminant_sign = _sign(discriminant, radicand)
+    if discriminant_sign < 0:  # pragma: no cover
+        raise RuntimeError("a real symmetric 2 by 2 spectrum had negative discriminant")
+
+    polynomial = _sympy_polynomial(_annihilating_coefficients(matrix, spectrum_kind))
+    roots = _root_data(polynomial)
+    rational_roots = _rational_branches(
+        roots, rational, radical, trace, spectrum_kind, radicand
+    )
+    if discriminant_sign == 0:
+        branches: tuple[tuple[Branch, int], ...] = (("REPEATED", 2),)
+    else:
+        branches = (("UPPER", 1), ("LOWER", 1))
+
+    selected = dict(rational_roots)
+    missing = tuple(
+        branch for branch, _multiplicity in branches if branch not in selected
+    )
+    if missing:
+        selected.update(
+            _select_nonrational_branches(
+                roots,
+                trace,
+                determinant,
+                spectrum_kind,
+                radicand,
+                missing,
+            )
+        )
+    return tuple(
+        RealAlgebraicMultiplicity(
+            value=selected[branch].value, multiplicity=multiplicity
+        )
+        for branch, multiplicity in branches
+    )
+
+
+def symmetric_spectrum(matrix: RealQuadraticMatrix) -> RealQuadraticSpectrum:
+    """Return the exact descending eigenvalue spectrum of a symmetric 2 by 2 matrix."""
+
+    return RealQuadraticSpectrum(
+        matrix=matrix,
+        spectrum_kind="SYMMETRIC_EIGENVALUES",
+        values=spectrum_rows(matrix, "SYMMETRIC_EIGENVALUES"),
+    )
+
+
+def singular_spectrum(matrix: RealQuadraticMatrix) -> RealQuadraticSpectrum:
+    """Return the exact descending singular-value spectrum of a 2 by 2 matrix."""
+
+    return RealQuadraticSpectrum(
+        matrix=matrix,
+        spectrum_kind="SINGULAR_VALUES",
+        values=spectrum_rows(matrix, "SINGULAR_VALUES"),
+    )
+
+
+def _swap_symmetric(matrix: list[list[Quadratic]], left: int, right: int) -> None:
+    if left == right:
+        return
+    matrix[left], matrix[right] = matrix[right], matrix[left]
+    for row in matrix:
+        row[left], row[right] = row[right], row[left]
+
+
+def _find_off_diagonal(
+    matrix: list[list[Quadratic]], index: int
+) -> tuple[int, int] | None:
+    for row in range(index, len(matrix)):
+        for column in range(row + 1, len(matrix)):
+            if not _is_zero(matrix[row][column]):
+                return row, column
+    return None
+
+
+def _two_by_two_inertia(
+    aa: Quadratic,
+    bb: Quadratic,
+    cc: Quadratic,
+    radicand: int,
+) -> tuple[int, int, int]:
+    determinant = _subtract(
+        _multiply(aa, cc, radicand),
+        _multiply(bb, bb, radicand),
+    )
+    determinant_sign = _sign(determinant, radicand)
+    if determinant_sign < 0:
+        return 1, 1, 0
+    trace_sign = _sign(_add(aa, cc), radicand)
+    if determinant_sign > 0:
+        return (2, 0, 0) if trace_sign > 0 else (0, 2, 0)
+    if trace_sign > 0:
+        return 1, 0, 1
+    if trace_sign < 0:
+        return 0, 1, 1
+    return 0, 0, 2
+
+
+def _eliminate_one(
+    matrix: list[list[Quadratic]],
+    index: int,
+    pivot: int,
+    radicand: int,
+) -> int:
+    _swap_symmetric(matrix, index, pivot)
+    diagonal = matrix[index][index]
+    for row in range(index + 1, len(matrix)):
+        if _is_zero(matrix[row][index]):
+            continue
+        factor = _divide(matrix[row][index], diagonal, radicand)
+        for column in range(index, len(matrix)):
+            matrix[row][column] = _subtract(
+                matrix[row][column],
+                _multiply(factor, matrix[index][column], radicand),
+            )
+        for column in range(index, len(matrix)):
+            matrix[column][row] = matrix[row][column]
+    return _sign(diagonal, radicand)
+
+
+def _eliminate_two(
+    matrix: list[list[Quadratic]],
+    index: int,
+    radicand: int,
+) -> tuple[int, int, int]:
+    off_diagonal = _find_off_diagonal(matrix, index)
+    if off_diagonal is None:  # pragma: no cover
+        raise RuntimeError("2 by 2 pivot requested without an off-diagonal entry")
+    first, second = off_diagonal
+    _swap_symmetric(matrix, index, first)
+    if second == index:
+        second = first
+    _swap_symmetric(matrix, index + 1, second)
+    aa = matrix[index][index]
+    bb = matrix[index][index + 1]
+    cc = matrix[index + 1][index + 1]
+    counts = _two_by_two_inertia(aa, bb, cc, radicand)
+    determinant = _subtract(
+        _multiply(aa, cc, radicand),
+        _multiply(bb, bb, radicand),
+    )
+    if index + 2 < len(matrix):
+        inverse_00 = _divide(cc, determinant, radicand)
+        inverse_01 = _divide(_negate(bb), determinant, radicand)
+        inverse_11 = _divide(aa, determinant, radicand)
+        for row in range(index + 2, len(matrix)):
+            left = matrix[row][index]
+            right = matrix[row][index + 1]
+            coefficient_0 = _add(
+                _multiply(left, inverse_00, radicand),
+                _multiply(right, inverse_01, radicand),
+            )
+            coefficient_1 = _add(
+                _multiply(left, inverse_01, radicand),
+                _multiply(right, inverse_11, radicand),
+            )
+            for column in range(index, len(matrix)):
+                matrix[row][column] = _subtract(
+                    matrix[row][column],
+                    _add(
+                        _multiply(coefficient_0, matrix[index][column], radicand),
+                        _multiply(
+                            coefficient_1,
+                            matrix[index + 1][column],
+                            radicand,
+                        ),
+                    ),
+                )
+            for column in range(index, len(matrix)):
+                matrix[column][row] = matrix[row][column]
+    return counts
+
+
+def _inertia_counts(matrix: RealQuadraticMatrix) -> tuple[int, int, int]:
+    radicand = matrix.entries[0][0].radicand
+    reduced = _matrix_entries(matrix)
+    positive = negative = zero = 0
+    index = 0
+    while index < len(reduced):
+        pivot = next(
+            (
+                row
+                for row in range(index, len(reduced))
+                if not _is_zero(reduced[row][row])
+            ),
+            None,
+        )
+        if pivot is not None:
+            sign = _eliminate_one(reduced, index, pivot, radicand)
+            positive += sign > 0
+            negative += sign < 0
+            index += 1
+            continue
+        if _find_off_diagonal(reduced, index) is None:
+            zero += len(reduced) - index
+            break
+        row_positive, row_negative, row_zero = _eliminate_two(reduced, index, radicand)
+        positive += row_positive
+        negative += row_negative
+        zero += row_zero
+        index += 2
+    return positive, negative, zero
+
+
+def _definiteness(positive: int, negative: int, zero: int) -> Definiteness:
+    if zero == 0:
+        if negative == 0:
+            return "positive_definite"
+        if positive == 0:
+            return "negative_definite"
+        return "indefinite"
+    if negative == 0:
+        return "positive_semidefinite"
+    if positive == 0:
+        return "negative_semidefinite"
+    return "indefinite"
+
+
+def inertia_data(
+    matrix: RealQuadraticMatrix,
+) -> tuple[int, int, int, Definiteness]:
+    """Return exact Sylvester inertia data for an admitted matrix."""
+
+    require_inertia_matrix(matrix)
+    positive, negative, zero = _inertia_counts(matrix)
+    return positive, negative, zero, _definiteness(positive, negative, zero)
+
+
+def inertia(matrix: RealQuadraticMatrix) -> RealQuadraticInertia:
+    """Return exact Sylvester inertia for a symmetric real-quadratic matrix."""
+
+    positive, negative, zero, definiteness = inertia_data(matrix)
+    return RealQuadraticInertia(
+        matrix=matrix,
+        n_positive=positive,
+        n_negative=negative,
+        n_zero=zero,
+        definiteness=definiteness,
+    )
+
+
+__all__ = ["inertia", "singular_spectrum", "symmetric_spectrum"]

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -676,6 +676,8 @@ def _inertia_counts(matrix: RealQuadraticMatrix) -> tuple[int, int, int]:
 
 
 def _definiteness(positive: int, negative: int, zero: int) -> Definiteness:
+    if positive == 0 and negative == 0:
+        return "zero"
     if zero == 0:
         if negative == 0:
             return "positive_definite"

--- a/src/jacobian/math/matrices/quadratic_spectral/values.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/values.py
@@ -1,0 +1,88 @@
+"""Source-bound exact values for real-quadratic matrix spectra."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.matrices.values import RealQuadraticMatrix
+from jacobian.math.real_algebraic import RealAlgebraicValue
+
+SpectrumKind = Literal["SYMMETRIC_EIGENVALUES", "SINGULAR_VALUES"]
+Definiteness = Literal[
+    "positive_definite",
+    "positive_semidefinite",
+    "negative_definite",
+    "negative_semidefinite",
+    "indefinite",
+]
+
+
+class RealAlgebraicMultiplicity(StrictModel):
+    """One exact real algebraic value and its spectral multiplicity."""
+
+    value: RealAlgebraicValue
+    multiplicity: StrictInt = Field(ge=1, le=2)
+
+
+class RealQuadraticSpectrum(StrictModel):
+    """A complete descending 2 by 2 spectrum bound to its source matrix."""
+
+    matrix: RealQuadraticMatrix
+    spectrum_kind: SpectrumKind
+    values: tuple[RealAlgebraicMultiplicity, ...] = Field(
+        min_length=1,
+        max_length=2,
+        description=(
+            "Distinct exact values in descending real order, with multiplicities "
+            "summing to two."
+        ),
+    )
+    ordering: Literal["DESCENDING"] = "DESCENDING"
+
+    @model_validator(mode="after")
+    def bind_complete_spectrum(self) -> Self:
+        from jacobian.math.matrices.quadratic_spectral.operations import spectrum_rows
+
+        if sum(row.multiplicity for row in self.values) != 2:
+            raise ValueError("2 by 2 spectral multiplicities must sum to two")
+        expected = spectrum_rows(self.matrix, self.spectrum_kind)
+        if self.values != expected:
+            raise ValueError("spectrum does not match the exact source matrix")
+        return self
+
+
+class RealQuadraticInertia(StrictModel):
+    """Sylvester inertia bound to a symmetric real-quadratic matrix."""
+
+    matrix: RealQuadraticMatrix
+    n_positive: StrictInt = Field(ge=0, le=4)
+    n_negative: StrictInt = Field(ge=0, le=4)
+    n_zero: StrictInt = Field(ge=0, le=4)
+    definiteness: Definiteness
+
+    @model_validator(mode="after")
+    def bind_exact_inertia(self) -> Self:
+        from jacobian.math.matrices.quadratic_spectral.operations import inertia_data
+
+        expected = inertia_data(self.matrix)
+        actual = (
+            self.n_positive,
+            self.n_negative,
+            self.n_zero,
+            self.definiteness,
+        )
+        if actual != expected:
+            raise ValueError("inertia does not match the exact source matrix")
+        return self
+
+
+__all__ = [
+    "Definiteness",
+    "RealAlgebraicMultiplicity",
+    "RealQuadraticInertia",
+    "RealQuadraticSpectrum",
+    "SpectrumKind",
+]

--- a/src/jacobian/math/matrices/quadratic_spectral/values.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/values.py
@@ -16,6 +16,7 @@ Definiteness = Literal[
     "positive_semidefinite",
     "negative_definite",
     "negative_semidefinite",
+    "zero",
     "indefinite",
 ]
 

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -14,6 +14,7 @@ from jacobian._exact import (
 )
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
+from jacobian.math.real_quadratic import RealQuadraticValue
 
 MAX_MATRIX_DIMENSION = 32
 MAX_MATRIX_SCALAR_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
@@ -58,6 +59,35 @@ class RationalMatrix(StrictModel):
             maximum=MAX_MATRIX_SCALAR_DIGITS,
             label="matrix",
         )
+        return self
+
+
+class RealQuadraticMatrix(StrictModel):
+    """One nonempty rectangular matrix over a shared real quadratic field."""
+
+    matrix_schema_version: Literal["1"] = "1"
+    domain: Literal["QQ_SQRT_D"] = "QQ_SQRT_D"
+    entries: tuple[tuple[RealQuadraticValue, ...], ...] = Field(
+        min_length=1,
+        max_length=MAX_MATRIX_DIMENSION,
+        description=(
+            "Nonempty rectangular rows of a+b*sqrt(d) values. Every entry "
+            "must carry the same square-free positive radicand d."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_rectangular_shared_field(self) -> Self:
+        column_count = len(self.entries[0])
+        if column_count == 0 or column_count > MAX_MATRIX_DIMENSION:
+            raise ValueError("matrix rows must contain between 1 and 32 entries")
+        if any(len(row) != column_count for row in self.entries):
+            raise ValueError("matrix rows must all have the same length")
+        radicand = self.entries[0][0].radicand
+        if any(entry.radicand != radicand for row in self.entries for entry in row):
+            raise ValueError(
+                "every matrix entry must belong to one shared real quadratic field"
+            )
         return self
 
 
@@ -142,6 +172,7 @@ __all__ = [
     "MAX_MATRIX_SCALAR_DIGITS",
     "IntegerMatrix",
     "RationalMatrix",
+    "RealQuadraticMatrix",
     "SmithNormalForm",
     "require_matrix_scalar_digits",
 ]

--- a/src/jacobian/math/real_algebraic.py
+++ b/src/jacobian/math/real_algebraic.py
@@ -1,0 +1,261 @@
+"""Canonical bounded real algebraic values and exact order."""
+
+from __future__ import annotations
+
+from math import gcd
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalInteger, CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+
+# A degree-eight value covers every singular value of a 2 by 2 matrix over a
+# real quadratic field.  The coefficient budget also bounds exact comparison:
+# the product of two defining polynomials has degree at most sixteen and
+# coefficient height below 2,002 decimal digits.  Mignotte's root-separation
+# bound then needs fewer than 32,768 decimal digits for rational isolating
+# endpoints, so every accepted comparison remains representable by the shared
+# canonical scalar envelope.
+MAX_REAL_ALGEBRAIC_DEGREE = 8
+MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS = 1_000
+
+RealAlgebraicOrder = Literal["LT", "EQ", "GT"]
+
+
+def _sympy_polynomial(value: RealAlgebraicValue):  # type: ignore[no-untyped-def]
+    import sympy
+
+    x = sympy.Symbol("x")
+    return sympy.Poly.from_list(
+        [parse_canonical_integer(coefficient) for coefficient in value.polynomial],
+        gens=x,
+        domain=sympy.ZZ,
+    )
+
+
+def _strict_root_count(poly, lower, upper) -> int:  # type: ignore[no-untyped-def]
+    """Count roots in an open interval, or at one singleton endpoint."""
+
+    if lower == upper:
+        return int(poly.eval(lower) == 0)
+    count = int(poly.count_roots(lower, upper))
+    if poly.eval(lower) == 0:
+        count -= 1
+    if poly.eval(upper) == 0:
+        count -= 1
+    return count
+
+
+def _rational(value) -> CanonicalRational:  # type: ignore[no-untyped-def]
+    import sympy
+
+    rational = sympy.Rational(value)
+    return CanonicalRational(
+        num=format_canonical_integer(int(rational.p)),
+        den=format_canonical_integer(int(rational.q)),
+    )
+
+
+class RealAlgebraicValue(StrictModel):
+    """One real algebraic number in canonical minimal-polynomial form.
+
+    ``polynomial`` is the primitive irreducible polynomial in ``ZZ[x]`` with
+    positive leading coefficient, listed in descending degree.  The
+    zero-based ``real_root_index`` selects one of its real roots in increasing
+    order.  This pair uniquely determines the value and its real embedding.
+    """
+
+    real_algebraic_schema_version: Literal["1"] = "1"
+    polynomial: tuple[CanonicalInteger, ...] = Field(
+        min_length=2,
+        max_length=MAX_REAL_ALGEBRAIC_DEGREE + 1,
+        description=(
+            "Primitive irreducible ZZ[x] coefficients in descending degree, "
+            "with positive leading coefficient and at most 1,000 digits each."
+        ),
+        examples=[["1", "0", "-2"]],
+    )
+    real_root_index: StrictInt = Field(
+        ge=0,
+        description=(
+            "Zero-based index of the selected real root when all real roots of "
+            "the minimal polynomial are ordered increasingly."
+        ),
+        examples=[1],
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_real_root(self) -> Self:
+        if any(
+            len(coefficient.lstrip("-")) > MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS
+            for coefficient in self.polynomial
+        ):
+            raise ValueError(
+                "real algebraic polynomial coefficients exceed the "
+                f"{MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS}-digit bound"
+            )
+        coefficients = tuple(
+            parse_canonical_integer(coefficient) for coefficient in self.polynomial
+        )
+        if coefficients[0] <= 0:
+            raise ValueError(
+                "real algebraic minimal polynomial must have positive leading coefficient"
+            )
+        content = 0
+        for coefficient in coefficients:
+            content = gcd(content, abs(coefficient))
+        if content != 1:
+            raise ValueError(
+                "real algebraic minimal polynomial must be primitive over ZZ"
+            )
+
+        polynomial = _sympy_polynomial(self)
+        if polynomial.is_irreducible is not True:
+            raise ValueError(
+                "real algebraic minimal polynomial must be irreducible over QQ"
+            )
+        real_root_count = len(polynomial.intervals())
+        if self.real_root_index >= real_root_count:
+            raise ValueError(
+                "real_root_index must select an existing real root of the minimal polynomial"
+            )
+        return self
+
+
+class RationalIsolatingInterval(StrictModel):
+    """A canonical rational interval isolating one real polynomial root."""
+
+    lower: CanonicalRational
+    upper: CanonicalRational
+    interval_type: Literal["OPEN", "SINGLETON"]
+
+    @model_validator(mode="after")
+    def require_interval_convention(self) -> Self:
+        lower = self.lower.as_fraction()
+        upper = self.upper.as_fraction()
+        if lower > upper:
+            raise ValueError("isolating interval lower endpoint must not exceed upper")
+        expected = "SINGLETON" if lower == upper else "OPEN"
+        if self.interval_type != expected:
+            raise ValueError(
+                "equal endpoints require SINGLETON; distinct endpoints require OPEN"
+            )
+        return self
+
+
+def _interval(lower, upper) -> RationalIsolatingInterval:  # type: ignore[no-untyped-def]
+    return RationalIsolatingInterval(
+        lower=_rational(lower),
+        upper=_rational(upper),
+        interval_type="SINGLETON" if lower == upper else "OPEN",
+    )
+
+
+def isolate_real_algebraic(value: RealAlgebraicValue) -> RationalIsolatingInterval:
+    """Return SymPy's deterministic exact interval for the selected real root."""
+
+    intervals = _sympy_polynomial(value).intervals()
+    (lower, upper), _multiplicity = intervals[value.real_root_index]
+    return _interval(lower, upper)
+
+
+def _order_data(
+    left: RealAlgebraicValue,
+    right: RealAlgebraicValue,
+) -> tuple[
+    RealAlgebraicOrder,
+    RationalIsolatingInterval,
+    RationalIsolatingInterval,
+]:
+    left_poly = _sympy_polynomial(left)
+    right_poly = _sympy_polynomial(right)
+    if left.polynomial == right.polynomial:
+        left_interval = isolate_real_algebraic(left)
+        right_interval = isolate_real_algebraic(right)
+        order: RealAlgebraicOrder = (
+            "LT"
+            if left.real_root_index < right.real_root_index
+            else "GT"
+            if left.real_root_index > right.real_root_index
+            else "EQ"
+        )
+        return order, left_interval, right_interval
+
+    # Distinct canonical minimal polynomials are coprime.  Isolating the roots
+    # of their square-free product gives one exact common ordered axis, avoiding
+    # floating-point matching between separately isolated root lists.
+    product_intervals = (left_poly * right_poly).intervals()
+    left_seen = right_seen = 0
+    selected_left: tuple[int, RationalIsolatingInterval] | None = None
+    selected_right: tuple[int, RationalIsolatingInterval] | None = None
+    for position, ((lower, upper), _multiplicity) in enumerate(product_intervals):
+        if _strict_root_count(left_poly, lower, upper):
+            if left_seen == left.real_root_index:
+                selected_left = (position, _interval(lower, upper))
+            left_seen += 1
+        if _strict_root_count(right_poly, lower, upper):
+            if right_seen == right.real_root_index:
+                selected_right = (position, _interval(lower, upper))
+            right_seen += 1
+
+    if selected_left is None or selected_right is None:  # pragma: no cover
+        raise RuntimeError("exact real-root isolation lost a selected root")
+    left_position, left_interval = selected_left
+    right_position, right_interval = selected_right
+    order = "LT" if left_position < right_position else "GT"
+    return order, left_interval, right_interval
+
+
+class RealAlgebraicOrderValue(StrictModel):
+    """Source-bound exact order with rational root-isolation evidence."""
+
+    left: RealAlgebraicValue
+    right: RealAlgebraicValue
+    order: RealAlgebraicOrder
+    left_isolating_interval: RationalIsolatingInterval
+    right_isolating_interval: RationalIsolatingInterval
+    comparison_basis: Literal["ORDERED_REAL_ROOT_ISOLATION"] = (
+        "ORDERED_REAL_ROOT_ISOLATION"
+    )
+
+    @model_validator(mode="after")
+    def bind_exact_order(self) -> Self:
+        order, left_interval, right_interval = _order_data(self.left, self.right)
+        if self.order != order:
+            raise ValueError("order must match the selected exact real roots")
+        if self.left_isolating_interval != left_interval:
+            raise ValueError("left isolating interval does not match the selected root")
+        if self.right_isolating_interval != right_interval:
+            raise ValueError(
+                "right isolating interval does not match the selected root"
+            )
+        return self
+
+
+def compare_real_algebraic(
+    left: RealAlgebraicValue,
+    right: RealAlgebraicValue,
+) -> RealAlgebraicOrderValue:
+    """Compare two bounded real algebraic values exactly."""
+
+    order, left_interval, right_interval = _order_data(left, right)
+    return RealAlgebraicOrderValue(
+        left=left,
+        right=right,
+        order=order,
+        left_isolating_interval=left_interval,
+        right_isolating_interval=right_interval,
+    )
+
+
+__all__ = [
+    "MAX_REAL_ALGEBRAIC_COEFFICIENT_DIGITS",
+    "MAX_REAL_ALGEBRAIC_DEGREE",
+    "RationalIsolatingInterval",
+    "RealAlgebraicOrderValue",
+    "RealAlgebraicValue",
+    "compare_real_algebraic",
+    "isolate_real_algebraic",
+]

--- a/src/jacobian/math/real_quadratic.py
+++ b/src/jacobian/math/real_quadratic.py
@@ -10,6 +10,7 @@ from pydantic import Field, StrictInt, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
 
 _MAX_RADICAND = 1_000_000
 _MAX_DIGITS = 256
@@ -72,6 +73,20 @@ class RealQuadraticOrderRequest(StrictModel):
     def require_shared_field(self) -> Self:
         if self.left.radicand != self.right.radicand:
             raise ValueError("comparison requires one shared radicand")
+        difference_components = (
+            self.left.rational_part.as_fraction()
+            - self.right.rational_part.as_fraction(),
+            self.left.radical_coefficient.as_fraction()
+            - self.right.radical_coefficient.as_fraction(),
+        )
+        if any(
+            len(format_canonical_integer(component.numerator).lstrip("-")) > _MAX_DIGITS
+            or len(format_canonical_integer(component.denominator)) > _MAX_DIGITS
+            for component in difference_components
+        ):
+            raise ValueError(
+                "exact quadratic difference exceeds the 256-digit result bound"
+            )
         return self
 
 

--- a/src/jacobian/math/root_isolation/_models.py
+++ b/src/jacobian/math/root_isolation/_models.py
@@ -8,6 +8,10 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math.real_algebraic import (
+    RealAlgebraicOrderValue,
+    RealAlgebraicValue,
+)
 
 
 class UnivariatePolynomialRequest(StrictModel):
@@ -42,43 +46,7 @@ class RootIsolationResult(StrictModel):
         return self
 
 
-class AlgebraicNumberInput(StrictModel):
-    polynomial: tuple[CanonicalRational, ...] = Field(min_length=2, max_length=64)
-    isolating_interval_lower: CanonicalRational
-    isolating_interval_upper: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_ordered_interval(self) -> Self:
-        if (
-            self.isolating_interval_lower.as_fraction()
-            >= self.isolating_interval_upper.as_fraction()
-        ):
-            raise ValueError("isolating interval must have lower < upper")
-        if self.polynomial[0].as_fraction() == 0:
-            raise ValueError(
-                "algebraic-number polynomial must have nonzero leading coefficient"
-            )
-        from sympy import Poly, Rational, symbols
-
-        x = symbols("x")
-        polynomial = Poly(
-            sum(
-                Rational(*coefficient.as_integer_ratio())
-                * x ** (len(self.polynomial) - 1 - index)
-                for index, coefficient in enumerate(self.polynomial)
-            ),
-            x,
-        )
-        lower = Rational(*self.isolating_interval_lower.as_integer_ratio())
-        upper = Rational(*self.isolating_interval_upper.as_integer_ratio())
-        roots = {
-            root
-            for root in polynomial.all_roots()
-            if root.is_real and lower <= root <= upper
-        }
-        if len(roots) != 1:
-            raise ValueError("isolating interval must contain exactly one real root")
-        return self
+AlgebraicNumberInput = RealAlgebraicValue
 
 
 class AlgebraicCompareRequest(StrictModel):
@@ -86,5 +54,13 @@ class AlgebraicCompareRequest(StrictModel):
     right: AlgebraicNumberInput
 
 
-class AlgebraicCompareResult(StrictModel):
-    order: Literal["LT", "EQ", "GT"]
+AlgebraicCompareResult = RealAlgebraicOrderValue
+
+
+__all__ = [
+    "AlgebraicCompareRequest",
+    "AlgebraicCompareResult",
+    "AlgebraicNumberInput",
+    "RootIsolationResult",
+    "UnivariatePolynomialRequest",
+]

--- a/src/jacobian/math/root_isolation/_operations.py
+++ b/src/jacobian/math/root_isolation/_operations.py
@@ -40,12 +40,4 @@ def compute_root_isolation(request: UnivariatePolynomialRequest) -> RootIsolatio
 def compute_algebraic_compare(
     request: AlgebraicCompareRequest,
 ) -> AlgebraicCompareResult:
-    order = compare_algebraic(
-        [{"num": c.num, "den": c.den} for c in request.left.polynomial],
-        request.left.isolating_interval_lower,
-        request.left.isolating_interval_upper,
-        [{"num": c.num, "den": c.den} for c in request.right.polynomial],
-        request.right.isolating_interval_lower,
-        request.right.isolating_interval_upper,
-    )
-    return AlgebraicCompareResult(order=order)
+    return compare_algebraic(request.left, request.right)

--- a/src/jacobian/math/root_isolation/_tools.py
+++ b/src/jacobian/math/root_isolation/_tools.py
@@ -83,7 +83,10 @@ ROOT_ISOLATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     ri_operation(
         "algebraic_number.compare",
         "Compare two algebraic numbers",
-        "Decide the exact order (LT, EQ, GT) of two algebraic numbers defined by minimal polynomials and isolating intervals.",
+        "Decide the exact order (LT, EQ, GT) of two bounded real algebraic "
+        "numbers. Each value uses its primitive irreducible integer minimal "
+        "polynomial and increasing real-root index; the source-bound result "
+        "returns exact rational root-isolation evidence.",
         AlgebraicCompareRequest,
         AlgebraicCompareResult,
         compute_algebraic_compare,
@@ -93,29 +96,23 @@ ROOT_ISOLATION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "compare_sqrt_two_and_three",
-                "Compare sqrt(2) with sqrt(3) from their isolating intervals.",
+                "Compare sqrt(2) with sqrt(3) using canonical minimal "
+                "polynomials and increasing real-root indices; each polynomial "
+                "must be primitive, irreducible, degree at most eight, and use "
+                "coefficients of at most 1,000 digits.",
                 {
                     "left": {
-                        "polynomial": [
-                            {"num": "1", "den": "1"},
-                            {"num": "0", "den": "1"},
-                            {"num": "-2", "den": "1"},
-                        ],
-                        "isolating_interval_lower": {"num": "1", "den": "1"},
-                        "isolating_interval_upper": {"num": "2", "den": "1"},
+                        "polynomial": ["1", "0", "-2"],
+                        "real_root_index": 1,
                     },
                     "right": {
-                        "polynomial": [
-                            {"num": "1", "den": "1"},
-                            {"num": "0", "den": "1"},
-                            {"num": "-3", "den": "1"},
-                        ],
-                        "isolating_interval_lower": {"num": "1", "den": "1"},
-                        "isolating_interval_upper": {"num": "2", "den": "1"},
+                        "polynomial": ["1", "0", "-3"],
+                        "real_root_index": 1,
                     },
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/src/jacobian/math/root_isolation/operations.py
+++ b/src/jacobian/math/root_isolation/operations.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any
 
 from jacobian.canonical import parse_canonical_integer
+from jacobian.math.real_algebraic import (
+    RealAlgebraicOrderValue,
+    RealAlgebraicValue,
+    compare_real_algebraic,
+)
 
 __all__ = ["compare_algebraic", "isolate_real_roots"]
 
@@ -30,42 +35,9 @@ def isolate_real_roots(coeffs_desc: Sequence[dict[str, str]]) -> Any:
 
 
 def compare_algebraic(
-    left_poly: Sequence[dict[str, str]],
-    left_lower: Any,
-    left_upper: Any,
-    right_poly: Sequence[dict[str, str]],
-    right_lower: Any,
-    right_upper: Any,
-) -> Literal["LT", "EQ", "GT"]:
-    import sympy
+    left: RealAlgebraicValue,
+    right: RealAlgebraicValue,
+) -> RealAlgebraicOrderValue:
+    """Compare canonical real algebraic values exactly."""
 
-    def selected_real_root(poly: Any, lower: Any, upper: Any) -> Any:
-        roots = {
-            root for root in poly.all_roots() if root.is_real and lower <= root <= upper
-        }
-        if len(roots) != 1:
-            raise ValueError("isolating interval must contain exactly one real root")
-        return roots.pop()
-
-    left_lower = sympy.Rational(
-        parse_canonical_integer(left_lower.num), parse_canonical_integer(left_lower.den)
-    )
-    left_upper = sympy.Rational(
-        parse_canonical_integer(left_upper.num), parse_canonical_integer(left_upper.den)
-    )
-    right_lower = sympy.Rational(
-        parse_canonical_integer(right_lower.num),
-        parse_canonical_integer(right_lower.den),
-    )
-    right_upper = sympy.Rational(
-        parse_canonical_integer(right_upper.num),
-        parse_canonical_integer(right_upper.den),
-    )
-    lr = selected_real_root(_polynomial(left_poly), left_lower, left_upper)
-    rr = selected_real_root(_polynomial(right_poly), right_lower, right_upper)
-    cmp = sympy.sign(lr - rr)
-    if cmp < 0:
-        return "LT"
-    if cmp > 0:
-        return "GT"
-    return "EQ"
+    return compare_real_algebraic(left, right)

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import pytest
 from pydantic import ValidationError
 
@@ -74,63 +76,52 @@ def test_algebraic_comparison_parses_canonical_interval_endpoints() -> None:
         AlgebraicCompareRequest.model_validate(
             {
                 "left": {
-                    "polynomial": _quadratic("-2"),
-                    "isolating_interval_lower": {"num": "1", "den": "1"},
-                    "isolating_interval_upper": {"num": "2", "den": "1"},
+                    "polynomial": ["1", "0", "-2"],
+                    "real_root_index": 1,
                 },
                 "right": {
-                    "polynomial": _quadratic("-3"),
-                    "isolating_interval_lower": {"num": "1", "den": "1"},
-                    "isolating_interval_upper": {"num": "2", "den": "1"},
+                    "polynomial": ["1", "0", "-3"],
+                    "real_root_index": 1,
                 },
             }
         )
     )
 
     assert result.order == "LT"
+    assert result.left_isolating_interval.lower.as_fraction() == 1
+    assert result.left_isolating_interval.upper.as_fraction() < 2
+    assert result.right_isolating_interval.lower.as_fraction() == Fraction(3, 2)
+    assert result.right_isolating_interval.upper.as_fraction() == 2
 
 
-def test_algebraic_comparison_accepts_coefficients_above_python_digit_limit() -> None:
-    oversized_coefficient = "1" + "0" * 5_000
-    result = compute_algebraic_compare(
+def test_algebraic_comparison_rejects_coefficients_above_its_work_bound() -> None:
+    oversized_coefficient = "1" + "0" * 1_000
+    with pytest.raises(ValidationError, match="1000-digit bound"):
         AlgebraicCompareRequest.model_validate(
             {
                 "left": {
-                    "polynomial": [
-                        {"num": oversized_coefficient, "den": "1"},
-                        {"num": "0", "den": "1"},
-                    ],
-                    "isolating_interval_lower": {"num": "-1", "den": "1"},
-                    "isolating_interval_upper": {"num": "1", "den": "1"},
+                    "polynomial": [oversized_coefficient, "1"],
+                    "real_root_index": 0,
                 },
                 "right": {
-                    "polynomial": [
-                        {"num": "1", "den": "1"},
-                        {"num": "0", "den": "1"},
-                    ],
-                    "isolating_interval_lower": {"num": "-1", "den": "1"},
-                    "isolating_interval_upper": {"num": "1", "den": "1"},
+                    "polynomial": ["1", "0"],
+                    "real_root_index": 0,
                 },
             }
         )
-    )
-
-    assert result.order == "EQ"
 
 
-def test_algebraic_comparison_contract_rejects_a_nonisolating_interval() -> None:
-    with pytest.raises(ValidationError, match="exactly one real root"):
+def test_algebraic_comparison_contract_rejects_a_missing_real_root() -> None:
+    with pytest.raises(ValidationError, match="existing real root"):
         AlgebraicCompareRequest.model_validate(
             {
                 "left": {
-                    "polynomial": _quadratic("-2"),
-                    "isolating_interval_lower": {"num": "-2", "den": "1"},
-                    "isolating_interval_upper": {"num": "2", "den": "1"},
+                    "polynomial": ["1", "0", "-2"],
+                    "real_root_index": 2,
                 },
                 "right": {
-                    "polynomial": _quadratic("-3"),
-                    "isolating_interval_lower": {"num": "1", "den": "1"},
-                    "isolating_interval_upper": {"num": "2", "den": "1"},
+                    "polynomial": ["1", "0", "-3"],
+                    "real_root_index": 1,
                 },
             }
         )

--- a/tests/math/matrices/test_quadratic_spectral.py
+++ b/tests/math/matrices/test_quadratic_spectral.py
@@ -195,6 +195,45 @@ def test_inertia_handles_exact_two_by_two_pivots(
     assert (result.n_positive, result.n_negative, result.n_zero) == expected
 
 
+@pytest.mark.parametrize(
+    ("entries", "expected"),
+    [
+        (((_q(),),), (0, 0, 1, "zero")),
+        (((_q(), _q()), (_q(), _q())), (0, 0, 2, "zero")),
+        (
+            (
+                (_q(0, 0, 6), _q(0, 0, 6)),
+                (_q(0, 0, 6), _q(0, 0, 6)),
+            ),
+            (0, 0, 2, "zero"),
+        ),
+        (((_q(1), _q()), (_q(), _q())), (1, 0, 1, "positive_semidefinite")),
+        (((_q(-1), _q()), (_q(), _q())), (0, 1, 1, "negative_semidefinite")),
+        (((_q(0, 1, 6),),), (1, 0, 0, "positive_definite")),
+    ],
+)
+def test_zero_forms_get_the_explicit_zero_category(
+    entries: tuple[tuple[RealQuadraticValue, ...], ...],
+    expected: tuple[int, int, int, str],
+) -> None:
+    result = inertia(_matrix(entries))
+
+    assert (
+        result.n_positive,
+        result.n_negative,
+        result.n_zero,
+        result.definiteness,
+    ) == expected
+
+
+def test_serialized_zero_form_inertia_stays_source_bound() -> None:
+    source = _matrix(((_q(), _q()), (_q(), _q())))
+
+    payload = inertia(source).model_dump()
+
+    assert RealQuadraticInertia.model_validate(payload) == inertia(source)
+
+
 def test_matrix_value_requires_one_explicit_quadratic_field() -> None:
     with pytest.raises(ValidationError, match="shared real quadratic field"):
         _matrix(((_q(radicand=2), _q(radicand=3)),))

--- a/tests/math/matrices/test_quadratic_spectral.py
+++ b/tests/math/matrices/test_quadratic_spectral.py
@@ -1,0 +1,255 @@
+"""Exact bounded spectra and inertia over real quadratic fields."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.matrices.quadratic_spectral import (
+    RealQuadraticInertia,
+    RealQuadraticSpectrum,
+    inertia,
+    singular_spectrum,
+    symmetric_spectrum,
+)
+from jacobian.math.matrices.quadratic_spectral._models import (
+    RealQuadraticInertiaRequest,
+    RealQuadraticSingularSpectrumRequest,
+    RealQuadraticSymmetricSpectrumRequest,
+)
+from jacobian.math.matrices.quadratic_spectral._tools import TOOLS
+from jacobian.math.matrices.values import RealQuadraticMatrix
+from jacobian.math.real_algebraic import compare_real_algebraic
+from jacobian.math.real_quadratic import RealQuadraticValue
+
+
+def _q(
+    rational: Fraction | int = 0,
+    radical: Fraction | int = 0,
+    radicand: int = 3,
+) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=CanonicalRational.from_fraction(Fraction(rational)),
+        radical_coefficient=CanonicalRational.from_fraction(Fraction(radical)),
+        radicand=radicand,
+    )
+
+
+def _matrix(
+    entries: tuple[tuple[RealQuadraticValue, ...], ...],
+) -> RealQuadraticMatrix:
+    return RealQuadraticMatrix(entries=entries)
+
+
+def test_pang_spectra_and_proof_critical_order_are_exact() -> None:
+    weighted_sum = _matrix(
+        (
+            (_q(Fraction(1, 2)), _q(0, Fraction(1, 20))),
+            (_q(0, Fraction(1, 20)), _q(Fraction(1, 2))),
+        )
+    )
+    projection_product = _matrix(
+        (
+            (_q(), _q(0, Fraction(3, 8))),
+            (_q(), _q()),
+        )
+    )
+
+    eigenvalues = symmetric_spectrum(weighted_sum)
+    singular_values = singular_spectrum(projection_product)
+
+    assert tuple(
+        (row.value.polynomial, row.value.real_root_index, row.multiplicity)
+        for row in eigenvalues.values
+    ) == (
+        (("400", "-400", "97"), 1, 1),
+        (("400", "-400", "97"), 0, 1),
+    )
+    assert tuple(
+        (row.value.polynomial, row.value.real_root_index, row.multiplicity)
+        for row in singular_values.values
+    ) == (
+        (("64", "0", "-27"), 1, 1),
+        (("1", "0"), 0, 1),
+    )
+    comparison = compare_real_algebraic(
+        singular_values.values[0].value,
+        eigenvalues.values[0].value,
+    )
+    assert comparison.order == "GT"
+    assert comparison.left_isolating_interval.lower.as_fraction() == Fraction(3, 5)
+    assert comparison.right_isolating_interval.upper.as_fraction() == Fraction(3, 5)
+
+
+def test_symmetric_spectrum_can_return_quartic_values() -> None:
+    source = _matrix(
+        (
+            (_q(0, 1, 2), _q(1, 0, 2)),
+            (_q(1, 0, 2), _q(0, 0, 2)),
+        )
+    )
+
+    result = symmetric_spectrum(source)
+
+    assert tuple(
+        (row.value.polynomial, row.value.real_root_index) for row in result.values
+    ) == (
+        (("1", "0", "-4", "0", "1"), 3),
+        (("1", "0", "-4", "0", "1"), 1),
+    )
+
+
+def test_singular_spectrum_can_return_degree_eight_values() -> None:
+    source = _matrix(
+        (
+            (_q(0, 0, 2), _q(1, 0, 2)),
+            (_q(1, 1, 2), _q(1, 0, 2)),
+        )
+    )
+
+    result = singular_spectrum(source)
+
+    polynomial = ("1", "0", "-10", "0", "23", "0", "-14", "0", "1")
+    assert tuple(
+        (row.value.polynomial, row.value.real_root_index) for row in result.values
+    ) == ((polynomial, 7), (polynomial, 5))
+
+
+def test_repeated_irrational_spectrum_keeps_multiplicity() -> None:
+    source = _matrix(
+        (
+            (_q(0, 2, 6), _q(0, 0, 6)),
+            (_q(0, 0, 6), _q(0, 2, 6)),
+        )
+    )
+
+    result = symmetric_spectrum(source)
+
+    assert len(result.values) == 1
+    assert result.values[0].value.polynomial == ("1", "0", "-24")
+    assert result.values[0].value.real_root_index == 1
+    assert result.values[0].multiplicity == 2
+
+
+def test_repeated_rational_singular_value_selects_nonnegative_root() -> None:
+    identity = _matrix(
+        (
+            (_q(1, 0, 2), _q(0, 0, 2)),
+            (_q(0, 0, 2), _q(1, 0, 2)),
+        )
+    )
+
+    result = singular_spectrum(identity)
+
+    assert len(result.values) == 1
+    assert result.values[0].value.polynomial == ("1", "-1")
+    assert result.values[0].value.real_root_index == 0
+    assert result.values[0].multiplicity == 2
+
+
+def test_maxwell_hessian_inertia_is_bound_to_the_exact_source() -> None:
+    zero = _q(0, 0, 39)
+    source = _matrix(
+        (
+            (_q(Fraction(19, 8), 0, 39), zero, _q(0, Fraction(-1, 2), 39)),
+            (zero, _q(Fraction(-45, 8), 0, 39), zero),
+            (_q(0, Fraction(-1, 2), 39), zero, _q(Fraction(13, 4), 0, 39)),
+        )
+    )
+
+    result = inertia(source)
+
+    assert (result.n_positive, result.n_negative, result.n_zero) == (1, 2, 0)
+    assert result.definiteness == "indefinite"
+
+
+@pytest.mark.parametrize(
+    ("entries", "expected"),
+    [
+        (
+            (
+                (_q(0, 0, 2), _q(1, 1, 2), _q(0, 0, 2)),
+                (_q(1, 1, 2), _q(0, 0, 2), _q(1, 0, 2)),
+                (_q(0, 0, 2), _q(1, 0, 2), _q(0, 0, 2)),
+            ),
+            (1, 1, 1),
+        ),
+        (
+            (
+                (_q(0, 0, 2), _q(1, 0, 2)),
+                (_q(1, 0, 2), _q(0, 0, 2)),
+            ),
+            (1, 1, 0),
+        ),
+    ],
+)
+def test_inertia_handles_exact_two_by_two_pivots(
+    entries: tuple[tuple[RealQuadraticValue, ...], ...],
+    expected: tuple[int, int, int],
+) -> None:
+    result = inertia(_matrix(entries))
+
+    assert (result.n_positive, result.n_negative, result.n_zero) == expected
+
+
+def test_matrix_value_requires_one_explicit_quadratic_field() -> None:
+    with pytest.raises(ValidationError, match="shared real quadratic field"):
+        _matrix(((_q(radicand=2), _q(radicand=3)),))
+    with pytest.raises(ValidationError, match="same length"):
+        _matrix(((_q(),), (_q(), _q())))
+
+
+def test_operation_specific_shape_and_work_bounds_are_preflighted() -> None:
+    nonsymmetric = _matrix(((_q(), _q(1)), (_q(0), _q())))
+    with pytest.raises(ValidationError, match="exact symmetry"):
+        RealQuadraticSymmetricSpectrumRequest(matrix=nonsymmetric)
+
+    five = tuple(tuple(_q(radicand=2) for _ in range(5)) for _ in range(5))
+    with pytest.raises(ValidationError, match="dimension at most 4"):
+        RealQuadraticInertiaRequest(matrix=_matrix(five))
+
+    huge = _q(10**255, 0, 2)
+    large_diagonal = _matrix(((huge, _q(radicand=2)), (_q(radicand=2), huge)))
+    with pytest.raises(ValidationError, match="996-digit"):
+        RealQuadraticSingularSpectrumRequest(matrix=large_diagonal)
+
+
+def test_source_bound_results_reject_forged_spectrum_and_inertia() -> None:
+    source = _matrix(
+        (
+            (_q(1, 0, 2), _q(0, 0, 2)),
+            (_q(0, 0, 2), _q(2, 0, 2)),
+        )
+    )
+    spectrum_payload = symmetric_spectrum(source).model_dump()
+    spectrum_payload["values"] = tuple(reversed(spectrum_payload["values"]))
+    with pytest.raises(ValidationError, match="spectrum does not match"):
+        RealQuadraticSpectrum.model_validate(spectrum_payload)
+
+    inertia_payload = inertia(source).model_dump()
+    inertia_payload["n_positive"] = 1
+    inertia_payload["n_zero"] = 1
+    inertia_payload["definiteness"] = "positive_semidefinite"
+    with pytest.raises(ValidationError, match="inertia does not match"):
+        RealQuadraticInertia.model_validate(inertia_payload)
+
+
+def test_quadratic_spectral_public_api_and_catalog_are_exact() -> None:
+    import jacobian.math.matrices.quadratic_spectral as public
+
+    assert tuple(public.__all__) == (
+        "RealAlgebraicMultiplicity",
+        "RealQuadraticInertia",
+        "RealQuadraticSpectrum",
+        "inertia",
+        "singular_spectrum",
+        "symmetric_spectrum",
+    )
+    assert {tool.operation_id for tool in TOOLS} == {
+        "matrix.real_quadratic.inertia.compute",
+        "matrix.real_quadratic.singular_spectrum.compute",
+        "matrix.real_quadratic.symmetric_spectrum.compute",
+    }

--- a/tests/math/test_real_algebraic.py
+++ b/tests/math/test_real_algebraic.py
@@ -1,0 +1,107 @@
+"""Canonical real algebraic values and exact-order evidence."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.real_algebraic import (
+    RealAlgebraicOrderValue,
+    RealAlgebraicValue,
+    compare_real_algebraic,
+    isolate_real_algebraic,
+)
+
+
+def _value(polynomial: tuple[str, ...], root: int) -> RealAlgebraicValue:
+    return RealAlgebraicValue(polynomial=polynomial, real_root_index=root)
+
+
+def test_minimal_polynomial_and_root_index_determine_one_value() -> None:
+    positive_sqrt_two = _value(("1", "0", "-2"), 1)
+
+    assert positive_sqrt_two.polynomial == ("1", "0", "-2")
+    assert positive_sqrt_two.real_root_index == 1
+    interval = isolate_real_algebraic(positive_sqrt_two)
+    assert interval.lower.as_fraction() == 1
+    assert interval.upper.as_fraction() == 2
+    assert interval.interval_type == "OPEN"
+
+
+def test_order_uses_one_exact_axis_for_distinct_minimal_polynomials() -> None:
+    result = compare_real_algebraic(
+        _value(("1", "0", "-2"), 1),
+        _value(("2", "-3"), 0),
+    )
+
+    assert result.order == "LT"
+    assert result.left_isolating_interval.upper.as_fraction() <= (
+        result.right_isolating_interval.lower.as_fraction()
+    )
+
+
+def test_order_within_one_minimal_polynomial_uses_real_root_indices() -> None:
+    negative_sqrt_two = _value(("1", "0", "-2"), 0)
+    positive_sqrt_two = _value(("1", "0", "-2"), 1)
+
+    assert compare_real_algebraic(negative_sqrt_two, positive_sqrt_two).order == "LT"
+    assert compare_real_algebraic(positive_sqrt_two, positive_sqrt_two).order == "EQ"
+
+
+@pytest.mark.parametrize(
+    ("polynomial", "message"),
+    [
+        (("-1", "0", "2"), "positive leading"),
+        (("2", "0", "-4"), "primitive"),
+        (("1", "0", "-1"), "irreducible"),
+    ],
+)
+def test_noncanonical_minimal_polynomials_are_rejected(
+    polynomial: tuple[str, ...], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        _value(polynomial, 0)
+
+
+def test_value_rejects_a_nonreal_or_missing_root() -> None:
+    with pytest.raises(ValidationError, match="existing real root"):
+        _value(("1", "0", "1"), 0)
+    with pytest.raises(ValidationError, match="existing real root"):
+        _value(("1", "0", "-2"), 2)
+
+
+def test_degree_and_coefficient_boundaries_are_closed() -> None:
+    degree_eight = _value(("1", "0", "0", "0", "0", "0", "0", "0", "-2"), 1)
+    thousand_digit_leading = _value(("1" + "0" * 999, "1"), 0)
+
+    assert len(degree_eight.polynomial) == 9
+    assert len(thousand_digit_leading.polynomial[0]) == 1_000
+    with pytest.raises(ValidationError):
+        _value(("1",) + ("0",) * 8 + ("-2",), 1)
+    with pytest.raises(ValidationError, match="1000-digit bound"):
+        _value(("1" + "0" * 1_000, "1"), 0)
+
+
+def test_order_result_rejects_forged_conclusion_or_evidence() -> None:
+    result = compare_real_algebraic(
+        _value(("1", "0", "-2"), 1),
+        _value(("1", "0", "-3"), 1),
+    )
+    forged_order = result.model_dump()
+    forged_order["order"] = "GT"
+    with pytest.raises(ValidationError, match="order must match"):
+        RealAlgebraicOrderValue.model_validate(forged_order)
+
+    forged_interval = result.model_dump()
+    forged_interval["left_isolating_interval"]["lower"] = {
+        "num": "0",
+        "den": "1",
+    }
+    with pytest.raises(ValidationError, match="left isolating interval"):
+        RealAlgebraicOrderValue.model_validate(forged_interval)
+
+
+def test_value_round_trips_without_backend_expressions() -> None:
+    value = _value(("1", "0", "-2"), 1)
+
+    assert RealAlgebraicValue.model_validate_json(value.model_dump_json()) == value

--- a/tests/math/test_real_quadratic.py
+++ b/tests/math/test_real_quadratic.py
@@ -1,0 +1,32 @@
+"""Admission tests for exact real-quadratic scalar operations."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.real_quadratic import (
+    RealQuadraticOrderRequest,
+    RealQuadraticValue,
+)
+
+
+def _value(rational: int) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=CanonicalRational.from_fraction(Fraction(rational)),
+        radical_coefficient=CanonicalRational(num="0", den="1"),
+        radicand=2,
+    )
+
+
+def test_order_preflights_a_difference_that_cannot_be_returned() -> None:
+    maximum_component = 10**256 - 1
+
+    with pytest.raises(ValidationError, match="difference exceeds the 256-digit"):
+        RealQuadraticOrderRequest(
+            left=_value(maximum_component),
+            right=_value(-maximum_component),
+        )


### PR DESCRIPTION
## Problem

Closes #939.

Jacobian could compare individual values in one quadratic field, but it had no
bounded canonical value for derived real algebraic quantities and no exact
spectrum or inertia operation for matrices with quadratic-radical entries. The
Pang weighted-projection and Maxwell Hessian examples therefore required agents
to reconstruct and compare the algebra manually.

## Solution

- Add `RealAlgebraicValue`: a primitive irreducible `ZZ[x]` minimum polynomial
  plus increasing real-root index, bounded to degree 8 and 1,000-digit
  coefficients. `algebraic_number.compare` v2 returns an exact, source-bound
  ordering with rational isolation intervals.
- Add `RealQuadraticMatrix` and three operations:
  `matrix.real_quadratic.symmetric_spectrum.compute`,
  `matrix.real_quadratic.singular_spectrum.compute`, and
  `matrix.real_quadratic.inertia.compute`. Spectra retain exact
  minimum-polynomial values and multiplicities; inertia returns signed counts
  and definiteness.
- Use SymPy 1.14 for exact integer-polynomial factoring/root isolation and
  python-flint 0.9 Arb only to select the physical spectral branch after exact
  norm-root construction. The 2×2 spectral norm has degree at most 8; the
  996-digit coefficient admission leaves headroom for the canonical 1,000-digit
  factor type and the fixed 32,768-bit Arb separation bound.
- Preflight the existing real-quadratic comparison so a difference that cannot
  fit its canonical result type is rejected before execution.

The change deliberately does not add universal algebraic coercion, floating
tolerances, or a separate checker: retained source-bound result validators
replay the exact operation within the same bounded envelope.

## Testing

- `uv run --locked pytest -n 0 tests/math/test_real_algebraic.py tests/math/test_real_quadratic.py tests/math/matrices/test_quadratic_spectral.py tests/integration/algebra/test_exact_operations.py tests/catalog/test_catalog_invariants.py tests/integration/catalog/test_public_operation_contract_conformance.py tests/integration/catalog/test_builtin_examples.py -q` — 1122 passed.
- Focused Ruff and mypy for all touched source modules — passed.
- A deterministic 200-case 2×2 probe agreed with independent SymPy numeric
  reconstruction for symmetric and singular spectra.

## Public contract impact

New `RealAlgebraicValue`, `RealQuadraticMatrix`, and three matrix operations.
`algebraic_number.compare` is a pre-stable v2 contract: it now accepts
canonical real-algebraic values and returns source-bound exact evidence rather
than caller-selected intervals. Existing real-quadratic ordering rejects
result-overflowing differences at request validation.

## Public operation admission

- Concrete gap: exact spectral quantities and inertia over `Q(sqrt(d))` were
  absent.
- Existing operations and values: rational and symbolic matrices do not retain
  a shared real-quadratic field or produce canonical real-algebraic spectral
  values.
- Stable mathematical result: complete 2×2 symmetric eigenvalue or
  singular-value spectrum, and bounded symmetric inertia.
- Semantic domain and admitted execution envelope: 2×2 for spectra; symmetric
  dimension ≤4 for inertia; one square-free radicand; spectrum norm
  coefficients ≤996 digits.
- Controlling work, intermediate, memory, and output quantities: degree ≤8,
  exact factor coefficients <1,000 digits, fixed 32,768-bit branch-selection
  precision, and canonical rational output limits.
- Exact representation, algorithm regimes, and maintained backend: SymPy exact
  polynomial operations plus python-flint Arb branch isolation; direct exact
  field arithmetic for the fixed small inertia kernel.
- Remaining fixed caps and their classification: matrix dimensions and
  coefficient/precision envelopes are conservative execution bounds.
- Admission decision: KEEP for the three operations.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Canonical bounded real-algebraic values and comparison | delivered | `algebraic_number.compare` v2 |
| Exact symmetric 2×2 spectrum over `Q(sqrt(d))` | delivered | `matrix.real_quadratic.symmetric_spectrum.compute` |
| Exact 2×2 singular spectrum over `Q(sqrt(d))` | delivered | `matrix.real_quadratic.singular_spectrum.compute` |
| Exact small symmetric inertia over `Q(sqrt(d))` | delivered | `matrix.real_quadratic.inertia.compute` |
| Universal coercion or independent checker | rejected | outside the atomic operation boundary |

## Checklist

- [ ] `make check` passes (the coordinator run ended without an observable exit result)
- [x] Public operation changes include owner-local admission decisions
- [x] Exact results replay their defining relation from retained sources
- [x] Bounds include source fixtures, boundary and adversarial coverage

Suggested review order: `real_algebraic.py`,
`quadratic_spectral/operations.py`, then the owner and catalog tests.
