### PR TITLE
Normalize numerical-semigroup generator presentations

### DIFF
--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -318,7 +318,13 @@ class FactorizationLengthsComputeRequest(StrictModel):
     """Compute the complete sorted length set of one element."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; factorization lengths use its increasing minimal "
+            "generator axis."
+        ),
     )
     value: CanonicalInteger
 
@@ -339,7 +345,7 @@ class FactorizationLengthsComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_length_set(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         value = parse_canonical_integer(self.value)
         if self.in_semigroup != bool(self.lengths):
             raise ValueError("membership must agree with the factorization lengths")
@@ -356,7 +362,13 @@ class FactorizationDistanceRequest(StrictModel):
     """Distance between two factorizations of the same element."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant, but both factorization coordinate tuples must use its "
+            "increasing minimal generator axis."
+        ),
     )
     value: CanonicalInteger
     first: tuple[int, ...] = Field(min_length=1)
@@ -460,7 +472,13 @@ class ElementDeltaSetRequest(StrictModel):
     """Delta set of one element in a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; factorization lengths use its increasing minimal "
+            "generator axis."
+        ),
     )
     value: CanonicalInteger
 
@@ -482,7 +500,7 @@ class ElementDeltaSetResult(StrictModel):
 
     @model_validator(mode="after")
     def require_set_semantics(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         value = parse_canonical_integer(self.value)
         expected_lengths = factorization_lengths(generators, value)
         if self.factorization_lengths != expected_lengths:
@@ -536,7 +554,7 @@ class ElementElasticityResult(StrictModel):
 
     @model_validator(mode="after")
     def require_length_ratio(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         expected_extrema = factorization_length_extrema(
             generators, parse_canonical_integer(self.value)
         )
@@ -553,7 +571,13 @@ class ElementCatenaryDegreeRequest(StrictModel):
     """Catenary degree of one element in a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; factorization coordinates use its increasing minimal "
+            "generator axis."
+        ),
     )
     value: CanonicalInteger
 
@@ -578,7 +602,7 @@ class ElementCatenaryDegreeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_exact_degree(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         family = factorizations(generators, parse_canonical_integer(self.value))
         if self.factorization_count != len(family):
             raise ValueError("factorization_count does not match the element")
@@ -591,7 +615,12 @@ class BettiElementsRequest(StrictModel):
     """Betti elements of a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; derived data uses its increasing minimal generator axis."
+        ),
     )
 
     @model_validator(mode="after")
@@ -611,7 +640,7 @@ class BettiElementsResult(StrictModel):
 
     @model_validator(mode="after")
     def require_complete_betti_data(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         apery, candidates, disconnected = betti_data(generators)
         if tuple(map(parse_canonical_integer, self.apery_set)) != apery:
             raise ValueError("apery_set does not match the minimal generators")
@@ -774,11 +803,12 @@ class PresentationBinomialsResult(StrictModel):
     def require_canonical_axis_and_homogeneous_binomials(self) -> Self:
         generators = _require_canonical_minimal_axis(self.minimal_generators)
         for binomial in self.binomials:
-            if (
-                len(binomial.left_exponents) != len(generators)
-                or len(binomial.right_exponents) != len(generators)
-            ):
-                raise ValueError("binomial exponents must match the minimal generator axis")
+            if len(binomial.left_exponents) != len(generators) or len(
+                binomial.right_exponents
+            ) != len(generators):
+                raise ValueError(
+                    "binomial exponents must match the minimal generator axis"
+                )
             if any(
                 exponent < 0
                 for exponent in (*binomial.left_exponents, *binomial.right_exponents)
@@ -805,7 +835,13 @@ class DeltaSetRequest(StrictModel):
     """Global delta set of a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; the complete delta set uses its increasing minimal "
+            "generator axis."
+        ),
     )
 
     @model_validator(mode="after")
@@ -828,7 +864,7 @@ class DeltaSetResult(StrictModel):
 
     @model_validator(mode="after")
     def require_set_semantics(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         if self.delta_set != tuple(sorted(set(self.delta_set))):
             raise ValueError("delta_set must be strictly increasing and duplicate-free")
         if any(delta <= 0 for delta in self.delta_set):
@@ -883,7 +919,13 @@ class CatenaryDegreeRequest(StrictModel):
     """Global catenary degree of a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; factorization coordinates use its increasing minimal "
+            "generator axis."
+        ),
     )
 
     @model_validator(mode="after")
@@ -910,7 +952,7 @@ class CatenaryDegreeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_maximizing_witnesses(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         _, _, disconnected = betti_data(generators)
         expected_records = tuple(
             BettiCatenaryDegree(

--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -51,15 +51,23 @@ def _require_positive_bounded_generators(generators: tuple[str, ...]) -> None:
 
 
 def _require_minimal_generators(generators: tuple[str, ...]) -> tuple[int, ...]:
+    """Normalize a valid presentation to its increasing minimal atom axis."""
+
+    _require_positive_bounded_generators(generators)
+    values = tuple(sorted({parse_canonical_integer(value) for value in generators}))
+    return minimal_generating_system(values)
+
+
+def _require_canonical_minimal_axis(
+    generators: tuple[str, ...],
+) -> tuple[int, ...]:
+    """Reject results whose coordinate axis is not the semigroup's atom axis."""
+
     _require_positive_bounded_generators(generators)
     values = tuple(parse_canonical_integer(value) for value in generators)
-    if values != tuple(sorted(set(values))):
-        raise ValueError("generators must be distinct and strictly increasing")
-    minimal = minimal_generating_system(values)
-    if values != minimal:
+    if values != _require_minimal_generators(generators):
         raise ValueError(
-            "generators must be the minimal generating system; "
-            f"expected {list(minimal)}"
+            "minimal_generators must use the canonical minimal generator axis"
         )
     return values
 
@@ -268,7 +276,13 @@ class FactorizationComputeRequest(StrictModel):
     """Compute the complete factorization family Z(s) for one element."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; returned coordinates use its increasing minimal "
+            "generator axis."
+        ),
     )
     value: CanonicalInteger
 
@@ -292,7 +306,7 @@ class FactorizationComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_exact_family(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         value = parse_canonical_integer(self.value)
         if self.in_semigroup != bool(self.factorizations):
             raise ValueError("membership must agree with the factorization family")
@@ -384,7 +398,12 @@ class FactorizationGraphComputeRequest(StrictModel):
     """Compute the standard factorization graph of one element."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; graph vertices use its increasing minimal generator axis."
+        ),
     )
     value: CanonicalInteger
 
@@ -411,7 +430,7 @@ class FactorizationGraphComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_graph_partition(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         value = parse_canonical_integer(self.value)
         vertex_count = len(self.factorizations)
         if self.in_semigroup != bool(self.factorizations):
@@ -487,8 +506,9 @@ class ElementElasticityRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            f"Distinct, strictly increasing minimal generators, each at most "
-            f"{MAX_GENERATOR}."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; results use its "
+            "increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger = Field(
@@ -608,7 +628,12 @@ class MinimalPresentationRequest(StrictModel):
     """One minimal presentation of a numerical semigroup."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; returned relations use its increasing minimal generator axis."
+        ),
     )
 
     @model_validator(mode="after")
@@ -644,7 +669,7 @@ class MinimalPresentationResult(StrictModel):
 
     @model_validator(mode="after")
     def require_minimal_relation_counts(self) -> Self:
-        generators = tuple(map(parse_canonical_integer, self.minimal_generators))
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
         _, _, disconnected = betti_data(generators)
         if tuple(map(parse_canonical_integer, self.betti_elements)) != tuple(
             disconnected
@@ -693,7 +718,13 @@ class PresentationBinomialsRequest(StrictModel):
     """Convert a minimal presentation to sparse binomial form."""
 
     generators: tuple[CanonicalInteger, ...] = Field(
-        min_length=1, max_length=MAX_GENERATORS
+        min_length=1,
+        max_length=MAX_GENERATORS,
+        description=(
+            "Positive generators with gcd 1. The presentation may be reordered "
+            "or redundant; relation coordinates must use its increasing minimal "
+            "generator axis."
+        ),
     )
     relations: tuple[MinimalPresentationRelation, ...]
 
@@ -738,6 +769,36 @@ class PresentationBinomialsResult(StrictModel):
 
     minimal_generators: tuple[CanonicalInteger, ...]
     binomials: tuple[PresentationBinomial, ...]
+
+    @model_validator(mode="after")
+    def require_canonical_axis_and_homogeneous_binomials(self) -> Self:
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        for binomial in self.binomials:
+            if (
+                len(binomial.left_exponents) != len(generators)
+                or len(binomial.right_exponents) != len(generators)
+            ):
+                raise ValueError("binomial exponents must match the minimal generator axis")
+            if any(
+                exponent < 0
+                for exponent in (*binomial.left_exponents, *binomial.right_exponents)
+            ):
+                raise ValueError("binomial exponents must be non-negative")
+            left_degree = sum(
+                exponent * generator
+                for exponent, generator in zip(
+                    binomial.left_exponents, generators, strict=True
+                )
+            )
+            right_degree = sum(
+                exponent * generator
+                for exponent, generator in zip(
+                    binomial.right_exponents, generators, strict=True
+                )
+            )
+            if left_degree != right_degree:
+                raise ValueError("binomial terms must have the same semigroup degree")
+        return self
 
 
 class DeltaSetRequest(StrictModel):
@@ -787,8 +848,9 @@ class ElasticityRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            f"Distinct, strictly increasing minimal generators, each at most "
-            f"{MAX_GENERATOR}."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; the ratio uses its "
+            "increasing minimal generator axis."
         ),
     )
 

--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -326,9 +326,9 @@ class FactorizationComputeRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; returned coordinates use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; returned "
+            "coordinates use its increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger
@@ -370,9 +370,9 @@ class FactorizationLengthsComputeRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; factorization lengths use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; factorization "
+            "lengths use its increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger
@@ -416,9 +416,10 @@ class FactorizationDistanceRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant, but both factorization coordinate tuples must use its "
-            "increasing minimal generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant, but both "
+            "factorization coordinate tuples must use its increasing minimal "
+            "generator axis."
         ),
     )
     value: CanonicalInteger
@@ -464,8 +465,9 @@ class FactorizationGraphComputeRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; graph vertices use its increasing minimal generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; graph vertices use "
+            "its increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger
@@ -528,9 +530,9 @@ class ElementDeltaSetRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; factorization lengths use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; factorization "
+            "lengths use its increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger
@@ -631,9 +633,9 @@ class ElementCatenaryDegreeRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; factorization coordinates use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; factorization "
+            "coordinates use its increasing minimal generator axis."
         ),
     )
     value: CanonicalInteger
@@ -677,8 +679,9 @@ class BettiElementsRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; derived data uses its increasing minimal generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; derived data uses "
+            "its increasing minimal generator axis."
         ),
     )
 
@@ -721,8 +724,9 @@ class MinimalPresentationRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; returned relations use its increasing minimal generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; returned relations "
+            "use its increasing minimal generator axis."
         ),
     )
 
@@ -813,9 +817,9 @@ class PresentationBinomialsRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; relation coordinates must use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; relation "
+            "coordinates must use its increasing minimal generator axis."
         ),
     )
     relations: tuple[MinimalPresentationRelation, ...]
@@ -903,9 +907,9 @@ class DeltaSetRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; the complete delta set uses its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; the complete delta "
+            "set uses its increasing minimal generator axis."
         ),
     )
 
@@ -989,9 +993,9 @@ class CatenaryDegreeRequest(StrictModel):
         min_length=1,
         max_length=MAX_GENERATORS,
         description=(
-            "Positive generators with gcd 1. The presentation may be reordered "
-            "or redundant; factorization coordinates use its increasing minimal "
-            "generator axis."
+            f"Positive generators with gcd 1, each at most {MAX_GENERATOR}. "
+            "The presentation may be reordered or redundant; factorization "
+            "coordinates use its increasing minimal generator axis."
         ),
     )
 

--- a/src/jacobian/math/numerical_semigroups/_models.py
+++ b/src/jacobian/math/numerical_semigroups/_models.py
@@ -72,6 +72,24 @@ def _require_canonical_minimal_axis(
     return values
 
 
+def _summary_invariants(
+    generators: tuple[int, ...],
+) -> tuple[int, int, int, int, int, tuple[int, ...]]:
+    """Replay the exact numerical-semigroup summary from its atom axis."""
+
+    apery = apery_set(generators)
+    conductor = max(apery) - generators[0] + 1
+    gaps = tuple(value for value in range(1, conductor) if not belongs(value, apery))
+    return (
+        generators[0],
+        len(generators),
+        conductor - 1,
+        conductor,
+        len(gaps),
+        gaps,
+    )
+
+
 def _require_bounded_value(value: str) -> int:
     parsed = parse_canonical_integer(value)
     if parsed > MAX_ELEMENT:
@@ -235,13 +253,42 @@ class NumericalSemigroupSummaryRequest(StrictModel):
 class NumericalSemigroupSummaryResult(StrictModel):
     """Summary of a numerical semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     multiplicity: CanonicalInteger
     embedding_dimension: int = Field(ge=1)
     frobenius_number: str
     conductor: str
     genus: int = Field(ge=0)
     gaps: tuple[CanonicalInteger, ...]
+
+    @model_validator(mode="after")
+    def require_exact_summary(self) -> Self:
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        (
+            multiplicity,
+            embedding_dimension,
+            frobenius_number,
+            conductor,
+            genus,
+            gaps,
+        ) = _summary_invariants(generators)
+        if parse_canonical_integer(self.multiplicity) != multiplicity:
+            raise ValueError("multiplicity does not match the minimal generators")
+        if self.embedding_dimension != embedding_dimension:
+            raise ValueError(
+                "embedding_dimension does not match the minimal generators"
+            )
+        if parse_canonical_integer(self.frobenius_number) != frobenius_number:
+            raise ValueError("frobenius_number does not match the minimal generators")
+        if parse_canonical_integer(self.conductor) != conductor:
+            raise ValueError("conductor does not match the minimal generators")
+        if self.genus != genus:
+            raise ValueError("genus does not match the minimal generators")
+        if tuple(map(parse_canonical_integer, self.gaps)) != gaps:
+            raise ValueError("gaps do not match the minimal generators")
+        return self
 
 
 class SemigroupMembershipRequest(StrictModel):
@@ -300,7 +347,9 @@ class FactorizationComputeResult(StrictModel):
     """Complete factorization family Z(s) for one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     in_semigroup: bool
     factorizations: tuple[tuple[int, ...], ...]
 
@@ -339,7 +388,9 @@ class FactorizationLengthsComputeResult(StrictModel):
     """Sorted length set of one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     in_semigroup: bool
     lengths: tuple[int, ...]
 
@@ -433,7 +484,9 @@ class FactorizationGraphComputeResult(StrictModel):
     """Standard factorization graph with connected components."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     in_semigroup: bool
     factorizations: tuple[tuple[int, ...], ...]
     edges: tuple[tuple[int, int], ...]
@@ -494,7 +547,9 @@ class ElementDeltaSetResult(StrictModel):
     """Delta set of one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     factorization_lengths: tuple[int, ...]
     delta_set: tuple[int, ...]
 
@@ -547,7 +602,9 @@ class ElementElasticityResult(StrictModel):
     """Elasticity of one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     minimum_length: int = Field(ge=1)
     maximum_length: int = Field(ge=1)
     elasticity: str
@@ -596,7 +653,9 @@ class ElementCatenaryDegreeResult(StrictModel):
     """Catenary degree of one element."""
 
     value: CanonicalInteger
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     factorization_count: int = Field(ge=1)
     catenary_degree: int = Field(ge=0)
 
@@ -633,7 +692,9 @@ class BettiElementsRequest(StrictModel):
 class BettiElementsResult(StrictModel):
     """Betti elements of a semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     apery_set: tuple[CanonicalInteger, ...]
     candidate_count: int = Field(ge=0)
     betti_elements: tuple[CanonicalInteger, ...]
@@ -692,7 +753,9 @@ class MinimalPresentationRelation(StrictModel):
 class MinimalPresentationResult(StrictModel):
     """One minimal presentation of the semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     betti_elements: tuple[CanonicalInteger, ...]
     relations: tuple[MinimalPresentationRelation, ...]
 
@@ -796,7 +859,9 @@ class PresentationBinomial(StrictModel):
 class PresentationBinomialsResult(StrictModel):
     """Presentation converted to sparse binomials."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     binomials: tuple[PresentationBinomial, ...]
 
     @model_validator(mode="after")
@@ -854,7 +919,9 @@ class DeltaSetRequest(StrictModel):
 class DeltaSetResult(StrictModel):
     """Global delta set of the semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     delta_set: tuple[int, ...]
     periodicity_bound: int = Field(ge=0)
     checked_through: int = Field(ge=0)
@@ -945,7 +1012,9 @@ class BettiCatenaryDegree(StrictModel):
 class CatenaryDegreeResult(StrictModel):
     """Global catenary degree of the semigroup."""
 
-    minimal_generators: tuple[CanonicalInteger, ...]
+    minimal_generators: tuple[CanonicalInteger, ...] = Field(
+        min_length=1, max_length=MAX_GENERATORS
+    )
     catenary_degree: int = Field(ge=0)
     betti_degrees: tuple[BettiCatenaryDegree, ...]
     witness_betti_elements: tuple[CanonicalInteger, ...]

--- a/src/jacobian/math/numerical_semigroups/_tools.py
+++ b/src/jacobian/math/numerical_semigroups/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.numerical_semigroups._models import (
+    MAX_GENERATOR,
     BettiElementsRequest,
     BettiElementsResult,
     CatenaryDegreeRequest,
@@ -115,10 +116,10 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _operation(
         "number_theory.numerical_semigroup.factorizations.compute",
         "Compute complete factorization family Z(s)",
-        "Given a finite positive generator presentation and an element, compute "
-        "the complete bounded factorization family Z(s) on the increasing minimal "
-        "generator axis. Redundant or reordered generators normalize before exact "
-        "output validation.",
+        f"Given positive gcd-one generators, each at most {MAX_GENERATOR}, and "
+        "an element, compute the complete bounded factorization family Z(s) on "
+        "the increasing minimal generator axis. Redundant or reordered generators "
+        "normalize before exact output validation.",
         FactorizationComputeRequest,
         FactorizationComputeResult,
         compute_factorizations,
@@ -197,9 +198,10 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _operation(
         "number_theory.numerical_semigroup.presentation_binomials.compute",
         "Convert presentation to sparse binomials",
-        "Normalize a generator presentation to its minimal axis, validate relations "
-        "against that axis, and convert each relation (u,v) to the toric binomial "
-        "X^u-X^v with coefficients 1 and -1.",
+        "Normalize a positive gcd-one generator presentation, each at most "
+        f"{MAX_GENERATOR}, to its minimal axis, validate relations against that "
+        "axis, and convert each relation (u,v) to the toric binomial X^u-X^v "
+        "with coefficients 1 and -1.",
         PresentationBinomialsRequest,
         PresentationBinomialsResult,
         compute_presentation_binomials,
@@ -274,8 +276,9 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "elasticity_15_in_3_5",
-                "Elasticity of 15 in <3,5>; positive gcd-one generators normalize "
-                "to the minimal axis and the value must be a positive member.",
+                "Elasticity of 15 in <3,5>; positive gcd-one generators, each at "
+                f"most {MAX_GENERATOR}, normalize to the minimal axis and the "
+                "value must be a positive member.",
                 {"generators": ["3", "5"], "value": "15"},
             ),
         ),
@@ -295,8 +298,8 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "global_elasticity_3_5",
-                "Global elasticity of <3,5>; positive gcd-one generators normalize "
-                "to the minimal axis.",
+                "Global elasticity of <3,5>; positive gcd-one generators, each at "
+                f"most {MAX_GENERATOR}, normalize to the minimal axis.",
                 {"generators": ["3", "5"]},
             ),
         ),

--- a/src/jacobian/math/numerical_semigroups/_tools.py
+++ b/src/jacobian/math/numerical_semigroups/_tools.py
@@ -115,10 +115,10 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _operation(
         "number_theory.numerical_semigroup.factorizations.compute",
         "Compute complete factorization family Z(s)",
-        "Given an ordered minimal generating system and an element, compute "
-        "the complete bounded factorization family Z(s), expressed as tuples "
-        "of generator multiplicities. Oversized exact outputs fail request "
-        "validation before computation.",
+        "Given a finite positive generator presentation and an element, compute "
+        "the complete bounded factorization family Z(s) on the increasing minimal "
+        "generator axis. Redundant or reordered generators normalize before exact "
+        "output validation.",
         FactorizationComputeRequest,
         FactorizationComputeResult,
         compute_factorizations,
@@ -197,8 +197,8 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     _operation(
         "number_theory.numerical_semigroup.presentation_binomials.compute",
         "Convert presentation to sparse binomials",
-        "Validate presentation relations against the declared minimal "
-        "generators and convert each relation (u,v) to the toric binomial "
+        "Normalize a generator presentation to its minimal axis, validate relations "
+        "against that axis, and convert each relation (u,v) to the toric binomial "
         "X^u-X^v with coefficients 1 and -1.",
         PresentationBinomialsRequest,
         PresentationBinomialsResult,
@@ -274,8 +274,8 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "elasticity_15_in_3_5",
-                "Elasticity of 15 in <3,5> with minimal generators (distinct, "
-                "strictly increasing, gcd 1) and positive member value.",
+                "Elasticity of 15 in <3,5>; positive gcd-one generators normalize "
+                "to the minimal axis and the value must be a positive member.",
                 {"generators": ["3", "5"], "value": "15"},
             ),
         ),
@@ -295,8 +295,8 @@ NUMERICAL_SEMIGROUP_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "global_elasticity_3_5",
-                "Global elasticity of <3,5> with minimal generators (distinct, "
-                "strictly increasing, gcd 1).",
+                "Global elasticity of <3,5>; positive gcd-one generators normalize "
+                "to the minimal axis.",
                 {"generators": ["3", "5"]},
             ),
         ),

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -194,6 +194,76 @@ def test_result_rejects_redundant_minimal_generator_axis(result_model, payload):
         result_model(minimal_generators=("3", "5", "6"), **payload)
 
 
+@pytest.mark.parametrize("axis", [(), tuple(map(str, range(30, 51)))])
+@pytest.mark.parametrize(
+    ("result_model", "payload"),
+    [
+        (
+            FactorizationComputeResult,
+            {"value": "-1", "in_semigroup": False, "factorizations": ()},
+        ),
+        (
+            FactorizationLengthsComputeResult,
+            {"value": "-1", "in_semigroup": False, "lengths": ()},
+        ),
+        (
+            FactorizationGraphComputeResult,
+            {
+                "value": "-1",
+                "in_semigroup": False,
+                "factorizations": (),
+                "edges": (),
+                "connected_components": (),
+                "is_connected": True,
+            },
+        ),
+        (
+            ElementDeltaSetResult,
+            {"value": "0", "factorization_lengths": (0,), "delta_set": ()},
+        ),
+        (
+            ElementElasticityResult,
+            {
+                "value": "30",
+                "minimum_length": 1,
+                "maximum_length": 1,
+                "elasticity": "1",
+            },
+        ),
+        (
+            ElementCatenaryDegreeResult,
+            {"value": "30", "factorization_count": 1, "catenary_degree": 0},
+        ),
+        (
+            BettiElementsResult,
+            {"apery_set": (), "candidate_count": 0, "betti_elements": ()},
+        ),
+        (
+            MinimalPresentationResult,
+            {"betti_elements": (), "relations": ()},
+        ),
+        (PresentationBinomialsResult, {"binomials": ()}),
+        (
+            DeltaSetResult,
+            {"delta_set": (), "periodicity_bound": 0, "checked_through": 0},
+        ),
+        (
+            CatenaryDegreeResult,
+            {
+                "catenary_degree": 0,
+                "betti_degrees": (),
+                "witness_betti_elements": (),
+            },
+        ),
+    ],
+)
+def test_result_rejects_empty_or_overlong_minimal_generator_axis(
+    axis, result_model, payload
+):
+    with pytest.raises(ValidationError):
+        result_model(minimal_generators=axis, **payload)
+
+
 class TestFactorizationLengths:
     def test_lengths_15_in_3_5(self):
         req = FactorizationLengthsComputeRequest(generators=("3", "5"), value="15")

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -12,11 +12,15 @@ from jacobian.math.numerical_semigroups._models import (
     ElementDeltaSetRequest,
     ElementElasticityRequest,
     FactorizationComputeRequest,
+    FactorizationComputeResult,
     FactorizationDistanceRequest,
     FactorizationGraphComputeRequest,
+    FactorizationGraphComputeResult,
     FactorizationLengthsComputeRequest,
     MinimalPresentationRequest,
+    MinimalPresentationResult,
     PresentationBinomialsRequest,
+    PresentationBinomialsResult,
 )
 from jacobian.math.numerical_semigroups._operations import (
     compute_betti_elements,
@@ -62,10 +66,23 @@ class TestFactorizations:
         with pytest.raises(ValidationError, match="positive"):
             FactorizationComputeRequest(generators=("0", "5"), value="10")
 
-    def test_factorizations_non_minimal_generators(self):
-        """Coordinate-bearing requests reject ambiguous redundant generators."""
-        with pytest.raises(ValidationError, match="minimal generating system"):
-            FactorizationComputeRequest(generators=("3", "5", "8"), value="15")
+    def test_factorizations_normalize_redundant_permuted_generators(self):
+        """Factorizations always use the canonical minimal-generator axis."""
+        result = compute_factorizations(
+            FactorizationComputeRequest(generators=("8", "5", "3"), value="15")
+        )
+
+        assert result.minimal_generators == ("3", "5")
+        assert result.factorizations == ((0, 3), (5, 0))
+
+    def test_factorization_result_rejects_a_redundant_coordinate_axis(self):
+        with pytest.raises(ValidationError, match="canonical minimal"):
+            FactorizationComputeResult(
+                value="15",
+                minimal_generators=("3", "5", "8"),
+                in_semigroup=True,
+                factorizations=((0, 3, 0), (5, 0, 0)),
+            )
 
     def test_factorization_materialization_is_complete_past_old_silent_cap(self):
         generators = ("6", "7", "8", "9", "10", "11")
@@ -123,7 +140,7 @@ class TestFactorizationDistance:
         assert result.distance == 0
 
     def test_distance_rejects_mismatched_lengths(self):
-        with pytest.raises(ValidationError, match="minimal generating system"):
+        with pytest.raises(ValidationError, match="coordinates must match"):
             FactorizationDistanceRequest(
                 generators=("3", "5"), value="15", first=(5, 0, 0), second=(0, 3)
             )
@@ -142,6 +159,26 @@ class TestFactorizationDistance:
 
 
 class TestFactorizationGraph:
+    def test_graph_normalizes_redundant_generators(self):
+        result = compute_factorization_graph(
+            FactorizationGraphComputeRequest(generators=("8", "3", "5"), value="15")
+        )
+
+        assert result.minimal_generators == ("3", "5")
+        assert result.factorizations == ((0, 3), (5, 0))
+
+    def test_graph_result_rejects_a_redundant_coordinate_axis(self):
+        with pytest.raises(ValidationError, match="canonical minimal"):
+            FactorizationGraphComputeResult(
+                value="15",
+                minimal_generators=("3", "5", "8"),
+                in_semigroup=True,
+                factorizations=((0, 3, 0), (5, 0, 0)),
+                edges=(),
+                connected_components=((0,), (1,)),
+                is_connected=False,
+            )
+
     def test_graph_15_in_3_5_disconnected(self):
         req = FactorizationGraphComputeRequest(generators=("3", "5"), value="15")
         result = compute_factorization_graph(req)
@@ -259,6 +296,26 @@ class TestBettiElements:
 
 
 class TestMinimalPresentation:
+    def test_presentation_normalizes_redundant_permuted_generators(self):
+        result = compute_minimal_presentation(
+            MinimalPresentationRequest(generators=("10", "9", "6", "4"))
+        )
+
+        assert result.minimal_generators == ("4", "6", "9")
+        assert all(
+            len(relation.first) == len(result.minimal_generators)
+            and len(relation.second) == len(result.minimal_generators)
+            for relation in result.relations
+        )
+
+    def test_presentation_result_rejects_a_redundant_coordinate_axis(self):
+        with pytest.raises(ValidationError, match="canonical minimal"):
+            MinimalPresentationResult(
+                minimal_generators=("3", "5", "8"),
+                betti_elements=("15",),
+                relations=({"first": [5, 0, 0], "second": [0, 3, 0]},),
+            )
+
     def test_presentation_3_5(self):
         req = MinimalPresentationRequest(generators=("3", "5"))
         result = compute_minimal_presentation(req)
@@ -301,6 +358,32 @@ class TestMinimalPresentation:
 
 
 class TestPresentationBinomials:
+    def test_binomials_accept_relations_on_the_normalized_axis(self):
+        presentation = compute_minimal_presentation(
+            MinimalPresentationRequest(generators=("8", "5", "3"))
+        )
+        result = compute_presentation_binomials(
+            PresentationBinomialsRequest(
+                generators=("3", "8", "5"), relations=presentation.relations
+            )
+        )
+
+        assert result.minimal_generators == ("3", "5")
+        assert result.binomials[0].left_exponents == (5, 0)
+        assert result.binomials[0].right_exponents == (0, 3)
+
+    def test_binomial_result_rejects_a_redundant_coordinate_axis(self):
+        with pytest.raises(ValidationError, match="canonical minimal"):
+            PresentationBinomialsResult(
+                minimal_generators=("3", "5", "8"),
+                binomials=(
+                    {
+                        "left_exponents": [5, 0, 0],
+                        "right_exponents": [0, 3, 0],
+                    },
+                ),
+            )
+
     def test_binomials_3_5(self):
         req = PresentationBinomialsRequest(
             generators=("3", "5"),

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -5,18 +5,25 @@ from pydantic import ValidationError
 
 from jacobian.math.numerical_semigroups._models import (
     BettiElementsRequest,
+    BettiElementsResult,
     CatenaryDegreeRequest,
+    CatenaryDegreeResult,
     DeltaSetRequest,
+    DeltaSetResult,
     ElasticityRequest,
     ElementCatenaryDegreeRequest,
+    ElementCatenaryDegreeResult,
     ElementDeltaSetRequest,
+    ElementDeltaSetResult,
     ElementElasticityRequest,
+    ElementElasticityResult,
     FactorizationComputeRequest,
     FactorizationComputeResult,
     FactorizationDistanceRequest,
     FactorizationGraphComputeRequest,
     FactorizationGraphComputeResult,
     FactorizationLengthsComputeRequest,
+    FactorizationLengthsComputeResult,
     MinimalPresentationRequest,
     MinimalPresentationResult,
     PresentationBinomialsRequest,
@@ -99,6 +106,94 @@ class TestFactorizations:
         assert result.in_semigroup
 
 
+@pytest.mark.parametrize(
+    ("result_model", "payload"),
+    [
+        (
+            FactorizationComputeResult,
+            {"value": "15", "in_semigroup": True, "factorizations": ((0, 3, 0),)},
+        ),
+        (
+            FactorizationLengthsComputeResult,
+            {"value": "18", "in_semigroup": True, "lengths": (3, 4, 5, 6)},
+        ),
+        (
+            FactorizationGraphComputeResult,
+            {
+                "value": "15",
+                "in_semigroup": True,
+                "factorizations": ((0, 3, 0),),
+                "edges": (),
+                "connected_components": ((0,),),
+                "is_connected": True,
+            },
+        ),
+        (
+            ElementDeltaSetResult,
+            {
+                "value": "18",
+                "factorization_lengths": (3, 4, 5, 6),
+                "delta_set": (1,),
+            },
+        ),
+        (
+            ElementElasticityResult,
+            {
+                "value": "18",
+                "minimum_length": 3,
+                "maximum_length": 6,
+                "elasticity": "2",
+            },
+        ),
+        (
+            ElementCatenaryDegreeResult,
+            {"value": "18", "factorization_count": 5, "catenary_degree": 3},
+        ),
+        (
+            BettiElementsResult,
+            {
+                "apery_set": ("0", "10", "5"),
+                "candidate_count": 6,
+                "betti_elements": ("15",),
+            },
+        ),
+        (
+            MinimalPresentationResult,
+            {
+                "betti_elements": ("15",),
+                "relations": ({"first": (5, 0, 0), "second": (0, 3, 0)},),
+            },
+        ),
+        (
+            PresentationBinomialsResult,
+            {
+                "binomials": (
+                    {
+                        "left_exponents": (5, 0, 0),
+                        "right_exponents": (0, 3, 0),
+                    },
+                )
+            },
+        ),
+        (
+            DeltaSetResult,
+            {"delta_set": (1,), "periodicity_bound": 45, "checked_through": 50},
+        ),
+        (
+            CatenaryDegreeResult,
+            {
+                "catenary_degree": 3,
+                "betti_degrees": ({"betti_element": "15", "catenary_degree": 3},),
+                "witness_betti_elements": ("15",),
+            },
+        ),
+    ],
+)
+def test_result_rejects_redundant_minimal_generator_axis(result_model, payload):
+    with pytest.raises(ValidationError, match="canonical minimal"):
+        result_model(minimal_generators=("3", "5", "6"), **payload)
+
+
 class TestFactorizationLengths:
     def test_lengths_15_in_3_5(self):
         req = FactorizationLengthsComputeRequest(generators=("3", "5"), value="15")
@@ -138,6 +233,18 @@ class TestFactorizationDistance:
         )
         result = compute_factorization_distance(req)
         assert result.distance == 0
+
+    def test_distance_normalizes_the_generator_presentation_not_coordinates(self):
+        result = compute_factorization_distance(
+            FactorizationDistanceRequest(
+                generators=("8", "5", "3"),
+                value="15",
+                first=(5, 0),
+                second=(0, 3),
+            )
+        )
+
+        assert result.distance == 5
 
     def test_distance_rejects_mismatched_lengths(self):
         with pytest.raises(ValidationError, match="coordinates must match"):

--- a/tests/math/numerical_semigroups/test_extended.py
+++ b/tests/math/numerical_semigroups/test_extended.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.numerical_semigroups._models import (
+    MAX_GENERATOR,
     BettiElementsRequest,
     BettiElementsResult,
     CatenaryDegreeRequest,
@@ -645,3 +646,50 @@ class TestGlobalCatenaryDegree:
         result = compute_catenary_degree(req)
         assert result.catenary_degree == 3
         assert result.witness_betti_elements == ("12", "18")
+
+
+class TestGeneratorEnvelopeIsSchemaVisible:
+    """The per-generator ceiling is published wherever acceptance is advertised."""
+
+    def test_request_schemas_state_the_per_generator_ceiling(self):
+        for model in (
+            BettiElementsRequest,
+            CatenaryDegreeRequest,
+            DeltaSetRequest,
+            ElementCatenaryDegreeRequest,
+            ElementDeltaSetRequest,
+            ElementElasticityRequest,
+            FactorizationComputeRequest,
+            FactorizationDistanceRequest,
+            FactorizationGraphComputeRequest,
+            FactorizationLengthsComputeRequest,
+            MinimalPresentationRequest,
+            PresentationBinomialsRequest,
+        ):
+            schema = model.model_json_schema()
+            description = schema["properties"]["generators"]["description"]
+            assert f"each at most {MAX_GENERATOR}" in description
+
+    def test_rejects_a_generator_above_the_published_ceiling(self):
+        with pytest.raises(ValidationError, match=f"at most {MAX_GENERATOR}"):
+            FactorizationComputeRequest(generators=("2", "501"), value="503")
+
+    def test_broadened_declarations_state_the_per_generator_ceiling(self):
+        from jacobian.math.numerical_semigroups._tools import TOOLS
+
+        tools = {tool.operation_id: tool for tool in TOOLS}
+        for operation_id in (
+            "number_theory.numerical_semigroup.factorizations.compute",
+            "number_theory.numerical_semigroup.presentation_binomials.compute",
+        ):
+            assert f"each at most {MAX_GENERATOR}" in tools[operation_id].description
+        for operation_id in (
+            "number_theory.numerical_semigroup.elasticity.compute",
+            "number_theory.numerical_semigroup.elasticity.global_compute",
+        ):
+            examples = tools[operation_id].examples
+            assert examples
+            assert all(
+                f"each at most {MAX_GENERATOR}" in example.description
+                for example in examples
+            )

--- a/tests/math/numerical_semigroups/test_numerical_semigroups.py
+++ b/tests/math/numerical_semigroups/test_numerical_semigroups.py
@@ -1,7 +1,11 @@
 """Tests for numerical semigroup operations."""
 
+import pytest
+from pydantic import ValidationError
+
 from jacobian.math.numerical_semigroups._models import (
     NumericalSemigroupSummaryRequest,
+    NumericalSemigroupSummaryResult,
     SemigroupMembershipRequest,
 )
 from jacobian.math.numerical_semigroups._operations import (
@@ -43,13 +47,56 @@ class TestSemigroupSummary:
         assert result.genus == 50
 
     def test_rejects_nonpositive_generators(self):
-        import pytest
-        from pydantic import ValidationError
-
         with pytest.raises(ValidationError, match="positive"):
             NumericalSemigroupSummaryRequest(generators=("-1",))
         with pytest.raises(ValidationError, match="positive"):
             SemigroupMembershipRequest(generators=("0", "2"), value="4")
+
+    def test_summary_result_rejects_a_redundant_minimal_axis(self):
+        with pytest.raises(ValidationError, match="canonical minimal"):
+            NumericalSemigroupSummaryResult(
+                minimal_generators=("3", "5", "8"),
+                multiplicity="3",
+                embedding_dimension=3,
+                frobenius_number="7",
+                conductor="8",
+                genus=4,
+                gaps=("1", "2", "4", "7"),
+            )
+
+    @pytest.mark.parametrize("axis", [(), tuple(map(str, range(30, 51)))])
+    def test_summary_result_rejects_empty_or_overlong_minimal_axis(self, axis):
+        with pytest.raises(ValidationError):
+            NumericalSemigroupSummaryResult(
+                minimal_generators=axis,
+                multiplicity="3",
+                embedding_dimension=2,
+                frobenius_number="7",
+                conductor="8",
+                genus=4,
+                gaps=("1", "2", "4", "7"),
+            )
+
+    @pytest.mark.parametrize(
+        ("field", "forged_value"),
+        [
+            ("multiplicity", "5"),
+            ("embedding_dimension", 3),
+            ("frobenius_number", "8"),
+            ("conductor", "9"),
+            ("genus", 3),
+            ("gaps", ("1", "2", "4")),
+        ],
+    )
+    def test_summary_result_replays_every_derived_field(self, field, forged_value):
+        result = compute_summary(
+            NumericalSemigroupSummaryRequest(generators=("3", "5"))
+        )
+        payload = result.model_dump()
+        payload[field] = forged_value
+
+        with pytest.raises(ValidationError):
+            NumericalSemigroupSummaryResult(**payload)
 
 
 class TestSemigroupMembership:


### PR DESCRIPTION
## Problem

Part of #1906. Numerical-semigroup operations return factorization coordinates on the minimal atom axis, but their requests previously rejected an equivalent redundant presentation such as `<3,5,8>`. That made coordinate-bearing results depend on input presentation rather than the canonical semigroup value.

## Solution

Accept valid positive gcd-one generator presentations, reduce them to the increasing minimal atom axis before bounded computation, and retain that axis in every coordinate-bearing result. The change covers factorization families and graphs, Betti elements, presentations, binomials, delta/catenary data, and summary values.

All result axes are now nonempty, capped at the domain generator limit, and replayed as canonical minimal atoms. Summary results additionally reconstruct multiplicity, embedding dimension, Frobenius number, conductor, genus, and gaps from that axis. This prevents a producer from labeling a redundant coordinate system as `minimal_generators`.

Malformed, nonpositive, or non-coprime presentations remain rejected. `FactorizationDistance` keeps its explicit canonical-coordinate requirement.

## Testing

- `make check` — 3,567 passed.
- Numerical-semigroup focused suite — 120 passed.
- Dispatcher checks exercised all ten admitted numerical-semigroup operations with redundant/permuted `['8', '5', '3']`; coordinate outputs normalize to `['3', '5']`.
- 5,744 valid and redundant presentations fuzzed the summary replay validator.
- Direct malformed-result tests cover empty, 21-generator, redundant, and forged-summary axes.

## Public contract impact

The affected operation IDs and result schema fields are unchanged. Requests now identify numerical semigroups by any valid finite generator presentation; outputs remain bound to the unique minimal atom axis. This is a pre-stable correction to the canonical value contract.

## Public operation admission

No new operation is added. This repair makes existing coordinate-producing operations use one canonical numerical-semigroup value and therefore compose across presentation choices.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Presentation-invariant canonical axes for existing factorization operations | delivered | existing numerical-semigroup operation IDs |
| Exact factorization-distance matrix and presentation-degree profile | not implemented | #1906 |
| Polynomial-carrier form of presentation binomials | deferred contract gap | #1906 |

## Checklist

- [x] `make check` passes
- [x] Public result replay and malformed-boundary validation are listed above
- [x] Result semantics remain exact and source-bound
