### PR TITLE
feat(graphs): add replayable SPQR decomposition

### DIFF
--- a/src/jacobian/math/graphs/decomposition/_admission.py
+++ b/src/jacobian/math/graphs/decomposition/_admission.py
@@ -11,6 +11,12 @@ from jacobian.math.graphs.decomposition._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "graph.decomposition.spqr_tree.compute",
+        AdmissionDecision.KEEP,
+        "bounded exact structural decomposition with source-edge ownership,"
+        " virtual-edge gluing, and a distinct replayable postcondition",
+    ),
+    OperationAdmission(
         "graph.decomposition.biconnected_components.compute",
         AdmissionDecision.NATIVE_ONLY,
         "useful projection of the retained block-cut-tree decomposition",

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -111,3 +111,106 @@ class BiconnectedComponentsResult(StrictModel):
 
     components: tuple[tuple[int, ...], ...] = Field(default=())
     convention: Literal["NETWORKX_BICONNECTED"] = "NETWORKX_BICONNECTED"
+
+
+# ---------------------------------------------------------------------------
+# SPQR trees
+# ---------------------------------------------------------------------------
+
+
+class SPQRTreeRequest(StrictModel):
+    """Request the normalized SPQR tree of one finite simple graph.
+
+    The positive branch uses the convention that a source graph must be
+    connected, biconnected, and have at least three vertices.  Other inputs
+    return a concrete ``NOT_BICONNECTED`` witness rather than an empty tree.
+    """
+
+    graph: UndirectedGraph = Field(
+        description=(
+            "Finite simple undirected source graph. A positive SPQR tree uses"
+            " the biconnected, at-least-three-vertices convention."
+        )
+    )
+
+
+class SPQRSkeletonEdge(StrictModel):
+    """One real source edge or one paired virtual skeleton edge."""
+
+    edge_id: str = Field(min_length=1, max_length=96)
+    left: int = Field(ge=0, le=63)
+    right: int = Field(ge=0, le=63)
+    kind: Literal["REAL", "VIRTUAL"]
+    source_edge: tuple[int, int] | None = None
+
+    @model_validator(mode="after")
+    def require_tagged_edge_invariant(self) -> Self:
+        if self.left == self.right:
+            raise ValueError("SPQR skeleton edges must be loopless")
+        if self.kind == "REAL":
+            if self.source_edge != (
+                min(self.left, self.right),
+                max(self.left, self.right),
+            ):
+                raise ValueError("a real skeleton edge must name its source edge")
+        elif self.source_edge is not None:
+            raise ValueError("a virtual skeleton edge must not name a source edge")
+        return self
+
+
+class SPQRSkeleton(StrictModel):
+    """One S, P, Q, or R skeleton with stable presentation identity."""
+
+    node_id: str = Field(min_length=1, max_length=64)
+    kind: Literal["S_NODE", "P_NODE", "Q_NODE", "R_NODE"]
+    vertices: tuple[int, ...] = Field(min_length=2, max_length=64)
+    edges: tuple[SPQRSkeletonEdge, ...] = Field(min_length=1, max_length=1_536)
+
+    @model_validator(mode="after")
+    def require_canonical_skeleton_carrier(self) -> Self:
+        if self.vertices != tuple(sorted(set(self.vertices))):
+            raise ValueError("SPQR skeleton vertices must be sorted and unique")
+        if any(
+            edge.left not in self.vertices or edge.right not in self.vertices
+            for edge in self.edges
+        ):
+            raise ValueError("SPQR skeleton edges must use declared skeleton vertices")
+        if len({edge.edge_id for edge in self.edges}) != len(self.edges):
+            raise ValueError("SPQR skeleton edge IDs must be unique")
+        return self
+
+
+class SPQRTreeResult(StrictModel):
+    """Source-bound normalized SPQR decomposition or a negative witness."""
+
+    source_graph: UndirectedGraph
+    status: Literal["SPQR_TREE", "NOT_BICONNECTED"]
+    witness_kind: Literal["ARTICULATION", "DISCONNECTED", "MINIMUM_SIZE"] | None = None
+    witness_vertices: tuple[int, ...] = Field(default=(), max_length=2)
+    nodes: tuple[SPQRSkeleton, ...] = Field(default=(), max_length=1_024)
+    tree_edges: tuple[tuple[str, str], ...] = Field(default=(), max_length=1_023)
+    virtual_edge_pairs: tuple[tuple[str, str], ...] = Field(
+        default=(), max_length=1_536
+    )
+    source_edge_owners: tuple[tuple[tuple[int, int], str, str], ...] = Field(
+        default=(), max_length=512
+    )
+    convention: Literal["JACOBIAN_NORMALIZED_FULL_SPQR_V1"] = (
+        "JACOBIAN_NORMALIZED_FULL_SPQR_V1"
+    )
+
+    @model_validator(mode="after")
+    def require_closed_branch_shape(self) -> Self:
+        if self.status == "NOT_BICONNECTED":
+            if self.witness_kind is None or not self.witness_vertices:
+                raise ValueError("a non-biconnected result requires a concrete witness")
+            if (
+                self.nodes
+                or self.tree_edges
+                or self.virtual_edge_pairs
+                or self.source_edge_owners
+            ):
+                raise ValueError("a non-biconnected result must not carry an SPQR tree")
+        elif self.witness_kind is not None or self.witness_vertices:
+            raise ValueError("an SPQR tree must not carry a negative witness")
+        return self

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -13,6 +13,7 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math.graphs.multigraph._models import LooplessMultigraph
 
 
 class UndirectedGraph(StrictModel):
@@ -134,49 +135,38 @@ class SPQRTreeRequest(StrictModel):
     )
 
 
-class SPQRSkeletonEdge(StrictModel):
-    """One real source edge or one paired virtual skeleton edge."""
-
-    edge_id: str = Field(min_length=1, max_length=96)
-    left: int = Field(ge=0, le=63)
-    right: int = Field(ge=0, le=63)
-    kind: Literal["REAL", "VIRTUAL"]
-    source_edge: tuple[int, int] | None = None
-
-    @model_validator(mode="after")
-    def require_tagged_edge_invariant(self) -> Self:
-        if self.left == self.right:
-            raise ValueError("SPQR skeleton edges must be loopless")
-        if self.kind == "REAL":
-            if self.source_edge != (
-                min(self.left, self.right),
-                max(self.left, self.right),
-            ):
-                raise ValueError("a real skeleton edge must name its source edge")
-        elif self.source_edge is not None:
-            raise ValueError("a virtual skeleton edge must not name a source edge")
-        return self
-
-
 class SPQRSkeleton(StrictModel):
     """One S, P, Q, or R skeleton with stable presentation identity."""
 
     node_id: str = Field(min_length=1, max_length=64)
     kind: Literal["S_NODE", "P_NODE", "Q_NODE", "R_NODE"]
     vertices: tuple[int, ...] = Field(min_length=2, max_length=64)
-    edges: tuple[SPQRSkeletonEdge, ...] = Field(min_length=1, max_length=1_536)
+    graph: LooplessMultigraph
+    real_edge_sources: tuple[tuple[str, tuple[int, int]], ...] = Field(default=())
+    virtual_edge_ids: tuple[str, ...] = Field(default=())
 
     @model_validator(mode="after")
     def require_canonical_skeleton_carrier(self) -> Self:
         if self.vertices != tuple(sorted(set(self.vertices))):
             raise ValueError("SPQR skeleton vertices must be sorted and unique")
-        if any(
-            edge.left not in self.vertices or edge.right not in self.vertices
-            for edge in self.edges
+        if self.graph.vertex_count != len(self.vertices):
+            raise ValueError(
+                "SPQR multigraph carrier must use the skeleton vertex axis"
+            )
+        edge_ids = self.graph.edge_id_set
+        real_ids = {edge_id for edge_id, _ in self.real_edge_sources}
+        virtual_ids = set(self.virtual_edge_ids)
+        if real_ids & virtual_ids or real_ids | virtual_ids != edge_ids:
+            raise ValueError("SPQR edge tags must partition the multigraph edge IDs")
+        if len(real_ids) != len(self.real_edge_sources) or len(virtual_ids) != len(
+            self.virtual_edge_ids
         ):
-            raise ValueError("SPQR skeleton edges must use declared skeleton vertices")
-        if len({edge.edge_id for edge in self.edges}) != len(self.edges):
-            raise ValueError("SPQR skeleton edge IDs must be unique")
+            raise ValueError("SPQR edge tags must not repeat edge IDs")
+        for edge_id, source_edge in self.real_edge_sources:
+            edge = self.graph.edge_by_id(edge_id)
+            endpoints = (self.vertices[edge.left], self.vertices[edge.right])
+            if tuple(sorted(endpoints)) != source_edge:
+                raise ValueError("a real skeleton edge must name its source edge")
         return self
 
 
@@ -217,4 +207,9 @@ class SPQRTreeResult(StrictModel):
                 raise ValueError("a non-biconnected result must not carry an SPQR tree")
         elif self.witness_kind is not None or self.witness_vertices:
             raise ValueError("an SPQR tree must not carry a negative witness")
+        # Keep source-bound replay at the ordinary deserialization boundary,
+        # not only in the producer. The lazy import avoids a module cycle.
+        from jacobian.math.graphs.decomposition._operations import _validate_spqr_tree
+
+        _validate_spqr_tree(self)
         return self

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -192,6 +192,9 @@ class SPQRTreeResult(StrictModel):
     virtual_edge_pairs: tuple[tuple[str, str], ...] = Field(
         default=(), max_length=1_536
     )
+    source_vertex_incidence: tuple[tuple[int, tuple[str, ...]], ...] = Field(
+        default=(), max_length=64
+    )
     source_edge_owners: tuple[tuple[tuple[int, int], str, str], ...] = Field(
         default=(), max_length=512
     )
@@ -208,6 +211,7 @@ class SPQRTreeResult(StrictModel):
                 self.nodes
                 or self.tree_edges
                 or self.virtual_edge_pairs
+                or self.source_vertex_incidence
                 or self.source_edge_owners
             ):
                 raise ValueError("a non-biconnected result must not carry an SPQR tree")

--- a/src/jacobian/math/graphs/decomposition/_models.py
+++ b/src/jacobian/math/graphs/decomposition/_models.py
@@ -2,8 +2,9 @@
 
 All operations in this module act on an undirected simple graph supplied as
 a vertex count and a tuple of ``(source, target)`` integer edges.  Vertices
-are labelled ``0..vertex_count-1``; the maximum vertex count is 64 and the
-maximum edge count is 512, matching the rest of the graph domains.
+are labelled ``0..vertex_count-1``; the vertex axis holds at most 64
+vertices, so a simple graph admits up to ``C(64, 2) = 2016`` edges, matching
+the shared multigraph carrier bounds.
 """
 
 from __future__ import annotations
@@ -13,14 +14,18 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.multigraph._models import LooplessMultigraph
+from jacobian.math.graphs.multigraph._models import MAX_EDGES, LooplessMultigraph
 
 
 class UndirectedGraph(StrictModel):
-    """A simple undirected graph for decomposition operations."""
+    """A simple undirected graph for decomposition operations.
+
+    The declared vertex axis bounds admission: at most 64 vertices, hence at
+    most ``C(64, 2) = 2016`` distinct undirected edges.
+    """
 
     vertex_count: int = Field(ge=1, le=64)
-    edges: tuple[tuple[int, int], ...] = Field(min_length=0, max_length=512)
+    edges: tuple[tuple[int, int], ...] = Field(min_length=0, max_length=MAX_EDGES)
 
     @model_validator(mode="after")
     def require_valid_edges(self) -> Self:
@@ -125,6 +130,9 @@ class SPQRTreeRequest(StrictModel):
     The positive branch uses the convention that a source graph must be
     connected, biconnected, and have at least three vertices.  Other inputs
     return a concrete ``NOT_BICONNECTED`` witness rather than an empty tree.
+    Work admission follows from that convention: the split search enumerates
+    at most ``C(vertex_count, 2)`` candidate separation pairs over a graph of
+    at most ``C(64, 2) = 2016`` edges.
     """
 
     graph: UndirectedGraph = Field(
@@ -186,7 +194,7 @@ class SPQRTreeResult(StrictModel):
         default=(), max_length=64
     )
     source_edge_owners: tuple[tuple[tuple[int, int], str, str], ...] = Field(
-        default=(), max_length=512
+        default=(), max_length=MAX_EDGES
     )
     convention: Literal["JACOBIAN_NORMALIZED_FULL_SPQR_V1"] = (
         "JACOBIAN_NORMALIZED_FULL_SPQR_V1"

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -354,6 +354,17 @@ class _SPQRBuilder:
                 if edge.source_edge is not None
             )
         )
+        vertex_incidence = tuple(
+            (
+                vertex,
+                tuple(
+                    node_id
+                    for node_id, (_, edges) in sorted(self._nodes.items())
+                    if any(vertex in (edge.left, edge.right) for edge in edges)
+                ),
+            )
+            for vertex in range(graph.vertex_count)
+        )
         pairs = tuple(
             sorted((left, right) for left, right in self._pairs.items() if left < right)
         )
@@ -368,6 +379,7 @@ class _SPQRBuilder:
                 )
             ),
             virtual_edge_pairs=pairs,
+            source_vertex_incidence=vertex_incidence,
             source_edge_owners=owners,
         )
         _validate_spqr_tree(result)
@@ -688,6 +700,19 @@ def _validate_spqr_tree(result: SPQRTreeResult) -> None:
     )
     if result.source_edge_owners != expected_owners:
         raise ValueError("source edge ownership must match the skeleton real edges")
+    expected_incidence = tuple(
+        (
+            vertex,
+            tuple(
+                node_id
+                for node_id, node in sorted(nodes.items())
+                if vertex in node.vertices
+            ),
+        )
+        for vertex in range(result.source_graph.vertex_count)
+    )
+    if result.source_vertex_incidence != expected_incidence:
+        raise ValueError("source vertex incidence must match the skeleton carriers")
     derived_tree = _validate_virtual_pairs(result, edge_locations)
     if tuple(sorted(derived_tree)) != result.tree_edges:
         raise ValueError("SPQR tree edges must be induced by virtual-edge pairs")

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -868,8 +868,18 @@ def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
         degrees[node.vertices[edge.left]] += 1
         degrees[node.vertices[edge.right]] += 1
     if node.kind == "Q_NODE":
-        if len(node.real_edge_sources) != 1 or len(node.graph.edges) > 2:
-            raise ValueError("a Q skeleton must contain exactly one source real edge")
+        if (
+            len(node.vertices) != 2
+            or len(node.real_edge_sources) != 1
+            or len(node.graph.edges) > 2
+            or any(
+                _global_endpoints(node, edge) != node.vertices
+                for edge in node.graph.edges
+            )
+        ):
+            raise ValueError(
+                "a Q skeleton must carry one source real edge on its two carriers"
+            )
         return
     if node.kind == "P_NODE":
         if (

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -897,12 +897,18 @@ def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
             )
         return
     if node.kind == "S_NODE":
+        skeleton_graph: nx.Graph[int] = nx.Graph()
+        skeleton_graph.add_nodes_from(node.vertices)
+        skeleton_graph.add_edges_from(
+            _global_endpoints(node, edge) for edge in node.graph.edges
+        )
         if (
             len(node.vertices) < 3
             or len(node.graph.edges) != len(node.vertices)
             or any(value != 2 for value in degrees.values())
+            or not nx.is_connected(skeleton_graph)
         ):
-            raise ValueError("an S skeleton must be a cycle")
+            raise ValueError("an S skeleton must be one cycle")
         return
     graph: nx.Graph[int] = nx.Graph()
     graph.add_nodes_from(node.vertices)

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -910,9 +910,12 @@ def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
         ):
             raise ValueError("an S skeleton must be one cycle")
         return
+    endpoint_pairs = [_global_endpoints(node, edge) for edge in node.graph.edges]
+    if len(set(endpoint_pairs)) != len(endpoint_pairs):
+        raise ValueError("an R skeleton must not repeat an endpoint pair")
     graph: nx.Graph[int] = nx.Graph()
     graph.add_nodes_from(node.vertices)
-    graph.add_edges_from(_global_endpoints(node, edge) for edge in node.graph.edges)
+    graph.add_edges_from(endpoint_pairs)
     if len(node.vertices) < 4 or not nx.is_biconnected(graph):
         raise ValueError("an R skeleton must be triconnected")
     for left, right in combinations(node.vertices, 2):

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -732,7 +732,7 @@ def _validate_spqr_tree(result: SPQRTreeResult) -> None:
     )
     if result.source_vertex_incidence != expected_incidence:
         raise ValueError("source vertex incidence must match the skeleton carriers")
-    derived_tree = _validate_virtual_pairs(result, edge_locations)
+    derived_tree = _validate_virtual_pairs(result, edge_locations, source_value)
     if tuple(sorted(derived_tree)) != result.tree_edges:
         raise ValueError("SPQR tree edges must be induced by virtual-edge pairs")
     _validate_normalized_tree(nodes, result.tree_edges)
@@ -757,9 +757,11 @@ def _collect_spqr_edges(
 def _validate_virtual_pairs(
     result: SPQRTreeResult,
     edge_locations: dict[str, tuple[str, SPQRSkeleton, MultigraphEdge]],
+    source_value: nx.Graph[int],
 ) -> set[tuple[str, str]]:
     pair_edges: set[str] = set()
     derived_tree: set[tuple[str, str]] = set()
+    separated_pairs: set[tuple[int, int]] = set()
     for left_id, right_id in result.virtual_edge_pairs:
         if left_id == right_id or left_id in pair_edges or right_id in pair_edges:
             raise ValueError("virtual edges must occur in exactly one distinct pair")
@@ -773,12 +775,20 @@ def _validate_virtual_pairs(
             or right_id not in right_skeleton.virtual_edge_ids
         ):
             raise ValueError("only virtual skeleton edges may be paired")
-        if _global_endpoints(left_skeleton, left) != _global_endpoints(
-            right_skeleton, right
-        ):
+        separator = _global_endpoints(left_skeleton, left)
+        if separator != _global_endpoints(right_skeleton, right):
             raise ValueError(
                 "paired virtual edges must share their separator endpoints"
             )
+        if separator not in separated_pairs:
+            remaining = source_value.copy()
+            remaining.remove_nodes_from(separator)
+            if nx.is_connected(remaining):
+                raise ValueError(
+                    "paired virtual edges must represent a genuine separation"
+                    " pair of the source graph"
+                )
+            separated_pairs.add(separator)
         if left_node == right_node:
             raise ValueError("paired virtual edges must join distinct SPQR nodes")
         pair_edges.update((left_id, right_id))
@@ -834,6 +844,12 @@ def _validate_negative_spqr_result(result: SPQRTreeResult) -> None:
         if len(result.witness_vertices) != 2:
             raise ValueError("disconnectedness requires two concrete vertices")
         left, right = result.witness_vertices
+        if not (
+            0 <= left < graph.vertex_count and 0 <= right < graph.vertex_count
+        ):
+            raise ValueError(
+                "disconnectedness witness vertices must name source vertices"
+            )
         if left == right or nx.has_path(value, left, right):
             raise ValueError("disconnectedness witness vertices must be disconnected")
         return

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import cast
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Literal, cast
 
 import networkx as nx
 
@@ -15,6 +17,10 @@ from jacobian.math.graphs.decomposition._models import (
     BridgeBlockResult,
     EarDecompositionRequest,
     EarDecompositionResult,
+    SPQRSkeleton,
+    SPQRSkeletonEdge,
+    SPQRTreeRequest,
+    SPQRTreeResult,
     UndirectedGraph,
 )
 
@@ -254,3 +260,545 @@ def compute_biconnected_components(
     return BiconnectedComponentsResult(
         components=tuple(tuple(sorted(component)) for component in components),
     )
+
+
+# ---------------------------------------------------------------------------
+# Bounded normalized SPQR construction
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SPQREdge:
+    edge_id: str
+    left: int
+    right: int
+    source_edge: tuple[int, int] | None
+
+    @property
+    def endpoints(self) -> tuple[int, int]:
+        return (min(self.left, self.right), max(self.left, self.right))
+
+    @property
+    def is_virtual(self) -> bool:
+        return self.source_edge is None
+
+
+@dataclass(frozen=True)
+class _Anchor:
+    node_id: str
+    edge_id: str
+
+
+type _SPQRKind = Literal["S_NODE", "P_NODE", "Q_NODE", "R_NODE"]
+
+
+class _SPQRBuilder:
+    """Deterministic split-component SPQR construction for one small graph.
+
+    This deliberately uses NetworkX only for connectedness/biconnectedness.
+    The split-component recursion owns separator choice, virtual-edge pairing,
+    S/P normalization, and the source-edge transport.  A boundary virtual
+    edge is retained while descending a child; when its endpoints are itself a
+    separation pair it becomes an edge of the new P skeleton.  That detail is
+    what prevents a recursive split from losing the parent's gluing interface.
+    """
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, tuple[_SPQRKind, tuple[_SPQREdge, ...]]] = {}
+        self._pairs: dict[str, str] = {}
+        self._tree_edges: list[tuple[str, str]] = []
+        self._next_node = 0
+        self._next_virtual = 0
+
+    def build(self, graph: UndirectedGraph) -> SPQRTreeResult:
+        source_edges = tuple(
+            _SPQREdge(
+                edge_id=f"real:{min(left, right)}:{max(left, right)}",
+                left=min(left, right),
+                right=max(left, right),
+                source_edge=(min(left, right), max(left, right)),
+            )
+            for left, right in sorted(graph.edges)
+        )
+        self._decompose(source_edges, boundary_edge_id=None)
+        self._normalize_adjacent_nodes()
+        nodes = tuple(
+            SPQRSkeleton(
+                node_id=node_id,
+                kind=kind,
+                vertices=tuple(
+                    sorted({v for edge in edges for v in (edge.left, edge.right)})
+                ),
+                edges=tuple(
+                    SPQRSkeletonEdge(
+                        edge_id=edge.edge_id,
+                        left=edge.left,
+                        right=edge.right,
+                        kind="VIRTUAL" if edge.is_virtual else "REAL",
+                        source_edge=edge.source_edge,
+                    )
+                    for edge in edges
+                ),
+            )
+            for node_id, (kind, edges) in sorted(self._nodes.items())
+        )
+        owners = tuple(
+            sorted(
+                (
+                    edge.source_edge,
+                    node_id,
+                    edge.edge_id,
+                )
+                for node_id, (_, edges) in self._nodes.items()
+                for edge in edges
+                if edge.source_edge is not None
+            )
+        )
+        pairs = tuple(
+            sorted((left, right) for left, right in self._pairs.items() if left < right)
+        )
+        result = SPQRTreeResult(
+            source_graph=graph,
+            status="SPQR_TREE",
+            nodes=nodes,
+            tree_edges=tuple(
+                sorted(
+                    (min(left, right), max(left, right))
+                    for left, right in self._tree_edges
+                )
+            ),
+            virtual_edge_pairs=pairs,
+            source_edge_owners=owners,
+        )
+        _validate_spqr_tree(result)
+        return result
+
+    def _new_virtual(self, left: int, right: int) -> _SPQREdge:
+        edge = _SPQREdge(
+            edge_id=f"virtual:{self._next_virtual}",
+            left=min(left, right),
+            right=max(left, right),
+            source_edge=None,
+        )
+        self._next_virtual += 1
+        return edge
+
+    def _new_node(self, kind: _SPQRKind, edges: tuple[_SPQREdge, ...]) -> str:
+        node_id = f"node:{self._next_node}"
+        self._next_node += 1
+        self._nodes[node_id] = (
+            kind,
+            tuple(sorted(edges, key=lambda edge: edge.edge_id)),
+        )
+        return node_id
+
+    def _pair(self, left: _Anchor, right: _Anchor) -> None:
+        if left.edge_id in self._pairs or right.edge_id in self._pairs:
+            raise ValueError("a virtual SPQR edge may have only one mate")
+        self._pairs[left.edge_id] = right.edge_id
+        self._pairs[right.edge_id] = left.edge_id
+        self._tree_edges.append((left.node_id, right.node_id))
+
+    def _normalize_adjacent_nodes(self) -> None:
+        """Merge every adjacent S/S or P/P pair through its virtual join."""
+        while True:
+            locations = {
+                edge.edge_id: node_id
+                for node_id, (_, edges) in self._nodes.items()
+                for edge in edges
+            }
+            merge: tuple[str, str, str, str] | None = None
+            for left_edge, right_edge in self._pairs.items():
+                if left_edge > right_edge:
+                    continue
+                left_node, right_node = locations[left_edge], locations[right_edge]
+                if left_node == right_node:
+                    continue
+                left_kind = self._nodes[left_node][0]
+                if left_kind == self._nodes[right_node][0] and left_kind in {
+                    "S_NODE",
+                    "P_NODE",
+                }:
+                    merge = (left_node, right_node, left_edge, right_edge)
+                    break
+            if merge is None:
+                return
+            self._merge_nodes(*merge)
+
+    def _merge_nodes(
+        self,
+        left_node: str,
+        right_node: str,
+        left_edge_id: str,
+        right_edge_id: str,
+    ) -> None:
+        kind, left_edges = self._nodes[left_node]
+        _, right_edges = self._nodes[right_node]
+        merged_edges = tuple(
+            edge
+            for edge in (*left_edges, *right_edges)
+            if edge.edge_id not in {left_edge_id, right_edge_id}
+        )
+        self._nodes[left_node] = (
+            kind,
+            tuple(sorted(merged_edges, key=lambda edge: edge.edge_id)),
+        )
+        del self._nodes[right_node]
+        del self._pairs[left_edge_id]
+        del self._pairs[right_edge_id]
+        normalized: set[tuple[str, str]] = set()
+        for source, target in self._tree_edges:
+            source = left_node if source == right_node else source
+            target = left_node if target == right_node else target
+            if source != target:
+                normalized.add((min(source, target), max(source, target)))
+        self._tree_edges = sorted(normalized)
+
+    def _decompose(
+        self,
+        edges: tuple[_SPQREdge, ...],
+        boundary_edge_id: str | None,
+    ) -> _Anchor | None:
+        base_kind = self._base_kind(edges)
+        split = (
+            None
+            if base_kind in {"S_NODE", "P_NODE", "Q_NODE"}
+            else self._first_split(edges, boundary_edge_id)
+        )
+        if split is None:
+            node_id = self._new_node(base_kind, edges)
+            if boundary_edge_id is None:
+                return None
+            if boundary_edge_id not in {edge.edge_id for edge in edges}:
+                raise ValueError("boundary virtual edge was lost during SPQR recursion")
+            return _Anchor(node_id, boundary_edge_id)
+
+        left, right, fragments, direct_real, direct_virtual = split
+        children: list[_Anchor] = []
+        for fragment in fragments:
+            child_boundary = self._new_virtual(left, right)
+            child = self._decompose((*fragment, child_boundary), child_boundary.edge_id)
+            if child is None:
+                raise ValueError("a split component must retain its boundary edge")
+            children.append(child)
+        for edge in direct_real:
+            child_boundary = self._new_virtual(left, right)
+            node_id = self._new_node("Q_NODE", (edge, child_boundary))
+            children.append(_Anchor(node_id, child_boundary.edge_id))
+
+        if direct_virtual:
+            p_edges = [
+                *direct_virtual,
+                *(self._new_virtual(left, right) for _ in children),
+            ]
+            node_id = self._new_node("P_NODE", tuple(p_edges))
+            for child, parent_edge in zip(
+                children, p_edges[len(direct_virtual) :], strict=True
+            ):
+                self._pair(_Anchor(node_id, parent_edge.edge_id), child)
+            if boundary_edge_id in {edge.edge_id for edge in direct_virtual}:
+                return _Anchor(node_id, boundary_edge_id)
+            return self._anchor_for_virtual(boundary_edge_id)
+
+        if len(children) == 2:
+            self._pair(children[0], children[1])
+            return self._anchor_for_virtual(boundary_edge_id)
+        if len(children) < 3:
+            raise ValueError("a non-boundary split must have at least two components")
+        p_virtual_edges = tuple(self._new_virtual(left, right) for _ in children)
+        node_id = self._new_node("P_NODE", p_virtual_edges)
+        for child, parent_edge in zip(children, p_virtual_edges, strict=True):
+            self._pair(_Anchor(node_id, parent_edge.edge_id), child)
+        return self._anchor_for_virtual(boundary_edge_id)
+
+    def _anchor_for_virtual(self, edge_id: str | None) -> _Anchor | None:
+        if edge_id is None:
+            return None
+        for node_id, (_, edges) in self._nodes.items():
+            if edge_id in {edge.edge_id for edge in edges}:
+                return _Anchor(node_id, edge_id)
+        raise ValueError("boundary virtual edge was lost during SPQR recursion")
+
+    def _first_split(
+        self,
+        edges: tuple[_SPQREdge, ...],
+        boundary_edge_id: str | None,
+    ) -> (
+        tuple[
+            int,
+            int,
+            tuple[tuple[_SPQREdge, ...], ...],
+            tuple[_SPQREdge, ...],
+            tuple[_SPQREdge, ...],
+        ]
+        | None
+    ):
+        vertices = tuple(
+            sorted({vertex for edge in edges for vertex in (edge.left, edge.right)})
+        )
+        for left, right in combinations(vertices, 2):
+            removed = {left, right}
+            graph: nx.Graph[int] = nx.Graph()
+            graph.add_nodes_from(vertex for vertex in vertices if vertex not in removed)
+            for edge in edges:
+                if edge.left not in removed and edge.right not in removed:
+                    graph.add_edge(edge.left, edge.right)
+            components = tuple(
+                sorted(
+                    (
+                        frozenset(component)
+                        for component in nx.connected_components(graph)
+                    ),
+                    key=lambda component: tuple(sorted(component)),
+                )
+            )
+            by_component: list[list[_SPQREdge]] = [[] for _ in components]
+            direct_real: list[_SPQREdge] = []
+            direct_virtual: list[_SPQREdge] = []
+            for edge in edges:
+                if edge.endpoints == (left, right):
+                    if edge.is_virtual:
+                        direct_virtual.append(edge)
+                    else:
+                        direct_real.append(edge)
+                    continue
+                endpoint = edge.left if edge.left not in removed else edge.right
+                for index, component in enumerate(components):
+                    if endpoint in component:
+                        by_component[index].append(edge)
+                        break
+                else:
+                    raise ValueError(
+                        "split component edge did not retain a non-separator endpoint"
+                    )
+            fragments = tuple(
+                tuple(sorted(fragment, key=lambda edge: edge.edge_id))
+                for fragment in by_component
+                if fragment
+            )
+            # A separation pair is determined by disconnectedness after its
+            # deletion. A direct edge between the pair is a split component
+            # only after that condition holds; otherwise every K4 edge would
+            # spuriously create a P node.
+            if len(fragments) >= 2:
+                if direct_virtual:
+                    return (
+                        left,
+                        right,
+                        fragments,
+                        tuple(sorted(direct_real, key=lambda edge: edge.edge_id)),
+                        tuple(sorted(direct_virtual, key=lambda edge: edge.edge_id)),
+                    )
+                return (
+                    left,
+                    right,
+                    fragments,
+                    tuple(sorted(direct_real, key=lambda edge: edge.edge_id)),
+                    (),
+                )
+        return None
+
+    @staticmethod
+    def _base_kind(edges: tuple[_SPQREdge, ...]) -> _SPQRKind:
+        real = tuple(edge for edge in edges if not edge.is_virtual)
+        vertices = {vertex for edge in edges for vertex in (edge.left, edge.right)}
+        if len(real) == 1 and len(edges) <= 2:
+            return "Q_NODE"
+        if len(vertices) == 2 and len(edges) >= 3:
+            return "P_NODE"
+        degree: dict[int, int] = dict.fromkeys(vertices, 0)
+        for edge in edges:
+            degree[edge.left] += 1
+            degree[edge.right] += 1
+        if (
+            len(vertices) >= 3
+            and len(edges) == len(vertices)
+            and all(value == 2 for value in degree.values())
+        ):
+            return "S_NODE"
+        return "R_NODE"
+
+
+def _negative_spqr_result(graph: UndirectedGraph) -> SPQRTreeResult:
+    if graph.vertex_count < 3:
+        return SPQRTreeResult(
+            source_graph=graph,
+            status="NOT_BICONNECTED",
+            witness_kind="MINIMUM_SIZE",
+            witness_vertices=(0,),
+        )
+    value = _build_graph(graph)
+    components = tuple(
+        sorted(nx.connected_components(value), key=lambda component: min(component))
+    )
+    if len(components) > 1:
+        return SPQRTreeResult(
+            source_graph=graph,
+            status="NOT_BICONNECTED",
+            witness_kind="DISCONNECTED",
+            witness_vertices=(min(components[0]), min(components[1])),
+        )
+    articulation = min(nx.articulation_points(value), default=None)
+    if articulation is None:
+        raise ValueError("positive SPQR precondition failed without a graph witness")
+    return SPQRTreeResult(
+        source_graph=graph,
+        status="NOT_BICONNECTED",
+        witness_kind="ARTICULATION",
+        witness_vertices=(articulation,),
+    )
+
+
+def compute_spqr_tree(request: SPQRTreeRequest) -> SPQRTreeResult:
+    """Compute a deterministic normalized full SPQR tree.
+
+    The producer enumerates bounded vertex-pair split components, inserts
+    paired virtual edges, and collapses every degree-two P junction.  It does
+    not use NetworkX as an SPQR backend: NetworkX only supplies the initial
+    biconnectivity classification and connected-component primitive.
+    """
+    graph = request.graph
+    value = _build_graph(graph)
+    if graph.vertex_count < 3 or not nx.is_biconnected(value):
+        return _negative_spqr_result(graph)
+    return _SPQRBuilder().build(graph)
+
+
+def _validate_spqr_tree(result: SPQRTreeResult) -> None:
+    """Replay the defining SPQR source, tree, and skeleton invariants."""
+    if result.status != "SPQR_TREE":
+        return
+    nodes = {node.node_id: node for node in result.nodes}
+    if not nodes:
+        raise ValueError("an SPQR tree must contain at least one skeleton")
+    if len(nodes) != len(result.nodes):
+        raise ValueError("SPQR node IDs must be unique")
+    edge_locations, real_sources = _collect_spqr_edges(result)
+    source = {tuple(sorted(edge)) for edge in result.source_graph.edges}
+    if set(real_sources) != source or len(real_sources) != len(source):
+        raise ValueError(
+            "real skeleton edges must reconstruct the source edge set exactly"
+        )
+    expected_owners = tuple(
+        sorted(
+            (edge.source_edge, node_id, edge.edge_id)
+            for node_id, edge in edge_locations.values()
+            if edge.source_edge is not None
+        )
+    )
+    if result.source_edge_owners != expected_owners:
+        raise ValueError("source edge ownership must match the skeleton real edges")
+    derived_tree = _validate_virtual_pairs(result, edge_locations)
+    if tuple(sorted(derived_tree)) != result.tree_edges:
+        raise ValueError("SPQR tree edges must be induced by virtual-edge pairs")
+    _validate_normalized_tree(nodes, result.tree_edges)
+
+
+def _collect_spqr_edges(
+    result: SPQRTreeResult,
+) -> tuple[dict[str, tuple[str, SPQRSkeletonEdge]], list[tuple[int, int]]]:
+    edge_locations: dict[str, tuple[str, SPQRSkeletonEdge]] = {}
+    real_sources: list[tuple[int, int]] = []
+    for node in result.nodes:
+        for edge in node.edges:
+            if edge.edge_id in edge_locations:
+                raise ValueError("a skeleton edge must occur in exactly one node")
+            edge_locations[edge.edge_id] = (node.node_id, edge)
+            if edge.kind == "REAL":
+                if edge.source_edge is None:
+                    raise ValueError("real skeleton edge missing source map")
+                real_sources.append(edge.source_edge)
+        _validate_skeleton_kind(node)
+    return edge_locations, real_sources
+
+
+def _validate_virtual_pairs(
+    result: SPQRTreeResult,
+    edge_locations: dict[str, tuple[str, SPQRSkeletonEdge]],
+) -> set[tuple[str, str]]:
+    pair_edges: set[str] = set()
+    derived_tree: set[tuple[str, str]] = set()
+    for left_id, right_id in result.virtual_edge_pairs:
+        if left_id == right_id or left_id in pair_edges or right_id in pair_edges:
+            raise ValueError("virtual edges must occur in exactly one distinct pair")
+        try:
+            left_node, left = edge_locations[left_id]
+            right_node, right = edge_locations[right_id]
+        except KeyError as exc:
+            raise ValueError("virtual pair references an absent skeleton edge") from exc
+        if left.kind != "VIRTUAL" or right.kind != "VIRTUAL":
+            raise ValueError("only virtual skeleton edges may be paired")
+        if (min(left.left, left.right), max(left.left, left.right)) != (
+            min(right.left, right.right),
+            max(right.left, right.right),
+        ):
+            raise ValueError(
+                "paired virtual edges must share their separator endpoints"
+            )
+        if left_node == right_node:
+            raise ValueError("paired virtual edges must join distinct SPQR nodes")
+        pair_edges.update((left_id, right_id))
+        derived_tree.add((min(left_node, right_node), max(left_node, right_node)))
+    all_virtual = {
+        edge_id
+        for edge_id, (_, edge) in edge_locations.items()
+        if edge.kind == "VIRTUAL"
+    }
+    if pair_edges != all_virtual:
+        raise ValueError("every virtual skeleton edge must have exactly one mate")
+    return derived_tree
+
+
+def _validate_normalized_tree(
+    nodes: dict[str, SPQRSkeleton], tree_edges: tuple[tuple[str, str], ...]
+) -> None:
+    tree: nx.Graph[str] = nx.Graph()
+    tree.add_nodes_from(nodes)
+    tree.add_edges_from(tree_edges)
+    if not nx.is_tree(tree):
+        raise ValueError("SPQR node graph must be a tree")
+    for left_id, right_id in tree_edges:
+        left, right = nodes[left_id], nodes[right_id]
+        if left.kind == right.kind and left.kind in {"S_NODE", "P_NODE"}:
+            raise ValueError(
+                "normalized SPQR trees may not have adjacent mergeable S/S or P/P nodes"
+            )
+
+
+def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
+    degrees: dict[int, int] = dict.fromkeys(node.vertices, 0)
+    for edge in node.edges:
+        degrees[edge.left] += 1
+        degrees[edge.right] += 1
+    if node.kind == "Q_NODE":
+        if sum(edge.kind == "REAL" for edge in node.edges) != 1 or len(node.edges) > 2:
+            raise ValueError("a Q skeleton must contain exactly one source real edge")
+        return
+    if node.kind == "P_NODE":
+        if (
+            len(node.vertices) != 2
+            or len(node.edges) < 3
+            or any(edge.kind != "VIRTUAL" for edge in node.edges)
+        ):
+            raise ValueError(
+                "a P skeleton must be a bond of at least three virtual edges"
+            )
+        return
+    if node.kind == "S_NODE":
+        if (
+            len(node.vertices) < 3
+            or len(node.edges) != len(node.vertices)
+            or any(value != 2 for value in degrees.values())
+        ):
+            raise ValueError("an S skeleton must be a cycle")
+        return
+    graph: nx.Graph[int] = nx.Graph()
+    graph.add_nodes_from(node.vertices)
+    graph.add_edges_from((edge.left, edge.right) for edge in node.edges)
+    if len(node.vertices) < 4 or not nx.is_biconnected(graph):
+        raise ValueError("an R skeleton must be triconnected")
+    for left, right in combinations(node.vertices, 2):
+        remaining = graph.copy()
+        remaining.remove_nodes_from((left, right))
+        if remaining.number_of_nodes() > 1 and not nx.is_connected(remaining):
+            raise ValueError("an R skeleton must have no separation pair")

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -844,9 +844,7 @@ def _validate_negative_spqr_result(result: SPQRTreeResult) -> None:
         if len(result.witness_vertices) != 2:
             raise ValueError("disconnectedness requires two concrete vertices")
         left, right = result.witness_vertices
-        if not (
-            0 <= left < graph.vertex_count and 0 <= right < graph.vertex_count
-        ):
+        if not (0 <= left < graph.vertex_count and 0 <= right < graph.vertex_count):
             raise ValueError(
                 "disconnectedness witness vertices must name source vertices"
             )

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -791,8 +791,13 @@ def _validate_virtual_pairs(
             separated_pairs.add(separator)
         if left_node == right_node:
             raise ValueError("paired virtual edges must join distinct SPQR nodes")
+        tree_edge = (min(left_node, right_node), max(left_node, right_node))
+        if tree_edge in derived_tree:
+            raise ValueError(
+                "an SPQR tree edge must be glued by exactly one virtual-edge pair"
+            )
         pair_edges.update((left_id, right_id))
-        derived_tree.add((min(left_node, right_node), max(left_node, right_node)))
+        derived_tree.add(tree_edge)
     all_virtual = {
         edge_id
         for edge_id, (_, node, _) in edge_locations.items()

--- a/src/jacobian/math/graphs/decomposition/_operations.py
+++ b/src/jacobian/math/graphs/decomposition/_operations.py
@@ -18,11 +18,11 @@ from jacobian.math.graphs.decomposition._models import (
     EarDecompositionRequest,
     EarDecompositionResult,
     SPQRSkeleton,
-    SPQRSkeletonEdge,
     SPQRTreeRequest,
     SPQRTreeResult,
     UndirectedGraph,
 )
+from jacobian.math.graphs.multigraph._models import LooplessMultigraph, MultigraphEdge
 
 
 def _build_graph(graph: UndirectedGraph) -> nx.Graph[int]:
@@ -292,6 +292,37 @@ class _Anchor:
 type _SPQRKind = Literal["S_NODE", "P_NODE", "Q_NODE", "R_NODE"]
 
 
+def _as_public_skeleton(
+    node_id: str, kind: _SPQRKind, edges: tuple[_SPQREdge, ...]
+) -> SPQRSkeleton:
+    vertices = tuple(
+        sorted({vertex for edge in edges for vertex in (edge.left, edge.right)})
+    )
+    positions = {vertex: index for index, vertex in enumerate(vertices)}
+    return SPQRSkeleton(
+        node_id=node_id,
+        kind=kind,
+        vertices=vertices,
+        graph=LooplessMultigraph(
+            vertex_count=len(vertices),
+            edges=tuple(
+                MultigraphEdge(
+                    edge_id=edge.edge_id,
+                    left=positions[edge.left],
+                    right=positions[edge.right],
+                )
+                for edge in edges
+            ),
+        ),
+        real_edge_sources=tuple(
+            (edge.edge_id, edge.source_edge)
+            for edge in edges
+            if edge.source_edge is not None
+        ),
+        virtual_edge_ids=tuple(edge.edge_id for edge in edges if edge.is_virtual),
+    )
+
+
 class _SPQRBuilder:
     """Deterministic split-component SPQR construction for one small graph.
 
@@ -323,23 +354,7 @@ class _SPQRBuilder:
         self._decompose(source_edges, boundary_edge_id=None)
         self._normalize_adjacent_nodes()
         nodes = tuple(
-            SPQRSkeleton(
-                node_id=node_id,
-                kind=kind,
-                vertices=tuple(
-                    sorted({v for edge in edges for v in (edge.left, edge.right)})
-                ),
-                edges=tuple(
-                    SPQRSkeletonEdge(
-                        edge_id=edge.edge_id,
-                        left=edge.left,
-                        right=edge.right,
-                        kind="VIRTUAL" if edge.is_virtual else "REAL",
-                        source_edge=edge.source_edge,
-                    )
-                    for edge in edges
-                ),
-            )
+            _as_public_skeleton(node_id, kind, edges)
             for node_id, (kind, edges) in sorted(self._nodes.items())
         )
         owners = tuple(
@@ -368,7 +383,7 @@ class _SPQRBuilder:
         pairs = tuple(
             sorted((left, right) for left, right in self._pairs.items() if left < right)
         )
-        result = SPQRTreeResult(
+        return SPQRTreeResult(
             source_graph=graph,
             status="SPQR_TREE",
             nodes=nodes,
@@ -382,8 +397,6 @@ class _SPQRBuilder:
             source_vertex_incidence=vertex_incidence,
             source_edge_owners=owners,
         )
-        _validate_spqr_tree(result)
-        return result
 
     def _new_virtual(self, left: int, right: int) -> _SPQREdge:
         edge = _SPQREdge(
@@ -678,8 +691,14 @@ def compute_spqr_tree(request: SPQRTreeRequest) -> SPQRTreeResult:
 
 def _validate_spqr_tree(result: SPQRTreeResult) -> None:
     """Replay the defining SPQR source, tree, and skeleton invariants."""
-    if result.status != "SPQR_TREE":
+    if result.status == "NOT_BICONNECTED":
+        _validate_negative_spqr_result(result)
         return
+    source_value = _build_graph(result.source_graph)
+    if result.source_graph.vertex_count < 3 or not nx.is_biconnected(source_value):
+        raise ValueError(
+            "an SPQR tree requires a biconnected source graph of at least three vertices"
+        )
     nodes = {node.node_id: node for node in result.nodes}
     if not nodes:
         raise ValueError("an SPQR tree must contain at least one skeleton")
@@ -693,9 +712,9 @@ def _validate_spqr_tree(result: SPQRTreeResult) -> None:
         )
     expected_owners = tuple(
         sorted(
-            (edge.source_edge, node_id, edge.edge_id)
-            for node_id, edge in edge_locations.values()
-            if edge.source_edge is not None
+            (_real_source(node, edge), node_id, edge.edge_id)
+            for node_id, node, edge in edge_locations.values()
+            if edge.edge_id not in node.virtual_edge_ids
         )
     )
     if result.source_edge_owners != expected_owners:
@@ -721,25 +740,23 @@ def _validate_spqr_tree(result: SPQRTreeResult) -> None:
 
 def _collect_spqr_edges(
     result: SPQRTreeResult,
-) -> tuple[dict[str, tuple[str, SPQRSkeletonEdge]], list[tuple[int, int]]]:
-    edge_locations: dict[str, tuple[str, SPQRSkeletonEdge]] = {}
+) -> tuple[dict[str, tuple[str, SPQRSkeleton, MultigraphEdge]], list[tuple[int, int]]]:
+    edge_locations: dict[str, tuple[str, SPQRSkeleton, MultigraphEdge]] = {}
     real_sources: list[tuple[int, int]] = []
     for node in result.nodes:
-        for edge in node.edges:
+        for edge in node.graph.edges:
             if edge.edge_id in edge_locations:
                 raise ValueError("a skeleton edge must occur in exactly one node")
-            edge_locations[edge.edge_id] = (node.node_id, edge)
-            if edge.kind == "REAL":
-                if edge.source_edge is None:
-                    raise ValueError("real skeleton edge missing source map")
-                real_sources.append(edge.source_edge)
+            edge_locations[edge.edge_id] = (node.node_id, node, edge)
+            if edge.edge_id not in node.virtual_edge_ids:
+                real_sources.append(_real_source(node, edge))
         _validate_skeleton_kind(node)
     return edge_locations, real_sources
 
 
 def _validate_virtual_pairs(
     result: SPQRTreeResult,
-    edge_locations: dict[str, tuple[str, SPQRSkeletonEdge]],
+    edge_locations: dict[str, tuple[str, SPQRSkeleton, MultigraphEdge]],
 ) -> set[tuple[str, str]]:
     pair_edges: set[str] = set()
     derived_tree: set[tuple[str, str]] = set()
@@ -747,15 +764,17 @@ def _validate_virtual_pairs(
         if left_id == right_id or left_id in pair_edges or right_id in pair_edges:
             raise ValueError("virtual edges must occur in exactly one distinct pair")
         try:
-            left_node, left = edge_locations[left_id]
-            right_node, right = edge_locations[right_id]
+            left_node, left_skeleton, left = edge_locations[left_id]
+            right_node, right_skeleton, right = edge_locations[right_id]
         except KeyError as exc:
             raise ValueError("virtual pair references an absent skeleton edge") from exc
-        if left.kind != "VIRTUAL" or right.kind != "VIRTUAL":
+        if (
+            left_id not in left_skeleton.virtual_edge_ids
+            or right_id not in right_skeleton.virtual_edge_ids
+        ):
             raise ValueError("only virtual skeleton edges may be paired")
-        if (min(left.left, left.right), max(left.left, left.right)) != (
-            min(right.left, right.right),
-            max(right.left, right.right),
+        if _global_endpoints(left_skeleton, left) != _global_endpoints(
+            right_skeleton, right
         ):
             raise ValueError(
                 "paired virtual edges must share their separator endpoints"
@@ -766,8 +785,8 @@ def _validate_virtual_pairs(
         derived_tree.add((min(left_node, right_node), max(left_node, right_node)))
     all_virtual = {
         edge_id
-        for edge_id, (_, edge) in edge_locations.items()
-        if edge.kind == "VIRTUAL"
+        for edge_id, (_, node, _) in edge_locations.items()
+        if edge_id in node.virtual_edge_ids
     }
     if pair_edges != all_virtual:
         raise ValueError("every virtual skeleton edge must have exactly one mate")
@@ -790,20 +809,59 @@ def _validate_normalized_tree(
             )
 
 
+def _global_endpoints(node: SPQRSkeleton, edge: MultigraphEdge) -> tuple[int, int]:
+    left, right = node.vertices[edge.left], node.vertices[edge.right]
+    return (min(left, right), max(left, right))
+
+
+def _real_source(node: SPQRSkeleton, edge: MultigraphEdge) -> tuple[int, int]:
+    for edge_id, source_edge in node.real_edge_sources:
+        if edge_id == edge.edge_id:
+            return source_edge
+    raise ValueError("real skeleton edge missing source map")
+
+
+def _validate_negative_spqr_result(result: SPQRTreeResult) -> None:
+    graph = result.source_graph
+    if result.witness_kind == "MINIMUM_SIZE":
+        if graph.vertex_count >= 3 or result.witness_vertices != (0,):
+            raise ValueError(
+                "minimum-size witness must prove the published SPQR convention"
+            )
+        return
+    value = _build_graph(graph)
+    if result.witness_kind == "DISCONNECTED":
+        if len(result.witness_vertices) != 2:
+            raise ValueError("disconnectedness requires two concrete vertices")
+        left, right = result.witness_vertices
+        if left == right or nx.has_path(value, left, right):
+            raise ValueError("disconnectedness witness vertices must be disconnected")
+        return
+    if result.witness_kind == "ARTICULATION":
+        if len(result.witness_vertices) != 1 or result.witness_vertices[0] not in set(
+            nx.articulation_points(value)
+        ):
+            raise ValueError(
+                "articulation witness must be an articulation vertex of the source"
+            )
+        return
+    raise ValueError("non-biconnected result has an unknown witness kind")
+
+
 def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
     degrees: dict[int, int] = dict.fromkeys(node.vertices, 0)
-    for edge in node.edges:
-        degrees[edge.left] += 1
-        degrees[edge.right] += 1
+    for edge in node.graph.edges:
+        degrees[node.vertices[edge.left]] += 1
+        degrees[node.vertices[edge.right]] += 1
     if node.kind == "Q_NODE":
-        if sum(edge.kind == "REAL" for edge in node.edges) != 1 or len(node.edges) > 2:
+        if len(node.real_edge_sources) != 1 or len(node.graph.edges) > 2:
             raise ValueError("a Q skeleton must contain exactly one source real edge")
         return
     if node.kind == "P_NODE":
         if (
             len(node.vertices) != 2
-            or len(node.edges) < 3
-            or any(edge.kind != "VIRTUAL" for edge in node.edges)
+            or len(node.graph.edges) < 3
+            or len(node.virtual_edge_ids) != len(node.graph.edges)
         ):
             raise ValueError(
                 "a P skeleton must be a bond of at least three virtual edges"
@@ -812,14 +870,14 @@ def _validate_skeleton_kind(node: SPQRSkeleton) -> None:
     if node.kind == "S_NODE":
         if (
             len(node.vertices) < 3
-            or len(node.edges) != len(node.vertices)
+            or len(node.graph.edges) != len(node.vertices)
             or any(value != 2 for value in degrees.values())
         ):
             raise ValueError("an S skeleton must be a cycle")
         return
     graph: nx.Graph[int] = nx.Graph()
     graph.add_nodes_from(node.vertices)
-    graph.add_edges_from((edge.left, edge.right) for edge in node.edges)
+    graph.add_edges_from(_global_endpoints(node, edge) for edge in node.graph.edges)
     if len(node.vertices) < 4 or not nx.is_biconnected(graph):
         raise ValueError("an R skeleton must be triconnected")
     for left, right in combinations(node.vertices, 2):

--- a/src/jacobian/math/graphs/decomposition/_tools.py
+++ b/src/jacobian/math/graphs/decomposition/_tools.py
@@ -15,12 +15,15 @@ from jacobian.math.graphs.decomposition._models import (
     BridgeBlockResult,
     EarDecompositionRequest,
     EarDecompositionResult,
+    SPQRTreeRequest,
+    SPQRTreeResult,
 )
 from jacobian.math.graphs.decomposition._operations import (
     compute_biconnected_components,
     compute_block_cut_tree,
     compute_bridge_block_tree,
     compute_ear_decomposition,
+    compute_spqr_tree,
 )
 
 
@@ -52,6 +55,43 @@ def graph_decomposition_operation[
 
 
 GRAPH_DECOMPOSITION_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
+    graph_decomposition_operation(
+        "graph.decomposition.spqr_tree.compute",
+        "Compute a normalized SPQR tree of an undirected graph",
+        "Compute a deterministic normalized S/P/Q/R decomposition of a"
+        " biconnected finite simple graph. Real source edges occur in exactly"
+        " one skeleton; paired virtual edges encode each separator gluing and"
+        " the returned tree replays to exactly the source graph. A graph outside"
+        " the biconnected minimum-size convention returns a concrete witness.",
+        SPQRTreeRequest,
+        SPQRTreeResult,
+        compute_spqr_tree,
+        "graph",
+        "decomposition",
+        "spqr",
+        "triconnected",
+        "exact",
+        examples=(
+            example(
+                "k4_rigid",
+                "Compute the rigid SPQR skeleton of K4; the source graph is"
+                " biconnected and has at least three vertices.",
+                {
+                    "graph": {
+                        "vertex_count": 4,
+                        "edges": [
+                            [0, 1],
+                            [0, 2],
+                            [0, 3],
+                            [1, 2],
+                            [1, 3],
+                            [2, 3],
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
     graph_decomposition_operation(
         "graph.decomposition.block_cut_tree.compute",
         "Compute the block-cut tree of an undirected graph",

--- a/src/jacobian/math/graphs/multigraph/_models.py
+++ b/src/jacobian/math/graphs/multigraph/_models.py
@@ -34,19 +34,23 @@ __all__ = [
 ]
 
 # Public bounds
-# The shared carrier also transports bounded SPQR skeletons for the existing
-# 64-vertex / 512-edge simple-graph decomposition envelope. Individual flow
-# and cycle operations retain their own work admission; widening this passive
-# value does not widen an exhaustive search claim.
+# The shared passive carrier transports the complete simple-graph envelope of
+# the declared vertex axis, including SPQR source graphs and skeletons: a
+# simple graph on 64 vertices admits up to C(64, 2) = 2016 edges. Individual
+# flow and cycle operations retain their own work admission; widening this
+# passive value does not widen an exhaustive search claim.
 MAX_VERTICES = 64
-MAX_EDGES = 512
+MAX_EDGES = MAX_VERTICES * (MAX_VERTICES - 1) // 2
 MAX_PARALLEL_MULTIPLICITY = 32
 MAX_GROUP_RANK = 6
 MAX_GROUP_MODULUS = 4096
 MAX_GROUP_CARDINALITY = 4096
 MAX_FLOW_SEARCH_STATES = 1_048_576
-MAX_CYCLE_COUNT = 64
-MAX_CYCLE_LENGTH = 64
+# One Eulerian decomposition splits the admitted edge multiset into cycles of
+# at least two edges each, and one simple cycle on the declared vertex axis
+# closes with at most MAX_VERTICES + 1 sequence entries.
+MAX_CYCLE_COUNT = MAX_EDGES // 2
+MAX_CYCLE_LENGTH = MAX_VERTICES + 1
 MAX_CYCLE_EDGE_INCIDENCES = 4096
 
 
@@ -713,7 +717,7 @@ class CycleRecord(StrictModel):
     )
     edge_ids: tuple[StrictStr, ...] = Field(
         min_length=2,
-        max_length=MAX_CYCLE_LENGTH,
+        max_length=MAX_VERTICES,
         description=(
             "Edge IDs alternating with vertices: edge_ids[i] connects "
             "vertices[i] and vertices[i+1]; no edge ID may repeat."

--- a/src/jacobian/math/graphs/multigraph/_models.py
+++ b/src/jacobian/math/graphs/multigraph/_models.py
@@ -34,8 +34,12 @@ __all__ = [
 ]
 
 # Public bounds
-MAX_VERTICES = 32
-MAX_EDGES = 128
+# The shared carrier also transports bounded SPQR skeletons for the existing
+# 64-vertex / 512-edge simple-graph decomposition envelope. Individual flow
+# and cycle operations retain their own work admission; widening this passive
+# value does not widen an exhaustive search claim.
+MAX_VERTICES = 64
+MAX_EDGES = 512
 MAX_PARALLEL_MULTIPLICITY = 32
 MAX_GROUP_RANK = 6
 MAX_GROUP_MODULUS = 4096

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -772,8 +772,7 @@ class TestSPQRTree:
         pair = next(
             (left, right)
             for left, right in genuine.virtual_edge_pairs
-            if {kinds[locations[left]], kinds[locations[right]]}
-            == {"P_NODE", "R_NODE"}
+            if {kinds[locations[left]], kinds[locations[right]]} == {"P_NODE", "R_NODE"}
         )
         assert {locations[side] for side in pair} == {p_id, r_id}
         malformed = genuine.model_dump(mode="json")

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -15,6 +15,7 @@ from jacobian.math.graphs.decomposition._models import (
     BridgeBlockResult,
     EarDecompositionRequest,
     EarDecompositionResult,
+    SPQRSkeleton,
     SPQRTreeRequest,
     SPQRTreeResult,
     UndirectedGraph,
@@ -26,7 +27,7 @@ from jacobian.math.graphs.decomposition._operations import (
     compute_ear_decomposition,
     compute_spqr_tree,
 )
-from jacobian.math.graphs.multigraph._models import LooplessMultigraph
+from jacobian.math.graphs.multigraph._models import LooplessMultigraph, MultigraphEdge
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -606,6 +607,121 @@ class TestSPQRTree:
         )
         with pytest.raises(ValidationError, match="at least one skeleton"):
             SPQRTreeResult.model_validate(forged.model_dump(mode="json"))
+
+    def test_negative_replay_rejects_witnesses_absent_from_source(self) -> None:
+        k4 = {"vertex_count": 4, "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]}
+        with pytest.raises(ValidationError, match="articulation witness"):
+            SPQRTreeResult.model_validate(
+                {
+                    "source_graph": k4,
+                    "status": "NOT_BICONNECTED",
+                    "witness_kind": "ARTICULATION",
+                    "witness_vertices": [0],
+                }
+            )
+        with pytest.raises(ValidationError, match="name source vertices"):
+            SPQRTreeResult.model_validate(
+                {
+                    "source_graph": {"vertex_count": 2, "edges": [[0, 1]]},
+                    "status": "NOT_BICONNECTED",
+                    "witness_kind": "DISCONNECTED",
+                    "witness_vertices": [0, 99],
+                }
+            )
+        with pytest.raises(ValidationError, match="name source vertices"):
+            SPQRTreeResult.model_validate(
+                {
+                    "source_graph": {"vertex_count": 2, "edges": [[0, 1]]},
+                    "status": "NOT_BICONNECTED",
+                    "witness_kind": "DISCONNECTED",
+                    "witness_vertices": [0, -1],
+                }
+            )
+
+    def test_replay_rejects_virtual_pair_without_genuine_separation(self) -> None:
+        """A forged R+Q split of K5 must fail even though every edge maps."""
+        k5_edges = [(i, j) for i in range(5) for j in range(i + 1, 5)]
+        genuine = _spqr_tree({"vertex_count": 5, "edges": k5_edges})
+        assert [node.kind for node in genuine.nodes] == ["R_NODE"]
+        rigid = genuine.nodes[0]
+        moved = (3, 4)
+        kept_sources = [e for e in rigid.real_edge_sources if e[1] != moved]
+        kept_edges = [
+            e
+            for e in rigid.graph.edges
+            if (rigid.vertices[e.left], rigid.vertices[e.right]) != moved
+        ]
+        positions = {vertex: index for index, vertex in enumerate(rigid.vertices)}
+        forged_rigid = SPQRSkeleton(
+            node_id=rigid.node_id,
+            kind="R_NODE",
+            vertices=tuple(rigid.vertices),
+            graph=LooplessMultigraph(
+                vertex_count=len(rigid.vertices),
+                edges=(
+                    *kept_edges,
+                    MultigraphEdge(
+                        edge_id="virtual:forged", left=positions[3], right=positions[4]
+                    ),
+                ),
+            ),
+            real_edge_sources=tuple(kept_sources),
+            virtual_edge_ids=("virtual:forged",),
+        )
+        forged_bridge = SPQRSkeleton(
+            node_id="node:forged",
+            kind="Q_NODE",
+            vertices=(3, 4),
+            graph=LooplessMultigraph(
+                vertex_count=2,
+                edges=(
+                    MultigraphEdge(edge_id="real:3:4", left=0, right=1),
+                    MultigraphEdge(edge_id="virtual:forged-mate", left=0, right=1),
+                ),
+            ),
+            real_edge_sources=(("real:3:4", (3, 4)),),
+            virtual_edge_ids=("virtual:forged-mate",),
+        )
+        owners = tuple(
+            sorted(
+                (source, skeleton.node_id, edge_id)
+                for skeleton in (forged_rigid, forged_bridge)
+                for edge_id, source in skeleton.real_edge_sources
+            )
+        )
+        incidence = tuple(
+            (
+                vertex,
+                tuple(
+                    skeleton.node_id
+                    for skeleton in sorted(
+                        (forged_rigid, forged_bridge), key=lambda s: s.node_id
+                    )
+                    if vertex in skeleton.vertices
+                ),
+            )
+            for vertex in range(5)
+        )
+        with pytest.raises(ValidationError, match="genuine separation pair"):
+            SPQRTreeResult(
+                source_graph=genuine.source_graph,
+                status="SPQR_TREE",
+                nodes=(forged_rigid, forged_bridge),
+                tree_edges=(tuple(sorted(("node:forged", rigid.node_id))),),
+                virtual_edge_pairs=(("virtual:forged", "virtual:forged-mate"),),
+                source_vertex_incidence=incidence,
+                source_edge_owners=owners,
+            )
+
+    def test_request_admits_complete_graphs_on_the_declared_vertex_axis(self) -> None:
+        k33_edges = [(i, j) for i in range(33) for j in range(i + 1, 33)]
+        result = _spqr_tree({"vertex_count": 33, "edges": k33_edges})
+        assert result.status == "SPQR_TREE"
+        assert [node.kind for node in result.nodes] == ["R_NODE"]
+        assert len(result.nodes[0].graph.edges) == len(k33_edges) == 528
+        assert len(result.source_edge_owners) == 528
+        replayed = SPQRTreeResult.model_validate(result.model_dump(mode="json"))
+        assert replayed == result
 
     def test_result_deserialization_round_trips_genuine_decomposition(self) -> None:
         result = _spqr_tree(

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -506,6 +506,13 @@ class TestSPQRTree:
         assert result.status == "SPQR_TREE"
         assert [node.kind for node in result.nodes].count("P_NODE") == 1
         assert len(result.virtual_edge_pairs) == 3
+        assert result.source_vertex_incidence == (
+            (0, ("node:0", "node:1", "node:2", "node:3")),
+            (1, ("node:0", "node:1", "node:2", "node:3")),
+            (2, ("node:0",)),
+            (3, ("node:1",)),
+            (4, ("node:2",)),
+        )
         assert len(result.source_edge_owners) == 6
 
     def test_non_biconnected_graph_returns_articulation_witness(self) -> None:

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -591,6 +591,32 @@ class TestSPQRTree:
         with pytest.raises(ValueError, match="articulation witness"):
             SPQRTreeResult.model_validate(forged_negative)
 
+    def test_result_validation_rejects_forged_empty_positive_tree(self) -> None:
+        k4 = UndirectedGraph.model_validate(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            }
+        )
+        with pytest.raises(ValidationError, match="at least one skeleton"):
+            SPQRTreeResult(source_graph=k4, status="SPQR_TREE")
+        forged = SPQRTreeResult.model_construct(
+            source_graph=k4,
+            status="SPQR_TREE",
+        )
+        with pytest.raises(ValidationError, match="at least one skeleton"):
+            SPQRTreeResult.model_validate(forged.model_dump(mode="json"))
+
+    def test_result_deserialization_round_trips_genuine_decomposition(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 5,
+                "edges": [(0, 2), (2, 1), (0, 3), (3, 1), (0, 4), (4, 1)],
+            }
+        )
+        replayed = SPQRTreeResult.model_validate(result.model_dump(mode="json"))
+        assert replayed == result
+
     def test_replays_every_biconnected_networkx_atlas_graph(self) -> None:
         """The finite atlas covers overlapping separator patterns through 7 vertices."""
         checked = 0

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -15,18 +15,18 @@ from jacobian.math.graphs.decomposition._models import (
     BridgeBlockResult,
     EarDecompositionRequest,
     EarDecompositionResult,
-    SPQRSkeleton,
     SPQRTreeRequest,
+    SPQRTreeResult,
     UndirectedGraph,
 )
 from jacobian.math.graphs.decomposition._operations import (
-    _validate_spqr_tree,
     compute_biconnected_components,
     compute_block_cut_tree,
     compute_bridge_block_tree,
     compute_ear_decomposition,
     compute_spqr_tree,
 )
+from jacobian.math.graphs.multigraph._models import LooplessMultigraph
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -521,39 +521,75 @@ class TestSPQRTree:
         assert result.witness_kind == "ARTICULATION"
         assert result.witness_vertices == (1,)
 
-    def test_replay_rejects_missing_real_source_edge(self) -> None:
+    def test_skeletons_reuse_the_shared_edge_id_multigraph_carrier(self) -> None:
         result = _spqr_tree(
             {
                 "vertex_count": 4,
                 "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
             }
         )
-        node = result.nodes[0]
-        malformed = result.model_copy(
-            update={
-                "nodes": (
-                    SPQRSkeleton(
-                        node_id=node.node_id,
-                        kind=node.kind,
-                        vertices=node.vertices,
-                        edges=node.edges[:-1],
-                    ),
-                )
+        assert isinstance(result.nodes[0].graph, LooplessMultigraph)
+
+    def test_result_deserialization_rejects_missing_real_source_edge(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
             }
         )
+        malformed = result.model_dump(mode="json")
+        malformed["source_graph"]["edges"] = malformed["source_graph"]["edges"][:-1]
         with pytest.raises(ValueError):
-            _validate_spqr_tree(malformed)
+            SPQRTreeResult.model_validate(malformed)
 
-    def test_replay_rejects_unpaired_virtual_edge(self) -> None:
+    def test_result_deserialization_rejects_virtual_pairing_and_transport_mutations(
+        self,
+    ) -> None:
         result = _spqr_tree(
             {
                 "vertex_count": 5,
                 "edges": [(0, 2), (2, 1), (0, 3), (3, 1), (0, 4), (4, 1)],
             }
         )
-        malformed = result.model_copy(update={"virtual_edge_pairs": ()})
+        malformed = result.model_dump(mode="json")
+        malformed["virtual_edge_pairs"] = []
         with pytest.raises(ValueError, match="every virtual skeleton edge"):
-            _validate_spqr_tree(malformed)
+            SPQRTreeResult.model_validate(malformed)
+        malformed = result.model_dump(mode="json")
+        malformed["source_edge_owners"][0][1] = "missing-node"
+        with pytest.raises(ValueError, match="source edge ownership"):
+            SPQRTreeResult.model_validate(malformed)
+        malformed = result.model_dump(mode="json")
+        malformed["source_vertex_incidence"] = []
+        with pytest.raises(ValueError, match="source vertex incidence"):
+            SPQRTreeResult.model_validate(malformed)
+
+    def test_result_deserialization_rejects_forged_branches(self) -> None:
+        positive = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            }
+        ).model_dump(mode="json")
+        positive["source_graph"] = {"vertex_count": 3, "edges": [[0, 1], [1, 2]]}
+        with pytest.raises(ValueError, match="biconnected source"):
+            SPQRTreeResult.model_validate(positive)
+        forged_negative = positive | {
+            "source_graph": {
+                "vertex_count": 4,
+                "edges": [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
+            },
+            "status": "NOT_BICONNECTED",
+            "witness_kind": "ARTICULATION",
+            "witness_vertices": [0],
+            "nodes": [],
+            "tree_edges": [],
+            "virtual_edge_pairs": [],
+            "source_vertex_incidence": [],
+            "source_edge_owners": [],
+        }
+        with pytest.raises(ValueError, match="articulation witness"):
+            SPQRTreeResult.model_validate(forged_negative)
 
     def test_replays_every_biconnected_networkx_atlas_graph(self) -> None:
         """The finite atlas covers overlapping separator patterns through 7 vertices."""

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import networkx as nx
 import pytest
 from pydantic import ValidationError
@@ -794,6 +796,99 @@ class TestSPQRTree:
         ]
         with pytest.raises(ValidationError, match="exactly one virtual-edge pair"):
             SPQRTreeResult.model_validate(malformed)
+
+    def test_replay_rejects_disconnected_s_skeleton_of_two_cycles(self) -> None:
+        """K6 plus an ear at {0,1}: a forged S skeleton of two disjoint triangles."""
+        source_edges = [(i, j) for i in range(6) for j in range(i + 1, 6)]
+        source_edges += [(0, 6), (1, 6)]
+        genuine = _spqr_tree(
+            {"vertex_count": 7, "edges": sorted(tuple(edge) for edge in source_edges)}
+        )
+        assert genuine.status == "SPQR_TREE"
+
+        def forged_skeleton(
+            node_id: str,
+            kind: Literal["S_NODE", "R_NODE"],
+            vertices: tuple[int, ...],
+            real: list[tuple[int, int]],
+            virtual_id: str,
+        ) -> SPQRSkeleton:
+            positions = {vertex: index for index, vertex in enumerate(vertices)}
+            return SPQRSkeleton(
+                node_id=node_id,
+                kind=kind,
+                vertices=vertices,
+                graph=LooplessMultigraph(
+                    vertex_count=len(vertices),
+                    edges=(
+                        *(
+                            MultigraphEdge(
+                                edge_id=f"real:{left}:{right}",
+                                left=positions[left],
+                                right=positions[right],
+                            )
+                            for left, right in real
+                        ),
+                        MultigraphEdge(
+                            edge_id=virtual_id,
+                            left=positions[0],
+                            right=positions[1],
+                        ),
+                    ),
+                ),
+                real_edge_sources=tuple(
+                    (f"real:{left}:{right}", (min(left, right), max(left, right)))
+                    for left, right in real
+                ),
+                virtual_edge_ids=(virtual_id,),
+            )
+
+        ear_triangle = forged_skeleton(
+            "node:s-forged",
+            "S_NODE",
+            (0, 1, 2, 3, 4, 6),
+            [(0, 6), (1, 6), (2, 3), (2, 4), (3, 4)],
+            "virtual:s",
+        )
+        remaining = [
+            (a, b)
+            for a, b in source_edges
+            if {a, b} <= {0, 1, 2, 3, 4, 5} and (a, b) not in {(2, 3), (2, 4), (3, 4)}
+        ]
+        rigid = forged_skeleton(
+            "node:r-forged", "R_NODE", (0, 1, 2, 3, 4, 5), remaining, "virtual:r"
+        )
+        assert len(ear_triangle.graph.edges) == len(ear_triangle.vertices) == 6
+        owners = tuple(
+            sorted(
+                (source_edge, skeleton.node_id, edge_id)
+                for skeleton in (ear_triangle, rigid)
+                for edge_id, source_edge in skeleton.real_edge_sources
+            )
+        )
+        incidence = tuple(
+            (
+                vertex,
+                tuple(
+                    skeleton.node_id
+                    for skeleton in sorted(
+                        (ear_triangle, rigid), key=lambda s: s.node_id
+                    )
+                    if vertex in skeleton.vertices
+                ),
+            )
+            for vertex in range(7)
+        )
+        with pytest.raises(ValidationError, match="S skeleton"):
+            SPQRTreeResult(
+                source_graph=genuine.source_graph,
+                status="SPQR_TREE",
+                nodes=(ear_triangle, rigid),
+                tree_edges=(("node:r-forged", "node:s-forged"),),
+                virtual_edge_pairs=(("virtual:s", "virtual:r"),),
+                source_vertex_incidence=incidence,
+                source_edge_owners=owners,
+            )
 
     def test_request_admits_complete_graphs_on_the_declared_vertex_axis(self) -> None:
         k33_edges = [(i, j) for i in range(33) for j in range(i + 1, 33)]

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -609,7 +609,10 @@ class TestSPQRTree:
             SPQRTreeResult.model_validate(forged.model_dump(mode="json"))
 
     def test_negative_replay_rejects_witnesses_absent_from_source(self) -> None:
-        k4 = {"vertex_count": 4, "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]}
+        k4 = {
+            "vertex_count": 4,
+            "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+        }
         with pytest.raises(ValidationError, match="articulation witness"):
             SPQRTreeResult.model_validate(
                 {

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -716,6 +716,34 @@ class TestSPQRTree:
                 source_edge_owners=owners,
             )
 
+    def test_result_deserialization_rejects_extra_isolated_q_carrier(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (1, 2), (2, 0), (0, 3), (3, 1)],
+            }
+        )
+        assert any(node.kind == "Q_NODE" for node in result.nodes)
+        malformed = result.model_dump(mode="json")
+        q_node = next(node for node in malformed["nodes"] if node["kind"] == "Q_NODE")
+        q_node["vertices"] = sorted([*q_node["vertices"], 9])
+        q_node["graph"]["vertex_count"] = len(q_node["vertices"])
+        malformed["source_vertex_incidence"] = [
+            (
+                vertex,
+                tuple(
+                    skeleton["node_id"]
+                    for skeleton in sorted(
+                        malformed["nodes"], key=lambda n: n["node_id"]
+                    )
+                    if vertex in skeleton["vertices"]
+                ),
+            )
+            for vertex in range(malformed["source_graph"]["vertex_count"])
+        ]
+        with pytest.raises(ValidationError, match="Q skeleton"):
+            SPQRTreeResult.model_validate(malformed)
+
     def test_request_admits_complete_graphs_on_the_declared_vertex_axis(self) -> None:
         k33_edges = [(i, j) for i in range(33) for j in range(i + 1, 33)]
         result = _spqr_tree({"vertex_count": 33, "edges": k33_edges})

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -747,7 +747,12 @@ class TestSPQRTree:
             SPQRTreeResult.model_validate(malformed)
 
     def test_replay_rejects_duplicate_virtual_pair_on_one_tree_edge(self) -> None:
-        """Two K4 blocks glued along {0,1}: one tree adjacency, one gluing pair."""
+        """Two K4 blocks glued along {0,1}: one tree adjacency, one gluing pair.
+
+        The forged second gluing copies a virtual edge onto the same R
+        skeleton endpoint pair, so the simpler parallel-edge invariant
+        rejects it before the duplicate-tree-edge check is reached.
+        """
         edges = [
             (0, 1),
             (0, 2),
@@ -794,8 +799,111 @@ class TestSPQRTree:
             *malformed["virtual_edge_pairs"],
             [f"virtual:forged-{p_id}", f"virtual:forged-{r_id}"],
         ]
-        with pytest.raises(ValidationError, match="exactly one virtual-edge pair"):
+        with pytest.raises(ValidationError, match="repeat an endpoint pair"):
             SPQRTreeResult.model_validate(malformed)
+
+    def test_replay_rejects_parallel_edges_inside_r_skeleton(self) -> None:
+        """Two K4 blocks sharing {0,1}: a forged R/R split without the P junction."""
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (0, 4),
+            (0, 5),
+            (1, 4),
+            (1, 5),
+            (4, 5),
+        ]
+        genuine = _spqr_tree({"vertex_count": 6, "edges": edges})
+        assert genuine.status == "SPQR_TREE"
+        kinds = [node.kind for node in genuine.nodes]
+        assert kinds.count("P_NODE") == 1
+        assert kinds.count("Q_NODE") == 1
+
+        def forged_rigid(
+            node_id: str,
+            vertices: tuple[int, ...],
+            real: list[tuple[int, int]],
+            virtual_id: str,
+        ) -> SPQRSkeleton:
+            positions = {vertex: index for index, vertex in enumerate(vertices)}
+            return SPQRSkeleton(
+                node_id=node_id,
+                kind="R_NODE",
+                vertices=vertices,
+                graph=LooplessMultigraph(
+                    vertex_count=len(vertices),
+                    edges=(
+                        *(
+                            MultigraphEdge(
+                                edge_id=f"real:{left}:{right}",
+                                left=positions[left],
+                                right=positions[right],
+                            )
+                            for left, right in real
+                        ),
+                        MultigraphEdge(
+                            edge_id=virtual_id, left=positions[0], right=positions[1]
+                        ),
+                    ),
+                ),
+                real_edge_sources=tuple(
+                    (f"real:{left}:{right}", (min(left, right), max(left, right)))
+                    for left, right in real
+                ),
+                virtual_edge_ids=(virtual_id,),
+            )
+
+        shared_block = forged_rigid(
+            "node:a",
+            (0, 1, 2, 3),
+            [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            "virtual:a",
+        )
+        other_block = forged_rigid(
+            "node:b",
+            (0, 1, 4, 5),
+            [(0, 4), (0, 5), (1, 4), (1, 5), (4, 5)],
+            "virtual:b",
+        )
+        shared_endpoint_pairs = [
+            (shared_block.vertices[edge.left], shared_block.vertices[edge.right])
+            for edge in shared_block.graph.edges
+        ]
+        assert len(shared_endpoint_pairs) > len(set(shared_endpoint_pairs))
+        owners = tuple(
+            sorted(
+                (source_edge, skeleton.node_id, edge_id)
+                for skeleton in (shared_block, other_block)
+                for edge_id, source_edge in skeleton.real_edge_sources
+            )
+        )
+        incidence = tuple(
+            (
+                vertex,
+                tuple(
+                    skeleton.node_id
+                    for skeleton in sorted(
+                        (shared_block, other_block), key=lambda s: s.node_id
+                    )
+                    if vertex in skeleton.vertices
+                ),
+            )
+            for vertex in range(6)
+        )
+        with pytest.raises(ValidationError, match="repeat an endpoint pair"):
+            SPQRTreeResult(
+                source_graph=genuine.source_graph,
+                status="SPQR_TREE",
+                nodes=(shared_block, other_block),
+                tree_edges=(("node:a", "node:b"),),
+                virtual_edge_pairs=(("virtual:a", "virtual:b"),),
+                source_vertex_incidence=incidence,
+                source_edge_owners=owners,
+            )
 
     def test_replay_rejects_disconnected_s_skeleton_of_two_cycles(self) -> None:
         """K6 plus an ear at {0,1}: a forged S skeleton of two disjoint triangles."""

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -744,6 +744,58 @@ class TestSPQRTree:
         with pytest.raises(ValidationError, match="Q skeleton"):
             SPQRTreeResult.model_validate(malformed)
 
+    def test_replay_rejects_duplicate_virtual_pair_on_one_tree_edge(self) -> None:
+        """Two K4 blocks glued along {0,1}: one tree adjacency, one gluing pair."""
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (0, 4),
+            (0, 5),
+            (1, 4),
+            (1, 5),
+            (4, 5),
+        ]
+        genuine = _spqr_tree({"vertex_count": 6, "edges": edges})
+        assert genuine.status == "SPQR_TREE"
+        kinds = {node.node_id: node.kind for node in genuine.nodes}
+        p_id = next(node_id for node_id, kind in kinds.items() if kind == "P_NODE")
+        r_id = next(node_id for node_id, kind in kinds.items() if kind == "R_NODE")
+        locations = {
+            edge.edge_id: node.node_id
+            for node in genuine.nodes
+            for edge in node.graph.edges
+        }
+        pair = next(
+            (left, right)
+            for left, right in genuine.virtual_edge_pairs
+            if {kinds[locations[left]], kinds[locations[right]]}
+            == {"P_NODE", "R_NODE"}
+        )
+        assert {locations[side] for side in pair} == {p_id, r_id}
+        malformed = genuine.model_dump(mode="json")
+        for node in malformed["nodes"]:
+            if node["node_id"] not in (p_id, r_id):
+                continue
+            extra_id = f"virtual:forged-{node['node_id']}"
+            glued = [
+                edge
+                for edge in node["graph"]["edges"]
+                if edge["edge_id"] in (pair[0], pair[1])
+            ]
+            assert len(glued) == 1
+            node["graph"]["edges"].append({**glued[0], "edge_id": extra_id})
+            node["virtual_edge_ids"] = [*node["virtual_edge_ids"], extra_id]
+        malformed["virtual_edge_pairs"] = [
+            *malformed["virtual_edge_pairs"],
+            [f"virtual:forged-{p_id}", f"virtual:forged-{r_id}"],
+        ]
+        with pytest.raises(ValidationError, match="exactly one virtual-edge pair"):
+            SPQRTreeResult.model_validate(malformed)
+
     def test_request_admits_complete_graphs_on_the_declared_vertex_axis(self) -> None:
         k33_edges = [(i, j) for i in range(33) for j in range(i + 1, 33)]
         result = _spqr_tree({"vertex_count": 33, "edges": k33_edges})

--- a/tests/math/graphs/test_graph_decomposition.py
+++ b/tests/math/graphs/test_graph_decomposition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import networkx as nx
 import pytest
 from pydantic import ValidationError
 
@@ -14,13 +15,17 @@ from jacobian.math.graphs.decomposition._models import (
     BridgeBlockResult,
     EarDecompositionRequest,
     EarDecompositionResult,
+    SPQRSkeleton,
+    SPQRTreeRequest,
     UndirectedGraph,
 )
 from jacobian.math.graphs.decomposition._operations import (
+    _validate_spqr_tree,
     compute_biconnected_components,
     compute_block_cut_tree,
     compute_bridge_block_tree,
     compute_ear_decomposition,
+    compute_spqr_tree,
 )
 
 # ---------------------------------------------------------------------------
@@ -50,6 +55,10 @@ def _biconnected_components(graph: dict) -> BiconnectedComponentsResult:
     return compute_biconnected_components(
         BiconnectedComponentsRequest.model_validate({"graph": graph}),
     )
+
+
+def _spqr_tree(graph: dict):
+    return compute_spqr_tree(SPQRTreeRequest.model_validate({"graph": graph}))
 
 
 def _edges_as_sets(edges: tuple[tuple[int, int], ...]) -> frozenset:
@@ -461,4 +470,97 @@ class TestOperationRegistration:
             "graph.decomposition.bridge_block_tree.compute",
             "graph.decomposition.ear.compute",
             "graph.decomposition.biconnected_components.compute",
+            "graph.decomposition.spqr_tree.compute",
         }
+
+
+class TestSPQRTree:
+    def test_rigid_k4_is_one_r_skeleton(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            }
+        )
+        assert result.status == "SPQR_TREE"
+        assert [node.kind for node in result.nodes] == ["R_NODE"]
+        assert result.virtual_edge_pairs == ()
+
+    def test_cycle_is_one_s_skeleton(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (1, 2), (2, 3), (3, 0)],
+            }
+        )
+        assert result.status == "SPQR_TREE"
+        assert [node.kind for node in result.nodes] == ["S_NODE"]
+
+    def test_theta_has_parallel_junction_and_paired_virtual_edges(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 5,
+                "edges": [(0, 2), (2, 1), (0, 3), (3, 1), (0, 4), (4, 1)],
+            }
+        )
+        assert result.status == "SPQR_TREE"
+        assert [node.kind for node in result.nodes].count("P_NODE") == 1
+        assert len(result.virtual_edge_pairs) == 3
+        assert len(result.source_edge_owners) == 6
+
+    def test_non_biconnected_graph_returns_articulation_witness(self) -> None:
+        result = _spqr_tree({"vertex_count": 3, "edges": [(0, 1), (1, 2)]})
+        assert result.status == "NOT_BICONNECTED"
+        assert result.witness_kind == "ARTICULATION"
+        assert result.witness_vertices == (1,)
+
+    def test_replay_rejects_missing_real_source_edge(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 4,
+                "edges": [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)],
+            }
+        )
+        node = result.nodes[0]
+        malformed = result.model_copy(
+            update={
+                "nodes": (
+                    SPQRSkeleton(
+                        node_id=node.node_id,
+                        kind=node.kind,
+                        vertices=node.vertices,
+                        edges=node.edges[:-1],
+                    ),
+                )
+            }
+        )
+        with pytest.raises(ValueError):
+            _validate_spqr_tree(malformed)
+
+    def test_replay_rejects_unpaired_virtual_edge(self) -> None:
+        result = _spqr_tree(
+            {
+                "vertex_count": 5,
+                "edges": [(0, 2), (2, 1), (0, 3), (3, 1), (0, 4), (4, 1)],
+            }
+        )
+        malformed = result.model_copy(update={"virtual_edge_pairs": ()})
+        with pytest.raises(ValueError, match="every virtual skeleton edge"):
+            _validate_spqr_tree(malformed)
+
+    def test_replays_every_biconnected_networkx_atlas_graph(self) -> None:
+        """The finite atlas covers overlapping separator patterns through 7 vertices."""
+        checked = 0
+        for atlas_graph in nx.graph_atlas_g():
+            if not 3 <= len(atlas_graph) <= 7 or not nx.is_biconnected(atlas_graph):
+                continue
+            relabelled = nx.convert_node_labels_to_integers(atlas_graph)
+            result = _spqr_tree(
+                {
+                    "vertex_count": len(relabelled),
+                    "edges": tuple(sorted(relabelled.edges())),
+                }
+            )
+            assert result.status == "SPQR_TREE"
+            checked += 1
+        assert checked == 538

--- a/tests/math/graphs_multigraph/test_multigraph.py
+++ b/tests/math/graphs_multigraph/test_multigraph.py
@@ -313,6 +313,24 @@ class TestEulerianDecomposition:
         assert result.covers_all
         assert len(result.cycles) == 0
 
+    def test_full_axis_ring_decomposition_round_trips(self) -> None:
+        """A ring through all 64 vertices closes with 65 sequence entries."""
+        ring = LooplessMultigraph(
+            vertex_count=64,
+            edges=tuple(
+                MultigraphEdge(edge_id=f"e{i}", left=i, right=(i + 1) % 64)
+                for i in range(64)
+            ),
+        )
+        result = compute_eulerian_cycles(EulerianCyclesRequest(graph=ring))
+        assert result.covers_all
+        assert len(result.cycles) == 1
+        cycle = result.cycles[0]
+        assert len(cycle.vertices) == 65
+        assert len(cycle.edge_ids) == 64
+        replayed = EulerianCyclesResult.model_validate(result.model_dump(mode="json"))
+        assert replayed == result
+
 
 # ---------------------------------------------------------------------------
 # Fixture 8: Submitted exact double cover with every edge multiplicity two


### PR DESCRIPTION
Closes #2264.

## Summary

Add `graph.decomposition.spqr_tree.compute`, returning either a deterministic
normalized S/P/Q/R tree or a concrete non-biconnected/minimum-size witness.
Every source edge has one real skeleton owner; every virtual edge has one mate;
and the result replays those maps, skeleton kinds, separator endpoints, and the
node tree before it crosses the operation boundary.

## Design

The producer uses NetworkX only for the initial biconnectivity and
connected-component primitives. The bounded Jacobian-owned split-component
recursion enumerates vertex-pair separators, retains virtual gluing interfaces
through nested splits, and merges adjacent S/S and P/P nodes. This keeps the
public result independent of backend rooting and traversal order.

OGDF remains an optional differential oracle, not a runtime dependency: its
maintained SPQR implementation is C++ and does not provide a maintained Python
binding compatible with Jacobian's ordinary installation.

The change intentionally does not add a submitted-tree checker, a separate
separation-pair projection, reconstruction operation, dynamic updates, or
planar-embedding workflow.

## Validation

- `uv run pytest tests/math/graphs/test_graph_decomposition.py tests/catalog -q` — 64 passed, including all 538 biconnected NetworkX atlas graphs through 7 vertices.
- `uv run pytest tests/integration -q` — 1128 passed.
- `uv run ruff check src/jacobian/math/graphs/decomposition tests/math/graphs/test_graph_decomposition.py` — passed.
- `uv run mypy src/jacobian/math/graphs/decomposition` — passed.

## Suggested review order

1. Review the source-bound skeleton/result models and replay invariants.
2. Review the split recursion and normalization in `_operations.py`.
3. Review the atlas and malformed-result regression tests.
