### PR TITLE
fix(graphs): source-bind and structurally validate graph-spectrum results

### DIFF
--- a/src/jacobian/math/graphs/spectral/_admission.py
+++ b/src/jacobian/math/graphs/spectral/_admission.py
@@ -23,12 +23,14 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "graph.spectrum.adjacency.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "exact adjacency eigenvalue/multiplicity multiset bound to its "
+        "retained source graph by structural checks and exact replay",
     ),
     OperationAdmission(
         "graph.spectrum.laplacian.compute",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "exact Laplacian eigenvalue/multiplicity multiset bound to its "
+        "retained source graph by structural checks and exact replay",
     ),
 )
 

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -54,7 +54,9 @@ class GraphSpectrumResult(StrictModel):
     the canonical exact SymPy rendering (over the algebraic closure of QQ,
     never a float) of one distinct eigenvalue; multiplicities are positive
     and sum to the graph order, so the claimed spectrum reconstructs
-    ``det(xI - A)`` exactly.
+    ``det(xI - A)`` exactly.  Pair order carries no mathematical meaning:
+    validation compares ``(eigenvalue, multiplicity)`` pairs as a multiset
+    rather than by backend iteration order.
     """
 
     graph: GraphEdgeList
@@ -75,6 +77,8 @@ class GraphSpectrumResult(StrictModel):
             raise ValueError(
                 "eigenvalue and multiplicity tuples must have equal length"
             )
+        if len(set(self.eigenvalues)) != len(self.eigenvalues):
+            raise ValueError("eigenvalues must be distinct")
         if any(multiplicity < 1 for multiplicity in self.multiplicities):
             raise ValueError("algebraic multiplicities must be positive")
         if sum(self.multiplicities) != order:
@@ -84,11 +88,8 @@ class GraphSpectrumResult(StrictModel):
             if self.matrix_convention == "ADJACENCY"
             else laplacian_spectrum(self.graph)
         )
-        if (
-            tuple(value for value, _ in replayed) != self.eigenvalues
-            or tuple(int(multiplicity) for _, multiplicity in replayed)
-            != self.multiplicities
-        ):
+        claimed = dict(zip(self.eigenvalues, self.multiplicities, strict=True))
+        if dict(replayed) != claimed:
             raise ValueError("spectrum must be the exact spectrum of the source graph")
         return self
 

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -54,9 +54,11 @@ class GraphSpectrumResult(StrictModel):
     the canonical exact SymPy rendering (over the algebraic closure of QQ,
     never a float) of one distinct eigenvalue; multiplicities are positive
     and sum to the graph order, so the claimed spectrum reconstructs
-    ``det(xI - A)`` exactly.  Pair order carries no mathematical meaning:
-    validation compares ``(eigenvalue, multiplicity)`` pairs as a multiset
-    rather than by backend iteration order.
+    ``det(xI - M)`` exactly, where ``M`` is the adjacency matrix A for
+    ``matrix_convention="ADJACENCY"`` and the Laplacian matrix L for
+    ``matrix_convention="LAPLACIAN"``.  Pair order carries no mathematical
+    meaning: validation compares ``(eigenvalue, multiplicity)`` pairs as a
+    multiset rather than by backend iteration order.
     """
 
     graph: GraphEdgeList

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -47,11 +47,50 @@ class GraphSpectrumRequest(StrictModel):
 
 
 class GraphSpectrumResult(StrictModel):
-    """The exact eigenvalues with algebraic multiplicities of a graph matrix."""
+    """The exact eigenvalues with algebraic multiplicities of a graph matrix.
 
+    Retains the source graph and matrix convention so validation replays
+    the exact spectrum of the same matrix.  Each ``eigenvalues`` entry is
+    the canonical exact SymPy rendering (over the algebraic closure of QQ,
+    never a float) of one distinct eigenvalue; multiplicities are positive
+    and sum to the graph order, so the claimed spectrum reconstructs
+    ``det(xI - A)`` exactly.
+    """
+
+    graph: GraphEdgeList
+    matrix_convention: Literal["ADJACENCY", "LAPLACIAN"]
     eigenvalues: tuple[str, ...]
     multiplicities: tuple[int, ...]
     convention: Literal["SYMPY_EIGENVALS"] = "SYMPY_EIGENVALS"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.graphs.spectral.operations import (
+            adjacency_spectrum,
+            laplacian_spectrum,
+        )
+
+        order = self.graph.vertex_count
+        if len(self.eigenvalues) != len(self.multiplicities):
+            raise ValueError(
+                "eigenvalue and multiplicity tuples must have equal length"
+            )
+        if any(multiplicity < 1 for multiplicity in self.multiplicities):
+            raise ValueError("algebraic multiplicities must be positive")
+        if sum(self.multiplicities) != order:
+            raise ValueError("multiplicities must sum to the graph order")
+        replayed = (
+            adjacency_spectrum(self.graph)
+            if self.matrix_convention == "ADJACENCY"
+            else laplacian_spectrum(self.graph)
+        )
+        if (
+            tuple(value for value, _ in replayed) != self.eigenvalues
+            or tuple(int(multiplicity) for _, multiplicity in replayed)
+            != self.multiplicities
+        ):
+            raise ValueError("spectrum must be the exact spectrum of the source graph")
+        return self
 
 
 def _dense_to_canonical_polynomial(

--- a/src/jacobian/math/graphs/spectral/_operations.py
+++ b/src/jacobian/math/graphs/spectral/_operations.py
@@ -18,6 +18,8 @@ from jacobian.math.graphs.spectral._models import (
 def compute_adjacency_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumResult:
     result = adjacency_spectrum(request.graph)
     return GraphSpectrumResult(
+        graph=request.graph,
+        matrix_convention="ADJACENCY",
         eigenvalues=tuple(v for v, _ in result),
         multiplicities=tuple(m for _, m in result),
     )
@@ -26,6 +28,8 @@ def compute_adjacency_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumRe
 def compute_laplacian_spectrum(request: GraphSpectrumRequest) -> GraphSpectrumResult:
     result = laplacian_spectrum(request.graph)
     return GraphSpectrumResult(
+        graph=request.graph,
+        matrix_convention="LAPLACIAN",
         eigenvalues=tuple(v for v, _ in result),
         multiplicities=tuple(m for _, m in result),
     )

--- a/src/jacobian/math/graphs/spectral/_tools.py
+++ b/src/jacobian/math/graphs/spectral/_tools.py
@@ -73,6 +73,7 @@ GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     graph_spectral_operation(
         "graph.spectrum.laplacian.compute",
@@ -98,6 +99,7 @@ GRAPH_SPECTRAL_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 },
             ),
         ),
+        version="2",
     ),
     graph_spectral_operation(
         "graph.spectrum.adjacency.characteristic_polynomial.compute",

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -166,6 +166,32 @@ def test_degenerate_and_repeated_spectra_stay_exact() -> None:
     }
 
 
+def test_v2_spectrum_operations_are_readmitted_with_source_bound_rationale() -> None:
+    """The materially changed v2 contracts carry fresh owner-local decisions."""
+
+    from jacobian.catalog.admission import AdmissionDecision
+    from jacobian.math.graphs.spectral._admission import ADMISSIONS
+
+    records = {
+        record.operation_id: record
+        for record in ADMISSIONS
+        if record.operation_id
+        in (
+            "graph.spectrum.adjacency.compute",
+            "graph.spectrum.laplacian.compute",
+        )
+    }
+    assert set(records) == {
+        "graph.spectrum.adjacency.compute",
+        "graph.spectrum.laplacian.compute",
+    }
+    for operation_id, record in sorted(records.items()):
+        assert record.decision is AdmissionDecision.KEEP, operation_id
+        rationale = record.rationale.lower()
+        assert "source graph" in rationale, operation_id
+        assert "replay" in rationale, operation_id
+
+
 def test_spectrum_reconstructs_the_characteristic_polynomial() -> None:
     """The spectrum factorization matches the source-bound charpoly producer."""
 

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -1,0 +1,145 @@
+"""Regression tests binding graph-spectrum results to their source graph."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.math.graphs.spectral._models import (
+    GraphEdgeList,
+    GraphSpectrumRequest,
+    GraphSpectrumResult,
+)
+from jacobian.math.graphs.spectral._operations import (
+    compute_adjacency_spectrum,
+    compute_laplacian_spectrum,
+)
+
+
+def _graph(vertex_count: int, edges: tuple[tuple[int, int], ...]) -> GraphEdgeList:
+    return GraphEdgeList(vertex_count=vertex_count, edges=edges)
+
+
+def test_producer_spectra_retain_source_and_replay() -> None:
+    path = _graph(3, ((0, 1), (1, 2)))
+
+    adjacency = compute_adjacency_spectrum(GraphSpectrumRequest(graph=path))
+    assert adjacency.graph == path
+    assert adjacency.matrix_convention == "ADJACENCY"
+    assert set(adjacency.eigenvalues) == {"-sqrt(2)", "0", "sqrt(2)"}
+    assert adjacency.multiplicities == (1, 1, 1)
+    assert GraphSpectrumResult.model_validate(adjacency.model_dump()) == adjacency
+
+    laplacian = compute_laplacian_spectrum(GraphSpectrumRequest(graph=path))
+    assert laplacian.matrix_convention == "LAPLACIAN"
+    assert set(laplacian.eigenvalues) == {"0", "1", "3"}
+    assert GraphSpectrumResult.model_validate(laplacian.model_dump()) == laplacian
+
+
+def test_structural_constraints_reject_forged_payloads() -> None:
+    path = _graph(3, ((0, 1), (1, 2)))
+    adjacency = compute_adjacency_spectrum(GraphSpectrumRequest(graph=path))
+    dumped = adjacency.model_dump()
+
+    length_mismatch = copy.deepcopy(dumped)
+    length_mismatch["multiplicities"] = [1, 1]
+    with pytest.raises(ValidationError, match="equal length"):
+        GraphSpectrumResult.model_validate(length_mismatch)
+
+    negative_multiplicity = copy.deepcopy(dumped)
+    negative_multiplicity["multiplicities"] = [1, -7, 1]
+    with pytest.raises(ValidationError, match="positive"):
+        GraphSpectrumResult.model_validate(negative_multiplicity)
+
+    zero_multiplicity = copy.deepcopy(dumped)
+    zero_multiplicity["multiplicities"] = [0, 2, 1]
+    with pytest.raises(ValidationError, match="positive"):
+        GraphSpectrumResult.model_validate(zero_multiplicity)
+
+    wrong_total = copy.deepcopy(dumped)
+    wrong_total["multiplicities"] = [1, 1, 2]
+    with pytest.raises(ValidationError, match="sum to the graph order"):
+        GraphSpectrumResult.model_validate(wrong_total)
+
+    arbitrary_string = copy.deepcopy(dumped)
+    arbitrary_string["eigenvalues"] = ["banana", "0", "sqrt(2)"]
+    with pytest.raises(ValidationError, match="exact spectrum"):
+        GraphSpectrumResult.model_validate(arbitrary_string)
+
+    forged_value = copy.deepcopy(dumped)
+    forged_value["eigenvalues"] = ["-1", "0", "sqrt(5)"]
+    with pytest.raises(ValidationError, match="exact spectrum"):
+        GraphSpectrumResult.model_validate(forged_value)
+
+    foreign_source = copy.deepcopy(dumped)
+    foreign_source["graph"] = {"vertex_count": 3, "edges": [[0, 1]]}
+    with pytest.raises(ValidationError, match="source graph"):
+        GraphSpectrumResult.model_validate(foreign_source)
+
+    swapped_convention = copy.deepcopy(dumped)
+    swapped_convention["matrix_convention"] = "LAPLACIAN"
+    with pytest.raises(ValidationError, match="exact spectrum"):
+        GraphSpectrumResult.model_validate(swapped_convention)
+
+
+def test_degenerate_and_repeated_spectra_stay_exact() -> None:
+    empty = compute_adjacency_spectrum(GraphSpectrumRequest(graph=_graph(2, ())))
+    assert empty.eigenvalues == ("0",)
+    assert empty.multiplicities == (2,)
+    assert GraphSpectrumResult.model_validate(empty.model_dump()) == empty
+
+    complete = compute_adjacency_spectrum(
+        GraphSpectrumRequest(
+            graph=_graph(4, ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)))
+        )
+    )
+    assert dict(zip(complete.eigenvalues, complete.multiplicities, strict=True)) == {
+        "-1": 3,
+        "3": 1,
+    }
+
+    laplacian_complete = compute_laplacian_spectrum(
+        GraphSpectrumRequest(
+            graph=_graph(4, ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)))
+        )
+    )
+    assert dict(
+        zip(
+            laplacian_complete.eigenvalues,
+            laplacian_complete.multiplicities,
+            strict=True,
+        )
+    ) == {
+        "0": 1,
+        "4": 3,
+    }
+
+
+def test_spectrum_reconstructs_the_characteristic_polynomial() -> None:
+    """The spectrum factorization matches the source-bound charpoly producer."""
+
+    from sympy import Poly, symbols, together
+
+    from jacobian.math.graphs.spectral._operations import (
+        compute_adjacency_characteristic_polynomial,
+    )
+    from jacobian.math.graphs.spectral.operations import _adjacency_matrix
+    from jacobian.math.polynomials._conversions import rational_polynomial_to_sympy
+
+    x = symbols("x")
+    path = _graph(4, ((0, 1), (1, 2), (2, 3)))
+    request = GraphSpectrumRequest(graph=path)
+    spectrum = compute_adjacency_spectrum(request)
+    charpoly_result = compute_adjacency_characteristic_polynomial(request)
+    expected = Poly(
+        rational_polynomial_to_sympy(charpoly_result.polynomial).as_expr(), x
+    )
+
+    factors = 1
+    for value, multiplicity in _adjacency_matrix(path).eigenvals().items():
+        factors *= (x - value) ** multiplicity
+    claimed = together(factors.expand())
+    assert together(expected.as_expr() - claimed) == 0
+    assert sum(spectrum.multiplicities) == path.vertex_count

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -84,6 +84,55 @@ def test_structural_constraints_reject_forged_payloads() -> None:
         GraphSpectrumResult.model_validate(swapped_convention)
 
 
+def test_permuted_pair_order_still_binds_to_source() -> None:
+    """A valid spectrum serialized in a different pair order still replays."""
+
+    complete = compute_adjacency_spectrum(
+        GraphSpectrumRequest(
+            graph=_graph(4, ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)))
+        )
+    )
+    dumped = complete.model_dump()
+    dumped["eigenvalues"] = list(reversed(dumped["eigenvalues"]))
+    dumped["multiplicities"] = list(reversed(dumped["multiplicities"]))
+
+    permuted = GraphSpectrumResult.model_validate(dumped)
+
+    assert sorted(
+        zip(permuted.eigenvalues, permuted.multiplicities, strict=True)
+    ) == sorted(zip(complete.eigenvalues, complete.multiplicities, strict=True))
+
+
+def test_duplicate_eigenvalue_entries_are_rejected() -> None:
+    path = _graph(3, ((0, 1), (1, 2)))
+    adjacency = compute_adjacency_spectrum(GraphSpectrumRequest(graph=path))
+    duplicated = copy.deepcopy(adjacency.model_dump())
+    duplicated["eigenvalues"] = ["0", "0", "sqrt(2)"]
+    duplicated["multiplicities"] = [1, 1, 1]
+
+    with pytest.raises(ValidationError, match="distinct"):
+        GraphSpectrumResult.model_validate(duplicated)
+
+
+def test_spectrum_operations_declare_version_two() -> None:
+    from jacobian.math.graphs.spectral._tools import TOOLS
+
+    versions = {
+        tool.operation_id: tool.version
+        for tool in TOOLS
+        if tool.operation_id
+        in (
+            "graph.spectrum.adjacency.compute",
+            "graph.spectrum.laplacian.compute",
+        )
+    }
+
+    assert versions == {
+        "graph.spectrum.adjacency.compute": "2",
+        "graph.spectrum.laplacian.compute": "2",
+    }
+
+
 def test_degenerate_and_repeated_spectra_stay_exact() -> None:
     empty = compute_adjacency_spectrum(GraphSpectrumRequest(graph=_graph(2, ())))
     assert empty.eigenvalues == ("0",)


### PR DESCRIPTION
## Problem

`GraphSpectrumResult` was a detached pair of unconstrained parallel string/int tuples (#2296): it retained neither the source graph nor an adjacency/Laplacian convention, and accepted values such as one arbitrary string with multiplicity −7. Nothing required equal lengths, positive multiplicities, order-summed multiplicities, or agreement with any matrix. The neighboring `GraphCharacteristicPolynomialResult` already modeled the correct source-bound contract.

## Fix

Following the issue's option 1 within this operation's existing envelope:

- The result retains `graph` + `matrix_convention`.
- Validation replays the exact spectrum of the same matrix through the domain kernel: equal tuple lengths; positive multiplicities; multiplicities summing to graph order; every eigenvalue string pinned to the canonical exact SymPy rendering of a distinct source eigenvalue (algebraic over QQ, never floats — arbitrary strings are rejected).
- Replay equality establishes that the factorization ∏(x−λ)^m reconstructs `det(xI−A)` exactly, agreeing with the existing source-bound characteristic-polynomial producer.

Eigenvalue entries remain exact SymPy renderings rather than a newly invented algebraic-number wire type; #2283's focused rational-spectrum checker remains the right follow-up for typed rational claims.

## Validation

- `make check` green.
- New regressions: P3 known answers for both conventions; empty/complete/repeated-eigenvalue spectra; irrational spectrum (±√2); mismatched lengths, negative/zero/out-of-sum multiplicities, arbitrary/forged eigenvalue strings, foreign graphs, and swapped conventions rejected; serialized round-trips; charpoly reconstruction identity.

Fixes #2296