### PR TITLE
Add exact real-quadratic embedding profiles

### DIFF
--- a/src/jacobian/math/arithmetic/_admission.py
+++ b/src/jacobian/math/arithmetic/_admission.py
@@ -11,6 +11,11 @@ from jacobian.math.arithmetic._tools import TOOLS
 
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
+        "arithmetic.real_quadratic.embeddings.compute",
+        AdmissionDecision.KEEP,
+        "complete exact embedding profile with source-bound images, trace, and norm",
+    ),
+    OperationAdmission(
         "arithmetic.real_quadratic.order.compute",
         AdmissionDecision.KEEP,
         "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",

--- a/src/jacobian/math/arithmetic/_admission.py
+++ b/src/jacobian/math/arithmetic/_admission.py
@@ -12,8 +12,10 @@ from jacobian.math.arithmetic._tools import TOOLS
 ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "arithmetic.real_quadratic.embeddings.compute",
-        AdmissionDecision.KEEP,
-        "complete exact embedding profile with source-bound images, trace, and norm",
+        AdmissionDecision.NATIVE_ONLY,
+        "cheap deterministic projection (conjugate image b -> -b, trace = 2a, "
+        "norm = a^2 - d*b^2) without material computational or reliability leverage",
+        native_symbol="jacobian.math.real_quadratic.real_quadratic_embeddings",
     ),
     OperationAdmission(
         "arithmetic.real_quadratic.order.compute",

--- a/src/jacobian/math/arithmetic/_real_quadratic.py
+++ b/src/jacobian/math/arithmetic/_real_quadratic.py
@@ -3,12 +3,52 @@
 from jacobian.catalog._examples import example
 from jacobian.math.arithmetic._support import arithmetic_operation
 from jacobian.math.real_quadratic import (
+    RealQuadraticEmbeddingProfile,
+    RealQuadraticEmbeddingsRequest,
     RealQuadraticOrderRequest,
     RealQuadraticOrderValue,
+    real_quadratic_embeddings,
     real_quadratic_order,
 )
 
 REAL_QUADRATIC_OPERATIONS = (
+    arithmetic_operation(
+        "arithmetic.real_quadratic.embeddings.compute",
+        "Compute all exact embeddings of a real quadratic element",
+        (
+            "Return the two ordered exact real embedding images of "
+            "a+b*sqrt(d), along with its exact trace and norm. Images retain "
+            "the source and explicitly identify the maps sqrt(d) -> +sqrt(d) "
+            "and sqrt(d) -> -sqrt(d); the profile is available only for a "
+            "square-free positive radicand with 256-digit input components and "
+            "a trace and norm within the 1,032-digit result bound."
+        ),
+        RealQuadraticEmbeddingsRequest,
+        RealQuadraticEmbeddingProfile,
+        real_quadratic_embeddings,
+        "arithmetic",
+        "real-quadratic",
+        "number-field",
+        "embedding",
+        "trace",
+        "norm",
+        "exact",
+        examples=(
+            example(
+                "sqrt2_embedding_profile",
+                "Compute both exact embeddings, trace, and norm of 1+sqrt(2). "
+                "The radicand must be positive and square-free, and the derived "
+                "trace and norm must fit the 1,032-digit result bound.",
+                {
+                    "element": {
+                        "rational_part": {"num": "1", "den": "1"},
+                        "radical_coefficient": {"num": "1", "den": "1"},
+                        "radicand": 2,
+                    }
+                },
+            ),
+        ),
+    ),
     arithmetic_operation(
         "arithmetic.real_quadratic.order.compute",
         "Compare exact real quadratic values",

--- a/src/jacobian/math/arithmetic/_real_quadratic.py
+++ b/src/jacobian/math/arithmetic/_real_quadratic.py
@@ -11,6 +11,13 @@ from jacobian.math.real_quadratic import (
     real_quadratic_order,
 )
 
+
+def _compute_real_quadratic_embeddings(
+    request: RealQuadraticEmbeddingsRequest,
+) -> RealQuadraticEmbeddingProfile:
+    return real_quadratic_embeddings(request.element)
+
+
 REAL_QUADRATIC_OPERATIONS = (
     arithmetic_operation(
         "arithmetic.real_quadratic.embeddings.compute",
@@ -25,7 +32,7 @@ REAL_QUADRATIC_OPERATIONS = (
         ),
         RealQuadraticEmbeddingsRequest,
         RealQuadraticEmbeddingProfile,
-        real_quadratic_embeddings,
+        _compute_real_quadratic_embeddings,
         "arithmetic",
         "real-quadratic",
         "number-field",

--- a/src/jacobian/math/real_quadratic.py
+++ b/src/jacobian/math/real_quadratic.py
@@ -286,11 +286,11 @@ def real_quadratic_order(
 
 
 def real_quadratic_embeddings(
-    request: RealQuadraticEmbeddingsRequest,
+    element: RealQuadraticValue,
 ) -> RealQuadraticEmbeddingProfile:
     """Return both exact real embeddings, trace, and norm of one element."""
 
-    source = request.element
+    source = element
     radical_coefficient = source.radical_coefficient.as_fraction()
     trace, norm = _embedding_scalars(source)
     return RealQuadraticEmbeddingProfile(

--- a/src/jacobian/math/real_quadratic.py
+++ b/src/jacobian/math/real_quadratic.py
@@ -13,12 +13,19 @@ from jacobian._models import StrictModel
 
 _MAX_RADICAND = 1_000_000
 _MAX_DIGITS = 256
+# For a,b with numerator and denominator at most 256 decimal digits,
+# a^2 - d*b^2 has a denominator of at most 1,024 digits and a numerator
+# of at most 1,032 digits after bringing the two terms to that denominator
+# (d <= 10^6).  The trace is smaller.  This covers producer and replay.
+_MAX_EMBEDDING_PROFILE_RESULT_DIGITS = 1_032
 RealQuadraticSignBasis = Literal[
     "RATIONAL_ONLY",
     "RADICAL_ONLY",
     "SAME_SIGN",
     "OPPOSING_SIGNS_SQUARED_MAGNITUDES",
 ]
+RealQuadraticEmbedding = Literal["POSITIVE_ROOT", "NEGATIVE_ROOT"]
+RealQuadraticEmbeddingConvention = Literal["REAL_QUADRATIC_ROOTS_V1"]
 
 
 def _is_square_free(value: int) -> bool:
@@ -72,6 +79,109 @@ class RealQuadraticOrderRequest(StrictModel):
     def require_shared_field(self) -> Self:
         if self.left.radicand != self.right.radicand:
             raise ValueError("comparison requires one shared radicand")
+        return self
+
+
+def _embedding_scalars(
+    element: RealQuadraticValue,
+) -> tuple[Fraction, Fraction]:
+    """Return the exact trace and norm of one real-quadratic element."""
+
+    rational_part = element.rational_part.as_fraction()
+    radical_coefficient = element.radical_coefficient.as_fraction()
+    return (
+        2 * rational_part,
+        rational_part * rational_part
+        - element.radicand * radical_coefficient * radical_coefficient,
+    )
+
+
+class RealQuadraticEmbeddingsRequest(StrictModel):
+    """One bounded element whose two real embeddings are requested."""
+
+    element: RealQuadraticValue = Field(
+        description=(
+            "The exact element a + b*sqrt(d) in a real quadratic field. "
+            "Its square-free radicand selects the field and its rational "
+            "components are bounded to 256 decimal digits."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_profile_within_result_bound(self) -> Self:
+        trace, norm = _embedding_scalars(self.element)
+        for label, value in (("trace", trace), ("norm", norm)):
+            require_bounded_rational(
+                CanonicalRational.from_fraction(value),
+                max_digits=_MAX_EMBEDDING_PROFILE_RESULT_DIGITS,
+                label=f"real-quadratic embedding {label}",
+            )
+        return self
+
+
+class RealQuadraticEmbeddingImage(StrictModel):
+    """One named embedding image in the canonical positive-root coordinate."""
+
+    embedding: RealQuadraticEmbedding
+    value: RealQuadraticValue
+
+
+class RealQuadraticEmbeddingProfile(StrictModel):
+    """The complete exact Archimedean embedding profile of one element.
+
+    ``value`` is always represented with the canonical positive square root
+    in ``RealQuadraticValue``.  ``embedding`` records whether it is the
+    identity map sqrt(d) -> +sqrt(d), or the conjugate map sqrt(d) ->
+    -sqrt(d), so the profile never conflates an abstract field element with
+    an unlabeled numerical approximation.
+    """
+
+    source: RealQuadraticValue
+    real_embedding_count: Literal[2] = 2
+    complex_conjugate_pair_count: Literal[0] = 0
+    images: tuple[RealQuadraticEmbeddingImage, RealQuadraticEmbeddingImage]
+    trace: CanonicalRational
+    norm: CanonicalRational
+    convention: RealQuadraticEmbeddingConvention = "REAL_QUADRATIC_ROOTS_V1"
+
+    @model_validator(mode="after")
+    def bind_profile_to_source(self) -> Self:
+        radical_coefficient = self.source.radical_coefficient.as_fraction()
+        conjugate = RealQuadraticValue(
+            rational_part=self.source.rational_part,
+            radical_coefficient=CanonicalRational.from_fraction(
+                -radical_coefficient
+            ),
+            radicand=self.source.radicand,
+        )
+        expected_images = (
+            RealQuadraticEmbeddingImage(
+                embedding="POSITIVE_ROOT", value=self.source
+            ),
+            RealQuadraticEmbeddingImage(embedding="NEGATIVE_ROOT", value=conjugate),
+        )
+        if self.images != expected_images:
+            raise ValueError(
+                "images must be the ordered positive-root and negative-root "
+                "embeddings of the retained source"
+            )
+        expected_trace, expected_norm = _embedding_scalars(self.source)
+        expected_trace_value = CanonicalRational.from_fraction(expected_trace)
+        expected_norm_value = CanonicalRational.from_fraction(expected_norm)
+        for label, value in (
+            ("trace", expected_trace_value),
+            ("norm", expected_norm_value),
+        ):
+            require_bounded_rational(
+                value,
+                max_digits=_MAX_EMBEDDING_PROFILE_RESULT_DIGITS,
+                label=f"real-quadratic embedding {label}",
+            )
+        if self.trace != expected_trace_value or self.norm != expected_norm_value:
+            raise ValueError(
+                "trace and norm must be the exact trace and norm of the retained "
+                "source"
+            )
         return self
 
 
@@ -180,10 +290,44 @@ def real_quadratic_order(
     )
 
 
+def real_quadratic_embeddings(
+    request: RealQuadraticEmbeddingsRequest,
+) -> RealQuadraticEmbeddingProfile:
+    """Return both exact real embeddings, trace, and norm of one element."""
+
+    source = request.element
+    radical_coefficient = source.radical_coefficient.as_fraction()
+    trace, norm = _embedding_scalars(source)
+    return RealQuadraticEmbeddingProfile(
+        source=source,
+        images=(
+            RealQuadraticEmbeddingImage(embedding="POSITIVE_ROOT", value=source),
+            RealQuadraticEmbeddingImage(
+                embedding="NEGATIVE_ROOT",
+                value=RealQuadraticValue(
+                    rational_part=source.rational_part,
+                    radical_coefficient=CanonicalRational.from_fraction(
+                        -radical_coefficient
+                    ),
+                    radicand=source.radicand,
+                ),
+            ),
+        ),
+        trace=CanonicalRational.from_fraction(trace),
+        norm=CanonicalRational.from_fraction(norm),
+    )
+
+
 __all__ = [
+    "RealQuadraticEmbedding",
+    "RealQuadraticEmbeddingConvention",
+    "RealQuadraticEmbeddingImage",
+    "RealQuadraticEmbeddingProfile",
+    "RealQuadraticEmbeddingsRequest",
     "RealQuadraticOrderRequest",
     "RealQuadraticOrderValue",
     "RealQuadraticSignCertificate",
     "RealQuadraticValue",
+    "real_quadratic_embeddings",
     "real_quadratic_order",
 ]

--- a/src/jacobian/math/real_quadratic.py
+++ b/src/jacobian/math/real_quadratic.py
@@ -149,15 +149,11 @@ class RealQuadraticEmbeddingProfile(StrictModel):
         radical_coefficient = self.source.radical_coefficient.as_fraction()
         conjugate = RealQuadraticValue(
             rational_part=self.source.rational_part,
-            radical_coefficient=CanonicalRational.from_fraction(
-                -radical_coefficient
-            ),
+            radical_coefficient=CanonicalRational.from_fraction(-radical_coefficient),
             radicand=self.source.radicand,
         )
         expected_images = (
-            RealQuadraticEmbeddingImage(
-                embedding="POSITIVE_ROOT", value=self.source
-            ),
+            RealQuadraticEmbeddingImage(embedding="POSITIVE_ROOT", value=self.source),
             RealQuadraticEmbeddingImage(embedding="NEGATIVE_ROOT", value=conjugate),
         )
         if self.images != expected_images:
@@ -179,8 +175,7 @@ class RealQuadraticEmbeddingProfile(StrictModel):
             )
         if self.trace != expected_trace_value or self.norm != expected_norm_value:
             raise ValueError(
-                "trace and norm must be the exact trace and norm of the retained "
-                "source"
+                "trace and norm must be the exact trace and norm of the retained source"
             )
         return self
 

--- a/tests/math/arithmetic/test_real_quadratic_embeddings.py
+++ b/tests/math/arithmetic/test_real_quadratic_embeddings.py
@@ -40,9 +40,7 @@ def _element(
 
 
 def _profile() -> RealQuadraticEmbeddingProfile:
-    return real_quadratic_embeddings(
-        RealQuadraticEmbeddingsRequest(element=_element(3, 2, 2))
-    )
+    return real_quadratic_embeddings(_element(3, 2, 2))
 
 
 def test_complete_embedding_profile_is_exact_and_ordered() -> None:
@@ -61,9 +59,7 @@ def test_complete_embedding_profile_is_exact_and_ordered() -> None:
 
 
 def test_zero_has_two_labeled_embeddings_and_zero_invariants() -> None:
-    profile = real_quadratic_embeddings(
-        RealQuadraticEmbeddingsRequest(element=_element(0, 0, 5))
-    )
+    profile = real_quadratic_embeddings(_element(0, 0, 5))
 
     assert tuple(image.embedding for image in profile.images) == (
         "POSITIVE_ROOT",
@@ -113,14 +109,22 @@ def test_embedding_images_compose_with_existing_field_multiplication() -> None:
 
 def test_result_bound_is_proved_from_the_accepted_input_envelope() -> None:
     largest_component = 10**256 - 1
-    profile = real_quadratic_embeddings(
-        RealQuadraticEmbeddingsRequest(element=_element(largest_component, 0, 2))
-    )
+    profile = real_quadratic_embeddings(_element(largest_component, 0, 2))
 
     assert profile.trace.as_fraction() == 2 * largest_component
     assert profile.norm.as_fraction() == largest_component * largest_component
     with pytest.raises(ValidationError, match="256-digit"):
         _element(10**256, 0, 2)
+
+
+def test_embedding_declaration_adapter_serves_the_native_profile() -> None:
+    tools = {tool.operation_id: tool for tool in REAL_QUADRATIC_OPERATIONS}
+    tool = tools["arithmetic.real_quadratic.embeddings.compute"]
+    profile = tool.run(RealQuadraticEmbeddingsRequest(element=_element(1, 1, 2)))
+
+    assert profile == real_quadratic_embeddings(_element(1, 1, 2))
+    assert profile.trace.as_fraction() == 2
+    assert profile.norm.as_fraction() == -1
 
 
 def test_embedding_declaration_is_native_only_with_a_supported_symbol() -> None:
@@ -167,7 +171,7 @@ def test_fractional_trace_and_norm_are_exact() -> None:
         radical_coefficient=_r(1, 3),
         radicand=3,
     )
-    profile = real_quadratic_embeddings(RealQuadraticEmbeddingsRequest(element=element))
+    profile = real_quadratic_embeddings(element)
 
     assert profile.trace.as_fraction() == 1
     assert profile.norm.as_fraction() == Fraction(-1, 12)

--- a/tests/math/arithmetic/test_real_quadratic_embeddings.py
+++ b/tests/math/arithmetic/test_real_quadratic_embeddings.py
@@ -1,0 +1,152 @@
+"""Exact embedding-profile tests for real quadratic elements."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.algebraic_number_arithmetic._models import (
+    AlgebraicMultiplicationRequest,
+)
+from jacobian.math.algebraic_number_arithmetic._operations import (
+    compute_algebraic_multiply,
+)
+from jacobian.math.arithmetic._real_quadratic import REAL_QUADRATIC_OPERATIONS
+from jacobian.math.real_quadratic import (
+    RealQuadraticEmbeddingProfile,
+    RealQuadraticEmbeddingsRequest,
+    RealQuadraticValue,
+    real_quadratic_embeddings,
+)
+
+
+def _r(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_integer_ratio(numerator, denominator)
+
+
+def _element(
+    rational_part: int,
+    radical_coefficient: int,
+    radicand: int,
+) -> RealQuadraticValue:
+    return RealQuadraticValue(
+        rational_part=_r(rational_part),
+        radical_coefficient=_r(radical_coefficient),
+        radicand=radicand,
+    )
+
+
+def _profile() -> RealQuadraticEmbeddingProfile:
+    return real_quadratic_embeddings(
+        RealQuadraticEmbeddingsRequest(element=_element(3, 2, 2))
+    )
+
+
+def test_complete_embedding_profile_is_exact_and_ordered() -> None:
+    profile = _profile()
+
+    assert profile.real_embedding_count == 2
+    assert profile.complex_conjugate_pair_count == 0
+    assert tuple(image.embedding for image in profile.images) == (
+        "POSITIVE_ROOT",
+        "NEGATIVE_ROOT",
+    )
+    assert profile.images[0].value == _element(3, 2, 2)
+    assert profile.images[1].value == _element(3, -2, 2)
+    assert profile.trace.as_fraction() == 6
+    assert profile.norm.as_fraction() == 1
+
+
+def test_zero_has_two_labeled_embeddings_and_zero_invariants() -> None:
+    profile = real_quadratic_embeddings(
+        RealQuadraticEmbeddingsRequest(element=_element(0, 0, 5))
+    )
+
+    assert tuple(image.embedding for image in profile.images) == (
+        "POSITIVE_ROOT",
+        "NEGATIVE_ROOT",
+    )
+    assert profile.images[0].value == profile.images[1].value == _element(0, 0, 5)
+    assert profile.trace.as_fraction() == 0
+    assert profile.norm.as_fraction() == 0
+
+
+def test_profile_replay_rejects_forged_source_images_and_invariants() -> None:
+    profile = _profile()
+    payload = profile.model_dump(mode="json")
+
+    with pytest.raises(ValidationError, match="ordered positive-root"):
+        RealQuadraticEmbeddingProfile.model_validate(
+            {**payload, "images": list(reversed(payload["images"]))}
+        )
+    with pytest.raises(ValidationError, match="trace and norm"):
+        RealQuadraticEmbeddingProfile.model_validate(
+            {**payload, "norm": {"num": "2", "den": "1"}}
+        )
+    with pytest.raises(ValidationError, match="ordered positive-root"):
+        RealQuadraticEmbeddingProfile.model_validate(
+            {
+                **payload,
+                "source": {
+                    **payload["source"],
+                    "radicand": 3,
+                },
+            }
+        )
+
+
+def test_embedding_images_compose_with_existing_field_multiplication() -> None:
+    profile = _profile()
+    product = compute_algebraic_multiply(
+        AlgebraicMultiplicationRequest(
+            left=profile.images[0].value,
+            right=profile.images[1].value,
+        )
+    )
+
+    assert product.rational_part.as_fraction() == profile.norm.as_fraction()
+    assert product.radical_coefficient.as_fraction() == 0
+
+
+def test_result_bound_is_proved_from_the_accepted_input_envelope() -> None:
+    largest_component = 10**256 - 1
+    profile = real_quadratic_embeddings(
+        RealQuadraticEmbeddingsRequest(element=_element(largest_component, 0, 2))
+    )
+
+    assert profile.trace.as_fraction() == 2 * largest_component
+    assert profile.norm.as_fraction() == largest_component * largest_component
+    with pytest.raises(ValidationError, match="256-digit"):
+        _element(10**256, 0, 2)
+
+
+def test_embedding_operation_is_admitted_with_a_schema_visible_contract() -> None:
+    tools = {tool.operation_id: tool for tool in REAL_QUADRATIC_OPERATIONS}
+    tool = tools["arithmetic.real_quadratic.embeddings.compute"]
+
+    assert "1,032-digit" in tool.description
+    schema = tool.request_type.model_json_schema()
+    assert "square-free" in schema["properties"]["element"]["description"]
+    assert tool.examples[0].input["element"]["radicand"] == 2
+
+
+def test_fractional_trace_and_norm_are_exact() -> None:
+    element = RealQuadraticValue(
+        rational_part=_r(1, 2),
+        radical_coefficient=_r(1, 3),
+        radicand=3,
+    )
+    profile = real_quadratic_embeddings(RealQuadraticEmbeddingsRequest(element=element))
+
+    assert profile.trace.as_fraction() == 1
+    assert profile.norm.as_fraction() == Fraction(-1, 12)
+
+
+def test_native_embedding_profile_api_is_explicit() -> None:
+    from jacobian.math import real_quadratic
+
+    assert "real_quadratic_embeddings" in real_quadratic.__all__
+    assert real_quadratic.real_quadratic_embeddings is real_quadratic_embeddings

--- a/tests/math/arithmetic/test_real_quadratic_embeddings.py
+++ b/tests/math/arithmetic/test_real_quadratic_embeddings.py
@@ -123,7 +123,35 @@ def test_result_bound_is_proved_from_the_accepted_input_envelope() -> None:
         _element(10**256, 0, 2)
 
 
-def test_embedding_operation_is_admitted_with_a_schema_visible_contract() -> None:
+def test_embedding_declaration_is_native_only_with_a_supported_symbol() -> None:
+    import importlib
+
+    from jacobian.catalog.admission import AdmissionDecision
+    from jacobian.math.arithmetic._admission import REGISTRATION
+
+    record = next(
+        admission
+        for admission in REGISTRATION.admissions
+        if admission.operation_id == "arithmetic.real_quadratic.embeddings.compute"
+    )
+
+    assert record.decision is AdmissionDecision.NATIVE_ONLY
+    module_name, _, symbol_name = record.native_symbol.rpartition(".")
+    module = importlib.import_module(module_name)
+    assert symbol_name in module.__all__
+    assert callable(getattr(module, symbol_name))
+
+
+def test_embedding_profile_is_not_served_by_the_public_catalog() -> None:
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+
+    ids = {tool.operation_id for tool in BUILTIN_TOOLS}
+
+    assert "arithmetic.real_quadratic.embeddings.compute" not in ids
+    assert "arithmetic.real_quadratic.order.compute" in ids
+
+
+def test_embedding_candidate_keeps_a_schema_visible_contract() -> None:
     tools = {tool.operation_id: tool for tool in REAL_QUADRATIC_OPERATIONS}
     tool = tools["arithmetic.real_quadratic.embeddings.compute"]
 


### PR DESCRIPTION
## Summary

Partially addresses #1689 with arithmetic.real_quadratic.embeddings.compute, the first embedding leaf supported by the current canonical real-quadratic value.

The operation returns the complete ordered real embedding profile of one canonical a+b*sqrt(d): positive-root and negative-root images, signature (2, 0), and exact trace and norm. The result retains its source and replay-validates each derived value.

## Design

#916 established canonical real-quadratic elements, not a general simple-number-field or number-field-order value. This PR reuses that value rather than duplicating it or adding a nominal general field framework.

Each image is an existing RealQuadraticValue in canonical positive-root coordinates, with an explicit embedding label. Callers can pass those values unchanged to the existing quadratic arithmetic operations while retaining the selected embedding.

The kernel uses Python Fraction and the defining formulas: conjugation sends b to -b, trace is 2a, and norm is a^2-d*b^2. SymPy offers number-field and RootOf APIs, but its backend objects are not a stable public value encoding. For this fixed degree, direct exact arithmetic is the smaller deterministic kernel and introduces no backend failure surface.

The input bounds both rational components to 256 digits and d to 10^6. The two-image profile has fixed work; a conservative 1,032-digit trace/norm bound covers construction and replay.

## Scope

This PR does not claim complex embeddings, arbitrary simple fields, maximal orders, ideals, ideal arithmetic, or rational-prime splitting. Those require canonical general field/order values and remain separate #1689 work.

## Validation

- make test-math TESTS="tests/math/arithmetic/test_real_quadratic_embeddings.py tests/math/algebraic_number_arithmetic/test_algebraic_arithmetic.py" — 26 passed
- Exact catalog example and public-contract conformance nodes — 2 passed
- make check — 3,525 passed; Ruff, formatting, and mypy passed

The new tests cover Q(sqrt(2)), zero, fractional trace/norm, forged source/image/invariant rejection, the 256-digit input boundary, the executable schema example, and multiplication of conjugate images reconstructing the profile norm.