### PR TITLE
Add exact multicommodity-flow profiles

### DIFF
--- a/src/jacobian/math/graphs/multicommodity_flow/__init__.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/__init__.py
@@ -1,0 +1,27 @@
+"""Exact bounded multicommodity-flow values and operations."""
+
+from jacobian.math.graphs.multicommodity_flow._models import (
+    CommodityDemand,
+    CommodityDivergence,
+    CommodityEdgeFlow,
+    EdgeLoadProfile,
+    MulticommodityFlow,
+    MulticommodityFlowProfileRequest,
+    MulticommodityFlowProfileResult,
+    MulticommodityFlowProfileWork,
+)
+from jacobian.math.graphs.multicommodity_flow._operations import (
+    compute_multicommodity_flow_profile,
+)
+
+__all__ = [
+    "CommodityDemand",
+    "CommodityDivergence",
+    "CommodityEdgeFlow",
+    "EdgeLoadProfile",
+    "MulticommodityFlow",
+    "MulticommodityFlowProfileRequest",
+    "MulticommodityFlowProfileResult",
+    "MulticommodityFlowProfileWork",
+    "compute_multicommodity_flow_profile",
+]

--- a/src/jacobian/math/graphs/multicommodity_flow/_admission.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_admission.py
@@ -1,0 +1,20 @@
+"""Admission decisions for exact multicommodity-flow operations."""
+
+from __future__ import annotations
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.graphs.multicommodity_flow._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "network.multicommodity_flow.profile.compute",
+        AdmissionDecision.KEEP,
+        "complete exact source-bound conservation and capacity profile of a canonical sparse commodity-by-edge tensor; distinct from single-commodity flow optimization and reusable by future feasibility, congestion, and routing operations",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -10,7 +10,8 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     EdgeLoadProfile,
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
-    derived_profile_digit_budget,
+    _component_sums,
+    derived_profile_digit_budget_from_sums,
 )
 
 
@@ -42,19 +43,8 @@ def profile_components(
     """
 
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
-    edge_keys = tuple((edge.source, edge.target) for edge in flow.network.edges)
-    budget = derived_profile_digit_budget(flow)
-    divergences = {
-        (commodity_id, vertex): Fraction(0)
-        for commodity_id in commodity_ids
-        for vertex in range(flow.network.vertex_count)
-    }
-    loads = {edge_key: Fraction(0) for edge_key in edge_keys}
-    for entry in flow.entries:
-        amount = entry.amount.as_fraction()
-        divergences[(entry.commodity_id, entry.source)] += amount
-        divergences[(entry.commodity_id, entry.target)] -= amount
-        loads[(entry.source, entry.target)] += amount
+    divergences, loads = _component_sums(flow)
+    budget = derived_profile_digit_budget_from_sums(flow, divergences, loads)
 
     divergence_rows = tuple(
         CommodityDivergence(

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -11,6 +11,8 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
     _component_sums_with_folds,
+    _require_admitted_profile_rows,
+    _require_profile_source_room,
     derived_profile_components_from_sums,
 )
 
@@ -38,14 +40,27 @@ def profile_components(
     """Return the complete deterministic profile components for ``flow``.
 
     One pass initializes and updates dense commodity/vertex divergence cells
-    and aggregate edge loads.  Result-model validation calls this same pure
-    kernel once more, so the returned work ledger charges both passes.
+    and aggregate edge loads.  The aggregate result envelope is admitted from
+    the same measured components -- the echoed source before the scan, every
+    priced row afterwards -- so admission adds no arithmetic pass of its own.
+    Result-model validation calls this same pure kernel once more, so the
+    returned work ledger charges both passes.
     """
 
+    _require_profile_source_room(flow)
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
     divergences, loads, denominator_folds = _component_sums_with_folds(flow)
-    budget, slacks, max_congestion_ratio = derived_profile_components_from_sums(
-        flow, divergences, loads
+    (
+        budget,
+        slacks,
+        max_congestion_ratio,
+        cell_bounds,
+        load_bounds,
+        slack_bounds,
+        congestion_bound,
+    ) = derived_profile_components_from_sums(flow, divergences, loads)
+    _require_admitted_profile_rows(
+        flow, cell_bounds, load_bounds, slack_bounds, congestion_bound
     )
 
     divergence_rows = tuple(

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -11,7 +11,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
     _component_sums,
-    derived_profile_digit_budget_from_sums,
+    derived_profile_components_from_sums,
 )
 
 
@@ -44,7 +44,9 @@ def profile_components(
 
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
     divergences, loads = _component_sums(flow)
-    budget = derived_profile_digit_budget_from_sums(flow, divergences, loads)
+    budget, slacks, max_congestion_ratio = derived_profile_components_from_sums(
+        flow, divergences, loads
+    )
 
     divergence_rows = tuple(
         CommodityDivergence(
@@ -74,7 +76,6 @@ def profile_components(
 
     edge_rows: list[EdgeLoadProfile] = []
     capacity_feasible = True
-    max_congestion_ratio = Fraction(0)
     zero_capacity_violation = False
     positive_capacity_edges = 0
     for edge in flow.network.edges:
@@ -88,15 +89,12 @@ def profile_components(
                 zero_capacity_violation = True
         else:
             positive_capacity_edges += 1
-            ratio = load / capacity
-            if ratio > max_congestion_ratio:
-                max_congestion_ratio = ratio
         edge_rows.append(
             EdgeLoadProfile(
                 source=edge.source,
                 target=edge.target,
                 load=_wire(load, max_digits=budget),
-                slack=_wire(capacity - load, max_digits=budget),
+                slack=_wire(slacks[edge_key], max_digits=budget),
             )
         )
 
@@ -104,16 +102,20 @@ def profile_components(
     divergence_cells = len(divergence_rows)
     edge_cells = len(edge_rows)
     # Each sparse entry adds to source divergence, sink divergence, and edge
-    # load. Each edge then subtracts its load from capacity. One demand is
-    # negated per commodity for its sink target. Every edge compares load to
-    # capacity and capacity to zero, then compares either load to zero or its
-    # ratio to the running congestion maximum. The demand scan above compares
-    # all commodity/vertex cells rather than short-circuiting at the first
-    # mismatch, so every charged comparison is executed exactly once.
+    # load. Each edge's slack is subtracted exactly once by the shared scan
+    # that returned the budget above, which also divides one ratio per
+    # positive-capacity edge; this loop reuses those measured components. One
+    # demand is negated per commodity for its sink target. Every edge is
+    # compared four times -- load against capacity and capacity against zero
+    # in this loop, capacity against zero in the shared scan, then either
+    # load against zero or its ratio against the running congestion maximum.
+    # The demand scan above compares all commodity/vertex cells rather than
+    # short-circuiting at the first mismatch, so every charged comparison is
+    # executed exactly once.
     additions = 3 * sparse_entries + edge_cells
     negations = len(flow.commodities)
     divisions = positive_capacity_edges
-    comparisons = divergence_cells + 3 * edge_cells
+    comparisons = divergence_cells + 4 * edge_cells
     per_pass = additions + negations + divisions + comparisons
     work = MulticommodityFlowProfileWork(
         execution_passes_per_call=2,

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -10,7 +10,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     EdgeLoadProfile,
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
-    _component_sums,
+    _component_sums_with_folds,
     derived_profile_components_from_sums,
 )
 
@@ -43,7 +43,7 @@ def profile_components(
     """
 
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
-    divergences, loads = _component_sums(flow)
+    divergences, loads, denominator_folds = _component_sums_with_folds(flow)
     budget, slacks, max_congestion_ratio = derived_profile_components_from_sums(
         flow, divergences, loads
     )
@@ -101,18 +101,22 @@ def profile_components(
     sparse_entries = len(flow.entries)
     divergence_cells = len(divergence_rows)
     edge_cells = len(edge_rows)
-    # Each sparse entry adds to source divergence, sink divergence, and edge
-    # load. Each edge's slack is subtracted exactly once by the shared scan
-    # that returned the budget above, which also divides one ratio per
-    # positive-capacity edge; this loop reuses those measured components. One
-    # demand is negated per commodity for its sink target. Every edge is
-    # compared four times -- load against capacity and capacity against zero
-    # in this loop, capacity against zero in the shared scan, then either
-    # load against zero or its ratio against the running congestion maximum.
-    # The demand scan above compares all commodity/vertex cells rather than
-    # short-circuiting at the first mismatch, so every charged comparison is
-    # executed exactly once.
-    additions = 3 * sparse_entries + edge_cells
+    # Each sparse entry performs three bucketed integer additions -- source
+    # divergence, sink divergence, and edge load -- and deposits its
+    # denominator into each of those three buckets. The shared sum scan then
+    # folds every distinct bucket denominator exactly once, counted inside
+    # the fold loop itself, so ``denominator_folds`` equals the fraction
+    # additions the scan executed. Each edge's slack is subtracted exactly
+    # once by the shared scan that returned the budget above, which also
+    # divides one ratio per positive-capacity edge; this loop reuses those
+    # measured components. One demand is negated per commodity for its sink
+    # target. Every edge is compared four times -- load against capacity and
+    # capacity against zero in this loop, capacity against zero in the shared
+    # scan, then either load against zero or its ratio against the running
+    # congestion maximum. The demand scan above compares all commodity/vertex
+    # cells rather than short-circuiting at the first mismatch, so every
+    # charged comparison is executed exactly once.
+    additions = 3 * sparse_entries + denominator_folds + edge_cells
     negations = len(flow.commodities)
     divisions = positive_capacity_edges
     comparisons = divergence_cells + 4 * edge_cells

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -6,14 +6,14 @@ from fractions import Fraction
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian.math.graphs.multicommodity_flow._models import (
+    AdmittedProfileScan,
     CommodityDivergence,
     EdgeLoadProfile,
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
-    _component_sums_with_folds,
     _require_admitted_profile_rows,
     _require_profile_source_room,
-    derived_profile_components_from_sums,
+    measured_profile_components,
 )
 
 
@@ -29,6 +29,7 @@ def _wire(value: Fraction, *, max_digits: int) -> CanonicalRational:
 
 def profile_components(
     flow: MulticommodityFlow,
+    admitted: AdmittedProfileScan | None = None,
 ) -> tuple[
     tuple[CommodityDivergence, ...],
     tuple[EdgeLoadProfile, ...],
@@ -43,25 +44,33 @@ def profile_components(
     and aggregate edge loads.  The aggregate result envelope is admitted from
     the same measured components -- the echoed source before the scan, every
     priced row afterwards -- so admission adds no arithmetic pass of its own.
-    Result-model validation calls this same pure kernel once more, so the
-    returned work ledger charges both passes.
+    Request parsing may supply ``admitted``, the scan it already performed
+    and validated against, which then serves as this producer pass verbatim;
+    otherwise the pass runs here. Result-model validation calls this same
+    pure kernel without a stash, so its replay always rescans independently
+    and the returned work ledger charges both passes.
     """
 
-    _require_profile_source_room(flow)
+    if admitted is None:
+        _require_profile_source_room(flow)
+        scan = measured_profile_components(flow)
+        _require_admitted_profile_rows(
+            flow,
+            scan.cell_bounds,
+            scan.load_bounds,
+            scan.slack_bounds,
+            scan.congestion_bound,
+        )
+    else:
+        scan = admitted
+
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
-    divergences, loads, denominator_folds = _component_sums_with_folds(flow)
-    (
-        budget,
-        slacks,
-        max_congestion_ratio,
-        cell_bounds,
-        load_bounds,
-        slack_bounds,
-        congestion_bound,
-    ) = derived_profile_components_from_sums(flow, divergences, loads)
-    _require_admitted_profile_rows(
-        flow, cell_bounds, load_bounds, slack_bounds, congestion_bound
-    )
+    divergences = scan.divergences
+    loads = scan.loads
+    denominator_folds = scan.denominator_folds
+    budget = scan.budget
+    slacks = scan.slacks
+    max_congestion_ratio = scan.max_congestion_ratio
 
     divergence_rows = tuple(
         CommodityDivergence(

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -77,8 +77,7 @@ def profile_components(
         for vertex in range(flow.network.vertex_count)
     }
     mismatched_divergence_cells = sum(
-        divergences[key] != expected
-        for key, expected in expected_divergences.items()
+        divergences[key] != expected for key, expected in expected_divergences.items()
     )
     all_demands_routed = mismatched_divergence_cells == 0
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -141,7 +141,9 @@ def profile_components(
         tuple(edge_rows),
         all_demands_routed,
         capacity_feasible,
-        None if zero_capacity_violation else _wire(max_congestion_ratio, max_digits=budget),
+        None
+        if zero_capacity_violation
+        else _wire(max_congestion_ratio, max_digits=budget),
         work,
     )
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -1,0 +1,144 @@
+"""Pure exact kernels for bounded multicommodity-flow profiles."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian.math.graphs.multicommodity_flow._models import (
+    MAX_PROFILE_RATIONAL_DIGITS,
+    CommodityDivergence,
+    EdgeLoadProfile,
+    MulticommodityFlow,
+    MulticommodityFlowProfileWork,
+)
+
+
+def _wire(value: Fraction) -> CanonicalRational:
+    result = CanonicalRational.from_fraction(value)
+    require_bounded_rational(
+        result,
+        max_digits=MAX_PROFILE_RATIONAL_DIGITS,
+        label="derived multicommodity-flow profile rational",
+    )
+    return result
+
+
+def profile_components(
+    flow: MulticommodityFlow,
+) -> tuple[
+    tuple[CommodityDivergence, ...],
+    tuple[EdgeLoadProfile, ...],
+    bool,
+    bool,
+    CanonicalRational | None,
+    MulticommodityFlowProfileWork,
+]:
+    """Return the complete deterministic profile components for ``flow``.
+
+    One pass initializes and updates dense commodity/vertex divergence cells
+    and aggregate edge loads.  Result-model validation calls this same pure
+    kernel once more, so the returned work ledger charges both passes.
+    """
+
+    commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
+    edge_keys = tuple((edge.source, edge.target) for edge in flow.network.edges)
+    divergences = {
+        (commodity_id, vertex): Fraction(0)
+        for commodity_id in commodity_ids
+        for vertex in range(flow.network.vertex_count)
+    }
+    loads = {edge_key: Fraction(0) for edge_key in edge_keys}
+    for entry in flow.entries:
+        amount = entry.amount.as_fraction()
+        divergences[(entry.commodity_id, entry.source)] += amount
+        divergences[(entry.commodity_id, entry.target)] -= amount
+        loads[(entry.source, entry.target)] += amount
+
+    divergence_rows = tuple(
+        CommodityDivergence(
+            commodity_id=commodity_id,
+            vertex=vertex,
+            divergence=_wire(divergences[(commodity_id, vertex)]),
+        )
+        for commodity_id in commodity_ids
+        for vertex in range(flow.network.vertex_count)
+    )
+    expected_divergences = {
+        (commodity.commodity_id, vertex): (
+            demand
+            if vertex == commodity.source
+            else -demand
+            if vertex == commodity.sink
+            else Fraction(0)
+        )
+        for commodity in flow.commodities
+        for demand in (commodity.demand.as_fraction(),)
+        for vertex in range(flow.network.vertex_count)
+    }
+    all_demands_routed = all(
+        divergences[key] == expected for key, expected in expected_divergences.items()
+    )
+
+    edge_rows: list[EdgeLoadProfile] = []
+    capacity_feasible = True
+    congestion: Fraction | None = Fraction(0)
+    positive_capacity_edges = 0
+    for edge in flow.network.edges:
+        edge_key = (edge.source, edge.target)
+        capacity = edge.capacity.as_fraction()
+        load = loads[edge_key]
+        if load > capacity:
+            capacity_feasible = False
+        if capacity == 0:
+            if load > 0:
+                congestion = None
+        else:
+            positive_capacity_edges += 1
+            ratio = load / capacity
+            if congestion is not None and ratio > congestion:
+                congestion = ratio
+        edge_rows.append(
+            EdgeLoadProfile(
+                source=edge.source,
+                target=edge.target,
+                load=_wire(load),
+                slack=_wire(capacity - load),
+            )
+        )
+
+    sparse_entries = len(flow.entries)
+    divergence_cells = len(divergence_rows)
+    edge_cells = len(edge_rows)
+    # Each sparse entry adds to source divergence, sink divergence, and edge
+    # load. Each edge then subtracts its load from capacity. One demand is
+    # negated per commodity for its sink target. Every edge compares load to
+    # capacity and capacity to zero, then compares either load to zero or its
+    # ratio to the running congestion maximum.
+    additions = 3 * sparse_entries + edge_cells
+    negations = len(flow.commodities)
+    divisions = positive_capacity_edges
+    comparisons = divergence_cells + 3 * edge_cells
+    per_pass = additions + negations + divisions + comparisons
+    work = MulticommodityFlowProfileWork(
+        execution_passes_per_call=2,
+        sparse_entries=sparse_entries,
+        commodity_vertex_cells=divergence_cells,
+        edge_cells=edge_cells,
+        rational_additions_per_pass=additions,
+        rational_negations_per_pass=negations,
+        rational_divisions_per_pass=divisions,
+        exact_comparisons_per_pass=comparisons,
+        logical_steps_per_call=2 * per_pass,
+    )
+    return (
+        divergence_rows,
+        tuple(edge_rows),
+        all_demands_routed,
+        capacity_feasible,
+        None if congestion is None else _wire(congestion),
+        work,
+    )
+
+
+__all__ = ["profile_components"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -6,19 +6,19 @@ from fractions import Fraction
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian.math.graphs.multicommodity_flow._models import (
-    MAX_PROFILE_RATIONAL_DIGITS,
     CommodityDivergence,
     EdgeLoadProfile,
     MulticommodityFlow,
     MulticommodityFlowProfileWork,
+    derived_profile_digit_budget,
 )
 
 
-def _wire(value: Fraction) -> CanonicalRational:
+def _wire(value: Fraction, *, max_digits: int) -> CanonicalRational:
     result = CanonicalRational.from_fraction(value)
     require_bounded_rational(
         result,
-        max_digits=MAX_PROFILE_RATIONAL_DIGITS,
+        max_digits=max_digits,
         label="derived multicommodity-flow profile rational",
     )
     return result
@@ -43,6 +43,7 @@ def profile_components(
 
     commodity_ids = tuple(commodity.commodity_id for commodity in flow.commodities)
     edge_keys = tuple((edge.source, edge.target) for edge in flow.network.edges)
+    budget = derived_profile_digit_budget(flow)
     divergences = {
         (commodity_id, vertex): Fraction(0)
         for commodity_id in commodity_ids
@@ -59,7 +60,7 @@ def profile_components(
         CommodityDivergence(
             commodity_id=commodity_id,
             vertex=vertex,
-            divergence=_wire(divergences[(commodity_id, vertex)]),
+            divergence=_wire(divergences[(commodity_id, vertex)], max_digits=budget),
         )
         for commodity_id in commodity_ids
         for vertex in range(flow.network.vertex_count)
@@ -104,8 +105,8 @@ def profile_components(
             EdgeLoadProfile(
                 source=edge.source,
                 target=edge.target,
-                load=_wire(load),
-                slack=_wire(capacity - load),
+                load=_wire(load, max_digits=budget),
+                slack=_wire(capacity - load, max_digits=budget),
             )
         )
 
@@ -140,7 +141,7 @@ def profile_components(
         tuple(edge_rows),
         all_demands_routed,
         capacity_feasible,
-        None if zero_capacity_violation else _wire(max_congestion_ratio),
+        None if zero_capacity_violation else _wire(max_congestion_ratio, max_digits=budget),
         work,
     )
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -76,13 +76,16 @@ def profile_components(
         for demand in (commodity.demand.as_fraction(),)
         for vertex in range(flow.network.vertex_count)
     }
-    all_demands_routed = all(
-        divergences[key] == expected for key, expected in expected_divergences.items()
+    mismatched_divergence_cells = sum(
+        divergences[key] != expected
+        for key, expected in expected_divergences.items()
     )
+    all_demands_routed = mismatched_divergence_cells == 0
 
     edge_rows: list[EdgeLoadProfile] = []
     capacity_feasible = True
-    congestion: Fraction | None = Fraction(0)
+    max_congestion_ratio = Fraction(0)
+    zero_capacity_violation = False
     positive_capacity_edges = 0
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
@@ -92,12 +95,12 @@ def profile_components(
             capacity_feasible = False
         if capacity == 0:
             if load > 0:
-                congestion = None
+                zero_capacity_violation = True
         else:
             positive_capacity_edges += 1
             ratio = load / capacity
-            if congestion is not None and ratio > congestion:
-                congestion = ratio
+            if ratio > max_congestion_ratio:
+                max_congestion_ratio = ratio
         edge_rows.append(
             EdgeLoadProfile(
                 source=edge.source,
@@ -114,7 +117,9 @@ def profile_components(
     # load. Each edge then subtracts its load from capacity. One demand is
     # negated per commodity for its sink target. Every edge compares load to
     # capacity and capacity to zero, then compares either load to zero or its
-    # ratio to the running congestion maximum.
+    # ratio to the running congestion maximum. The demand scan above compares
+    # all commodity/vertex cells rather than short-circuiting at the first
+    # mismatch, so every charged comparison is executed exactly once.
     additions = 3 * sparse_entries + edge_cells
     negations = len(flow.commodities)
     divisions = positive_capacity_edges
@@ -136,7 +141,7 @@ def profile_components(
         tuple(edge_rows),
         all_demands_routed,
         capacity_feasible,
-        None if congestion is None else _wire(congestion),
+        None if zero_capacity_violation else _wire(max_congestion_ratio),
         work,
     )
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_kernel.py
@@ -70,7 +70,9 @@ def profile_components(
     denominator_folds = scan.denominator_folds
     budget = scan.budget
     slacks = scan.slacks
-    max_congestion_ratio = scan.max_congestion_ratio
+    congestion_ratio = scan.congestion_ratio
+    scan_divisions = scan.scan_divisions
+    scan_comparisons = scan.scan_comparisons
 
     divergence_rows = tuple(
         CommodityDivergence(
@@ -100,19 +102,11 @@ def profile_components(
 
     edge_rows: list[EdgeLoadProfile] = []
     capacity_feasible = True
-    zero_capacity_violation = False
-    positive_capacity_edges = 0
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
-        capacity = edge.capacity.as_fraction()
         load = loads[edge_key]
-        if load > capacity:
+        if load > edge.capacity.as_fraction():
             capacity_feasible = False
-        if capacity == 0:
-            if load > 0:
-                zero_capacity_violation = True
-        else:
-            positive_capacity_edges += 1
         edge_rows.append(
             EdgeLoadProfile(
                 source=edge.source,
@@ -131,19 +125,21 @@ def profile_components(
     # folds every distinct bucket denominator exactly once, counted inside
     # the fold loop itself, so ``denominator_folds`` equals the fraction
     # additions the scan executed. Each edge's slack is subtracted exactly
-    # once by the shared scan that returned the budget above, which also
-    # divides one ratio per positive-capacity edge; this loop reuses those
-    # measured components. One demand is negated per commodity for its sink
-    # target. Every edge is compared four times -- load against capacity and
-    # capacity against zero in this loop, capacity against zero in the shared
-    # scan, then either load against zero or its ratio against the running
-    # congestion maximum. The demand scan above compares all commodity/vertex
-    # cells rather than short-circuiting at the first mismatch, so every
-    # charged comparison is executed exactly once.
+    # once by the shared derivative scan that returned the budget above; that
+    # scan also owns the zero-capacity classification, so when a loaded
+    # zero-capacity edge makes the congestion value null it divides and
+    # compares no ratios at all, and otherwise each positive-capacity ratio
+    # is divided exactly once and compared against the running maximum once.
+    # Its reported comparison and division counts charge exactly the work it
+    # executed, and this loop adds only its load-vs-capacity feasibility test
+    # per edge. One demand is negated per commodity for its sink target, and
+    # the demand scan above compares all commodity/vertex cells rather than
+    # short-circuiting at the first mismatch, so every charged comparison is
+    # executed exactly once.
     additions = 3 * sparse_entries + denominator_folds + edge_cells
     negations = len(flow.commodities)
-    divisions = positive_capacity_edges
-    comparisons = divergence_cells + 4 * edge_cells
+    divisions = scan_divisions
+    comparisons = divergence_cells + edge_cells + scan_comparisons
     per_pass = additions + negations + divisions + comparisons
     work = MulticommodityFlowProfileWork(
         execution_passes_per_call=2,
@@ -162,8 +158,8 @@ def profile_components(
         all_demands_routed,
         capacity_feasible,
         None
-        if zero_capacity_violation
-        else _wire(max_congestion_ratio, max_digits=budget),
+        if congestion_ratio is None
+        else _wire(congestion_ratio, max_digits=budget),
         work,
     )
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -54,10 +54,10 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # when its own component bounds limit the two sides separately; the
 # conservative row overhead reserves ASCII keys, labels, separators, and
 # vertices. This envelope belongs to the profile operation, not to the
-# canonical tensor value: the profile kernel measures the echoed source
-# before its scan and prices every returned row from the same measured
-# bounds afterwards, so admission adds no arithmetic pass of its own and
-# the two-pass work ledger stays an exact per-call accounting.
+# canonical tensor value: request parsing validates it completely so every
+# accepted request is admissible before execution, and the kernel prices
+# its result from its own measured components, adding no arithmetic pass
+# of its own and keeping the two-pass work ledger exact.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
@@ -529,6 +529,26 @@ def _require_admitted_profile_rows(
         )
 
 
+def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
+    """Reject tensors whose derived rows or echoed source exceed the envelope.
+
+    Request parsing runs this complete mathematical validation so every
+    accepted ``math.run`` request reaches the kernel guaranteed admissible,
+    and native callers get the same typed rejection before any result
+    construction. The kernel still prices its result from its own measured
+    components, so an accepted request's execution remains exactly the two
+    charged passes.
+    """
+
+    _require_profile_source_room(flow)
+    cell_bounds, load_bounds, slack_bounds, congestion_bound = (
+        _profile_component_digit_bounds(flow)
+    )
+    _require_admitted_profile_rows(
+        flow, cell_bounds, load_bounds, slack_bounds, congestion_bound
+    )
+
+
 class MulticommodityFlow(StrictModel):
     """A canonical sparse exact commodity-by-edge tensor over one FlowGraph.
 
@@ -589,6 +609,11 @@ class MulticommodityFlowProfileRequest(StrictModel):
             "result envelope below 8 MiB."
         )
     )
+
+    @model_validator(mode="after")
+    def require_admitted_profile_work_and_result(self) -> Self:
+        _require_profile_output_admission(self.flow)
+        return self
 
 
 class CommodityDivergence(StrictModel):

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -9,7 +9,11 @@ from pydantic import Field, StrictStr, model_validator
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.canonical import encode_strict_json, format_canonical_integer
+from jacobian.canonical import (
+    encode_strict_json,
+    format_canonical_integer,
+    parse_canonical_integer,
+)
 from jacobian.math.graphs.flow._models import FlowGraph
 
 # This operation scans a sparse commodity-by-edge tensor and materializes one
@@ -175,22 +179,45 @@ def _component_sums(
 ) -> tuple[dict[tuple[str, int], Fraction], dict[tuple[int, int], Fraction]]:
     """Return the exact divergence-cell and edge-load sums for one tensor.
 
-    Accumulation order is irrelevant to admission: partial sums may grow
-    arbitrarily and later cancel, so the canonical cap is applied only to the
-    completed reduced components.
+    Amounts are bucketed by identical denominator and combined smallest
+    denominator first: integer bucket sums never exceed the request volume,
+    shared denominators add with zero growth, and every cross-denominator
+    fold is checked against the canonical cap so adversarial
+    coprime-denominator floods abort after constant work instead of
+    constructing huge intermediate fractions.
     """
 
-    divergences = {
-        (commodity.commodity_id, vertex): Fraction(0)
+    cell_buckets: dict[tuple[str, int], dict[int, int]] = {
+        (commodity.commodity_id, vertex): {}
         for commodity in flow.commodities
         for vertex in range(flow.network.vertex_count)
     }
-    loads = {(edge.source, edge.target): Fraction(0) for edge in flow.network.edges}
+    edge_buckets: dict[tuple[int, int], dict[int, int]] = {
+        (edge.source, edge.target): {} for edge in flow.network.edges
+    }
     for entry in flow.entries:
-        amount = entry.amount.as_fraction()
-        divergences[(entry.commodity_id, entry.source)] += amount
-        divergences[(entry.commodity_id, entry.target)] -= amount
-        loads[(entry.source, entry.target)] += amount
+        numerator = parse_canonical_integer(entry.amount.num)
+        denominator = parse_canonical_integer(entry.amount.den)
+        source_key = (entry.commodity_id, entry.source)
+        target_key = (entry.commodity_id, entry.target)
+        edge_key = (entry.source, entry.target)
+        source_bucket = cell_buckets.setdefault(source_key, {})
+        source_bucket[denominator] = source_bucket.get(denominator, 0) + numerator
+        target_bucket = cell_buckets.setdefault(target_key, {})
+        target_bucket[denominator] = target_bucket.get(denominator, 0) - numerator
+        bucket = edge_buckets.setdefault(edge_key, {})
+        bucket[denominator] = bucket.get(denominator, 0) + numerator
+
+    def _combine(buckets: dict[int, int]) -> Fraction:
+        total = Fraction(0)
+        for den in sorted(buckets, key=int.bit_length):
+            total += Fraction(buckets[den], den)
+            for digits in _rational_side_bounds(total):
+                _require_side_within_cap(digits)
+        return total
+
+    divergences = {key: _combine(bucket) for key, bucket in cell_buckets.items()}
+    loads = {key: _combine(bucket) for key, bucket in edge_buckets.items()}
     return divergences, loads
 
 
@@ -242,9 +269,9 @@ def _profile_component_digit_bounds(
     )
 
     cell_bounds = {
-        key: _rational_side_bounds(value) for key, value in divergences.items()
+        key: _measured_side_bounds(value) for key, value in divergences.items()
     }
-    load_bounds = {key: _rational_side_bounds(value) for key, value in loads.items()}
+    load_bounds = {key: _measured_side_bounds(value) for key, value in loads.items()}
     slack_bounds: dict[tuple[int, int], tuple[int, int]] = {}
     max_ratio = Fraction(0)
     for edge in flow.network.edges:

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -60,19 +60,22 @@ _RATIONAL_JSON_OVERHEAD_BYTES = 24
 _PROFILE_RESULT_HEADER_BYTES = 1_024
 
 # One pass performs at most 3F+E additions/subtractions, K negations, E
-# divisions, and K*V+3E comparisons. Sparse entries are distinct
+# divisions, and K*V+4E comparisons. Sparse entries are distinct
 # commodity-by-edge cells of the conceptual tensor, so F <= K*E <= 256 * 512.
 # Every admitted commodity occupies V >= 2 distinct commodity-vertex cells
 # because its source and sink differ, so the 512-cell divergence budget
 # admits at most 256 commodities, one negation each, and FlowGraph's own
-# 512-edge tuple bounds E. With the admitted maxima this is 396,544 logical
-# steps per pass; producer plus exact result replay therefore costs at most
-# 793,088.
-MAX_PROFILE_LOGICAL_STEPS = 793_088
+# 512-edge tuple bounds E. Each edge is compared four times: load against
+# capacity and capacity against zero in the kernel loop, capacity against
+# zero in the shared derivative scan, then either load against zero or its
+# ratio against the running congestion maximum. With the admitted maxima
+# this is 397,056 logical steps per pass; producer plus exact result replay
+# therefore costs at most 794,112.
+MAX_PROFILE_LOGICAL_STEPS = 794_112
 MAX_PROFILE_ADDITIONS_PER_PASS = 393_728
 MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
 MAX_PROFILE_DIVISIONS_PER_PASS = 512
-MAX_PROFILE_COMPARISONS_PER_PASS = 2_048
+MAX_PROFILE_COMPARISONS_PER_PASS = 2_560
 MAX_SPARSE_FLOW_ENTRIES = (MAX_COMMODITY_VERTEX_CELLS // 2) * MAX_MULTICOMMODITY_EDGES
 
 
@@ -243,6 +246,49 @@ def _measured_side_bounds(value: Fraction) -> tuple[int, int]:
     return sides
 
 
+def _edge_slacks_and_max_congestion(
+    flow: MulticommodityFlow,
+    loads: dict[tuple[int, int], Fraction],
+) -> tuple[dict[tuple[int, int], Fraction], Fraction]:
+    """Return each exact edge slack and the maximum positive-capacity ratio.
+
+    Every slack is subtracted here exactly once and every positive-capacity
+    congestion ratio divided exactly once, so the profile kernel reuses these
+    measured components instead of repeating that arithmetic in its own edge
+    loop.
+    """
+
+    slacks: dict[tuple[int, int], Fraction] = {}
+    max_ratio = Fraction(0)
+    for edge in flow.network.edges:
+        edge_key = (edge.source, edge.target)
+        capacity = edge.capacity.as_fraction()
+        slacks[edge_key] = capacity - loads[edge_key]
+        if capacity > 0:
+            max_ratio = max(max_ratio, loads[edge_key] / capacity)
+    return slacks, max_ratio
+
+
+def _measured_component_digit_bounds(
+    divergences: dict[tuple[str, int], Fraction],
+    loads: dict[tuple[int, int], Fraction],
+    slacks: dict[tuple[int, int], Fraction],
+    max_ratio: Fraction,
+) -> tuple[
+    dict[tuple[str, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    tuple[int, int],
+]:
+    cell_bounds = {
+        key: _measured_side_bounds(value) for key, value in divergences.items()
+    }
+    load_bounds = {key: _measured_side_bounds(value) for key, value in loads.items()}
+    slack_bounds = {key: _measured_side_bounds(value) for key, value in slacks.items()}
+    congestion_bound = _measured_side_bounds(max_ratio)
+    return cell_bounds, load_bounds, slack_bounds, congestion_bound
+
+
 def _profile_component_digit_bounds(
     flow: MulticommodityFlow,
     component_sums: tuple[
@@ -267,38 +313,32 @@ def _profile_component_digit_bounds(
     divergences, loads = (
         component_sums if component_sums is not None else (_component_sums(flow))
     )
-
-    cell_bounds = {
-        key: _measured_side_bounds(value) for key, value in divergences.items()
-    }
-    load_bounds = {key: _measured_side_bounds(value) for key, value in loads.items()}
-    slack_bounds: dict[tuple[int, int], tuple[int, int]] = {}
-    max_ratio = Fraction(0)
-    for edge in flow.network.edges:
-        edge_key = (edge.source, edge.target)
-        capacity = edge.capacity.as_fraction()
-        slack_bounds[edge_key] = _measured_side_bounds(capacity - loads[edge_key])
-        if capacity > 0:
-            max_ratio = max(max_ratio, loads[edge_key] / capacity)
-    congestion_bound = _measured_side_bounds(max_ratio)
-    return cell_bounds, load_bounds, slack_bounds, congestion_bound
+    slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
+    return _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
 
 
 def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
     """Return the exact digit bound shared by every derived profile component."""
 
-    return derived_profile_digit_budget_from_sums(flow, *_component_sums(flow))
+    return derived_profile_components_from_sums(flow, *_component_sums(flow))[0]
 
 
-def derived_profile_digit_budget_from_sums(
+def derived_profile_components_from_sums(
     flow: MulticommodityFlow,
     divergences: dict[tuple[str, int], Fraction],
     loads: dict[tuple[int, int], Fraction],
-) -> int:
-    """Return the shared digit budget from already-computed component sums."""
+) -> tuple[int, dict[tuple[int, int], Fraction], Fraction]:
+    """Return the shared digit budget with each once-computed edge derivative.
 
+    The returned slacks and maximum congestion ratio are the same measured
+    components priced into the budget, so one producer or replay pass
+    subtracts each slack and divides each positive-capacity ratio exactly
+    once and the work ledger charges that single execution.
+    """
+
+    slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
     cell_bounds, load_bounds, slack_bounds, congestion_bound = (
-        _profile_component_digit_bounds(flow, (divergences, loads))
+        _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
     )
     component_sides = [
         *cell_bounds.values(),
@@ -306,7 +346,7 @@ def derived_profile_digit_budget_from_sums(
         *slack_bounds.values(),
         congestion_bound,
     ]
-    return max(max(sides) for sides in component_sides)
+    return max(max(sides) for sides in component_sides), slacks, max_ratio
 
 
 def _require_profile_output_admission(flow: MulticommodityFlow) -> None:

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Self
 
 from pydantic import Field, StrictStr, model_validator
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
-from jacobian.canonical import encode_strict_json
+from jacobian.canonical import encode_strict_json, format_canonical_integer
 from jacobian.math.graphs.flow._models import FlowGraph
 
 # This operation scans a sparse commodity-by-edge tensor and materializes one
@@ -27,24 +28,16 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # reach it: a divergence cell sums the amounts incident to one
 # commodity/vertex pair, an edge load sums the amounts carried by that edge, a
 # slack subtracts one capacity from one such load, and the congestion ratio
-# divides one load by one capacity.  Numerator and denominator growth are
-# tracked separately: a reduced sum denominator divides the operand lcm and
-# so accumulates each operand's denominator digits once; a reduced sum
-# numerator adds at most its largest operand numerator on top of that common
-# denominator plus eight carry digits for up to 256 accumulated endpoints;
-# the slack subtraction pushes the numerator through both denominators once
-# and adds one carry digit; and the division crosses the load with the
-# capacity numerator only.  A component fed by a single operand equals that
-# already-canonical operand exactly, so its own two sides are its bounds and
-# no summation growth is charged; when that lone amount also equals the edge
-# capacity, the slack is the exact zero rational and the congestion ratio is
-# exactly one.  An edge carrying no amount has the exact zero load, so only
-# single-digit zero operands compose with its capacity.  A component stays
-# admissible when each side of this split bound fits the canonical cap on
-# its own.  Demands take part only in exact conservation comparisons, never
-# in arithmetic, so they are covered by the measured source echo instead of
-# these budgets.
-_DERIVED_DIGIT_SLACK = 8
+# divides one load by one capacity.  Summation growth cannot be bounded from
+# digit counts alone — shared denominators, cancellation, and lone operands
+# all keep components far smaller than any worst case — so admission measures
+# the actual reduced numerator and denominator of every component with a pure
+# bounded scan that aborts as soon as a side crosses the canonical cap.  A
+# request whose exact load equals its capacity therefore reports the exact
+# zero slack and exactly-one congestion instead of phantom growth, while a
+# request whose sums genuinely exceed the cap fails closed.  Demands take
+# part only in exact conservation comparisons, never in arithmetic, so they
+# are covered by the measured source echo instead of these budgets.
 
 # A result echoes its source tensor, then includes one divergence row per
 # commodity-vertex cell, one edge row per network edge, and one congestion
@@ -177,6 +170,28 @@ def _require_canonical_entries(
             raise ValueError("flow entry references an undeclared directed edge")
 
 
+def _rational_side_bounds(value: Fraction) -> tuple[int, int]:
+    return len(format_canonical_integer(abs(value.numerator))), len(
+        format_canonical_integer(value.denominator)
+    )
+
+
+def _require_side_within_cap(digits: int) -> None:
+    if digits > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise ValueError(
+            "multicommodity-flow profile derives a "
+            f"{digits}-digit rational above the "
+            f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit canonical cap"
+        )
+
+
+def _measured_side_bounds(value: Fraction) -> tuple[int, int]:
+    sides = _rational_side_bounds(value)
+    _require_side_within_cap(sides[0])
+    _require_side_within_cap(sides[1])
+    return sides
+
+
 def _profile_component_digit_bounds(
     flow: MulticommodityFlow,
 ) -> tuple[
@@ -185,83 +200,49 @@ def _profile_component_digit_bounds(
     dict[tuple[int, int], tuple[int, int]],
     tuple[int, int],
 ]:
-    """Return exact numerator/denominator digit bounds for derived rows."""
+    """Measure the exact numerator/denominator sizes of every derived row.
 
-    cell_den: dict[tuple[str, int], int] = {}
-    cell_num: dict[tuple[str, int], int] = {}
-    cell_operands: dict[tuple[str, int], int] = {}
-    edge_den: dict[tuple[int, int], int] = {}
-    edge_num: dict[tuple[int, int], int] = {}
-    edge_operands: dict[tuple[int, int], int] = {}
-    edge_sole_amount: dict[tuple[int, int], CanonicalRational] = {}
+    Shared denominators, cancellation, and lone operands all keep real sums
+    far below any digit-count worst case, so each component is measured as
+    the exact reduced rational the kernel will produce; any accumulation that
+    crosses the canonical cap aborts immediately instead of growing further.
+    """
+
+    divergences = {
+        (commodity.commodity_id, vertex): Fraction(0)
+        for commodity in flow.commodities
+        for vertex in range(flow.network.vertex_count)
+    }
+    loads = {(edge.source, edge.target): Fraction(0) for edge in flow.network.edges}
+
+    def _absorb(current: Fraction, amount: Fraction) -> Fraction:
+        total = current + amount
+        for digits in _rational_side_bounds(total):
+            _require_side_within_cap(digits)
+        return total
+
     for entry in flow.entries:
-        amount_num = len(entry.amount.num)
-        amount_den = len(entry.amount.den)
+        amount = entry.amount.as_fraction()
+        source_key = (entry.commodity_id, entry.source)
+        target_key = (entry.commodity_id, entry.target)
+        divergences[source_key] = _absorb(divergences[source_key], amount)
+        divergences[target_key] = _absorb(divergences[target_key], -amount)
         edge_key = (entry.source, entry.target)
-        edge_den[edge_key] = edge_den.get(edge_key, 0) + amount_den
-        edge_num[edge_key] = max(edge_num.get(edge_key, 0), amount_num)
-        edge_operands[edge_key] = edge_operands.get(edge_key, 0) + 1
-        edge_sole_amount.setdefault(edge_key, entry.amount)
-        for vertex in (entry.source, entry.target):
-            cell_key = (entry.commodity_id, vertex)
-            cell_den[cell_key] = cell_den.get(cell_key, 0) + amount_den
-            cell_num[cell_key] = max(cell_num.get(cell_key, 0), amount_num)
-            cell_operands[cell_key] = cell_operands.get(cell_key, 0) + 1
+        loads[edge_key] = _absorb(loads[edge_key], amount)
 
-    def _sum_bound(operand_count: int, den_total: int, max_num: int) -> tuple[int, int]:
-        # One operand is its own reduced sum: the component equals that
-        # already-canonical operand and charges no summation growth.
-        if operand_count == 1:
-            return max_num, den_total
-        return den_total + max_num + _DERIVED_DIGIT_SLACK, den_total
-
-    cell_bounds: dict[tuple[str, int], tuple[int, int]] = {}
-    for commodity in flow.commodities:
-        for vertex in range(flow.network.vertex_count):
-            key = (commodity.commodity_id, vertex)
-            if key in cell_den:
-                cell_bounds[key] = _sum_bound(
-                    cell_operands[key], cell_den[key], cell_num[key]
-                )
-            else:
-                cell_bounds[key] = (1, 1)
-
-    load_bounds: dict[tuple[int, int], tuple[int, int]] = {}
+    cell_bounds = {
+        key: _rational_side_bounds(value) for key, value in divergences.items()
+    }
+    load_bounds = {key: _rational_side_bounds(value) for key, value in loads.items()}
     slack_bounds: dict[tuple[int, int], tuple[int, int]] = {}
-    congestion_bound = (1, 1)
+    max_ratio = Fraction(0)
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
-        capacity_num = len(edge.capacity.num)
-        capacity_den = len(edge.capacity.den)
-        den_total = edge_den.get(edge_key)
-        if den_total is None:
-            # No amount reaches this edge: its load is exactly the zero
-            # rational, its slack is exactly its capacity, and its congestion
-            # ratio reduces to exactly zero.
-            load_bounds[edge_key] = (1, 1)
-            slack_bounds[edge_key] = (capacity_num, capacity_den)
-            continue
-        load_n, load_d = _sum_bound(
-            edge_operands[edge_key], den_total, edge_num[edge_key]
-        )
-        if edge_operands[edge_key] == 1 and edge_sole_amount[edge_key] == edge.capacity:
-            # The lone amount equals the capacity exactly: the load is the
-            # capacity, the slack is the exact zero rational, and the
-            # congestion ratio reduces to exactly one.
-            load_bounds[edge_key] = (load_n, load_d)
-            slack_bounds[edge_key] = (1, 1)
-            continue
-        slack_n = max(capacity_num + den_total, load_n + capacity_den) + 1
-        slack_d = capacity_den + den_total
-        load_bounds[edge_key] = (load_n, load_d)
-        slack_bounds[edge_key] = (slack_n, slack_d)
-        # The ratio divides one load by one capacity: cross-multiplication
-        # grows the ratio numerator by the capacity denominator and the ratio
-        # denominator by the capacity numerator.
-        congestion_bound = (
-            max(congestion_bound[0], load_n + capacity_den),
-            max(congestion_bound[1], den_total + capacity_num),
-        )
+        capacity = edge.capacity.as_fraction()
+        slack_bounds[edge_key] = _measured_side_bounds(capacity - loads[edge_key])
+        if capacity > 0:
+            max_ratio = max(max_ratio, loads[edge_key] / capacity)
+    congestion_bound = _measured_side_bounds(max_ratio)
     return cell_bounds, load_bounds, slack_bounds, congestion_bound
 
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -170,6 +170,30 @@ def _require_canonical_entries(
             raise ValueError("flow entry references an undeclared directed edge")
 
 
+def _component_sums(
+    flow: MulticommodityFlow,
+) -> tuple[dict[tuple[str, int], Fraction], dict[tuple[int, int], Fraction]]:
+    """Return the exact divergence-cell and edge-load sums for one tensor.
+
+    Accumulation order is irrelevant to admission: partial sums may grow
+    arbitrarily and later cancel, so the canonical cap is applied only to the
+    completed reduced components.
+    """
+
+    divergences = {
+        (commodity.commodity_id, vertex): Fraction(0)
+        for commodity in flow.commodities
+        for vertex in range(flow.network.vertex_count)
+    }
+    loads = {(edge.source, edge.target): Fraction(0) for edge in flow.network.edges}
+    for entry in flow.entries:
+        amount = entry.amount.as_fraction()
+        divergences[(entry.commodity_id, entry.source)] += amount
+        divergences[(entry.commodity_id, entry.target)] -= amount
+        loads[(entry.source, entry.target)] += amount
+    return divergences, loads
+
+
 def _rational_side_bounds(value: Fraction) -> tuple[int, int]:
     return len(format_canonical_integer(abs(value.numerator))), len(
         format_canonical_integer(value.denominator)
@@ -194,6 +218,11 @@ def _measured_side_bounds(value: Fraction) -> tuple[int, int]:
 
 def _profile_component_digit_bounds(
     flow: MulticommodityFlow,
+    component_sums: tuple[
+        dict[tuple[str, int], Fraction],
+        dict[tuple[int, int], Fraction],
+    ]
+    | None = None,
 ) -> tuple[
     dict[tuple[str, int], tuple[int, int]],
     dict[tuple[int, int], tuple[int, int]],
@@ -208,27 +237,9 @@ def _profile_component_digit_bounds(
     crosses the canonical cap aborts immediately instead of growing further.
     """
 
-    divergences = {
-        (commodity.commodity_id, vertex): Fraction(0)
-        for commodity in flow.commodities
-        for vertex in range(flow.network.vertex_count)
-    }
-    loads = {(edge.source, edge.target): Fraction(0) for edge in flow.network.edges}
-
-    def _absorb(current: Fraction, amount: Fraction) -> Fraction:
-        total = current + amount
-        for digits in _rational_side_bounds(total):
-            _require_side_within_cap(digits)
-        return total
-
-    for entry in flow.entries:
-        amount = entry.amount.as_fraction()
-        source_key = (entry.commodity_id, entry.source)
-        target_key = (entry.commodity_id, entry.target)
-        divergences[source_key] = _absorb(divergences[source_key], amount)
-        divergences[target_key] = _absorb(divergences[target_key], -amount)
-        edge_key = (entry.source, entry.target)
-        loads[edge_key] = _absorb(loads[edge_key], amount)
+    divergences, loads = (
+        component_sums if component_sums is not None else (_component_sums(flow))
+    )
 
     cell_bounds = {
         key: _rational_side_bounds(value) for key, value in divergences.items()
@@ -249,8 +260,18 @@ def _profile_component_digit_bounds(
 def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
     """Return the exact digit bound shared by every derived profile component."""
 
+    return derived_profile_digit_budget_from_sums(flow, *_component_sums(flow))
+
+
+def derived_profile_digit_budget_from_sums(
+    flow: MulticommodityFlow,
+    divergences: dict[tuple[str, int], Fraction],
+    loads: dict[tuple[int, int], Fraction],
+) -> int:
+    """Return the shared digit budget from already-computed component sums."""
+
     cell_bounds, load_bounds, slack_bounds, congestion_bound = (
-        _profile_component_digit_bounds(flow)
+        _profile_component_digit_bounds(flow, (divergences, loads))
     )
     component_sides = [
         *cell_bounds.values(),
@@ -259,19 +280,6 @@ def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
         congestion_bound,
     ]
     return max(max(sides) for sides in component_sides)
-
-
-def _require_derived_digit_budget(flow: MulticommodityFlow) -> int:
-    """Reject operands whose implied profile cannot remain a canonical value."""
-
-    budget = derived_profile_digit_budget(flow)
-    if budget > MAX_CANONICAL_RATIONAL_DIGITS:
-        raise ValueError(
-            "multicommodity-flow arithmetic operands imply a "
-            f"{budget}-digit derived-profile bound above the "
-            f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit canonical cap"
-        )
-    return budget
 
 
 def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
@@ -357,7 +365,6 @@ class MulticommodityFlow(StrictModel):
             edge_keys=edge_keys,
             commodity_ids=commodity_ids,
         )
-        _require_derived_digit_budget(self)
         _require_profile_output_admission(self)
         return self
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -15,11 +15,11 @@ from jacobian.math.graphs.flow._models import FlowGraph
 # divergence value for every commodity/vertex pair.  Vertex count and edge
 # count are owned by FlowGraph; admission controls the dense divergence table
 # through the commodity-vertex cell budget, the sparse tensor through the
-# entry and commodity-edge cell budgets, and the whole returned value through
-# the aggregate result envelope below.  The commodity count is bounded by
-# those same derived quantities rather than an independent fixed ceiling.
+# entry budget, and the whole returned value through the aggregate result
+# envelope below.  Commodity and edge counts are never capped independently:
+# the kernel consumes sparse entries and per-edge sums rather than a dense
+# commodity-by-edge tensor.
 MAX_MULTICOMMODITY_EDGES = 512
-MAX_COMMODITY_EDGE_CELLS = 2_048
 MAX_COMMODITY_VERTEX_CELLS = 512
 MAX_SPARSE_FLOW_ENTRIES = 128
 
@@ -136,10 +136,6 @@ def _require_canonical_commodities(
             and commodity.sink < network.vertex_count
         ):
             raise ValueError("commodity terminals must be in 0..network.vertex_count-1")
-    if len(commodities) * len(network.edges) > MAX_COMMODITY_EDGE_CELLS:
-        raise ValueError(
-            f"commodity-by-edge cell count exceeds {MAX_COMMODITY_EDGE_CELLS}"
-        )
     if len(commodities) * network.vertex_count > MAX_COMMODITY_VERTEX_CELLS:
         raise ValueError(
             "commodity-by-vertex divergence cell count exceeds "
@@ -338,12 +334,11 @@ class MulticommodityFlowProfileRequest(StrictModel):
     flow: MulticommodityFlow = Field(
         description=(
             "Canonical sparse tensor bounded by derived quantities: at most "
-            "2,048 conceptual commodity-edge cells, 512 returned "
-            "commodity-vertex cells (hence at most 256 commodities), at most "
-            "the 512 network edges FlowGraph itself admits, 128 nonzero "
-            "entries, a per-component exact digit budget derived from each "
-            "component's own operands, and an admitted aggregate result "
-            "envelope below 8 MiB."
+            "512 returned commodity-vertex cells (hence at most 256 "
+            "commodities), at most the 512 network edges FlowGraph itself "
+            "admits, 128 nonzero entries, a per-component exact digit budget "
+            "derived from each component's own operands, and an admitted "
+            "aggregate result envelope below 8 MiB."
         )
     )
 
@@ -429,7 +424,6 @@ class MulticommodityFlowProfileResult(StrictModel):
 
 
 __all__ = [
-    "MAX_COMMODITY_EDGE_CELLS",
     "MAX_COMMODITY_VERTEX_CELLS",
     "MAX_MULTICOMMODITY_EDGES",
     "MAX_PROFILE_ADDITIONS_PER_PASS",

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -1,0 +1,383 @@
+"""Canonical values and source-bound profiles for exact multicommodity flow."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, StrictStr, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel
+from jacobian.canonical import encode_strict_json
+from jacobian.math.graphs.flow._models import FlowGraph
+
+# This operation scans a sparse commodity-by-edge tensor and materializes one
+# divergence value for every commodity/vertex pair.  The bounds are deliberately
+# independent: a dense tensor has K*E cells, while the returned divergence table
+# has K*V cells.  The sparse payload itself is capped separately.
+MAX_MULTICOMMODITY_VERTICES = 32
+MAX_MULTICOMMODITY_EDGES = 128
+MAX_MULTICOMMODITIES = 16
+MAX_COMMODITY_EDGE_CELLS = 2_048
+MAX_COMMODITY_VERTEX_CELLS = 512
+MAX_SPARSE_FLOW_ENTRIES = 128
+MAX_FLOW_RATIONAL_DIGITS = 32
+
+# A load or divergence can sum at most 128 reduced 32-digit rationals. Before
+# reduction, one common denominator has at most 128*32 digits; the sum and one
+# capacity subtraction add at most three decimal digits, and a congestion ratio
+# multiplies one further 32-digit capacity component. 4,132 is therefore a
+# conservative strict bound below CanonicalRational's global 32,768-digit cap.
+MAX_PROFILE_RATIONAL_DIGITS = 4_132
+
+# A result echoes its source tensor, then includes at most 512 divergence rows
+# and 128 edge rows. A derived rational can occupy at most 2*d+24 canonical
+# JSON bytes for d decimal digits; the conservative row overhead reserves ASCII
+# keys, labels, separators, and vertices. At the declared maxima this estimate
+# is below 6.6 MiB, leaving explicit headroom under the 10 MiB transport limit.
+MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
+_DERIVED_RATIONAL_WIRE_BYTES = 2 * MAX_PROFILE_RATIONAL_DIGITS + 24
+_DIVERGENCE_ROW_OVERHEAD_BYTES = 128
+_EDGE_ROW_OVERHEAD_BYTES = 128
+_PROFILE_RESULT_HEADER_BYTES = 1_024
+
+# One pass performs at most 3F+E additions/subtractions, K negations, E
+# divisions, and K*V+3E comparisons. With the admitted maxima this is 1,552
+# logical steps; producer plus exact result replay therefore costs at most 3,104.
+MAX_PROFILE_LOGICAL_STEPS = 3_104
+MAX_PROFILE_ADDITIONS_PER_PASS = 512
+MAX_PROFILE_NEGATIONS_PER_PASS = 16
+MAX_PROFILE_DIVISIONS_PER_PASS = 128
+MAX_PROFILE_COMPARISONS_PER_PASS = 896
+
+
+def _require_flow_rational(value: CanonicalRational, label: str) -> None:
+    require_bounded_rational(
+        value,
+        max_digits=MAX_FLOW_RATIONAL_DIGITS,
+        label=label,
+    )
+
+
+class CommodityDemand(StrictModel):
+    """One labelled source-to-sink demand in a directed capacitated network."""
+
+    commodity_id: StrictStr = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z][A-Za-z0-9_.-]*$",
+        description=(
+            "Stable ASCII label for this commodity. Commodity tuples are sorted "
+            "lexicographically by this field."
+        ),
+    )
+    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    sink: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    demand: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_distinct_positive_terminals(self) -> Self:
+        if self.source == self.sink:
+            raise ValueError("commodity source and sink must be distinct")
+        if self.demand.as_fraction() <= 0:
+            raise ValueError("commodity demand must be strictly positive")
+        _require_flow_rational(self.demand, "commodity demand")
+        return self
+
+
+class CommodityEdgeFlow(StrictModel):
+    """One positive sparse entry of a commodity-by-directed-edge flow tensor."""
+
+    commodity_id: StrictStr = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z][A-Za-z0-9_.-]*$",
+    )
+    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    amount: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_positive_bounded_amount(self) -> Self:
+        if self.amount.as_fraction() <= 0:
+            raise ValueError("sparse flow entries must have strictly positive amounts")
+        _require_flow_rational(self.amount, "flow amount")
+        return self
+
+
+def _require_canonical_network(network: FlowGraph) -> tuple[tuple[int, int], ...]:
+    if network.vertex_count > MAX_MULTICOMMODITY_VERTICES:
+        raise ValueError(
+            "multicommodity flow networks may have at most "
+            f"{MAX_MULTICOMMODITY_VERTICES} vertices"
+        )
+    if len(network.edges) > MAX_MULTICOMMODITY_EDGES:
+        raise ValueError(
+            "multicommodity flow networks may have at most "
+            f"{MAX_MULTICOMMODITY_EDGES} edges"
+        )
+    edge_keys = tuple((edge.source, edge.target) for edge in network.edges)
+    if edge_keys != tuple(sorted(edge_keys)):
+        raise ValueError("network edges must be sorted by (source, target)")
+    for edge in network.edges:
+        _require_flow_rational(edge.capacity, "network capacity")
+    return edge_keys
+
+
+def _require_canonical_commodities(
+    network: FlowGraph,
+    commodities: tuple[CommodityDemand, ...],
+) -> tuple[str, ...]:
+    commodity_ids = tuple(commodity.commodity_id for commodity in commodities)
+    if commodity_ids != tuple(sorted(commodity_ids)):
+        raise ValueError("commodities must be sorted by commodity_id")
+    if len(set(commodity_ids)) != len(commodity_ids):
+        raise ValueError("commodity IDs must be unique")
+    for commodity in commodities:
+        if not (
+            commodity.source < network.vertex_count
+            and commodity.sink < network.vertex_count
+        ):
+            raise ValueError("commodity terminals must be in 0..network.vertex_count-1")
+    if len(commodities) * len(network.edges) > MAX_COMMODITY_EDGE_CELLS:
+        raise ValueError(
+            f"commodity-by-edge cell count exceeds {MAX_COMMODITY_EDGE_CELLS}"
+        )
+    if len(commodities) * network.vertex_count > MAX_COMMODITY_VERTEX_CELLS:
+        raise ValueError(
+            "commodity-by-vertex divergence cell count exceeds "
+            f"{MAX_COMMODITY_VERTEX_CELLS}"
+        )
+    return commodity_ids
+
+
+def _require_canonical_entries(
+    entries: tuple[CommodityEdgeFlow, ...],
+    *,
+    edge_keys: tuple[tuple[int, int], ...],
+    commodity_ids: tuple[str, ...],
+) -> None:
+    entry_keys = tuple(
+        (entry.commodity_id, entry.source, entry.target) for entry in entries
+    )
+    if entry_keys != tuple(sorted(entry_keys)):
+        raise ValueError(
+            "flow entries must be sorted by (commodity_id, source, target)"
+        )
+    if len(set(entry_keys)) != len(entry_keys):
+        raise ValueError("each commodity-by-edge flow entry may occur once")
+    declared_edges = set(edge_keys)
+    declared_commodities = set(commodity_ids)
+    for entry in entries:
+        if entry.commodity_id not in declared_commodities:
+            raise ValueError("flow entry references an undeclared commodity")
+        if (entry.source, entry.target) not in declared_edges:
+            raise ValueError("flow entry references an undeclared directed edge")
+
+
+def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
+    source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
+    divergence_bytes = (
+        len(flow.commodities)
+        * flow.network.vertex_count
+        * (_DERIVED_RATIONAL_WIRE_BYTES + _DIVERGENCE_ROW_OVERHEAD_BYTES)
+    )
+    edge_bytes = len(flow.network.edges) * (
+        2 * _DERIVED_RATIONAL_WIRE_BYTES + _EDGE_ROW_OVERHEAD_BYTES
+    )
+    estimated_bytes = (
+        source_bytes + divergence_bytes + edge_bytes + _PROFILE_RESULT_HEADER_BYTES
+    )
+    if estimated_bytes > MAX_PROFILE_RESULT_BYTES:
+        raise ValueError(
+            "multicommodity-flow profile result would exceed the "
+            f"{MAX_PROFILE_RESULT_BYTES}-byte aggregate result bound"
+        )
+
+
+class MulticommodityFlow(StrictModel):
+    """A canonical sparse exact commodity-by-edge tensor over one FlowGraph.
+
+    Every omitted tensor cell denotes exact zero.  Graph edges, commodities, and
+    nonzero tensor entries are sorted so the value has one JSON representation.
+    The source network and demand tuple remain attached to the tensor, allowing
+    downstream operations to consume this value without reconstructing context.
+    """
+
+    network: FlowGraph = Field(
+        description=(
+            "Directed capacitated network. Its edges must be sorted by "
+            "(source, target) for this canonical multicommodity-flow value."
+        )
+    )
+    commodities: tuple[CommodityDemand, ...] = Field(
+        min_length=1,
+        max_length=MAX_MULTICOMMODITIES,
+        description=(
+            "Distinct commodity records sorted lexicographically by commodity_id."
+        ),
+    )
+    entries: tuple[CommodityEdgeFlow, ...] = Field(
+        default=(),
+        max_length=MAX_SPARSE_FLOW_ENTRIES,
+        description=(
+            "Nonzero tensor entries sorted by (commodity_id, source, target); "
+            "omitted entries are exact zero."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_tensor(self) -> Self:
+        edge_keys = _require_canonical_network(self.network)
+        commodity_ids = _require_canonical_commodities(self.network, self.commodities)
+        _require_canonical_entries(
+            self.entries,
+            edge_keys=edge_keys,
+            commodity_ids=commodity_ids,
+        )
+        _require_profile_output_admission(self)
+        return self
+
+
+class MulticommodityFlowProfileRequest(StrictModel):
+    """Compute one exact conservation, load, slack, and congestion profile."""
+
+    flow: MulticommodityFlow = Field(
+        description=(
+            "Canonical sparse tensor with at most 16 commodities, 128 nonzero "
+            "entries, 2,048 conceptual commodity-edge cells, 512 returned "
+            "commodity-vertex cells, 32-digit input rationals, and an admitted "
+            "aggregate result envelope below 8 MiB."
+        )
+    )
+
+
+class CommodityDivergence(StrictModel):
+    """The exact outgoing-minus-incoming flow for one commodity at one vertex."""
+
+    commodity_id: StrictStr
+    vertex: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    divergence: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_divergence(self) -> Self:
+        require_bounded_rational(
+            self.divergence,
+            max_digits=MAX_PROFILE_RATIONAL_DIGITS,
+            label="derived multicommodity-flow divergence",
+        )
+        return self
+
+
+class EdgeLoadProfile(StrictModel):
+    """Exact aggregate load and signed capacity slack for one directed edge."""
+
+    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    target: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    load: CanonicalRational
+    slack: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_bounded_profile_values(self) -> Self:
+        for value, label in ((self.load, "load"), (self.slack, "slack")):
+            require_bounded_rational(
+                value,
+                max_digits=MAX_PROFILE_RATIONAL_DIGITS,
+                label=f"derived multicommodity-flow {label}",
+            )
+        return self
+
+
+class MulticommodityFlowProfileWork(StrictModel):
+    """Exact finite accounting for producer and source-bound result replay."""
+
+    execution_passes_per_call: int = Field(ge=2, le=2)
+    sparse_entries: int = Field(ge=0, le=MAX_SPARSE_FLOW_ENTRIES)
+    commodity_vertex_cells: int = Field(ge=1, le=MAX_COMMODITY_VERTEX_CELLS)
+    edge_cells: int = Field(ge=1, le=MAX_MULTICOMMODITY_EDGES)
+    rational_additions_per_pass: int = Field(ge=0, le=MAX_PROFILE_ADDITIONS_PER_PASS)
+    rational_negations_per_pass: int = Field(ge=0, le=MAX_PROFILE_NEGATIONS_PER_PASS)
+    rational_divisions_per_pass: int = Field(ge=0, le=MAX_PROFILE_DIVISIONS_PER_PASS)
+    exact_comparisons_per_pass: int = Field(ge=0, le=MAX_PROFILE_COMPARISONS_PER_PASS)
+    logical_steps_per_call: int = Field(ge=0, le=MAX_PROFILE_LOGICAL_STEPS)
+
+
+class MulticommodityFlowProfileResult(StrictModel):
+    """A complete exact source-bound profile of a multicommodity flow tensor."""
+
+    flow: MulticommodityFlow
+    divergences: tuple[CommodityDivergence, ...] = Field(
+        min_length=1,
+        max_length=MAX_COMMODITY_VERTEX_CELLS,
+        description=(
+            "Dense rows sorted by (commodity_id, vertex), including exact zero "
+            "divergences."
+        ),
+    )
+    edge_profiles: tuple[EdgeLoadProfile, ...] = Field(
+        min_length=1,
+        max_length=MAX_MULTICOMMODITY_EDGES,
+        description=(
+            "One row per network edge, sorted by (source, target), including "
+            "zero-load edges. Slack is capacity minus aggregate load."
+        ),
+    )
+    all_demands_routed: bool
+    capacity_feasible: bool
+    congestion: CanonicalRational | None = Field(
+        default=None,
+        description=(
+            "max(load/capacity) over positive-capacity edges, or null exactly "
+            "when a zero-capacity edge carries positive load."
+        ),
+    )
+    work: MulticommodityFlowProfileWork
+
+    @model_validator(mode="after")
+    def require_exact_source_bound_profile(self) -> Self:
+        from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
+
+        if self.congestion is not None:
+            require_bounded_rational(
+                self.congestion,
+                max_digits=MAX_PROFILE_RATIONAL_DIGITS,
+                label="derived multicommodity-flow congestion",
+            )
+        expected = profile_components(self.flow)
+        actual = (
+            self.divergences,
+            self.edge_profiles,
+            self.all_demands_routed,
+            self.capacity_feasible,
+            self.congestion,
+            self.work,
+        )
+        if actual != expected:
+            raise ValueError("result must match the exact multicommodity-flow profile")
+        return self
+
+
+__all__ = [
+    "MAX_COMMODITY_EDGE_CELLS",
+    "MAX_COMMODITY_VERTEX_CELLS",
+    "MAX_FLOW_RATIONAL_DIGITS",
+    "MAX_MULTICOMMODITIES",
+    "MAX_MULTICOMMODITY_EDGES",
+    "MAX_MULTICOMMODITY_VERTICES",
+    "MAX_PROFILE_ADDITIONS_PER_PASS",
+    "MAX_PROFILE_COMPARISONS_PER_PASS",
+    "MAX_PROFILE_DIVISIONS_PER_PASS",
+    "MAX_PROFILE_LOGICAL_STEPS",
+    "MAX_PROFILE_NEGATIONS_PER_PASS",
+    "MAX_PROFILE_RATIONAL_DIGITS",
+    "MAX_PROFILE_RESULT_BYTES",
+    "MAX_SPARSE_FLOW_ENTRIES",
+    "CommodityDemand",
+    "CommodityDivergence",
+    "CommodityEdgeFlow",
+    "EdgeLoadProfile",
+    "MulticommodityFlow",
+    "MulticommodityFlowProfileRequest",
+    "MulticommodityFlowProfileResult",
+    "MulticommodityFlowProfileWork",
+]

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from typing import Self
+from typing import NamedTuple, Self
 
-from pydantic import Field, StrictStr, model_validator
+from pydantic import Field, PrivateAttr, StrictStr, model_validator
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
@@ -54,10 +54,11 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # when its own component bounds limit the two sides separately; the
 # conservative row overhead reserves ASCII keys, labels, separators, and
 # vertices. This envelope belongs to the profile operation, not to the
-# canonical tensor value: request parsing validates it completely so every
-# accepted request is admissible before execution, and the kernel prices
-# its result from its own measured components, adding no arithmetic pass
-# of its own and keeping the two-pass work ledger exact.
+# canonical tensor value: request parsing performs the operation's single
+# component scan, admits work and result envelope from it, and hands the
+# measured components to the producer pass, while the replay pass always
+# rescans independently -- so an accepted call executes exactly the two
+# charged passes and the work ledger stays an exact per-call accounting.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
@@ -394,35 +395,39 @@ def _profile_component_digit_bounds(
     return _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
 
 
-def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
-    """Return the exact digit bound shared by every derived profile component."""
+class AdmittedProfileScan(NamedTuple):
+    """The once-computed components of one measured profile scan.
 
-    return derived_profile_components_from_sums(flow, *_component_sums(flow))[0]
+    Request parsing performs this scan, admits work and result envelope
+    from it, and hands it to the producer pass, which otherwise recomputes
+    it; the replay pass always rescans independently. Either way an
+    accepted call executes exactly two arithmetic passes.
+    """
+
+    divergences: dict[tuple[str, int], Fraction]
+    loads: dict[tuple[int, int], Fraction]
+    denominator_folds: int
+    budget: int
+    slacks: dict[tuple[int, int], Fraction]
+    max_congestion_ratio: Fraction
+    cell_bounds: dict[tuple[str, int], tuple[int, int]]
+    load_bounds: dict[tuple[int, int], tuple[int, int]]
+    slack_bounds: dict[tuple[int, int], tuple[int, int]]
+    congestion_bound: tuple[int, int]
 
 
-def derived_profile_components_from_sums(
-    flow: MulticommodityFlow,
-    divergences: dict[tuple[str, int], Fraction],
-    loads: dict[tuple[int, int], Fraction],
-) -> tuple[
-    int,
-    dict[tuple[int, int], Fraction],
-    Fraction,
-    dict[tuple[str, int], tuple[int, int]],
-    dict[tuple[int, int], tuple[int, int]],
-    dict[tuple[int, int], tuple[int, int]],
-    tuple[int, int],
-]:
-    """Return the shared digit budget with each once-computed derivative.
+def measured_profile_components(flow: MulticommodityFlow) -> AdmittedProfileScan:
+    """Run the single bucketed component scan and derive every priced bound.
 
     The returned slacks and maximum congestion ratio are the same measured
     components priced into the budget, so one producer or replay pass
     subtracts each slack and divides each positive-capacity ratio exactly
-    once and the work ledger charges that single execution. The returned
-    per-row bound maps are those same measurements, letting envelope
-    admission price the result without any second arithmetic pass.
+    once and the work ledger charges that single execution. The per-row
+    bound maps are those same measurements, letting envelope admission
+    price the result without any second arithmetic pass.
     """
 
+    divergences, loads, denominator_folds = _component_sums_with_folds(flow)
     slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
     cell_bounds, load_bounds, slack_bounds, congestion_bound = (
         _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
@@ -433,16 +438,46 @@ def derived_profile_components_from_sums(
         *slack_bounds.values(),
         congestion_bound,
     ]
-    budget = max(max(sides) for sides in component_sides)
-    return (
-        budget,
-        slacks,
-        max_ratio,
-        cell_bounds,
-        load_bounds,
-        slack_bounds,
-        congestion_bound,
+    return AdmittedProfileScan(
+        divergences=divergences,
+        loads=loads,
+        denominator_folds=denominator_folds,
+        budget=max(max(sides) for sides in component_sides),
+        slacks=slacks,
+        max_congestion_ratio=max_ratio,
+        cell_bounds=cell_bounds,
+        load_bounds=load_bounds,
+        slack_bounds=slack_bounds,
+        congestion_bound=congestion_bound,
     )
+
+
+def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
+    """Return the exact digit bound shared by every derived profile component."""
+
+    return measured_profile_components(flow).budget
+
+
+def _require_profile_output_admission(flow: MulticommodityFlow) -> AdmittedProfileScan:
+    """Admit the profile envelope and return its once-computed components.
+
+    Request parsing runs this complete mathematical validation so every
+    accepted ``math.run`` request reaches the kernel guaranteed admissible,
+    and native callers get the same typed rejection before any result
+    construction. The returned scan is reused as the producer pass, so an
+    accepted call executes exactly the two charged passes.
+    """
+
+    _require_profile_source_room(flow)
+    scan = measured_profile_components(flow)
+    _require_admitted_profile_rows(
+        flow,
+        scan.cell_bounds,
+        scan.load_bounds,
+        scan.slack_bounds,
+        scan.congestion_bound,
+    )
+    return scan
 
 
 def _require_profile_source_room(flow: MulticommodityFlow) -> None:
@@ -529,26 +564,6 @@ def _require_admitted_profile_rows(
         )
 
 
-def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
-    """Reject tensors whose derived rows or echoed source exceed the envelope.
-
-    Request parsing runs this complete mathematical validation so every
-    accepted ``math.run`` request reaches the kernel guaranteed admissible,
-    and native callers get the same typed rejection before any result
-    construction. The kernel still prices its result from its own measured
-    components, so an accepted request's execution remains exactly the two
-    charged passes.
-    """
-
-    _require_profile_source_room(flow)
-    cell_bounds, load_bounds, slack_bounds, congestion_bound = (
-        _profile_component_digit_bounds(flow)
-    )
-    _require_admitted_profile_rows(
-        flow, cell_bounds, load_bounds, slack_bounds, congestion_bound
-    )
-
-
 class MulticommodityFlow(StrictModel):
     """A canonical sparse exact commodity-by-edge tensor over one FlowGraph.
 
@@ -610,9 +625,11 @@ class MulticommodityFlowProfileRequest(StrictModel):
         )
     )
 
+    _admitted_scan: AdmittedProfileScan | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def require_admitted_profile_work_and_result(self) -> Self:
-        _require_profile_output_admission(self.flow)
+        self._admitted_scan = _require_profile_output_admission(self.flow)
         return self
 
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -6,37 +6,44 @@ from typing import Self
 
 from pydantic import Field, StrictStr, model_validator
 
-from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import encode_strict_json
 from jacobian.math.graphs.flow._models import FlowGraph
 
 # This operation scans a sparse commodity-by-edge tensor and materializes one
-# divergence value for every commodity/vertex pair.  The bounds are deliberately
-# independent: a dense tensor has K*E cells, while the returned divergence table
-# has K*V cells.  The sparse payload itself is capped separately.
-MAX_MULTICOMMODITY_VERTICES = 32
+# divergence value for every commodity/vertex pair.  Vertex count is owned by
+# FlowGraph; admission controls the dense divergence table through the
+# commodity-vertex cell budget, the sparse tensor through the entry and
+# commodity-edge cell budgets, and the whole returned value through the
+# aggregate result envelope below.
 MAX_MULTICOMMODITY_EDGES = 128
 MAX_MULTICOMMODITIES = 16
 MAX_COMMODITY_EDGE_CELLS = 2_048
 MAX_COMMODITY_VERTEX_CELLS = 512
 MAX_SPARSE_FLOW_ENTRIES = 128
-MAX_FLOW_RATIONAL_DIGITS = 32
 
-# A load or divergence can sum at most 128 reduced 32-digit rationals. Before
-# reduction, one common denominator has at most 128*32 digits; the sum and one
-# capacity subtraction add at most three decimal digits, and a congestion ratio
-# multiplies one further 32-digit capacity component. 4,132 is therefore a
-# conservative strict bound below CanonicalRational's global 32,768-digit cap.
-MAX_PROFILE_RATIONAL_DIGITS = 4_132
+# Entry amounts and edge capacities are the only arithmetic operands: every
+# divergence cell and edge load sums a subset of the amounts, every slack
+# subtracts one such sum from one capacity, and the congestion ratio divides
+# one load by one capacity.  Adding one operand to a running sum contributes
+# at most its numerator and denominator digits plus three carry digits, and
+# the slack subtraction and congestion division each compose one further
+# operand, so eight slack digits on top of the totaled operand digits bound
+# every intermediate and derived numerator and denominator exactly.  Demands
+# take part only in exact conservation comparisons, never in arithmetic, so
+# they are covered by the measured source echo instead of this budget.
+_DERIVED_DIGIT_SLACK = 8
 
 # A result echoes its source tensor, then includes at most 512 divergence rows
-# and 128 edge rows. A derived rational can occupy at most 2*d+24 canonical
-# JSON bytes for d decimal digits; the conservative row overhead reserves ASCII
-# keys, labels, separators, and vertices. At the declared maxima this estimate
-# is below 6.6 MiB, leaving explicit headroom under the 10 MiB transport limit.
+# and 128 edge rows. A derived rational occupies at most 2*d+24 canonical JSON
+# bytes when its budget bounds d decimal digits per component; the conservative
+# row overhead reserves ASCII keys, labels, separators, and vertices. Admission
+# measures the echoed source exactly and estimates the derived rows from the
+# request's own digit budget against this aggregate envelope, keeping the
+# serialized result inside the envelope with headroom under the 10 MiB
+# transport limit.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
-_DERIVED_RATIONAL_WIRE_BYTES = 2 * MAX_PROFILE_RATIONAL_DIGITS + 24
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
 _PROFILE_RESULT_HEADER_BYTES = 1_024
@@ -51,14 +58,6 @@ MAX_PROFILE_DIVISIONS_PER_PASS = 128
 MAX_PROFILE_COMPARISONS_PER_PASS = 896
 
 
-def _require_flow_rational(value: CanonicalRational, label: str) -> None:
-    require_bounded_rational(
-        value,
-        max_digits=MAX_FLOW_RATIONAL_DIGITS,
-        label=label,
-    )
-
-
 class CommodityDemand(StrictModel):
     """One labelled source-to-sink demand in a directed capacitated network."""
 
@@ -71,8 +70,8 @@ class CommodityDemand(StrictModel):
             "lexicographically by this field."
         ),
     )
-    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
-    sink: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    source: int = Field(ge=0, le=63)
+    sink: int = Field(ge=0, le=63)
     demand: CanonicalRational
 
     @model_validator(mode="after")
@@ -81,7 +80,6 @@ class CommodityDemand(StrictModel):
             raise ValueError("commodity source and sink must be distinct")
         if self.demand.as_fraction() <= 0:
             raise ValueError("commodity demand must be strictly positive")
-        _require_flow_rational(self.demand, "commodity demand")
         return self
 
 
@@ -93,24 +91,18 @@ class CommodityEdgeFlow(StrictModel):
         max_length=64,
         pattern=r"^[A-Za-z][A-Za-z0-9_.-]*$",
     )
-    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
-    target: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    source: int = Field(ge=0, le=63)
+    target: int = Field(ge=0, le=63)
     amount: CanonicalRational
 
     @model_validator(mode="after")
-    def require_positive_bounded_amount(self) -> Self:
+    def require_positive_amount(self) -> Self:
         if self.amount.as_fraction() <= 0:
             raise ValueError("sparse flow entries must have strictly positive amounts")
-        _require_flow_rational(self.amount, "flow amount")
         return self
 
 
 def _require_canonical_network(network: FlowGraph) -> tuple[tuple[int, int], ...]:
-    if network.vertex_count > MAX_MULTICOMMODITY_VERTICES:
-        raise ValueError(
-            "multicommodity flow networks may have at most "
-            f"{MAX_MULTICOMMODITY_VERTICES} vertices"
-        )
     if len(network.edges) > MAX_MULTICOMMODITY_EDGES:
         raise ValueError(
             "multicommodity flow networks may have at most "
@@ -119,8 +111,6 @@ def _require_canonical_network(network: FlowGraph) -> tuple[tuple[int, int], ...
     edge_keys = tuple((edge.source, edge.target) for edge in network.edges)
     if edge_keys != tuple(sorted(edge_keys)):
         raise ValueError("network edges must be sorted by (source, target)")
-    for edge in network.edges:
-        _require_flow_rational(edge.capacity, "network capacity")
     return edge_keys
 
 
@@ -175,15 +165,45 @@ def _require_canonical_entries(
             raise ValueError("flow entry references an undeclared directed edge")
 
 
-def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
+def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
+    """Return the exact digit bound shared by every derived profile component."""
+
+    return _DERIVED_DIGIT_SLACK + sum(
+        len(operand.num) + len(operand.den)
+        for operand in (
+            *(entry.amount for entry in flow.entries),
+            *(edge.capacity for edge in flow.network.edges),
+        )
+    )
+
+
+def _require_derived_digit_budget(flow: MulticommodityFlow) -> int:
+    """Reject operands whose implied profile cannot remain a canonical value."""
+
+    budget = derived_profile_digit_budget(flow)
+    if budget > MAX_CANONICAL_RATIONAL_DIGITS:
+        raise ValueError(
+            "multicommodity-flow arithmetic operands imply a "
+            f"{budget}-digit derived-profile bound above the "
+            f"{MAX_CANONICAL_RATIONAL_DIGITS}-digit canonical cap"
+        )
+    return budget
+
+
+def _require_profile_output_admission(
+    flow: MulticommodityFlow,
+    *,
+    digit_budget: int,
+) -> None:
     source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
+    derived_rational_bytes = 2 * digit_budget + 24
     divergence_bytes = (
         len(flow.commodities)
         * flow.network.vertex_count
-        * (_DERIVED_RATIONAL_WIRE_BYTES + _DIVERGENCE_ROW_OVERHEAD_BYTES)
+        * (derived_rational_bytes + _DIVERGENCE_ROW_OVERHEAD_BYTES)
     )
     edge_bytes = len(flow.network.edges) * (
-        2 * _DERIVED_RATIONAL_WIRE_BYTES + _EDGE_ROW_OVERHEAD_BYTES
+        2 * derived_rational_bytes + _EDGE_ROW_OVERHEAD_BYTES
     )
     estimated_bytes = (
         source_bytes + divergence_bytes + edge_bytes + _PROFILE_RESULT_HEADER_BYTES
@@ -235,7 +255,8 @@ class MulticommodityFlow(StrictModel):
             edge_keys=edge_keys,
             commodity_ids=commodity_ids,
         )
-        _require_profile_output_admission(self)
+        digit_budget = _require_derived_digit_budget(self)
+        _require_profile_output_admission(self, digit_budget=digit_budget)
         return self
 
 
@@ -246,8 +267,9 @@ class MulticommodityFlowProfileRequest(StrictModel):
         description=(
             "Canonical sparse tensor with at most 16 commodities, 128 nonzero "
             "entries, 2,048 conceptual commodity-edge cells, 512 returned "
-            "commodity-vertex cells, 32-digit input rationals, and an admitted "
-            "aggregate result envelope below 8 MiB."
+            "commodity-vertex cells, an operand-derived exact digit budget for "
+            "every input and derived rational, and an admitted aggregate "
+            "result envelope below 8 MiB."
         )
     )
 
@@ -256,36 +278,17 @@ class CommodityDivergence(StrictModel):
     """The exact outgoing-minus-incoming flow for one commodity at one vertex."""
 
     commodity_id: StrictStr
-    vertex: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    vertex: int = Field(ge=0, le=63)
     divergence: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_bounded_divergence(self) -> Self:
-        require_bounded_rational(
-            self.divergence,
-            max_digits=MAX_PROFILE_RATIONAL_DIGITS,
-            label="derived multicommodity-flow divergence",
-        )
-        return self
 
 
 class EdgeLoadProfile(StrictModel):
     """Exact aggregate load and signed capacity slack for one directed edge."""
 
-    source: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
-    target: int = Field(ge=0, le=MAX_MULTICOMMODITY_VERTICES - 1)
+    source: int = Field(ge=0, le=63)
+    target: int = Field(ge=0, le=63)
     load: CanonicalRational
     slack: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_bounded_profile_values(self) -> Self:
-        for value, label in ((self.load, "load"), (self.slack, "slack")):
-            require_bounded_rational(
-                value,
-                max_digits=MAX_PROFILE_RATIONAL_DIGITS,
-                label=f"derived multicommodity-flow {label}",
-            )
-        return self
 
 
 class MulticommodityFlowProfileWork(StrictModel):
@@ -337,12 +340,6 @@ class MulticommodityFlowProfileResult(StrictModel):
     def require_exact_source_bound_profile(self) -> Self:
         from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
 
-        if self.congestion is not None:
-            require_bounded_rational(
-                self.congestion,
-                max_digits=MAX_PROFILE_RATIONAL_DIGITS,
-                label="derived multicommodity-flow congestion",
-            )
         expected = profile_components(self.flow)
         actual = (
             self.divergences,
@@ -360,16 +357,13 @@ class MulticommodityFlowProfileResult(StrictModel):
 __all__ = [
     "MAX_COMMODITY_EDGE_CELLS",
     "MAX_COMMODITY_VERTEX_CELLS",
-    "MAX_FLOW_RATIONAL_DIGITS",
     "MAX_MULTICOMMODITIES",
     "MAX_MULTICOMMODITY_EDGES",
-    "MAX_MULTICOMMODITY_VERTICES",
     "MAX_PROFILE_ADDITIONS_PER_PASS",
     "MAX_PROFILE_COMPARISONS_PER_PASS",
     "MAX_PROFILE_DIVISIONS_PER_PASS",
     "MAX_PROFILE_LOGICAL_STEPS",
     "MAX_PROFILE_NEGATIONS_PER_PASS",
-    "MAX_PROFILE_RATIONAL_DIGITS",
     "MAX_PROFILE_RESULT_BYTES",
     "MAX_SPARSE_FLOW_ENTRIES",
     "CommodityDemand",
@@ -380,4 +374,5 @@ __all__ = [
     "MulticommodityFlowProfileRequest",
     "MulticommodityFlowProfileResult",
     "MulticommodityFlowProfileWork",
+    "derived_profile_digit_budget",
 ]

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -14,14 +14,13 @@ from jacobian.math.graphs.flow._models import FlowGraph
 # This operation scans a sparse commodity-by-edge tensor and materializes one
 # divergence value for every commodity/vertex pair.  Vertex count and edge
 # count are owned by FlowGraph; admission controls the dense divergence table
-# through the commodity-vertex cell budget, the sparse tensor through the
-# entry budget, and the whole returned value through the aggregate result
-# envelope below.  Commodity and edge counts are never capped independently:
-# the kernel consumes sparse entries and per-edge sums rather than a dense
-# commodity-by-edge tensor.
+# through the commodity-vertex cell budget and the whole returned value
+# through the aggregate result envelope below.  Commodity, edge, and entry
+# counts are never capped independently: entries are distinct commodity-by-
+# edge cells and the kernel consumes sparse entries and per-edge sums rather
+# than a dense tensor.
 MAX_MULTICOMMODITY_EDGES = 512
 MAX_COMMODITY_VERTEX_CELLS = 512
-MAX_SPARSE_FLOW_ENTRIES = 128
 
 # Entry amounts and edge capacities are the only arithmetic operands, and each
 # derived component is computed independently from only the operands that can
@@ -43,31 +42,37 @@ MAX_SPARSE_FLOW_ENTRIES = 128
 # source echo instead of these budgets.
 _DERIVED_DIGIT_SLACK = 8
 
-# A result echoes its source tensor, then includes at most 512 divergence rows
-# and 128 edge rows. A derived rational occupies at most 2*d+24 canonical JSON
-# bytes when its own component bound limits d decimal digits per component;
-# the conservative row overhead reserves ASCII keys, labels, separators, and
-# vertices. Admission measures the echoed source exactly and prices every
-# divergence row and edge row from its own component's digit bound against
-# this aggregate envelope, keeping the serialized result inside the envelope
-# with headroom under the 10 MiB transport limit.
+# A result echoes its source tensor, then includes one divergence row per
+# commodity-vertex cell, one edge row per network edge, and one congestion
+# value. A derived rational occupies at most num+den+24 canonical JSON bytes
+# when its own component bounds limit the two sides separately; the
+# conservative row overhead reserves ASCII keys, labels, separators, and
+# vertices. Admission measures the echoed source exactly, prices exact-zero
+# loads as the single-digit zero rational, and prices every other row from
+# its own numerator and denominator bounds against this aggregate envelope,
+# keeping the serialized result inside the envelope with headroom under the
+# 10 MiB transport limit.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
+_RATIONAL_JSON_OVERHEAD_BYTES = 24
 _PROFILE_RESULT_HEADER_BYTES = 1_024
 
 # One pass performs at most 3F+E additions/subtractions, K negations, E
-# divisions, and K*V+3E comparisons. Every admitted commodity occupies V >= 2
-# distinct commodity-vertex cells because its source and sink differ, so the
-# 512-cell divergence budget admits at most 256 commodities, one negation
-# each, and FlowGraph's own 512-edge tuple bounds E. With the admitted maxima
-# this is 3,712 logical steps; producer plus exact result replay therefore
-# costs at most 7,424.
-MAX_PROFILE_LOGICAL_STEPS = 7_424
-MAX_PROFILE_ADDITIONS_PER_PASS = 896
+# divisions, and K*V+3E comparisons. Sparse entries are distinct
+# commodity-by-edge cells of the conceptual tensor, so F <= K*E <= 256 * 512.
+# Every admitted commodity occupies V >= 2 distinct commodity-vertex cells
+# because its source and sink differ, so the 512-cell divergence budget
+# admits at most 256 commodities, one negation each, and FlowGraph's own
+# 512-edge tuple bounds E. With the admitted maxima this is 396,544 logical
+# steps per pass; producer plus exact result replay therefore costs at most
+# 793,088.
+MAX_PROFILE_LOGICAL_STEPS = 793_088
+MAX_PROFILE_ADDITIONS_PER_PASS = 393_728
 MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
 MAX_PROFILE_DIVISIONS_PER_PASS = 512
 MAX_PROFILE_COMPARISONS_PER_PASS = 2_048
+MAX_SPARSE_FLOW_ENTRIES = (MAX_COMMODITY_VERTEX_CELLS // 2) * MAX_MULTICOMMODITY_EDGES
 
 
 class CommodityDemand(StrictModel):
@@ -171,11 +176,12 @@ def _require_canonical_entries(
 def _profile_component_digit_bounds(
     flow: MulticommodityFlow,
 ) -> tuple[
-    dict[tuple[str, int], int],
-    dict[tuple[int, int], int],
-    dict[tuple[int, int], int],
+    dict[tuple[str, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    tuple[int, int],
 ]:
-    """Return exact divergence-cell, edge-load, and edge-slack digit bounds."""
+    """Return exact numerator/denominator digit bounds for derived rows."""
 
     cell_den: dict[tuple[str, int], int] = {}
     cell_num: dict[tuple[str, int], int] = {}
@@ -192,54 +198,60 @@ def _profile_component_digit_bounds(
             cell_den[cell_key] = cell_den.get(cell_key, 0) + amount_den
             cell_num[cell_key] = max(cell_num.get(cell_key, 0), amount_num)
 
-    def _sum_bound(den_total: int, max_num: int) -> int:
-        return den_total + max_num + _DERIVED_DIGIT_SLACK
+    def _sum_bound(den_total: int, max_num: int) -> tuple[int, int]:
+        return den_total + max_num + _DERIVED_DIGIT_SLACK, den_total
 
-    cell_bounds: dict[tuple[str, int], int] = {}
+    cell_bounds: dict[tuple[str, int], tuple[int, int]] = {}
     for commodity in flow.commodities:
         for vertex in range(flow.network.vertex_count):
             key = (commodity.commodity_id, vertex)
-            cell_bounds[key] = _sum_bound(
-                cell_den.get(key, 0),
-                cell_num.get(key, 0),
-            )
+            if key in cell_den:
+                cell_bounds[key] = _sum_bound(cell_den[key], cell_num[key])
+            else:
+                cell_bounds[key] = (1, 1)
 
-    load_bounds: dict[tuple[int, int], int] = {}
-    slack_bounds: dict[tuple[int, int], int] = {}
+    load_bounds: dict[tuple[int, int], tuple[int, int]] = {}
+    slack_bounds: dict[tuple[int, int], tuple[int, int]] = {}
+    congestion_bound = (1, 1)
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
         capacity_num = len(edge.capacity.num)
         capacity_den = len(edge.capacity.den)
         den_total = edge_den.get(edge_key)
         if den_total is None:
-            # No amount reaches this edge: its load is exactly zero, its slack
-            # is exactly its capacity, and its congestion ratio is exactly
-            # zero, so each bound is just the larger capacity component.
-            load_bounds[edge_key] = max(capacity_num, capacity_den)
-            slack_bounds[edge_key] = max(capacity_num, capacity_den)
+            # No amount reaches this edge: its load is exactly the zero
+            # rational, its slack is exactly its capacity, and its congestion
+            # ratio reduces to exactly zero.
+            load_bounds[edge_key] = (1, 1)
+            slack_bounds[edge_key] = (capacity_num, capacity_den)
             continue
-        sum_num = _sum_bound(den_total, edge_num[edge_key])
-        load_bounds[edge_key] = max(sum_num, den_total)
-        slack_bounds[edge_key] = max(
-            # Slack numerator: the subtraction runs through both denominators.
-            max(capacity_num + den_total, sum_num + capacity_den) + 1,
-            capacity_den + den_total,
-            # Congestion numerator over its reduced denominator.
-            sum_num + capacity_num,
-            den_total + capacity_num,
+        load_n, load_d = _sum_bound(den_total, edge_num[edge_key])
+        slack_n = max(capacity_num + den_total, load_n + capacity_den) + 1
+        slack_d = capacity_den + den_total
+        load_bounds[edge_key] = (load_n, load_d)
+        slack_bounds[edge_key] = (slack_n, slack_d)
+        # The ratio divides one load by one capacity: both sides pick up the
+        # capacity numerator only.
+        congestion_bound = (
+            max(congestion_bound[0], load_n + capacity_num),
+            max(congestion_bound[1], den_total + capacity_num),
         )
-    return cell_bounds, load_bounds, slack_bounds
+    return cell_bounds, load_bounds, slack_bounds, congestion_bound
 
 
 def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
     """Return the exact digit bound shared by every derived profile component."""
 
-    cell_bounds, load_bounds, slack_bounds = _profile_component_digit_bounds(flow)
-    return max(
-        max(cell_bounds.values(), default=_DERIVED_DIGIT_SLACK),
-        max(load_bounds.values(), default=_DERIVED_DIGIT_SLACK),
-        max(slack_bounds.values(), default=_DERIVED_DIGIT_SLACK),
+    cell_bounds, load_bounds, slack_bounds, congestion_bound = (
+        _profile_component_digit_bounds(flow)
     )
+    component_sides = [
+        *cell_bounds.values(),
+        *load_bounds.values(),
+        *slack_bounds.values(),
+        congestion_bound,
+    ]
+    return max(max(sides) for sides in component_sides)
 
 
 def _require_derived_digit_budget(flow: MulticommodityFlow) -> int:
@@ -258,22 +270,37 @@ def _require_derived_digit_budget(flow: MulticommodityFlow) -> int:
 def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
     """Reject tensors whose echoed source and priced rows exceed the envelope."""
 
-    cell_bounds, load_bounds, slack_bounds = _profile_component_digit_bounds(flow)
+    cell_bounds, load_bounds, slack_bounds, congestion_bound = (
+        _profile_component_digit_bounds(flow)
+    )
     source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
     divergence_bytes = sum(
-        2 * bound + 24 + _DIVERGENCE_ROW_OVERHEAD_BYTES
-        for bound in cell_bounds.values()
+        num_digits
+        + den_digits
+        + _RATIONAL_JSON_OVERHEAD_BYTES
+        + _DIVERGENCE_ROW_OVERHEAD_BYTES
+        for num_digits, den_digits in cell_bounds.values()
     )
-    edge_bytes = sum(
-        2 * load_bounds[(edge.source, edge.target)]
-        + 24
-        + 2 * slack_bounds[(edge.source, edge.target)]
-        + 24
-        + _EDGE_ROW_OVERHEAD_BYTES
-        for edge in flow.network.edges
-    )
+    edge_bytes = 0
+    congestion_bytes = sum(congestion_bound) + _RATIONAL_JSON_OVERHEAD_BYTES
+    for edge in flow.network.edges:
+        edge_key = (edge.source, edge.target)
+        load_num, load_den = load_bounds[edge_key]
+        slack_num, slack_den = slack_bounds[edge_key]
+        edge_bytes += (
+            load_num
+            + load_den
+            + slack_num
+            + slack_den
+            + 2 * _RATIONAL_JSON_OVERHEAD_BYTES
+            + _EDGE_ROW_OVERHEAD_BYTES
+        )
     estimated_bytes = (
-        source_bytes + divergence_bytes + edge_bytes + _PROFILE_RESULT_HEADER_BYTES
+        source_bytes
+        + divergence_bytes
+        + edge_bytes
+        + congestion_bytes
+        + _PROFILE_RESULT_HEADER_BYTES
     )
     if estimated_bytes > MAX_PROFILE_RESULT_BYTES:
         raise ValueError(
@@ -336,9 +363,10 @@ class MulticommodityFlowProfileRequest(StrictModel):
             "Canonical sparse tensor bounded by derived quantities: at most "
             "512 returned commodity-vertex cells (hence at most 256 "
             "commodities), at most the 512 network edges FlowGraph itself "
-            "admits, 128 nonzero entries, a per-component exact digit budget "
-            "derived from each component's own operands, and an admitted "
-            "aggregate result envelope below 8 MiB."
+            "admits, nonzero entries bounded by the distinct commodity-by-edge "
+            "cells they occupy, a per-component exact digit budget derived "
+            "from each component's own operands, and an admitted aggregate "
+            "result envelope below 8 MiB."
         )
     )
 

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -12,13 +12,13 @@ from jacobian.canonical import encode_strict_json
 from jacobian.math.graphs.flow._models import FlowGraph
 
 # This operation scans a sparse commodity-by-edge tensor and materializes one
-# divergence value for every commodity/vertex pair.  Vertex count is owned by
-# FlowGraph; admission controls the dense divergence table through the
-# commodity-vertex cell budget, the sparse tensor through the entry and
-# commodity-edge cell budgets, and the whole returned value through the
-# aggregate result envelope below.  The commodity count is bounded by those
-# same derived quantities rather than an independent fixed ceiling.
-MAX_MULTICOMMODITY_EDGES = 128
+# divergence value for every commodity/vertex pair.  Vertex count and edge
+# count are owned by FlowGraph; admission controls the dense divergence table
+# through the commodity-vertex cell budget, the sparse tensor through the
+# entry and commodity-edge cell budgets, and the whole returned value through
+# the aggregate result envelope below.  The commodity count is bounded by
+# those same derived quantities rather than an independent fixed ceiling.
+MAX_MULTICOMMODITY_EDGES = 512
 MAX_COMMODITY_EDGE_CELLS = 2_048
 MAX_COMMODITY_VERTEX_CELLS = 512
 MAX_SPARSE_FLOW_ENTRIES = 128
@@ -26,14 +26,19 @@ MAX_SPARSE_FLOW_ENTRIES = 128
 # Entry amounts and edge capacities are the only arithmetic operands, and each
 # derived component is computed independently from only the operands that can
 # reach it: a divergence cell sums the amounts incident to one
-# commodity/vertex pair, an edge load sums the amounts carried by that edge,
-# a slack subtracts one capacity from one such load, and the congestion ratio
-# divides one load by one capacity.  Adding one operand to a running sum
-# contributes at most its numerator and denominator digits plus three carry
-# digits, and the slack subtraction and congestion division each compose one
-# further operand, so eight slack digits on top of a component's own totaled
-# operand digits bound that component's intermediates and derived numerator
-# and denominator exactly.  Demands take part only in exact conservation
+# commodity/vertex pair, an edge load sums the amounts carried by that edge, a
+# slack subtracts one capacity from one such load, and the congestion ratio
+# divides one load by one capacity.  Numerator and denominator growth are
+# tracked separately: a reduced sum denominator divides the operand lcm and
+# so accumulates each operand's denominator digits once; a reduced sum
+# numerator adds at most its largest operand numerator on top of that common
+# denominator plus eight carry digits for up to 256 accumulated endpoints;
+# the slack subtraction pushes the numerator through both denominators once
+# and adds one carry digit; and the division crosses the load with the
+# capacity numerator only.  An edge carrying no amount has the exact zero
+# load, so only single-digit zero operands compose with its capacity.  A
+# component stays admissible when each side of this split bound fits the
+# canonical cap on its own.  Demands take part only in exact conservation
 # comparisons, never in arithmetic, so they are covered by the measured
 # source echo instead of these budgets.
 _DERIVED_DIGIT_SLACK = 8
@@ -55,13 +60,14 @@ _PROFILE_RESULT_HEADER_BYTES = 1_024
 # divisions, and K*V+3E comparisons. Every admitted commodity occupies V >= 2
 # distinct commodity-vertex cells because its source and sink differ, so the
 # 512-cell divergence budget admits at most 256 commodities, one negation
-# each. With the admitted maxima this is 1,792 logical steps; producer plus
-# exact result replay therefore costs at most 3,584.
-MAX_PROFILE_LOGICAL_STEPS = 3_584
-MAX_PROFILE_ADDITIONS_PER_PASS = 512
+# each, and FlowGraph's own 512-edge tuple bounds E. With the admitted maxima
+# this is 3,712 logical steps; producer plus exact result replay therefore
+# costs at most 7,424.
+MAX_PROFILE_LOGICAL_STEPS = 7_424
+MAX_PROFILE_ADDITIONS_PER_PASS = 896
 MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
-MAX_PROFILE_DIVISIONS_PER_PASS = 128
-MAX_PROFILE_COMPARISONS_PER_PASS = 896
+MAX_PROFILE_DIVISIONS_PER_PASS = 512
+MAX_PROFILE_COMPARISONS_PER_PASS = 2_048
 
 
 class CommodityDemand(StrictModel):
@@ -109,11 +115,6 @@ class CommodityEdgeFlow(StrictModel):
 
 
 def _require_canonical_network(network: FlowGraph) -> tuple[tuple[int, int], ...]:
-    if len(network.edges) > MAX_MULTICOMMODITY_EDGES:
-        raise ValueError(
-            "multicommodity flow networks may have at most "
-            f"{MAX_MULTICOMMODITY_EDGES} edges"
-        )
     edge_keys = tuple((edge.source, edge.target) for edge in network.edges)
     if edge_keys != tuple(sorted(edge_keys)):
         raise ValueError("network edges must be sorted by (source, target)")
@@ -171,10 +172,6 @@ def _require_canonical_entries(
             raise ValueError("flow entry references an undeclared directed edge")
 
 
-def _operand_digits(value: CanonicalRational) -> int:
-    return len(value.num) + len(value.den)
-
-
 def _profile_component_digit_bounds(
     flow: MulticommodityFlow,
 ) -> tuple[
@@ -184,27 +181,57 @@ def _profile_component_digit_bounds(
 ]:
     """Return exact divergence-cell, edge-load, and edge-slack digit bounds."""
 
+    cell_den: dict[tuple[str, int], int] = {}
+    cell_num: dict[tuple[str, int], int] = {}
+    edge_den: dict[tuple[int, int], int] = {}
+    edge_num: dict[tuple[int, int], int] = {}
+    for entry in flow.entries:
+        amount_num = len(entry.amount.num)
+        amount_den = len(entry.amount.den)
+        edge_key = (entry.source, entry.target)
+        edge_den[edge_key] = edge_den.get(edge_key, 0) + amount_den
+        edge_num[edge_key] = max(edge_num.get(edge_key, 0), amount_num)
+        for vertex in (entry.source, entry.target):
+            cell_key = (entry.commodity_id, vertex)
+            cell_den[cell_key] = cell_den.get(cell_key, 0) + amount_den
+            cell_num[cell_key] = max(cell_num.get(cell_key, 0), amount_num)
+
+    def _sum_bound(den_total: int, max_num: int) -> int:
+        return den_total + max_num + _DERIVED_DIGIT_SLACK
+
     cell_bounds: dict[tuple[str, int], int] = {}
+    for commodity in flow.commodities:
+        for vertex in range(flow.network.vertex_count):
+            key = (commodity.commodity_id, vertex)
+            cell_bounds[key] = _sum_bound(
+                cell_den.get(key, 0),
+                cell_num.get(key, 0),
+            )
+
     load_bounds: dict[tuple[int, int], int] = {}
     slack_bounds: dict[tuple[int, int], int] = {}
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
-        load_bounds[edge_key] = _DERIVED_DIGIT_SLACK
-        slack_bounds[edge_key] = _DERIVED_DIGIT_SLACK + _operand_digits(edge.capacity)
-    for entry in flow.entries:
-        digits = _operand_digits(entry.amount)
-        edge_key = (entry.source, entry.target)
-        load_bounds[edge_key] += digits
-        slack_bounds[edge_key] += digits
-        for vertex in (entry.source, entry.target):
-            key = (entry.commodity_id, vertex)
-            cell_bounds[key] = cell_bounds.get(key, _DERIVED_DIGIT_SLACK) + digits
-    for commodity in flow.commodities:
-        for vertex in range(flow.network.vertex_count):
-            cell_bounds.setdefault(
-                (commodity.commodity_id, vertex),
-                _DERIVED_DIGIT_SLACK,
-            )
+        capacity_num = len(edge.capacity.num)
+        capacity_den = len(edge.capacity.den)
+        den_total = edge_den.get(edge_key)
+        if den_total is None:
+            # No amount reaches this edge: its load is exactly zero, its slack
+            # is exactly its capacity, and its congestion ratio is exactly
+            # zero, so each bound is just the larger capacity component.
+            load_bounds[edge_key] = max(capacity_num, capacity_den)
+            slack_bounds[edge_key] = max(capacity_num, capacity_den)
+            continue
+        sum_num = _sum_bound(den_total, edge_num[edge_key])
+        load_bounds[edge_key] = max(sum_num, den_total)
+        slack_bounds[edge_key] = max(
+            # Slack numerator: the subtraction runs through both denominators.
+            max(capacity_num + den_total, sum_num + capacity_den) + 1,
+            capacity_den + den_total,
+            # Congestion numerator over its reduced denominator.
+            sum_num + capacity_num,
+            den_total + capacity_num,
+        )
     return cell_bounds, load_bounds, slack_bounds
 
 
@@ -312,9 +339,10 @@ class MulticommodityFlowProfileRequest(StrictModel):
         description=(
             "Canonical sparse tensor bounded by derived quantities: at most "
             "2,048 conceptual commodity-edge cells, 512 returned "
-            "commodity-vertex cells (hence at most 256 commodities), 128 "
-            "nonzero entries, a per-component exact digit budget derived from "
-            "each component's own operands, and an admitted aggregate result "
+            "commodity-vertex cells (hence at most 256 commodities), at most "
+            "the 512 network edges FlowGraph itself admits, 128 nonzero "
+            "entries, a per-component exact digit budget derived from each "
+            "component's own operands, and an admitted aggregate result "
             "envelope below 8 MiB."
         )
     )

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -59,8 +59,13 @@ _EDGE_ROW_OVERHEAD_BYTES = 128
 _RATIONAL_JSON_OVERHEAD_BYTES = 24
 _PROFILE_RESULT_HEADER_BYTES = 1_024
 
-# One pass performs at most 3F+E additions/subtractions, K negations, E
-# divisions, and K*V+4E comparisons. Sparse entries are distinct
+# One pass performs at most 6F+E additions/subtractions, K negations, E
+# divisions, and K*V+4E comparisons. Each sparse entry performs three bucketed
+# numerator additions -- source divergence, sink divergence, and edge load --
+# and deposits its denominator into each of those three buckets, so the shared
+# combination adds at most one fraction per distinct (bucket, denominator)
+# pair: at most 3F denominator folds on top of the 3F numerator additions,
+# plus one slack subtraction per edge. Sparse entries are distinct
 # commodity-by-edge cells of the conceptual tensor, so F <= K*E <= 256 * 512.
 # Every admitted commodity occupies V >= 2 distinct commodity-vertex cells
 # because its source and sink differ, so the 512-cell divergence budget
@@ -69,14 +74,21 @@ _PROFILE_RESULT_HEADER_BYTES = 1_024
 # capacity and capacity against zero in the kernel loop, capacity against
 # zero in the shared derivative scan, then either load against zero or its
 # ratio against the running congestion maximum. With the admitted maxima
-# this is 397,056 logical steps per pass; producer plus exact result replay
-# therefore costs at most 794,112.
-MAX_PROFILE_LOGICAL_STEPS = 794_112
-MAX_PROFILE_ADDITIONS_PER_PASS = 393_728
-MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
-MAX_PROFILE_DIVISIONS_PER_PASS = 512
-MAX_PROFILE_COMPARISONS_PER_PASS = 2_560
+# this is 790,272 logical steps per pass; producer plus exact result replay
+# therefore costs at most 1,580,544.
 MAX_SPARSE_FLOW_ENTRIES = (MAX_COMMODITY_VERTEX_CELLS // 2) * MAX_MULTICOMMODITY_EDGES
+MAX_PROFILE_ADDITIONS_PER_PASS = 6 * MAX_SPARSE_FLOW_ENTRIES + MAX_MULTICOMMODITY_EDGES
+MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
+MAX_PROFILE_DIVISIONS_PER_PASS = MAX_MULTICOMMODITY_EDGES
+MAX_PROFILE_COMPARISONS_PER_PASS = (
+    MAX_COMMODITY_VERTEX_CELLS + 4 * MAX_MULTICOMMODITY_EDGES
+)
+MAX_PROFILE_LOGICAL_STEPS = 2 * (
+    MAX_PROFILE_ADDITIONS_PER_PASS
+    + MAX_PROFILE_NEGATIONS_PER_PASS
+    + MAX_PROFILE_DIVISIONS_PER_PASS
+    + MAX_PROFILE_COMPARISONS_PER_PASS
+)
 
 
 class CommodityDemand(StrictModel):
@@ -180,14 +192,29 @@ def _require_canonical_entries(
 def _component_sums(
     flow: MulticommodityFlow,
 ) -> tuple[dict[tuple[str, int], Fraction], dict[tuple[int, int], Fraction]]:
-    """Return the exact divergence-cell and edge-load sums for one tensor.
+    """Return the exact divergence-cell and edge-load sums for one tensor."""
+
+    divergences, loads, _fold_additions = _component_sums_with_folds(flow)
+    return divergences, loads
+
+
+def _component_sums_with_folds(
+    flow: MulticommodityFlow,
+) -> tuple[
+    dict[tuple[str, int], Fraction],
+    dict[tuple[int, int], Fraction],
+    int,
+]:
+    """Return the exact sums plus how many fraction folds were performed.
 
     Amounts are bucketed by identical denominator and combined smallest
     denominator first: integer bucket sums never exceed the request volume,
     shared denominators add with zero growth, and every cross-denominator
     fold is checked against the canonical cap so adversarial
     coprime-denominator floods abort after constant work instead of
-    constructing huge intermediate fractions.
+    constructing huge intermediate fractions. The fold counter increments
+    inside the combination loop itself, so the profile work ledger charges
+    exactly the additions this scan executes.
     """
 
     cell_buckets: dict[tuple[str, int], dict[int, int]] = {
@@ -211,17 +238,21 @@ def _component_sums(
         bucket = edge_buckets.setdefault(edge_key, {})
         bucket[denominator] = bucket.get(denominator, 0) + numerator
 
+    fold_additions = 0
+
     def _combine(buckets: dict[int, int]) -> Fraction:
+        nonlocal fold_additions
         total = Fraction(0)
         for den in sorted(buckets, key=int.bit_length):
             total += Fraction(buckets[den], den)
+            fold_additions += 1
             for digits in _rational_side_bounds(total):
                 _require_side_within_cap(digits)
         return total
 
     divergences = {key: _combine(bucket) for key, bucket in cell_buckets.items()}
     loads = {key: _combine(bucket) for key, bucket in edge_buckets.items()}
-    return divergences, loads
+    return divergences, loads, fold_additions
 
 
 def _rational_side_bounds(value: Fraction) -> tuple[int, int]:
@@ -352,10 +383,38 @@ def derived_profile_components_from_sums(
 def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
     """Reject tensors whose echoed source and priced rows exceed the envelope."""
 
+    # The echoed source is measured before any exact component work. Every
+    # admitted result contains at least the header, one congestion rational,
+    # and one divergence and one edge row (FlowGraph admits no zero-edge
+    # graphs and commodities at least one source/sink pair), so a serialized
+    # source that already leaves no room for that skeleton can never pass the
+    # priced estimate below and fails closed immediately instead of paying
+    # the full component scan first.
+    source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
+    minimum_result_bytes = (
+        source_bytes
+        + _PROFILE_RESULT_HEADER_BYTES
+        # One congestion rational and the mandatory first divergence row,
+        # each priced at one digit per side like the estimate below.
+        + _RATIONAL_JSON_OVERHEAD_BYTES
+        + 2
+        + _DIVERGENCE_ROW_OVERHEAD_BYTES
+        + _RATIONAL_JSON_OVERHEAD_BYTES
+        + 2
+        # The mandatory first edge row prices two rationals.
+        + _EDGE_ROW_OVERHEAD_BYTES
+        + 2 * _RATIONAL_JSON_OVERHEAD_BYTES
+        + 4
+    )
+    if minimum_result_bytes > MAX_PROFILE_RESULT_BYTES:
+        raise ValueError(
+            "multicommodity-flow profile result would exceed the "
+            f"{MAX_PROFILE_RESULT_BYTES}-byte aggregate result bound"
+        )
+
     cell_bounds, load_bounds, slack_bounds, congestion_bound = (
         _profile_component_digit_bounds(flow)
     )
-    source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
     divergence_bytes = sum(
         num_digits
         + den_digits

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -37,17 +37,16 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # all keep components far smaller than any worst case — so admission measures
 # the actual reduced numerator and denominator of every completed component
 # and enforces the canonical cap exactly there.  Fold work is bounded
-# separately: every quantity a cross-denominator fold can touch — bucket
-# numerators, reduced partial sums, and the unreduced products inside one
-# rational addition — carries at most three times the operand digit mass plus
-# a small constant, so folds are checked against that derived envelope while
-# the canonical component cap alone decides admission of completed sums.
-# Fold order therefore never shrinks the safe mathematical domain: a request
-# whose exact load equals its capacity reports the exact zero slack and
-# exactly-one congestion instead of phantom growth, while a request whose
-# completed sums exceed the cap still fails closed.  Demands take part only
-# in exact conservation comparisons, never in arithmetic, so they are covered
-# by the measured source echo instead of these budgets.
+# separately and BEFORE any cross-denominator arithmetic: the budget below is
+# derived from what one fold of two canonical-bounded operands can produce,
+# so no constructed fraction can outgrow it regardless of request size, and
+# fold order cannot shrink the safe mathematical domain beyond that derived
+# intermediate depth.  A request whose exact load equals its capacity
+# therefore reports the exact zero slack and exactly-one congestion instead
+# of phantom growth, while a request whose completed sums exceed the cap
+# still fails closed.  Demands take part only in exact conservation
+# comparisons, never in arithmetic, so they are covered by the measured
+# source echo instead of these budgets.
 
 # A result echoes its source tensor, then includes one divergence row per
 # commodity-vertex cell, one edge row per network edge, and one congestion
@@ -216,16 +215,15 @@ def _component_sums_with_folds(
     Amounts are bucketed by identical denominator and combined smallest
     denominator first: integer bucket sums never exceed the request volume,
     shared denominators add with zero growth, and every cross-denominator
-    fold is checked against the operand-mass fold envelope so adversarial
-    floods abort after constant work instead of constructing huge
-    intermediate fractions. The canonical cap is enforced on the completed
-    reduced sums by the component measurement, so fold order cannot shrink
-    the safe mathematical domain. The fold counter increments inside the
-    combination loop itself, so the profile work ledger charges exactly the
-    additions this scan executes.
+    fold is pre-checked against the fold-intermediate budget from its
+    operands' measured sides, so adversarial floods abort before
+    constructing huge intermediate fractions. The canonical cap is enforced
+    on the completed reduced sums by the component measurement, so fold
+    order cannot shrink the safe mathematical domain. The fold counter
+    increments inside the combination loop itself, so the profile work
+    ledger charges exactly the additions this scan executes.
     """
 
-    amount_digit_mass = 0
     cell_buckets: dict[tuple[str, int], dict[int, int]] = {
         (commodity.commodity_id, vertex): {}
         for commodity in flow.commodities
@@ -237,7 +235,6 @@ def _component_sums_with_folds(
     for entry in flow.entries:
         numerator = parse_canonical_integer(entry.amount.num)
         denominator = parse_canonical_integer(entry.amount.den)
-        amount_digit_mass += len(entry.amount.num) + len(entry.amount.den)
         source_key = (entry.commodity_id, entry.source)
         target_key = (entry.commodity_id, entry.target)
         edge_key = (entry.source, entry.target)
@@ -249,16 +246,29 @@ def _component_sums_with_folds(
         bucket[denominator] = bucket.get(denominator, 0) + numerator
 
     fold_additions = 0
-    fold_digit_cap = _fold_intermediate_digit_cap(amount_digit_mass)
 
     def _combine(buckets: dict[int, int]) -> Fraction:
         nonlocal fold_additions
         total = Fraction(0)
+        total_sides = (1, 1)
         for den in sorted(buckets, key=int.bit_length):
-            total += Fraction(buckets[den], den)
+            operand = Fraction(buckets[den], den)
+            num_digits, den_digits = _rational_side_bounds(operand)
+            # The unreduced sum of a/b and c/d carries at most
+            # len(b) + len(d) denominator digits and
+            # max(len(a) + len(d), len(c) + len(b)) + 1 numerator digits,
+            # so refusing folds on those predicted bounds enforces the
+            # intermediate budget BEFORE any cross-denominator
+            # multiplication, reduction, or decimal measurement runs:
+            # no constructed fraction ever outgrows the budget-sized
+            # envelope, whatever the request's total digit mass is.
+            _require_side_within_fold_budget(
+                max(total_sides[0] + den_digits, num_digits + total_sides[1]) + 1
+            )
+            _require_side_within_fold_budget(total_sides[1] + den_digits)
+            total += operand
             fold_additions += 1
-            for digits in _rational_side_bounds(total):
-                _require_fold_intermediate_within_envelope(digits, fold_digit_cap)
+            total_sides = _rational_side_bounds(total)
         return total
 
     divergences = {key: _combine(bucket) for key, bucket in cell_buckets.items()}
@@ -266,28 +276,28 @@ def _component_sums_with_folds(
     return divergences, loads, fold_additions
 
 
-# Every quantity a cross-denominator fold can touch stays within three times
-# the summed amount digit mass plus a small constant: a bucket numerator sums
-# its members' digits once, a reduced partial denominator divides the lcm of
-# the processed denominators whose digits sum to at most that mass, a reduced
-# partial numerator adds at most one mass-sized factor over it, and the
-# unreduced products inside a single rational addition cost at most one more
-# mass-sized factor.  The headroom below covers those constants, so the cap
-# provably never rejects any fold of any request; it fails closed only if the
-# summation strategy ever violates the derivation.
-_FOLD_INTERMEDIATE_HEADROOM_DIGITS = 256
+# One cross-denominator fold adds two reduced rationals whose sides are
+# measured before the arithmetic.  Every fold operand is itself bounded by
+# the canonical cap -- bucket numerators sum only entry numerators sharing
+# one denominator and grow by at most the logarithm of the entry count --
+# so a fold whose accumulator sits inside the canonical cap has predicted
+# unreduced sides of at most twice the cap plus one carry digit, exactly
+# the composition of two maximal canonical operands.  The headroom below
+# covers that carry, and the budget admits every such fold while any fold
+# that would push the accumulator past it must first reduce back beneath
+# the budget; monotone adversarial growth therefore aborts after
+# constantly many cheap budget-sized folds instead of constructing
+# multi-million-digit fractions.
+MAX_PROFILE_FOLD_INTERMEDIATE_DIGITS = 2 * MAX_CANONICAL_RATIONAL_DIGITS + 8
 
 
-def _fold_intermediate_digit_cap(amount_digit_mass: int) -> int:
-    return 4 * amount_digit_mass + _FOLD_INTERMEDIATE_HEADROOM_DIGITS
-
-
-def _require_fold_intermediate_within_envelope(digits: int, cap: int) -> None:
-    if digits > cap:
+def _require_side_within_fold_budget(digits: int) -> None:
+    if digits > MAX_PROFILE_FOLD_INTERMEDIATE_DIGITS:
         raise ValueError(
-            "multicommodity-flow summation produced a "
+            "multicommodity-flow profile derives a "
             f"{digits}-digit fold intermediate above the "
-            f"{cap}-digit operand-mass envelope"
+            f"{MAX_PROFILE_FOLD_INTERMEDIATE_DIGITS}"
+            "-digit fold-intermediate budget"
         )
 
 
@@ -633,6 +643,7 @@ __all__ = [
     "MAX_PROFILE_ADDITIONS_PER_PASS",
     "MAX_PROFILE_COMPARISONS_PER_PASS",
     "MAX_PROFILE_DIVISIONS_PER_PASS",
+    "MAX_PROFILE_FOLD_INTERMEDIATE_DIGITS",
     "MAX_PROFILE_LOGICAL_STEPS",
     "MAX_PROFILE_NEGATIONS_PER_PASS",
     "MAX_PROFILE_RESULT_BYTES",

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -16,44 +16,50 @@ from jacobian.math.graphs.flow._models import FlowGraph
 # FlowGraph; admission controls the dense divergence table through the
 # commodity-vertex cell budget, the sparse tensor through the entry and
 # commodity-edge cell budgets, and the whole returned value through the
-# aggregate result envelope below.
+# aggregate result envelope below.  The commodity count is bounded by those
+# same derived quantities rather than an independent fixed ceiling.
 MAX_MULTICOMMODITY_EDGES = 128
-MAX_MULTICOMMODITIES = 16
 MAX_COMMODITY_EDGE_CELLS = 2_048
 MAX_COMMODITY_VERTEX_CELLS = 512
 MAX_SPARSE_FLOW_ENTRIES = 128
 
-# Entry amounts and edge capacities are the only arithmetic operands: every
-# divergence cell and edge load sums a subset of the amounts, every slack
-# subtracts one such sum from one capacity, and the congestion ratio divides
-# one load by one capacity.  Adding one operand to a running sum contributes
-# at most its numerator and denominator digits plus three carry digits, and
-# the slack subtraction and congestion division each compose one further
-# operand, so eight slack digits on top of the totaled operand digits bound
-# every intermediate and derived numerator and denominator exactly.  Demands
-# take part only in exact conservation comparisons, never in arithmetic, so
-# they are covered by the measured source echo instead of this budget.
+# Entry amounts and edge capacities are the only arithmetic operands, and each
+# derived component is computed independently from only the operands that can
+# reach it: a divergence cell sums the amounts incident to one
+# commodity/vertex pair, an edge load sums the amounts carried by that edge,
+# a slack subtracts one capacity from one such load, and the congestion ratio
+# divides one load by one capacity.  Adding one operand to a running sum
+# contributes at most its numerator and denominator digits plus three carry
+# digits, and the slack subtraction and congestion division each compose one
+# further operand, so eight slack digits on top of a component's own totaled
+# operand digits bound that component's intermediates and derived numerator
+# and denominator exactly.  Demands take part only in exact conservation
+# comparisons, never in arithmetic, so they are covered by the measured
+# source echo instead of these budgets.
 _DERIVED_DIGIT_SLACK = 8
 
 # A result echoes its source tensor, then includes at most 512 divergence rows
 # and 128 edge rows. A derived rational occupies at most 2*d+24 canonical JSON
-# bytes when its budget bounds d decimal digits per component; the conservative
-# row overhead reserves ASCII keys, labels, separators, and vertices. Admission
-# measures the echoed source exactly and estimates the derived rows from the
-# request's own digit budget against this aggregate envelope, keeping the
-# serialized result inside the envelope with headroom under the 10 MiB
-# transport limit.
+# bytes when its own component bound limits d decimal digits per component;
+# the conservative row overhead reserves ASCII keys, labels, separators, and
+# vertices. Admission measures the echoed source exactly and prices every
+# divergence row and edge row from its own component's digit bound against
+# this aggregate envelope, keeping the serialized result inside the envelope
+# with headroom under the 10 MiB transport limit.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
 _PROFILE_RESULT_HEADER_BYTES = 1_024
 
 # One pass performs at most 3F+E additions/subtractions, K negations, E
-# divisions, and K*V+3E comparisons. With the admitted maxima this is 1,552
-# logical steps; producer plus exact result replay therefore costs at most 3,104.
-MAX_PROFILE_LOGICAL_STEPS = 3_104
+# divisions, and K*V+3E comparisons. Every admitted commodity occupies V >= 2
+# distinct commodity-vertex cells because its source and sink differ, so the
+# 512-cell divergence budget admits at most 256 commodities, one negation
+# each. With the admitted maxima this is 1,792 logical steps; producer plus
+# exact result replay therefore costs at most 3,584.
+MAX_PROFILE_LOGICAL_STEPS = 3_584
 MAX_PROFILE_ADDITIONS_PER_PASS = 512
-MAX_PROFILE_NEGATIONS_PER_PASS = 16
+MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
 MAX_PROFILE_DIVISIONS_PER_PASS = 128
 MAX_PROFILE_COMPARISONS_PER_PASS = 896
 
@@ -165,15 +171,51 @@ def _require_canonical_entries(
             raise ValueError("flow entry references an undeclared directed edge")
 
 
+def _operand_digits(value: CanonicalRational) -> int:
+    return len(value.num) + len(value.den)
+
+
+def _profile_component_digit_bounds(
+    flow: MulticommodityFlow,
+) -> tuple[
+    dict[tuple[str, int], int],
+    dict[tuple[int, int], int],
+    dict[tuple[int, int], int],
+]:
+    """Return exact divergence-cell, edge-load, and edge-slack digit bounds."""
+
+    cell_bounds: dict[tuple[str, int], int] = {}
+    load_bounds: dict[tuple[int, int], int] = {}
+    slack_bounds: dict[tuple[int, int], int] = {}
+    for edge in flow.network.edges:
+        edge_key = (edge.source, edge.target)
+        load_bounds[edge_key] = _DERIVED_DIGIT_SLACK
+        slack_bounds[edge_key] = _DERIVED_DIGIT_SLACK + _operand_digits(edge.capacity)
+    for entry in flow.entries:
+        digits = _operand_digits(entry.amount)
+        edge_key = (entry.source, entry.target)
+        load_bounds[edge_key] += digits
+        slack_bounds[edge_key] += digits
+        for vertex in (entry.source, entry.target):
+            key = (entry.commodity_id, vertex)
+            cell_bounds[key] = cell_bounds.get(key, _DERIVED_DIGIT_SLACK) + digits
+    for commodity in flow.commodities:
+        for vertex in range(flow.network.vertex_count):
+            cell_bounds.setdefault(
+                (commodity.commodity_id, vertex),
+                _DERIVED_DIGIT_SLACK,
+            )
+    return cell_bounds, load_bounds, slack_bounds
+
+
 def derived_profile_digit_budget(flow: MulticommodityFlow) -> int:
     """Return the exact digit bound shared by every derived profile component."""
 
-    return _DERIVED_DIGIT_SLACK + sum(
-        len(operand.num) + len(operand.den)
-        for operand in (
-            *(entry.amount for entry in flow.entries),
-            *(edge.capacity for edge in flow.network.edges),
-        )
+    cell_bounds, load_bounds, slack_bounds = _profile_component_digit_bounds(flow)
+    return max(
+        max(cell_bounds.values(), default=_DERIVED_DIGIT_SLACK),
+        max(load_bounds.values(), default=_DERIVED_DIGIT_SLACK),
+        max(slack_bounds.values(), default=_DERIVED_DIGIT_SLACK),
     )
 
 
@@ -190,20 +232,22 @@ def _require_derived_digit_budget(flow: MulticommodityFlow) -> int:
     return budget
 
 
-def _require_profile_output_admission(
-    flow: MulticommodityFlow,
-    *,
-    digit_budget: int,
-) -> None:
+def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
+    """Reject tensors whose echoed source and priced rows exceed the envelope."""
+
+    cell_bounds, load_bounds, slack_bounds = _profile_component_digit_bounds(flow)
     source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
-    derived_rational_bytes = 2 * digit_budget + 24
-    divergence_bytes = (
-        len(flow.commodities)
-        * flow.network.vertex_count
-        * (derived_rational_bytes + _DIVERGENCE_ROW_OVERHEAD_BYTES)
+    divergence_bytes = sum(
+        2 * bound + 24 + _DIVERGENCE_ROW_OVERHEAD_BYTES
+        for bound in cell_bounds.values()
     )
-    edge_bytes = len(flow.network.edges) * (
-        2 * derived_rational_bytes + _EDGE_ROW_OVERHEAD_BYTES
+    edge_bytes = sum(
+        2 * load_bounds[(edge.source, edge.target)]
+        + 24
+        + 2 * slack_bounds[(edge.source, edge.target)]
+        + 24
+        + _EDGE_ROW_OVERHEAD_BYTES
+        for edge in flow.network.edges
     )
     estimated_bytes = (
         source_bytes + divergence_bytes + edge_bytes + _PROFILE_RESULT_HEADER_BYTES
@@ -232,9 +276,10 @@ class MulticommodityFlow(StrictModel):
     )
     commodities: tuple[CommodityDemand, ...] = Field(
         min_length=1,
-        max_length=MAX_MULTICOMMODITIES,
         description=(
-            "Distinct commodity records sorted lexicographically by commodity_id."
+            "Distinct commodity records sorted lexicographically by commodity_id. "
+            "The count is bounded by the commodity-vertex and commodity-edge "
+            "cell budgets rather than a fixed ceiling."
         ),
     )
     entries: tuple[CommodityEdgeFlow, ...] = Field(
@@ -255,8 +300,8 @@ class MulticommodityFlow(StrictModel):
             edge_keys=edge_keys,
             commodity_ids=commodity_ids,
         )
-        digit_budget = _require_derived_digit_budget(self)
-        _require_profile_output_admission(self, digit_budget=digit_budget)
+        _require_derived_digit_budget(self)
+        _require_profile_output_admission(self)
         return self
 
 
@@ -265,11 +310,12 @@ class MulticommodityFlowProfileRequest(StrictModel):
 
     flow: MulticommodityFlow = Field(
         description=(
-            "Canonical sparse tensor with at most 16 commodities, 128 nonzero "
-            "entries, 2,048 conceptual commodity-edge cells, 512 returned "
-            "commodity-vertex cells, an operand-derived exact digit budget for "
-            "every input and derived rational, and an admitted aggregate "
-            "result envelope below 8 MiB."
+            "Canonical sparse tensor bounded by derived quantities: at most "
+            "2,048 conceptual commodity-edge cells, 512 returned "
+            "commodity-vertex cells (hence at most 256 commodities), 128 "
+            "nonzero entries, a per-component exact digit budget derived from "
+            "each component's own operands, and an admitted aggregate result "
+            "envelope below 8 MiB."
         )
     )
 
@@ -357,7 +403,6 @@ class MulticommodityFlowProfileResult(StrictModel):
 __all__ = [
     "MAX_COMMODITY_EDGE_CELLS",
     "MAX_COMMODITY_VERTEX_CELLS",
-    "MAX_MULTICOMMODITIES",
     "MAX_MULTICOMMODITY_EDGES",
     "MAX_PROFILE_ADDITIONS_PER_PASS",
     "MAX_PROFILE_COMPARISONS_PER_PASS",

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -34,12 +34,16 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # denominator plus eight carry digits for up to 256 accumulated endpoints;
 # the slack subtraction pushes the numerator through both denominators once
 # and adds one carry digit; and the division crosses the load with the
-# capacity numerator only.  An edge carrying no amount has the exact zero
-# load, so only single-digit zero operands compose with its capacity.  A
-# component stays admissible when each side of this split bound fits the
-# canonical cap on its own.  Demands take part only in exact conservation
-# comparisons, never in arithmetic, so they are covered by the measured
-# source echo instead of these budgets.
+# capacity numerator only.  A component fed by a single operand equals that
+# already-canonical operand exactly, so its own two sides are its bounds and
+# no summation growth is charged; when that lone amount also equals the edge
+# capacity, the slack is the exact zero rational and the congestion ratio is
+# exactly one.  An edge carrying no amount has the exact zero load, so only
+# single-digit zero operands compose with its capacity.  A component stays
+# admissible when each side of this split bound fits the canonical cap on
+# its own.  Demands take part only in exact conservation comparisons, never
+# in arithmetic, so they are covered by the measured source echo instead of
+# these budgets.
 _DERIVED_DIGIT_SLACK = 8
 
 # A result echoes its source tensor, then includes one divergence row per
@@ -185,20 +189,30 @@ def _profile_component_digit_bounds(
 
     cell_den: dict[tuple[str, int], int] = {}
     cell_num: dict[tuple[str, int], int] = {}
+    cell_operands: dict[tuple[str, int], int] = {}
     edge_den: dict[tuple[int, int], int] = {}
     edge_num: dict[tuple[int, int], int] = {}
+    edge_operands: dict[tuple[int, int], int] = {}
+    edge_sole_amount: dict[tuple[int, int], CanonicalRational] = {}
     for entry in flow.entries:
         amount_num = len(entry.amount.num)
         amount_den = len(entry.amount.den)
         edge_key = (entry.source, entry.target)
         edge_den[edge_key] = edge_den.get(edge_key, 0) + amount_den
         edge_num[edge_key] = max(edge_num.get(edge_key, 0), amount_num)
+        edge_operands[edge_key] = edge_operands.get(edge_key, 0) + 1
+        edge_sole_amount.setdefault(edge_key, entry.amount)
         for vertex in (entry.source, entry.target):
             cell_key = (entry.commodity_id, vertex)
             cell_den[cell_key] = cell_den.get(cell_key, 0) + amount_den
             cell_num[cell_key] = max(cell_num.get(cell_key, 0), amount_num)
+            cell_operands[cell_key] = cell_operands.get(cell_key, 0) + 1
 
-    def _sum_bound(den_total: int, max_num: int) -> tuple[int, int]:
+    def _sum_bound(operand_count: int, den_total: int, max_num: int) -> tuple[int, int]:
+        # One operand is its own reduced sum: the component equals that
+        # already-canonical operand and charges no summation growth.
+        if operand_count == 1:
+            return max_num, den_total
         return den_total + max_num + _DERIVED_DIGIT_SLACK, den_total
 
     cell_bounds: dict[tuple[str, int], tuple[int, int]] = {}
@@ -206,7 +220,9 @@ def _profile_component_digit_bounds(
         for vertex in range(flow.network.vertex_count):
             key = (commodity.commodity_id, vertex)
             if key in cell_den:
-                cell_bounds[key] = _sum_bound(cell_den[key], cell_num[key])
+                cell_bounds[key] = _sum_bound(
+                    cell_operands[key], cell_den[key], cell_num[key]
+                )
             else:
                 cell_bounds[key] = (1, 1)
 
@@ -225,7 +241,19 @@ def _profile_component_digit_bounds(
             load_bounds[edge_key] = (1, 1)
             slack_bounds[edge_key] = (capacity_num, capacity_den)
             continue
-        load_n, load_d = _sum_bound(den_total, edge_num[edge_key])
+        load_n, load_d = _sum_bound(
+            edge_operands[edge_key], den_total, edge_num[edge_key]
+        )
+        if (
+            edge_operands[edge_key] == 1
+            and edge_sole_amount[edge_key] == edge.capacity
+        ):
+            # The lone amount equals the capacity exactly: the load is the
+            # capacity, the slack is the exact zero rational, and the
+            # congestion ratio reduces to exactly one.
+            load_bounds[edge_key] = (load_n, load_d)
+            slack_bounds[edge_key] = (1, 1)
+            continue
         slack_n = max(capacity_num + den_total, load_n + capacity_den) + 1
         slack_d = capacity_den + den_total
         load_bounds[edge_key] = (load_n, load_d)

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -35,13 +35,19 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # divides one load by one capacity.  Summation growth cannot be bounded from
 # digit counts alone — shared denominators, cancellation, and lone operands
 # all keep components far smaller than any worst case — so admission measures
-# the actual reduced numerator and denominator of every component with a pure
-# bounded scan that aborts as soon as a side crosses the canonical cap.  A
-# request whose exact load equals its capacity therefore reports the exact
-# zero slack and exactly-one congestion instead of phantom growth, while a
-# request whose sums genuinely exceed the cap fails closed.  Demands take
-# part only in exact conservation comparisons, never in arithmetic, so they
-# are covered by the measured source echo instead of these budgets.
+# the actual reduced numerator and denominator of every completed component
+# and enforces the canonical cap exactly there.  Fold work is bounded
+# separately: every quantity a cross-denominator fold can touch — bucket
+# numerators, reduced partial sums, and the unreduced products inside one
+# rational addition — carries at most three times the operand digit mass plus
+# a small constant, so folds are checked against that derived envelope while
+# the canonical component cap alone decides admission of completed sums.
+# Fold order therefore never shrinks the safe mathematical domain: a request
+# whose exact load equals its capacity reports the exact zero slack and
+# exactly-one congestion instead of phantom growth, while a request whose
+# completed sums exceed the cap still fails closed.  Demands take part only
+# in exact conservation comparisons, never in arithmetic, so they are covered
+# by the measured source echo instead of these budgets.
 
 # A result echoes its source tensor, then includes one divergence row per
 # commodity-vertex cell, one edge row per network edge, and one congestion
@@ -210,13 +216,16 @@ def _component_sums_with_folds(
     Amounts are bucketed by identical denominator and combined smallest
     denominator first: integer bucket sums never exceed the request volume,
     shared denominators add with zero growth, and every cross-denominator
-    fold is checked against the canonical cap so adversarial
-    coprime-denominator floods abort after constant work instead of
-    constructing huge intermediate fractions. The fold counter increments
-    inside the combination loop itself, so the profile work ledger charges
-    exactly the additions this scan executes.
+    fold is checked against the operand-mass fold envelope so adversarial
+    floods abort after constant work instead of constructing huge
+    intermediate fractions. The canonical cap is enforced on the completed
+    reduced sums by the component measurement, so fold order cannot shrink
+    the safe mathematical domain. The fold counter increments inside the
+    combination loop itself, so the profile work ledger charges exactly the
+    additions this scan executes.
     """
 
+    amount_digit_mass = 0
     cell_buckets: dict[tuple[str, int], dict[int, int]] = {
         (commodity.commodity_id, vertex): {}
         for commodity in flow.commodities
@@ -228,6 +237,7 @@ def _component_sums_with_folds(
     for entry in flow.entries:
         numerator = parse_canonical_integer(entry.amount.num)
         denominator = parse_canonical_integer(entry.amount.den)
+        amount_digit_mass += len(entry.amount.num) + len(entry.amount.den)
         source_key = (entry.commodity_id, entry.source)
         target_key = (entry.commodity_id, entry.target)
         edge_key = (entry.source, entry.target)
@@ -239,6 +249,7 @@ def _component_sums_with_folds(
         bucket[denominator] = bucket.get(denominator, 0) + numerator
 
     fold_additions = 0
+    fold_digit_cap = _fold_intermediate_digit_cap(amount_digit_mass)
 
     def _combine(buckets: dict[int, int]) -> Fraction:
         nonlocal fold_additions
@@ -247,12 +258,37 @@ def _component_sums_with_folds(
             total += Fraction(buckets[den], den)
             fold_additions += 1
             for digits in _rational_side_bounds(total):
-                _require_side_within_cap(digits)
+                _require_fold_intermediate_within_envelope(digits, fold_digit_cap)
         return total
 
     divergences = {key: _combine(bucket) for key, bucket in cell_buckets.items()}
     loads = {key: _combine(bucket) for key, bucket in edge_buckets.items()}
     return divergences, loads, fold_additions
+
+
+# Every quantity a cross-denominator fold can touch stays within three times
+# the summed amount digit mass plus a small constant: a bucket numerator sums
+# its members' digits once, a reduced partial denominator divides the lcm of
+# the processed denominators whose digits sum to at most that mass, a reduced
+# partial numerator adds at most one mass-sized factor over it, and the
+# unreduced products inside a single rational addition cost at most one more
+# mass-sized factor.  The headroom below covers those constants, so the cap
+# provably never rejects any fold of any request; it fails closed only if the
+# summation strategy ever violates the derivation.
+_FOLD_INTERMEDIATE_HEADROOM_DIGITS = 256
+
+
+def _fold_intermediate_digit_cap(amount_digit_mass: int) -> int:
+    return 4 * amount_digit_mass + _FOLD_INTERMEDIATE_HEADROOM_DIGITS
+
+
+def _require_fold_intermediate_within_envelope(digits: int, cap: int) -> None:
+    if digits > cap:
+        raise ValueError(
+            "multicommodity-flow summation produced a "
+            f"{digits}-digit fold intermediate above the "
+            f"{cap}-digit operand-mass envelope"
+        )
 
 
 def _rational_side_bounds(value: Fraction) -> tuple[int, int]:

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -53,11 +53,14 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # value. A derived rational occupies at most num+den+24 canonical JSON bytes
 # when its own component bounds limit the two sides separately; the
 # conservative row overhead reserves ASCII keys, labels, separators, and
-# vertices. Admission measures the echoed source exactly, prices exact-zero
-# loads as the single-digit zero rational, and prices every other row from
-# its own numerator and denominator bounds against this aggregate envelope,
-# keeping the serialized result inside the envelope with headroom under the
-# 10 MiB transport limit.
+# vertices. This envelope belongs to the profile operation, not to the
+# canonical tensor value: the profile request validator measures the echoed
+# source exactly (rejecting immediately when no result skeleton fits),
+# prices exact-zero loads as the single-digit zero rational, and prices
+# every other row from its own numerator and denominator bounds against
+# this aggregate envelope, keeping the serialized result inside the
+# envelope with headroom under the 10 MiB transport limit. The native
+# compute boundary enforces the same admission for directly passed values.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
@@ -503,6 +506,8 @@ class MulticommodityFlow(StrictModel):
     nonzero tensor entries are sorted so the value has one JSON representation.
     The source network and demand tuple remain attached to the tensor, allowing
     downstream operations to consume this value without reconstructing context.
+    Only canonical representation bounds live here: each consumer operation
+    enforces its own execution envelope at its own boundary.
     """
 
     network: FlowGraph = Field(
@@ -537,7 +542,6 @@ class MulticommodityFlow(StrictModel):
             edge_keys=edge_keys,
             commodity_ids=commodity_ids,
         )
-        _require_profile_output_admission(self)
         return self
 
 
@@ -555,6 +559,11 @@ class MulticommodityFlowProfileRequest(StrictModel):
             "result envelope below 8 MiB."
         )
     )
+
+    @model_validator(mode="after")
+    def require_admitted_profile_work_and_result(self) -> Self:
+        _require_profile_output_admission(self.flow)
+        return self
 
 
 class CommodityDivergence(StrictModel):

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -54,13 +54,10 @@ MAX_COMMODITY_VERTEX_CELLS = 512
 # when its own component bounds limit the two sides separately; the
 # conservative row overhead reserves ASCII keys, labels, separators, and
 # vertices. This envelope belongs to the profile operation, not to the
-# canonical tensor value: the profile request validator measures the echoed
-# source exactly (rejecting immediately when no result skeleton fits),
-# prices exact-zero loads as the single-digit zero rational, and prices
-# every other row from its own numerator and denominator bounds against
-# this aggregate envelope, keeping the serialized result inside the
-# envelope with headroom under the 10 MiB transport limit. The native
-# compute boundary enforces the same admission for directly passed values.
+# canonical tensor value: the profile kernel measures the echoed source
+# before its scan and prices every returned row from the same measured
+# bounds afterwards, so admission adds no arithmetic pass of its own and
+# the two-pass work ledger stays an exact per-call accounting.
 MAX_PROFILE_RESULT_BYTES = 8 * 1024 * 1024
 _DIVERGENCE_ROW_OVERHEAD_BYTES = 128
 _EDGE_ROW_OVERHEAD_BYTES = 128
@@ -407,13 +404,23 @@ def derived_profile_components_from_sums(
     flow: MulticommodityFlow,
     divergences: dict[tuple[str, int], Fraction],
     loads: dict[tuple[int, int], Fraction],
-) -> tuple[int, dict[tuple[int, int], Fraction], Fraction]:
-    """Return the shared digit budget with each once-computed edge derivative.
+) -> tuple[
+    int,
+    dict[tuple[int, int], Fraction],
+    Fraction,
+    dict[tuple[str, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    dict[tuple[int, int], tuple[int, int]],
+    tuple[int, int],
+]:
+    """Return the shared digit budget with each once-computed derivative.
 
     The returned slacks and maximum congestion ratio are the same measured
     components priced into the budget, so one producer or replay pass
     subtracts each slack and divides each positive-capacity ratio exactly
-    once and the work ledger charges that single execution.
+    once and the work ledger charges that single execution. The returned
+    per-row bound maps are those same measurements, letting envelope
+    admission price the result without any second arithmetic pass.
     """
 
     slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
@@ -426,19 +433,30 @@ def derived_profile_components_from_sums(
         *slack_bounds.values(),
         congestion_bound,
     ]
-    return max(max(sides) for sides in component_sides), slacks, max_ratio
+    budget = max(max(sides) for sides in component_sides)
+    return (
+        budget,
+        slacks,
+        max_ratio,
+        cell_bounds,
+        load_bounds,
+        slack_bounds,
+        congestion_bound,
+    )
 
 
-def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
-    """Reject tensors whose echoed source and priced rows exceed the envelope."""
+def _require_profile_source_room(flow: MulticommodityFlow) -> None:
+    """Reject tensors whose echoed source leaves no room for any result.
 
-    # The echoed source is measured before any exact component work. Every
-    # admitted result contains at least the header, one congestion rational,
-    # and one divergence and one edge row (FlowGraph admits no zero-edge
-    # graphs and commodities at least one source/sink pair), so a serialized
-    # source that already leaves no room for that skeleton can never pass the
-    # priced estimate below and fails closed immediately instead of paying
-    # the full component scan first.
+    The echoed source is measured before any exact component work. Every
+    admitted result contains at least the header, one congestion rational,
+    and one divergence and one edge row (FlowGraph admits no zero-edge
+    graphs and commodities at least one source/sink pair), so a serialized
+    source that already leaves no room for that skeleton can never pass the
+    priced estimate below and fails closed immediately instead of paying
+    the full component scan first.
+    """
+
     source_bytes = len(encode_strict_json(flow.model_dump(mode="json")))
     minimum_result_bytes = (
         source_bytes
@@ -461,9 +479,21 @@ def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
             f"{MAX_PROFILE_RESULT_BYTES}-byte aggregate result bound"
         )
 
-    cell_bounds, load_bounds, slack_bounds, congestion_bound = (
-        _profile_component_digit_bounds(flow)
-    )
+
+def _require_admitted_profile_rows(
+    flow: MulticommodityFlow,
+    cell_bounds: dict[tuple[str, int], tuple[int, int]],
+    load_bounds: dict[tuple[int, int], tuple[int, int]],
+    slack_bounds: dict[tuple[int, int], tuple[int, int]],
+    congestion_bound: tuple[int, int],
+) -> None:
+    """Price every returned row against the aggregate result envelope.
+
+    The bounds are the ones the kernel's single measured scan already
+    produced, so admission prices the result without a second arithmetic
+    pass and the two-pass work ledger stays exact.
+    """
+
     divergence_bytes = sum(
         num_digits
         + den_digits
@@ -486,7 +516,7 @@ def _require_profile_output_admission(flow: MulticommodityFlow) -> None:
             + _EDGE_ROW_OVERHEAD_BYTES
         )
     estimated_bytes = (
-        source_bytes
+        len(encode_strict_json(flow.model_dump(mode="json")))
         + divergence_bytes
         + edge_bytes
         + congestion_bytes
@@ -559,11 +589,6 @@ class MulticommodityFlowProfileRequest(StrictModel):
             "result envelope below 8 MiB."
         )
     )
-
-    @model_validator(mode="after")
-    def require_admitted_profile_work_and_result(self) -> Self:
-        _require_profile_output_admission(self.flow)
-        return self
 
 
 class CommodityDivergence(StrictModel):

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -244,10 +244,7 @@ def _profile_component_digit_bounds(
         load_n, load_d = _sum_bound(
             edge_operands[edge_key], den_total, edge_num[edge_key]
         )
-        if (
-            edge_operands[edge_key] == 1
-            and edge_sole_amount[edge_key] == edge.capacity
-        ):
+        if edge_operands[edge_key] == 1 and edge_sole_amount[edge_key] == edge.capacity:
             # The lone amount equals the capacity exactly: the load is the
             # capacity, the slack is the exact zero rational, and the
             # congestion ratio reduces to exactly one.

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -65,29 +65,32 @@ _EDGE_ROW_OVERHEAD_BYTES = 128
 _RATIONAL_JSON_OVERHEAD_BYTES = 24
 _PROFILE_RESULT_HEADER_BYTES = 1_024
 
-# One pass performs at most 6F+E additions/subtractions, K negations, E
-# divisions, and K*V+4E comparisons. Each sparse entry performs three bucketed
-# numerator additions -- source divergence, sink divergence, and edge load --
-# and deposits its denominator into each of those three buckets, so the shared
-# combination adds at most one fraction per distinct (bucket, denominator)
-# pair: at most 3F denominator folds on top of the 3F numerator additions,
-# plus one slack subtraction per edge. Sparse entries are distinct
+# One pass performs at most 6F+E additions/subtractions, K negations, at
+# most E divisions, and K*V+3E comparisons. Each sparse entry performs three
+# bucketed numerator additions -- source divergence, sink divergence, and
+# edge load -- and deposits its denominator into each of those three buckets,
+# so the shared combination adds at most one fraction per distinct (bucket,
+# denominator) pair: at most 3F denominator folds on top of the 3F numerator
+# additions, plus one slack subtraction per edge. Sparse entries are distinct
 # commodity-by-edge cells of the conceptual tensor, so F <= K*E <= 256 * 512.
 # Every admitted commodity occupies V >= 2 distinct commodity-vertex cells
 # because its source and sink differ, so the 512-cell divergence budget
 # admits at most 256 commodities, one negation each, and FlowGraph's own
-# 512-edge tuple bounds E. Each edge is compared four times: load against
-# capacity and capacity against zero in the kernel loop, capacity against
-# zero in the shared derivative scan, then either load against zero or its
-# ratio against the running congestion maximum. With the admitted maxima
-# this is 790,272 logical steps per pass; producer plus exact result replay
-# therefore costs at most 1,580,544.
+# 512-edge tuple bounds E. The shared derivative scan also classifies each
+# edge's capacity with one zero-capacity comparison and checks each
+# zero-capacity edge's load once: when a loaded zero-capacity edge exists the
+# result's congestion is null, so no ratio is divided or compared at all;
+# otherwise those checks pair every edge either with a zero-capacity load
+# test or with one ratio division plus one running-maximum comparison, and
+# the kernel's own edge loop needs only its load-vs-capacity feasibility
+# test. With the admitted maxima this bounds each pass by 789,760 logical
+# steps; producer plus exact result replay therefore costs at most 1,579,520.
 MAX_SPARSE_FLOW_ENTRIES = (MAX_COMMODITY_VERTEX_CELLS // 2) * MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_ADDITIONS_PER_PASS = 6 * MAX_SPARSE_FLOW_ENTRIES + MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_NEGATIONS_PER_PASS = MAX_COMMODITY_VERTEX_CELLS // 2
 MAX_PROFILE_DIVISIONS_PER_PASS = MAX_MULTICOMMODITY_EDGES
 MAX_PROFILE_COMPARISONS_PER_PASS = (
-    MAX_COMMODITY_VERTEX_CELLS + 4 * MAX_MULTICOMMODITY_EDGES
+    MAX_COMMODITY_VERTEX_CELLS + 3 * MAX_MULTICOMMODITY_EDGES
 )
 MAX_PROFILE_LOGICAL_STEPS = 2 * (
     MAX_PROFILE_ADDITIONS_PER_PASS
@@ -327,43 +330,70 @@ def _measured_side_bounds(value: Fraction) -> tuple[int, int]:
 def _edge_slacks_and_max_congestion(
     flow: MulticommodityFlow,
     loads: dict[tuple[int, int], Fraction],
-) -> tuple[dict[tuple[int, int], Fraction], Fraction]:
-    """Return each exact edge slack and the maximum positive-capacity ratio.
+) -> tuple[dict[tuple[int, int], Fraction], Fraction | None, int, int]:
+    """Return each exact slack plus the congestion ratio when it is returned.
 
-    Every slack is subtracted here exactly once and every positive-capacity
-    congestion ratio divided exactly once, so the profile kernel reuses these
-    measured components instead of repeating that arithmetic in its own edge
-    loop.
+    Every slack is subtracted here exactly once. The same loop classifies
+    each edge with one zero-capacity comparison and tests each zero-capacity
+    edge's load once: a loaded zero-capacity edge forces the public result's
+    ``congestion`` to be null, so in that case no positive-capacity ratio is
+    divided, compared against a running maximum, capped, or priced -- the
+    returned ratio is None and the division count is zero. Otherwise every
+    positive-capacity edge contributes exactly one ratio division and one
+    running-maximum comparison. The returned counts are the comparisons and
+    divisions this scan executed, so the profile work ledger charges exactly
+    the arithmetic this scan performs.
     """
 
     slacks: dict[tuple[int, int], Fraction] = {}
-    max_ratio = Fraction(0)
+    positive_capacity_edges: list[tuple[Fraction, Fraction]] = []
+    zero_capacity_violation = False
+    comparisons = 0
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
         capacity = edge.capacity.as_fraction()
         slacks[edge_key] = capacity - loads[edge_key]
-        if capacity > 0:
-            max_ratio = max(max_ratio, loads[edge_key] / capacity)
-    return slacks, max_ratio
+        comparisons += 1
+        if capacity == 0:
+            comparisons += 1
+            if loads[edge_key] > 0:
+                zero_capacity_violation = True
+        else:
+            positive_capacity_edges.append((loads[edge_key], capacity))
+    if zero_capacity_violation:
+        return slacks, None, comparisons, 0
+    max_ratio = Fraction(0)
+    divisions = 0
+    for load, capacity in positive_capacity_edges:
+        candidate = load / capacity
+        divisions += 1
+        if candidate > max_ratio:
+            max_ratio = candidate
+        comparisons += 1
+    return slacks, max_ratio, comparisons, divisions
 
 
 def _measured_component_digit_bounds(
     divergences: dict[tuple[str, int], Fraction],
     loads: dict[tuple[int, int], Fraction],
     slacks: dict[tuple[int, int], Fraction],
-    max_ratio: Fraction,
+    congestion_ratio: Fraction | None,
 ) -> tuple[
     dict[tuple[str, int], tuple[int, int]],
     dict[tuple[int, int], tuple[int, int]],
     dict[tuple[int, int], tuple[int, int]],
-    tuple[int, int],
+    tuple[int, int] | None,
 ]:
     cell_bounds = {
         key: _measured_side_bounds(value) for key, value in divergences.items()
     }
     load_bounds = {key: _measured_side_bounds(value) for key, value in loads.items()}
     slack_bounds = {key: _measured_side_bounds(value) for key, value in slacks.items()}
-    congestion_bound = _measured_side_bounds(max_ratio)
+    # A null congestion ratio is exactly the loaded zero-capacity-edge case in
+    # which the result returns no congestion value: there is nothing to cap.
+    congestion_bound = (
+        None if congestion_ratio is None else _measured_side_bounds(congestion_ratio)
+    )
     return cell_bounds, load_bounds, slack_bounds, congestion_bound
 
 
@@ -378,7 +408,7 @@ def _profile_component_digit_bounds(
     dict[tuple[str, int], tuple[int, int]],
     dict[tuple[int, int], tuple[int, int]],
     dict[tuple[int, int], tuple[int, int]],
-    tuple[int, int],
+    tuple[int, int] | None,
 ]:
     """Measure the exact numerator/denominator sizes of every derived row.
 
@@ -386,13 +416,19 @@ def _profile_component_digit_bounds(
     far below any digit-count worst case, so each component is measured as
     the exact reduced rational the kernel will produce; any accumulation that
     crosses the canonical cap aborts immediately instead of growing further.
+    The congestion bound is None exactly when the result returns no
+    congestion value.
     """
 
     divergences, loads = (
         component_sums if component_sums is not None else (_component_sums(flow))
     )
-    slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
-    return _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
+    slacks, congestion_ratio, _comparisons, _divisions = (
+        _edge_slacks_and_max_congestion(flow, loads)
+    )
+    return _measured_component_digit_bounds(
+        divergences, loads, slacks, congestion_ratio
+    )
 
 
 class AdmittedProfileScan(NamedTuple):
@@ -402,6 +438,11 @@ class AdmittedProfileScan(NamedTuple):
     from it, and hands it to the producer pass, which otherwise recomputes
     it; the replay pass always rescans independently. Either way an
     accepted call executes exactly two arithmetic passes.
+
+    ``congestion_ratio`` is None exactly when a loaded zero-capacity edge
+    makes the public result's congestion null, so no ratio arithmetic ran;
+    ``scan_comparisons`` and ``scan_divisions`` count the comparisons and
+    divisions this scan executed for the exact work ledger.
     """
 
     divergences: dict[tuple[str, int], Fraction]
@@ -409,42 +450,51 @@ class AdmittedProfileScan(NamedTuple):
     denominator_folds: int
     budget: int
     slacks: dict[tuple[int, int], Fraction]
-    max_congestion_ratio: Fraction
+    congestion_ratio: Fraction | None
+    scan_divisions: int
+    scan_comparisons: int
     cell_bounds: dict[tuple[str, int], tuple[int, int]]
     load_bounds: dict[tuple[int, int], tuple[int, int]]
     slack_bounds: dict[tuple[int, int], tuple[int, int]]
-    congestion_bound: tuple[int, int]
+    congestion_bound: tuple[int, int] | None
 
 
 def measured_profile_components(flow: MulticommodityFlow) -> AdmittedProfileScan:
     """Run the single bucketed component scan and derive every priced bound.
 
-    The returned slacks and maximum congestion ratio are the same measured
-    components priced into the budget, so one producer or replay pass
-    subtracts each slack and divides each positive-capacity ratio exactly
-    once and the work ledger charges that single execution. The per-row
-    bound maps are those same measurements, letting envelope admission
-    price the result without any second arithmetic pass.
+    The returned slacks and congestion ratio are the same measured components
+    priced into the budget, so one producer or replay pass subtracts each
+    slack exactly once and divides each positive-capacity ratio exactly once
+    whenever the result returns a congestion value (and never divides one
+    when a loaded zero-capacity edge forces it to be null); the work ledger
+    charges that single execution. The per-row bound maps are those same
+    measurements, letting envelope admission price the result without any
+    second arithmetic pass.
     """
 
     divergences, loads, denominator_folds = _component_sums_with_folds(flow)
-    slacks, max_ratio = _edge_slacks_and_max_congestion(flow, loads)
+    slacks, congestion_ratio, scan_comparisons, scan_divisions = (
+        _edge_slacks_and_max_congestion(flow, loads)
+    )
     cell_bounds, load_bounds, slack_bounds, congestion_bound = (
-        _measured_component_digit_bounds(divergences, loads, slacks, max_ratio)
+        _measured_component_digit_bounds(divergences, loads, slacks, congestion_ratio)
     )
     component_sides = [
         *cell_bounds.values(),
         *load_bounds.values(),
         *slack_bounds.values(),
-        congestion_bound,
     ]
+    if congestion_bound is not None:
+        component_sides.append(congestion_bound)
     return AdmittedProfileScan(
         divergences=divergences,
         loads=loads,
         denominator_folds=denominator_folds,
         budget=max(max(sides) for sides in component_sides),
         slacks=slacks,
-        max_congestion_ratio=max_ratio,
+        congestion_ratio=congestion_ratio,
+        scan_divisions=scan_divisions,
+        scan_comparisons=scan_comparisons,
         cell_bounds=cell_bounds,
         load_bounds=load_bounds,
         slack_bounds=slack_bounds,
@@ -520,13 +570,15 @@ def _require_admitted_profile_rows(
     cell_bounds: dict[tuple[str, int], tuple[int, int]],
     load_bounds: dict[tuple[int, int], tuple[int, int]],
     slack_bounds: dict[tuple[int, int], tuple[int, int]],
-    congestion_bound: tuple[int, int],
+    congestion_bound: tuple[int, int] | None,
 ) -> None:
     """Price every returned row against the aggregate result envelope.
 
     The bounds are the ones the kernel's single measured scan already
     produced, so admission prices the result without a second arithmetic
-    pass and the two-pass work ledger stays exact.
+    pass and the two-pass work ledger stays exact. A null congestion bound
+    is the loaded zero-capacity-edge case whose result serializes a null:
+    the reserved rational overhead alone covers that field's bytes.
     """
 
     divergence_bytes = sum(
@@ -537,7 +589,11 @@ def _require_admitted_profile_rows(
         for num_digits, den_digits in cell_bounds.values()
     )
     edge_bytes = 0
-    congestion_bytes = sum(congestion_bound) + _RATIONAL_JSON_OVERHEAD_BYTES
+    congestion_bytes = (
+        _RATIONAL_JSON_OVERHEAD_BYTES
+        if congestion_bound is None
+        else (sum(congestion_bound) + _RATIONAL_JSON_OVERHEAD_BYTES)
+    )
     for edge in flow.network.edges:
         edge_key = (edge.source, edge.target)
         load_num, load_den = load_bounds[edge_key]

--- a/src/jacobian/math/graphs/multicommodity_flow/_models.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_models.py
@@ -255,10 +255,11 @@ def _profile_component_digit_bounds(
         slack_d = capacity_den + den_total
         load_bounds[edge_key] = (load_n, load_d)
         slack_bounds[edge_key] = (slack_n, slack_d)
-        # The ratio divides one load by one capacity: both sides pick up the
-        # capacity numerator only.
+        # The ratio divides one load by one capacity: cross-multiplication
+        # grows the ratio numerator by the capacity denominator and the ratio
+        # denominator by the capacity numerator.
         congestion_bound = (
-            max(congestion_bound[0], load_n + capacity_num),
+            max(congestion_bound[0], load_n + capacity_den),
             max(congestion_bound[1], den_total + capacity_num),
         )
     return cell_bounds, load_bounds, slack_bounds, congestion_bound

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
 from jacobian.math.graphs.multicommodity_flow._models import (
+    MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
 )
 
 
 def compute_multicommodity_flow_profile(
-    request: MulticommodityFlowProfileRequest,
+    flow: MulticommodityFlow,
 ) -> MulticommodityFlowProfileResult:
     """Compute the exact bounded load and conservation profile of one tensor."""
 
@@ -21,9 +22,9 @@ def compute_multicommodity_flow_profile(
         capacity_feasible,
         congestion,
         work,
-    ) = profile_components(request.flow)
+    ) = profile_components(flow)
     return MulticommodityFlowProfileResult(
-        flow=request.flow,
+        flow=flow,
         divergences=divergences,
         edge_profiles=edge_profiles,
         all_demands_routed=all_demands_routed,
@@ -31,6 +32,14 @@ def compute_multicommodity_flow_profile(
         congestion=congestion,
         work=work,
     )
+
+
+def _run_multicommodity_flow_profile(
+    request: MulticommodityFlowProfileRequest,
+) -> MulticommodityFlowProfileResult:
+    """Run one parsed MCP request through the native profile computation."""
+
+    return compute_multicommodity_flow_profile(request.flow)
 
 
 __all__ = ["compute_multicommodity_flow_profile"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -7,25 +7,20 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
-    _require_profile_output_admission,
 )
 
 
 def compute_multicommodity_flow_profile(
     flow: MulticommodityFlow,
 ) -> MulticommodityFlowProfileResult:
-    """Compute the exact bounded load and conservation profile of one tensor."""
+    """Compute the exact bounded load and conservation profile of one tensor.
 
-    # The canonical tensor carries only representation bounds, so this native
-    # boundary enforces the profile execution envelope itself. The MCP path
-    # has already admitted its flow once during request parsing.
-    _require_profile_output_admission(flow)
-    return _admitted_profile_result(flow)
+    The canonical tensor value carries only representation bounds; this
+    execution boundary admits the profile work and result envelope inside
+    the kernel's single measured scan, for native calls and parsed MCP
+    requests alike.
+    """
 
-
-def _admitted_profile_result(
-    flow: MulticommodityFlow,
-) -> MulticommodityFlowProfileResult:
     (
         divergences,
         edge_profiles,
@@ -50,7 +45,7 @@ def _run_multicommodity_flow_profile(
 ) -> MulticommodityFlowProfileResult:
     """Run one parsed MCP request through the native profile computation."""
 
-    return _admitted_profile_result(request.flow)
+    return compute_multicommodity_flow_profile(request.flow)
 
 
 __all__ = ["compute_multicommodity_flow_profile"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -7,6 +7,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
+    _require_profile_output_admission,
 )
 
 
@@ -15,6 +16,16 @@ def compute_multicommodity_flow_profile(
 ) -> MulticommodityFlowProfileResult:
     """Compute the exact bounded load and conservation profile of one tensor."""
 
+    # The canonical tensor carries only representation bounds, so this native
+    # boundary enforces the profile execution envelope itself. The MCP path
+    # has already admitted its flow once during request parsing.
+    _require_profile_output_admission(flow)
+    return _admitted_profile_result(flow)
+
+
+def _admitted_profile_result(
+    flow: MulticommodityFlow,
+) -> MulticommodityFlowProfileResult:
     (
         divergences,
         edge_profiles,
@@ -39,7 +50,7 @@ def _run_multicommodity_flow_profile(
 ) -> MulticommodityFlowProfileResult:
     """Run one parsed MCP request through the native profile computation."""
 
-    return compute_multicommodity_flow_profile(request.flow)
+    return _admitted_profile_result(request.flow)
 
 
 __all__ = ["compute_multicommodity_flow_profile"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
 from jacobian.math.graphs.multicommodity_flow._models import (
+    AdmittedProfileScan,
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
@@ -17,11 +18,17 @@ def compute_multicommodity_flow_profile(
 
     The canonical tensor value carries only representation bounds; this
     execution boundary admits the profile work and result envelope inside
-    the kernel's single measured scan, so a native call executes exactly the
-    two charged passes. Parsed MCP requests were already validated with the
-    same admission at request parsing.
+    its own measured scan, so a native call executes exactly the two
+    charged passes. Parsed MCP requests reuse their parse-time scan instead.
     """
 
+    return _profile_result(flow, None)
+
+
+def _profile_result(
+    flow: MulticommodityFlow,
+    admitted: AdmittedProfileScan | None,
+) -> MulticommodityFlowProfileResult:
     (
         divergences,
         edge_profiles,
@@ -29,7 +36,7 @@ def compute_multicommodity_flow_profile(
         capacity_feasible,
         congestion,
         work,
-    ) = profile_components(flow)
+    ) = profile_components(flow, admitted)
     return MulticommodityFlowProfileResult(
         flow=flow,
         divergences=divergences,
@@ -44,9 +51,14 @@ def compute_multicommodity_flow_profile(
 def _run_multicommodity_flow_profile(
     request: MulticommodityFlowProfileRequest,
 ) -> MulticommodityFlowProfileResult:
-    """Run one parsed MCP request through the native profile computation."""
+    """Run one parsed MCP request through the native profile computation.
 
-    return compute_multicommodity_flow_profile(request.flow)
+    Request validation already performed and admitted the operation's single
+    component scan; it is reused here as the producer pass, so execution
+    adds only the independent replay pass.
+    """
+
+    return _profile_result(request.flow, request._admitted_scan)
 
 
 __all__ = ["compute_multicommodity_flow_profile"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -17,8 +17,9 @@ def compute_multicommodity_flow_profile(
 
     The canonical tensor value carries only representation bounds; this
     execution boundary admits the profile work and result envelope inside
-    the kernel's single measured scan, for native calls and parsed MCP
-    requests alike.
+    the kernel's single measured scan, so a native call executes exactly the
+    two charged passes. Parsed MCP requests were already validated with the
+    same admission at request parsing.
     """
 
     (

--- a/src/jacobian/math/graphs/multicommodity_flow/_operations.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_operations.py
@@ -1,0 +1,36 @@
+"""Public operation adapters for exact multicommodity-flow profiles."""
+
+from __future__ import annotations
+
+from jacobian.math.graphs.multicommodity_flow._kernel import profile_components
+from jacobian.math.graphs.multicommodity_flow._models import (
+    MulticommodityFlowProfileRequest,
+    MulticommodityFlowProfileResult,
+)
+
+
+def compute_multicommodity_flow_profile(
+    request: MulticommodityFlowProfileRequest,
+) -> MulticommodityFlowProfileResult:
+    """Compute the exact bounded load and conservation profile of one tensor."""
+
+    (
+        divergences,
+        edge_profiles,
+        all_demands_routed,
+        capacity_feasible,
+        congestion,
+        work,
+    ) = profile_components(request.flow)
+    return MulticommodityFlowProfileResult(
+        flow=request.flow,
+        divergences=divergences,
+        edge_profiles=edge_profiles,
+        all_demands_routed=all_demands_routed,
+        capacity_feasible=capacity_feasible,
+        congestion=congestion,
+        work=work,
+    )
+
+
+__all__ = ["compute_multicommodity_flow_profile"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_tools.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_tools.py
@@ -1,0 +1,112 @@
+"""Exact multicommodity-flow operation declarations."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.graphs.multicommodity_flow._models import (
+    MulticommodityFlowProfileRequest,
+    MulticommodityFlowProfileResult,
+)
+from jacobian.math.graphs.multicommodity_flow._operations import (
+    compute_multicommodity_flow_profile,
+)
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="network.multicommodity_flow.profile.compute",
+        version="1",
+        title="Compute an exact multicommodity-flow profile",
+        description=(
+            "Compute exact commodity conservation, aggregate edge loads, signed "
+            "capacity slacks, capacity feasibility, and congestion for one "
+            "canonical sparse rational multicommodity-flow tensor. The result "
+            "retains and replays the complete network, demands, and tensor; it "
+            "does not search for a flow or solve an optimization problem."
+        ),
+        request_type=MulticommodityFlowProfileRequest,
+        result_type=MulticommodityFlowProfileResult,
+        run=compute_multicommodity_flow_profile,
+        tags=(
+            "network",
+            "multicommodity-flow",
+            "flow-profile",
+            "conservation",
+            "capacity",
+            "exact",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "two_commodities_share_a_bottleneck",
+                "Profile two exact commodity flows sharing a directed bottleneck; "
+                "network edges, commodities, and nonzero entries must use their "
+                "published canonical sort orders.",
+                {
+                    "flow": {
+                        "network": {
+                            "vertex_count": 4,
+                            "edges": [
+                                {
+                                    "source": 0,
+                                    "target": 2,
+                                    "capacity": {"num": "2", "den": "1"},
+                                },
+                                {
+                                    "source": 1,
+                                    "target": 2,
+                                    "capacity": {"num": "2", "den": "1"},
+                                },
+                                {
+                                    "source": 2,
+                                    "target": 3,
+                                    "capacity": {"num": "3", "den": "1"},
+                                },
+                            ],
+                        },
+                        "commodities": [
+                            {
+                                "commodity_id": "a",
+                                "source": 0,
+                                "sink": 3,
+                                "demand": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "commodity_id": "b",
+                                "source": 1,
+                                "sink": 3,
+                                "demand": {"num": "2", "den": "1"},
+                            },
+                        ],
+                        "entries": [
+                            {
+                                "commodity_id": "a",
+                                "source": 0,
+                                "target": 2,
+                                "amount": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "commodity_id": "a",
+                                "source": 2,
+                                "target": 3,
+                                "amount": {"num": "1", "den": "1"},
+                            },
+                            {
+                                "commodity_id": "b",
+                                "source": 1,
+                                "target": 2,
+                                "amount": {"num": "2", "den": "1"},
+                            },
+                            {
+                                "commodity_id": "b",
+                                "source": 2,
+                                "target": 3,
+                                "amount": {"num": "2", "den": "1"},
+                            },
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/graphs/multicommodity_flow/_tools.py
+++ b/src/jacobian/math/graphs/multicommodity_flow/_tools.py
@@ -7,7 +7,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlowProfileResult,
 )
 from jacobian.math.graphs.multicommodity_flow._operations import (
-    compute_multicommodity_flow_profile,
+    _run_multicommodity_flow_profile,
 )
 
 TOOLS: MathTools = (
@@ -24,7 +24,7 @@ TOOLS: MathTools = (
         ),
         request_type=MulticommodityFlowProfileRequest,
         result_type=MulticommodityFlowProfileResult,
-        run=compute_multicommodity_flow_profile,
+        run=_run_multicommodity_flow_profile,
         tags=(
             "network",
             "multicommodity-flow",

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -18,6 +18,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlowProfileResult,
 )
 from jacobian.math.graphs.multicommodity_flow._operations import (
+    _run_multicommodity_flow_profile,
     compute_multicommodity_flow_profile,
 )
 from jacobian.math.graphs.multicommodity_flow._tools import TOOLS
@@ -56,10 +57,21 @@ def test_catalog_contains_the_audited_multicommodity_profile() -> None:
     }
 
 
-def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
-    result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
+def test_native_api_accepts_the_canonical_flow_value_directly() -> None:
+    flow = shared_bottleneck_flow()
+
+    native = compute_multicommodity_flow_profile(flow)
+    via_request = _run_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=flow)
     )
+
+    assert native == via_request
+    assert native.flow == flow
+    assert native.congestion == q(1)
+
+
+def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
+    result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
 
     assert result.all_demands_routed is True
     assert result.capacity_feasible is True
@@ -110,9 +122,7 @@ def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
             )
         }
     )
-    capacity_result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=capacity_only)
-    )
+    capacity_result = compute_multicommodity_flow_profile(capacity_only)
     assert capacity_result.all_demands_routed is True
     assert capacity_result.capacity_feasible is False
     assert capacity_result.congestion == q(3, 2)
@@ -126,9 +136,7 @@ def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
             )
         }
     )
-    conservation_result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=conservation_only)
-    )
+    conservation_result = compute_multicommodity_flow_profile(conservation_only)
     assert conservation_result.all_demands_routed is False
     assert conservation_result.capacity_feasible is True
 
@@ -142,9 +150,7 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
         commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
         entries=(CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),),
     )
-    result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=flow)
-    )
+    result = compute_multicommodity_flow_profile(flow)
     assert result.all_demands_routed is True
     assert result.capacity_feasible is False
     assert result.congestion is None
@@ -153,6 +159,66 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
     assert result.work.rational_divisions_per_pass == 0
     assert result.work.exact_comparisons_per_pass == 5
     assert result.work.logical_steps_per_call == 20
+
+
+def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> None:
+    # Commodity "a" already mismatches at the very first divergence cell, yet
+    # the demand scan must compare all eight commodity/vertex cells rather
+    # than short-circuiting while still charging them.
+    flow = shared_bottleneck_flow().model_copy(
+        update={
+            "commodities": (
+                CommodityDemand(commodity_id="a", source=0, sink=3, demand=q(2)),
+                CommodityDemand(commodity_id="b", source=1, sink=3, demand=q(2)),
+            )
+        }
+    )
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is False
+    assert result.capacity_feasible is True
+    assert result.work.commodity_vertex_cells == 8
+    assert result.work.edge_cells == 3
+    assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
+    assert result.work.logical_steps_per_call == 74
+
+
+def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
+    def mixed_flow(zero_capacity_edge_first: bool) -> MulticommodityFlow:
+        capacities = ((q(0), q(1), q(1)), (q(1), q(1), q(0)))[
+            zero_capacity_edge_first
+        ]
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=4,
+                edges=(
+                    CapacitatedEdge(source=0, target=1, capacity=capacities[0]),
+                    CapacitatedEdge(source=1, target=2, capacity=capacities[1]),
+                    CapacitatedEdge(source=2, target=3, capacity=capacities[2]),
+                ),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=3, demand=q(1)),
+            ),
+            entries=(
+                CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),
+                CommodityEdgeFlow(commodity_id="a", source=1, target=2, amount=q(1)),
+                CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1)),
+            ),
+        )
+
+    for zero_capacity_edge_first in (True, False):
+        result = compute_multicommodity_flow_profile(
+            mixed_flow(zero_capacity_edge_first)
+        )
+        assert result.all_demands_routed is True
+        assert result.capacity_feasible is False
+        # Both positive-capacity ratios are divided and compared against the
+        # running maximum even when a preceding zero-capacity edge has already
+        # made the congestion value null.
+        assert result.congestion is None
+        assert result.work.rational_divisions_per_pass == 2
+        assert result.work.exact_comparisons_per_pass == 4 + 3 * 3
+        assert result.work.logical_steps_per_call == 56
 
 
 def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
@@ -174,9 +240,7 @@ def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> Non
             CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1, 2)),
         ),
     )
-    result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=flow)
-    )
+    result = compute_multicommodity_flow_profile(flow)
     assert result.all_demands_routed is True
     assert result.capacity_feasible is True
     assert result.congestion == q(1)
@@ -225,9 +289,7 @@ def test_tighter_multicommodity_envelope_rejects_vertex_and_rational_overflow() 
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:
-    result = compute_multicommodity_flow_profile(
-        MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
-    )
+    result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
     payload = result.model_dump(mode="json")
 
     forged_load = deepcopy(payload)

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -405,10 +405,12 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
             CanonicalRational(num="9" * 32_768, den="1"),
         )
     )
-    with pytest.raises(ValidationError, match="canonical cap"):
-        MulticommodityFlowProfileRequest(flow=over_boundary)
     with pytest.raises(ValueError, match="canonical cap"):
         compute_multicommodity_flow_profile(over_boundary)
+    with pytest.raises(ValueError, match="canonical cap"):
+        _run_multicommodity_flow_profile(
+            MulticommodityFlowProfileRequest(flow=over_boundary)
+        )
 
 
 def test_sole_operand_components_inherit_their_canonical_sides() -> None:
@@ -810,10 +812,10 @@ def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
 
     # Unit-capacity edges carrying 22,000-digit amounts make the echoed
     # entries, divergence cells, loads, slacks, and congestion genuinely
-    # exceed 8 MiB together, so the profile request boundary fails closed
+    # exceed 8 MiB together, so the profile execution boundary fails closed
     # before any backend.
-    with pytest.raises(ValidationError, match="aggregate result bound"):
-        MulticommodityFlowProfileRequest(flow=comb_amount_tensor(22_000))
+    with pytest.raises(ValueError, match="aggregate result bound"):
+        compute_multicommodity_flow_profile(comb_amount_tensor(22_000))
 
 
 def test_congestion_bound_uses_the_capacity_denominator() -> None:
@@ -941,10 +943,10 @@ def test_coprime_denominator_flood_fails_closed() -> None:
     flood = MulticommodityFlow(
         network=network, commodities=commodities, entries=entries
     )
-    with pytest.raises(ValidationError, match="canonical cap"):
-        MulticommodityFlowProfileRequest(flow=flood)
     with pytest.raises(ValueError, match="canonical cap"):
         compute_multicommodity_flow_profile(flood)
+    with pytest.raises(ValueError, match="canonical cap"):
+        _run_multicommodity_flow_profile(MulticommodityFlowProfileRequest(flow=flood))
 
 
 def oversized_echo_flow() -> MulticommodityFlow:
@@ -983,18 +985,18 @@ def oversized_echo_flow() -> MulticommodityFlow:
 def test_oversized_source_is_rejected_before_the_component_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from jacobian.math.graphs.multicommodity_flow import _models
+    from jacobian.math.graphs.multicommodity_flow import _kernel
 
     scanned: list[MulticommodityFlow] = []
-    original = _models._profile_component_digit_bounds
+    original = _kernel._component_sums_with_folds
 
     def spy(flow: MulticommodityFlow) -> object:
         scanned.append(flow)
         return original(flow)
 
-    monkeypatch.setattr(_models, "_profile_component_digit_bounds", spy)
-    with pytest.raises(ValidationError, match="aggregate result bound"):
-        MulticommodityFlowProfileRequest(flow=oversized_echo_flow())
+    monkeypatch.setattr(_kernel, "_component_sums_with_folds", spy)
+    with pytest.raises(ValueError, match="aggregate result bound"):
+        compute_multicommodity_flow_profile(oversized_echo_flow())
     assert scanned == []
 
 
@@ -1044,8 +1046,8 @@ def test_oversized_source_rejection_precedes_a_doomed_exact_scan() -> None:
             ),
         ),
     )
-    with pytest.raises(ValidationError, match="aggregate result bound"):
-        MulticommodityFlowProfileRequest(flow=doomed_echo)
+    with pytest.raises(ValueError, match="aggregate result bound"):
+        compute_multicommodity_flow_profile(doomed_echo)
 
 
 def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
@@ -1269,8 +1271,6 @@ def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() ->
             ),
         ),
     )
-    with pytest.raises(ValidationError, match="fold-intermediate budget"):
-        MulticommodityFlowProfileRequest(flow=cancelling_cell)
     with pytest.raises(ValueError, match="fold-intermediate budget"):
         compute_multicommodity_flow_profile(cancelling_cell)
 
@@ -1289,9 +1289,9 @@ def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None
     p_digits = "1" + "0" * 31_998 + "1"
     q_digits = "3" + "0" * 31_998 + "1"
     r_digits = "5" + "0" * 31_998 + "3"
-    with pytest.raises(ValidationError, match="fold-intermediate budget"):
-        MulticommodityFlowProfileRequest(
-            flow=MulticommodityFlow(
+    with pytest.raises(ValueError, match="fold-intermediate budget"):
+        compute_multicommodity_flow_profile(
+            MulticommodityFlow(
                 network=FlowGraph(
                     vertex_count=3,
                     edges=(

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -457,9 +457,9 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
 
 def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
     # FlowGraph owns the structural edge domain; this operation controls only
-    # the derived commodity-edge cells, ledger, and result envelope. A
-    # one-commodity 129-edge network over 12 vertices executes 658 steps per
-    # pass with a tiny result, so no independent edge ceiling may reject it.
+    # the ledger and result envelope. A one-commodity 129-edge network over 12
+    # vertices executes 658 steps per pass with a tiny result, so no
+    # independent edge ceiling may reject it.
     def many_edge_flow(vertex_count: int, edge_count: int) -> MulticommodityFlow:
         pairs = [
             (source, target)
@@ -502,10 +502,51 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
         many_edge_flow(64, 513)
 
 
+def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
+    # The kernel scans sparse entries and per-edge sums; it never materializes
+    # a dense commodity-by-edge tensor, so five commodities over a full
+    # 512-edge graph are admitted on the quantities actually consumed and
+    # returned: 120 divergence rows, 512 small edge rows, 5,370 steps.
+    def wide_network(commodity_count: int) -> MulticommodityFlow:
+        pairs = [
+            (source, target)
+            for source in range(24)
+            for target in range(24)
+            if source != target
+        ][:512]
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=24,
+                edges=tuple(
+                    CapacitatedEdge(source=source, target=target, capacity=q(1))
+                    for source, target in pairs
+                ),
+            ),
+            commodities=tuple(
+                CommodityDemand(
+                    commodity_id=f"c{index:04d}", source=0, sink=23, demand=q(1)
+                )
+                for index in range(commodity_count)
+            ),
+        )
+
+    result = compute_multicommodity_flow_profile(wide_network(5))
+    assert result.all_demands_routed is False
+    assert result.capacity_feasible is True
+    assert result.congestion == q(0)
+    assert len(result.divergences) == 120
+    assert len(result.edge_profiles) == 512
+    assert result.work.rational_additions_per_pass == 512
+    assert result.work.rational_negations_per_pass == 5
+    assert result.work.rational_divisions_per_pass == 512
+    assert result.work.exact_comparisons_per_pass == 120 + 3 * 512
+    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 3 * 512)
+
+
 def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
-    # Commodity count is bounded by the derived commodity-vertex and
-    # commodity-edge cell budgets rather than an independent fixed ceiling:
-    # 17 commodities over two vertices occupy only 34 cells of constant size.
+    # Commodity count is bounded by the derived commodity-vertex cell budget
+    # rather than an independent fixed ceiling: 17 commodities over two
+    # vertices occupy only 34 cells of constant size.
     def dense_commodities(commodity_count: int) -> MulticommodityFlow:
         return MulticommodityFlow(
             network=FlowGraph(

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -502,6 +502,56 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
         many_edge_flow(64, 513)
 
 
+def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
+    # Sparse entries are distinct commodity-by-edge cells, so a one-commodity
+    # network with 129 sorted unit edges carries 129 admissible unit entries:
+    # 13 divergence rows, 129 edge rows, and 1,046 steps per pass sit well
+    # inside the published addition, comparison, work, and output envelopes.
+    def filled_network(vertex_count: int, edge_count: int) -> MulticommodityFlow:
+        pairs = [
+            (source, target)
+            for source in range(vertex_count)
+            for target in range(vertex_count)
+            if source != target
+        ][:edge_count]
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=vertex_count,
+                edges=tuple(
+                    CapacitatedEdge(source=source, target=target, capacity=q(1))
+                    for source, target in pairs
+                ),
+            ),
+            commodities=(
+                CommodityDemand(
+                    commodity_id="a", source=0, sink=vertex_count - 1, demand=q(1)
+                ),
+            ),
+            entries=tuple(
+                CommodityEdgeFlow(
+                    commodity_id="a", source=source, target=target, amount=q(1)
+                )
+                for source, target in pairs
+            ),
+        )
+
+    result = compute_multicommodity_flow_profile(filled_network(13, 129))
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert result.work.sparse_entries == 129
+    assert len(result.edge_profiles) == 129
+    assert all(row.load == q(1) for row in result.edge_profiles)
+    assert result.work.rational_additions_per_pass == 3 * 129 + 129
+    assert result.work.exact_comparisons_per_pass == 13 + 3 * 129
+    assert result.work.logical_steps_per_call == 2 * (516 + 1 + 129 + 400)
+
+    # The entry count inherits the derived cell maxima: one commodity over a
+    # full 512-edge graph admits exactly 512 distinct entries.
+    full = compute_multicommodity_flow_profile(filled_network(64, 512))
+    assert full.work.sparse_entries == 512
+    assert full.work.rational_additions_per_pass == 3 * 512 + 512
+
+
 def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
     # The kernel scans sparse entries and per-edge sums; it never materializes
     # a dense commodity-by-edge tensor, so five commodities over a full
@@ -582,16 +632,16 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
         dense_commodities(257)
 
 
-def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
+def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
     from itertools import combinations
 
-    def comb_edge_tensor(capacity: CanonicalRational) -> MulticommodityFlow:
-        # 128 edges keep the echoed source under the 10 MiB canonical encoder
-        # while the priced derived rows cross the 8 MiB result envelope.
+    def comb_edge_tensor(
+        capacity: CanonicalRational, edge_count: int
+    ) -> MulticommodityFlow:
         edges = tuple(
             CapacitatedEdge(source=source, target=target, capacity=capacity)
             for source, target in combinations(range(32), 2)
-        )[:128]
+        )[:edge_count]
         return MulticommodityFlow(
             network=FlowGraph(vertex_count=32, edges=edges),
             commodities=tuple(
@@ -602,19 +652,43 @@ def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
             ),
         )
 
-    # Every edge slack is priced at its own worst-case digit bound, so 128
-    # 30,000-digit capacities price the edge rows alone above the aggregate
-    # envelope and the tensor is rejected before any backend runs.
-    with pytest.raises(ValidationError, match="aggregate result bound"):
-        comb_edge_tensor(CanonicalRational(num="9" * 30_000, den="1"))
+    def comb_amount_tensor(amount_digits: int) -> MulticommodityFlow:
+        pairs = list(combinations(range(32), 2))[:128]
+        amount = CanonicalRational(num="9" * amount_digits, den="1")
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=32,
+                edges=tuple(
+                    CapacitatedEdge(source=source, target=target, capacity=q(1))
+                    for source, target in pairs
+                ),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=31, demand=q(1)),
+            ),
+            entries=tuple(
+                CommodityEdgeFlow(
+                    commodity_id="a", source=source, target=target, amount=amount
+                )
+                for source, target in pairs
+            ),
+        )
 
-    # Halving the operand size keeps every priced row inside the envelope:
-    # large exact operands are admitted whenever the components they can
-    # reach stay bounded, never because of a fixed input cap.
-    admitted = comb_edge_tensor(CanonicalRational(num="9" * 5_000, den="1"))
+    # With no entries each load is exactly zero and each slack equals its
+    # capacity: 100 capacities with 32,000-digit numerators echo about
+    # 3.2 MB and repeat them once as slacks, about 6.4 MB total, so the
+    # request stays inside the aggregate envelope. Pricing the zero loads at
+    # the slack bound would have inflated this above 8 MiB and rejected it.
+    admitted = comb_edge_tensor(CanonicalRational(num="9" * 32_000, den="1"), 100)
     result = compute_multicommodity_flow_profile(admitted)
     assert result.capacity_feasible is True
     assert result.work.edge_cells == len(result.flow.network.edges)
+
+    # Unit-capacity edges carrying 22,000-digit amounts make the echoed
+    # entries, divergence cells, loads, slacks, and congestion genuinely
+    # exceed 8 MiB together, so admission fails closed before any backend.
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        comb_amount_tensor(22_000)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -403,9 +403,7 @@ def test_sole_operand_components_inherit_their_canonical_sides() -> None:
     assert result.congestion == q(1)
     assert result.edge_profiles[0].load == operand
     assert result.edge_profiles[0].slack == q(0)
-    negative_operand = CanonicalRational(
-        num="-" + "9" * 20_000, den="1" + "0" * 19_999
-    )
+    negative_operand = CanonicalRational(num="-" + "9" * 20_000, den="1" + "0" * 19_999)
     assert [row.divergence for row in result.divergences] == [
         operand,
         negative_operand,

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -1098,6 +1098,8 @@ def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
     assert divergence[("a", 0)] == Fraction(1, 2) + Fraction(1, 3)
     assert divergence[("b", 0)] == Fraction(1, 2)
     assert result.edge_profiles[0].load.as_fraction() == Fraction(1)
+
+
 def test_fold_intermediates_admit_coprime_sums_with_small_components() -> None:
     # One edge, four commodities carrying 1/p, 1/q, (p-2)/(2p), (q-2)/(2q)
     # with p and q coprime 20,000-digit odd integers: denominator sorting

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -397,14 +397,18 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
     assert result.congestion == CanonicalRational(num="9" * 32_768, den="1")
 
     # Two such amounts on one edge genuinely add: their exact load has
-    # 32,769 digits, above the canonical cap, so admission fails closed.
-    with pytest.raises(ValidationError, match="canonical cap"):
-        unit_edge_amounts(
-            (
-                CanonicalRational(num="9" * 32_768, den="1"),
-                CanonicalRational(num="9" * 32_768, den="1"),
-            )
+    # 32,769 digits, above the canonical cap, so the profile boundary fails
+    # closed while the canonical tensor itself stays constructible.
+    over_boundary = unit_edge_amounts(
+        (
+            CanonicalRational(num="9" * 32_768, den="1"),
+            CanonicalRational(num="9" * 32_768, den="1"),
         )
+    )
+    with pytest.raises(ValidationError, match="canonical cap"):
+        MulticommodityFlowProfileRequest(flow=over_boundary)
+    with pytest.raises(ValueError, match="canonical cap"):
+        compute_multicommodity_flow_profile(over_boundary)
 
 
 def test_sole_operand_components_inherit_their_canonical_sides() -> None:
@@ -806,9 +810,10 @@ def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
 
     # Unit-capacity edges carrying 22,000-digit amounts make the echoed
     # entries, divergence cells, loads, slacks, and congestion genuinely
-    # exceed 8 MiB together, so admission fails closed before any backend.
+    # exceed 8 MiB together, so the profile request boundary fails closed
+    # before any backend.
     with pytest.raises(ValidationError, match="aggregate result bound"):
-        comb_amount_tensor(22_000)
+        MulticommodityFlowProfileRequest(flow=comb_amount_tensor(22_000))
 
 
 def test_congestion_bound_uses_the_capacity_denominator() -> None:
@@ -933,8 +938,13 @@ def test_coprime_denominator_flood_fails_closed() -> None:
             amount=CanonicalRational(num="1", den="7" + "0" * 12_775 + "1"),
         ),
     )
+    flood = MulticommodityFlow(
+        network=network, commodities=commodities, entries=entries
+    )
     with pytest.raises(ValidationError, match="canonical cap"):
-        MulticommodityFlow(network=network, commodities=commodities, entries=entries)
+        MulticommodityFlowProfileRequest(flow=flood)
+    with pytest.raises(ValueError, match="canonical cap"):
+        compute_multicommodity_flow_profile(flood)
 
 
 def oversized_echo_flow() -> MulticommodityFlow:
@@ -984,7 +994,7 @@ def test_oversized_source_is_rejected_before_the_component_scan(
 
     monkeypatch.setattr(_models, "_profile_component_digit_bounds", spy)
     with pytest.raises(ValidationError, match="aggregate result bound"):
-        oversized_echo_flow()
+        MulticommodityFlowProfileRequest(flow=oversized_echo_flow())
     assert scanned == []
 
 
@@ -1001,40 +1011,41 @@ def test_oversized_source_rejection_precedes_a_doomed_exact_scan() -> None:
         if source != target and (source, target) != (0, 1)
     ][:268]
     big = CanonicalRational(num="9" * 32_000, den="1")
+    doomed_echo = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=vertex_count,
+            edges=tuple(
+                CapacitatedEdge(source=source, target=target, capacity=q(1))
+                for source, target in [(0, 1), *bulk_pairs]
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=16, demand=q(1)),
+            CommodityDemand(commodity_id="b", source=0, sink=1, demand=q(1)),
+        ),
+        entries=(
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=0,
+                target=1,
+                amount=CanonicalRational(num="1", den="3" + "0" * 19_999),
+            ),
+            *(
+                CommodityEdgeFlow(
+                    commodity_id="a", source=source, target=target, amount=big
+                )
+                for source, target in bulk_pairs
+            ),
+            CommodityEdgeFlow(
+                commodity_id="b",
+                source=0,
+                target=1,
+                amount=CanonicalRational(num="1", den="7" + "0" * 12_775 + "1"),
+            ),
+        ),
+    )
     with pytest.raises(ValidationError, match="aggregate result bound"):
-        MulticommodityFlow(
-            network=FlowGraph(
-                vertex_count=vertex_count,
-                edges=tuple(
-                    CapacitatedEdge(source=source, target=target, capacity=q(1))
-                    for source, target in [(0, 1), *bulk_pairs]
-                ),
-            ),
-            commodities=(
-                CommodityDemand(commodity_id="a", source=0, sink=16, demand=q(1)),
-                CommodityDemand(commodity_id="b", source=0, sink=1, demand=q(1)),
-            ),
-            entries=(
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=0,
-                    target=1,
-                    amount=CanonicalRational(num="1", den="3" + "0" * 19_999),
-                ),
-                *(
-                    CommodityEdgeFlow(
-                        commodity_id="a", source=source, target=target, amount=big
-                    )
-                    for source, target in bulk_pairs
-                ),
-                CommodityEdgeFlow(
-                    commodity_id="b",
-                    source=0,
-                    target=1,
-                    amount=CanonicalRational(num="1", den="7" + "0" * 12_775 + "1"),
-                ),
-            ),
-        )
+        MulticommodityFlowProfileRequest(flow=doomed_echo)
 
 
 def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
@@ -1227,40 +1238,41 @@ def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() ->
     p_digits = "1" + "0" * 23_998 + "1"
     q_digits = "3" + "0" * 23_998 + "1"
     r_digits = "5" + "0" * 23_998 + "3"
+    cancelling_cell = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                CapacitatedEdge(source=1, target=0, capacity=q(1)),
+                CapacitatedEdge(source=2, target=0, capacity=q(1)),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+        entries=(
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=0,
+                target=1,
+                amount=CanonicalRational(num="1", den=p_digits),
+            ),
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=1,
+                target=0,
+                amount=CanonicalRational(num="1", den=q_digits),
+            ),
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=2,
+                target=0,
+                amount=CanonicalRational(num="1", den=r_digits),
+            ),
+        ),
+    )
     with pytest.raises(ValidationError, match="fold-intermediate budget"):
-        MulticommodityFlow(
-            network=FlowGraph(
-                vertex_count=3,
-                edges=(
-                    CapacitatedEdge(source=0, target=1, capacity=q(1)),
-                    CapacitatedEdge(source=1, target=0, capacity=q(1)),
-                    CapacitatedEdge(source=2, target=0, capacity=q(1)),
-                ),
-            ),
-            commodities=(
-                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
-            ),
-            entries=(
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=0,
-                    target=1,
-                    amount=CanonicalRational(num="1", den=p_digits),
-                ),
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=1,
-                    target=0,
-                    amount=CanonicalRational(num="1", den=q_digits),
-                ),
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=2,
-                    target=0,
-                    amount=CanonicalRational(num="1", den=r_digits),
-                ),
-            ),
-        )
+        MulticommodityFlowProfileRequest(flow=cancelling_cell)
+    with pytest.raises(ValueError, match="fold-intermediate budget"):
+        compute_multicommodity_flow_profile(cancelling_cell)
 
 
 def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None:
@@ -1278,38 +1290,40 @@ def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None
     q_digits = "3" + "0" * 31_998 + "1"
     r_digits = "5" + "0" * 31_998 + "3"
     with pytest.raises(ValidationError, match="fold-intermediate budget"):
-        MulticommodityFlow(
-            network=FlowGraph(
-                vertex_count=3,
-                edges=(
-                    CapacitatedEdge(source=0, target=1, capacity=q(1)),
-                    CapacitatedEdge(source=1, target=0, capacity=q(1)),
-                    CapacitatedEdge(source=2, target=0, capacity=q(1)),
+        MulticommodityFlowProfileRequest(
+            flow=MulticommodityFlow(
+                network=FlowGraph(
+                    vertex_count=3,
+                    edges=(
+                        CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                        CapacitatedEdge(source=1, target=0, capacity=q(1)),
+                        CapacitatedEdge(source=2, target=0, capacity=q(1)),
+                    ),
                 ),
-            ),
-            commodities=(
-                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
-            ),
-            entries=(
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=0,
-                    target=1,
-                    amount=CanonicalRational(num="1", den=p_digits),
+                commodities=(
+                    CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
                 ),
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=1,
-                    target=0,
-                    amount=CanonicalRational(num="1", den=q_digits),
+                entries=(
+                    CommodityEdgeFlow(
+                        commodity_id="a",
+                        source=0,
+                        target=1,
+                        amount=CanonicalRational(num="1", den=p_digits),
+                    ),
+                    CommodityEdgeFlow(
+                        commodity_id="a",
+                        source=1,
+                        target=0,
+                        amount=CanonicalRational(num="1", den=q_digits),
+                    ),
+                    CommodityEdgeFlow(
+                        commodity_id="a",
+                        source=2,
+                        target=0,
+                        amount=CanonicalRational(num="1", den=r_digits),
+                    ),
                 ),
-                CommodityEdgeFlow(
-                    commodity_id="a",
-                    source=2,
-                    target=0,
-                    amount=CanonicalRational(num="1", den=r_digits),
-                ),
-            ),
+            )
         )
 
 

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -11,6 +11,8 @@ from pydantic import ValidationError
 from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
 from jacobian.math.graphs.multicommodity_flow._models import (
+    MAX_COMMODITY_VERTEX_CELLS,
+    MAX_MULTICOMMODITY_EDGES,
     CommodityDemand,
     CommodityEdgeFlow,
     MulticommodityFlow,
@@ -269,21 +271,130 @@ def test_sparse_tensor_rejects_zero_duplicate_unknown_and_unsorted_cells() -> No
         MulticommodityFlow.model_validate(unsorted)
 
 
-def test_tighter_multicommodity_envelope_rejects_vertex_and_rational_overflow() -> None:
-    payload = shared_bottleneck_flow().model_dump(mode="json")
+def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
+    # A 33-vertex graph with one edge and terminals 0->1 has tiny work and
+    # output; the commodity-vertex cell budget (K*V <= 512) and the aggregate
+    # result envelope bound admission, not an independent vertex ceiling.
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=33,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=q(2)),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),
+        ),
+    )
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1, 2)
+    assert len(result.divergences) == 33
+    assert result.work.commodity_vertex_cells == 33
+    assert result.work.exact_comparisons_per_pass == 33 + 3
+    assert result.work.logical_steps_per_call == 2 * (4 + 1 + 1 + 36)
 
-    too_many_vertices = deepcopy(payload)
-    too_many_vertices["network"]["vertex_count"] = 33
-    with pytest.raises(ValidationError, match="at most 32 vertices"):
-        MulticommodityFlow.model_validate(too_many_vertices)
+    # Eight commodities over all 64 FlowGraph vertices reach exactly 512
+    # returned cells; a ninth commodity exceeds the dense divergence budget.
+    def wide_flow(commodity_count: int) -> MulticommodityFlow:
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=64,
+                edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+            ),
+            commodities=tuple(
+                CommodityDemand(
+                    commodity_id=chr(ord("a") + index),
+                    source=0,
+                    sink=1,
+                    demand=q(1),
+                )
+                for index in range(commodity_count)
+            ),
+        )
 
-    too_many_digits = deepcopy(payload)
-    too_many_digits["network"]["edges"][0]["capacity"] = {
-        "num": str(10**32),
-        "den": "1",
-    }
-    with pytest.raises(ValidationError, match="32-digit"):
-        MulticommodityFlow.model_validate(too_many_digits)
+    full = compute_multicommodity_flow_profile(wide_flow(8))
+    assert len(full.divergences) == 512
+    assert full.work.commodity_vertex_cells == MAX_COMMODITY_VERTEX_CELLS
+
+    with pytest.raises(ValidationError, match="commodity-by-vertex"):
+        wide_flow(9)
+
+
+def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> None:
+    # A 33-digit capacity performs constant work here and returns only a
+    # 33-digit slack; operand-derived digit budgets, not a fixed input cap,
+    # decide whether such exact scalars are admitted.
+    big_capacity = q(10**32)
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=big_capacity),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+        ),
+    )
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is False
+    assert result.capacity_feasible is True
+    assert result.congestion == q(0)
+    assert result.edge_profiles[0].slack == big_capacity
+    assert result.work.sparse_entries == 0
+    assert result.work.commodity_vertex_cells == 2
+    assert result.work.edge_cells == 1
+    assert result.work.rational_additions_per_pass == 1
+    assert result.work.rational_negations_per_pass == 1
+    assert result.work.rational_divisions_per_pass == 1
+    assert result.work.exact_comparisons_per_pass == 5
+    assert result.work.logical_steps_per_call == 16
+
+
+def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
+    def single_edge_flow(capacity: CanonicalRational) -> MulticommodityFlow:
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=2,
+                edges=(CapacitatedEdge(source=0, target=1, capacity=capacity),),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+            ),
+        )
+
+    # One 32,759-digit numerator plus its one-digit denominator and the eight
+    # derivation slack digits reach exactly the canonical 32,768-digit cap.
+    at_boundary = single_edge_flow(
+        CanonicalRational(num="9" * 32_759, den="1")
+    )
+    result = compute_multicommodity_flow_profile(at_boundary)
+    assert result.capacity_feasible is True
+    assert result.edge_profiles[0].slack.num == "9" * 32_759
+
+    beyond_boundary = CanonicalRational(num="9" * 32_760, den="1")
+    with pytest.raises(ValidationError, match="canonical cap"):
+        single_edge_flow(beyond_boundary)
+
+
+def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
+    from itertools import combinations
+
+    edges = tuple(
+        CapacitatedEdge(source=source, target=target, capacity=q(int("9" * 100)))
+        for source, target in combinations(range(32), 2)
+    )[:MAX_MULTICOMMODITY_EDGES]
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        MulticommodityFlow(
+            network=FlowGraph(vertex_count=32, edges=edges),
+            commodities=tuple(
+                CommodityDemand(
+                    commodity_id=f"c{index:02d}", source=0, sink=31, demand=q(1)
+                )
+                for index in range(16)
+            ),
+        )
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -838,6 +838,37 @@ def test_cancelling_amounts_are_admitted_regardless_of_entry_order() -> None:
     assert result.capacity_feasible is True
 
 
+def test_coprime_denominator_flood_fails_closed() -> None:
+    # Two unit-fraction entries whose distinct near-cap denominators are
+    # coprime would construct a roughly 32,776-digit load denominator; the
+    # bucketed combination checks every fold against the canonical cap and
+    # fails closed immediately instead of building the huge fraction.
+    network = FlowGraph(
+        vertex_count=2,
+        edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+    )
+    commodities = (
+        CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+        CommodityDemand(commodity_id="b", source=0, sink=1, demand=q(1)),
+    )
+    entries = (
+        CommodityEdgeFlow(
+            commodity_id="a",
+            source=0,
+            target=1,
+            amount=CanonicalRational(num="1", den="3" + "0" * 19_999),
+        ),
+        CommodityEdgeFlow(
+            commodity_id="b",
+            source=0,
+            target=1,
+            amount=CanonicalRational(num="1", den="7" + "0" * 12_775 + "1"),
+        ),
+    )
+    with pytest.raises(ValidationError, match="canonical cap"):
+        MulticommodityFlow(network=network, commodities=commodities, entries=entries)
+
+
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:
     result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
     payload = result.model_dump(mode="json")

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -280,12 +280,8 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
             vertex_count=33,
             edges=(CapacitatedEdge(source=0, target=1, capacity=q(2)),),
         ),
-        commodities=(
-            CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
-        ),
-        entries=(
-            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),
-        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+        entries=(CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),),
     )
     result = compute_multicommodity_flow_profile(flow)
     assert result.all_demands_routed is True
@@ -333,9 +329,7 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
             vertex_count=2,
             edges=(CapacitatedEdge(source=0, target=1, capacity=big_capacity),),
         ),
-        commodities=(
-            CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
-        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
     )
     result = compute_multicommodity_flow_profile(flow)
     assert result.all_demands_routed is False
@@ -366,9 +360,7 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
 
     # One 32,759-digit numerator plus its one-digit denominator and the eight
     # derivation slack digits reach exactly the canonical 32,768-digit cap.
-    at_boundary = single_edge_flow(
-        CanonicalRational(num="9" * 32_759, den="1")
-    )
+    at_boundary = single_edge_flow(CanonicalRational(num="9" * 32_759, den="1"))
     result = compute_multicommodity_flow_profile(at_boundary)
     assert result.capacity_feasible is True
     assert result.edge_profiles[0].slack.num == "9" * 32_759

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -9,7 +9,7 @@ from fractions import Fraction
 import pytest
 from pydantic import ValidationError
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
 from jacobian.math.graphs.multicommodity_flow._models import (
@@ -141,15 +141,17 @@ def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
     # Every entry shares denominator 1, so the bucket fold performs one
     # fraction addition per nonempty bucket: six touched divergence cells and
     # three edges add nine folds to the twelve numerator additions, plus the
-    # three slack subtractions.
+    # three slack subtractions. The shared derivative scan classifies each
+    # edge once and compares each positive-capacity ratio against its running
+    # maximum once; the kernel loop adds one feasibility test per edge.
     assert result.work.sparse_entries == 4
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
     assert result.work.rational_additions_per_pass == 3 * 4 + (6 + 3) + 3
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 3
-    assert result.work.exact_comparisons_per_pass == 20
-    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 20)
+    assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
+    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 17)
 
 
 def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
@@ -197,14 +199,14 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
     assert result.all_demands_routed is True
     assert result.capacity_feasible is False
     assert result.congestion is None
-    # A zero-capacity edge still compares load to capacity and capacity to
-    # zero in the edge loop, capacity to zero in the shared slack scan, then
-    # checks whether its load is positive; no ratio division is attempted.
-    # The lone entry folds one denominator into each of its two divergence
-    # cells and one edge bucket: three fold additions beyond 3*1 + 1.
+    # The shared derivative scan classifies the zero-capacity edge and checks
+    # its load; because that load is positive no ratio is ever divided, and
+    # the kernel loop adds only its load-vs-capacity feasibility test. The
+    # lone entry folds one denominator into each of its two divergence cells
+    # and one edge bucket: three fold additions beyond 3*1 + 1.
     assert result.work.rational_divisions_per_pass == 0
-    assert result.work.exact_comparisons_per_pass == 6
-    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 0 + 6)
+    assert result.work.exact_comparisons_per_pass == 2 + 1 + 2
+    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 0 + 5)
 
 
 def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> None:
@@ -224,8 +226,8 @@ def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> 
     assert result.capacity_feasible is True
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
-    assert result.work.exact_comparisons_per_pass == 8 + 4 * 3
-    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 20)
+    assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
+    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 17)
 
 
 def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
@@ -256,13 +258,15 @@ def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -
         )
         assert result.all_demands_routed is True
         assert result.capacity_feasible is False
-        # Both positive-capacity ratios are divided and compared against the
-        # running maximum even when a preceding zero-capacity edge has already
-        # made the congestion value null.
+        # The loaded zero-capacity edge makes the congestion value null, so
+        # the shared derivative scan divides no positive-capacity ratio at
+        # all: it classifies each of the three edges and checks the loaded
+        # zero-capacity load once, and the kernel loop adds one feasibility
+        # test per edge.
         assert result.congestion is None
-        assert result.work.rational_divisions_per_pass == 2
-        assert result.work.exact_comparisons_per_pass == 4 + 4 * 3
-        assert result.work.logical_steps_per_call == 2 * ((9 + 7 + 3) + 1 + 2 + 16)
+        assert result.work.rational_divisions_per_pass == 0
+        assert result.work.exact_comparisons_per_pass == 4 + 3 + (3 + 1)
+        assert result.work.logical_steps_per_call == 2 * ((9 + 7 + 3) + 1 + 0 + 11)
 
 
 def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
@@ -333,8 +337,8 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
     assert result.congestion == q(1, 2)
     assert len(result.divergences) == 33
     assert result.work.commodity_vertex_cells == 33
-    assert result.work.exact_comparisons_per_pass == 33 + 4
-    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 1 + 37)
+    assert result.work.exact_comparisons_per_pass == 33 + 3
+    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 1 + 36)
 
     # Eight commodities over all 64 FlowGraph vertices reach exactly 512
     # returned cells; a ninth commodity exceeds the dense divergence budget.
@@ -389,8 +393,8 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
     assert result.work.rational_additions_per_pass == 1
     assert result.work.rational_negations_per_pass == 1
     assert result.work.rational_divisions_per_pass == 1
-    assert result.work.exact_comparisons_per_pass == 6
-    assert result.work.logical_steps_per_call == 18
+    assert result.work.exact_comparisons_per_pass == 5
+    assert result.work.logical_steps_per_call == 16
 
 
 def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
@@ -594,17 +598,17 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
     assert len(result.edge_profiles) == 129
     assert result.work.edge_cells == 129
     assert result.work.rational_additions_per_pass == 129
-    assert result.work.exact_comparisons_per_pass == 12 + 4 * 129
-    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 4 * 129)
+    assert result.work.exact_comparisons_per_pass == 12 + 3 * 129
+    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 3 * 129)
 
     # The ledger and returned rows inherit FlowGraph's own 512-edge maximum:
     # a full 512-edge network is admitted and accounted exactly.
     full = compute_multicommodity_flow_profile(many_edge_flow(64, 512))
     assert len(full.edge_profiles) == 512
-    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 4 * 512)
+    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 3 * 512)
 
     # Eight commodities over the same full 512-edge graph fill the dense
-    # divergence budget alongside every edge: 512 cells plus four comparisons
+    # divergence budget alongside every edge: 512 cells plus three comparisons
     # per edge is exactly the published comparison envelope, and the widened
     # work fields must admit that worst case.
     crowded = MulticommodityFlow(
@@ -695,9 +699,9 @@ def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
     assert result.work.rational_additions_per_pass == (
         3 * 129 + unit_fold_additions(flow) + 129
     )
-    assert result.work.exact_comparisons_per_pass == 13 + 4 * 129
+    assert result.work.exact_comparisons_per_pass == 13 + 3 * 129
     assert result.work.logical_steps_per_call == 2 * (
-        3 * 129 + unit_fold_additions(flow) + 129 + 1 + 129 + (13 + 4 * 129)
+        3 * 129 + unit_fold_additions(flow) + 129 + 1 + 129 + (13 + 3 * 129)
     )
 
     # The entry count inherits the derived cell maxima: one commodity over a
@@ -747,8 +751,8 @@ def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
     assert result.work.rational_additions_per_pass == 512
     assert result.work.rational_negations_per_pass == 5
     assert result.work.rational_divisions_per_pass == 512
-    assert result.work.exact_comparisons_per_pass == 120 + 4 * 512
-    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 4 * 512)
+    assert result.work.exact_comparisons_per_pass == 120 + 3 * 512
+    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 3 * 512)
 
 
 def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
@@ -776,7 +780,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     assert len(unrouted.divergences) == 34
     assert unrouted.work.commodity_vertex_cells == 34
     assert unrouted.work.rational_negations_per_pass == 17
-    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 4)
+    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 3)
 
     # Each commodity occupies at least two distinct commodity-vertex cells,
     # so exactly half of the 512-cell divergence budget, 256 commodities, is
@@ -784,7 +788,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     full = compute_multicommodity_flow_profile(dense_commodities(256))
     assert len(full.divergences) == MAX_COMMODITY_VERTEX_CELLS
     assert full.work.rational_negations_per_pass == 256
-    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 4)
+    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 3)
 
     with pytest.raises(ValidationError, match="commodity-by-vertex"):
         dense_commodities(257)
@@ -872,6 +876,135 @@ def test_congestion_bound_uses_the_capacity_denominator() -> None:
     assert congestion_bound == (4_000, 1)
     assert max(load_bounds.values()) == (1, 1)
     assert slack_bounds[(0, 1)] == (4_000, 4_000)
+
+
+def oversized_ratio_tensor() -> MulticommodityFlow:
+    # A load a/b over a capacity c/d whose reduced quotient has both sides
+    # far above the 32,768-digit canonical cap: the numerators are 30,000
+    # digits, the denominators 5,001 digits, and c*b - a*d stays below d, so
+    # every returned component -- divergences, load, slack -- remains inside
+    # the cap while only the congestion quotient exceeds it.
+    b = 10**5_000 + 3
+    d = 10**5_000 + 7
+    c = 10**30_000 + 9
+    a = (c * b) // d
+
+    def rational(value: Fraction) -> CanonicalRational:
+        return CanonicalRational.from_fraction(value)
+
+    load = Fraction(a, b)
+    capacity = Fraction(c, d)
+    return MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=rational(capacity)),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=rational(load)),
+        ),
+        entries=(
+            CommodityEdgeFlow(
+                commodity_id="a", source=0, target=1, amount=rational(load)
+            ),
+        ),
+    )
+
+
+def test_null_congestion_admits_ratios_the_result_omits() -> None:
+    # A positive-capacity edge whose reduced load/capacity quotient exceeds
+    # the canonical cap stands beside an unrelated loaded zero-capacity edge,
+    # so the public result's congestion is null exactly as its contract
+    # defines: the oversized ratio is a value the result omits, and admission
+    # must not reject a representable profile because of it. The shared
+    # derivative scan therefore divides no ratio at all, prices no congestion
+    # row beyond the null field's bytes, and excludes it from the budget.
+    from jacobian.canonical import encode_strict_json
+    from jacobian.math.graphs.multicommodity_flow._models import (
+        _RATIONAL_JSON_OVERHEAD_BYTES,
+        derived_profile_digit_budget,
+    )
+
+    b = 10**5_000 + 3
+    d = 10**5_000 + 7
+    c = 10**30_000 + 9
+    a = (c * b) // d
+
+    def rational(value: Fraction) -> CanonicalRational:
+        return CanonicalRational.from_fraction(value)
+
+    capacity = Fraction(c, d)
+    load = Fraction(a, b)
+    ratio = load / capacity
+    assert len(format_canonical_integer(abs(ratio.numerator))) > (
+        MAX_CANONICAL_RATIONAL_DIGITS
+    )
+    assert len(format_canonical_integer(load.numerator)) < MAX_CANONICAL_RATIONAL_DIGITS
+    assert len(format_canonical_integer(ratio.denominator)) > (
+        MAX_CANONICAL_RATIONAL_DIGITS
+    )
+    # The reserved overhead must cover the serialized null congestion field,
+    # otherwise null-priced envelopes would underprice their results.
+    assert (
+        len(encode_strict_json({"congestion": None})) <= _RATIONAL_JSON_OVERHEAD_BYTES
+    )
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=rational(capacity)),
+                CapacitatedEdge(
+                    source=1, target=2, capacity=CanonicalRational(num="0", den="1")
+                ),
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=rational(load)),
+            CommodityDemand(commodity_id="b", source=1, sink=2, demand=q(1)),
+        ),
+        entries=(
+            CommodityEdgeFlow(
+                commodity_id="a", source=0, target=1, amount=rational(load)
+            ),
+            CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=q(1)),
+        ),
+    )
+    # Every priced component is the operands' own size; the omitted ratio's
+    # 35,001-digit sides never enter the budget.
+    assert derived_profile_digit_budget(flow) == 30_000
+    result = compute_multicommodity_flow_profile(flow)
+    via_request = _run_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=flow)
+    )
+    assert result == via_request
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is False
+    assert result.congestion is None
+    assert [row.load for row in result.edge_profiles] == [
+        rational(load),
+        q(1),
+    ]
+    # Two sparse entries fold one denominator into each of their two
+    # divergence cells plus two edge buckets (six folds), two slack
+    # subtractions run, and the scan classifies each edge once and checks
+    # the loaded zero-capacity load once while dividing nothing; the kernel
+    # loop adds one feasibility test per edge.
+    assert result.work.sparse_entries == 2
+    assert result.work.rational_additions_per_pass == 3 * 2 + 6 + 2
+    assert result.work.rational_divisions_per_pass == 0
+    assert result.work.exact_comparisons_per_pass == 6 + 2 + (2 + 1)
+    assert result.work.logical_steps_per_call == 2 * (14 + 2 + 0 + 11)
+
+
+def test_returned_congestion_ratio_is_still_capped() -> None:
+    # Without a loaded zero-capacity edge the same oversized quotient is the
+    # value the result actually returns under "congestion", so the canonical
+    # cap still applies to it fail-closed on both surfaces: narrowing the
+    # scan to returned values did not widen the returned-value contract.
+    flow = oversized_ratio_tensor()
+    with pytest.raises(ValidationError, match="canonical cap"):
+        MulticommodityFlowProfileRequest(flow=flow)
+    with pytest.raises(ValueError, match="canonical cap"):
+        compute_multicommodity_flow_profile(flow)
 
 
 def test_shared_denominator_sums_stay_at_operand_size() -> None:
@@ -1148,8 +1281,8 @@ def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
     assert result.work.rational_additions_per_pass == 3 * 5 + folds + 4
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 4
-    assert result.work.exact_comparisons_per_pass == 8 + 4 * 4
-    assert result.work.logical_steps_per_call == 2 * (33 + 2 + 4 + 24)
+    assert result.work.exact_comparisons_per_pass == 8 + 3 * 4
+    assert result.work.logical_steps_per_call == 2 * (33 + 2 + 4 + 20)
     # The exact values stay the known answers even though the fold order
     # follows ascending denominator bit length rather than entry order.
     divergence = {
@@ -1273,8 +1406,8 @@ def test_folding_intermediates_cancel_beneath_the_completed_cap() -> None:
     assert result.work.sparse_entries == 4
     assert result.work.commodity_vertex_cells == 8
     assert result.work.rational_additions_per_pass == 3 * 4 + (8 + 4) + 1
-    assert result.work.exact_comparisons_per_pass == 8 + 4
-    assert result.work.logical_steps_per_call == 2 * (25 + 4 + 1 + 12)
+    assert result.work.exact_comparisons_per_pass == 8 + 3
+    assert result.work.logical_steps_per_call == 2 * (25 + 4 + 1 + 11)
 
 
 def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -348,32 +348,49 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
 
 
 def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
-    def unit_edge_amount(amount: CanonicalRational) -> MulticommodityFlow:
+    def unit_edge_amounts(
+        amounts: tuple[CanonicalRational, ...],
+    ) -> MulticommodityFlow:
         return MulticommodityFlow(
             network=FlowGraph(
                 vertex_count=2,
                 edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
             ),
-            commodities=(
-                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+            commodities=tuple(
+                CommodityDemand(
+                    commodity_id=chr(ord("a") + index), source=0, sink=1, demand=q(1)
+                )
+                for index in range(len(amounts))
             ),
-            entries=(
-                CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=amount),
+            entries=tuple(
+                CommodityEdgeFlow(
+                    commodity_id=chr(ord("a") + index),
+                    source=0,
+                    target=1,
+                    amount=amount,
+                )
+                for index, amount in enumerate(amounts)
             ),
         )
 
-    # One lone operand is its own reduced sum: the 32,766-digit amount
-    # numerator, its one-digit denominator, and the two subtraction-composition
-    # digits reach exactly the canonical 32,768-digit component cap.
-    at_boundary = unit_edge_amount(CanonicalRational(num="9" * 32_766, den="1"))
+    # A lone amount is its own reduced sum: even at the canonical 32,768-digit
+    # maximum, measured admission keeps it because every derived component
+    # stays within that operand's own size.
+    at_boundary = unit_edge_amounts((CanonicalRational(num="9" * 32_768, den="1"),))
     result = compute_multicommodity_flow_profile(at_boundary)
     assert result.capacity_feasible is False
-    assert result.edge_profiles[0].load.num == "9" * 32_766
-    assert result.congestion == CanonicalRational(num="9" * 32_766, den="1")
+    assert result.edge_profiles[0].load.num == "9" * 32_768
+    assert result.congestion == CanonicalRational(num="9" * 32_768, den="1")
 
-    beyond_boundary = CanonicalRational(num="9" * 32_767, den="1")
+    # Two such amounts on one edge genuinely add: their exact load has
+    # 32,769 digits, above the canonical cap, so admission fails closed.
     with pytest.raises(ValidationError, match="canonical cap"):
-        unit_edge_amount(beyond_boundary)
+        unit_edge_amounts(
+            (
+                CanonicalRational(num="9" * 32_768, den="1"),
+                CanonicalRational(num="9" * 32_768, den="1"),
+            )
+        )
 
 
 def test_sole_operand_components_inherit_their_canonical_sides() -> None:
@@ -485,10 +502,9 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
             CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=big_amount),
         ),
     )
-    # Each edge and divergence cell receives one lone 16,380-digit operand, so
-    # no component charges summation growth: the slack composition digits give
-    # the shared budget.
-    assert derived_profile_digit_budget(amounts_flow) == 16_380 + 2
+    # With unrelated operands no derived value ever sums them: each component
+    # measures at its own operand's size or one borrow digit beyond it.
+    assert derived_profile_digit_budget(amounts_flow) == 16_380
     amounts_result = compute_multicommodity_flow_profile(amounts_flow)
     assert amounts_result.all_demands_routed is False
     assert amounts_result.edge_profiles[0].load == big_amount
@@ -719,9 +735,7 @@ def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
     # request stays inside the aggregate envelope. Pricing the zero loads at
     # the slack bound would have inflated this above 8 MiB and rejected it.
     admitted = comb_edge_tensor(CanonicalRational(num="9" * 32_000, den="1"), 100)
-    result = compute_multicommodity_flow_profile(admitted)
-    assert result.capacity_feasible is True
-    assert result.work.edge_cells == len(result.flow.network.edges)
+    assert derived_profile_digit_budget(admitted) == 32_000
 
     # Unit-capacity edges carrying 22,000-digit amounts make the echoed
     # entries, divergence cells, loads, slacks, and congestion genuinely
@@ -751,9 +765,41 @@ def test_congestion_bound_uses_the_capacity_denominator() -> None:
     _cell_bounds, load_bounds, slack_bounds, congestion_bound = (
         _profile_component_digit_bounds(flow)
     )
-    assert congestion_bound == (4_001, 2)
+    assert congestion_bound == (4_000, 1)
     assert max(load_bounds.values()) == (1, 1)
-    assert slack_bounds[(0, 1)] == (4_002, 4_001)
+    assert slack_bounds[(0, 1)] == (4_000, 4_000)
+
+
+def test_shared_denominator_sums_stay_at_operand_size() -> None:
+    # Two commodities carry 1/D and (D-1)/D over one unit-capacity edge with
+    # matching demands: the exact load is 1, the slack is exactly zero, the
+    # congestion is exactly one, and every divergence stays within D's own
+    # 20,000-digit sides -- the shared denominator prevents any denominator
+    # growth, so no summed digit-count bound rejects this small result.
+    denominator = "5" * 20_000
+    first = CanonicalRational(num="1", den=denominator)
+    second = CanonicalRational(num="5" * 19_999 + "4", den=denominator)
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=first),
+            CommodityDemand(commodity_id="b", source=0, sink=1, demand=second),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=first),
+            CommodityEdgeFlow(commodity_id="b", source=0, target=1, amount=second),
+        ),
+    )
+    assert derived_profile_digit_budget(flow) == 20_000
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert result.edge_profiles[0].load == q(1)
+    assert result.edge_profiles[0].slack == q(0)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -361,18 +361,55 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
             ),
         )
 
-    # One 32,757-digit amount numerator, its one-digit denominator, the eight
-    # sum carry digits, and one subtraction-composition digit reach exactly
-    # the canonical 32,768-digit component cap.
-    at_boundary = unit_edge_amount(CanonicalRational(num="9" * 32_757, den="1"))
+    # One lone operand is its own reduced sum: the 32,766-digit amount
+    # numerator, its one-digit denominator, and the two subtraction-composition
+    # digits reach exactly the canonical 32,768-digit component cap.
+    at_boundary = unit_edge_amount(CanonicalRational(num="9" * 32_766, den="1"))
     result = compute_multicommodity_flow_profile(at_boundary)
     assert result.capacity_feasible is False
-    assert result.edge_profiles[0].load.num == "9" * 32_757
-    assert result.congestion == CanonicalRational(num="9" * 32_757, den="1")
+    assert result.edge_profiles[0].load.num == "9" * 32_766
+    assert result.congestion == CanonicalRational(num="9" * 32_766, den="1")
 
-    beyond_boundary = CanonicalRational(num="9" * 32_758, den="1")
+    beyond_boundary = CanonicalRational(num="9" * 32_767, den="1")
     with pytest.raises(ValidationError, match="canonical cap"):
         unit_edge_amount(beyond_boundary)
+
+
+def test_sole_operand_components_inherit_their_canonical_sides() -> None:
+    # A two-vertex, one-edge tensor whose sole entry, matching capacity, and
+    # demand are the same reduced rational with a 20,000-digit numerator and
+    # denominator: every divergence and the load equal that already-canonical
+    # operand, the slack is the exact zero rational, and the congestion is
+    # exactly one. Admission tracks the contributing operand count instead of
+    # charging nonexistent summation growth, so no 40,008-digit component is
+    # implied and the tensor stays far below every bound.
+    operand = CanonicalRational(num="9" * 20_000, den="1" + "0" * 19_999)
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=operand),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=operand),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=operand),
+        ),
+    )
+    assert derived_profile_digit_budget(flow) == 20_000
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert result.edge_profiles[0].load == operand
+    assert result.edge_profiles[0].slack == q(0)
+    negative_operand = CanonicalRational(
+        num="-" + "9" * 20_000, den="1" + "0" * 19_999
+    )
+    assert [row.divergence for row in result.divergences] == [
+        operand,
+        negative_operand,
+    ]
 
 
 def test_rational_components_are_bounded_independently() -> None:
@@ -449,7 +486,10 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
             CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=big_amount),
         ),
     )
-    assert derived_profile_digit_budget(amounts_flow) == 8 + 16_381 + 2
+    # Each edge and divergence cell receives one lone 16,380-digit operand, so
+    # no component charges summation growth: the slack composition digits give
+    # the shared budget.
+    assert derived_profile_digit_budget(amounts_flow) == 16_380 + 2
     amounts_result = compute_multicommodity_flow_profile(amounts_flow)
     assert amounts_result.all_demands_routed is False
     assert amounts_result.edge_profiles[0].load == big_amount

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
 from jacobian.math.graphs.multicommodity_flow._models import (
     MAX_COMMODITY_VERTEX_CELLS,
@@ -20,6 +21,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
+    _fold_intermediate_digit_cap,
     _profile_component_digit_bounds,
     derived_profile_digit_budget,
 )
@@ -906,9 +908,10 @@ def test_cancelling_amounts_are_admitted_regardless_of_entry_order() -> None:
 
 def test_coprime_denominator_flood_fails_closed() -> None:
     # Two unit-fraction entries whose distinct near-cap denominators are
-    # coprime would construct a roughly 32,776-digit load denominator; the
-    # bucketed combination checks every fold against the canonical cap and
-    # fails closed immediately instead of building the huge fraction.
+    # coprime complete to a roughly 32,776-digit load denominator above the
+    # canonical cap: their fold intermediates stay inside the operand-mass
+    # envelope, and admission fails closed on the measured completed load
+    # instead of admitting the huge component.
     network = FlowGraph(
         vertex_count=2,
         edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
@@ -1095,6 +1098,76 @@ def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
     assert divergence[("a", 0)] == Fraction(1, 2) + Fraction(1, 3)
     assert divergence[("b", 0)] == Fraction(1, 2)
     assert result.edge_profiles[0].load.as_fraction() == Fraction(1)
+def test_fold_intermediates_admit_coprime_sums_with_small_components() -> None:
+    # One edge, four commodities carrying 1/p, 1/q, (p-2)/(2p), (q-2)/(2q)
+    # with p and q coprime 20,000-digit odd integers: denominator sorting
+    # folds 1/p + 1/q first, whose reduced intermediate has the roughly
+    # 40,000-digit denominator p*q. That transient exceeds the 32,768-digit
+    # canonical cap but stays far inside the operand-mass fold envelope, and
+    # each completed sum is small -- the load is exactly one because each
+    # corresponding pair sums to exactly one half. Fold order must therefore
+    # not reject this tensor.
+    p = 5 * 10**19_999 + 3
+
+    def amount(numerator: int, denominator: int) -> CanonicalRational:
+        return CanonicalRational(
+            num=format_canonical_integer(numerator),
+            den=format_canonical_integer(denominator),
+        )
+
+    commodity_amounts = (
+        amount(1, p),
+        amount(1, p + 2),
+        amount(p - 2, 2 * p),
+        amount(p, 2 * (p + 2)),
+    )
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+        ),
+        commodities=tuple(
+            CommodityDemand(
+                commodity_id=chr(ord("a") + index),
+                source=0,
+                sink=1,
+                demand=amount,
+            )
+            for index, amount in enumerate(commodity_amounts)
+        ),
+        entries=tuple(
+            CommodityEdgeFlow(
+                commodity_id=chr(ord("a") + index),
+                source=0,
+                target=1,
+                amount=amount,
+            )
+            for index, amount in enumerate(commodity_amounts)
+        ),
+    )
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert result.edge_profiles[0].load == q(1)
+    assert result.edge_profiles[0].slack == q(0)
+    assert [row.divergence for row in result.divergences] == [
+        signed
+        for amount in commodity_amounts
+        for signed in (
+            amount,
+            CanonicalRational.from_fraction(-amount.as_fraction()),
+        )
+    ]
+
+
+def test_fold_intermediate_cap_covers_the_proven_operand_mass_envelope() -> None:
+    # The derivation bounds every bucket numerator, reduced partial sum, and
+    # unreduced addition product by three times the amount digit mass plus a
+    # small constant; the admitted cap must dominate that envelope so it can
+    # only fail closed on a violated derivation, never on an admitted fold.
+    for mass in (0, 1, 120_004, 10**7):
+        assert _fold_intermediate_digit_cap(mass) >= 3 * mass + 9
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -184,9 +184,7 @@ def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> 
 
 def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
     def mixed_flow(zero_capacity_edge_first: bool) -> MulticommodityFlow:
-        capacities = ((q(0), q(1), q(1)), (q(1), q(1), q(0)))[
-            zero_capacity_edge_first
-        ]
+        capacities = ((q(0), q(1), q(1)), (q(1), q(1), q(0)))[zero_capacity_edge_first]
         return MulticommodityFlow(
             network=FlowGraph(
                 vertex_count=4,

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -802,6 +802,42 @@ def test_shared_denominator_sums_stay_at_operand_size() -> None:
     assert result.edge_profiles[0].slack == q(0)
 
 
+def test_cancelling_amounts_are_admitted_regardless_of_entry_order() -> None:
+    # Canonical entry order processes both edges leaving vertex 0 before the
+    # incoming ones, so the partial divergence at vertex 0 is 2A. The
+    # canonical cap applies to completed components only: every final
+    # divergence cancels to at most one digit, each large edge has exactly
+    # zero slack and unit congestion, and the tensor is admitted.
+    big = CanonicalRational(num="9" * 32_768, den="1")
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=big),
+                CapacitatedEdge(source=0, target=2, capacity=big),
+                CapacitatedEdge(source=1, target=0, capacity=big),
+                CapacitatedEdge(source=1, target=2, capacity=q(1)),
+                CapacitatedEdge(source=2, target=0, capacity=big),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=2, demand=q(1)),),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=big),
+            CommodityEdgeFlow(commodity_id="a", source=0, target=2, amount=big),
+            CommodityEdgeFlow(commodity_id="a", source=1, target=0, amount=big),
+            CommodityEdgeFlow(commodity_id="a", source=1, target=2, amount=q(1)),
+            CommodityEdgeFlow(commodity_id="a", source=2, target=0, amount=big),
+        ),
+    )
+    result = compute_multicommodity_flow_profile(flow)
+    assert len(result.divergences) == 3
+    assert {row.divergence for row in result.divergences} <= {q(1), q(-1), q(0)}
+    assert [row.slack for row in result.edge_profiles[:4]] == [q(0)] * 4
+    assert result.edge_profiles[4].slack == q(0)
+    assert result.congestion == q(1)
+    assert result.capacity_feasible is True
+
+
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:
     result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
     payload = result.model_dump(mode="json")

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -18,6 +18,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
+    derived_profile_digit_budget,
 )
 from jacobian.math.graphs.multicommodity_flow._operations import (
     _run_multicommodity_flow_profile,
@@ -370,15 +371,107 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
         single_edge_flow(beyond_boundary)
 
 
+def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
+    # Loads and slacks are computed independently per edge and divergence
+    # cells independently per commodity/vertex pair, so each component's
+    # budget covers only the operands that can reach it. Two unrelated
+    # 16,380-digit capacities stay admitted even though summing both would
+    # imply a 32,770-digit bound above the canonical 32,768-digit cap.
+    big_capacity = CanonicalRational(num="9" * 16_380, den="1")
+    capacities_flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=big_capacity),
+                CapacitatedEdge(source=1, target=2, capacity=big_capacity),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=2, demand=q(1)),),
+    )
+    assert derived_profile_digit_budget(capacities_flow) == 8 + 16_380 + 1
+    capacities_result = compute_multicommodity_flow_profile(capacities_flow)
+    assert capacities_result.capacity_feasible is True
+    assert capacities_result.congestion == q(0)
+    assert [row.slack for row in capacities_result.edge_profiles] == [
+        big_capacity,
+        big_capacity,
+    ]
+
+    # The same independence holds between amounts on different edges: no
+    # component ever sums both operands, so the paired tensor below stays
+    # admitted although its aggregated operand digits exceed the cap.
+    big_amount = CanonicalRational(num="9" * 16_380, den="1")
+    amounts_flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                CapacitatedEdge(source=1, target=2, capacity=q(1)),
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+            CommodityDemand(commodity_id="b", source=1, sink=2, demand=q(1)),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=big_amount),
+            CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=big_amount),
+        ),
+    )
+    assert derived_profile_digit_budget(amounts_flow) == 8 + 16_381 + 2
+    amounts_result = compute_multicommodity_flow_profile(amounts_flow)
+    assert amounts_result.all_demands_routed is False
+    assert amounts_result.edge_profiles[0].load == big_amount
+
+
+def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
+    # Commodity count is bounded by the derived commodity-vertex and
+    # commodity-edge cell budgets rather than an independent fixed ceiling:
+    # 17 commodities over two vertices occupy only 34 cells of constant size.
+    def dense_commodities(commodity_count: int) -> MulticommodityFlow:
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=2,
+                edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+            ),
+            commodities=tuple(
+                CommodityDemand(
+                    commodity_id=f"c{index:04d}", source=0, sink=1, demand=q(1)
+                )
+                for index in range(commodity_count)
+            ),
+        )
+
+    unrouted = compute_multicommodity_flow_profile(dense_commodities(17))
+    assert unrouted.all_demands_routed is False
+    assert unrouted.capacity_feasible is True
+    assert unrouted.congestion == q(0)
+    assert len(unrouted.divergences) == 34
+    assert unrouted.work.commodity_vertex_cells == 34
+    assert unrouted.work.rational_negations_per_pass == 17
+    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 3)
+
+    # Each commodity occupies at least two distinct commodity-vertex cells,
+    # so exactly half of the 512-cell divergence budget, 256 commodities, is
+    # admitted over two vertices; one more exceeds the dense table.
+    full = compute_multicommodity_flow_profile(dense_commodities(256))
+    assert len(full.divergences) == MAX_COMMODITY_VERTEX_CELLS
+    assert full.work.rational_negations_per_pass == 256
+    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 3)
+
+    with pytest.raises(ValidationError, match="commodity-by-vertex"):
+        dense_commodities(257)
+
+
 def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
     from itertools import combinations
 
-    edges = tuple(
-        CapacitatedEdge(source=source, target=target, capacity=q(int("9" * 100)))
-        for source, target in combinations(range(32), 2)
-    )[:MAX_MULTICOMMODITY_EDGES]
-    with pytest.raises(ValidationError, match="aggregate result bound"):
-        MulticommodityFlow(
+    def comb_edge_tensor(capacity: CanonicalRational) -> MulticommodityFlow:
+        edges = tuple(
+            CapacitatedEdge(source=source, target=target, capacity=capacity)
+            for source, target in combinations(range(32), 2)
+        )[:MAX_MULTICOMMODITY_EDGES]
+        return MulticommodityFlow(
             network=FlowGraph(vertex_count=32, edges=edges),
             commodities=tuple(
                 CommodityDemand(
@@ -387,6 +480,20 @@ def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
                 for index in range(16)
             ),
         )
+
+    # Every edge slack is priced at its own worst-case digit bound, so 128
+    # 30,000-digit capacities price the edge rows alone above the aggregate
+    # envelope and the tensor is rejected before any backend runs.
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        comb_edge_tensor(CanonicalRational(num="9" * 30_000, den="1"))
+
+    # Halving the operand size keeps every priced row inside the envelope:
+    # large exact operands are admitted whenever the components they can
+    # reach stay bounded, never because of a fixed input cap.
+    admitted = comb_edge_tensor(CanonicalRational(num="9" * 5_000, den="1"))
+    result = compute_multicommodity_flow_profile(admitted)
+    assert result.capacity_feasible is True
+    assert result.work.edge_cells == MAX_MULTICOMMODITY_EDGES
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -17,6 +17,7 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
+    _profile_component_digit_bounds,
     derived_profile_digit_budget,
 )
 from jacobian.math.graphs.multicommodity_flow._operations import (
@@ -727,6 +728,32 @@ def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
     # exceed 8 MiB together, so admission fails closed before any backend.
     with pytest.raises(ValidationError, match="aggregate result bound"):
         comb_amount_tensor(22_000)
+
+
+def test_congestion_bound_uses_the_capacity_denominator() -> None:
+    # A unit load over capacity 1/D reduces to exactly D: cross-multiplication
+    # grows the congestion numerator by the capacity denominator's 4,000
+    # digits plus one additive digit, not by its one-digit numerator.
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(
+                CapacitatedEdge(
+                    source=0,
+                    target=1,
+                    capacity=CanonicalRational(num="1", den="5" * 4_000),
+                ),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+        entries=(CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),),
+    )
+    _cell_bounds, load_bounds, slack_bounds, congestion_bound = (
+        _profile_component_digit_bounds(flow)
+    )
+    assert congestion_bound == (4_001, 2)
+    assert max(load_bounds.values()) == (1, 1)
+    assert slack_bounds[(0, 1)] == (4_002, 4_001)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -405,12 +405,10 @@ def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
             CanonicalRational(num="9" * 32_768, den="1"),
         )
     )
+    with pytest.raises(ValidationError, match="canonical cap"):
+        MulticommodityFlowProfileRequest(flow=over_boundary)
     with pytest.raises(ValueError, match="canonical cap"):
         compute_multicommodity_flow_profile(over_boundary)
-    with pytest.raises(ValueError, match="canonical cap"):
-        _run_multicommodity_flow_profile(
-            MulticommodityFlowProfileRequest(flow=over_boundary)
-        )
 
 
 def test_sole_operand_components_inherit_their_canonical_sides() -> None:
@@ -812,10 +810,10 @@ def test_result_envelope_prices_rows_at_their_actual_sides() -> None:
 
     # Unit-capacity edges carrying 22,000-digit amounts make the echoed
     # entries, divergence cells, loads, slacks, and congestion genuinely
-    # exceed 8 MiB together, so the profile execution boundary fails closed
-    # before any backend.
-    with pytest.raises(ValueError, match="aggregate result bound"):
-        compute_multicommodity_flow_profile(comb_amount_tensor(22_000))
+    # exceed 8 MiB together, so request parsing fails closed before any
+    # backend.
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        MulticommodityFlowProfileRequest(flow=comb_amount_tensor(22_000))
 
 
 def test_congestion_bound_uses_the_capacity_denominator() -> None:
@@ -943,10 +941,10 @@ def test_coprime_denominator_flood_fails_closed() -> None:
     flood = MulticommodityFlow(
         network=network, commodities=commodities, entries=entries
     )
+    with pytest.raises(ValidationError, match="canonical cap"):
+        MulticommodityFlowProfileRequest(flow=flood)
     with pytest.raises(ValueError, match="canonical cap"):
         compute_multicommodity_flow_profile(flood)
-    with pytest.raises(ValueError, match="canonical cap"):
-        _run_multicommodity_flow_profile(MulticommodityFlowProfileRequest(flow=flood))
 
 
 def oversized_echo_flow() -> MulticommodityFlow:
@@ -985,19 +983,36 @@ def oversized_echo_flow() -> MulticommodityFlow:
 def test_oversized_source_is_rejected_before_the_component_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from jacobian.math.graphs.multicommodity_flow import _kernel
+    from jacobian.math.graphs.multicommodity_flow import _kernel, _models
 
-    scanned: list[MulticommodityFlow] = []
-    original = _kernel._component_sums_with_folds
+    measured: list[MulticommodityFlow] = []
+    executed: list[MulticommodityFlow] = []
+    original_bounds = _models._profile_component_digit_bounds
+    original_scan = _kernel._component_sums_with_folds
 
-    def spy(flow: MulticommodityFlow) -> object:
-        scanned.append(flow)
-        return original(flow)
+    def bounds_spy(flow: MulticommodityFlow) -> object:
+        measured.append(flow)
+        return original_bounds(flow)
 
-    monkeypatch.setattr(_kernel, "_component_sums_with_folds", spy)
+    def scan_spy(flow: MulticommodityFlow) -> object:
+        executed.append(flow)
+        return original_scan(flow)
+
+    monkeypatch.setattr(_models, "_profile_component_digit_bounds", bounds_spy)
+    monkeypatch.setattr(_kernel, "_component_sums_with_folds", scan_spy)
+    # Request parsing measures the echoed source first and fails closed
+    # before its own component measurement, and execution therefore never
+    # starts, so neither spy records the tensor.
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        MulticommodityFlowProfileRequest(flow=oversized_echo_flow())
+    assert measured == []
+    assert executed == []
+    # A native call is rejected by the same preflight inside the kernel's
+    # own admission, likewise before any rational arithmetic.
     with pytest.raises(ValueError, match="aggregate result bound"):
         compute_multicommodity_flow_profile(oversized_echo_flow())
-    assert scanned == []
+    assert measured == []
+    assert executed == []
 
 
 def test_oversized_source_rejection_precedes_a_doomed_exact_scan() -> None:
@@ -1046,6 +1061,8 @@ def test_oversized_source_rejection_precedes_a_doomed_exact_scan() -> None:
             ),
         ),
     )
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        MulticommodityFlowProfileRequest(flow=doomed_echo)
     with pytest.raises(ValueError, match="aggregate result bound"):
         compute_multicommodity_flow_profile(doomed_echo)
 
@@ -1271,6 +1288,8 @@ def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() ->
             ),
         ),
     )
+    with pytest.raises(ValidationError, match="fold-intermediate budget"):
+        MulticommodityFlowProfileRequest(flow=cancelling_cell)
     with pytest.raises(ValueError, match="fold-intermediate budget"):
         compute_multicommodity_flow_profile(cancelling_cell)
 
@@ -1289,42 +1308,41 @@ def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None
     p_digits = "1" + "0" * 31_998 + "1"
     q_digits = "3" + "0" * 31_998 + "1"
     r_digits = "5" + "0" * 31_998 + "3"
+    near_cap_growth = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=3,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                CapacitatedEdge(source=1, target=0, capacity=q(1)),
+                CapacitatedEdge(source=2, target=0, capacity=q(1)),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+        entries=(
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=0,
+                target=1,
+                amount=CanonicalRational(num="1", den=p_digits),
+            ),
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=1,
+                target=0,
+                amount=CanonicalRational(num="1", den=q_digits),
+            ),
+            CommodityEdgeFlow(
+                commodity_id="a",
+                source=2,
+                target=0,
+                amount=CanonicalRational(num="1", den=r_digits),
+            ),
+        ),
+    )
+    with pytest.raises(ValidationError, match="fold-intermediate budget"):
+        MulticommodityFlowProfileRequest(flow=near_cap_growth)
     with pytest.raises(ValueError, match="fold-intermediate budget"):
-        compute_multicommodity_flow_profile(
-            MulticommodityFlow(
-                network=FlowGraph(
-                    vertex_count=3,
-                    edges=(
-                        CapacitatedEdge(source=0, target=1, capacity=q(1)),
-                        CapacitatedEdge(source=1, target=0, capacity=q(1)),
-                        CapacitatedEdge(source=2, target=0, capacity=q(1)),
-                    ),
-                ),
-                commodities=(
-                    CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
-                ),
-                entries=(
-                    CommodityEdgeFlow(
-                        commodity_id="a",
-                        source=0,
-                        target=1,
-                        amount=CanonicalRational(num="1", den=p_digits),
-                    ),
-                    CommodityEdgeFlow(
-                        commodity_id="a",
-                        source=1,
-                        target=0,
-                        amount=CanonicalRational(num="1", den=q_digits),
-                    ),
-                    CommodityEdgeFlow(
-                        commodity_id="a",
-                        source=2,
-                        target=0,
-                        amount=CanonicalRational(num="1", den=r_digits),
-                    ),
-                ),
-            )
-        )
+        compute_multicommodity_flow_profile(near_cap_growth)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -1,0 +1,246 @@
+"""Contract tests for exact bounded multicommodity-flow profiles."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
+from jacobian.math.graphs.multicommodity_flow._models import (
+    CommodityDemand,
+    CommodityEdgeFlow,
+    MulticommodityFlow,
+    MulticommodityFlowProfileRequest,
+    MulticommodityFlowProfileResult,
+)
+from jacobian.math.graphs.multicommodity_flow._operations import (
+    compute_multicommodity_flow_profile,
+)
+from jacobian.math.graphs.multicommodity_flow._tools import TOOLS
+
+
+def q(numerator: int, denominator: int = 1) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(numerator, denominator))
+
+
+def shared_bottleneck_flow() -> MulticommodityFlow:
+    return MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=4,
+            edges=(
+                CapacitatedEdge(source=0, target=2, capacity=q(2)),
+                CapacitatedEdge(source=1, target=2, capacity=q(2)),
+                CapacitatedEdge(source=2, target=3, capacity=q(3)),
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=3, demand=q(1)),
+            CommodityDemand(commodity_id="b", source=1, sink=3, demand=q(2)),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=2, amount=q(1)),
+            CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1)),
+            CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=q(2)),
+            CommodityEdgeFlow(commodity_id="b", source=2, target=3, amount=q(2)),
+        ),
+    )
+
+
+def test_catalog_contains_the_audited_multicommodity_profile() -> None:
+    assert {tool.operation_id for tool in TOOLS} == {
+        "network.multicommodity_flow.profile.compute"
+    }
+
+
+def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
+    result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
+    )
+
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert [
+        (row.source, row.target, row.load.as_fraction(), row.slack.as_fraction())
+        for row in result.edge_profiles
+    ] == [
+        (0, 2, Fraction(1), Fraction(1)),
+        (1, 2, Fraction(2), Fraction(0)),
+        (2, 3, Fraction(3), Fraction(0)),
+    ]
+    assert [
+        (row.commodity_id, row.vertex, row.divergence.as_fraction())
+        for row in result.divergences
+    ] == [
+        ("a", 0, Fraction(1)),
+        ("a", 1, Fraction(0)),
+        ("a", 2, Fraction(0)),
+        ("a", 3, Fraction(-1)),
+        ("b", 0, Fraction(0)),
+        ("b", 1, Fraction(2)),
+        ("b", 2, Fraction(0)),
+        ("b", 3, Fraction(-2)),
+    ]
+    # Producer and replay both scan the four sparse entries, four-by-two dense
+    # divergence cells, and three edges; the ledger is exact rather than a cap.
+    assert result.work.sparse_entries == 4
+    assert result.work.commodity_vertex_cells == 8
+    assert result.work.edge_cells == 3
+    assert result.work.rational_additions_per_pass == 15
+    assert result.work.rational_negations_per_pass == 2
+    assert result.work.rational_divisions_per_pass == 3
+    assert result.work.exact_comparisons_per_pass == 17
+    assert result.work.logical_steps_per_call == 74
+
+
+def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
+    capacity_only = shared_bottleneck_flow().model_copy(
+        update={
+            "network": FlowGraph(
+                vertex_count=4,
+                edges=(
+                    CapacitatedEdge(source=0, target=2, capacity=q(2)),
+                    CapacitatedEdge(source=1, target=2, capacity=q(2)),
+                    CapacitatedEdge(source=2, target=3, capacity=q(2)),
+                ),
+            )
+        }
+    )
+    capacity_result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=capacity_only)
+    )
+    assert capacity_result.all_demands_routed is True
+    assert capacity_result.capacity_feasible is False
+    assert capacity_result.congestion == q(3, 2)
+
+    conservation_only = shared_bottleneck_flow().model_copy(
+        update={
+            "entries": (
+                CommodityEdgeFlow(commodity_id="a", source=0, target=2, amount=q(1)),
+                CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1)),
+                CommodityEdgeFlow(commodity_id="b", source=1, target=2, amount=q(2)),
+            )
+        }
+    )
+    conservation_result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=conservation_only)
+    )
+    assert conservation_result.all_demands_routed is False
+    assert conservation_result.capacity_feasible is True
+
+
+def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=q(0)),),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+        entries=(CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1)),),
+    )
+    result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=flow)
+    )
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is False
+    assert result.congestion is None
+    # A zero-capacity edge still compares load to capacity and capacity to zero,
+    # then checks whether its load is positive; no ratio division is attempted.
+    assert result.work.rational_divisions_per_pass == 0
+    assert result.work.exact_comparisons_per_pass == 5
+    assert result.work.logical_steps_per_call == 20
+
+
+def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=4,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=q(1, 2)),
+                CapacitatedEdge(source=0, target=2, capacity=q(1, 2)),
+                CapacitatedEdge(source=1, target=3, capacity=q(1, 2)),
+                CapacitatedEdge(source=2, target=3, capacity=q(1, 2)),
+            ),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=3, demand=q(1)),),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1, 2)),
+            CommodityEdgeFlow(commodity_id="a", source=0, target=2, amount=q(1, 2)),
+            CommodityEdgeFlow(commodity_id="a", source=1, target=3, amount=q(1, 2)),
+            CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1, 2)),
+        ),
+    )
+    result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=flow)
+    )
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert all(row.slack == q(0) for row in result.edge_profiles)
+
+
+def test_sparse_tensor_rejects_zero_duplicate_unknown_and_unsorted_cells() -> None:
+    payload = shared_bottleneck_flow().model_dump(mode="json")
+
+    zero = deepcopy(payload)
+    zero["entries"][0]["amount"] = {"num": "0", "den": "1"}
+    with pytest.raises(ValidationError, match="strictly positive"):
+        MulticommodityFlow.model_validate(zero)
+
+    duplicate = deepcopy(payload)
+    duplicate["entries"].append(deepcopy(duplicate["entries"][0]))
+    with pytest.raises(ValidationError, match=r"sorted|once"):
+        MulticommodityFlow.model_validate(duplicate)
+
+    undeclared = deepcopy(payload)
+    undeclared["entries"][1]["commodity_id"] = "aa"
+    with pytest.raises(ValidationError, match="undeclared commodity"):
+        MulticommodityFlow.model_validate(undeclared)
+
+    unsorted = deepcopy(payload)
+    unsorted["entries"] = list(reversed(unsorted["entries"]))
+    with pytest.raises(ValidationError, match="sorted"):
+        MulticommodityFlow.model_validate(unsorted)
+
+
+def test_tighter_multicommodity_envelope_rejects_vertex_and_rational_overflow() -> None:
+    payload = shared_bottleneck_flow().model_dump(mode="json")
+
+    too_many_vertices = deepcopy(payload)
+    too_many_vertices["network"]["vertex_count"] = 33
+    with pytest.raises(ValidationError, match="at most 32 vertices"):
+        MulticommodityFlow.model_validate(too_many_vertices)
+
+    too_many_digits = deepcopy(payload)
+    too_many_digits["network"]["edges"][0]["capacity"] = {
+        "num": str(10**32),
+        "den": "1",
+    }
+    with pytest.raises(ValidationError, match="32-digit"):
+        MulticommodityFlow.model_validate(too_many_digits)
+
+
+def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:
+    result = compute_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
+    )
+    payload = result.model_dump(mode="json")
+
+    forged_load = deepcopy(payload)
+    forged_load["edge_profiles"][2]["load"] = {"num": "2", "den": "1"}
+    with pytest.raises(ValidationError, match="exact multicommodity-flow profile"):
+        MulticommodityFlowProfileResult.model_validate(forged_load)
+
+    forged_source = deepcopy(payload)
+    forged_source["flow"]["commodities"][1]["demand"] = {"num": "1", "den": "1"}
+    with pytest.raises(ValidationError, match="exact multicommodity-flow profile"):
+        MulticommodityFlowProfileResult.model_validate(forged_source)
+
+    forged_work = deepcopy(payload)
+    forged_work["work"]["logical_steps_per_call"] = 1
+    with pytest.raises(ValidationError, match="exact multicommodity-flow profile"):
+        MulticommodityFlowProfileResult.model_validate(forged_work)

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -21,7 +21,6 @@ from jacobian.math.graphs.multicommodity_flow._models import (
     MulticommodityFlow,
     MulticommodityFlowProfileRequest,
     MulticommodityFlowProfileResult,
-    _fold_intermediate_digit_cap,
     _profile_component_digit_bounds,
     derived_profile_digit_budget,
 )
@@ -908,9 +907,9 @@ def test_cancelling_amounts_are_admitted_regardless_of_entry_order() -> None:
 
 def test_coprime_denominator_flood_fails_closed() -> None:
     # Two unit-fraction entries whose distinct near-cap denominators are
-    # coprime complete to a roughly 32,776-digit load denominator above the
-    # canonical cap: their fold intermediates stay inside the operand-mass
-    # envelope, and admission fails closed on the measured completed load
+    # coprime complete to a roughly 32,777-digit load denominator above the
+    # canonical cap: their single fold stays inside the fold-intermediate
+    # budget, and admission fails closed on the measured completed load
     # instead of admitting the huge component.
     network = FlowGraph(
         vertex_count=2,
@@ -1105,10 +1104,10 @@ def test_fold_intermediates_admit_coprime_sums_with_small_components() -> None:
     # with p and q coprime 20,000-digit odd integers: denominator sorting
     # folds 1/p + 1/q first, whose reduced intermediate has the roughly
     # 40,000-digit denominator p*q. That transient exceeds the 32,768-digit
-    # canonical cap but stays far inside the operand-mass fold envelope, and
-    # each completed sum is small -- the load is exactly one because each
-    # corresponding pair sums to exactly one half. Fold order must therefore
-    # not reject this tensor.
+    # canonical cap but stays inside the derived fold-intermediate budget,
+    # and each completed sum is small -- the load is exactly one because
+    # each corresponding pair sums to exactly one half. Fold order must
+    # therefore not reject this tensor.
     p = 5 * 10**19_999 + 3
 
     def amount(numerator: int, denominator: int) -> CanonicalRational:
@@ -1163,13 +1162,155 @@ def test_fold_intermediates_admit_coprime_sums_with_small_components() -> None:
     ]
 
 
-def test_fold_intermediate_cap_covers_the_proven_operand_mass_envelope() -> None:
-    # The derivation bounds every bucket numerator, reduced partial sum, and
-    # unreduced addition product by three times the amount digit mass plus a
-    # small constant; the admitted cap must dominate that envelope so it can
-    # only fail closed on a violated derivation, never on an admitted fold.
-    for mass in (0, 1, 120_004, 10**7):
-        assert _fold_intermediate_digit_cap(mass) >= 3 * mass + 9
+def test_folding_intermediates_cancel_beneath_the_completed_cap() -> None:
+    # One edge carries 1/p and 1/q alongside (p-2)/(2p) and (q-2)/(2q) for
+    # coprime 20,000-digit odd p and q, with matching demands. Folding the
+    # smallest denominators first forms the temporary (p+q)/(pq) whose
+    # denominator has about 40,000 digits -- above the canonical cap but
+    # within the separately derived fold-intermediate budget -- and the
+    # later terms cancel each pair to exactly one half, so the completed
+    # load is exactly 1 while every divergence stays input-sized.
+    p_digits = "1" + "0" * 19_998 + "1"
+    q_digits = "3" + "0" * 19_998 + "1"
+    first = CanonicalRational(num="1", den=p_digits)
+    second = CanonicalRational(num="1", den=q_digits)
+    half_of_p = CanonicalRational(num="9" * 19_999, den="2" + "0" * 19_998 + "2")
+    half_of_q = CanonicalRational(num="2" + "9" * 19_999, den="6" + "0" * 19_998 + "2")
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=1, demand=first),
+            CommodityDemand(commodity_id="b", source=0, sink=1, demand=second),
+            CommodityDemand(commodity_id="c", source=0, sink=1, demand=half_of_p),
+            CommodityDemand(commodity_id="d", source=0, sink=1, demand=half_of_q),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=first),
+            CommodityEdgeFlow(commodity_id="b", source=0, target=1, amount=second),
+            CommodityEdgeFlow(commodity_id="c", source=0, target=1, amount=half_of_p),
+            CommodityEdgeFlow(commodity_id="d", source=0, target=1, amount=half_of_q),
+        ),
+    )
+    assert derived_profile_digit_budget(flow) == 20_000
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.all_demands_routed is True
+    assert result.capacity_feasible is True
+    assert result.congestion == q(1)
+    assert result.edge_profiles[0].load == q(1)
+    assert result.edge_profiles[0].slack == q(0)
+    divergence = {
+        (row.commodity_id, row.vertex): row.divergence for row in result.divergences
+    }
+    assert divergence[("c", 0)] == half_of_p
+    assert divergence[("d", 1)].as_fraction() == -half_of_q.as_fraction()
+    # Ledger: twelve entry additions, eight single-denominator divergence
+    # folds plus four distinct edge-bucket denominator folds, one slack.
+    assert result.work.sparse_entries == 4
+    assert result.work.commodity_vertex_cells == 8
+    assert result.work.rational_additions_per_pass == 3 * 4 + (8 + 4) + 1
+    assert result.work.exact_comparisons_per_pass == 8 + 4
+    assert result.work.logical_steps_per_call == 2 * (25 + 4 + 1 + 12)
+
+
+def test_folds_are_bounded_by_the_intermediate_budget_not_the_component_cap() -> None:
+    # Three pairwise-coprime 24,000-digit denominators meet in one divergence
+    # cell (+1/p - 1/q - 1/r, sources minus sinks). Any pair fold keeps its
+    # full product denominator -- about 48,000 digits, far above the
+    # canonical cap yet inside the fold-intermediate budget -- and the third
+    # fold's predicted unreduced product crosses that budget, so the request
+    # fails closed before the cross-denominator arithmetic runs. Pairwise
+    # coprimality: 3p-q = 2, r - 5p = -2, and r - q = 2p share no odd factor
+    # with any denominator.
+    p_digits = "1" + "0" * 23_998 + "1"
+    q_digits = "3" + "0" * 23_998 + "1"
+    r_digits = "5" + "0" * 23_998 + "3"
+    with pytest.raises(ValidationError, match="fold-intermediate budget"):
+        MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=3,
+                edges=(
+                    CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                    CapacitatedEdge(source=1, target=0, capacity=q(1)),
+                    CapacitatedEdge(source=2, target=0, capacity=q(1)),
+                ),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+            ),
+            entries=(
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=0,
+                    target=1,
+                    amount=CanonicalRational(num="1", den=p_digits),
+                ),
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=1,
+                    target=0,
+                    amount=CanonicalRational(num="1", den=q_digits),
+                ),
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=2,
+                    target=0,
+                    amount=CanonicalRational(num="1", den=r_digits),
+                ),
+            ),
+        )
+
+
+def test_near_cap_coprime_growth_aborts_within_budget_sized_arithmetic() -> None:
+    # The exhaustion shape behind the finding: distinct near-cap coprime
+    # denominators folded into one divergence cell (+1/p - 1/q - 1/r,
+    # sources minus sinks of one commodity) grow a monotone accumulator
+    # whose digit mass tracks no single operand. Because every fold is
+    # pre-checked against the derived budget from measured operand sides,
+    # the third fold is refused before its roughly 96,000-digit product is
+    # ever constructed: admission never builds a fraction larger than twice
+    # the canonical cap, whatever the request's total digit mass, so
+    # request validation cannot be driven into multi-million-digit rational
+    # arithmetic by a sub-envelope tensor. Pairwise coprimality as above.
+    p_digits = "1" + "0" * 31_998 + "1"
+    q_digits = "3" + "0" * 31_998 + "1"
+    r_digits = "5" + "0" * 31_998 + "3"
+    with pytest.raises(ValidationError, match="fold-intermediate budget"):
+        MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=3,
+                edges=(
+                    CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                    CapacitatedEdge(source=1, target=0, capacity=q(1)),
+                    CapacitatedEdge(source=2, target=0, capacity=q(1)),
+                ),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
+            ),
+            entries=(
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=0,
+                    target=1,
+                    amount=CanonicalRational(num="1", den=p_digits),
+                ),
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=1,
+                    target=0,
+                    amount=CanonicalRational(num="1", den=q_digits),
+                ),
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=2,
+                    target=0,
+                    amount=CanonicalRational(num="1", den=r_digits),
+                ),
+            ),
+        )
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -12,6 +12,8 @@ from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
 from jacobian.math.graphs.multicommodity_flow._models import (
     MAX_COMMODITY_VERTEX_CELLS,
+    MAX_PROFILE_COMPARISONS_PER_PASS,
+    MAX_PROFILE_LOGICAL_STEPS,
     CommodityDemand,
     CommodityEdgeFlow,
     MulticommodityFlow,
@@ -108,8 +110,8 @@ def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
     assert result.work.rational_additions_per_pass == 15
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 3
-    assert result.work.exact_comparisons_per_pass == 17
-    assert result.work.logical_steps_per_call == 74
+    assert result.work.exact_comparisons_per_pass == 20
+    assert result.work.logical_steps_per_call == 80
 
 
 def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
@@ -157,11 +159,12 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
     assert result.all_demands_routed is True
     assert result.capacity_feasible is False
     assert result.congestion is None
-    # A zero-capacity edge still compares load to capacity and capacity to zero,
-    # then checks whether its load is positive; no ratio division is attempted.
+    # A zero-capacity edge still compares load to capacity and capacity to
+    # zero in the edge loop, capacity to zero in the shared slack scan, then
+    # checks whether its load is positive; no ratio division is attempted.
     assert result.work.rational_divisions_per_pass == 0
-    assert result.work.exact_comparisons_per_pass == 5
-    assert result.work.logical_steps_per_call == 20
+    assert result.work.exact_comparisons_per_pass == 6
+    assert result.work.logical_steps_per_call == 22
 
 
 def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> None:
@@ -181,8 +184,8 @@ def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> 
     assert result.capacity_feasible is True
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
-    assert result.work.exact_comparisons_per_pass == 8 + 3 * 3
-    assert result.work.logical_steps_per_call == 74
+    assert result.work.exact_comparisons_per_pass == 8 + 4 * 3
+    assert result.work.logical_steps_per_call == 80
 
 
 def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
@@ -218,8 +221,8 @@ def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -
         # made the congestion value null.
         assert result.congestion is None
         assert result.work.rational_divisions_per_pass == 2
-        assert result.work.exact_comparisons_per_pass == 4 + 3 * 3
-        assert result.work.logical_steps_per_call == 56
+        assert result.work.exact_comparisons_per_pass == 4 + 4 * 3
+        assert result.work.logical_steps_per_call == 62
 
 
 def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
@@ -290,8 +293,8 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
     assert result.congestion == q(1, 2)
     assert len(result.divergences) == 33
     assert result.work.commodity_vertex_cells == 33
-    assert result.work.exact_comparisons_per_pass == 33 + 3
-    assert result.work.logical_steps_per_call == 2 * (4 + 1 + 1 + 36)
+    assert result.work.exact_comparisons_per_pass == 33 + 4
+    assert result.work.logical_steps_per_call == 2 * (4 + 1 + 1 + 37)
 
     # Eight commodities over all 64 FlowGraph vertices reach exactly 512
     # returned cells; a ninth commodity exceeds the dense divergence budget.
@@ -323,7 +326,10 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
 def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> None:
     # A 33-digit capacity performs constant work here and returns only a
     # 33-digit slack; operand-derived digit budgets, not a fixed input cap,
-    # decide whether such exact scalars are admitted.
+    # decide whether such exact scalars are admitted. Even on this one-edge
+    # flow the single slack subtraction and the single congestion division
+    # execute exactly once per pass because the kernel reuses the measured
+    # components of the shared derivative scan.
     big_capacity = q(10**32)
     flow = MulticommodityFlow(
         network=FlowGraph(
@@ -343,8 +349,8 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
     assert result.work.rational_additions_per_pass == 1
     assert result.work.rational_negations_per_pass == 1
     assert result.work.rational_divisions_per_pass == 1
-    assert result.work.exact_comparisons_per_pass == 5
-    assert result.work.logical_steps_per_call == 16
+    assert result.work.exact_comparisons_per_pass == 6
+    assert result.work.logical_steps_per_call == 18
 
 
 def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
@@ -513,7 +519,7 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
 def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
     # FlowGraph owns the structural edge domain; this operation controls only
     # the ledger and result envelope. A one-commodity 129-edge network over 12
-    # vertices executes 658 steps per pass with a tiny result, so no
+    # vertices executes 787 steps per pass with a tiny result, so no
     # independent edge ceiling may reject it.
     def many_edge_flow(vertex_count: int, edge_count: int) -> MulticommodityFlow:
         pairs = [
@@ -544,14 +550,48 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
     assert len(result.edge_profiles) == 129
     assert result.work.edge_cells == 129
     assert result.work.rational_additions_per_pass == 129
-    assert result.work.exact_comparisons_per_pass == 12 + 3 * 129
-    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 387)
+    assert result.work.exact_comparisons_per_pass == 12 + 4 * 129
+    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 4 * 129)
 
     # The ledger and returned rows inherit FlowGraph's own 512-edge maximum:
     # a full 512-edge network is admitted and accounted exactly.
     full = compute_multicommodity_flow_profile(many_edge_flow(64, 512))
     assert len(full.edge_profiles) == 512
-    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 3 * 512)
+    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 4 * 512)
+
+    # Eight commodities over the same full 512-edge graph fill the dense
+    # divergence budget alongside every edge: 512 cells plus four comparisons
+    # per edge is exactly the published comparison envelope, and the widened
+    # work fields must admit that worst case.
+    crowded = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=64,
+            edges=tuple(
+                CapacitatedEdge(source=source, target=target, capacity=q(1))
+                for source, target in [
+                    (source, target)
+                    for source in range(64)
+                    for target in range(64)
+                    if source != target
+                ][:512]
+            ),
+        ),
+        commodities=tuple(
+            CommodityDemand(
+                commodity_id=chr(ord("a") + index), source=0, sink=63, demand=q(1)
+            )
+            for index in range(8)
+        ),
+    )
+    crowded_result = compute_multicommodity_flow_profile(crowded)
+    assert crowded_result.capacity_feasible is True
+    assert crowded_result.congestion == q(0)
+    assert crowded_result.work.commodity_vertex_cells == MAX_COMMODITY_VERTEX_CELLS
+    assert crowded_result.work.edge_cells == 512
+    assert crowded_result.work.exact_comparisons_per_pass == (
+        MAX_PROFILE_COMPARISONS_PER_PASS
+    )
+    assert crowded_result.work.logical_steps_per_call <= MAX_PROFILE_LOGICAL_STEPS
 
     with pytest.raises(ValidationError, match=r"at most 512 item"):
         many_edge_flow(64, 513)
@@ -560,7 +600,7 @@ def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
 def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
     # Sparse entries are distinct commodity-by-edge cells, so a one-commodity
     # network with 129 sorted unit edges carries 129 admissible unit entries:
-    # 13 divergence rows, 129 edge rows, and 1,046 steps per pass sit well
+    # 13 divergence rows, 129 edge rows, and 1,175 steps per pass sit well
     # inside the published addition, comparison, work, and output envelopes.
     def filled_network(vertex_count: int, edge_count: int) -> MulticommodityFlow:
         pairs = [
@@ -597,8 +637,8 @@ def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
     assert len(result.edge_profiles) == 129
     assert all(row.load == q(1) for row in result.edge_profiles)
     assert result.work.rational_additions_per_pass == 3 * 129 + 129
-    assert result.work.exact_comparisons_per_pass == 13 + 3 * 129
-    assert result.work.logical_steps_per_call == 2 * (516 + 1 + 129 + 400)
+    assert result.work.exact_comparisons_per_pass == 13 + 4 * 129
+    assert result.work.logical_steps_per_call == 2 * (516 + 1 + 129 + 529)
 
     # The entry count inherits the derived cell maxima: one commodity over a
     # full 512-edge graph admits exactly 512 distinct entries.
@@ -611,7 +651,7 @@ def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
     # The kernel scans sparse entries and per-edge sums; it never materializes
     # a dense commodity-by-edge tensor, so five commodities over a full
     # 512-edge graph are admitted on the quantities actually consumed and
-    # returned: 120 divergence rows, 512 small edge rows, 5,370 steps.
+    # returned: 120 divergence rows, 512 small edge rows, 6,394 steps.
     def wide_network(commodity_count: int) -> MulticommodityFlow:
         pairs = [
             (source, target)
@@ -644,8 +684,8 @@ def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
     assert result.work.rational_additions_per_pass == 512
     assert result.work.rational_negations_per_pass == 5
     assert result.work.rational_divisions_per_pass == 512
-    assert result.work.exact_comparisons_per_pass == 120 + 3 * 512
-    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 3 * 512)
+    assert result.work.exact_comparisons_per_pass == 120 + 4 * 512
+    assert result.work.logical_steps_per_call == 2 * (512 + 5 + 512 + 120 + 4 * 512)
 
 
 def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
@@ -673,7 +713,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     assert len(unrouted.divergences) == 34
     assert unrouted.work.commodity_vertex_cells == 34
     assert unrouted.work.rational_negations_per_pass == 17
-    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 3)
+    assert unrouted.work.logical_steps_per_call == 2 * (1 + 17 + 1 + 34 + 4)
 
     # Each commodity occupies at least two distinct commodity-vertex cells,
     # so exactly half of the 512-cell divergence budget, 256 commodities, is
@@ -681,7 +721,7 @@ def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
     full = compute_multicommodity_flow_profile(dense_commodities(256))
     assert len(full.divergences) == MAX_COMMODITY_VERTEX_CELLS
     assert full.work.rational_negations_per_pass == 256
-    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 3)
+    assert full.work.logical_steps_per_call == 2 * (1 + 256 + 1 + 512 + 4)
 
     with pytest.raises(ValidationError, match="commodity-by-vertex"):
         dense_commodities(257)

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -77,6 +77,38 @@ def test_native_api_accepts_the_canonical_flow_value_directly() -> None:
     assert native.congestion == q(1)
 
 
+def test_accepted_calls_execute_exactly_the_two_charged_scans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Request parsing performs the operation's component scan once, admits
+    # work and result envelope from it, and hands it to the producer pass;
+    # the replay rescans independently. A native call runs the same producer
+    # scan itself. Either way an accepted call must execute exactly two
+    # arithmetic scans -- any more underreports nothing but wasted work,
+    # any fewer breaks exactness.
+    from jacobian.math.graphs.multicommodity_flow import _models
+
+    scans = {"count": 0}
+    original_models_scan = _models._component_sums_with_folds
+
+    def models_spy(flow: MulticommodityFlow) -> object:
+        scans["count"] += 1
+        return original_models_scan(flow)
+
+    monkeypatch.setattr(_models, "_component_sums_with_folds", models_spy)
+
+    via_request = _run_multicommodity_flow_profile(
+        MulticommodityFlowProfileRequest(flow=shared_bottleneck_flow())
+    )
+    assert scans == {"count": 2}
+
+    scans.update(count=0)
+    native = compute_multicommodity_flow_profile(shared_bottleneck_flow())
+    assert scans == {"count": 2}
+
+    assert native == via_request
+
+
 def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
     result = compute_multicommodity_flow_profile(shared_bottleneck_flow())
 
@@ -983,12 +1015,12 @@ def oversized_echo_flow() -> MulticommodityFlow:
 def test_oversized_source_is_rejected_before_the_component_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from jacobian.math.graphs.multicommodity_flow import _kernel, _models
+    from jacobian.math.graphs.multicommodity_flow import _models
 
     measured: list[MulticommodityFlow] = []
     executed: list[MulticommodityFlow] = []
     original_bounds = _models._profile_component_digit_bounds
-    original_scan = _kernel._component_sums_with_folds
+    original_scan = _models._component_sums_with_folds
 
     def bounds_spy(flow: MulticommodityFlow) -> object:
         measured.append(flow)
@@ -999,7 +1031,7 @@ def test_oversized_source_is_rejected_before_the_component_scan(
         return original_scan(flow)
 
     monkeypatch.setattr(_models, "_profile_component_digit_bounds", bounds_spy)
-    monkeypatch.setattr(_kernel, "_component_sums_with_folds", scan_spy)
+    monkeypatch.setattr(_models, "_component_sums_with_folds", scan_spy)
     # Request parsing measures the echoed source first and fails closed
     # before its own component measurement, and execution therefore never
     # starts, so neither spy records the tensor.

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from copy import deepcopy
 from fractions import Fraction
 
@@ -104,14 +105,18 @@ def test_exact_shared_bottleneck_profile_replays_its_source() -> None:
     ]
     # Producer and replay both scan the four sparse entries, four-by-two dense
     # divergence cells, and three edges; the ledger is exact rather than a cap.
+    # Every entry shares denominator 1, so the bucket fold performs one
+    # fraction addition per nonempty bucket: six touched divergence cells and
+    # three edges add nine folds to the twelve numerator additions, plus the
+    # three slack subtractions.
     assert result.work.sparse_entries == 4
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
-    assert result.work.rational_additions_per_pass == 15
+    assert result.work.rational_additions_per_pass == 3 * 4 + (6 + 3) + 3
     assert result.work.rational_negations_per_pass == 2
     assert result.work.rational_divisions_per_pass == 3
     assert result.work.exact_comparisons_per_pass == 20
-    assert result.work.logical_steps_per_call == 80
+    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 20)
 
 
 def test_profile_distinguishes_capacity_and_conservation_failures() -> None:
@@ -162,9 +167,11 @@ def test_zero_capacity_positive_load_has_no_finite_congestion() -> None:
     # A zero-capacity edge still compares load to capacity and capacity to
     # zero in the edge loop, capacity to zero in the shared slack scan, then
     # checks whether its load is positive; no ratio division is attempted.
+    # The lone entry folds one denominator into each of its two divergence
+    # cells and one edge bucket: three fold additions beyond 3*1 + 1.
     assert result.work.rational_divisions_per_pass == 0
     assert result.work.exact_comparisons_per_pass == 6
-    assert result.work.logical_steps_per_call == 22
+    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 0 + 6)
 
 
 def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> None:
@@ -185,7 +192,7 @@ def test_early_divergence_mismatch_still_executes_every_counted_comparison() -> 
     assert result.work.commodity_vertex_cells == 8
     assert result.work.edge_cells == 3
     assert result.work.exact_comparisons_per_pass == 8 + 4 * 3
-    assert result.work.logical_steps_per_call == 80
+    assert result.work.logical_steps_per_call == 2 * (24 + 2 + 3 + 20)
 
 
 def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -> None:
@@ -222,7 +229,7 @@ def test_mixed_zero_and_positive_capacities_execute_every_counted_comparison() -
         assert result.congestion is None
         assert result.work.rational_divisions_per_pass == 2
         assert result.work.exact_comparisons_per_pass == 4 + 4 * 3
-        assert result.work.logical_steps_per_call == 62
+        assert result.work.logical_steps_per_call == 2 * ((9 + 7 + 3) + 1 + 2 + 16)
 
 
 def test_fractional_split_flow_uses_exact_rational_loads_and_congestion() -> None:
@@ -294,7 +301,7 @@ def test_low_commodity_networks_admit_vertices_up_to_the_cell_budget() -> None:
     assert len(result.divergences) == 33
     assert result.work.commodity_vertex_cells == 33
     assert result.work.exact_comparisons_per_pass == 33 + 4
-    assert result.work.logical_steps_per_call == 2 * (4 + 1 + 1 + 37)
+    assert result.work.logical_steps_per_call == 2 * ((3 + 3 + 1) + 1 + 1 + 37)
 
     # Eight commodities over all 64 FlowGraph vertices reach exactly 512
     # returned cells; a ninth commodity exceeds the dense divergence budget.
@@ -630,21 +637,40 @@ def test_entry_count_is_bounded_by_distinct_cells_not_a_fixed_ceiling() -> None:
             ),
         )
 
-    result = compute_multicommodity_flow_profile(filled_network(13, 129))
+    # Every amount shares denominator 1, so each bucket performs exactly one
+    # fold per distinct bucket key: one per touched commodity/vertex cell and
+    # one per loaded edge, counted independently of the kernel below.
+    def unit_fold_additions(flow: MulticommodityFlow) -> int:
+        touched_cells = {
+            (entry.commodity_id, vertex)
+            for entry in flow.entries
+            for vertex in (entry.source, entry.target)
+        }
+        return len(touched_cells) + len({(e.source, e.target) for e in flow.entries})
+
+    flow = filled_network(13, 129)
+    result = compute_multicommodity_flow_profile(flow)
     assert result.capacity_feasible is True
     assert result.congestion == q(1)
     assert result.work.sparse_entries == 129
     assert len(result.edge_profiles) == 129
     assert all(row.load == q(1) for row in result.edge_profiles)
-    assert result.work.rational_additions_per_pass == 3 * 129 + 129
+    assert result.work.rational_additions_per_pass == (
+        3 * 129 + unit_fold_additions(flow) + 129
+    )
     assert result.work.exact_comparisons_per_pass == 13 + 4 * 129
-    assert result.work.logical_steps_per_call == 2 * (516 + 1 + 129 + 529)
+    assert result.work.logical_steps_per_call == 2 * (
+        3 * 129 + unit_fold_additions(flow) + 129 + 1 + 129 + (13 + 4 * 129)
+    )
 
     # The entry count inherits the derived cell maxima: one commodity over a
     # full 512-edge graph admits exactly 512 distinct entries.
-    full = compute_multicommodity_flow_profile(filled_network(64, 512))
+    full_flow = filled_network(64, 512)
+    full = compute_multicommodity_flow_profile(full_flow)
     assert full.work.sparse_entries == 512
-    assert full.work.rational_additions_per_pass == 3 * 512 + 512
+    assert full.work.rational_additions_per_pass == (
+        3 * 512 + unit_fold_additions(full_flow) + 512
+    )
 
 
 def test_sparse_scan_admits_commodities_over_a_full_edge_graph() -> None:
@@ -907,6 +933,168 @@ def test_coprime_denominator_flood_fails_closed() -> None:
     )
     with pytest.raises(ValidationError, match="canonical cap"):
         MulticommodityFlow(network=network, commodities=commodities, entries=entries)
+
+
+def oversized_echo_flow() -> MulticommodityFlow:
+    # One commodity carries 270 lone 32,000-digit entries on distinct edges:
+    # every derived component is a single operand inside the canonical cap,
+    # so only the serialized echo -- about 8.7 MB of numerator digits --
+    # exhausts the 8 MiB aggregate result envelope.
+    vertex_count = 17
+    pairs = [
+        (source, target)
+        for source in range(vertex_count)
+        for target in range(vertex_count)
+        if source != target
+    ][:270]
+    big = CanonicalRational(num="9" * 32_000, den="1")
+    return MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=vertex_count,
+            edges=tuple(
+                CapacitatedEdge(source=source, target=target, capacity=q(1))
+                for source, target in pairs
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=16, demand=q(1)),
+        ),
+        entries=tuple(
+            CommodityEdgeFlow(
+                commodity_id="a", source=source, target=target, amount=big
+            )
+            for source, target in pairs
+        ),
+    )
+
+
+def test_oversized_source_is_rejected_before_the_component_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from jacobian.math.graphs.multicommodity_flow import _models
+
+    scanned: list[MulticommodityFlow] = []
+    original = _models._profile_component_digit_bounds
+
+    def spy(flow: MulticommodityFlow) -> object:
+        scanned.append(flow)
+        return original(flow)
+
+    monkeypatch.setattr(_models, "_profile_component_digit_bounds", spy)
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        oversized_echo_flow()
+    assert scanned == []
+
+
+def test_oversized_source_rejection_precedes_a_doomed_exact_scan() -> None:
+    # Same oversized echo, but two commodities fold coprime near-cap
+    # denominators into one shared edge bucket whose sum would abort the
+    # component scan with a canonical-cap error. The envelope preflight must
+    # win: the request fails for its result size before any exact arithmetic.
+    vertex_count = 17
+    bulk_pairs = [
+        (source, target)
+        for source in range(vertex_count)
+        for target in range(vertex_count)
+        if source != target and (source, target) != (0, 1)
+    ][:268]
+    big = CanonicalRational(num="9" * 32_000, den="1")
+    with pytest.raises(ValidationError, match="aggregate result bound"):
+        MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=vertex_count,
+                edges=tuple(
+                    CapacitatedEdge(source=source, target=target, capacity=q(1))
+                    for source, target in [(0, 1), *bulk_pairs]
+                ),
+            ),
+            commodities=(
+                CommodityDemand(commodity_id="a", source=0, sink=16, demand=q(1)),
+                CommodityDemand(commodity_id="b", source=0, sink=1, demand=q(1)),
+            ),
+            entries=(
+                CommodityEdgeFlow(
+                    commodity_id="a",
+                    source=0,
+                    target=1,
+                    amount=CanonicalRational(num="1", den="3" + "0" * 19_999),
+                ),
+                *(
+                    CommodityEdgeFlow(
+                        commodity_id="a", source=source, target=target, amount=big
+                    )
+                    for source, target in bulk_pairs
+                ),
+                CommodityEdgeFlow(
+                    commodity_id="b",
+                    source=0,
+                    target=1,
+                    amount=CanonicalRational(num="1", den="7" + "0" * 12_775 + "1"),
+                ),
+            ),
+        )
+
+
+def test_ledger_charges_every_performed_bucket_fold_addition() -> None:
+    # Five entries carry four pairwise-coprime denominators into buckets that
+    # share cells and one edge, so the denominator-fold pass performs one
+    # fraction addition per distinct (bucket, denominator) pair -- fourteen
+    # here -- beyond the fifteen bucketed numerator additions and four slack
+    # subtractions. The reference count below re-derives the bucket shapes
+    # from the entry list itself, so the ledger can only match by charging
+    # exactly the arithmetic the scan executes.
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=4,
+            edges=(
+                CapacitatedEdge(source=0, target=1, capacity=q(1)),
+                CapacitatedEdge(source=0, target=2, capacity=q(1)),
+                CapacitatedEdge(source=1, target=3, capacity=q(1)),
+                CapacitatedEdge(source=2, target=3, capacity=q(1)),
+            ),
+        ),
+        commodities=(
+            CommodityDemand(commodity_id="a", source=0, sink=3, demand=q(1)),
+            CommodityDemand(commodity_id="b", source=0, sink=1, demand=q(1)),
+        ),
+        entries=(
+            CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=q(1, 2)),
+            CommodityEdgeFlow(commodity_id="a", source=0, target=2, amount=q(1, 3)),
+            CommodityEdgeFlow(commodity_id="a", source=1, target=3, amount=q(1, 5)),
+            CommodityEdgeFlow(commodity_id="a", source=2, target=3, amount=q(1, 7)),
+            CommodityEdgeFlow(commodity_id="b", source=0, target=1, amount=q(1, 2)),
+        ),
+    )
+
+    def bucket_fold_additions(tensor: MulticommodityFlow) -> int:
+        cell_denominators: dict[tuple[str, int], set[int]] = defaultdict(set)
+        edge_denominators: dict[tuple[int, int], set[int]] = defaultdict(set)
+        for entry in tensor.entries:
+            denominator = entry.amount.as_fraction().denominator
+            cell_denominators[(entry.commodity_id, entry.source)].add(denominator)
+            cell_denominators[(entry.commodity_id, entry.target)].add(denominator)
+            edge_denominators[(entry.source, entry.target)].add(denominator)
+        cell_folds = sum(len(sides) for sides in cell_denominators.values())
+        edge_folds = sum(len(sides) for sides in edge_denominators.values())
+        return cell_folds + edge_folds
+
+    result = compute_multicommodity_flow_profile(flow)
+    folds = bucket_fold_additions(flow)
+    assert folds == 14
+    assert result.work.rational_additions_per_pass == 3 * 5 + folds + 4
+    assert result.work.rational_negations_per_pass == 2
+    assert result.work.rational_divisions_per_pass == 4
+    assert result.work.exact_comparisons_per_pass == 8 + 4 * 4
+    assert result.work.logical_steps_per_call == 2 * (33 + 2 + 4 + 24)
+    # The exact values stay the known answers even though the fold order
+    # follows ascending denominator bit length rather than entry order.
+    divergence = {
+        (row.commodity_id, row.vertex): row.divergence.as_fraction()
+        for row in result.divergences
+    }
+    assert divergence[("a", 0)] == Fraction(1, 2) + Fraction(1, 3)
+    assert divergence[("b", 0)] == Fraction(1, 2)
+    assert result.edge_profiles[0].load.as_fraction() == Fraction(1)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:

--- a/tests/math/multicommodity_flow/test_profile.py
+++ b/tests/math/multicommodity_flow/test_profile.py
@@ -12,7 +12,6 @@ from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.flow._models import CapacitatedEdge, FlowGraph
 from jacobian.math.graphs.multicommodity_flow._models import (
     MAX_COMMODITY_VERTEX_CELLS,
-    MAX_MULTICOMMODITY_EDGES,
     CommodityDemand,
     CommodityEdgeFlow,
     MulticommodityFlow,
@@ -348,27 +347,56 @@ def test_large_exact_scalars_are_admitted_when_derived_digits_stay_bounded() -> 
 
 
 def test_operand_digit_budget_bounds_the_canonical_boundary() -> None:
-    def single_edge_flow(capacity: CanonicalRational) -> MulticommodityFlow:
+    def unit_edge_amount(amount: CanonicalRational) -> MulticommodityFlow:
         return MulticommodityFlow(
             network=FlowGraph(
                 vertex_count=2,
-                edges=(CapacitatedEdge(source=0, target=1, capacity=capacity),),
+                edges=(CapacitatedEdge(source=0, target=1, capacity=q(1)),),
             ),
             commodities=(
                 CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),
             ),
+            entries=(
+                CommodityEdgeFlow(commodity_id="a", source=0, target=1, amount=amount),
+            ),
         )
 
-    # One 32,759-digit numerator plus its one-digit denominator and the eight
-    # derivation slack digits reach exactly the canonical 32,768-digit cap.
-    at_boundary = single_edge_flow(CanonicalRational(num="9" * 32_759, den="1"))
+    # One 32,757-digit amount numerator, its one-digit denominator, the eight
+    # sum carry digits, and one subtraction-composition digit reach exactly
+    # the canonical 32,768-digit component cap.
+    at_boundary = unit_edge_amount(CanonicalRational(num="9" * 32_757, den="1"))
     result = compute_multicommodity_flow_profile(at_boundary)
-    assert result.capacity_feasible is True
-    assert result.edge_profiles[0].slack.num == "9" * 32_759
+    assert result.capacity_feasible is False
+    assert result.edge_profiles[0].load.num == "9" * 32_757
+    assert result.congestion == CanonicalRational(num="9" * 32_757, den="1")
 
-    beyond_boundary = CanonicalRational(num="9" * 32_760, den="1")
+    beyond_boundary = CanonicalRational(num="9" * 32_758, den="1")
     with pytest.raises(ValidationError, match="canonical cap"):
-        single_edge_flow(beyond_boundary)
+        unit_edge_amount(beyond_boundary)
+
+
+def test_rational_components_are_bounded_independently() -> None:
+    # A reduced capacity whose numerator and denominator are EACH 20,000
+    # digits is itself a valid canonical rational: its slack equals that
+    # capacity exactly and its congestion is zero, so numerator and denominator
+    # growth are tracked separately and the tensor is admitted even though the
+    # summed component lengths exceed the per-component 32,768-digit cap.
+    capacity = CanonicalRational(num="9" * 20_000, den="1" + "0" * 19_999)
+    flow = MulticommodityFlow(
+        network=FlowGraph(
+            vertex_count=2,
+            edges=(CapacitatedEdge(source=0, target=1, capacity=capacity),),
+        ),
+        commodities=(CommodityDemand(commodity_id="a", source=0, sink=1, demand=q(1)),),
+    )
+    # With no entries the load is exactly zero: the slack equals the capacity,
+    # the congestion is exactly zero, and no composition digit is added, so
+    # the shared budget is just the larger capacity component.
+    assert derived_profile_digit_budget(flow) == 20_000
+    result = compute_multicommodity_flow_profile(flow)
+    assert result.capacity_feasible is True
+    assert result.congestion == q(0)
+    assert result.edge_profiles[0].slack == capacity
 
 
 def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
@@ -388,7 +416,10 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
         ),
         commodities=(CommodityDemand(commodity_id="a", source=0, sink=2, demand=q(1)),),
     )
-    assert derived_profile_digit_budget(capacities_flow) == 8 + 16_380 + 1
+    # With no entries each load is exactly zero: its slack equals its
+    # capacity, its congestion ratio is exactly zero, and no composition
+    # digit is added, so the shared budget is just a capacity component.
+    assert derived_profile_digit_budget(capacities_flow) == 16_380
     capacities_result = compute_multicommodity_flow_profile(capacities_flow)
     assert capacities_result.capacity_feasible is True
     assert capacities_result.congestion == q(0)
@@ -422,6 +453,53 @@ def test_per_component_digit_bounds_admit_unrelated_large_operands() -> None:
     amounts_result = compute_multicommodity_flow_profile(amounts_flow)
     assert amounts_result.all_demands_routed is False
     assert amounts_result.edge_profiles[0].load == big_amount
+
+
+def test_derived_quantities_admit_edges_without_a_fixed_ceiling() -> None:
+    # FlowGraph owns the structural edge domain; this operation controls only
+    # the derived commodity-edge cells, ledger, and result envelope. A
+    # one-commodity 129-edge network over 12 vertices executes 658 steps per
+    # pass with a tiny result, so no independent edge ceiling may reject it.
+    def many_edge_flow(vertex_count: int, edge_count: int) -> MulticommodityFlow:
+        pairs = [
+            (source, target)
+            for source in range(vertex_count)
+            for target in range(vertex_count)
+            if source != target
+        ][:edge_count]
+        return MulticommodityFlow(
+            network=FlowGraph(
+                vertex_count=vertex_count,
+                edges=tuple(
+                    CapacitatedEdge(source=source, target=target, capacity=q(1))
+                    for source, target in pairs
+                ),
+            ),
+            commodities=(
+                CommodityDemand(
+                    commodity_id="a", source=0, sink=vertex_count - 1, demand=q(1)
+                ),
+            ),
+        )
+
+    result = compute_multicommodity_flow_profile(many_edge_flow(12, 129))
+    assert result.all_demands_routed is False
+    assert result.capacity_feasible is True
+    assert result.congestion == q(0)
+    assert len(result.edge_profiles) == 129
+    assert result.work.edge_cells == 129
+    assert result.work.rational_additions_per_pass == 129
+    assert result.work.exact_comparisons_per_pass == 12 + 3 * 129
+    assert result.work.logical_steps_per_call == 2 * (129 + 1 + 129 + 12 + 387)
+
+    # The ledger and returned rows inherit FlowGraph's own 512-edge maximum:
+    # a full 512-edge network is admitted and accounted exactly.
+    full = compute_multicommodity_flow_profile(many_edge_flow(64, 512))
+    assert len(full.edge_profiles) == 512
+    assert full.work.logical_steps_per_call == 2 * (512 + 1 + 512 + 64 + 3 * 512)
+
+    with pytest.raises(ValidationError, match=r"at most 512 item"):
+        many_edge_flow(64, 513)
 
 
 def test_cell_budgets_admit_commodities_without_a_fixed_ceiling() -> None:
@@ -467,17 +545,19 @@ def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
     from itertools import combinations
 
     def comb_edge_tensor(capacity: CanonicalRational) -> MulticommodityFlow:
+        # 128 edges keep the echoed source under the 10 MiB canonical encoder
+        # while the priced derived rows cross the 8 MiB result envelope.
         edges = tuple(
             CapacitatedEdge(source=source, target=target, capacity=capacity)
             for source, target in combinations(range(32), 2)
-        )[:MAX_MULTICOMMODITY_EDGES]
+        )[:128]
         return MulticommodityFlow(
             network=FlowGraph(vertex_count=32, edges=edges),
             commodities=tuple(
                 CommodityDemand(
                     commodity_id=f"c{index:02d}", source=0, sink=31, demand=q(1)
                 )
-                for index in range(16)
+                for index in range(4)
             ),
         )
 
@@ -493,7 +573,7 @@ def test_result_envelope_rejects_wide_tensors_with_large_operands() -> None:
     admitted = comb_edge_tensor(CanonicalRational(num="9" * 5_000, den="1"))
     result = compute_multicommodity_flow_profile(admitted)
     assert result.capacity_feasible is True
-    assert result.work.edge_cells == MAX_MULTICOMMODITY_EDGES
+    assert result.work.edge_cells == len(result.flow.network.edges)
 
 
 def test_result_replay_rejects_forged_source_and_derived_ledger_fields() -> None:


### PR DESCRIPTION
## Problem

Partially addresses #1710.

Jacobian exposes single-commodity flow and cut operations, but callers cannot retain a labelled commodity set with its exact sparse commodity-by-edge tensor and obtain the shared conservation/capacity ledger. Reconstructing those relations at each caller loses a reusable typed value and makes zero-capacity congestion semantics easy to get wrong.

## Solution

Add network.multicommodity_flow.profile.compute over a canonical MulticommodityFlow value. It retains the directed capacitated network, sorted commodity demands, and sorted positive sparse tensor entries; omitted cells mean exact zero. The source-bound result returns dense per-commodity divergences, per-edge loads and signed slacks, demand-routing and capacity predicates, and exact congestion (or null only when a zero-capacity edge carries positive load).

The model validator replays the full profile with exact Fraction arithmetic, including the published producer-plus-replay work ledger. NetworkX was considered but its documented maximum-flow API is single-commodity; this operation only derives a submitted finite tensor, so a bounded standard-library rational scan is the smaller exact kernel.

This PR intentionally does not add a feasibility solver, minimum-congestion optimizer, unsplittable-routing search, or rounding algorithm.

## Testing

- make test-math TESTS=tests/math/multicommodity_flow/test_profile.py — 8 passed.
- make check — passed Ruff, formatting, mypy, and the Lean-free math/catalog/dispatch/CLI/tooling handoff.
- uv run pytest tests/math/multicommodity_flow/test_profile.py tests/integration/catalog/test_builtin_examples.py — 541 passed.

The new tests cover shared bottlenecks, exact fractional splitting, independent conservation versus capacity failures, zero-capacity positive load, canonical sparse-entry rejection, source/result/work-ledger forgery, and tighter vertex/rational bounds.

## Public contract impact

Adds the version-1 operation network.multicommodity_flow.profile.compute and the native MulticommodityFlow value family. Existing contracts are unchanged.

## Public operation admission

- Concrete gap: no existing operation returns the complete exact multicommodity conservation and capacity relation of a submitted tensor.
- Why existing operations or typed values are insufficient: current graph flow outputs are single-commodity and do not retain labelled commodities or commodity-by-edge amounts.
- Stable mathematical result: a source-bound exact profile of one finite rational multicommodity flow.
- Semantic domain and admitted execution envelope: finite directed networks with at most 32 vertices and 128 edges; at most 16 commodities, 128 nonzero entries, 2,048 conceptual commodity-edge cells, and 512 divergence cells.
- Controlling work, intermediate, memory, and output quantities: sparse entries control additions; commodity-vertex cells control the dense divergence result; edges control loads/slacks and congestion comparisons. Input rationals have at most 32 digits; derived rationals are bounded to 4,132 digits and the conservative serialized-result envelope is below 8 MiB.
- Exact representation, algorithm regimes, and maintained backend: canonical sparse tensor plus dense derived ledgers; one exact Fraction scan, with no solver or backend regime.
- Remaining fixed caps and their classification: conservative representation/work/output caps for this materialized profile; they do not restrict the mathematical definition.
- Admission decision: KEEP, recorded in the owner-local admission ledger.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Submitted fractional flow conservation/load profile | Delivered | network.multicommodity_flow.profile.compute |
| Exact feasibility with primal/dual certificate | Deferred | #1710 remains open |
| Exact minimum congestion | Deferred | #1710 remains open |
| Unsplittable routing check/search and single-source rounding | Deferred | #1710 remains open |

## Suggested review order

1. Read the canonical value and admission bounds in _models.py.
2. Check the pure exact profile kernel and result replay in _kernel.py.
3. Read the operation declaration/example, then the adversarial contract tests.

## Checklist

- [x] make check passes
- [x] Public operation change has an owner-local admission decision
- [x] Result has complete exact semantics; no incomplete solver outcome is claimed
- [x] Bounds include canonical, rational, work, output, and zero-capacity boundary coverage
- [x] No generic solver, routing workflow, or persistent state is introduced