### PR TITLE
Remove generic math discovery text caps

### DIFF
--- a/src/jacobian/catalog/models.py
+++ b/src/jacobian/catalog/models.py
@@ -42,7 +42,7 @@ class OperationExample(StrictModel):
 class OperationDiscoveryRequest(StrictModel):
     """Compact installed-portfolio search, independent of any transport."""
 
-    query: str = Field(min_length=1, max_length=512)
+    query: str = Field(min_length=1)
     domain: str | None = Field(
         default=None,
         pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$",
@@ -64,7 +64,7 @@ class OperationDiscoveryMatch(StrictModel):
 
     operation_id: OperationId
     title: str = Field(min_length=1, max_length=128)
-    description: str = Field(min_length=1, max_length=512)
+    description: str = Field(min_length=1)
     tags: tuple[str, ...] = ()
     relevance_score: int = Field(default=0, ge=0, strict=True)
     applicability: Literal[
@@ -106,7 +106,7 @@ class OperationBrowseCard(StrictModel):
 
     operation_id: OperationId
     title: str = Field(min_length=1, max_length=128)
-    description: str = Field(min_length=1, max_length=512)
+    description: str = Field(min_length=1)
     tags: tuple[str, ...] = ()
 
 
@@ -145,7 +145,7 @@ class OperationDescriptor(StrictModel):
     operation_id: OperationId
     version: str = Field(min_length=1, max_length=64)
     title: str = Field(min_length=1, max_length=128)
-    description: str = Field(min_length=1, max_length=512)
+    description: str = Field(min_length=1)
     input_schema: dict[str, Any]
     output_schema: dict[str, Any]
     read_only: bool = False

--- a/src/jacobian/mcp/models.py
+++ b/src/jacobian/mcp/models.py
@@ -17,7 +17,7 @@ from jacobian.catalog.models import (
 
 class OperationSearchRequest(StrictModel):
     op: Literal["search"]
-    query: Annotated[str, Field(min_length=1, max_length=512)]
+    query: Annotated[str, Field(min_length=1)]
     domain: Annotated[
         str | None,
         Field(pattern=r"^[A-Za-z][A-Za-z0-9_-]{0,127}$"),

--- a/tests/catalog/test_models.py
+++ b/tests/catalog/test_models.py
@@ -4,8 +4,12 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.catalog.models import (
+    OperationBrowseCard,
     OperationBrowseResult,
     OperationCatalogSnapshot,
+    OperationDescriptor,
+    OperationDiscoveryMatch,
+    OperationDiscoveryRequest,
     OperationDiscoveryResult,
 )
 
@@ -19,6 +23,33 @@ def _descriptor(operation_id: str) -> dict[str, object]:
         "input_schema": {"type": "object"},
         "output_schema": {"type": "object"},
     }
+
+
+def test_catalog_discovery_text_has_no_arbitrary_character_cap() -> None:
+    long_text = "x" * 513
+
+    request = OperationDiscoveryRequest(query=long_text)
+    descriptor = OperationDescriptor(
+        **{**_descriptor("integer.compute.gcd"), "description": long_text}
+    )
+    match = OperationDiscoveryMatch(
+        operation_id="integer.compute.gcd",
+        title="Compute gcd",
+        description=long_text,
+        relevance_score=0,
+        applicability="NEEDS_MORE_TYPED_REQUIREMENTS",
+        applicability_code="FULL_REQUEST_REQUIRED",
+    )
+    card = OperationBrowseCard(
+        operation_id="integer.compute.gcd",
+        title="Compute gcd",
+        description=long_text,
+    )
+
+    assert request.query == long_text
+    assert descriptor.description == long_text
+    assert match.description == long_text
+    assert card.description == long_text
 
 
 def test_discovery_page_metadata_is_bound_to_returned_matches() -> None:

--- a/tests/math/lattice_polytopes/test_lattice_polytopes.py
+++ b/tests/math/lattice_polytopes/test_lattice_polytopes.py
@@ -813,7 +813,6 @@ class TestBoundedEmptyHalfspacePolytopes:
             "polytope.lattice_points.count",
         ):
             description = tools[operation_id].description.lower()
-            assert len(tools[operation_id].description) <= 512
             assert "empty" in description
         schema = LatticePolytopeRequest.model_json_schema()
         halfspaces_description = schema["properties"]["halfspaces"]["description"]
@@ -1091,7 +1090,6 @@ class TestThirdWaveRegressions:
         ):
             description = tools[operation_id].description.lower()
             assert "nonzero" in description
-            assert len(tools[operation_id].description) <= 512
 
     def test_halfspace_example_no_longer_claims_lower_dimensional_rejection(self):
         """Only V-representations are rejected for lower dimension; the

--- a/tests/mcp/test_catalog_isolation.py
+++ b/tests/mcp/test_catalog_isolation.py
@@ -48,6 +48,12 @@ def test_math_find_does_not_acquire_an_execution_runtime() -> None:
     assert result.root.kind == "discovery"
 
 
+def test_math_find_search_accepts_a_long_mathematical_query() -> None:
+    request = OperationSearchRequest(op="search", query="q" * 513)
+
+    assert len(request.query) == 513
+
+
 def test_math_find_browse_does_not_acquire_an_execution_runtime() -> None:
     state = AppState(
         operation_catalog=_Catalog(),


### PR DESCRIPTION
## Summary

Removes the arbitrary 512-character limits from mathematical operation descriptions and `math.find` search queries. Complex mathematical operations can now publish enough semantic context, domain conditions, and composition guidance for an agent to select and invoke them correctly.

The change covers the canonical catalog descriptor, browse card, search match, catalog search request, and MCP search request. It leaves the existing response-byte budget and explicit metadata-truncation projection intact, so oversized discovery responses remain bounded and observable instead of silently relying on a per-field text cap.

## Validation

- `make check` — 3,518 passed
- Focused catalog/MCP/lattice-polytope contract tests — 82 passed
- Added 513-character regressions for catalog descriptions and `math.find` queries.