### PR TITLE
Replace raw graph homomorphism checks with typed maps

### DIFF
--- a/src/jacobian/math/graphs/morphisms/_admission.py
+++ b/src/jacobian/math/graphs/morphisms/_admission.py
@@ -21,24 +21,9 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
         "exact bounded injective edge-preserving subgraph-monomorphism search with material leverage over bespoke enumeration",
     ),
     OperationAdmission(
-        "graph.core.check",
-        AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
-    ),
-    OperationAdmission(
         "graph.homomorphism.check",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
-    ),
-    OperationAdmission(
-        "graph.homomorphism.find",
-        AdmissionDecision.KEEP,
-        "distinct exact or explicitly bounded search outcome with material computational leverage",
-    ),
-    OperationAdmission(
-        "graph.retraction.check",
-        AdmissionDecision.KEEP,
-        "distinct exact or explicitly bounded search outcome with material computational leverage",
+        "complete canonical graph-map check with a reusable source-bound positive value or exact first edge-image obstruction",
     ),
 )
 

--- a/src/jacobian/math/graphs/morphisms/_models.py
+++ b/src/jacobian/math/graphs/morphisms/_models.py
@@ -10,114 +10,184 @@ from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
-MAX_VERTICES = 64
-MAX_EDGES = 512
-
 # Exhaustive backtracking search over graph morphisms is exponential in the
 # vertex count.  This dedicated bound keeps every search-based morphism
 # operation inside a tested, provably bounded domain.
 MORPHISM_MAX_VERTICES = 20
 
+# Source-bound graph results retain their input graphs and may add witnesses.
+# This reserved envelope covers the result wrapper and field names after those
+# representation-dependent components.
+_RESULT_ENVELOPE_RESERVE_BYTES = 1_024
 
-class SimpleGraph(StrictModel):
-    """A simple undirected graph with integer-labelled vertices."""
 
-    vertex_count: int = Field(ge=1, le=MAX_VERTICES)
-    edges: tuple[tuple[int, int], ...] = Field(default=(), max_length=MAX_EDGES)
+def _graph_wire_bytes(graph: SimpleUndirectedGraph) -> int:
+    return len(encode_strict_json(graph.model_dump(mode="json")))
+
+
+def _label_wire_bytes(labels: tuple[str, ...]) -> int:
+    return sum(len(encode_strict_json(label) + b",") for label in labels)
+
+
+def _require_output_headroom(
+    source_bytes: int, witness_label_bytes: int, operation: str
+) -> None:
+    estimated_result_bytes = (
+        source_bytes + witness_label_bytes + _RESULT_ENVELOPE_RESERVE_BYTES
+    )
+    output_limit = CanonicalLimits().max_output_bytes
+    if estimated_result_bytes > output_limit:
+        raise ValueError(
+            f"the {operation} result retains its sources and would exceed the "
+            f"{output_limit}-byte canonical output limit; "
+            "shorten vertex labels or shrink the graphs"
+        )
+
+
+class GraphVertexMapRow(StrictModel):
+    """One canonical source-vertex to target-vertex assignment."""
+
+    source_vertex: str
+    target_vertex: str
+
+
+class GraphVertexMap(StrictModel):
+    """A complete canonical vertex map between two labelled simple graphs.
+
+    The rows are ordered by source label rather than either graph's display
+    order.  This binds one total function to its precise source and target
+    graphs without making row order mathematical data.
+    """
+
+    source_graph: SimpleUndirectedGraph
+    target_graph: SimpleUndirectedGraph
+    rows: tuple[GraphVertexMapRow, ...] = Field(max_length=256)
 
     @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        seen: set[tuple[int, int]] = set()
-        for u, v in self.edges:
-            if not (0 <= u < self.vertex_count and 0 <= v < self.vertex_count):
-                raise ValueError("edge vertices must be in 0..vertex_count-1")
-            if u == v:
-                raise ValueError("self-loops are not allowed")
-            endpoint_pair = (min(u, v), max(u, v))
-            if endpoint_pair in seen:
-                raise ValueError("edges must be unique")
-            seen.add(endpoint_pair)
+    def require_complete_canonical_map(self) -> Self:
+        expected_sources = tuple(sorted(self.source_graph.vertices))
+        actual_sources = tuple(row.source_vertex for row in self.rows)
+        if actual_sources != expected_sources:
+            raise ValueError(
+                "vertex-map rows must cover every source vertex exactly once "
+                "in canonical source-label order"
+            )
+        target_vertices = set(self.target_graph.vertices)
+        if any(row.target_vertex not in target_vertices for row in self.rows):
+            raise ValueError(
+                "vertex-map targets must be declared target-graph vertices"
+            )
+
+        max_obstruction_label_bytes = max(
+            (
+                len(encode_strict_json(label))
+                for label in self.source_graph.vertices + self.target_graph.vertices
+            ),
+            default=0,
+        )
+        estimated_result_bytes = (
+            len(encode_strict_json(self.model_dump(mode="json")))
+            + 4 * max_obstruction_label_bytes
+            + _RESULT_ENVELOPE_RESERVE_BYTES
+        )
+        if estimated_result_bytes > CanonicalLimits().max_output_bytes:
+            raise ValueError(
+                "the source-bound graph-homomorphism result would exceed the "
+                f"{CanonicalLimits().max_output_bytes}-byte canonical output limit"
+            )
         return self
+
+
+def _first_homomorphism_obstruction(
+    vertex_map: GraphVertexMap,
+) -> tuple[tuple[str, str], tuple[str, str]] | None:
+    """Return the first declared source edge with a nonedge image, if any."""
+
+    images = {row.source_vertex: row.target_vertex for row in vertex_map.rows}
+    target_edges = set(vertex_map.target_graph.edges)
+    for source_edge in vertex_map.source_graph.edges:
+        image_edge = (images[source_edge[0]], images[source_edge[1]])
+        canonical_image = tuple(sorted(image_edge))
+        if image_edge[0] == image_edge[1] or canonical_image not in target_edges:
+            return source_edge, image_edge
+    return None
+
+
+class GraphHomomorphism(StrictModel):
+    """A source-bound complete vertex map that preserves every source edge."""
+
+    vertex_map: GraphVertexMap
+
+    @model_validator(mode="after")
+    def require_edge_preservation(self) -> Self:
+        if _first_homomorphism_obstruction(self.vertex_map) is not None:
+            raise ValueError("a graph homomorphism must preserve every source edge")
+        return self
+
+
+class GraphHomomorphismObstruction(StrictModel):
+    """The first source edge whose map is not a target edge."""
+
+    source_edge: tuple[str, str]
+    image_vertices: tuple[str, str]
 
 
 class HomomorphismCheckRequest(StrictModel):
-    source_graph: SimpleGraph
-    target_graph: SimpleGraph
-    vertex_map: tuple[int, ...]
+    """Check one complete source-bound graph vertex map exactly."""
 
-    @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if len(self.vertex_map) != self.source_graph.vertex_count:
-            raise ValueError("vertex_map length must match source_graph vertex_count")
-        if any(not 0 <= v < self.target_graph.vertex_count for v in self.vertex_map):
-            raise ValueError("vertex_map entries must be valid target_graph vertices")
-        return self
-
-
-class HomomorphismFindRequest(StrictModel):
-    source_graph: SimpleGraph
-    target_graph: SimpleGraph
-
-    @model_validator(mode="after")
-    def require_search_bounded(self) -> Self:
-        if self.source_graph.vertex_count > MORPHISM_MAX_VERTICES:
-            raise ValueError(
-                f"source graph must have at most {MORPHISM_MAX_VERTICES} vertices"
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Check one complete canonical vertex map. Admission validates "
+                "its retained source/map result envelope before execution; the "
+                "kernel builds target adjacency once and scans every source edge "
+                "once."
             )
-        return self
+        }
+    )
 
-
-class CoreCheckRequest(StrictModel):
-    graph: SimpleGraph
-
-    @model_validator(mode="after")
-    def require_search_bounded(self) -> Self:
-        if self.graph.vertex_count > MORPHISM_MAX_VERTICES:
-            raise ValueError(
-                f"graph must have at most {MORPHISM_MAX_VERTICES} vertices"
-            )
-        return self
-
-
-class RetractionCheckRequest(StrictModel):
-    graph: SimpleGraph
-    subgraph_vertices: tuple[int, ...]
-
-    @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if self.graph.vertex_count > MORPHISM_MAX_VERTICES:
-            raise ValueError(
-                f"graph must have at most {MORPHISM_MAX_VERTICES} vertices"
-            )
-        if len(self.subgraph_vertices) > self.graph.vertex_count:
-            raise ValueError("subgraph_vertices must be a subset")
-        for v in self.subgraph_vertices:
-            if not 0 <= v < self.graph.vertex_count:
-                raise ValueError("subgraph_vertices must be valid vertex indices")
-        if len(set(self.subgraph_vertices)) != len(self.subgraph_vertices):
-            raise ValueError("subgraph_vertices must be unique")
-        return self
+    vertex_map: GraphVertexMap
 
 
 class HomomorphismCheckResult(StrictModel):
-    is_homomorphism: bool
-    method: str = "EDGE_PRESERVING_CHECK"
+    """A replayable positive homomorphism or first edge-image obstruction."""
 
+    vertex_map: GraphVertexMap
+    status: Literal["HOMOMORPHISM", "EDGE_IMAGE_NOT_EDGE"]
+    homomorphism: GraphHomomorphism | None = None
+    obstruction: GraphHomomorphismObstruction | None = None
 
-class HomomorphismFindResult(StrictModel):
-    found: bool
-    vertex_map: tuple[int, ...] = ()
-    method: str = "BACKTRACKING_SEARCH"
+    @model_validator(mode="after")
+    def require_replayable_result(self) -> Self:
+        expected = _first_homomorphism_obstruction(self.vertex_map)
+        if expected is None:
+            if self.status != "HOMOMORPHISM":
+                raise ValueError("a preserved map must have HOMOMORPHISM status")
+            if self.obstruction is not None:
+                raise ValueError("a homomorphism result must not carry an obstruction")
+            if (
+                self.homomorphism is None
+                or self.homomorphism.vertex_map != self.vertex_map
+            ):
+                raise ValueError(
+                    "a HOMOMORPHISM result must retain the checked source-bound map"
+                )
+            return self
 
-
-class CoreCheckResult(StrictModel):
-    is_core: bool
-    method: str = "ENDOMORPHISM_CHECK"
-
-
-class RetractionCheckResult(StrictModel):
-    is_retraction: bool
-    method: str = "HOMOMORPHISM_CHECK"
+        source_edge, image_vertices = expected
+        if self.status != "EDGE_IMAGE_NOT_EDGE":
+            raise ValueError("a nonedge image must have EDGE_IMAGE_NOT_EDGE status")
+        if self.homomorphism is not None:
+            raise ValueError("a non-homomorphism result must not carry a homomorphism")
+        if self.obstruction is None:
+            raise ValueError("a non-homomorphism result requires its first obstruction")
+        if self.obstruction.source_edge != source_edge:
+            raise ValueError(
+                "obstruction source_edge must be the first failing source edge"
+            )
+        if self.obstruction.image_vertices != image_vertices:
+            raise ValueError("obstruction image_vertices must replay the submitted map")
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -138,35 +208,6 @@ SEARCH_PASSES_PER_NEGATIVE_DECISION = 2
 _MAX_SEARCH_PATHS_PER_PASS = (
     MAX_CYCLE_SEARCH_PATHS // SEARCH_PASSES_PER_NEGATIVE_DECISION
 )
-
-# Results retain their source graphs, so a request near the canonical input
-# limit can produce a response past the identical output limit.  Admission
-# reserves this much for the result envelope beyond the echoed sources and
-# witness labels.
-_RESULT_ENVELOPE_RESERVE_BYTES = 1_024
-
-
-def _graph_wire_bytes(graph: SimpleUndirectedGraph) -> int:
-    return len(encode_strict_json(graph.model_dump(mode="json")))
-
-
-def _label_wire_bytes(graph: SimpleUndirectedGraph) -> int:
-    return sum(len(encode_strict_json(label) + b",") for label in graph.vertices)
-
-
-def _require_output_headroom(
-    source_bytes: int, witness_label_bytes: int, operation: str
-) -> None:
-    estimated_result_bytes = (
-        source_bytes + witness_label_bytes + _RESULT_ENVELOPE_RESERVE_BYTES
-    )
-    output_limit = CanonicalLimits().max_output_bytes
-    if estimated_result_bytes > output_limit:
-        raise ValueError(
-            f"the {operation} result retains its sources and would exceed the "
-            f"{output_limit}-byte canonical output limit; "
-            "shorten vertex labels or shrink the graphs"
-        )
 
 
 def _canonical_max_degree(graph: SimpleUndirectedGraph) -> int:
@@ -225,7 +266,7 @@ class FixedLengthCycleRequest(StrictModel):
         # the envelope and witness labels beyond that echo.
         _require_output_headroom(
             _graph_wire_bytes(self.graph),
-            _label_wire_bytes(self.graph),
+            _label_wire_bytes(self.graph.vertices),
             "fixed-length cycle",
         )
         return self
@@ -391,7 +432,7 @@ class SubgraphPatternFindRequest(StrictModel):
         # the envelope and witness labels beyond those echoes.
         _require_output_headroom(
             _graph_wire_bytes(self.pattern) + _graph_wire_bytes(self.host),
-            _label_wire_bytes(self.host),
+            _label_wire_bytes(self.host.vertices),
             "subgraph-pattern",
         )
         return self

--- a/src/jacobian/math/graphs/morphisms/_models.py
+++ b/src/jacobian/math/graphs/morphisms/_models.py
@@ -101,11 +101,11 @@ class GraphVertexMap(StrictModel):
 def _first_homomorphism_obstruction(
     vertex_map: GraphVertexMap,
 ) -> tuple[tuple[str, str], tuple[str, str]] | None:
-    """Return the first declared source edge with a nonedge image, if any."""
+    """Return the lexicographically first source edge with a nonedge image."""
 
     images = {row.source_vertex: row.target_vertex for row in vertex_map.rows}
     target_edges = set(vertex_map.target_graph.edges)
-    for source_edge in vertex_map.source_graph.edges:
+    for source_edge in sorted(vertex_map.source_graph.edges):
         image_edge = (images[source_edge[0]], images[source_edge[1]])
         canonical_image = tuple(sorted(image_edge))
         if image_edge[0] == image_edge[1] or canonical_image not in target_edges:
@@ -126,10 +126,25 @@ class GraphHomomorphism(StrictModel):
 
 
 class GraphHomomorphismObstruction(StrictModel):
-    """The first source edge whose map is not a target edge."""
+    """A source-bound first edge image that is not a target edge."""
 
+    vertex_map: GraphVertexMap
     source_edge: tuple[str, str]
     image_vertices: tuple[str, str]
+
+    @model_validator(mode="after")
+    def require_first_replayable_obstruction(self) -> Self:
+        expected = _first_homomorphism_obstruction(self.vertex_map)
+        if expected is None:
+            raise ValueError("a homomorphism has no edge-image obstruction")
+        source_edge, image_vertices = expected
+        if self.source_edge != source_edge:
+            raise ValueError(
+                "obstruction source_edge must be the first failing source edge"
+            )
+        if self.image_vertices != image_vertices:
+            raise ValueError("obstruction image_vertices must replay the submitted map")
+        return self
 
 
 class HomomorphismCheckRequest(StrictModel):
@@ -140,8 +155,8 @@ class HomomorphismCheckRequest(StrictModel):
             "description": (
                 "Check one complete canonical vertex map. Admission validates "
                 "its retained source/map result envelope before execution; the "
-                "kernel builds target adjacency once and scans every source edge "
-                "once."
+                "kernel orders source edges canonically, builds target adjacency "
+                "once, and scans every source edge once."
             )
         }
     )
@@ -152,41 +167,25 @@ class HomomorphismCheckRequest(StrictModel):
 class HomomorphismCheckResult(StrictModel):
     """A replayable positive homomorphism or first edge-image obstruction."""
 
-    vertex_map: GraphVertexMap
     status: Literal["HOMOMORPHISM", "EDGE_IMAGE_NOT_EDGE"]
     homomorphism: GraphHomomorphism | None = None
     obstruction: GraphHomomorphismObstruction | None = None
 
     @model_validator(mode="after")
     def require_replayable_result(self) -> Self:
-        expected = _first_homomorphism_obstruction(self.vertex_map)
-        if expected is None:
-            if self.status != "HOMOMORPHISM":
-                raise ValueError("a preserved map must have HOMOMORPHISM status")
+        if self.status == "HOMOMORPHISM":
             if self.obstruction is not None:
                 raise ValueError("a homomorphism result must not carry an obstruction")
-            if (
-                self.homomorphism is None
-                or self.homomorphism.vertex_map != self.vertex_map
-            ):
+            if self.homomorphism is None:
                 raise ValueError(
                     "a HOMOMORPHISM result must retain the checked source-bound map"
                 )
             return self
 
-        source_edge, image_vertices = expected
-        if self.status != "EDGE_IMAGE_NOT_EDGE":
-            raise ValueError("a nonedge image must have EDGE_IMAGE_NOT_EDGE status")
         if self.homomorphism is not None:
             raise ValueError("a non-homomorphism result must not carry a homomorphism")
         if self.obstruction is None:
             raise ValueError("a non-homomorphism result requires its first obstruction")
-        if self.obstruction.source_edge != source_edge:
-            raise ValueError(
-                "obstruction source_edge must be the first failing source edge"
-            )
-        if self.obstruction.image_vertices != image_vertices:
-            raise ValueError("obstruction image_vertices must replay the submitted map")
         return self
 
 

--- a/src/jacobian/math/graphs/morphisms/_operations.py
+++ b/src/jacobian/math/graphs/morphisms/_operations.py
@@ -21,15 +21,14 @@ def compute_homomorphism_check(
     obstruction = _first_homomorphism_obstruction(request.vertex_map)
     if obstruction is None:
         return HomomorphismCheckResult(
-            vertex_map=request.vertex_map,
             status="HOMOMORPHISM",
             homomorphism=GraphHomomorphism(vertex_map=request.vertex_map),
         )
     source_edge, image_vertices = obstruction
     return HomomorphismCheckResult(
-        vertex_map=request.vertex_map,
         status="EDGE_IMAGE_NOT_EDGE",
         obstruction=GraphHomomorphismObstruction(
+            vertex_map=request.vertex_map,
             source_edge=source_edge,
             image_vertices=image_vertices,
         ),

--- a/src/jacobian/math/graphs/morphisms/_operations.py
+++ b/src/jacobian/math/graphs/morphisms/_operations.py
@@ -3,179 +3,37 @@
 from __future__ import annotations
 
 from jacobian.math.graphs.morphisms._models import (
-    CoreCheckRequest,
-    CoreCheckResult,
     FixedLengthCycleRequest,
     FixedLengthCycleResult,
+    GraphHomomorphism,
+    GraphHomomorphismObstruction,
     HomomorphismCheckRequest,
     HomomorphismCheckResult,
-    HomomorphismFindRequest,
-    HomomorphismFindResult,
-    RetractionCheckRequest,
-    RetractionCheckResult,
     SubgraphPatternFindRequest,
     SubgraphPatternFindResult,
+    _first_homomorphism_obstruction,
 )
-
-
-def _adjacency(graph_edges: tuple[tuple[int, int], ...]) -> set[tuple[int, int]]:
-    """Return a set of all directed edges (both directions)."""
-    adj: set[tuple[int, int]] = set()
-    for u, v in graph_edges:
-        adj.add((u, v))
-        adj.add((v, u))
-    return adj
-
-
-def _is_homomorphism(
-    source_edges: tuple[tuple[int, int], ...],
-    target_edges: tuple[tuple[int, int], ...],
-    vertex_map: list[int],
-) -> bool:
-    target_adj = _adjacency(target_edges)
-    return all((vertex_map[u], vertex_map[v]) in target_adj for u, v in source_edges)
 
 
 def compute_homomorphism_check(
     request: HomomorphismCheckRequest,
 ) -> HomomorphismCheckResult:
-    is_h = _is_homomorphism(
-        request.source_graph.edges,
-        request.target_graph.edges,
-        list(request.vertex_map),
+    obstruction = _first_homomorphism_obstruction(request.vertex_map)
+    if obstruction is None:
+        return HomomorphismCheckResult(
+            vertex_map=request.vertex_map,
+            status="HOMOMORPHISM",
+            homomorphism=GraphHomomorphism(vertex_map=request.vertex_map),
+        )
+    source_edge, image_vertices = obstruction
+    return HomomorphismCheckResult(
+        vertex_map=request.vertex_map,
+        status="EDGE_IMAGE_NOT_EDGE",
+        obstruction=GraphHomomorphismObstruction(
+            source_edge=source_edge,
+            image_vertices=image_vertices,
+        ),
     )
-    return HomomorphismCheckResult(is_homomorphism=is_h)
-
-
-def compute_homomorphism_find(
-    request: HomomorphismFindRequest,
-) -> HomomorphismFindResult:
-    source = request.source_graph
-    target = request.target_graph
-    target_adj = _adjacency(target.edges)
-
-    vertex_map: list[int] = [-1] * source.vertex_count
-
-    def backtrack(pos: int) -> bool:
-        if pos == source.vertex_count:
-            return True
-        for candidate in range(target.vertex_count):
-            vertex_map[pos] = candidate
-            ok = True
-            for u, v in source.edges:
-                if (
-                    u == pos
-                    and vertex_map[v] != -1
-                    and (vertex_map[u], vertex_map[v]) not in target_adj
-                ):
-                    ok = False
-                    break
-                if (
-                    v == pos
-                    and vertex_map[u] != -1
-                    and (vertex_map[u], vertex_map[v]) not in target_adj
-                ):
-                    ok = False
-                    break
-            if ok and backtrack(pos + 1):
-                return True
-            vertex_map[pos] = -1
-        return False
-
-    found = backtrack(0)
-    return HomomorphismFindResult(
-        found=found,
-        vertex_map=tuple(vertex_map) if found else (),
-    )
-
-
-def _is_endomorphism(
-    source_edges: tuple[tuple[int, int], ...],
-    source_adj: set[tuple[int, int]],
-    mapping: list[int],
-) -> bool:
-    return all((mapping[u], mapping[v]) in source_adj for u, v in source_edges)
-
-
-def compute_core_check(request: CoreCheckRequest) -> CoreCheckResult:
-    """A graph is a core iff it has no non-injective endomorphism."""
-    source = request.graph
-    source_adj = _adjacency(source.edges)
-    vertex_map: list[int] = [-1] * source.vertex_count
-    has_non_injective = [False]
-
-    def search_non_injective(pos: int) -> bool:
-        if pos == source.vertex_count:
-            used = set(vertex_map)
-            if len(used) < source.vertex_count:
-                has_non_injective[0] = True
-                return True
-            return False
-        for candidate in range(source.vertex_count):
-            vertex_map[pos] = candidate
-            assigned_edges = tuple(
-                (u, v)
-                for u, v in source.edges
-                if vertex_map[u] != -1 and vertex_map[v] != -1
-            )
-            if _is_endomorphism(
-                assigned_edges, source_adj, vertex_map
-            ) and search_non_injective(pos + 1):
-                return True
-            vertex_map[pos] = -1
-        return False
-
-    found = search_non_injective(0)
-    return CoreCheckResult(is_core=not found)
-
-
-def compute_retraction_check(
-    request: RetractionCheckRequest,
-) -> RetractionCheckResult:
-    """Check if a retraction onto an induced subgraph exists."""
-    source = request.graph
-    subgraph = set(request.subgraph_vertices)
-
-    target_edges = [(u, v) for u, v in source.edges if u in subgraph and v in subgraph]
-    target_adj = _adjacency(tuple(target_edges))
-
-    vertex_map: list[int] = [-1] * source.vertex_count
-    subgraph_list = list(subgraph)
-
-    for v in subgraph_list:
-        vertex_map[v] = v
-
-    remaining = [i for i in range(source.vertex_count) if i not in subgraph]
-
-    def backtrack(pos: int) -> bool:
-        if pos == len(remaining):
-            return True
-        v = remaining[pos]
-        for candidate in subgraph_list:
-            vertex_map[v] = candidate
-            ok = True
-            for u, w in source.edges:
-                if (
-                    u == v
-                    and vertex_map[w] != -1
-                    and (candidate, vertex_map[w]) not in target_adj
-                ):
-                    ok = False
-                    break
-                if (
-                    w == v
-                    and vertex_map[u] != -1
-                    and (vertex_map[u], candidate) not in target_adj
-                ):
-                    ok = False
-                    break
-            if ok and backtrack(pos + 1):
-                return True
-            vertex_map[v] = -1
-        return False
-
-    found = backtrack(0)
-    return RetractionCheckResult(is_retraction=found)
 
 
 def _canonical_label_adjacency(

--- a/src/jacobian/math/graphs/morphisms/_tools.py
+++ b/src/jacobian/math/graphs/morphisms/_tools.py
@@ -7,25 +7,16 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.graphs.morphisms._models import (
-    CoreCheckRequest,
-    CoreCheckResult,
     FixedLengthCycleRequest,
     FixedLengthCycleResult,
     HomomorphismCheckRequest,
     HomomorphismCheckResult,
-    HomomorphismFindRequest,
-    HomomorphismFindResult,
-    RetractionCheckRequest,
-    RetractionCheckResult,
     SubgraphPatternFindRequest,
     SubgraphPatternFindResult,
 )
 from jacobian.math.graphs.morphisms._operations import (
-    compute_core_check,
     compute_fixed_length_cycle,
     compute_homomorphism_check,
-    compute_homomorphism_find,
-    compute_retraction_check,
     compute_subgraph_pattern_find,
 )
 
@@ -100,9 +91,10 @@ SUBGRAPH_P3_NOT_IN_MATCHING = {
 TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "graph.homomorphism.check",
-        "Check if a vertex map is a graph homomorphism",
-        "Check whether a given vertex map from source to target preserves "
-        "all edges of the source graph.",
+        "Check one complete graph vertex map",
+        "Check a complete canonical vertex map between two labelled simple "
+        "graphs. Returns either the source-bound checked homomorphism or the "
+        "first source edge whose image is not a target edge.",
         HomomorphismCheckRequest,
         HomomorphismCheckResult,
         compute_homomorphism_check,
@@ -112,99 +104,26 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "identity_homomorphism",
-                "Check the identity map on a single edge graph.",
+                "Check the canonical identity map on a single edge graph.",
                 {
-                    "source_graph": {
-                        "vertex_count": 2,
-                        "edges": [[0, 1]],
-                    },
-                    "target_graph": {
-                        "vertex_count": 2,
-                        "edges": [[0, 1]],
-                    },
-                    "vertex_map": [0, 1],
-                },
-            ),
-        ),
-    ),
-    _op(
-        "graph.homomorphism.find",
-        "Find a graph homomorphism if one exists",
-        "Search for a homomorphism from the source graph to the target graph "
-        "using backtracking. Returns whether a homomorphism exists and a "
-        "witness vertex map.",
-        HomomorphismFindRequest,
-        HomomorphismFindResult,
-        compute_homomorphism_find,
-        "graph",
-        "homomorphism",
-        "exact",
-        examples=(
-            example(
-                "k2_to_k2",
-                "Find a homomorphism from K2 to K2.",
-                {
-                    "source_graph": {
-                        "vertex_count": 2,
-                        "edges": [[0, 1]],
-                    },
-                    "target_graph": {
-                        "vertex_count": 2,
-                        "edges": [[0, 1]],
+                    "vertex_map": {
+                        "source_graph": {
+                            "vertices": ["a", "b"],
+                            "edges": [["a", "b"]],
+                        },
+                        "target_graph": {
+                            "vertices": ["a", "b"],
+                            "edges": [["a", "b"]],
+                        },
+                        "rows": [
+                            {"source_vertex": "a", "target_vertex": "a"},
+                            {"source_vertex": "b", "target_vertex": "b"},
+                        ],
                     },
                 },
             ),
         ),
-    ),
-    _op(
-        "graph.core.check",
-        "Check if a graph is a core",
-        "Check whether a graph is a core, i.e., has no non-injective "
-        "endomorphism. Returns true if the graph is a core.",
-        CoreCheckRequest,
-        CoreCheckResult,
-        compute_core_check,
-        "graph",
-        "core",
-        "exact",
-        examples=(
-            example(
-                "k2_is_core",
-                "Check if K2 is a core.",
-                {
-                    "graph": {
-                        "vertex_count": 2,
-                        "edges": [[0, 1]],
-                    },
-                },
-            ),
-        ),
-    ),
-    _op(
-        "graph.retraction.check",
-        "Check if a retraction onto a subgraph exists",
-        "Check whether there exists a homomorphism from the graph to an "
-        "subgraph induced by the given vertices that fixes every vertex of "
-        "the subgraph.",
-        RetractionCheckRequest,
-        RetractionCheckResult,
-        compute_retraction_check,
-        "graph",
-        "retraction",
-        "exact",
-        examples=(
-            example(
-                "k3_retract_to_k2",
-                "Check retraction from K3 to an edge.",
-                {
-                    "graph": {
-                        "vertex_count": 3,
-                        "edges": [[0, 1], [1, 2], [0, 2]],
-                    },
-                    "subgraph_vertices": [0, 1],
-                },
-            ),
-        ),
+        version="2",
     ),
     _op(
         "graph.cycle.fixed_length.decide",

--- a/tests/catalog/test_graph_homomorphism_catalog.py
+++ b/tests/catalog/test_graph_homomorphism_catalog.py
@@ -11,7 +11,6 @@ def test_graph_homomorphism_check_exposes_only_the_canonical_map_contract() -> N
     assert set(descriptor.input_schema["properties"]) == {"vertex_map"}
     assert "SimpleGraph" not in descriptor.input_schema.get("$defs", {})
     assert {
-        "vertex_map",
         "status",
         "homomorphism",
         "obstruction",

--- a/tests/catalog/test_graph_homomorphism_catalog.py
+++ b/tests/catalog/test_graph_homomorphism_catalog.py
@@ -1,0 +1,29 @@
+"""Public catalog contract for canonical graph-homomorphism checks."""
+
+from jacobian.catalog.catalog import Catalog
+
+
+def test_graph_homomorphism_check_exposes_only_the_canonical_map_contract() -> None:
+    descriptor = Catalog.open().inspect("graph.homomorphism.check")
+
+    assert descriptor is not None
+    assert descriptor.version == "2"
+    assert set(descriptor.input_schema["properties"]) == {"vertex_map"}
+    assert "SimpleGraph" not in descriptor.input_schema.get("$defs", {})
+    assert {
+        "vertex_map",
+        "status",
+        "homomorphism",
+        "obstruction",
+    } == set(descriptor.output_schema["properties"])
+
+
+def test_catalog_does_not_publish_retired_raw_graph_morphism_operations() -> None:
+    catalog = Catalog.open()
+
+    for operation_id in (
+        "graph.homomorphism.find",
+        "graph.core.check",
+        "graph.retraction.check",
+    ):
+        assert catalog.operation(operation_id) is None

--- a/tests/dispatch/test_graph_homomorphism_dispatch.py
+++ b/tests/dispatch/test_graph_homomorphism_dispatch.py
@@ -1,0 +1,70 @@
+"""Dispatch boundary for the canonical graph-homomorphism check."""
+
+from typing import Any
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+
+
+def _canonical_payload() -> dict[str, Any]:
+    return {
+        "vertex_map": {
+            "source_graph": {
+                "vertices": ["a", "b"],
+                "edges": [["a", "b"]],
+            },
+            "target_graph": {
+                "vertices": ["x", "y"],
+                "edges": [["x", "y"]],
+            },
+            "rows": [
+                {"source_vertex": "a", "target_vertex": "x"},
+                {"source_vertex": "b", "target_vertex": "y"},
+            ],
+        }
+    }
+
+
+def test_dispatch_runs_canonical_graph_homomorphism_check() -> None:
+    result = invoke_operation(
+        "graph.homomorphism.check",
+        _canonical_payload(),
+        Catalog.open(),
+    )
+
+    assert result.operation_version == "2"
+    assert result.output["status"] == "HOMOMORPHISM"
+    vertex_map = result.output["homomorphism"]["vertex_map"]
+    assert vertex_map["rows"] == _canonical_payload()["vertex_map"]["rows"]
+    assert vertex_map["source_graph"]["graph_schema_version"] == "1"
+    assert vertex_map["target_graph"]["graph_schema_version"] == "1"
+
+
+def test_dispatch_rejects_the_retired_raw_integer_graph_payload() -> None:
+    with pytest.raises(OperationRequestValidationError):
+        invoke_operation(
+            "graph.homomorphism.check",
+            {
+                "source_graph": {"vertex_count": 2, "edges": [[0, 1]]},
+                "target_graph": {"vertex_count": 2, "edges": [[0, 1]]},
+                "vertex_map": [0, 1],
+            },
+            Catalog.open(),
+        )
+
+
+@pytest.mark.parametrize(
+    "operation_id",
+    (
+        "graph.homomorphism.find",
+        "graph.core.check",
+        "graph.retraction.check",
+    ),
+)
+def test_dispatch_rejects_retired_raw_graph_morphism_operations(
+    operation_id: str,
+) -> None:
+    with pytest.raises(ValueError, match="unknown operation"):
+        invoke_operation(operation_id, {}, Catalog.open())

--- a/tests/dispatch/test_graph_homomorphism_dispatch.py
+++ b/tests/dispatch/test_graph_homomorphism_dispatch.py
@@ -42,6 +42,31 @@ def test_dispatch_runs_canonical_graph_homomorphism_check() -> None:
     assert vertex_map["target_graph"]["graph_schema_version"] == "1"
 
 
+def test_dispatch_admits_a_near_limit_positive_map_without_duplicate_storage() -> None:
+    label_width = 18_000
+    source_vertices = [
+        f"{index:03d}-" + "s" * (label_width - 4) for index in range(256)
+    ]
+    payload = {
+        "vertex_map": {
+            "source_graph": {"vertices": source_vertices, "edges": []},
+            "target_graph": {"vertices": ["t"], "edges": []},
+            "rows": [
+                {"source_vertex": source_vertex, "target_vertex": "t"}
+                for source_vertex in source_vertices
+            ],
+        }
+    }
+
+    result = invoke_operation("graph.homomorphism.check", payload, Catalog.open())
+
+    assert result.output["status"] == "HOMOMORPHISM"
+    assert (
+        result.output["homomorphism"]["vertex_map"]["rows"]
+        == payload["vertex_map"]["rows"]
+    )
+
+
 def test_dispatch_rejects_the_retired_raw_integer_graph_payload() -> None:
     with pytest.raises(OperationRequestValidationError):
         invoke_operation(

--- a/tests/math/graph_morphisms/test_graph_morphisms.py
+++ b/tests/math/graph_morphisms/test_graph_morphisms.py
@@ -77,6 +77,7 @@ def test_homomorphism_check_returns_first_edge_image_nonedge() -> None:
     assert result.status == "EDGE_IMAGE_NOT_EDGE"
     assert result.homomorphism is None
     assert result.obstruction == GraphHomomorphismObstruction(
+        vertex_map=vertex_map,
         source_edge=("a", "b"),
         image_vertices=("x", "x"),
     )
@@ -126,18 +127,37 @@ def test_vertex_map_rejects_incomplete_out_of_order_and_foreign_rows() -> None:
 
 
 def test_homomorphism_result_replays_and_rejects_forged_conclusions() -> None:
-    vertex_map = _vertex_map(
-        ("a", "b"),
-        (("a", "b"),),
-        ("x", "y"),
-        (("x", "y"),),
-        (("a", "x"), ("b", "y")),
-    )
-    with pytest.raises(ValidationError, match="preserved map"):
+    with pytest.raises(ValidationError, match="requires its first obstruction"):
         HomomorphismCheckResult(
-            vertex_map=vertex_map,
             status="EDGE_IMAGE_NOT_EDGE",
         )
+
+
+def test_homomorphism_check_orders_edge_obstructions_canonically() -> None:
+    def first_obstruction(
+        source_edges: tuple[tuple[str, str], ...],
+    ) -> GraphHomomorphismObstruction:
+        vertex_map = _vertex_map(
+            ("a", "b", "c"),
+            source_edges,
+            ("x", "y"),
+            (("x", "y"),),
+            (("a", "x"), ("b", "x"), ("c", "x")),
+        )
+        result = compute_homomorphism_check(
+            HomomorphismCheckRequest(vertex_map=vertex_map)
+        )
+        assert result.obstruction is not None
+        return result.obstruction
+
+    assert first_obstruction((("a", "b"), ("a", "c"))).source_edge == (
+        "a",
+        "b",
+    )
+    assert first_obstruction((("a", "c"), ("a", "b"))).source_edge == (
+        "a",
+        "b",
+    )
 
 
 def test_homomorphism_check_preflights_retained_result_bytes(

--- a/tests/math/graph_morphisms/test_graph_morphisms.py
+++ b/tests/math/graph_morphisms/test_graph_morphisms.py
@@ -1,161 +1,159 @@
 """Tests for graph morphism operations."""
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import CanonicalLimits
+from jacobian.math.graphs.morphisms import _models as morphism_models
 from jacobian.math.graphs.morphisms._models import (
-    CoreCheckRequest,
+    GraphHomomorphism,
+    GraphHomomorphismObstruction,
+    GraphVertexMap,
+    GraphVertexMapRow,
     HomomorphismCheckRequest,
-    HomomorphismFindRequest,
-    RetractionCheckRequest,
-    SimpleGraph,
+    HomomorphismCheckResult,
 )
-from jacobian.math.graphs.morphisms._operations import (
-    compute_core_check,
-    compute_homomorphism_check,
-    compute_homomorphism_find,
-    compute_retraction_check,
-)
+from jacobian.math.graphs.morphisms._operations import compute_homomorphism_check
 from jacobian.math.graphs.morphisms._tools import TOOLS
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 
 def test_catalog_contains_only_audited_operations() -> None:
     assert {tool.operation_id for tool in TOOLS} == {
-        "graph.core.check",
         "graph.cycle.fixed_length.decide",
         "graph.homomorphism.check",
-        "graph.homomorphism.find",
-        "graph.retraction.check",
         "graph.subgraph_pattern.find",
     }
 
 
-def test_homomorphism_check_identity() -> None:
-    request = HomomorphismCheckRequest(
-        source_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
-        target_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
-        vertex_map=(0, 1),
+def _vertex_map(
+    source_vertices: tuple[str, ...],
+    source_edges: tuple[tuple[str, str], ...],
+    target_vertices: tuple[str, ...],
+    target_edges: tuple[tuple[str, str], ...],
+    rows: tuple[tuple[str, str], ...],
+) -> GraphVertexMap:
+    return GraphVertexMap(
+        source_graph=SimpleUndirectedGraph(
+            vertices=source_vertices,
+            edges=source_edges,
+        ),
+        target_graph=SimpleUndirectedGraph(
+            vertices=target_vertices,
+            edges=target_edges,
+        ),
+        rows=tuple(
+            GraphVertexMapRow(source_vertex=source, target_vertex=target)
+            for source, target in rows
+        ),
     )
-    result = compute_homomorphism_check(request)
-    assert result.is_homomorphism is True
 
 
-def test_homomorphism_check_non_homomorphism() -> None:
-    request = HomomorphismCheckRequest(
-        source_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
-        target_graph=SimpleGraph(vertex_count=2, edges=()),
-        vertex_map=(0, 0),
+def test_homomorphism_check_returns_source_bound_checked_map() -> None:
+    """Rows are canonical by label even when a graph's display order is not."""
+
+    vertex_map = _vertex_map(
+        ("b", "a"),
+        (("a", "b"),),
+        ("y", "x"),
+        (("x", "y"),),
+        (("a", "x"), ("b", "y")),
     )
-    result = compute_homomorphism_check(request)
-    assert result.is_homomorphism is False
+    result = compute_homomorphism_check(HomomorphismCheckRequest(vertex_map=vertex_map))
+    assert result.status == "HOMOMORPHISM"
+    assert result.obstruction is None
+    assert result.homomorphism == GraphHomomorphism(vertex_map=vertex_map)
 
 
-def test_homomorphism_find_k2_to_k2() -> None:
-    request = HomomorphismFindRequest(
-        source_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
-        target_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
+def test_homomorphism_check_returns_first_edge_image_nonedge() -> None:
+    vertex_map = _vertex_map(
+        ("a", "b", "c"),
+        (("a", "b"), ("a", "c")),
+        ("x", "y"),
+        (("x", "y"),),
+        (("a", "x"), ("b", "x"), ("c", "y")),
     )
-    result = compute_homomorphism_find(request)
-    assert result.found is True
-    assert len(result.vertex_map) == 2
-
-
-def test_homomorphism_find_no_homomorphism() -> None:
-    request = HomomorphismFindRequest(
-        source_graph=SimpleGraph(vertex_count=2, edges=((0, 1),)),
-        target_graph=SimpleGraph(vertex_count=1, edges=()),
+    result = compute_homomorphism_check(HomomorphismCheckRequest(vertex_map=vertex_map))
+    assert result.status == "EDGE_IMAGE_NOT_EDGE"
+    assert result.homomorphism is None
+    assert result.obstruction == GraphHomomorphismObstruction(
+        source_edge=("a", "b"),
+        image_vertices=("x", "x"),
     )
-    result = compute_homomorphism_find(request)
-    assert result.found is False
 
 
-def test_core_check_k2_is_core() -> None:
-    request = CoreCheckRequest(graph=SimpleGraph(vertex_count=2, edges=((0, 1),)))
-    result = compute_core_check(request)
-    assert result.is_core is True
-
-
-def test_core_check_independent_set_is_not_core() -> None:
-    request = CoreCheckRequest(graph=SimpleGraph(vertex_count=3, edges=()))
-    result = compute_core_check(request)
-    assert result.is_core is False
-
-
-def test_retraction_check_k3_to_edge() -> None:
-    request = RetractionCheckRequest(
-        graph=SimpleGraph(vertex_count=3, edges=((0, 1), (1, 2), (0, 2))),
-        subgraph_vertices=(0, 1),
+def test_homomorphism_check_accepts_edgeless_noninjective_map() -> None:
+    vertex_map = _vertex_map(
+        ("a", "b"),
+        (),
+        ("x",),
+        (),
+        (("a", "x"), ("b", "x")),
     )
-    result = compute_retraction_check(request)
-    assert result.is_retraction is False
+    result = compute_homomorphism_check(HomomorphismCheckRequest(vertex_map=vertex_map))
+    assert result.status == "HOMOMORPHISM"
+    assert result.homomorphism is not None
 
 
-def test_core_check_p3_is_not_core() -> None:
-    """P3 (3-vertex path) retracts onto an edge, so it is not a core."""
-    request = CoreCheckRequest(
-        graph=SimpleGraph(vertex_count=3, edges=((0, 1), (1, 2)))
-    )
-    result = compute_core_check(request)
-    assert result.is_core is False
+def test_vertex_map_rejects_incomplete_out_of_order_and_foreign_rows() -> None:
+    source = SimpleUndirectedGraph(vertices=("a", "b"), edges=(("a", "b"),))
+    target = SimpleUndirectedGraph(vertices=("x", "y"), edges=(("x", "y"),))
 
-
-def test_core_check_c4_is_not_core() -> None:
-    """C4 (4-cycle) retracts onto an edge, so it is not a core."""
-    request = CoreCheckRequest(
-        graph=SimpleGraph(vertex_count=4, edges=((0, 1), (1, 2), (2, 3), (0, 3)))
-    )
-    result = compute_core_check(request)
-    assert result.is_core is False
-
-
-def test_core_check_k3_is_core() -> None:
-    """K3 (complete graph on 3 vertices) is a core."""
-    request = CoreCheckRequest(
-        graph=SimpleGraph(vertex_count=3, edges=((0, 1), (1, 2), (0, 2)))
-    )
-    result = compute_core_check(request)
-    assert result.is_core is True
-
-
-def test_retraction_check_p3_to_edge() -> None:
-    """P3 retracts onto the edge {0,1}: vertex 2 maps to 0."""
-    request = RetractionCheckRequest(
-        graph=SimpleGraph(vertex_count=3, edges=((0, 1), (1, 2))),
-        subgraph_vertices=(0, 1),
-    )
-    result = compute_retraction_check(request)
-    assert result.is_retraction is True
-
-
-def test_core_check_c5_is_core() -> None:
-    """C5 (5-cycle, odd) is a core: every endomorphism is an automorphism."""
-    request = CoreCheckRequest(
-        graph=SimpleGraph(
-            vertex_count=5, edges=((0, 1), (1, 2), (2, 3), (3, 4), (4, 0))
+    with pytest.raises(ValidationError, match="cover every source vertex"):
+        GraphVertexMap(
+            source_graph=source,
+            target_graph=target,
+            rows=(GraphVertexMapRow(source_vertex="a", target_vertex="x"),),
         )
-    )
-    result = compute_core_check(request)
-    assert result.is_core is True
-
-
-def test_core_check_k4_is_core() -> None:
-    """K4 (complete graph on 4 vertices) is a core."""
-    request = CoreCheckRequest(
-        graph=SimpleGraph(
-            vertex_count=4,
-            edges=((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)),
+    with pytest.raises(ValidationError, match="canonical source-label order"):
+        GraphVertexMap(
+            source_graph=source,
+            target_graph=target,
+            rows=(
+                GraphVertexMapRow(source_vertex="b", target_vertex="y"),
+                GraphVertexMapRow(source_vertex="a", target_vertex="x"),
+            ),
         )
-    )
-    result = compute_core_check(request)
-    assert result.is_core is True
+    with pytest.raises(ValidationError, match="declared target-graph"):
+        GraphVertexMap(
+            source_graph=source,
+            target_graph=target,
+            rows=(
+                GraphVertexMapRow(source_vertex="a", target_vertex="x"),
+                GraphVertexMapRow(source_vertex="b", target_vertex="z"),
+            ),
+        )
 
 
-def test_retraction_check_c4_to_edge() -> None:
-    """C4 retracts onto any of its edges: vertex 2 maps to 0, vertex 3 maps to 1."""
-    request = RetractionCheckRequest(
-        graph=SimpleGraph(vertex_count=4, edges=((0, 1), (1, 2), (2, 3), (0, 3))),
-        subgraph_vertices=(0, 1),
+def test_homomorphism_result_replays_and_rejects_forged_conclusions() -> None:
+    vertex_map = _vertex_map(
+        ("a", "b"),
+        (("a", "b"),),
+        ("x", "y"),
+        (("x", "y"),),
+        (("a", "x"), ("b", "y")),
     )
-    result = compute_retraction_check(request)
-    assert result.is_retraction is True
+    with pytest.raises(ValidationError, match="preserved map"):
+        HomomorphismCheckResult(
+            vertex_map=vertex_map,
+            status="EDGE_IMAGE_NOT_EDGE",
+        )
+
+
+def test_homomorphism_check_preflights_retained_result_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    small_limit = CanonicalLimits(max_output_bytes=400)
+    monkeypatch.setattr(morphism_models, "CanonicalLimits", lambda: small_limit)
+
+    with pytest.raises(ValidationError, match="canonical output limit"):
+        _vertex_map(
+            ("a" * 100,),
+            (),
+            ("b" * 100,),
+            (),
+            (("a" * 100, "b" * 100),),
+        )
 
 
 def _canonical_graph(


### PR DESCRIPTION
## Summary

Closes #1794 by replacing the legacy raw `SimpleGraph` homomorphism checks with one typed, canonical map-validation operation: `graph.homomorphism.check`.

The operation accepts canonical simple undirected graphs and a total source-to-target vertex map. It returns the retained map exactly once with either a successful homomorphism result or the first lexicographically ordered source edge whose image is not an edge. Request and result admission account for the full map and bounded serialized output before evaluation.

The old boolean check, bounded-map finder, core/retraction helpers, raw graph payloads, and compatibility aliases are removed. This deliberately does not add graph-homomorphism search, counting, automorphism, retraction, or core operations; those have distinct postconditions and need their own finite contracts.

## Validation

- `make check` — 3519 passed
- Focused graph morphism, catalog, and dispatch tests — 38 passed
- Exhaustive small-map oracle comparison (600 maps), direct and JSON dispatch replay
- Near-10 MiB positive/negative output-bound probes and edge-order permutation regression coverage

## Compatibility

This is a pre-stable public-contract correction. The retired operation IDs and raw payload shape are intentionally not preserved.
