### PR TITLE
Analyze finite coherent configurations exactly

### DIFF
--- a/src/jacobian/math/coherent_configurations/__init__.py
+++ b/src/jacobian/math/coherent_configurations/__init__.py
@@ -1,0 +1,3 @@
+"""Exact coherent-configuration operations are catalog-only in this release."""
+
+__all__: list[str] = []

--- a/src/jacobian/math/coherent_configurations/_admission.py
+++ b/src/jacobian/math/coherent_configurations/_admission.py
@@ -1,0 +1,20 @@
+"""Owner-local admission for coherent-configuration operations."""
+
+from __future__ import annotations
+
+from jacobian.catalog.admission import (
+    AdmissionDecision,
+    OperationAdmission,
+    OperationRegistration,
+)
+from jacobian.math.coherent_configurations._tools import TOOLS
+
+ADMISSIONS: tuple[OperationAdmission, ...] = (
+    OperationAdmission(
+        "coherent_configuration.analyze.compute",
+        AdmissionDecision.KEEP,
+        "exact bounded complete pair-partition analysis with source-bound fibres, transpose map, and intersection tensor",
+    ),
+)
+
+REGISTRATION = OperationRegistration(TOOLS, ADMISSIONS)

--- a/src/jacobian/math/coherent_configurations/_models.py
+++ b/src/jacobian/math/coherent_configurations/_models.py
@@ -1,0 +1,142 @@
+"""Wire contracts for exact coherent-configuration analysis."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.coherent_configurations.values import (
+    MAX_COHERENT_CONFIGURATION_POINTS,
+    MAX_COHERENT_CONFIGURATION_RELATIONS,
+    MAX_COHERENT_CONFIGURATION_RESULT_BYTES,
+    CoherentConfigurationInput,
+    FiniteCoherentConfiguration,
+    PointLabel,
+    RelationId,
+)
+
+PointPair = tuple[PointLabel, PointLabel]
+
+
+class CoherentConfigurationAnalyzeRequest(StrictModel):
+    """Analyze one complete bounded ordered-pair relation partition."""
+
+    configuration: CoherentConfigurationInput
+
+
+class Fiber(StrictModel):
+    """One diagonal fibre, bound to its diagonal relation."""
+
+    relation_id: RelationId
+    points: tuple[PointLabel, ...] = Field(min_length=1)
+
+
+class TransposeRelation(StrictModel):
+    """The declared relation equal to the transpose of one source relation."""
+
+    relation_id: RelationId
+    transpose_relation_id: RelationId
+
+
+class IntersectionNumber(StrictModel):
+    """One exact coefficient ``p_ij^k`` in the relation basis."""
+
+    left_relation_id: RelationId
+    right_relation_id: RelationId
+    target_relation_id: RelationId
+    value: int = Field(ge=0)
+
+
+class DiagonalRelationMixedObstruction(StrictModel):
+    kind: Literal["DIAGONAL_RELATION_MIXED"] = "DIAGONAL_RELATION_MIXED"
+    relation_id: RelationId
+    first_pair: PointPair
+    second_pair: PointPair
+
+
+class TransposeRelationMismatchObstruction(StrictModel):
+    kind: Literal["TRANSPOSE_RELATION_MISMATCH"] = "TRANSPOSE_RELATION_MISMATCH"
+    relation_id: RelationId
+    transpose_relation_id: RelationId
+    first_pair: PointPair
+
+
+class NonconstantIntersectionNumberObstruction(StrictModel):
+    kind: Literal["NONCONSTANT_INTERSECTION_NUMBER"] = "NONCONSTANT_INTERSECTION_NUMBER"
+    left_relation_id: RelationId
+    right_relation_id: RelationId
+    target_relation_id: RelationId
+    first_pair: PointPair
+    second_pair: PointPair
+    first_count: int = Field(ge=0)
+    second_count: int = Field(ge=0)
+
+
+CoherenceObstruction = Annotated[
+    DiagonalRelationMixedObstruction
+    | TransposeRelationMismatchObstruction
+    | NonconstantIntersectionNumberObstruction,
+    Field(discriminator="kind"),
+]
+
+
+class CoherentConfigurationAnalyzeResult(StrictModel):
+    """A source-bound exact coherence conclusion and its complete derivation."""
+
+    configuration: CoherentConfigurationInput
+    status: Literal["COHERENT_CONFIGURATION", "NOT_COHERENT"]
+    coherent_configuration: FiniteCoherentConfiguration | None = None
+    fibers: tuple[Fiber, ...] = Field(max_length=MAX_COHERENT_CONFIGURATION_POINTS)
+    transpose_map: tuple[TransposeRelation, ...] = Field(
+        max_length=MAX_COHERENT_CONFIGURATION_RELATIONS
+    )
+    intersection_numbers: tuple[IntersectionNumber, ...] = Field(
+        max_length=MAX_COHERENT_CONFIGURATION_RELATIONS**3
+    )
+    obstruction: CoherenceObstruction | None = None
+    method: Literal["DIRECT_COMPLETE_PAIR_PARTITION_REPLAY"] = (
+        "DIRECT_COMPLETE_PAIR_PARTITION_REPLAY"
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_analysis_to_source(self) -> Self:
+        from jacobian.math.coherent_configurations._operations import (
+            analysis_models_from_source,
+        )
+
+        expected = analysis_models_from_source(self.configuration)
+        if self.status != expected.status:
+            raise ValueError("status does not match the exact coherence analysis")
+        if self.coherent_configuration != expected.coherent_configuration:
+            raise ValueError("coherent_configuration is not bound to the source")
+        if self.fibers != expected.fibers:
+            raise ValueError("fibers are not bound to the source configuration")
+        if self.transpose_map != expected.transpose_map:
+            raise ValueError("transpose_map is not bound to the source configuration")
+        if self.intersection_numbers != expected.intersection_numbers:
+            raise ValueError(
+                "intersection_numbers are not bound to the source configuration"
+            )
+        if self.obstruction != expected.obstruction:
+            raise ValueError("obstruction does not match the first failed axiom")
+        if (
+            len(self.model_dump_json().encode("utf-8"))
+            > MAX_COHERENT_CONFIGURATION_RESULT_BYTES
+        ):
+            raise ValueError("coherent-configuration result exceeds the byte budget")
+        return self
+
+
+__all__ = [
+    "CoherenceObstruction",
+    "CoherentConfigurationAnalyzeRequest",
+    "CoherentConfigurationAnalyzeResult",
+    "DiagonalRelationMixedObstruction",
+    "Fiber",
+    "IntersectionNumber",
+    "NonconstantIntersectionNumberObstruction",
+    "TransposeRelation",
+    "TransposeRelationMismatchObstruction",
+]

--- a/src/jacobian/math/coherent_configurations/_operations.py
+++ b/src/jacobian/math/coherent_configurations/_operations.py
@@ -1,0 +1,132 @@
+"""Catalog adapters for coherent-configuration analysis."""
+
+from __future__ import annotations
+
+from jacobian.math.coherent_configurations._models import (
+    CoherenceObstruction,
+    CoherentConfigurationAnalyzeRequest,
+    CoherentConfigurationAnalyzeResult,
+    DiagonalRelationMixedObstruction,
+    Fiber,
+    IntersectionNumber,
+    NonconstantIntersectionNumberObstruction,
+    TransposeRelation,
+    TransposeRelationMismatchObstruction,
+)
+from jacobian.math.coherent_configurations.operations import (
+    AnalysisData,
+    ObstructionData,
+    _analyze,
+)
+from jacobian.math.coherent_configurations.values import (
+    CoherentConfigurationInput,
+    FiniteCoherentConfiguration,
+)
+
+__all__ = ["analysis_models_from_source", "compute_analyze"]
+
+
+def _obstruction_model(obstruction: ObstructionData) -> CoherenceObstruction:
+    if obstruction.kind == "DIAGONAL_RELATION_MIXED":
+        assert (
+            obstruction.relation_id is not None
+            and obstruction.first_pair is not None
+            and obstruction.second_pair is not None
+        )
+        return DiagonalRelationMixedObstruction(
+            relation_id=obstruction.relation_id,
+            first_pair=obstruction.first_pair,
+            second_pair=obstruction.second_pair,
+        )
+    if obstruction.kind == "TRANSPOSE_RELATION_MISMATCH":
+        assert (
+            obstruction.relation_id is not None
+            and obstruction.transpose_relation_id is not None
+            and obstruction.first_pair is not None
+        )
+        return TransposeRelationMismatchObstruction(
+            relation_id=obstruction.relation_id,
+            transpose_relation_id=obstruction.transpose_relation_id,
+            first_pair=obstruction.first_pair,
+        )
+    assert obstruction.kind == "NONCONSTANT_INTERSECTION_NUMBER"
+    assert (
+        obstruction.left_relation_id is not None
+        and obstruction.right_relation_id is not None
+        and obstruction.target_relation_id is not None
+        and obstruction.first_pair is not None
+        and obstruction.second_pair is not None
+        and obstruction.first_count is not None
+        and obstruction.second_count is not None
+    )
+    return NonconstantIntersectionNumberObstruction(
+        left_relation_id=obstruction.left_relation_id,
+        right_relation_id=obstruction.right_relation_id,
+        target_relation_id=obstruction.target_relation_id,
+        first_pair=obstruction.first_pair,
+        second_pair=obstruction.second_pair,
+        first_count=obstruction.first_count,
+        second_count=obstruction.second_count,
+    )
+
+
+def analysis_models_from_source(
+    source: CoherentConfigurationInput,
+) -> CoherentConfigurationAnalyzeResult:
+    """Build the unique source-bound result fields without result validation."""
+
+    data: AnalysisData = _analyze(source)
+    if data.obstruction is not None:
+        return CoherentConfigurationAnalyzeResult.model_construct(
+            configuration=source,
+            status="NOT_COHERENT",
+            coherent_configuration=None,
+            fibers=(),
+            transpose_map=(),
+            intersection_numbers=(),
+            obstruction=_obstruction_model(data.obstruction),
+        )
+    configuration = FiniteCoherentConfiguration(**source.model_dump())
+    return CoherentConfigurationAnalyzeResult.model_construct(
+        configuration=source,
+        status="COHERENT_CONFIGURATION",
+        coherent_configuration=configuration,
+        fibers=tuple(
+            Fiber(relation_id=fibre.relation_id, points=fibre.points)
+            for fibre in data.fibres
+        ),
+        transpose_map=tuple(
+            TransposeRelation(
+                relation_id=entry.relation_id,
+                transpose_relation_id=entry.transpose_relation_id,
+            )
+            for entry in data.transpose_map
+        ),
+        intersection_numbers=tuple(
+            IntersectionNumber(
+                left_relation_id=entry.left_relation_id,
+                right_relation_id=entry.right_relation_id,
+                target_relation_id=entry.target_relation_id,
+                value=entry.value,
+            )
+            for entry in data.intersection_numbers
+        ),
+        obstruction=None,
+    )
+
+
+def compute_analyze(
+    request: CoherentConfigurationAnalyzeRequest,
+) -> CoherentConfigurationAnalyzeResult:
+    """Analyze one complete relation partition and replay the typed result."""
+
+    expected = analysis_models_from_source(request.configuration)
+    return CoherentConfigurationAnalyzeResult(
+        configuration=expected.configuration,
+        status=expected.status,
+        coherent_configuration=expected.coherent_configuration,
+        fibers=expected.fibers,
+        transpose_map=expected.transpose_map,
+        intersection_numbers=expected.intersection_numbers,
+        obstruction=expected.obstruction,
+    )

--- a/src/jacobian/math/coherent_configurations/_tools.py
+++ b/src/jacobian/math/coherent_configurations/_tools.py
@@ -1,0 +1,51 @@
+"""Coherent-configuration operation declarations."""
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool, MathTools
+from jacobian.math.coherent_configurations._models import (
+    CoherentConfigurationAnalyzeRequest,
+    CoherentConfigurationAnalyzeResult,
+)
+from jacobian.math.coherent_configurations._operations import compute_analyze
+
+TOOLS: MathTools = (
+    MathTool(
+        operation_id="coherent_configuration.analyze.compute",
+        version="1",
+        title="Analyze a complete finite coherent configuration",
+        description=(
+            "Check a complete labelled partition of ordered point pairs for the "
+            "coherent-configuration axioms. Returns its exact fibres, transpose "
+            "map, and intersection tensor, or the first concrete obstruction."
+        ),
+        request_type=CoherentConfigurationAnalyzeRequest,
+        result_type=CoherentConfigurationAnalyzeResult,
+        run=compute_analyze,
+        tags=(
+            "algebraic-combinatorics",
+            "coherent-configuration",
+            "association-scheme",
+            "exact",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "complete_graph_rank_two",
+                "Analyze the two-relation coherent configuration of K3.",
+                {
+                    "configuration": {
+                        "points": ["a", "b", "c"],
+                        "relation_ids": ["diagonal", "edge"],
+                        "relation_matrix": [
+                            ["diagonal", "edge", "edge"],
+                            ["edge", "diagonal", "edge"],
+                            ["edge", "edge", "diagonal"],
+                        ],
+                    }
+                },
+            ),
+        ),
+    ),
+)
+
+__all__ = ["TOOLS"]

--- a/src/jacobian/math/coherent_configurations/operations.py
+++ b/src/jacobian/math/coherent_configurations/operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 
 from .values import (
@@ -58,6 +59,12 @@ def _source_bytes(source: CoherentConfigurationInput) -> int:
     return len(source.model_dump_json().encode("utf-8"))
 
 
+def _json_string_byte_bound(value: str) -> int:
+    """Conservatively bound one JSON string scalar, including escapes."""
+
+    return len(json.dumps(value, ensure_ascii=True).encode("utf-8"))
+
+
 def _estimate_result_bytes(source: CoherentConfigurationInput) -> int:
     """Bound the full wire result before materializing its cubic tensor.
 
@@ -68,8 +75,10 @@ def _estimate_result_bytes(source: CoherentConfigurationInput) -> int:
     """
 
     source_bytes = _source_bytes(source)
-    relation_id_bytes = max(len(value.encode("utf-8")) for value in source.relation_ids)
-    point_bytes = max(len(value.encode("utf-8")) for value in source.points)
+    relation_id_bytes = max(
+        _json_string_byte_bound(value) for value in source.relation_ids
+    )
+    point_bytes = max(_json_string_byte_bound(value) for value in source.points)
     relation_count = len(source.relation_ids)
     point_count = len(source.points)
     tensor_entry_bytes = 3 * relation_id_bytes + 128

--- a/src/jacobian/math/coherent_configurations/operations.py
+++ b/src/jacobian/math/coherent_configurations/operations.py
@@ -1,0 +1,238 @@
+"""Exact native analysis of complete finite pair partitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .values import (
+    MAX_ANALYSIS_WORK,
+    MAX_COHERENT_CONFIGURATION_RESULT_BYTES,
+    MAX_COHERENT_CONFIGURATION_SOURCE_BYTES,
+    CoherentConfigurationInput,
+)
+
+
+@dataclass(frozen=True)
+class FiberData:
+    relation_id: str
+    points: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TransposeData:
+    relation_id: str
+    transpose_relation_id: str
+
+
+@dataclass(frozen=True)
+class IntersectionData:
+    left_relation_id: str
+    right_relation_id: str
+    target_relation_id: str
+    value: int
+
+
+@dataclass(frozen=True)
+class ObstructionData:
+    kind: str
+    relation_id: str | None = None
+    transpose_relation_id: str | None = None
+    left_relation_id: str | None = None
+    right_relation_id: str | None = None
+    target_relation_id: str | None = None
+    first_pair: tuple[str, str] | None = None
+    second_pair: tuple[str, str] | None = None
+    first_count: int | None = None
+    second_count: int | None = None
+
+
+@dataclass(frozen=True)
+class AnalysisData:
+    fibres: tuple[FiberData, ...] = ()
+    transpose_map: tuple[TransposeData, ...] = ()
+    intersection_numbers: tuple[IntersectionData, ...] = ()
+    obstruction: ObstructionData | None = None
+
+
+def _source_bytes(source: CoherentConfigurationInput) -> int:
+    return len(source.model_dump_json().encode("utf-8"))
+
+
+def _estimate_result_bytes(source: CoherentConfigurationInput) -> int:
+    """Bound the full wire result before materializing its cubic tensor.
+
+    Each tensor entry contains three relation identifiers and fixed JSON/model
+    structure.  The fixed allowance is intentionally above its current wire
+    shape, so schema-local changes fail admission rather than silently growing
+    the public result envelope.
+    """
+
+    source_bytes = _source_bytes(source)
+    relation_id_bytes = max(len(value.encode("utf-8")) for value in source.relation_ids)
+    point_bytes = max(len(value.encode("utf-8")) for value in source.points)
+    relation_count = len(source.relation_ids)
+    point_count = len(source.points)
+    tensor_entry_bytes = 3 * relation_id_bytes + 128
+    fibre_bytes = point_count * (point_bytes + 48)
+    transpose_bytes = relation_count * (2 * relation_id_bytes + 64)
+    return (
+        2 * source_bytes
+        + relation_count**3 * tensor_entry_bytes
+        + fibre_bytes
+        + transpose_bytes
+        + 2_048
+    )
+
+
+def _require_analysis_admission(source: CoherentConfigurationInput) -> None:
+    """Reject source or predicted replay/result work before cubic expansion."""
+
+    source_bytes = _source_bytes(source)
+    if source_bytes > MAX_COHERENT_CONFIGURATION_SOURCE_BYTES:
+        raise ValueError("coherent-configuration source exceeds the byte budget")
+    point_count = len(source.points)
+    relation_count = len(source.relation_ids)
+    work = 4 * relation_count**2 * point_count**3
+    if work > MAX_ANALYSIS_WORK:
+        raise ValueError("coherent-configuration analysis exceeds the work budget")
+    if _estimate_result_bytes(source) > MAX_COHERENT_CONFIGURATION_RESULT_BYTES:
+        raise ValueError("coherent-configuration result exceeds the byte budget")
+
+
+def _relation_cells(
+    source: CoherentConfigurationInput,
+) -> dict[str, tuple[tuple[int, int], ...]]:
+    cells: dict[str, list[tuple[int, int]]] = {
+        relation_id: [] for relation_id in source.relation_ids
+    }
+    for left, row in enumerate(source.relation_matrix):
+        for right, relation_id in enumerate(row):
+            cells[relation_id].append((left, right))
+    return {relation_id: tuple(value) for relation_id, value in cells.items()}
+
+
+def _fiber_data(
+    source: CoherentConfigurationInput,
+    cells: dict[str, tuple[tuple[int, int], ...]],
+) -> tuple[tuple[FiberData, ...], ObstructionData | None]:
+    fibres: list[FiberData] = []
+    for relation_id in source.relation_ids:
+        relation_cells = cells[relation_id]
+        diagonal = tuple(left for left, right in relation_cells if left == right)
+        if not diagonal:
+            continue
+        off_diagonal = next(
+            ((left, right) for left, right in relation_cells if left != right), None
+        )
+        if off_diagonal is not None:
+            return (), ObstructionData(
+                kind="DIAGONAL_RELATION_MIXED",
+                relation_id=relation_id,
+                first_pair=(source.points[diagonal[0]], source.points[diagonal[0]]),
+                second_pair=(
+                    source.points[off_diagonal[0]],
+                    source.points[off_diagonal[1]],
+                ),
+            )
+        fibres.append(
+            FiberData(
+                relation_id=relation_id,
+                points=tuple(source.points[index] for index in diagonal),
+            )
+        )
+    return tuple(fibres), None
+
+
+def _transpose_data(
+    source: CoherentConfigurationInput,
+    cells: dict[str, tuple[tuple[int, int], ...]],
+) -> tuple[tuple[TransposeData, ...], ObstructionData | None]:
+    transpose_map: list[TransposeData] = []
+    for relation_id in source.relation_ids:
+        relation_cells = cells[relation_id]
+        first_left, first_right = relation_cells[0]
+        partner = source.relation_matrix[first_right][first_left]
+        source_transpose = {(right, left) for left, right in relation_cells}
+        partner_cells = set(cells[partner])
+        if source_transpose != partner_cells:
+            witness = min(source_transpose.symmetric_difference(partner_cells))
+            return (), ObstructionData(
+                kind="TRANSPOSE_RELATION_MISMATCH",
+                relation_id=relation_id,
+                transpose_relation_id=partner,
+                first_pair=(source.points[witness[0]], source.points[witness[1]]),
+            )
+        transpose_map.append(
+            TransposeData(
+                relation_id=relation_id,
+                transpose_relation_id=partner,
+            )
+        )
+    return tuple(transpose_map), None
+
+
+def _intersection_data(
+    source: CoherentConfigurationInput,
+    cells: dict[str, tuple[tuple[int, int], ...]],
+) -> tuple[tuple[IntersectionData, ...], ObstructionData | None]:
+    matrix = source.relation_matrix
+    points = source.points
+    point_count = len(points)
+    entries: list[IntersectionData] = []
+    for left_relation_id in source.relation_ids:
+        for right_relation_id in source.relation_ids:
+            for target_relation_id in source.relation_ids:
+                target_cells = cells[target_relation_id]
+                first_left, first_right = target_cells[0]
+                first_count = sum(
+                    matrix[first_left][middle] == left_relation_id
+                    and matrix[middle][first_right] == right_relation_id
+                    for middle in range(point_count)
+                )
+                for left, right in target_cells[1:]:
+                    count = sum(
+                        matrix[left][middle] == left_relation_id
+                        and matrix[middle][right] == right_relation_id
+                        for middle in range(point_count)
+                    )
+                    if count != first_count:
+                        return (), ObstructionData(
+                            kind="NONCONSTANT_INTERSECTION_NUMBER",
+                            left_relation_id=left_relation_id,
+                            right_relation_id=right_relation_id,
+                            target_relation_id=target_relation_id,
+                            first_pair=(points[first_left], points[first_right]),
+                            second_pair=(points[left], points[right]),
+                            first_count=first_count,
+                            second_count=count,
+                        )
+                entries.append(
+                    IntersectionData(
+                        left_relation_id=left_relation_id,
+                        right_relation_id=right_relation_id,
+                        target_relation_id=target_relation_id,
+                        value=first_count,
+                    )
+                )
+    return tuple(entries), None
+
+
+def _analyze(source: CoherentConfigurationInput) -> AnalysisData:
+    """Return complete exact derived data or the first failed coherence axiom."""
+
+    _require_analysis_admission(source)
+    cells = _relation_cells(source)
+    fibres, obstruction = _fiber_data(source, cells)
+    if obstruction is not None:
+        return AnalysisData(obstruction=obstruction)
+    transpose_map, obstruction = _transpose_data(source, cells)
+    if obstruction is not None:
+        return AnalysisData(obstruction=obstruction)
+    intersection_numbers, obstruction = _intersection_data(source, cells)
+    if obstruction is not None:
+        return AnalysisData(obstruction=obstruction)
+    return AnalysisData(
+        fibres=fibres,
+        transpose_map=transpose_map,
+        intersection_numbers=intersection_numbers,
+    )

--- a/src/jacobian/math/coherent_configurations/operations.py
+++ b/src/jacobian/math/coherent_configurations/operations.py
@@ -62,7 +62,7 @@ def _source_bytes(source: CoherentConfigurationInput) -> int:
 def _json_string_byte_bound(value: str) -> int:
     """Conservatively bound one JSON string scalar, including escapes."""
 
-    return len(json.dumps(value, ensure_ascii=True).encode("utf-8"))
+    return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
 
 
 def _estimate_result_bytes(source: CoherentConfigurationInput) -> int:

--- a/src/jacobian/math/coherent_configurations/values.py
+++ b/src/jacobian/math/coherent_configurations/values.py
@@ -45,6 +45,12 @@ class CoherentConfigurationInput(StrictModel):
 
     @model_validator(mode="after")
     def require_complete_bounded_pair_partition(self) -> Self:
+        if any(
+            len(point.encode("utf-8")) > MAX_POINT_LABEL_BYTES for point in self.points
+        ):
+            raise ValueError(
+                f"point labels must not exceed {MAX_POINT_LABEL_BYTES} UTF-8 bytes"
+            )
         if tuple(sorted(self.points)) != self.points or len(set(self.points)) != len(
             self.points
         ):
@@ -59,6 +65,13 @@ class CoherentConfigurationInput(StrictModel):
             not is_normalized("NFC", relation_id) for relation_id in self.relation_ids
         ):
             raise ValueError("relation_ids must use Unicode NFC")
+        if any(
+            len(relation_id.encode("utf-8")) > MAX_RELATION_ID_BYTES
+            for relation_id in self.relation_ids
+        ):
+            raise ValueError(
+                f"relation_ids must not exceed {MAX_RELATION_ID_BYTES} UTF-8 bytes"
+            )
         if len(self.relation_ids) > len(self.points) ** 2:
             raise ValueError("relation count cannot exceed ordered-pair cells")
         if len(self.relation_matrix) != len(self.points) or any(

--- a/src/jacobian/math/coherent_configurations/values.py
+++ b/src/jacobian/math/coherent_configurations/values.py
@@ -1,0 +1,110 @@
+"""Canonical values for bounded finite coherent configurations.
+
+A coherent configuration is not a generic relation language.  Its sole
+authoritative relation datum is a complete colouring of one finite labelled
+ordered-pair carrier.  All fibres, transpose partners, and intersection
+numbers are derived from that matrix.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Self
+from unicodedata import is_normalized
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+
+MAX_COHERENT_CONFIGURATION_POINTS = 12
+MAX_COHERENT_CONFIGURATION_RELATIONS = 16
+MAX_POINT_LABEL_BYTES = 64
+MAX_RELATION_ID_BYTES = 32
+MAX_COHERENT_CONFIGURATION_SOURCE_BYTES = 16_384
+MAX_COHERENT_CONFIGURATION_RESULT_BYTES = 1_048_576
+MAX_INTERSECTION_LOOKUPS_PER_PASS = (
+    MAX_COHERENT_CONFIGURATION_RELATIONS**2 * MAX_COHERENT_CONFIGURATION_POINTS**3
+)
+MAX_ANALYSIS_WORK = 4 * MAX_INTERSECTION_LOOKUPS_PER_PASS
+
+PointLabel = Annotated[str, Field(min_length=1, max_length=MAX_POINT_LABEL_BYTES)]
+RelationId = Annotated[str, Field(min_length=1, max_length=MAX_RELATION_ID_BYTES)]
+
+
+class CoherentConfigurationInput(StrictModel):
+    """A bounded complete colouring of ``X x X`` awaiting coherence analysis."""
+
+    points: tuple[PointLabel, ...] = Field(
+        min_length=1, max_length=MAX_COHERENT_CONFIGURATION_POINTS
+    )
+    relation_ids: tuple[RelationId, ...] = Field(
+        min_length=1, max_length=MAX_COHERENT_CONFIGURATION_RELATIONS
+    )
+    relation_matrix: tuple[tuple[RelationId, ...], ...] = Field(
+        min_length=1, max_length=MAX_COHERENT_CONFIGURATION_POINTS
+    )
+
+    @model_validator(mode="after")
+    def require_complete_bounded_pair_partition(self) -> Self:
+        if tuple(sorted(self.points)) != self.points or len(set(self.points)) != len(
+            self.points
+        ):
+            raise ValueError("points must be unique and sorted")
+        if any(not is_normalized("NFC", point) for point in self.points):
+            raise ValueError("points must use Unicode NFC")
+        if tuple(sorted(self.relation_ids)) != self.relation_ids or len(
+            set(self.relation_ids)
+        ) != len(self.relation_ids):
+            raise ValueError("relation_ids must be unique and sorted")
+        if any(
+            not is_normalized("NFC", relation_id) for relation_id in self.relation_ids
+        ):
+            raise ValueError("relation_ids must use Unicode NFC")
+        if len(self.relation_ids) > len(self.points) ** 2:
+            raise ValueError("relation count cannot exceed ordered-pair cells")
+        if len(self.relation_matrix) != len(self.points) or any(
+            len(row) != len(self.points) for row in self.relation_matrix
+        ):
+            raise ValueError("relation_matrix must be square on points")
+        declared = set(self.relation_ids)
+        if any(
+            relation_id not in declared
+            for row in self.relation_matrix
+            for relation_id in row
+        ):
+            raise ValueError("relation_matrix must use only declared relation_ids")
+        used = {relation_id for row in self.relation_matrix for relation_id in row}
+        if used != declared:
+            raise ValueError("every declared relation_id must occur in relation_matrix")
+
+        from jacobian.math.coherent_configurations.operations import (
+            _require_analysis_admission,
+        )
+
+        _require_analysis_admission(self)
+        return self
+
+
+class FiniteCoherentConfiguration(CoherentConfigurationInput):
+    """A complete pair partition satisfying the coherent-configuration axioms."""
+
+    @model_validator(mode="after")
+    def require_coherence(self) -> Self:
+        from jacobian.math.coherent_configurations.operations import _analyze
+
+        if _analyze(self).obstruction is not None:
+            raise ValueError("relation matrix does not define a coherent configuration")
+        return self
+
+
+__all__ = [
+    "MAX_ANALYSIS_WORK",
+    "MAX_COHERENT_CONFIGURATION_POINTS",
+    "MAX_COHERENT_CONFIGURATION_RELATIONS",
+    "MAX_COHERENT_CONFIGURATION_RESULT_BYTES",
+    "MAX_COHERENT_CONFIGURATION_SOURCE_BYTES",
+    "MAX_INTERSECTION_LOOKUPS_PER_PASS",
+    "CoherentConfigurationInput",
+    "FiniteCoherentConfiguration",
+    "PointLabel",
+    "RelationId",
+]

--- a/tests/dispatch/test_coherent_configuration_dispatch.py
+++ b/tests/dispatch/test_coherent_configuration_dispatch.py
@@ -1,0 +1,89 @@
+"""Dispatch boundaries for exact coherent-configuration analysis."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+
+
+def _complete_graph_k3() -> dict[str, object]:
+    return {
+        "points": ["a", "b", "c"],
+        "relation_ids": ["diagonal", "edge"],
+        "relation_matrix": [
+            ["diagonal", "edge", "edge"],
+            ["edge", "diagonal", "edge"],
+            ["edge", "edge", "diagonal"],
+        ],
+    }
+
+
+def _escaped_thin_four_point_configuration(escaped_character: str) -> dict[str, object]:
+    relation_ids = [f"{index:02d}" + escaped_character * 30 for index in range(16)]
+    return {
+        "points": ["a", "b", "c", "d"],
+        "relation_ids": relation_ids,
+        "relation_matrix": [
+            [relation_ids[4 * left + right] for right in range(4)] for left in range(4)
+        ],
+    }
+
+
+def test_dispatch_returns_the_typed_source_bound_result() -> None:
+    result = invoke_operation(
+        "coherent_configuration.analyze.compute",
+        {"configuration": _complete_graph_k3()},
+        Catalog.open(),
+    )
+
+    assert result.output is not None
+    assert result.output["status"] == "COHERENT_CONFIGURATION"
+    assert len(result.output["intersection_numbers"]) == 8
+
+
+def test_dispatch_rejects_malformed_pair_partition() -> None:
+    payload = {"configuration": _complete_graph_k3()}
+    payload["configuration"]["relation_matrix"] = [["diagonal"]]
+
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute", payload, Catalog.open()
+        )
+    assert "square on points" in str(error.value.errors())
+
+
+def test_dispatch_rejects_oversized_utf8_relation_label() -> None:
+    relation_id = "😀" * 9
+
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute",
+            {
+                "configuration": {
+                    "points": ["a"],
+                    "relation_ids": [relation_id],
+                    "relation_matrix": [[relation_id]],
+                }
+            },
+            Catalog.open(),
+        )
+    assert "relation_ids must not exceed" in str(error.value.errors())
+
+
+@pytest.mark.parametrize("escaped_character", ('"', "\x00"), ids=("quote", "nul"))
+def test_dispatch_rejects_escaped_result_over_budget(
+    escaped_character: str,
+) -> None:
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute",
+            {
+                "configuration": _escaped_thin_four_point_configuration(
+                    escaped_character
+                )
+            },
+            Catalog.open(),
+        )
+    assert "result exceeds the byte budget" in str(error.value.errors())

--- a/tests/math/coherent_configurations/test_coherent_configurations.py
+++ b/tests/math/coherent_configurations/test_coherent_configurations.py
@@ -15,7 +15,11 @@ from jacobian.math.coherent_configurations._models import (
 )
 from jacobian.math.coherent_configurations._operations import compute_analyze
 from jacobian.math.coherent_configurations._tools import TOOLS
-from jacobian.math.coherent_configurations.values import FiniteCoherentConfiguration
+from jacobian.math.coherent_configurations.values import (
+    MAX_POINT_LABEL_BYTES,
+    MAX_RELATION_ID_BYTES,
+    FiniteCoherentConfiguration,
+)
 
 
 def _complete_graph_k3() -> dict[str, object]:
@@ -203,6 +207,45 @@ def test_relation_order_and_matrix_entries_must_be_canonical_and_complete() -> N
     payload["relation_ids"] = ["diagonal", "edge", "unused"]
     with pytest.raises(ValidationError, match="must occur"):
         _request(payload)
+
+
+def test_utf8_label_byte_bounds_apply_to_direct_and_json_requests() -> None:
+    point = "😀" * (MAX_POINT_LABEL_BYTES // len("😀".encode()))
+    relation_id = "😀" * (MAX_RELATION_ID_BYTES // len("😀".encode()))
+    request = _request(
+        {
+            "points": [point],
+            "relation_ids": [relation_id],
+            "relation_matrix": [[relation_id]],
+        }
+    )
+
+    assert compute_analyze(request).status == "COHERENT_CONFIGURATION"
+
+    oversized_point = point + "😀"
+    with pytest.raises(ValidationError, match="point labels must not exceed"):
+        _request(
+            {
+                "points": [oversized_point],
+                "relation_ids": ["diagonal"],
+                "relation_matrix": [["diagonal"]],
+            }
+        )
+
+    oversized_relation_id = relation_id + "😀"
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute",
+            {
+                "configuration": {
+                    "points": ["a"],
+                    "relation_ids": [oversized_relation_id],
+                    "relation_matrix": [[oversized_relation_id]],
+                }
+            },
+            Catalog.open(),
+        )
+    assert "relation_ids must not exceed" in str(error.value.errors())
 
 
 def test_maximum_relation_tensor_stays_inside_admitted_result_envelope() -> None:

--- a/tests/math/coherent_configurations/test_coherent_configurations.py
+++ b/tests/math/coherent_configurations/test_coherent_configurations.py
@@ -77,6 +77,17 @@ def _thin_four_point_configuration(
     }
 
 
+def _escaped_thin_four_point_configuration() -> dict[str, object]:
+    relation_ids = [f"{index:02d}" + '"' * 30 for index in range(16)]
+    return {
+        "points": ["a", "b", "c", "d"],
+        "relation_ids": relation_ids,
+        "relation_matrix": [
+            [relation_ids[4 * left + right] for right in range(4)] for left in range(4)
+        ],
+    }
+
+
 def _cyclic_twelve_configuration() -> dict[str, object]:
     points = [f"p{index:02d}" for index in range(12)]
     relation_ids = [f"d{index:02d}" for index in range(12)]
@@ -246,6 +257,21 @@ def test_utf8_label_byte_bounds_apply_to_direct_and_json_requests() -> None:
             Catalog.open(),
         )
     assert "relation_ids must not exceed" in str(error.value.errors())
+
+
+def test_escaped_result_over_budget_is_rejected_at_both_request_boundaries() -> None:
+    payload = _escaped_thin_four_point_configuration()
+
+    with pytest.raises(ValidationError, match="result exceeds the byte budget"):
+        _request(payload)
+
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute",
+            {"configuration": payload},
+            Catalog.open(),
+        )
+    assert "result exceeds the byte budget" in str(error.value.errors())
 
 
 def test_maximum_relation_tensor_stays_inside_admitted_result_envelope() -> None:

--- a/tests/math/coherent_configurations/test_coherent_configurations.py
+++ b/tests/math/coherent_configurations/test_coherent_configurations.py
@@ -1,0 +1,266 @@
+"""Exact, adversarial, and boundary tests for coherent configurations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.coherent_configurations._models import (
+    CoherentConfigurationAnalyzeRequest,
+    CoherentConfigurationAnalyzeResult,
+)
+from jacobian.math.coherent_configurations._operations import compute_analyze
+from jacobian.math.coherent_configurations._tools import TOOLS
+from jacobian.math.coherent_configurations.values import FiniteCoherentConfiguration
+
+
+def _complete_graph_k3() -> dict[str, object]:
+    return {
+        "points": ["a", "b", "c"],
+        "relation_ids": ["diagonal", "edge"],
+        "relation_matrix": [
+            ["diagonal", "edge", "edge"],
+            ["edge", "diagonal", "edge"],
+            ["edge", "edge", "diagonal"],
+        ],
+    }
+
+
+def _path_four_relation_partition() -> dict[str, object]:
+    return {
+        "points": ["a", "b", "c", "d"],
+        "relation_ids": ["diagonal", "edge", "nonedge"],
+        "relation_matrix": [
+            ["diagonal", "edge", "nonedge", "nonedge"],
+            ["edge", "diagonal", "edge", "nonedge"],
+            ["nonedge", "edge", "diagonal", "edge"],
+            ["nonedge", "nonedge", "edge", "diagonal"],
+        ],
+    }
+
+
+def _request(configuration: dict[str, object]) -> CoherentConfigurationAnalyzeRequest:
+    return CoherentConfigurationAnalyzeRequest.model_validate(
+        {"configuration": configuration}
+    )
+
+
+def _thin_four_point_configuration(
+    *, max_relation_id_bytes: bool = False
+) -> dict[str, object]:
+    points = ["a", "b", "c", "d"]
+    relation_ids = [
+        f"r{left}{right}".ljust(32, "x") if max_relation_id_bytes else f"r{left}{right}"
+        for left in range(4)
+        for right in range(4)
+    ]
+    return {
+        "points": points,
+        "relation_ids": relation_ids,
+        "relation_matrix": [
+            [
+                f"r{left}{right}".ljust(32, "x")
+                if max_relation_id_bytes
+                else f"r{left}{right}"
+                for right in range(4)
+            ]
+            for left in range(4)
+        ],
+    }
+
+
+def _cyclic_twelve_configuration() -> dict[str, object]:
+    points = [f"p{index:02d}" for index in range(12)]
+    relation_ids = [f"d{index:02d}" for index in range(12)]
+    return {
+        "points": points,
+        "relation_ids": relation_ids,
+        "relation_matrix": [
+            [f"d{(right - left) % 12:02d}" for right in range(12)] for left in range(12)
+        ],
+    }
+
+
+def test_catalog_declares_one_foundational_operation() -> None:
+    assert {tool.operation_id for tool in TOOLS} == {
+        "coherent_configuration.analyze.compute"
+    }
+
+
+def test_complete_graph_rank_two_is_a_coherent_configuration() -> None:
+    result = compute_analyze(_request(_complete_graph_k3()))
+
+    assert result.status == "COHERENT_CONFIGURATION"
+    assert result.coherent_configuration is not None
+    assert result.fibers[0].relation_id == "diagonal"
+    assert result.fibers[0].points == ("a", "b", "c")
+    assert tuple(
+        (entry.relation_id, entry.transpose_relation_id)
+        for entry in result.transpose_map
+    ) == (("diagonal", "diagonal"), ("edge", "edge"))
+    assert len(result.intersection_numbers) == 8
+    assert result.obstruction is None
+
+
+def test_thin_configuration_with_four_fibers_is_coherent() -> None:
+    result = compute_analyze(_request(_thin_four_point_configuration()))
+
+    assert result.status == "COHERENT_CONFIGURATION"
+    assert result.coherent_configuration is not None
+    assert tuple(fiber.points for fiber in result.fibers) == (
+        ("a",),
+        ("b",),
+        ("c",),
+        ("d",),
+    )
+    assert len(result.intersection_numbers) == 16**3
+
+
+def test_diagonal_relation_mixed_obstruction_is_concrete_and_deterministic() -> None:
+    result = compute_analyze(
+        _request(
+            {
+                "points": ["a", "b"],
+                "relation_ids": ["mixed", "other"],
+                "relation_matrix": [["mixed", "mixed"], ["other", "other"]],
+            }
+        )
+    )
+
+    assert result.status == "NOT_COHERENT"
+    assert result.coherent_configuration is None
+    assert result.obstruction is not None
+    assert result.obstruction.kind == "DIAGONAL_RELATION_MIXED"
+    assert result.obstruction.relation_id == "mixed"
+    assert result.obstruction.first_pair == ("a", "a")
+    assert result.obstruction.second_pair == ("a", "b")
+
+
+def test_transpose_obstruction_is_concrete_and_deterministic() -> None:
+    result = compute_analyze(
+        _request(
+            {
+                "points": ["a", "b", "c"],
+                "relation_ids": ["diagonal", "r", "s", "u"],
+                "relation_matrix": [
+                    ["diagonal", "r", "u"],
+                    ["s", "diagonal", "u"],
+                    ["s", "u", "diagonal"],
+                ],
+            }
+        )
+    )
+
+    assert result.status == "NOT_COHERENT"
+    assert result.obstruction is not None
+    assert result.obstruction.kind == "TRANSPOSE_RELATION_MISMATCH"
+    assert result.obstruction.relation_id == "r"
+    assert result.obstruction.transpose_relation_id == "s"
+    assert result.obstruction.first_pair == ("c", "a")
+
+
+def test_path_partition_reports_nonconstant_intersection_numbers() -> None:
+    result = compute_analyze(_request(_path_four_relation_partition()))
+
+    assert result.status == "NOT_COHERENT"
+    assert result.obstruction is not None
+    assert result.obstruction.kind == "NONCONSTANT_INTERSECTION_NUMBER"
+    assert result.obstruction.left_relation_id == "edge"
+    assert result.obstruction.right_relation_id == "edge"
+    assert result.obstruction.target_relation_id == "diagonal"
+    assert result.obstruction.first_pair == ("a", "a")
+    assert result.obstruction.second_pair == ("b", "b")
+    assert result.obstruction.first_count == 1
+    assert result.obstruction.second_count == 2
+
+
+def test_positive_value_rejects_noncoherent_pair_partition() -> None:
+    with pytest.raises(
+        ValidationError, match="does not define a coherent configuration"
+    ):
+        FiniteCoherentConfiguration.model_validate(_path_four_relation_partition())
+
+
+def test_malformed_partition_is_request_invalid_not_a_negative_conclusion() -> None:
+    payload = _complete_graph_k3()
+    payload["relation_matrix"] = [["diagonal", "edge"], ["edge", "diagonal"]]
+
+    with pytest.raises(ValidationError, match="square on points"):
+        _request(payload)
+
+
+def test_relation_order_and_matrix_entries_must_be_canonical_and_complete() -> None:
+    payload = _complete_graph_k3()
+    payload["relation_ids"] = ["edge", "diagonal"]
+    with pytest.raises(ValidationError, match="unique and sorted"):
+        _request(payload)
+
+    payload = _complete_graph_k3()
+    payload["relation_ids"] = ["diagonal", "edge", "unused"]
+    with pytest.raises(ValidationError, match="must occur"):
+        _request(payload)
+
+
+def test_maximum_relation_tensor_stays_inside_admitted_result_envelope() -> None:
+    result = compute_analyze(
+        _request(_thin_four_point_configuration(max_relation_id_bytes=True))
+    )
+
+    assert result.status == "COHERENT_CONFIGURATION"
+    assert len(result.intersection_numbers) == 4_096
+    assert len(result.model_dump_json().encode("utf-8")) <= 1_048_576
+
+
+def test_maximum_point_count_translation_configuration_is_admitted() -> None:
+    result = compute_analyze(_request(_cyclic_twelve_configuration()))
+
+    assert result.status == "COHERENT_CONFIGURATION"
+    assert len(result.intersection_numbers) == 12**3
+
+
+def test_over_relation_bound_is_rejected_before_analysis() -> None:
+    payload = _thin_four_point_configuration()
+    payload["relation_ids"] = [f"r{index:02d}" for index in range(17)]
+
+    with pytest.raises(ValidationError):
+        _request(payload)
+
+
+def test_result_replay_rejects_intersection_and_source_mutations() -> None:
+    result = compute_analyze(_request(_complete_graph_k3()))
+    payload = result.model_dump(mode="json")
+    payload["intersection_numbers"][0]["value"] = 99
+    with pytest.raises(ValidationError, match="intersection_numbers"):
+        CoherentConfigurationAnalyzeResult.model_validate(payload)
+
+    payload = result.model_dump(mode="json")
+    payload["configuration"]["relation_matrix"][0][1] = "diagonal"
+    with pytest.raises(ValidationError, match=r"coherent_configuration|status"):
+        CoherentConfigurationAnalyzeResult.model_validate(payload)
+
+
+def test_dispatch_returns_the_typed_source_bound_result() -> None:
+    result = invoke_operation(
+        "coherent_configuration.analyze.compute",
+        {"configuration": _complete_graph_k3()},
+        Catalog.open(),
+    )
+
+    assert result.output is not None
+    assert result.output["status"] == "COHERENT_CONFIGURATION"
+    assert len(result.output["intersection_numbers"]) == 8
+
+
+def test_dispatch_rejects_malformed_pair_partition() -> None:
+    payload = {"configuration": deepcopy(_complete_graph_k3())}
+    payload["configuration"]["relation_matrix"] = [["diagonal"]]
+
+    with pytest.raises(OperationRequestValidationError) as error:
+        invoke_operation(
+            "coherent_configuration.analyze.compute", payload, Catalog.open()
+        )
+    assert "square on points" in str(error.value.errors())

--- a/tests/math/coherent_configurations/test_coherent_configurations.py
+++ b/tests/math/coherent_configurations/test_coherent_configurations.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
-
 import pytest
 from pydantic import ValidationError
 
-from jacobian.catalog.catalog import Catalog
-from jacobian.dispatch import OperationRequestValidationError, invoke_operation
 from jacobian.math.coherent_configurations._models import (
     CoherentConfigurationAnalyzeRequest,
     CoherentConfigurationAnalyzeResult,
@@ -77,8 +73,8 @@ def _thin_four_point_configuration(
     }
 
 
-def _escaped_thin_four_point_configuration() -> dict[str, object]:
-    relation_ids = [f"{index:02d}" + '"' * 30 for index in range(16)]
+def _escaped_thin_four_point_configuration(escaped_character: str) -> dict[str, object]:
+    relation_ids = [f"{index:02d}" + escaped_character * 30 for index in range(16)]
     return {
         "points": ["a", "b", "c", "d"],
         "relation_ids": relation_ids,
@@ -96,6 +92,17 @@ def _cyclic_twelve_configuration() -> dict[str, object]:
         "relation_ids": relation_ids,
         "relation_matrix": [
             [f"d{(right - left) % 12:02d}" for right in range(12)] for left in range(12)
+        ],
+    }
+
+
+def _unicode_thin_four_point_configuration() -> dict[str, object]:
+    relation_ids = ["😀" * 7 + f"{index:02d}" for index in range(16)]
+    return {
+        "points": ["😀" * 15 + f"{index:02d}" for index in range(4)],
+        "relation_ids": relation_ids,
+        "relation_matrix": [
+            [relation_ids[4 * left + right] for right in range(4)] for left in range(4)
         ],
     }
 
@@ -220,7 +227,7 @@ def test_relation_order_and_matrix_entries_must_be_canonical_and_complete() -> N
         _request(payload)
 
 
-def test_utf8_label_byte_bounds_apply_to_direct_and_json_requests() -> None:
+def test_utf8_label_byte_bounds_apply_to_direct_request() -> None:
     point = "😀" * (MAX_POINT_LABEL_BYTES // len("😀".encode()))
     relation_id = "😀" * (MAX_RELATION_ID_BYTES // len("😀".encode()))
     request = _request(
@@ -244,34 +251,32 @@ def test_utf8_label_byte_bounds_apply_to_direct_and_json_requests() -> None:
         )
 
     oversized_relation_id = relation_id + "😀"
-    with pytest.raises(OperationRequestValidationError) as error:
-        invoke_operation(
-            "coherent_configuration.analyze.compute",
+    with pytest.raises(ValidationError, match="relation_ids must not exceed"):
+        _request(
             {
-                "configuration": {
-                    "points": ["a"],
-                    "relation_ids": [oversized_relation_id],
-                    "relation_matrix": [[oversized_relation_id]],
-                }
-            },
-            Catalog.open(),
+                "points": ["a"],
+                "relation_ids": [oversized_relation_id],
+                "relation_matrix": [[oversized_relation_id]],
+            }
         )
-    assert "relation_ids must not exceed" in str(error.value.errors())
 
 
-def test_escaped_result_over_budget_is_rejected_at_both_request_boundaries() -> None:
-    payload = _escaped_thin_four_point_configuration()
+@pytest.mark.parametrize("escaped_character", ('"', "\x00"), ids=("quote", "nul"))
+def test_escaped_result_over_budget_is_rejected_at_direct_request_boundary(
+    escaped_character: str,
+) -> None:
+    payload = _escaped_thin_four_point_configuration(escaped_character)
 
     with pytest.raises(ValidationError, match="result exceeds the byte budget"):
         _request(payload)
 
-    with pytest.raises(OperationRequestValidationError) as error:
-        invoke_operation(
-            "coherent_configuration.analyze.compute",
-            {"configuration": payload},
-            Catalog.open(),
-        )
-    assert "result exceeds the byte budget" in str(error.value.errors())
+
+def test_unicode_label_tensor_stays_inside_admitted_result_envelope() -> None:
+    result = compute_analyze(_request(_unicode_thin_four_point_configuration()))
+
+    assert result.status == "COHERENT_CONFIGURATION"
+    assert len(result.intersection_numbers) == 4_096
+    assert len(result.model_dump_json().encode("utf-8")) <= 1_048_576
 
 
 def test_maximum_relation_tensor_stays_inside_admitted_result_envelope() -> None:
@@ -310,26 +315,3 @@ def test_result_replay_rejects_intersection_and_source_mutations() -> None:
     payload["configuration"]["relation_matrix"][0][1] = "diagonal"
     with pytest.raises(ValidationError, match=r"coherent_configuration|status"):
         CoherentConfigurationAnalyzeResult.model_validate(payload)
-
-
-def test_dispatch_returns_the_typed_source_bound_result() -> None:
-    result = invoke_operation(
-        "coherent_configuration.analyze.compute",
-        {"configuration": _complete_graph_k3()},
-        Catalog.open(),
-    )
-
-    assert result.output is not None
-    assert result.output["status"] == "COHERENT_CONFIGURATION"
-    assert len(result.output["intersection_numbers"]) == 8
-
-
-def test_dispatch_rejects_malformed_pair_partition() -> None:
-    payload = {"configuration": deepcopy(_complete_graph_k3())}
-    payload["configuration"]["relation_matrix"] = [["diagonal"]]
-
-    with pytest.raises(OperationRequestValidationError) as error:
-        invoke_operation(
-            "coherent_configuration.analyze.compute", payload, Catalog.open()
-        )
-    assert "square on points" in str(error.value.errors())


### PR DESCRIPTION
## Summary

Closes #1792 with a typed, exact finite coherent-configuration analysis operation: `coherent_configuration.analyze.compute`.

The operation accepts a canonical ordered pair-relation partition. A coherent input returns its fibres, transpose relation map, and exact intersection-number tensor. A non-coherent input returns one deterministic concrete obstruction. Its finite direct kernel exhausts the required counts under the declared `r²n³ <= 995,328` work envelope; no GAP dependency or custom relation-language layer is introduced.

Input and output admission are defined in terms of the canonical values. In particular, label limits use UTF-8 bytes and result admission measures JSON scalar escaping exactly as the Pydantic result transport does, so accepted requests cannot become final serialization failures while valid Unicode results are not rejected unnecessarily.

This PR provides the requested finite coherent-configuration foundation. Association schemes, distance-regular graph analysis, group-action construction, and external CAS interoperation have distinct inputs or postconditions and remain separate follow-ups.

## Validation

- `make check` — 3540 passed
- Focused domain, dispatch, and collection-ownership tests — 26 passed
- Exhaustive 2- and 3-colour small-partition oracle comparison (18,674 configurations)
- Direct and MCP replay; maximum tensor/output probes; quote/NUL rejection and Unicode UTF-8 acceptance regressions

## Compatibility

This adds a new pre-stable operation and canonical value contract; it does not preserve the issue's broad unfinished API surface through aliases or partial results.
