### PR TITLE
fix(math): emit hypergraph clique expansion as a canonical simple graph

### DIFF
--- a/src/jacobian/math/hypergraphs/_admission.py
+++ b/src/jacobian/math/hypergraphs/_admission.py
@@ -32,7 +32,9 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "hypergraph.clique_expansion.compute",
         AdmissionDecision.KEEP,
-        "exact 2-section graph where vertices are adjacent if they share a hyperedge",
+        "exact 2-section of a finite hypergraph as a canonical "
+        "SimpleUndirectedGraph: two vertices are adjacent if they share a "
+        "hyperedge",
     ),
 )
 

--- a/src/jacobian/math/hypergraphs/_models.py
+++ b/src/jacobian/math/hypergraphs/_models.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import unicodedata
 from typing import Self
 
 from pydantic import Field, model_validator
 
 from jacobian._models import StrictModel
+from jacobian.math.graphs.values import SimpleUndirectedGraph
 
 MAX_VERTICES = 100
 MAX_EDGES = 100
@@ -205,38 +207,46 @@ class IncidenceGraphResult(StrictModel):
 
 
 class CliqueExpansionRequest(StrictModel):
-    """Request the clique expansion (2-section) of a hypergraph."""
+    """Request the clique expansion (2-section) of a hypergraph.
+
+    The expansion is emitted as the domain-owned canonical
+    ``SimpleUndirectedGraph``, whose value requires NFC-normalized vertex
+    labels; hypergraphs whose declared labels are not NFC are outside this
+    operation's admitted domain.
+    """
 
     hypergraph: FiniteHypergraph
+
+    @model_validator(mode="after")
+    def require_nfc_vertex_labels(self) -> Self:
+        if any(
+            not unicodedata.is_normalized("NFC", vertex)
+            for vertex in self.hypergraph.vertices
+        ):
+            raise ValueError("clique expansion requires NFC-normalized vertex labels")
+        return self
 
 
 class CliqueExpansionResult(StrictModel):
     """The primal/2-section graph of a finite hypergraph.
 
-    Two distinct vertices are adjacent in the 2-section if and only if they
-    share at least one hyperedge.  ``vertices`` lists the vertices in
-    declared order; ``adjacency`` maps each vertex to the tuple of its
-    neighbours in declared vertex order; ``edges`` lists each unordered
-    adjacency pair ``(u, v)`` with ``u`` before ``v`` in declared order,
-    sorted by the first component then the second.
+    ``graph`` is the canonical :class:`SimpleUndirectedGraph` whose vertices
+    are exactly the hypergraph's declared vertex labels, in declared order,
+    and in which two distinct vertices are adjacent if and only if they
+    share at least one hyperedge.  Each edge's endpoints appear in lexical
+    order per the canonical graph value's own convention, independent of the
+    source hypergraph's declared ordering, so the value composes directly
+    with downstream graph operations without translation.  This defining
+    property is validated against the retained source hypergraph.
     """
 
     hypergraph: FiniteHypergraph
-    vertices: tuple[str, ...]
-    adjacency: tuple[tuple[str, tuple[str, ...]], ...]
-    edges: tuple[tuple[str, str], ...]
+    graph: SimpleUndirectedGraph
 
     @model_validator(mode="after")
     def bind_clique_expansion(self) -> Self:
-        from jacobian.math.hypergraphs._operations import _clique_expansion_data
+        from jacobian.math.hypergraphs._operations import _clique_expansion_graph
 
-        vertices, adjacency, edges = _clique_expansion_data(self.hypergraph)
-        if self.vertices != vertices:
-            raise ValueError("vertices must be the declared vertex list")
-        if self.adjacency != adjacency:
-            raise ValueError(
-                "adjacency must be the exact neighbour map of the 2-section"
-            )
-        if self.edges != edges:
-            raise ValueError("edges must be the exact 2-section edge list")
+        if self.graph != _clique_expansion_graph(self.hypergraph):
+            raise ValueError("graph must be the exact 2-section of the hypergraph")
         return self

--- a/src/jacobian/math/hypergraphs/_operations.py
+++ b/src/jacobian/math/hypergraphs/_operations.py
@@ -1,5 +1,6 @@
 """Exact bounded finite hypergraph operations."""
 
+from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.hypergraphs._models import (
     CliqueExpansionRequest,
     CliqueExpansionResult,
@@ -122,53 +123,28 @@ def _incidence_graph_data(
     return vertex_incidence_pairs, edge_incidence_pairs, incidence_edges
 
 
-def _clique_expansion_data(
-    hypergraph: FiniteHypergraph,
-) -> tuple[
-    tuple[str, ...],
-    tuple[tuple[str, tuple[str, ...]], ...],
-    tuple[tuple[str, str], ...],
-]:
-    """Compute the 2-section (primal/clique expansion) graph.
+def _clique_expansion_graph(hypergraph: FiniteHypergraph) -> SimpleUndirectedGraph:
+    """Compute the 2-section (primal/clique expansion) canonical graph.
 
-    Two distinct vertices are adjacent if they share at least one hyperedge.
-    ``adjacency`` maps each vertex to its neighbours in declared vertex order.
-    ``edges`` lists each adjacency pair ``(u, v)`` with ``u`` before ``v`` in
-    declared order, sorted by the first component then the second.
+    Two distinct vertices are adjacent if and only if they share at least
+    one hyperedge.  Vertex labels carry over unchanged, in declared order;
+    each undirected adjacency pair is emitted in lexical order, following
+    the ``SimpleUndirectedGraph`` convention independently of the source
+    hypergraph's declared vertex ordering.
     """
 
-    edges = _canonical_edges(hypergraph)
-    index = {vertex: i for i, vertex in enumerate(hypergraph.vertices)}
-    adjacent: list[set[str]] = [set() for _ in hypergraph.vertices]
-    for _, members in edges:
-        n = len(members)
-        for i in range(n):
-            for j in range(i + 1, n):
-                u, v = members[i], members[j]
-                if u == v:
-                    continue
-                adjacent[index[u]].add(v)
-                adjacent[index[v]].add(u)
-    vertices = hypergraph.vertices
-    adjacency = tuple(
-        (
-            vertex,
-            tuple(
-                neighbour
-                for neighbour in hypergraph.vertices
-                if neighbour in adjacent[index[vertex]]
-            ),
+    adjacent: dict[str, set[str]] = {vertex: set() for vertex in hypergraph.vertices}
+    for _, members in _canonical_edges(hypergraph):
+        for i, u in enumerate(members):
+            for v in members[i + 1 :]:
+                adjacent[u].add(v)
+                adjacent[v].add(u)
+    graph_edges = tuple(
+        sorted(
+            (u, v) for u, neighbours in adjacent.items() for v in neighbours if u < v
         )
-        for vertex in hypergraph.vertices
     )
-    edge_list: list[tuple[str, str]] = []
-    for i, vertex in enumerate(hypergraph.vertices):
-        for neighbour in adjacent[i]:
-            j = index[neighbour]
-            if j > i:
-                edge_list.append((vertex, neighbour))
-    edge_list.sort(key=lambda pair: (index[pair[0]], index[pair[1]]))
-    return vertices, adjacency, tuple(edge_list)
+    return SimpleUndirectedGraph(vertices=hypergraph.vertices, edges=graph_edges)
 
 
 def compute_parameters(request: ParametersRequest) -> ParametersResult:
@@ -230,10 +206,7 @@ def compute_clique_expansion(
 ) -> CliqueExpansionResult:
     """Compute the 2-section (primal/clique expansion) of a hypergraph."""
 
-    vertices, adjacency, edges = _clique_expansion_data(request.hypergraph)
     return CliqueExpansionResult(
         hypergraph=request.hypergraph,
-        vertices=vertices,
-        adjacency=adjacency,
-        edges=edges,
+        graph=_clique_expansion_graph(request.hypergraph),
     )

--- a/src/jacobian/math/hypergraphs/_tools.py
+++ b/src/jacobian/math/hypergraphs/_tools.py
@@ -145,8 +145,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
     _op(
         "hypergraph.clique_expansion.compute",
         "Compute the 2-section (clique expansion) of a hypergraph",
-        "Compute the primal/2-section graph where two vertices are "
-        "adjacent if and only if they share a hyperedge.",
+        "Compute the primal/2-section of a finite hypergraph as a canonical "
+        "simple undirected graph: two vertices are adjacent if and only if "
+        "they share a hyperedge, with edge endpoints in lexical order.",
         CliqueExpansionRequest,
         CliqueExpansionResult,
         compute_clique_expansion,

--- a/tests/math/hypergraphs/test_hypergraphs.py
+++ b/tests/math/hypergraphs/test_hypergraphs.py
@@ -3,8 +3,14 @@
 import pytest
 from pydantic import ValidationError
 
+from jacobian.math.graphs.independence import (
+    IndependenceNumberRequest,
+    independence_number,
+)
+from jacobian.math.graphs.values import SimpleUndirectedGraph
 from jacobian.math.hypergraphs._models import (
     CliqueExpansionRequest,
+    CliqueExpansionResult,
     DualRequest,
     FiniteHypergraph,
     IncidenceGraphRequest,
@@ -50,6 +56,12 @@ NO_EDGES = {
 SINGLETON = {
     "vertices": ["v"],
     "edges": [["e", ["v"]]],
+}
+
+# Declared vertex order disagrees with lexical order (issue #2300).
+REVERSED_ORDER = {
+    "vertices": ["z", "a"],
+    "edges": [["e", ["z", "a"]]],
 }
 
 
@@ -255,18 +267,11 @@ class TestIncidenceGraph:
 
 
 class TestCliqueExpansion:
-    def test_basic(self) -> None:
+    def test_canonical_graph(self) -> None:
         r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=HYPERGRAPH))
-        assert r.vertices == ("a", "b", "c", "d")
-        adj = dict(r.adjacency)
-        assert adj["a"] == ("b", "c", "d")
-        assert adj["b"] == ("a", "c", "d")
-        assert adj["c"] == ("a", "b", "d")
-        assert adj["d"] == ("a", "b", "c")
-
-    def test_edges(self) -> None:
-        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=HYPERGRAPH))
-        assert set(r.edges) == {
+        assert isinstance(r.graph, SimpleUndirectedGraph)
+        assert r.graph.vertices == ("a", "b", "c", "d")
+        assert set(r.graph.edges) == {
             ("a", "b"),
             ("a", "c"),
             ("a", "d"),
@@ -275,43 +280,110 @@ class TestCliqueExpansion:
             ("c", "d"),
         }
 
-    def test_uniform_no_overlap(self) -> None:
+    def test_endpoint_order_follows_graph_convention(self) -> None:
+        """The ('z', 'a') reproduction: endpoints are lexical, not declared."""
+
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=REVERSED_ORDER))
+        assert r.graph.vertices == ("z", "a")
+        assert r.graph.edges == (("a", "z"),)
+
+    def test_defining_property_against_source(self) -> None:
+        for hypergraph in (HYPERGRAPH, UNIFORM):
+            hg = FiniteHypergraph(**hypergraph)
+            r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=hg))
+            members = [set(members) for _, members in hg.edges]
+            adjacent = set(r.graph.edges)
+            vertices = hg.vertices
+            for i, u in enumerate(vertices):
+                for v in vertices[i + 1 :]:
+                    shared = any(u in m and v in m for m in members)
+                    pair = (min(u, v), max(u, v))
+                    assert (pair in adjacent) == shared
+
+    def test_degenerate_edges_admitted(self) -> None:
         hg = {
-            "vertices": ["a", "b", "c", "d"],
+            "vertices": ["a", "b", "c"],
             "edges": [
-                ["e1", ["a", "b"]],
-                ["e2", ["c", "d"]],
+                ["empty", []],
+                ["one", ["a"]],
+                ["dup1", ["a", "b"]],
+                ["dup2", ["b", "a"]],
+                ["pair", ["b", "c"]],
             ],
         }
         r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=hg))
-        adj = dict(r.adjacency)
-        assert adj["a"] == ("b",)
-        assert adj["b"] == ("a",)
-        assert adj["c"] == ("d",)
-        assert adj["d"] == ("c",)
-        assert set(r.edges) == {("a", "b"), ("c", "d")}
+        assert r.graph.vertices == ("a", "b", "c")
+        assert r.graph.edges == (("a", "b"), ("b", "c"))
 
-    def test_no_edges_no_adjacency(self) -> None:
+    def test_no_edges(self) -> None:
         r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=NO_EDGES))
-        assert dict(r.adjacency) == {"a": (), "b": ()}
-        assert r.edges == ()
+        assert r.graph.vertices == ("a", "b")
+        assert r.graph.edges == ()
 
     def test_singleton(self) -> None:
         r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=SINGLETON))
-        assert dict(r.adjacency) == {"v": ()}
-        assert r.edges == ()
+        assert r.graph.vertices == ("v",)
+        assert r.graph.edges == ()
 
-    def test_edges_sorted_by_vertex_order(self) -> None:
-        hg = {
-            "vertices": ["d", "c", "b", "a"],
-            "edges": [["e", ["a", "b", "c", "d"]]],
-        }
-        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=hg))
-        idx = {v: i for i, v in enumerate(r.vertices)}
-        for u, v in r.edges:
-            assert idx[u] < idx[v]
-        edge_keys = [(idx[u], idx[v]) for u, v in r.edges]
-        assert edge_keys == sorted(edge_keys)
+    def test_non_nfc_vertex_label_rejected(self) -> None:
+        decomposed = "e\u0301"
+        with pytest.raises(ValidationError, match="NFC-normalized"):
+            CliqueExpansionRequest(
+                hypergraph={
+                    "vertices": [decomposed, "a"],
+                    "edges": [["e", [decomposed, "a"]]],
+                }
+            )
+
+    def test_nfc_vertex_label_accepted(self) -> None:
+        composed = "\u00e9"
+        r = compute_clique_expansion(
+            CliqueExpansionRequest(
+                hypergraph={
+                    "vertices": [composed, "a"],
+                    "edges": [["e", [composed, "a"]]],
+                }
+            )
+        )
+        assert r.graph.vertices == ("\u00e9", "a")
+        assert r.graph.edges == (("a", "\u00e9"),)
+
+    def test_dual_expansion_independence_composition(self) -> None:
+        """Dual -> clique expansion -> independence number, with no rewriting.
+
+        The expansion of the dual is the intersection graph on the original
+        indexed hyperedges; a maximum independent set is exactly a maximum
+        pairwise-disjoint family of source hyperedges.
+        """
+
+        hg = FiniteHypergraph(
+            vertices=["a", "b", "c", "d", "e", "f"],
+            edges=[
+                ["e1", ["a", "b"]],
+                ["e2", ["c", "d"]],
+                ["e3", ["e", "f"]],
+                ["e4", ["a", "c"]],
+            ],
+        )
+        dual = compute_dual(DualRequest(hypergraph=hg)).dual
+        expansion = compute_clique_expansion(CliqueExpansionRequest(hypergraph=dual))
+
+        consumer_request = IndependenceNumberRequest(graph=expansion.graph.model_dump())
+        result = independence_number(consumer_request)
+        assert result.status == "EXACT"
+        assert result.optimum_value == 3
+
+        members = dict(hg.edges)
+        witnesses = result.witness_vertices
+        assert len(witnesses) == 3
+        for i, u in enumerate(witnesses):
+            for v in witnesses[i + 1 :]:
+                assert not set(members[u]) & set(members[v])
+
+    def test_serialization_round_trip(self) -> None:
+        r = compute_clique_expansion(CliqueExpansionRequest(hypergraph=HYPERGRAPH))
+        restored = CliqueExpansionResult.model_validate_json(r.model_dump_json())
+        assert restored == r
 
 
 class TestBindingSafety:
@@ -352,27 +424,35 @@ class TestBindingSafety:
             )
 
     def test_clique_expansion_binding(self) -> None:
-        from jacobian.math.hypergraphs._models import (
-            CliqueExpansionResult,
-        )
-
         hg = FiniteHypergraph(**HYPERGRAPH)
-        with pytest.raises(ValidationError, match="adjacency"):
-            CliqueExpansionResult(
-                hypergraph=hg,
-                vertices=("a", "b", "c", "d"),
-                adjacency=(
-                    ("a", ("b",)),
-                    ("b", ("a", "c", "d")),
-                    ("c", ("a", "b", "d")),
-                    ("d", ("a", "b", "c")),
-                ),
-                edges=(
-                    ("a", "b"),
-                    ("a", "c"),
-                    ("a", "d"),
-                    ("b", "c"),
-                    ("b", "d"),
-                    ("c", "d"),
-                ),
-            )
+        missing_edge = SimpleUndirectedGraph(
+            vertices=("a", "b", "c", "d"),
+            edges=(
+                ("a", "b"),
+                ("a", "c"),
+                ("a", "d"),
+                ("b", "c"),
+                ("b", "d"),
+            ),
+        )
+        with pytest.raises(ValidationError, match="exact 2-section"):
+            CliqueExpansionResult(hypergraph=hg, graph=missing_edge)
+
+    def test_clique_expansion_binding_rejects_declared_order_endpoints(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="edges must contain two declared vertices in order",
+        ):
+            SimpleUndirectedGraph(vertices=("z", "a"), edges=(("z", "a"),))
+
+    def test_clique_expansion_binding_rejects_spurious_adjacency(self) -> None:
+        disjoint = FiniteHypergraph(
+            vertices=["u", "v", "w"],
+            edges=[["p", ["u", "v"]]],
+        )
+        spurious = SimpleUndirectedGraph(
+            vertices=("u", "v", "w"),
+            edges=(("u", "v"), ("u", "w")),
+        )
+        with pytest.raises(ValidationError, match="exact 2-section"):
+            CliqueExpansionResult(hypergraph=disjoint, graph=spurious)


### PR DESCRIPTION
## Problem

`hypergraph.clique_expansion.compute` emitted the 2-section as bespoke `vertices`/`adjacency`/`edges` tuples whose endpoint pairs were ordered by the source hypergraph's *declared* vertex order. The domain's one canonical simple-graph value, `SimpleUndirectedGraph`, requires each endpoint pair in lexical order. The two individually valid contracts were not producer-consumer compatible: a hypergraph declaring vertices `("z", "a")` with one hyperedge containing both produced the edge `("z", "a")`, which every canonical graph consumer rejects because the canonical pair is `("a", "z")`.

This blocked the otherwise exact reusable composition for hypergraph matching:

```
hypergraph.dual.compute -> hypergraph.clique_expansion.compute -> graph.invariant.independence_number.compute
```

The expansion of the dual is the intersection graph on the original indexed hyperedges; its independent-set witness is exactly a pairwise-disjoint hyperedge family. Budgets already align (≤ 100 hyperedges, independence order ≤ 128); wire incompatibility was the only missing step.

## Root cause

The operation recreated the canonical graph value as operation-specific parallel tuple fields (violating the one-canonical-type-per-value rule) and normalized endpoints against the hypergraph's declared ordering instead of the graph value's own lexical convention.

## Fix

- `CliqueExpansionResult` now retains a single `graph: SimpleUndirectedGraph` field instead of parallel tuples. Its vertices are exactly the declared hypergraph labels in declared order (the explicit identity mapping), and two distinct vertices are adjacent iff they share at least one hyperedge — with endpoint pairs in the canonical value's own lexical convention, independent of declared ordering.
- The defining property is replayed against the retained source hypergraph in result binding, which fail-closes on tampered, partial, spurious, or reordered graphs.
- Because the canonical value requires NFC-normalized vertex labels, `CliqueExpansionRequest` now admits only NFC-labeled hypergraphs — encoding the accepted domain at request validation rather than leaking a host exception from backend expansion.
- Operation description and admission rationale updated; no matching solver added (#1742's boundary preserved).

## Validation

- `uv run --locked pytest tests/math/hypergraphs tests/math/graphs -q` → 291 passed
- Regression evidence from the issue: the `("z","a")` endpoint-order reproduction; declared orders disagreeing with lexical order; empty, singleton, duplicate-indexed, and isolated hyperedges; exhaustive adjacency-vs-source defining-property check; direct producer-to-consumer construction (`dual → clique expansion → independence_number`, optimum 3, witness source-edge IDs replayed pairwise disjoint) with no caller-side rewriting; JSON serialization round-trip; mutation rejection via result binding.
- `make check` (lint + typecheck + fast owner lanes) → 3523 passed
- `uv run ruff check` / `ruff format --check` on changed packages → clean
- `uv run mypy src/jacobian/math/hypergraphs src/jacobian/math/graphs` → no issues

Fixes #2300