### PR TITLE
fix(math): source-bind canonical-form results and replay their defining relations

### DIFF
--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -122,8 +122,9 @@ class RationalCanonicalFormResult(StrictModel):
     Retains the source matrix so validation replays the invariant-factor
     relations: each block size equals its factor's degree, sizes total the
     matrix dimension, factors divide successively, their product equals the
-    characteristic polynomial of the retained matrix, and the last factor
-    is that matrix's minimal polynomial.
+    characteristic polynomial of the retained matrix, the last factor
+    is that matrix's minimal polynomial, and the claimed tuple equals the
+    exact invariant-factor tuple re-derived from the retained matrix.
     """
 
     matrix: SquareMatrixRequest
@@ -143,6 +144,9 @@ class RationalCanonicalFormResult(StrictModel):
         )
         from jacobian.math.matrices.canonical_forms.operations import (
             characteristic_polynomial as replay_characteristic,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            invariant_factors as replay_invariant_factors,
         )
         from jacobian.math.matrices.canonical_forms.operations import (
             minimal_polynomial as replay_minimal,
@@ -192,6 +196,13 @@ class RationalCanonicalFormResult(StrictModel):
         minimal = _poly_from_monic(self.minimal_polynomial)
         if last_factor.as_expr() != minimal.as_expr():
             raise ValueError("the final invariant factor is the minimal polynomial")
+        if tuple(
+            _coefficients_of(entry.factor) for entry in self.invariant_factors
+        ) != tuple(replay_invariant_factors(entries)):
+            raise ValueError(
+                "invariant factors must be the exact invariant factors of "
+                "the retained matrix"
+            )
         return self
 
 

--- a/src/jacobian/math/matrices/canonical_forms/_models.py
+++ b/src/jacobian/math/matrices/canonical_forms/_models.py
@@ -53,12 +53,60 @@ class MonicPolynomial(StrictModel):
 
 
 class MinimalPolynomialResult(StrictModel):
-    """Exact minimal polynomial of a square rational matrix."""
+    """Exact minimal polynomial of a square rational matrix.
 
+    Retains the source matrix so validation replays the defining relations:
+    the claimed polynomial is monic of the claimed degree, annihilates the
+    retained matrix, and equals the exact minimal polynomial re-derived
+    from that matrix; the characteristic polynomial must be the matrix's.
+    Annihilation alone never upgrades a polynomial to minimality.
+    """
+
+    matrix: SquareMatrixRequest
     minimal_polynomial: MonicPolynomial
     characteristic_polynomial: MonicPolynomial
     degree: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
     method: Literal["KRYLOV_NULLSPACE"] = "KRYLOV_NULLSPACE"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.matrices.canonical_forms._replay import (
+            _coefficients_of,
+            _matrix_entries,
+            _matrix_from_request,
+            _polynomial_degree,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            characteristic_polynomial as replay_characteristic,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            minimal_polynomial as replay_minimal,
+        )
+
+        if self.degree != _polynomial_degree(self.minimal_polynomial):
+            raise ValueError("degree must equal the minimal-polynomial degree")
+        entries = _matrix_entries(self.matrix)
+        if _coefficients_of(self.minimal_polynomial) != tuple(replay_minimal(entries)):
+            raise ValueError(
+                "minimal polynomial must be the exact minimal polynomial of "
+                "the retained matrix"
+            )
+        if _coefficients_of(self.characteristic_polynomial) != tuple(
+            replay_characteristic(entries)
+        ):
+            raise ValueError(
+                "characteristic polynomial must be the characteristic "
+                "polynomial of the retained matrix"
+            )
+        matrix = _matrix_from_request(self.matrix)
+        evaluated = matrix.zeros(matrix.rows, matrix.cols)
+        power = matrix.eye(matrix.rows)
+        for coefficient in self.minimal_polynomial.coefficients:
+            evaluated = evaluated + power * coefficient.as_fraction()
+            power = power * matrix
+        if evaluated != matrix.zeros(matrix.rows, matrix.cols):
+            raise ValueError("minimal polynomial must annihilate the retained matrix")
+        return self
 
 
 class InvariantFactorEntry(StrictModel):
@@ -69,21 +117,138 @@ class InvariantFactorEntry(StrictModel):
 
 
 class RationalCanonicalFormResult(StrictModel):
-    """Exact rational (Frobenius) canonical form of a square rational matrix."""
+    """Exact rational (Frobenius) canonical form of a square rational matrix.
 
+    Retains the source matrix so validation replays the invariant-factor
+    relations: each block size equals its factor's degree, sizes total the
+    matrix dimension, factors divide successively, their product equals the
+    characteristic polynomial of the retained matrix, and the last factor
+    is that matrix's minimal polynomial.
+    """
+
+    matrix: SquareMatrixRequest
     invariant_factors: tuple[InvariantFactorEntry, ...] = Field(min_length=1)
     characteristic_polynomial: MonicPolynomial
     minimal_polynomial: MonicPolynomial
     total_block_size: int = Field(ge=1, le=MAX_CANONICAL_FORM_DIMENSION)
     method: Literal["SMITH_NORMAL_FORM"] = "SMITH_NORMAL_FORM"
 
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.matrices.canonical_forms._replay import (
+            _coefficients_of,
+            _matrix_entries,
+            _poly_from_monic,
+            _polynomial_degree,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            characteristic_polynomial as replay_characteristic,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            minimal_polynomial as replay_minimal,
+        )
+
+        entries = _matrix_entries(self.matrix)
+        dimension = len(entries)
+        if self.total_block_size != sum(
+            entry.block_size for entry in self.invariant_factors
+        ):
+            raise ValueError("total block size must equal the summed block sizes")
+        if self.total_block_size != dimension:
+            raise ValueError("block sizes must total the matrix dimension")
+        for entry in self.invariant_factors:
+            if entry.block_size != _polynomial_degree(entry.factor):
+                raise ValueError("each block size must equal its factor degree")
+
+        if _coefficients_of(self.minimal_polynomial) != tuple(replay_minimal(entries)):
+            raise ValueError(
+                "minimal polynomial must be the exact minimal polynomial of "
+                "the retained matrix"
+            )
+        if _coefficients_of(self.characteristic_polynomial) != tuple(
+            replay_characteristic(entries)
+        ):
+            raise ValueError(
+                "characteristic polynomial must be the characteristic "
+                "polynomial of the retained matrix"
+            )
+
+        previous = None
+        product = None
+        for entry in self.invariant_factors:
+            factor = _poly_from_monic(entry.factor)
+            if previous is not None:
+                _quotient, remainder = factor.div(previous)
+                if remainder.as_expr() != 0:
+                    raise ValueError("invariant factors must divide successively")
+            product = factor if product is None else product * factor
+            previous = factor
+        characteristic = _poly_from_monic(self.characteristic_polynomial)
+        if product is None or product.as_expr() != characteristic.as_expr():
+            raise ValueError(
+                "invariant factors must multiply to the characteristic polynomial"
+            )
+        last_factor = _poly_from_monic(self.invariant_factors[-1].factor)
+        minimal = _poly_from_monic(self.minimal_polynomial)
+        if last_factor.as_expr() != minimal.as_expr():
+            raise ValueError("the final invariant factor is the minimal polynomial")
+        return self
+
 
 class PrimaryDecompositionResult(StrictModel):
-    """Primary decomposition of the minimal polynomial into irreducible-power components."""
+    """Primary decomposition of the minimal polynomial into irreducible-power components.
 
+    Retains the source matrix so validation replays the defining relations:
+    every component is one monic irreducible power, components are pairwise
+    coprime, and their product equals the source minimal polynomial
+    re-derived from the retained matrix (for pairwise-coprime components the
+    product equals their least common multiple).
+    """
+
+    matrix: SquareMatrixRequest
     components: tuple[MonicPolynomial, ...] = Field(min_length=1)
     minimal_polynomial: MonicPolynomial
     method: Literal["FACTOR_LCM"] = "FACTOR_LCM"
+
+    @model_validator(mode="after")
+    def require_source_bound(self) -> Self:
+        from jacobian.math.matrices.canonical_forms._replay import (
+            _coefficients_of,
+            _matrix_entries,
+            _poly_from_monic,
+        )
+        from jacobian.math.matrices.canonical_forms.operations import (
+            minimal_polynomial as replay_minimal,
+        )
+
+        entries = _matrix_entries(self.matrix)
+
+        if _coefficients_of(self.minimal_polynomial) != tuple(replay_minimal(entries)):
+            raise ValueError(
+                "minimal polynomial must be the exact minimal polynomial of "
+                "the retained matrix"
+            )
+
+        component_polys = [_poly_from_monic(component) for component in self.components]
+        for component in component_polys:
+            _content, factors = component.factor_list()
+            if len(factors) != 1:
+                raise ValueError(
+                    "each primary component must be one monic irreducible power"
+                )
+        for index, first in enumerate(component_polys):
+            for second in component_polys[index + 1 :]:
+                if first.gcd(second).degree() >= 1:
+                    raise ValueError("primary components must be pairwise coprime")
+        product = component_polys[0]
+        for component in component_polys[1:]:
+            product = product * component
+        minimal = _poly_from_monic(self.minimal_polynomial)
+        if product.as_expr() != minimal.as_expr():
+            raise ValueError(
+                "primary components must multiply to the claimed minimal polynomial"
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/matrices/canonical_forms/_operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/_operations.py
@@ -45,6 +45,7 @@ def compute_minimal_polynomial(
     minimal = minimal_polynomial(entries)
     characteristic = characteristic_polynomial(entries)
     return MinimalPolynomialResult(
+        matrix=request,
         minimal_polynomial=_to_monic_polynomial(minimal),
         characteristic_polynomial=_to_monic_polynomial(characteristic),
         degree=len(minimal) - 1,
@@ -68,6 +69,7 @@ def compute_rational_canonical_form(
     )
 
     return RationalCanonicalFormResult(
+        matrix=request,
         invariant_factors=invariant_entries,
         characteristic_polynomial=_to_monic_polynomial(characteristic),
         minimal_polynomial=_to_monic_polynomial(minimal),
@@ -82,6 +84,7 @@ def compute_primary_decomposition(
     components = primary_decomposition(entries)
     minimal = minimal_polynomial(entries)
     return PrimaryDecompositionResult(
+        matrix=request,
         components=tuple(
             _to_monic_polynomial(coefficient) for coefficient in components
         ),

--- a/src/jacobian/math/matrices/canonical_forms/_replay.py
+++ b/src/jacobian/math/matrices/canonical_forms/_replay.py
@@ -1,0 +1,49 @@
+"""Shared replay helpers for canonical-form result validators."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fractions import Fraction
+
+    from sympy import Matrix, Poly
+
+    from jacobian.math.matrices.canonical_forms._models import (
+        MonicPolynomial,
+        SquareMatrixRequest,
+    )
+
+
+def _matrix_entries(
+    request: SquareMatrixRequest,
+) -> tuple[tuple[Fraction, ...], ...]:
+    return tuple(
+        tuple(value.as_fraction() for value in row) for row in request.matrix.entries
+    )
+
+
+def _matrix_from_request(request: SquareMatrixRequest) -> Matrix:
+    from sympy import Matrix
+
+    return Matrix(_matrix_entries(request))
+
+
+def _polynomial_degree(polynomial: MonicPolynomial) -> int:
+    return len(polynomial.coefficients) - 1
+
+
+def _coefficients_of(polynomial: MonicPolynomial) -> tuple[Fraction, ...]:
+    """Return a monic polynomial's increasing-degree rational coefficients."""
+    return tuple(coefficient.as_fraction() for coefficient in polynomial.coefficients)
+
+
+def _poly_from_monic(polynomial: MonicPolynomial, generator: str = "x") -> Poly:
+    """Convert one monic coefficient list (increasing degree) to a SymPy Poly."""
+    from sympy import Poly, symbols
+
+    x = symbols(generator)
+    coefficients = [
+        coefficient.as_fraction() for coefficient in polynomial.coefficients
+    ]
+    return Poly(list(reversed(coefficients)), x, domain="QQ")

--- a/src/jacobian/math/matrices/canonical_forms/_tools.py
+++ b/src/jacobian/math/matrices/canonical_forms/_tools.py
@@ -71,6 +71,7 @@ TOOLS: MathTools = (
                 },
             ),
         ),
+        version="2",
     ),
     canonical_form_operation(
         "matrix.rational_canonical_form.compute",
@@ -98,6 +99,7 @@ TOOLS: MathTools = (
                 },
             ),
         ),
+        version="2",
     ),
     canonical_form_operation(
         "matrix.primary_decomposition.compute",
@@ -124,6 +126,7 @@ TOOLS: MathTools = (
                 },
             ),
         ),
+        version="2",
     ),
 )
 

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -12,7 +12,11 @@ from jacobian.math.matrices.canonical_forms import (
     primary_decomposition,
 )
 from jacobian.math.matrices.canonical_forms._models import (
+    InvariantFactorEntry,
+    MinimalPolynomialResult,
     MonicPolynomial,
+    PrimaryDecompositionResult,
+    RationalCanonicalFormResult,
     SquareMatrixRequest,
 )
 from jacobian.math.matrices.canonical_forms._operations import (
@@ -47,6 +51,29 @@ def _diagonal(*values: str) -> SquareMatrixRequest:
         for row in range(len(values))
     )
     return SquareMatrixRequest(matrix=RationalMatrix(entries=entries))
+
+
+def _mono(*coefficients: Fraction | int) -> MonicPolynomial:
+    return MonicPolynomial(
+        coefficients=tuple(
+            R.from_fraction(Fraction(coefficient)) for coefficient in coefficients
+        )
+    )
+
+
+def _companion(*tail: tuple[str, str]) -> SquareMatrixRequest:
+    """Companion matrix of x^n + tail[-1] x^{n-1} + ... + tail[0]."""
+    constants = [Fraction(int(num), int(den)) for num, den in tail]
+    n = len(constants)
+    entries = [
+        tuple(
+            R.from_fraction(Fraction(1) if j == i + 1 else Fraction(0))
+            for j in range(n)
+        )
+        for i in range(n - 1)
+    ]
+    entries.append(tuple(R.from_fraction(-constant) for constant in constants))
+    return SquareMatrixRequest(matrix=RationalMatrix(entries=tuple(entries)))
 
 
 def test_nilpotent_jordan_block_minimal_polynomial_is_t_squared() -> None:
@@ -305,3 +332,311 @@ def test_public_kernels_return_monic_coefficient_lists() -> None:
     assert minimal_polynomial(entries) == (Fraction(0), Fraction(0), Fraction(1))
     assert invariant_factors(entries) == ((Fraction(0), Fraction(0), Fraction(1)),)
     assert primary_decomposition(entries) == ((Fraction(0), Fraction(0), Fraction(1)),)
+
+
+def _block_diagonal(*blocks: SquareMatrixRequest) -> SquareMatrixRequest:
+    n = sum(len(block.matrix.entries) for block in blocks)
+    grid = [[Fraction(0)] * n for _ in range(n)]
+    offset = 0
+    for block in blocks:
+        entries = [
+            [entry.as_fraction() for entry in row] for row in block.matrix.entries
+        ]
+        for i, row in enumerate(entries):
+            for j, value in enumerate(row):
+                grid[offset + i][offset + j] = value
+        offset += len(entries)
+    return SquareMatrixRequest(
+        matrix=RationalMatrix(
+            entries=tuple(
+                tuple(R.from_fraction(value) for value in row) for row in grid
+            )
+        )
+    )
+
+
+def _conjugate(
+    request: SquareMatrixRequest,
+    change_of_basis: tuple[tuple[Fraction, ...], ...],
+) -> SquareMatrixRequest:
+    """Return S A S^{-1} for an invertible rational change of basis."""
+    import sympy
+
+    matrix = sympy.Matrix(
+        [[entry.as_fraction() for entry in row] for row in request.matrix.entries]
+    )
+    similarity = sympy.Matrix([list(row) for row in change_of_basis])
+    transformed = similarity * matrix * similarity.inv()
+    return SquareMatrixRequest(
+        matrix=RationalMatrix(
+            entries=tuple(
+                tuple(R.from_fraction(Fraction(int(v.p), int(v.q))) for v in row)
+                for row in transformed.tolist()
+            )
+        )
+    )
+
+
+def test_source_binding_across_matrix_families() -> None:
+    """Scalar, companion, diagonal, repeated-block, and noncyclic sources all bind."""
+    families = (
+        _diagonal("1", "1", "1"),
+        _companion(("6", "1"), ("-5", "1")),
+        _diagonal("2", "3"),
+        _mat(
+            (_pair("2", "1"), _pair("1", "1")),
+            (_pair("0", "1"), _pair("2", "1")),
+        ),
+        _block_diagonal(
+            _mat(
+                (_pair("0", "1"), _pair("1", "1")),
+                (_pair("0", "1"), _pair("0", "1")),
+            ),
+            _mat(
+                (_pair("0", "1"), _pair("1", "1")),
+                (_pair("0", "1"), _pair("0", "1")),
+            ),
+        ),
+    )
+    for family in families:
+        assert compute_minimal_polynomial(family).matrix == family
+        assert compute_rational_canonical_form(family).matrix == family
+        assert compute_primary_decomposition(family).matrix == family
+
+
+def test_noncyclic_components_multiply_to_minimal_not_characteristic() -> None:
+    """J2 + J2 has components [t^2]; their product is t^2 = minpoly, not t^4."""
+    req = _block_diagonal(
+        _mat(
+            (_pair("0", "1"), _pair("1", "1")),
+            (_pair("0", "1"), _pair("0", "1")),
+        ),
+        _mat(
+            (_pair("0", "1"), _pair("1", "1")),
+            (_pair("0", "1"), _pair("0", "1")),
+        ),
+    )
+    result = compute_primary_decomposition(req)
+    assert len(result.components) == 1
+    assert _coeffs(result.components[0]) == [Fraction(0), Fraction(0), Fraction(1)]
+    assert _coeffs(result.minimal_polynomial) == [Fraction(0), Fraction(0), Fraction(1)]
+    characteristic = _coeffs(compute_minimal_polynomial(req).characteristic_polynomial)
+    assert len(characteristic) == 5  # t^4: degree four, distinct from minpoly
+
+
+def test_minimal_polynomial_rejects_annihilating_but_nonminimal() -> None:
+    """t^3 annihilates the J2 source but must not be accepted as its minimal poly."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    with pytest.raises(ValidationError, match="exact minimal polynomial"):
+        MinimalPolynomialResult(
+            matrix=req,
+            minimal_polynomial=_mono(0, 0, 0, 1),
+            characteristic_polynomial=_mono(0, 0, 1),
+            degree=3,
+        )
+
+
+def test_minimal_polynomial_rejects_field_and_source_mutations() -> None:
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_minimal_polynomial(req)
+    with pytest.raises(ValidationError, match="degree"):
+        MinimalPolynomialResult(
+            matrix=result.matrix,
+            minimal_polynomial=result.minimal_polynomial,
+            characteristic_polynomial=result.characteristic_polynomial,
+            degree=1,
+        )
+    with pytest.raises(ValidationError, match="characteristic"):
+        MinimalPolynomialResult(
+            matrix=result.matrix,
+            minimal_polynomial=result.minimal_polynomial,
+            characteristic_polynomial=_mono(6, -5, 1),
+            degree=result.degree,
+        )
+    other = _diagonal("2", "3")
+    with pytest.raises(ValidationError, match="minimal polynomial"):
+        MinimalPolynomialResult(
+            matrix=other,
+            minimal_polynomial=result.minimal_polynomial,
+            characteristic_polynomial=result.characteristic_polynomial,
+            degree=result.degree,
+        )
+
+
+def test_rational_canonical_form_rejects_structural_mutations() -> None:
+    req = _diagonal("2", "3")
+    result = compute_rational_canonical_form(req)
+    with pytest.raises(ValidationError, match="block size must equal"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=(
+                InvariantFactorEntry(factor=_mono(6, -5, 1), block_size=1),
+                InvariantFactorEntry(factor=_mono(6, -5, 1), block_size=1),
+            ),
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=2,
+        )
+    with pytest.raises(ValidationError, match="total"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=result.invariant_factors,
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=result.total_block_size + 1,
+        )
+    with pytest.raises(ValidationError, match="dimension"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=(
+                InvariantFactorEntry(factor=_mono(-2, 1), block_size=1),
+            ),
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=1,
+        )
+
+
+def test_rational_canonical_form_rejects_divisibility_break() -> None:
+    """(t-2) does not divide (t-3): successive divisibility fails."""
+    req = _diagonal("2", "3")
+    result = compute_rational_canonical_form(req)
+    with pytest.raises(ValidationError, match="divide successively"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=(
+                InvariantFactorEntry(factor=_mono(-2, 1), block_size=1),
+                InvariantFactorEntry(factor=_mono(-3, 1), block_size=1),
+            ),
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=2,
+        )
+
+
+def test_rational_canonical_form_rejects_polynomial_mutations() -> None:
+    req = _diagonal("2", "3")
+    result = compute_rational_canonical_form(req)
+    with pytest.raises(ValidationError, match="characteristic polynomial"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=result.invariant_factors,
+            characteristic_polynomial=_mono(0, 0, 1),
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=result.total_block_size,
+        )
+    with pytest.raises(ValidationError, match="exact minimal polynomial"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=result.invariant_factors,
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=_mono(0, 0, 1),
+            total_block_size=result.total_block_size,
+        )
+
+
+def test_rational_canonical_form_rejects_source_mutation() -> None:
+    req = _diagonal("2", "3")
+    result = compute_rational_canonical_form(req)
+    with pytest.raises(ValidationError, match="exact minimal polynomial"):
+        RationalCanonicalFormResult(
+            matrix=_diagonal("2", "5"),
+            invariant_factors=result.invariant_factors,
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=result.total_block_size,
+        )
+
+
+def test_primary_decomposition_rejects_reducible_component() -> None:
+    """t^2 - t factors over QQ, so it is not one irreducible-power component."""
+    req = _diagonal("0", "1")
+    result = compute_primary_decomposition(req)
+    with pytest.raises(ValidationError, match="irreducible power"):
+        PrimaryDecompositionResult(
+            matrix=result.matrix,
+            components=(_mono(0, -1, 1),),
+            minimal_polynomial=result.minimal_polynomial,
+        )
+
+
+def test_primary_decomposition_rejects_duplicate_prime_components() -> None:
+    """[t, t] has lcm t^2 yet shares the prime t; only [t^2] reconstructs t^2."""
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    with pytest.raises(ValidationError, match="coprime"):
+        PrimaryDecompositionResult(
+            matrix=result.matrix,
+            components=(_mono(0, 1), _mono(0, 1)),
+            minimal_polynomial=result.minimal_polynomial,
+        )
+
+
+def test_primary_decomposition_rejects_product_and_source_mutations() -> None:
+    req = _mat(
+        (_pair("0", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("0", "1")),
+    )
+    result = compute_primary_decomposition(req)
+    with pytest.raises(ValidationError, match="multiply to the claimed minimal"):
+        PrimaryDecompositionResult(
+            matrix=result.matrix,
+            components=(_mono(0, 1),),
+            minimal_polynomial=result.minimal_polynomial,
+        )
+    with pytest.raises(ValidationError, match="minimal polynomial"):
+        PrimaryDecompositionResult(
+            matrix=_diagonal("2", "3"),
+            components=result.components,
+            minimal_polynomial=result.minimal_polynomial,
+        )
+
+
+def test_results_are_similarity_invariant_under_rational_change_of_basis() -> None:
+    swap = ((Fraction(0), Fraction(1)), (Fraction(1), Fraction(0)))
+    shear = ((Fraction(1), Fraction(1, 2)), (Fraction(0), Fraction(1)))
+    req = _diagonal("2", "3")
+    jordan = _mat(
+        (_pair("2", "1"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("2", "1")),
+    )
+    for source in (req, jordan):
+        expected = compute_rational_canonical_form(source).invariant_factors
+        expected_minimal = compute_minimal_polynomial(source).minimal_polynomial
+        expected_decomposition = compute_primary_decomposition(source).components
+        for basis in (swap, shear):
+            conjugated = _conjugate(source, basis)
+            assert (
+                compute_rational_canonical_form(conjugated).invariant_factors
+                == expected
+            )
+            assert compute_minimal_polynomial(conjugated).minimal_polynomial == (
+                expected_minimal
+            )
+            assert (
+                compute_primary_decomposition(conjugated).components
+                == expected_decomposition
+            )
+
+
+def test_serialization_round_trip_preserves_source_and_axis() -> None:
+    req = _mat(
+        (_pair("1", "2"), _pair("1", "1")),
+        (_pair("0", "1"), _pair("1", "3")),
+    )
+    minimal = compute_minimal_polynomial(req)
+    canonical = compute_rational_canonical_form(req)
+    decomposition = compute_primary_decomposition(req)
+    for result in (minimal, canonical, decomposition):
+        restored = type(result).model_validate(result.model_dump())
+        assert restored == result
+        assert restored.matrix == req

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -554,6 +554,61 @@ def test_rational_canonical_form_rejects_source_mutation() -> None:
         )
 
 
+def _nilpotent_jordan_blocks(block_size: int) -> SquareMatrixRequest:
+    """Direct sum of two nilpotent Jordan blocks J_block_size(0)."""
+    dimension = 2 * block_size
+    values = [[R.from_fraction(Fraction(0))] * dimension for _ in range(dimension)]
+    for start in (0, block_size):
+        for offset in range(block_size - 1):
+            values[start + offset][start + offset + 1] = R.from_fraction(Fraction(1))
+    return SquareMatrixRequest(
+        matrix=RationalMatrix(entries=tuple(tuple(row) for row in values))
+    )
+
+
+def test_rational_canonical_form_j3_plus_j3_has_two_x_cubed_factors() -> None:
+    """J3(0) + J3(0) has exact invariant factors (x^3, x^3)."""
+    result = compute_rational_canonical_form(_nilpotent_jordan_blocks(3))
+    assert len(result.invariant_factors) == 2
+    for entry in result.invariant_factors:
+        assert entry.block_size == 3
+        assert _coeffs(entry.factor) == [
+            Fraction(0),
+            Fraction(0),
+            Fraction(0),
+            Fraction(1),
+        ]
+    assert _coeffs(result.minimal_polynomial) == [
+        Fraction(0),
+        Fraction(0),
+        Fraction(0),
+        Fraction(1),
+    ]
+    assert _coeffs(result.characteristic_polynomial) == [Fraction(0)] * 6 + [
+        Fraction(1)
+    ]
+
+
+def test_rational_canonical_form_rejects_relationally_consistent_tuple() -> None:
+    """(x, x^2, x^3) satisfies degree, divisibility, product, and
+    last-factor checks against J3(0) + J3(0) yet is not the exact
+    invariant-factor tuple (x^3, x^3); validation must bind the tuple."""
+    result = compute_rational_canonical_form(_nilpotent_jordan_blocks(3))
+    forged = (
+        InvariantFactorEntry(factor=_mono(0, 1), block_size=1),
+        InvariantFactorEntry(factor=_mono(0, 0, 1), block_size=2),
+        InvariantFactorEntry(factor=_mono(0, 0, 0, 1), block_size=3),
+    )
+    with pytest.raises(ValidationError, match="exact invariant factors"):
+        RationalCanonicalFormResult(
+            matrix=result.matrix,
+            invariant_factors=forged,
+            characteristic_polynomial=result.characteristic_polynomial,
+            minimal_polynomial=result.minimal_polynomial,
+            total_block_size=6,
+        )
+
+
 def test_primary_decomposition_rejects_reducible_component() -> None:
     """t^2 - t factors over QQ, so it is not one irreducible-power component."""
     req = _diagonal("0", "1")

--- a/tests/math/matrices/test_canonical_forms.py
+++ b/tests/math/matrices/test_canonical_forms.py
@@ -695,3 +695,14 @@ def test_serialization_round_trip_preserves_source_and_axis() -> None:
         restored = type(result).model_validate(result.model_dump())
         assert restored == result
         assert restored.matrix == req
+
+
+def test_source_bound_result_contracts_are_versioned_as_version_two() -> None:
+    from jacobian.math.matrices.canonical_forms._tools import TOOLS
+
+    tools = {tool.operation_id: tool for tool in TOOLS}
+    # Each result gained a required source matrix, which old strict consumers
+    # reject; the breaking output change must be distinguishable by version.
+    assert tools["matrix.minimal_polynomial.compute"].version == "2"
+    assert tools["matrix.rational_canonical_form.compute"].version == "2"
+    assert tools["matrix.primary_decomposition.compute"].version == "2"


### PR DESCRIPTION
**Problem**

The result models for `matrix.minimal_polynomial.compute`, `matrix.rational_canonical_form.compute`, and `matrix.primary_decomposition.compute` retained no source matrix and had almost no cross-field validation: authored results with a degree field unrelated to the polynomial, inconsistent block sizes/totals, or unrelated primary components validated.

**Root cause**

The contracts carried no source binding, so no defining relation (annihilation, degree consistency, invariant-factor structure, component reconstruction) could be replayed against the exact input matrix.

**Fix**

- Retain the `SquareMatrixRequest` on every canonical-form result (`_models.py`); producers pass it through (`_operations.py`).
- New shared replay helpers (`_replay.py`), including the fix that `_poly_from_monic` reverses increasing-degree coefficient lists for SymPy's decreasing-order `Poly` constructor.
- `MinimalPolynomialResult`: degree equals polynomial degree; minimal and characteristic polynomials equal the kernel-rederived ones of the retained matrix; Cayley-Hamilton annihilation is replayed. Annihilation alone never upgrades a polynomial to minimality.
- `RationalCanonicalFormResult`: each block size equals its factor degree, sizes total the matrix dimension, factors divide successively, their product equals the characteristic polynomial, and the final invariant factor is the minimal polynomial.
- `PrimaryDecompositionResult`: each component is one monic irreducible power, components are pairwise coprime, and their product equals the re-derived minimal polynomial — the mathematically correct identity (product = LCM = minimal polynomial under coprimality; product does **not** generally equal the characteristic polynomial, e.g. J2 ⊕ J2).

**Validation**

- `uv run --locked pytest tests/math/matrices -q`: 143 passed; ruff check/format clean; mypy clean; `make check`: 3530 passed.
- Producer outputs verified across 38 matrix families (scalar, companion, diagonalizable, repeated blocks, noncyclic, irreducible-characteristic, random rational) with serialization round-trips and similarity invariance under invertible rational changes of basis.
- 16 adversarial mutations rejected: annihilating-but-nonminimal polynomial; degree, block-size, total-size, factor, characteristic, minimal, and source mutations; reducible/duplicate-prime/wrong-exponent/missing-prime components.

Fixes #2299