### PR TITLE
fix(math): bind rational linear-system results to their source systems

### DIFF
--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -386,14 +386,24 @@ class MatrixProductResult(StrictModel):
 
 
 class RationalLinearSolveResult(StrictModel):
-    """Result of solving a linear system Ax=b over QQ.
+    """One square-system classification over QQ, bound to its source system.
 
-    The outcome discriminates between:
-    - UNIQUE: the system has a unique solution (solution field is populated)
-    - INCONSISTENT: the system has no solution
-    - NON_UNIQUE: the system has infinitely many solutions (non-unique)
+    Retains the coefficient matrix and right-hand side so validation replays
+    the classification with the same exact kernel: a unique solution carries
+    one coordinate per column, satisfies ``A x = b`` exactly, and requires
+    the retained coefficient matrix to be nonsingular; an inconsistent
+    outcome requires ``rank(A) < rank([A | b])`` on the retained system; a
+    non-unique outcome requires a consistent, rank-deficient retained system.
+    The rational matrix domain admits at least one row and column, so
+    zero-row shapes are rejected by request admission rather than silently
+    dropped.
     """
 
+    matrix: RationalMatrix
+    rhs: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_MATRIX_DIMENSION,
+    )
     outcome: Literal["UNIQUE", "INCONSISTENT", "NON_UNIQUE"]
     solution: tuple[CanonicalRational, ...] | None = Field(
         default=None,
@@ -405,14 +415,48 @@ class RationalLinearSolveResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def require_outcome_solution_consistency(self) -> Self:
+    def require_source_bound_classification(self) -> Self:
+        solution = self.solution
         if self.outcome == "UNIQUE":
-            if self.solution is None:
+            if solution is None:
                 raise ValueError("a unique solution must populate the solution field")
-        else:
-            if self.solution is not None:
+        elif solution is not None:
+            raise ValueError(
+                "a non-unique or inconsistent result must not populate the solution field"
+            )
+        if len(self.rhs) != len(self.matrix.entries):
+            raise ValueError("right-hand side length must equal the source row count")
+
+        from jacobian.math.matrices._operations import _system_rank_replay
+
+        coefficient_rank, augmented_rank = _system_rank_replay(self.matrix, self.rhs)
+        columns = len(self.matrix.entries[0])
+        if solution is not None:
+            components = [value.as_fraction() for value in solution]
+            if len(components) != columns:
+                raise ValueError("solution length must equal the source column count")
+            for row, bound in zip(self.matrix.entries, self.rhs, strict=True):
+                residual = sum(
+                    coefficient.as_fraction() * component
+                    for coefficient, component in zip(row, components, strict=True)
+                )
+                if residual != bound.as_fraction():
+                    raise ValueError("solution does not satisfy A x = b exactly")
+            if coefficient_rank != columns:
                 raise ValueError(
-                    "a non-unique or inconsistent result must not populate the solution field"
+                    "a unique outcome requires a nonsingular source coefficient matrix"
+                )
+        elif self.outcome == "INCONSISTENT":
+            if coefficient_rank >= augmented_rank:
+                raise ValueError(
+                    "an inconsistent outcome requires rank(A) < rank([A | b]) "
+                    "on the source system"
+                )
+        else:
+            if coefficient_rank == columns or coefficient_rank != augmented_rank:
+                raise ValueError(
+                    "a non-unique outcome requires a consistent, rank-deficient "
+                    "source system"
                 )
         return self
 

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -32,6 +32,27 @@ def _check_integer_digits(
         raise ValueError(f"matrix scalars are limited to {maximum} decimal digits")
 
 
+def _require_square_system_admission(
+    matrix: RationalMatrix, rhs: tuple[CanonicalRational, ...]
+) -> None:
+    """Apply the linear-solve shape and scalar envelope to one system.
+
+    Shared by the wire request and by result validation, so a retained
+    source can never reach replay arithmetic outside this operation's
+    admitted work envelope.
+    """
+
+    rows = len(matrix.entries)
+    if len(matrix.entries[0]) != rows or len(rhs) != rows:
+        raise ValueError("linear solve requires a square matrix and matching rhs")
+    require_matrix_scalar_digits(
+        matrix.entries, maximum=MAX_INPUT_SCALAR_DIGITS, label="matrix input"
+    )
+    for value in rhs:
+        _check_integer_digits(value.num)
+        _check_integer_digits(value.den)
+
+
 class RationalMatrixRequest(StrictModel):
     matrix: RationalMatrix
 
@@ -185,15 +206,7 @@ class RationalLinearSolveRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_square_system(self) -> Self:
-        rows = len(self.matrix.entries)
-        if len(self.matrix.entries[0]) != rows or len(self.rhs) != rows:
-            raise ValueError("linear solve requires a square matrix and matching rhs")
-        require_matrix_scalar_digits(
-            self.matrix.entries, maximum=MAX_INPUT_SCALAR_DIGITS, label="matrix input"
-        )
-        for value in self.rhs:
-            _check_integer_digits(value.num)
-            _check_integer_digits(value.den)
+        _require_square_system_admission(self.matrix, self.rhs)
         return self
 
 
@@ -394,6 +407,9 @@ class RationalLinearSolveResult(StrictModel):
     the retained coefficient matrix to be nonsingular; an inconsistent
     outcome requires ``rank(A) < rank([A | b])`` on the retained system; a
     non-unique outcome requires a consistent, rank-deficient retained system.
+    Validation first reapplies the request's squareness and scalar envelope
+    to the retained source, so deserializing a relayed payload can never push
+    replay arithmetic outside this operation's admitted work envelope.
     The rational matrix domain admits at least one row and column, so
     zero-row shapes are rejected by request admission rather than silently
     dropped.
@@ -424,6 +440,10 @@ class RationalLinearSolveResult(StrictModel):
             raise ValueError(
                 "a non-unique or inconsistent result must not populate the solution field"
             )
+        # Deserialized source components pass the canonical rational domain
+        # but not this operation's work envelope, so reapply request
+        # admission before any exact replay arithmetic runs.
+        _require_square_system_admission(self.matrix, self.rhs)
         if len(self.rhs) != len(self.matrix.entries):
             raise ValueError("right-hand side length must equal the source row count")
 

--- a/src/jacobian/math/matrices/_operations.py
+++ b/src/jacobian/math/matrices/_operations.py
@@ -60,6 +60,19 @@ def _rank_replay(matrix: RationalMatrix) -> tuple[int, tuple[int, ...]]:
     return int(rank), tuple(int(pivot) for pivot in pivots)
 
 
+def _system_rank_replay(
+    matrix: RationalMatrix, rhs: tuple[CanonicalRational, ...]
+) -> tuple[int, int]:
+    """Return the exact coefficient and augmented ranks of a retained system."""
+    import sympy
+
+    source = conversions.rational_matrix_to_sympy(matrix)
+    column = sympy.Matrix([sympy.Rational(value.as_fraction()) for value in rhs])
+    coefficient_rank, _pivots = matrices.rank(source)
+    augmented_rank, _augmented_pivots = matrices.rank(source.row_join(column))
+    return coefficient_rank, augmented_rank
+
+
 def compute_rank(request: MatrixRankRequest) -> MatrixRankResult:
     rank, pivot_columns = matrices.rank(
         conversions.rational_matrix_to_sympy(request.matrix)
@@ -176,10 +189,20 @@ def compute_rational_linear_solve(
     try:
         solution, parameters = matrices.solve_linear_system(source, rhs)
     except ValueError:
-        return RationalLinearSolveResult(outcome="INCONSISTENT")
+        return RationalLinearSolveResult(
+            matrix=request.matrix,
+            rhs=request.rhs,
+            outcome="INCONSISTENT",
+        )
     if parameters.rows:
-        return RationalLinearSolveResult(outcome="NON_UNIQUE")
+        return RationalLinearSolveResult(
+            matrix=request.matrix,
+            rhs=request.rhs,
+            outcome="NON_UNIQUE",
+        )
     return RationalLinearSolveResult(
+        matrix=request.matrix,
+        rhs=request.rhs,
         outcome="UNIQUE",
         solution=tuple(conversions.rational_from_sympy(value) for value in solution),
     )

--- a/src/jacobian/math/matrices/_tools.py
+++ b/src/jacobian/math/matrices/_tools.py
@@ -235,7 +235,7 @@ MATRIX_OPERATIONS = (
                 },
             ),
         ),
-        version="2",
+        version="3",
     ),
     matrix_operation(
         "matrix.adjugate.compute",

--- a/src/jacobian/math/matrices/rational_linear/_models.py
+++ b/src/jacobian/math/matrices/rational_linear/_models.py
@@ -73,8 +73,17 @@ class LinearRationalSolutionFindRequest(StrictModel):
 
 
 class LinearRationalSolutionResult(StrictModel):
-    """Whether a rational linear system has an exact solution."""
+    """One exact solution outcome bound to its declared source system.
 
+    Retains the canonical ``LinearRationalSystem`` so validation replays the
+    defining relation: an admitted solution carries one coordinate per
+    declared variable and satisfies ``A x = b`` exactly over QQ, while an
+    inconsistent outcome carries no values.  The coefficient domain admits at
+    least one row and column, so zero-row shapes are rejected by request
+    admission rather than silently dropped.
+    """
+
+    system: LinearRationalSystem
     status: Literal["SOLUTION", "INCONSISTENT"] = "SOLUTION"
     values: tuple[CanonicalRational, ...] | None = Field(
         default=None,
@@ -83,16 +92,44 @@ class LinearRationalSolutionResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def bind_values_to_status(self) -> Self:
+    def bind_solution_to_source(self) -> Self:
         produced = self.status == "SOLUTION"
         if produced != (self.values is not None):
             raise ValueError("solution values must agree with the result status")
+        if self.values is None:
+            return self
+        if len(self.values) != len(self.system.variables):
+            raise ValueError("solution length must equal the source variable count")
+        components = [value.as_fraction() for value in self.values]
+        for row, bound in zip(
+            self.system.coefficients.entries,
+            self.system.rhs,
+            strict=True,
+        ):
+            residual = sum(
+                coefficient.as_fraction() * component
+                for coefficient, component in zip(row, components, strict=True)
+            )
+            if residual != bound.as_fraction():
+                raise ValueError("solution does not satisfy A x = b exactly")
         return self
 
 
 class LinearRationalInconsistencyResult(StrictModel):
-    """Whether a rational linear system is inconsistent."""
+    """One exact inconsistency outcome bound to its declared source system.
 
+    Retains the canonical ``LinearRationalSystem`` so validation replays the
+    defining relations: an admitted separating witness ``y`` carries one
+    coordinate per source row, annihilates every source column exactly
+    (``y^T A = 0``), and its recorded pairing equals ``y^T b`` on the
+    retained right-hand side and is nonzero.  The witness is defined up to a
+    nonzero scaling; the producer emits the backend-scaled witness whose
+    pairing equals one.  A consistent outcome carries no witness.  The
+    coefficient domain admits at least one row and column, so zero-row shapes
+    are rejected by request admission rather than silently dropped.
+    """
+
+    system: LinearRationalSystem
     status: Literal["INCONSISTENT", "CONSISTENT"] = "INCONSISTENT"
     left_witness: tuple[CanonicalRational, ...] | None = Field(
         default=None,
@@ -102,10 +139,37 @@ class LinearRationalInconsistencyResult(StrictModel):
     rhs_pairing: CanonicalRational | None = None
 
     @model_validator(mode="after")
-    def bind_witness_to_status(self) -> Self:
+    def bind_witness_to_source(self) -> Self:
         produced = self.status == "INCONSISTENT"
         if produced != (self.left_witness is not None and self.rhs_pairing is not None):
             raise ValueError("inconsistency witness must agree with the result status")
+        if self.left_witness is None or self.rhs_pairing is None:
+            return self
+        if len(self.left_witness) != len(self.system.rhs):
+            raise ValueError("witness length must equal the source row count")
+        coordinates = [value.as_fraction() for value in self.left_witness]
+        columns = range(len(self.system.coefficients.entries[0]))
+        for column in columns:
+            if (
+                sum(
+                    row[column].as_fraction() * coordinate
+                    for row, coordinate in zip(
+                        self.system.coefficients.entries,
+                        coordinates,
+                        strict=True,
+                    )
+                )
+                != 0
+            ):
+                raise ValueError("witness does not satisfy y^T A = 0 exactly")
+        pairing = sum(
+            bound.as_fraction() * coordinate
+            for bound, coordinate in zip(self.system.rhs, coordinates, strict=True)
+        )
+        if pairing != self.rhs_pairing.as_fraction():
+            raise ValueError("recorded pairing must equal y^T b on the source system")
+        if pairing == 0:
+            raise ValueError("separating witness must have a nonzero pairing")
         return self
 
 

--- a/src/jacobian/math/matrices/rational_linear/_models.py
+++ b/src/jacobian/math/matrices/rational_linear/_models.py
@@ -78,9 +78,10 @@ class LinearRationalSolutionResult(StrictModel):
     Retains the canonical ``LinearRationalSystem`` so validation replays the
     defining relation: an admitted solution carries one coordinate per
     declared variable and satisfies ``A x = b`` exactly over QQ, while an
-    inconsistent outcome carries no values.  The coefficient domain admits at
-    least one row and column, so zero-row shapes are rejected by request
-    admission rather than silently dropped.
+    inconsistent outcome carries no values and requires the retained system
+    itself to be inconsistent (``rank(A) < rank([A | b])``).  The coefficient
+    domain admits at least one row and column, so zero-row shapes are rejected
+    by request admission rather than silently dropped.
     """
 
     system: LinearRationalSystem
@@ -97,6 +98,16 @@ class LinearRationalSolutionResult(StrictModel):
         if produced != (self.values is not None):
             raise ValueError("solution values must agree with the result status")
         if self.values is None:
+            from jacobian.math.matrices._operations import _system_rank_replay
+
+            coefficient_rank, augmented_rank = _system_rank_replay(
+                self.system.coefficients, self.system.rhs
+            )
+            if coefficient_rank >= augmented_rank:
+                raise ValueError(
+                    "an inconsistent outcome requires rank(A) < rank([A | b]) "
+                    "on the source system"
+                )
             return self
         if len(self.values) != len(self.system.variables):
             raise ValueError("solution length must equal the source variable count")
@@ -124,9 +135,10 @@ class LinearRationalInconsistencyResult(StrictModel):
     (``y^T A = 0``), and its recorded pairing equals ``y^T b`` on the
     retained right-hand side and is nonzero.  The witness is defined up to a
     nonzero scaling; the producer emits the backend-scaled witness whose
-    pairing equals one.  A consistent outcome carries no witness.  The
-    coefficient domain admits at least one row and column, so zero-row shapes
-    are rejected by request admission rather than silently dropped.
+    pairing equals one.  A consistent outcome carries no witness and requires
+    the retained system itself to be consistent (``rank(A) == rank([A | b])``).
+    The coefficient domain admits at least one row and column, so zero-row
+    shapes are rejected by request admission rather than silently dropped.
     """
 
     system: LinearRationalSystem
@@ -144,6 +156,16 @@ class LinearRationalInconsistencyResult(StrictModel):
         if produced != (self.left_witness is not None and self.rhs_pairing is not None):
             raise ValueError("inconsistency witness must agree with the result status")
         if self.left_witness is None or self.rhs_pairing is None:
+            from jacobian.math.matrices._operations import _system_rank_replay
+
+            coefficient_rank, augmented_rank = _system_rank_replay(
+                self.system.coefficients, self.system.rhs
+            )
+            if coefficient_rank != augmented_rank:
+                raise ValueError(
+                    "a consistent outcome requires rank(A) == rank([A | b]) "
+                    "on the source system"
+                )
             return self
         if len(self.left_witness) != len(self.system.rhs):
             raise ValueError("witness length must equal the source row count")

--- a/src/jacobian/math/matrices/rational_linear/_operations.py
+++ b/src/jacobian/math/matrices/rational_linear/_operations.py
@@ -30,6 +30,15 @@ def _canonical_rational(value: Any) -> CanonicalRational:
     )
 
 
+def _canonical_fraction(value: Fraction) -> CanonicalRational:
+    """Convert one exact Python fraction through the canonical wire form."""
+
+    return CanonicalRational(
+        num=format_canonical_integer(value.numerator),
+        den=format_canonical_integer(value.denominator),
+    )
+
+
 def _solve(
     coefficients: list[list[Fraction]], rhs: list[Fraction], flint: Any
 ) -> list[Any] | None:
@@ -67,9 +76,10 @@ def compute_rational_solution(
 
     values = _solve(coefficients, bounds, flint)
     if values is None:
-        return LinearRationalSolutionResult(status="INCONSISTENT")
+        return LinearRationalSolutionResult(system=system, status="INCONSISTENT")
     return LinearRationalSolutionResult(
-        values=tuple(_canonical_rational(value) for value in values)
+        system=system,
+        values=tuple(_canonical_rational(value) for value in values),
     )
 
 
@@ -92,10 +102,19 @@ def compute_rational_inconsistency(
     dual.append(bounds)
     values = _solve(dual, [Fraction(0)] * column_count + [Fraction(1)], flint)
     if values is None:
-        return LinearRationalInconsistencyResult(status="CONSISTENT")
+        return LinearRationalInconsistencyResult(system=system, status="CONSISTENT")
+    witness = tuple(_canonical_rational(value) for value in values)
+    pairing: Fraction = sum(
+        (
+            bound * coordinate.as_fraction()
+            for bound, coordinate in zip(bounds, witness, strict=True)
+        ),
+        Fraction(0),
+    )
     return LinearRationalInconsistencyResult(
-        left_witness=tuple(_canonical_rational(value) for value in values),
-        rhs_pairing=CanonicalRational(num="1", den="1"),
+        system=system,
+        left_witness=witness,
+        rhs_pairing=_canonical_fraction(pairing),
     )
 
 

--- a/src/jacobian/math/matrices/rational_linear/_operations.py
+++ b/src/jacobian/math/matrices/rational_linear/_operations.py
@@ -124,7 +124,7 @@ def rational_linear_operations() -> MathTools:
     return (
         MathTool(
             operation_id="linear.rational_solution.compute",
-            version="2",
+            version="3",
             title="Compute an exact rational solution",
             description="Return an exact rational solution or an inconsistent outcome.",
             request_type=LinearRationalSolutionFindRequest,
@@ -147,7 +147,7 @@ def rational_linear_operations() -> MathTools:
         ),
         MathTool(
             operation_id="linear.rational_inconsistency.compute",
-            version="2",
+            version="3",
             title="Compute an exact rational inconsistency witness",
             description="Return an inconsistency witness or a consistent outcome.",
             request_type=LinearRationalInconsistencyFindRequest,

--- a/tests/integration/linear/test_models.py
+++ b/tests/integration/linear/test_models.py
@@ -53,13 +53,23 @@ def test_linear_find_request_rejects_ambiguous_or_oversized_rationals() -> None:
 
 
 def test_inline_results_keep_only_mathematical_values() -> None:
-    solution = LinearRationalSolutionResult(values=(_q(2), _q(1)))
+    system = LinearRationalSystem.model_validate(_system())
+    solution = LinearRationalSolutionResult(system=system, values=(_q(2), _q(1)))
+    dependent = LinearRationalSystem.model_validate(
+        {
+            "variables": ["x", "y"],
+            "coefficients": {"entries": [[_q(1), _q(1)], [_q(1), _q(1)]]},
+            "rhs": [_q(0), _q(1)],
+        }
+    )
     inconsistency = LinearRationalInconsistencyResult(
-        left_witness=(_q(-2), _q(1)),
+        system=dependent,
+        left_witness=(_q(-1), _q(1)),
         rhs_pairing=_q(1),
     )
 
     assert solution.status == "SOLUTION"
+    assert solution.system == system
     assert solution.values is not None
     assert inconsistency.status == "INCONSISTENT"
     assert inconsistency.left_witness is not None
@@ -67,13 +77,18 @@ def test_inline_results_keep_only_mathematical_values() -> None:
 
 
 def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
-    solution = LinearRationalSolutionResult(status="INCONSISTENT")
-    inconsistency = LinearRationalInconsistencyResult(status="CONSISTENT")
+    system = LinearRationalSystem.model_validate(_system())
+    solution = LinearRationalSolutionResult(system=system, status="INCONSISTENT")
+    inconsistency = LinearRationalInconsistencyResult(
+        system=system,
+        status="CONSISTENT",
+    )
 
     assert solution.values is None
     assert inconsistency.left_witness is None
     with pytest.raises(ValidationError, match="agree with the result status"):
         LinearRationalSolutionResult(
+            system=system,
             status="INCONSISTENT",
             values=(_q(2), _q(1)),
         )

--- a/tests/integration/linear/test_models.py
+++ b/tests/integration/linear/test_models.py
@@ -77,10 +77,23 @@ def test_inline_results_keep_only_mathematical_values() -> None:
 
 
 def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
-    system = LinearRationalSystem.model_validate(_system())
-    solution = LinearRationalSolutionResult(system=system, status="INCONSISTENT")
+    dependent = LinearRationalSystem.model_validate(
+        {
+            "variables": ["x", "y"],
+            "coefficients": {"entries": [[_q(1), _q(1)], [_q(1), _q(1)]]},
+            "rhs": [_q(0), _q(1)],
+        }
+    )
+    solution = LinearRationalSolutionResult(system=dependent, status="INCONSISTENT")
+    free = LinearRationalSystem.model_validate(
+        {
+            "variables": ["x", "y"],
+            "coefficients": {"entries": [[_q(1), _q(1)]]},
+            "rhs": [_q(1)],
+        }
+    )
     inconsistency = LinearRationalInconsistencyResult(
-        system=system,
+        system=free,
         status="CONSISTENT",
     )
 
@@ -88,9 +101,16 @@ def test_inline_results_preserve_completed_no_candidate_outcomes() -> None:
     assert inconsistency.left_witness is None
     with pytest.raises(ValidationError, match="agree with the result status"):
         LinearRationalSolutionResult(
-            system=system,
+            system=dependent,
             status="INCONSISTENT",
             values=(_q(2), _q(1)),
+        )
+    with pytest.raises(ValidationError, match="agree with the result status"):
+        LinearRationalInconsistencyResult(
+            system=dependent,
+            status="CONSISTENT",
+            left_witness=(_q(-1), _q(1)),
+            rhs_pairing=_q(1),
         )
 
 

--- a/tests/math/matrices/test_linear_solve.py
+++ b/tests/math/matrices/test_linear_solve.py
@@ -272,3 +272,33 @@ def test_serialized_results_round_trip_through_the_wire_shape() -> None:
         restored = RationalLinearSolveResult.model_validate(result.model_dump())
         assert restored == result
         assert restored.convention == "LINEAR_SYSTEM_CLASSIFICATION_OVER_QQ"
+
+
+def test_result_reapplies_source_admission_before_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relayed source outside the work envelope is rejected before replay."""
+
+    import jacobian.math.matrices._operations as operations
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("rank replay ran on an unadmitted source system")
+
+    monkeypatch.setattr(operations, "_system_rank_replay", fail_if_called)
+    unadmitted = {
+        "matrix": {
+            "entries": [
+                [{"num": "1", "den": "1"}, {"num": "0", "den": "1"}],
+                [{"num": "0", "den": "1"}, {"num": "9" * 257, "den": "1"}],
+            ]
+        },
+        "rhs": _rhs("1", "1"),
+        "outcome": "INCONSISTENT",
+    }
+    with pytest.raises(ValidationError, match="limited to 256"):
+        RationalLinearSolveResult.model_validate(unadmitted)
+
+    non_square = dict(unadmitted)
+    non_square["matrix"] = {"entries": [[{"num": "1", "den": "1"}]]}
+    with pytest.raises(ValidationError, match="square matrix"):
+        RationalLinearSolveResult.model_validate(non_square)

--- a/tests/math/matrices/test_linear_solve.py
+++ b/tests/math/matrices/test_linear_solve.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import copy
+
 import pytest
 import sympy
 from pydantic import ValidationError
 
 from jacobian.math.matrices._operation_models import (
     RationalLinearSolveRequest,
+    RationalLinearSolveResult,
 )
 from jacobian.math.matrices._operations import compute_rational_linear_solve
 
@@ -99,3 +102,173 @@ def test_singular_inverse_rejected() -> None:
         NonsingularIntegerMatrixRequest.model_validate(
             {"matrix": {"entries": [["1", "2"], ["2", "4"]]}}
         )
+
+
+def _mutable(dumped: dict) -> dict:
+    """JSON round-trip so nested tuple payloads become mutable lists."""
+    import json
+
+    return json.loads(json.dumps(dumped))
+
+
+def test_results_retain_their_source_system() -> None:
+    """Every outcome retains the exact coefficient matrix and right-hand side."""
+
+    cases = (
+        (_matrix([["1", "0"], ["0", "1"]]), _rhs("2", "3"), "UNIQUE"),
+        (_matrix([["1", "1"], ["1", "1"]]), _rhs("0", "1"), "INCONSISTENT"),
+        (_matrix([["1", "1"], ["1", "1"]]), _rhs("1", "1"), "NON_UNIQUE"),
+    )
+    for entries, rhs, outcome in cases:
+        request = RationalLinearSolveRequest.model_validate(
+            {"matrix": {"entries": entries}, "rhs": rhs}
+        )
+        result = compute_rational_linear_solve(request)
+        assert result.outcome == outcome
+        assert result.matrix == request.matrix
+        assert result.rhs == request.rhs
+        assert (
+            RationalLinearSolveResult.model_validate_json(result.model_dump_json())
+            == result
+        )
+
+
+def test_unique_result_rejects_forged_solution_mutations() -> None:
+    """A mutated solution coordinate fails the A x = b replay."""
+
+    request = RationalLinearSolveRequest.model_validate(
+        {
+            "matrix": {"entries": _matrix([["2", "0"], ["0", "3"]])},
+            "rhs": _rhs("2", "3"),
+        }
+    )
+    dumped = _mutable(compute_rational_linear_solve(request).model_dump())
+
+    forged_coordinate = copy.deepcopy(dumped)
+    forged_coordinate["solution"][1] = {"num": "4", "den": "1"}
+    with pytest.raises(ValidationError, match="A x = b"):
+        RationalLinearSolveResult.model_validate(forged_coordinate)
+
+    forged_length = copy.deepcopy(dumped)
+    forged_length["solution"] = [
+        {"num": "1", "den": "1"},
+        {"num": "1", "den": "1"},
+        {"num": "1", "den": "1"},
+    ]
+    with pytest.raises(ValidationError):
+        RationalLinearSolveResult.model_validate(forged_length)
+
+    missing_solution = copy.deepcopy(dumped)
+    missing_solution["solution"] = None
+    with pytest.raises(ValidationError, match="populate the solution field"):
+        RationalLinearSolveResult.model_validate(missing_solution)
+
+
+def test_results_reject_outcome_and_source_mutations() -> None:
+    """Outcome flips and source edits fail the classification replay."""
+
+    inconsistent_request = RationalLinearSolveRequest.model_validate(
+        {
+            "matrix": {"entries": _matrix([["1", "1"], ["1", "1"]])},
+            "rhs": _rhs("0", "1"),
+        }
+    )
+    inconsistent = _mutable(
+        compute_rational_linear_solve(inconsistent_request).model_dump()
+    )
+
+    flipped_non_unique = copy.deepcopy(inconsistent)
+    flipped_non_unique["outcome"] = "NON_UNIQUE"
+    with pytest.raises(ValidationError, match="consistent, rank-deficient"):
+        RationalLinearSolveResult.model_validate(flipped_non_unique)
+
+    flipped_unique = copy.deepcopy(inconsistent)
+    flipped_unique["outcome"] = "UNIQUE"
+    with pytest.raises(ValidationError, match="populate the solution field"):
+        RationalLinearSolveResult.model_validate(flipped_unique)
+
+    feasible_source = copy.deepcopy(inconsistent)
+    feasible_source["rhs"] = _rhs("0", "0")
+    with pytest.raises(ValidationError, match="rank\\(A\\) < rank"):
+        RationalLinearSolveResult.model_validate(feasible_source)
+
+    nonsingular_source = copy.deepcopy(inconsistent)
+    nonsingular_source["matrix"]["entries"] = _matrix([["1", "0"], ["0", "1"]])
+    with pytest.raises(ValidationError, match="rank\\(A\\) < rank"):
+        RationalLinearSolveResult.model_validate(nonsingular_source)
+
+    nonunique_request = RationalLinearSolveRequest.model_validate(
+        {
+            "matrix": {"entries": _matrix([["1", "1"], ["1", "1"]])},
+            "rhs": _rhs("1", "1"),
+        }
+    )
+    non_unique = _mutable(compute_rational_linear_solve(nonunique_request).model_dump())
+
+    flipped_inconsistent = copy.deepcopy(non_unique)
+    flipped_inconsistent["outcome"] = "INCONSISTENT"
+    with pytest.raises(ValidationError, match="rank\\(A\\) < rank"):
+        RationalLinearSolveResult.model_validate(flipped_inconsistent)
+
+    singular_to_nonsingular = copy.deepcopy(non_unique)
+    singular_to_nonsingular["matrix"]["entries"] = _matrix([["1", "0"], ["0", "1"]])
+    singular_to_nonsingular["rhs"] = _rhs("1", "1")
+    with pytest.raises(ValidationError, match="consistent, rank-deficient"):
+        RationalLinearSolveResult.model_validate(singular_to_nonsingular)
+
+    unique_request = RationalLinearSolveRequest.model_validate(
+        {
+            "matrix": {"entries": _matrix([["2", "0"], ["0", "3"]])},
+            "rhs": _rhs("2", "3"),
+        }
+    )
+    unique = _mutable(compute_rational_linear_solve(unique_request).model_dump())
+
+    foreign_rhs = copy.deepcopy(unique)
+    foreign_rhs["rhs"] = _rhs("2", "4")
+    with pytest.raises(ValidationError, match="A x = b"):
+        RationalLinearSolveResult.model_validate(foreign_rhs)
+
+    # A singular source whose claimed solution still satisfies A x = b
+    # exactly: only the nonsingularity replay can reject this forgery.
+    singular_source = {
+        "matrix": {"entries": _matrix([["1", "1"], ["2", "2"]])},
+        "rhs": _rhs("2", "4"),
+        "outcome": "UNIQUE",
+        "solution": [{"num": "1", "den": "1"}, {"num": "1", "den": "1"}],
+    }
+    with pytest.raises(ValidationError, match="nonsingular"):
+        RationalLinearSolveResult.model_validate(singular_source)
+
+
+def test_serialized_results_round_trip_through_the_wire_shape() -> None:
+    """Producer output validates through a JSON round trip on every outcome."""
+
+    requests = (
+        RationalLinearSolveRequest.model_validate(
+            {
+                "matrix": {
+                    "entries": [
+                        [{"num": "1", "den": "2"}, {"num": "0", "den": "1"}],
+                        [{"num": "0", "den": "1"}, {"num": "1", "den": "3"}],
+                    ]
+                },
+                "rhs": [{"num": "1", "den": "2"}, {"num": "-5", "den": "3"}],
+            }
+        ),
+        RationalLinearSolveRequest.model_validate(
+            {
+                "matrix": {
+                    "entries": _matrix(
+                        [["1", "2", "3"], ["4", "5", "6"], ["7", "8", "9"]]
+                    )
+                },
+                "rhs": _rhs("1", "1", "1"),
+            }
+        ),
+    )
+    for request in requests:
+        result = compute_rational_linear_solve(request)
+        restored = RationalLinearSolveResult.model_validate(result.model_dump())
+        assert restored == result
+        assert restored.convention == "LINEAR_SYSTEM_CLASSIFICATION_OVER_QQ"

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -1,0 +1,327 @@
+"""Regression tests binding rational solution and inconsistency results to their source (#2294)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from fractions import Fraction
+
+import pytest
+from pydantic import ValidationError
+from tests.support.rationals import rational_payload as q
+
+from jacobian.math.matrices.rational_linear._models import (
+    LinearRationalInconsistencyFindRequest,
+    LinearRationalInconsistencyResult,
+    LinearRationalSolutionFindRequest,
+    LinearRationalSolutionResult,
+    LinearRationalSystem,
+)
+from jacobian.math.matrices.rational_linear._operations import (
+    compute_rational_inconsistency,
+    compute_rational_solution,
+)
+
+pytestmark = pytest.mark.requires_backend("flint")
+
+
+def _system(
+    variables: list[str],
+    entries: list[list[Fraction]],
+    rhs: list[Fraction],
+) -> dict[str, object]:
+    return {
+        "variables": variables,
+        "coefficients": {"entries": [[q(value) for value in row] for row in entries]},
+        "rhs": [q(value) for value in rhs],
+    }
+
+
+def _unique_system() -> dict[str, object]:
+    return _system(
+        ["x", "y"],
+        [[Fraction(2), Fraction(1)], [Fraction(1), Fraction(-1)]],
+        [Fraction(5), Fraction(1)],
+    )
+
+
+def _inconsistent_system() -> dict[str, object]:
+    return _system(
+        ["x", "y"],
+        [[Fraction(1), Fraction(1)], [Fraction(1), Fraction(1)]],
+        [Fraction(0), Fraction(1)],
+    )
+
+
+def _underdetermined_system() -> dict[str, object]:
+    return _system(
+        ["x", "y", "z"],
+        [[Fraction(1), Fraction(1), Fraction(0)]],
+        [Fraction(1)],
+    )
+
+
+def _mutable(dumped: dict) -> dict:
+    """JSON round-trip so nested tuple payloads become mutable lists."""
+
+    return json.loads(json.dumps(dumped))
+
+
+def test_producer_results_retain_their_source_system() -> None:
+    """Every outcome retains the exact declared system, including degenerate shapes."""
+
+    for payload in (
+        _unique_system(),
+        _inconsistent_system(),
+        _underdetermined_system(),
+    ):
+        request = LinearRationalSolutionFindRequest.model_validate({"system": payload})
+        solution = compute_rational_solution(request)
+        assert solution.system == request.system
+
+        dual_request = LinearRationalInconsistencyFindRequest.model_validate(
+            {"system": payload}
+        )
+        inconsistency = compute_rational_inconsistency(dual_request)
+        assert inconsistency.system == dual_request.system
+
+
+def test_solution_result_replays_against_the_source() -> None:
+    """The admitted solution satisfies A x = b exactly on the retained system."""
+
+    system = LinearRationalSystem.model_validate(_unique_system())
+    result = compute_rational_solution(LinearRationalSolutionFindRequest(system=system))
+
+    assert result.status == "SOLUTION"
+    assert result.values is not None
+    assert len(result.values) == len(system.variables)
+    components = [value.as_fraction() for value in result.values]
+    for row, bound in zip(
+        system.coefficients.entries,
+        (value.as_fraction() for value in system.rhs),
+        strict=True,
+    ):
+        residual = sum(
+            coefficient.as_fraction() * component
+            for coefficient, component in zip(row, components, strict=True)
+        )
+        assert residual == bound
+
+
+def test_inconsistent_result_replays_witness_relations() -> None:
+    """The separating witness annihilates every column with a nonzero pairing."""
+
+    system = LinearRationalSystem.model_validate(_inconsistent_system())
+    result = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest(system=system)
+    )
+
+    assert result.status == "INCONSISTENT"
+    assert result.left_witness is not None
+    assert result.rhs_pairing is not None
+    assert len(result.left_witness) == len(system.rhs)
+    coordinates = [value.as_fraction() for value in result.left_witness]
+    for column in range(len(system.coefficients.entries[0])):
+        assert (
+            sum(
+                row[column].as_fraction() * coordinate
+                for row, coordinate in zip(
+                    system.coefficients.entries,
+                    coordinates,
+                    strict=True,
+                )
+            )
+            == 0
+        )
+    pairing = sum(
+        bound.as_fraction() * coordinate
+        for bound, coordinate in zip(system.rhs, coordinates, strict=True)
+    )
+    assert pairing == result.rhs_pairing.as_fraction()
+    assert pairing != 0
+
+
+@pytest.mark.parametrize("payload", (_unique_system(), _inconsistent_system()))
+def test_serialized_results_round_trip(payload: dict[str, object]) -> None:
+    """Producer output validates through the JSON wire shape."""
+
+    solution = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate({"system": payload})
+    )
+    assert (
+        LinearRationalSolutionResult.model_validate_json(solution.model_dump_json())
+        == solution
+    )
+
+    inconsistency = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest.model_validate({"system": payload})
+    )
+    assert (
+        LinearRationalInconsistencyResult.model_validate_json(
+            inconsistency.model_dump_json()
+        )
+        == inconsistency
+    )
+
+
+def test_solution_result_rejects_forged_and_foreign_claims() -> None:
+    """Mutated values or a mutated source fail the A x = b replay."""
+
+    dumped = _mutable(
+        compute_rational_solution(
+            LinearRationalSolutionFindRequest.model_validate(
+                {"system": _unique_system()}
+            )
+        ).model_dump()
+    )
+    assert dumped["status"] == "SOLUTION"
+
+    forged_value = copy.deepcopy(dumped)
+    forged_value["values"][0] = q(Fraction(7))
+    with pytest.raises(ValidationError, match="A x = b"):
+        LinearRationalSolutionResult.model_validate(forged_value)
+
+    dropped_value = copy.deepcopy(dumped)
+    dropped_value["values"] = [dumped["values"][0]]
+    with pytest.raises(ValidationError, match="variable count"):
+        LinearRationalSolutionResult.model_validate(dropped_value)
+
+    foreign_source = copy.deepcopy(dumped)
+    foreign_source["system"]["rhs"][0] = q(Fraction(6))
+    with pytest.raises(ValidationError, match="A x = b"):
+        LinearRationalSolutionResult.model_validate(foreign_source)
+
+
+def test_inconsistent_result_rejects_forged_and_foreign_claims() -> None:
+    """Mutated witnesses or pairings fail the y^T A = 0 and y^T b replays."""
+
+    dumped = _mutable(
+        compute_rational_inconsistency(
+            LinearRationalInconsistencyFindRequest.model_validate(
+                {"system": _inconsistent_system()}
+            )
+        ).model_dump()
+    )
+    assert dumped["status"] == "INCONSISTENT"
+    witness = tuple(
+        Fraction(int(value["num"]), int(value["den"]))
+        for value in dumped["left_witness"]
+    )
+    true_pairing = sum(
+        bound * coordinate
+        for bound, coordinate in zip((Fraction(0), Fraction(1)), witness, strict=True)
+    )
+
+    forged_witness = copy.deepcopy(dumped)
+    forged_witness["left_witness"][0] = q(witness[0] + 1)
+    with pytest.raises(ValidationError, match=r"y\^T A = 0"):
+        LinearRationalInconsistencyResult.model_validate(forged_witness)
+
+    forged_pairing = copy.deepcopy(dumped)
+    forged_pairing["rhs_pairing"] = q(true_pairing + 1)
+    with pytest.raises(ValidationError, match=r"y\^T b"):
+        LinearRationalInconsistencyResult.model_validate(forged_pairing)
+
+    flat_witness = copy.deepcopy(dumped)
+    flat_witness["left_witness"] = [q(Fraction(0)) for _ in dumped["left_witness"]]
+    flat_witness["rhs_pairing"] = q(Fraction(0))
+    with pytest.raises(ValidationError, match="nonzero"):
+        LinearRationalInconsistencyResult.model_validate(flat_witness)
+
+    dropped_coordinate = copy.deepcopy(dumped)
+    dropped_coordinate["left_witness"] = [dumped["left_witness"][0]]
+    with pytest.raises(ValidationError, match="source row count"):
+        LinearRationalInconsistencyResult.model_validate(dropped_coordinate)
+
+    foreign_source = copy.deepcopy(dumped)
+    foreign_source["system"]["coefficients"]["entries"][1] = [
+        q(Fraction(1)),
+        q(Fraction(2)),
+    ]
+    with pytest.raises(ValidationError):
+        LinearRationalInconsistencyResult.model_validate(foreign_source)
+
+
+def test_consistent_outcome_rejects_bare_or_mutated_claims() -> None:
+    """A consistent outcome carries no witness; flipped claims fail the replay."""
+
+    consistent = _mutable(
+        compute_rational_inconsistency(
+            LinearRationalInconsistencyFindRequest.model_validate(
+                {"system": _unique_system()}
+            )
+        ).model_dump()
+    )
+    assert consistent["status"] == "CONSISTENT"
+    assert consistent["left_witness"] is None
+    assert consistent["rhs_pairing"] is None
+
+    bare_witness = copy.deepcopy(consistent)
+    bare_witness["left_witness"] = [q(Fraction(1)), q(Fraction(-1))]
+    bare_witness["rhs_pairing"] = q(Fraction(1))
+    with pytest.raises(ValidationError, match="agree with the result status"):
+        LinearRationalInconsistencyResult.model_validate(bare_witness)
+
+    flipped_status = copy.deepcopy(consistent)
+    flipped_status["status"] = "INCONSISTENT"
+    flipped_status["left_witness"] = [q(Fraction(1)), q(Fraction(1))]
+    flipped_status["rhs_pairing"] = q(Fraction(1))
+    with pytest.raises(ValidationError, match=r"y\^T A = 0"):
+        LinearRationalInconsistencyResult.model_validate(flipped_status)
+
+
+def test_polynomial_coordinate_composition_reconstructs_the_target() -> None:
+    """A Ringel-style span solve stays bound: A c = t reconstructs the target."""
+
+    # Declared generator functionals in monomial coordinates, one per column.
+    generators = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(0), Fraction(1)),
+        (Fraction(1), Fraction(1)),
+    )
+    target = (Fraction(3), Fraction(2))
+    payload = _system(
+        ["c1", "c2", "c3"],
+        [list(column) for column in zip(*generators, strict=True)],
+        list(target),
+    )
+
+    result = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate({"system": payload})
+    )
+    assert result.status == "SOLUTION"
+    assert result.system == LinearRationalSystem.model_validate(payload)
+    weights = [value.as_fraction() for value in result.values] if result.values else []
+    reconstructed = tuple(
+        sum(
+            weight * generator[index]
+            for weight, generator in zip(weights, generators, strict=True)
+        )
+        for index in range(len(target))
+    )
+    assert reconstructed == target
+
+
+def test_separating_functional_annihilates_generators_but_not_the_target() -> None:
+    """A Ringel-style separation stays bound: y^T A = 0 while y^T b != 0."""
+
+    generators = (
+        (Fraction(1), Fraction(0)),
+        (Fraction(2), Fraction(0)),
+    )
+    target = (Fraction(0), Fraction(1))
+    payload = _system(
+        ["c1", "c2"],
+        [list(column) for column in zip(*generators, strict=True)],
+        list(target),
+    )
+
+    result = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest.model_validate({"system": payload})
+    )
+    assert result.status == "INCONSISTENT"
+    assert result.left_witness is not None
+    coordinates = [value.as_fraction() for value in result.left_witness]
+    for generator in generators:
+        assert sum(y * g for y, g in zip(coordinates, generator, strict=True)) == 0
+    assert sum(y * t for y, t in zip(coordinates, target, strict=True)) != 0

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -270,6 +270,102 @@ def test_consistent_outcome_rejects_bare_or_mutated_claims() -> None:
         LinearRationalInconsistencyResult.model_validate(flipped_status)
 
 
+def test_inconsistent_outcome_requires_a_genuinely_inconsistent_source() -> None:
+    """A mutated INCONSISTENT claim cannot attach to a consistent source."""
+
+    dumped = _mutable(
+        compute_rational_solution(
+            LinearRationalSolutionFindRequest.model_validate(
+                {"system": _unique_system()}
+            )
+        ).model_dump()
+    )
+    assert dumped["status"] == "SOLUTION"
+
+    flipped = copy.deepcopy(dumped)
+    flipped["status"] = "INCONSISTENT"
+    flipped["values"] = None
+    with pytest.raises(ValidationError, match=r"rank\(A\) < rank"):
+        LinearRationalSolutionResult.model_validate(flipped)
+
+    identity = copy.deepcopy(dumped)
+    identity["system"] = _system(
+        ["x", "y"],
+        [[Fraction(1), Fraction(0)], [Fraction(0), Fraction(1)]],
+        [Fraction(0), Fraction(0)],
+    )
+    identity["status"] = "INCONSISTENT"
+    identity["values"] = None
+    with pytest.raises(ValidationError, match=r"rank\(A\) < rank"):
+        LinearRationalSolutionResult.model_validate(identity)
+
+
+def test_consistent_outcome_requires_a_genuinely_consistent_source() -> None:
+    """A CONSISTENT claim cannot attach to a contradictory source system."""
+
+    consistent = _mutable(
+        compute_rational_inconsistency(
+            LinearRationalInconsistencyFindRequest.model_validate(
+                {"system": _unique_system()}
+            )
+        ).model_dump()
+    )
+    assert consistent["status"] == "CONSISTENT"
+
+    contradictory = copy.deepcopy(consistent)
+    contradictory["system"] = _system(
+        ["x"],
+        [[Fraction(1)], [Fraction(1)]],
+        [Fraction(0), Fraction(1)],
+    )
+    with pytest.raises(ValidationError, match=r"rank\(A\) == rank"):
+        LinearRationalInconsistencyResult.model_validate(contradictory)
+
+
+def test_negative_outcomes_round_trip_on_their_true_sources() -> None:
+    """Genuine no-witness outcomes replay successfully against their own system."""
+
+    solution = compute_rational_solution(
+        LinearRationalSolutionFindRequest.model_validate(
+            {"system": _inconsistent_system()}
+        )
+    )
+    assert solution.status == "INCONSISTENT"
+    assert (
+        LinearRationalSolutionResult.model_validate_json(solution.model_dump_json())
+        == solution
+    )
+
+    inconsistency = compute_rational_inconsistency(
+        LinearRationalInconsistencyFindRequest.model_validate(
+            {"system": _underdetermined_system()}
+        )
+    )
+    assert inconsistency.status == "CONSISTENT"
+    assert (
+        LinearRationalInconsistencyResult.model_validate_json(
+            inconsistency.model_dump_json()
+        )
+        == inconsistency
+    )
+
+
+def test_source_bound_result_versions_track_wire_shape() -> None:
+    """The required source fields bump all three affected declarations."""
+
+    from jacobian.math.matrices._tools import TOOLS as MATRIX_TOOLS
+    from jacobian.math.matrices.rational_linear._tools import TOOLS as LINEAR_TOOLS
+
+    versions = {
+        tool.operation_id: tool.version
+        for tool in (*MATRIX_TOOLS, *LINEAR_TOOLS)
+    }
+
+    assert versions["matrix.rational_linear_system.solve"] == "3"
+    assert versions["linear.rational_solution.compute"] == "3"
+    assert versions["linear.rational_inconsistency.compute"] == "3"
+
+
 def test_polynomial_coordinate_composition_reconstructs_the_target() -> None:
     """A Ringel-style span solve stays bound: A c = t reconstructs the target."""
 

--- a/tests/math/matrices/test_rational_linear_source_binding.py
+++ b/tests/math/matrices/test_rational_linear_source_binding.py
@@ -357,8 +357,7 @@ def test_source_bound_result_versions_track_wire_shape() -> None:
     from jacobian.math.matrices.rational_linear._tools import TOOLS as LINEAR_TOOLS
 
     versions = {
-        tool.operation_id: tool.version
-        for tool in (*MATRIX_TOOLS, *LINEAR_TOOLS)
+        tool.operation_id: tool.version for tool in (*MATRIX_TOOLS, *LINEAR_TOOLS)
     }
 
     assert versions["matrix.rational_linear_system.solve"] == "3"


### PR DESCRIPTION
## Problem

The exact rational-linear operations returned authoritative results detached from the system they describe (#2294):

- `RationalLinearSolveResult` (square `matrix.rational_linear_system.solve`) held only an outcome and optional solution;
- `LinearRationalSolutionResult` and `LinearRationalInconsistencyResult` (rectangular `linear.rational_solution.compute` / `linear.rational_inconsistency.compute`) held only a status plus optional values, left witness, and claimed rhs pairing.

Their validators checked only presence against status. An authored solution vector or separating witness validated independently of any source system, and the same result could be attached informally to a different system. The producers computed correct values but discarded the declared source.

## Root cause

Result contracts did not retain their source request values, so no defining relation (`A x = b`, `y^T A = 0`, `y^T b ≠ 0`, rank comparison) could be replayed at validation time — the same defect class already fixed for RREF, rank, and nullspace results.

## Fix

- `RationalLinearSolveResult` now retains the coefficient matrix and right-hand side. Its validator replays the classification with the same exact kernel: a unique solution carries one coordinate per column, satisfies `A x = b` exactly, and requires a nonsingular retained coefficient matrix; an inconsistent outcome requires `rank(A) < rank([A | b])`; a non-unique outcome requires a consistent, rank-deficient retained system.
- `LinearRationalSolutionResult` now retains the declared `LinearRationalSystem`; an admitted solution carries one coordinate per variable and satisfies `A x = b` exactly over QQ.
- `LinearRationalInconsistencyResult` now retains the declared system; an admitted separating witness carries one coordinate per source row, annihilates every column exactly (`y^T A = 0`), and its recorded pairing equals `y^T b` and is nonzero. The witness stays defined up to nonzero scaling; the producer now computes the true pairing instead of asserting one. Consistent outcomes carry no witness.
- Zero-row shapes stay rejected by request admission rather than silently dropped; operational outcomes (no witness found) remain distinct from mathematical conclusions.

Regression coverage: known unique/inconsistent/non-unique/underdetermined cases; forged solution, witness, pairing, outcome, and source mutations all rejected; JSON serialization round-trips; polynomial-coordinate composition reconstructing the target and a separating functional annihilating every declared generator but not the target (Ringel composition shape from the issue).

## Validation

- `uv run --locked pytest tests/math/matrices -q` — 187 passed (incl. new `test_rational_linear_source_binding.py` and extended `test_linear_solve.py`)
- `uv run --locked pytest tests/integration/linear -q` — green (two inline-result tests updated to the source-bound contract)
- Full suite `uv run --locked pytest -q` — 4977 passed
- `make check` — lint, typecheck, test-fast green
- `uv run ruff check` + `ruff format --check` on changed paths; `uv run mypy src/jacobian/math/matrices` clean

Fixes #2294