### PR TITLE
docs: add known-backend-defects registry and derivation-discipline guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ caller composes the returned mathematical values.
   rules for public mathematical operations.
 - [Mathematical backends](reference/mathematical-backends.md) — adapter,
   conversion, and external-process contracts.
+- [Known backend defects](reference/backend-known-defects.md) — upstream
+  defects that adapters compensate for, with guard tests.
 - [Public operation admission](reference/public-operation-admission.md) — what
   belongs in the agent-visible catalog.
 - [Native Python API](reference/python-api.md) — supported `jacobian.math`

--- a/docs/reference/backend-known-defects.md
+++ b/docs/reference/backend-known-defects.md
@@ -1,0 +1,27 @@
+# Known backend defects
+
+[Documentation home](../index.md)
+
+This registry lists defects in maintained mathematical backends that Jacobian
+adapters compensate for. A backend defect is any behavior where the backend
+returns a mathematically wrong or unsound value for inputs inside its own
+documented domain — not a limitation that narrows what the backend supports.
+
+Before trusting backend output for a new claim, check this registry. Add an
+entry whenever an adapter compensates for backend behavior instead of
+narrowing the public domain, and remove the entry (and the compensation) when
+an upgraded backend version makes it redundant. The guard test named in each
+entry must fail if the backend behavior changes in either direction.
+
+| Upstream defect | Affected operations | Adapter compensation | Guard tests |
+| --- | --- | --- | --- |
+| [SymPy #10666](https://github.com/sympy/sympy/issues/10666) — `resultant` returns `(-1)^(m*n)` times the true Sylvester determinant when `deg(left) < deg(right)` and both degrees are odd; the subresultant PRS swaps the inputs without recompensing the swap sign. Still present in SymPy 1.14. | `polynomial.multivariate.resultant.compute` (`SYLVESTER_DETERMINANT` convention) | `_sylvester_resultant_value` in `src/jacobian/math/polynomials/multivariate/_operations.py` negates the backend value under exactly that degree condition. | `tests/math/polynomials/test_multivariate_polynomial.py`: `test_resultant_matches_sylvester_determinant_oracle` (independent determinant oracle), `test_resultant_sign_matches_sylvester_orientation`, `test_resultant_swap_law_with_degenerate_rows`. Remove the compensation when a SymPy release fixes #10666; the swap-law and oracle tests then hold with the compensation deleted. |
+
+## Adding an entry
+
+Name the upstream issue, the exact affected operation and declared
+convention, the compensating code location, and the guard test whose failure
+signals that the backend changed. Prefer a guard built from an independent
+construction — an object assembled from the definition rather than another
+path through the same backend — so the test cannot reproduce the shared
+defect. Record the backend versions known to be affected.

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -105,6 +105,11 @@ or reasoning before designing an implementation (see
 Only a genuine operation gap proceeds to the
 [admission contract](public-operation-admission.md).
 
+Before trusting backend output for a new claim, consult the
+[known backend defects](backend-known-defects.md) registry; add an entry
+whenever the adapter compensates for backend behavior instead of narrowing
+the public domain.
+
 Every new or materially changed public operation must include the following
 completed review artifact in its issue or pull request. A field may say `Not
 applicable` with a reason; it must not be omitted.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -77,6 +77,18 @@ value mathematically valid. Then name the smallest set of tests that establishes
 that invariant and rejects plausible results that satisfy only a weaker
 mathematical claim.
 
+When authoring or changing an operation's contract or backend adapter, derive
+at least one expected value from the mathematical definition rather than from
+the maintained backend before merging: a worked computation, brute-force
+enumeration on a small admitted slice, or an independently constructed object
+such as a determinant assembled directly from coefficients. Agreement with the
+backend is not independent evidence — every code path in one backend can share
+one defect. Where the operation already advertises an identity, such as
+reconstruction, a swap law, or invariance under a change of basis, test that
+identity against the same change. Before trusting backend output for a new
+claim, consult the [known backend defects](backend-known-defects.md) registry;
+add an entry whenever an adapter compensates for backend behavior.
+
 Classify each fixture by the evidence it contributes:
 
 | Fixture role | What it establishes |


### PR DESCRIPTION
## Problem

Backend defects can hide beneath correct-looking contracts. SymPy's resultant sign defect ([sympy#10666](https://github.com/sympy/sympy/issues/10666)) affected admitted inputs of an already-public operation and surfaced only because contract-widening work (#2293) forced deriving expected values from first principles; the knowledge of that defect and its adapter compensation currently lives only in a docstring and a PR body.

## Change

Two small documentation additions — no code, no per-operation test quotas:

1. **`docs/reference/testing-strategy.md`** (Evidence plans for exact operations): when authoring or changing an operation's contract or backend adapter, derive at least one expected value from the mathematical definition rather than the maintained backend (worked computation, brute-force enumeration on a small slice, or an independently constructed object); test identities the operation already advertises. A review-time derivation discipline, scoped to change sites — zero cost on untouched operations.

2. **`docs/reference/backend-known-defects.md`** (new): registry of upstream defects that adapters compensate for, with one row per defect: upstream issue, affected operations/convention, compensating code location, guard tests, and removal condition. First entry: sympy#10666 with its orientation-restoration shim and its three guard tests. Includes guidance to prefer guards built from independent constructions so the test cannot reproduce the shared defect.

3. One-sentence pointer in **domain-operation-library.md**'s operation preflight and a Reference-list entry in **docs/index.md**.

## Validation

- `make docs-linkcheck` green; `git diff --check` clean.
- Registry paths verified against current main (`_sylvester_resultant_value`, the three guard-test names).