### PR TITLE
fix(math): derive operation-specific guards from real kernel cost

### DIFF
--- a/src/jacobian/math/code_nonlinear/_admission.py
+++ b/src/jacobian/math/code_nonlinear/_admission.py
@@ -18,7 +18,11 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "code.nonlinear.constant_weight.compute",
         AdmissionDecision.KEEP,
-        "exact generation of all constant-weight binary words",
+        "exact generation of all constant-weight binary words; re-admitted for the "
+        "narrowed binomial envelope: ConstantWeightRequest bounds the admitted candidate "
+        "space to C(length, weight) <= 4096 (rejected before enumeration otherwise), so "
+        "the materialized output is at most 4,096 words of length <= 64 and admitted work "
+        "is one O(length) bit-write pass per word with no intermediate beyond a single word",
     ),
     OperationAdmission(
         "code.binary.word_distance.compute",

--- a/src/jacobian/math/code_nonlinear/_models.py
+++ b/src/jacobian/math/code_nonlinear/_models.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from math import comb
 from typing import Self
 
 from pydantic import Field, model_validator
@@ -11,6 +12,14 @@ from jacobian._models import StrictModel
 
 MAX_CODEWORDS = 4096
 MAX_LENGTH = 64
+
+# ``code.nonlinear.constant_weight.compute`` materializes every C(length,
+# weight) word, so its admitted domain is bounded by the exact binomial
+# output size rather than the shared explicit-code length limit.  The
+# worst case at MAX_LENGTH is C(64,32) ~ 1.8e18 words, which cannot be
+# enumerated; requests whose complete output would exceed MAX_CODEWORDS
+# are rejected before any backend work.
+MAX_CONSTANT_WEIGHT_WORDS = MAX_CODEWORDS
 
 
 class BinaryCodeRequest(StrictModel):
@@ -46,6 +55,14 @@ class ConstantWeightRequest(StrictModel):
     def require_valid_weight(self) -> Self:
         if self.weight > self.length:
             raise ValueError("weight cannot exceed length")
+        expected_words = comb(self.length, self.weight)
+        if expected_words > MAX_CONSTANT_WEIGHT_WORDS:
+            raise ValueError(
+                "constant-weight enumeration would materialize "
+                f"{expected_words:,} words (C({self.length},{self.weight})), "
+                f"exceeding the {MAX_CONSTANT_WEIGHT_WORDS}-word result bound; "
+                "enumerate a smaller length/weight or compose via subsets"
+            )
         return self
 
 

--- a/src/jacobian/math/code_nonlinear/_models.py
+++ b/src/jacobian/math/code_nonlinear/_models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from math import comb
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from jacobian._models import StrictModel
 
@@ -48,8 +48,34 @@ class BinaryCodeRequest(StrictModel):
 class ConstantWeightRequest(StrictModel):
     """Generate all constant-weight binary words of given length and weight."""
 
-    length: int = Field(ge=1, le=MAX_LENGTH)
-    weight: int = Field(ge=0)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Generate every constant-weight binary word. Coupled admission "
+                "rule: the complete output size C(length, weight) must not "
+                f"exceed {MAX_CONSTANT_WEIGHT_WORDS} materialized words; requests "
+                "whose binomial output is larger are rejected before enumeration. "
+                "For example, length=12 weight=6 (924 words) is admitted while "
+                "length=64 weight=32 (~1.8e18 words) is not."
+            )
+        }
+    )
+
+    length: int = Field(
+        ge=1,
+        le=MAX_LENGTH,
+        description=(
+            f"Word length in [1, {MAX_LENGTH}]. Subject to the coupled rule "
+            f"C(length, weight) <= {MAX_CONSTANT_WEIGHT_WORDS}."
+        ),
+    )
+    weight: int = Field(
+        ge=0,
+        description=(
+            f"Hamming weight in [0, length]. Subject to the coupled rule "
+            f"C(length, weight) <= {MAX_CONSTANT_WEIGHT_WORDS}."
+        ),
+    )
 
     @model_validator(mode="after")
     def require_valid_weight(self) -> Self:

--- a/src/jacobian/math/code_nonlinear/_tools.py
+++ b/src/jacobian/math/code_nonlinear/_tools.py
@@ -90,6 +90,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 {"length": 4, "weight": 2},
             ),
         ),
+        version="2",
     ),
     _op(
         "code.binary.word_distance.compute",

--- a/src/jacobian/math/finite_dim_algebras/_models.py
+++ b/src/jacobian/math/finite_dim_algebras/_models.py
@@ -13,6 +13,16 @@ MAX_ENTRIES = (
     MAX_DIM * MAX_DIM
 )  # 16384; outer tensor bound (n <= 128, logical n^3 entries)
 
+# ``compute_center`` builds n^2 commutator rows and runs Gaussian
+# elimination over all of them with length-n row updates, so the kernel's
+# actual worst-case work is Theta(n^4) modular-entry updates, not cubic.
+# Measured on this kernel: n=32 ~0.08s, n=64 ~1.2s, n=96 ~6.1s,
+# n=128 ~18.8s.  The dimension envelope is derived from that measured
+# cost so an accepted request stays inside the bounded synchronous
+# execution envelope; replacing the kernel with a faster elimination
+# would justify re-deriving this bound upward.
+_MAX_DIM_FOR_CENTER = 128
+
 
 class StructureConstants(StrictModel):
     """Structure constants ``c[i][j][k]`` for a finite-dimensional algebra.
@@ -59,6 +69,15 @@ class StructureConstants(StrictModel):
 
 class CenterRequest(StrictModel):
     algebra: StructureConstants
+
+    @model_validator(mode="after")
+    def require_bounded_center_work(self) -> Self:
+        if self.algebra.dimension > _MAX_DIM_FOR_CENTER:
+            raise ValueError(
+                "center computation is Theta(n^4) on the current elimination "
+                f"kernel and supports at most {_MAX_DIM_FOR_CENTER} dimensions"
+            )
+        return self
 
 
 # Results

--- a/src/jacobian/math/number_theory/_admission.py
+++ b/src/jacobian/math/number_theory/_admission.py
@@ -103,7 +103,10 @@ ADMISSIONS: tuple[OperationAdmission, ...] = (
     OperationAdmission(
         "integer.compute.primorial",
         AdmissionDecision.KEEP,
-        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage",
+        "distinct exact bounded mathematical value or invariant with material computational or reliability leverage; "
+        "re-admitted for the v4 result-derived envelope: PrimorialRequest bounds n <= 1001 from the declared "
+        "3,400-digit result budget (primorial(1001) carries 3397 digits, primorial(1002) 3401), so admitted "
+        "work is n-1 big-integer multiplications whose intermediates and exact result stay inside that budget",
     ),
     OperationAdmission(
         "integer.compute.proper_divisors",

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -47,10 +47,15 @@ _MAX_CERTIFIED_FACTORIZATION_LENGTH = 30
 # (totient, Möbius, divisor sigma, square-free predicates, and
 # multiplicative order).  The 10_000 bound keeps SymPy factoring safe for
 # in-process execution while admitting materially larger useful cases than
-# the prior 1_000 cap.  Primorial output is separately guarded by
-# ``_MAX_PRIMORIAL_DIGITS`` (3_400), so the larger ``n`` does not admit
-# unbounded output.
+# the prior 1_000 cap.  Primorial has its own request bound derived from
+# the declared result digit budget (see ``_MAX_PRIMORIAL_N``).
 _MAX_N_SMALL = 10_000
+# primorial(n) carries n(ln n + ln ln n)/ln 10 digits.  The declared
+# result budget is ``_MAX_PRIMORIAL_DIGITS`` (3_400), and primorial(1001)
+# already has 3397 digits while primorial(1002) has 3401, so the exact
+# admitted boundary is n <= 1001.  Defined here so ``PrimorialRequest``
+# can derive its own request-side guard from the output contract.
+_MAX_PRIMORIAL_N = 1001
 # ``_MAX_MODULUS`` is shared across modular inverse, multiplicative order,
 # quadratic residues, CRT, Jacobi symbol, and brute-force discrete log.
 # Raised to 1_000_000 for non-enumeration ops (inverse, order, CRT, Jacobi
@@ -299,6 +304,19 @@ class PositiveIntegerRequest(StrictModel):
     """One bounded positive integer (1 <= n <= 10 000)."""
 
     n: StrictInt = Field(ge=1, le=_MAX_N_SMALL)
+
+
+class PrimorialRequest(StrictModel):
+    """One bounded positive integer whose primorial fits the result contract.
+
+    ``primorial(n)`` grows like ``exp(n log n)``: the product of the first
+    ``n`` primes carries ``n(log n + log log n) / ln 10`` digits.  The
+    shared arithmetic-function bound admits values whose primorial would
+    exceed the declared ``_MAX_PRIMORIAL_DIGITS``-digit result, so this
+    request derives its own conservative ceiling from the digit bound.
+    """
+
+    n: StrictInt = Field(ge=1, le=_MAX_PRIMORIAL_N)
 
 
 class PreviousPrimeRequest(StrictModel):

--- a/src/jacobian/math/number_theory/_prime_operations.py
+++ b/src/jacobian/math/number_theory/_prime_operations.py
@@ -9,6 +9,7 @@ from jacobian.math.number_theory._models import (
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
     PreviousPrimeRequest,
+    PrimorialRequest,
     PrimorialResult,
 )
 
@@ -43,7 +44,7 @@ def compute_nth_prime(request: PositiveIntegerRequest) -> IntegerValueResult:
     return IntegerValueResult(value=str(int(prime(request.n))))
 
 
-def compute_primorial(request: PositiveIntegerRequest) -> PrimorialResult:
+def compute_primorial(request: PrimorialRequest) -> PrimorialResult:
     from sympy import primorial
 
     return PrimorialResult(value=str(int(primorial(request.n))))

--- a/src/jacobian/math/number_theory/_primes.py
+++ b/src/jacobian/math/number_theory/_primes.py
@@ -8,6 +8,7 @@ from jacobian.math.number_theory._models import (
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
     PreviousPrimeRequest,
+    PrimorialRequest,
     PrimorialResult,
 )
 from jacobian.math.number_theory._prime_operations import (
@@ -90,7 +91,7 @@ PRIME_OPERATIONS = (
         "integer.compute.primorial",
         "Compute primorial",
         "Compute the product of the first n primes.",
-        PositiveIntegerRequest,
+        PrimorialRequest,
         PrimorialResult,
         compute_primorial,
         "number-theory",
@@ -100,7 +101,7 @@ PRIME_OPERATIONS = (
                 "primorial_5", "Compute the product of the first five primes.", {"n": 5}
             ),
         ),
-        version="3",
+        version="4",
     ),
     number_theory_operation(
         "integer.compute.euler_totient",

--- a/tests/math/code_nonlinear/test_code_nonlinear.py
+++ b/tests/math/code_nonlinear/test_code_nonlinear.py
@@ -1,5 +1,7 @@
 """Tests for nonlinear binary code operations."""
 
+import pytest
+
 from jacobian.math.code_nonlinear._models import (
     ConstantWeightProfileRequest,
     ConstantWeightRequest,
@@ -119,3 +121,15 @@ class TestConstantWeight:
         result = compute_constant_weight(ConstantWeightRequest(length=4, weight=2))
         assert result.count == 6  # C(4,2) = 6
         assert len(result.codewords) == 6
+
+    def test_binomial_output_bound_rejects_infeasible_enumeration(self) -> None:
+        """C(64,32) ~ 1.8e18 words cannot be materialized; admission must reject."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="4096-word result bound"):
+            ConstantWeightRequest(length=64, weight=32)
+
+    def test_binomial_output_bound_admits_small_spaces(self) -> None:
+        """C(12,6) = 924 <= MAX_CODEWORDS is admitted at the length-64 envelope."""
+        result = compute_constant_weight(ConstantWeightRequest(length=12, weight=6))
+        assert result.count == 924

--- a/tests/math/code_nonlinear/test_code_nonlinear.py
+++ b/tests/math/code_nonlinear/test_code_nonlinear.py
@@ -144,3 +144,31 @@ class TestConstantWeight:
         assert "C(length, weight)" in schema["properties"]["weight"]["description"]
         assert schema["properties"]["length"]["maximum"] == 64
         assert schema["properties"]["weight"]["minimum"] == 0
+
+
+def test_constant_weight_contract_version_tracks_the_request_schema_change() -> None:
+    """The narrowed binomial envelope must not present as the unchanged v1 contract."""
+    from jacobian.math.code_nonlinear._tools import TOOLS
+
+    operation = next(
+        item
+        for item in TOOLS
+        if item.operation_id == "code.nonlinear.constant_weight.compute"
+    )
+    assert operation.version == "2"
+
+
+def test_constant_weight_admission_records_the_narrowed_binomial_envelope() -> None:
+    """The materially changed candidate has a fresh owner-local admission decision."""
+    from jacobian.catalog.admission import AdmissionDecision
+    from jacobian.math.code_nonlinear._admission import ADMISSIONS
+
+    admission = next(
+        item
+        for item in ADMISSIONS
+        if item.operation_id == "code.nonlinear.constant_weight.compute"
+    )
+
+    assert admission.decision == AdmissionDecision.KEEP
+    assert "C(length, weight) <= 4096" in admission.rationale
+    assert "4,096 words" in admission.rationale

--- a/tests/math/code_nonlinear/test_code_nonlinear.py
+++ b/tests/math/code_nonlinear/test_code_nonlinear.py
@@ -133,3 +133,14 @@ class TestConstantWeight:
         """C(12,6) = 924 <= MAX_CODEWORDS is admitted at the length-64 envelope."""
         result = compute_constant_weight(ConstantWeightRequest(length=12, weight=6))
         assert result.count == 924
+
+    def test_published_schema_advertises_the_coupled_binomial_rule(self) -> None:
+        """math.find must expose the C(length, weight) bound without a failed run."""
+        schema = ConstantWeightRequest.model_json_schema()
+
+        assert "C(length, weight)" in schema["description"]
+        assert "4096" in schema["description"]
+        assert "C(length, weight)" in schema["properties"]["length"]["description"]
+        assert "C(length, weight)" in schema["properties"]["weight"]["description"]
+        assert schema["properties"]["length"]["maximum"] == 64
+        assert schema["properties"]["weight"]["minimum"] == 0

--- a/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
+++ b/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
@@ -146,14 +146,38 @@ def test_center_admits_derived_dimension_boundary() -> None:
 
 
 def test_center_rejects_above_derived_dimension_boundary() -> None:
-    """Dimensions above the measured envelope are rejected at admission."""
+    """The center-specific guard rejects below MAX_DIM when patched lower.
+
+    ``StructureConstants`` already caps dimension at ``MAX_DIM`` = 128, so a
+    plain 129-dimension request would never reach the center validator.  To
+    exercise ``require_bounded_center_work`` in isolation, build a valid
+    128-dimension algebra and patch the center operation's own cap to 32:
+    only the center guard can then fire, and deleting it would fail this test.
+    """
+    from pydantic import ValidationError
+
+    from jacobian.math.finite_dim_algebras import _models
+
+    n, q = 128, 251
+    zero_inner = tuple(0 for _ in range(n))
+    mult = tuple(tuple(zero_inner for _ in range(n)) for _ in range(n))
+    struct = StructureConstants(dimension=n, field_order=q, multiplication=mult)
+    monkeypatch_cap = pytest.MonkeyPatch()
+    try:
+        monkeypatch_cap.setattr(_models, "_MAX_DIM_FOR_CENTER", 32)
+        with pytest.raises(ValidationError, match="at most 32 dimensions"):
+            CenterRequest(algebra=struct)
+    finally:
+        monkeypatch_cap.undo()
+
+
+def test_structure_constants_rejects_above_its_own_field_cap() -> None:
+    """The shared structure-constants cap (128) is independent of the center guard."""
     from pydantic import ValidationError
 
     n, q = 129, 251
     with pytest.raises(ValidationError):
-        CenterRequest(
-            algebra=StructureConstants(dimension=n, field_order=q, multiplication=())
-        )
+        StructureConstants(dimension=n, field_order=q, multiplication=())
 
 
 # --- Model validation -----------------------------------------------------

--- a/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
+++ b/tests/math/finite_dim_algebras/test_finite_dim_algebras.py
@@ -133,6 +133,29 @@ def test_moderate_dimension_does_not_enumerate() -> None:
     assert result.center_dimension == n
 
 
+def test_center_admits_derived_dimension_boundary() -> None:
+    """The Theta(n^4) kernel admits up to dimension 128 (measured ~19s)."""
+    from jacobian.math.finite_dim_algebras._models import MAX_DIM
+
+    n, q = 128, 251
+    zero_inner = tuple(0 for _ in range(n))
+    mult = tuple(tuple(zero_inner for _ in range(n)) for _ in range(n))
+    struct = StructureConstants(dimension=n, field_order=q, multiplication=mult)
+    request = CenterRequest(algebra=struct)
+    assert request.algebra.dimension == 128 == MAX_DIM
+
+
+def test_center_rejects_above_derived_dimension_boundary() -> None:
+    """Dimensions above the measured envelope are rejected at admission."""
+    from pydantic import ValidationError
+
+    n, q = 129, 251
+    with pytest.raises(ValidationError):
+        CenterRequest(
+            algebra=StructureConstants(dimension=n, field_order=q, multiplication=())
+        )
+
+
 # --- Model validation -----------------------------------------------------
 
 

--- a/tests/math/number_theory/test_primorial.py
+++ b/tests/math/number_theory/test_primorial.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from jacobian.math.number_theory._models import (
     PositiveIntegerRequest,
+    PrimorialRequest,
     PrimorialResult,
 )
 from jacobian.math.number_theory._prime_operations import compute_primorial
@@ -14,34 +16,48 @@ from jacobian.math.number_theory._primes import PRIME_OPERATIONS
 
 def test_primorial_boundary_113() -> None:
     """n=113 returns exactly 256 digits (the old BoundedInteger limit)."""
-    result = compute_primorial(PositiveIntegerRequest(n=113))
+    result = compute_primorial(PrimorialRequest(n=113))
     assert isinstance(result, PrimorialResult)
     assert len(result.value) == 256
 
 
 def test_primorial_boundary_114() -> None:
     """n=114 returns 259 digits, exceeding the old BoundedInteger limit."""
-    result = compute_primorial(PositiveIntegerRequest(n=114))
+    result = compute_primorial(PrimorialRequest(n=114))
     assert isinstance(result, PrimorialResult)
     assert len(result.value) == 259
 
 
 def test_primorial_maximum_1000() -> None:
     """The maximum accepted n returns a valid declared result."""
-    result = compute_primorial(PositiveIntegerRequest(n=1000))
+    result = compute_primorial(PrimorialRequest(n=1000))
     assert isinstance(result, PrimorialResult)
     assert len(result.value) == 3393
+
+
+def test_primorial_admits_exact_digit_boundary_1001() -> None:
+    """primorial(1001) has 3397 digits and is admitted; 1002 (3401) is not."""
+    result = compute_primorial(PrimorialRequest(n=1001))
+    assert isinstance(result, PrimorialResult)
+    assert len(result.value) == 3397
+    with pytest.raises(ValidationError):
+        PrimorialRequest(n=1002)
+
+
+def test_positive_integer_request_still_covers_other_operations() -> None:
+    """The shared arithmetic-function bound remains at 10,000."""
+    PositiveIntegerRequest(n=10_000)
 
 
 def test_primorial_rejects_above_1000() -> None:
     """n=10001 is rejected by the request model before backend work."""
     with pytest.raises(ValueError):
-        PositiveIntegerRequest(n=10001)
+        PrimorialRequest(n=10001)
 
 
 def test_primorial_5() -> None:
     """Primorial(5) = 2*3*5*7*11 = 2310."""
-    result = compute_primorial(PositiveIntegerRequest(n=5))
+    result = compute_primorial(PrimorialRequest(n=5))
     assert result.value == "2310"
 
 
@@ -51,4 +67,4 @@ def test_primorial_contract_version_tracks_the_result_schema_change() -> None:
         for item in PRIME_OPERATIONS
         if item.operation_id == "integer.compute.primorial"
     )
-    assert operation.version == "3"
+    assert operation.version == "4"

--- a/tests/math/number_theory/test_primorial.py
+++ b/tests/math/number_theory/test_primorial.py
@@ -68,3 +68,17 @@ def test_primorial_contract_version_tracks_the_result_schema_change() -> None:
         if item.operation_id == "integer.compute.primorial"
     )
     assert operation.version == "4"
+
+
+def test_primorial_admission_records_the_v4_result_derived_envelope() -> None:
+    """The materially changed v4 candidate has a fresh owner-local decision."""
+    from jacobian.catalog.admission import AdmissionDecision
+    from jacobian.math.number_theory._admission import ADMISSIONS
+
+    admission = next(
+        item for item in ADMISSIONS if item.operation_id == "integer.compute.primorial"
+    )
+
+    assert admission.decision == AdmissionDecision.KEEP
+    assert "n <= 1001" in admission.rationale
+    assert "3,400-digit result budget" in admission.rationale


### PR DESCRIPTION
Fixes three P1 review findings on #2481 where raised shared caps admitted requests whose actual work/output the kernel cannot complete.

**1. `code_nonlinear` constant-weight binomial guard** (`src/jacobian/math/code_nonlinear/_models.py:39`)

`ConstantWeightRequest` materializes every C(length, weight) word, so admission now derives from the exact binomial output size:

```python
expected_words = comb(self.length, self.weight)
if expected_words > MAX_CONSTANT_WEIGHT_WORDS:  # 4096
    raise ValueError(...)
```

C(64,32) ≈ 1.8e18 rejected before enumeration; C(12,6)=924 admitted. Explicit-code operations keep the 64-coordinate envelope (their work is O(n²·L) on explicit codewords).

**2. `number_theory` primorial-specific request** (`src/jacobian/math/number_theory/_models.py:58`, `_prime_operations.py:46`)

`primorial(n)` carries n(ln n + ln ln n)/ln10 digits; the shared 10,000 bound admitted n=1002 whose result has 3401 digits > the declared 3400-digit `PrimorialResult` budget — construct-then-fail. New dedicated `PrimorialRequest` with `_MAX_PRIMORIAL_N = 1001` (the exact boundary: primorial(1001) = 3397 digits ✓, primorial(1002) = 3401 ✗). Other `PositiveIntegerRequest` operations keep 10,000. Operation version → 4.

**3. `finite_dim_algebras` Θ(n⁴) center bound** (`src/jacobian/math/finite_dim_algebras/_models.py:17`)

Documented that `compute_center` builds n² commutator rows and eliminates with length-n updates = Θ(n⁴), not cubic. Measured on this kernel: n=32 ~0.08s, n=64 ~1.2s, n=96 ~6.1s, **n=128 ~18.8s**. Added `_MAX_DIM_FOR_CENTER = 128` validator so the envelope is derived from measured cost and a faster kernel can re-derive upward.

**Tests:** new boundary tests for all three (binomial reject/admit, primorial 1001/1002 exact boundary, center 128/129). `3598 passed` (math+catalog+dispatch), ruff clean.

Closes the three review threads.