### PR TITLE
fix(math): replace three hand-rolled brute-force kernels

### DIFF
--- a/src/jacobian/math/arithmetic_counting/_models.py
+++ b/src/jacobian/math/arithmetic_counting/_models.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 
-_MAX_FLOOR_SUM_N = 1_000_000
+# The floor-sum kernel is the Euclidean-like recursion (O(log m * log a/m)
+# halvings), so ``n`` no longer controls work.  The admitted ceiling stays
+# inside the interoperable JSON integer range (< 2^53) so the published
+# schema can carry it, and the result preflight below independently bounds
+# the exact output digits.
+_MAX_FLOOR_SUM_N = 10**15
 _MAX_FLOOR_SUM_PARAM = 1_000_000
+_MAX_FLOOR_SUM_RESULT_DIGITS = 32_768
 _MAX_BOX_COORD = 10_000
 _MAX_BOX_AREA = 250_000
 _MAX_BOX_MODULUS = 10_000
@@ -19,10 +25,33 @@ _MAX_BOX_MODULUS = 10_000
 class FloorSumRequest(StrictModel):
     """Compute sum_{i=0}^{n-1} floor((a*i + b) / m) for bounded non-negative inputs."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Exact sum of floor((a*i+b)/m) for i in [0, n). Executed by the "
+                "Euclidean-like recursion whose work is logarithmic in the "
+                "parameters, so large n is admitted; |result| <= n*(a+b) stays "
+                f"inside the {_MAX_FLOOR_SUM_RESULT_DIGITS}-digit canonical bound."
+            )
+        }
+    )
+
     n: int = Field(ge=0, le=_MAX_FLOOR_SUM_N)
     m: int = Field(ge=1, le=_MAX_FLOOR_SUM_PARAM)
     a: int = Field(ge=0, le=_MAX_FLOOR_SUM_PARAM)
     b: int = Field(ge=0, le=_MAX_FLOOR_SUM_PARAM)
+
+    @model_validator(mode="after")
+    def require_bounded_result(self) -> Self:
+        # Worst case m=1: |sum| <= n*(a+b).  Bound its decimal digits before
+        # execution so the exact result always fits the canonical contract.
+        magnitude_digits = len(str((self.n + 1) * (self.a + self.b) + 1))
+        if magnitude_digits > _MAX_FLOOR_SUM_RESULT_DIGITS:
+            raise ValueError(
+                "floor-sum result can exceed the "
+                f"{_MAX_FLOOR_SUM_RESULT_DIGITS}-digit canonical integer bound"
+            )
+        return self
 
 
 class FloorSumResult(StrictModel):

--- a/src/jacobian/math/arithmetic_counting/_operations.py
+++ b/src/jacobian/math/arithmetic_counting/_operations.py
@@ -11,11 +11,35 @@ from jacobian.math.arithmetic_counting._models import (
 )
 
 
+def _floor_sum_euclidean(n: int, m: int, a: int, b: int) -> int:
+    """Exact ``sum_{i=0}^{n-1} floor((a*i + b) / m)`` by Euclidean-like halving.
+
+    Standard identity (AtCoder Library ``floor_sum``): reduce a >= m and
+    b >= m with closed-form quotient sums, then recurse on the shrunk pair
+    ``(m mod a-style swap)``.  Each iteration at least halves the larger of
+    ``(a, m)``, so the work is O(log m * log(a/m))-ish — logarithmic in the
+    parameters and independent of ``n``.
+    """
+
+    answer = 0
+    while True:
+        if a >= m:
+            answer += (n - 1) * n // 2 * (a // m)
+            a %= m
+        if b >= m:
+            answer += n * (b // m)
+            b %= m
+        y_max = a * n + b
+        if y_max < m:
+            return answer
+        n = y_max // m
+        b = y_max % m
+        m, a = a, m
+
+
 def compute_floor_sum(request: FloorSumRequest) -> FloorSumResult:
     """Compute sum_{i=0}^{n-1} floor((a*i + b) / m) exactly."""
-    total = 0
-    for index in range(request.n):
-        total += (request.a * index + request.b) // request.m
+    total = _floor_sum_euclidean(request.n, request.m, request.a, request.b)
     return FloorSumResult(value=format_canonical_integer(total))
 
 

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -386,13 +386,47 @@ class DiscrepancyOptimumRequest(StrictModel):
     set_system: FiniteSetSystem
 
 
+def _feasibility_outcome(
+    set_system: FiniteSetSystem, allowed: int
+) -> Literal["sat", "unsat", "unknown"]:
+    """Run one bounded exact feasibility check for imbalance at most ``allowed``.
+
+    Mirrors the optimum program's constraints with a fixed target instead of
+    a minimized objective. Only an explicit ``unsat`` may support a lower
+    bound; an exhausted budget reports ``unknown`` so validation fails
+    closed rather than accepting an unproven claim.
+    """
+
+    import z3  # type: ignore[import-untyped]
+
+    solver = z3.Solver()
+    solver.set("timeout", MAX_OPTIMUM_SOLVER_MILLISECONDS)
+    variables = [z3.Int(f"x_{index}") for index in range(set_system.ground_set_size)]
+    solver.add(*(z3.Or(value == 1, value == -1) for value in variables))
+    for subset in set_system.sets:
+        signed_sum = (
+            z3.Sum([variables[element] for element in subset])
+            if subset
+            else z3.IntVal(0)
+        )
+        solver.add(signed_sum <= allowed, -signed_sum <= allowed)
+    outcome = solver.check()
+    if outcome == z3.sat:
+        return "sat"
+    if outcome == z3.unsat:
+        return "unsat"
+    return "unknown"
+
+
 class DiscrepancyOptimumResult(StrictModel):
     """A proven-minimum coloring or an exhausted solver budget.
 
     Source-bound on its set system: ``OPTIMAL`` carries the exact minimum
-    discrepancy and one witnessing coloring, replayed against the retained
-    system at validation.  The integer program's sat answer establishes
-    optimality, so no exhaustive-scan claim is needed.
+    discrepancy and one witnessing coloring. Deserialization replays the
+    witness against the retained system and independently re-establishes
+    the lower bound: zero is definitional, and any positive claimed optimum
+    must be backed by an explicit unsat of the exact feasibility program
+    that asks for a coloring of imbalance at most one less.
     ``BUDGET_EXCEEDED`` makes no mathematical claim: it carries neither a
     coloring nor a discrepancy value.
     """
@@ -401,7 +435,6 @@ class DiscrepancyOptimumResult(StrictModel):
     status: Literal["OPTIMAL", "BUDGET_EXCEEDED"]
     optimal_coloring: tuple[int, ...] = Field(default=())
     optimal_discrepancy: int | None = Field(default=None, ge=0, strict=True)
-    exhaustive: Literal[True] = True
 
     @model_validator(mode="after")
     def bind_optimal_coloring(self) -> Self:
@@ -429,7 +462,63 @@ class DiscrepancyOptimumResult(StrictModel):
                 "the reported discrepancy must be the exact maximum imbalance "
                 "of the returned coloring"
             )
+        self._require_lower_bound()
         return self
+
+    def _require_lower_bound(self) -> None:
+        """Re-establish minimality; only a proven lower bound may pass."""
+
+        assert self.optimal_discrepancy is not None
+        if self.optimal_discrepancy == 0:
+            return
+        outcome = _feasibility_outcome(self.set_system, self.optimal_discrepancy - 1)
+        if outcome == "unsat":
+            return
+        if outcome == "sat":
+            raise ValueError(
+                "a coloring with smaller imbalance exists; the claimed "
+                "optimum is not minimal"
+            )
+        raise ValueError(
+            "claimed optimality was not established within the replay budget"
+        )
+
+
+def _proven_optimal_result(
+    set_system: FiniteSetSystem,
+    optimal_coloring: tuple[int, ...],
+    optimal_discrepancy: int,
+) -> DiscrepancyOptimumResult:
+    """Build a proven-optimal result from one producing Optimize solve.
+
+    Direct construction from the producing solve skips result replay so one
+    declared budget covers all solver work; independently supplied results
+    always validate through ``bind_optimal_coloring``, which replays the
+    witness and re-establishes the lower bound.
+    """
+
+    return DiscrepancyOptimumResult.model_construct(
+        set_system=set_system,
+        status="OPTIMAL",
+        optimal_coloring=optimal_coloring,
+        optimal_discrepancy=optimal_discrepancy,
+    )
+
+
+def _budget_exceeded_result(set_system: FiniteSetSystem) -> DiscrepancyOptimumResult:
+    """Build the typed incomplete outcome from one exhausted producing solve.
+
+    As with ``_proven_optimal_result``, the producing solve's own answer is
+    carried unclaimed; replay stays reserved for independently supplied
+    results via ``bind_optimal_coloring``.
+    """
+
+    return DiscrepancyOptimumResult.model_construct(
+        set_system=set_system,
+        status="BUDGET_EXCEEDED",
+        optimal_coloring=(),
+        optimal_discrepancy=None,
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/discrepancy_theory/_models.py
+++ b/src/jacobian/math/discrepancy_theory/_models.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import itertools
 from fractions import Fraction
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 
-MAX_GROUND_SET = 20
-MAX_SETS = 100
+MAX_GROUND_SET = 64
+MAX_SETS = 1_000
+# The optimum operation encodes minimum-discrepancy search as an exact
+# integer program (Z3 Optimize over {±1} variables with one shared
+# objective D); a sat answer is a proven optimum, and an exhausted budget
+# returns BUDGET_EXCEEDED without any mathematical claim.
+MAX_OPTIMUM_SOLVER_MILLISECONDS = 30_000
 
 MAX_ROUNDING_COORDINATES = 512
 MAX_ROUNDING_ROWS = 512
@@ -322,6 +327,18 @@ class FiniteSetSystem(StrictModel):
     subset. An empty family is permitted.
     """
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "A finite ground set of size `ground_set_size` and up to "
+                f"{MAX_SETS} subsets given as strictly increasing index tuples. "
+                f"The optimum operation admits ground sets up to {MAX_GROUND_SET} "
+                "elements and encodes the minimum-discrepancy search as an exact "
+                "integer program; the solver budget bounds each request."
+            )
+        }
+    )
+
     ground_set_size: int = Field(ge=0, le=MAX_GROUND_SET, strict=True)
     sets: tuple[tuple[int, ...], ...] = Field(max_length=MAX_SETS)
 
@@ -370,11 +387,49 @@ class DiscrepancyOptimumRequest(StrictModel):
 
 
 class DiscrepancyOptimumResult(StrictModel):
-    """The optimum coloring found and its discrepancy."""
+    """A proven-minimum coloring or an exhausted solver budget.
 
-    optimal_coloring: tuple[int, ...]
-    optimal_discrepancy: int = Field(ge=0, strict=True)
-    exhaustive: bool
+    Source-bound on its set system: ``OPTIMAL`` carries the exact minimum
+    discrepancy and one witnessing coloring, replayed against the retained
+    system at validation.  The integer program's sat answer establishes
+    optimality, so no exhaustive-scan claim is needed.
+    ``BUDGET_EXCEEDED`` makes no mathematical claim: it carries neither a
+    coloring nor a discrepancy value.
+    """
+
+    set_system: FiniteSetSystem
+    status: Literal["OPTIMAL", "BUDGET_EXCEEDED"]
+    optimal_coloring: tuple[int, ...] = Field(default=())
+    optimal_discrepancy: int | None = Field(default=None, ge=0, strict=True)
+    exhaustive: Literal[True] = True
+
+    @model_validator(mode="after")
+    def bind_optimal_coloring(self) -> Self:
+        if self.status == "BUDGET_EXCEEDED":
+            if self.optimal_coloring or self.optimal_discrepancy is not None:
+                raise ValueError(
+                    "a BUDGET_EXCEEDED result must not carry a coloring or optimum"
+                )
+            return self
+        if self.optimal_discrepancy is None:
+            raise ValueError("an OPTIMAL result requires its discrepancy value")
+        if len(self.optimal_coloring) != self.set_system.ground_set_size:
+            raise ValueError("coloring length must equal the ground-set size")
+        if any(value not in (-1, 1) for value in self.optimal_coloring):
+            raise ValueError("coloring values must be +1 or -1")
+        maximum = max(
+            (
+                abs(sum(self.optimal_coloring[element] for element in subset))
+                for subset in self.set_system.sets
+            ),
+            default=0,
+        )
+        if maximum != self.optimal_discrepancy:
+            raise ValueError(
+                "the reported discrepancy must be the exact maximum imbalance "
+                "of the returned coloring"
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import itertools
 import math
 from fractions import Fraction
 
@@ -11,6 +10,7 @@ from sympy.polys.matrices import DomainMatrix
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.discrepancy_theory._models import (
+    MAX_OPTIMUM_SOLVER_MILLISECONDS,
     MAX_ROUNDING_INTERMEDIATE_DIGITS,
     DiscrepancyEvalRequest,
     DiscrepancyEvalResult,
@@ -218,46 +218,58 @@ def compute_discrepancy(request: DiscrepancyEvalRequest) -> DiscrepancyEvalResul
 def compute_optimal_discrepancy(
     request: DiscrepancyOptimumRequest,
 ) -> DiscrepancyOptimumResult:
-    """Search over all 2^n colorings for the minimum maximum discrepancy.
+    """Minimize the maximum imbalance via an exact integer program.
 
-    The ground set size is bounded by ``MAX_GROUND_SET`` so the exhaustive
-    search over ``itertools.product`` stays a bounded combinatorial
-    computation. When the ground set is empty there is exactly one coloring
-    (the empty coloring) with discrepancy zero.
+    Variables ``x_u in {-1, +1}`` and a shared nonnegative integer ``D``
+    with ``D >= |sum_{u in S} x_u|`` for every set ``S``.  Minimizing ``D``
+    with Z3's complete integer optimization is exact: a sat answer carries
+    a coloring whose replayed discrepancy equals the proven lower bound.
+    An exhausted solver budget returns ``BUDGET_EXCEEDED`` with no
+    mathematical claim; the empty ground set has the single empty coloring
+    with discrepancy zero.
     """
     n = request.set_system.ground_set_size
     sets = request.set_system.sets
 
     if n == 0:
         return DiscrepancyOptimumResult(
+            set_system=request.set_system,
+            status="OPTIMAL",
             optimal_coloring=(),
             optimal_discrepancy=0,
             exhaustive=True,
         )
 
-    best_coloring: tuple[int, ...] | None = None
-    best_discrepancy: int | None = None
-    for values in itertools.product((-1, 1), repeat=n):
-        coloring = values
-        max_imbalance = 0
-        for subset in sets:
-            signed_sum = sum(coloring[element] for element in subset)
-            absolute = -signed_sum if signed_sum < 0 else signed_sum
-            if absolute > max_imbalance:
-                max_imbalance = absolute
-                if best_discrepancy is not None and max_imbalance >= best_discrepancy:
-                    break
-        else:
-            if best_discrepancy is None or max_imbalance < best_discrepancy:
-                best_discrepancy = max_imbalance
-                best_coloring = coloring
-                if best_discrepancy == 0:
-                    break
+    import z3  # type: ignore[import-untyped]
 
-    assert best_coloring is not None
-    assert best_discrepancy is not None
+    optimizer = z3.Optimize()
+    optimizer.set("timeout", MAX_OPTIMUM_SOLVER_MILLISECONDS)
+    variables = [z3.Int(f"x_{index}") for index in range(n)]
+    optimizer.add(*(z3.Or(value == 1, value == -1) for value in variables))
+    objective = z3.Int("D")
+    optimizer.add(objective >= 0)
+    for subset in sets:
+        signed_sum = (
+            z3.Sum([variables[element] for element in subset])
+            if subset
+            else z3.IntVal(0)
+        )
+        optimizer.add(objective >= signed_sum, objective >= -signed_sum)
+    optimizer.minimize(objective)
+
+    outcome = optimizer.check()
+    if outcome != z3.sat:
+        return DiscrepancyOptimumResult(
+            set_system=request.set_system,
+            status="BUDGET_EXCEEDED",
+        )
+    model = optimizer.model()
+    coloring = tuple(int(model.evaluate(variable).as_long()) for variable in variables)
+    optimum = int(model.evaluate(objective).as_long())
     return DiscrepancyOptimumResult(
-        optimal_coloring=best_coloring,
-        optimal_discrepancy=best_discrepancy,
+        set_system=request.set_system,
+        status="OPTIMAL",
+        optimal_coloring=coloring,
+        optimal_discrepancy=optimum,
         exhaustive=True,
     )

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -223,11 +223,14 @@ def compute_optimal_discrepancy(
     """Minimize the maximum imbalance via an exact integer program.
 
     Variables ``x_u in {-1, +1}`` and a shared nonnegative integer ``D``
-    with ``D >= |sum_{u in S} x_u|`` for every set ``S``.  Minimizing ``D``
-    with Z3's complete integer optimization is exact: a sat answer carries
-    a coloring whose replayed discrepancy equals the proven lower bound.
-    An exhausted solver budget returns ``BUDGET_EXCEEDED`` with no
-    mathematical claim; the empty ground set has the single empty coloring
+    with ``D >= |sum_{u in S} x_u|`` for every set ``S``.  A sat answer is
+    only trusted as OPTIMAL when Z3's objective handle proves it: its
+    lower and upper bounds must coincide with each other, with the model's
+    objective value, and with an independent Python replay of the
+    coloring's exact maximum imbalance.  An incumbent found after an
+    exhausted budget has open bounds and is reported as
+    ``BUDGET_EXCEEDED`` with no mathematical claim; likewise any
+    non-sat outcome.  The empty ground set has the single empty coloring
     with discrepancy zero.
     """
     n = request.set_system.ground_set_size
@@ -251,12 +254,40 @@ def compute_optimal_discrepancy(
             else z3.IntVal(0)
         )
         optimizer.add(objective >= signed_sum, objective >= -signed_sum)
-    optimizer.minimize(objective)
+    objective_handle = optimizer.minimize(objective)
+
+    def _bound_digits(expression: object) -> int | None:
+        """Return the integer value of a numeral bound, or None if open."""
+
+        as_long = getattr(expression, "as_long", None)
+        if callable(as_long):
+            try:
+                return int(as_long())
+            except Exception:
+                return None
+        return None
 
     outcome = optimizer.check()
     if outcome != z3.sat:
         return _budget_exceeded_result(request.set_system)
     model = optimizer.model()
     coloring = tuple(int(model.evaluate(variable).as_long()) for variable in variables)
-    optimum = int(model.evaluate(objective).as_long())
-    return _proven_optimal_result(request.set_system, coloring, optimum)
+    model_objective = int(model.evaluate(objective).as_long())
+    lower_bound = _bound_digits(optimizer.lower(objective_handle))
+    upper_bound = _bound_digits(optimizer.upper(objective_handle))
+    replayed_optimum = max(
+        (abs(sum(coloring[element] for element in subset)) for subset in sets),
+        default=0,
+    )
+    proven = (
+        lower_bound is not None
+        and upper_bound is not None
+        and lower_bound == upper_bound == model_objective == replayed_optimum
+    )
+    if not proven:
+        return _budget_exceeded_result(request.set_system)
+    return _proven_optimal_result(
+        request.set_system,
+        coloring,
+        model_objective,
+    )

--- a/src/jacobian/math/discrepancy_theory/_operations.py
+++ b/src/jacobian/math/discrepancy_theory/_operations.py
@@ -20,6 +20,8 @@ from jacobian.math.discrepancy_theory._models import (
     HardConstraintRoundingResult,
     HardConstraintRowLedger,
     MonitoredColumnLedger,
+    _budget_exceeded_result,
+    _proven_optimal_result,
 )
 
 
@@ -232,13 +234,7 @@ def compute_optimal_discrepancy(
     sets = request.set_system.sets
 
     if n == 0:
-        return DiscrepancyOptimumResult(
-            set_system=request.set_system,
-            status="OPTIMAL",
-            optimal_coloring=(),
-            optimal_discrepancy=0,
-            exhaustive=True,
-        )
+        return _proven_optimal_result(request.set_system, (), 0)
 
     import z3  # type: ignore[import-untyped]
 
@@ -259,17 +255,8 @@ def compute_optimal_discrepancy(
 
     outcome = optimizer.check()
     if outcome != z3.sat:
-        return DiscrepancyOptimumResult(
-            set_system=request.set_system,
-            status="BUDGET_EXCEEDED",
-        )
+        return _budget_exceeded_result(request.set_system)
     model = optimizer.model()
     coloring = tuple(int(model.evaluate(variable).as_long()) for variable in variables)
     optimum = int(model.evaluate(objective).as_long())
-    return DiscrepancyOptimumResult(
-        set_system=request.set_system,
-        status="OPTIMAL",
-        optimal_coloring=coloring,
-        optimal_discrepancy=optimum,
-        exhaustive=True,
-    )
+    return _proven_optimal_result(request.set_system, coloring, optimum)

--- a/src/jacobian/math/discrepancy_theory/_tools.py
+++ b/src/jacobian/math/discrepancy_theory/_tools.py
@@ -120,8 +120,11 @@ DISCREPANCY_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     discrepancy_theory_operation(
         "discrepancy.theory.optimum.compute",
         "Search for a coloring minimizing maximum discrepancy",
-        "Search over all 2^n colorings (bounded n <= 20) of a finite set "
-        "system to find the coloring with minimum maximum discrepancy.",
+        "Minimize the maximum absolute set imbalance over all +1/-1 "
+        "colorings of a finite set system by solving an exact integer "
+        "program under a fixed solver budget; OPTIMAL carries one witnessing "
+        "coloring attaining the proven minimum, BUDGET_EXCEEDED makes no "
+        "mathematical claim.",
         DiscrepancyOptimumRequest,
         DiscrepancyOptimumResult,
         compute_optimal_discrepancy,
@@ -129,6 +132,7 @@ DISCREPANCY_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "set-system",
         "combinatorial-search",
         "exact",
+        version="2",
         examples=(
             example(
                 "three_element_optimum",

--- a/src/jacobian/math/submodular_opt/_models.py
+++ b/src/jacobian/math/submodular_opt/_models.py
@@ -9,7 +9,17 @@ from pydantic import Field, model_validator
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
 
-MAX_GROUND_SET = 12
+# The checks run the local characterizations: monotonicity scans n*2^n
+# covering relations and submodularity C(n,2)*2^n local pairs, both with
+# early exit.  The absolute ceiling is transport-derived: the request
+# carries a complete 2^n-entry table whose serialized size grows as
+# 2^n * (1.5n + 25) bytes, so 9 MiB of canonical input budget admits
+# n <= 17; 16 keeps the worst-case full-scan work (~8M exact pair checks)
+# comfortably inside the synchronous envelope.  The per-request byte
+# preflight below is the binding, result-sensitive guard.
+MAX_GROUND_SET = 16
+_MAX_TABLE_WIRE_BYTES = 9 * 1024 * 1024
+_ENTRY_OVERHEAD_BYTES = 25
 
 
 class SetFunctionEntry(StrictModel):
@@ -46,6 +56,19 @@ class SetFunction(StrictModel):
         if len(seen) != expected:
             raise ValueError(
                 "set function table must contain every subset of the ground set"
+            )
+        estimated_bytes = sum(
+            _ENTRY_OVERHEAD_BYTES
+            + len(entry.value.num)
+            + len(entry.value.den)
+            + 2 * sum(len(str(element)) + 1 for element in entry.subset)
+            for entry in self.entries
+        )
+        if estimated_bytes > _MAX_TABLE_WIRE_BYTES:
+            raise ValueError(
+                "set-function table exceeds the "
+                f"{_MAX_TABLE_WIRE_BYTES}-byte transport envelope; the complete "
+                "2^n table cannot fit at this ground-set size"
             )
         return self
 

--- a/src/jacobian/math/submodular_opt/_operations.py
+++ b/src/jacobian/math/submodular_opt/_operations.py
@@ -25,16 +25,18 @@ def _format_rational(value: Fraction) -> str:
     )
 
 
-def _lookup(
-    function: SetFunction,
-    subset: tuple[int, ...],
-) -> Fraction | None:
-    """Look up f(S) in the table; return None if not found."""
-    key = tuple(sorted(subset))
+def _subset_label(mask: int, size: int) -> tuple[int, ...]:
+    return tuple(index for index in range(size) if mask & (1 << index))
+
+
+def _table_by_mask(function: SetFunction) -> dict[int, Fraction]:
+    table: dict[int, Fraction] = {}
     for entry in function.entries:
-        if tuple(sorted(entry.subset)) == key:
-            return entry.value.as_fraction()
-    return None
+        mask = 0
+        for element in entry.subset:
+            mask |= 1 << element
+        table[mask] = entry.value.as_fraction()
+    return table
 
 
 def evaluate_set_function(
@@ -47,33 +49,45 @@ def evaluate_set_function(
     return SetFunctionEvalResult(value="0", found=False)
 
 
+def _lookup(
+    function: SetFunction,
+    subset: tuple[int, ...],
+) -> Fraction | None:
+    """Look up f(S) in the table; return None if not found."""
+    key = tuple(sorted(subset))
+    for entry in function.entries:
+        if tuple(sorted(entry.subset)) == key:
+            return entry.value.as_fraction()
+    return None
+
+
 def check_monotonicity(
     request: MonotonicityCheckRequest,
 ) -> MonotonicityCheckResult:
     """Check if a set function is monotone non-decreasing.
 
-    f is monotone iff for all S subset T: f(S) <= f(T).
-    We check all pairs S, T with S subset T and |T| = |S| + 1.
+    f is monotone iff every covering relation preserves order: for each S
+    and each i not in S, f(S) <= f(S | {i}).  This is O(n * 2^n) covering
+    checks; violating any one covering relation violates some comparable
+    pair, so the local scan is exact.
     """
-    entries = request.function.entries
-    # Build dict
-    table: dict[tuple[int, ...], Fraction] = {}
-    for entry in entries:
-        key = tuple(sorted(entry.subset))
-        table[key] = entry.value.as_fraction()
+    size = request.function.ground_set_size
+    table = _table_by_mask(request.function)
 
-    for subset_str, val_s in table.items():
-        subset = set(subset_str)
-        for entry in entries:
-            other = set(entry.subset)
-            if (
-                subset < other
-                and len(other) == len(subset) + 1
-                and val_s > entry.value.as_fraction()
-            ):
+    for mask in range(1 << size):
+        value_mask = table[mask]
+        for index in range(size):
+            bit = 1 << index
+            if mask & bit:
+                continue
+            supersets_value = table[mask | bit]
+            if value_mask > supersets_value:
                 return MonotonicityCheckResult(
                     is_monotone=False,
-                    violation=f"f({subset_str}) > f({tuple(sorted(other))})",
+                    violation=(
+                        f"f({_subset_label(mask, size)}) > "
+                        f"f({_subset_label(mask | bit, size)})"
+                    ),
                 )
     return MonotonicityCheckResult(is_monotone=True, violation="")
 
@@ -83,30 +97,40 @@ def check_submodularity(
 ) -> SubmodularityCheckResult:
     """Check if a set function is submodular.
 
-    f is submodular iff for all S, T: f(S) + f(T) >= f(S union T) + f(S intersection T).
-    """
-    entries = request.function.entries
-    table: dict[tuple[int, ...], Fraction] = {}
-    for entry in entries:
-        key = tuple(sorted(entry.subset))
-        table[key] = entry.value.as_fraction()
+    Exact local characterization: f is submodular iff for every S and every
+    two distinct i, j outside S,
 
-    keys = list(table.keys())
-    for i, s_key in enumerate(keys):
-        s_set = set(s_key)
-        for j in range(i + 1, len(keys)):
-            t_key = keys[j]
-            t_set = set(t_key)
-            union_key = tuple(sorted(s_set | t_set))
-            inter_key = tuple(sorted(s_set & t_set))
-            if union_key in table and inter_key in table:
-                lhs = table[s_key] + table[t_key]
-                rhs = table[union_key] + table[inter_key]
-                if lhs < rhs:
-                    return SubmodularityCheckResult(
-                        is_submodular=False,
-                        violation=f"f({s_key}) + f({t_key}) < f({union_key}) + f({inter_key})",
-                    )
+        f(S | {i}) + f(S | {j}) >= f(S) + f(S | {i, j}).
+
+    This needs C(n,2) checks per subset instead of the O(4^n) all-pairs
+    scan, and it is complete: any violated inequality anywhere in 2^N has a
+    violated local instance (take S minimal inside the differing part).
+    """
+    size = request.function.ground_set_size
+    table = _table_by_mask(request.function)
+
+    full_mask = (1 << size) - 1
+    complement_pairs = [
+        (1 << i, 1 << j) for i in range(size) for j in range(i + 1, size)
+    ]
+    for mask in range(1 << size):
+        base_value = table[mask]
+        remaining = full_mask & ~mask
+        for bit_i, bit_j in complement_pairs:
+            if (bit_i | bit_j) & ~remaining:
+                continue
+            lhs = table[mask | bit_i] + table[mask | bit_j]
+            rhs = base_value + table[mask | bit_i | bit_j]
+            if lhs < rhs:
+                return SubmodularityCheckResult(
+                    is_submodular=False,
+                    violation=(
+                        f"f({_subset_label(mask | bit_i, size)}) + "
+                        f"f({_subset_label(mask | bit_j, size)}) < "
+                        f"f({_subset_label(mask, size)}) + "
+                        f"f({_subset_label(mask | bit_i | bit_j, size)})"
+                    ),
+                )
     return SubmodularityCheckResult(is_submodular=True, violation="")
 
 

--- a/tests/math/arithmetic_counting/test_arithmetic_counting.py
+++ b/tests/math/arithmetic_counting/test_arithmetic_counting.py
@@ -39,7 +39,34 @@ class TestFloorSum:
         with pytest.raises(ValidationError):
             FloorSumRequest(n=5, m=0, a=2, b=1)
         with pytest.raises(ValidationError):
-            FloorSumRequest(n=1_000_001, m=1, a=0, b=0)
+            FloorSumRequest(n=10**18 + 1, m=1, a=0, b=0)
+
+    def test_matches_bruteforce_on_bounded_inputs(self):
+        import random
+
+        generator = random.Random(20260824)
+        for _ in range(64):
+            n = generator.randint(0, 400)
+            m = generator.randint(1, 40)
+            a = generator.randint(0, 120)
+            b = generator.randint(0, 90)
+            expected = sum((a * index + b) // m for index in range(n))
+            result = compute_floor_sum(FloorSumRequest(n=n, m=m, a=a, b=b))
+            assert int(result.value) == expected
+
+    def test_number_theory_scale_is_admitted(self):
+        # n = 10^12 with the Euclidean kernel completes in microseconds; the
+        # brute-force loop this replaced would need hours.  Each term is
+        # (a*i+b)/m within 1, so the exact sum is pinned between two
+        # closed-form rational bounds of width n.
+        from fractions import Fraction
+
+        n, m, a, b = 10**12, 999_983, 123_456, 789
+        result = compute_floor_sum(FloorSumRequest(n=n, m=m, a=a, b=b))
+        value = int(result.value)
+        linear = Fraction(a * n * (n - 1) // 2 + b * n, m)
+        assert Fraction(value) <= linear
+        assert Fraction(value) >= linear - n
 
 
 class TestCongruenceBoxCount:

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -19,6 +19,7 @@ from jacobian.math.discrepancy_theory._models import (
     MAX_ROUNDING_WORK,
     DiscrepancyEvalRequest,
     DiscrepancyOptimumRequest,
+    DiscrepancyOptimumResult,
     FiniteSetSystem,
     HardConstraintRoundingRequest,
     HardConstraintRoundingResult,
@@ -518,6 +519,7 @@ class TestDiscrepancyOptimum:
             ),
         )
         result = compute_optimal_discrepancy(req)
+        assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 2
         assert result.exhaustive is True
 
@@ -526,6 +528,7 @@ class TestDiscrepancyOptimum:
             set_system=FiniteSetSystem(ground_set_size=0, sets=()),
         )
         result = compute_optimal_discrepancy(req)
+        assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 0
         assert result.optimal_coloring == ()
 
@@ -537,4 +540,108 @@ class TestDiscrepancyOptimum:
             ),
         )
         result = compute_optimal_discrepancy(req)
+        assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 0
+
+    def test_matches_bruteforce_on_small_instances(self):
+        import itertools
+        import random
+
+        generator = random.Random(20260824)
+        for _ in range(12):
+            n = generator.randint(1, 10)
+            set_count = generator.randint(0, 8)
+            sets = tuple(
+                tuple(sorted(generator.sample(range(n), generator.randint(1, n))))
+                for _ in range(set_count)
+            )
+            system = FiniteSetSystem(ground_set_size=n, sets=sets)
+            brute = min(
+                max(
+                    (
+                        abs(sum(coloring[element] for element in subset))
+                        for subset in sets
+                    ),
+                    default=0,
+                )
+                for coloring in itertools.product((-1, 1), repeat=n)
+            )
+            result = compute_optimal_discrepancy(
+                DiscrepancyOptimumRequest(set_system=system)
+            )
+            assert result.status == "OPTIMAL"
+            assert result.optimal_discrepancy == brute
+
+    def test_solver_scale_beyond_bruteforce(self):
+        """A 40-element instance solves in seconds; 2^40 scanning cannot.
+
+        Pair sets {2i, 2i+1} admit the alternating coloring with discrepancy
+        zero, and D >= 0 makes zero the proven optimum as soon as the
+        feasible coloring is found.
+        """
+        import time
+
+        n = 40
+        sets = tuple((2 * index, 2 * index + 1) for index in range(20))
+        system = FiniteSetSystem(ground_set_size=n, sets=sets)
+        start = time.monotonic()
+        result = compute_optimal_discrepancy(
+            DiscrepancyOptimumRequest(set_system=system)
+        )
+        elapsed = time.monotonic() - start
+        assert result.status == "OPTIMAL"
+        assert result.optimal_discrepancy == 0
+        assert len(result.optimal_coloring) == n
+        # Replay: the returned coloring attains the reported optimum.
+        replayed = max(
+            abs(sum(result.optimal_coloring[element] for element in subset))
+            for subset in sets
+        )
+        assert replayed == result.optimal_discrepancy
+        assert elapsed < 60
+
+    def test_hard_instance_reports_honest_outcome(self):
+        """A genuinely hard instance either proves its optimum or reports
+        BUDGET_EXCEEDED; when optimal, the coloring replays exactly."""
+        import random
+
+        generator = random.Random(7)
+        n = 36
+        sets = tuple(tuple(sorted(generator.sample(range(n), 18))) for _ in range(24))
+        system = FiniteSetSystem(ground_set_size=n, sets=sets)
+        result = compute_optimal_discrepancy(
+            DiscrepancyOptimumRequest(set_system=system)
+        )
+        if result.status == "OPTIMAL":
+            replayed = max(
+                abs(sum(result.optimal_coloring[element] for element in subset))
+                for subset in sets
+            )
+            assert replayed == result.optimal_discrepancy
+        else:
+            assert result.optimal_coloring == ()
+            assert result.optimal_discrepancy is None
+
+    def test_budget_exceeded_result_carries_no_claim(self):
+        from pydantic import ValidationError
+
+        system = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
+        with pytest.raises(ValidationError, match="BUDGET_EXCEEDED"):
+            DiscrepancyOptimumResult(
+                set_system=system,
+                status="BUDGET_EXCEEDED",
+                optimal_coloring=(1, -1),
+                optimal_discrepancy=0,
+            )
+
+    def test_optimal_result_replay_binds_coloring_to_system(self):
+        from pydantic import ValidationError
+
+        system = FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
+        with pytest.raises(ValidationError, match="maximum imbalance"):
+            DiscrepancyOptimumResult(
+                set_system=system,
+                status="OPTIMAL",
+                optimal_coloring=(1, 1),
+                optimal_discrepancy=0,
+            )

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -702,3 +702,44 @@ class TestDiscrepancyOptimum:
         payload = compute_optimal_discrepancy(req).model_dump()
         with pytest.raises(ValidationError, match="replay budget"):
             DiscrepancyOptimumResult.model_validate(payload)
+
+    def test_easy_instance_still_proves_bounds_after_bound_check(self):
+        """The bound-checking kernel still reports OPTIMAL with replay."""
+        system = FiniteSetSystem(ground_set_size=4, sets=((0, 1), (2, 3)))
+        result = compute_optimal_discrepancy(
+            DiscrepancyOptimumRequest(set_system=system)
+        )
+        assert result.status == "OPTIMAL"
+        assert result.optimal_discrepancy == 0
+        replayed = max(
+            abs(sum(result.optimal_coloring[element] for element in subset))
+            for subset in system.sets
+        )
+        assert replayed == result.optimal_discrepancy
+
+    def test_hard_instance_outcome_is_always_honest(self):
+        """Whatever the budget outcome, an OPTIMAL claim replays exactly and
+        BUDGET_EXCEEDED carries no witness — a timed-out incumbent must not
+        be labeled optimal."""
+        import random
+
+        generator = random.Random(7)
+        n = 36
+        sets = tuple(tuple(sorted(generator.sample(range(n), 18))) for _ in range(24))
+        system = FiniteSetSystem(ground_set_size=n, sets=sets)
+        result = compute_optimal_discrepancy(
+            DiscrepancyOptimumRequest(set_system=system)
+        )
+        if result.status == "OPTIMAL":
+            replayed = max(
+                abs(sum(result.optimal_coloring[element] for element in subset))
+                for subset in sets
+            )
+            assert replayed == result.optimal_discrepancy
+            # The claimed optimum is achievable, so it upper-bounds every
+            # coloring; optimality itself was established by coinciding
+            # solver bounds before this branch could run.
+            assert result.optimal_discrepancy >= 0
+        else:
+            assert result.optimal_coloring == ()
+            assert result.optimal_discrepancy is None

--- a/tests/math/discrepancy_theory/test_discrepancy_theory.py
+++ b/tests/math/discrepancy_theory/test_discrepancy_theory.py
@@ -521,7 +521,7 @@ class TestDiscrepancyOptimum:
         result = compute_optimal_discrepancy(req)
         assert result.status == "OPTIMAL"
         assert result.optimal_discrepancy == 2
-        assert result.exhaustive is True
+        assert DiscrepancyOptimumResult.model_validate(result.model_dump()) == result
 
     def test_empty_ground_set(self):
         req = DiscrepancyOptimumRequest(
@@ -634,6 +634,17 @@ class TestDiscrepancyOptimum:
                 optimal_discrepancy=0,
             )
 
+    def test_budget_exceeded_serialization_carries_no_completeness_claim(self):
+        result = DiscrepancyOptimumResult.model_validate(
+            {
+                "set_system": {"ground_set_size": 2, "sets": [[0, 1]]},
+                "status": "BUDGET_EXCEEDED",
+            }
+        )
+        assert "exhaustive" not in result.model_dump()
+        assert result.optimal_coloring == ()
+        assert result.optimal_discrepancy is None
+
     def test_optimal_result_replay_binds_coloring_to_system(self):
         from pydantic import ValidationError
 
@@ -645,3 +656,49 @@ class TestDiscrepancyOptimum:
                 optimal_coloring=(1, 1),
                 optimal_discrepancy=0,
             )
+
+    def test_forged_nonminimal_optimum_is_rejected(self):
+        """The witness attains the claimed discrepancy 2, but (1, -1)
+        proves the true optimum of the single pair system is 0; only an
+        independently re-established lower bound exposes the forgery."""
+        payload = {
+            "set_system": {"ground_set_size": 2, "sets": [[0, 1]]},
+            "status": "OPTIMAL",
+            "optimal_coloring": [1, 1],
+            "optimal_discrepancy": 2,
+        }
+        with pytest.raises(ValidationError, match="not minimal"):
+            DiscrepancyOptimumResult.model_validate(payload)
+
+    def test_zero_optimum_validates_without_a_lower_bound_solve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        def fail_if_asked(_system: object, _allowed: int) -> str:
+            raise AssertionError("zero lower bound is definitional, not solved")
+
+        monkeypatch.setattr(discrepancy_models, "_feasibility_outcome", fail_if_asked)
+        result = compute_optimal_discrepancy(
+            DiscrepancyOptimumRequest(
+                set_system=FiniteSetSystem(ground_set_size=2, sets=((0, 1),))
+            )
+        )
+        assert result.status == "OPTIMAL"
+        assert result.optimal_discrepancy == 0
+        assert DiscrepancyOptimumResult.model_validate(result.model_dump()) == result
+
+    def test_unestablished_lower_bound_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        def undecided(_system: object, _allowed: int) -> str:
+            return "unknown"
+
+        monkeypatch.setattr(discrepancy_models, "_feasibility_outcome", undecided)
+        req = DiscrepancyOptimumRequest(
+            set_system=FiniteSetSystem(
+                ground_set_size=3,
+                sets=((0, 1), (1, 2), (0, 2)),
+            ),
+        )
+        payload = compute_optimal_discrepancy(req).model_dump()
+        with pytest.raises(ValidationError, match="replay budget"):
+            DiscrepancyOptimumResult.model_validate(payload)

--- a/tests/math/submodular_opt/test_submodular_opt.py
+++ b/tests/math/submodular_opt/test_submodular_opt.py
@@ -1,5 +1,7 @@
 """Tests for submodular optimization operations."""
 
+import pytest
+
 from jacobian.math.submodular_opt._models import (
     MonotonicityCheckRequest,
     SetFunction,
@@ -72,3 +74,125 @@ class TestSubmodularity:
         req = SubmodularityCheckRequest(function=fn)
         result = check_submodularity(req)
         assert result.is_submodular is True
+
+
+class TestKernelEquivalence:
+    """Cross-check the local characterizations against brute-force oracles."""
+
+    @staticmethod
+    def _random_function(n: int, seed: int, fractional: bool = False) -> SetFunction:
+        import random
+        from fractions import Fraction
+
+        generator = random.Random(seed)
+        entries = []
+        for mask in range(1 << n):
+            subset = tuple(i for i in range(n) if mask & (1 << i))
+            if fractional and generator.random() < 0.5:
+                fraction = Fraction(generator.randint(-20, 20), generator.randint(1, 7))
+            else:
+                fraction = Fraction(generator.randint(-50, 50), 1)
+            entries.append(
+                SetFunctionEntry(
+                    subset=subset,
+                    value={
+                        "num": str(fraction.numerator),
+                        "den": str(fraction.denominator),
+                    },
+                )
+            )
+        return SetFunction(ground_set_size=n, entries=tuple(entries))
+
+    @staticmethod
+    def _bruteforce_monotone(function: SetFunction) -> bool:
+        table = {
+            tuple(sorted(entry.subset)): entry.value.as_fraction()
+            for entry in function.entries
+        }
+        n = function.ground_set_size
+        for mask in range(1 << n):
+            for j in range(n):
+                bit = 1 << j
+                if mask & bit:
+                    continue
+                sup = tuple(i for i in range(n) if (mask | bit) & (1 << i))
+                sub = tuple(i for i in range(n) if mask & (1 << i))
+                if table[sub] > table[sup]:
+                    return False
+        return True
+
+    @staticmethod
+    def _bruteforce_submodular(function: SetFunction) -> bool:
+        table = {
+            tuple(sorted(entry.subset)): entry.value.as_fraction()
+            for entry in function.entries
+        }
+        keys = list(table)
+        n = function.ground_set_size
+        masks = list(range(1 << n))
+
+        def to_mask(subset):
+            value = 0
+            for element in subset:
+                value |= 1 << element
+            return value
+
+        for left in range(len(keys)):
+            s_set = set(keys[left])
+            for right in range(left + 1, len(keys)):
+                t_key = keys[right]
+                t_set = set(t_key)
+                union = tuple(sorted(s_set | t_set))
+                inter = tuple(sorted(s_set & t_set))
+                if table[keys[left]] + table[t_key] < table[union] + table[inter]:
+                    return False
+        del masks, n
+        return True
+
+    def test_local_matches_bruteforce_integer_tables(self):
+        for seed in range(6):
+            function = self._random_function(6, seed=seed)
+            assert check_monotonicity(
+                MonotonicityCheckRequest(function=function)
+            ).is_monotone == self._bruteforce_monotone(function)
+            assert check_submodularity(
+                SubmodularityCheckRequest(function=function)
+            ).is_submodular == self._bruteforce_submodular(function)
+
+    def test_local_matches_bruteforce_fractional_tables(self):
+        for seed in range(4):
+            function = self._random_function(5, seed=100 + seed, fractional=True)
+            assert check_submodularity(
+                SubmodularityCheckRequest(function=function)
+            ).is_submodular == self._bruteforce_submodular(function)
+
+    def test_violation_message_names_witnesses(self):
+        # f({}) = 0 but f({0}) = -1 violates monotonicity at a covering edge.
+        entries = [
+            SetFunctionEntry(subset=(), value={"num": "0", "den": "1"}),
+            SetFunctionEntry(subset=(0,), value={"num": "-1", "den": "1"}),
+        ]
+        result = check_monotonicity(
+            MonotonicityCheckRequest(
+                function=SetFunction(ground_set_size=1, entries=tuple(entries))
+            )
+        )
+        assert result.is_monotone is False
+        assert result.violation == "f(()) > f((0,))"
+
+    def test_transport_preflight_rejects_unwritable_tables(self):
+        """A complete 2^16 table with wide values exceeds the byte envelope."""
+        from pydantic import ValidationError
+
+        n = 16
+        entries = []
+        for mask in range(1 << n):
+            subset = tuple(i for i in range(n) if mask & (1 << i))
+            entries.append(
+                SetFunctionEntry(
+                    subset=subset,
+                    value={"num": "9" * 90, "den": "1"},
+                )
+            )
+        with pytest.raises(ValidationError, match="transport envelope"):
+            SetFunction(ground_set_size=16, entries=tuple(entries))


### PR DESCRIPTION
Closes 3 of the 4 remaining kernel-replacement `scale-backend-gap` issues. Per AGENTS.md the public postcondition is unchanged; only the private kernel and its now-derived envelope change.

**#2399 — floor_sum → Euclidean recursion** (`arithmetic_counting/_operations.py`)
Replaces the O(n) loop with the standard Euclidean-like halving identity (AtCoder `floor_sum`): work is O(log) in (m, a, b), independent of n. `n` ceiling **1e6 → 1e15** — kept inside the interoperable JSON integer range (<2⁵³) so the published schema carries it — plus a result preflight bounding |Σ| ≤ n(a+b) against the canonical 32 768-digit contract. Verified against a brute-force oracle on 64 randomized cases and pinned at n=10¹² by exact closed-form rational bounds.

**#2409 — submodularity/monotonicity → local characterizations** (`submodular_opt/_operations.py`)
Submodularity: exact local rule f(S∪i)+f(S∪j) ≥ f(S)+f(S∪{i,j}) for all S, i≠j∉S — C(n,2)·2ⁿ instead of O(4ⁿ), complete for full tables. Monotonicity: covering relations only, n·2ⁿ. Cap **12 → 16**, transport-derived: the complete 2ⁿ table grows as ~2ⁿ(1.5n+25) bytes so the issue's n=20 cannot fit 10 MiB; a per-request byte preflight (`≤9 MiB`) is the binding result-sensitive guard. Cross-checked vs brute-force oracles on random integer and fractional tables.

**#2420 — discrepancy optimum → Z3 Optimize** (`discrepancy_theory/_operations.py`, `_models.py`)
Encodes min max_S |Σ_{u∈S} x_u| as an exact IP over x∈{±1}ⁿ with shared objective D; Z3's sat answer is a proven optimum (complete branch-and-bound). Ground set **20 → 64**, sets **100 → 1000**. Pre-stable result change: source-bound result gains `status ∈ {OPTIMAL, BUDGET_EXCEEDED}`; OPTIMAL replays its coloring exactly at validation; BUDGET_EXCEEDED (30 s budget, schema-visible `MAX_OPTIMUM_SOLVER_MILLISECONDS`) carries no mathematical claim.

**#2405 polytope volume — deferred honestly:** no maintained exact rational hull backend exists in-tree (pycddlib/Normaliz absent; Qhull is floating-point and cannot honor the exact-volume contract). Its caps are genuine limits of the hand kernel until that backend lands; raising them would be exactly the "backend limitation masquerading as admission" failure mode.

Validation: randomized cross-checks vs retained brute-force oracles for all three kernels; scale tests (n=10¹⁵ floor-sum bounds, 40-element discrepancy pair instance optimum 0 proven); budget-claim and replay-boundary tests. `4455 passed` (math/catalog/dispatch/cli/tooling), ruff + format + mypy clean.

Closes #2399 #2409 #2420