### PR TITLE
feat(npm): install a thin Jacobian skill with MCP setup

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -37,8 +37,9 @@ npx jacobian@latest setup
 ```
 
 Choose detected agents and review the changes before they are written. Setup
-writes only a `jacobian` MCP entry for selected agents; existing unowned
-entries are protected unless you explicitly pass `--force`.
+writes a `jacobian` MCP entry and installs the `jacobian-math` skill for each
+selected agent. Existing unowned MCP entries and skills are protected unless
+you explicitly pass `--force`.
 
 The generated launcher pins the Jacobian version that ran setup. Setup itself
 does not install or upgrade Node.js, `uv`, Python, or an agent.

--- a/npm/carrier.test.mjs
+++ b/npm/carrier.test.mjs
@@ -214,6 +214,9 @@ test("setup dry-run emits a pinned, non-mutating Codex plan", async () => {
     await assert.rejects(readFile(join(env.HOME, ".codex", "config.toml")), {
       code: "ENOENT",
     });
+    await assert.rejects(readFile(join(env.HOME, ".agents", "skills", "jacobian-math", "SKILL.md")), {
+      code: "ENOENT",
+    });
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -265,10 +268,25 @@ test("setup configures every supported client and preserves unrelated configurat
       cwd: ".",
       enabled: true,
     });
+    const universalSkill = await readFile(
+      join(env.HOME, ".agents", "skills", "jacobian-math", "SKILL.md"),
+      "utf8",
+    );
+    assert.match(universalSkill, /^---\nname: jacobian-math\n/);
+    assert.match(universalSkill, /<!-- Managed by Jacobian setup\. -->/);
+    for (const relative of [
+      ".claude/skills/jacobian-math/SKILL.md",
+      ".cursor/skills/jacobian-math/SKILL.md",
+      ".gemini/skills/jacobian-math/SKILL.md",
+      ".agent/skills/jacobian-math/SKILL.md",
+    ]) {
+      assert.equal(await readFile(join(env.HOME, relative), "utf8"), universalSkill);
+    }
 
     const repeat = runCarrier(["setup", "--codex", "--dry-run", "--json"], env);
     assert.equal(repeat.status, 0, repeat.stderr);
     assert.equal(JSON.parse(repeat.stdout).clients[0].action, "already current");
+    assert.equal(JSON.parse(repeat.stdout).clients[0].skill_action, "already current");
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -289,6 +307,23 @@ test("setup protects an unmanaged Jacobian registration", async () => {
     assert.equal(result.status, 1);
     assert.match(result.stderr, /refusing to replace an unmanaged Jacobian entry/);
     assert.equal(await readFile(configPath, "utf8"), original);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("setup protects an unmanaged Jacobian skill", async () => {
+  const base = await mkdtemp(join(tmpdir(), "jacobian-carrier-setup-skill-conflict-"));
+  try {
+    const env = await setupEnvironment(base);
+    const skillPath = join(env.HOME, ".agents", "skills", "jacobian-math", "SKILL.md");
+    await mkdir(dirname(skillPath), { recursive: true });
+    await writeFile(skillPath, "user-owned skill\n", "utf8");
+
+    const result = runCarrier(["setup", "--codex", "--dry-run", "--json"], env);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /refusing to replace an unmanaged Jacobian skill/);
+    assert.equal(await readFile(skillPath, "utf8"), "user-owned skill\n");
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -335,7 +370,7 @@ test("package metadata carries setup dependencies and packs the setup adapter", 
     "jsonc-parser": "^3.3.1",
   });
   assert.equal(packageMetadata.bundleDependencies, undefined);
-  assert.deepEqual(packageMetadata.files, ["bin", "lib", "README.md"]);
+  assert.deepEqual(packageMetadata.files, ["bin", "lib", "skill", "README.md"]);
   assert.deepEqual(Object.keys(packageMetadata.bin), ["jacobian"]);
 
   const base = await mkdtemp(join(tmpdir(), "jacobian-carrier-pack-"));
@@ -358,6 +393,7 @@ test("package metadata carries setup dependencies and packs the setup adapter", 
     const entries = JSON.parse(list.stdout)[0].files.map((file) => file.path);
     assert.ok(entries.includes("bin/jacobian.cjs"));
     assert.ok(entries.includes("lib/setup.cjs"));
+    assert.ok(entries.includes("skill/jacobian-math/SKILL.md"));
     assert.ok(entries.includes("README.md"));
     assert.ok(!entries.some((path) => path.startsWith("install.sh")));
     assert.ok(tarball.length > 0);

--- a/npm/lib/setup.cjs
+++ b/npm/lib/setup.cjs
@@ -12,6 +12,9 @@ const { applyEdits, modify, parse, printParseErrorCode } = require("jsonc-parser
 const SERVER_NAME = "jacobian";
 const MANAGED_SETUP_ARGUMENT = "--managed-by-setup";
 const TOML_MARKER = "# Managed by Jacobian setup.";
+const SKILL_MARKER = "<!-- Managed by Jacobian setup. -->";
+const SKILL_NAME = "jacobian-math";
+const BUNDLED_SKILL_PATH = path.join(__dirname, "..", "skill", SKILL_NAME, "SKILL.md");
 const MAX_CONFIG_BYTES = 8 * 1024 * 1024;
 
 const CLIENTS = [
@@ -21,6 +24,7 @@ const CLIENTS = [
     kind: "json",
     section: "mcpServers",
     paths: [".claude.json"],
+    skillPath: ".claude/skills/jacobian-math/SKILL.md",
     detected: (home) => [".claude", ".claude.json"].some((entry) => exists(path.join(home, entry))),
   },
   {
@@ -34,6 +38,7 @@ const CLIENTS = [
       ".config/opencode/.opencode.json",
       ".config/opencode/.opencode.jsonc",
     ],
+    skillPath: ".agents/skills/jacobian-math/SKILL.md",
     detected: (home) => exists(path.join(home, ".config/opencode")),
   },
   {
@@ -41,6 +46,7 @@ const CLIENTS = [
     displayName: "Codex",
     kind: "toml",
     paths: [".codex/config.toml"],
+    skillPath: ".agents/skills/jacobian-math/SKILL.md",
     detected: (home) => exists(path.join(home, ".codex")),
   },
   {
@@ -49,6 +55,7 @@ const CLIENTS = [
     kind: "json",
     section: "mcpServers",
     paths: [".cursor/mcp.json"],
+    skillPath: ".cursor/skills/jacobian-math/SKILL.md",
     detected: (home) => exists(path.join(home, ".cursor")),
   },
   {
@@ -57,6 +64,7 @@ const CLIENTS = [
     kind: "json",
     section: "mcpServers",
     paths: [".gemini/settings.json"],
+    skillPath: ".gemini/skills/jacobian-math/SKILL.md",
     detected: (home) => exists(path.join(home, ".gemini")),
   },
   {
@@ -65,6 +73,7 @@ const CLIENTS = [
     kind: "json",
     section: "mcpServers",
     paths: [".gemini/config/mcp_config.json"],
+    skillPath: ".agent/skills/jacobian-math/SKILL.md",
     detected: (home) =>
       [".gemini/antigravity", ".agent"].some((entry) => exists(path.join(home, entry))),
   },
@@ -96,9 +105,9 @@ Options:
   --json                 Emit the resolved report as JSON (requires explicit selection).
   -h, --help             Show this help.
 
-Setup never installs Node.js, uv, Python, or an MCP client. It writes only the
-selected client configuration entries, which launch the exact npm version that
-performed setup.\n`;
+Setup never installs Node.js, uv, Python, or an MCP client. It writes the
+selected client configuration entries and the Jacobian skill, both from the
+exact npm version that performed setup.\n`;
 }
 
 function parseArgs(args) {
@@ -312,6 +321,8 @@ async function buildPlan(clientIds, home, version, force) {
   const detected = detectClients(home);
   const runtime = launcher(version);
   const plan = [];
+  const skillSource = await fs.readFile(BUNDLED_SKILL_PATH, "utf8");
+  const skillPlans = new Map();
   for (const clientId of clientIds) {
     const client = CLIENTS.find((candidate) => candidate.id === clientId);
     const filePath = choosePath(client, home);
@@ -320,12 +331,30 @@ async function buildPlan(clientIds, home, version, force) {
       client.kind === "toml"
         ? planTomlEdit(filePath, original, runtime, force)
         : planJsonEdit(client, filePath, original, runtime, force);
+    const skillPath = path.join(home, client.skillPath);
+    let skill = skillPlans.get(skillPath);
+    if (!skill) {
+      const skillOriginal = await readOptional(skillPath);
+      if (skillOriginal !== null && !skillOriginal.includes(SKILL_MARKER) && !force) {
+        throw new SetupError(
+          `refusing to replace an unmanaged Jacobian skill at ${skillPath}; review it, then retry with --force`,
+        );
+      }
+      skill = {
+        path: skillPath,
+        original: skillOriginal,
+        updated: skillOriginal === skillSource ? null : skillSource,
+        action: skillOriginal === skillSource ? "already current" : skillOriginal === null ? "create" : "update",
+      };
+      skillPlans.set(skillPath, skill);
+    }
     plan.push({
       client,
       path: filePath,
       original,
       ...change,
       detected: detected.has(client.id),
+      skill,
     });
   }
   return { plan, runtime, detected };
@@ -350,8 +379,17 @@ async function restore(filePath, original) {
 
 async function applyPlan(plan) {
   const applied = [];
+  const changes = [];
+  const seenPaths = new Set();
+  for (const entry of plan) {
+    for (const change of [entry, entry.skill]) {
+      if (seenPaths.has(change.path)) continue;
+      seenPaths.add(change.path);
+      changes.push(change);
+    }
+  }
   try {
-    for (const entry of plan) {
+    for (const entry of changes) {
       if (entry.updated === null) continue;
       const current = await readOptional(entry.path);
       if (current !== entry.original) {
@@ -374,7 +412,7 @@ async function applyPlan(plan) {
     }
     throw error;
   }
-  for (const entry of plan) {
+  for (const entry of changes) {
     if (entry.updated !== null && (await readOptional(entry.path)) !== entry.updated) {
       throw new SetupError(`could not verify configuration after write: ${entry.path}`);
     }
@@ -390,7 +428,9 @@ function renderPreflight(plan, runtime, force) {
   lines.push("", "  Launcher");
   lines.push(`    ${runtime.command} ${runtime.args.join(" ")}`);
   lines.push("    Exact package version is pinned; first client start may use npm and uv caches.");
-  lines.push("", "  Setup writes only the selected client configuration entries.");
+  lines.push("", "  Skill");
+  for (const entry of plan) lines.push(`    ${entry.client.displayName}: ${entry.skill.path} — ${entry.skill.action}`);
+  lines.push("", "  Setup writes the selected client configuration entries and Jacobian skill.");
   lines.push("  It does not install or update uv, Python, Node.js, or any agent.");
   if (force) lines.push("  Explicit override: an unmanaged Jacobian entry may be replaced.");
   return lines.join("\n");
@@ -409,6 +449,8 @@ function report({ plan, runtime, dryRun, cancelled, force }) {
       detected: entry.detected,
       path: entry.path,
       action: entry.action,
+      skill_path: entry.skill.path,
+      skill_action: entry.skill.action,
     })),
   };
 }
@@ -427,7 +469,7 @@ function printReport(value, json) {
     return;
   }
   const names = value.clients.map((client) => client.display_name).join(", ");
-  console.log(`◆ Jacobian is configured for ${names}.`);
+  console.log(`◆ Jacobian MCP and skill are configured for ${names}.`);
   console.log("  Restart or reload those clients, then use math.find to discover an operation.");
 }
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -27,6 +27,7 @@
   "files": [
     "bin",
     "lib",
+    "skill",
     "README.md"
   ]
 }

--- a/npm/skill/jacobian-math/SKILL.md
+++ b/npm/skill/jacobian-math/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: jacobian-math
+description: Use Jacobian's MCP operations for nontrivial mathematical computation, finite search, structural analysis, formal checking, probability, or optimization.
+---
+
+<!-- Managed by Jacobian setup. -->
+
+# Jacobian mathematics
+
+Use Jacobian when a mathematical task benefits from exact computation or a
+bounded check. Search with `math.find`, then execute a selected operation with
+`math.run`.
+
+Keep the mathematical reasoning in the agent. Treat operations as atomic
+instruments: compose their typed results yourself rather than asking discovery
+to prescribe a proof strategy or workflow.
+
+Before running an operation:
+
+- Inspect its exact request schema and mathematical scope with `math.find`.
+- Supply canonical mathematical values without backend-specific expressions or
+  ambient contexts.
+- Respect the operation's declared bounds and distinguish exact results from
+  incomplete, unknown, unavailable, or transport outcomes.
+
+Use returned values and certificates only for the conclusion they establish.
+Absence of a witness, a timeout, or an incomplete search is not a proof of a
+global mathematical claim.


### PR DESCRIPTION
## Problem

`npx jacobian@latest setup` currently registers the MCP server but leaves agents without a small, discoverable cue for when Jacobian is relevant. The live MCP contract is authoritative once an agent reaches it, but that contract cannot by itself reliably steer an agent to use Jacobian for a mathematical task.

This revisits #1207 with a narrower boundary. The previous managed Skill became a shadow API because it copied operation IDs, payload shapes, examples, and routing policy. The desired Skill should instead follow Jacobian's product model: expose the mathematical vocabulary, let the agent reason and compose, and keep all changing capability facts in `math.find` and `math.run`.

## Solution

Install a thin `jacobian-math` Skill alongside the pinned MCP registration for every client selected by `jacobian setup`.

The bundled Skill contains only stable guidance:

- when exact computation or a bounded mathematical check may benefit from Jacobian;
- `math.find` for live discovery and schema inspection;
- `math.run` for one selected atomic operation;
- the distinction between exact conclusions and incomplete, unknown, unavailable, or transport outcomes.

It deliberately contains no operation IDs, copied request schemas, payload examples, solver strategy, or capability catalog. The npm release remains the install source, so MCP registration and steering guidance are versioned together without a setup-time GitHub download.

Setup plans, reports, and applies the MCP and Skill writes together. Existing unmanaged Skills are protected unless the user passes `--force`, shared universal Skill paths are deduplicated, dry-run remains non-mutating, and rollback covers both artifacts.

## Testing

```sh
cd npm && npm test
make docs-linkcheck
git diff --check origin/main...HEAD
```

- npm carrier/setup suite: 16/16 passed, including all-client installation, dry-run, repeat setup, unmanaged-Skill protection, and npm pack contents.
- Documentation command and link checks passed.
- `make check` completed Ruff and mypy successfully and ran 5,207 tests: 5,206 passed, while `test_atlas_weighted_lift_k1_d2_has_generic_degree_three` returned the operation's typed `TIMEOUT`; the same test returned `TIMEOUT` when rerun alone. The failing Singular-backed mathematical path is outside this npm-only diff.
- Specialist validation run: none; the MCP tool schema and transport are unchanged.

## Public contract impact

No operation ID, request/result schema, native API, MCP tool contract, or mathematical semantics change. The npm setup contract now installs one managed steering Skill alongside each selected MCP registration.

## Public operation admission

Not applicable.

## Closure matrix

None.

## Checklist

- [ ] `make check` passes (one unrelated Singular-backed operation returned typed `TIMEOUT`; details above)
- [x] Explicitly relevant specialist validation is listed above
- [x] Harbor task or verifier changes ran the required validation (not applicable)
- [x] Public operation changes include an owner-local admission decision (not applicable)
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] New or changed bounds include boundary, algorithm-crossover, and source-backed scale evidence (not applicable)
- [x] New shared abstractions replace duplication in at least two surviving production paths (not applicable)
