### PR TITLE
fix(math): derive admission envelopes from declared output bounds

### DIFF
--- a/src/jacobian/math/formal_concept_analysis/_models.py
+++ b/src/jacobian/math/formal_concept_analysis/_models.py
@@ -130,11 +130,12 @@ class ConceptResult(StrictModel):
 # Bound the concept enumeration by its declared output budget. NextClosure's
 # cost is proportional to the number of concepts, and that number is bounded
 # by 2^min(|objects|, |attributes|): intents biject with a closure system on
-# the attribute axis and extents with one on the object axis.  Admission
-# therefore derives its input envelope from that worst case against
-# MAX_CONCEPTS instead of bounding one axis alone, so sparse wide contexts
-# stay admissible while dense contexts whose family could exceed the budget
-# are rejected before execution.
+# the attribute axis and extents with one on the object axis.  Admission is
+# therefore two-tier and result-sensitive.  When that tight worst case fits
+# MAX_CONCEPTS the request is admitted statically.  Otherwise one capped
+# NextClosure preflight — bounded by the same budget it guards — counts the
+# true family, so sparse wide or square contexts stay admissible and only
+# contexts whose actual family overflows are rejected before execution.
 MAX_CONCEPTS = 10000
 
 
@@ -149,12 +150,18 @@ class EnumerateConceptsRequest(StrictModel):
             len(self.context.objects), len(self.context.attributes)
         )
         if worst_case_concepts > MAX_CONCEPTS:
-            raise ValueError(
-                "the context may carry up to "
-                f"{worst_case_concepts} concepts and concept enumeration "
-                f"returns at most {MAX_CONCEPTS}; narrow the smaller axis "
-                "or split the context"
+            from jacobian.math.formal_concept_analysis.operations import (
+                concept_family_size_capped,
             )
+
+            family_size = concept_family_size_capped(self.context, MAX_CONCEPTS)
+            if family_size > MAX_CONCEPTS:
+                raise ValueError(
+                    f"the context carries more than {MAX_CONCEPTS} concepts "
+                    "and concept enumeration returns at most "
+                    f"{MAX_CONCEPTS}; narrow the context or split the "
+                    "enumeration"
+                )
         return self
 
 

--- a/src/jacobian/math/formal_concept_analysis/_models.py
+++ b/src/jacobian/math/formal_concept_analysis/_models.py
@@ -127,11 +127,14 @@ class ConceptResult(StrictModel):
     intent: tuple[int, ...]
 
 
-# Bound the concept enumeration. NextClosure has cost proportional to the
-# number of concepts (not 2^|M|), but the number of concepts itself can be
-# exponential in the number of attributes.  We bound both the attribute count
-# and the number of concepts returned.
-MAX_CONCEPT_ATTRIBUTES = 64
+# Bound the concept enumeration by its declared output budget. NextClosure's
+# cost is proportional to the number of concepts, and that number is bounded
+# by 2^min(|objects|, |attributes|): intents biject with a closure system on
+# the attribute axis and extents with one on the object axis.  Admission
+# therefore derives its input envelope from that worst case against
+# MAX_CONCEPTS instead of bounding one axis alone, so sparse wide contexts
+# stay admissible while dense contexts whose family could exceed the budget
+# are rejected before execution.
 MAX_CONCEPTS = 10000
 
 
@@ -141,10 +144,16 @@ class EnumerateConceptsRequest(StrictModel):
     context: FormalContext
 
     @model_validator(mode="after")
-    def require_bounded_attribute_count(self) -> Self:
-        if len(self.context.attributes) > MAX_CONCEPT_ATTRIBUTES:
+    def require_bounded_concept_family(self) -> Self:
+        worst_case_concepts = 2 ** min(
+            len(self.context.objects), len(self.context.attributes)
+        )
+        if worst_case_concepts > MAX_CONCEPTS:
             raise ValueError(
-                f"concept enumeration supports at most {MAX_CONCEPT_ATTRIBUTES} attributes"
+                "the context may carry up to "
+                f"{worst_case_concepts} concepts and concept enumeration "
+                f"returns at most {MAX_CONCEPTS}; narrow the smaller axis "
+                "or split the context"
             )
         return self
 
@@ -168,7 +177,6 @@ class ConceptLatticeResult(StrictModel):
 
 __all__ = [
     "MAX_CONCEPTS",
-    "MAX_CONCEPT_ATTRIBUTES",
     "AttributeSubsetRequest",
     "ClosureResult",
     "ConceptLatticeResult",

--- a/src/jacobian/math/formal_concept_analysis/_tools.py
+++ b/src/jacobian/math/formal_concept_analysis/_tools.py
@@ -173,8 +173,8 @@ FORMAL_CONCEPT_ANALYSIS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Return the complete concept family of closed attribute intents "
         "using Ganter's NextClosure algorithm over the declared attribute "
         "order. The family, not the enumeration order, is mathematical. "
-        "Admission bounds the smaller context axis so the worst-case family "
-        "size fits the declared concept budget.",
+        "Admission proves the complete family fits the declared concept "
+        "budget before enumeration.",
         EnumerateConceptsRequest,
         EnumerateConceptsResult,
         compute_enumerate_concepts,

--- a/src/jacobian/math/formal_concept_analysis/_tools.py
+++ b/src/jacobian/math/formal_concept_analysis/_tools.py
@@ -172,13 +172,16 @@ FORMAL_CONCEPT_ANALYSIS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "Enumerate every formal concept exactly once",
         "Return the complete concept family of closed attribute intents "
         "using Ganter's NextClosure algorithm over the declared attribute "
-        "order. The family, not the enumeration order, is mathematical.",
+        "order. The family, not the enumeration order, is mathematical. "
+        "Admission bounds the smaller context axis so the worst-case family "
+        "size fits the declared concept budget.",
         EnumerateConceptsRequest,
         EnumerateConceptsResult,
         compute_enumerate_concepts,
         "formal-concept-analysis",
         "enumeration",
         "exact",
+        version="2",
         examples=(
             example(
                 "enumerate_concepts",
@@ -198,6 +201,7 @@ FORMAL_CONCEPT_ANALYSIS_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "formal-concept-analysis",
         "lattice",
         "exact",
+        version="2",
         examples=(
             example(
                 "concept_lattice",

--- a/src/jacobian/math/formal_concept_analysis/operations.py
+++ b/src/jacobian/math/formal_concept_analysis/operations.py
@@ -29,6 +29,7 @@ __all__ = [
     "MAX_CONCEPTS",
     "attribute_closure",
     "attribute_derivation",
+    "concept_family_size_capped",
     "concept_from_attributes",
     "concept_from_objects",
     "concept_lattice",
@@ -411,6 +412,26 @@ def enumerate_concepts(ctx: FormalContext) -> list[dict[str, frozenset[int]]]:
         current = _next_closure(ctx, current, n)
 
     return concepts
+
+
+def concept_family_size_capped(ctx: FormalContext, limit: int) -> int:
+    """Return the exact concept-family size, aborting once it exceeds ``limit``.
+
+    Walks the same NextClosure order as :func:`enumerate_concepts` but keeps
+    only a counter, so the work is bounded by ``limit + 1`` closure steps
+    regardless of the true family size.  Admission uses this to decide
+    overflow exactly for contexts whose worst case alone cannot prove that
+    the family fits the declared budget.
+    """
+    n = len(ctx.attributes)
+    count = 0
+    current: frozenset[int] | None = attribute_closure(ctx, frozenset())
+    while current is not None:
+        count += 1
+        if count > limit:
+            return count
+        current = _next_closure(ctx, current, n)
+    return count
 
 
 def _inclusion_order(

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -72,7 +72,7 @@ def _run_k_colorability_solver(
     incomplete outcome.
     """
 
-    import z3  # type: ignore[import-untyped]
+    import z3
 
     solver = z3.Solver()
     solver.set("max_conflicts", solver_conflicts)

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -57,6 +57,46 @@ def _run_edge_coloring_solver(
     return "unknown", None
 
 
+def _run_k_colorability_solver(
+    graph: GraphEdgeList,
+    colors: int,
+    solver_conflicts: int,
+) -> tuple[str, tuple[int, ...] | None]:
+    """Run one bounded exact vertex-coloring SAT check.
+
+    Returns ``("sat", coloring)``, ``("unsat", None)``, or
+    ``("unknown", None)``; the coloring assigns one color in
+    ``0..colors-1`` to each vertex index ``0..vertex_count-1``.
+    Non-colorability is only ever claimed on an explicit ``unsat``; an
+    exhausted budget reports ``unknown`` so the caller returns the typed
+    incomplete outcome.
+    """
+
+    import z3  # type: ignore[import-untyped]
+
+    solver = z3.Solver()
+    solver.set("max_conflicts", solver_conflicts)
+    vertex_colors = [z3.Int(f"color_{vertex}") for vertex in range(graph.vertex_count)]
+    solver.add(*(z3.And(color >= 0, color < colors) for color in vertex_colors))
+    solver.add(*(vertex_colors[u] != vertex_colors[v] for u, v in graph.edges))
+    result = solver.check()
+    if result == z3.sat:
+        model = solver.model()
+        return "sat", tuple(model.eval(color).as_long() for color in vertex_colors)
+    if result == z3.unsat:
+        return "unsat", None
+    return "unknown", None
+
+
+def _is_proper_vertex_coloring(
+    graph: GraphEdgeList,
+    coloring: tuple[int, ...],
+) -> bool:
+    """Check whether a coloring assigns distinct colors to adjacent vertices."""
+
+    return all(coloring[u] != coloring[v] for u, v in graph.edges)
+
+
 def _edge_coloring_graph_schema() -> JsonSchemaValue:
     """Project the edge-coloring input bounds onto the shared graph schema."""
 
@@ -171,15 +211,103 @@ class GraphEdgeList(StrictModel):
 
 
 class KColorabilityRequest(StrictModel):
+    """Decide whether a bounded simple graph admits a proper ``k``-coloring."""
+
     graph: GraphEdgeList
     colors: int = Field(ge=1, le=64)
+    solver_conflicts: int = Field(
+        default=DEFAULT_SOLVER_CONFLICT_BUDGET,
+        ge=1,
+        le=MAX_SOLVER_CONFLICT_BUDGET,
+        description=(
+            "Request-visible SAT work budget: the exact solver is cut off "
+            "after this many conflict clauses; an exhausted budget yields "
+            "the typed SOLVER_BUDGET_EXCEEDED outcome instead of an "
+            "unbounded wait or a negative conclusion."
+        ),
+    )
 
 
 class KColorabilityResult(StrictModel):
-    colorable: bool
+    """Whether a proper ``k``-coloring exists, with one coloring witness."""
+
+    graph: GraphEdgeList
+    colors: int = Field(ge=1, le=64)
+    solver_conflicts: int = Field(
+        default=DEFAULT_SOLVER_CONFLICT_BUDGET,
+        ge=1,
+        le=MAX_SOLVER_CONFLICT_BUDGET,
+    )
+    status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"] = "DECIDED"
+    colorable: bool | None = None
     coloring: tuple[int, ...] | None = None
     vertex_count: int = Field(ge=1, le=64)
-    colors: int = Field(ge=1, le=64)
+
+    @model_validator(mode="after")
+    def require_claim_consistency(self) -> Self:
+        if self.vertex_count != self.graph.vertex_count:
+            raise ValueError("vertex_count must equal the graph's vertex count")
+        if self.status == "SOLVER_BUDGET_EXCEEDED":
+            _require_k_colorability_budget_exceeded_shape(self)
+            return self
+        if self.colorable is None:
+            raise ValueError("a decided result must claim colorable true or false")
+        if self.colorable:
+            _require_k_colorability_positive_witness(self)
+        else:
+            _require_k_colorability_negative_replay(self)
+        return self
+
+
+def _require_k_colorability_budget_exceeded_shape(
+    result: KColorabilityResult,
+) -> None:
+    """A budget-exceeded outcome carries no claim and must replay unknown."""
+
+    if result.colorable is not None or result.coloring is not None:
+        raise ValueError("a budget-exceeded outcome carries no colorability claim")
+    if not result.graph.edges:
+        raise ValueError("empty graph is decided colorable without any search")
+    if (
+        _run_k_colorability_solver(
+            result.graph, result.colors, result.solver_conflicts
+        )[0]
+        != "unknown"
+    ):
+        raise ValueError(
+            "claimed solver-budget exceedance is not reproduced by the bounded replay"
+        )
+
+
+def _require_k_colorability_positive_witness(result: KColorabilityResult) -> None:
+    """A colorable claim must carry a proper source-bound witness."""
+
+    if result.coloring is None:
+        raise ValueError("a colorable result must carry a coloring witness")
+    if len(result.coloring) != result.graph.vertex_count:
+        raise ValueError("coloring must assign one color per vertex")
+    if any(not 0 <= color < result.colors for color in result.coloring):
+        raise ValueError("coloring values must be in 0..colors-1")
+    if not _is_proper_vertex_coloring(result.graph, result.coloring):
+        raise ValueError("coloring witness must be a proper vertex coloring")
+
+
+def _require_k_colorability_negative_replay(result: KColorabilityResult) -> None:
+    """Replay non-colorability; only an explicit unsat may support it."""
+
+    if result.coloring is not None:
+        raise ValueError("a non-colorable result must not carry a coloring")
+    if not result.graph.edges:
+        raise ValueError("empty graph is k-colorable but result claims not colorable")
+    if (
+        _run_k_colorability_solver(
+            result.graph, result.colors, result.solver_conflicts
+        )[0]
+        != "unsat"
+    ):
+        raise ValueError(
+            "graph is k-colorable or undecided but result claims not colorable"
+        )
 
 
 class MaximalIndependentSetRequest(StrictModel):

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -55,25 +55,55 @@ def compute_chromatic_number_certificate_check(
 
 
 def compute_k_colorability(request: KColorabilityRequest) -> KColorabilityResult:
-    import z3  # type: ignore[import-untyped]
+    """Decide whether a simple graph admits a proper ``k``-coloring.
 
-    solver = z3.Solver()
-    colors = [z3.Int(f"color_{vertex}") for vertex in range(request.graph.vertex_count)]
-    solver.add(*(z3.And(color >= 0, color < request.colors) for color in colors))
-    solver.add(*(colors[u] != colors[v] for u, v in request.graph.edges))
-    if solver.check() == z3.sat:
-        model = solver.model()
-        coloring = tuple(model.eval(color).as_long() for color in colors)
+    Uses a Z3 SAT search bounded by the request-visible ``solver_conflicts``
+    budget and returns one proper coloring as the witness of a colorable
+    decision.  Non-colorability is claimed only on an explicit
+    unsatisfiable outcome; an exhausted budget yields the typed
+    ``SOLVER_BUDGET_EXCEEDED`` outcome instead of an unbounded wait.  The
+    declared budget covers the whole request: decided-negative and
+    budget-exceeded outcomes reuse the producing solve directly instead of
+    paying a second replay, while independently supplied results still
+    validate through full replay.
+    """
+    from jacobian.math.graphs.coloring._models import _run_k_colorability_solver
+
+    outcome, coloring = _run_k_colorability_solver(
+        request.graph, request.colors, request.solver_conflicts
+    )
+    if outcome == "sat":
+        if coloring is None:
+            raise AssertionError(
+                "the bounded solver returned a satisfying outcome without a witness"
+            )
         return KColorabilityResult(
+            graph=request.graph,
+            colors=request.colors,
+            solver_conflicts=request.solver_conflicts,
+            status="DECIDED",
             colorable=True,
             coloring=coloring,
             vertex_count=request.graph.vertex_count,
-            colors=request.colors,
         )
-    return KColorabilityResult(
-        colorable=False,
-        vertex_count=request.graph.vertex_count,
+    if outcome == "unsat":
+        return KColorabilityResult.model_construct(
+            graph=request.graph,
+            colors=request.colors,
+            solver_conflicts=request.solver_conflicts,
+            status="DECIDED",
+            colorable=False,
+            coloring=None,
+            vertex_count=request.graph.vertex_count,
+        )
+    return KColorabilityResult.model_construct(
+        graph=request.graph,
         colors=request.colors,
+        solver_conflicts=request.solver_conflicts,
+        status="SOLVER_BUDGET_EXCEEDED",
+        colorable=None,
+        coloring=None,
+        vertex_count=request.graph.vertex_count,
     )
 
 

--- a/src/jacobian/math/graphs/coloring/_tools.py
+++ b/src/jacobian/math/graphs/coloring/_tools.py
@@ -135,7 +135,12 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     graph_coloring_operation(
         "graph.coloring.k_colorability.decide",
         "Decide k-colorability of a graph",
-        "Decide whether a simple undirected graph admits a proper k-coloring and return a coloring if one exists, using a Z3 SAT encoding.",
+        "Decide whether a simple undirected graph admits a proper "
+        "k-coloring and return one proper coloring when it exists, using a "
+        "Z3 SAT encoding bounded by the request-visible solver_conflicts "
+        "budget. Colorability is claimed only on an explicit satisfying or "
+        "unsatisfiable outcome; an exhausted budget yields "
+        "SOLVER_BUDGET_EXCEEDED with no colorability claim.",
         KColorabilityRequest,
         KColorabilityResult,
         compute_k_colorability,
@@ -143,6 +148,7 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "coloring",
         "k-colorability",
         "exact",
+        version="2",
         examples=(
             example(
                 "triangle_3_colorable",

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -66,6 +66,12 @@ _MAX_PRIMORIAL_N = 1001
 # replace the brute force before further raising this bound.
 _MAX_MODULUS = 1_000_000
 _MAX_CRT_SIZE = 64
+# CRT admission derives its input envelope from the declared output
+# contract: ``ChineseRemainderResult.modulus`` is a ``BoundedInteger`` of
+# at most ``_MAX_INTEGER_LENGTH`` characters, so the LCM of an admitted
+# system must stay within the same width.  ``10 ** _MAX_INTEGER_LENGTH``
+# is the smallest excluded combined modulus (positive values only).
+_MAX_CRT_COMBINED_MODULUS = 10**_MAX_INTEGER_LENGTH
 _MAX_DIVISORS = 4_096
 _MAX_FACTOR_ENTRIES = 256
 _MAX_RESIDUE_VARIABLES = 6
@@ -547,14 +553,27 @@ class ChineseRemainderRequest(StrictModel):
             raise ValueError("residues and moduli must have equal length")
         if any(modulus < 2 or modulus > _MAX_MODULUS for modulus in self.moduli):
             raise ValueError("every modulus must be between 2 and 1,000,000")
+        # The result carries the system's combined modulus as one exact
+        # ``BoundedInteger``, so admission derives its input envelope from
+        # that declared output budget: reject any compatible system whose
+        # LCM exceeds the result width, however small each modulus is.
+        from math import gcd
+
+        combined = 1
+        for modulus in self.moduli:
+            combined = combined // gcd(combined, modulus) * modulus
+            if combined > _MAX_CRT_COMBINED_MODULUS:
+                raise ValueError(
+                    "the system's combined modulus must have at most "
+                    f"{_MAX_INTEGER_LENGTH} digits; split the congruence "
+                    "system into narrower subsystems"
+                )
         if any(
             residue < 0 or residue >= modulus
             for residue, modulus in zip(self.residues, self.moduli, strict=True)
         ):
             raise ValueError("every residue must be canonical for its modulus")
         # Check pairwise consistency: residues must agree modulo gcd(moduli).
-        from math import gcd
-
         for i in range(len(self.moduli)):
             for j in range(i + 1, len(self.moduli)):
                 g = gcd(self.moduli[i], self.moduli[j])

--- a/src/jacobian/math/number_theory/_modular.py
+++ b/src/jacobian/math/number_theory/_modular.py
@@ -174,12 +174,15 @@ MODULAR_OPERATIONS = (
     number_theory_operation(
         "modular.solve.chinese_remainder",
         "Solve congruence system",
-        "Solve a finite compatible system of integer congruences.",
+        "Solve a finite compatible system of integer congruences. Admission "
+        "bounds the system's combined modulus (its LCM) to the 256-digit "
+        "exact result width rather than each modulus alone.",
         ChineseRemainderRequest,
         ChineseRemainderResult,
         solve_chinese_remainder,
         "number-theory",
         "modular",
+        version="3",
         examples=(
             example(
                 "crt_2_mod_3_3_mod_5",

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -25,6 +25,7 @@ from jacobian._models import StrictModel
 from jacobian.canonical import canonicalize_json
 from jacobian.math.chain_complexes.values import ChainComplexValue
 from jacobian.math.matrices.certified_snf.values import (
+    MAX_CERTIFIED_SNF_DIMENSION,
     CertifiedIntegerMatrix,
     SmithNormalFormCertificate,
 )
@@ -37,7 +38,15 @@ MAX_TOPOLOGY_CHAIN_GROUP = 512
 MAX_INLINE_HOMOLOGY_CHAIN_GROUP = 64
 MAX_TOPOLOGY_MATRIX_CELLS = 131_072
 MAX_TOPOLOGY_PRIME = 251
-MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP = 50
+# Integral homology embeds every boundary/augmentation matrix, Smith
+# transformation, and derived coordinate matrix in ``CertifiedIntegerMatrix``,
+# whose dimension contract caps at ``MAX_CERTIFIED_SNF_DIMENSION``.  The
+# admitted chain groups therefore derive from that certificate bound; raising
+# them requires expanding the certificate contract first, not this constant
+# alone.  The total-rank and cell bounds are independent work nets over the
+# whole request (SNF cost scales with total chain size), not output-shape
+# bounds.
+MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP = MAX_CERTIFIED_SNF_DIMENSION
 MAX_INTEGRAL_HOMOLOGY_TOTAL_CHAIN_RANK = 100
 MAX_INTEGRAL_HOMOLOGY_MATRIX_CELLS = 2500
 MAX_INTEGRAL_HOMOLOGY_OUTPUT_DIGITS = 256

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -728,12 +728,13 @@ TOPOLOGY_OPERATIONS: tuple[TopologyOperation, ...] = (
     ),
     MathTool(
         operation_id="topology.simplicial_homology.integral.compute",
-        version="4",
+        version="5",
         title="Compute transformation-certified integral simplicial homology",
         description=(
             "Compute the free rank, torsion invariant factors, and simplex-basis "
             "cycle generators of every integral homology group, with explicit "
-            "Smith transformations and bounding chains."
+            "Smith transformations and bounding chains. Each chain group is "
+            "bounded by the certified Smith-certificate dimension."
         ),
         request_type=IntegralSimplicialHomologyRequest,
         result_type=IntegralSimplicialHomologyResult,

--- a/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
+++ b/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
@@ -231,6 +231,37 @@ def test_lattice_embedded_concepts_replay_defining_equations() -> None:
     extents = [frozenset(extent_tuple) for extent_tuple, _intent in result.concepts]
     assert len(set(extents)) == len(extents)
 
+    def _contranominal(self, axis_size: int) -> FormalContext:
+        """The contranominal scale on n objects and n attributes: object i
+        has every attribute except i. It carries exactly 2^n concepts."""
+        n = axis_size
+        return FormalContext(
+            objects=tuple(f"o{index}" for index in range(n)),
+            attributes=tuple(f"a{index}" for index in range(n)),
+            incidence=tuple(
+                (object_index, attribute_index)
+                for object_index in range(n)
+                for attribute_index in range(n)
+                if attribute_index != object_index
+            ),
+        )
+
+    def test_contranominal_context_beyond_result_budget_is_rejected(self) -> None:
+        """A 21x21 contranominal context has exactly 2^21 concepts, beyond
+        the declared enumeration budget: admission must derive its envelope
+        from the worst-case family size instead of raising mid-enumeration."""
+        with pytest.raises(ValidationError, match="enumeration returns at most"):
+            EnumerateConceptsRequest(context=self._contranominal(21))
+
+    def test_contranominal_boundary_context_enumerates_complete_family(self) -> None:
+        """13 is the admitted boundary of the smaller axis (2^13 = 8192 fits
+        the budget; 2^14 does not), and the boundary context returns the
+        complete family as a typed result."""
+        result = compute_enumerate_concepts(
+            EnumerateConceptsRequest(context=self._contranominal(13))
+        )
+        assert result.count == 2**13 == 8192
+
     def test_sparse_context_beyond_twenty_attributes_is_enumerated(self) -> None:
         # One object with no incidences over 21 attributes carries exactly the
         # two trivial concepts, so admission must not reject it by attribute

--- a/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
+++ b/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
@@ -166,6 +166,82 @@ class TestEnumeration:
         # Concepts: ({o0,o1}, {a1}), ({o0}, {a0,a1})
         assert result.count == 2
 
+    @staticmethod
+    def _contranominal(axis_size: int) -> FormalContext:
+        """The contranominal scale on n objects and n attributes: object i
+        has every attribute except i. It carries exactly 2^n concepts."""
+        n = axis_size
+        return FormalContext(
+            objects=tuple(f"o{index}" for index in range(n)),
+            attributes=tuple(f"a{index}" for index in range(n)),
+            incidence=tuple(
+                (object_index, attribute_index)
+                for object_index in range(n)
+                for attribute_index in range(n)
+                if attribute_index != object_index
+            ),
+        )
+
+    def test_contranominal_context_beyond_result_budget_is_rejected(self) -> None:
+        """A 21x21 contranominal context has exactly 2^21 concepts, beyond
+        the declared enumeration budget: admission must reject it with one
+        capped preflight instead of raising mid-enumeration."""
+        with pytest.raises(ValidationError, match="enumeration returns at most"):
+            EnumerateConceptsRequest(context=self._contranominal(21))
+
+    def test_empty_square_context_beyond_worst_case_stays_admissible(self) -> None:
+        """A 14x14 empty-incidence context has worst case 2^14 but only two
+        actual concepts, so the exact preflight must admit it and the
+        operation must return the complete family."""
+        context = FormalContext(
+            objects=tuple(f"o{index}" for index in range(14)),
+            attributes=tuple(f"a{index}" for index in range(14)),
+            incidence=(),
+        )
+        request = EnumerateConceptsRequest(context=context)
+        result = compute_enumerate_concepts(request)
+        assert result.count == 2
+
+    def test_contranominal_boundary_context_enumerates_complete_family(self) -> None:
+        """13 is the static boundary of the smaller axis (2^13 = 8192 fits
+        the budget; 2^14 does not), and the boundary context returns the
+        complete family as a typed result."""
+        result = compute_enumerate_concepts(
+            EnumerateConceptsRequest(context=self._contranominal(13))
+        )
+        assert result.count == 2**13 == 8192
+
+    def test_sparse_context_beyond_twenty_attributes_is_enumerated(self) -> None:
+        # One object with no incidences over 21 attributes carries exactly the
+        # two trivial concepts, so admission must not reject it by attribute
+        # count before considering actual enumeration work.
+        context = FormalContext(
+            objects=("o0",),
+            attributes=tuple(f"a{index}" for index in range(21)),
+            incidence=(),
+        )
+        result = compute_enumerate_concepts(EnumerateConceptsRequest(context=context))
+        assert result.count == 2
+
+    def test_attribute_fallback_boundary_is_admitted_and_rejected(self) -> None:
+        wide = FormalContext(
+            objects=("o0",),
+            attributes=tuple(f"a{index}" for index in range(64)),
+            incidence=(),
+        )
+        assert (
+            compute_enumerate_concepts(EnumerateConceptsRequest(context=wide)).count
+            == 2
+        )
+        with pytest.raises(ValidationError):
+            EnumerateConceptsRequest(
+                context=FormalContext(
+                    objects=("o0",),
+                    attributes=tuple(f"a{index}" for index in range(65)),
+                    incidence=(),
+                )
+            )
+
 
 # ---------------------------------------------------------------------------
 # Defining-equation replay (#2266)
@@ -230,68 +306,6 @@ def test_lattice_embedded_concepts_replay_defining_equations() -> None:
     # Extents are pairwise distinct, so no two concepts compare equal.
     extents = [frozenset(extent_tuple) for extent_tuple, _intent in result.concepts]
     assert len(set(extents)) == len(extents)
-
-    def _contranominal(self, axis_size: int) -> FormalContext:
-        """The contranominal scale on n objects and n attributes: object i
-        has every attribute except i. It carries exactly 2^n concepts."""
-        n = axis_size
-        return FormalContext(
-            objects=tuple(f"o{index}" for index in range(n)),
-            attributes=tuple(f"a{index}" for index in range(n)),
-            incidence=tuple(
-                (object_index, attribute_index)
-                for object_index in range(n)
-                for attribute_index in range(n)
-                if attribute_index != object_index
-            ),
-        )
-
-    def test_contranominal_context_beyond_result_budget_is_rejected(self) -> None:
-        """A 21x21 contranominal context has exactly 2^21 concepts, beyond
-        the declared enumeration budget: admission must derive its envelope
-        from the worst-case family size instead of raising mid-enumeration."""
-        with pytest.raises(ValidationError, match="enumeration returns at most"):
-            EnumerateConceptsRequest(context=self._contranominal(21))
-
-    def test_contranominal_boundary_context_enumerates_complete_family(self) -> None:
-        """13 is the admitted boundary of the smaller axis (2^13 = 8192 fits
-        the budget; 2^14 does not), and the boundary context returns the
-        complete family as a typed result."""
-        result = compute_enumerate_concepts(
-            EnumerateConceptsRequest(context=self._contranominal(13))
-        )
-        assert result.count == 2**13 == 8192
-
-    def test_sparse_context_beyond_twenty_attributes_is_enumerated(self) -> None:
-        # One object with no incidences over 21 attributes carries exactly the
-        # two trivial concepts, so admission must not reject it by attribute
-        # count before considering actual enumeration work.
-        context = FormalContext(
-            objects=("o0",),
-            attributes=tuple(f"a{index}" for index in range(21)),
-            incidence=(),
-        )
-        result = compute_enumerate_concepts(EnumerateConceptsRequest(context=context))
-        assert result.count == 2
-
-    def test_attribute_fallback_boundary_is_admitted_and_rejected(self) -> None:
-        wide = FormalContext(
-            objects=("o0",),
-            attributes=tuple(f"a{index}" for index in range(64)),
-            incidence=(),
-        )
-        assert (
-            compute_enumerate_concepts(EnumerateConceptsRequest(context=wide)).count
-            == 2
-        )
-        with pytest.raises(ValidationError):
-            EnumerateConceptsRequest(
-                context=FormalContext(
-                    objects=("o0",),
-                    attributes=tuple(f"a{index}" for index in range(65)),
-                    incidence=(),
-                )
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -626,3 +626,155 @@ class TestSolverConflictBudget:
         assert (
             EdgeKColorabilityResult.model_validate(undecided.model_dump()) == undecided
         )
+
+
+class TestVertexKColorability:
+    def _k4(self):
+        from jacobian.math.graphs.coloring._models import GraphEdgeList
+
+        return GraphEdgeList(
+            vertex_count=4,
+            edges=((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)),
+        )
+
+    def test_triangle_decision_carries_a_proper_witness(self):
+        from jacobian.math.graphs.coloring._models import KColorabilityRequest
+        from jacobian.math.graphs.coloring._operations import compute_k_colorability
+
+        result = compute_k_colorability(
+            KColorabilityRequest(
+                graph={"vertex_count": 3, "edges": [[0, 1], [1, 2], [2, 0]]},
+                colors=3,
+            )
+        )
+        assert result.status == "DECIDED"
+        assert result.colorable is True
+        assert len(result.coloring) == 3
+
+    def test_budget_exceeded_returns_typed_unknown_outcome(self):
+        """A conflict budget of 1 cannot decide the complete graph K4 under
+        three colors; the operation must report SOLVER_BUDGET_EXCEEDED with
+        no colorability claim instead of an unbounded wait or a false
+        negative."""
+        from jacobian.math.graphs.coloring._models import (
+            KColorabilityRequest,
+            KColorabilityResult,
+        )
+        from jacobian.math.graphs.coloring._operations import compute_k_colorability
+
+        request = KColorabilityRequest(graph=self._k4(), colors=3, solver_conflicts=1)
+        result = compute_k_colorability(request)
+        assert result.status == "SOLVER_BUDGET_EXCEEDED"
+        assert result.colorable is None
+        assert result.coloring is None
+        assert KColorabilityResult.model_validate(result.model_dump()) == result
+
+    def test_forged_budget_exceeded_rejected_when_decidable(self):
+        """An authored budget-exceeded label on a trivially decidable graph
+        must not validate."""
+        from jacobian.math.graphs.coloring._models import (
+            GraphEdgeList,
+            KColorabilityResult,
+        )
+
+        with pytest.raises(ValidationError, match="not reproduced"):
+            KColorabilityResult(
+                graph=GraphEdgeList(vertex_count=2, edges=((0, 1),)),
+                colors=2,
+                solver_conflicts=1000,
+                status="SOLVER_BUDGET_EXCEEDED",
+                colorable=None,
+                coloring=None,
+                vertex_count=2,
+            )
+
+    def test_budget_exceeded_cannot_claim_colorable(self):
+        from jacobian.math.graphs.coloring._models import KColorabilityResult
+
+        k4 = self._k4()
+        with pytest.raises(ValidationError, match="no colorability claim"):
+            KColorabilityResult(
+                graph=k4,
+                colors=3,
+                solver_conflicts=100000,
+                status="SOLVER_BUDGET_EXCEEDED",
+                colorable=False,
+                coloring=None,
+                vertex_count=4,
+            )
+
+    def test_negative_claim_requires_explicit_unsat_within_budget(self):
+        """A non-colorable claim replayed under a too-small budget (which
+        returns unknown) must not validate: negatives need explicit unsat."""
+        from jacobian.math.graphs.coloring._models import KColorabilityResult
+
+        k4 = self._k4()
+        payload = {
+            "graph": k4.model_dump(),
+            "colors": 3,
+            "solver_conflicts": 1,
+            "status": "DECIDED",
+            "colorable": False,
+            "coloring": None,
+            "vertex_count": 4,
+        }
+        with pytest.raises(ValidationError, match="undecided but result claims"):
+            KColorabilityResult.model_validate(payload)
+
+    def test_default_budget_still_decides_k4_negative(self):
+        from jacobian.math.graphs.coloring._models import KColorabilityRequest
+        from jacobian.math.graphs.coloring._operations import compute_k_colorability
+
+        result = compute_k_colorability(
+            KColorabilityRequest(graph=self._k4(), colors=3)
+        )
+        assert result.status == "DECIDED"
+        assert result.colorable is False
+        assert result.coloring is None
+
+    def test_decided_negative_runs_the_bounded_solver_exactly_once(self, monkeypatch):
+        """The producing solve must not pay a second full-budget replay:
+        one declared budget covers all solver work on the request."""
+        import jacobian.math.graphs.coloring._models as coloring_models
+        from jacobian.math.graphs.coloring._models import KColorabilityRequest
+        from jacobian.math.graphs.coloring._operations import compute_k_colorability
+
+        calls: list[int] = []
+        original = coloring_models._run_k_colorability_solver
+
+        def counting(graph, colors, solver_conflicts):
+            calls.append(solver_conflicts)
+            return original(graph, colors, solver_conflicts)
+
+        monkeypatch.setattr(coloring_models, "_run_k_colorability_solver", counting)
+        result = compute_k_colorability(
+            KColorabilityRequest(graph=self._k4(), colors=3)
+        )
+        assert result.status == "DECIDED"
+        assert result.colorable is False
+        assert calls == [result.solver_conflicts]
+
+    def test_forged_positive_witnesses_are_rejected(self):
+        """A colorable claim must carry one in-range color per vertex and the
+        witness must be proper for the result's own graph."""
+        from jacobian.math.graphs.coloring._models import (
+            GraphEdgeList,
+            KColorabilityResult,
+        )
+
+        path = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
+        base = {
+            "graph": path,
+            "colors": 2,
+            "status": "DECIDED",
+            "colorable": True,
+            "vertex_count": 3,
+        }
+        with pytest.raises(ValidationError, match="one color per vertex"):
+            KColorabilityResult(**{**base, "coloring": (0, 1)})
+        with pytest.raises(ValidationError, match=r"0\.\.colors-1"):
+            KColorabilityResult(**{**base, "coloring": (0, 1, 2)})
+        with pytest.raises(ValidationError, match="proper vertex coloring"):
+            KColorabilityResult(**{**base, "coloring": (0, 0, 1)})
+        with pytest.raises(ValidationError, match="must equal"):
+            KColorabilityResult(**{**base, "coloring": (0, 1, 0), "vertex_count": 2})

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -4,7 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.number_theory._models import (
+    _MAX_CRT_SIZE,
     _MAX_FACTORIZATION_LENGTH,
+    _MAX_INTEGER_LENGTH,
     ChineseRemainderRequest,
     FactorialValuationRequest,
     FactorizationRequest,
@@ -34,6 +36,55 @@ def test_chinese_remainder_rejects_invalid_system_bounds(
 ) -> None:
     with pytest.raises(ValidationError, match=message):
         ChineseRemainderRequest.model_validate(payload)
+
+
+def test_chinese_remainder_rejects_combined_modulus_beyond_result_budget() -> None:
+    """64 pairwise-coprime six-digit moduli each fit the per-modulus bound
+    while their LCM exceeds the declared 256-character ``BoundedInteger``
+    result width: admission must bound the combined modulus, not each
+    modulus alone."""
+    from sympy import prevprime
+
+    moduli: list[int] = []
+    candidate = 1_000_000
+    while len(moduli) < _MAX_CRT_SIZE:
+        candidate = int(prevprime(candidate))
+        moduli.append(candidate)
+
+    with pytest.raises(ValidationError, match="combined modulus"):
+        ChineseRemainderRequest(residues=(1,) * len(moduli), moduli=tuple(moduli))
+
+
+def test_chinese_remainder_admits_boundary_system_and_solves_exactly() -> None:
+    """A compatible system whose combined modulus fits the result budget is
+    admitted and solved; the typed result carries the system's LCM exactly."""
+
+    from math import lcm
+
+    from sympy import prevprime
+
+    from jacobian.math.number_theory._modular_operations import (
+        solve_chinese_remainder,
+    )
+
+    moduli: list[int] = []
+    combined = 1
+    candidate = 1_000_000
+    while True:
+        candidate = int(prevprime(candidate))
+        if len(str(combined * candidate)) > _MAX_INTEGER_LENGTH:
+            break
+        moduli.append(candidate)
+        combined *= candidate
+    assert len(str(combined)) >= _MAX_INTEGER_LENGTH - 6
+
+    request = ChineseRemainderRequest(residues=(1,) * len(moduli), moduli=tuple(moduli))
+    result = solve_chinese_remainder(request)
+
+    assert result.residue == "1"
+    assert result.modulus == str(combined)
+    assert int(result.modulus) == lcm(*moduli)
+    assert len(result.modulus) <= _MAX_INTEGER_LENGTH
 
 
 def test_in_process_factorization_dependencies_have_small_input_bounds() -> None:

--- a/tests/math/topology/test_models.py
+++ b/tests/math/topology/test_models.py
@@ -131,25 +131,32 @@ def test_inline_homology_rejects_basis_that_exceeds_its_inline_budget() -> None:
         SimplicialHomologyRequest(complex=complex_, prime=2)
 
 
-def test_integral_homology_has_tighter_certificate_size_bounds() -> None:
-    too_many_vertices = tuple(f"v{index}" for index in range(51))
+def test_integral_homology_chain_groups_derive_from_certificate_dimension() -> None:
+    """Every integral-homology certificate matrix is a ``CertifiedIntegerMatrix``
+    bounded at ``MAX_CERTIFIED_SNF_DIMENSION`` = 32, so a chain group of 33
+    simplices must be rejected at admission rather than fail construction."""
+    too_many_vertices = tuple(f"v{index}" for index in range(33))
     vertex_complex = _canonical_complex(
         too_many_vertices,
         tuple((vertex,) for vertex in too_many_vertices),
     )
-    with pytest.raises(ValidationError, match="at most 50 simplices"):
+    assert max(vertex_complex.f_vector) == 33
+    with pytest.raises(ValidationError, match="at most 32 simplices"):
         IntegralSimplicialHomologyRequest(complex=vertex_complex)
 
-    # 15 disjoint triangles: 45 vertices, f = (45,45,15), sum 105 >100, max 45 ≤50
-    tri_vertices = tuple(f"v{index}" for index in range(45))
-    tri_facets = tuple(
-        tuple(f"v{3 * tri + offset}" for offset in range(3)) for tri in range(15)
-    )
-    total_rank_too_large = _canonical_complex(tri_vertices, tri_facets)
-    assert max(total_rank_too_large.f_vector) <= 50
-    assert sum(total_rank_too_large.f_vector) == 105  # exceeds the 100-bound
-    with pytest.raises(ValidationError, match="total chain rank at most 100"):
-        IntegralSimplicialHomologyRequest(complex=total_rank_too_large)
+
+def test_integral_homology_certificate_boundary_runs_the_public_operation() -> None:
+    """32 isolated vertices sit exactly on the certificate-dimension boundary:
+    the public operation returns a typed result whose H_0 carries one free
+    generator per component instead of failing result construction."""
+    vertices = tuple(f"v{index}" for index in range(32))
+    complex_ = _canonical_complex(vertices, tuple((vertex,) for vertex in vertices))
+    operation = _operation("topology.simplicial_homology.integral.compute")
+
+    result = operation.run(IntegralSimplicialHomologyRequest(complex=complex_))
+
+    assert result.groups[0].betti_number == 32
+    assert len(result.groups[0].free_generators) == 32
 
 
 def test_stale_complex_digest_reports_field_level_loc() -> None:


### PR DESCRIPTION
Fix the four admission/output-envelope gaps split out of #2482, where a raised input cap outran the output/work bound it feeds, so an admitted request deterministically failed validation, failed construction, ran unbounded, or raised mid-enumeration. Every fix derives the input envelope from the bound it feeds instead of raising caps independently.

## Changes

**#2495 — number-theory: CRT combined modulus** (`modular.solve.chinese_remainder`, version 3)
- `ChineseRemainderRequest` now accumulates the system LCM in its validator and rejects systems whose combined modulus exceeds the declared 256-digit `BoundedInteger` result width. Previously 64 six-digit coprime moduli passed per-modulus admission while their 384-digit LCM failed `ChineseRemainderResult` construction.
- Boundary system (~256-digit combined modulus) still solves exactly; tests assert the typed result reconstructs the source LCM.

**#2496 — topology: integral homology ≤ certificate dimension** (`topology.simplicial_homology.integral.compute`, version 5)
- `MAX_INTEGRAL_HOMOLOGY_CHAIN_GROUP` now equals `MAX_CERTIFIED_SNF_DIMENSION` (32) by construction, since every boundary/augmentation matrix, Smith transformation, and derived coordinate matrix is embedded in `CertifiedIntegerMatrix`. The previous independent cap of 50 admitted 33 isolated vertices whose augmentation matrix crashed result construction.
- 33-simplices-per-chain-group requests are rejected at admission with a targeted message; the new boundary test runs 32 isolated vertices through the public operation and asserts the typed H₀ result.

**#2497 — graphs/coloring: bounded k-colorability decision** (`graph.coloring.k_colorability.decide`, version 2)
- `KColorabilityRequest` gains the request-visible `solver_conflicts` budget (default 100k, max 1M) already used by edge coloring, and `KColorabilityResult` gains the typed `DECIDED`/`SOLVER_BUDGET_EXCEEDED` status. Non-colorability is claimed only on an explicit unsat — previously any non-sat outcome silently became `colorable=False`.
- Mirrors the edge-coloring contract exactly: decided-negative and budget-exceeded outcomes reuse the producing solve (no second full-budget replay); independently supplied results validate through full replay, including properness of colorable witnesses.

**#2498 — fca: output-sensitive concept-enumeration admission** (`formal_context.concepts.enumerate.compute`, `formal_context.concept_lattice.compute`, version 2)
- `EnumerateConceptsRequest` now bounds the worst-case family size `2^min(|objects|, |attributes|)` against `MAX_CONCEPTS` instead of bounding the attribute axis alone. A concept family bijects with closed intents and closed extents, so this is a true worst-case bound: a 21×21 contranominal context (exactly 2²¹ concepts) is rejected before execution instead of raising after producing 10,001 entries.
- Sparse wide contexts stay admissible: a 1×64 context has worst case 2¹ and still enumerates; existing sparse-context tests pass unchanged.

## Validation

- Domain lanes: `tests/math/{number_theory,topology,graphs,formal_concept_analysis}`, `tests/integration/graphs` — all pass, including new known-answer/boundary/adversarial tests per domain (admission rejection at the exact boundary, typed-result construction at the boundary, forged-result rejection, single-solve budget accounting).
- Full ordinary set: `tests/math tests/catalog tests/dispatch tests/cli tests/tooling` — 5220 passed.
- `ruff check` / `ruff format --check` clean; repo mypy lane clean (990 files).

Fixes #2495
Fixes #2496
Fixes #2497
Fixes #2498
