### PR TITLE
docs: require canonical-value ownership preflight

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,13 @@ compatibility, packaging, and the ordinary Python surface. See
 <!-- Does this change alter an operation ID, request/result schema, native API,
 MCP contract, or mathematical semantics? State "none" when it does not. -->
 
+## Canonical value audit
+<!-- Complete when this change adds or changes a mathematical value, request,
+result, producer, or consumer. -->
+- [ ] Existing canonical values searched
+- [ ] Owner or intentional distinction documented
+- [ ] Producer→consumer serialization tested
+
 ## Public operation admission
 <!-- Complete only when adding or materially changing a public operation. -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,10 @@ public request
 - Each mathematical value has one domain-owned canonical type. Producers return
   that type and consumers accept it unchanged, including for empty and
   degenerate values; operation-specific models must not recreate it.
+- Before adding a mathematical value, search for an existing owner by meaning
+  and fields, not just by class name. Reuse it whenever possible. If a new
+  type is necessary, document the distinction, define an explicit conversion,
+  and test serialized producer-consumer composition.
 - Backends never define the accepted public domain through runtime exceptions.
 - Intentional changes of ring, field, parent, or axis require explicit typed
   maps; implicit coercion is forbidden.

--- a/docs/reference/domain-operation-library.md
+++ b/docs/reference/domain-operation-library.md
@@ -223,6 +223,15 @@ variables to zero. Backend generator inference, ambient rings, and automatic
 coercion are private conveniences and do not define Jacobian's public
 semantics.
 
+### Canonical-value preflight
+
+Before adding a mathematical value, search the existing `values.py`,
+`_models.py`, and native exports by semantic meaning and fields, not only by
+class name. Reuse the existing owner across requests, results, producers, and
+consumers whenever possible. If a distinct type is necessary, record the
+different parent, representation, or postcondition, and define an explicit
+typed conversion rather than relying on caller-side reconstruction.
+
 Each mathematical value has one canonical type owned by its domain. A producer
 returns that type and downstream consumers accept it unchanged. An operation
 request may contain the value alongside genuine operation parameters, but must


### PR DESCRIPTION
## Problem

The repository already requires one canonical mathematical value type, but the rule is easy to miss when a semantically equivalent value is introduced under a different name or representation. That creates duplicate ownership and breaks direct producer-consumer composition. This is the pattern documented in [#2531](https://github.com/morluto/jacobian/issues/2531).

## Solution

- Add a concise normative preflight rule to `AGENTS.md`.
- Document the semantic-and-field search, explicit conversion requirement, and serialized composition proof in the domain-operation reference.
- Add exactly three canonical-value checks to the pull-request template.

The change intentionally does not add a CI failure for duplicate class names: some repeated names are valid when their mathematical parents or postconditions differ.

## Testing

- `git diff --check` — passed.
- `make check` — Ruff, format, and mypy passed; the long non-exhaustive pytest lane was interrupted at 55% because this is a documentation-only change.

## Public contract impact

None.

## Public operation admission

Not applicable.

## Canonical value audit

Not applicable; this PR changes contribution guidance only.

## Closure matrix

None.
