### PR TITLE
fix(logic): carry signed coefficients and exact scaled numerators in SMT UNSAT cores

### DIFF
--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -82,6 +82,16 @@ def _pairs_common_denominator(
     return lcm(*(denominator for _numerator, denominator in pairs))
 
 
+def _negated_envelope(envelope: _CoefficientEnvelope) -> _CoefficientEnvelope:
+    if envelope.pairs is None:
+        return envelope
+    return envelope._replace(
+        pairs=tuple(
+            (-numerator, denominator) for numerator, denominator in envelope.pairs
+        )
+    )
+
+
 def _scaled_pairs(
     scalar: Fraction,
     pairs: tuple[tuple[int, int], ...] | None,
@@ -91,7 +101,7 @@ def _scaled_pairs(
     return _capped_pairs(
         {
             (
-                abs((Fraction(numerator, denominator) * scalar).numerator),
+                (Fraction(numerator, denominator) * scalar).numerator,
                 (Fraction(numerator, denominator) * scalar).denominator,
             )
             for numerator, denominator in pairs
@@ -646,7 +656,7 @@ def _coefficient_height(
             _merged_pairs(left.pairs, right.pairs),
         )
     if kind == z3.Z3_OP_UMINUS:
-        return child_envelopes[0]
+        return _negated_envelope(child_envelopes[0])
     if kind == z3.Z3_OP_MUL:
         return _multiplied_envelope(
             child_envelopes,
@@ -667,6 +677,9 @@ def _coefficient_height(
     if kind in (z3.Z3_OP_ADD, z3.Z3_OP_SUB):
         return _signed_sum_envelope(
             child_envelopes,
+            signs=(1,) * len(child_envelopes)
+            if kind == z3.Z3_OP_ADD
+            else (1,) + (-1,) * (len(child_envelopes) - 1),
             validate_budget=enforce_digit_budget,
         )
     if kind in (
@@ -736,7 +749,7 @@ def _product_pairs(
             for shared_numerator, shared_denominator in result:
                 right = Fraction(shared_numerator, shared_denominator)
                 product = left * right
-                combined.add((abs(product.numerator), product.denominator))
+                combined.add((product.numerator, product.denominator))
         result = combined
         if len(result) > _MAX_ENVELOPE_PAIRS:
             return None
@@ -774,9 +787,10 @@ def _divided_envelope(
 def _signed_sum_envelope(
     envelopes: tuple[_CoefficientEnvelope, ...],
     *,
+    signs: tuple[int, ...],
     validate_budget: bool,
 ) -> _CoefficientEnvelope:
-    """Merge child readings the way signed sums combine their coefficients."""
+    """Merge child readings the way the node's signed combination does."""
 
     height = Fraction(0)
     for envelope in envelopes:
@@ -795,10 +809,10 @@ def _signed_sum_envelope(
     shared = _shared_denominator_of_pairs(envelopes)
     if shared is not None:
         lifted: list[set[Fraction]] = []
-        for envelope in envelopes:
+        for sign, envelope in zip(signs, envelopes, strict=True):
             lifted.append(
                 {
-                    Fraction(numerator, denominator) * shared
+                    sign * Fraction(numerator, denominator) * shared
                     for numerator, denominator in envelope.pairs or ()
                 }
             )
@@ -810,10 +824,7 @@ def _signed_sum_envelope(
         else:
             pairs = _capped_pairs(
                 {
-                    (
-                        abs((total / shared).numerator),
-                        (total / shared).denominator,
-                    )
+                    ((total / shared).numerator, (total / shared).denominator)
                     for total in totals
                 }
             )
@@ -863,7 +874,11 @@ def _compared_envelope(
         _require_bounded_normalized_coefficient(height)
     shared = _shared_denominator_of_pairs(envelopes)
     if shared is None:
-        fallback = _signed_sum_envelope(envelopes, validate_budget=validate_budget)
+        fallback = _signed_sum_envelope(
+            envelopes,
+            signs=(1,) * len(envelopes),
+            validate_budget=validate_budget,
+        )
         return _CoefficientEnvelope(
             height,
             fallback.numerator_digits,
@@ -918,7 +933,7 @@ def _closed_value_envelope(value: Fraction) -> _CoefficientEnvelope:
         abs(value),
         len(str(abs(value.numerator))),
         len(str(value.denominator)),
-        ((abs(value.numerator), value.denominator),),
+        ((value.numerator, value.denominator),),
     )
 
 
@@ -932,9 +947,7 @@ def _affine_form_envelope(
         height,
         max(len(str(abs(value.numerator))) for value in coefficients),
         max(len(str(value.denominator)) for value in coefficients),
-        _capped_pairs(
-            {(abs(value.numerator), value.denominator) for value in coefficients}
-        ),
+        _capped_pairs({(value.numerator, value.denominator) for value in coefficients}),
     )
 
 
@@ -950,6 +963,11 @@ def _scaled_coefficient_envelope(
     common_denominator = _pairs_common_denominator(pairs)
     if common_denominator is not None:
         denominator_digits = min(denominator_digits, len(str(common_denominator)))
+        widest_scaled_numerator = max(
+            abs(numerator) for numerator, _denominator in pairs or ()
+        )
+        if widest_scaled_numerator:
+            numerator_digits = min(numerator_digits, len(str(widest_scaled_numerator)))
     _require_bounded_coefficient_digit_budget(numerator_digits, denominator_digits)
     return _CoefficientEnvelope(
         coefficient * envelope.height,

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -37,8 +37,9 @@ class _CoefficientEnvelope(NamedTuple):
     magnitude at most ``height``, numerator digit count at most
     ``numerator_digits``, and denominator digit count at most
     ``denominator_digits``. ``pairs`` is the exact closure of reachable
-    ``(numerator bound, denominator)`` pairs, or ``None`` when only the
-    marginal digit budgets are tracked; sums and comparisons use it to keep
+    ``(numerator bound, denominator)`` pairs, or a conservative closure that
+    also retains unmatched child coefficients, or ``None`` when only the
+    marginal digit budgets are tracked. Sums and comparisons use it to keep
     shared denominators from compounding while still bounding merged
     numerators soundly.
     """
@@ -822,10 +823,13 @@ def _signed_sum_envelope(
             if len(totals) > _MAX_ENVELOPE_PAIRS:
                 break
         else:
+            reachable: set[Fraction] = set(totals)
+            for values in lifted:
+                reachable.update(values)
             pairs = _capped_pairs(
                 {
-                    ((total / shared).numerator, (total / shared).denominator)
-                    for total in totals
+                    ((value / shared).numerator, (value / shared).denominator)
+                    for value in reachable
                 }
             )
             common_denominator = _pairs_common_denominator(pairs)
@@ -833,7 +837,7 @@ def _signed_sum_envelope(
                 denominator_digits = min(
                     denominator_digits, len(str(common_denominator))
                 )
-            widest_merged = max(abs((total / shared).numerator) for total in totals)
+            widest_merged = max(abs((value / shared).numerator) for value in reachable)
             numerator_digits = min(numerator_digits, len(str(widest_merged)))
     else:
         pairs = None

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -960,6 +960,47 @@ def test_request_bounds_shared_denominator_comparison_numerator_digits() -> None
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_scaled_formless_comparison_lifted_numerators() -> None:
+    scalar = "1" + "0" * 99
+    odd = "9" * 200
+    ite_template = "(ite {p} (/ (* 9 x) 2) (/ x {odd}))"
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* {scalar} {ite_template.format(p='p', odd=odd)}) "
+        f"(* {scalar} {ite_template.format(p='q', odd=odd)})))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_scaled_formless_comparison_still_admitted() -> None:
+    scalar = "1" + "0" * 79
+    odd = "9" * 160
+    ite_template = "(ite {p} (/ (* 9 x) 2) (/ x {odd}))"
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* {scalar} {ite_template.format(p='p', odd=odd)}) "
+        f"(* {scalar} {ite_template.format(p='q', odd=odd)})))\n"
+        "(assert (>= x 0))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
+
+
 def test_request_bounds_nested_division_of_formless_ite_denominator_digits() -> None:
     outer = "9" * 200
     inner = "9" * 100

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -812,12 +812,12 @@ def test_request_bounds_formless_ite_sum_denominator_digits() -> None:
 
 
 def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
-    odd = "9" * 200
-    scalar = "9" * 100
-    ite_template = "(ite {p} (* (/ 9 2) x) (* (/ 1 {odd}) x))"
+    power = "3" * 170
+    scalar = "7" * 100
+    ite_template = "(ite {p} (* 4.5 x) (* (/ 1 {power}) x))"
     sum_term = (
-        f"(+ {ite_template.format(p='p', odd=odd)} "
-        f"{ite_template.format(p='q', odd=odd)})"
+        f"(+ {ite_template.format(p='p', power=power)} "
+        f"{ite_template.format(p='q', power=power)})"
     )
     scaled_source = (
         "(set-logic QF_LRA)\n"
@@ -841,6 +841,43 @@ def test_request_bounds_mixed_denominator_formless_ite_sum_scaling() -> None:
     )
 
     assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=unscaled_source)
+
+
+def test_request_bounds_opposite_sign_comparison_numerator_digits() -> None:
+    divisor = "8" + "0" * 254 + "9"
+    numerator = "9" * 256
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(assert (= (ite p (* (- (/ "
+        f"{numerator} {divisor}))) x) "
+        "(ite q (* (/ "
+        f"{numerator} {divisor})) x)))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
+def test_bounded_reciprocal_cancelling_formless_ite_still_admitted() -> None:
+    digits = "9" * 256
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const x Real)\n"
+        f"(assert (= (* (/ 1 {digits}) (ite p (* {digits} x) x)) 1))\n"
+        "(check-sat)\n"
+    )
+
+    assert SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+    result = compute_smt_unsat_core(SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source))
+
+    assert result.outcome == "SAT"
+    assert result.core_indices == ()
 
 
 def test_request_bounds_four_shared_denominator_formless_ite_terms() -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -978,6 +978,29 @@ def test_request_bounds_scaled_formless_comparison_lifted_numerators() -> None:
         SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
 
 
+def test_request_bounds_scaled_formless_sum_retains_unmatched_coefficients() -> None:
+    digits = "9" * 255
+    scalar = "7" * 10
+    left = f"(/ (+ (* (+ {digits} 1) {{variable}}) (+ {digits} 1)) (* 2 {digits}))"
+    right = f"(/ (+ (* (- {digits} 1) {{variable}}) (- {digits} 1)) (* 2 {digits}))"
+    source = (
+        "(set-logic QF_LRA)\n"
+        "(declare-const p Bool)\n"
+        "(declare-const q Bool)\n"
+        "(declare-const x Real)\n"
+        "(declare-const y Real)\n"
+        "(declare-const u Real)\n"
+        "(declare-const v Real)\n"
+        f"(assert (= (/ (- (ite p {left.format(variable='x')} "
+        f"{left.format(variable='y')}) (ite q {right.format(variable='u')} "
+        f"{right.format(variable='v')})) (/ 1 {scalar})) 0))\n"
+        "(check-sat)\n"
+    )
+
+    with pytest.raises(ValidationError, match="normalized SMT coefficient"):
+        SmtUnsatCoreRequest(logic="QF_LRA", smtlib=source)
+
+
 def test_bounded_scaled_formless_comparison_still_admitted() -> None:
     scalar = "1" + "0" * 79
     odd = "9" * 160


### PR DESCRIPTION
Follow-up to #2364 (squash-merged as 54b1d1ce before the final two late-arriving review fixes landed on the branch).

Carries the two post-merge commits cherry-picked onto current main:

- **Signed comparison numerators** — comparison pairs stored absolute numerators, so opposite-sign sides reduced `-(A+B)/D` to `|A-B|/D` and admitted requests beyond the advertised numerator-digit bound. Pairs now keep signed numerators end-to-end (negation through UMINUS/SUB/scalings); comparisons reduce exact pairwise signed differences.
- **Exact scaled budgets** — scaling estimated numerators additively even when exact scaled pairs existed, over-rejecting cancelling forms like `(* (/ 1 D) (ite p (* D x) x))` at the 256-digit boundary. Scaled budgets now tighten from exact pairs.
- Test coverage for both behaviors (`test_request_bounds_opposite_sign_comparison_numerator_digits`, `test_bounded_reciprocal_cancelling_formless_ite_still_admitted`, plus scaled formless comparison lifted-numerator coverage).

Validation: `pytest tests/math/logic -n 4 --timeout=120` 171 passed; ruff + mypy clean on src/jacobian/math/logic.