### PR TITLE
fix(math): reduce colliding class sums before measuring coefficient heights

### DIFF
--- a/src/jacobian/math/polynomials/differential_operators/_bounds.py
+++ b/src/jacobian/math/polynomials/differential_operators/_bounds.py
@@ -628,6 +628,12 @@ def _per_exponent_height_bits(
             total = numerator_sum * (new_lcm // lcm) + scaled_numerator * (
                 new_lcm // class_denominator
             )
+            # Reduce the class fraction so shared factors between the summed
+            # numerator and the common denominator - contributions r and 2r
+            # over L = r - never inflate the measured height.
+            common = math.gcd(total, new_lcm)
+            new_lcm //= common
+            total //= common
             if new_lcm.bit_length() > cap or total.bit_length() > cap:
                 return None
             classes[target] = (new_lcm, total)

--- a/tests/math/polynomials/differential_operators/test_differential_operators.py
+++ b/tests/math/polynomials/differential_operators/test_differential_operators.py
@@ -1904,6 +1904,67 @@ def test_falling_factorial_cancels_against_source_denominators() -> None:
     assert replayed == result
 
 
+def test_class_sums_are_reduced_before_height_measurement() -> None:
+    variables = ("x",)
+    big = 10**32_767
+    shared_denominator = 6 * big + 1
+    source = RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(
+                        Fraction(3 * big, shared_denominator)
+                    ),
+                    exponents=(1,),
+                ),
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(
+                        Fraction(9 * big + 2, shared_denominator)
+                    ),
+                    exponents=(0,),
+                ),
+            )
+        ),
+    )
+    operator = _operator(variables, {(0,): 1, (1,): 1})
+    expected = RationalPolynomial(
+        variables=variables,
+        polynomial=SparseRationalPolynomial(
+            terms=(
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(
+                        Fraction(3 * big, shared_denominator)
+                    ),
+                    exponents=(1,),
+                ),
+                RationalPolynomialTerm(
+                    coefficient=CanonicalRational.from_fraction(Fraction(2)),
+                    exponents=(0,),
+                ),
+            )
+        ),
+    )
+
+    result = compute_differential_operator_application(
+        DifferentialOperatorApplyRequest(
+            polynomial=source,
+            operator=operator,
+            iterations=1,
+            expected=expected,
+        )
+    )
+    replayed = DifferentialOperatorApplyResult.model_validate(
+        result.model_dump(mode="json")
+    )
+
+    assert result.output == expected
+    assert len(result.output.polynomial.terms[0].coefficient.num) == 32_768
+    assert result.matches_expected is True
+    assert result.is_zero is False
+    assert replayed == result
+
+
 def test_colliding_output_exponents_share_the_candidate_budget() -> None:
     variables = ("x",)
     source = _polynomial(variables, {(degree,): 1 for degree in range(2_049)})


### PR DESCRIPTION
Follow-up to #2342 (squash-merged as 22ef4389c before the final review fix landed; the original branch was deleted, so this cherry-picks the fix onto current main).

Resolves review thread [b3cUJ](https://github.com/morluto/jacobian/pull/2342#discussion_r-1) on #2342:

- **Root cause:** `_per_exponent_height_bits` measured coefficient heights on the raw product `(total, new_lcm)` before reducing by their gcd, so colliding class sums inflated heights and caused conservative rejections at the height cap.
- **Fix:** reduce each accumulated sum by its gcd before cap checks and storage.
- Regression test: `test_class_sums_are_reduced_before_height_measurement`.

Validation: `pytest tests/math/polynomials/differential_operators -n 4 --timeout=120` 83 passed; ruff + mypy clean (applied cleanly onto the post-squash main tip).