### PR TITLE
ci(testing): select pull-request math evidence

### DIFF
--- a/.github/actions/run-test-lane/action.yml
+++ b/.github/actions/run-test-lane/action.yml
@@ -13,16 +13,29 @@ inputs:
   coverage-file:
     description: Coverage database filename after the lane is isolated.
     required: true
+  tests:
+    description: Optional space-separated test paths selected by the CI planner.
+    required: false
+    default: ""
+  collect-coverage:
+    description: Whether this lane contributes a coverage database.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
     - name: Run ${{ inputs.lane }} tests
       shell: bash
       env:
-        PYTEST_ARGS: >-
-          --junitxml=pytest.xml
-          --cov --cov-report= --cov-fail-under=0
-      run: make test-${{ inputs.lane }}
+        COLLECT_COVERAGE: ${{ inputs.collect-coverage }}
+        TESTS: ${{ inputs.tests }}
+      run: |
+        pytest_args=(--junitxml=pytest.xml)
+        if [ "$COLLECT_COVERAGE" = true ]; then
+          pytest_args+=(--cov --cov-report= --cov-fail-under=0)
+        fi
+        env PYTEST_ARGS="${pytest_args[*]}" \
+          make test-${{ inputs.lane }} TESTS="$TESTS"
     - if: ${{ !cancelled() }}
       shell: bash
       run: uv cache prune --ci
@@ -33,11 +46,11 @@ runs:
         path: pytest.xml
         if-no-files-found: ignore
         retention-days: 7
-    - if: ${{ !cancelled() }}
+    - if: ${{ !cancelled() && inputs.collect-coverage == 'true' }}
       shell: bash
       run: mv .coverage ${{ inputs.coverage-file }}
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && inputs.collect-coverage == 'true' }}
       with:
         name: ${{ inputs.coverage-artifact }}
         path: ${{ inputs.coverage-file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,26 +57,131 @@ jobs:
           name: dist
           path: dist/
 
+  plan:
+    name: plan test evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pr_lanes: ${{ steps.plan.outputs.pr_lanes }}
+      run_math: ${{ steps.plan.outputs.run_math }}
+      math_tests: ${{ steps.plan.outputs.math_tests }}
+      run_catalog: ${{ steps.plan.outputs.run_catalog }}
+      run_catalog_examples: ${{ steps.plan.outputs.run_catalog_examples }}
+      plan: ${{ steps.plan.outputs.plan }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_LANES: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_lanes) }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || github.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          event="$EVENT_NAME"
+          if [ "$PR_LANES" = true ]; then
+            event=pull_request
+          fi
+          if [ "$event" = pull_request ] && [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+            # A manually dispatched PR-lane run has no pull-request base SHA.
+            # Preserve evidence by using the planner's full-suite event policy.
+            event=workflow_dispatch
+          fi
+          if [ "$event" = pull_request ]; then
+            git diff --no-ext-diff --no-textconv --name-only "$BASE_SHA...$HEAD_SHA" > changed-paths.txt
+          else
+            : > changed-paths.txt
+          fi
+          python tools/ci_test_plan.py \
+            --event "$event" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --changed-paths changed-paths.txt \
+            --github-output "$GITHUB_OUTPUT"
+          echo "pr_lanes=$PR_LANES" >> "$GITHUB_OUTPUT"
+
+  math:
+    name: python (math)
+    needs: plan
+    if: ${{ needs.plan.outputs.run_math == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - uses: ./.github/actions/run-test-lane
+        with:
+          lane: math
+          junit-artifact: junit-python-math-3.12
+          coverage-artifact: coverage-data-python-math
+          coverage-file: .coverage.python-math
+          tests: ${{ needs.plan.outputs.math_tests }}
+          collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
+
+  catalog:
+    name: python (catalog)
+    needs: plan
+    if: ${{ needs.plan.outputs.run_catalog == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - uses: ./.github/actions/run-test-lane
+        with:
+          lane: catalog
+          junit-artifact: junit-python-catalog-3.12
+          coverage-artifact: coverage-data-python-catalog
+          coverage-file: .coverage.python-catalog
+          collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
+
+  catalog_examples:
+    name: python (catalog examples)
+    needs: plan
+    if: ${{ needs.plan.outputs.run_catalog_examples == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - uses: ./.github/actions/run-test-lane
+        with:
+          lane: integration
+          junit-artifact: junit-python-catalog-examples-3.12
+          coverage-artifact: coverage-data-python-catalog-examples
+          coverage-file: .coverage.python-catalog-examples
+          tests: tests/integration/catalog/test_builtin_examples.py
+          collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
+
   python:
     name: python (${{ matrix.lane }})
+    needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - lane: math
-            timeout-minutes: 25
-          - lane: catalog
-            timeout-minutes: 10
           - lane: dispatch
             timeout-minutes: 10
           - lane: cli
             timeout-minutes: 10
           - lane: tooling
             timeout-minutes: 15
-          - lane: integration
-            timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -90,9 +195,11 @@ jobs:
           junit-artifact: junit-python-${{ matrix.lane }}-3.12
           coverage-artifact: coverage-data-python-${{ matrix.lane }}
           coverage-file: .coverage.python-${{ matrix.lane }}
+          collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
 
   boundaries:
     name: boundaries (${{ matrix.lane }})
+    needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -112,6 +219,7 @@ jobs:
           junit-artifact: junit-${{ matrix.lane }}-3.12
           coverage-artifact: coverage-data-${{ matrix.lane }}
           coverage-file: .coverage.${{ matrix.lane }}
+          collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
 
   singular:
     name: Singular Runtime
@@ -202,16 +310,24 @@ jobs:
 
   coverage:
     name: Coverage
-    if: ${{ always() }}
-    needs: [python, boundaries]
+    if: ${{ always() && needs.plan.outputs.pr_lanes != 'true' }}
+    needs: [plan, math, catalog, catalog_examples, python, boundaries]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Require python and boundary lanes
+      - name: Require selected final-tree test lanes
         env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          MATH_RESULT: ${{ needs.math.result }}
+          CATALOG_RESULT: ${{ needs.catalog.result }}
+          CATALOG_EXAMPLES_RESULT: ${{ needs.catalog_examples.result }}
           PYTHON_RESULT: ${{ needs.python.result }}
           BOUNDARIES_RESULT: ${{ needs.boundaries.result }}
         run: |
+          test "$PLAN_RESULT" = success
+          test "$MATH_RESULT" = success
+          test "$CATALOG_RESULT" = success
+          test "$CATALOG_EXAMPLES_RESULT" = success
           test "$PYTHON_RESULT" = success
           test "$BOUNDARIES_RESULT" = success
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -246,17 +362,23 @@ jobs:
   required:
     name: required
     if: ${{ always() }}
-    needs: [static, python, boundaries, singular, wheel, coverage, lean]
+    needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, coverage, lean]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require static python boundaries wheel coverage and selected specialist lanes
+      - name: Require selected evidence and final-tree specialist lanes
         env:
-          EVENT_NAME: ${{ github.event_name }}
           # True for pull_request runs and for autofix dispatches that select
           # the pull_request lane set; Lean then counts skipped as passing.
-          PR_LANE_SELECTION: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_lanes) }}
+          PR_LANE_SELECTION: ${{ needs.plan.outputs.pr_lanes }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+          RUN_MATH: ${{ needs.plan.outputs.run_math }}
+          RUN_CATALOG: ${{ needs.plan.outputs.run_catalog }}
+          RUN_CATALOG_EXAMPLES: ${{ needs.plan.outputs.run_catalog_examples }}
           STATIC_RESULT: ${{ needs.static.result }}
+          MATH_RESULT: ${{ needs.math.result }}
+          CATALOG_RESULT: ${{ needs.catalog.result }}
+          CATALOG_EXAMPLES_RESULT: ${{ needs.catalog_examples.result }}
           PYTHON_RESULT: ${{ needs.python.result }}
           BOUNDARIES_RESULT: ${{ needs.boundaries.result }}
           SINGULAR_RESULT: ${{ needs.singular.result }}
@@ -264,14 +386,25 @@ jobs:
           COVERAGE_RESULT: ${{ needs.coverage.result }}
           LEAN_RESULT: ${{ needs.lean.result }}
         run: |
+          selected_result() {
+            case "$1:$2" in
+              true:success|false:skipped) ;;
+              *) echo "selected=$1 result=$2" >&2; exit 1 ;;
+            esac
+          }
+          test "$PLAN_RESULT" = success
           test "$STATIC_RESULT" = success
+          selected_result "$RUN_MATH" "$MATH_RESULT"
+          selected_result "$RUN_CATALOG" "$CATALOG_RESULT"
+          selected_result "$RUN_CATALOG_EXAMPLES" "$CATALOG_EXAMPLES_RESULT"
           test "$PYTHON_RESULT" = success
           test "$BOUNDARIES_RESULT" = success
           test "$SINGULAR_RESULT" = success
           test "$WHEEL_RESULT" = success
-          test "$COVERAGE_RESULT" = success
           if [ "$PR_LANE_SELECTION" = true ]; then
+            test "$COVERAGE_RESULT" = skipped
             test "$LEAN_RESULT" = skipped || test "$LEAN_RESULT" = success
           else
+            test "$COVERAGE_RESULT" = success
             test "$LEAN_RESULT" = success
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,10 @@ Then open a pull request. `make setup` installs the locked development
 environment with the complete maintained Python backend stack. `make check`
 runs Ruff, mypy, and the Lean-free math, catalog, dispatch, CLI, and tooling
 owners. Add the named `make test-*` lane for the behavior or boundary changed;
-CI runs the complete fixed semantic matrix.
+pull-request CI runs static checks plus the changed mathematical owner. Public
+operation, model, admission, and canonical-contract changes also run catalog
+conformance and every advertised invocation example; merge-group candidates
+and `main` run the full mathematical suite.
 Open the PR once it is green, and add any explicitly relevant specialist
 validation called out below.
 
@@ -54,8 +57,9 @@ pre-push hook stays `make lint typecheck`. Focused debugging uses
 `uv run pytest path/to/test.py`. Default `uv run pytest` collects the ordinary
 Lean-free `testpaths`; it does not run process, MCP, or Lean trees.
 
-CI runs the ordinary Python surface, MCP boundaries, and the wheel smoke. Full
-Lean runs on merge-group candidates and on `main`, not on every pull request.
+CI runs static checks, the selected ordinary Python surface, MCP boundaries,
+and the wheel smoke. Full mathematical and Lean suites run on merge-group
+candidates and on `main`, not on every pull request.
 That gate needs GitHub merge queue
 enabled on `main`; without a queue, Lean only runs after a push to `main`. You
 do not need to reproduce Lean locally for a routine change unless you edited
@@ -75,8 +79,8 @@ operation.
 ### When the quick path is not enough
 
 - **Documentation only:** `make docs-linkcheck` is the dedicated lane; CI runs
-  it too. See [Documentation](#documentation). Ordinary Python tests still run
-  on documentation PRs.
+  it too. See [Documentation](#documentation). Static and boundary CI evidence
+  still runs, but no mathematical owner is selected.
 - **Broad or unknown impact** (CI, dependencies, shared infrastructure): run
   `make check-static` plus the affected tests, and let CI own the fail-closed
   functional lanes.
@@ -145,7 +149,8 @@ Before final validation, run `make check` plus the named lane that owns the
 changed behavior. If the tree changes during validation, rerun checks whose
 evidence was invalidated by that change; do not describe results from an
 earlier tree as final-tree validation. `make check-all` is an explicit broad
-reproduction, not a routine closeout requirement. CI owns the complete matrix.
+reproduction, not a routine closeout requirement. Merge-group CI owns the
+complete mathematical matrix.
 Use `make check-external` when the fixed Lean check changes, and run the owning
 mathematical test when a maintained Python backend changes.
 

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -29,6 +29,17 @@ real boundary:
 `make check-all` is an intentional broad reproduction. Do not use a full suite
 as a substitute for a focused regression test.
 
+## CI lifecycle
+
+Pull requests always run static validation. The checked-in CI planner selects
+the changed `tests/math` owner and, when a public operation, model, admission,
+or canonical contract changes, catalog conformance plus the advertised-example
+integration test. Shared runtime, CI, dependency, and unmapped mathematical
+paths fail closed to the full math suite. Merge-group candidates and `main`
+always run the full non-exhaustive `tests/math` suite. Scheduled validation owns
+exhaustive and repeated property checks. Collection inspection remains a manual
+diagnostic, not a prerequisite for every test lane.
+
 ## What to test
 
 For an operation, test the typed request boundary, the domain result, and a

--- a/tests/tooling/test_ci_test_plan.py
+++ b/tests/tooling/test_ci_test_plan.py
@@ -1,0 +1,122 @@
+"""Tests for the fail-closed mathematical CI selector."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+
+
+def _load() -> ModuleType:
+    path = ROOT / "tools" / "ci_test_plan.py"
+    spec = importlib.util.spec_from_file_location("ci_test_plan", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _plan(paths: list[str], *, event: str = "pull_request") -> object:
+    planner = _load()
+    return planner.build_plan(
+        event=event,
+        base_revision="a" * 40,
+        head_revision="b" * 40,
+        changed_paths=paths,
+        repository=ROOT,
+    )
+
+
+def test_model_change_selects_its_math_owner_and_public_contract_evidence() -> None:
+    plan = _plan(["src/jacobian/math/code_theory/_models.py"])
+
+    assert plan.run_math is True
+    assert plan.math_tests == ("tests/math/code_theory",)
+    assert plan.run_catalog is True
+    assert plan.run_catalog_examples is True
+
+
+def test_public_operation_kernel_selects_catalog_examples() -> None:
+    plan = _plan(["src/jacobian/math/code_theory/_dual_operations.py"])
+
+    assert plan.run_math is True
+    assert plan.run_catalog is True
+    assert plan.run_catalog_examples is True
+
+
+def test_nested_math_owner_selects_its_top_level_test_root() -> None:
+    plan = _plan(["src/jacobian/math/matrices/canonical_forms/_models.py"])
+
+    assert plan.run_math is True
+    assert plan.math_tests == ("tests/math/matrices",)
+
+
+def test_math_test_change_runs_only_the_changed_test() -> None:
+    path = "tests/math/code_theory/test_exact_code_enumeration.py"
+    plan = _plan([path])
+
+    assert plan.run_math is True
+    assert plan.math_tests == (path,)
+    assert plan.run_catalog is False
+
+
+def test_shared_runtime_path_falls_back_to_full_math_and_public_contracts() -> None:
+    plan = _plan(["src/jacobian/canonical.py"])
+
+    assert plan.run_math is True
+    assert plan.math_tests == ()
+    assert plan.run_catalog is True
+    assert plan.run_catalog_examples is True
+    assert "shared CI or runtime path changed" in plan.reasons[0]
+
+
+def test_unknown_math_owner_falls_back_to_full_math(tmp_path: Path) -> None:
+    planner = _load()
+    plan = planner.build_plan(
+        event="pull_request",
+        base_revision="a" * 40,
+        head_revision="b" * 40,
+        changed_paths=["src/jacobian/math/future_owner/_models.py"],
+        repository=tmp_path,
+    )
+
+    assert plan.run_math is True
+    assert plan.math_tests == ()
+    assert plan.run_catalog is True
+    assert "no explicit test root" in plan.reasons[0]
+
+
+def test_documentation_change_skips_product_evidence() -> None:
+    plan = _plan(["docs/reference/testing-strategy.md"])
+
+    assert plan.run_math is False
+    assert plan.run_catalog is False
+    assert plan.run_catalog_examples is False
+
+
+def test_merge_group_always_owns_full_math_and_public_contracts() -> None:
+    plan = _plan(["docs/reference/testing-strategy.md"], event="merge_group")
+
+    assert plan.run_math is True
+    assert plan.math_tests == ()
+    assert plan.run_catalog is True
+    assert plan.run_catalog_examples is True
+
+
+def test_rejects_non_normalized_paths() -> None:
+    planner = _load()
+
+    with pytest.raises(ValueError, match="normalized and repository-relative"):
+        planner.build_plan(
+            event="pull_request",
+            base_revision="a" * 40,
+            head_revision="b" * 40,
+            changed_paths=["../tests/math/test_anything.py"],
+            repository=ROOT,
+        )

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -46,7 +46,7 @@ def test_process_lane_is_invoked_by_ci() -> None:
 
     assert "lane: [process, mcp]" in workflow
     assert "uses: ./.github/actions/run-test-lane" in workflow
-    assert "run: make test-${{ inputs.lane }}" in action
+    assert 'make test-${{ inputs.lane }} TESTS="$TESTS"' in action
 
 
 def test_singular_backend_has_a_pinned_required_ci_lane() -> None:
@@ -59,7 +59,7 @@ def test_singular_backend_has_a_pinned_required_ci_lane() -> None:
     assert 'system("version")' in singular
     assert "make test-singular" in singular
     assert (
-        "needs: [static, python, boundaries, singular, wheel, coverage, lean]"
+        "needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, coverage, lean]"
         in required
     )
     assert 'test "$SINGULAR_RESULT" = success' in required
@@ -71,9 +71,10 @@ def test_python_and_boundary_lanes_share_evidence_collection() -> None:
         encoding="utf-8"
     )
 
-    assert workflow.count("uses: ./.github/actions/run-test-lane") == 2
+    assert workflow.count("uses: ./.github/actions/run-test-lane") == 5
     assert "--junitxml=pytest.xml" in action
-    assert "--cov --cov-report= --cov-fail-under=0" in action
+    assert "pytest_args+=(--cov --cov-report= --cov-fail-under=0)" in action
+    assert "inputs.collect-coverage == 'true'" in action
     assert action.count("actions/upload-artifact@") == 2
     assert "uv cache prune --ci" in action
 
@@ -112,12 +113,17 @@ def test_optional_boundary_jobs_have_explicit_workflow_gates() -> None:
     assert "name: Deployment Tests" not in workflow
 
 
-def test_python_jobs_use_fixed_local_semantic_targets() -> None:
+def test_python_jobs_select_math_and_public_contract_evidence_from_the_plan() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
 
     assert "name: python (${{ matrix.lane }})" in workflow
-    for lane in ("math", "catalog", "dispatch", "cli", "tooling", "integration"):
+    assert "name: python (math)" in workflow
+    assert "name: python (catalog)" in workflow
+    assert "name: python (catalog examples)" in workflow
+    assert "tests: ${{ needs.plan.outputs.math_tests }}" in workflow
+    assert "tests: tests/integration/catalog/test_builtin_examples.py" in workflow
+    for lane in ("dispatch", "cli", "tooling"):
         assert f"lane: {lane}" in workflow
     assert "lane: e2e" not in workflow
     assert "lane: provider" not in workflow
@@ -133,14 +139,15 @@ def test_python_jobs_use_fixed_local_semantic_targets() -> None:
     assert "check-external: test-lean test-provider" not in makefile
 
 
-def test_product_ci_does_not_emit_a_plan_receipt() -> None:
+def test_product_ci_uses_a_versioned_checked_in_test_plan() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert "python .github/scripts/emit-plan-receipt" not in workflow
-    assert "ci-plan-receipt" not in workflow
-    assert "classify-ci-paths" not in workflow
-    assert not (ROOT / ".github/scripts/emit-plan-receipt").exists()
-    assert not (ROOT / ".github/scripts/validate-benchmark-plan").exists()
+    assert "name: plan test evidence" in workflow
+    assert "python tools/ci_test_plan.py" in workflow
+    assert '--base "$BASE_SHA"' in workflow
+    assert '--head "$HEAD_SHA"' in workflow
+    assert "event=workflow_dispatch" in workflow
+    assert (ROOT / "tools" / "ci_test_plan.py").exists()
 
 
 def test_static_job_runs_docs_linkcheck() -> None:
@@ -194,3 +201,13 @@ def test_coverage_report_lives_in_the_job_summary_not_a_pr_comment() -> None:
     assert "jacobian-coverage-report" not in workflow
     assert "issues/$PR_NUMBER/comments" not in workflow
     assert "pull-requests: write" not in coverage
+
+
+def test_required_accepts_only_explicitly_skipped_pr_evidence() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    required = workflow.split("  required:", 1)[1]
+
+    assert "selected_result" in required
+    assert "true:success|false:skipped" in required
+    assert 'test "$COVERAGE_RESULT" = skipped' in required
+    assert 'test "$COVERAGE_RESULT" = success' in required

--- a/tools/ci_test_plan.py
+++ b/tools/ci_test_plan.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Plan bounded CI evidence from normalized repository-relative paths."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+
+PLAN_VERSION = 1
+SUPPORTED_EVENTS = frozenset(
+    {"pull_request", "merge_group", "push", "schedule", "workflow_dispatch"}
+)
+_REVISION = re.compile(r"[0-9a-f]{7,64}\Z")
+_SHARED_PATHS = frozenset(
+    {
+        "Makefile",
+        "pyproject.toml",
+        "uv.lock",
+        "src/jacobian/_exact.py",
+        "src/jacobian/_models.py",
+        "src/jacobian/canonical.py",
+    }
+)
+_SHARED_PREFIXES = (
+    ".github/",
+    "make/",
+    "tools/",
+    "src/jacobian/catalog/",
+    "src/jacobian/mcp/",
+)
+_PUBLIC_MATH_FILES = frozenset(
+    {
+        "_admission.py",
+        "_models.py",
+        "_operations.py",
+        "_tools.py",
+        "operations.py",
+        "values.py",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TestPlan:
+    version: int
+    event: str
+    base_revision: str
+    head_revision: str
+    topology_digest: str
+    run_math: bool
+    math_tests: tuple[str, ...]
+    run_catalog: bool
+    run_catalog_examples: bool
+    reasons: tuple[str, ...]
+
+    def as_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class PathDecision:
+    math_tests: tuple[str, ...] = ()
+    run_catalog: bool = False
+    run_catalog_examples: bool = False
+    full_math_reason: str | None = None
+
+
+def _normalize_paths(paths: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for raw_path in paths:
+        path = raw_path.strip()
+        if not path:
+            continue
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute() or "\\" in path or ".." in candidate.parts:
+            raise ValueError(
+                f"path must be normalized and repository-relative: {raw_path!r}"
+            )
+        normalized.append(candidate.as_posix())
+    return tuple(sorted(set(normalized)))
+
+
+def _topology_digest() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _is_shared(path: str) -> bool:
+    return path in _SHARED_PATHS or path.startswith(_SHARED_PREFIXES)
+
+
+def _math_owner_tests(owner: str, repository: Path) -> tuple[str, ...] | None:
+    root = repository / "tests" / "math"
+    paths: list[str] = []
+    owner_root = root / owner
+    if owner_root.exists():
+        paths.append(owner_root.relative_to(repository).as_posix())
+    paths.extend(
+        path.relative_to(repository).as_posix()
+        for path in sorted(root.glob(f"test_{owner}*.py"))
+    )
+    return tuple(dict.fromkeys(paths)) or None
+
+
+def _math_test_change(path: str) -> tuple[str, ...] | None:
+    relative = PurePosixPath(path).relative_to("tests/math")
+    if relative.name.startswith("_") or relative.name == "conftest.py":
+        return None
+    return (path,)
+
+
+def _is_public_math_path(path: str) -> bool:
+    filename = PurePosixPath(path).name
+    return filename in _PUBLIC_MATH_FILES or filename.endswith("_operations.py")
+
+
+def _classify_path(path: str, repository: Path) -> PathDecision:
+    if _is_shared(path):
+        return PathDecision(
+            run_catalog=True,
+            run_catalog_examples=True,
+            full_math_reason=f"shared CI or runtime path changed: {path}",
+        )
+    if path.startswith("src/jacobian/math/"):
+        parts = PurePosixPath(path).parts
+        owner = parts[3] if len(parts) > 3 else ""
+        selected = _math_owner_tests(owner, repository) if owner else None
+        if selected is None:
+            return PathDecision(
+                run_catalog=True,
+                run_catalog_examples=True,
+                full_math_reason=f"math owner has no explicit test root: {path}",
+            )
+        public_contract = _is_public_math_path(path)
+        return PathDecision(
+            math_tests=selected,
+            run_catalog=public_contract,
+            run_catalog_examples=public_contract,
+        )
+    if path.startswith("tests/math/"):
+        selected = _math_test_change(path)
+        if selected is None:
+            return PathDecision(
+                full_math_reason=f"shared mathematical test support changed: {path}"
+            )
+        return PathDecision(math_tests=selected)
+    if path.startswith("tests/catalog/"):
+        return PathDecision(run_catalog=True)
+    if path.startswith("tests/integration/catalog/"):
+        return PathDecision(run_catalog_examples=True)
+    if path.startswith("src/jacobian/"):
+        return PathDecision(
+            run_catalog=True,
+            run_catalog_examples=True,
+            full_math_reason=f"unmapped Jacobian runtime path changed: {path}",
+        )
+    return PathDecision()
+
+
+def _pull_request_plan(
+    *,
+    base_revision: str,
+    head_revision: str,
+    paths: tuple[str, ...],
+    repository: Path,
+) -> TestPlan:
+    math_tests: set[str] = set()
+    run_catalog = False
+    run_catalog_examples = False
+    full_math_reason: str | None = None
+    reasons: list[str] = []
+
+    for path in paths:
+        decision = _classify_path(path, repository)
+        math_tests.update(decision.math_tests)
+        run_catalog = run_catalog or decision.run_catalog
+        run_catalog_examples = run_catalog_examples or decision.run_catalog_examples
+        if decision.full_math_reason:
+            full_math_reason = decision.full_math_reason
+            break
+
+    if full_math_reason:
+        reasons.append(full_math_reason)
+        math_tests.clear()
+    else:
+        if math_tests:
+            reasons.append(
+                "selected mathematical owners: " + ", ".join(sorted(math_tests))
+            )
+        if run_catalog:
+            reasons.append(
+                "public operation, model, admission, or canonical contract changed"
+            )
+        if run_catalog_examples:
+            reasons.append(
+                "catalog invocation examples cover the changed public contract"
+            )
+        if not reasons:
+            reasons.append("no mathematical or public-contract path changed")
+    return TestPlan(
+        version=PLAN_VERSION,
+        event="pull_request",
+        base_revision=base_revision,
+        head_revision=head_revision,
+        topology_digest=_topology_digest(),
+        run_math=bool(math_tests) or full_math_reason is not None,
+        math_tests=tuple(sorted(math_tests)),
+        run_catalog=run_catalog,
+        run_catalog_examples=run_catalog_examples,
+        reasons=tuple(reasons),
+    )
+
+
+def build_plan(
+    *,
+    event: str,
+    base_revision: str,
+    head_revision: str,
+    changed_paths: Iterable[str],
+    repository: Path,
+) -> TestPlan:
+    if event not in SUPPORTED_EVENTS:
+        raise ValueError(f"unsupported CI event: {event!r}")
+    if not _REVISION.fullmatch(base_revision) or not _REVISION.fullmatch(head_revision):
+        raise ValueError("base and head revisions must be Git object IDs")
+
+    paths = _normalize_paths(changed_paths)
+    if event != "pull_request":
+        return TestPlan(
+            version=PLAN_VERSION,
+            event=event,
+            base_revision=base_revision,
+            head_revision=head_revision,
+            topology_digest=_topology_digest(),
+            run_math=True,
+            math_tests=(),
+            run_catalog=True,
+            run_catalog_examples=True,
+            reasons=(
+                f"{event} owns the complete mathematical and public-contract suite",
+            ),
+        )
+
+    return _pull_request_plan(
+        base_revision=base_revision,
+        head_revision=head_revision,
+        paths=paths,
+        repository=repository,
+    )
+
+
+def _write_github_output(plan: TestPlan, output: Path) -> None:
+    values = {
+        "plan": plan.as_json(),
+        "run_math": str(plan.run_math).lower(),
+        "math_tests": " ".join(plan.math_tests),
+        "run_catalog": str(plan.run_catalog).lower(),
+        "run_catalog_examples": str(plan.run_catalog_examples).lower(),
+    }
+    with output.open("a", encoding="utf-8") as stream:
+        for name, value in values.items():
+            stream.write(f"{name}<<JACOBIAN_CI_PLAN\n{value}\nJACOBIAN_CI_PLAN\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--changed-paths", type=Path, required=True)
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--github-output", type=Path)
+    arguments = parser.parse_args()
+    plan = build_plan(
+        event=arguments.event,
+        base_revision=arguments.base,
+        head_revision=arguments.head,
+        changed_paths=arguments.changed_paths.read_text(encoding="utf-8").splitlines(),
+        repository=arguments.repository.resolve(),
+    )
+    if arguments.github_output:
+        _write_github_output(plan, arguments.github_output)
+    print(plan.as_json())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Every pull request currently runs the full `tests/math` lane, even when a change belongs to one mathematical owner. That makes small owner-local edits wait for unrelated mathematical tests. Public contract edits also need explicit catalog and advertised-example evidence, rather than relying on the broad lane incidentally covering them.

## Solution

Add a checked-in, versioned CI planner that classifies normalized changed paths and records the base/head revisions and planner digest in its outputs. Pull requests run the changed mathematical owner; public operation, model, admission, and canonical-contract paths additionally run catalog conformance and the advertised-example integration test. Shared, unmapped, configuration, and invalid-path cases fall back to the full math suite.

Merge-group candidates and pushes to `main` always select full non-exhaustive math, catalog, and example evidence. The stable `required` job distinguishes deliberate planner skips from unexpectedly skipped work. PR lanes do not produce coverage artifacts; coverage remains a final-tree gate. The current no-collection default is retained, with collection left as a manual diagnostic rather than an unconditional predecessor.

The planner does not select or defer process, MCP, Singular, wheel, static, dispatch, CLI, or tooling evidence; those retain their existing lifecycle ownership.

## Testing

- `uv run --locked pytest -q tests/tooling/test_ci_test_plan.py tests/tooling/test_product_ci_contract.py` — 24 passed
- `uv run --locked ruff check tools/ci_test_plan.py tests/tooling/test_ci_test_plan.py tests/tooling/test_product_ci_contract.py` — passed
- `uv run --locked ruff format --check tools/ci_test_plan.py tests/tooling/test_ci_test_plan.py tests/tooling/test_product_ci_contract.py` — passed
- `uv run --locked pre-commit run check-yaml --files .github/workflows/ci.yml .github/actions/run-test-lane/action.yml` — passed
- `uv run --locked pre-commit run actionlint --files .github/workflows/ci.yml .github/actions/run-test-lane/action.yml` — passed
- `make docs-linkcheck` — passed

## Public contract impact

None.

## Operation boundary ownership

Not applicable.

## Canonical value audit

Not applicable.

## Catalog admission

Not applicable.

## Closure matrix

None.
