### PR TITLE
fix(mcp): harden cancellation, statelessness, and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
       - run: make docs-linkcheck
       - run: make npm-test
       - run: make build
+      - name: Pack npm distribution
+        working-directory: npm
+        run: |
+          mkdir -p ../dist/npm
+          npm pack --pack-destination ../dist/npm
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
@@ -246,7 +251,7 @@ jobs:
       - run: make test-singular
 
   wheel:
-    name: wheel (Python ${{ matrix.python-version }})
+    name: ${{ matrix.artifact }} (Python ${{ matrix.python-version }})
     needs: [static]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -254,6 +259,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
+        artifact: [wheel, sdist]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -268,26 +274,94 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Install and start the built wheel
+      - name: Install and smoke the built Python artifact over MCP
         run: |
-          wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$wheel"
-          environment="$RUNNER_TEMP/jacobian-wheel-${{ matrix.python-version }}"
+          case "${{ matrix.artifact }}" in
+            wheel)
+              package="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+              install_policy=(--only-binary :all:)
+              ;;
+            sdist)
+              package="$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+              install_policy=()
+              ;;
+          esac
+          test -n "$package"
+          package="$(realpath "$package")"
+          environment="$RUNNER_TEMP/jacobian-${{ matrix.artifact }}-${{ matrix.python-version }}"
           uv venv --python "${{ matrix.python-version }}" "$environment"
           uv pip install --python "$environment/bin/python" \
-            --only-binary :all: "$wheel"
-          "$environment/bin/jacobian" --help
-          "$environment/bin/jacobian-mcp" --help
-          "$environment/bin/jacobian" run integer.compute.extended_gcd \
-            --json '{"left":"84","right":"30"}'
-      - if: matrix.python-version == '3.13'
+            "${install_policy[@]}" "$package"
+          version="$("$environment/bin/python" -c \
+            'import importlib.metadata; print(importlib.metadata.version("jacobian"))')"
+          PYTHONPATH= "$environment/bin/python" "$GITHUB_WORKSPACE/deploy/smoke_stdio.py" \
+            --expect-version "$version" \
+            --startup-timeout-seconds 60 \
+            --request-timeout-seconds 20 \
+            --shutdown-timeout-seconds 10 \
+            -- "$environment/bin/jacobian-mcp"
+      - if: matrix.python-version == '3.13' && matrix.artifact == 'wheel'
         uses: ./.github/actions/setup-python-tests
         with:
           python-version: "3.13"
-      - if: matrix.python-version == '3.13'
+      - if: matrix.python-version == '3.13' && matrix.artifact == 'wheel'
         run: make test-compatibility
         env:
           PYTEST_ARGS: --junitxml=pytest.xml
+
+  npm-package:
+    name: npm tarball (Node ${{ matrix.node-version }})
+    needs: [static]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.28"
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+      - name: Install and smoke the packed npm carrier over MCP
+        run: |
+          wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          tarball="$(find dist/npm -maxdepth 1 -name '*.tgz' -print -quit)"
+          test -n "$wheel"
+          test -n "$tarball"
+          wheel="$(realpath "$wheel")"
+          tarball="$(realpath "$tarball")"
+          client_environment="$RUNNER_TEMP/jacobian-npm-client"
+          project="$RUNNER_TEMP/jacobian-npm-project"
+          uv venv --python 3.12 "$client_environment"
+          uv pip install --python "$client_environment/bin/python" \
+            --only-binary :all: "$wheel"
+          mkdir -p "$project"
+          npm install --prefix "$project" "$tarball"
+          version="$("$client_environment/bin/python" -c \
+            'import importlib.metadata; print(importlib.metadata.version("jacobian"))')"
+          JACOBIAN_PACKAGE="$wheel" \
+          JACOBIAN_UV_BIN="$(command -v uvx)" \
+          PYTHONPATH= \
+            "$client_environment/bin/python" "$GITHUB_WORKSPACE/deploy/smoke_stdio.py" \
+              --expect-version "$version" \
+              --startup-timeout-seconds 60 \
+              --request-timeout-seconds 20 \
+              --shutdown-timeout-seconds 10 \
+              -- "$project/node_modules/.bin/jacobian" mcp
 
   lean:
     name: Lean Runtime
@@ -362,11 +436,11 @@ jobs:
   required:
     name: required
     if: ${{ always() }}
-    needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, coverage, lean]
+    needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, npm-package, coverage, lean]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require selected evidence and final-tree specialist lanes
+      - name: Require selected evidence packages and final-tree specialist lanes
         env:
           # True for pull_request runs and for autofix dispatches that select
           # the pull_request lane set; Lean then counts skipped as passing.
@@ -383,6 +457,7 @@ jobs:
           BOUNDARIES_RESULT: ${{ needs.boundaries.result }}
           SINGULAR_RESULT: ${{ needs.singular.result }}
           WHEEL_RESULT: ${{ needs.wheel.result }}
+          NPM_PACKAGE_RESULT: ${{ needs.npm-package.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}
           LEAN_RESULT: ${{ needs.lean.result }}
         run: |
@@ -401,6 +476,7 @@ jobs:
           test "$BOUNDARIES_RESULT" = success
           test "$SINGULAR_RESULT" = success
           test "$WHEEL_RESULT" = success
+          test "$NPM_PACKAGE_RESULT" = success
           if [ "$PR_LANE_SELECTION" = true ]; then
             test "$COVERAGE_RESULT" = skipped
             test "$LEAN_RESULT" = skipped || test "$LEAN_RESULT" = success

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -62,6 +62,44 @@ jobs:
           docker run --rm --entrypoint uv jacobian:pull-request \
             run --no-sync jacobian run sat.refutation.check --json "$INVALID_REQUEST" \
             | jq -e '.output.outcome == "INVALID_REFUTATION"'
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - name: Smoke the built image's configured MCP entry point
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          container_id="$(docker run -d --rm \
+            -p 127.0.0.1:8000:8000 \
+            jacobian:pull-request \
+            --allow-anonymous --host 0.0.0.0 --port 8000 --path /mcp)"
+          cleanup() {
+            docker logs "$container_id" || true
+            docker stop --time 5 "$container_id" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          success=false
+          for attempt in $(seq 1 20); do
+            set +e
+            uv run --locked python -m deploy.smoke_remote \
+              http://127.0.0.1:8000/mcp \
+              --expect-version "$PACKAGE_VERSION" \
+              --expect-session-mode stateless \
+              --timeout-seconds 5 \
+              > "$RUNNER_TEMP/container-mcp-smoke.json"
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
+              success=true
+              break
+            fi
+            if [ "$status" -ne 75 ]; then
+              exit "$status"
+            fi
+            sleep 1
+          done
+          test "$success" = true
+          cat "$RUNNER_TEMP/container-mcp-smoke.json" >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish container image
@@ -115,6 +153,47 @@ jobs:
           cache-to: type=gha,mode=max,scope=jacobian-container
           provenance: mode=max
           sbom: true
+      - uses: ./.github/actions/setup-python-tests
+        with:
+          python-version: "3.12"
+      - name: Smoke the digest-addressed image's configured MCP entry point
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          image="$REGISTRY/$IMAGE_NAME@$DIGEST"
+          docker pull "$image"
+          container_id="$(docker run -d --rm \
+            -p 127.0.0.1:8000:8000 \
+            "$image" \
+            --allow-anonymous --host 0.0.0.0 --port 8000 --path /mcp)"
+          cleanup() {
+            docker logs "$container_id" || true
+            docker stop --time 5 "$container_id" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          success=false
+          for attempt in $(seq 1 20); do
+            set +e
+            uv run --locked python -m deploy.smoke_remote \
+              http://127.0.0.1:8000/mcp \
+              --expect-version "$PACKAGE_VERSION" \
+              --expect-session-mode stateless \
+              --timeout-seconds 5 \
+              > "$RUNNER_TEMP/container-mcp-smoke.json"
+            status=$?
+            set -e
+            if [ "$status" -eq 0 ]; then
+              success=true
+              break
+            fi
+            if [ "$status" -ne 75 ]; then
+              exit "$status"
+            fi
+            sleep 1
+          done
+          test "$success" = true
+          cat "$RUNNER_TEMP/container-mcp-smoke.json" >> "$GITHUB_STEP_SUMMARY"
       - name: Record digest-addressed publication evidence
         env:
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/heldout-benchmarks.yml
+++ b/.github/workflows/heldout-benchmarks.yml
@@ -87,7 +87,7 @@ jobs:
           docker run --rm -d --name jacobian-heldout-probe \
             -p 127.0.0.1:8000:8000 "$image" \
             --transport streamable-http --host 0.0.0.0 --port 8000 \
-            --allow-anonymous --stateless-http
+            --allow-anonymous
           echo "url=http://127.0.0.1:8000/mcp" >> "$GITHUB_OUTPUT"
       - name: Execute and resume at complete pair boundaries
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,53 @@ jobs:
           mkdir -p ../dist/npm
           npm pack --pack-destination ../dist/npm
         working-directory: npm
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Smoke exact Python and npm release artifacts over MCP
+        run: |
+          version="$(python -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          wheel="$(find dist/python -maxdepth 1 -name '*.whl' -print -quit)"
+          sdist="$(find dist/python -maxdepth 1 -name '*.tar.gz' -print -quit)"
+          tarball="$(find dist/npm -maxdepth 1 -name '*.tgz' -print -quit)"
+          test -n "$wheel"
+          test -n "$sdist"
+          test -n "$tarball"
+          wheel="$(realpath "$wheel")"
+          sdist="$(realpath "$sdist")"
+          tarball="$(realpath "$tarball")"
+          for artifact_type in wheel sdist; do
+            if [ "$artifact_type" = wheel ]; then
+              artifact="$wheel"
+            else
+              artifact="$sdist"
+            fi
+            environment="$RUNNER_TEMP/release-$artifact_type"
+            uv venv --python 3.12 "$environment"
+            uv pip install --python "$environment/bin/python" "$artifact"
+            PYTHONPATH= "$environment/bin/python" "$GITHUB_WORKSPACE/deploy/smoke_stdio.py" \
+              --expect-version "$version" \
+              --startup-timeout-seconds 60 \
+              --request-timeout-seconds 20 \
+              --shutdown-timeout-seconds 10 \
+              -- "$environment/bin/jacobian-mcp"
+          done
+          client_environment="$RUNNER_TEMP/release-npm-client"
+          npm_project="$RUNNER_TEMP/release-npm-project"
+          uv venv --python 3.12 "$client_environment"
+          uv pip install --python "$client_environment/bin/python" \
+            --only-binary :all: "$wheel"
+          mkdir -p "$npm_project"
+          npm install --prefix "$npm_project" "$tarball"
+          JACOBIAN_PACKAGE="$wheel" \
+          JACOBIAN_UV_BIN="$(command -v uvx)" \
+          PYTHONPATH= \
+            "$client_environment/bin/python" "$GITHUB_WORKSPACE/deploy/smoke_stdio.py" \
+              --expect-version "$version" \
+              --startup-timeout-seconds 60 \
+              --request-timeout-seconds 20 \
+              --shutdown-timeout-seconds 10 \
+              -- "$npm_project/node_modules/.bin/jacobian" mcp
+      - name: Upload release distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-distributions
           path: dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,11 @@ pre-push hook stays `make lint typecheck`. Focused debugging uses
 `uv run pytest path/to/test.py`. Default `uv run pytest` collects the ordinary
 Lean-free `testpaths`; it does not run process, MCP, or Lean trees.
 
-CI runs static checks, the selected ordinary Python surface, MCP boundaries,
-and the wheel smoke. Full mathematical and Lean suites run on merge-group
-candidates and on `main`, not on every pull request.
+CI runs static checks, the selected ordinary Python surface, and MCP boundaries,
+then installs the built wheel, source distribution, and npm tarball in isolated
+environments and exercises their MCP entry points. The container workflow runs
+the same protocol journey against the built image. Full mathematical and Lean
+suites run on merge-group candidates and on `main`, not on every pull request.
 That gate needs GitHub merge queue
 enabled on `main`; without a queue, Lean only runs after a push to `main`. You
 do not need to reproduce Lean locally for a routine change unless you edited
@@ -251,8 +253,9 @@ Verify every relative Markdown link before submitting the change
 ## Releases
 
 The manifest-driven Release Please configuration keeps the Python and npm
-package versions synchronized. CI tests and packs the npm launcher
-independently, then publishes both distributions after a release is created.
+package versions synchronized. CI and the release build protocol-smoke the
+exact wheel, source distribution, npm tarball, and container route before the
+corresponding artifacts are published.
 The `jacobian` package on npm must authorize `.github/workflows/release.yml` as
 its trusted GitHub Actions publisher, using the `npm` environment; releases use
 OIDC rather than a long-lived npm token.

--- a/deploy/smoke_remote.py
+++ b/deploy/smoke_remote.py
@@ -7,22 +7,58 @@ import asyncio
 import hashlib
 import json
 import os
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
 from typing import Any
 
 import httpx2
-from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import Implementation, TextContent, TextResourceContents
 
-from .smoke import exit_for_smoke_failure, raise_for_http_error
 from jacobian import __version__
 from jacobian.canonical import canonicalize_json
+from mcp import Client
+
+from .smoke import (
+    TransientSmokeError,
+    exit_for_smoke_failure,
+    is_transient_transport_failure,
+    raise_for_http_error,
+)
 
 REQUIRED_TOOLS = {
     "math.find",
     "math.run",
 }
 DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
+_OPERATION_ID = "integer.compute.extended_gcd"
+
+
+async def _phase[T](
+    name: str,
+    timeout_seconds: float,
+    call: Callable[[], Awaitable[T]],
+) -> T:
+    started = time.monotonic()
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            return await call()
+    except TimeoutError as exc:
+        elapsed = time.monotonic() - started
+        raise TransientSmokeError(
+            f"remote MCP smoke phase {name!r} timed out after {elapsed:.3f}s "
+            f"(limit {timeout_seconds:.3f}s)"
+        ) from exc
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        failure_type = (
+            TransientSmokeError if is_transient_transport_failure(exc) else RuntimeError
+        )
+        raise failure_type(
+            f"remote MCP smoke phase {name!r} failed after {elapsed:.3f}s: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
 
 
 def _require_server_info(server_info: Implementation | None) -> Implementation:
@@ -54,6 +90,12 @@ def _parser() -> argparse.ArgumentParser:
         "--query",
         default="exact finite graph invariant",
         help="read-only operation discovery query",
+    )
+    parser.add_argument(
+        "--expect-session-mode",
+        choices=("stateless", "stateful"),
+        default="stateless",
+        help="required Streamable HTTP session mode; defaults to stateless",
     )
     parser.add_argument("--timeout-seconds", type=float, default=120)
     return parser
@@ -101,6 +143,125 @@ def _validate_server_version(
         )
 
 
+async def _inspect_catalog(
+    client: Client,
+    *,
+    required_operations: set[str],
+    timeout_seconds: float,
+    failures: list[str],
+) -> dict[str, Any]:
+    catalog_result = await _phase(
+        "operation catalog",
+        timeout_seconds,
+        lambda: client.read_resource("operation://catalog"),
+    )
+    catalog_content = catalog_result.contents[0]
+    if not isinstance(catalog_content, TextResourceContents):
+        raise RuntimeError("deployed operation catalog is not text")
+    catalog_text = catalog_content.text
+    catalog = json.loads(catalog_text)
+    operation_ids = {operation["operation_id"] for operation in catalog["operations"]}
+    missing = sorted(required_operations - operation_ids)
+    if missing:
+        failures.append(f"deployed catalog is missing required operations: {missing!r}")
+    catalog_digest = hashlib.sha256(
+        canonicalize_json(
+            {
+                "operations": catalog["operations"],
+            }
+        )
+    ).hexdigest()
+    return {
+        "operations": len(operation_ids),
+        "catalog_digest": f"sha256:{catalog_digest}",
+        "sha256": hashlib.sha256(catalog_text.encode("utf-8")).hexdigest(),
+    }
+
+
+async def _inspect_discovery(
+    client: Client,
+    *,
+    query: str,
+    timeout_seconds: float,
+    failures: list[str],
+) -> dict[str, Any]:
+    result = await _phase(
+        "math.find search",
+        timeout_seconds,
+        lambda: client.call_tool(
+            "math.find",
+            {"request": {"op": "search", "query": query, "limit": 5}},
+        ),
+    )
+    if result.is_error:
+        failures.append("deployed operation discovery returned an MCP error")
+    content = result.content[0]
+    if not isinstance(content, TextContent):
+        raise RuntimeError("deployed operation discovery is not text")
+    if not isinstance(result.structured_content, dict):
+        raise RuntimeError("deployed operation discovery is not structured")
+    discovery = result.structured_content
+    discovery_bytes = len(
+        json.dumps(discovery, ensure_ascii=False, indent=2).encode("utf-8")
+    )
+    if discovery["response_byte_limit"] != DISCOVERY_RESPONSE_BYTE_LIMIT:
+        failures.append("deployed discovery byte limit does not match the contract")
+    if discovery_bytes > DISCOVERY_RESPONSE_BYTE_LIMIT:
+        failures.append("deployed discovery response exceeds its byte limit")
+    return {
+        "bytes": discovery_bytes,
+        "model_visible_bytes": len(content.text.encode("utf-8")),
+        "matches": [match["operation_id"] for match in discovery["matches"]],
+    }
+
+
+async def _inspect_execution(
+    client: Client,
+    *,
+    timeout_seconds: float,
+    failures: list[str],
+) -> dict[str, str]:
+    inspection_result = await _phase(
+        "math.find inspect",
+        timeout_seconds,
+        lambda: client.call_tool(
+            "math.find",
+            {"request": {"op": "inspect", "operation_id": _OPERATION_ID}},
+        ),
+    )
+    if not isinstance(inspection_result.structured_content, dict):
+        raise RuntimeError("deployed operation inspection is not structured")
+    if (
+        inspection_result.structured_content.get("operation", {}).get("operation_id")
+        != _OPERATION_ID
+    ):
+        failures.append("deployed operation inspection returned the wrong operation")
+
+    async def run(left: str, right: str, phase: str) -> str:
+        result = await _phase(
+            phase,
+            timeout_seconds,
+            lambda: client.call_tool(
+                "math.run",
+                {
+                    "operation_id": _OPERATION_ID,
+                    "payload": {"left": left, "right": right},
+                },
+            ),
+        )
+        if not isinstance(result.structured_content, dict):
+            raise RuntimeError(f"deployed {phase} result is not structured")
+        return str(result.structured_content.get("output", {}).get("gcd"))
+
+    gcd = await run("84", "30", "math.run")
+    second_gcd = await run("21", "14", "second math.run")
+    if gcd != "6":
+        failures.append("deployed math.run did not return gcd 6")
+    if second_gcd != "7":
+        failures.append("deployed second math.run did not return gcd 7")
+    return {"operation_id": _OPERATION_ID, "gcd": gcd, "second_gcd": second_gcd}
+
+
 async def inspect(
     *,
     url: str,
@@ -109,92 +270,92 @@ async def inspect(
     required_operations: set[str],
     query: str,
     timeout_seconds: float,
+    expected_session_mode: str = "stateless",
 ) -> dict[str, Any]:
     headers = _headers()
     failures: list[str] = []
-    async with (
-        httpx2.AsyncClient(
-            headers=headers,
-            event_hooks={"response": [raise_for_http_error]},
-            trust_env=False,
-            timeout=timeout_seconds,
-        ) as http,
-        Client(
-            streamable_http_client(url, http_client=http),
-            raise_exceptions=True,
-        ) as client,
-    ):
+    session_ids: set[str] = set()
+
+    async def inspect_http_response(response: httpx2.Response) -> None:
+        await raise_for_http_error(response)
+        session_id = response.headers.get("mcp-session-id")
+        if session_id:
+            session_ids.add(session_id)
+
+    stack = AsyncExitStack()
+    primary_failure: BaseException | None = None
+    try:
+        http = await stack.enter_async_context(
+            httpx2.AsyncClient(
+                headers=headers,
+                event_hooks={"response": [inspect_http_response]},
+                trust_env=False,
+                timeout=timeout_seconds,
+            )
+        )
+        client = await _phase(
+            "initialization",
+            timeout_seconds,
+            lambda: stack.enter_async_context(
+                Client(
+                    streamable_http_client(url, http_client=http),
+                    raise_exceptions=True,
+                )
+            ),
+        )
         server_info = _require_server_info(client.server_info)
         server_version = server_info.version
         _validate_server_version(server_version, expected_version, failures)
 
-        listed = await client.list_tools()
+        listed = await _phase("tool discovery", timeout_seconds, client.list_tools)
         tool_names = _validate_tool_surface(listed, failures)
 
-        catalog_result = await client.read_resource("operation://catalog")
-        catalog_content = catalog_result.contents[0]
-        if not isinstance(catalog_content, TextResourceContents):
-            raise RuntimeError("deployed operation catalog is not text")
-        catalog_text = catalog_content.text
-        catalog = json.loads(catalog_text)
-        catalog_digest = (
-            "sha256:"
-            + hashlib.sha256(
-                canonicalize_json(
-                    {
-                        "operations": catalog["operations"],
-                    }
-                )
-            ).hexdigest()
+        catalog_report = await _inspect_catalog(
+            client,
+            required_operations=required_operations,
+            timeout_seconds=timeout_seconds,
+            failures=failures,
         )
-        operation_ids = {
-            operation["operation_id"] for operation in catalog["operations"]
-        }
-        missing = sorted(required_operations - operation_ids)
-        if missing:
+        discovery_report = await _inspect_discovery(
+            client,
+            query=query,
+            timeout_seconds=timeout_seconds,
+            failures=failures,
+        )
+        execution_report = await _inspect_execution(
+            client,
+            timeout_seconds=timeout_seconds,
+            failures=failures,
+        )
+
+        observed_session_mode = "stateful" if session_ids else "stateless"
+        if observed_session_mode != expected_session_mode:
             failures.append(
-                f"deployed catalog is missing required operations: {missing!r}"
+                "deployed MCP session mode mismatch: "
+                f"expected {expected_session_mode}, observed {observed_session_mode}"
             )
-        discovery_result = await client.call_tool(
-            "math.find",
-            {"request": {"op": "search", "query": query, "limit": 5}},
-        )
-        if discovery_result.is_error:
-            failures.append("deployed operation discovery returned an MCP error")
-        discovery_content = discovery_result.content[0]
-        if not isinstance(discovery_content, TextContent):
-            raise RuntimeError("deployed operation discovery is not text")
-        discovery_text = discovery_content.text
-        if not isinstance(discovery_result.structured_content, dict):
-            raise RuntimeError("deployed operation discovery is not structured")
-        discovery = discovery_result.structured_content
-        discovery_bytes = len(
-            json.dumps(discovery, ensure_ascii=False, indent=2).encode("utf-8")
-        )
-        discovery_model_visible_bytes = len(discovery_text.encode("utf-8"))
-        if discovery["response_byte_limit"] != DISCOVERY_RESPONSE_BYTE_LIMIT:
-            failures.append("deployed discovery byte limit does not match the contract")
-        if discovery_bytes > DISCOVERY_RESPONSE_BYTE_LIMIT:
-            failures.append("deployed discovery response exceeds its byte limit")
 
         report = {
             "url": url,
+            "session_mode": observed_session_mode,
             "server": {
                 "name": server_info.name,
                 "version": server_version,
             },
             "tool_names": sorted(tool_names),
-            "catalog": {
-                "operations": len(operation_ids),
-                "catalog_digest": catalog_digest,
-                "sha256": hashlib.sha256(catalog_text.encode("utf-8")).hexdigest(),
-            },
-            "discovery": {
-                "bytes": discovery_bytes,
-                "model_visible_bytes": discovery_model_visible_bytes,
-                "matches": [match["operation_id"] for match in discovery["matches"]],
-            },
+            "catalog": catalog_report,
+            "discovery": discovery_report,
+            "execution": execution_report,
         }
+    except BaseException as exc:
+        primary_failure = exc
+        raise
+    finally:
+        try:
+            await _phase("shutdown", timeout_seconds, stack.aclose)
+        except BaseException:
+            if primary_failure is None:
+                raise
     if failures:
         raise RuntimeError("; ".join(failures))
     return report
@@ -210,6 +371,7 @@ async def _main() -> None:
         required_operations=set(args.require_operation),
         query=args.query,
         timeout_seconds=args.timeout_seconds,
+        expected_session_mode=args.expect_session_mode,
     )
     print(json.dumps(report, indent=2, sort_keys=True))
 

--- a/deploy/smoke_stdio.py
+++ b/deploy/smoke_stdio.py
@@ -1,0 +1,274 @@
+"""Exercise an installed Jacobian MCP entry point over the real stdio protocol.
+
+This driver deliberately imports no Jacobian modules. Release checks run it
+from outside the checkout with the command supplied after ``--`` so successful
+execution proves the installed artifact, rather than a source tree or editable
+install, owns the server under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any
+
+from mcp import Client, StdioServerParameters, stdio_client
+
+_STDERR_TAIL_BYTES = 8_192
+_OPERATION_ID = "integer.compute.extended_gcd"
+
+
+class SmokePhaseError(RuntimeError):
+    """One named protocol phase failed or exceeded its deadline."""
+
+
+async def _phase[T](
+    name: str,
+    timeout_seconds: float,
+    call: Callable[[], Awaitable[T]],
+) -> T:
+    started = time.monotonic()
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            return await call()
+    except TimeoutError as exc:
+        elapsed = time.monotonic() - started
+        raise SmokePhaseError(
+            f"MCP smoke phase {name!r} timed out after {elapsed:.3f}s "
+            f"(limit {timeout_seconds:.3f}s)"
+        ) from exc
+    except Exception as exc:
+        elapsed = time.monotonic() - started
+        raise SmokePhaseError(
+            f"MCP smoke phase {name!r} failed after {elapsed:.3f}s: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _require_structured(name: str, result: Any) -> dict[str, Any]:
+    if result.is_error:
+        raise RuntimeError(f"{name} returned an MCP tool error")
+    if not isinstance(result.structured_content, dict):
+        raise RuntimeError(f"{name} did not return structured content")
+    return result.structured_content
+
+
+async def inspect(
+    *,
+    command: list[str],
+    expected_version: str,
+    startup_timeout_seconds: float,
+    request_timeout_seconds: float,
+    shutdown_timeout_seconds: float,
+    cwd: Path,
+    stderr: Any,
+) -> dict[str, Any]:
+    environment = dict(os.environ)
+    environment.pop("PYTHONPATH", None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    parameters = StdioServerParameters(
+        command=command[0],
+        args=command[1:],
+        env=environment,
+        cwd=cwd,
+    )
+    stack = AsyncExitStack()
+    client: Client | None = None
+    primary_failure: BaseException | None = None
+    try:
+        client = await _phase(
+            "initialization",
+            startup_timeout_seconds,
+            lambda: stack.enter_async_context(
+                Client(
+                    stdio_client(parameters, errlog=stderr),
+                    raise_exceptions=True,
+                )
+            ),
+        )
+        if client.server_info is None:
+            raise SmokePhaseError("MCP initialization returned no server info")
+        if client.server_info.version != expected_version:
+            raise SmokePhaseError(
+                "MCP initialization version mismatch: "
+                f"expected {expected_version!r}, got {client.server_info.version!r}"
+            )
+
+        listed = await _phase(
+            "tool discovery",
+            request_timeout_seconds,
+            client.list_tools,
+        )
+        tool_names = {tool.name for tool in listed.tools}
+        required_tools = {"math.find", "math.run"}
+        if tool_names != required_tools:
+            raise SmokePhaseError(
+                f"MCP tool surface mismatch: expected {sorted(required_tools)!r}, "
+                f"got {sorted(tool_names)!r}"
+            )
+
+        search = _require_structured(
+            "math.find search",
+            await _phase(
+                "math.find search",
+                request_timeout_seconds,
+                lambda: client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "search",
+                            "query": "integer greatest common divisor Bezout coefficients",
+                            "limit": 5,
+                        }
+                    },
+                ),
+            ),
+        )
+        inspection = _require_structured(
+            "math.find inspect",
+            await _phase(
+                "math.find inspect",
+                request_timeout_seconds,
+                lambda: client.call_tool(
+                    "math.find",
+                    {
+                        "request": {
+                            "op": "inspect",
+                            "operation_id": _OPERATION_ID,
+                        }
+                    },
+                ),
+            ),
+        )
+        if inspection.get("operation", {}).get("operation_id") != _OPERATION_ID:
+            raise SmokePhaseError("math.find inspection returned the wrong operation")
+
+        first_run = _require_structured(
+            "math.run",
+            await _phase(
+                "math.run",
+                request_timeout_seconds,
+                lambda: client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": _OPERATION_ID,
+                        "payload": {"left": "84", "right": "30"},
+                    },
+                ),
+            ),
+        )
+        if first_run.get("output", {}).get("gcd") != "6":
+            raise SmokePhaseError("math.run did not return gcd 6")
+
+        second_run = _require_structured(
+            "second math.run",
+            await _phase(
+                "second math.run",
+                request_timeout_seconds,
+                lambda: client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": _OPERATION_ID,
+                        "payload": {"left": "21", "right": "14"},
+                    },
+                ),
+            ),
+        )
+        if second_run.get("output", {}).get("gcd") != "7":
+            raise SmokePhaseError("second math.run did not return gcd 7")
+
+        return {
+            "transport": "stdio",
+            "command": command,
+            "server": {
+                "name": client.server_info.name,
+                "version": client.server_info.version,
+            },
+            "tool_names": sorted(tool_names),
+            "search_matches": [
+                match["operation_id"] for match in search.get("matches", [])
+            ],
+            "inspected_operation": _OPERATION_ID,
+            "runs": [
+                {"left": "84", "right": "30", "gcd": "6"},
+                {"left": "21", "right": "14", "gcd": "7"},
+            ],
+        }
+    except BaseException as exc:
+        primary_failure = exc
+        raise
+    finally:
+        try:
+            await _phase("shutdown", shutdown_timeout_seconds, stack.aclose)
+        except BaseException:
+            if primary_failure is None:
+                raise
+
+
+def _stderr_tail(stderr: Any) -> str:
+    stderr.flush()
+    stderr.seek(0, os.SEEK_END)
+    size = stderr.tell()
+    stderr.seek(max(0, size - _STDERR_TAIL_BYTES))
+    return stderr.read()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Smoke an installed Jacobian MCP command over stdio.",
+    )
+    parser.add_argument("--expect-version", required=True)
+    parser.add_argument("--startup-timeout-seconds", type=float, default=60)
+    parser.add_argument("--request-timeout-seconds", type=float, default=20)
+    parser.add_argument("--shutdown-timeout-seconds", type=float, default=10)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+async def _main() -> None:
+    args = _parser().parse_args()
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise SystemExit("an installed MCP command is required after --")
+    for name in (
+        "startup_timeout_seconds",
+        "request_timeout_seconds",
+        "shutdown_timeout_seconds",
+    ):
+        if getattr(args, name) <= 0:
+            raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+
+    with (
+        tempfile.TemporaryDirectory(prefix="jacobian-packaged-mcp-") as directory,
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr,
+    ):
+        try:
+            report = await inspect(
+                command=command,
+                expected_version=args.expect_version,
+                startup_timeout_seconds=args.startup_timeout_seconds,
+                request_timeout_seconds=args.request_timeout_seconds,
+                shutdown_timeout_seconds=args.shutdown_timeout_seconds,
+                cwd=Path(directory),
+                stderr=stderr,
+            )
+        except Exception as exc:
+            tail = _stderr_tail(stderr)
+            diagnostic = f"packaged MCP smoke failed: {exc}"
+            if tail:
+                diagnostic += f"\nserver stderr tail:\n{tail}"
+            raise SystemExit(diagnostic) from exc
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/deploy/systemd/jacobian-mcp-anonymous.conf
+++ b/deploy/systemd/jacobian-mcp-anonymous.conf
@@ -11,6 +11,5 @@ ExecStart=/usr/bin/env /opt/jacobian/current/.venv/bin/jacobian-remote-mcp \
   --host 127.0.0.1 \
   --port 8765 \
   --path /mcp \
-  --stateless-http \
   --allow-anonymous \
   --anonymous-tenant-id replace-with-unique-test-id

--- a/deploy/systemd/jacobian-mcp.service
+++ b/deploy/systemd/jacobian-mcp.service
@@ -17,7 +17,6 @@ ExecStart=/usr/bin/env /opt/jacobian/current/.venv/bin/jacobian-remote-mcp \
   --host 127.0.0.1 \
   --port 8765 \
   --path /mcp \
-  --stateless-http \
   --auth-tokens-file %d/tokens.json \
   --public-base-url https://math-tools.example.org
 Restart=on-failure

--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -63,6 +63,15 @@ URL must route `/mcp` without stripping the path. For a disposable local
 transport test, use `--allow-anonymous`; never expose that mode as an
 authenticated service.
 
+Streamable HTTP is stateless by default: the server does not retain MCP
+sessions between requests, matching Jacobian's stateless execution contract
+and horizontally scaled deployment model. `--stateless-http` remains an
+accepted explicit spelling. Use `--stateful-http` only when a client requires
+MCP session continuity and the deployment deliberately provides sticky routing
+and process-lifetime session ownership. An explicit command-line flag is the
+only session-mode override; there is no environment-variable or config-file
+session setting.
+
 ## Install the example service files
 
 [`deploy/systemd/jacobian-mcp.service`](../../deploy/systemd/jacobian-mcp.service)
@@ -78,6 +87,13 @@ and public endpoint before directing traffic to the new artifact. Where Lean is
 intentionally installed, also run `uv run python -m deploy.smoke_lean <url>`.
 The probe implementations live in [`deploy/`](../../deploy/). Roll back by
 selecting the previous immutable artifact and rerunning the probes.
+
+The remote probe verifies initialization, the exact two-tool surface, catalog
+access, `math.find` search and inspection, two bounded `math.run` requests, and
+the absence of an MCP session ID in the default stateless mode. Each phase has
+the `--timeout-seconds` deadline and identifies itself in failure diagnostics.
+Pass `--expect-session-mode stateful` only when the server was deliberately
+started with `--stateful-http`.
 
 When moving hosts, provision the same pinned artifact, transfer operator-owned
 configuration and secrets, run the probes, and move traffic.

--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -41,6 +41,13 @@ their dedicated commands.
 `make check-all` is an intentional broad reproduction. Do not use a full suite
 as a substitute for a focused regression test.
 
+Release-facing MCP checks install the built wheel and source distribution in
+isolated Python 3.12 and 3.13 environments, install the packed npm carrier at
+its supported Node boundary and release version, and run the built container's
+configured entry point. They must use the real MCP protocol journey in
+`deploy/smoke_stdio.py` or `deploy/smoke_remote.py`; source imports, editable
+installs, help output, and direct CLI operation calls are not artifact evidence.
+
 ## CI lifecycle
 
 Pull requests always run static validation. The checked-in CI planner selects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
+    "anyio>=4.14,<5",
     "mcp==2.0.0",
     "networkx==3.6.1",
     "pydantic>=2.12,<3",

--- a/src/jacobian/mcp/remote_cli.py
+++ b/src/jacobian/mcp/remote_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from jacobian import __version__
@@ -26,10 +27,19 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--path", default="/mcp")
-    parser.add_argument(
+    session_mode = parser.add_mutually_exclusive_group()
+    session_mode.add_argument(
         "--stateless-http",
+        dest="stateless_http",
         action="store_true",
-        help="use stateless Streamable HTTP sessions",
+        default=True,
+        help="use stateless Streamable HTTP sessions (default)",
+    )
+    session_mode.add_argument(
+        "--stateful-http",
+        dest="stateless_http",
+        action="store_false",
+        help="explicitly opt in to stateful Streamable HTTP sessions",
     )
     parser.add_argument(
         "--auth-tokens-file",
@@ -94,6 +104,12 @@ def main() -> None:
         auth=auth,
     )
     if args.transport == "streamable-http":
+        session_mode = "stateless" if args.stateless_http else "stateful"
+        print(
+            f"Jacobian remote MCP: transport=streamable-http session_mode={session_mode}",
+            file=sys.stderr,
+            flush=True,
+        )
         server.run(
             "streamable-http",
             host=args.host,

--- a/src/jacobian/mcp/runtime.py
+++ b/src/jacobian/mcp/runtime.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, cast
 
 from mcp.server.mcpserver import Context
 
@@ -19,6 +19,14 @@ class AppState:
 
 class AuthenticationError(PermissionError):
     """A remote request lacks a usable authenticated tenant subject."""
+
+
+class _RequestCancellation(Protocol):
+    """The pinned SDK's request-owned cancellation signal."""
+
+    def is_set(self) -> bool: ...
+
+    def wait(self) -> Awaitable[None]: ...
 
 
 def _state(ctx: Context[Any, Any]) -> AppState:
@@ -45,6 +53,28 @@ def _authorize(ctx: Context[Any, Any]) -> None:
     callback = _state(ctx).authorize
     if callback is not None:
         callback()
+
+
+def _request_cancellation(ctx: Context[Any, Any]) -> _RequestCancellation:
+    """Return the cancellation signal for this exact MCP request.
+
+    MCP 2.0 exposes the signal on its dispatch context, while the higher-level
+    ``mcpserver.Context`` currently retains that context behind
+    ``ServerSession._request_outbound``.  Keep the pinned-SDK compatibility
+    seam here so an SDK change fails closed instead of silently disconnecting
+    request cancellation from subprocess ownership.
+    """
+
+    session = ctx.request_context.session
+    outbound = getattr(session, "_request_outbound", None)
+    signal = getattr(outbound, "cancel_requested", None)
+    if (
+        signal is None
+        or not callable(getattr(signal, "is_set", None))
+        or not callable(getattr(signal, "wait", None))
+    ):
+        raise RuntimeError("MCP request cancellation signal is unavailable")
+    return cast(_RequestCancellation, signal)
 
 
 __all__ = ["AppState", "AuthenticationError"]

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import anyio
 from mcp.server.mcpserver import Context
 from mcp.shared.exceptions import MCPError
 from mcp.types import INVALID_PARAMS
@@ -28,7 +30,9 @@ from jacobian.mcp.runtime import (
     AppState,
     _authorize,
     _catalog,
+    _request_cancellation,
 )
+from jacobian.process import bounded_process_cancellation
 
 _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
@@ -80,7 +84,7 @@ def math_find(
     )
 
 
-def math_run(
+async def math_run(
     operation_id: OperationId,
     payload: dict[str, Any],
     *,
@@ -89,12 +93,52 @@ def math_run(
     """Run one math tool. Role comes from the tool ID."""
     _authorize(ctx)
     catalog = _catalog(ctx)
+    request_cancellation = _request_cancellation(ctx)
+    process_cancellation = threading.Event()
+    relay_finished = threading.Event()
+    if request_cancellation.is_set():
+        process_cancellation.set()
+
+    async def relay_cancellation() -> None:
+        # The SDK cancels the request scope immediately after setting its
+        # signal. Shield this small relay until the worker has observed the
+        # signal or finished, so cancellation cannot strand subprocess work.
+        with anyio.CancelScope(shield=True):
+            while not relay_finished.is_set():
+                if request_cancellation.is_set():
+                    process_cancellation.set()
+                    return
+                await anyio.sleep(0.01)
+
+    result: list[OperationResult] = []
+    failure: list[BaseException] = []
+
+    def invoke() -> None:
+        try:
+            with bounded_process_cancellation(process_cancellation):
+                result.append(invoke_operation(operation_id, payload, catalog))
+        except BaseException as exc:
+            # Carry the original exception across the task group boundary so
+            # expected validation errors are not wrapped in ExceptionGroup.
+            failure.append(exc)
+
     try:
-        return invoke_operation(
-            operation_id,
-            payload,
-            catalog,
-        )
+        await anyio.lowlevel.checkpoint_if_cancelled()
+        async with anyio.create_task_group() as tasks:
+            tasks.start_soon(relay_cancellation)
+            try:
+                await anyio.to_thread.run_sync(
+                    invoke,
+                    abandon_on_cancel=False,
+                )
+            finally:
+                relay_finished.set()
+                tasks.cancel_scope.cancel()
+        if failure:
+            raise failure[0]
+        if not result:  # pragma: no cover - defensive worker invariant
+            raise RuntimeError("operation worker returned no result")
+        return result[0]
     except OperationRequestValidationError as exc:
         errors = _bounded_validation_issues(exc.errors())
         data = OperationInvalidRequestData(

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -40,6 +40,8 @@ _CANCELLATION_EVENT: ContextVar[threading.Event | None] = ContextVar(
     default=None,
 )
 _PIPE_DRAIN_GRACE_SECONDS = 0.5
+_PROCESS_TERMINATION_GRACE_SECONDS = 0.5
+_PROCESS_KILL_GRACE_SECONDS = 0.5
 _DEFAULT_LOCALE = "C.UTF-8"
 
 
@@ -186,29 +188,91 @@ def _resource_limited_command(
     return [prlimit, *options, "--", *command], True
 
 
-def _kill_process_tree(
+def _signal_process_tree(
     process: subprocess.Popen[bytes],
+    *,
+    force: bool,
     platform_tools: ProcessPlatformTools | None = None,
 ) -> None:
-    """Best-effort termination of a worker and every descendant it created."""
+    """Signal a worker and every descendant in its owned process group."""
 
     if os.name == "posix":
         with suppress(ProcessLookupError):
-            os.killpg(process.pid, signal.SIGKILL)
+            os.killpg(process.pid, signal.SIGKILL if force else signal.SIGTERM)
         return
 
     taskkill = (
         platform_tools.taskkill_executable if platform_tools is not None else None
     )
     if taskkill is not None:  # pragma: no cover - exercised in cross-platform CI
-        subprocess.run(
-            [taskkill, "/PID", str(process.pid), "/T", "/F"],
-            check=False,
-            capture_output=True,
-        )
+        command = [taskkill, "/PID", str(process.pid), "/T"]
+        if force:
+            command.append("/F")
+        with suppress(subprocess.TimeoutExpired):
+            subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                timeout=_PROCESS_KILL_GRACE_SECONDS,
+            )
         return
 
-    process.kill()  # pragma: no cover - defensive fallback
+    action = process.kill if force else process.terminate
+    with suppress(ProcessLookupError):  # pragma: no cover - defensive fallback
+        action()
+
+
+def _process_tree_alive(process: subprocess.Popen[bytes]) -> bool:
+    """Report whether the owned POSIX group or fallback root still exists."""
+
+    if os.name != "posix":
+        return process.poll() is None  # pragma: no cover - platform dependent
+    try:
+        os.killpg(process.pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover - the child is owned by this process
+        return True
+    return True
+
+
+def _wait_for_process_tree(
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float,
+) -> bool:
+    """Reap the root and wait at most *timeout_seconds* for its group to vanish."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        process.poll()
+        if not _process_tree_alive(process):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(0.01, remaining))
+
+
+def _terminate_and_reap_process_tree(
+    process: subprocess.Popen[bytes],
+    platform_tools: ProcessPlatformTools | None = None,
+) -> bool:
+    """Terminate the owned tree with bounded graceful and forced phases."""
+
+    _signal_process_tree(process, force=False, platform_tools=platform_tools)
+    if _wait_for_process_tree(process, _PROCESS_TERMINATION_GRACE_SECONDS):
+        return True
+    _signal_process_tree(process, force=True, platform_tools=platform_tools)
+    return _wait_for_process_tree(process, _PROCESS_KILL_GRACE_SECONDS)
+
+
+def _kill_process_tree(
+    process: subprocess.Popen[bytes],
+    platform_tools: ProcessPlatformTools | None = None,
+) -> None:
+    """Force the owned tree to stop; the coordinator performs bounded reaping."""
+
+    _signal_process_tree(process, force=True, platform_tools=platform_tools)
 
 
 def _capture_stream(
@@ -254,8 +318,7 @@ def _apply_post_start_limits(
     try:
         _apply_resource_limits(process, resource_limits)
     except (OSError, ValueError):
-        _kill_process_tree(process, platform_tools)
-        process.wait()
+        _terminate_and_reap_process_tree(process, platform_tools)
         raise
 
 
@@ -276,14 +339,12 @@ def _monitor_bounded_process(
     while process.poll() is None:
         if cancellation_event is not None and cancellation_event.is_set():
             cancelled = True
-            _kill_process_tree(process, platform_tools)
-            process.wait()
+            _terminate_and_reap_process_tree(process, platform_tools)
             break
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             timed_out = True
-            _kill_process_tree(process, platform_tools)
-            process.wait()
+            _terminate_and_reap_process_tree(process, platform_tools)
             break
         try:
             process.wait(timeout=min(0.1, remaining))
@@ -299,7 +360,7 @@ def _drain_reader_threads(
 ) -> bool:
     """Kill the tree, drain readers, and return ``True`` if any survived."""
 
-    _kill_process_tree(process, platform_tools)
+    _terminate_and_reap_process_tree(process, platform_tools)
     drain_deadline = time.monotonic() + _PIPE_DRAIN_GRACE_SECONDS
     for reader in readers:
         reader.join(timeout=max(0.0, drain_deadline - time.monotonic()))
@@ -347,6 +408,16 @@ def run_bounded_process(
     stderr_exceeded = threading.Event()
     if cancellation_event is None:
         cancellation_event = _CANCELLATION_EVENT.get()
+    if cancellation_event is not None and cancellation_event.is_set():
+        return BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+            cancelled=True,
+        )
 
     prlimit_executable = (
         platform_tools.prlimit_executable if platform_tools is not None else None

--- a/tests/mcp/_cancellation_server.py
+++ b/tests/mcp/_cancellation_server.py
@@ -1,0 +1,71 @@
+"""Synthetic process-backed MCP server used by cancellation regression tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+from jacobian.catalog.builtins import BUILTIN_TOOLS
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import MathTool
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
+from jacobian.process import run_bounded_process
+
+
+class ProcessRequest(StrictModel):
+    marker: str = Field(min_length=1, max_length=4_096)
+
+
+class ProcessResult(StrictModel):
+    cancelled: bool
+    timed_out: bool
+
+
+def _run_process(request: ProcessRequest) -> ProcessResult:
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os, pathlib, signal, subprocess, sys, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "child=subprocess.Popen([sys.executable, '-c', "
+                "'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "time.sleep(30)']); "
+                "pathlib.Path(sys.argv[1]).write_text(json.dumps([os.getpid(), child.pid])); "
+                "time.sleep(30)"
+            ),
+            request.marker,
+        ],
+        input_bytes=b"",
+        timeout_seconds=20,
+        environment=dict(os.environ),
+        stdout_limit=4_096,
+        stderr_limit=4_096,
+    )
+    return ProcessResult(
+        cancelled=completed.cancelled,
+        timed_out=completed.timed_out,
+    )
+
+
+def main() -> None:
+    operation = MathTool(
+        operation_id="test.process.wait",
+        title="Wait in an owned process tree",
+        description="Synthetic bounded process used only by MCP regression tests.",
+        request_type=ProcessRequest,
+        result_type=ProcessResult,
+        run=_run_process,
+    )
+    catalog = Catalog((*BUILTIN_TOOLS, operation))
+    server = _build_server(state=AppState(operation_catalog=catalog))
+    server.run("stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mcp/test_mcp_cancellation.py
+++ b/tests/mcp/test_mcp_cancellation.py
@@ -1,0 +1,87 @@
+"""MCP request cancellation owns process-backed operation cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER = Path(__file__).with_name("_cancellation_server.py")
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _read_pids(marker: Path) -> list[int]:
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        if marker.exists():
+            text = marker.read_text(encoding="utf-8").strip()
+            if text:
+                return list(json.loads(text))
+        await asyncio.sleep(0.01)
+    raise AssertionError("process-backed operation did not publish its PID marker")
+
+
+async def _assert_pids_exit(pids: list[int]) -> None:
+    deadline = time.monotonic() + 4
+    while time.monotonic() < deadline:
+        if all(not _pid_exists(pid) for pid in pids):
+            return
+        await asyncio.sleep(0.01)
+    surviving = [pid for pid in pids if _pid_exists(pid)]
+    raise AssertionError(f"cancelled process tree survived: {surviving}")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-tree assertion is POSIX")
+def test_stdio_cancellation_reaps_tree_and_server_remains_responsive(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        from mcp import Client, StdioServerParameters, stdio_client
+
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=[str(SERVER)],
+            env=dict(os.environ),
+            cwd=ROOT,
+        )
+        async with Client(stdio_client(parameters), raise_exceptions=True) as client:
+            for index in range(3):
+                marker = tmp_path / f"request-{index}.json"
+                with pytest.raises(MCPError) as cancellation:
+                    await client.call_tool(
+                        "math.run",
+                        {
+                            "operation_id": "test.process.wait",
+                            "payload": {"marker": str(marker)},
+                        },
+                        read_timeout_seconds=0.4,
+                    )
+                assert cancellation.value.code == -32001
+                await _assert_pids_exit(await _read_pids(marker))
+
+            follow_up = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {"left": "84", "right": "30"},
+                },
+                read_timeout_seconds=3,
+            )
+            assert follow_up.structured_content is not None
+            assert follow_up.structured_content["output"]["gcd"] == "6"
+
+    asyncio.run(scenario())

--- a/tests/mcp/test_mcp_sdk_2_conformance.py
+++ b/tests/mcp/test_mcp_sdk_2_conformance.py
@@ -5,18 +5,38 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import inspect
+from types import SimpleNamespace
 
+import pytest
 from mcp.types.methods import serialize_server_result
 
 import jacobian.mcp.server as server_module
 from jacobian.catalog.models import OperationCatalogSnapshot, OperationResult
+from jacobian.mcp.runtime import _request_cancellation
 from jacobian.mcp.server import create_server
 from jacobian.mcp.tools import math_run
 
 
 def test_mcp_sdk_is_exactly_pinned_and_v2_bindings_are_used() -> None:
     assert importlib.metadata.version("mcp") == "2.0.0"
-    assert not inspect.iscoroutinefunction(math_run)
+    assert inspect.iscoroutinefunction(math_run)
+
+
+def test_pinned_sdk_request_cancellation_seam_fails_closed() -> None:
+    signal = SimpleNamespace(is_set=lambda: False, wait=lambda: None)
+    context = SimpleNamespace(
+        request_context=SimpleNamespace(
+            session=SimpleNamespace(
+                _request_outbound=SimpleNamespace(cancel_requested=signal)
+            )
+        )
+    )
+
+    assert _request_cancellation(context) is signal
+    with pytest.raises(RuntimeError, match="cancellation signal is unavailable"):
+        _request_cancellation(
+            SimpleNamespace(request_context=SimpleNamespace(session=SimpleNamespace()))
+        )
 
 
 def test_mcp_v2_uses_sdk_typed_tools_lifespan_and_structured_resources(

--- a/tests/mcp/test_remote_mcp_auth.py
+++ b/tests/mcp/test_remote_mcp_auth.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+import jacobian.mcp.remote as remote_module
+import jacobian.mcp.remote_cli as remote_cli
 from jacobian.mcp.remote import (
     StaticTokenGrant,
     StaticTokenVerifier,
@@ -211,3 +213,56 @@ def test_token_file_is_strict_and_remote_cli_fails_closed(
     )
     assert conflicting_auth.returncode != 0
     assert "mutually exclusive" in conflicting_auth.stderr
+
+
+@pytest.mark.parametrize(
+    ("session_arguments", "expected_stateless", "expected_mode"),
+    [
+        ([], True, "stateless"),
+        (["--stateless-http"], True, "stateless"),
+        (["--stateful-http"], False, "stateful"),
+    ],
+)
+def test_remote_streamable_http_session_mode_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    session_arguments: list[str],
+    expected_stateless: bool,
+    expected_mode: str,
+) -> None:
+    run_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    class FakeServer:
+        def run(self, *args: object, **kwargs: object) -> None:
+            run_calls.append((args, kwargs))
+
+    monkeypatch.setattr(remote_module, "create_remote_server", lambda **_: FakeServer())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "jacobian-remote-mcp",
+            "--allow-anonymous",
+            *session_arguments,
+        ],
+    )
+
+    remote_cli.main()
+
+    assert run_calls == [
+        (
+            ("streamable-http",),
+            {
+                "host": "127.0.0.1",
+                "port": 8000,
+                "streamable_http_path": "/mcp",
+                "stateless_http": expected_stateless,
+            },
+        )
+    ]
+    assert f"session_mode={expected_mode}" in capsys.readouterr().err
+
+
+def test_remote_session_mode_flags_are_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit):
+        remote_cli._parser().parse_args(["--stateless-http", "--stateful-http"])

--- a/tests/process/test_bounded_process.py
+++ b/tests/process/test_bounded_process.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import shutil
+import signal
 import sys
 import threading
 import time
@@ -12,12 +13,44 @@ from pathlib import Path
 
 import pytest
 
+import jacobian.process as process_module
 from jacobian.process import (
     ProcessPlatformTools,
     ProcessResourceLimits,
     bounded_process_cancellation,
     run_bounded_process,
 )
+
+
+def _cancel_after_marker(event: threading.Event, marker: Path) -> threading.Thread:
+    def wait_and_cancel() -> None:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if marker.exists():
+                event.set()
+                return
+            time.sleep(0.01)
+
+    thread = threading.Thread(target=wait_and_cancel)
+    thread.start()
+    return thread
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_pid_exit(pid: int) -> bool:
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        if not _pid_exists(pid):
+            return True
+        time.sleep(0.01)
+    return not _pid_exists(pid)
 
 
 @pytest.mark.parametrize("timeout_seconds", [math.inf, math.nan])
@@ -97,6 +130,150 @@ def test_cancellation_stops_worker_before_its_wall_time_budget() -> None:
     assert completed.cancelled
     assert not completed.timed_out
     assert time.monotonic() - started < 3
+
+
+def test_cancellation_before_spawn_returns_without_launching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancellation_event = threading.Event()
+    cancellation_event.set()
+
+    def unexpected_spawn(*args: object, **kwargs: object) -> None:
+        raise AssertionError(f"unexpected process spawn: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(process_module.subprocess, "Popen", unexpected_spawn)
+    completed = run_bounded_process(
+        [sys.executable, "-c", "raise SystemExit(0)"],
+        input_bytes=b"",
+        timeout_seconds=1,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+        cancellation_event=cancellation_event,
+    )
+
+    assert completed.cancelled
+    assert not completed.timed_out
+    assert completed.returncode is None
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX signal grace is required")
+def test_cancellation_allows_graceful_process_tree_termination(tmp_path: Path) -> None:
+    ready = tmp_path / "ready"
+    terminated = tmp_path / "terminated"
+    cancellation_event = threading.Event()
+    canceller = _cancel_after_marker(cancellation_event, ready)
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import pathlib, signal, sys, time; "
+                "ready=pathlib.Path(sys.argv[1]); stopped=pathlib.Path(sys.argv[2]); "
+                "signal.signal(signal.SIGTERM, lambda *_: "
+                "(stopped.write_text('term'), sys.exit(0))); "
+                "ready.write_text('ready'); time.sleep(30)"
+            ),
+            str(ready),
+            str(terminated),
+        ],
+        input_bytes=b"",
+        timeout_seconds=20,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+        cancellation_event=cancellation_event,
+    )
+    canceller.join(timeout=1)
+
+    assert completed.cancelled
+    assert not completed.timed_out
+    assert terminated.read_text(encoding="utf-8") == "term"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX signal escalation is required")
+def test_cancellation_forces_a_process_that_ignores_sigterm(tmp_path: Path) -> None:
+    ready = tmp_path / "ready"
+    cancellation_event = threading.Event()
+    canceller = _cancel_after_marker(cancellation_event, ready)
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import pathlib, signal, sys, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "pathlib.Path(sys.argv[1]).write_text('ready'); time.sleep(30)"
+            ),
+            str(ready),
+        ],
+        input_bytes=b"",
+        timeout_seconds=20,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+        cancellation_event=cancellation_event,
+    )
+    canceller.join(timeout=1)
+
+    assert completed.cancelled
+    assert not completed.timed_out
+    assert completed.returncode == -signal.SIGKILL
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-owned")
+def test_cancellation_removes_the_complete_owned_process_tree(tmp_path: Path) -> None:
+    marker = tmp_path / "processes.json"
+    cancellation_event = threading.Event()
+    canceller = _cancel_after_marker(cancellation_event, marker)
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os, pathlib, subprocess, sys, time; "
+                "child=subprocess.Popen([sys.executable, '-c', "
+                "'import time; time.sleep(30)']); "
+                "pathlib.Path(sys.argv[1]).write_text(json.dumps([os.getpid(), child.pid])); "
+                "time.sleep(30)"
+            ),
+            str(marker),
+        ],
+        input_bytes=b"",
+        timeout_seconds=20,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+        cancellation_event=cancellation_event,
+    )
+    canceller.join(timeout=1)
+    pids = json.loads(marker.read_text(encoding="utf-8"))
+
+    assert completed.cancelled
+    assert all(_wait_for_pid_exit(pid) for pid in pids)
+
+
+def test_timeout_and_execution_failure_remain_distinct() -> None:
+    timed_out = run_bounded_process(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        input_bytes=b"",
+        timeout_seconds=0.1,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+    )
+    failed = run_bounded_process(
+        [sys.executable, "-c", "raise SystemExit(7)"],
+        input_bytes=b"",
+        timeout_seconds=1,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+    )
+
+    assert timed_out.timed_out and not timed_out.cancelled
+    assert not failed.timed_out and not failed.cancelled
+    assert failed.returncode == 7
 
 
 @pytest.mark.skipif(

--- a/tests/process/tooling/test_deploy_helpers.py
+++ b/tests/process/tooling/test_deploy_helpers.py
@@ -9,9 +9,16 @@ rollout machinery.
 
 from __future__ import annotations
 
+import asyncio
+import json
+import subprocess
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
 import httpx2
 import pytest
-from deploy import smoke_lean
+from deploy import smoke_lean, smoke_remote
 from deploy.smoke import (
     TRANSIENT_SMOKE_EXIT,
     TransientSmokeError,
@@ -19,6 +26,8 @@ from deploy.smoke import (
     is_transient_transport_failure,
     raise_for_http_error,
 )
+
+ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_smoke_retry_classification_is_transport_only() -> None:
@@ -111,3 +120,67 @@ def test_lean_smoke_uses_one_shot_typed_outcomes() -> None:
             expected="REJECTED",
             require_diagnostics=True,
         )
+
+
+def test_packaged_stdio_smoke_runs_the_complete_protocol_journey() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "deploy" / "smoke_stdio.py"),
+            "--expect-version",
+            version("jacobian"),
+            "--",
+            sys.executable,
+            "-m",
+            "jacobian.mcp",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=ROOT,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+    assert report["tool_names"] == ["math.find", "math.run"]
+    assert report["inspected_operation"] == "integer.compute.extended_gcd"
+    assert [run["gcd"] for run in report["runs"]] == ["6", "7"]
+
+
+def test_packaged_stdio_smoke_has_phase_timeout_and_stderr_diagnostics() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "deploy" / "smoke_stdio.py"),
+            "--expect-version",
+            version("jacobian"),
+            "--startup-timeout-seconds",
+            "0.1",
+            "--shutdown-timeout-seconds",
+            "1",
+            "--",
+            sys.executable,
+            "-c",
+            "import sys, time; print('server-started', file=sys.stderr); time.sleep(30)",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        cwd=ROOT,
+    )
+
+    assert completed.returncode != 0
+    assert "phase 'initialization' timed out" in completed.stderr
+    assert "server stderr tail" in completed.stderr
+    assert "server-started" in completed.stderr
+
+
+@pytest.mark.anyio
+async def test_remote_smoke_request_timeout_names_the_failed_phase() -> None:
+    async def never_returns() -> None:
+        await asyncio.sleep(30)
+
+    with pytest.raises(RuntimeError, match=r"phase 'math.run' timed out"):
+        await smoke_remote._phase("math.run", 0.01, never_returns)

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -20,15 +20,45 @@ def test_pr_metadata_edits_do_not_restart_product_ci() -> None:
     assert "unlabeled" not in pull_request_trigger
 
 
-def test_wheel_job_covers_supported_pythons_and_313_compatibility_smoke() -> None:
+def test_python_artifact_job_covers_routes_pythons_and_packaged_mcp() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    wheel = workflow.split("  wheel:", 1)[1].split("  lean:", 1)[0]
+    wheel = workflow.split("  wheel:", 1)[1].split("  npm-package:", 1)[0]
 
     assert 'python-version: ["3.12", "3.13"]' in wheel
+    assert "artifact: [wheel, sdist]" in wheel
     assert "--only-binary :all:" in wheel
-    assert '"$environment/bin/jacobian" run integer.compute.extended_gcd' in wheel
+    assert '"$GITHUB_WORKSPACE/deploy/smoke_stdio.py"' in wheel
+    assert "--startup-timeout-seconds 60" in wheel
+    assert "--request-timeout-seconds 20" in wheel
+    assert "--shutdown-timeout-seconds 10" in wheel
+    assert '"$environment/bin/jacobian-mcp"' in wheel
+    assert "PYTHONPATH=" in wheel
+    assert "--editable" not in wheel
     assert "make test-compatibility" in wheel
     assert "make test\n" not in wheel
+
+
+def test_npm_tarball_is_installed_and_smoked_on_supported_node_bounds() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    npm_package = workflow.split("  npm-package:", 1)[1].split("  lean:", 1)[0]
+
+    assert "node-version: [18, 24]" in npm_package
+    assert "npm install --prefix" in npm_package
+    assert 'JACOBIAN_PACKAGE="$wheel"' in npm_package
+    assert '"$project/node_modules/.bin/jacobian" mcp' in npm_package
+    assert "smoke_stdio.py" in npm_package
+
+
+def test_container_workflow_runs_packaged_remote_mcp_smoke() -> None:
+    workflow = (ROOT / ".github/workflows/container-image.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "load: true" in workflow
+    assert workflow.count("python -m deploy.smoke_remote") == 2
+    assert workflow.count("--expect-session-mode stateless") == 2
+    assert "jacobian:pull-request" in workflow
+    assert 'image="$REGISTRY/$IMAGE_NAME@$DIGEST"' in workflow
 
 
 def test_global_timeout_is_not_a_pytest_deadline() -> None:
@@ -59,10 +89,11 @@ def test_singular_backend_has_a_pinned_required_ci_lane() -> None:
     assert 'system("version")' in singular
     assert "make test-singular" in singular
     assert (
-        "needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, coverage, lean]"
+        "needs: [plan, static, math, catalog, catalog_examples, python, boundaries, singular, wheel, npm-package, coverage, lean]"
         in required
     )
     assert 'test "$SINGULAR_RESULT" = success' in required
+    assert 'test "$NPM_PACKAGE_RESULT" = success' in required
 
 
 def test_python_and_boundary_lanes_share_evidence_collection() -> None:

--- a/tests/tooling/test_release_workflow.py
+++ b/tests/tooling/test_release_workflow.py
@@ -81,6 +81,25 @@ def test_release_build_resolves_and_verifies_one_immutable_sha() -> None:
     ) < _step_names(build).index("Build Python distributions")
 
 
+def test_release_smokes_exact_artifacts_before_upload() -> None:
+    build = _job(_workflow(), "build")
+    smoke = _named_step(build, "Smoke exact Python and npm release artifacts over MCP")
+    script = smoke["run"]
+    assert isinstance(script, str)
+
+    assert "dist/python" in script
+    assert "*.whl" in script
+    assert "*.tar.gz" in script
+    assert "dist/npm" in script and "*.tgz" in script
+    assert "deploy/smoke_stdio.py" in script
+    assert '"$environment/bin/jacobian-mcp"' in script
+    assert '"$npm_project/node_modules/.bin/jacobian" mcp' in script
+    assert "PYTHONPATH=" in script
+    assert _step_names(build).index(
+        "Smoke exact Python and npm release artifacts over MCP"
+    ) < _step_names(build).index("Upload release distributions")
+
+
 def test_release_candidate_dispatches_full_ci_after_lockfile_sync() -> None:
     release_please = RELEASE_PLEASE_WORKFLOW.read_text(encoding="utf-8")
     ci = CI_WORKFLOW.read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,7 @@ name = "jacobian"
 version = "0.13.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "mcp" },
     { name = "networkx" },
     { name = "pydantic" },
@@ -594,6 +595,7 @@ dev-core = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.14,<5" },
     { name = "mcp", specifier = "==2.0.0" },
     { name = "networkx", specifier = "==3.6.1" },
     { name = "pydantic", specifier = ">=2.12,<3" },


### PR DESCRIPTION
## Summary

- connect the MCP SDK's per-request cancellation signal to Jacobian's bounded subprocess ownership, with a bounded graceful process-tree termination phase followed by forced termination and reaping
- make `jacobian-remote-mcp` Streamable HTTP stateless by default while retaining stateful sessions only behind the explicit `--stateful-http` opt-in
- install and exercise the actual wheel, sdist, npm tarball, and container entry points over the real MCP protocol in CI/release checks, with named startup/request/shutdown deadlines and diagnostic stderr tails

These changes remain one narrow production-hardening PR because all three issues meet at the MCP delivery boundary: request lifetime, remote transport lifetime, and the release evidence for those entry points. Mathematical operation semantics are unchanged.

## Reproduction before the fix

- `remote_cli._parser().parse_args([])` produced `transport=streamable-http` with `stateless_http=False`, despite the deployment contract describing a stateless service.
- A real stdio MCP request to a synthetic process-backed operation was cancelled by the client after about 0.4 seconds and returned MCP error `-32001`, but the spawned child PID was still alive. A subsequent `math.run` remained usable, showing that request cancellation and worker ownership—not the server loop—were disconnected.
- The focused baseline suites passed (`8` MCP tests; `16` process tests plus one platform skip) because there was no regression coverage for request cancellation before/during spawn, TERM escalation, descendant cleanup, or installed-artifact protocol execution.
- CI installed only the wheel and exercised help/direct CLI paths; the sdist was not installed, the npm carrier only had mocked forwarding tests, container checks bypassed its configured MCP entry point, and the release workflow uploaded exact artifacts without starting them over MCP.

## Behavioral changes

### Request cancellation and bounded process cleanup

`math.run` is now async at the MCP boundary. It relays the pinned MCP 2.0 request cancellation signal into a request-owned thread event while the synchronous typed operation runs in a non-abandoned worker thread. Process-backed operations consume that event through the existing cancellation context.

The bounded process supervisor now:

- refuses to spawn when cancellation is already set
- distinguishes `cancelled`, `timed_out`, and ordinary nonzero execution failure
- sends graceful termination to the complete owned POSIX process group, waits at most 0.5 seconds, escalates to `SIGKILL`, and bounds the forced-reap phase to another 0.5 seconds
- uses bounded `taskkill /T` then `/T /F` phases when the trusted Windows tool is available, with a root-process fallback
- joins the cancellation relay and worker cleanup rather than abandoning a task or swallowing cancellation

The POSIX process-tree contract is exercised with parent and child PIDs, including a TERM-ignoring tree and three repeated real MCP cancellations followed by a successful `math.run`.

### Stateless remote default

Streamable HTTP now starts with `stateless_http=True` by default. `--stateless-http` remains an accepted explicit spelling, while `--stateful-http` is the only stateful opt-in. The flags are mutually exclusive, startup logs identify the selected session mode, and systemd/deployment examples exercise the default rather than redundantly forcing it. Authentication CLI/environment precedence is unchanged; there is intentionally no environment or config-file session-mode layer.

The remote smoke records whether any response supplied `mcp-session-id` and fails if that observed mode differs from `--expect-session-mode` (stateless by default).

### Distributable MCP evidence

`deploy/smoke_stdio.py` imports no Jacobian source modules, removes `PYTHONPATH`, sets an isolated working directory, captures server stderr, and drives initialization, exact tool discovery, `math.find` search and inspection, and two bounded `math.run` requests over stdio. Every phase has an explicit timeout and names itself in diagnostics.

CI now covers:

- wheel and sdist installs on CPython 3.12 and 3.13
- the packed npm carrier on Node 18 and 24, resolving its Python server from the exact built wheel
- the built PR container through its configured entry point
- the digest-addressed published container before publication evidence is recorded

The release workflow repeats the exact wheel, sdist, and npm tarball protocol smoke before uploading distributions. The remote/container smoke now performs the same discovery/inspection/execution journey and verifies statelessness.

## Validation and packaged-artifact evidence

Focused final-tree checks:

- `make test-mcp TESTS='tests/mcp/test_mcp_cancellation.py tests/mcp/test_mcp_sdk_2_conformance.py tests/mcp/test_remote_mcp_auth.py'` — 11 passed
- `make test-process TESTS='tests/process/test_bounded_process.py tests/process/tooling/test_deploy_helpers.py'` — 24 passed, 1 skipped locally because macOS has no `prlimit`
- `make test-tooling TESTS='tests/tooling/test_product_ci_contract.py tests/tooling/test_release_workflow.py tests/tooling/test_ci_test_plan.py'` — 32 passed
- a live default `jacobian-remote-mcp` plus `python -m deploy.smoke_remote` — stateless mode observed; exact two-tool surface, catalog, search, inspect, gcd 6, and second gcd 7 all passed

Required/static checks:

- `make check-static` — passed (lint-full, dependency/dead-code checks, mypy, import contracts, architecture, build, wheel contents)
- `make docs-linkcheck` — passed
- workflow YAML parse and `git diff --check` — passed
- `make check` — lint and mypy passed; the test phase reported 6166 passed and 60 skipped. Seventeen unrelated multivariate-factor tests fail on macOS because the worker correctly refuses to run without the hard address-space limit supplied by Linux `prlimit`. One additional namespace failure came from a stale ignored `__pycache__` left by an older checkout; after removing that cache, the exact namespace test passed. No mathematical or resource-bound behavior was weakened to mask either local condition.

From freshly rebuilt final-tree artifacts in isolated CPython 3.12 environments, the wheel, sdist, and installed npm tarball each passed the complete MCP journey and reported:

```text
wheel  -> tools [math.find, math.run], gcd runs [6, 7]
sdist  -> tools [math.find, math.run], gcd runs [6, 7]
npm    -> tools [math.find, math.run], gcd runs [6, 7]
```

The same wheel/sdist journey was also characterized locally on CPython 3.13 before the final upstream rebase; the final-tree 3.12/3.13 and Node 18/24 matrices are mandatory CI jobs. Docker is installed locally but its daemon is unavailable, so the container route could not be executed on this host; the PR and publish container workflows now make that protocol smoke mandatory on Linux.

Fixes #2646
Fixes #2647
Fixes #2648
