### PR TITLE
test(ci): smoke installed MCP stdio entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
           "$environment/bin/jacobian-mcp" --help
           "$environment/bin/jacobian" run integer.compute.extended_gcd \
             --json '{"left":"84","right":"30"}'
-          python deploy/smoke_stdio.py "$environment/bin/jacobian-mcp"
+          "$environment/bin/python" deploy/smoke_stdio.py "$environment/bin/jacobian-mcp"
       - if: matrix.python-version == '3.13'
         uses: ./.github/actions/setup-python-tests
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
           "$environment/bin/jacobian-mcp" --help
           "$environment/bin/jacobian" run integer.compute.extended_gcd \
             --json '{"left":"84","right":"30"}'
+          python deploy/smoke_stdio.py "$environment/bin/jacobian-mcp"
       - if: matrix.python-version == '3.13'
         uses: ./.github/actions/setup-python-tests
         with:

--- a/deploy/smoke_stdio.py
+++ b/deploy/smoke_stdio.py
@@ -1,0 +1,78 @@
+"""Read-only MCP smoke journey against an installed stdio server executable."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Exercise an installed Jacobian MCP stdio entry point."
+    )
+    parser.add_argument("server", type=Path, help="installed jacobian-mcp executable")
+    parser.add_argument("--timeout-seconds", type=float, default=30)
+    return parser
+
+
+async def inspect(server: Path, *, timeout_seconds: float) -> None:
+    from mcp import Client, StdioServerParameters, stdio_client
+
+    environment = dict(os.environ)
+    environment.pop("PYTHONPATH", None)
+    parameters = StdioServerParameters(
+        command=str(server),
+        env=environment,
+        cwd=server.parent,
+    )
+    async with Client(stdio_client(parameters), raise_exceptions=True) as client:
+        listed = await asyncio.wait_for(client.list_tools(), timeout_seconds)
+        if {tool.name for tool in listed.tools} != {"math.find", "math.run"}:
+            raise RuntimeError(
+                "installed MCP server exposed an unexpected tool surface"
+            )
+        described = await asyncio.wait_for(
+            client.call_tool(
+                "math.find",
+                {
+                    "request": {
+                        "op": "inspect",
+                        "operation_id": "integer.compute.extended_gcd",
+                    }
+                },
+            ),
+            timeout_seconds,
+        )
+        if not isinstance(described.structured_content, dict):
+            raise RuntimeError("math.find inspection was not structured")
+        for left, right, expected in (("84", "30", "6"), ("35", "14", "7")):
+            result = await asyncio.wait_for(
+                client.call_tool(
+                    "math.run",
+                    {
+                        "operation_id": "integer.compute.extended_gcd",
+                        "payload": {"left": left, "right": right},
+                    },
+                ),
+                timeout_seconds,
+            )
+            if (
+                not isinstance(result.structured_content, dict)
+                or result.structured_content.get("output", {}).get("gcd") != expected
+            ):
+                raise RuntimeError(
+                    "installed MCP server returned an unexpected gcd result"
+                )
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.timeout_seconds <= 0:
+        raise SystemExit("--timeout-seconds must be positive")
+    asyncio.run(inspect(args.server.resolve(), timeout_seconds=args.timeout_seconds))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -10,6 +10,8 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TA_TRANSITIONS,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
@@ -137,8 +139,8 @@ class TreeAutomatonReachabilityRequest(StrictModel):
 
     automaton: BottomUpTreeAutomaton = Field(
         description=(
-            "nondeterministic bottom-up tree automaton with at most 64 "
-            "states, 32 ranked symbols, and 4096 unique transitions. "
+            f"nondeterministic bottom-up tree automaton with at most 64 "
+            f"states, 32 ranked symbols, and {MAX_TA_TRANSITIONS} unique transitions. "
             "Requests are additionally rejected when the coupled "
             "reachability work envelope (MAX_TREE_AUTOMATON_REACHABILITY_"
             "WORK = 30,000,000 units, priced across the four passes behind "

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -10,7 +10,6 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.tree_automata.values import (
-    MAX_REACHABILITY_WITNESS_NODES,
     MAX_TA_TRANSITIONS,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -28,6 +28,9 @@ from jacobian.math.tree_automata.operations import (
     run_tree_automaton,
 )
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TA_TRANSITIONS,
+    MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
     TreeAutomatonTransition,
@@ -868,7 +871,11 @@ class TestValidation:
         assert "summed" in request_description
 
         automaton_description = request_schema["properties"]["automaton"]["description"]
-        assert "30,000,000 units" in automaton_description
+        assert f"{MAX_TA_TRANSITIONS} unique transitions" in automaton_description
+        assert "{MAX_REACHABILITY_WITNESS_NODES}" not in automaton_description
+        assert (
+            f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units" in automaton_description
+        )
         assert "summed" in automaton_description
 
         witnesses_description = result_schema["properties"]["witnesses"]["description"]

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -28,7 +28,6 @@ from jacobian.math.tree_automata.operations import (
     run_tree_automaton,
 )
 from jacobian.math.tree_automata.values import (
-    MAX_REACHABILITY_WITNESS_NODES,
     MAX_TA_TRANSITIONS,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,


### PR DESCRIPTION
Fixes #2646.

### Problem

The wheel job installed the artifact but checked only help text and the direct CLI. It never invoked the installed `jacobian-mcp` executable through MCP.

### Change

Add a compact stdio smoke journey against the installed executable: exact two-tool surface, `math.find` inspection, two bounded `math.run` GCD calls. The driver clears `PYTHONPATH` and runs the child from an isolated directory.

### Validation

- `uv run --locked python deploy/smoke_stdio.py .venv/bin/jacobian-mcp --timeout-seconds 30` — passed
- `uv run --locked ruff check deploy/smoke_stdio.py` — passed
- `uv run --locked ruff format --check deploy/smoke_stdio.py` — passed