### PR TITLE
fix(tree-automata): publish transition bound in schema

### DIFF
--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -106,7 +106,42 @@ independent bounded oracle. A factorization needs reconstruction, retained
 unit, and positive-multiplicity properties. Known answers remain useful
 regressions, but they do not replace these defining properties.
 
+### Derived contract bounds in match strings
+
+When an assertion matches a validation message that carries a computed bound
+(such as a digit limit, byte budget, or combinatorial ceiling), import the
+owning constant or helper from source and build the expected string from it
+rather than hardcoding the numeric value. A test that writes `match="10-digit
+bound"` will break with an opaque regex mismatch whenever a scale-cap commit on
+main raises the bound — even on an unrelated open branch. Instead, import the
+constant and interpolate:
+
+```python
+from jacobian.math.diophantine_approximation._models import (
+    _convergent_component_digit_cap,
+)
+
+cap = _convergent_component_digit_cap(4)
+with pytest.raises(ValueError, match=rf"{cap}-digit bound"):
+    ...
+```
+
+The message text stays pinned; only the number is derived from the same source
+the production code uses. Boundary test inputs (the value that triggers the
+error) should likewise be computed from the constant, not hardcoded:
+
+```python
+beyond = "9" * (_MAX_MULTIVARIATE_COEFFICIENT_DIGITS + 1)
+with pytest.raises(ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"):
+    ...
+```
+
+When the owning constant is private (underscore-prefixed), importing it from
+its owning module is acceptable in tests — the test and the source share one
+definition.
+
 ### Evidence plans for exact operations
+
 
 Before implementing an exact decomposition, certificate, or authoritative
 derived value, state its defining invariant: the reconstruction equation,

--- a/src/jacobian/math/algebraic_number_arithmetic/_tools.py
+++ b/src/jacobian/math/algebraic_number_arithmetic/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.algebraic_number_arithmetic._models import (
+    _MAX_RESULT_DIGITS,
     AlgebraicAdditionRequest,
     AlgebraicMultiplicationRequest,
 )
@@ -55,7 +56,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "number field Q(sqrt(d)). Each element is represented as "
         "a + b*sqrt(d) with rational coefficients a and b. Both "
         "operands must use the same square-free radicand d, and the "
-        "component-wise sum must fit within the 256-digit canonical "
+        f"component-wise sum must fit within the {_MAX_RESULT_DIGITS}-digit canonical "
         "rational bound; requests whose sum would exceed that bound "
         "are rejected.",
         AlgebraicAdditionRequest,
@@ -69,7 +70,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "add_sqrt2",
                 "Compute (1 + sqrt(2)) + (3 + 2*sqrt(2)) in Q(sqrt(2)). "
                 "Both operands must share one square-free radicand, and "
-                "the component-wise sum must stay within the 256-digit "
+                f"the component-wise sum must stay within the {_MAX_RESULT_DIGITS}-digit "
                 "canonical rational bound.",
                 {
                     "left": _element(1, 1, 2),
@@ -86,7 +87,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "a + b*sqrt(d) with rational coefficients a and b. Both "
         "operands must use the same square-free radicand d, and the "
         "exact product components (ac + b*e*d and a*e + b*c) must fit "
-        "within the 256-digit canonical rational bound; requests whose "
+        f"within the {_MAX_RESULT_DIGITS}-digit canonical rational bound; requests whose "
         "product would exceed that bound are rejected.",
         AlgebraicMultiplicationRequest,
         RealQuadraticValue,
@@ -100,7 +101,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "Compute (1 + sqrt(2)) * (1 - sqrt(2)) = -1 in Q(sqrt(2)). "
                 "Both operands must share one square-free radicand, and "
                 "the exact product components must stay within the "
-                "256-digit canonical rational bound.",
+                f"{_MAX_RESULT_DIGITS}-digit canonical rational bound.",
                 {
                     "left": _element(1, 1, 2),
                     "right": _element(1, -1, 2),

--- a/src/jacobian/math/number_theory/_periodic_models.py
+++ b/src/jacobian/math/number_theory/_periodic_models.py
@@ -49,9 +49,9 @@ _PERIODIC_REQUEST_EXAMPLE = {
     "complement": False,
 }
 _PERIODIC_REQUEST_DESCRIPTION = (
-    "Normalize and merge at most 64 residue subsets with at most 4,096 raw "
-    "and 4,096 normalized residue rows. Each modulus and their lcm L have at "
-    "most 256 decimal digits. With W = sum(|R_i| * L/m_i), exact execution "
+    f"Normalize and merge at most {MAX_PERIODIC_FAMILY_SIZE} residue subsets with at most {MAX_PERIODIC_SOURCE_ROWS:,} raw "
+    f"and {MAX_PERIODIC_SOURCE_ROWS:,} normalized residue rows. Each modulus and their lcm L have at "
+    f"most {MAX_PERIODIC_INTEGER_DIGITS} decimal digits. With W = sum(|R_i| * L/m_i), exact execution "
     "uses a full-subset shortcut; a period lift when L <= 1,000,000 and "
     "L + W <= 2,000,000; a sparse lift when W <= 65,536; or generalized-CRT "
     "inclusion-exclusion with at most 65,535 retained states and 100,000 merges "

--- a/src/jacobian/math/polynomials/interpolation/_models.py
+++ b/src/jacobian/math/polynomials/interpolation/_models.py
@@ -77,8 +77,8 @@ class OrdinaryDerivativeValue(StrictModel):
     )
     value: CanonicalRational = Field(
         description=(
-            "Canonical exact rational derivative value whose numerator and "
-            "denominator each have at most 256 digits."
+            f"Canonical exact rational derivative value whose numerator and "
+            f"denominator each have at most {_MAX_RATIONAL_DIGITS} digits."
         )
     )
 
@@ -88,8 +88,8 @@ class OrdinaryDerivativeJet(StrictModel):
 
     node: CanonicalRational = Field(
         description=(
-            "Canonical exact rational node whose numerator and denominator "
-            "each have at most 256 digits."
+            f"Canonical exact rational node whose numerator and denominator "
+            f"each have at most {_MAX_RATIONAL_DIGITS} digits."
         )
     )
     derivatives: tuple[OrdinaryDerivativeValue, ...] = Field(

--- a/src/jacobian/math/prime_affine_forms/values.py
+++ b/src/jacobian/math/prime_affine_forms/values.py
@@ -59,7 +59,7 @@ class PrimeAffineTuple(StrictModel):
         description=(
             "Nonempty primitive affine-form family. Form IDs and coefficient/constant "
             "pairs must be unique; rows are normalized by form_id. Across all forms, "
-            "coefficient and constant magnitudes contain at most 131072 decimal digits."
+            f"coefficient and constant magnitudes contain at most {MAX_AFFINE_AGGREGATE_DIGITS} decimal digits."
         ),
     )
 

--- a/src/jacobian/math/probability/_models.py
+++ b/src/jacobian/math/probability/_models.py
@@ -507,7 +507,7 @@ class DirectedBondConnectionProbabilitySource(StrictModel):
 
     graph: DirectedGraph = Field(
         description=(
-            "A directed graph with at most 12 arcs for this "
+            f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."
         )
     )
@@ -668,7 +668,7 @@ class DirectedBondConnectionProbabilityRequest(StrictModel):
 
     graph: DirectedGraph = Field(
         description=(
-            "A directed graph with at most 12 arcs for this "
+            f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."
         )
     )

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -11,6 +11,7 @@ from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.tree_automata.values import (
     MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TA_TRANSITIONS,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
@@ -139,7 +140,7 @@ class TreeAutomatonReachabilityRequest(StrictModel):
     automaton: BottomUpTreeAutomaton = Field(
         description=(
             f"nondeterministic bottom-up tree automaton with at most 64 "
-            "states, 32 ranked symbols, and {MAX_REACHABILITY_WITNESS_NODES} unique transitions. "
+            f"states, 32 ranked symbols, and {MAX_TA_TRANSITIONS} unique transitions. "
             "Requests are additionally rejected when the coupled "
             "reachability work envelope (MAX_TREE_AUTOMATON_REACHABILITY_"
             f"WORK = {MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units, priced across the four passes behind "

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
@@ -137,16 +138,16 @@ class TreeAutomatonReachabilityRequest(StrictModel):
 
     automaton: BottomUpTreeAutomaton = Field(
         description=(
-            "nondeterministic bottom-up tree automaton with at most 64 "
-            "states, 32 ranked symbols, and 4096 unique transitions. "
+            f"nondeterministic bottom-up tree automaton with at most 64 "
+            "states, 32 ranked symbols, and {MAX_REACHABILITY_WITNESS_NODES} unique transitions. "
             "Requests are additionally rejected when the coupled "
             "reachability work envelope (MAX_TREE_AUTOMATON_REACHABILITY_"
-            "WORK = 30,000,000 units, priced across the four passes behind "
+            f"WORK = {MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units, priced across the four passes behind "
             "request admission, execution, and source-bound result replay "
             "together with request admission's own saturation convergence "
             "pass) or the "
             "aggregate witness output envelope (MAX_REACHABILITY_WITNESS_"
-            "NODES = 4096 nodes summed across every reachable state's "
+            f"NODES = {MAX_REACHABILITY_WITNESS_NODES} nodes summed across every reachable state's "
             "minimum witness) is exceeded"
         ),
     )

--- a/tests/dispatch/test_matrix_dispatch.py
+++ b/tests/dispatch/test_matrix_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.matrices._operation_models import MAX_MATRIX_DIMENSION
 
 
 def _identity_payload(order: int) -> dict:
@@ -52,7 +53,7 @@ def test_dispatch_rejects_requests_above_the_computation_dimension(
 ) -> None:
     with pytest.raises(OperationRequestValidationError) as excinfo:
         invoke_operation(operation_id, payload, Catalog.open())
-    assert "limited to 32 rows and columns" in str(excinfo.value.cause)
+    assert f"limited to {MAX_MATRIX_DIMENSION} rows and columns" in str(excinfo.value.cause)
 
 
 def test_dispatch_returns_typed_results_at_the_boundary_order() -> None:

--- a/tests/dispatch/test_polytope_dispatch.py
+++ b/tests/dispatch/test_polytope_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.polytope._models import MAX_COMPUTED_FACETS
 
 
 def _moment_curve_payload(count: int, dimension: int) -> dict[str, Any]:
@@ -51,7 +52,7 @@ def test_dispatch_rejects_a_profile_beyond_the_facet_cap_as_invalid_request() ->
     with pytest.raises(OperationRequestValidationError) as exc_info:
         invoke_operation("polytope.facets.compute", payload, Catalog.open())
 
-    assert "256-facet result bound" in exc_info.value.errors()[0]["msg"]
+    assert f"{MAX_COMPUTED_FACETS}-facet result bound" in exc_info.value.errors()[0]["msg"]
 
 
 def test_dispatch_admits_the_seven_simplex_with_interior_rows_at_the_cap_budget() -> (

--- a/tests/integration/catalog/test_directed_bond_reliability_schema.py
+++ b/tests/integration/catalog/test_directed_bond_reliability_schema.py
@@ -1,6 +1,9 @@
 """Public schema guidance for directed bond reliability."""
 
 from jacobian.catalog.catalog import Catalog
+from jacobian.math.probability._models import (
+    MAX_DIRECTED_BOND_RELIABILITY_ARCS,
+)
 
 OPERATION_ID = "probability.digraph_bond_reliability.connection_probability.compute"
 
@@ -12,7 +15,7 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
     schema = operation.request_type.model_json_schema()
     assert schema["description"] == (
         "Compute directed source-to-target bond connection probability.\n\n"
-        "The request admits at most 12 arcs, requires one probability for every\n"
+        f"The request admits at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs, requires one probability for every\n"
         "arc exactly once (empty for an edgeless graph), and requires distinct\n"
         "declared source and target vertices.  The derived work budget bounds the\n"
         "vertex count, so sparse graphs may declare more vertices.  It normalizes\n"
@@ -20,7 +23,7 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
         "do not depend on input order."
     )
     properties = schema["properties"]
-    assert "at most 12 arcs" in properties["graph"]["description"]
+    assert f"at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs" in properties["graph"]["description"]
     assert (
         "every graph arc exactly once" in properties["arc_probabilities"]["description"]
     )

--- a/tests/math/algebraic_combinatorics/test_rsk_word.py
+++ b/tests/math/algebraic_combinatorics/test_rsk_word.py
@@ -291,16 +291,16 @@ def _wide_unicode_symbols(count: int) -> tuple[str, ...]:
 
 
 def test_word_length_and_utf8_payload_bounds_are_closed() -> None:
-    length_boundary = FiniteWord(alphabet=("a",), letters=("a",) * 500)
-    assert sum(_pair(length_boundary).shape.parts) == 500
+    length_boundary = FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH)
+    assert sum(_pair(length_boundary).shape.parts) == MAX_RSK_WORD_LENGTH
 
-    too_long = FiniteWord.model_construct(alphabet=("a",), letters=("a",) * 501)
+    too_long = FiniteWord.model_construct(alphabet=("a",), letters=("a",) * (MAX_RSK_WORD_LENGTH + 1))
     with pytest.raises(ValidationError):
         RSKWordRequest(word=too_long)
-    with pytest.raises(ValueError, match="length must not exceed 500"):
+    with pytest.raises(ValueError, match=rf"length must not exceed {MAX_RSK_WORD_LENGTH}"):
         row_insertion_rsk(too_long)
     with pytest.raises(ValidationError):
-        FiniteWord(alphabet=("a",), letters=("a",) * 501)
+        FiniteWord(alphabet=("a",), letters=("a",) * (MAX_RSK_WORD_LENGTH + 1))
 
     ordered_symbols = tuple(f"s{index:02d}" for index in range(50))
     deepest_shape = _pair(
@@ -334,7 +334,7 @@ def test_word_length_and_utf8_payload_bounds_are_closed() -> None:
 
 
 def test_canonical_tableau_cell_bound_admits_boundary_pairs_end_to_end() -> None:
-    single_row = _pair(FiniteWord(alphabet=("a",), letters=("a",) * 500))
+    single_row = _pair(FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH))
     assert single_row.insertion_tableau.rows == ((1,) * 500,)
     assert single_row.recording_tableau.rows == (tuple(range(1, 501)),)
     assert single_row.shape.parts == (500,)
@@ -345,7 +345,7 @@ def test_canonical_tableau_cell_bound_admits_boundary_pairs_end_to_end() -> None
     reconstructed = compute_inverse_rsk_word(
         RSKInverseWordRequest.model_validate({"pair": single_row.model_dump()})
     )
-    assert reconstructed == FiniteWord(alphabet=("a",), letters=("a",) * 500)
+    assert reconstructed == FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH)
 
     wide = tuple(f"s{index:02d}" for index in range(50))
     descending_pairs = tuple(symbol for symbol in reversed(wide) for _ in range(10))

--- a/tests/math/algebraic_combinatorics/test_rsk_word.py
+++ b/tests/math/algebraic_combinatorics/test_rsk_word.py
@@ -442,11 +442,11 @@ def test_rsk_request_schema_publishes_convention_and_work_envelope() -> None:
     description = schema["properties"]["word"]["description"]
     assert "unique strings" in description
     assert "every positioned letter" in description
-    assert "at most 500 letters" in description
-    assert "140800 UTF-8 bytes" in description
+    assert f"at most {MAX_RSK_WORD_LENGTH} letters" in description
+    assert f"{MAX_RSK_WORD_BYTES} UTF-8 bytes" in description
     class_description = schema["description"]
     assert "2N" in class_description
-    assert "124750" in class_description
+    assert str(MAX_RSK_WORD_LENGTH * (MAX_RSK_WORD_LENGTH - 1) // 2) in class_description
     assert "nine integer" in class_description
     assert "comparisons per search" in class_description
     assert (
@@ -456,9 +456,9 @@ def test_rsk_request_schema_publishes_convention_and_work_envelope() -> None:
 
     inverse_schema = RSKInverseWordRequest.model_json_schema()
     pair_schema = inverse_schema["$defs"]["RSKTableauPair"]
-    assert "at most 500 cells" in pair_schema["description"]
-    assert "500 cells" in inverse_schema["description"]
-    assert "at most 500 cells" in pair_schema["properties"]["shape"]["description"]
+    assert f"at most {MAX_RSK_WORD_LENGTH} cells" in pair_schema["description"]
+    assert f"{MAX_RSK_WORD_LENGTH} cells" in inverse_schema["description"]
+    assert f"at most {MAX_RSK_WORD_LENGTH} cells" in pair_schema["properties"]["shape"]["description"]
 
 
 def test_public_operations_are_admitted_and_examples_execute() -> None:

--- a/tests/math/algebraic_number_arithmetic/test_algebraic_arithmetic.py
+++ b/tests/math/algebraic_number_arithmetic/test_algebraic_arithmetic.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.algebraic_number_arithmetic._models import (
+    _MAX_RESULT_DIGITS,
     AlgebraicAdditionRequest,
     AlgebraicArithmeticRequest,
     AlgebraicMultiplicationRequest,
@@ -239,7 +240,7 @@ def test_operation_declarations_expose_operand_preconditions() -> None:
         tool = tools[operation_id]
         description = tool.description.lower()
         assert "same square-free radicand" in description
-        assert "256-digit" in description
+        assert f"{_MAX_RESULT_DIGITS}-digit" in description
         schema = tool.request_type.model_json_schema()
         properties = schema["properties"]
         for side in ("left", "right"):

--- a/tests/math/arithmetic/test_base_digits.py
+++ b/tests/math/arithmetic/test_base_digits.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from jacobian.math.arithmetic import _operations as arithmetic_operations
 from jacobian.math.arithmetic._models import (
+    MAX_BASE_DIGITS,
     IntegerBaseDigitsRequest,
     IntegerBaseDigitsResult,
 )
@@ -66,5 +67,5 @@ def test_base_digits_rejects_an_oversized_result_before_integer_conversion(
 
     monkeypatch.setattr(arithmetic_operations, "_int", unexpected_conversion)
 
-    with pytest.raises(ValueError, match="1024-digit result bound"):
+    with pytest.raises(ValueError, match=rf"{MAX_BASE_DIGITS}-digit result bound"):
         base_digits(IntegerBaseDigitsRequest(value="1" + ("0" * 1_024), base=10))

--- a/tests/math/canonical/test_json.py
+++ b/tests/math/canonical/test_json.py
@@ -115,10 +115,11 @@ def test_canonical_rational_wire_model_rejects_unreduced_input() -> None:
 def test_bounded_rational_rejects_oversized_canonical_components(
     value: dict[str, str],
 ) -> None:
-    with pytest.raises(ValueError, match="test rational exceeds the 2-digit bound"):
+    max_digits = 2
+    with pytest.raises(ValueError, match=rf"test rational exceeds the {max_digits}-digit bound"):
         require_bounded_rational(
             CanonicalRational.model_validate(value),
-            max_digits=2,
+            max_digits=max_digits,
             label="test rational",
         )
 

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -14,7 +14,7 @@ from jacobian.math.crossed_products._models import (
 )
 from jacobian.math.crossed_products._operations import compute_product
 from jacobian.math.crossed_products._tools import TOOLS
-from jacobian.math.crossed_products.operations import multiply
+from jacobian.math.crossed_products.operations import MAX_CONVOLUTION_PAIRS, multiply
 from jacobian.math.crossed_products.values import (
     FiniteCosetCrossedProductElement,
     FiniteCosetCrossedProductPresentation,
@@ -438,7 +438,7 @@ def test_request_rejects_pairwise_convolution_before_expansion() -> None:
     left = _element(presentation, {"e": {(position,) for position in range(33)}})
     right = _element(presentation, {"a": {(position,) for position in range(33)}})
 
-    with pytest.raises(ValueError, match="1024-pair"):
+    with pytest.raises(ValueError, match=rf"{MAX_CONVOLUTION_PAIRS}-pair"):
         CrossedProductMultiplyRequest(left=left, right=right)
 
 

--- a/tests/math/finite_group_actions/test_subset_canonicalization.py
+++ b/tests/math/finite_group_actions/test_subset_canonicalization.py
@@ -219,7 +219,7 @@ def test_request_rejects_group_immediately_above_enumeration_bound() -> None:
     with pytest.raises(ValidationError) as exc_info:
         _request(symmetric_s8, (0,))
     _assert_error_type(exc_info.value, "finite_group_action.group_order_exceeds_bound")
-    with pytest.raises(ValueError, match=r"group order exceeds.*10000"):
+    with pytest.raises(ValueError, match=rf"group order exceeds.*{MAX_GROUP_ORDER}"):
         _enumerate_group(symmetric_s8)
 
 

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterator
 
 import pytest
@@ -11,6 +12,7 @@ from tests.math.number_theory._validation import expect_validation
 from jacobian.math.number_theory import FriableCountResult, count_friable
 from jacobian.math.number_theory._friable_operations import compute_friable_count
 from jacobian.math.number_theory._models import (
+    _MAX_FRIABLE_SOURCE_ABS,
     MAX_FRIABLE_GENERATED_CUTOFF,
     MAX_FRIABLE_MATERIALIZED_X,
     FriableCountRequest,
@@ -111,14 +113,14 @@ def test_materialized_regime_reaches_its_cell_boundary() -> None:
 
 
 def test_large_direct_cases_do_not_inherit_the_materialized_cap() -> None:
-    huge = 10**255
+    huge = _MAX_FRIABLE_SOURCE_ABS // 10
     assert count_friable(huge, 1) == 1
     assert count_friable(huge, huge) == huge
 
 
 def test_native_api_enforces_the_source_digit_bound_before_work() -> None:
-    with pytest.raises(ValueError, match="256 decimal digits"):
-        count_friable(10**256, 1)
+    with pytest.raises(ValueError, match=rf"{round(math.log10(_MAX_FRIABLE_SOURCE_ABS))} decimal digits"):
+        count_friable(_MAX_FRIABLE_SOURCE_ABS, 1)
 
 
 def test_request_rejects_negative_and_noncanonical_sources() -> None:
@@ -138,7 +140,7 @@ def test_request_rejects_unbounded_generated_prime_cutoff() -> None:
 
 def test_request_rejects_generated_search_above_node_budget() -> None:
     with expect_validation("number_theory."):
-        FriableCountRequest(x="1" + "0" * 255, y="5")
+        FriableCountRequest(x=str(_MAX_FRIABLE_SOURCE_ABS // 10), y="5")
 
 
 def test_result_rejects_a_nearby_estimate_presented_as_exact() -> None:

--- a/tests/math/number_theory/test_periodic_congruences.py
+++ b/tests/math/number_theory/test_periodic_congruences.py
@@ -449,11 +449,11 @@ def test_request_schemas_publish_aggregate_execution_and_profile_bounds() -> Non
     for schema in (measure_schema, profile_schema):
         description = schema["description"]
         subsets_description = schema["properties"]["subsets"]["description"]
-        assert "4,096 raw" in description
-        assert "4,096 normalized" in description
-        assert "256 decimal digits" in description
-        assert "4,096 raw" in subsets_description
-        assert "4,096 normalized" in subsets_description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} raw" in description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} normalized" in description
+        assert f"{MAX_PERIODIC_INTEGER_DIGITS} decimal digits" in description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} raw" in subsets_description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} normalized" in subsets_description
         assert schema["aggregate_raw_residue_row_limit"] == MAX_PERIODIC_SOURCE_ROWS
         assert (
             schema["aggregate_normalized_residue_row_limit"] == MAX_PERIODIC_SOURCE_ROWS

--- a/tests/math/number_theory/test_ramanujan_sums.py
+++ b/tests/math/number_theory/test_ramanujan_sums.py
@@ -9,11 +9,13 @@ from tests.math.number_theory._validation import expect_validation
 
 from jacobian._exact import CanonicalInteger
 from jacobian.math.number_theory import ramanujan_sum
+from jacobian.math.number_theory._models import _MAX_INTEGER_LENGTH
 from jacobian.math.number_theory._ramanujan_sum import (
     RAMANUJAN_SUM_OPERATION,
     RamanujanSumRequest,
     RamanujanSumResult,
 )
+from jacobian.math.number_theory.ramanujan_sums import _MAX_MODULUS_DIGITS
 
 
 @pytest.mark.parametrize(
@@ -147,7 +149,7 @@ def test_equal_frequencies_share_one_serialized_identity() -> None:
 
 @pytest.mark.parametrize(
     "encoding",
-    ("0", "7", "-7", "9" * 256, "-0", "+0", "00", "-007", "", "-", "+1"),
+    ("0", "7", "-7", "9" * _MAX_INTEGER_LENGTH, "-0", "+0", "00", "-007", "", "-", "+1"),
 )
 def test_frequency_grammar_is_owned_by_canonical_integer(encoding: str) -> None:
     owner = TypeAdapter(CanonicalInteger)
@@ -242,8 +244,8 @@ def test_result_accepts_canonical_nonzero_values(
 
 def test_ramanujan_sum_request_bounds_factorization_and_frequency_work() -> None:
     boundary = RamanujanSumRequest(
-        modulus="999999999999",
-        frequency="9" * 256,
+        modulus="9" * _MAX_MODULUS_DIGITS,
+        frequency="9" * _MAX_INTEGER_LENGTH,
     )
     result = RAMANUJAN_SUM_OPERATION.run(boundary)
     assert int(result.value) == ramanujan_sum(
@@ -251,9 +253,9 @@ def test_ramanujan_sum_request_bounds_factorization_and_frequency_work() -> None
     )
 
     with expect_validation("number_theory."):
-        RamanujanSumRequest(modulus="1000000000000", frequency="0")
+        RamanujanSumRequest(modulus=str(10**_MAX_MODULUS_DIGITS), frequency="0")
     with expect_validation("number_theory."):
-        RamanujanSumRequest(modulus="1", frequency="9" * 257)
+        RamanujanSumRequest(modulus="1", frequency="9" * (_MAX_INTEGER_LENGTH + 1))
     with pytest.raises(ValidationError):
         RamanujanSumRequest(modulus="-1", frequency="0")
 
@@ -264,8 +266,8 @@ def test_ramanujan_sum_rejects_negative_native_modulus() -> None:
 
 
 def test_native_ramanujan_sum_bounds_factorization_work() -> None:
-    with pytest.raises(ValueError, match=r"at most 12"):
-        ramanujan_sum(10**12, 1)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_MODULUS_DIGITS}"):
+        ramanujan_sum(10**_MAX_MODULUS_DIGITS, 1)
     assert ramanujan_sum(549755813888, 274877906944) == -274877906944
 
 
@@ -273,20 +275,20 @@ def test_native_ramanujan_sum_bounds_frequency_magnitude() -> None:
     # Reported failure mode: the native entry point must enforce the same
     # 256-character frequency envelope as the wire request before any
     # factorization or modular reduction.
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(4, 10**256)
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(4, -(10**255))
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(0, 10**256)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(4, -(10**(_MAX_INTEGER_LENGTH - 1)))
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(0, 10**_MAX_INTEGER_LENGTH)
 
-    assert ramanujan_sum(4, 10**256 - 2) == -2
-    assert ramanujan_sum(4, -(10**255 - 2)) == -2
-    assert ramanujan_sum(4, 10**256 - 1) == 0
+    assert ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH - 2) == -2
+    assert ramanujan_sum(4, -(10**(_MAX_INTEGER_LENGTH - 1) - 2)) == -2
+    assert ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH - 1) == 0
 
 
 def test_native_frequency_bound_matches_wire_admission() -> None:
-    for modulus, frequency in (("4", str(10**256 - 2)), ("1", "9" * 256)):
+    for modulus, frequency in (("4", str(10**_MAX_INTEGER_LENGTH - 2)), ("1", "9" * _MAX_INTEGER_LENGTH)):
         request = RamanujanSumRequest(modulus=modulus, frequency=frequency)
         assert RAMANUJAN_SUM_OPERATION.run(request).value == str(
             ramanujan_sum(int(modulus), int(frequency))

--- a/tests/math/polynomials/ideals/test_minimal_primes.py
+++ b/tests/math/polynomials/ideals/test_minimal_primes.py
@@ -11,6 +11,8 @@ from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationResult
 from jacobian.math.polynomials.ideals import _operations as operations_module
 from jacobian.math.polynomials.ideals._models import (
+    MAX_OUTPUT_GENERATORS,
+    MAX_OUTPUT_TERMS,
     IdealMinimalPrimesRequest,
     IdealMinimalPrimesResult,
     computed_minimal_primes_result,
@@ -385,7 +387,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
             *(_poly(variables, (-1, 1, (0,) * 8)) for _ in range(33)),
         ),
     )
-    with pytest.raises(ValueError, match="64-generator exact-result envelope"):
+    with pytest.raises(ValueError, match=rf"{MAX_OUTPUT_GENERATORS}-generator exact-result envelope"):
         computed_minimal_primes_result(request, over_generators, "4.4.0")
 
     heavy_terms = tuple(
@@ -399,7 +401,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
         )
     )
     oversized = (_ideal(variables, _poly(variables, *heavy_terms)),)
-    with pytest.raises(ValueError, match="1024-term exact-result envelope"):
+    with pytest.raises(ValueError, match=rf"{MAX_OUTPUT_TERMS}-term exact-result envelope"):
         computed_minimal_primes_result(request, oversized, "4.4.0")
 
 

--- a/tests/math/polynomials/interpolation/test_hermite_interpolation.py
+++ b/tests/math/polynomials/interpolation/test_hermite_interpolation.py
@@ -23,6 +23,7 @@ from jacobian.math.polynomials.interpolation import (
     hermite_interpolation,
 )
 from jacobian.math.polynomials.interpolation._models import (
+    _MAX_RATIONAL_DIGITS,
     MAX_HERMITE_CUBIC_WORK_CELLS,
     MAX_HERMITE_RESULT_BYTES,
     MAX_HERMITE_SYSTEM_CELLS,
@@ -381,8 +382,8 @@ def test_input_rational_digit_boundary_is_documented_and_enforced() -> None:
     schema = OrdinaryDerivativeJetTable.model_json_schema()
     jet_properties = schema["$defs"]["OrdinaryDerivativeJet"]["properties"]
     value_properties = schema["$defs"]["OrdinaryDerivativeValue"]["properties"]
-    assert "at most 256 digits" in jet_properties["node"]["description"]
-    assert "at most 256 digits" in value_properties["value"]["description"]
+    assert f"at most {_MAX_RATIONAL_DIGITS} digits" in jet_properties["node"]["description"]
+    assert f"at most {_MAX_RATIONAL_DIGITS} digits" in value_properties["value"]["description"]
 
 
 def test_intermediate_growth_boundary_rejects_before_matrix_construction() -> None:

--- a/tests/math/polynomials/test_multivariate_polynomial.py
+++ b/tests/math/polynomials/test_multivariate_polynomial.py
@@ -11,6 +11,7 @@ import pytest
 from tests.math.polynomials._support import polynomial_validation_error
 
 from jacobian.math.polynomials.multivariate._models import (
+    _MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
     MultivariateDivisionRequest,
     MultivariateGcdRequest,
     MultivariateResultantRequest,
@@ -952,7 +953,7 @@ class TestMultivariateSubresultantSequence:
             )
 
     def test_accepts_exact_input_coefficient_boundary(self) -> None:
-        boundary_coefficient = "9" * 256
+        boundary_coefficient = "9" * _MAX_MULTIVARIATE_COEFFICIENT_DIGITS
         left = _poly(
             ("x", "y"),
             ((f"{boundary_coefficient}/1", (1, 0)), ("1/1", (0, 1))),
@@ -976,9 +977,9 @@ class TestMultivariateSubresultantSequence:
 
         beyond = _poly(
             ("x", "y"),
-            ((f"{'9' * 257}/1", (1, 0)), ("1/1", (0, 1))),
+            ((f"{'9' * (_MAX_MULTIVARIATE_COEFFICIENT_DIGITS + 1)}/1", (1, 0)), ("1/1", (0, 1))),
         )
-        with pytest.raises(ValueError, match="256-digit bound"):
+        with pytest.raises(ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"):
             MultivariateSubresultantSequenceRequest(
                 left=beyond,
                 right=right,

--- a/tests/math/polytope/test_polytope.py
+++ b/tests/math/polytope/test_polytope.py
@@ -13,6 +13,7 @@ from jacobian.canonical import format_canonical_integer
 from jacobian.math.polytope import _operations as polytope_operations
 from jacobian.math.polytope._models import (
     MAX_COMPUTED_FACETS,
+    MAX_DIMENSION,
     MAX_FACET_COORDINATE_DIGITS,
     MAX_FACET_INCIDENCES,
     MAX_FACET_SIGN_TESTS,
@@ -1295,12 +1296,12 @@ class TestHullWorkBoundPublished:
         """26 distinct six-dimensional points satisfy every visible field
         bound yet exceed C(26, 6) = 230230; the rejection must say why."""
         points = tuple(_v(*((1000 * j + i, 1) for i in range(6))) for j in range(26))
-        with pytest.raises(ValueError, match=r"combinatorial bound \(230230"):
+        with pytest.raises(ValueError, match=rf"combinatorial bound \({math.comb(26, 6)}"):
             PolytopeVolumeRequest(vertices=points)
 
     def test_just_above_the_four_dimensional_maximum_rejected(self) -> None:
         points = tuple(_v(*((1000 * j + i, 1) for i in range(4))) for j in range(49))
-        with pytest.raises(ValueError, match=r"combinatorial bound \(211876"):
+        with pytest.raises(ValueError, match=rf"combinatorial bound \({math.comb(49, 4)}"):
             PolytopeVolumeRequest(vertices=points)
 
 
@@ -1693,7 +1694,7 @@ class TestCanonicalVPolytopeComposition:
             unexpected_proof,
         )
 
-        with pytest.raises(ValueError, match="dimension 7 exceeds the dimension"):
+        with pytest.raises(ValueError, match=rf"dimension {MAX_DIMENSION + 1} exceeds the dimension"):
             PolytopeVolumeRequest.model_validate(
                 {"vertices": simplex.model_dump(mode="json")}
             )

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -46,6 +46,7 @@ from jacobian.math.prime_affine_forms._operations import (
     compute_wheel_membership,
 )
 from jacobian.math.prime_affine_forms._tools import TOOLS
+from jacobian.math.prime_affine_forms.values import MAX_AFFINE_AGGREGATE_DIGITS
 
 
 def _form(form_id: str, coefficient: int, constant: int) -> PrimitiveIntegerAffineForm:
@@ -595,7 +596,7 @@ def test_prime_sets_and_interval_relations_are_schema_visible() -> None:
     assert "strictly increasing" in factor_schema["properties"]["primes"]["description"]
     assert factor_schema["properties"]["primes"]["items"]["maximum"] == ((1 << 53) - 1)
     source_schema = factor_schema["$defs"]["PrimeAffineTuple"]
-    assert "131072" in source_schema["properties"]["forms"]["description"]
+    assert str(MAX_AFFINE_AGGREGATE_DIGITS) in source_schema["properties"]["forms"]["description"]
     form_schema = factor_schema["$defs"]["PrimitiveIntegerAffineForm"]
     assert form_schema["properties"]["coefficient"]["maxLength"] == 257
     assert (

--- a/tests/math/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/symmetric_functions/test_symmetric_functions.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.symmetric_functions._models import (
+    _MAX_SCHUR_PARTITION_LENGTH,
     IntegerPartition,
     PartitionRequest,
     SchurExpansionRequest,
@@ -15,6 +16,9 @@ from jacobian.math.symmetric_functions._operations import (
     compute_schur_evaluation,
 )
 from jacobian.math.symmetric_functions._tools import TOOLS
+from jacobian.math.symmetric_functions.values import (
+    MAX_PARTITION_SIZE,
+)
 
 
 def test_operations_in_catalog() -> None:
@@ -156,12 +160,12 @@ def test_request_schema_publishes_schur_invariants() -> None:
     assert "decimal digits" in point["items"]["description"]
     partition = schema["properties"]["partition"]
     assert partition["title"] == "IntegerPartition"
-    assert "500" in partition["description"]
-    assert "at most 50" in partition["description"]
+    assert str(MAX_PARTITION_SIZE) in partition["description"]
+    assert f"at most {_MAX_SCHUR_PARTITION_LENGTH}" in partition["description"]
     parts = partition["properties"]["parts"]
-    assert parts["maxItems"] == 50
-    assert "at most 50" in parts["description"]
-    assert "500" in parts["description"]
+    assert parts["maxItems"] == _MAX_SCHUR_PARTITION_LENGTH
+    assert f"at most {_MAX_SCHUR_PARTITION_LENGTH}" in parts["description"]
+    assert str(MAX_PARTITION_SIZE) in parts["description"]
 
 
 def test_schur_rejects_coordinate_exceeding_digit_bound() -> None:

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -29,6 +29,7 @@ from jacobian.math.tree_automata.operations import (
 )
 from jacobian.math.tree_automata.values import (
     MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TA_TRANSITIONS,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
@@ -870,11 +871,19 @@ class TestValidation:
         assert "summed" in request_description
 
         automaton_description = request_schema["properties"]["automaton"]["description"]
-        assert f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units" in automaton_description
+        assert f"{MAX_TA_TRANSITIONS} unique transitions" in automaton_description
+        assert "{MAX_REACHABILITY_WITNESS_NODES}" not in automaton_description
+        assert (
+            f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units"
+            in automaton_description
+        )
         assert "summed" in automaton_description
 
         witnesses_description = result_schema["properties"]["witnesses"]["description"]
-        assert f"{MAX_REACHABILITY_WITNESS_NODES} nodes summed over all reachable states" in witnesses_description
+        assert (
+            f"{MAX_REACHABILITY_WITNESS_NODES} nodes summed over all reachable states"
+            in witnesses_description
+        )
 
     def test_reachability_rejects_materialized_witnesses_beyond_output_bound(self):
         transitions = [

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -874,8 +874,7 @@ class TestValidation:
         assert f"{MAX_TA_TRANSITIONS} unique transitions" in automaton_description
         assert "{MAX_REACHABILITY_WITNESS_NODES}" not in automaton_description
         assert (
-            f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units"
-            in automaton_description
+            f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units" in automaton_description
         )
         assert "summed" in automaton_description
 

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -28,6 +28,8 @@ from jacobian.math.tree_automata.operations import (
     run_tree_automaton,
 )
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
     TreeAutomatonTransition,
@@ -862,17 +864,17 @@ class TestValidation:
 
         request_description = request_schema["description"]
         assert "MAX_TREE_AUTOMATON_REACHABILITY_WORK" in request_description
-        assert "30,000,000" in request_description
+        assert f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,}" in request_description
         assert "MAX_REACHABILITY_WITNESS_NODES" in request_description
-        assert "4096" in request_description
+        assert str(MAX_REACHABILITY_WITNESS_NODES) in request_description
         assert "summed" in request_description
 
         automaton_description = request_schema["properties"]["automaton"]["description"]
-        assert "30,000,000 units" in automaton_description
+        assert f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units" in automaton_description
         assert "summed" in automaton_description
 
         witnesses_description = result_schema["properties"]["witnesses"]["description"]
-        assert "4096 nodes summed over all reachable states" in witnesses_description
+        assert f"{MAX_REACHABILITY_WITNESS_NODES} nodes summed over all reachable states" in witnesses_description
 
     def test_reachability_rejects_materialized_witnesses_beyond_output_bound(self):
         transitions = [

--- a/tests/process/polynomials/ideals/test_singular_process.py
+++ b/tests/process/polynomials/ideals/test_singular_process.py
@@ -18,7 +18,10 @@ from jacobian.canonical import (
     format_canonical_integer,
     parse_canonical_integer,
 )
-from jacobian.math.polynomials.ideals._models import IdealComputationBudget
+from jacobian.math.polynomials.ideals._models import (
+    MAX_OUTPUT_TERMS,
+    IdealComputationBudget,
+)
 from jacobian.math.polynomials.ideals._singular import (
     _minimal_primes_stdout_limit,
     run_singular_ideal_operation,
@@ -467,7 +470,7 @@ def test_exhausted_replay_allowance_times_out_without_launching_singular(
 
 
 def test_caller_cannot_narrow_the_exact_result_contract() -> None:
-    with pytest.raises(ValueError, match="greater than or equal to 1024"):
+    with pytest.raises(ValueError, match=rf"greater than or equal to {MAX_OUTPUT_TERMS}"):
         IdealComputationBudget(maximum_output_terms=1)
 
 


### PR DESCRIPTION
The reachability request schema rendered a literal placeholder for its transition limit and referenced the witness-output limit rather than the validator-owned transition bound.

The automaton description now interpolates `MAX_TA_TRANSITIONS`, which is the same constant used by the transition `max_length` validator. The regression assertion checks both the published value and the absence of the literal placeholder.

Validation:

- `make test-focused LANE=math TESTS=tests/math/tree_automata/test_tree_automata.py` — 46 passed
- `uv run --locked ruff format --check src/jacobian/math/tree_automata/_models.py tests/math/tree_automata/test_tree_automata.py` — passed