### PR TITLE
fix(mcp): cancel bounded subprocess trees

### DIFF
--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import anyio
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
@@ -30,6 +31,7 @@ from jacobian.mcp.runtime import (
     _authorize,
     _catalog,
 )
+from jacobian.process import bounded_process_cancellation
 
 _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
@@ -93,11 +95,11 @@ def math_run(
     if catalog.operation(operation_id) is None:
         raise ToolError(f"unknown operation: {operation_id}")
     try:
-        return invoke_operation(
-            operation_id,
-            payload,
-            catalog,
-        )
+        # MCP runs synchronous tools in a worker thread.  Its request event
+        # is polled by the shared external-process runner, which kills and
+        # reaps only an operation's owned child tree.
+        with bounded_process_cancellation(_request_cancellation(ctx)):
+            return invoke_operation(operation_id, payload, catalog)
     except OperationRequestValidationError as exc:
         errors = _bounded_validation_issues(exc.errors())
         data = OperationInvalidRequestData(
@@ -109,6 +111,12 @@ def math_run(
             message="operation payload failed validation",
             data=data.model_dump(mode="json"),
         ) from exc
+
+
+def _request_cancellation(ctx: Context[AppState, Any]) -> anyio.Event:
+    """Return MCP 2.1's request signal through its only available SDK seam."""
+
+    return ctx.request_context.session._request_outbound.cancel_requested
 
 
 def _bounded_validation_issues(

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Protocol
 
-import anyio
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
@@ -37,6 +36,12 @@ _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
 _MAX_VALIDATION_LOCATION_LENGTH = 128
 _MAX_VALIDATION_ISSUES_BYTES = 48 * 1_024
+
+
+class _CancellationSignal(Protocol):
+    """Cooperative request cancellation observed by external process work."""
+
+    def is_set(self) -> bool: ...
 
 
 def math_find(
@@ -113,7 +118,7 @@ def math_run(
         ) from exc
 
 
-def _request_cancellation(ctx: Context[AppState, Any]) -> anyio.Event:
+def _request_cancellation(ctx: Context[AppState, Any]) -> _CancellationSignal:
     """Return MCP 2.1's request signal through its only available SDK seam."""
 
     return ctx.request_context.session._request_outbound.cancel_requested

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, cast
+from typing import BinaryIO, Protocol, cast
 
 __all__ = [
     "BoundedProcessResult",
@@ -35,7 +35,14 @@ __all__ = [
     "worker_environment",
 ]
 
-_CANCELLATION_EVENT: ContextVar[threading.Event | None] = ContextVar(
+
+class _CancellationSignal(Protocol):
+    """Minimal cooperative signal accepted by the process monitor."""
+
+    def is_set(self) -> bool: ...
+
+
+_CANCELLATION_EVENT: ContextVar[_CancellationSignal | None] = ContextVar(
     "jacobian_bounded_process_cancellation_event",
     default=None,
 )
@@ -56,7 +63,7 @@ class BoundedProcessResult:
 
 @contextmanager
 def bounded_process_cancellation(
-    event: threading.Event,
+    event: _CancellationSignal,
 ) -> Iterator[None]:
     """Bind cooperative subprocess cancellation to the current worker context."""
 
@@ -263,7 +270,7 @@ def _monitor_bounded_process(
     process: subprocess.Popen[bytes],
     *,
     deadline: float,
-    cancellation_event: threading.Event | None,
+    cancellation_event: _CancellationSignal | None,
     platform_tools: ProcessPlatformTools | None,
 ) -> tuple[bool, bool]:
     """Poll the child until exit, timeout, or cancellation.
@@ -317,7 +324,7 @@ def run_bounded_process(
     resource_limits: ProcessResourceLimits | None = None,
     cwd: str | None = None,
     platform_tools: ProcessPlatformTools | None = None,
-    cancellation_event: threading.Event | None = None,
+    cancellation_event: _CancellationSignal | None = None,
 ) -> BoundedProcessResult:
     """Run a child with bounded output, time, lifetime, and supported resources.
 

--- a/tests/mcp/_cancellation_server.py
+++ b/tests/mcp/_cancellation_server.py
@@ -1,0 +1,66 @@
+"""Synthetic process-backed server used only by MCP cancellation tests."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from pydantic import Field
+
+from jacobian._models import StrictModel
+from jacobian.catalog.builtins import BUILTIN_TOOLS
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import MathTool
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.server import _build_server
+from jacobian.process import run_bounded_process
+
+
+class ProcessRequest(StrictModel):
+    marker: str = Field(min_length=1, max_length=4_096)
+
+
+class ProcessResult(StrictModel):
+    cancelled: bool
+
+
+def _run_process(request: ProcessRequest) -> ProcessResult:
+    completed = run_bounded_process(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os, pathlib, signal, subprocess, sys, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "child=subprocess.Popen([sys.executable, '-c', "
+                "'import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)']); "
+                "pathlib.Path(sys.argv[1]).write_text(json.dumps([os.getpid(), child.pid])); "
+                "time.sleep(30)"
+            ),
+            request.marker,
+        ],
+        input_bytes=b"",
+        timeout_seconds=20,
+        environment=dict(os.environ),
+        stdout_limit=4_096,
+        stderr_limit=4_096,
+    )
+    return ProcessResult(cancelled=completed.cancelled)
+
+
+def main() -> None:
+    operation = MathTool(
+        operation_id="test.process.wait",
+        title="Wait in an owned process tree",
+        description="Synthetic bounded process used only by MCP regression tests.",
+        request_type=ProcessRequest,
+        result_type=ProcessResult,
+        run=_run_process,
+    )
+    _build_server(
+        state=AppState(operation_catalog=Catalog((*BUILTIN_TOOLS, operation)))
+    ).run("stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mcp/test_mcp_cancellation.py
+++ b/tests/mcp/test_mcp_cancellation.py
@@ -1,0 +1,77 @@
+"""MCP cancellation must terminate request-owned subprocesses."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER = Path(__file__).with_name("_cancellation_server.py")
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _read_pids(marker: Path) -> list[int]:
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        if marker.exists() and (text := marker.read_text().strip()):
+            return list(json.loads(text))
+        await asyncio.sleep(0.01)
+    raise AssertionError("process-backed operation did not publish its PID marker")
+
+
+async def _assert_pids_exit(pids: list[int]) -> None:
+    deadline = time.monotonic() + 4
+    while time.monotonic() < deadline:
+        if all(not _pid_exists(pid) for pid in pids):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"cancelled process tree survived: {pids}")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-tree assertion is POSIX")
+def test_stdio_cancellation_reaps_tree_and_server_remains_responsive(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        from mcp import Client, StdioServerParameters, stdio_client
+
+        parameters = StdioServerParameters(
+            command=sys.executable, args=[str(SERVER)], env=dict(os.environ), cwd=ROOT
+        )
+        async with Client(stdio_client(parameters), raise_exceptions=True) as client:
+            for attempt in range(3):
+                marker = tmp_path / f"request-{attempt}.json"
+                with pytest.raises(MCPError, match="timed out"):
+                    await client.call_tool(
+                        "math.run",
+                        {
+                            "operation_id": "test.process.wait",
+                            "payload": {"marker": str(marker)},
+                        },
+                        read_timeout_seconds=2,
+                    )
+                await _assert_pids_exit(await _read_pids(marker))
+            follow_up = await client.call_tool(
+                "math.run",
+                {
+                    "operation_id": "integer.compute.extended_gcd",
+                    "payload": {"left": "84", "right": "30"},
+                },
+            )
+            assert follow_up.structured_content["output"]["gcd"] == "6"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Fixes #2648.

## Problem

When an MCP client abandons `math.run`, the SDK records the request cancellation, but Jacobian did not bind that signal to its bounded subprocess runner. An external backend could therefore continue after its client had stopped waiting.

## Solution

Keep `math.run` synchronous. MCP dispatches synchronous tools in a worker thread, where the request-scoped SDK cancellation event is bound once to the existing common process runner. The runner polls that signal and kills and reaps the owned process tree. In-process operations remain synchronous and unchanged.

MCP 2.1 does not expose cancellation on its high-level tool `Context`; the bridge is contained in one helper that reads the current request dispatcher event through the SDK's available session seam. It can be replaced when the SDK exposes that event publicly.

## Testing

- `make test-mcp TESTS='tests/mcp/test_mcp_cancellation.py tests/mcp/test_mcp_sdk_2_conformance.py'` — 3 passed. The new stdio regression cancels three process trees, verifies both parent and child exit, then runs `integer.compute.extended_gcd` on the same server.
- `uv run --locked ruff check src/jacobian/mcp/tools.py src/jacobian/process.py tests/mcp/_cancellation_server.py tests/mcp/test_mcp_cancellation.py` — passed.
- `uv run --locked ruff format --check src/jacobian/mcp/tools.py src/jacobian/process.py tests/mcp/_cancellation_server.py tests/mcp/test_mcp_cancellation.py` — passed.
- `make check` completed its lint and typecheck stages; the full math/catalog test command was started but its terminal completion status was not captured, so it is intentionally not claimed as passing here.

## Public contract impact

None. `math.run` remains synchronous and operation request/result contracts are unchanged.

## Operation boundary ownership

- Changed stage: transport cancellation into external-process execution control.
- Request-bounds owner and controlling quantities: unchanged.
- Backend or kernel path: unchanged; only existing subprocess-backed operations observe the request signal.
- Result construction: unchanged.
- Independent-result verifier: none.
- Native/MCP parity: native calls are unchanged; MCP adds transport-only cancellation for request-owned external child processes.
- Serialized-result and round-trip evidence: not applicable.

## Checklist

- [ ] `make check` passes
- [x] Explicitly relevant specialist validation is listed above
- [x] New shared abstraction replaces duplicate cancellation bridging across external backends