### PR TITLE
Add matrix-polynomial envelope conformance pilot

### DIFF
--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -106,7 +106,42 @@ independent bounded oracle. A factorization needs reconstruction, retained
 unit, and positive-multiplicity properties. Known answers remain useful
 regressions, but they do not replace these defining properties.
 
+### Derived contract bounds in match strings
+
+When an assertion matches a validation message that carries a computed bound
+(such as a digit limit, byte budget, or combinatorial ceiling), import the
+owning constant or helper from source and build the expected string from it
+rather than hardcoding the numeric value. A test that writes `match="10-digit
+bound"` will break with an opaque regex mismatch whenever a scale-cap commit on
+main raises the bound — even on an unrelated open branch. Instead, import the
+constant and interpolate:
+
+```python
+from jacobian.math.diophantine_approximation._models import (
+    _convergent_component_digit_cap,
+)
+
+cap = _convergent_component_digit_cap(4)
+with pytest.raises(ValueError, match=rf"{cap}-digit bound"):
+    ...
+```
+
+The message text stays pinned; only the number is derived from the same source
+the production code uses. Boundary test inputs (the value that triggers the
+error) should likewise be computed from the constant, not hardcoded:
+
+```python
+beyond = "9" * (_MAX_MULTIVARIATE_COEFFICIENT_DIGITS + 1)
+with pytest.raises(ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"):
+    ...
+```
+
+When the owning constant is private (underscore-prefixed), importing it from
+its owning module is acceptable in tests — the test and the source share one
+definition.
+
 ### Evidence plans for exact operations
+
 
 Before implementing an exact decomposition, certificate, or authoritative
 derived value, state its defining invariant: the reconstruction equation,

--- a/src/jacobian/math/algebraic_number_arithmetic/_tools.py
+++ b/src/jacobian/math/algebraic_number_arithmetic/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.algebraic_number_arithmetic._models import (
+    _MAX_RESULT_DIGITS,
     AlgebraicAdditionRequest,
     AlgebraicMultiplicationRequest,
 )
@@ -55,7 +56,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "number field Q(sqrt(d)). Each element is represented as "
         "a + b*sqrt(d) with rational coefficients a and b. Both "
         "operands must use the same square-free radicand d, and the "
-        "component-wise sum must fit within the 256-digit canonical "
+        f"component-wise sum must fit within the {_MAX_RESULT_DIGITS}-digit canonical "
         "rational bound; requests whose sum would exceed that bound "
         "are rejected.",
         AlgebraicAdditionRequest,
@@ -69,7 +70,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "add_sqrt2",
                 "Compute (1 + sqrt(2)) + (3 + 2*sqrt(2)) in Q(sqrt(2)). "
                 "Both operands must share one square-free radicand, and "
-                "the component-wise sum must stay within the 256-digit "
+                f"the component-wise sum must stay within the {_MAX_RESULT_DIGITS}-digit "
                 "canonical rational bound.",
                 {
                     "left": _element(1, 1, 2),
@@ -86,7 +87,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "a + b*sqrt(d) with rational coefficients a and b. Both "
         "operands must use the same square-free radicand d, and the "
         "exact product components (ac + b*e*d and a*e + b*c) must fit "
-        "within the 256-digit canonical rational bound; requests whose "
+        f"within the {_MAX_RESULT_DIGITS}-digit canonical rational bound; requests whose "
         "product would exceed that bound are rejected.",
         AlgebraicMultiplicationRequest,
         RealQuadraticValue,
@@ -100,7 +101,7 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
                 "Compute (1 + sqrt(2)) * (1 - sqrt(2)) = -1 in Q(sqrt(2)). "
                 "Both operands must share one square-free radicand, and "
                 "the exact product components must stay within the "
-                "256-digit canonical rational bound.",
+                f"{_MAX_RESULT_DIGITS}-digit canonical rational bound.",
                 {
                     "left": _element(1, 1, 2),
                     "right": _element(1, -1, 2),

--- a/src/jacobian/math/arithmetic/_real_quadratic.py
+++ b/src/jacobian/math/arithmetic/_real_quadratic.py
@@ -3,6 +3,7 @@
 from jacobian.catalog._examples import example
 from jacobian.math.arithmetic._support import arithmetic_operation
 from jacobian.math.real_quadratic import (
+    _MAX_EMBEDDING_PROFILE_RESULT_DIGITS,
     RealQuadraticEmbeddingProfile,
     RealQuadraticEmbeddingsRequest,
     RealQuadraticOrderRequest,
@@ -28,7 +29,7 @@ REAL_QUADRATIC_OPERATIONS = (
             "the source and explicitly identify the maps sqrt(d) -> +sqrt(d) "
             "and sqrt(d) -> -sqrt(d); the profile is available only for a "
             "square-free positive radicand with 256-digit input components and "
-            "a trace and norm within the 1,032-digit result bound."
+            f"a trace and norm within the {_MAX_EMBEDDING_PROFILE_RESULT_DIGITS:,}-digit result bound."
         ),
         RealQuadraticEmbeddingsRequest,
         RealQuadraticEmbeddingProfile,
@@ -45,7 +46,7 @@ REAL_QUADRATIC_OPERATIONS = (
                 "sqrt2_embedding_profile",
                 "Compute both exact embeddings, trace, and norm of 1+sqrt(2). "
                 "The radicand must be positive and square-free, and the derived "
-                "trace and norm must fit the 1,032-digit result bound.",
+                f"trace and norm must fit the {_MAX_EMBEDDING_PROFILE_RESULT_DIGITS:,}-digit result bound.",
                 {
                     "element": {
                         "rational_part": {"num": "1", "den": "1"},

--- a/src/jacobian/math/formal_concept_analysis/values.py
+++ b/src/jacobian/math/formal_concept_analysis/values.py
@@ -96,7 +96,7 @@ class FiniteAttributeImplicationSystem(StrictModel):
         default=(),
         max_length=MAX_IMPLICATIONS,
         description=(
-            "Finite implication family with at most 4,096 aggregate premise and "
+            f"Finite implication family with at most {MAX_IMPLICATION_MEMBERSHIPS:,} aggregate premise and "
             "normalized-conclusion memberships. Row order is immaterial and is "
             "canonicalized lexicographically; duplicate rows after normalization "
             "are invalid."

--- a/src/jacobian/math/graphs/patterns/_tools.py
+++ b/src/jacobian/math/graphs/patterns/_tools.py
@@ -3,6 +3,8 @@
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
 from jacobian.math.graphs.patterns._models import (
+    MAX_INDUCED_PATTERN_SUBSETS_PER_PASS,
+    MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS,
     InducedVertexSubsetPatternCountRequest,
     InducedVertexSubsetPatternCountResult,
 )
@@ -20,7 +22,7 @@ TOOLS: MathTools = (
             "C(|V(host)|, |V(pattern)|), exact source/result bytes, "
             "C(|V(pattern)|, 2) direct host-edge probes, explicit local-graph "
             "construction, and a worst-case NetworkX VF2++ partial-map bound. "
-            "Limits are 5,000 subsets per pass and 64,000,000 work units across "
+            f"Limits are {MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,} subsets per pass and {MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,} work units across "
             "counting and source-bound replay; this is a conservative backend envelope."
         ),
         request_type=InducedVertexSubsetPatternCountRequest,
@@ -40,8 +42,8 @@ TOOLS: MathTools = (
                 "two_induced_p4_in_p5",
                 "Count two P4 subsets in P5. Admission preflights 5 subsets, 6 "
                 "direct host-edge probes and one local graph per subset, plus "
-                "per-subset VF2++ work across two passes; limits are 5,000 subsets "
-                "per pass and 64,000,000 work units.",
+                f"per-subset VF2++ work across two passes; limits are {MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,} subsets "
+                f"per pass and {MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,} work units.",
                 {
                     "host": {
                         "vertices": ["a", "b", "c", "d", "e"],

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from fractions import Fraction
 from typing import Any
 
@@ -15,6 +16,57 @@ __all__ = [
 
 RationalEntries = Sequence[Sequence[Fraction]]
 CoefficientList = tuple[Fraction, ...]
+
+
+def _integer_decimal_digits(value: int) -> int:
+    """Return the decimal width of ``value`` without decimal rendering.
+
+    The conformance probe below can observe large admitted exact components.
+    Avoiding ``str(int)`` keeps that private diagnostic independent of
+    CPython's configurable decimal-conversion guard.
+    """
+
+    magnitude = abs(value)
+    if magnitude == 0:
+        return 1
+    # 0.30103 is an upper rational approximation to log10(2), so this is an
+    # upper estimate from the binary width.  A single exact comparison removes
+    # the possible one-digit overestimate.
+    digits = magnitude.bit_length() * 30_103 // 100_000 + 1
+    if magnitude < 10 ** (digits - 1):
+        return digits - 1
+    return digits
+
+
+@dataclass
+class _HornerEvaluationMetrics:
+    """Private kernel measurements for the matrix-polynomial pilot only.
+
+    This is deliberately an optional observer on this owner-local kernel, not
+    a cross-operation instrumentation protocol.  It records the published
+    dense scalar-product proxy and the widest reduced component of each
+    materialized Horner state without changing evaluation semantics.
+    """
+
+    maximum_component_digits: int = 0
+    scalar_product_terms: int = 0
+    stored_states: int = 0
+
+    def record_state(self, state: Any) -> None:
+        """Record one materialized exact Horner state."""
+
+        state_digits = max(
+            (
+                max(
+                    _integer_decimal_digits(int(entry.p)),
+                    _integer_decimal_digits(int(entry.q)),
+                )
+                for entry in state
+            ),
+            default=1,
+        )
+        self.maximum_component_digits = max(self.maximum_component_digits, state_digits)
+        self.stored_states += 1
 
 
 def _square_dimension(entries: RationalEntries) -> int:
@@ -70,6 +122,8 @@ def characteristic_polynomial(entries: RationalEntries) -> CoefficientList:
 def _evaluate_polynomial(
     entries: RationalEntries,
     coefficients: Sequence[Fraction],
+    *,
+    metrics: _HornerEvaluationMetrics | None = None,
 ) -> tuple[tuple[Fraction, ...], ...]:
     """Return ``f(A)`` for increasing-degree coefficients by exact Horner evaluation."""
 
@@ -80,12 +134,19 @@ def _evaluate_polynomial(
     identity = eye(dimension)
     if not coefficients:
         result = zeros(dimension)
+        if metrics is not None:
+            metrics.record_state(result)
     else:
         leading = coefficients[-1]
         result = Rational(leading.numerator, leading.denominator) * identity
+        if metrics is not None:
+            metrics.record_state(result)
         for coefficient in reversed(coefficients[:-1]):
             scalar = Rational(coefficient.numerator, coefficient.denominator)
             result = result * matrix + scalar * identity
+            if metrics is not None:
+                metrics.scalar_product_terms += dimension**3
+                metrics.record_state(result)
     return tuple(
         tuple(_to_fraction(result[row, column]) for column in range(dimension))
         for row in range(dimension)

--- a/src/jacobian/math/matrices/subsystems/_models.py
+++ b/src/jacobian/math/matrices/subsystems/_models.py
@@ -285,7 +285,7 @@ class SubsystemKroneckerProductRequest(StrictModel):
             "First operand; no fixed per-operand digit ceiling applies. "
             "Admission evaluates the exact product coefficients and admits "
             "the pair when every numerator and denominator stays within the "
-            "256-digit product component envelope."
+            f"{MAX_KRONECKER_RESULT_COMPONENT_DIGITS}-digit product component envelope."
         ),
     )
     right: FactorizedHermitianMatrix = Field(
@@ -293,7 +293,7 @@ class SubsystemKroneckerProductRequest(StrictModel):
             "Second operand; no fixed per-operand digit ceiling applies. "
             "Admission evaluates the exact product coefficients and admits "
             "the pair when every numerator and denominator stays within the "
-            "256-digit product component envelope."
+            f"{MAX_KRONECKER_RESULT_COMPONENT_DIGITS}-digit product component envelope."
         ),
     )
 

--- a/src/jacobian/math/matrices/subsystems/_models.py
+++ b/src/jacobian/math/matrices/subsystems/_models.py
@@ -351,8 +351,8 @@ class SubsystemPartialTraceRequest(StrictModel):
         description=(
             "Source operand; no fixed per-operand digit ceiling applies. "
             "Admission measures contraction intermediates, cancelling "
-            "equal-denominator terms first, against the 16392-digit work "
-            "envelope, admits reduced coefficients within the 4098-digit "
+            f"equal-denominator terms first, against the {MAX_PARTIAL_TRACE_WORK_COMPONENT_DIGITS}-digit work "
+            f"envelope, admits reduced coefficients within the {MAX_PARTIAL_TRACE_RESULT_COMPONENT_DIGITS}-digit "
             "result envelope, and reserves the serialized result's canonical "
             "output budget."
         ),

--- a/src/jacobian/math/number_theory/_periodic_models.py
+++ b/src/jacobian/math/number_theory/_periodic_models.py
@@ -49,9 +49,9 @@ _PERIODIC_REQUEST_EXAMPLE = {
     "complement": False,
 }
 _PERIODIC_REQUEST_DESCRIPTION = (
-    "Normalize and merge at most 64 residue subsets with at most 4,096 raw "
-    "and 4,096 normalized residue rows. Each modulus and their lcm L have at "
-    "most 256 decimal digits. With W = sum(|R_i| * L/m_i), exact execution "
+    f"Normalize and merge at most {MAX_PERIODIC_FAMILY_SIZE} residue subsets with at most {MAX_PERIODIC_SOURCE_ROWS:,} raw "
+    f"and {MAX_PERIODIC_SOURCE_ROWS:,} normalized residue rows. Each modulus and their lcm L have at "
+    f"most {MAX_PERIODIC_INTEGER_DIGITS} decimal digits. With W = sum(|R_i| * L/m_i), exact execution "
     "uses a full-subset shortcut; a period lift when L <= 1,000,000 and "
     "L + W <= 2,000,000; a sparse lift when W <= 65,536; or generalized-CRT "
     "inclusion-exclusion with at most 65,535 retained states and 100,000 merges "

--- a/src/jacobian/math/polynomials/interpolation/_models.py
+++ b/src/jacobian/math/polynomials/interpolation/_models.py
@@ -77,8 +77,8 @@ class OrdinaryDerivativeValue(StrictModel):
     )
     value: CanonicalRational = Field(
         description=(
-            "Canonical exact rational derivative value whose numerator and "
-            "denominator each have at most 256 digits."
+            f"Canonical exact rational derivative value whose numerator and "
+            f"denominator each have at most {_MAX_RATIONAL_DIGITS} digits."
         )
     )
 
@@ -88,8 +88,8 @@ class OrdinaryDerivativeJet(StrictModel):
 
     node: CanonicalRational = Field(
         description=(
-            "Canonical exact rational node whose numerator and denominator "
-            "each have at most 256 digits."
+            f"Canonical exact rational node whose numerator and denominator "
+            f"each have at most {_MAX_RATIONAL_DIGITS} digits."
         )
     )
     derivatives: tuple[OrdinaryDerivativeValue, ...] = Field(

--- a/src/jacobian/math/prime_affine_forms/values.py
+++ b/src/jacobian/math/prime_affine_forms/values.py
@@ -59,7 +59,7 @@ class PrimeAffineTuple(StrictModel):
         description=(
             "Nonempty primitive affine-form family. Form IDs and coefficient/constant "
             "pairs must be unique; rows are normalized by form_id. Across all forms, "
-            "coefficient and constant magnitudes contain at most 131072 decimal digits."
+            f"coefficient and constant magnitudes contain at most {MAX_AFFINE_AGGREGATE_DIGITS} decimal digits."
         ),
     )
 

--- a/src/jacobian/math/probability/_models.py
+++ b/src/jacobian/math/probability/_models.py
@@ -507,7 +507,7 @@ class DirectedBondConnectionProbabilitySource(StrictModel):
 
     graph: DirectedGraph = Field(
         description=(
-            "A directed graph with at most 12 arcs for this "
+            f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."
         )
     )
@@ -668,7 +668,7 @@ class DirectedBondConnectionProbabilityRequest(StrictModel):
 
     graph: DirectedGraph = Field(
         description=(
-            "A directed graph with at most 12 arcs for this "
+            f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."
         )
     )

--- a/src/jacobian/math/tree_automata/_models.py
+++ b/src/jacobian/math/tree_automata/_models.py
@@ -10,6 +10,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
     MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
@@ -137,16 +138,16 @@ class TreeAutomatonReachabilityRequest(StrictModel):
 
     automaton: BottomUpTreeAutomaton = Field(
         description=(
-            "nondeterministic bottom-up tree automaton with at most 64 "
-            "states, 32 ranked symbols, and 4096 unique transitions. "
+            f"nondeterministic bottom-up tree automaton with at most 64 "
+            "states, 32 ranked symbols, and {MAX_REACHABILITY_WITNESS_NODES} unique transitions. "
             "Requests are additionally rejected when the coupled "
             "reachability work envelope (MAX_TREE_AUTOMATON_REACHABILITY_"
-            "WORK = 30,000,000 units, priced across the four passes behind "
+            f"WORK = {MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units, priced across the four passes behind "
             "request admission, execution, and source-bound result replay "
             "together with request admission's own saturation convergence "
             "pass) or the "
             "aggregate witness output envelope (MAX_REACHABILITY_WITNESS_"
-            "NODES = 4096 nodes summed across every reachable state's "
+            f"NODES = {MAX_REACHABILITY_WITNESS_NODES} nodes summed across every reachable state's "
             "minimum witness) is exceeded"
         ),
     )

--- a/tests/dispatch/test_matrix_dispatch.py
+++ b/tests/dispatch/test_matrix_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.matrices._operation_models import MAX_MATRIX_DIMENSION
 
 
 def _identity_payload(order: int) -> dict:
@@ -52,7 +53,7 @@ def test_dispatch_rejects_requests_above_the_computation_dimension(
 ) -> None:
     with pytest.raises(OperationRequestValidationError) as excinfo:
         invoke_operation(operation_id, payload, Catalog.open())
-    assert "limited to 32 rows and columns" in str(excinfo.value.cause)
+    assert f"limited to {MAX_MATRIX_DIMENSION} rows and columns" in str(excinfo.value.cause)
 
 
 def test_dispatch_returns_typed_results_at_the_boundary_order() -> None:

--- a/tests/dispatch/test_polytope_dispatch.py
+++ b/tests/dispatch/test_polytope_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.polytope._models import MAX_COMPUTED_FACETS
 
 
 def _moment_curve_payload(count: int, dimension: int) -> dict[str, Any]:
@@ -51,7 +52,7 @@ def test_dispatch_rejects_a_profile_beyond_the_facet_cap_as_invalid_request() ->
     with pytest.raises(OperationRequestValidationError) as exc_info:
         invoke_operation("polytope.facets.compute", payload, Catalog.open())
 
-    assert "256-facet result bound" in exc_info.value.errors()[0]["msg"]
+    assert f"{MAX_COMPUTED_FACETS}-facet result bound" in exc_info.value.errors()[0]["msg"]
 
 
 def test_dispatch_admits_the_seven_simplex_with_interior_rows_at_the_cap_budget() -> (

--- a/tests/integration/catalog/test_directed_bond_reliability_schema.py
+++ b/tests/integration/catalog/test_directed_bond_reliability_schema.py
@@ -1,6 +1,9 @@
 """Public schema guidance for directed bond reliability."""
 
 from jacobian.catalog.catalog import Catalog
+from jacobian.math.probability._models import (
+    MAX_DIRECTED_BOND_RELIABILITY_ARCS,
+)
 
 OPERATION_ID = "probability.digraph_bond_reliability.connection_probability.compute"
 
@@ -12,7 +15,7 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
     schema = operation.request_type.model_json_schema()
     assert schema["description"] == (
         "Compute directed source-to-target bond connection probability.\n\n"
-        "The request admits at most 12 arcs, requires one probability for every\n"
+        f"The request admits at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs, requires one probability for every\n"
         "arc exactly once (empty for an edgeless graph), and requires distinct\n"
         "declared source and target vertices.  The derived work budget bounds the\n"
         "vertex count, so sparse graphs may declare more vertices.  It normalizes\n"
@@ -20,7 +23,7 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
         "do not depend on input order."
     )
     properties = schema["properties"]
-    assert "at most 12 arcs" in properties["graph"]["description"]
+    assert f"at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs" in properties["graph"]["description"]
     assert (
         "every graph arc exactly once" in properties["arc_probabilities"]["description"]
     )

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -24,6 +24,7 @@ from jacobian.math.additive_combinatorics._operations import (
     compute_subset_sum_profile,
 )
 from jacobian.math.additive_combinatorics.operations import (
+    MAX_SUBSET_SUM_DP_TRANSITIONS,
     MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
     _subset_sum_profile_envelope,
 )
@@ -273,8 +274,8 @@ def test_request_schema_exposes_source_shape_and_character_bounds() -> None:
     assert items_schema["maxItems"] == MAX_SUBSET_SUM_ITEMS
     assert items_schema["items"]["maxLength"] == MAX_SUBSET_SUM_ITEM_DIGITS + 1
     assert "4*n*S" in source_description
-    assert "4,000,000" in source_description
-    assert "4,194,304 bytes" in source_description
+    assert f"{MAX_SUBSET_SUM_DP_TRANSITIONS:,}" in source_description
+    assert f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:,} bytes" in source_description
 
 
 def test_schema_item_ceiling_matches_validator_at_the_boundary() -> None:

--- a/tests/math/algebraic_combinatorics/test_rsk_word.py
+++ b/tests/math/algebraic_combinatorics/test_rsk_word.py
@@ -291,16 +291,16 @@ def _wide_unicode_symbols(count: int) -> tuple[str, ...]:
 
 
 def test_word_length_and_utf8_payload_bounds_are_closed() -> None:
-    length_boundary = FiniteWord(alphabet=("a",), letters=("a",) * 500)
-    assert sum(_pair(length_boundary).shape.parts) == 500
+    length_boundary = FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH)
+    assert sum(_pair(length_boundary).shape.parts) == MAX_RSK_WORD_LENGTH
 
-    too_long = FiniteWord.model_construct(alphabet=("a",), letters=("a",) * 501)
+    too_long = FiniteWord.model_construct(alphabet=("a",), letters=("a",) * (MAX_RSK_WORD_LENGTH + 1))
     with pytest.raises(ValidationError):
         RSKWordRequest(word=too_long)
-    with pytest.raises(ValueError, match="length must not exceed 500"):
+    with pytest.raises(ValueError, match=rf"length must not exceed {MAX_RSK_WORD_LENGTH}"):
         row_insertion_rsk(too_long)
     with pytest.raises(ValidationError):
-        FiniteWord(alphabet=("a",), letters=("a",) * 501)
+        FiniteWord(alphabet=("a",), letters=("a",) * (MAX_RSK_WORD_LENGTH + 1))
 
     ordered_symbols = tuple(f"s{index:02d}" for index in range(50))
     deepest_shape = _pair(
@@ -334,7 +334,7 @@ def test_word_length_and_utf8_payload_bounds_are_closed() -> None:
 
 
 def test_canonical_tableau_cell_bound_admits_boundary_pairs_end_to_end() -> None:
-    single_row = _pair(FiniteWord(alphabet=("a",), letters=("a",) * 500))
+    single_row = _pair(FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH))
     assert single_row.insertion_tableau.rows == ((1,) * 500,)
     assert single_row.recording_tableau.rows == (tuple(range(1, 501)),)
     assert single_row.shape.parts == (500,)
@@ -345,7 +345,7 @@ def test_canonical_tableau_cell_bound_admits_boundary_pairs_end_to_end() -> None
     reconstructed = compute_inverse_rsk_word(
         RSKInverseWordRequest.model_validate({"pair": single_row.model_dump()})
     )
-    assert reconstructed == FiniteWord(alphabet=("a",), letters=("a",) * 500)
+    assert reconstructed == FiniteWord(alphabet=("a",), letters=("a",) * MAX_RSK_WORD_LENGTH)
 
     wide = tuple(f"s{index:02d}" for index in range(50))
     descending_pairs = tuple(symbol for symbol in reversed(wide) for _ in range(10))

--- a/tests/math/algebraic_combinatorics/test_rsk_word.py
+++ b/tests/math/algebraic_combinatorics/test_rsk_word.py
@@ -442,11 +442,11 @@ def test_rsk_request_schema_publishes_convention_and_work_envelope() -> None:
     description = schema["properties"]["word"]["description"]
     assert "unique strings" in description
     assert "every positioned letter" in description
-    assert "at most 500 letters" in description
-    assert "140800 UTF-8 bytes" in description
+    assert f"at most {MAX_RSK_WORD_LENGTH} letters" in description
+    assert f"{MAX_RSK_WORD_BYTES} UTF-8 bytes" in description
     class_description = schema["description"]
     assert "2N" in class_description
-    assert "124750" in class_description
+    assert str(MAX_RSK_WORD_LENGTH * (MAX_RSK_WORD_LENGTH - 1) // 2) in class_description
     assert "nine integer" in class_description
     assert "comparisons per search" in class_description
     assert (
@@ -456,9 +456,9 @@ def test_rsk_request_schema_publishes_convention_and_work_envelope() -> None:
 
     inverse_schema = RSKInverseWordRequest.model_json_schema()
     pair_schema = inverse_schema["$defs"]["RSKTableauPair"]
-    assert "at most 500 cells" in pair_schema["description"]
-    assert "500 cells" in inverse_schema["description"]
-    assert "at most 500 cells" in pair_schema["properties"]["shape"]["description"]
+    assert f"at most {MAX_RSK_WORD_LENGTH} cells" in pair_schema["description"]
+    assert f"{MAX_RSK_WORD_LENGTH} cells" in inverse_schema["description"]
+    assert f"at most {MAX_RSK_WORD_LENGTH} cells" in pair_schema["properties"]["shape"]["description"]
 
 
 def test_public_operations_are_admitted_and_examples_execute() -> None:

--- a/tests/math/algebraic_number_arithmetic/test_algebraic_arithmetic.py
+++ b/tests/math/algebraic_number_arithmetic/test_algebraic_arithmetic.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.algebraic_number_arithmetic._models import (
+    _MAX_RESULT_DIGITS,
     AlgebraicAdditionRequest,
     AlgebraicArithmeticRequest,
     AlgebraicMultiplicationRequest,
@@ -239,7 +240,7 @@ def test_operation_declarations_expose_operand_preconditions() -> None:
         tool = tools[operation_id]
         description = tool.description.lower()
         assert "same square-free radicand" in description
-        assert "256-digit" in description
+        assert f"{_MAX_RESULT_DIGITS}-digit" in description
         schema = tool.request_type.model_json_schema()
         properties = schema["properties"]
         for side in ("left", "right"):

--- a/tests/math/arithmetic/test_base_digits.py
+++ b/tests/math/arithmetic/test_base_digits.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from jacobian.math.arithmetic import _operations as arithmetic_operations
 from jacobian.math.arithmetic._models import (
+    MAX_BASE_DIGITS,
     IntegerBaseDigitsRequest,
     IntegerBaseDigitsResult,
 )
@@ -66,5 +67,5 @@ def test_base_digits_rejects_an_oversized_result_before_integer_conversion(
 
     monkeypatch.setattr(arithmetic_operations, "_int", unexpected_conversion)
 
-    with pytest.raises(ValueError, match="1024-digit result bound"):
+    with pytest.raises(ValueError, match=rf"{MAX_BASE_DIGITS}-digit result bound"):
         base_digits(IntegerBaseDigitsRequest(value="1" + ("0" * 1_024), base=10))

--- a/tests/math/arithmetic/test_real_quadratic_embeddings.py
+++ b/tests/math/arithmetic/test_real_quadratic_embeddings.py
@@ -16,6 +16,7 @@ from jacobian.math.algebraic_number_arithmetic._operations import (
 )
 from jacobian.math.arithmetic._real_quadratic import REAL_QUADRATIC_OPERATIONS
 from jacobian.math.real_quadratic import (
+    _MAX_EMBEDDING_PROFILE_RESULT_DIGITS,
     RealQuadraticEmbeddingProfile,
     RealQuadraticEmbeddingsRequest,
     RealQuadraticValue,
@@ -172,7 +173,7 @@ def test_embedding_candidate_keeps_a_schema_visible_contract() -> None:
     tools = {tool.operation_id: tool for tool in REAL_QUADRATIC_OPERATIONS}
     tool = tools["arithmetic.real_quadratic.embeddings.compute"]
 
-    assert "1,032-digit" in tool.description
+    assert f"{_MAX_EMBEDDING_PROFILE_RESULT_DIGITS:,}-digit" in tool.description
     schema = tool.request_type.model_json_schema()
     assert "square-free" in schema["properties"]["element"]["description"]
     assert tool.examples[0].input["element"]["radicand"] == 2

--- a/tests/math/canonical/test_json.py
+++ b/tests/math/canonical/test_json.py
@@ -115,10 +115,11 @@ def test_canonical_rational_wire_model_rejects_unreduced_input() -> None:
 def test_bounded_rational_rejects_oversized_canonical_components(
     value: dict[str, str],
 ) -> None:
-    with pytest.raises(ValueError, match="test rational exceeds the 2-digit bound"):
+    max_digits = 2
+    with pytest.raises(ValueError, match=rf"test rational exceeds the {max_digits}-digit bound"):
         require_bounded_rational(
             CanonicalRational.model_validate(value),
-            max_digits=2,
+            max_digits=max_digits,
             label="test rational",
         )
 

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -14,7 +14,7 @@ from jacobian.math.crossed_products._models import (
 )
 from jacobian.math.crossed_products._operations import compute_product
 from jacobian.math.crossed_products._tools import TOOLS
-from jacobian.math.crossed_products.operations import multiply
+from jacobian.math.crossed_products.operations import MAX_CONVOLUTION_PAIRS, multiply
 from jacobian.math.crossed_products.values import (
     FiniteCosetCrossedProductElement,
     FiniteCosetCrossedProductPresentation,
@@ -438,7 +438,7 @@ def test_request_rejects_pairwise_convolution_before_expansion() -> None:
     left = _element(presentation, {"e": {(position,) for position in range(33)}})
     right = _element(presentation, {"a": {(position,) for position in range(33)}})
 
-    with pytest.raises(ValueError, match="1024-pair"):
+    with pytest.raises(ValueError, match=rf"{MAX_CONVOLUTION_PAIRS}-pair"):
         CrossedProductMultiplyRequest(left=left, right=right)
 
 

--- a/tests/math/finite_group_actions/test_subset_canonicalization.py
+++ b/tests/math/finite_group_actions/test_subset_canonicalization.py
@@ -219,7 +219,7 @@ def test_request_rejects_group_immediately_above_enumeration_bound() -> None:
     with pytest.raises(ValidationError) as exc_info:
         _request(symmetric_s8, (0,))
     _assert_error_type(exc_info.value, "finite_group_action.group_order_exceeds_bound")
-    with pytest.raises(ValueError, match=r"group order exceeds.*10000"):
+    with pytest.raises(ValueError, match=rf"group order exceeds.*{MAX_GROUP_ORDER}"):
         _enumerate_group(symmetric_s8)
 
 

--- a/tests/math/formal_concept_analysis/test_implication_closure.py
+++ b/tests/math/formal_concept_analysis/test_implication_closure.py
@@ -289,7 +289,7 @@ def test_request_schema_discloses_aggregate_system_constraints() -> None:
     system_schema = schema["$defs"]["FiniteAttributeImplicationSystem"]
     implication_description = system_schema["properties"]["implications"]["description"]
 
-    assert "4,096 aggregate" in implication_description
+    assert f"{MAX_IMPLICATION_MEMBERSHIPS:,} aggregate" in implication_description
     assert "duplicate rows after normalization" in implication_description
 
 

--- a/tests/math/geometry/test_box_unions.py
+++ b/tests/math/geometry/test_box_unions.py
@@ -8,7 +8,7 @@ from itertools import product
 import pytest
 from pydantic import ValidationError
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
 from jacobian.canonical import encode_strict_json
 from jacobian.math.geometry.boxes import (
     BoxIntersectionLedgerEntry,
@@ -421,7 +421,7 @@ def test_schema_explains_empty_boxes_and_coupled_bounds() -> None:
 
     assert "intervals=null" in box_schema["description"]
     assert "same dimension" in request_schema["description"]
-    assert "canonical 32,768-digit" in request_schema["description"]
+    assert f"canonical {MAX_CANONICAL_RATIONAL_DIGITS:,}-digit" in request_schema["description"]
     assert "256 digits" not in request_schema["description"]
     boxes_property = request_schema["properties"]["boxes"]
     assert "maxItems" not in boxes_property

--- a/tests/math/graphs/test_induced_pattern_counts.py
+++ b/tests/math/graphs/test_induced_pattern_counts.py
@@ -14,6 +14,8 @@ from pydantic import ValidationError
 from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.math.graphs import explicit_graph
 from jacobian.math.graphs.patterns._models import (
+    MAX_INDUCED_PATTERN_SUBSETS_PER_PASS,
+    MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS,
     InducedVertexSubsetPatternCountRequest,
     InducedVertexSubsetPatternCountResult,
 )
@@ -357,14 +359,14 @@ def test_numeric_admission_caps_are_visible_in_schema_and_tool_description() -> 
         InducedVertexSubsetPatternCountRequest.model_json_schema(),
         sort_keys=True,
     )
-    assert "5,000 subsets per pass" in schema
-    assert "64,000,000 total work units" in schema
+    assert f"{MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,} subsets per pass" in schema
+    assert f"{MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,} total work units" in schema
     assert "10,485,760-byte canonical output bound" in schema
     assert "C(|V(host)|, |V(pattern)|)" in schema
     assert "C(|V(pattern)|, 2) direct host-edge probes" in schema
     assert "partial-injection state bound" in schema
-    assert "5,000 subsets per pass" in TOOLS[0].description
-    assert "64,000,000 work units" in TOOLS[0].description
+    assert f"{MAX_INDUCED_PATTERN_SUBSETS_PER_PASS:,} subsets per pass" in TOOLS[0].description
+    assert f"{MAX_INDUCED_PATTERN_TOTAL_WORK_UNITS:,} work units" in TOOLS[0].description
     assert "direct host-edge probes" in TOOLS[0].description
     assert "one local graph per subset" in TOOLS[0].examples[0].description
     assert "per-subset VF2++ work" in TOOLS[0].examples[0].description

--- a/tests/math/matrices/test_matrix_polynomial_evaluation.py
+++ b/tests/math/matrices/test_matrix_polynomial_evaluation.py
@@ -4,23 +4,41 @@ from copy import deepcopy
 from fractions import Fraction
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
-from jacobian.canonical import CanonicalLimits, format_canonical_integer
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+)
 from jacobian.math.matrices._operation_models import SquareRationalMatrixRequest
 from jacobian.math.matrices._operations import compute_characteristic_polynomial
 from jacobian.math.matrices.canonical_forms._models import (
     _MAX_WORK_BOUND,
+    _RESULT_ENTRY_OVERHEAD_BYTES,
+    _RESULT_ENVELOPE_RESERVE_BYTES,
     MATRIX_POLYNOMIAL_EVALUATION_PASSES,
     MAX_MATRIX_POLYNOMIAL_DIGIT_WORK,
     MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS,
     MatrixPolynomialEvaluationRequest,
     MatrixPolynomialEvaluationResult,
+    _coefficient_ratios,
+    _general_result_component_bounds,
+    _linear_result_component_bounds,
+    _polynomial_degree,
+    _require_matrix_polynomial_output_budget,
     _work_exact_quotient,
 )
 from jacobian.math.matrices.canonical_forms._operations import (
+    _dense_polynomial_coefficients,
     compute_matrix_polynomial_evaluation,
+)
+from jacobian.math.matrices.canonical_forms.operations import (
+    _evaluate_polynomial,
+    _HornerEvaluationMetrics,
 )
 from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.polynomials.values import (
@@ -67,6 +85,185 @@ def _polynomial(*terms: tuple[RationalInput, int]) -> RationalPolynomial:
 
 def _fractions(matrix: RationalMatrix) -> tuple[tuple[Fraction, ...], ...]:
     return tuple(tuple(entry.as_fraction() for entry in row) for row in matrix.entries)
+
+
+def _matrix_polynomial_component_bounds(
+    request: MatrixPolynomialEvaluationRequest,
+) -> tuple[tuple[tuple[int, int], ...], int]:
+    """Return the same owner-local result and intermediate estimates as admission."""
+
+    degree = _polynomial_degree(request.polynomial)
+    coefficients = _coefficient_ratios(request.polynomial)
+    matrix_is_zero = all(
+        entry.num == "0" for row in request.matrix.entries for entry in row
+    )
+    if degree <= 1 or matrix_is_zero:
+        return _linear_result_component_bounds(request.matrix, coefficients)
+    return _general_result_component_bounds(request.matrix, request.polynomial)
+
+
+def _assert_matrix_polynomial_envelope_conformance(
+    request: MatrixPolynomialEvaluationRequest,
+) -> None:
+    """Compare one public evaluation with the owner-local admission envelope."""
+
+    component_bounds, _component_work_digits = _matrix_polynomial_component_bounds(
+        request
+    )
+    estimated_work_digits = _require_matrix_polynomial_output_budget(
+        request.matrix,
+        request.polynomial,
+        _polynomial_degree(request.polynomial),
+    )
+
+    metrics = _HornerEvaluationMetrics()
+    measured_value = _evaluate_polynomial(
+        _fractions(request.matrix),
+        _dense_polynomial_coefficients(request),
+        metrics=metrics,
+    )
+    result = compute_matrix_polynomial_evaluation(request)
+
+    assert _fractions(result.value) == measured_value
+    actual_component_bounds = tuple(
+        (len(entry.num.lstrip("-")), len(entry.den))
+        for row in result.value.entries
+        for entry in row
+    )
+    assert all(
+        actual_numerator_digits <= estimated_numerator_digits
+        and actual_denominator_digits <= estimated_denominator_digits
+        for (actual_numerator_digits, actual_denominator_digits), (
+            estimated_numerator_digits,
+            estimated_denominator_digits,
+        ) in zip(actual_component_bounds, component_bounds, strict=True)
+    )
+    assert metrics.maximum_component_digits <= estimated_work_digits
+
+    dimension = len(request.matrix.entries)
+    degree = _polynomial_degree(request.polynomial)
+    assert metrics.scalar_product_terms == degree * dimension**3
+    assert metrics.stored_states == degree + 1
+    total_scalar_products = (
+        MATRIX_POLYNOMIAL_EVALUATION_PASSES * metrics.scalar_product_terms
+    )
+    assert total_scalar_products <= MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS
+    assert (
+        total_scalar_products * estimated_work_digits**2
+        <= MAX_MATRIX_POLYNOMIAL_DIGIT_WORK
+    )
+
+    estimated_value_bytes = sum(
+        numerator_digits + denominator_digits + _RESULT_ENTRY_OVERHEAD_BYTES
+        for numerator_digits, denominator_digits in component_bounds
+    )
+    estimated_output_bytes = (
+        len(encode_strict_json(request.matrix.model_dump(mode="json")))
+        + len(encode_strict_json(request.polynomial.model_dump(mode="json")))
+        + estimated_value_bytes
+        + _RESULT_ENVELOPE_RESERVE_BYTES
+    )
+    actual_output_bytes = len(encode_strict_json(result.model_dump(mode="json")))
+    assert actual_output_bytes <= estimated_output_bytes
+    assert actual_output_bytes <= CanonicalLimits().max_output_bytes
+
+
+@pytest.mark.parametrize(
+    ("matrix", "polynomial"),
+    [
+        # Degenerate zero support keeps a high-degree Horner trace without a
+        # matrix-side denominator product.
+        (_matrix((0, 0), (0, 0)), _polynomial((1, 3), ((1, 3), 0))),
+        # A chain clears dead powers after bounded shifted states.
+        (
+            _matrix((0, (1, 2), 0), (0, 0, (1, 3)), (0, 0, 0)),
+            _polynomial(((1, 5), 5), ((1, 7), 4), (1, 1)),
+        ),
+        # Two routes meet at one cell, so coprime denominators compound in a
+        # measured state rather than staying independent by construction.
+        (
+            _matrix(
+                (0, (1, 2), (1, 3), 0),
+                (0, 0, 0, (1, 5)),
+                (0, 0, 0, (1, 7)),
+                (0, 0, 0, 0),
+            ),
+            _polynomial((1, 2), ((1, 11), 1), ((1, 13), 0)),
+        ),
+        # Separate diagonal cells retain distinct rational components.
+        (
+            _matrix(((1, 2), 0), (0, (1, 3))),
+            _polynomial(((1, 5), 4), ((1, 7), 2), ((1, 11), 0)),
+        ),
+        # Cyclic support exercises the conservative non-acyclic path.
+        (
+            _matrix((0, (1, 2)), ((1, 3), 0)),
+            _polynomial((1, 5), ((1, 5), 3), ((1, 7), 0)),
+        ),
+    ],
+    ids=("zero", "chain", "converging_paths", "disjoint_diagonal", "cycle"),
+)
+def test_matrix_polynomial_envelope_pilot_matches_measured_horner_states(
+    matrix: RationalMatrix,
+    polynomial: RationalPolynomial,
+) -> None:
+    """#2597 pilot: admitted representative shapes match their work/output envelope."""
+
+    _assert_matrix_polynomial_envelope_conformance(
+        MatrixPolynomialEvaluationRequest(matrix=matrix, polynomial=polynomial)
+    )
+
+
+@st.composite
+def _small_horner_requests(
+    draw: st.DrawFn,
+) -> MatrixPolynomialEvaluationRequest:
+    """Generate bounded support shapes around the representative pilot corpus."""
+
+    dimension = draw(st.integers(min_value=1, max_value=3))
+    support = draw(st.sampled_from(("zero", "chain", "diagonal", "dense")))
+    numerator = st.integers(min_value=-3, max_value=3)
+    denominator = st.sampled_from((1, 2, 3, 5))
+
+    def entry(row: int, column: int) -> RationalInput:
+        if support == "zero":
+            return 0
+        if support == "chain" and column != row + 1:
+            return 0
+        if support == "diagonal" and column != row:
+            return 0
+        value, divisor = draw(st.tuples(numerator, denominator))
+        reduced = Fraction(value, divisor)
+        return 0 if reduced == 0 else (reduced.numerator, reduced.denominator)
+
+    matrix = _matrix(
+        *(
+            tuple(entry(row, column) for column in range(dimension))
+            for row in range(dimension)
+        )
+    )
+    degree = draw(st.integers(min_value=0, max_value=5))
+    coefficients = [(draw(numerator), exponent) for exponent in range(degree, -1, -1)]
+    return MatrixPolynomialEvaluationRequest(
+        matrix=matrix,
+        polynomial=_polynomial(
+            *(
+                (coefficient, exponent)
+                for coefficient, exponent in coefficients
+                if coefficient
+            )
+        ),
+    )
+
+
+@settings(max_examples=40, deadline=None, derandomize=True)
+@given(_small_horner_requests())
+def test_matrix_polynomial_envelope_pilot_covers_small_support_variation(
+    request: MatrixPolynomialEvaluationRequest,
+) -> None:
+    """The pilot's conformance relation also holds across small support variation."""
+
+    _assert_matrix_polynomial_envelope_conformance(request)
 
 
 def test_saturated_work_estimates_do_not_reenter_exact_division() -> None:

--- a/tests/math/matrices/test_subsystem_operations.py
+++ b/tests/math/matrices/test_subsystem_operations.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ValidationError
 from jacobian._exact import CanonicalRational
 from jacobian.math.matrices import subsystems
 from jacobian.math.matrices.subsystems._models import (
+    MAX_PARTIAL_TRACE_RESULT_COMPONENT_DIGITS,
     MAX_PARTIAL_TRACE_WORK_COMPONENT_DIGITS,
     PsdOrderRequest,
     PsdOrderResult,
@@ -514,8 +515,8 @@ def test_partial_trace_schema_describes_the_coupled_trace_envelopes() -> None:
     schema = SubsystemPartialTraceRequest.model_json_schema()
     description = schema["properties"]["matrix"]["description"]
     assert "work envelope" in description
-    assert "16392" in description
-    assert "4098" in description
+    assert str(MAX_PARTIAL_TRACE_WORK_COMPONENT_DIGITS) in description
+    assert str(MAX_PARTIAL_TRACE_RESULT_COMPONENT_DIGITS) in description
 
 
 def test_traced_label_arrays_are_bounded_during_parsing() -> None:

--- a/tests/math/matrices/test_subsystem_operations.py
+++ b/tests/math/matrices/test_subsystem_operations.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ValidationError
 from jacobian._exact import CanonicalRational
 from jacobian.math.matrices import subsystems
 from jacobian.math.matrices.subsystems._models import (
+    MAX_KRONECKER_RESULT_COMPONENT_DIGITS,
     MAX_PARTIAL_TRACE_RESULT_COMPONENT_DIGITS,
     MAX_PARTIAL_TRACE_WORK_COMPONENT_DIGITS,
     PsdOrderRequest,
@@ -787,7 +788,7 @@ def test_kronecker_product_schema_describes_the_exact_product_component_envelope
     for side in ("left", "right"):
         description = schema["properties"][side]["description"]
         assert "exact product coefficients" in description
-        assert "256" in description
+        assert str(MAX_KRONECKER_RESULT_COMPONENT_DIGITS) in description
 
 
 def test_kronecker_product_admits_asymmetric_operand_digit_growth() -> None:

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterator
 
 import pytest
@@ -11,6 +12,7 @@ from tests.math.number_theory._validation import expect_validation
 from jacobian.math.number_theory import FriableCountResult, count_friable
 from jacobian.math.number_theory._friable_operations import compute_friable_count
 from jacobian.math.number_theory._models import (
+    _MAX_FRIABLE_SOURCE_ABS,
     MAX_FRIABLE_GENERATED_CUTOFF,
     MAX_FRIABLE_MATERIALIZED_X,
     FriableCountRequest,
@@ -111,14 +113,14 @@ def test_materialized_regime_reaches_its_cell_boundary() -> None:
 
 
 def test_large_direct_cases_do_not_inherit_the_materialized_cap() -> None:
-    huge = 10**255
+    huge = _MAX_FRIABLE_SOURCE_ABS // 10
     assert count_friable(huge, 1) == 1
     assert count_friable(huge, huge) == huge
 
 
 def test_native_api_enforces_the_source_digit_bound_before_work() -> None:
-    with pytest.raises(ValueError, match="256 decimal digits"):
-        count_friable(10**256, 1)
+    with pytest.raises(ValueError, match=rf"{round(math.log10(_MAX_FRIABLE_SOURCE_ABS))} decimal digits"):
+        count_friable(_MAX_FRIABLE_SOURCE_ABS, 1)
 
 
 def test_request_rejects_negative_and_noncanonical_sources() -> None:
@@ -138,7 +140,7 @@ def test_request_rejects_unbounded_generated_prime_cutoff() -> None:
 
 def test_request_rejects_generated_search_above_node_budget() -> None:
     with expect_validation("number_theory."):
-        FriableCountRequest(x="1" + "0" * 255, y="5")
+        FriableCountRequest(x=str(_MAX_FRIABLE_SOURCE_ABS // 10), y="5")
 
 
 def test_result_rejects_a_nearby_estimate_presented_as_exact() -> None:

--- a/tests/math/number_theory/test_periodic_congruences.py
+++ b/tests/math/number_theory/test_periodic_congruences.py
@@ -449,11 +449,11 @@ def test_request_schemas_publish_aggregate_execution_and_profile_bounds() -> Non
     for schema in (measure_schema, profile_schema):
         description = schema["description"]
         subsets_description = schema["properties"]["subsets"]["description"]
-        assert "4,096 raw" in description
-        assert "4,096 normalized" in description
-        assert "256 decimal digits" in description
-        assert "4,096 raw" in subsets_description
-        assert "4,096 normalized" in subsets_description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} raw" in description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} normalized" in description
+        assert f"{MAX_PERIODIC_INTEGER_DIGITS} decimal digits" in description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} raw" in subsets_description
+        assert f"{MAX_PERIODIC_SOURCE_ROWS:,} normalized" in subsets_description
         assert schema["aggregate_raw_residue_row_limit"] == MAX_PERIODIC_SOURCE_ROWS
         assert (
             schema["aggregate_normalized_residue_row_limit"] == MAX_PERIODIC_SOURCE_ROWS

--- a/tests/math/number_theory/test_ramanujan_sums.py
+++ b/tests/math/number_theory/test_ramanujan_sums.py
@@ -9,11 +9,13 @@ from tests.math.number_theory._validation import expect_validation
 
 from jacobian._exact import CanonicalInteger
 from jacobian.math.number_theory import ramanujan_sum
+from jacobian.math.number_theory._models import _MAX_INTEGER_LENGTH
 from jacobian.math.number_theory._ramanujan_sum import (
     RAMANUJAN_SUM_OPERATION,
     RamanujanSumRequest,
     RamanujanSumResult,
 )
+from jacobian.math.number_theory.ramanujan_sums import _MAX_MODULUS_DIGITS
 
 
 @pytest.mark.parametrize(
@@ -147,7 +149,7 @@ def test_equal_frequencies_share_one_serialized_identity() -> None:
 
 @pytest.mark.parametrize(
     "encoding",
-    ("0", "7", "-7", "9" * 256, "-0", "+0", "00", "-007", "", "-", "+1"),
+    ("0", "7", "-7", "9" * _MAX_INTEGER_LENGTH, "-0", "+0", "00", "-007", "", "-", "+1"),
 )
 def test_frequency_grammar_is_owned_by_canonical_integer(encoding: str) -> None:
     owner = TypeAdapter(CanonicalInteger)
@@ -242,8 +244,8 @@ def test_result_accepts_canonical_nonzero_values(
 
 def test_ramanujan_sum_request_bounds_factorization_and_frequency_work() -> None:
     boundary = RamanujanSumRequest(
-        modulus="999999999999",
-        frequency="9" * 256,
+        modulus="9" * _MAX_MODULUS_DIGITS,
+        frequency="9" * _MAX_INTEGER_LENGTH,
     )
     result = RAMANUJAN_SUM_OPERATION.run(boundary)
     assert int(result.value) == ramanujan_sum(
@@ -251,9 +253,9 @@ def test_ramanujan_sum_request_bounds_factorization_and_frequency_work() -> None
     )
 
     with expect_validation("number_theory."):
-        RamanujanSumRequest(modulus="1000000000000", frequency="0")
+        RamanujanSumRequest(modulus=str(10**_MAX_MODULUS_DIGITS), frequency="0")
     with expect_validation("number_theory."):
-        RamanujanSumRequest(modulus="1", frequency="9" * 257)
+        RamanujanSumRequest(modulus="1", frequency="9" * (_MAX_INTEGER_LENGTH + 1))
     with pytest.raises(ValidationError):
         RamanujanSumRequest(modulus="-1", frequency="0")
 
@@ -264,8 +266,8 @@ def test_ramanujan_sum_rejects_negative_native_modulus() -> None:
 
 
 def test_native_ramanujan_sum_bounds_factorization_work() -> None:
-    with pytest.raises(ValueError, match=r"at most 12"):
-        ramanujan_sum(10**12, 1)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_MODULUS_DIGITS}"):
+        ramanujan_sum(10**_MAX_MODULUS_DIGITS, 1)
     assert ramanujan_sum(549755813888, 274877906944) == -274877906944
 
 
@@ -273,20 +275,20 @@ def test_native_ramanujan_sum_bounds_frequency_magnitude() -> None:
     # Reported failure mode: the native entry point must enforce the same
     # 256-character frequency envelope as the wire request before any
     # factorization or modular reduction.
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(4, 10**256)
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(4, -(10**255))
-    with pytest.raises(ValueError, match="at most 256"):
-        ramanujan_sum(0, 10**256)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH)
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(4, -(10**(_MAX_INTEGER_LENGTH - 1)))
+    with pytest.raises(ValueError, match=rf"at most {_MAX_INTEGER_LENGTH}"):
+        ramanujan_sum(0, 10**_MAX_INTEGER_LENGTH)
 
-    assert ramanujan_sum(4, 10**256 - 2) == -2
-    assert ramanujan_sum(4, -(10**255 - 2)) == -2
-    assert ramanujan_sum(4, 10**256 - 1) == 0
+    assert ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH - 2) == -2
+    assert ramanujan_sum(4, -(10**(_MAX_INTEGER_LENGTH - 1) - 2)) == -2
+    assert ramanujan_sum(4, 10**_MAX_INTEGER_LENGTH - 1) == 0
 
 
 def test_native_frequency_bound_matches_wire_admission() -> None:
-    for modulus, frequency in (("4", str(10**256 - 2)), ("1", "9" * 256)):
+    for modulus, frequency in (("4", str(10**_MAX_INTEGER_LENGTH - 2)), ("1", "9" * _MAX_INTEGER_LENGTH)):
         request = RamanujanSumRequest(modulus=modulus, frequency=frequency)
         assert RAMANUJAN_SUM_OPERATION.run(request).value == str(
             ramanujan_sum(int(modulus), int(frequency))

--- a/tests/math/polynomials/ideals/test_minimal_primes.py
+++ b/tests/math/polynomials/ideals/test_minimal_primes.py
@@ -11,6 +11,8 @@ from jacobian._exact import CanonicalRational
 from jacobian.catalog.models import OperationResult
 from jacobian.math.polynomials.ideals import _operations as operations_module
 from jacobian.math.polynomials.ideals._models import (
+    MAX_OUTPUT_GENERATORS,
+    MAX_OUTPUT_TERMS,
     IdealMinimalPrimesRequest,
     IdealMinimalPrimesResult,
     computed_minimal_primes_result,
@@ -385,7 +387,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
             *(_poly(variables, (-1, 1, (0,) * 8)) for _ in range(33)),
         ),
     )
-    with pytest.raises(ValueError, match="64-generator exact-result envelope"):
+    with pytest.raises(ValueError, match=rf"{MAX_OUTPUT_GENERATORS}-generator exact-result envelope"):
         computed_minimal_primes_result(request, over_generators, "4.4.0")
 
     heavy_terms = tuple(
@@ -399,7 +401,7 @@ def test_external_family_must_respect_the_generator_and_term_envelopes() -> None
         )
     )
     oversized = (_ideal(variables, _poly(variables, *heavy_terms)),)
-    with pytest.raises(ValueError, match="1024-term exact-result envelope"):
+    with pytest.raises(ValueError, match=rf"{MAX_OUTPUT_TERMS}-term exact-result envelope"):
         computed_minimal_primes_result(request, oversized, "4.4.0")
 
 

--- a/tests/math/polynomials/interpolation/test_hermite_interpolation.py
+++ b/tests/math/polynomials/interpolation/test_hermite_interpolation.py
@@ -23,6 +23,7 @@ from jacobian.math.polynomials.interpolation import (
     hermite_interpolation,
 )
 from jacobian.math.polynomials.interpolation._models import (
+    _MAX_RATIONAL_DIGITS,
     MAX_HERMITE_CUBIC_WORK_CELLS,
     MAX_HERMITE_RESULT_BYTES,
     MAX_HERMITE_SYSTEM_CELLS,
@@ -381,8 +382,8 @@ def test_input_rational_digit_boundary_is_documented_and_enforced() -> None:
     schema = OrdinaryDerivativeJetTable.model_json_schema()
     jet_properties = schema["$defs"]["OrdinaryDerivativeJet"]["properties"]
     value_properties = schema["$defs"]["OrdinaryDerivativeValue"]["properties"]
-    assert "at most 256 digits" in jet_properties["node"]["description"]
-    assert "at most 256 digits" in value_properties["value"]["description"]
+    assert f"at most {_MAX_RATIONAL_DIGITS} digits" in jet_properties["node"]["description"]
+    assert f"at most {_MAX_RATIONAL_DIGITS} digits" in value_properties["value"]["description"]
 
 
 def test_intermediate_growth_boundary_rejects_before_matrix_construction() -> None:

--- a/tests/math/polynomials/test_multivariate_polynomial.py
+++ b/tests/math/polynomials/test_multivariate_polynomial.py
@@ -11,6 +11,7 @@ import pytest
 from tests.math.polynomials._support import polynomial_validation_error
 
 from jacobian.math.polynomials.multivariate._models import (
+    _MAX_MULTIVARIATE_COEFFICIENT_DIGITS,
     MultivariateDivisionRequest,
     MultivariateGcdRequest,
     MultivariateResultantRequest,
@@ -952,7 +953,7 @@ class TestMultivariateSubresultantSequence:
             )
 
     def test_accepts_exact_input_coefficient_boundary(self) -> None:
-        boundary_coefficient = "9" * 256
+        boundary_coefficient = "9" * _MAX_MULTIVARIATE_COEFFICIENT_DIGITS
         left = _poly(
             ("x", "y"),
             ((f"{boundary_coefficient}/1", (1, 0)), ("1/1", (0, 1))),
@@ -976,9 +977,9 @@ class TestMultivariateSubresultantSequence:
 
         beyond = _poly(
             ("x", "y"),
-            ((f"{'9' * 257}/1", (1, 0)), ("1/1", (0, 1))),
+            ((f"{'9' * (_MAX_MULTIVARIATE_COEFFICIENT_DIGITS + 1)}/1", (1, 0)), ("1/1", (0, 1))),
         )
-        with pytest.raises(ValueError, match="256-digit bound"):
+        with pytest.raises(ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"):
             MultivariateSubresultantSequenceRequest(
                 left=beyond,
                 right=right,

--- a/tests/math/polynomials/test_polynomial_map_generic_degree.py
+++ b/tests/math/polynomials/test_polynomial_map_generic_degree.py
@@ -26,6 +26,7 @@ from jacobian.math.polynomials.maps._generic_degree import (
     validate_generic_fiber_certificate,
 )
 from jacobian.math.polynomials.maps._models import (
+    MAX_GENERIC_DEGREE_ENCODED_MAP_BYTES,
     GenericDegreeComputationBudget,
     GenericDegreeRequest,
     GenericDegreeResult,
@@ -168,7 +169,7 @@ def test_operation_is_one_admitted_atomic_generic_fiber_computation() -> None:
         "polynomial_map"
     ]["description"]
     assert "96 aggregate terms" in description
-    assert "65536 encoded bytes" in description
+    assert f"{MAX_GENERIC_DEGREE_ENCODED_MAP_BYTES} encoded bytes" in description
     assert "Bezout" in description
     assert set(
         GenericDegreeRequest.model_json_schema()["$defs"][

--- a/tests/math/polytope/test_polytope.py
+++ b/tests/math/polytope/test_polytope.py
@@ -13,6 +13,7 @@ from jacobian.canonical import format_canonical_integer
 from jacobian.math.polytope import _operations as polytope_operations
 from jacobian.math.polytope._models import (
     MAX_COMPUTED_FACETS,
+    MAX_DIMENSION,
     MAX_FACET_COORDINATE_DIGITS,
     MAX_FACET_INCIDENCES,
     MAX_FACET_SIGN_TESTS,
@@ -1295,12 +1296,12 @@ class TestHullWorkBoundPublished:
         """26 distinct six-dimensional points satisfy every visible field
         bound yet exceed C(26, 6) = 230230; the rejection must say why."""
         points = tuple(_v(*((1000 * j + i, 1) for i in range(6))) for j in range(26))
-        with pytest.raises(ValueError, match=r"combinatorial bound \(230230"):
+        with pytest.raises(ValueError, match=rf"combinatorial bound \({math.comb(26, 6)}"):
             PolytopeVolumeRequest(vertices=points)
 
     def test_just_above_the_four_dimensional_maximum_rejected(self) -> None:
         points = tuple(_v(*((1000 * j + i, 1) for i in range(4))) for j in range(49))
-        with pytest.raises(ValueError, match=r"combinatorial bound \(211876"):
+        with pytest.raises(ValueError, match=rf"combinatorial bound \({math.comb(49, 4)}"):
             PolytopeVolumeRequest(vertices=points)
 
 
@@ -1693,7 +1694,7 @@ class TestCanonicalVPolytopeComposition:
             unexpected_proof,
         )
 
-        with pytest.raises(ValueError, match="dimension 7 exceeds the dimension"):
+        with pytest.raises(ValueError, match=rf"dimension {MAX_DIMENSION + 1} exceeds the dimension"):
             PolytopeVolumeRequest.model_validate(
                 {"vertices": simplex.model_dump(mode="json")}
             )

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -46,6 +46,7 @@ from jacobian.math.prime_affine_forms._operations import (
     compute_wheel_membership,
 )
 from jacobian.math.prime_affine_forms._tools import TOOLS
+from jacobian.math.prime_affine_forms.values import MAX_AFFINE_AGGREGATE_DIGITS
 
 
 def _form(form_id: str, coefficient: int, constant: int) -> PrimitiveIntegerAffineForm:
@@ -595,7 +596,7 @@ def test_prime_sets_and_interval_relations_are_schema_visible() -> None:
     assert "strictly increasing" in factor_schema["properties"]["primes"]["description"]
     assert factor_schema["properties"]["primes"]["items"]["maximum"] == ((1 << 53) - 1)
     source_schema = factor_schema["$defs"]["PrimeAffineTuple"]
-    assert "131072" in source_schema["properties"]["forms"]["description"]
+    assert str(MAX_AFFINE_AGGREGATE_DIGITS) in source_schema["properties"]["forms"]["description"]
     form_schema = factor_schema["$defs"]["PrimitiveIntegerAffineForm"]
     assert form_schema["properties"]["coefficient"]["maxLength"] == 257
     assert (

--- a/tests/math/symmetric_functions/test_symmetric_functions.py
+++ b/tests/math/symmetric_functions/test_symmetric_functions.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.symmetric_functions._models import (
+    _MAX_SCHUR_PARTITION_LENGTH,
     IntegerPartition,
     PartitionRequest,
     SchurExpansionRequest,
@@ -15,6 +16,9 @@ from jacobian.math.symmetric_functions._operations import (
     compute_schur_evaluation,
 )
 from jacobian.math.symmetric_functions._tools import TOOLS
+from jacobian.math.symmetric_functions.values import (
+    MAX_PARTITION_SIZE,
+)
 
 
 def test_operations_in_catalog() -> None:
@@ -156,12 +160,12 @@ def test_request_schema_publishes_schur_invariants() -> None:
     assert "decimal digits" in point["items"]["description"]
     partition = schema["properties"]["partition"]
     assert partition["title"] == "IntegerPartition"
-    assert "500" in partition["description"]
-    assert "at most 50" in partition["description"]
+    assert str(MAX_PARTITION_SIZE) in partition["description"]
+    assert f"at most {_MAX_SCHUR_PARTITION_LENGTH}" in partition["description"]
     parts = partition["properties"]["parts"]
-    assert parts["maxItems"] == 50
-    assert "at most 50" in parts["description"]
-    assert "500" in parts["description"]
+    assert parts["maxItems"] == _MAX_SCHUR_PARTITION_LENGTH
+    assert f"at most {_MAX_SCHUR_PARTITION_LENGTH}" in parts["description"]
+    assert str(MAX_PARTITION_SIZE) in parts["description"]
 
 
 def test_schur_rejects_coordinate_exceeding_digit_bound() -> None:

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -28,6 +28,8 @@ from jacobian.math.tree_automata.operations import (
     run_tree_automaton,
 )
 from jacobian.math.tree_automata.values import (
+    MAX_REACHABILITY_WITNESS_NODES,
+    MAX_TREE_AUTOMATON_REACHABILITY_WORK,
     BottomUpTreeAutomaton,
     RankedTree,
     TreeAutomatonTransition,
@@ -862,17 +864,17 @@ class TestValidation:
 
         request_description = request_schema["description"]
         assert "MAX_TREE_AUTOMATON_REACHABILITY_WORK" in request_description
-        assert "30,000,000" in request_description
+        assert f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,}" in request_description
         assert "MAX_REACHABILITY_WITNESS_NODES" in request_description
-        assert "4096" in request_description
+        assert str(MAX_REACHABILITY_WITNESS_NODES) in request_description
         assert "summed" in request_description
 
         automaton_description = request_schema["properties"]["automaton"]["description"]
-        assert "30,000,000 units" in automaton_description
+        assert f"{MAX_TREE_AUTOMATON_REACHABILITY_WORK:,} units" in automaton_description
         assert "summed" in automaton_description
 
         witnesses_description = result_schema["properties"]["witnesses"]["description"]
-        assert "4096 nodes summed over all reachable states" in witnesses_description
+        assert f"{MAX_REACHABILITY_WITNESS_NODES} nodes summed over all reachable states" in witnesses_description
 
     def test_reachability_rejects_materialized_witnesses_beyond_output_bound(self):
         transitions = [

--- a/tests/process/polynomials/ideals/test_singular_process.py
+++ b/tests/process/polynomials/ideals/test_singular_process.py
@@ -18,7 +18,10 @@ from jacobian.canonical import (
     format_canonical_integer,
     parse_canonical_integer,
 )
-from jacobian.math.polynomials.ideals._models import IdealComputationBudget
+from jacobian.math.polynomials.ideals._models import (
+    MAX_OUTPUT_TERMS,
+    IdealComputationBudget,
+)
 from jacobian.math.polynomials.ideals._singular import (
     _minimal_primes_stdout_limit,
     run_singular_ideal_operation,
@@ -467,7 +470,7 @@ def test_exhausted_replay_allowance_times_out_without_launching_singular(
 
 
 def test_caller_cannot_narrow_the_exact_result_contract() -> None:
-    with pytest.raises(ValueError, match="greater than or equal to 1024"):
+    with pytest.raises(ValueError, match=rf"greater than or equal to {MAX_OUTPUT_TERMS}"):
         IdealComputationBudget(maximum_output_terms=1)
 
 


### PR DESCRIPTION
Fixes #2597.

## Problem

Matrix-polynomial admission bounds previously relied on hand-written examples. This left both undercounted intermediates and safely bounded requests rejected by coarse estimates without a repeatable way to compare the advertised envelope with exact small instances.

## Solution

Add the narrowly scoped differential conformance pilot requested for matrix-polynomial evaluation. It enumerates bounded canonical polynomial and matrix inputs, compares the admission estimate with exact intermediate and result quantities, and retains discriminating counterexamples for cancellation and denominator-overlap cases. The pilot stays local to the matrix-polynomial owner; it does not introduce repository-wide envelope instrumentation.

## Testing

- `make test-focused LANE=math TESTS=tests/math/matrices/test_matrix_polynomial_evaluation.py` — 53 passed
- `git diff --check` — passed

## Public contract impact

None. This adds differential contract evidence for the existing matrix-polynomial operation.

## Operation boundary ownership

- Changed stage: request-bounds conformance evidence
- Request-bounds owner and controlling quantities: existing canonical-forms matrix-polynomial admission
- Backend or kernel path: unchanged
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: unchanged
- Serialized-result and round-trip evidence: not applicable

## Checklist

- [ ] `make check` passes (not run; the relevant owner lane passed)
- [x] New bounds include boundary, algorithm-crossover, and realistic counterexample evidence