### PR TITLE
Add matrix-polynomial envelope conformance pilot

### DIFF
--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from fractions import Fraction
 from typing import Any
 
@@ -15,6 +16,57 @@ __all__ = [
 
 RationalEntries = Sequence[Sequence[Fraction]]
 CoefficientList = tuple[Fraction, ...]
+
+
+def _integer_decimal_digits(value: int) -> int:
+    """Return the decimal width of ``value`` without decimal rendering.
+
+    The conformance probe below can observe large admitted exact components.
+    Avoiding ``str(int)`` keeps that private diagnostic independent of
+    CPython's configurable decimal-conversion guard.
+    """
+
+    magnitude = abs(value)
+    if magnitude == 0:
+        return 1
+    # 0.30103 is an upper rational approximation to log10(2), so this is an
+    # upper estimate from the binary width.  A single exact comparison removes
+    # the possible one-digit overestimate.
+    digits = magnitude.bit_length() * 30_103 // 100_000 + 1
+    if magnitude < 10 ** (digits - 1):
+        return digits - 1
+    return digits
+
+
+@dataclass
+class _HornerEvaluationMetrics:
+    """Private kernel measurements for the matrix-polynomial pilot only.
+
+    This is deliberately an optional observer on this owner-local kernel, not
+    a cross-operation instrumentation protocol.  It records the published
+    dense scalar-product proxy and the widest reduced component of each
+    materialized Horner state without changing evaluation semantics.
+    """
+
+    maximum_component_digits: int = 0
+    scalar_product_terms: int = 0
+    stored_states: int = 0
+
+    def record_state(self, state: Any) -> None:
+        """Record one materialized exact Horner state."""
+
+        state_digits = max(
+            (
+                max(
+                    _integer_decimal_digits(int(entry.p)),
+                    _integer_decimal_digits(int(entry.q)),
+                )
+                for entry in state
+            ),
+            default=1,
+        )
+        self.maximum_component_digits = max(self.maximum_component_digits, state_digits)
+        self.stored_states += 1
 
 
 def _square_dimension(entries: RationalEntries) -> int:
@@ -70,6 +122,8 @@ def characteristic_polynomial(entries: RationalEntries) -> CoefficientList:
 def _evaluate_polynomial(
     entries: RationalEntries,
     coefficients: Sequence[Fraction],
+    *,
+    metrics: _HornerEvaluationMetrics | None = None,
 ) -> tuple[tuple[Fraction, ...], ...]:
     """Return ``f(A)`` for increasing-degree coefficients by exact Horner evaluation."""
 
@@ -80,12 +134,19 @@ def _evaluate_polynomial(
     identity = eye(dimension)
     if not coefficients:
         result = zeros(dimension)
+        if metrics is not None:
+            metrics.record_state(result)
     else:
         leading = coefficients[-1]
         result = Rational(leading.numerator, leading.denominator) * identity
+        if metrics is not None:
+            metrics.record_state(result)
         for coefficient in reversed(coefficients[:-1]):
             scalar = Rational(coefficient.numerator, coefficient.denominator)
             result = result * matrix + scalar * identity
+            if metrics is not None:
+                metrics.scalar_product_terms += dimension**3
+                metrics.record_state(result)
     return tuple(
         tuple(_to_fraction(result[row, column]) for column in range(dimension))
         for row in range(dimension)

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -44,8 +44,9 @@ class _HornerEvaluationMetrics:
 
     This is deliberately an optional observer on this owner-local kernel, not
     a cross-operation instrumentation protocol.  It records the published
-    dense scalar-product proxy and the widest reduced component of each
-    materialized Horner state without changing evaluation semantics.
+    dense scalar-product proxy and the widest component of every materialized
+    Horner state -- each pre-addition matrix product together with each
+    reduced accumulator -- without changing evaluation semantics.
     """
 
     maximum_component_digits: int = 0
@@ -143,9 +144,14 @@ def _evaluate_polynomial(
             metrics.record_state(result)
         for coefficient in reversed(coefficients[:-1]):
             scalar = Rational(coefficient.numerator, coefficient.denominator)
-            result = result * matrix + scalar * identity
+            product = result * matrix
             if metrics is not None:
                 metrics.scalar_product_terms += dimension**3
+                # The product is materialized before the scalar term can
+                # cancel it, so the observed bound must cover this state too.
+                metrics.record_state(product)
+            result = product + scalar * identity
+            if metrics is not None:
                 metrics.record_state(result)
     return tuple(
         tuple(_to_fraction(result[row, column]) for column in range(dimension))

--- a/src/jacobian/math/matrices/canonical_forms/operations.py
+++ b/src/jacobian/math/matrices/canonical_forms/operations.py
@@ -46,7 +46,11 @@ class _HornerEvaluationMetrics:
     a cross-operation instrumentation protocol.  It records the published
     dense scalar-product proxy and the widest component of every materialized
     Horner state -- each pre-addition matrix product together with each
-    reduced accumulator -- without changing evaluation semantics.
+    reduced accumulator -- without changing evaluation semantics.  Inside a
+    measured matrix product the observer additionally records every scalar
+    multiplication term and every partial accumulation of the standard
+    row-times-column dot products, so canceling terms are observed at their
+    full product width before the following addition reduces them.
     """
 
     maximum_component_digits: int = 0
@@ -68,6 +72,48 @@ class _HornerEvaluationMetrics:
         )
         self.maximum_component_digits = max(self.maximum_component_digits, state_digits)
         self.stored_states += 1
+
+
+def _measured_matrix_product(
+    result: Any,
+    matrix: Any,
+    dimension: int,
+    metrics: _HornerEvaluationMetrics,
+) -> Any:
+    """Return ``result * matrix`` while observing inside each dot product.
+
+    SymPy reduces every dot product fully before ``result * matrix``
+    returns, so a plain product observer never sees canceling scalar-product
+    terms: with ``A = H [[1, 1], [-1, -1]]`` the square ``A**2`` is zero even
+    though each entry forms ``H**2`` and ``-H**2`` terms mid-multiplication.
+    This helper walks the same standard row-times-column accumulation in one
+    deterministic order (entries row-major, each inner index ascending), and
+    SymPy still performs every entry multiplication and addition.  The
+    returned matrix equals ``result * matrix`` exactly because reduced
+    rational arithmetic is independent of the association order.
+    """
+
+    from sympy import Matrix, S
+
+    rows: list[list[Any]] = []
+    for row_index in range(dimension):
+        row_entries: list[Any] = []
+        for column_index in range(dimension):
+            accumulator = S.Zero
+            for inner_index in range(dimension):
+                term = (
+                    result[row_index, inner_index] * matrix[inner_index, column_index]
+                )
+                metrics.record_state((term,))
+                accumulator = accumulator + term
+                metrics.record_state((accumulator,))
+            row_entries.append(accumulator)
+        rows.append(row_entries)
+    product = Matrix(rows)
+    # The assembled product is materialized before the scalar term can
+    # cancel it, so the observed bound must cover this state too.
+    metrics.record_state(product)
+    return product
 
 
 def _square_dimension(entries: RationalEntries) -> int:
@@ -144,12 +190,17 @@ def _evaluate_polynomial(
             metrics.record_state(result)
         for coefficient in reversed(coefficients[:-1]):
             scalar = Rational(coefficient.numerator, coefficient.denominator)
-            product = result * matrix
-            if metrics is not None:
+            if metrics is None:
+                product = result * matrix
+            else:
+                # Each dot product reduces before ``result * matrix`` would
+                # return, so measuring the plain product alone would miss
+                # canceling scalar-product terms.  The measured expansion
+                # records every term and partial accumulation of the same
+                # standard row-times-column order and returns the identical
+                # exact matrix.
                 metrics.scalar_product_terms += dimension**3
-                # The product is materialized before the scalar term can
-                # cancel it, so the observed bound must cover this state too.
-                metrics.record_state(product)
+                product = _measured_matrix_product(result, matrix, dimension, metrics)
             result = product + scalar * identity
             if metrics is not None:
                 metrics.record_state(result)

--- a/tests/math/matrices/test_matrix_polynomial_evaluation.py
+++ b/tests/math/matrices/test_matrix_polynomial_evaluation.py
@@ -4,23 +4,41 @@ from copy import deepcopy
 from fractions import Fraction
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
-from jacobian.canonical import CanonicalLimits, format_canonical_integer
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    format_canonical_integer,
+)
 from jacobian.math.matrices._operation_models import SquareRationalMatrixRequest
 from jacobian.math.matrices._operations import compute_characteristic_polynomial
 from jacobian.math.matrices.canonical_forms._models import (
     _MAX_WORK_BOUND,
+    _RESULT_ENTRY_OVERHEAD_BYTES,
+    _RESULT_ENVELOPE_RESERVE_BYTES,
     MATRIX_POLYNOMIAL_EVALUATION_PASSES,
     MAX_MATRIX_POLYNOMIAL_DIGIT_WORK,
     MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS,
     MatrixPolynomialEvaluationRequest,
     MatrixPolynomialEvaluationResult,
+    _coefficient_ratios,
+    _general_result_component_bounds,
+    _linear_result_component_bounds,
+    _polynomial_degree,
+    _require_matrix_polynomial_output_budget,
     _work_exact_quotient,
 )
 from jacobian.math.matrices.canonical_forms._operations import (
+    _dense_polynomial_coefficients,
     compute_matrix_polynomial_evaluation,
+)
+from jacobian.math.matrices.canonical_forms.operations import (
+    _evaluate_polynomial,
+    _HornerEvaluationMetrics,
 )
 from jacobian.math.matrices.values import RationalMatrix
 from jacobian.math.polynomials.values import (
@@ -67,6 +85,185 @@ def _polynomial(*terms: tuple[RationalInput, int]) -> RationalPolynomial:
 
 def _fractions(matrix: RationalMatrix) -> tuple[tuple[Fraction, ...], ...]:
     return tuple(tuple(entry.as_fraction() for entry in row) for row in matrix.entries)
+
+
+def _matrix_polynomial_component_bounds(
+    request: MatrixPolynomialEvaluationRequest,
+) -> tuple[tuple[tuple[int, int], ...], int]:
+    """Return the same owner-local result and intermediate estimates as admission."""
+
+    degree = _polynomial_degree(request.polynomial)
+    coefficients = _coefficient_ratios(request.polynomial)
+    matrix_is_zero = all(
+        entry.num == "0" for row in request.matrix.entries for entry in row
+    )
+    if degree <= 1 or matrix_is_zero:
+        return _linear_result_component_bounds(request.matrix, coefficients)
+    return _general_result_component_bounds(request.matrix, request.polynomial)
+
+
+def _assert_matrix_polynomial_envelope_conformance(
+    request: MatrixPolynomialEvaluationRequest,
+) -> None:
+    """Compare one public evaluation with the owner-local admission envelope."""
+
+    component_bounds, _component_work_digits = _matrix_polynomial_component_bounds(
+        request
+    )
+    estimated_work_digits = _require_matrix_polynomial_output_budget(
+        request.matrix,
+        request.polynomial,
+        _polynomial_degree(request.polynomial),
+    )
+
+    metrics = _HornerEvaluationMetrics()
+    measured_value = _evaluate_polynomial(
+        _fractions(request.matrix),
+        _dense_polynomial_coefficients(request),
+        metrics=metrics,
+    )
+    result = compute_matrix_polynomial_evaluation(request)
+
+    assert _fractions(result.value) == measured_value
+    actual_component_bounds = tuple(
+        (len(entry.num.lstrip("-")), len(entry.den))
+        for row in result.value.entries
+        for entry in row
+    )
+    assert all(
+        actual_numerator_digits <= estimated_numerator_digits
+        and actual_denominator_digits <= estimated_denominator_digits
+        for (actual_numerator_digits, actual_denominator_digits), (
+            estimated_numerator_digits,
+            estimated_denominator_digits,
+        ) in zip(actual_component_bounds, component_bounds, strict=True)
+    )
+    assert metrics.maximum_component_digits <= estimated_work_digits
+
+    dimension = len(request.matrix.entries)
+    degree = _polynomial_degree(request.polynomial)
+    assert metrics.scalar_product_terms == degree * dimension**3
+    assert metrics.stored_states == degree + 1
+    total_scalar_products = (
+        MATRIX_POLYNOMIAL_EVALUATION_PASSES * metrics.scalar_product_terms
+    )
+    assert total_scalar_products <= MAX_MATRIX_POLYNOMIAL_SCALAR_PRODUCTS
+    assert (
+        total_scalar_products * estimated_work_digits**2
+        <= MAX_MATRIX_POLYNOMIAL_DIGIT_WORK
+    )
+
+    estimated_value_bytes = sum(
+        numerator_digits + denominator_digits + _RESULT_ENTRY_OVERHEAD_BYTES
+        for numerator_digits, denominator_digits in component_bounds
+    )
+    estimated_output_bytes = (
+        len(encode_strict_json(request.matrix.model_dump(mode="json")))
+        + len(encode_strict_json(request.polynomial.model_dump(mode="json")))
+        + estimated_value_bytes
+        + _RESULT_ENVELOPE_RESERVE_BYTES
+    )
+    actual_output_bytes = len(encode_strict_json(result.model_dump(mode="json")))
+    assert actual_output_bytes <= estimated_output_bytes
+    assert actual_output_bytes <= CanonicalLimits().max_output_bytes
+
+
+@pytest.mark.parametrize(
+    ("matrix", "polynomial"),
+    [
+        # Degenerate zero support keeps a high-degree Horner trace without a
+        # matrix-side denominator product.
+        (_matrix((0, 0), (0, 0)), _polynomial((1, 3), ((1, 3), 0))),
+        # A chain clears dead powers after bounded shifted states.
+        (
+            _matrix((0, (1, 2), 0), (0, 0, (1, 3)), (0, 0, 0)),
+            _polynomial(((1, 5), 5), ((1, 7), 4), (1, 1)),
+        ),
+        # Two routes meet at one cell, so coprime denominators compound in a
+        # measured state rather than staying independent by construction.
+        (
+            _matrix(
+                (0, (1, 2), (1, 3), 0),
+                (0, 0, 0, (1, 5)),
+                (0, 0, 0, (1, 7)),
+                (0, 0, 0, 0),
+            ),
+            _polynomial((1, 2), ((1, 11), 1), ((1, 13), 0)),
+        ),
+        # Separate diagonal cells retain distinct rational components.
+        (
+            _matrix(((1, 2), 0), (0, (1, 3))),
+            _polynomial(((1, 5), 4), ((1, 7), 2), ((1, 11), 0)),
+        ),
+        # Cyclic support exercises the conservative non-acyclic path.
+        (
+            _matrix((0, (1, 2)), ((1, 3), 0)),
+            _polynomial((1, 5), ((1, 5), 3), ((1, 7), 0)),
+        ),
+    ],
+    ids=("zero", "chain", "converging_paths", "disjoint_diagonal", "cycle"),
+)
+def test_matrix_polynomial_envelope_pilot_matches_measured_horner_states(
+    matrix: RationalMatrix,
+    polynomial: RationalPolynomial,
+) -> None:
+    """#2597 pilot: admitted representative shapes match their work/output envelope."""
+
+    _assert_matrix_polynomial_envelope_conformance(
+        MatrixPolynomialEvaluationRequest(matrix=matrix, polynomial=polynomial)
+    )
+
+
+@st.composite
+def _small_horner_requests(
+    draw: st.DrawFn,
+) -> MatrixPolynomialEvaluationRequest:
+    """Generate bounded support shapes around the representative pilot corpus."""
+
+    dimension = draw(st.integers(min_value=1, max_value=3))
+    support = draw(st.sampled_from(("zero", "chain", "diagonal", "dense")))
+    numerator = st.integers(min_value=-3, max_value=3)
+    denominator = st.sampled_from((1, 2, 3, 5))
+
+    def entry(row: int, column: int) -> RationalInput:
+        if support == "zero":
+            return 0
+        if support == "chain" and column != row + 1:
+            return 0
+        if support == "diagonal" and column != row:
+            return 0
+        value, divisor = draw(st.tuples(numerator, denominator))
+        reduced = Fraction(value, divisor)
+        return 0 if reduced == 0 else (reduced.numerator, reduced.denominator)
+
+    matrix = _matrix(
+        *(
+            tuple(entry(row, column) for column in range(dimension))
+            for row in range(dimension)
+        )
+    )
+    degree = draw(st.integers(min_value=0, max_value=5))
+    coefficients = [(draw(numerator), exponent) for exponent in range(degree, -1, -1)]
+    return MatrixPolynomialEvaluationRequest(
+        matrix=matrix,
+        polynomial=_polynomial(
+            *(
+                (coefficient, exponent)
+                for coefficient, exponent in coefficients
+                if coefficient
+            )
+        ),
+    )
+
+
+@settings(max_examples=40, deadline=None, derandomize=True)
+@given(_small_horner_requests())
+def test_matrix_polynomial_envelope_pilot_covers_small_support_variation(
+    request: MatrixPolynomialEvaluationRequest,
+) -> None:
+    """The pilot's conformance relation also holds across small support variation."""
+
+    _assert_matrix_polynomial_envelope_conformance(request)
 
 
 def test_saturated_work_estimates_do_not_reenter_exact_division() -> None:

--- a/tests/math/matrices/test_matrix_polynomial_evaluation.py
+++ b/tests/math/matrices/test_matrix_polynomial_evaluation.py
@@ -143,7 +143,7 @@ def _assert_matrix_polynomial_envelope_conformance(
     dimension = len(request.matrix.entries)
     degree = _polynomial_degree(request.polynomial)
     assert metrics.scalar_product_terms == degree * dimension**3
-    assert metrics.stored_states == degree + 1
+    assert metrics.stored_states == 2 * degree + 1
     total_scalar_products = (
         MATRIX_POLYNOMIAL_EVALUATION_PASSES * metrics.scalar_product_terms
     )
@@ -212,6 +212,40 @@ def test_matrix_polynomial_envelope_pilot_matches_measured_horner_states(
     _assert_matrix_polynomial_envelope_conformance(
         MatrixPolynomialEvaluationRequest(matrix=matrix, polynomial=polynomial)
     )
+
+
+def test_cancelled_horner_products_are_recorded_before_the_scalar_addition() -> None:
+    # Scalar matrix A = [[H]] with f = t^2 - H*t: the first Horner
+    # multiplication materializes H, yet adding c_1 = -H reduces the
+    # accumulator to zero immediately, so every addition-reduced state stays
+    # single-digit. The observer must charge the wide pre-addition product,
+    # otherwise the conformance bound passes vacuously while admission
+    # underestimates the shifted intermediate.
+    height = 10**120
+    request = MatrixPolynomialEvaluationRequest(
+        matrix=_matrix((height,)),
+        polynomial=_polynomial((1, 2), (-height, 1)),
+    )
+
+    metrics = _HornerEvaluationMetrics()
+    measured_value = _evaluate_polynomial(
+        _fractions(request.matrix),
+        _dense_polynomial_coefficients(request),
+        metrics=metrics,
+    )
+
+    assert measured_value == ((Fraction(0),),)
+    assert metrics.maximum_component_digits == len(str(height))
+    assert metrics.stored_states == 2 * 2 + 1
+
+    estimated_work_digits = _require_matrix_polynomial_output_budget(
+        request.matrix,
+        request.polynomial,
+        _polynomial_degree(request.polynomial),
+    )
+    assert len(str(height)) <= estimated_work_digits
+    assert metrics.maximum_component_digits <= estimated_work_digits
+    _assert_matrix_polynomial_envelope_conformance(request)
 
 
 @st.composite

--- a/tests/math/matrices/test_matrix_polynomial_evaluation.py
+++ b/tests/math/matrices/test_matrix_polynomial_evaluation.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import random
 from copy import deepcopy
 from fractions import Fraction
+from typing import Any
 
 import pytest
 from hypothesis import given, settings
@@ -143,7 +145,11 @@ def _assert_matrix_polynomial_envelope_conformance(
     dimension = len(request.matrix.entries)
     degree = _polynomial_degree(request.polynomial)
     assert metrics.scalar_product_terms == degree * dimension**3
-    assert metrics.stored_states == 2 * degree + 1
+    # One initial state; per multiplication every scalar-product term and
+    # partial accumulation inside each dot product is recorded (two states
+    # per term) together with the assembled product and the reduced
+    # accumulator.
+    assert metrics.stored_states == 1 + degree * (2 * dimension**3 + 2)
     total_scalar_products = (
         MATRIX_POLYNOMIAL_EVALUATION_PASSES * metrics.scalar_product_terms
     )
@@ -236,7 +242,7 @@ def test_cancelled_horner_products_are_recorded_before_the_scalar_addition() -> 
 
     assert measured_value == ((Fraction(0),),)
     assert metrics.maximum_component_digits == len(str(height))
-    assert metrics.stored_states == 2 * 2 + 1
+    assert metrics.stored_states == 1 + 2 * (2 * 1**3 + 2)
 
     estimated_work_digits = _require_matrix_polynomial_output_budget(
         request.matrix,
@@ -246,6 +252,141 @@ def test_cancelled_horner_products_are_recorded_before_the_scalar_addition() -> 
     assert len(str(height)) <= estimated_work_digits
     assert metrics.maximum_component_digits <= estimated_work_digits
     _assert_matrix_polynomial_envelope_conformance(request)
+
+
+def test_canceling_dot_product_terms_are_observed_inside_each_product() -> None:
+    # A = H [[1, 1], [-1, -1]] squares to zero: every entry of A^2 is a dot
+    # product whose H^2 and -H^2 terms cancel, so recording only reduced
+    # matrices observes nothing wider than H even though the multiplication
+    # forms full H^2 terms mid-dot-product.  An admission regression that
+    # underbounds scalar-product intermediates would then pass the
+    # conformance assertion vacuously; the measured expansion must charge
+    # each term and partial accumulation at its product width.
+    height = 10**120
+    request = MatrixPolynomialEvaluationRequest(
+        matrix=_matrix((height, height), (-height, -height)),
+        polynomial=_polynomial((1, 2)),
+    )
+
+    metrics = _HornerEvaluationMetrics()
+    measured_value = _evaluate_polynomial(
+        _fractions(request.matrix),
+        _dense_polynomial_coefficients(request),
+        metrics=metrics,
+    )
+
+    assert measured_value == (
+        (Fraction(0), Fraction(0)),
+        (Fraction(0), Fraction(0)),
+    )
+    assert metrics.maximum_component_digits == len(str(height**2))
+    assert metrics.stored_states == 1 + 2 * (2 * 2**3 + 2)
+
+    estimated_work_digits = _require_matrix_polynomial_output_budget(
+        request.matrix,
+        request.polynomial,
+        _polynomial_degree(request.polynomial),
+    )
+    assert len(str(height**2)) <= estimated_work_digits
+    _assert_matrix_polynomial_envelope_conformance(request)
+
+
+def _plain_sympy_horner_trace(
+    entries: tuple[tuple[Fraction, ...], ...],
+    coefficients: tuple[Fraction, ...],
+) -> tuple[tuple[tuple[Fraction, ...], ...], int]:
+    """Evaluate ``f(A)`` with plain SymPy matrix products, old-observer style.
+
+    Returns the exact value together with the widest component among the
+    pre-addition products and reduced accumulators -- exactly what recording
+    whole matrices observed before dot products were expanded.
+    """
+
+    from sympy import Matrix, Rational, eye, zeros
+
+    dimension = len(entries)
+    matrix = Matrix(
+        [
+            [Rational(entry.numerator, entry.denominator) for entry in row]
+            for row in entries
+        ]
+    )
+    widest = 0
+
+    def observe(state: Any) -> None:
+        nonlocal widest
+        widest = max(
+            widest,
+            max(
+                max(len(str(abs(int(entry.p)))), len(str(int(entry.q))))
+                for entry in state
+            ),
+        )
+
+    if not coefficients:
+        result = zeros(dimension)
+        observe(result)
+    else:
+        result = Rational(
+            coefficients[-1].numerator, coefficients[-1].denominator
+        ) * eye(dimension)
+        observe(result)
+        for coefficient in reversed(coefficients[:-1]):
+            scalar = Rational(coefficient.numerator, coefficient.denominator)
+            observe(result * matrix)
+            result = result * matrix + scalar * eye(dimension)
+            observe(result)
+    value = tuple(
+        tuple(
+            Fraction(int(result[row, column].p), int(result[row, column].q))
+            for column in range(dimension)
+        )
+        for row in range(dimension)
+    )
+    return value, widest
+
+
+def test_measured_dot_product_expansion_matches_plain_sympy_multiplication() -> None:
+    # Semantic neutrality of the observer expansion: on deterministic
+    # pseudo-random shapes the instrumented evaluation returns exactly the
+    # same rational matrix as plain ``result * matrix`` Horner evaluation,
+    # while observing a superset of the plain whole-matrix states.
+    rng = random.Random(20260826)
+    cancellation_cases = (
+        (
+            ((Fraction(1), Fraction(1)), (Fraction(-1), Fraction(-1))),
+            (Fraction(0), Fraction(0), Fraction(1)),
+        ),
+        (
+            ((Fraction(1, 2), Fraction(1, 3)), (Fraction(-1, 3), Fraction(-1, 2))),
+            (Fraction(0), Fraction(2), Fraction(1)),
+        ),
+    )
+    random_cases = []
+    for _case in range(6):
+        dimension = rng.randint(1, 4)
+        degree = rng.randint(0, 5)
+        entries = tuple(
+            tuple(
+                Fraction(rng.randint(-6, 6), rng.choice((1, 1, 2, 3)))
+                for _column in range(dimension)
+            )
+            for _row in range(dimension)
+        )
+        coefficients = tuple(
+            Fraction(rng.randint(-9, 9), rng.choice((1, 2, 5)))
+            for _exponent in range(degree + 1)
+        )
+        random_cases.append((entries, coefficients))
+
+    for entries, coefficients in cancellation_cases + tuple(random_cases):
+        plain_value, plain_widest = _plain_sympy_horner_trace(entries, coefficients)
+
+        metrics = _HornerEvaluationMetrics()
+        measured_value = _evaluate_polynomial(entries, coefficients, metrics=metrics)
+
+        assert measured_value == plain_value
+        assert metrics.maximum_component_digits >= plain_widest
 
 
 @st.composite


### PR DESCRIPTION
Fixes #2597.

## Problem

Matrix-polynomial admission bounds previously relied on hand-written examples. This left both undercounted intermediates and safely bounded requests rejected by coarse estimates without a repeatable way to compare the advertised envelope with exact small instances.

## Solution

Add the narrowly scoped differential conformance pilot requested for matrix-polynomial evaluation. It enumerates bounded canonical polynomial and matrix inputs, compares the admission estimate with exact intermediate and result quantities, and retains discriminating counterexamples for cancellation and denominator-overlap cases. The pilot stays local to the matrix-polynomial owner; it does not introduce repository-wide envelope instrumentation.

## Testing

- `make test-focused LANE=math TESTS=tests/math/matrices/test_matrix_polynomial_evaluation.py` — 53 passed
- `git diff --check` — passed

## Public contract impact

None. This adds differential contract evidence for the existing matrix-polynomial operation.

## Operation boundary ownership

- Changed stage: request-bounds conformance evidence
- Request-bounds owner and controlling quantities: existing canonical-forms matrix-polynomial admission
- Backend or kernel path: unchanged
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: unchanged
- Serialized-result and round-trip evidence: not applicable

## Checklist

- [ ] `make check` passes (not run; the relevant owner lane passed)
- [x] New bounds include boundary, algorithm-crossover, and realistic counterexample evidence