### PR TITLE
Clarify finite-geometry envelopes and canonical value maps

### DIFF
--- a/src/jacobian/math/finite_geometry/__init__.py
+++ b/src/jacobian/math/finite_geometry/__init__.py
@@ -1,3 +1,7 @@
-"""Finite geometry operations."""
+"""Finite geometry operations and explicit canonical-value maps."""
 
-__all__: list[str] = []
+from jacobian.math.finite_geometry.conversions import (
+    embed_projective_point_in_finite_field,
+)
+
+__all__ = ["embed_projective_point_in_finite_field"]

--- a/src/jacobian/math/finite_geometry/__init__.py
+++ b/src/jacobian/math/finite_geometry/__init__.py
@@ -1,7 +1,19 @@
-"""Finite geometry operations and explicit canonical-value maps."""
+"""Finite geometry canonical values, native constructors, and explicit maps."""
 
 from jacobian.math.finite_geometry.conversions import (
     embed_projective_point_in_finite_field,
 )
+from jacobian.math.finite_geometry.operations import projective_point
+from jacobian.math.finite_geometry.values import (
+    PrimeFieldVectorSpace,
+    ProjectivePoint,
+    ProjectivePointSequence,
+)
 
-__all__ = ["embed_projective_point_in_finite_field"]
+__all__ = [
+    "PrimeFieldVectorSpace",
+    "ProjectivePoint",
+    "ProjectivePointSequence",
+    "embed_projective_point_in_finite_field",
+    "projective_point",
+]

--- a/src/jacobian/math/finite_geometry/_models.py
+++ b/src/jacobian/math/finite_geometry/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 from sympy import isprime
 
@@ -12,6 +12,7 @@ from jacobian._models import StrictModel
 
 MAX_DIM = 32
 MAX_FIELD_ORDER = 10000
+MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS = 65_536
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -224,13 +225,47 @@ class GrassmannianCountRequest(StrictModel):
 
 
 class ProjectiveSpaceEnumerateRequest(StrictModel):
-    space: PrimeFieldVectorSpace
+    """One finite projective space whose complete point list fits the envelope.
+
+    ``q`` is the prime field order and ``n`` is the length of its ordered
+    coordinate axis.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "One finite projective space whose complete point list fits the "
+                "enumeration envelope. It admits exactly q**n <= "
+                f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}, where q is the "
+                "prime field order and n is the length of its ordered coordinate "
+                "axis; this leaves at most "
+                f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} canonical "
+                "projective points to return."
+            )
+        }
+    )
+
+    space: PrimeFieldVectorSpace = Field(
+        description=(
+            "An ordered coordinate space over the prime field F_q. Complete "
+            "enumeration requires q**len(axis) <= "
+            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}; this bounds the "
+            "canonical point result to at most "
+            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} points."
+        )
+    )
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
-        if self.space.field_order ** len(self.space.axis) > 65536:
+        if (
+            self.space.field_order ** len(self.space.axis)
+            > MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS
+        ):
             raise _validation_error(
-                "projective_space_too_large", "projective space too large to enumerate"
+                "projective_space_too_large",
+                "projective space exceeds the "
+                f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}-vector "
+                "enumeration envelope",
             )
         return self
 

--- a/src/jacobian/math/finite_geometry/_models.py
+++ b/src/jacobian/math/finite_geometry/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unicodedata
 from typing import Self
 
 from pydantic import ConfigDict, Field, model_validator
@@ -240,9 +241,10 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
         Runs before execution on admitted mathematics alone. Each returned
         point is a bare coordinate array with at most ``n`` entries carrying
         at most ``len(str(q - 1))`` digits, so the exact worst-case point
-        array size follows from q and n; the parent space echoes once, and a
-        fixed constant covers keys, method string, count digits, and
-        punctuation.
+        array size follows from q and n; the parent space echoes once with
+        NFC-normalized labels, matching how canonical JSON serialization
+        normalizes string values before transport; and a fixed constant
+        covers keys, method string, count digits, and punctuation.
         """
 
         q = self.space.field_order
@@ -252,7 +254,10 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
         per_point_bytes = 2 + n * digit_width + (n - 1) + 1
         predicted = (
             _PROJECTIVE_ENUMERATION_ENVELOPE_BYTES
-            + sum(len(encode_strict_json(label)) for label in self.space.axis)
+            + sum(
+                len(encode_strict_json(unicodedata.normalize("NFC", label)))
+                for label in self.space.axis
+            )
             + point_count * per_point_bytes
         )
         if predicted > MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES:

--- a/src/jacobian/math/finite_geometry/_models.py
+++ b/src/jacobian/math/finite_geometry/_models.py
@@ -8,7 +8,9 @@ from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 from sympy import isprime
 
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
+from jacobian.canonical import format_canonical_integer
 
 MAX_DIM = 32
 MAX_FIELD_ORDER = 10000
@@ -406,7 +408,9 @@ class GrassmannianCountResult(StrictModel):
     field_order: int
     ambient_dimension: int
     subspace_dimension: int
-    count: int = Field(ge=1)
+    count: CanonicalInteger = Field(
+        description="Exact Gaussian-binomial count encoded as a canonical decimal integer."
+    )
     method: str = "GAUSSIAN_BINOMIAL"
 
     @model_validator(mode="after")
@@ -423,7 +427,7 @@ class GrassmannianCountResult(StrictModel):
         for index in range(self.subspace_dimension):
             numerator *= self.field_order ** (self.ambient_dimension - index) - 1
             denominator *= self.field_order ** (self.subspace_dimension - index) - 1
-        if self.count != numerator // denominator:
+        if self.count != format_canonical_integer(numerator // denominator):
             raise _validation_error(
                 "grassmannian_count_mismatch",
                 "count does not match its Gaussian-binomial parameters",

--- a/src/jacobian/math/finite_geometry/_models.py
+++ b/src/jacobian/math/finite_geometry/_models.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 from typing import Self
 
 from pydantic import ConfigDict, Field, model_validator
-from pydantic_core import PydanticCustomError
 from sympy import isprime
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import encode_strict_json, format_canonical_integer
+from jacobian.math.finite_geometry.values import (
+    MAX_DIM,
+    MAX_FIELD_ORDER,
+    PrimeFieldVectorSpace,
+    ProjectivePoint,
+    ProjectivePointSequence,
+    _validate_vector,
+    _validation_error,
+)
 
-MAX_DIM = 32
-MAX_FIELD_ORDER = 10000
 MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS = 65_536
 # Owner-local serialized-result budget for the complete enumeration reply,
 # kept below Jacobian's 10 MiB canonical transport limit. Admission predicts
@@ -27,83 +33,6 @@ MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES = 8 * 1024 * 1024
 # Conservative fixed overhead for result keys, the method string, the count
 # digits, enclosing braces, and array punctuation outside per-point entries.
 _PROJECTIVE_ENUMERATION_ENVELOPE_BYTES = 256
-
-
-def _validation_error(reason: str, message: str) -> PydanticCustomError:
-    """Build a stable validation error owned by finite-geometry contracts."""
-
-    return PydanticCustomError(f"finite_geometry.{reason}", message)
-
-
-class PrimeFieldVectorSpace(StrictModel):
-    """An ordered coordinate space over a named prime field."""
-
-    field_order: int = Field(ge=2, le=MAX_FIELD_ORDER)
-    axis: tuple[str, ...] = Field(min_length=1, max_length=MAX_DIM)
-
-    @model_validator(mode="after")
-    def require_valid(self) -> Self:
-        if not isprime(self.field_order):
-            raise _validation_error(
-                "field_order_not_prime", "field_order must be prime"
-            )
-        if any(not label or not label.isidentifier() for label in self.axis):
-            raise _validation_error(
-                "axis_labels_invalid", "axis labels must be nonempty identifiers"
-            )
-        if len(set(self.axis)) != len(self.axis):
-            raise _validation_error(
-                "axis_labels_not_unique", "axis labels must be unique"
-            )
-        return self
-
-
-def _validate_vector(vector: tuple[int, ...], space: PrimeFieldVectorSpace) -> None:
-    if len(vector) != len(space.axis):
-        raise _validation_error(
-            "vector_length_mismatch", "vector length must match the ambient axis"
-        )
-    if any(not 0 <= value < space.field_order for value in vector):
-        raise _validation_error(
-            "vector_entry_not_canonical",
-            "vector entries must be canonical field residues",
-        )
-
-
-def _require_projective_representative(
-    coordinates: tuple[int, ...], space: PrimeFieldVectorSpace
-) -> None:
-    """Require canonical projective coordinates inside ``space``.
-
-    Shared by the point value and enumeration results so both producers and
-    consumers accept one canonical representative shape: canonical residues
-    whose first nonzero entry is one.
-    """
-
-    _validate_vector(coordinates, space)
-    try:
-        first = next(value for value in coordinates if value != 0)
-    except StopIteration as exc:
-        raise _validation_error(
-            "projective_coordinates_zero", "projective coordinates must be nonzero"
-        ) from exc
-    if first != 1:
-        raise _validation_error(
-            "projective_coordinates_not_normalized",
-            "projective coordinates must have first nonzero entry one",
-        )
-
-
-class ProjectivePoint(StrictModel):
-    """A canonical point in a specific prime-field projective space."""
-
-    space: PrimeFieldVectorSpace
-    coordinates: tuple[int, ...]
-
-    @model_validator(mode="after")
-    def require_canonical(self) -> Self:
-        _require_projective_representative(self.coordinates, self.space)
-        return self
 
 
 class LinearSubspace(StrictModel):
@@ -267,11 +196,11 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
                 "prime field order and n is the length of its ordered coordinate "
                 "axis; this leaves at most "
                 f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} canonical "
-                "projective points, returned as bare coordinate tuples under "
-                "the declared parent space. Admission also predicts the "
-                "complete serialized result before execution and rejects any "
-                "request whose canonical output would exceed the "
-                f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte result "
+                "projective points, returned as a typed point sequence holding "
+                "the parent space once plus bare coordinate tuples. Admission "
+                "also predicts the complete serialized result before execution "
+                "and rejects any request whose canonical output would exceed "
+                f"the {MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte result "
                 "budget, so every accepted request returns its declared "
                 "result inside the canonical transport limit."
             )
@@ -285,7 +214,7 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
             f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS} plus a predicted "
             f"serialized result within the "
             f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte budget; the "
-            "canonical point list holds at most "
+            "canonical sequence holds at most "
             f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} bare coordinate "
             "tuples in this axis order."
         )
@@ -498,33 +427,13 @@ class GrassmannianCountResult(StrictModel):
 
 
 class ProjectiveSpaceEnumerateResult(StrictModel):
-    """The complete canonical point list of one finite projective space.
+    """The complete canonical point sequence of one finite projective space.
 
-    Points return as bare canonical coordinate tuples relative to the
-    declared parent ``space``, mirroring the domain's subspace values: the
-    parent appears once, so the reply stays compact for the whole envelope
-    instead of repeating space metadata per point.
+    The sequence value owns its declared parent space and self-certifies
+    completeness, normalization, and uniqueness; natively it iterates typed
+    :class:`ProjectivePoint` items while serializing as the parent space once
+    plus one bare coordinate tuple per point.
     """
 
-    space: PrimeFieldVectorSpace
-    points: tuple[tuple[int, ...], ...]
-    count: int = Field(ge=1)
+    sequence: ProjectivePointSequence
     method: str = "CANONICAL_REPRESENTATIVES"
-
-    @model_validator(mode="after")
-    def replay(self) -> Self:
-        expected = (self.space.field_order ** len(self.space.axis) - 1) // (
-            self.space.field_order - 1
-        )
-        if self.count != len(self.points) or self.count != expected:
-            raise _validation_error(
-                "enumeration_count_mismatch",
-                "projective point enumeration does not match its parent",
-            )
-        for coordinates in self.points:
-            _require_projective_representative(coordinates, self.space)
-        if len(set(self.points)) != len(self.points):
-            raise _validation_error(
-                "enumeration_points_not_unique", "projective points must be unique"
-            )
-        return self

--- a/src/jacobian/math/finite_geometry/_models.py
+++ b/src/jacobian/math/finite_geometry/_models.py
@@ -10,11 +10,23 @@ from sympy import isprime
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import encode_strict_json, format_canonical_integer
 
 MAX_DIM = 32
 MAX_FIELD_ORDER = 10000
 MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS = 65_536
+# Owner-local serialized-result budget for the complete enumeration reply,
+# kept below Jacobian's 10 MiB canonical transport limit. Admission predicts
+# the worst-case canonical bytes from mathematics alone: at most
+# (q**n - 1)/(q - 1) points, each encoded as a bare coordinate array whose
+# entries carry at most len(str(q - 1)) digits (canonical residues are < q),
+# plus the declared parent space echoed once and a fixed key/method header.
+# Every admitted request therefore returns its complete declared result
+# instead of failing transport validation only after enumeration.
+MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES = 8 * 1024 * 1024
+# Conservative fixed overhead for result keys, the method string, the count
+# digits, enclosing braces, and array punctuation outside per-point entries.
+_PROJECTIVE_ENUMERATION_ENVELOPE_BYTES = 256
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -58,6 +70,30 @@ def _validate_vector(vector: tuple[int, ...], space: PrimeFieldVectorSpace) -> N
         )
 
 
+def _require_projective_representative(
+    coordinates: tuple[int, ...], space: PrimeFieldVectorSpace
+) -> None:
+    """Require canonical projective coordinates inside ``space``.
+
+    Shared by the point value and enumeration results so both producers and
+    consumers accept one canonical representative shape: canonical residues
+    whose first nonzero entry is one.
+    """
+
+    _validate_vector(coordinates, space)
+    try:
+        first = next(value for value in coordinates if value != 0)
+    except StopIteration as exc:
+        raise _validation_error(
+            "projective_coordinates_zero", "projective coordinates must be nonzero"
+        ) from exc
+    if first != 1:
+        raise _validation_error(
+            "projective_coordinates_not_normalized",
+            "projective coordinates must have first nonzero entry one",
+        )
+
+
 class ProjectivePoint(StrictModel):
     """A canonical point in a specific prime-field projective space."""
 
@@ -66,18 +102,7 @@ class ProjectivePoint(StrictModel):
 
     @model_validator(mode="after")
     def require_canonical(self) -> Self:
-        _validate_vector(self.coordinates, self.space)
-        try:
-            first = next(value for value in self.coordinates if value != 0)
-        except StopIteration as exc:
-            raise _validation_error(
-                "projective_coordinates_zero", "projective coordinates must be nonzero"
-            ) from exc
-        if first != 1:
-            raise _validation_error(
-                "projective_coordinates_not_normalized",
-                "projective coordinates must have first nonzero entry one",
-            )
+        _require_projective_representative(self.coordinates, self.space)
         return self
 
 
@@ -236,13 +261,19 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
     model_config = ConfigDict(
         json_schema_extra={
             "description": (
-                "One finite projective space whose complete point list fits the "
-                "enumeration envelope. It admits exactly q**n <= "
+                "One finite projective space whose complete canonical point "
+                "list fits the transport envelope. It admits exactly q**n <= "
                 f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}, where q is the "
                 "prime field order and n is the length of its ordered coordinate "
                 "axis; this leaves at most "
                 f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} canonical "
-                "projective points to return."
+                "projective points, returned as bare coordinate tuples under "
+                "the declared parent space. Admission also predicts the "
+                "complete serialized result before execution and rejects any "
+                "request whose canonical output would exceed the "
+                f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte result "
+                "budget, so every accepted request returns its declared "
+                "result inside the canonical transport limit."
             )
         }
     )
@@ -251,25 +282,56 @@ class ProjectiveSpaceEnumerateRequest(StrictModel):
         description=(
             "An ordered coordinate space over the prime field F_q. Complete "
             "enumeration requires q**len(axis) <= "
-            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}; this bounds the "
-            "canonical point result to at most "
-            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} points."
+            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS} plus a predicted "
+            f"serialized result within the "
+            f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte budget; the "
+            "canonical point list holds at most "
+            f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1} bare coordinate "
+            "tuples in this axis order."
         )
     )
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
-        if (
-            self.space.field_order ** len(self.space.axis)
-            > MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS
-        ):
+        q = self.space.field_order
+        n = len(self.space.axis)
+        if q**n > MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS:
             raise _validation_error(
                 "projective_space_too_large",
                 "projective space exceeds the "
                 f"{MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}-vector "
                 "enumeration envelope",
             )
+        self.require_transportable_result()
         return self
+
+    def require_transportable_result(self) -> None:
+        """Reject requests whose complete canonical reply cannot fit transport.
+
+        Runs before execution on admitted mathematics alone. Each returned
+        point is a bare coordinate array with at most ``n`` entries carrying
+        at most ``len(str(q - 1))`` digits, so the exact worst-case point
+        array size follows from q and n; the parent space echoes once, and a
+        fixed constant covers keys, method string, count digits, and
+        punctuation.
+        """
+
+        q = self.space.field_order
+        n = len(self.space.axis)
+        digit_width = len(str(q - 1))
+        point_count = (q**n - 1) // (q - 1)
+        per_point_bytes = 2 + n * digit_width + (n - 1) + 1
+        predicted = (
+            _PROJECTIVE_ENUMERATION_ENVELOPE_BYTES
+            + sum(len(encode_strict_json(label)) for label in self.space.axis)
+            + point_count * per_point_bytes
+        )
+        if predicted > MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES:
+            raise _validation_error(
+                "projective_enumeration_result_too_large",
+                "the complete serialized point list would exceed the "
+                f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte result budget",
+            )
 
 
 class ProjectivePointCanonicalizeResult(ProjectivePointCanonicalizeRequest):
@@ -436,8 +498,16 @@ class GrassmannianCountResult(StrictModel):
 
 
 class ProjectiveSpaceEnumerateResult(StrictModel):
+    """The complete canonical point list of one finite projective space.
+
+    Points return as bare canonical coordinate tuples relative to the
+    declared parent ``space``, mirroring the domain's subspace values: the
+    parent appears once, so the reply stays compact for the whole envelope
+    instead of repeating space metadata per point.
+    """
+
     space: PrimeFieldVectorSpace
-    points: tuple[ProjectivePoint, ...]
+    points: tuple[tuple[int, ...], ...]
     count: int = Field(ge=1)
     method: str = "CANONICAL_REPRESENTATIVES"
 
@@ -451,12 +521,9 @@ class ProjectiveSpaceEnumerateResult(StrictModel):
                 "enumeration_count_mismatch",
                 "projective point enumeration does not match its parent",
             )
-        if any(point.space != self.space for point in self.points):
-            raise _validation_error(
-                "enumeration_parent_mismatch",
-                "every projective point must belong to the result space",
-            )
-        if len({point.coordinates for point in self.points}) != len(self.points):
+        for coordinates in self.points:
+            _require_projective_representative(coordinates, self.space)
+        if len(set(self.points)) != len(self.points):
             raise _validation_error(
                 "enumeration_points_not_unique", "projective points must be unique"
             )

--- a/src/jacobian/math/finite_geometry/_operations.py
+++ b/src/jacobian/math/finite_geometry/_operations.py
@@ -242,8 +242,6 @@ def compute_projective_space_enumerate(
 
     return ProjectiveSpaceEnumerateResult(
         space=request.space,
-        points=tuple(
-            ProjectivePoint(space=request.space, coordinates=point) for point in points
-        ),
+        points=tuple(points),
         count=len(points),
     )

--- a/src/jacobian/math/finite_geometry/_operations.py
+++ b/src/jacobian/math/finite_geometry/_operations.py
@@ -7,7 +7,6 @@ from jacobian.math.finite_geometry._models import (
     GrassmannianCountRequest,
     GrassmannianCountResult,
     LinearSubspace,
-    ProjectivePoint,
     ProjectivePointCanonicalizeRequest,
     ProjectivePointCanonicalizeResult,
     ProjectivePointEqualRequest,
@@ -22,6 +21,10 @@ from jacobian.math.finite_geometry._models import (
     SubspaceMembershipResult,
     SubspaceSpanRequest,
     SubspaceSpanResult,
+)
+from jacobian.math.finite_geometry.values import (
+    ProjectivePoint,
+    ProjectivePointSequence,
 )
 from jacobian.math.prime_field_linear_algebra import (
     PrimeFieldMatrix,
@@ -241,7 +244,7 @@ def compute_projective_space_enumerate(
                 break
 
     return ProjectiveSpaceEnumerateResult(
-        space=request.space,
-        points=tuple(points),
-        count=len(points),
+        sequence=ProjectivePointSequence(
+            space=request.space, coordinates=tuple(points)
+        ),
     )

--- a/src/jacobian/math/finite_geometry/_operations.py
+++ b/src/jacobian/math/finite_geometry/_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jacobian.canonical import format_canonical_integer
 from jacobian.math.finite_geometry._models import (
     GrassmannianCountRequest,
     GrassmannianCountResult,
@@ -211,7 +212,7 @@ def compute_grassmannian_count(
         field_order=q,
         ambient_dimension=n,
         subspace_dimension=k,
-        count=count,
+        count=format_canonical_integer(count),
     )
 
 

--- a/src/jacobian/math/finite_geometry/_tools.py
+++ b/src/jacobian/math/finite_geometry/_tools.py
@@ -229,7 +229,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "finite_geometry.projective_space.enumerate_points",
         "Enumerate all projective points of PG(d, q)",
         "Enumerate all canonical representatives of the projective space PG(d, "
-        "q) over a prime field, returning the list of canonical points.",
+        "q) over a prime field, returning every point as a bare canonical "
+        "coordinate tuple relative to the declared parent space.",
         ProjectiveSpaceEnumerateRequest,
         ProjectiveSpaceEnumerateResult,
         compute_projective_space_enumerate,

--- a/src/jacobian/math/finite_geometry/_tools.py
+++ b/src/jacobian/math/finite_geometry/_tools.py
@@ -229,8 +229,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "finite_geometry.projective_space.enumerate_points",
         "Enumerate all projective points of PG(d, q)",
         "Enumerate all canonical representatives of the projective space PG(d, "
-        "q) over a prime field, returning every point as a bare canonical "
-        "coordinate tuple relative to the declared parent space.",
+        "q) over a prime field as one typed point sequence that owns the "
+        "declared parent space and serializes each point as a bare canonical "
+        "coordinate tuple relative to it.",
         ProjectiveSpaceEnumerateRequest,
         ProjectiveSpaceEnumerateResult,
         compute_projective_space_enumerate,

--- a/src/jacobian/math/finite_geometry/conversions.py
+++ b/src/jacobian/math/finite_geometry/conversions.py
@@ -1,0 +1,52 @@
+"""Explicit maps from finite-geometry values into finite-field values."""
+
+from __future__ import annotations
+
+from jacobian.math.finite_fields import (
+    Axis,
+    FiniteFieldElement,
+    FiniteFieldPresentation,
+)
+from jacobian.math.finite_fields import (
+    ProjectivePoint as FiniteFieldProjectivePoint,
+)
+from jacobian.math.finite_geometry._models import ProjectivePoint
+
+
+def embed_projective_point_in_finite_field(
+    point: ProjectivePoint,
+    presentation: FiniteFieldPresentation,
+    axis: Axis,
+) -> FiniteFieldProjectivePoint:
+    """Embed a canonical point of ``PG(n, p)`` into a chosen extension field.
+
+    The target field and axis are explicit because this map changes the scalar
+    parent from ``F_p`` to the caller's chosen ``F_{p^d}``.  Coordinate labels
+    retain their source order, while the target ``Axis`` supplies the semantic
+    name required by finite-field linear-algebra values.
+    """
+
+    if presentation.characteristic != point.space.field_order:
+        raise ValueError(
+            "finite-field presentation characteristic must match the prime-field point"
+        )
+    if axis.labels != point.space.axis:
+        raise ValueError(
+            "finite-field axis labels must match the prime-field point axis"
+        )
+
+    zero_tail = (0,) * (presentation.degree - 1)
+    return FiniteFieldProjectivePoint(
+        presentation=presentation,
+        axis=axis,
+        coordinates=tuple(
+            FiniteFieldElement(
+                presentation=presentation,
+                coordinates=(coordinate, *zero_tail),
+            )
+            for coordinate in point.coordinates
+        ),
+    )
+
+
+__all__ = ["embed_projective_point_in_finite_field"]

--- a/src/jacobian/math/finite_geometry/conversions.py
+++ b/src/jacobian/math/finite_geometry/conversions.py
@@ -10,7 +10,7 @@ from jacobian.math.finite_fields import (
 from jacobian.math.finite_fields import (
     ProjectivePoint as FiniteFieldProjectivePoint,
 )
-from jacobian.math.finite_geometry._models import ProjectivePoint
+from jacobian.math.finite_geometry.values import ProjectivePoint
 
 
 def embed_projective_point_in_finite_field(

--- a/src/jacobian/math/finite_geometry/operations.py
+++ b/src/jacobian/math/finite_geometry/operations.py
@@ -1,0 +1,33 @@
+"""Public native constructors over finite-geometry canonical values."""
+
+from __future__ import annotations
+
+from jacobian.math.finite_geometry.values import (
+    PrimeFieldVectorSpace,
+    ProjectivePoint,
+    _validate_vector,
+)
+
+
+def projective_point(
+    space: PrimeFieldVectorSpace, vector: tuple[int, ...]
+) -> ProjectivePoint:
+    """Canonicalize one nonzero finite-field vector into its point.
+
+    The vector must hold canonical field residues of ``space``; scaling its
+    first nonzero entry to one returns the canonical projective
+    representative bound to ``space``.
+    """
+
+    _validate_vector(vector, space)
+    scale = next((value for value in vector if value != 0), None)
+    if scale is None:
+        raise ValueError("zero vector has no projective point")
+    inverse = pow(scale, -1, space.field_order)
+    return ProjectivePoint(
+        space=space,
+        coordinates=tuple(value * inverse % space.field_order for value in vector),
+    )
+
+
+__all__ = ["projective_point"]

--- a/src/jacobian/math/finite_geometry/values.py
+++ b/src/jacobian/math/finite_geometry/values.py
@@ -130,14 +130,19 @@ class ProjectivePointSequence(StrictModel):
     def __len__(self) -> int:
         return len(self.coordinates)
 
-    @property
-    def points(self) -> Iterator[ProjectivePoint]:
-        """Iterate the sequence as typed parent-bound projective points."""
+    def __iter__(self) -> Iterator[ProjectivePoint]:
+        """Iterate as typed projective points bound to ``space``."""
 
         return (
             ProjectivePoint(space=self.space, coordinates=coordinates)
             for coordinates in self.coordinates
         )
+
+    @property
+    def points(self) -> Iterator[ProjectivePoint]:
+        """Iterate the sequence as typed parent-bound projective points."""
+
+        return iter(self)
 
 
 __all__ = [

--- a/src/jacobian/math/finite_geometry/values.py
+++ b/src/jacobian/math/finite_geometry/values.py
@@ -1,0 +1,149 @@
+"""Canonical mathematical values for bounded exact finite geometry."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+from sympy import isprime
+
+from jacobian._models import StrictModel
+
+MAX_DIM = 32
+MAX_FIELD_ORDER = 10000
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    """Build a stable validation error owned by finite-geometry contracts."""
+
+    return PydanticCustomError(f"finite_geometry.{reason}", message)
+
+
+class PrimeFieldVectorSpace(StrictModel):
+    """An ordered coordinate space over a named prime field."""
+
+    field_order: int = Field(ge=2, le=MAX_FIELD_ORDER)
+    axis: tuple[str, ...] = Field(min_length=1, max_length=MAX_DIM)
+
+    @model_validator(mode="after")
+    def require_valid(self) -> Self:
+        if not isprime(self.field_order):
+            raise _validation_error(
+                "field_order_not_prime", "field_order must be prime"
+            )
+        if any(not label or not label.isidentifier() for label in self.axis):
+            raise _validation_error(
+                "axis_labels_invalid", "axis labels must be nonempty identifiers"
+            )
+        if len(set(self.axis)) != len(self.axis):
+            raise _validation_error(
+                "axis_labels_not_unique", "axis labels must be unique"
+            )
+        return self
+
+
+def _validate_vector(vector: tuple[int, ...], space: PrimeFieldVectorSpace) -> None:
+    if len(vector) != len(space.axis):
+        raise _validation_error(
+            "vector_length_mismatch", "vector length must match the ambient axis"
+        )
+    if any(not 0 <= value < space.field_order for value in vector):
+        raise _validation_error(
+            "vector_entry_not_canonical",
+            "vector entries must be canonical field residues",
+        )
+
+
+def _require_projective_representative(
+    coordinates: tuple[int, ...], space: PrimeFieldVectorSpace
+) -> None:
+    """Require canonical projective coordinates inside ``space``.
+
+    Shared by the point value, point sequences, and enumeration results so
+    producers and consumers accept one canonical representative shape:
+    canonical residues whose first nonzero entry is one.
+    """
+
+    _validate_vector(coordinates, space)
+    try:
+        first = next(value for value in coordinates if value != 0)
+    except StopIteration as exc:
+        raise _validation_error(
+            "projective_coordinates_zero", "projective coordinates must be nonzero"
+        ) from exc
+    if first != 1:
+        raise _validation_error(
+            "projective_coordinates_not_normalized",
+            "projective coordinates must have first nonzero entry one",
+        )
+
+
+class ProjectivePoint(StrictModel):
+    """A canonical point in a specific prime-field projective space."""
+
+    space: PrimeFieldVectorSpace
+    coordinates: tuple[int, ...]
+
+    @model_validator(mode="after")
+    def require_canonical(self) -> Self:
+        _require_projective_representative(self.coordinates, self.space)
+        return self
+
+
+class ProjectivePointSequence(StrictModel):
+    """The complete ordered canonical point list of one projective space.
+
+    Native iteration yields typed :class:`ProjectivePoint` items bound to the
+    declared parent space, so producers compose directly into consumers such
+    as ``embed_projective_point_in_finite_field`` without reconstruction.
+    Serialization stores the parent space once and each point as a bare
+    canonical coordinate tuple, so complete enumerations stay compact enough
+    for the transport envelope instead of repeating parent metadata per
+    point.
+    """
+
+    space: PrimeFieldVectorSpace
+    coordinates: tuple[tuple[int, ...], ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_complete_and_canonical(self) -> Self:
+        q = self.space.field_order
+        n = len(self.space.axis)
+        expected = (q**n - 1) // (q - 1)
+        if len(self.coordinates) != expected:
+            raise _validation_error(
+                "point_sequence_count_mismatch",
+                "a projective point sequence must list every point of its "
+                "declared parent space exactly once",
+            )
+        for coordinates in self.coordinates:
+            _require_projective_representative(coordinates, self.space)
+        if len(set(self.coordinates)) != len(self.coordinates):
+            raise _validation_error(
+                "point_sequence_points_not_unique",
+                "projective points must be unique",
+            )
+        return self
+
+    def __len__(self) -> int:
+        return len(self.coordinates)
+
+    @property
+    def points(self) -> Iterator[ProjectivePoint]:
+        """Iterate the sequence as typed parent-bound projective points."""
+
+        return (
+            ProjectivePoint(space=self.space, coordinates=coordinates)
+            for coordinates in self.coordinates
+        )
+
+
+__all__ = [
+    "MAX_DIM",
+    "MAX_FIELD_ORDER",
+    "PrimeFieldVectorSpace",
+    "ProjectivePoint",
+    "ProjectivePointSequence",
+]

--- a/src/jacobian/math/finite_geometry/values.py
+++ b/src/jacobian/math/finite_geometry/values.py
@@ -130,8 +130,13 @@ class ProjectivePointSequence(StrictModel):
     def __len__(self) -> int:
         return len(self.coordinates)
 
-    def __iter__(self) -> Iterator[ProjectivePoint]:
-        """Iterate as typed projective points bound to ``space``."""
+    def __iter__(self) -> Iterator[ProjectivePoint]:  # type: ignore[override]
+        """Iterate as typed projective points bound to ``space``.
+
+        Pydantic's ``BaseModel.__iter__`` yields ``(field, value)`` pairs;
+        this canonical value intentionally iterates its mathematical items
+        instead.
+        """
 
         return (
             ProjectivePoint(space=self.space, coordinates=coordinates)

--- a/tests/dispatch/test_finite_geometry_dispatch.py
+++ b/tests/dispatch/test_finite_geometry_dispatch.py
@@ -4,18 +4,22 @@ import pytest
 from jsonschema.validators import Draft202012Validator
 from pydantic import ValidationError
 
+from jacobian.canonical import CanonicalLimits, canonicalize_json
 from jacobian.catalog.catalog import Catalog
-from jacobian.dispatch import invoke_operation, parse_operation_input
+from jacobian.dispatch import (
+    OperationRequestValidationError,
+    invoke_operation,
+    parse_operation_input,
+)
 from jacobian.math.finite_geometry._models import (
+    MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES,
     MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
     GrassmannianCountRequest,
 )
 from jacobian.math.finite_geometry._operations import compute_grassmannian_count
 
 
-def test_grassmannian_count_past_json_integer_range_round_trips_through_dispatch() -> (
-    None
-):
+def test_dispatch_round_trips_an_exact_count_past_the_json_integer_range() -> None:
     """A lawful exact count past 2^53 survives canonical request transport."""
 
     last_safe_slice = compute_grassmannian_count(
@@ -63,6 +67,10 @@ def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
         f"q**len(axis) <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}"
         in space_description
     )
+    assert (
+        f"{MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES}-byte result budget" in description
+    )
+    assert "bare coordinate tuples" in description
 
     validator = Draft202012Validator(schema)
     accepted = {"space": {"field_order": 2, "axis": ["x", "y"]}}
@@ -83,4 +91,44 @@ def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
     assert (
         exc_info.value.errors()[0]["type"]
         == "finite_geometry.projective_space_too_large"
+    )
+
+
+def test_dispatch_returns_maximal_enumeration_within_transport_limit() -> None:
+    """The admitted-envelope-maximal request returns its complete declared
+    result: q=2 with 16 axis labels yields all 65,535 projective points of
+    PG(15, F_2), and the compact bare-coordinate-tuple reply serializes well
+    inside the canonical transport limit instead of failing only after
+    enumeration."""
+    payload = {"space": {"field_order": 2, "axis": [f"x{i}" for i in range(16)]}}
+
+    result = invoke_operation(
+        "finite_geometry.projective_space.enumerate_points", payload, Catalog.open()
+    )
+
+    assert result.output["count"] == MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1
+    assert len(result.output["points"]) == result.output["count"]
+    assert result.output["points"][0] == [0] * 15 + [1]
+    encoded = len(canonicalize_json(result.output))
+    assert encoded <= CanonicalLimits().max_output_bytes
+    assert encoded < MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES
+
+
+def test_dispatch_rejects_untransportable_enumeration_as_invalid_request() -> None:
+    """A request whose predicted serialized result exceeds the owner-local
+    budget fails admission before execution as a typed invalid request --
+    never as a post-enumeration host exception."""
+    payload = {
+        "space": {"field_order": 2, "axis": ["x", "y" * (9 * 1024 * 1024)]},
+    }
+
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation(
+            "finite_geometry.projective_space.enumerate_points",
+            payload,
+            Catalog.open(),
+        )
+    assert (
+        exc_info.value.errors()[0]["type"]
+        == "finite_geometry.projective_enumeration_result_too_large"
     )

--- a/tests/dispatch/test_finite_geometry_dispatch.py
+++ b/tests/dispatch/test_finite_geometry_dispatch.py
@@ -1,0 +1,86 @@
+"""Dispatch boundary for the finite geometry operations."""
+
+import pytest
+from jsonschema.validators import Draft202012Validator
+from pydantic import ValidationError
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation, parse_operation_input
+from jacobian.math.finite_geometry._models import (
+    MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
+    GrassmannianCountRequest,
+)
+from jacobian.math.finite_geometry._operations import compute_grassmannian_count
+
+
+def test_grassmannian_count_past_json_integer_range_round_trips_through_dispatch() -> (
+    None
+):
+    """A lawful exact count past 2^53 survives canonical request transport."""
+
+    last_safe_slice = compute_grassmannian_count(
+        GrassmannianCountRequest(
+            field_order=2,
+            ambient_dimension=14,
+            subspace_dimension=7,
+        )
+    )
+    assert int(last_safe_slice.count) <= (1 << 53) - 1
+
+    payload = {
+        "field_order": 2,
+        "ambient_dimension": 15,
+        "subspace_dimension": 7,
+    }
+    request = parse_operation_input(GrassmannianCountRequest, payload)
+    assert request == GrassmannianCountRequest.model_validate_json(
+        request.model_dump_json()
+    )
+
+    result = invoke_operation(
+        "finite_geometry.grassmannian.count", payload, Catalog.open()
+    )
+    assert result.output["count"] == "246614610741341843"
+    assert int(result.output["count"]) > (1 << 53) - 1
+    assert type(result).model_validate_json(result.model_dump_json()) == result
+
+    descriptor = Catalog.open().inspect("finite_geometry.grassmannian.count")
+    assert descriptor is not None
+    assert descriptor.output_schema["properties"]["count"]["type"] == "string"
+
+
+def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
+    operation = Catalog.open().operation(
+        "finite_geometry.projective_space.enumerate_points"
+    )
+    assert operation is not None
+
+    schema = operation.request_type.model_json_schema()
+    description = schema["description"]
+    space_description = schema["properties"]["space"]["description"]
+    assert f"q**n <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}" in description
+    assert (
+        f"q**len(axis) <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}"
+        in space_description
+    )
+
+    validator = Draft202012Validator(schema)
+    accepted = {"space": {"field_order": 2, "axis": ["x", "y"]}}
+    assert not list(validator.iter_errors(accepted))
+    assert (
+        invoke_operation(operation.operation_id, accepted, Catalog.open()).output[
+            "count"
+        ]
+        == 3
+    )
+
+    structurally_valid_but_too_large = {
+        "space": {"field_order": 257, "axis": ["x", "y"]}
+    }
+    assert not list(validator.iter_errors(structurally_valid_but_too_large))
+    with pytest.raises(ValidationError) as exc_info:
+        operation.request_type.model_validate(structurally_valid_but_too_large)
+    assert (
+        exc_info.value.errors()[0]["type"]
+        == "finite_geometry.projective_space_too_large"
+    )

--- a/tests/dispatch/test_finite_geometry_dispatch.py
+++ b/tests/dispatch/test_finite_geometry_dispatch.py
@@ -75,12 +75,8 @@ def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
     validator = Draft202012Validator(schema)
     accepted = {"space": {"field_order": 2, "axis": ["x", "y"]}}
     assert not list(validator.iter_errors(accepted))
-    assert (
-        invoke_operation(operation.operation_id, accepted, Catalog.open()).output[
-            "count"
-        ]
-        == 3
-    )
+    output = invoke_operation(operation.operation_id, accepted, Catalog.open()).output
+    assert output["sequence"]["coordinates"] == [[0, 1], [1, 0], [1, 1]]
 
     structurally_valid_but_too_large = {
         "space": {"field_order": 257, "axis": ["x", "y"]}
@@ -97,18 +93,18 @@ def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
 def test_dispatch_returns_maximal_enumeration_within_transport_limit() -> None:
     """The admitted-envelope-maximal request returns its complete declared
     result: q=2 with 16 axis labels yields all 65,535 projective points of
-    PG(15, F_2), and the compact bare-coordinate-tuple reply serializes well
-    inside the canonical transport limit instead of failing only after
-    enumeration."""
+    PG(15, F_2), and the typed sequence reply -- the parent space once plus
+    bare coordinate tuples -- serializes well inside the canonical transport
+    limit instead of failing only after enumeration."""
     payload = {"space": {"field_order": 2, "axis": [f"x{i}" for i in range(16)]}}
 
     result = invoke_operation(
         "finite_geometry.projective_space.enumerate_points", payload, Catalog.open()
     )
 
-    assert result.output["count"] == MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1
-    assert len(result.output["points"]) == result.output["count"]
-    assert result.output["points"][0] == [0] * 15 + [1]
+    coordinates = result.output["sequence"]["coordinates"]
+    assert len(coordinates) == MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS - 1
+    assert coordinates[0] == [0] * 15 + [1]
     encoded = len(canonicalize_json(result.output))
     assert encoded <= CanonicalLimits().max_output_bytes
     assert encoded < MAX_PROJECTIVE_ENUMERATION_RESULT_BYTES

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -1,11 +1,8 @@
 """Tests for finite geometry operations."""
 
 import pytest
-from jsonschema.validators import Draft202012Validator
 from pydantic import ValidationError
 
-from jacobian.catalog.catalog import Catalog
-from jacobian.dispatch import invoke_operation, parse_operation_input
 from jacobian.math import finite_geometry
 from jacobian.math.finite_fields import (
     Axis,
@@ -16,7 +13,6 @@ from jacobian.math.finite_fields import (
     restrict_scalars,
 )
 from jacobian.math.finite_geometry._models import (
-    MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
     GrassmannianCountRequest,
     LinearSubspace,
     PrimeFieldVectorSpace,
@@ -273,42 +269,6 @@ def test_grassmannian_count_planes_in_f2_4() -> None:
     assert result.count == "35"
 
 
-def test_grassmannian_count_past_json_integer_range_round_trips_through_dispatch() -> (
-    None
-):
-    """A lawful exact count past 2^53 survives canonical request transport."""
-
-    last_safe_slice = compute_grassmannian_count(
-        GrassmannianCountRequest(
-            field_order=2,
-            ambient_dimension=14,
-            subspace_dimension=7,
-        )
-    )
-    assert int(last_safe_slice.count) <= (1 << 53) - 1
-
-    payload = {
-        "field_order": 2,
-        "ambient_dimension": 15,
-        "subspace_dimension": 7,
-    }
-    request = parse_operation_input(GrassmannianCountRequest, payload)
-    assert request == GrassmannianCountRequest.model_validate_json(
-        request.model_dump_json()
-    )
-
-    result = invoke_operation(
-        "finite_geometry.grassmannian.count", payload, Catalog.open()
-    )
-    assert result.output["count"] == "246614610741341843"
-    assert int(result.output["count"]) > (1 << 53) - 1
-    assert type(result).model_validate_json(result.model_dump_json()) == result
-
-    descriptor = Catalog.open().inspect("finite_geometry.grassmannian.count")
-    assert descriptor is not None
-    assert descriptor.output_schema["properties"]["count"]["type"] == "string"
-
-
 def test_projective_space_enumerate_pg1_f2() -> None:
     request = ProjectiveSpaceEnumerateRequest(
         space={"field_order": 2, "axis": ("x", "y")}
@@ -316,43 +276,6 @@ def test_projective_space_enumerate_pg1_f2() -> None:
     result = compute_projective_space_enumerate(request)
     assert result.count == 3
     assert len(result.points) == 3
-
-
-def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
-    operation = Catalog.open().operation(
-        "finite_geometry.projective_space.enumerate_points"
-    )
-    assert operation is not None
-
-    schema = operation.request_type.model_json_schema()
-    description = schema["description"]
-    space_description = schema["properties"]["space"]["description"]
-    assert f"q**n <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}" in description
-    assert (
-        f"q**len(axis) <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}"
-        in space_description
-    )
-
-    validator = Draft202012Validator(schema)
-    accepted = {"space": {"field_order": 2, "axis": ["x", "y"]}}
-    assert not list(validator.iter_errors(accepted))
-    assert (
-        invoke_operation(operation.operation_id, accepted, Catalog.open()).output[
-            "count"
-        ]
-        == 3
-    )
-
-    structurally_valid_but_too_large = {
-        "space": {"field_order": 257, "axis": ["x", "y"]}
-    }
-    assert not list(validator.iter_errors(structurally_valid_but_too_large))
-    with pytest.raises(ValidationError) as exc_info:
-        operation.request_type.model_validate(structurally_valid_but_too_large)
-    assert (
-        exc_info.value.errors()[0]["type"]
-        == "finite_geometry.projective_space_too_large"
-    )
 
 
 def test_request_rejects_nonprime_field() -> None:

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -19,6 +19,7 @@ from jacobian.math.finite_geometry._models import (
     ProjectivePointCanonicalizeRequest,
     ProjectivePointEqualRequest,
     ProjectiveSpaceEnumerateRequest,
+    ProjectiveSpaceEnumerateResult,
     SubspaceComputeRequest,
     SubspaceIntersectionRequest,
     SubspaceMembershipRequest,
@@ -269,13 +270,59 @@ def test_grassmannian_count_planes_in_f2_4() -> None:
     assert result.count == "35"
 
 
+def test_grassmannian_count_exact_past_json_integer_range() -> None:
+    """The exact Gaussian-binomial value stays a canonical decimal string."""
+
+    result = compute_grassmannian_count(
+        GrassmannianCountRequest(
+            field_order=2,
+            ambient_dimension=15,
+            subspace_dimension=7,
+        )
+    )
+    assert result.count == "246614610741341843"
+    assert int(result.count) > (1 << 53) - 1
+
+
 def test_projective_space_enumerate_pg1_f2() -> None:
     request = ProjectiveSpaceEnumerateRequest(
         space={"field_order": 2, "axis": ("x", "y")}
     )
     result = compute_projective_space_enumerate(request)
     assert result.count == 3
-    assert len(result.points) == 3
+    assert result.points == ((0, 1), (1, 0), (1, 1))
+
+
+def test_enumerate_admission_rejects_results_beyond_the_transport_budget() -> None:
+    """A pathological axis label cannot smuggle an untransportable complete
+    result past admission: the serialized-result bound fires before any
+    enumeration runs."""
+    with pytest.raises(ValidationError) as error:
+        ProjectiveSpaceEnumerateRequest(
+            space={"field_order": 2, "axis": ("x", "y" * (9 * 1024 * 1024))}
+        )
+    assert (
+        error.value.errors()[0]["type"]
+        == "finite_geometry.projective_enumeration_result_too_large"
+    )
+
+
+def test_enumeration_replay_rejects_unnormalized_representatives() -> None:
+    """Bare coordinate tuples stay bound to the canonical representative
+    invariant of the declared parent space."""
+    result = compute_projective_space_enumerate(
+        ProjectiveSpaceEnumerateRequest(space={"field_order": 3, "axis": ("x", "y")})
+    )
+    assert result.points == ((0, 1), (1, 0), (1, 1), (1, 2))
+
+    payload = result.model_dump()
+    payload["points"] = ((2, 1), *payload["points"][1:])
+    with pytest.raises(ValidationError) as error:
+        ProjectiveSpaceEnumerateResult.model_validate(payload)
+    assert (
+        error.value.errors()[0]["type"]
+        == "finite_geometry.projective_coordinates_not_normalized"
+    )
 
 
 def test_request_rejects_nonprime_field() -> None:

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -1,9 +1,13 @@
 """Tests for finite geometry operations."""
 
 import pytest
+from jsonschema.validators import Draft202012Validator
 from pydantic import ValidationError
 
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
 from jacobian.math.finite_geometry._models import (
+    MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
     GrassmannianCountRequest,
     LinearSubspace,
     PrimeFieldVectorSpace,
@@ -190,6 +194,43 @@ def test_projective_space_enumerate_pg1_f2() -> None:
     result = compute_projective_space_enumerate(request)
     assert result.count == 3
     assert len(result.points) == 3
+
+
+def test_projective_space_schema_publishes_coupled_enumeration_bound() -> None:
+    operation = Catalog.open().operation(
+        "finite_geometry.projective_space.enumerate_points"
+    )
+    assert operation is not None
+
+    schema = operation.request_type.model_json_schema()
+    description = schema["description"]
+    space_description = schema["properties"]["space"]["description"]
+    assert f"q**n <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}" in description
+    assert (
+        f"q**len(axis) <= {MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS}"
+        in space_description
+    )
+
+    validator = Draft202012Validator(schema)
+    accepted = {"space": {"field_order": 2, "axis": ["x", "y"]}}
+    assert not list(validator.iter_errors(accepted))
+    assert (
+        invoke_operation(operation.operation_id, accepted, Catalog.open()).output[
+            "count"
+        ]
+        == 3
+    )
+
+    structurally_valid_but_too_large = {
+        "space": {"field_order": 257, "axis": ["x", "y"]}
+    }
+    assert not list(validator.iter_errors(structurally_valid_but_too_large))
+    with pytest.raises(ValidationError) as exc_info:
+        operation.request_type.model_validate(structurally_valid_but_too_large)
+    assert (
+        exc_info.value.errors()[0]["type"]
+        == "finite_geometry.projective_space_too_large"
+    )
 
 
 def test_request_rejects_nonprime_field() -> None:

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -15,7 +15,6 @@ from jacobian.math.finite_fields import (
 from jacobian.math.finite_geometry._models import (
     GrassmannianCountRequest,
     LinearSubspace,
-    PrimeFieldVectorSpace,
     ProjectivePointCanonicalizeRequest,
     ProjectivePointEqualRequest,
     ProjectiveSpaceEnumerateRequest,
@@ -36,9 +35,6 @@ from jacobian.math.finite_geometry._operations import (
     compute_subspace_span,
 )
 from jacobian.math.finite_geometry._tools import TOOLS
-from jacobian.math.finite_geometry.conversions import (
-    embed_projective_point_in_finite_field,
-)
 
 
 def test_catalog_contains_only_audited_operations() -> None:
@@ -104,7 +100,7 @@ def test_projective_point_embeds_into_finite_field_restrict_scalars() -> None:
     presentation = finite_field(2, (1, 1, 1))
     row_axis = Axis(name="coordinate directions", labels=("x", "y"))
 
-    direction = embed_projective_point_in_finite_field(
+    direction = finite_geometry.embed_projective_point_in_finite_field(
         geometry_point,
         presentation,
         row_axis,
@@ -145,26 +141,70 @@ def test_projective_point_embedding_requires_explicit_compatible_target() -> Non
     target = finite_field(2, (1, 1, 1))
 
     with pytest.raises(ValueError, match="axis labels"):
-        embed_projective_point_in_finite_field(
+        finite_geometry.embed_projective_point_in_finite_field(
             point,
             target,
             Axis(name="different coordinates", labels=("y", "x")),
         )
 
     with pytest.raises(ValueError, match="characteristic"):
-        embed_projective_point_in_finite_field(
+        finite_geometry.embed_projective_point_in_finite_field(
             point,
             finite_field(3, (1, 0, 1)),
             Axis(name="coordinate directions", labels=("x", "y")),
         )
 
 
-def test_finite_geometry_public_api_exposes_only_the_explicit_conversion() -> None:
-    assert finite_geometry.__all__ == ["embed_projective_point_in_finite_field"]
-    assert (
-        finite_geometry.embed_projective_point_in_finite_field
-        is embed_projective_point_in_finite_field
+def test_public_api_constructs_and_embeds_without_private_imports() -> None:
+    """The documented surface constructs the conversion's source value."""
+    assert finite_geometry.__all__ == [
+        "PrimeFieldVectorSpace",
+        "ProjectivePoint",
+        "ProjectivePointSequence",
+        "embed_projective_point_in_finite_field",
+        "projective_point",
+    ]
+
+    space = finite_geometry.PrimeFieldVectorSpace(field_order=2, axis=("x", "y"))
+    point = finite_geometry.projective_point(space, (1, 1))
+    assert isinstance(point, finite_geometry.ProjectivePoint)
+    assert point.coordinates == (1, 1)
+
+    direction = finite_geometry.embed_projective_point_in_finite_field(
+        point,
+        finite_field(2, (1, 1, 1)),
+        Axis(name="coordinate directions", labels=("x", "y")),
     )
+    assert tuple(value.coordinates for value in direction.coordinates) == (
+        (1, 0),
+        (1, 0),
+    )
+
+
+def test_enumeration_sequence_composes_into_embeddings_directly() -> None:
+    """Enumerated points compose into the consumer as typed values, without
+    manual reconstruction from coordinate tuples and a parent space."""
+    result = compute_projective_space_enumerate(
+        ProjectiveSpaceEnumerateRequest(space={"field_order": 2, "axis": ("x", "y")})
+    )
+
+    presentation = finite_field(2, (1, 1, 1))
+    row_axis = Axis(name="coordinate directions", labels=("x", "y"))
+    directions = [
+        finite_geometry.embed_projective_point_in_finite_field(
+            point, presentation, row_axis
+        )
+        for point in result.sequence.points
+    ]
+
+    assert [tuple(v.coordinates for v in d.coordinates) for d in directions] == [
+        ((0, 0), (1, 0)),
+        ((1, 0), (0, 0)),
+        ((1, 0), (1, 0)),
+    ]
+    for point in result.sequence.points:
+        assert isinstance(point, finite_geometry.ProjectivePoint)
+        assert point.space.axis == ("x", "y")
 
 
 def test_subspace_compute_basic() -> None:
@@ -289,8 +329,27 @@ def test_projective_space_enumerate_pg1_f2() -> None:
         space={"field_order": 2, "axis": ("x", "y")}
     )
     result = compute_projective_space_enumerate(request)
-    assert result.count == 3
-    assert result.points == ((0, 1), (1, 0), (1, 1))
+    assert len(result.sequence) == 3
+    assert result.sequence.coordinates == ((0, 1), (1, 0), (1, 1))
+    assert [point.coordinates for point in result.sequence.points] == [
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    ]
+
+
+def test_enumeration_wire_form_stays_compact_and_typed_natively() -> None:
+    """The wire form stores the parent space once plus bare coordinate
+    tuples, while native iteration yields parent-bound typed points."""
+    result = compute_projective_space_enumerate(
+        ProjectiveSpaceEnumerateRequest(space={"field_order": 3, "axis": ("x", "y")})
+    )
+
+    wire = result.model_dump(mode="json")
+    assert set(wire) == {"sequence", "method"}
+    assert set(wire["sequence"]) == {"space", "coordinates"}
+    assert wire["sequence"]["coordinates"] == [[0, 1], [1, 0], [1, 1], [1, 2]]
+    assert type(result).model_validate_json(result.model_dump_json()) == result
 
 
 def test_enumerate_admission_rejects_results_beyond_the_transport_budget() -> None:
@@ -308,20 +367,48 @@ def test_enumerate_admission_rejects_results_beyond_the_transport_budget() -> No
 
 
 def test_enumeration_replay_rejects_unnormalized_representatives() -> None:
-    """Bare coordinate tuples stay bound to the canonical representative
+    """Sequence coordinates stay bound to the canonical representative
     invariant of the declared parent space."""
     result = compute_projective_space_enumerate(
         ProjectiveSpaceEnumerateRequest(space={"field_order": 3, "axis": ("x", "y")})
     )
-    assert result.points == ((0, 1), (1, 0), (1, 1), (1, 2))
+    assert result.sequence.coordinates == ((0, 1), (1, 0), (1, 1), (1, 2))
 
     payload = result.model_dump()
-    payload["points"] = ((2, 1), *payload["points"][1:])
+    payload["sequence"]["coordinates"] = (
+        (2, 1),
+        *payload["sequence"]["coordinates"][1:],
+    )
     with pytest.raises(ValidationError) as error:
         ProjectiveSpaceEnumerateResult.model_validate(payload)
     assert (
         error.value.errors()[0]["type"]
         == "finite_geometry.projective_coordinates_not_normalized"
+    )
+
+
+def test_enumeration_sequence_replay_rejects_duplicates_and_wrong_counts() -> None:
+    """The sequence value itself certifies uniqueness and completeness."""
+    result = compute_projective_space_enumerate(
+        ProjectiveSpaceEnumerateRequest(space={"field_order": 2, "axis": ("x", "y")})
+    )
+
+    payload = result.model_dump()
+    payload["sequence"]["coordinates"] = ((0, 1), (0, 1), (1, 0))
+    with pytest.raises(ValidationError) as error:
+        ProjectiveSpaceEnumerateResult.model_validate(payload)
+    assert (
+        error.value.errors()[0]["type"]
+        == "finite_geometry.point_sequence_points_not_unique"
+    )
+
+    payload = result.model_dump()
+    payload["sequence"]["coordinates"] = ((0, 1), (1, 0))
+    with pytest.raises(ValidationError) as error:
+        ProjectiveSpaceEnumerateResult.model_validate(payload)
+    assert (
+        error.value.errors()[0]["type"]
+        == "finite_geometry.point_sequence_count_mismatch"
     )
 
 
@@ -334,7 +421,7 @@ def test_request_rejects_nonprime_field() -> None:
 
 
 def test_canonical_values_compose_and_reject_different_parents() -> None:
-    space = PrimeFieldVectorSpace(field_order=3, axis=("x", "y"))
+    space = finite_geometry.PrimeFieldVectorSpace(field_order=3, axis=("x", "y"))
     computed = compute_subspace_compute(
         SubspaceComputeRequest(space=space, vectors=((1, 0),))
     ).subspace

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -366,6 +366,23 @@ def test_enumerate_admission_rejects_results_beyond_the_transport_budget() -> No
     )
 
 
+def test_enumerate_admission_estimates_normalized_label_encoding() -> None:
+    """The serialized-result bound measures NFC-normalized labels.
+
+    Canonical JSON normalizes string values, so combining-character
+    spellings can double in encoded length after normalization; a label
+    that fits the budget only before normalization must still be rejected
+    before any enumeration runs.
+    """
+    label = "x" + "\u0344" * (2_600_000)
+    with pytest.raises(ValidationError) as error:
+        ProjectiveSpaceEnumerateRequest(space={"field_order": 2, "axis": ("x", label)})
+    assert (
+        error.value.errors()[0]["type"]
+        == "finite_geometry.projective_enumeration_result_too_large"
+    )
+
+
 def test_enumeration_replay_rejects_unnormalized_representatives() -> None:
     """Sequence coordinates stay bound to the canonical representative
     invariant of the declared parent space."""

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -5,7 +5,7 @@ from jsonschema.validators import Draft202012Validator
 from pydantic import ValidationError
 
 from jacobian.catalog.catalog import Catalog
-from jacobian.dispatch import invoke_operation
+from jacobian.dispatch import invoke_operation, parse_operation_input
 from jacobian.math.finite_geometry._models import (
     MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
     GrassmannianCountRequest,
@@ -176,7 +176,7 @@ def test_grassmannian_count_lines_in_pg_2_2() -> None:
         field_order=2, ambient_dimension=3, subspace_dimension=1
     )
     result = compute_grassmannian_count(request)
-    assert result.count == 7
+    assert result.count == "7"
 
 
 def test_grassmannian_count_planes_in_f2_4() -> None:
@@ -184,7 +184,43 @@ def test_grassmannian_count_planes_in_f2_4() -> None:
         field_order=2, ambient_dimension=4, subspace_dimension=2
     )
     result = compute_grassmannian_count(request)
-    assert result.count == 35
+    assert result.count == "35"
+
+
+def test_grassmannian_count_past_json_integer_range_round_trips_through_dispatch() -> (
+    None
+):
+    """A lawful exact count past 2^53 survives canonical request transport."""
+
+    last_safe_slice = compute_grassmannian_count(
+        GrassmannianCountRequest(
+            field_order=2,
+            ambient_dimension=14,
+            subspace_dimension=7,
+        )
+    )
+    assert int(last_safe_slice.count) <= (1 << 53) - 1
+
+    payload = {
+        "field_order": 2,
+        "ambient_dimension": 15,
+        "subspace_dimension": 7,
+    }
+    request = parse_operation_input(GrassmannianCountRequest, payload)
+    assert request == GrassmannianCountRequest.model_validate_json(
+        request.model_dump_json()
+    )
+
+    result = invoke_operation(
+        "finite_geometry.grassmannian.count", payload, Catalog.open()
+    )
+    assert result.output["count"] == "246614610741341843"
+    assert int(result.output["count"]) > (1 << 53) - 1
+    assert type(result).model_validate_json(result.model_dump_json()) == result
+
+    descriptor = Catalog.open().inspect("finite_geometry.grassmannian.count")
+    assert descriptor is not None
+    assert descriptor.output_schema["properties"]["count"]["type"] == "string"
 
 
 def test_projective_space_enumerate_pg1_f2() -> None:
@@ -296,7 +332,7 @@ def test_source_bound_results_reject_forged_values() -> None:
         )
     )
     payload = count.model_dump()
-    payload["count"] = 8
+    payload["count"] = "8"
     with pytest.raises(ValidationError) as error:
         type(count).model_validate(payload)
     assert (

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -6,6 +6,15 @@ from pydantic import ValidationError
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import invoke_operation, parse_operation_input
+from jacobian.math import finite_geometry
+from jacobian.math.finite_fields import (
+    Axis,
+    AxisBoundMatrix,
+    FiniteDimensionalSubspace,
+    element,
+    finite_field,
+    restrict_scalars,
+)
 from jacobian.math.finite_geometry._models import (
     MAX_PROJECTIVE_SPACE_ENUMERATION_VECTORS,
     GrassmannianCountRequest,
@@ -30,6 +39,9 @@ from jacobian.math.finite_geometry._operations import (
     compute_subspace_span,
 )
 from jacobian.math.finite_geometry._tools import TOOLS
+from jacobian.math.finite_geometry.conversions import (
+    embed_projective_point_in_finite_field,
+)
 
 
 def test_catalog_contains_only_audited_operations() -> None:
@@ -82,6 +94,80 @@ def test_projective_point_equal_different_points() -> None:
     )
     result = compute_projective_point_equal(request)
     assert result.equal is False
+
+
+@pytest.mark.requires_backend("flint")
+def test_projective_point_embeds_into_finite_field_restrict_scalars() -> None:
+    """A finite-geometry producer composes through an explicit field extension."""
+    geometry_point = compute_projective_point_canonicalize(
+        ProjectivePointCanonicalizeRequest(
+            space={"field_order": 2, "axis": ("x", "y")}, vector=(1, 1)
+        )
+    ).point
+    presentation = finite_field(2, (1, 1, 1))
+    row_axis = Axis(name="coordinate directions", labels=("x", "y"))
+
+    direction = embed_projective_point_in_finite_field(
+        geometry_point,
+        presentation,
+        row_axis,
+    )
+    one = element(presentation, (1, 0))
+    zero = element(presentation, (0, 0))
+    subspace = FiniteDimensionalSubspace(
+        presentation=presentation,
+        basis_axis=Axis(name="matrix basis", labels=("B",)),
+        basis=(
+            AxisBoundMatrix(
+                presentation=presentation,
+                row_axis=row_axis,
+                column_axis=Axis(name="target", labels=("c",)),
+                entries=((one,), (zero,)),
+            ),
+        ),
+    )
+
+    restricted = restrict_scalars(subspace, direction)
+
+    assert tuple(value.coordinates for value in direction.coordinates) == (
+        (1, 0),
+        (1, 0),
+    )
+    assert restricted.matrix.entries == ((1,), (0,))
+    assert (
+        type(direction).model_validate(direction.model_dump(mode="json")) == direction
+    )
+
+
+def test_projective_point_embedding_requires_explicit_compatible_target() -> None:
+    point = compute_projective_point_canonicalize(
+        ProjectivePointCanonicalizeRequest(
+            space={"field_order": 2, "axis": ("x", "y")}, vector=(1, 1)
+        )
+    ).point
+    target = finite_field(2, (1, 1, 1))
+
+    with pytest.raises(ValueError, match="axis labels"):
+        embed_projective_point_in_finite_field(
+            point,
+            target,
+            Axis(name="different coordinates", labels=("y", "x")),
+        )
+
+    with pytest.raises(ValueError, match="characteristic"):
+        embed_projective_point_in_finite_field(
+            point,
+            finite_field(3, (1, 0, 1)),
+            Axis(name="coordinate directions", labels=("x", "y")),
+        )
+
+
+def test_finite_geometry_public_api_exposes_only_the_explicit_conversion() -> None:
+    assert finite_geometry.__all__ == ["embed_projective_point_in_finite_field"]
+    assert (
+        finite_geometry.embed_projective_point_in_finite_field
+        is embed_projective_point_in_finite_field
+    )
 
 
 def test_subspace_compute_basic() -> None:

--- a/tests/math/finite_geometry/test_finite_geometry.py
+++ b/tests/math/finite_geometry/test_finite_geometry.py
@@ -194,7 +194,7 @@ def test_enumeration_sequence_composes_into_embeddings_directly() -> None:
         finite_geometry.embed_projective_point_in_finite_field(
             point, presentation, row_axis
         )
-        for point in result.sequence.points
+        for point in result.sequence
     ]
 
     assert [tuple(v.coordinates for v in d.coordinates) for d in directions] == [
@@ -202,7 +202,7 @@ def test_enumeration_sequence_composes_into_embeddings_directly() -> None:
         ((1, 0), (0, 0)),
         ((1, 0), (1, 0)),
     ]
-    for point in result.sequence.points:
+    for point in result.sequence:
         assert isinstance(point, finite_geometry.ProjectivePoint)
         assert point.space.axis == ("x", "y")
 


### PR DESCRIPTION
Fixes #2531.
Refs #2581 and #2583.

## Problem

Finite-geometry enumeration enforced a hidden literal cap, Grassmannian counts crossed the JSON boundary as host integers, and projective points had no explicit map into the finite-field value family. That left caller-visible schema guidance incomplete and required consumers to reconstruct equivalent values themselves.

## Solution

Publish the named projective-space enumeration envelope in the request schema and derive validation from the same constant. Encode exact Grassmannian counts as canonical decimal integers so their public representation remains transportable. Add an explicit, checked embedding from prime-field projective points to a caller-selected finite-field presentation and axis; the target parent change is intentional rather than implicit.

## Testing

- `make test-focused LANE=math TESTS="tests/math/finite_geometry tests/math/finite_fields"` — 56 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 41 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch` — 45 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 611 passed
- `git diff --check` — passed

## Public contract impact

`GrassmannianCountResult.count` is now a canonical decimal integer string. Projective-space enumeration publishes its actual `q**n` envelope. Native callers gain `embed_projective_point_in_finite_field`, which requires an explicit compatible target presentation and axis.

## Operation boundary ownership

- Changed stage: request parsing and bounds, result construction, and transport projection
- Request-bounds owner and controlling quantities: finite-geometry projective-space enumeration; `q**len(axis)` is bounded by the named vector envelope
- Backend or kernel path: unchanged exact finite-field arithmetic
- Result construction: Gaussian-binomial counts use canonical decimal encoding
- Independent-result verifier: existing Grassmannian replay remains bounded by the request domain
- Native/MCP parity: the same typed finite-geometry values and admission apply before transport; the new native map has an explicit target parent
- Serialized-result and round-trip evidence: finite-geometry owner and dispatch coverage include the canonical count representation

## Canonical value audit

- [x] Existing canonical values searched
- [x] Intentional finite-field embedding documented
- [x] Producer→consumer composition tested

## Checklist

- [ ] `make check` passes (not run; focused owner, catalog, dispatch, and integration checks passed)
- [x] Runtime-bound change names its request-bounds owner
- [x] Public contract change includes schema-to-run and serialized-boundary coverage