### PR TITLE
Share canonical modular-polynomial term values

### DIFF
--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -28,6 +28,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.modular_polynomials import _INTEGER as _TERM_INTEGER
 from jacobian.math.modular_polynomials import (
     ModularPolynomialTerm as _ModularPolynomialTerm,
 )
@@ -537,19 +538,24 @@ class ModularPolynomialVariable(StrictModel):
 def _residue_image_term_schema() -> JsonSchemaValue:
     """Project the shared term schema onto residue-image admission.
 
-    ``ModularPolynomialTerm`` publishes the widest consumer envelope: a
-    coefficient of a sign plus 256 digits and up to 20 exponents of
-    magnitude 256. Residue-image admission rejects any coefficient string
+    ``ModularPolynomialTerm`` publishes the widest consumer envelope: any
+    canonical-integer string of a sign plus 256 digits and up to 20 exponents
+    of magnitude 256. Residue-image admission rejects any coefficient string
     longer than ``_MAX_INTEGER_LENGTH`` characters, exponent magnitudes
     above ``_MAX_RESIDUE_EXPONENT``, and — because every exponent vector
     must match at most ``_MAX_RESIDUE_VARIABLES`` variables — vectors longer
     than six entries. Discovery publishes exactly that narrower envelope so
     schema-driven callers never submit a term the request validator rejects.
-    Validation itself stays with the shared runtime type.
+    The coefficient pattern is the shared type's own canonical-integer
+    grammar — the same compiled pattern its ``field_validator`` enforces —
+    so the published grammar cannot drift from runtime parsing. Validation
+    itself stays with the shared runtime type.
     """
 
     schema = _ModularPolynomialTerm.model_json_schema()
-    schema["properties"]["coefficient"]["maxLength"] = _MAX_INTEGER_LENGTH
+    coefficient = schema["properties"]["coefficient"]
+    coefficient["maxLength"] = _MAX_INTEGER_LENGTH
+    coefficient["pattern"] = _TERM_INTEGER.pattern
     exponents = schema["properties"]["exponents"]
     exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
     exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
@@ -963,6 +969,34 @@ class QuadraticResiduesResult(StrictModel):
     residues: tuple[BoundedInteger, ...]
 
 
+def _residue_image_normalized_term_schema() -> JsonSchemaValue:
+    """Project the shared normalized term schema onto residue-image results.
+
+    ``NormalizedModularPolynomialTerm`` publishes the widest consumer
+    envelope: up to 20 exponent entries of arbitrary magnitude.
+    ``_validate_residue_image_shape`` rejects every normalized term whose
+    exponent vector differs from ``variable_order`` — itself capped at
+    ``_MAX_RESIDUE_VARIABLES`` entries — or carries an exponent outside
+    0..``_MAX_RESIDUE_EXPONENT``. Discovery publishes exactly that shape so
+    both residue-image operations advertise only results their declared
+    model can produce or parse. Validation itself stays with the shared
+    runtime type.
+    """
+
+    schema = _NormalizedModularPolynomialTerm.model_json_schema()
+    exponents = schema["properties"]["exponents"]
+    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
+    exponents["items"]["minimum"] = 0
+    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
+    return schema
+
+
+ResidueImageNormalizedPolynomialTerm = Annotated[
+    _NormalizedModularPolynomialTerm,
+    WithJsonSchema(_residue_image_normalized_term_schema()),
+]
+
+
 class ModularPolynomialResidueCount(StrictModel):
     """Multiplicity of one reachable residue in the declared assignment table."""
 
@@ -996,7 +1030,7 @@ class ModularPolynomialResidueImageResult(StrictModel):
         min_length=1,
         max_length=_MAX_RESIDUE_VARIABLES,
     )
-    normalized_terms: tuple[_NormalizedModularPolynomialTerm, ...] = Field(
+    normalized_terms: tuple[ResidueImageNormalizedPolynomialTerm, ...] = Field(
         min_length=0,
         max_length=_MAX_RESIDUE_TERMS,
     )

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -16,7 +16,15 @@ from collections import Counter
 from itertools import product
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StringConstraints,
+    WithJsonSchema,
+    model_validator,
+)
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -526,6 +534,34 @@ class ModularPolynomialVariable(StrictModel):
         return self
 
 
+def _residue_image_term_schema() -> JsonSchemaValue:
+    """Project the shared term schema onto residue-image admission.
+
+    ``ModularPolynomialTerm`` publishes the widest consumer envelope: a
+    coefficient of a sign plus 256 digits and up to 20 exponents of
+    magnitude 256. Residue-image admission rejects any coefficient string
+    longer than ``_MAX_INTEGER_LENGTH`` characters, exponent magnitudes
+    above ``_MAX_RESIDUE_EXPONENT``, and — because every exponent vector
+    must match at most ``_MAX_RESIDUE_VARIABLES`` variables — vectors longer
+    than six entries. Discovery publishes exactly that narrower envelope so
+    schema-driven callers never submit a term the request validator rejects.
+    Validation itself stays with the shared runtime type.
+    """
+
+    schema = _ModularPolynomialTerm.model_json_schema()
+    schema["properties"]["coefficient"]["maxLength"] = _MAX_INTEGER_LENGTH
+    exponents = schema["properties"]["exponents"]
+    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
+    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
+    return schema
+
+
+ResidueImagePolynomialTerm = Annotated[
+    _ModularPolynomialTerm,
+    WithJsonSchema(_residue_image_term_schema()),
+]
+
+
 class ModularPolynomialResidueImageRequest(StrictModel):
     """A bounded sparse polynomial over declared finite residue domains."""
 
@@ -534,7 +570,7 @@ class ModularPolynomialResidueImageRequest(StrictModel):
         min_length=1,
         max_length=_MAX_RESIDUE_VARIABLES,
     )
-    terms: tuple[_ModularPolynomialTerm, ...] = Field(
+    terms: tuple[ResidueImagePolynomialTerm, ...] = Field(
         min_length=0,
         max_length=_MAX_RESIDUE_TERMS,
     )

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -20,6 +20,12 @@ from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_vali
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.modular_polynomials import (
+    ModularPolynomialTerm as _ModularPolynomialTerm,
+)
+from jacobian.math.modular_polynomials import (
+    NormalizedModularPolynomialTerm as _NormalizedModularPolynomialTerm,
+)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -520,28 +526,6 @@ class ModularPolynomialVariable(StrictModel):
         return self
 
 
-class ModularPolynomialTerm(StrictModel):
-    """One nonzero sparse integer-polynomial term in canonical exponent order."""
-
-    coefficient: BoundedInteger
-    exponents: tuple[StrictInt, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_VARIABLES,
-    )
-
-    @model_validator(mode="after")
-    def require_nonnegative_exponents(self) -> Self:
-        if any(
-            exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
-            for exponent in self.exponents
-        ):
-            raise _validation_error(
-                "f_term_exponents_must_be_between_0_and",
-                f"term exponents must be between 0 and {_MAX_RESIDUE_EXPONENT}",
-            )
-        return self
-
-
 class ModularPolynomialResidueImageRequest(StrictModel):
     """A bounded sparse polynomial over declared finite residue domains."""
 
@@ -550,7 +534,7 @@ class ModularPolynomialResidueImageRequest(StrictModel):
         min_length=1,
         max_length=_MAX_RESIDUE_VARIABLES,
     )
-    terms: tuple[ModularPolynomialTerm, ...] = Field(
+    terms: tuple[_ModularPolynomialTerm, ...] = Field(
         min_length=0,
         max_length=_MAX_RESIDUE_TERMS,
     )
@@ -584,6 +568,18 @@ class ModularPolynomialResidueImageRequest(StrictModel):
             raise _validation_error(
                 "every_term_exponent_vector_must_match_the_variable_count",
                 "every term exponent vector must match the variable count",
+            )
+        if any(
+            len(term.coefficient) > _MAX_INTEGER_LENGTH
+            or any(
+                exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
+                for exponent in term.exponents
+            )
+            for term in self.terms
+        ):
+            raise _validation_error(
+                "term_outside_residue_image_admission",
+                "term coefficient or exponents exceed the residue-image admission",
             )
         exponent_vectors = [term.exponents for term in self.terms]
         if exponent_vectors != sorted(set(exponent_vectors)):
@@ -931,16 +927,6 @@ class QuadraticResiduesResult(StrictModel):
     residues: tuple[BoundedInteger, ...]
 
 
-class NormalizedModularPolynomialTerm(StrictModel):
-    """One sparse term with its coefficient reduced to the canonical residue."""
-
-    coefficient: StrictInt = Field(ge=1, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
-    exponents: tuple[StrictInt, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_VARIABLES,
-    )
-
-
 class ModularPolynomialResidueCount(StrictModel):
     """Multiplicity of one reachable residue in the declared assignment table."""
 
@@ -974,7 +960,7 @@ class ModularPolynomialResidueImageResult(StrictModel):
         min_length=1,
         max_length=_MAX_RESIDUE_VARIABLES,
     )
-    normalized_terms: tuple[NormalizedModularPolynomialTerm, ...] = Field(
+    normalized_terms: tuple[_NormalizedModularPolynomialTerm, ...] = Field(
         min_length=0,
         max_length=_MAX_RESIDUE_TERMS,
     )
@@ -1007,7 +993,7 @@ class ModularPolynomialResidueImageResult(StrictModel):
 
 
 def _evaluate_normalized_modular_polynomial(
-    terms: tuple[NormalizedModularPolynomialTerm, ...],
+    terms: tuple[_NormalizedModularPolynomialTerm, ...],
     assignment: tuple[int, ...],
     modulus: int,
 ) -> int:

--- a/src/jacobian/math/number_theory/_modular_operations.py
+++ b/src/jacobian/math/number_theory/_modular_operations.py
@@ -7,6 +7,7 @@ from itertools import product
 from typing import Literal, cast
 
 from jacobian.math.arithmetic.values import IntegerValue
+from jacobian.math.modular_polynomials import NormalizedModularPolynomialTerm
 from jacobian.math.number_theory._models import (
     ChineseRemainderRequest,
     ChineseRemainderResult,
@@ -19,7 +20,6 @@ from jacobian.math.number_theory._models import (
     ModularPolynomialResidueWitness,
     ModularUnitRequest,
     ModulusRequest,
-    NormalizedModularPolynomialTerm,
     QuadraticResiduesResult,
 )
 

--- a/tests/math/number_theory/test_modular_polynomial_values.py
+++ b/tests/math/number_theory/test_modular_polynomial_values.py
@@ -25,6 +25,16 @@ def _request(*, exponent: int = 1) -> ModularPolynomialResidueImageRequest:
     )
 
 
+def _request_with_coefficient(
+    coefficient: str,
+) -> ModularPolynomialResidueImageRequest:
+    return ModularPolynomialResidueImageRequest(
+        modulus=5,
+        variables=(ModularPolynomialVariable(name="x", residues=(0, 1)),),
+        terms=(ModularPolynomialTerm(coefficient=coefficient, exponents=(1,)),),
+    )
+
+
 def test_residue_image_consumes_and_produces_the_canonical_term_types() -> None:
     request = _request()
 
@@ -52,3 +62,38 @@ def test_residue_image_consumes_and_produces_the_canonical_term_types() -> None:
 def test_residue_image_keeps_its_narrower_exponent_admission() -> None:
     with expect_validation("number_theory.term_outside_residue_image_admission"):
         _request(exponent=33)
+
+
+def test_published_term_schema_matches_residue_image_admission() -> None:
+    term_schema = ModularPolynomialResidueImageRequest.model_json_schema()[
+        "properties"
+    ]["terms"]["items"]
+
+    assert term_schema["properties"]["coefficient"]["maxLength"] == 256
+    assert term_schema["properties"]["exponents"]["maxItems"] == 6
+    assert term_schema["properties"]["exponents"]["items"]["maximum"] == 32
+
+    shared_schema = ModularPolynomialTerm.model_json_schema()
+    assert shared_schema["properties"]["coefficient"]["maxLength"] == 257
+    assert shared_schema["properties"]["exponents"]["maxItems"] == 20
+
+
+def test_coefficient_boundary_follows_the_advertised_envelope() -> None:
+    admitted = _request_with_coefficient("-" + "9" * 255)
+    assert int(admitted.terms[0].coefficient) < 0
+
+    with expect_validation("number_theory.term_outside_residue_image_admission"):
+        _request_with_coefficient("-" + "9" * 256)
+
+
+def test_shared_term_type_retains_its_wider_envelope_elsewhere() -> None:
+    widest = "-" + "9" * 256
+    identity = modular_polynomial_identity(
+        ModularPolynomialIdentityRequest(
+            modulus=5,
+            variables=("x",),
+            left=(ModularPolynomialTerm(coefficient=widest, exponents=(1,)),),
+        )
+    )
+
+    assert identity.normalized_left[0].coefficient == int(widest) % 5

--- a/tests/math/number_theory/test_modular_polynomial_values.py
+++ b/tests/math/number_theory/test_modular_polynomial_values.py
@@ -1,8 +1,15 @@
 """Composition checks for sparse modular-polynomial values."""
 
+import copy
+import re
+
+import pytest
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
 from tests.math.number_theory._validation import expect_validation
 
 from jacobian.math.modular_polynomials import (
+    _INTEGER,
     ModularPolynomialIdentityRequest,
     ModularPolynomialTerm,
     NormalizedModularPolynomialTerm,
@@ -10,9 +17,11 @@ from jacobian.math.modular_polynomials import (
 )
 from jacobian.math.number_theory._models import (
     ModularPolynomialResidueImageRequest,
+    ModularPolynomialResidueImageResult,
     ModularPolynomialVariable,
 )
 from jacobian.math.number_theory._modular_operations import (
+    compute_modular_polynomial_residue_assignments,
     compute_modular_polynomial_residue_image,
 )
 
@@ -33,6 +42,14 @@ def _request_with_coefficient(
         variables=(ModularPolynomialVariable(name="x", residues=(0, 1)),),
         terms=(ModularPolynomialTerm(coefficient=coefficient, exponents=(1,)),),
     )
+
+
+def _request_payload(coefficient: str) -> dict[str, object]:
+    return {
+        "modulus": 5,
+        "variables": [{"name": "x", "residues": [0, 1]}],
+        "terms": [{"coefficient": coefficient, "exponents": [1]}],
+    }
 
 
 def test_residue_image_consumes_and_produces_the_canonical_term_types() -> None:
@@ -68,14 +85,108 @@ def test_published_term_schema_matches_residue_image_admission() -> None:
     term_schema = ModularPolynomialResidueImageRequest.model_json_schema()[
         "properties"
     ]["terms"]["items"]
+    coefficient_schema = term_schema["properties"]["coefficient"]
 
-    assert term_schema["properties"]["coefficient"]["maxLength"] == 256
+    assert coefficient_schema["maxLength"] == 256
+    assert coefficient_schema["pattern"] == _INTEGER.pattern
     assert term_schema["properties"]["exponents"]["maxItems"] == 6
     assert term_schema["properties"]["exponents"]["items"]["maximum"] == 32
 
     shared_schema = ModularPolynomialTerm.model_json_schema()
     assert shared_schema["properties"]["coefficient"]["maxLength"] == 257
+    assert "pattern" not in shared_schema["properties"]["coefficient"]
     assert shared_schema["properties"]["exponents"]["maxItems"] == 20
+
+
+def test_published_input_schema_rejects_non_canonical_coefficients() -> None:
+    request_schema = ModularPolynomialResidueImageRequest.model_json_schema()
+    validator = Draft202012Validator(request_schema)
+
+    pattern = request_schema["properties"]["terms"]["items"]["properties"][
+        "coefficient"
+    ]["pattern"]
+    assert re.search(pattern, "abc") is None
+    assert re.fullmatch(pattern, "-" + "9" * 255)
+    assert re.fullmatch(pattern, "0")
+
+    assert list(validator.iter_errors(_request_payload("abc")))
+    assert not list(validator.iter_errors(_request_payload("-" + "9" * 255)))
+    assert not list(validator.iter_errors(_request_payload("3")))
+
+
+def test_published_result_schema_matches_residue_image_output_scope() -> None:
+    term_items = ModularPolynomialResidueImageResult.model_json_schema()["properties"][
+        "normalized_terms"
+    ]["items"]
+    exponents_schema = term_items["properties"]["exponents"]
+
+    assert exponents_schema["maxItems"] == 6
+    assert exponents_schema["items"]["minimum"] == 0
+    assert exponents_schema["items"]["maximum"] == 32
+
+    shared_schema = NormalizedModularPolynomialTerm.model_json_schema()
+    assert shared_schema["properties"]["exponents"]["maxItems"] == 20
+    assert "minimum" not in shared_schema["properties"]["exponents"]["items"]
+    assert "maximum" not in shared_schema["properties"]["exponents"]["items"]
+
+
+def test_both_residue_image_operations_advertise_the_restored_bounds() -> None:
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+
+    residue_image_tools = [
+        tool
+        for tool in BUILTIN_TOOLS
+        if tool.operation_id.startswith("modular.polynomial_residue_image.")
+    ]
+    assert len(residue_image_tools) == 2
+
+    for tool in residue_image_tools:
+        exponents_schema = tool.result_type.model_json_schema()["properties"][
+            "normalized_terms"
+        ]["items"]["properties"]["exponents"]
+        assert exponents_schema["maxItems"] == 6
+        assert exponents_schema["items"]["minimum"] == 0
+        assert exponents_schema["items"]["maximum"] == 32
+
+
+def test_emitted_results_parse_under_their_advertised_output_schema() -> None:
+    request = _request()
+    validator = Draft202012Validator(
+        ModularPolynomialResidueImageResult.model_json_schema()
+    )
+
+    documents = [
+        operation.model_dump(mode="json")
+        for operation in (
+            compute_modular_polynomial_residue_image(request),
+            compute_modular_polynomial_residue_assignments(request),
+        )
+    ]
+    for document in documents:
+        assert not list(validator.iter_errors(document))
+
+    widened = copy.deepcopy(documents[0])
+    widened["normalized_terms"][0]["exponents"] = [1] * 7
+    assert list(validator.iter_errors(widened))
+    with pytest.raises(ValidationError):
+        ModularPolynomialResidueImageResult.model_validate(widened)
+
+    inflated = copy.deepcopy(documents[0])
+    inflated["normalized_terms"][0]["exponents"] = [33]
+    assert list(validator.iter_errors(inflated))
+
+
+def test_shared_normalized_term_type_retains_its_wider_envelope_elsewhere() -> None:
+    wide_vector = (0, 0, 0, 0, 0, 0, 1)
+    identity = modular_polynomial_identity(
+        ModularPolynomialIdentityRequest(
+            modulus=5,
+            variables=("a", "b", "c", "d", "e", "f", "g"),
+            left=(ModularPolynomialTerm(coefficient="1", exponents=wide_vector),),
+        )
+    )
+
+    assert identity.normalized_left[0].exponents == wide_vector
 
 
 def test_coefficient_boundary_follows_the_advertised_envelope() -> None:

--- a/tests/math/number_theory/test_modular_polynomial_values.py
+++ b/tests/math/number_theory/test_modular_polynomial_values.py
@@ -1,0 +1,54 @@
+"""Composition checks for sparse modular-polynomial values."""
+
+from tests.math.number_theory._validation import expect_validation
+
+from jacobian.math.modular_polynomials import (
+    ModularPolynomialIdentityRequest,
+    ModularPolynomialTerm,
+    NormalizedModularPolynomialTerm,
+    modular_polynomial_identity,
+)
+from jacobian.math.number_theory._models import (
+    ModularPolynomialResidueImageRequest,
+    ModularPolynomialVariable,
+)
+from jacobian.math.number_theory._modular_operations import (
+    compute_modular_polynomial_residue_image,
+)
+
+
+def _request(*, exponent: int = 1) -> ModularPolynomialResidueImageRequest:
+    return ModularPolynomialResidueImageRequest(
+        modulus=5,
+        variables=(ModularPolynomialVariable(name="x", residues=(0, 1)),),
+        terms=(ModularPolynomialTerm(coefficient="3", exponents=(exponent,)),),
+    )
+
+
+def test_residue_image_consumes_and_produces_the_canonical_term_types() -> None:
+    request = _request()
+
+    assert type(request.terms[0]) is ModularPolynomialTerm
+    assert request.model_dump(mode="json")["terms"] == [
+        {"coefficient": "3", "exponents": [1]}
+    ]
+
+    identity = modular_polynomial_identity(
+        ModularPolynomialIdentityRequest(
+            modulus=5,
+            variables=("x",),
+            left=request.terms,
+        )
+    )
+    result = compute_modular_polynomial_residue_image(request)
+
+    assert type(result.normalized_terms[0]) is NormalizedModularPolynomialTerm
+    assert identity.normalized_left == result.normalized_terms
+    assert result.model_dump(mode="json")["normalized_terms"] == [
+        {"coefficient": 3, "exponents": [1]}
+    ]
+
+
+def test_residue_image_keeps_its_narrower_exponent_admission() -> None:
+    with expect_validation("number_theory.term_outside_residue_image_admission"):
+        _request(exponent=33)


### PR DESCRIPTION
Fixes #2526.

## Problem

The modular-polynomial identity and number-theory residue-image families defined separate raw and normalized sparse-term models despite carrying the same mathematical values. Native callers therefore had to serialize and revalidate a term when composing the two operations.

## Solution

Use the canonical modular-polynomial term types in the number-theory residue-image request, kernel, and result models. The number-theory request continues to enforce its own tighter coefficient and exponent admission before execution. The wire representation and operation IDs are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/number_theory` — 213 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Number-theory residue-image models now consume and return shared canonical term values. Their JSON representation and operation contracts are unchanged.

## Operation boundary ownership

- Changed stage: request parsing and result construction
- Request-bounds owner and controlling quantities: `ModularPolynomialResidueImageRequest`; its variable, term, coefficient, and exponent bounds remain local to number theory
- Backend or kernel path: number-theory modular residue-image kernel
- Result construction: canonical normalized modular-polynomial terms
- Independent-result verifier: none
- Native/MCP parity: unchanged semantic operation path; no MCP projection change
- Serialized-result and round-trip evidence: `tests/math/number_theory/test_modular_polynomial_values.py`

## Canonical value audit

- [x] Existing canonical values searched
- [x] Owner documented by reuse of `jacobian.math.modular_polynomials`
- [x] Producer-to-consumer serialization tested

## Checklist

- [ ] `make check` passes (not run; the owning math lane passed)