### PR TITLE
Share the canonical finite-integer-set value

### DIFF
--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -25,6 +25,7 @@ from jacobian.math.additive_combinatorics.values import (
     IndexedIntegerSequence,
     indexed_sequence_item_ceiling,
 )
+from jacobian.math.finite_sets._models import FiniteIntegerSet
 
 # This conservative materialized-axis cap bounds source parsing and binomial
 # preflight. Operation-specific work and result bounds impose the sharper
@@ -336,20 +337,6 @@ def _check_first_collision(
         )
 
 
-class FiniteIntegerSet(StrictModel):
-    """One finite set of canonical integers, possibly empty."""
-
-    elements: tuple[CanonicalInteger, ...] = Field(max_length=_MAX_SET_SIZE)
-
-    @model_validator(mode="after")
-    def require_unique_elements(self) -> Self:
-        if len(set(self.elements)) != len(self.elements):
-            raise _validation_error(
-                "require_unique_elements", "finite set elements must be unique"
-            )
-        return self
-
-
 def _require_bounded_cartesian_product(
     left: FiniteIntegerSet,
     right: FiniteIntegerSet,
@@ -493,8 +480,8 @@ def _multiset_sum_source_values(source: FiniteIntegerSet) -> tuple[int, ...]:
 
 
 _MULTISET_SUM_SOURCE_DESCRIPTION = (
-    f"A materialized finite set of at most {_MAX_SET_SIZE} distinct canonical "
-    "integers in strictly increasing numeric order; each element carries at "
+    "A materialized finite set of distinct canonical integers in strictly "
+    "increasing numeric order; each element carries at "
     f"most {_MAX_MULTISET_SUM_ELEMENT_DIGITS} digits."
 )
 

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -14,9 +14,29 @@ from jacobian.math.additive_combinatorics._operations import (
     compute_sumset_cardinality,
     decide_direct_sum_predicate,
 )
+from jacobian.math.finite_sets._models import (
+    FiniteIntegerSet as CanonicalFiniteIntegerSet,
+)
 
 
 class TestRepresentationProfile:
+    def test_finite_set_value_is_shared_with_the_finite_sets_owner(self):
+        value = CanonicalFiniteIntegerSet(elements=("1", "2"))
+
+        assert FiniteIntegerSet is CanonicalFiniteIntegerSet
+        request = RepresentationProfileRequest(left=value, right=value)
+        assert request.left is value
+        assert request.right is value
+
+        serialized_request = RepresentationProfileRequest.model_validate(
+            {
+                "left": value.model_dump(mode="json"),
+                "right": value.model_dump(mode="json"),
+            }
+        )
+        assert serialized_request.left == value
+        assert serialized_request.right == value
+
     def test_two_by_two(self):
         req = RepresentationProfileRequest(
             left=FiniteIntegerSet(elements=("1", "2")),

--- a/tests/math/additive_combinatorics/test_multiset_sum.py
+++ b/tests/math/additive_combinatorics/test_multiset_sum.py
@@ -82,6 +82,12 @@ def test_empty_zero_and_singleton_conventions(
     assert _profile(source, arity) == expected
 
 
+def test_zero_arity_uses_derived_admission_not_the_legacy_source_cap() -> None:
+    source = tuple(range(_MAX_SET_SIZE + 1))
+
+    assert _profile(source, 0) == {0: 1}
+
+
 def test_closed_window_is_complete_only_for_its_declared_scope() -> None:
     result = compute_multiset_sum_representation_profile(_request((0, 1, 2), 3, (2, 3)))
     assert result.window is not None
@@ -176,7 +182,7 @@ def test_request_rejects_oversized_source_integer_before_parsing() -> None:
 def test_request_schema_exposes_collection_and_scalar_bounds() -> None:
     schema = MultisetSumRepresentationProfileRequest.model_json_schema()
     source_schema = schema["$defs"]["FiniteIntegerSet"]
-    assert source_schema["properties"]["elements"]["maxItems"] == _MAX_SET_SIZE
+    assert source_schema["properties"]["elements"]["maxItems"] == 50_000
     assert schema["properties"]["arity"]["maximum"] == _MAX_MULTISET_SUM_ARITY
     window_schema = schema["$defs"]["MultisetSumWindow"]
     assert (


### PR DESCRIPTION
Fixes #2523.

## Problem

Additive combinatorics had a second `FiniteIntegerSet` class, so an additive value could not be directly supplied to a finite-set consumer even though their JSON shapes matched.

## Solution

Reuse the finite-sets owner’s `FiniteIntegerSet`. Additive operation-specific bounds remain at its request and admission boundary. Direct typed and serialized producer-to-consumer tests cover ordinary and zero-arity inputs, including the path that would previously be constrained by the duplicate value’s generic item cap.

## Testing

- `make test-focused LANE=math TESTS=tests/math/additive_combinatorics` — 177 passed
- `make test-catalog` — 41 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The wire shape remains `{ "elements": [...] }`; native Python callers now use one finite-integer-set identity.

## Operation boundary ownership

- Changed stage: request parsing and native typed composition
- Request-bounds owner and controlling quantities: additive-combinatorics request admission remains unchanged
- Backend or kernel path: unchanged
- Result construction: unchanged apart from returning the canonical finite-set value
- Independent-result verifier: none
- Native/MCP parity: unchanged semantic path and transport projection
- Serialized-result and round-trip evidence: additive-combinatorics producer-to-consumer tests

## Canonical value audit

- [x] Existing canonical values searched
- [x] Finite sets remains the single value owner
- [x] Producer-to-consumer serialization tested

## Checklist

- [ ] `make check` passes (not complete; focused owner and catalog checks passed)