### PR TITLE
Reuse geometry’s canonical rational interval in analysis

### DIFF
--- a/src/jacobian/math/analysis/_models.py
+++ b/src/jacobian/math/analysis/_models.py
@@ -20,6 +20,7 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
+from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
 
 def _validation_error(message: str) -> PydanticCustomError:
@@ -258,27 +259,6 @@ class IntervalExpressionEnclosureRequest(StrictModel):
         if any(node.op == "var" and node.variable is not None for node in nodes):
             raise _validation_error(
                 "point-enclosure variable nodes must remain anonymous"
-            )
-        return self
-
-
-class RationalClosedInterval(StrictModel):
-    """One exact closed rational interval in an ordered source box."""
-
-    lower: CanonicalRational
-    upper: CanonicalRational
-
-    @model_validator(mode="after")
-    def require_ordered_bounded_endpoints(self) -> Self:
-        for endpoint in (self.lower, self.upper):
-            require_bounded_rational(
-                endpoint,
-                max_digits=MAX_RATIONAL_DIGITS,
-                label="expression-box endpoint",
-            )
-        if self.lower.as_fraction() > self.upper.as_fraction():
-            raise _validation_error(
-                "box interval lower endpoint exceeds upper endpoint"
             )
         return self
 

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -31,13 +31,13 @@ from jacobian.math.analysis._models import (
     IntervalExpressionSecondJetEnclosureStatus,
     PointEnclosureCheckRequest,
     PointEnclosureCheckResult,
-    RationalClosedInterval,
     _preflight_box_expression,
     _rational_box_bounds,
 )
 from jacobian.math.analysis._point_enclosure_check import (
     point_enclosure_check_outcome,
 )
+from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
 
 class _EvaluationFailure(StrEnum):

--- a/tests/math/test_analysis_expression_box_enclosure.py
+++ b/tests/math/test_analysis_expression_box_enclosure.py
@@ -13,11 +13,13 @@ from jacobian.math.analysis._models import (
     IntervalExpressionBoxEnclosureRequest,
     IntervalExpressionBoxEnclosureResult,
     IntervalExpressionEnclosureRequest,
+    RationalIntervalBox,
 )
 from jacobian.math.analysis._operations import (
     _box_expression_enclosure,
     _expression_enclosure,
 )
+from jacobian.math.geometry.boxes import RationalAxisAlignedBox, RationalClosedInterval
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:
@@ -66,6 +68,27 @@ def _var(name: str) -> dict[str, Any]:
 
 def _const(value: int) -> dict[str, Any]:
     return {"op": "const", "value": _q(value)}
+
+
+def test_analysis_and_geometry_boxes_compose_through_the_same_interval_value() -> None:
+    interval = RationalClosedInterval(lower=_q(0), upper=_q(1))
+
+    analysis_box = RationalIntervalBox(variables=("x",), intervals=(interval,))
+    geometry_box = RationalAxisAlignedBox(dimension=1, intervals=(interval,))
+
+    assert analysis_box.intervals[0] is interval
+    assert geometry_box.intervals is not None
+    assert geometry_box.intervals[0] is interval
+
+
+def test_analysis_request_keeps_its_endpoint_digit_admission() -> None:
+    interval = RationalClosedInterval(lower=_q(0), upper={"num": "1" * 129, "den": "1"})
+    box = RationalIntervalBox(variables=("x",), intervals=(interval,))
+
+    with analysis_validation_error():
+        IntervalExpressionBoxEnclosureRequest(
+            expression={"op": "var", "variable": "x"}, box=box
+        )
 
 
 @pytest.mark.parametrize("op", ["exp", "log"])


### PR DESCRIPTION
Fixes #2540.

## Problem

Analysis and geometry each defined a closed rational interval with the same `lower`/`upper` representation and ordered-endpoint invariant. A geometry box interval could therefore only be consumed by analysis after JSON serialization and revalidation, despite being the same mathematical value.

## Solution

Use geometry’s `RationalClosedInterval` as the interval type in `RationalIntervalBox` and the analysis enclosure kernel. Analysis retains its own request-boundary checks for coordinate count and 128-digit endpoints. The JSON shape, operation IDs, and enclosure semantics are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/test_analysis_expression_box_enclosure.py` — 43 passed
- `make test-focused LANE=catalog TESTS=tests/catalog/test_catalog.py` — 12 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 611 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Analysis boxes now accept the geometry-owned canonical interval value directly. Their serialized representation is unchanged.

## Operation boundary ownership

- Changed stage: request parsing and native typed composition
- Request-bounds owner and controlling quantities: analysis retains `RationalIntervalBox` coordinate-count and endpoint-digit admission
- Backend or kernel path: unchanged interval-expression enclosure kernel
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: unchanged semantic path and transport projection
- Serialized-result and round-trip evidence: analysis enclosure regression tests

## Canonical value audit

- [x] Existing canonical values searched
- [x] Geometry boxes remains the single interval-value owner
- [x] Direct producer-to-consumer composition tested

## Checklist

- [ ] `make check` passes (not complete; focused owner, catalog, and integration checks passed)