### PR TITLE
Share the exact strict-root interval predicate

### DIFF
--- a/src/jacobian/math/_root_isolation.py
+++ b/src/jacobian/math/_root_isolation.py
@@ -1,0 +1,25 @@
+"""Exact SymPy root-isolation primitives shared by mathematical owners."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["strict_root_count"]
+
+
+def strict_root_count(poly: Any, lower: Any, upper: Any) -> int:
+    """Count roots strictly between endpoints, or at a singleton endpoint.
+
+    SymPy's interval convention includes roots at the endpoints. The
+    root-isolation owners use open intervals for irrational roots and a
+    singleton for a rational root, so remove endpoint roots explicitly.
+    """
+
+    if lower == upper:
+        return int(poly.eval(lower) == 0)
+    count = int(poly.count_roots(lower, upper))
+    if poly.eval(lower) == 0:
+        count -= 1
+    if poly.eval(upper) == 0:
+        count -= 1
+    return count

--- a/src/jacobian/math/matrices/quadratic_spectral/operations.py
+++ b/src/jacobian/math/matrices/quadratic_spectral/operations.py
@@ -8,6 +8,7 @@ from math import gcd, lcm
 from typing import Any, Literal
 
 from jacobian.canonical import format_canonical_integer
+from jacobian.math._root_isolation import strict_root_count
 from jacobian.math.matrices.quadratic_spectral.values import (
     Definiteness,
     RealAlgebraicMultiplicity,
@@ -267,17 +268,6 @@ def _sympy_polynomial(coefficients: tuple[int, ...]):  # type: ignore[no-untyped
     return sympy.Poly.from_list(coefficients, gens=sympy.Symbol("x"), domain=sympy.ZZ)
 
 
-def _strict_root_count(poly, lower, upper) -> int:  # type: ignore[no-untyped-def]
-    if lower == upper:
-        return int(poly.eval(lower) == 0)
-    count = int(poly.count_roots(lower, upper))
-    if poly.eval(lower) == 0:
-        count -= 1
-    if poly.eval(upper) == 0:
-        count -= 1
-    return count
-
-
 def _canonical_factor(factor) -> tuple[str, ...]:  # type: ignore[no-untyped-def]
     coefficients = [int(coefficient) for coefficient in factor.all_coeffs()]
     content = 0
@@ -297,7 +287,7 @@ def _root_data(polynomial) -> tuple[_RootData, ...]:  # type: ignore[no-untyped-
         matches = [
             index
             for index, (factor, _factor_multiplicity) in enumerate(factors)
-            if _strict_root_count(factor, lower, upper) == 1
+            if strict_root_count(factor, lower, upper) == 1
         ]
         if len(matches) != 1:  # pragma: no cover
             raise RuntimeError("exact factor isolation did not identify one root")

--- a/src/jacobian/math/real_algebraic.py
+++ b/src/jacobian/math/real_algebraic.py
@@ -11,6 +11,7 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalInteger, CanonicalRational
 from jacobian._models import StrictModel
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.math._root_isolation import strict_root_count
 
 # A degree-eight value covers every singular value of a 2 by 2 matrix over a
 # real quadratic field.  The coefficient budget also bounds exact comparison:
@@ -39,19 +40,6 @@ def _sympy_polynomial(value: RealAlgebraicValue):  # type: ignore[no-untyped-def
         gens=x,
         domain=sympy.ZZ,
     )
-
-
-def _strict_root_count(poly, lower, upper) -> int:  # type: ignore[no-untyped-def]
-    """Count roots in an open interval, or at one singleton endpoint."""
-
-    if lower == upper:
-        return int(poly.eval(lower) == 0)
-    count = int(poly.count_roots(lower, upper))
-    if poly.eval(lower) == 0:
-        count -= 1
-    if poly.eval(upper) == 0:
-        count -= 1
-    return count
 
 
 def _rational(value) -> CanonicalRational:  # type: ignore[no-untyped-def]
@@ -205,11 +193,11 @@ def _order_data(
     selected_left: tuple[int, RationalIsolatingInterval] | None = None
     selected_right: tuple[int, RationalIsolatingInterval] | None = None
     for position, ((lower, upper), _multiplicity) in enumerate(product_intervals):
-        if _strict_root_count(left_poly, lower, upper):
+        if strict_root_count(left_poly, lower, upper):
             if left_seen == left.real_root_index:
                 selected_left = (position, _interval(lower, upper))
             left_seen += 1
-        if _strict_root_count(right_poly, lower, upper):
+        if strict_root_count(right_poly, lower, upper):
             if right_seen == right.real_root_index:
                 selected_right = (position, _interval(lower, upper))
             right_seen += 1

--- a/tests/math/root_isolation/test_sympy.py
+++ b/tests/math/root_isolation/test_sympy.py
@@ -1,0 +1,26 @@
+"""Boundary cases for shared exact SymPy root-isolation primitives."""
+
+import sympy
+
+from jacobian.math._root_isolation import strict_root_count
+
+
+def _polynomial() -> sympy.Poly:
+    x = sympy.Symbol("x")
+    return sympy.Poly(x * (x - 1) * (x - 2), x, domain=sympy.ZZ)
+
+
+def test_strict_root_count_uses_singletons_for_rational_roots() -> None:
+    polynomial = _polynomial()
+
+    assert strict_root_count(polynomial, 1, 1) == 1
+    assert (
+        strict_root_count(polynomial, sympy.Rational(1, 2), sympy.Rational(1, 2)) == 0
+    )
+
+
+def test_strict_root_count_excludes_roots_at_open_interval_endpoints() -> None:
+    polynomial = _polynomial()
+
+    assert strict_root_count(polynomial, 0, 2) == 1
+    assert strict_root_count(polynomial, -1, 1) == 1


### PR DESCRIPTION
Fixes #2542.

## Problem

Real-algebraic comparison and quadratic-spectral factor isolation each implemented the same endpoint-aware strict root-count predicate. Future corrections to singleton intervals or roots at either open endpoint could therefore diverge between the two public paths.

## Solution

Move the exact predicate into a small shared math helper and use it from both owners. Boundary tests cover singleton intervals and roots at the left and right endpoints; polynomial construction, admission, and result-specific contracts remain owner-local.

## Testing

- `make test-focused LANE=math TESTS="tests/math/test_real_algebraic.py tests/math/matrices/test_quadratic_spectral.py tests/math/root_isolation/test_sympy.py"` — 31 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This refactor preserves existing operation schemas and mathematical semantics.

## Checklist

- [ ] `make check` passes (not run; focused cross-owner tests passed)