### PR TITLE
Share the canonical indexed simple-graph value

### DIFF
--- a/src/jacobian/math/graphs/__init__.py
+++ b/src/jacobian/math/graphs/__init__.py
@@ -25,6 +25,7 @@ from jacobian.math.graphs.transforms import (
 from jacobian.math.graphs.values import (
     ColoredUndirectedGraph,
     GraphCompositionInput,
+    IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
 )
 
@@ -34,6 +35,7 @@ __all__ = [
     "IndependenceNumberBudget",
     "IndependenceNumberRequest",
     "IndependenceNumberResult",
+    "IndexedSimpleUndirectedGraph",
     "SimpleUndirectedGraph",
     "biconnected_components",
     "complement",

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -9,7 +9,10 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.graphs.values import SimpleUndirectedGraph
+from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
+    SimpleUndirectedGraph,
+)
 
 MAX_EDGE_COLORING_VERTICES = 64
 MAX_EDGE_COLORING_EDGES = (
@@ -26,6 +29,34 @@ DEFAULT_SOLVER_CONFLICT_BUDGET = 100_000
 
 MAX_SOLVER_CONFLICT_BUDGET = 1_000_000
 """Upper bound on the accepted SAT conflict budget."""
+
+
+def _require_indexed_coloring_graph(graph: IndexedSimpleUndirectedGraph) -> None:
+    if graph.vertex_count > MAX_EDGE_COLORING_VERTICES:
+        raise PydanticCustomError(
+            "graph.coloring_vertex_count_exceeds_operation_bound",
+            f"coloring operations support at most {MAX_EDGE_COLORING_VERTICES} vertices",
+        )
+
+
+def _indexed_coloring_graph_schema() -> JsonSchemaValue:
+    """Project the coloring envelope onto the shared indexed graph value."""
+
+    schema = IndexedSimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "An integer-indexed simple undirected graph accepted by the coloring "
+        f"operations: at most {MAX_EDGE_COLORING_VERTICES} vertices and at most "
+        f"{MAX_EDGE_COLORING_EDGES} edges."
+    )
+    schema["properties"]["vertex_count"].update(maximum=MAX_EDGE_COLORING_VERTICES)
+    schema["properties"]["edges"].update(maxItems=MAX_EDGE_COLORING_EDGES)
+    return schema
+
+
+IndexedColoringGraph = Annotated[
+    IndexedSimpleUndirectedGraph,
+    WithJsonSchema(_indexed_coloring_graph_schema()),
+]
 
 
 def _run_edge_coloring_solver(
@@ -59,7 +90,7 @@ def _run_edge_coloring_solver(
 
 
 def _run_k_colorability_solver(
-    graph: GraphEdgeList,
+    graph: IndexedSimpleUndirectedGraph,
     colors: int,
     solver_conflicts: int,
 ) -> tuple[str, tuple[int, ...] | None]:
@@ -90,7 +121,7 @@ def _run_k_colorability_solver(
 
 
 def _is_proper_vertex_coloring(
-    graph: GraphEdgeList,
+    graph: IndexedSimpleUndirectedGraph,
     coloring: tuple[int, ...],
 ) -> bool:
     """Check whether a coloring assigns distinct colors to adjacent vertices."""
@@ -206,46 +237,10 @@ def _require_conflicting_pair(
         )
 
 
-class GraphEdgeList(StrictModel):
-    """A simple undirected graph given by an edge list."""
-
-    # SAT instances are bounded by the explicit solver conflict budget but
-    # capped at 64 vertices for one direct stateless call; polynomial-time
-    # checks (maximal independent set) use the same envelope and run in
-    # O(V+E).
-    vertex_count: int = Field(ge=1, le=64)
-    edges: tuple[tuple[int, int], ...] = Field(
-        max_length=MAX_EDGE_COLORING_EDGES,
-    )
-
-    @model_validator(mode="after")
-    def require_valid_edges(self) -> Self:
-        seen: set[tuple[int, int]] = set()
-        for u, v in self.edges:
-            if not (0 <= u < self.vertex_count and 0 <= v < self.vertex_count):
-                raise PydanticCustomError(
-                    "graph.edge_vertices_must_be_in_0_vertex_count_1",
-                    "edge vertices must be in 0..vertex_count-1",
-                )
-            if u == v:
-                raise PydanticCustomError(
-                    "graph.a_simple_graph_cannot_contain_self_loops",
-                    "a simple graph cannot contain self-loops",
-                )
-            edge = (min(u, v), max(u, v))
-            if edge in seen:
-                raise PydanticCustomError(
-                    "graph.a_simple_graph_cannot_contain_duplicate_edges",
-                    "a simple graph cannot contain duplicate edges",
-                )
-            seen.add(edge)
-        return self
-
-
 class KColorabilityRequest(StrictModel):
     """Decide whether a bounded simple graph admits a proper ``k``-coloring."""
 
-    graph: GraphEdgeList
+    graph: IndexedColoringGraph
     colors: int = Field(ge=1, le=64)
     solver_conflicts: int = Field(
         default=DEFAULT_SOLVER_CONFLICT_BUDGET,
@@ -259,11 +254,16 @@ class KColorabilityRequest(StrictModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def require_admitted_graph(self) -> Self:
+        _require_indexed_coloring_graph(self.graph)
+        return self
+
 
 class KColorabilityResult(StrictModel):
     """Whether a proper ``k``-coloring exists, with one coloring witness."""
 
-    graph: GraphEdgeList
+    graph: IndexedColoringGraph
     colors: int = Field(ge=1, le=64)
     solver_conflicts: int = Field(
         default=DEFAULT_SOLVER_CONFLICT_BUDGET,
@@ -277,6 +277,7 @@ class KColorabilityResult(StrictModel):
 
     @model_validator(mode="after")
     def require_claim_consistency(self) -> Self:
+        _require_indexed_coloring_graph(self.graph)
         if self.vertex_count != self.graph.vertex_count:
             raise PydanticCustomError(
                 "graph.vertex_count_must_equal_the_graph_s_vertex_count",
@@ -377,11 +378,12 @@ def _require_k_colorability_negative_replay(result: KColorabilityResult) -> None
 class MaximalIndependentSetRequest(StrictModel):
     """One canonical candidate set in a bounded simple graph."""
 
-    graph: GraphEdgeList
+    graph: IndexedColoringGraph
     candidate_set: tuple[int, ...] = Field(max_length=64)
 
     @model_validator(mode="after")
     def require_canonical_candidate_set(self) -> Self:
+        _require_indexed_coloring_graph(self.graph)
         if tuple(sorted(self.candidate_set)) != self.candidate_set:
             raise PydanticCustomError(
                 "graph.candidate_set_must_be_strictly_increasing",

--- a/src/jacobian/math/graphs/coloring/_models.py
+++ b/src/jacobian/math/graphs/coloring/_models.py
@@ -273,7 +273,7 @@ class KColorabilityResult(StrictModel):
     status: Literal["DECIDED", "SOLVER_BUDGET_EXCEEDED"] = "DECIDED"
     colorable: bool | None = None
     coloring: tuple[int, ...] | None = None
-    vertex_count: int = Field(ge=1, le=64)
+    vertex_count: int = Field(ge=0, le=64)
 
     @model_validator(mode="after")
     def require_claim_consistency(self) -> Self:

--- a/src/jacobian/math/graphs/coloring/_tools.py
+++ b/src/jacobian/math/graphs/coloring/_tools.py
@@ -153,7 +153,7 @@ GRAPH_COLORING_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
                 {
                     "graph": {
                         "vertex_count": 3,
-                        "edges": [[0, 1], [1, 2], [2, 0]],
+                        "edges": [[0, 1], [1, 2], [0, 2]],
                     },
                     "colors": 3,
                 },

--- a/src/jacobian/math/graphs/spectral/__init__.py
+++ b/src/jacobian/math/graphs/spectral/__init__.py
@@ -1,6 +1,5 @@
 """Supported exact graph spectral API."""
 
-from jacobian.math.graphs.spectral._models import GraphEdgeList
 from jacobian.math.graphs.spectral.operations import (
     adjacency_characteristic_polynomial,
     adjacency_spectrum,
@@ -9,7 +8,6 @@ from jacobian.math.graphs.spectral.operations import (
 )
 
 __all__ = [
-    "GraphEdgeList",
     "adjacency_characteristic_polynomial",
     "adjacency_spectrum",
     "laplacian_characteristic_polynomial",

--- a/src/jacobian/math/graphs/spectral/_models.py
+++ b/src/jacobian/math/graphs/spectral/_models.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
 from jacobian._models import StrictModel
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
@@ -22,38 +24,43 @@ _MAX_CHARPOLY_EXPONENT = 32
 _MAX_CHARPOLY_COEFFICIENT_DIGITS = 128
 
 
-class GraphEdgeList(StrictModel):
-    """A simple undirected graph given by an edge list."""
+_MAX_SPECTRAL_VERTICES = 32
 
-    vertex_count: int = Field(ge=1, le=32)
-    edges: tuple[tuple[int, int], ...] = Field(max_length=512)
 
-    @model_validator(mode="after")
-    def require_simple_graph(self) -> Self:
-        seen: set[tuple[int, int]] = set()
-        for u, v in self.edges:
-            if not (0 <= u < self.vertex_count and 0 <= v < self.vertex_count):
-                raise PydanticCustomError(
-                    "graph.edge_vertices_must_be_in_0_vertex_count_1",
-                    "edge vertices must be in 0..vertex_count-1",
-                )
-            if u == v:
-                raise PydanticCustomError(
-                    "graph.a_simple_graph_cannot_contain_self_loops",
-                    "a simple graph cannot contain self-loops",
-                )
-            edge = (min(u, v), max(u, v))
-            if edge in seen:
-                raise PydanticCustomError(
-                    "graph.a_simple_graph_cannot_contain_duplicate_edges",
-                    "a simple graph cannot contain duplicate edges",
-                )
-            seen.add(edge)
-        return self
+def _require_spectral_graph(graph: IndexedSimpleUndirectedGraph) -> None:
+    if graph.vertex_count > _MAX_SPECTRAL_VERTICES:
+        raise PydanticCustomError(
+            "graph.spectral_vertex_count_exceeds_operation_bound",
+            "spectral operations support at most 32 vertices",
+        )
+
+
+def _spectral_graph_schema() -> JsonSchemaValue:
+    """Project the spectral-operation envelope onto the shared graph value."""
+
+    schema = IndexedSimpleUndirectedGraph.model_json_schema()
+    schema["description"] = (
+        "An integer-indexed simple undirected graph accepted by the spectral "
+        "operations: at most 32 vertices and at most 512 edges."
+    )
+    schema["properties"]["vertex_count"].update(maximum=_MAX_SPECTRAL_VERTICES)
+    schema["properties"]["edges"].update(maxItems=512)
+    return schema
+
+
+SpectralGraph = Annotated[
+    IndexedSimpleUndirectedGraph,
+    WithJsonSchema(_spectral_graph_schema()),
+]
 
 
 class GraphSpectrumRequest(StrictModel):
-    graph: GraphEdgeList
+    graph: SpectralGraph
+
+    @model_validator(mode="after")
+    def require_admitted_graph(self) -> Self:
+        _require_spectral_graph(self.graph)
+        return self
 
 
 class GraphSpectrumResult(StrictModel):
@@ -71,7 +78,7 @@ class GraphSpectrumResult(StrictModel):
     multiset rather than by backend iteration order.
     """
 
-    graph: GraphEdgeList
+    graph: SpectralGraph
     matrix_convention: Literal["ADJACENCY", "LAPLACIAN"]
     eigenvalues: tuple[str, ...]
     multiplicities: tuple[int, ...]
@@ -84,6 +91,7 @@ class GraphSpectrumResult(StrictModel):
             laplacian_spectrum,
         )
 
+        _require_spectral_graph(self.graph)
         order = self.graph.vertex_count
         if len(self.eigenvalues) != len(self.multiplicities):
             raise PydanticCustomError(
@@ -142,7 +150,7 @@ class GraphCharacteristicPolynomialResult(StrictModel):
     determinant relation.
     """
 
-    graph: GraphEdgeList
+    graph: SpectralGraph
     convention: Literal["ADJACENCY", "LAPLACIAN"]
     polynomial: RationalPolynomial
 
@@ -156,6 +164,7 @@ class GraphCharacteristicPolynomialResult(StrictModel):
             rational_polynomial_to_sympy,
         )
 
+        _require_spectral_graph(self.graph)
         if self.polynomial.variables != (_VARIABLE,):
             raise PydanticCustomError(
                 "graph.characteristic_polynomial_must_be_univariate_in_",
@@ -187,7 +196,6 @@ class GraphCharacteristicPolynomialResult(StrictModel):
 
 __all__ = [
     "GraphCharacteristicPolynomialResult",
-    "GraphEdgeList",
     "GraphSpectrumRequest",
     "GraphSpectrumResult",
 ]

--- a/src/jacobian/math/graphs/spectral/operations.py
+++ b/src/jacobian/math/graphs/spectral/operations.py
@@ -12,7 +12,8 @@ __all__ = [
 ]
 
 from jacobian._exact import CanonicalRational
-from jacobian.math.graphs.spectral._models import GraphEdgeList
+from jacobian.math.graphs.spectral._models import _require_spectral_graph
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.polynomials.values import RationalPolynomial
 
 
@@ -38,9 +39,10 @@ def _dense_to_canonical_polynomial(
     return _dense_to_canonical_polynomial(coefficients)
 
 
-def _adjacency_matrix(graph: GraphEdgeList) -> Any:
+def _adjacency_matrix(graph: IndexedSimpleUndirectedGraph) -> Any:
     import sympy
 
+    _require_spectral_graph(graph)
     mat = sympy.zeros(graph.vertex_count)
     for u, v in graph.edges:
         mat[u, v] = 1
@@ -48,7 +50,7 @@ def _adjacency_matrix(graph: GraphEdgeList) -> Any:
     return mat
 
 
-def _laplacian_matrix(graph: GraphEdgeList) -> Any:
+def _laplacian_matrix(graph: IndexedSimpleUndirectedGraph) -> Any:
     import sympy
 
     adj = _adjacency_matrix(graph)
@@ -56,19 +58,21 @@ def _laplacian_matrix(graph: GraphEdgeList) -> Any:
     return degree - adj
 
 
-def adjacency_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
+def adjacency_spectrum(graph: IndexedSimpleUndirectedGraph) -> list[tuple[str, int]]:
+    _require_spectral_graph(graph)
     mat = _adjacency_matrix(graph)
     eigenvals = mat.eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]
 
 
-def laplacian_spectrum(graph: GraphEdgeList) -> list[tuple[str, int]]:
+def laplacian_spectrum(graph: IndexedSimpleUndirectedGraph) -> list[tuple[str, int]]:
+    _require_spectral_graph(graph)
     eigenvals = _laplacian_matrix(graph).eigenvals()
     return [(str(val), int(mult)) for val, mult in eigenvals.items()]
 
 
 def adjacency_characteristic_polynomial(
-    graph: GraphEdgeList,
+    graph: IndexedSimpleUndirectedGraph,
 ) -> RationalPolynomial:
     """Return det(xI - A) as the canonical sparse rational polynomial."""
 
@@ -78,7 +82,7 @@ def adjacency_characteristic_polynomial(
 
 
 def laplacian_characteristic_polynomial(
-    graph: GraphEdgeList,
+    graph: IndexedSimpleUndirectedGraph,
 ) -> RationalPolynomial:
     """Return det(xI - L) as the canonical sparse rational polynomial."""
 

--- a/src/jacobian/math/graphs/values.py
+++ b/src/jacobian/math/graphs/values.py
@@ -20,6 +20,10 @@ GraphCompositionOperation = Literal[
 
 MAX_GRAPH_LABEL_BYTES = 64
 MAX_GRAPH_COLOR_BYTES = 64
+MAX_INDEXED_SIMPLE_GRAPH_VERTICES = 256
+MAX_INDEXED_SIMPLE_GRAPH_EDGES = (
+    MAX_INDEXED_SIMPLE_GRAPH_VERTICES * (MAX_INDEXED_SIMPLE_GRAPH_VERTICES - 1) // 2
+)
 
 GraphVertexLabel = Annotated[
     str,
@@ -79,6 +83,38 @@ class SimpleUndirectedGraph(StrictModel):
             raise PydanticCustomError(
                 "graph.graph_edges_must_be_unique", "graph edges must be unique"
             )
+        return self
+
+
+class IndexedSimpleUndirectedGraph(StrictModel):
+    """A finite simple undirected graph on the integer axis ``0..n-1``."""
+
+    vertex_count: int = Field(ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
+    edges: tuple[tuple[int, int], ...] = Field(
+        max_length=MAX_INDEXED_SIMPLE_GRAPH_EDGES
+    )
+
+    @model_validator(mode="after")
+    def require_simple_indexed_graph(self) -> Self:
+        seen: set[tuple[int, int]] = set()
+        for left, right in self.edges:
+            if not (0 <= left < self.vertex_count and 0 <= right < self.vertex_count):
+                raise PydanticCustomError(
+                    "graph.edge_vertices_must_be_in_0_vertex_count_1",
+                    "edge vertices must be in 0..vertex_count-1",
+                )
+            if left == right:
+                raise PydanticCustomError(
+                    "graph.a_simple_graph_cannot_contain_self_loops",
+                    "a simple graph cannot contain self-loops",
+                )
+            edge = (min(left, right), max(left, right))
+            if edge in seen:
+                raise PydanticCustomError(
+                    "graph.a_simple_graph_cannot_contain_duplicate_edges",
+                    "a simple graph cannot contain duplicate edges",
+                )
+            seen.add(edge)
         return self
 
 
@@ -188,11 +224,14 @@ class GraphCompositionInput(StrictModel):
 __all__ = [
     "MAX_GRAPH_COLOR_BYTES",
     "MAX_GRAPH_LABEL_BYTES",
+    "MAX_INDEXED_SIMPLE_GRAPH_EDGES",
+    "MAX_INDEXED_SIMPLE_GRAPH_VERTICES",
     "ColoredUndirectedGraph",
     "GraphColor",
     "GraphCompositionInput",
     "GraphCompositionOperation",
     "GraphVertexLabel",
+    "IndexedSimpleUndirectedGraph",
     "SimpleUndirectedGraph",
     "simple_undirected_graph_wire_bytes",
 ]

--- a/src/jacobian/math/graphs/values.py
+++ b/src/jacobian/math/graphs/values.py
@@ -87,9 +87,14 @@ class SimpleUndirectedGraph(StrictModel):
 
 
 class IndexedSimpleUndirectedGraph(StrictModel):
-    """A finite simple undirected graph on the integer axis ``0..n-1``."""
+    """A finite simple undirected graph on the integer axis ``0..n-1``.
 
-    vertex_count: int = Field(ge=1, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
+    The null graph (``vertex_count=0`` with no edges) is a valid canonical
+    value; operations admitting only nonempty graphs enforce that envelope
+    in their own request validators.
+    """
+
+    vertex_count: int = Field(ge=0, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
     edges: tuple[tuple[int, int], ...] = Field(
         max_length=MAX_INDEXED_SIMPLE_GRAPH_EDGES
     )

--- a/src/jacobian/math/graphs/values.py
+++ b/src/jacobian/math/graphs/values.py
@@ -89,9 +89,12 @@ class SimpleUndirectedGraph(StrictModel):
 class IndexedSimpleUndirectedGraph(StrictModel):
     """A finite simple undirected graph on the integer axis ``0..n-1``.
 
-    The null graph (``vertex_count=0`` with no edges) is a valid canonical
-    value; operations admitting only nonempty graphs enforce that envelope
-    in their own request validators.
+    Edges are canonical ordered pairs ``(left, right)`` with
+    ``left < right``, matching ``SimpleUndirectedGraph``, so serialized
+    equality identifies mathematically identical graphs.  The null graph
+    (``vertex_count=0`` with no edges) is a valid canonical value;
+    operations admitting only nonempty graphs enforce that envelope in
+    their own request validators.
     """
 
     vertex_count: int = Field(ge=0, le=MAX_INDEXED_SIMPLE_GRAPH_VERTICES)
@@ -113,13 +116,17 @@ class IndexedSimpleUndirectedGraph(StrictModel):
                     "graph.a_simple_graph_cannot_contain_self_loops",
                     "a simple graph cannot contain self-loops",
                 )
-            edge = (min(left, right), max(left, right))
-            if edge in seen:
+            if left > right:
+                raise PydanticCustomError(
+                    "graph.indexed_edges_must_be_canonical_pairs_with_left",
+                    "indexed edges must be canonical pairs with left < right",
+                )
+            if (left, right) in seen:
                 raise PydanticCustomError(
                     "graph.a_simple_graph_cannot_contain_duplicate_edges",
                     "a simple graph cannot contain duplicate edges",
                 )
-            seen.add(edge)
+            seen.add((left, right))
         return self
 
 

--- a/tests/integration/graphs/test_exact_operations.py
+++ b/tests/integration/graphs/test_exact_operations.py
@@ -105,16 +105,18 @@ def test_spectral_contract_rejects_non_simple_graphs() -> None:
 
 def test_native_spectral_api_requires_a_validated_simple_graph() -> None:
     from jacobian.math.graphs.spectral import (
-        GraphEdgeList,
         adjacency_spectrum,
         laplacian_spectrum,
     )
+    from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
-    graph = GraphEdgeList(vertex_count=2, edges=((0, 1),))
+    graph = IndexedSimpleUndirectedGraph(vertex_count=2, edges=((0, 1),))
     assert dict(laplacian_spectrum(graph)) == {"0": 1, "2": 1}
 
     with graph_validation_error():
-        adjacency_spectrum(GraphEdgeList(vertex_count=2, edges=((0, 0),)))
+        adjacency_spectrum(
+            IndexedSimpleUndirectedGraph(vertex_count=2, edges=((0, 0),))
+        )
 
 
 def test_laplacian_spectrum_uses_normalized_simple_graph_degree() -> None:

--- a/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
@@ -106,6 +106,13 @@ class TestAdjacencyCharacteristicPolynomial:
         result = compute_adjacency_characteristic_polynomial(_request([], 1))
         assert _coeffs(result.polynomial) == [Fraction(0), Fraction(1)]
 
+    def test_null_graph(self):
+        # The 0x0 matrix has det(xI - A) equal to the empty product 1.
+        result = compute_adjacency_characteristic_polynomial(_request([], 0))
+        assert _coeffs(result.polynomial) == [Fraction(1)]
+        laplacian = compute_laplacian_characteristic_polynomial(_request([], 0))
+        assert _coeffs(laplacian.polynomial) == [Fraction(1)]
+
     def test_result_is_monic(self):
         result = compute_adjacency_characteristic_polynomial(
             _request([[0, 1], [1, 2], [0, 2]], 3)

--- a/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
+++ b/tests/math/graphs/spectral/test_graph_characteristic_polynomial.py
@@ -12,7 +12,6 @@ from jacobian.math.graphs.spectral import (
 )
 from jacobian.math.graphs.spectral._models import (
     GraphCharacteristicPolynomialResult,
-    GraphEdgeList,
     GraphSpectrumRequest,
 )
 from jacobian.math.graphs.spectral._operations import (
@@ -20,6 +19,7 @@ from jacobian.math.graphs.spectral._operations import (
     compute_laplacian_characteristic_polynomial,
 )
 from jacobian.math.graphs.spectral._tools import TOOLS
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 from jacobian.math.polynomials._elementary_operations import (
     rational_polynomial_derivative,
 )
@@ -32,7 +32,9 @@ from jacobian.math.polynomials.values import (
 
 
 def _graph(edges, vc):
-    return GraphEdgeList(vertex_count=vc, edges=tuple(tuple(e) for e in edges))
+    return IndexedSimpleUndirectedGraph(
+        vertex_count=vc, edges=tuple(tuple(e) for e in edges)
+    )
 
 
 def _request(edges, vc):
@@ -72,7 +74,9 @@ def _univariate_polynomial(coefficients: dict[int, str]) -> RationalPolynomial:
 def _charpoly_payload(polynomial: RationalPolynomial) -> dict:
     """Serialize a result payload bound to the P3 adjacency source."""
     return {
-        "graph": GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2))).model_dump(),
+        "graph": IndexedSimpleUndirectedGraph(
+            vertex_count=3, edges=((0, 1), (1, 2))
+        ).model_dump(),
         "convention": "ADJACENCY",
         "polynomial": polynomial.model_dump(),
     }
@@ -161,7 +165,7 @@ class TestLaplacianCharacteristicPolynomial:
 
 
 def test_forged_result_rejected():
-    graph = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
+    graph = IndexedSimpleUndirectedGraph(vertex_count=3, edges=((0, 1), (1, 2)))
     with pytest.raises(ValidationError):
         GraphCharacteristicPolynomialResult.model_validate(
             {
@@ -210,7 +214,9 @@ def test_maximum_shaped_nonmatching_polynomial_fails_only_on_source_binding():
 
 def test_maximal_path_round_trips_through_serialization():
     # Degree exactly 32 exercises the replay degree bound from above.
-    graph = GraphEdgeList(vertex_count=32, edges=tuple((i, i + 1) for i in range(31)))
+    graph = IndexedSimpleUndirectedGraph(
+        vertex_count=32, edges=tuple((i, i + 1) for i in range(31))
+    )
     polynomial = adjacency_characteristic_polynomial(graph)
     restored = GraphCharacteristicPolynomialResult.model_validate(
         GraphCharacteristicPolynomialResult(

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -630,9 +630,9 @@ class TestSolverConflictBudget:
 
 class TestVertexKColorability:
     def _k4(self):
-        from jacobian.math.graphs.coloring._models import GraphEdgeList
+        from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
-        return GraphEdgeList(
+        return IndexedSimpleUndirectedGraph(
             vertex_count=4,
             edges=((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)),
         )
@@ -673,13 +673,13 @@ class TestVertexKColorability:
         """An authored budget-exceeded label on a trivially decidable graph
         must not validate."""
         from jacobian.math.graphs.coloring._models import (
-            GraphEdgeList,
             KColorabilityResult,
         )
+        from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
         with pytest.raises(ValidationError):
             KColorabilityResult(
-                graph=GraphEdgeList(vertex_count=2, edges=((0, 1),)),
+                graph=IndexedSimpleUndirectedGraph(vertex_count=2, edges=((0, 1),)),
                 colors=2,
                 solver_conflicts=1000,
                 status="SOLVER_BUDGET_EXCEEDED",
@@ -758,11 +758,11 @@ class TestVertexKColorability:
         """A colorable claim must carry one in-range color per vertex and the
         witness must be proper for the result's own graph."""
         from jacobian.math.graphs.coloring._models import (
-            GraphEdgeList,
             KColorabilityResult,
         )
+        from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
-        path = GraphEdgeList(vertex_count=3, edges=((0, 1), (1, 2)))
+        path = IndexedSimpleUndirectedGraph(vertex_count=3, edges=((0, 1), (1, 2)))
         base = {
             "graph": path,
             "colors": 2,

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -98,6 +98,17 @@ def test_all_vertices_of_empty_graph_form_a_maximal_set() -> None:
     assert result.decision == "MAXIMAL"
 
 
+def test_null_graph_makes_the_empty_candidate_maximal() -> None:
+    """The canonical value carries the null graph; the empty candidate set
+    is its unique maximal independent set."""
+
+    result = compute_maximal_independent_set_decision(
+        _request(vertex_count=0, edges=[], candidate_set=[])
+    )
+
+    assert result.decision == "MAXIMAL"
+
+
 @pytest.mark.parametrize(
     ("candidate_set", "message"),
     [
@@ -636,6 +647,28 @@ class TestVertexKColorability:
             vertex_count=4,
             edges=((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)),
         )
+
+    def test_null_graph_is_decided_colorable_with_an_empty_witness(self):
+        """The null graph is k-colorable for every palette; the produced
+        result must round-trip through full validation."""
+        from jacobian.math.graphs.coloring._models import (
+            KColorabilityRequest,
+            KColorabilityResult,
+        )
+        from jacobian.math.graphs.coloring._operations import compute_k_colorability
+        from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
+
+        result = compute_k_colorability(
+            KColorabilityRequest(
+                graph=IndexedSimpleUndirectedGraph(vertex_count=0, edges=()),
+                colors=3,
+            )
+        )
+        assert result.status == "DECIDED"
+        assert result.colorable is True
+        assert result.coloring == ()
+        assert result.vertex_count == 0
+        assert KColorabilityResult.model_validate(result.model_dump()) == result
 
     def test_triangle_decision_carries_a_proper_witness(self):
         from jacobian.math.graphs.coloring._models import KColorabilityRequest

--- a/tests/math/graphs/test_graph_coloring.py
+++ b/tests/math/graphs/test_graph_coloring.py
@@ -45,7 +45,7 @@ def test_non_independent_candidate_returns_canonical_blocking_edge() -> None:
     result = compute_maximal_independent_set_decision(
         _request(
             vertex_count=3,
-            edges=[[1, 0], [1, 2]],
+            edges=[[0, 1], [1, 2]],
             candidate_set=[0, 1],
         )
     )
@@ -676,7 +676,7 @@ class TestVertexKColorability:
 
         result = compute_k_colorability(
             KColorabilityRequest(
-                graph={"vertex_count": 3, "edges": [[0, 1], [1, 2], [2, 0]]},
+                graph={"vertex_count": 3, "edges": [[0, 1], [1, 2], [0, 2]]},
                 colors=3,
             )
         )

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -8,7 +8,6 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.graphs.spectral._models import (
-    GraphEdgeList,
     GraphSpectrumRequest,
     GraphSpectrumResult,
 )
@@ -16,10 +15,28 @@ from jacobian.math.graphs.spectral._operations import (
     compute_adjacency_spectrum,
     compute_laplacian_spectrum,
 )
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 
-def _graph(vertex_count: int, edges: tuple[tuple[int, int], ...]) -> GraphEdgeList:
-    return GraphEdgeList(vertex_count=vertex_count, edges=edges)
+def _graph(
+    vertex_count: int, edges: tuple[tuple[int, int], ...]
+) -> IndexedSimpleUndirectedGraph:
+    return IndexedSimpleUndirectedGraph(vertex_count=vertex_count, edges=edges)
+
+
+def test_indexed_graph_value_composes_with_coloring_and_spectral_requests() -> None:
+    from jacobian.math.graphs.coloring._models import KColorabilityRequest
+
+    graph = _graph(3, ((0, 1), (1, 2)))
+    assert KColorabilityRequest(graph=graph, colors=2).graph is graph
+    assert GraphSpectrumRequest(graph=graph).graph is graph
+
+
+def test_spectral_request_rejects_the_shared_value_outside_its_envelope() -> None:
+    graph = _graph(33, tuple((index, index + 1) for index in range(32)))
+
+    with pytest.raises(ValidationError, match="spectral operations support"):
+        GraphSpectrumRequest(graph=graph)
 
 
 def test_producer_spectra_retain_source_and_replay() -> None:

--- a/tests/math/graphs/test_graph_spectrum_binding.py
+++ b/tests/math/graphs/test_graph_spectrum_binding.py
@@ -32,6 +32,25 @@ def test_indexed_graph_value_composes_with_coloring_and_spectral_requests() -> N
     assert GraphSpectrumRequest(graph=graph).graph is graph
 
 
+def test_null_graph_composes_and_yields_the_empty_spectrum() -> None:
+    """The shared canonical value admits the null graph end to end: both
+    spectral conventions decide it exactly with no eigenvalues."""
+    from jacobian.math.graphs.coloring._models import KColorabilityRequest
+
+    null_graph = _graph(0, ())
+    assert KColorabilityRequest(graph=null_graph, colors=2).graph is null_graph
+
+    adjacency = compute_adjacency_spectrum(GraphSpectrumRequest(graph=null_graph))
+    assert adjacency.eigenvalues == ()
+    assert adjacency.multiplicities == ()
+    assert GraphSpectrumResult.model_validate(adjacency.model_dump()) == adjacency
+
+    laplacian = compute_laplacian_spectrum(GraphSpectrumRequest(graph=null_graph))
+    assert laplacian.eigenvalues == ()
+    assert laplacian.multiplicities == ()
+    assert GraphSpectrumResult.model_validate(laplacian.model_dump()) == laplacian
+
+
 def test_spectral_request_rejects_the_shared_value_outside_its_envelope() -> None:
     graph = _graph(33, tuple((index, index + 1) for index in range(32)))
 

--- a/tests/math/graphs/test_public_api.py
+++ b/tests/math/graphs/test_public_api.py
@@ -47,6 +47,7 @@ def test_exact_public_api_symbols() -> None:
         "IndependenceNumberBudget",
         "IndependenceNumberRequest",
         "IndependenceNumberResult",
+        "IndexedSimpleUndirectedGraph",
         "SimpleUndirectedGraph",
         "biconnected_components",
         "complement",

--- a/tests/math/graphs/test_values.py
+++ b/tests/math/graphs/test_values.py
@@ -1,4 +1,4 @@
-"""Edge case tests for the SimpleUndirectedGraph validator."""
+"""Edge case tests for the simple-graph canonical value validators."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian.canonical import encode_strict_json
 from jacobian.math.graphs.values import (
+    IndexedSimpleUndirectedGraph,
     SimpleUndirectedGraph,
     simple_undirected_graph_wire_bytes,
 )
@@ -46,3 +47,28 @@ def test_graph_wire_size_matches_its_canonical_value_serialization() -> None:
     assert simple_undirected_graph_wire_bytes(graph) == len(
         encode_strict_json(graph.model_dump(mode="json"))
     )
+
+
+def test_indexed_null_graph_is_a_canonical_value() -> None:
+    """The shared indexed value represents the valid null graph."""
+
+    graph = IndexedSimpleUndirectedGraph(vertex_count=0, edges=())
+
+    assert graph.vertex_count == 0
+    assert IndexedSimpleUndirectedGraph.model_validate(graph.model_dump()) == graph
+    assert (
+        IndexedSimpleUndirectedGraph.model_validate_json(graph.model_dump_json())
+        == graph
+    )
+
+
+def test_indexed_null_graph_admits_no_edge() -> None:
+    """With zero vertices every edge endpoint lies outside 0..n-1."""
+
+    with pytest.raises(ValidationError):
+        IndexedSimpleUndirectedGraph(vertex_count=0, edges=((0, 1),))
+
+
+def test_indexed_graph_rejects_negative_vertex_counts() -> None:
+    with pytest.raises(ValidationError):
+        IndexedSimpleUndirectedGraph(vertex_count=-1, edges=())

--- a/tests/math/graphs/test_values.py
+++ b/tests/math/graphs/test_values.py
@@ -72,3 +72,37 @@ def test_indexed_null_graph_admits_no_edge() -> None:
 def test_indexed_graph_rejects_negative_vertex_counts() -> None:
     with pytest.raises(ValidationError):
         IndexedSimpleUndirectedGraph(vertex_count=-1, edges=())
+
+
+def test_indexed_graph_requires_canonical_edge_orientation() -> None:
+    """A reversed pair must be rejected, not silently retained: the shared
+    value composes on serialized equality, so ``(1, 0)`` and ``(0, 1)``
+    cannot both represent the same undirected edge."""
+
+    with pytest.raises(ValidationError, match="left < right"):
+        IndexedSimpleUndirectedGraph(vertex_count=2, edges=((1, 0),))
+
+
+def test_indexed_graph_rejects_duplicate_edges_across_orientation() -> None:
+    """``(0, 1)`` and ``(1, 0)`` are the same undirected edge; submitting
+    both can never validate.  As in ``SimpleUndirectedGraph``, the
+    per-edge canonical-order rule fires before duplicate detection."""
+
+    with pytest.raises(ValidationError):
+        IndexedSimpleUndirectedGraph(vertex_count=2, edges=((1, 0), (0, 1)))
+    with pytest.raises(ValidationError, match="left < right"):
+        IndexedSimpleUndirectedGraph(vertex_count=3, edges=((0, 1), (2, 0)))
+
+
+def test_indexed_canonical_edges_round_trip_serialization() -> None:
+    """Canonical nonempty values keep their exact edge order through the
+    serialized composition boundary."""
+
+    graph = IndexedSimpleUndirectedGraph(vertex_count=3, edges=((0, 1), (1, 2), (0, 2)))
+
+    assert graph.edges == ((0, 1), (1, 2), (0, 2))
+    assert IndexedSimpleUndirectedGraph.model_validate(graph.model_dump()) == graph
+    assert (
+        IndexedSimpleUndirectedGraph.model_validate_json(graph.model_dump_json())
+        == graph
+    )


### PR DESCRIPTION
Fixes #2525.

## Problem

Graph coloring and spectral operations used separate indexed edge-list models for the same finite simple undirected graph. Equivalent native values required serialization and revalidation before crossing the owner boundary.

## Solution

Add the graph-owned `IndexedSimpleUndirectedGraph` value and use it in both coloring and spectral contracts. The value enforces the common indexed simple-graph invariants, is exported from the graphs API, and preserves the existing JSON wire shape and operation IDs.

## Testing

- `make test-focused LANE=math TESTS=tests/math/graphs` — 525 passed
- `make test-focused LANE=integration TESTS=tests/integration/graphs/test_exact_operations.py` — 8 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 41 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 611 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Coloring and spectral operations now share one native graph-value identity. JSON representations and operation IDs remain unchanged.

## Operation boundary ownership

- Changed stage: request parsing, result construction, and native typed composition
- Request-bounds owner and controlling quantities: operation-local graph bounds remain unchanged
- Backend or kernel path: unchanged
- Result construction: graph-owned canonical indexed simple-graph values
- Independent-result verifier: none
- Native/MCP parity: unchanged semantic path and transport projection
- Serialized-result and round-trip evidence: coloring/spectral composition and graph integration tests

## Canonical value audit

- [x] Existing canonical values searched
- [x] Graphs owns the indexed simple-graph value
- [x] Producer-to-consumer serialization tested

## Checklist

- [ ] `make check` passes (not run; owner, catalog, and advertised-example checks passed)