### PR TITLE
Remove the alias-only polynomial-map request export

### DIFF
--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -108,9 +108,6 @@ class EvalResult(StrictModel):
     value: CanonicalRational
 
 
-JacobianRequest = RationalPolynomialMap
-
-
 class JacobianResult(StrictModel):
     """The row-major Jacobian matrix over the source polynomial ring."""
 
@@ -646,7 +643,6 @@ __all__ = [
     "GenericFiberCertificate",
     "GenericFiberPolynomial",
     "GenericFiberTerm",
-    "JacobianRequest",
     "JacobianResult",
     "VariablePoint",
 ]


### PR DESCRIPTION
Fixes #2562.

## Problem

The polynomial-map module still exported `JacobianRequest` as an alias-only public residue. The supported operation uses its owner-local request model directly, so the alias added another name without a distinct mathematical contract.

## Solution

Remove the alias and its exports, including stale import surfaces. The supported polynomial-Jacobian operation, schema, and catalog identity are unchanged.

## Testing

- focused polynomial-map math tests — 7 passed
- catalog conformance — 12 passed
- advertised polynomial-Jacobian example — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The unsupported `JacobianRequest` alias is removed. Callers should use the operation’s owner-local request contract.

## Checklist

- [ ] `make check` passes (not complete; focused math, catalog, and example checks passed)