### PR TITLE
Share crossed-product matrix-vector multiplication

### DIFF
--- a/src/jacobian/math/crossed_products/operations.py
+++ b/src/jacobian/math/crossed_products/operations.py
@@ -10,6 +10,7 @@ from jacobian.math.crossed_products.values import (
     FiniteCosetCrossedProductElement,
     FiniteCosetCrossedProductPresentation,
     FiniteCosetCrossedProductTerm,
+    _integer_matrix_vector_product,
 )
 
 MAX_CONVOLUTION_PAIRS = 1_024
@@ -35,16 +36,6 @@ def _integer_cocycle(
             tuple(parse_canonical_integer(entry) for entry in vector) for vector in row
         )
         for row in presentation.cocycle_table
-    )
-
-
-def _matrix_vector_product(
-    matrix: tuple[tuple[int, ...], ...],
-    vector: tuple[int, ...],
-) -> tuple[int, ...]:
-    return tuple(
-        sum(entry * coordinate for entry, coordinate in zip(row, vector, strict=True))
-        for row in matrix
     )
 
 
@@ -204,7 +195,9 @@ def _multiply_admitted(
                 right_coset
             ]
             product_coset = coset_index[product_coset_label]
-            transformed = _matrix_vector_product(actions[left_coset], right_exponents)
+            transformed = _integer_matrix_vector_product(
+                actions[left_coset], right_exponents
+            )
             product_exponents = tuple(
                 left_coordinate + transformed_coordinate + cocycle_coordinate
                 for left_coordinate, transformed_coordinate, cocycle_coordinate in zip(

--- a/tests/math/crossed_products/test_crossed_products.py
+++ b/tests/math/crossed_products/test_crossed_products.py
@@ -20,10 +20,16 @@ from jacobian.math.crossed_products.values import (
     FiniteCosetCrossedProductElement,
     FiniteCosetCrossedProductPresentation,
     FiniteCosetCrossedProductTerm,
+    _integer_matrix_vector_product,
 )
 
 Exponent = tuple[int, ...]
 Support = set[Exponent]
+
+
+def test_integer_matrix_vector_product_handles_zero_and_full_rank_actions() -> None:
+    assert _integer_matrix_vector_product((), ()) == ()
+    assert _integer_matrix_vector_product(((2, -1), (3, 4)), (5, -2)) == (12, 7)
 
 
 def _c2_presentation(


### PR DESCRIPTION
Fixes #2544.

## Problem

Crossed-product value validation and operation execution each implemented the same exact integer matrix-vector multiplication. A future correction to dimensions, empty vectors, or arithmetic could split the validator and kernel semantics.

## Solution

Use the crossed-products-owned matrix-vector primitive from both paths. Parsing, action admission, work budgets, and public results remain at their existing owners.

## Testing

- `make test-focused LANE=math TESTS=tests/math/crossed_products/test_crossed_products.py` — 25 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. Operation schemas, IDs, and mathematical results are unchanged.

## Checklist

- [ ] `make check` passes (not complete; the owning math lane passed)