### PR TITLE
Share canonical rational polytope values and geometry kernels

### DIFF
--- a/src/jacobian/math/lattice_polytopes/_models.py
+++ b/src/jacobian/math/lattice_polytopes/_models.py
@@ -9,10 +9,11 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
     CanonicalInteger,
-    CanonicalRational,
     require_bounded_rational,
 )
 from jacobian._models import StrictModel
+from jacobian.math.polytope.values import Halfspace as RationalHalfspace
+from jacobian.math.polytope.values import Vertex as RationalVertex
 
 if TYPE_CHECKING:
     from jacobian.math.lattice_polytopes._operations import AdmittedGeometry
@@ -84,45 +85,12 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"lattice_polytope.{reason}", message)
 
 
-class Vertex(StrictModel):
-    """One rational vertex of a V-representation."""
-
-    coordinates: tuple[CanonicalRational, ...] = Field(
-        min_length=1, max_length=MAX_DIMENSION
-    )
-
-
-class Halfspace(StrictModel):
-    """One rational half-space ``<a, x> <= b`` of an H-representation."""
-
-    coefficients: tuple[CanonicalRational, ...] = Field(
-        min_length=1,
-        max_length=MAX_DIMENSION,
-        description=(
-            "The normal vector ``a`` of ``<a, x> <= b``.  At least one "
-            "coefficient must be nonzero: constant rows ``0 <= b`` are "
-            "rejected, including the contradiction ``0 <= -1``."
-        ),
-    )
-    offset: CanonicalRational = Field(
-        description="The right-hand side ``b`` of ``<a, x> <= b``.",
-    )
-
-    @model_validator(mode="after")
-    def require_nonzero_normal(self) -> Self:
-        if all(c.as_fraction() == 0 for c in self.coefficients):
-            raise _validation_error(
-                "halfspace_normal_zero", "half-space coefficients must not all be zero"
-            )
-        return self
-
-
 class LatticePolytopeRequest(StrictModel):
     """A bounded rational polytope in exactly one representation."""
 
     _geometry: AdmittedGeometry | None = PrivateAttr(default=None)
 
-    vertices: tuple[Vertex, ...] | None = Field(
+    vertices: tuple[RationalVertex, ...] | None = Field(
         default=None,
         min_length=1,
         max_length=MAX_VERTICES,
@@ -136,7 +104,7 @@ class LatticePolytopeRequest(StrictModel):
             "exclusive with ``halfspaces``."
         ),
     )
-    halfspaces: tuple[Halfspace, ...] | None = Field(
+    halfspaces: tuple[RationalHalfspace, ...] | None = Field(
         default=None,
         min_length=1,
         max_length=MAX_HALFSPACES,
@@ -422,9 +390,7 @@ __all__ = [
     "CountLatticePointsResult",
     "EnumerateLatticePointsRequest",
     "EnumerateLatticePointsResult",
-    "Halfspace",
     "LatticePoint",
     "LatticePolytopeRequest",
     "RepresentationName",
-    "Vertex",
 ]

--- a/src/jacobian/math/lattice_polytopes/_operations.py
+++ b/src/jacobian/math/lattice_polytopes/_operations.py
@@ -34,11 +34,10 @@ from __future__ import annotations
 
 import math
 from fractions import Fraction
-from itertools import combinations, product
+from itertools import product
 from typing import Literal
 
 from sympy import Matrix, Rational
-from sympy.matrices.exceptions import NonInvertibleMatrixError
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.lattice_polytopes._models import (
@@ -48,8 +47,13 @@ from jacobian.math.lattice_polytopes._models import (
     EnumerateLatticePointsResult,
     LatticePoint,
     LatticePolytopeRequest,
-    Vertex,
 )
+from jacobian.math.polytope import _rational_geometry
+from jacobian.math.polytope._rational_geometry import (
+    recession_cone_is_trivial,
+    vertices_from_halfspaces,
+)
+from jacobian.math.polytope.values import Vertex
 
 __all__ = ["count_lattice_points", "enumerate_lattice_points"]
 
@@ -66,58 +70,6 @@ class LatticePointBudgetError(ValueError):
     """Raised when the enumeration would exceed a fail-closed budget bound."""
 
 
-def _hyperplane_normal(points: list[list[Rational]]) -> Matrix | None:
-    """Return a normal vector to the hyperplane through ``points``.
-
-    ``points`` holds exactly ``d`` points in ``d``-dimensional space.
-    The normal is any non-zero vector in the null space of the matrix
-    whose rows are ``points[i] - points[0]`` for ``i >= 1``.  Returns
-    ``None`` when the points are affinely dependent (no unique
-    hyperplane).
-    """
-    d = len(points)
-    if d == 1:
-        return Matrix([Rational(1)])
-    diffs = Matrix(
-        [[points[i][k] - points[0][k] for k in range(d)] for i in range(1, d)]
-    )
-    basis = diffs.nullspace()
-    if not basis:
-        return None
-    return basis[0]
-
-
-def _facets_from_points(
-    verts: list[list[Rational]], d: int
-) -> list[tuple[Matrix, Rational]]:
-    """Enumerate the facet half-spaces of the convex hull of ``verts``.
-
-    Each facet is returned as ``(normal, offset)`` with the orientation
-    ``normal . x <= offset`` satisfied by every vertex.  Facets are
-    deduplicated by their (normal, offset) signature.
-    """
-    facets: list[tuple[Matrix, Rational]] = []
-    for combo in combinations(range(len(verts)), d):
-        pts = [verts[i] for i in combo]
-        normal = _hyperplane_normal(pts)
-        if normal is None:
-            continue
-        offset = sum(normal[k] * pts[0][k] for k in range(d))
-        residuals = [sum(normal[k] * v[k] for k in range(d)) - offset for v in verts]
-        if all(v <= 0 for v in residuals):
-            facets.append((normal, offset))
-        elif all(v >= 0 for v in residuals):
-            facets.append((Matrix([-x for x in normal]), -offset))
-    seen: set[tuple[tuple[Rational, ...], Rational]] = set()
-    out: list[tuple[Matrix, Rational]] = []
-    for normal, offset in facets:
-        key = (tuple(Rational(x) for x in normal), offset)
-        if key not in seen:
-            seen.add(key)
-            out.append((normal, offset))
-    return out
-
-
 def _is_bounded_h(halfspaces: list[tuple[list[Rational], Rational]], d: int) -> bool:
     """Decide whether ``{x : A x <= b}`` is bounded.
 
@@ -131,30 +83,9 @@ def _is_bounded_h(halfspaces: list[tuple[list[Rational], Rational]], d: int) -> 
     polyhedron is unbounded even though the hull's single facet has
     positive offset.
     """
-    normals = [coeffs for coeffs, _ in halfspaces]
-    if d == 1:
-        positive = any(n[0] > 0 for n in normals)
-        negative = any(n[0] < 0 for n in normals)
-        return positive and negative
-    rows = [list(n) for n in normals]
-    # Positive spanning requires the normals' convex hull to be full-
-    # dimensional.  Check affine rank of the point set.
-    if len(rows) < d + 1:
-        return False
-    # Affine rank via differences from first point
-    diff_rows = [
-        [rows[i][k] - rows[0][k] for k in range(d)] for i in range(1, len(rows))
-    ]
-    # Use Rational matrix rank for exactness
-    try:
-        if Matrix(diff_rows).rank() < d:
-            return False
-    except Exception:
-        return False
-    hull_facets = _facets_from_points([Matrix(r) for r in rows], d)
-    if not hull_facets:
-        return False
-    return all(Rational(0) < offset for _, offset in hull_facets)
+    return recession_cone_is_trivial(
+        [coefficients for coefficients, _offset in halfspaces], d
+    )
 
 
 def _vertices_from_h_representation(
@@ -169,42 +100,8 @@ def _vertices_from_h_representation(
     dimensions this operation admits.
     """
     dim = len(halfspaces[0][0])
-    n = len(halfspaces)
 
-    found: list[list[Rational]] = []
-    for indices in combinations(range(n), dim):
-        rows = [halfspaces[i] for i in indices]
-        mat = Matrix([rows[i][0] for i in range(dim)])
-        rhs = Matrix([[rows[i][1]] for i in range(dim)])
-        try:
-            det = mat.det()
-        except Exception:
-            continue
-        if det == 0:
-            continue
-        try:
-            solution = mat.solve(rhs)
-        except (NonInvertibleMatrixError, ValueError):
-            continue
-        point = [Rational(solution[i, 0]) for i in range(dim)]
-        feasible = True
-        for coeffs, offset in halfspaces:
-            lhs = sum(c * p for c, p in zip(coeffs, point, strict=True))
-            if lhs > offset:
-                feasible = False
-                break
-        if not feasible:
-            continue
-        found.append(point)
-
-    unique: list[list[Rational]] = []
-    seen: set[tuple[Rational, ...]] = set()
-    for point in found:
-        key = tuple(point)
-        if key not in seen:
-            seen.add(key)
-            unique.append(point)
-    return unique, dim
+    return [list(point) for point in vertices_from_halfspaces(halfspaces, dim)], dim
 
 
 def _rational_vertices(
@@ -444,7 +341,7 @@ def _facets_and_box(  # noqa: C901
                 (Matrix([Rational(-1)]), -low),
             ]
         else:
-            rational_facets = _facets_from_points(verts, d)
+            rational_facets = _rational_geometry.facets_from_points(verts, d)
         facets = [
             _to_integer_facet(normal, offset, d) for normal, offset in rational_facets
         ]

--- a/src/jacobian/math/polytope/__init__.py
+++ b/src/jacobian/math/polytope/__init__.py
@@ -15,6 +15,7 @@ from jacobian.math.polytope._models import (
     RationalVPolytope,
     require_support_components_within_envelope,
 )
+from jacobian.math.polytope.values import Halfspace, Vertex
 
 
 def polytope_support(
@@ -109,12 +110,14 @@ def convex_hull_volume(
 
 
 __all__ = [
+    "Halfspace",
     "PolytopeSupportResult",
     "RationalCoordinateSpace",
     "RationalCovector",
     "RationalExposedFace",
     "RationalPolytopeVertex",
     "RationalVPolytope",
+    "Vertex",
     "convex_hull_volume",
     "polytope_support",
 ]

--- a/src/jacobian/math/polytope/_models.py
+++ b/src/jacobian/math/polytope/_models.py
@@ -21,6 +21,11 @@ from pydantic_core import PydanticCustomError
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.math.polytope.values import (
+    MAX_RATIONAL_POLYTOPE_DIMENSION,
+    Halfspace,
+    Vertex,
+)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -48,7 +53,7 @@ whose own envelopes are narrower reject over-dimensional values through
 their published dimension bounds.
 """
 
-MAX_FACET_DIMENSION = 7
+MAX_FACET_DIMENSION = MAX_RATIONAL_POLYTOPE_DIMENSION
 """Ambient-dimension bound for complete V-representation facet profiles.
 
 This is deliberately one dimension wider than exact volume: the 14-vertex
@@ -973,14 +978,6 @@ def require_volume_components_within_result_bound(
     _require_triangulated_volume_within_result_bound(table, triangulation, dim)
 
 
-class Vertex(StrictModel):
-    """One rational vertex of a V-representation."""
-
-    coordinates: tuple[CanonicalRational, ...] = Field(
-        min_length=1, max_length=MAX_FACET_DIMENSION
-    )
-
-
 class PrimitiveFacet(StrictModel):
     """One canonically scaled supporting inequality and its source incidences.
 
@@ -1501,26 +1498,6 @@ class RationalExposedFace(StrictModel):
                 "exposed face exceeds the canonical JSON output bound",
             ) from exc
         return self
-
-
-class Halfspace(StrictModel):
-    """One rational half-space ``<a, x> <= b`` of an H-representation.
-
-    The normal ``a`` must be nonzero: at least one coefficient entry must
-    differ from zero.  A row with all-zero coefficients is a tautology or
-    contradiction, not a half-space, and is rejected as a typed request
-    error rather than silently changing the polytope.
-    """
-
-    coefficients: tuple[CanonicalRational, ...] = Field(
-        min_length=1,
-        max_length=MAX_FACET_DIMENSION,
-        description=(
-            "Normal vector a of the half-space <a, x> <= b; at least one "
-            "entry must be nonzero (all-zero rows are rejected)."
-        ),
-    )
-    offset: CanonicalRational
 
 
 def require_support_components_within_envelope(

--- a/src/jacobian/math/polytope/_operations.py
+++ b/src/jacobian/math/polytope/_operations.py
@@ -43,7 +43,6 @@ from jacobian.math.polytope._models import (
     MAX_SUPPORT_VERTEX_SUBSETS,
     FacetIncidenceRequest,
     FacetIncidenceResult,
-    Halfspace,
     PolytopeSupportRequest,
     PolytopeSupportResult,
     PolytopeVolumeRequest,
@@ -52,7 +51,6 @@ from jacobian.math.polytope._models import (
     RationalCovector,
     RationalPolytopeVertex,
     RationalVPolytope,
-    Vertex,
 )
 from jacobian.math.polytope._rational_geometry import (
     facets_from_points as _facets_from_points,
@@ -61,6 +59,7 @@ from jacobian.math.polytope._rational_geometry import (
     recession_cone_is_trivial,
     vertices_from_halfspaces,
 )
+from jacobian.math.polytope.values import Halfspace, Vertex
 
 # Absolute combinatorial ceiling: reject vertex enumeration that would
 # attempt to solve more subsystems than this. With ``MAX_FACETS = 64``

--- a/src/jacobian/math/polytope/_operations.py
+++ b/src/jacobian/math/polytope/_operations.py
@@ -29,7 +29,6 @@ from itertools import combinations
 from typing import Literal
 
 from sympy import Matrix, Rational
-from sympy.matrices.exceptions import NonInvertibleMatrixError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
@@ -55,6 +54,13 @@ from jacobian.math.polytope._models import (
     RationalVPolytope,
     Vertex,
 )
+from jacobian.math.polytope._rational_geometry import (
+    facets_from_points as _facets_from_points,
+)
+from jacobian.math.polytope._rational_geometry import (
+    recession_cone_is_trivial,
+    vertices_from_halfspaces,
+)
 
 # Absolute combinatorial ceiling: reject vertex enumeration that would
 # attempt to solve more subsystems than this. With ``MAX_FACETS = 64``
@@ -65,60 +71,6 @@ MAX_SUBSYSTEM_SOLVES = 5_000_000
 # ``MAX_HULL_SUBFACETS`` (the C(n, d) hull-enumeration ceiling) is owned
 # by ``_models`` beside the other published request bounds, which quote it
 # in their schema-visible descriptions.
-
-
-def _hyperplane_normal(points: list[list[Rational]]) -> Matrix | None:
-    """Return a normal vector to the hyperplane through ``points``.
-
-    ``points`` holds exactly ``d`` points in ``d``-dimensional space.
-    The normal is any non-zero vector in the null space of the matrix
-    whose rows are ``points[i] - points[0]`` for ``i >= 1``. Returns
-    ``None`` when the points are affinely dependent (no unique
-    hyperplane).
-    """
-
-    d = len(points)
-    if d == 1:
-        return Matrix([Rational(1)])
-    diffs = Matrix(
-        [[points[i][k] - points[0][k] for k in range(d)] for i in range(1, d)]
-    )
-    basis = diffs.nullspace()
-    if len(basis) != 1:
-        return None
-    return basis[0]
-
-
-def _facets_from_points(
-    verts: list[list[Rational]], dim: int
-) -> list[tuple[Matrix, Rational]]:
-    """Enumerate the facet half-spaces of the convex hull of ``verts``.
-
-    Each facet is returned as ``(normal, offset)`` with the orientation
-    ``normal . x <= offset`` satisfied by every vertex. Facets are
-    deduplicated by their (normal, offset) signature.
-    """
-
-    facets: list[tuple[Matrix, Rational]] = []
-    for combo in combinations(range(len(verts)), dim):
-        pts = [verts[i] for i in combo]
-        normal = _hyperplane_normal(pts)
-        if normal is None:
-            continue
-        offset = sum(normal[k] * pts[0][k] for k in range(dim))
-        residuals = [sum(normal[k] * v[k] for k in range(dim)) - offset for v in verts]
-        if all(v <= 0 for v in residuals):
-            facets.append((normal, offset))
-        elif all(v >= 0 for v in residuals):
-            facets.append((Matrix([-x for x in normal]), -offset))
-    seen: set[tuple[tuple[Rational, ...], Rational]] = set()
-    out: list[tuple[Matrix, Rational]] = []
-    for normal, offset in facets:
-        key = (tuple(Rational(x) for x in normal), offset)
-        if key not in seen:
-            seen.add(key)
-            out.append((normal, offset))
-    return out
 
 
 def _deduplicate_source_rows(points: list[list[Rational]]) -> list[list[Rational]]:
@@ -348,15 +300,6 @@ def _is_bounded_h(halfspaces: tuple[Halfspace, ...]) -> bool:
     # dimensional; otherwise the polyhedron is unbounded.
     if len(normals) < dim + 1:
         return False
-    diff_rows = [
-        [normals[i][k] - normals[0][k] for k in range(dim)]
-        for i in range(1, len(normals))
-    ]
-    try:
-        if Matrix(diff_rows).rank() < dim:
-            return False
-    except Exception:
-        return False
     # Guard the exact facet enumeration of the row normals: the budget
     # applies to the distinct rows after duplicate removal, exactly as the
     # enumeration below counts its own work.
@@ -370,10 +313,7 @@ def _is_bounded_h(halfspaces: tuple[Halfspace, ...]) -> bool:
             f"{MAX_BOUNDEDNESS_COMBINATIONS}-combination budget "
             f"({combo_count} > {MAX_BOUNDEDNESS_COMBINATIONS})"
         )
-    hull_facets = _facets_from_points(normals, dim)
-    if not hull_facets:
-        return False
-    return all(Rational(0) < offset for _, offset in hull_facets)
+    return recession_cone_is_trivial(normals, dim)
 
 
 def _format_rational(value: Rational) -> str:
@@ -818,39 +758,6 @@ def _halfspace_rows(
     ]
 
 
-def _solve_subsystem_vertex(
-    rows: list[tuple[list[Rational], Rational]],
-    indices: tuple[int, ...],
-    dim: int,
-) -> tuple[Rational, ...] | None:
-    """Solve the dim-subsystem of hyperplanes, or None if singular."""
-    mat = Matrix([rows[i][0] for i in indices])
-    rhs = Matrix([[rows[i][1]] for i in indices])
-    try:
-        det = mat.det()
-    except Exception:
-        return None
-    if det == 0:
-        return None
-    try:
-        solution = mat.solve(rhs)
-    except (NonInvertibleMatrixError, ValueError):
-        return None
-    return tuple(Rational(solution[i, 0]) for i in range(dim))
-
-
-def _is_feasible(
-    point: tuple[Rational, ...],
-    rows: list[tuple[list[Rational], Rational]],
-) -> bool:
-    """Return True if ``point`` satisfies every half-space ``<a, x> <= b``."""
-    for coeffs, offset in rows:
-        lhs = sum(c * p for c, p in zip(coeffs, point, strict=True))
-        if lhs > offset:
-            return False
-    return True
-
-
 def _vertices_from_h_representation(
     halfspaces: tuple[Halfspace, ...],
 ) -> tuple[list[tuple[Rational, ...]], int]:
@@ -879,21 +786,10 @@ def _vertices_from_h_representation(
             f"({subsystem_count} > {MAX_SUBSYSTEM_SOLVES} subsystems)"
         )
 
-    found: list[tuple[Rational, ...]] = []
-    for indices in combinations(range(n), dim):
-        point = _solve_subsystem_vertex(rows, indices, dim)
-        if point is None or not _is_feasible(point, rows):
-            continue
-        found.append(point)
-
-    # Deduplicate coincident vertices found from different subsystems.
-    unique: list[tuple[Rational, ...]] = []
-    unique_seen: set[tuple[Rational, ...]] = set()
-    for point in found:
-        if point not in unique_seen:
-            unique_seen.add(point)
-            unique.append(point)
-    result: tuple[list[tuple[Rational, ...]], int] = (unique, dim)
+    result: tuple[list[tuple[Rational, ...]], int] = (
+        vertices_from_halfspaces(rows, dim),
+        dim,
+    )
     return result
 
 

--- a/src/jacobian/math/polytope/_rational_geometry.py
+++ b/src/jacobian/math/polytope/_rational_geometry.py
@@ -1,0 +1,126 @@
+"""Shared exact geometry primitives for rational polytope owners.
+
+The helpers establish geometric facts only.  Callers own every request's
+combination, intermediate-height, scan, and result-envelope admission.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import combinations
+
+from sympy import Matrix, Rational
+from sympy.matrices.exceptions import NonInvertibleMatrixError
+
+RationalRow = tuple[Sequence[Rational], Rational]
+
+
+def hyperplane_normal(points: Sequence[Sequence[Rational]]) -> Matrix | None:
+    """Return the unique normal through ``dim`` affine points, if one exists."""
+
+    dimension = len(points)
+    if dimension == 1:
+        return Matrix([Rational(1)])
+    differences = Matrix(
+        [
+            [points[index][axis] - points[0][axis] for axis in range(dimension)]
+            for index in range(1, dimension)
+        ]
+    )
+    basis = differences.nullspace()
+    return basis[0] if len(basis) == 1 else None
+
+
+def facets_from_points(
+    vertices: Sequence[Sequence[Rational]], dimension: int
+) -> list[tuple[Matrix, Rational]]:
+    """Enumerate distinct oriented supporting rows of ``conv(vertices)``."""
+
+    candidates: list[tuple[Matrix, Rational]] = []
+    for indices in combinations(range(len(vertices)), dimension):
+        points = [vertices[index] for index in indices]
+        normal = hyperplane_normal(points)
+        if normal is None:
+            continue
+        offset = sum(normal[axis] * points[0][axis] for axis in range(dimension))
+        residuals = [
+            sum(normal[axis] * vertex[axis] for axis in range(dimension)) - offset
+            for vertex in vertices
+        ]
+        if all(value <= 0 for value in residuals):
+            candidates.append((normal, offset))
+        elif all(value >= 0 for value in residuals):
+            candidates.append((Matrix([-value for value in normal]), -offset))
+
+    seen: set[tuple[tuple[Rational, ...], Rational]] = set()
+    facets: list[tuple[Matrix, Rational]] = []
+    for normal, offset in candidates:
+        key = tuple(Rational(value) for value in normal), offset
+        if key not in seen:
+            seen.add(key)
+            facets.append((normal, offset))
+    return facets
+
+
+def recession_cone_is_trivial(
+    normals: Sequence[Sequence[Rational]], dimension: int
+) -> bool:
+    """Decide whether ``{y : Ay <= 0}`` contains only the zero vector."""
+
+    normals = [list(normal) for normal in normals]
+    if dimension == 1:
+        return any(row[0] > 0 for row in normals) and any(row[0] < 0 for row in normals)
+    if len(normals) < dimension + 1:
+        return False
+    differences = [
+        [normals[index][axis] - normals[0][axis] for axis in range(dimension)]
+        for index in range(1, len(normals))
+    ]
+    try:
+        if Matrix(differences).rank() < dimension:
+            return False
+    except Exception:
+        return False
+    hull_facets = facets_from_points(normals, dimension)
+    return bool(hull_facets) and all(
+        Rational(0) < offset for _normal, offset in hull_facets
+    )
+
+
+def vertices_from_halfspaces(
+    rows: Sequence[RationalRow], dimension: int
+) -> list[tuple[Rational, ...]]:
+    """Enumerate feasible, distinct vertices of a bounded H-representation."""
+
+    vertices: list[tuple[Rational, ...]] = []
+    for indices in combinations(range(len(rows)), dimension):
+        selected = [rows[index] for index in indices]
+        matrix = Matrix([coefficients for coefficients, _offset in selected])
+        rhs = Matrix([[_offset] for _coefficients, _offset in selected])
+        try:
+            if matrix.det() == 0:
+                continue
+            solution = matrix.solve(rhs)
+        except (NonInvertibleMatrixError, ValueError):
+            continue
+        point = tuple(Rational(solution[axis, 0]) for axis in range(dimension))
+        if all(
+            sum(
+                coefficient * coordinate
+                for coefficient, coordinate in zip(coefficients, point, strict=True)
+            )
+            <= offset
+            for coefficients, offset in rows
+        ):
+            vertices.append(point)
+
+    return list(dict.fromkeys(vertices))
+
+
+__all__ = [
+    "RationalRow",
+    "facets_from_points",
+    "hyperplane_normal",
+    "recession_cone_is_trivial",
+    "vertices_from_halfspaces",
+]

--- a/src/jacobian/math/polytope/values.py
+++ b/src/jacobian/math/polytope/values.py
@@ -1,0 +1,55 @@
+"""Canonical rational V- and H-representation values."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import Field, model_validator
+from pydantic_core import PydanticCustomError
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+
+MAX_RATIONAL_POLYTOPE_DIMENSION = 7
+"""Largest ambient axis supported by the canonical rational values."""
+
+
+def _validation_error(reason: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(f"polytope.{reason}", message)
+
+
+class Vertex(StrictModel):
+    """One rational vertex of a V-representation."""
+
+    coordinates: tuple[CanonicalRational, ...] = Field(
+        min_length=1, max_length=MAX_RATIONAL_POLYTOPE_DIMENSION
+    )
+
+
+class Halfspace(StrictModel):
+    """One rational half-space ``<a, x> <= b`` of an H-representation."""
+
+    coefficients: tuple[CanonicalRational, ...] = Field(
+        min_length=1,
+        max_length=MAX_RATIONAL_POLYTOPE_DIMENSION,
+        description=(
+            "Normal vector a of the half-space <a, x> <= b; at least one "
+            "entry must be nonzero (all-zero rows are rejected)."
+        ),
+    )
+    offset: CanonicalRational
+
+    @model_validator(mode="after")
+    def require_nonzero_normal(self) -> Self:
+        if all(coefficient.as_fraction() == 0 for coefficient in self.coefficients):
+            raise _validation_error(
+                "halfspace_normal_zero", "half-space coefficients must not all be zero"
+            )
+        return self
+
+
+__all__ = [
+    "MAX_RATIONAL_POLYTOPE_DIMENSION",
+    "Halfspace",
+    "Vertex",
+]

--- a/tests/math/lattice_polytopes/test_lattice_polytopes.py
+++ b/tests/math/lattice_polytopes/test_lattice_polytopes.py
@@ -12,15 +12,14 @@ from jacobian.math.lattice_polytopes._models import (
     MAX_BOUND_SPAN,
     MAX_DIMENSION,
     EnumerateLatticePointsRequest,
-    Halfspace,
     LatticePolytopeRequest,
-    Vertex,
 )
 from jacobian.math.lattice_polytopes._operations import (
     LatticePointBudgetError,
     count_lattice_points,
     enumerate_lattice_points,
 )
+from jacobian.math.polytope import Halfspace, Vertex
 
 
 def _cr(num: str, den: str = "1") -> dict[str, str]:
@@ -58,6 +57,18 @@ UNIT_SQUARE_H = (
     _hs((("0", "1"), ("1", "1")), ("1", "1")),  #  y <= 1
     _hs((("0", "1"), ("-1", "1")), ("0", "1")),  # -y <= 0
 )
+
+
+def test_canonical_polytope_values_feed_lattice_requests_directly() -> None:
+    vertex = Vertex(coordinates=(_cr("0"),))
+    upper = Halfspace(coefficients=(_cr("1"),), offset=_cr("0"))
+    lower = Halfspace(coefficients=(_cr("-1"),), offset=_cr("0"))
+
+    vertex_request = LatticePolytopeRequest(vertices=(vertex,))
+    halfspace_request = LatticePolytopeRequest(halfspaces=(upper, lower))
+
+    assert vertex_request.vertices == (vertex,)
+    assert halfspace_request.halfspaces == (upper, lower)
 
 
 class TestEnumerate:
@@ -249,11 +260,12 @@ class TestRejection:
             LatticePolytopeRequest()
 
     def test_all_zero_halfspace_normal_rejected(self) -> None:
-        with raises_code("halfspace_normal_zero"):
+        with pytest.raises(ValidationError) as error:
             Halfspace(
                 coefficients=(_cr("0"), _cr("0")),
                 offset=_cr("1"),
             )
+        assert error.value.errors()[0]["type"] == "polytope.halfspace_normal_zero"
 
 
 class TestBudgets:
@@ -663,17 +675,17 @@ class TestFacetGeometryComputedOnce:
     )
 
     def _count_facet_passes(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
-        from jacobian.math.lattice_polytopes import _operations
+        from jacobian.math.polytope import _rational_geometry
 
         passes = []
 
-        original = _operations._facets_from_points
+        original = _rational_geometry.facets_from_points
 
         def counting(verts, d):
             passes.append(d)
             return original(verts, d)
 
-        monkeypatch.setattr(_operations, "_facets_from_points", counting)
+        monkeypatch.setattr(_rational_geometry, "facets_from_points", counting)
         return passes
 
     def test_enumerate_request_and_execution_share_one_facet_pass(

--- a/tests/math/lattice_polytopes/test_lattice_polytopes.py
+++ b/tests/math/lattice_polytopes/test_lattice_polytopes.py
@@ -69,6 +69,8 @@ def test_canonical_polytope_values_feed_lattice_requests_directly() -> None:
 
     assert vertex_request.vertices == (vertex,)
     assert halfspace_request.halfspaces == (upper, lower)
+    assert count_lattice_points(vertex_request).point_count == 1
+    assert count_lattice_points(halfspace_request).point_count == 1
 
 
 class TestEnumerate:

--- a/tests/math/polytope/test_polytope.py
+++ b/tests/math/polytope/test_polytope.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
+from jacobian.math.polytope import Halfspace, Vertex
 from jacobian.math.polytope import _operations as polytope_operations
 from jacobian.math.polytope._models import (
     MAX_COMPUTED_FACETS,
@@ -22,7 +23,6 @@ from jacobian.math.polytope._models import (
     MAX_VERTICES,
     FacetIncidenceRequest,
     FacetIncidenceResult,
-    Halfspace,
     PolytopeSupportRequest,
     PolytopeVolumeRequest,
     PolytopeVolumeResult,
@@ -33,7 +33,6 @@ from jacobian.math.polytope._models import (
 )
 from jacobian.math.polytope._operations import (
     PrimitiveFacet,
-    Vertex,
     compute_facet_incidence,
     compute_polytope_support,
     compute_polytope_volume,
@@ -1222,16 +1221,12 @@ class TestNonzeroNormalContractPublished:
     def test_zero_normal_row_rejected_at_request_admission(self) -> None:
         """The reviewer's tautology `0*x + 0*y <= 1` fails typed validation,
         not a host exception after acceptance."""
-        with pytest.raises(ValueError, match="must not all be zero"):
-            PolytopeVolumeRequest(
-                halfspaces=(
-                    _h((1, 1), (0, 1), offset=(1, 1)),
-                    _h((-1, 1), (0, 1), offset=(0, 1)),
-                    _h((0, 1), (1, 1), offset=(1, 1)),
-                    _h((0, 1), (-1, 1), offset=(0, 1)),
-                    _h((0, 1), (0, 1), offset=(1, 1)),
-                )
+        with pytest.raises(ValidationError) as error:
+            Halfspace(
+                coefficients=(_cr0(), _cr0()),
+                offset=_cr0(),
             )
+        assert error.value.errors()[0]["type"] == "polytope.halfspace_normal_zero"
 
     def test_nonzero_normal_rule_is_schema_visible(self) -> None:
         schema = Halfspace.model_json_schema()


### PR DESCRIPTION
Fixes #2527.

## Problem

Rational polytope and lattice-polytope operations defined duplicate `Vertex` and `Halfspace` values and duplicate exact facet, boundedness, and H-representation geometry helpers. Equal native values could not cross the owner boundary directly, and corrections to the shared geometry semantics risked drifting.

## Solution

Make polytope the canonical owner of rational `Vertex` and `Halfspace` values and exact rational-geometry helpers. Both polytope families consume them, while retaining their distinct operation-level admission envelopes. JSON shapes, catalog IDs, and operation semantics remain unchanged.

## Testing

- `make test-focused LANE=math TESTS="tests/math/polytope/test_polytope.py tests/math/lattice_polytopes/test_lattice_polytopes.py"` — 188 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 41 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py PYTEST_ARGS="-k polytope"` — 6 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Native callers share the canonical rational `Vertex` and `Halfspace` identities. Serialized value shapes and operation IDs are unchanged.

## Operation boundary ownership

- Changed stage: request parsing and kernel adapter
- Request-bounds owner and controlling quantities: volume and lattice-polytope owners retain their existing distinct admission envelopes
- Backend or kernel path: shared exact rational geometry helpers
- Result construction: canonical shared values
- Independent-result verifier: none
- Native/MCP parity: unchanged semantic path and transport projection
- Serialized-result and round-trip evidence: direct cross-owner canonical-value and invariant tests

## Canonical value audit

- [x] Existing canonical values consolidated
- [x] Polytope documented as the shared value and helper owner
- [x] Direct producer-to-consumer composition tested

## Checklist

- [ ] `make check` passes (not run; focused owner, catalog, and advertised-example checks passed)