### PR TITLE
Admit modularly empty binary quadratic-form representations

### DIFF
--- a/src/jacobian/math/integral_binary_quadratic_forms/_models.py
+++ b/src/jacobian/math/integral_binary_quadratic_forms/_models.py
@@ -230,7 +230,9 @@ class BinaryQuadraticFormRepresentationsRequest(StrictModel):
         le=MAX_REPRESENTATION_TARGET,
         description=(
             "Nonnegative target n. With D=b^2-4ac for form, this request is "
-            "admitted exactly when 2*floor_sqrt(4*a*n/(-D))+1 is at most "
+            "admitted exactly when either (a,b,c)=(1,0,1) and n mod 4 is 3, "
+            "where squares are 0 or 1 modulo 4 so x^2+y^2=n is proved empty "
+            "without any scan, or 2*floor_sqrt(4*a*n/(-D))+1 is at most "
             f"{MAX_REPRESENTATION_Y_CANDIDATES}; that is the complete "
             "y-coordinate scan size."
         ),

--- a/src/jacobian/math/integral_binary_quadratic_forms/_models.py
+++ b/src/jacobian/math/integral_binary_quadratic_forms/_models.py
@@ -176,10 +176,25 @@ def _representation_y_bound(
     return isqrt((4 * form.a * target) // (-form.discriminant))
 
 
+def _has_sum_of_two_squares_mod_four_obstruction(
+    form: PrimitivePositiveDefiniteBinaryQuadraticForm, target: int
+) -> bool:
+    """Whether a request has the immediate ``x² + y² ≡ 3 (mod 4)`` obstruction.
+
+    Squares modulo four are zero or one, so the sum-of-two-squares form cannot
+    represent a target congruent to three.  This is a complete empty-result
+    certificate, not a heuristic used to narrow the general y-coordinate scan.
+    """
+
+    return (form.a, form.b, form.c) == (1, 0, 1) and target % 4 == 3
+
+
 def _require_representation_budget(
     form: PrimitivePositiveDefiniteBinaryQuadraticForm, target: int
-) -> int:
-    """Return the complete y-bound after checking the exact scan envelope."""
+) -> int | None:
+    """Return the complete scan bound, or ``None`` for a proved empty result."""
+    if _has_sum_of_two_squares_mod_four_obstruction(form, target):
+        return None
     y_bound = _representation_y_bound(form, target)
     if 2 * y_bound + 1 > MAX_REPRESENTATION_Y_CANDIDATES:
         raise _validation_error(

--- a/src/jacobian/math/integral_binary_quadratic_forms/_operations.py
+++ b/src/jacobian/math/integral_binary_quadratic_forms/_operations.py
@@ -298,6 +298,8 @@ def _enumerate_representations(
     discriminant = form.discriminant
     rows: list[BinaryQuadraticFormRepresentation] = []
     y_bound = _require_representation_budget(form, target)
+    if y_bound is None:
+        return ()
     for y in range(-y_bound, y_bound + 1):
         x_discriminant = 4 * a * target + discriminant * y * y
         if x_discriminant < 0:

--- a/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
+++ b/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
@@ -376,6 +376,13 @@ class TestRepresentations:
         ]["target"]
         assert "2*floor_sqrt(4*a*n/(-D))+1" in target_schema["description"]
 
+    def test_schema_exposes_the_modular_empty_admission_exception(self) -> None:
+        target_schema = BinaryQuadraticFormRepresentationsRequest.model_json_schema()[
+            "properties"
+        ]["target"]
+        assert "(a,b,c)=(1,0,1)" in target_schema["description"]
+        assert "n mod 4 is 3" in target_schema["description"]
+
     def test_x_squared_plus_y_squared_of_five_has_eight_ordered_signed_pairs(
         self,
     ) -> None:

--- a/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
+++ b/tests/math/integral_binary_quadratic_forms/test_integral_binary_quadratic_forms.py
@@ -5,6 +5,8 @@ from pydantic import ValidationError
 
 from jacobian.canonical import canonicalize_json
 from jacobian.math.integral_binary_quadratic_forms._models import (
+    MAX_REPRESENTATION_TARGET,
+    MAX_REPRESENTATION_Y_CANDIDATES,
     BinaryQuadraticFormCheckRequest,
     BinaryQuadraticFormEvaluateRequest,
     BinaryQuadraticFormEvaluateResult,
@@ -14,6 +16,7 @@ from jacobian.math.integral_binary_quadratic_forms._models import (
     BinaryQuadraticFormRepresentationsRequest,
     BinaryQuadraticFormRepresentationsResult,
     PrimitivePositiveDefiniteBinaryQuadraticForm,
+    _representation_y_bound,
 )
 from jacobian.math.integral_binary_quadratic_forms._operations import (
     compute_check,
@@ -411,6 +414,31 @@ class TestRepresentations:
         )
         assert result.representations == ()
         assert result.count == result.primitive_count == 0
+
+    def test_mod_four_obstruction_skips_an_inapplicable_general_scan(self) -> None:
+        """A huge ``3 mod 4`` sum-of-two-squares target is proved empty first."""
+        target = MAX_REPRESENTATION_TARGET - 1
+        form = _positive_form(1, 0, 1)
+        assert target % 4 == 3
+        assert 2 * _representation_y_bound(form, target) + 1 > (
+            MAX_REPRESENTATION_Y_CANDIDATES
+        )
+
+        result = compute_representations(
+            BinaryQuadraticFormRepresentationsRequest(form=form, target=target)
+        )
+
+        assert result.representations == ()
+        assert result.count == result.primitive_count == 0
+        assert type(result).model_validate(result.model_dump(mode="json")) == result
+
+        with pytest.raises(ValidationError) as exc_info:
+            BinaryQuadraticFormRepresentationsRequest(
+                form=form, target=MAX_REPRESENTATION_TARGET
+            )
+        _assert_error_type(
+            exc_info, "integral_binary_quadratic_form.representation_candidate_budget"
+        )
 
     def test_zero_has_the_single_nonprimitive_origin(self) -> None:
         result = compute_representations(


### PR DESCRIPTION
Part of #2605.

## Problem

A request to represent `999999999999` as a sum of two squares was rejected by the general candidate budget, even though the target is 3 modulo 4 and has no representations. The empty result is exact and should not be charged as an impossible general search.

## Solution

Recognize the complete mod-four obstruction before applying the general candidate budget, returning the exact empty representation result. This addresses one owner-local degenerate path and does not close the broader #2605 admission program.

## Testing

- binary quadratic-form owner tests — 45 passed
- catalog conformance — 12 passed
- targeted advertised example and public contract conformance — 2 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Previously rejected, mathematically empty requests in the admitted structural case now return their exact empty result. Other request bounds, operation IDs, and result schemas are unchanged.

## Operation boundary ownership

- Changed stage: request admission
- Request-bounds owner and controlling quantities: integral binary-quadratic-form representation admission; the mod-four obstruction proves general-path candidates cannot exist
- Backend or kernel path: unchanged for nondegenerate requests
- Result construction: exact empty result for the proven obstruction
- Independent-result verifier: unchanged
- Native/MCP parity: shared typed operation path
- Serialized-result and round-trip evidence: targeted catalog contract test

## Checklist

- [ ] `make check` passes (not run; focused owner, catalog, and contract evidence passed)