### PR TITLE
Route colored-graph canonicalization through a typed kernel

### DIFF
--- a/src/jacobian/math/graphs/isomorphism/_canonicalization_bounds.py
+++ b/src/jacobian/math/graphs/isomorphism/_canonicalization_bounds.py
@@ -1,0 +1,48 @@
+"""Shared mathematical admission for colored-graph canonicalization."""
+
+from pydantic_core import PydanticCustomError
+
+from jacobian.math.graphs.isomorphism._canonicalization import (
+    MAX_CANONICAL_PERMUTATIONS,
+    MAX_CANONICAL_REPLAY_WORK,
+    MAX_CANONICALIZATION_RESULT_BYTES,
+    canonical_permutation_count,
+    canonical_replay_work,
+    canonicalization_result_wire_bytes,
+)
+from jacobian.math.graphs.values import ColoredUndirectedGraph
+
+
+def require_admitted_colored_graph_canonicalization(
+    graph: ColoredUndirectedGraph,
+) -> None:
+    """Check the full execution and canonical-result envelope for ``graph``."""
+
+    candidate_count = canonical_permutation_count(graph)
+    if candidate_count > MAX_CANONICAL_PERMUTATIONS:
+        raise PydanticCustomError(
+            "graph.colored_canonicalization_exceeds_max_canonical_permutations_permutatio",
+            "colored-graph canonicalization exceeds the "
+            f"{MAX_CANONICAL_PERMUTATIONS}-permutation bound",
+        )
+    replay_work = canonical_replay_work(graph)
+    if replay_work > MAX_CANONICAL_REPLAY_WORK:
+        raise PydanticCustomError(
+            "graph.colored_canonicalization_exceeds_max_canonical_replay_work",
+            "colored-graph canonicalization exceeds the "
+            f"{MAX_CANONICAL_REPLAY_WORK}-unit execution-and-replay work bound",
+        )
+    result_bytes = canonicalization_result_wire_bytes(graph)
+    if result_bytes > MAX_CANONICALIZATION_RESULT_BYTES:
+        raise PydanticCustomError(
+            "graph.colored_canonicalization_exceeds_max_canonicalization_result_bytes",
+            "colored-graph canonicalization exceeds the "
+            f"{MAX_CANONICALIZATION_RESULT_BYTES}-byte result bound",
+        )
+
+
+__all__ = [
+    "MAX_CANONICALIZATION_RESULT_BYTES",
+    "canonicalization_result_wire_bytes",
+    "require_admitted_colored_graph_canonicalization",
+]

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -9,14 +9,11 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 from jacobian.math.graphs.isomorphism._canonicalization import (
-    MAX_CANONICAL_PERMUTATIONS,
-    MAX_CANONICAL_REPLAY_WORK,
-    MAX_CANONICALIZATION_RESULT_BYTES,
     apply_colored_graph_relabeling,
-    canonical_permutation_count,
-    canonical_replay_work,
-    canonicalization_result_wire_bytes,
     canonicalize_colored_graph_data,
+)
+from jacobian.math.graphs.isomorphism._canonicalization_bounds import (
+    require_admitted_colored_graph_canonicalization,
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph, GraphVertexLabel
 
@@ -134,27 +131,7 @@ class ColoredGraphCanonicalizationRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_bounded_canonicalization(self) -> Self:
-        candidate_count = canonical_permutation_count(self.colored_graph)
-        if candidate_count > MAX_CANONICAL_PERMUTATIONS:
-            raise PydanticCustomError(
-                "graph.colored_canonicalization_exceeds_max_canonical_permutations_permutatio",
-                "colored-graph canonicalization exceeds the "
-                f"{MAX_CANONICAL_PERMUTATIONS}-permutation bound",
-            )
-        replay_work = canonical_replay_work(self.colored_graph)
-        if replay_work > MAX_CANONICAL_REPLAY_WORK:
-            raise PydanticCustomError(
-                "graph.colored_canonicalization_exceeds_max_canonical_replay_work",
-                "colored-graph canonicalization exceeds the "
-                f"{MAX_CANONICAL_REPLAY_WORK}-unit execution-and-replay work bound",
-            )
-        result_bytes = canonicalization_result_wire_bytes(self.colored_graph)
-        if result_bytes > MAX_CANONICALIZATION_RESULT_BYTES:
-            raise PydanticCustomError(
-                "graph.colored_canonicalization_exceeds_max_canonicalization_result_bytes",
-                "colored-graph canonicalization exceeds the "
-                f"{MAX_CANONICALIZATION_RESULT_BYTES}-byte result bound",
-            )
+        require_admitted_colored_graph_canonicalization(self.colored_graph)
         return self
 
 
@@ -191,7 +168,7 @@ class ColoredGraphCanonicalizationResult(StrictModel):
 
     @model_validator(mode="after")
     def require_exact_source_bound_canonical_form(self) -> Self:
-        ColoredGraphCanonicalizationRequest(colored_graph=self.source_graph)
+        require_admitted_colored_graph_canonicalization(self.source_graph)
         if tuple(item.source_vertex for item in self.relabeling) != (
             self.source_graph.graph.vertices
         ):

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -19,6 +19,7 @@ from jacobian.math.graphs.isomorphism._models import (
     SimpleGraph,
     VertexMappingPair,
 )
+from jacobian.math.graphs.values import ColoredUndirectedGraph
 
 
 def _build_graph(graph: SimpleGraph) -> nx.Graph[int] | nx.DiGraph[int]:
@@ -76,15 +77,22 @@ def compute_colored_graph_canonicalization(
 ) -> ColoredGraphCanonicalizationResult:
     """Return the exact canonical form for one admitted request.
 
-    This is the shared request-accepting implementation: ``math.run`` parses
-    and admits the typed request once, and the native
-    ``canonicalize_colored_graph`` entry point validates its value by
-    constructing this same request before delegating here.
+    ``math.run`` parses and admits the typed request before calling this thin
+    adapter. Native callers use the same typed kernel after owner-local
+    admission without constructing a wire request.
     """
 
-    canonical_graph, relabeling = canonicalize_colored_graph_data(request.colored_graph)
+    return canonicalize_colored_graph_kernel(request.colored_graph)
+
+
+def canonicalize_colored_graph_kernel(
+    graph: ColoredUndirectedGraph,
+) -> ColoredGraphCanonicalizationResult:
+    """Construct the exact canonical value from one admitted graph value."""
+
+    canonical_graph, relabeling = canonicalize_colored_graph_data(graph)
     return ColoredGraphCanonicalizationResult(
-        source_graph=request.colored_graph,
+        source_graph=graph,
         canonical_graph=canonical_graph,
         relabeling=tuple(
             GraphRelabelingPair(source_vertex=source, canonical_vertex=target)

--- a/src/jacobian/math/graphs/isomorphism/operations.py
+++ b/src/jacobian/math/graphs/isomorphism/operations.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from jacobian.math.graphs.isomorphism._models import (
-    ColoredGraphCanonicalizationRequest,
-    ColoredGraphCanonicalizationResult,
+from jacobian.math.graphs.isomorphism._canonicalization_bounds import (
+    require_admitted_colored_graph_canonicalization,
 )
+from jacobian.math.graphs.isomorphism._models import ColoredGraphCanonicalizationResult
 from jacobian.math.graphs.isomorphism._operations import (
-    compute_colored_graph_canonicalization,
+    canonicalize_colored_graph_kernel,
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph
 
@@ -17,9 +17,8 @@ def canonicalize_colored_graph(
 ) -> ColoredGraphCanonicalizationResult:
     """Return the exact color-preserving canonical form and one relabeling."""
 
-    return compute_colored_graph_canonicalization(
-        ColoredGraphCanonicalizationRequest(colored_graph=graph)
-    )
+    require_admitted_colored_graph_canonicalization(graph)
+    return canonicalize_colored_graph_kernel(graph)
 
 
 __all__ = ["canonicalize_colored_graph"]

--- a/src/jacobian/math/graphs/isomorphism/operations.py
+++ b/src/jacobian/math/graphs/isomorphism/operations.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pydantic import ValidationError
+from pydantic_core import PydanticCustomError
+
 from jacobian.math.graphs.isomorphism._canonicalization_bounds import (
     require_admitted_colored_graph_canonicalization,
 )
@@ -15,9 +18,20 @@ from jacobian.math.graphs.values import ColoredUndirectedGraph
 def canonicalize_colored_graph(
     graph: ColoredUndirectedGraph,
 ) -> ColoredGraphCanonicalizationResult:
-    """Return the exact color-preserving canonical form and one relabeling."""
+    """Return the exact color-preserving canonical form and one relabeling.
 
-    require_admitted_colored_graph_canonicalization(graph)
+    Owner-local admission keeps the same typed outcome as the wire path:
+    over-bound graphs raise the public ``ValidationError``, not a core-level
+    ``PydanticCustomError``, and no wire request is constructed.
+    """
+
+    try:
+        require_admitted_colored_graph_canonicalization(graph)
+    except PydanticCustomError as error:
+        raise ValidationError.from_exception_data(
+            title="canonicalize_colored_graph",
+            line_errors=[{"type": error, "input": graph}],
+        ) from error
     return canonicalize_colored_graph_kernel(graph)
 
 

--- a/tests/integration/catalog/test_colored_graph_canonicalization.py
+++ b/tests/integration/catalog/test_colored_graph_canonicalization.py
@@ -2,7 +2,11 @@
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import invoke_operation
-from jacobian.math.graphs.isomorphism import ColoredGraphCanonicalizationResult
+from jacobian.math.graphs.isomorphism import (
+    ColoredGraphCanonicalizationResult,
+    ColoredUndirectedGraph,
+    canonicalize_colored_graph,
+)
 
 
 def test_public_catalog_invocation_returns_replayable_value() -> None:
@@ -24,3 +28,24 @@ def test_public_catalog_invocation_returns_replayable_value() -> None:
         ("v00", "v01"),
         ("v00", "v02"),
     )
+
+
+def test_public_catalog_invocation_matches_the_native_typed_value() -> None:
+    payload = {
+        "colored_graph": {
+            "graph": {
+                "vertices": ["a", "b", "c", "d"],
+                "edges": [["a", "b"], ["b", "c"], ["c", "d"]],
+            },
+            "vertex_colors": ["endpoint", "middle", "middle", "endpoint"],
+            "edge_colors": ["outer", "middle", "outer"],
+        }
+    }
+    dispatched = invoke_operation(
+        "graph.isomorphism.canonicalize.compute", payload, Catalog.open()
+    )
+    native_graph = ColoredUndirectedGraph.model_validate(payload["colored_graph"])
+
+    assert ColoredGraphCanonicalizationResult.model_validate(
+        dispatched.output
+    ) == canonicalize_colored_graph(native_graph)

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 import networkx as nx
 import pytest
 from pydantic import ValidationError
+from pydantic_core import PydanticCustomError
 
 import jacobian.math.graphs.isomorphism._canonicalization as isomorphism_canonicalization
 import jacobian.math.graphs.isomorphism._canonicalization_bounds as isomorphism_bounds
@@ -367,6 +368,42 @@ def test_request_rejects_edge_key_work_before_enumeration() -> None:
                 tuple(itertools.combinations(nine_vertices, 2)),
             )
         )
+
+
+@pytest.mark.parametrize(
+    "graph",
+    [
+        _graph(tuple(f"v{index:02d}" for index in range(10)), ()),
+        _graph(
+            tuple(f"v{index:02d}" for index in range(9)),
+            tuple(
+                itertools.combinations(tuple(f"v{index:02d}" for index in range(9)), 2)
+            ),
+        ),
+    ],
+    ids=["permutation-bound", "replay-work-bound"],
+)
+def test_native_admission_failure_raises_wire_validation_error(
+    graph: ColoredUndirectedGraph,
+) -> None:
+    """Native callers see the public ValidationError the wire path raises.
+
+    A valid graph over the execution bound must not leak the core
+    ``PydanticCustomError`` from the shared admission function; the native
+    entry point translates it without rebuilding a wire request, keeping the
+    advertised native/wire typed-outcome parity.
+    """
+
+    with pytest.raises(ValidationError) as native:
+        canonicalize_colored_graph(graph)
+
+    assert isinstance(native.value.__cause__, PydanticCustomError)
+    with pytest.raises(ValidationError) as wire:
+        ColoredGraphCanonicalizationRequest(colored_graph=graph)
+
+    assert [item | {"input": None} for item in native.value.errors()] == [
+        item | {"input": None} for item in wire.value.errors()
+    ]
 
 
 def _dense_complete_colored_graph(label_bytes: int) -> ColoredUndirectedGraph:

--- a/tests/math/graphs/test_colored_graph_canonicalization.py
+++ b/tests/math/graphs/test_colored_graph_canonicalization.py
@@ -13,7 +13,8 @@ import networkx as nx
 import pytest
 from pydantic import ValidationError
 
-import jacobian.math.graphs.isomorphism._models as isomorphism_models
+import jacobian.math.graphs.isomorphism._canonicalization as isomorphism_canonicalization
+import jacobian.math.graphs.isomorphism._canonicalization_bounds as isomorphism_bounds
 from jacobian.math.graphs import explicit_graph
 from jacobian.math.graphs.isomorphism import (
     ColoredGraphCanonicalizationRequest,
@@ -390,7 +391,8 @@ def test_request_admits_transport_bounded_dense_results() -> None:
     dense_graph = _dense_complete_colored_graph(49)
 
     assert (
-        isomorphism_models.canonicalization_result_wire_bytes(dense_graph) > 512 * 1024
+        isomorphism_canonicalization.canonicalization_result_wire_bytes(dense_graph)
+        > 512 * 1024
     )
     result = compute_colored_graph_canonicalization(
         ColoredGraphCanonicalizationRequest(colored_graph=dense_graph)
@@ -405,12 +407,12 @@ def test_request_admits_transport_bounded_dense_results() -> None:
 def test_request_enforces_source_bound_result_byte_boundary(monkeypatch) -> None:
     max_shape = _dense_complete_colored_graph(64)
     assert (
-        isomorphism_models.canonicalization_result_wire_bytes(max_shape)
-        <= isomorphism_models.MAX_CANONICALIZATION_RESULT_BYTES
+        isomorphism_canonicalization.canonicalization_result_wire_bytes(max_shape)
+        <= isomorphism_canonicalization.MAX_CANONICALIZATION_RESULT_BYTES
     )
 
     monkeypatch.setattr(
-        isomorphism_models,
+        isomorphism_bounds,
         "MAX_CANONICALIZATION_RESULT_BYTES",
         512 * 1024,
     )
@@ -567,14 +569,14 @@ def test_catalog_execution_admits_the_parsed_request_once(monkeypatch) -> None:
     expected = canonicalize_colored_graph(parsed.colored_graph)
 
     admissions: list[ColoredUndirectedGraph] = []
-    real_preflight = isomorphism_models.canonicalization_result_wire_bytes
+    real_preflight = isomorphism_bounds.canonicalization_result_wire_bytes
 
     def counted_preflight(graph: ColoredUndirectedGraph) -> int:
         admissions.append(graph)
         return real_preflight(graph)
 
     monkeypatch.setattr(
-        isomorphism_models,
+        isomorphism_bounds,
         "canonicalization_result_wire_bytes",
         counted_preflight,
     )


### PR DESCRIPTION
Related to #2591.

## Problem

The colored-graph native entry point and `math.run` path duplicated request handling, leaving this operation family vulnerable to divergent admission or result construction.

## Solution

Route both paths through one owner-local typed kernel and canonical projection. This is a focused colored-graph refactor; it intentionally does not claim to close the repository-wide parity program.

## Testing

- graph owner tests — 27 passed
- catalog integration parity — 2 passed
- MCP client `math.run` output equals native typed canonicalization
- MCP SDK conformance — 2 passed
- catalog invariants — 5 passed
- advertised canonicalization example — 1 passed
- `git diff --check` — passed

## Public contract impact

None. Operation IDs, schemas, and mathematical results are unchanged.

## Checklist

- [ ] `make check` passes (not run; focused native/MCP boundary evidence passed)