### PR TITLE
Keep directed graph carrier bounds out of bond reliability

### DIFF
--- a/docs/reference/operations/graphs/directed-bond-reliability.md
+++ b/docs/reference/operations/graphs/directed-bond-reliability.md
@@ -13,11 +13,13 @@ retains the canonical graph, terminal pair, and arc-probability map, then uses
 an explicit bounded verifier to replay the complete enumeration. Reversing the
 terminals is therefore a different event.
 
-The current exact envelope admits at most 12 arcs; the derived
-producer-and-verifier work budget bounds the vertex count, so sparse graphs can
-declare more vertices. The arc limit bounds all 4096 states, the full ledger,
-rational-product digit growth, and both the producer and explicit verifier
-passes.
+The current exact envelope admits at most 12 arcs. Traversal and replay
+materialize only the relevant vertices (the two terminals plus the endpoints
+of open arcs), so executed work scales with arc count rather than with the
+declared vertex count; declared vertex labels are bounded instead by the
+interoperable JSON integer transport range. The arc limit bounds all 4096
+states, the full ledger, rational-product digit growth, and both the producer
+and explicit verifier passes.
 Edgeless directed graphs are admitted: with two distinct terminals the event
 has exact probability zero and the ledger holds the single empty state.
 Python-FLINT performs producer

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, WithJsonSchema, model_validator
+from pydantic import Field, WithJsonSchema, field_validator, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
@@ -37,14 +37,29 @@ class DirectedGraph(StrictModel):
     vertex_count: int = Field(ge=2)
     edges: tuple[tuple[int, int], ...] = Field()
 
-    @model_validator(mode="after")
-    def require_valid_edges(self) -> Self:
-        if len(self.edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES:
+    @field_validator("edges", mode="before")
+    @classmethod
+    def require_edge_parse_envelope(cls, edges: object) -> object:
+        """Reject oversized edge lists before any nested row is materialized.
+
+        Pydantic coerces and validates each nested tuple only after this
+        before-validator returns, so a payload beyond the parse-safety
+        envelope rejects on its raw sequence length without building the
+        edge tuples or entering structural validation at all.
+        """
+
+        if isinstance(edges, (list, tuple)) and (
+            len(edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES
+        ):
             raise PydanticCustomError(
                 "graph.edge_list_parse_envelope_exceeded",
                 "directed graph edge list exceeds the "
                 f"{MAX_DIRECTED_GRAPH_PARSE_EDGES}-edge parse-safety envelope",
             )
+        return edges
+
+    @model_validator(mode="after")
+    def require_valid_edges(self) -> Self:
         seen: set[tuple[int, int]] = set()
         for source, target in self.edges:
             if not (

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -90,7 +90,7 @@ DirectedOperationGraph = Annotated[
 
 class ReachabilityRequest(StrictModel):
     graph: DirectedOperationGraph
-    source: int = Field(ge=0)
+    source: int = Field(ge=0, le=MAX_DIRECTED_OPERATION_VERTICES - 1)
 
     @model_validator(mode="after")
     def require_valid_source(self) -> Self:

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -59,9 +59,7 @@ class DirectedGraph(StrictModel):
                     "directed graph edge list exceeds the "
                     f"{MAX_DIRECTED_GRAPH_PARSE_EDGES}-edge parse-safety envelope",
                 )
-            return tuple(
-                tuple(row) if isinstance(row, list) else row for row in edges
-            )
+            return tuple(tuple(row) if isinstance(row, list) else row for row in edges)
         if isinstance(edges, tuple) and len(edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES:
             raise PydanticCustomError(
                 "graph.edge_list_parse_envelope_exceeded",

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -64,8 +65,31 @@ def _require_directed_operation_admission(graph: DirectedGraph) -> None:
         )
 
 
+def _directed_operation_graph_schema() -> JsonSchemaValue:
+    """Project the direct-operation envelope onto the shared carrier schema."""
+
+    schema = DirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A structurally valid finite simple directed graph accepted by the "
+        "direct traversal operations: at most "
+        f"{MAX_DIRECTED_OPERATION_VERTICES} vertices and at most "
+        f"{MAX_DIRECTED_OPERATION_EDGES} edges."
+    )
+    schema["properties"]["vertex_count"].update(
+        maximum=MAX_DIRECTED_OPERATION_VERTICES,
+    )
+    schema["properties"]["edges"].update(maxItems=MAX_DIRECTED_OPERATION_EDGES)
+    return schema
+
+
+DirectedOperationGraph = Annotated[
+    DirectedGraph,
+    WithJsonSchema(_directed_operation_graph_schema()),
+]
+
+
 class ReachabilityRequest(StrictModel):
-    graph: DirectedGraph
+    graph: DirectedOperationGraph
     source: int = Field(ge=0)
 
     @model_validator(mode="after")
@@ -87,7 +111,7 @@ class ReachabilityResult(StrictModel):
 
 
 class StronglyConnectedComponentsRequest(StrictModel):
-    graph: DirectedGraph
+    graph: DirectedOperationGraph
 
     @model_validator(mode="after")
     def require_operation_admission(self) -> Self:
@@ -104,7 +128,7 @@ class StronglyConnectedComponentsResult(StrictModel):
 
 
 class CondensationRequest(StrictModel):
-    graph: DirectedGraph
+    graph: DirectedOperationGraph
 
     @model_validator(mode="after")
     def require_operation_admission(self) -> Self:
@@ -125,7 +149,7 @@ class CondensationResult(StrictModel):
 
 
 class AcyclicOrderRequest(StrictModel):
-    graph: DirectedGraph
+    graph: DirectedOperationGraph
 
     @model_validator(mode="after")
     def require_operation_admission(self) -> Self:

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -40,17 +40,29 @@ class DirectedGraph(StrictModel):
     @field_validator("edges", mode="before")
     @classmethod
     def require_edge_parse_envelope(cls, edges: object) -> object:
-        """Reject oversized edge lists before any nested row is materialized.
+        """Bound the raw edge sequence before any nested row is materialized.
 
         Pydantic coerces and validates each nested tuple only after this
         before-validator returns, so a payload beyond the parse-safety
         envelope rejects on its raw sequence length without building the
-        edge tuples or entering structural validation at all.
+        edge tuples or entering structural validation at all. Admitted
+        lists are canonicalized to tuples here because strict JSON parsing
+        treats values returned by a before-validator as runtime data, which
+        no longer coerces lists to tuples (the container-canonicalization
+        rule shared with strict-JSON preflight models).
         """
 
-        if isinstance(edges, (list, tuple)) and (
-            len(edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES
-        ):
+        if isinstance(edges, list):
+            if len(edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES:
+                raise PydanticCustomError(
+                    "graph.edge_list_parse_envelope_exceeded",
+                    "directed graph edge list exceeds the "
+                    f"{MAX_DIRECTED_GRAPH_PARSE_EDGES}-edge parse-safety envelope",
+                )
+            return tuple(
+                tuple(row) if isinstance(row, list) else row for row in edges
+            )
+        if isinstance(edges, tuple) and len(edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES:
             raise PydanticCustomError(
                 "graph.edge_list_parse_envelope_exceeded",
                 "directed graph edge list exceeds the "

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -9,17 +9,18 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
 
+# These are the execution envelope for the four direct NetworkX operations
+# below.  ``DirectedGraph`` itself remains reusable by consumers whose work is
+# bounded more sharply from their own request data.
+MAX_DIRECTED_OPERATION_VERTICES = 256
+MAX_DIRECTED_OPERATION_EDGES = 512
+
 
 class DirectedGraph(StrictModel):
-    """A simple directed graph for reachability, SCC, and related analyses.
+    """A structurally valid finite simple directed graph."""
 
-    ``vertex_count`` carries a conservative admission fallback bounding
-    linear-time traversal work and vertex-sized results; consumers with
-    sharper derived budgets refine admission further.
-    """
-
-    vertex_count: int = Field(ge=2, le=256)
-    edges: tuple[tuple[int, int], ...] = Field(max_length=512)
+    vertex_count: int = Field(ge=2)
+    edges: tuple[tuple[int, int], ...] = Field()
 
     @model_validator(mode="after")
     def require_valid_edges(self) -> Self:
@@ -46,12 +47,30 @@ class DirectedGraph(StrictModel):
         return self
 
 
+def _require_directed_operation_admission(graph: DirectedGraph) -> None:
+    """Bound one direct traversal operation before constructing NetworkX state."""
+
+    if graph.vertex_count > MAX_DIRECTED_OPERATION_VERTICES:
+        raise PydanticCustomError(
+            "graph.directed_vertex_budget_exceeded",
+            "directed graph operation supports at most "
+            f"{MAX_DIRECTED_OPERATION_VERTICES} vertices",
+        )
+    if len(graph.edges) > MAX_DIRECTED_OPERATION_EDGES:
+        raise PydanticCustomError(
+            "graph.directed_edge_budget_exceeded",
+            "directed graph operation supports at most "
+            f"{MAX_DIRECTED_OPERATION_EDGES} edges",
+        )
+
+
 class ReachabilityRequest(StrictModel):
     graph: DirectedGraph
-    source: int = Field(ge=0, le=255)
+    source: int = Field(ge=0)
 
     @model_validator(mode="after")
     def require_valid_source(self) -> Self:
+        _require_directed_operation_admission(self.graph)
         if not (0 <= self.source < self.graph.vertex_count):
             raise PydanticCustomError(
                 "graph.source_must_be_in_0_graph_vertex_count_1",
@@ -70,6 +89,11 @@ class ReachabilityResult(StrictModel):
 class StronglyConnectedComponentsRequest(StrictModel):
     graph: DirectedGraph
 
+    @model_validator(mode="after")
+    def require_operation_admission(self) -> Self:
+        _require_directed_operation_admission(self.graph)
+        return self
+
 
 class StronglyConnectedComponentsResult(StrictModel):
     component_count: int = Field(ge=0, strict=True)
@@ -81,6 +105,11 @@ class StronglyConnectedComponentsResult(StrictModel):
 
 class CondensationRequest(StrictModel):
     graph: DirectedGraph
+
+    @model_validator(mode="after")
+    def require_operation_admission(self) -> Self:
+        _require_directed_operation_admission(self.graph)
+        return self
 
 
 class CondensationEdge(StrictModel):
@@ -97,6 +126,11 @@ class CondensationResult(StrictModel):
 
 class AcyclicOrderRequest(StrictModel):
     graph: DirectedGraph
+
+    @model_validator(mode="after")
+    def require_operation_admission(self) -> Self:
+        _require_directed_operation_admission(self.graph)
+        return self
 
 
 class AcyclicOrderResult(StrictModel):

--- a/src/jacobian/math/graphs/directed/_models.py
+++ b/src/jacobian/math/graphs/directed/_models.py
@@ -9,12 +9,26 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.canonical import CanonicalLimits
 
 # These are the execution envelope for the four direct NetworkX operations
 # below.  ``DirectedGraph`` itself remains reusable by consumers whose work is
 # bounded more sharply from their own request data.
 MAX_DIRECTED_OPERATION_VERTICES = 256
 MAX_DIRECTED_OPERATION_EDGES = 512
+
+# Parse-safety envelope for the shared carrier's edge list: a transport guard,
+# not admission.  The minimal canonical JSON encoding of one arc inside
+# ``edges`` is ``[0,0],`` -- five content bytes plus one separator byte --
+# so a maximal 10 MiB request document could still minimally encode roughly
+# 1.75 million arcs.  This envelope deliberately sits far below that: it is
+# one sixty-fourth of ``CanonicalLimits().max_input_bytes`` (163,840 arcs),
+# so even a worst-case admitted list consumes under a tenth of the transport
+# input envelope while remaining 320x the loosest current admission (the
+# direct operations' 512 arcs above; directed bond reliability admits 12).  No schema-admitted request can reach it, and
+# payloads beyond it reject here in O(1) instead of paying the full
+# duplicate-detecting scan first.
+MAX_DIRECTED_GRAPH_PARSE_EDGES = CanonicalLimits().max_input_bytes // 64
 
 
 class DirectedGraph(StrictModel):
@@ -25,6 +39,12 @@ class DirectedGraph(StrictModel):
 
     @model_validator(mode="after")
     def require_valid_edges(self) -> Self:
+        if len(self.edges) > MAX_DIRECTED_GRAPH_PARSE_EDGES:
+            raise PydanticCustomError(
+                "graph.edge_list_parse_envelope_exceeded",
+                "directed graph edge list exceeds the "
+                f"{MAX_DIRECTED_GRAPH_PARSE_EDGES}-edge parse-safety envelope",
+            )
         seen: set[tuple[int, int]] = set()
         for source, target in self.edges:
             if not (

--- a/src/jacobian/math/probability/_models.py
+++ b/src/jacobian/math/probability/_models.py
@@ -44,9 +44,6 @@ MAX_GRAPH_RELIABILITY_VERTICES = 16
 MAX_GRAPH_RELIABILITY_EDGES = 12
 MAX_GRAPH_RELIABILITY_STATES = 1 << MAX_GRAPH_RELIABILITY_EDGES
 MAX_GRAPH_RELIABILITY_LEDGER_BYTES = 9 * 1024 * 1024
-# Reference vertex count used only to derive the work budget below; admission
-# is bounded by that derived budget, not by this count.
-MAX_DIRECTED_BOND_RELIABILITY_VERTICES = 16
 MAX_DIRECTED_BOND_RELIABILITY_ARCS = 12
 MAX_DIRECTED_BOND_RELIABILITY_STATES = 1 << MAX_DIRECTED_BOND_RELIABILITY_ARCS
 MAX_DIRECTED_BOND_RELIABILITY_LEDGER_BYTES = 9 * 1024 * 1024
@@ -57,31 +54,41 @@ MAX_DIRECTED_BOND_RELIABILITY_RATIONAL_DIGITS = (
     + MAX_DIRECTED_BOND_RELIABILITY_ARCS
 )
 # The producer enumerates every arc subset and result validation replays it.
-# Per state and pass it selects open arcs, evaluates every probability, adds
-# open arcs to the directed graph, and traverses them: at most four arc visits.
-# It also adds every graph vertex, visits vertices during descendants, and
-# materializes both the reachable and unreachable partitions: four vertex
-# visits.  The producer constructs one complete state record and validation
-# compares one; each records or compares at most every open arc and its three
-# scalar fields.  The final result also compares a fixed set of aggregate
-# fields, charged below.
+# Per state and pass it selects open arcs, evaluates every probability,
+# collects the endpoints of open arcs into the relevant vertex set (two
+# endpoint visits per open arc), adds those arcs to the directed graph, and
+# traverses them: six arc visits.  Traversal materializes only the relevant
+# vertices -- the two terminals plus both endpoints of every open arc, at most
+# ``2 * arcs + 2`` because a state's open arcs are a subset of the declared
+# arcs -- inserting each once and visiting each once during the search;
+# four relevant-vertex visits charge that with margin.  The producer
+# constructs one complete state record and validation compares one; each
+# records or compares at most every open arc and its three scalar fields.
+# Together that is ``7 * arcs + 4 * relevant + 3`` work per state and pass.
+# The final result also compares a fixed set of aggregate fields, charged
+# below.
+MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES = (
+    2 * MAX_DIRECTED_BOND_RELIABILITY_ARCS + 2
+)
 MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK = (
     2
     * MAX_DIRECTED_BOND_RELIABILITY_STATES
     * (
-        5 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
-        + 4 * MAX_DIRECTED_BOND_RELIABILITY_VERTICES
+        7 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
+        + 4 * MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES
         + 3
     )
     + 8
 )
-# Loosest declared-vertex count the joint work budget admits, derived by
-# solving ``2 * (4 * vertices + 3) + 8 <= budget`` for the edgeless case that
-# spends no arc work.  Denser sources admit fewer vertices through the same
-# budget; this is the per-field ceiling the published schema can advertise.
-MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES = (
-    (MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK - 8) // 2 - 3
-) // 4
+# Declared vertex labels stopped expanding execution when traversal began
+# materializing only the relevant vertices charged above; admission now pays
+# for them solely as scalars.  ``vertex_count``, ``source``, ``target``, and
+# every arc endpoint travel as bare JSON integers, so the interoperable
+# canonical-JSON range bounds each declared label: values above ``2**53 - 1``
+# cannot cross the transport boundary at all.  That transport maximum is the
+# per-field ceiling the published schema can advertise; label widths inside
+# state records stay charged directly by the ledger estimate below.
+MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES = (1 << 53) - 1
 
 
 def _require_bounded_fraction(
@@ -487,10 +494,10 @@ def _directed_bond_reliability_graph_schema() -> JsonSchemaValue:
     schema["description"] = (
         "A structurally valid finite simple directed graph accepted by this "
         f"complete-enumeration operation: at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} "
-        "arcs and at most "
-        f"{MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES} declared vertices. "
-        "Vertices and arcs share one derived work budget, so sparse graphs may "
-        "declare more vertices while dense graphs admit fewer."
+        f"arcs, and declared vertex labels inside the interoperable JSON "
+        f"integer range (at most {MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES}). "
+        "Traversal work scales with relevant vertices (terminals plus arc "
+        "endpoints), not with declared vertices."
     )
     schema["properties"]["vertex_count"].update(
         maximum=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
@@ -530,18 +537,22 @@ class DirectedBondReliabilityArcProbability(StrictModel):
 class DirectedBondConnectionProbabilitySource(StrictModel):
     __doc__ = f"""One finite directed bond-percolation source in canonical arc order.
 
-    Sources have at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs; the derived producer-and-replay work budget
-    bounds the vertex count, so sparse sources may declare more vertices.  The
-    probability map must contain every graph arc exactly once and is empty for
-    an edgeless source, and source/target are distinct declared vertices.
-    Input arc rows are normalized to lexicographic arc order before state
-    indices and result records are assigned.
+    Sources have at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs; traversal and replay materialize
+    only relevant vertices (the terminals plus arc endpoints), so sparse
+    sources may declare very large vertex counts within the published
+    declared-vertex label bound.  The probability map must contain every
+    graph arc exactly once and is empty for an edgeless source, and
+    source/target are distinct declared vertices.  Input arc rows are
+    normalized to lexicographic arc order before state indices and result
+    records are assigned.
     """
 
     graph: DirectedBondReliabilityGraph = Field(
         description=(
             f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
-            "complete-enumeration operation."
+            "complete-enumeration operation. Traversal work scales with "
+            "relevant vertices (terminals plus arc endpoints), not with "
+            "declared vertices."
         )
     )
     arc_probabilities: tuple[DirectedBondReliabilityArcProbability, ...] = Field(
@@ -607,13 +618,23 @@ class DirectedBondConnectionProbabilitySource(StrictModel):
 
         arc_count = len(canonical_arcs)
         state_count = 1 << arc_count
-        logical_work = (
-            2 * state_count * (5 * arc_count + 4 * self.graph.vertex_count + 3) + 8
+        # Producer and replay materialize only these relevant vertices, so
+        # executed work scales with arc count and this set -- never with the
+        # declared vertex count.
+        relevant_vertices = len(
+            {self.source, self.target}
+            | {vertex for arc in canonical_arcs for vertex in arc}
         )
+        logical_work = 2 * state_count * (7 * arc_count + 4 * relevant_vertices + 3) + 8
         if logical_work > MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK:
             raise _validation_error(
                 "directed bond reliability exceeds the complete producer and "
                 "replay work budget"
+            )
+        if self.graph.vertex_count > MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES:
+            raise _validation_error(
+                "declared vertex labels exceed the interoperable JSON integer "
+                f"range of {MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES}"
             )
         repeated_arc_bytes = (state_count // 2) * sum(
             len(encode_strict_json(list(arc))) + 1 for arc in canonical_arcs
@@ -693,16 +714,19 @@ class DirectedBondConnectionProbabilityRequest(StrictModel):
 
     The request admits at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs, requires one probability for every
     arc exactly once (empty for an edgeless graph), and requires distinct
-    declared source and target vertices.  The derived work budget bounds the
-    vertex count, so sparse graphs may declare more vertices.  It normalizes
-    arc rows lexicographically, so state indices and the source-bound result
-    do not depend on input order.
+    declared source and target vertices.  Traversal work depends only on
+    relevant vertices (terminals plus arc endpoints), so sparse graphs may
+    declare very large vertex counts.  It normalizes arc rows
+    lexicographically, so state indices and the source-bound result do not
+    depend on input order.
     """
 
     graph: DirectedBondReliabilityGraph = Field(
         description=(
             f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
-            "complete-enumeration operation."
+            "complete-enumeration operation. Traversal work scales with "
+            "relevant vertices (terminals plus arc endpoints), not with "
+            "declared vertices."
         )
     )
     arc_probabilities: tuple[DirectedBondReliabilityArcProbability, ...] = Field(
@@ -1332,8 +1356,8 @@ class FiniteConvolutionResult(StrictModel):
 
 __all__ = [
     "MAX_DIRECTED_BOND_RELIABILITY_ARCS",
+    "MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES",
     "MAX_DIRECTED_BOND_RELIABILITY_STATES",
-    "MAX_DIRECTED_BOND_RELIABILITY_VERTICES",
     "MAX_FINITE_CONVOLUTION_PAIRS",
     "MAX_FINITE_DISTRIBUTION_ATOMS",
     "MAX_GAUSSIAN_EXPANSION_PATHS",

--- a/src/jacobian/math/probability/_models.py
+++ b/src/jacobian/math/probability/_models.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from fractions import Fraction
 from itertools import pairwise
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictInt, model_validator
+from pydantic import Field, StrictInt, WithJsonSchema, model_validator
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import (
@@ -74,6 +75,13 @@ MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK = (
     )
     + 8
 )
+# Loosest declared-vertex count the joint work budget admits, derived by
+# solving ``2 * (4 * vertices + 3) + 8 <= budget`` for the edgeless case that
+# spends no arc work.  Denser sources admit fewer vertices through the same
+# budget; this is the per-field ceiling the published schema can advertise.
+MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES = (
+    (MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK - 8) // 2 - 3
+) // 4
 
 
 def _require_bounded_fraction(
@@ -472,6 +480,31 @@ class GraphConnectionProbabilityResult(StrictModel):
         return self
 
 
+def _directed_bond_reliability_graph_schema() -> JsonSchemaValue:
+    """Project the bond-reliability envelope onto the shared carrier schema."""
+
+    schema = DirectedGraph.model_json_schema()
+    schema["description"] = (
+        "A structurally valid finite simple directed graph accepted by this "
+        f"complete-enumeration operation: at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} "
+        "arcs and at most "
+        f"{MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES} declared vertices. "
+        "Vertices and arcs share one derived work budget, so sparse graphs may "
+        "declare more vertices while dense graphs admit fewer."
+    )
+    schema["properties"]["vertex_count"].update(
+        maximum=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
+    )
+    schema["properties"]["edges"].update(maxItems=MAX_DIRECTED_BOND_RELIABILITY_ARCS)
+    return schema
+
+
+DirectedBondReliabilityGraph = Annotated[
+    DirectedGraph,
+    WithJsonSchema(_directed_bond_reliability_graph_schema()),
+]
+
+
 class DirectedBondReliabilityArcProbability(StrictModel):
     """The independent open probability attached to one directed arc."""
 
@@ -505,7 +538,7 @@ class DirectedBondConnectionProbabilitySource(StrictModel):
     indices and result records are assigned.
     """
 
-    graph: DirectedGraph = Field(
+    graph: DirectedBondReliabilityGraph = Field(
         description=(
             f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."
@@ -666,7 +699,7 @@ class DirectedBondConnectionProbabilityRequest(StrictModel):
     do not depend on input order.
     """
 
-    graph: DirectedGraph = Field(
+    graph: DirectedBondReliabilityGraph = Field(
         description=(
             f"A directed graph with at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs for this "
             "complete-enumeration operation."

--- a/src/jacobian/math/probability/_operations.py
+++ b/src/jacobian/math/probability/_operations.py
@@ -9,8 +9,6 @@ from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, MathTools
-from jacobian.math.graphs.directed._models import ReachabilityRequest
-from jacobian.math.graphs.directed._operations import compute_reachability
 from jacobian.math.probability._gaussian_inputs import (
     CanonicalGaussianPolynomialMomentRequest,
 )
@@ -405,9 +403,8 @@ def _directed_bond_connection_probability_data(
 ) -> tuple[Fraction, tuple[tuple[tuple[tuple[int, int], ...], bool, Fraction], ...]]:
     """Replay the full directed bond-percolation source with exact rationals.
 
-    Directed reachability is delegated to the directed-graph owner.  The
-    standard-library ``Fraction`` replay is deliberately independent from the
-    Python-FLINT producer used by the public operation below.
+    The standard-library ``Fraction`` replay is deliberately independent from
+    the Python-FLINT producer used by the public operation below.
     """
 
     probabilities = tuple(
@@ -426,19 +423,33 @@ def _directed_bond_connection_probability_data(
             state_probability *= (
                 probability if state_index & (1 << index) else 1 - probability
             )
-        reaches_target = (
-            source.target
-            in compute_reachability(
-                ReachabilityRequest(
-                    graph=source.graph.model_copy(update={"edges": open_arcs}),
-                    source=source.source,
-                )
-            ).reachable
+        reaches_target = _directed_path_exists(
+            vertex_count=source.graph.vertex_count,
+            arcs=open_arcs,
+            source=source.source,
+            target=source.target,
         )
         if reaches_target:
             connection_probability += state_probability
         states.append((open_arcs, reaches_target, state_probability))
     return connection_probability, tuple(states)
+
+
+def _directed_path_exists(
+    *,
+    vertex_count: int,
+    arcs: tuple[tuple[int, int], ...],
+    source: int,
+    target: int,
+) -> bool:
+    """Test one admitted directed percolation state without another operation's cap."""
+
+    import networkx as nx
+
+    graph: Any = nx.DiGraph()
+    graph.add_nodes_from(range(vertex_count))
+    graph.add_edges_from(arcs)
+    return nx.has_path(graph, source, target)
 
 
 def _directed_bond_connection_probability(
@@ -470,14 +481,11 @@ def _directed_bond_connection_probability(
             state_probability *= (
                 probability if state_index & (1 << index) else 1 - probability
             )
-        reaches_target = (
-            source.target
-            in compute_reachability(
-                ReachabilityRequest(
-                    graph=source.graph.model_copy(update={"edges": open_arcs}),
-                    source=source.source,
-                )
-            ).reachable
+        reaches_target = _directed_path_exists(
+            vertex_count=source.graph.vertex_count,
+            arcs=open_arcs,
+            source=source.source,
+            target=source.target,
         )
         if reaches_target:
             connection_probability += state_probability

--- a/src/jacobian/math/probability/_operations.py
+++ b/src/jacobian/math/probability/_operations.py
@@ -424,7 +424,6 @@ def _directed_bond_connection_probability_data(
                 probability if state_index & (1 << index) else 1 - probability
             )
         reaches_target = _directed_path_exists(
-            vertex_count=source.graph.vertex_count,
             arcs=open_arcs,
             source=source.source,
             target=source.target,
@@ -437,17 +436,24 @@ def _directed_bond_connection_probability_data(
 
 def _directed_path_exists(
     *,
-    vertex_count: int,
     arcs: tuple[tuple[int, int], ...],
     source: int,
     target: int,
 ) -> bool:
-    """Test one admitted directed percolation state without another operation's cap."""
+    """Test one admitted directed percolation state without another operation's cap.
+
+    Reachability depends only on the open arcs and the two terminals, so the
+    traversal state materializes just those relevant vertices instead of every
+    declared vertex of a possibly sparse source.
+    """
 
     import networkx as nx
 
+    relevant_vertices = {source, target}
+    relevant_vertices.update(vertex for arc in arcs for vertex in arc)
+
     graph: Any = nx.DiGraph()
-    graph.add_nodes_from(range(vertex_count))
+    graph.add_nodes_from(relevant_vertices)
     graph.add_edges_from(arcs)
     return nx.has_path(graph, source, target)
 
@@ -482,7 +488,6 @@ def _directed_bond_connection_probability(
                 probability if state_index & (1 << index) else 1 - probability
             )
         reaches_target = _directed_path_exists(
-            vertex_count=source.graph.vertex_count,
             arcs=open_arcs,
             source=source.source,
             target=source.target,

--- a/tests/integration/catalog/test_directed_bond_reliability_schema.py
+++ b/tests/integration/catalog/test_directed_bond_reliability_schema.py
@@ -18,10 +18,11 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
         "Compute directed source-to-target bond connection probability.\n\n"
         f"The request admits at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs, requires one probability for every\n"
         "arc exactly once (empty for an edgeless graph), and requires distinct\n"
-        "declared source and target vertices.  The derived work budget bounds the\n"
-        "vertex count, so sparse graphs may declare more vertices.  It normalizes\n"
-        "arc rows lexicographically, so state indices and the source-bound result\n"
-        "do not depend on input order."
+        "declared source and target vertices.  Traversal work depends only on\n"
+        "relevant vertices (terminals plus arc endpoints), so sparse graphs may\n"
+        "declare very large vertex counts.  It normalizes arc rows\n"
+        "lexicographically, so state indices and the source-bound result do not\n"
+        "depend on input order."
     )
     properties = schema["properties"]
     assert (

--- a/tests/integration/catalog/test_directed_bond_reliability_schema.py
+++ b/tests/integration/catalog/test_directed_bond_reliability_schema.py
@@ -3,6 +3,7 @@
 from jacobian.catalog.catalog import Catalog
 from jacobian.math.probability._models import (
     MAX_DIRECTED_BOND_RELIABILITY_ARCS,
+    MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
 )
 
 OPERATION_ID = "probability.digraph_bond_reliability.connection_probability.compute"
@@ -26,6 +27,14 @@ def test_directed_bond_reliability_schema_exposes_cross_field_contract() -> None
     assert (
         f"at most {MAX_DIRECTED_BOND_RELIABILITY_ARCS} arcs"
         in properties["graph"]["description"]
+    )
+    assert (
+        properties["graph"]["properties"]["edges"]["maxItems"]
+        == MAX_DIRECTED_BOND_RELIABILITY_ARCS
+    )
+    assert (
+        properties["graph"]["properties"]["vertex_count"]["maximum"]
+        == MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES
     )
     assert (
         "every graph arc exactly once" in properties["arc_probabilities"]["description"]

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -392,6 +392,36 @@ class TestDirectOperationEnvelope:
             with pytest.raises(ValidationError):
                 AcyclicOrderRequest.model_validate(request)
 
+    def test_reachability_source_schema_matches_the_vertex_envelope(self) -> None:
+        """The published source field keeps the operation-wide vertex maximum."""
+
+        source_schema = ReachabilityRequest.model_json_schema()["properties"]["source"]
+        assert source_schema["maximum"] == MAX_DIRECTED_OPERATION_VERTICES - 1
+        assert "exclusiveMaximum" not in source_schema
+
+        full_graph = {
+            "graph": {
+                "vertex_count": MAX_DIRECTED_OPERATION_VERTICES,
+                "edges": [],
+            }
+        }
+        request = {**full_graph, "source": MAX_DIRECTED_OPERATION_VERTICES - 1}
+        accepted = ReachabilityRequest.model_validate(request)
+        assert accepted.source == MAX_DIRECTED_OPERATION_VERTICES - 1
+
+        beyond = {**full_graph, "source": MAX_DIRECTED_OPERATION_VERTICES}
+        with pytest.raises(ValidationError):
+            ReachabilityRequest.model_validate(beyond)
+
+    def test_cross_field_source_check_still_binds_below_the_field_maximum(self) -> None:
+        """source < vertex_count stays enforced inside the advertised range."""
+
+        small_graph = {"graph": {"vertex_count": 4, "edges": []}}
+        with pytest.raises(ValidationError):
+            ReachabilityRequest.model_validate({**small_graph, "source": 4})
+        with pytest.raises(ValidationError):
+            ReachabilityRequest.model_validate({**small_graph, "source": 255})
+
 
 # ---------------------------------------------------------------------------
 # Cross-consistency

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from itertools import combinations, islice
+
 import networkx as nx
 import pytest
 from pydantic import ValidationError
 
 from jacobian.math.graphs.directed._models import (
+    MAX_DIRECTED_OPERATION_EDGES,
+    MAX_DIRECTED_OPERATION_VERTICES,
     AcyclicOrderRequest,
     AcyclicOrderResult,
     CondensationRequest,
@@ -47,6 +51,12 @@ def _condensation(graph: dict) -> CondensationResult:
 
 def _acyclic_order(graph: dict) -> AcyclicOrderResult:
     return compute_acyclic_order(AcyclicOrderRequest.model_validate({"graph": graph}))
+
+
+def _directed_pairs(edge_count: int) -> list[list[int]]:
+    """Distinct loop-free directed pairs over 33 vertices: C(33, 2) = 528."""
+
+    return [list(pair) for pair in islice(combinations(range(33), 2), edge_count)]
 
 
 # ---------------------------------------------------------------------------
@@ -297,6 +307,90 @@ class TestAcyclicOrder:
         result = _acyclic_order({"vertex_count": 2, "edges": [[0, 1]]})
         assert result.acyclic
         assert result.order == (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# Published direct-operation envelope
+# ---------------------------------------------------------------------------
+
+
+DIRECT_OPERATION_REQUESTS = (
+    ReachabilityRequest,
+    StronglyConnectedComponentsRequest,
+    CondensationRequest,
+    AcyclicOrderRequest,
+)
+
+
+class TestDirectOperationEnvelope:
+    """Published schemas advertise exactly the direct-operation admission."""
+
+    def test_published_schemas_advertise_the_operation_envelope(self) -> None:
+        for request_type in DIRECT_OPERATION_REQUESTS:
+            graph_schema = request_type.model_json_schema()["properties"]["graph"]
+            assert (
+                graph_schema["properties"]["vertex_count"]["maximum"]
+                == MAX_DIRECTED_OPERATION_VERTICES
+            )
+            assert (
+                graph_schema["properties"]["edges"]["maxItems"]
+                == MAX_DIRECTED_OPERATION_EDGES
+            )
+            assert str(MAX_DIRECTED_OPERATION_VERTICES) in graph_schema["description"]
+            assert str(MAX_DIRECTED_OPERATION_EDGES) in graph_schema["description"]
+
+    def test_shared_carrier_schema_stays_free_of_the_operation_caps(self) -> None:
+        """The reusable carrier keeps its structural schema without this cap."""
+
+        carrier_properties = DirectedGraph.model_json_schema()["properties"]
+        assert "maximum" not in carrier_properties["vertex_count"]
+        assert "maxItems" not in carrier_properties["edges"]
+
+    def test_envelope_boundary_is_admitted_by_every_direct_request(self) -> None:
+        edgeless = {
+            "graph": {"vertex_count": MAX_DIRECTED_OPERATION_VERTICES, "edges": []}
+        }
+        ReachabilityRequest.model_validate({**edgeless, "source": 0})
+        StronglyConnectedComponentsRequest.model_validate(edgeless)
+        CondensationRequest.model_validate(edgeless)
+        AcyclicOrderRequest.model_validate(edgeless)
+
+        full_envelope = {
+            "graph": {
+                "vertex_count": MAX_DIRECTED_OPERATION_VERTICES,
+                "edges": _directed_pairs(MAX_DIRECTED_OPERATION_EDGES),
+            }
+        }
+        assert len(full_envelope["graph"]["edges"]) == MAX_DIRECTED_OPERATION_EDGES
+        ReachabilityRequest.model_validate({**full_envelope, "source": 0})
+        StronglyConnectedComponentsRequest.model_validate(full_envelope)
+        CondensationRequest.model_validate(full_envelope)
+        AcyclicOrderRequest.model_validate(full_envelope)
+
+    def test_requests_beyond_the_envelope_are_rejected_at_runtime(self) -> None:
+        beyond_envelope = [
+            {
+                "graph": {
+                    "vertex_count": MAX_DIRECTED_OPERATION_VERTICES + 1,
+                    "edges": [],
+                }
+            },
+            {
+                "graph": {
+                    "vertex_count": MAX_DIRECTED_OPERATION_VERTICES,
+                    "edges": _directed_pairs(MAX_DIRECTED_OPERATION_EDGES + 1),
+                }
+            },
+        ]
+        for request in beyond_envelope:
+            with pytest.raises(ValidationError):
+                ReachabilityRequest.model_validate({**request, "source": 0})
+            with pytest.raises(ValidationError):
+                StronglyConnectedComponentsRequest.model_validate(request)
+            with pytest.raises(ValidationError):
+                CondensationRequest.model_validate(request)
+            with pytest.raises(ValidationError):
+                AcyclicOrderRequest.model_validate(request)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -448,6 +448,25 @@ class TestCarrierParseEnvelope:
         assert "unique" not in message
         assert "self-loops" not in message
 
+    def test_oversized_rejection_precedes_nested_row_materialization(self) -> None:
+        """The envelope fires on the raw sequence before any row is coerced.
+
+        Every oversized row is deliberately not even an edge tuple, so an
+        after-validator placement would fail with coercion errors instead of
+        the parse-safety envelope.
+        """
+        edges = ["not-an-edge"] * (MAX_DIRECTED_GRAPH_PARSE_EDGES + 1)
+
+        with pytest.raises(ValidationError) as excinfo:
+            DirectedGraph.model_validate({"vertex_count": 2, "edges": edges})
+
+        message = str(excinfo.value)
+        assert "parse-safety envelope" in message
+        assert excinfo.value.errors(include_url=False)[0]["type"] == (
+            "graph.edge_list_parse_envelope_exceeded"
+        )
+        assert len(excinfo.value.errors(include_url=False)) == 1
+
     def test_oversized_rejection_covers_every_request_consumer(self) -> None:
         edges = [
             [index % 97, (index + 1) % 97]

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -11,6 +11,7 @@ from jacobian.math.graphs.directed._models import (
     AcyclicOrderResult,
     CondensationRequest,
     CondensationResult,
+    DirectedGraph,
     ReachabilityRequest,
     ReachabilityResult,
     StronglyConnectedComponentsRequest,
@@ -142,10 +143,17 @@ class TestReachabilityContract:
             )
 
     def test_rejects_vertex_count_above_the_conservative_fallback(self) -> None:
+        graph = DirectedGraph(vertex_count=257, edges=())
+        assert graph.vertex_count == 257
+
         with pytest.raises(ValidationError):
-            ReachabilityRequest.model_validate(
-                {"graph": {"vertex_count": 257, "edges": []}, "source": 0}
-            )
+            ReachabilityRequest(graph=graph, source=0)
+        with pytest.raises(ValidationError):
+            StronglyConnectedComponentsRequest(graph=graph)
+        with pytest.raises(ValidationError):
+            CondensationRequest(graph=graph)
+        with pytest.raises(ValidationError):
+            AcyclicOrderRequest(graph=graph)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_directed_graph.py
+++ b/tests/math/graphs/test_directed_graph.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.graphs.directed._models import (
+    MAX_DIRECTED_GRAPH_PARSE_EDGES,
     MAX_DIRECTED_OPERATION_EDGES,
     MAX_DIRECTED_OPERATION_VERTICES,
     AcyclicOrderRequest,
@@ -421,6 +422,65 @@ class TestDirectOperationEnvelope:
             ReachabilityRequest.model_validate({**small_graph, "source": 4})
         with pytest.raises(ValidationError):
             ReachabilityRequest.model_validate({**small_graph, "source": 255})
+
+
+class TestCarrierParseEnvelope:
+    """The carrier rejects oversized edge lists before structural scanning.
+
+    A near-10 MiB payload of distinct valid arcs must fail on the carrier's
+    parse-safety envelope instead of paying the full duplicate-detecting
+    scan, and the envelope must stay far above every consumer's admission.
+    """
+
+    def test_oversized_valid_arcs_reject_before_deep_validation(self) -> None:
+        arc_count = 250_000
+        edges = [[index, index + 1] for index in range(arc_count)]
+        edges.append([0, 1])
+        edges.append([1, 1])
+
+        with pytest.raises(ValidationError) as excinfo:
+            DirectedGraph.model_validate(
+                {"vertex_count": arc_count + 2, "edges": edges}
+            )
+
+        message = str(excinfo.value)
+        assert "parse-safety envelope" in message
+        assert "unique" not in message
+        assert "self-loops" not in message
+
+    def test_oversized_rejection_covers_every_request_consumer(self) -> None:
+        edges = [
+            [index % 97, (index + 1) % 97]
+            for index in range(MAX_DIRECTED_GRAPH_PARSE_EDGES + 1)
+        ]
+        for request_type in DIRECT_OPERATION_REQUESTS:
+            payload: dict = {"graph": {"vertex_count": 97, "edges": edges}}
+            if request_type is ReachabilityRequest:
+                payload["source"] = 0
+            with pytest.raises(ValidationError) as excinfo:
+                request_type.model_validate(payload)
+            assert "parse-safety envelope" in str(excinfo.value)
+
+    def test_envelope_boundary_remains_structurally_valid(self) -> None:
+        vertex_count = MAX_DIRECTED_GRAPH_PARSE_EDGES + 1
+        edges = [[index, index + 1] for index in range(MAX_DIRECTED_GRAPH_PARSE_EDGES)]
+        accepted = DirectedGraph.model_validate(
+            {"vertex_count": vertex_count, "edges": edges}
+        )
+        assert len(accepted.edges) == MAX_DIRECTED_GRAPH_PARSE_EDGES
+
+    def test_operation_admission_still_rejects_below_the_parse_envelope(self) -> None:
+        edges = _directed_pairs(MAX_DIRECTED_OPERATION_EDGES + 1)
+        with pytest.raises(ValidationError) as excinfo:
+            StronglyConnectedComponentsRequest.model_validate(
+                {"graph": {"vertex_count": 33, "edges": edges}}
+            )
+        message = str(excinfo.value)
+        assert "directed_edge_budget_exceeded" in message
+        assert "parse-safety envelope" not in message
+
+    def test_envelope_dwarfs_the_direct_operation_admission(self) -> None:
+        assert MAX_DIRECTED_GRAPH_PARSE_EDGES > 64 * MAX_DIRECTED_OPERATION_EDGES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/probability/test_directed_bond_reliability.py
+++ b/tests/math/probability/test_directed_bond_reliability.py
@@ -15,8 +15,8 @@ from jacobian.math.probability._models import (
     MAX_DIRECTED_BOND_RELIABILITY_ARCS,
     MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
     MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK,
+    MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES,
     MAX_DIRECTED_BOND_RELIABILITY_STATES,
-    MAX_DIRECTED_BOND_RELIABILITY_VERTICES,
     DirectedBondConnectionProbabilityRequest,
     DirectedBondConnectionProbabilityResult,
     DirectedBondConnectionProbabilitySource,
@@ -307,10 +307,10 @@ def test_probability_bound_rejects_thirteenth_arc_before_enumeration() -> None:
 
 
 def test_logical_work_bound_covers_two_pass_reachability_and_state_records() -> None:
-    """The 12-arc, 16-vertex envelope charges both complete passes."""
+    """The 12-arc envelope charges both passes over the relevant vertices."""
     per_state_kernel_work = (
-        4 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
-        + 4 * MAX_DIRECTED_BOND_RELIABILITY_VERTICES
+        6 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
+        + 4 * MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES
     )
     per_state_record_work = MAX_DIRECTED_BOND_RELIABILITY_ARCS + 3
 
@@ -354,6 +354,46 @@ def test_zero_and_one_probabilities_keep_complete_state_convention() -> None:
     assert tuple(state.state_index for state in result.states) == (0, 1, 2, 3)
 
 
+def test_edgeless_million_vertex_request_matches_small_equivalent() -> None:
+    """Sparse admission prices executed work, not the declared index space."""
+
+    large = _directed_bond_connection_probability(
+        _request(
+            vertex_count=1_000_000,
+            arcs=(),
+            probabilities=(),
+            source=0,
+            target=999_999,
+        )
+    )
+    small = _directed_bond_connection_probability(
+        _request(vertex_count=2, arcs=(), probabilities=(), source=0, target=1)
+    )
+
+    assert _probability(large) == _probability(small) == 0
+    assert [
+        (
+            state.state_index,
+            state.open_arcs,
+            state.source_reaches_target,
+            state.state_probability.as_fraction(),
+        )
+        for state in large.states
+    ] == [
+        (
+            state.state_index,
+            state.open_arcs,
+            state.source_reaches_target,
+            state.state_probability.as_fraction(),
+        )
+        for state in small.states
+    ]
+    replay = DirectedBondConnectionProbabilityResult.model_validate(
+        large.model_dump(mode="json")
+    )
+    assert replay == large
+
+
 def test_edgeless_source_at_the_declared_vertex_bound_stays_exact() -> None:
     """Sparse admission materializes terminals, not every declared vertex."""
 
@@ -377,7 +417,34 @@ def test_edgeless_source_at_the_declared_vertex_bound_stays_exact() -> None:
     assert replay == result
 
 
-def test_declared_vertex_admission_rejects_one_past_the_derived_bound() -> None:
+def test_dense_source_at_the_relevant_vertex_bound_is_admitted() -> None:
+    """Twelve disjoint arcs plus outside terminals fill the relevant set."""
+
+    arcs = tuple((2 * index, 2 * index + 1) for index in range(12))
+    vertex_count = MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES
+    result = _directed_bond_connection_probability(
+        _request(
+            vertex_count=vertex_count,
+            arcs=arcs,
+            probabilities=(Fraction(1, 2),) * len(arcs),
+            source=vertex_count - 2,
+            target=vertex_count - 1,
+        )
+    )
+
+    assert result.arc_count == MAX_DIRECTED_BOND_RELIABILITY_ARCS
+    assert result.visited_states == MAX_DIRECTED_BOND_RELIABILITY_STATES
+    assert all(not state.source_reaches_target for state in result.states)
+    assert _probability(result) == 0
+    replay = DirectedBondConnectionProbabilityResult.model_validate(
+        result.model_dump(mode="json")
+    )
+    assert replay == result
+
+
+def test_declared_vertex_admission_rejects_one_past_the_label_bound() -> None:
+    """The scalar transport ceiling, not traversal work, caps vertex labels."""
+
     with pytest.raises(ValidationError):
         _request(
             vertex_count=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES + 1,
@@ -408,6 +475,8 @@ class TestPublishedBondReliabilityEnvelope:
                 == MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES
             )
             assert "at most 12 arcs" in graph_schema["description"]
+            assert "relevant vertices" in graph_schema["description"]
+            assert "work budget" not in graph_schema["description"]
 
     def test_shared_carrier_schema_stays_free_of_the_reliability_caps(self) -> None:
         carrier_properties = DirectedGraph.model_json_schema()["properties"]

--- a/tests/math/probability/test_directed_bond_reliability.py
+++ b/tests/math/probability/test_directed_bond_reliability.py
@@ -191,9 +191,9 @@ def test_sparse_graph_above_sixteen_vertices_is_admitted() -> None:
 
 
 def test_edgeless_graph_above_the_shared_vertex_cap_is_admitted() -> None:
-    """A 65-vertex edgeless source stays inside the derived work budget."""
+    """A 257-vertex edgeless source stays inside the derived work budget."""
     result = _directed_bond_connection_probability(
-        _request(vertex_count=65, arcs=(), probabilities=(), source=0, target=1)
+        _request(vertex_count=257, arcs=(), probabilities=(), source=0, target=1)
     )
 
     assert _probability(result) == 0

--- a/tests/math/probability/test_directed_bond_reliability.py
+++ b/tests/math/probability/test_directed_bond_reliability.py
@@ -10,7 +10,10 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
-from jacobian.math.graphs.directed._models import DirectedGraph
+from jacobian.math.graphs.directed._models import (
+    MAX_DIRECTED_GRAPH_PARSE_EDGES,
+    DirectedGraph,
+)
 from jacobian.math.probability._models import (
     MAX_DIRECTED_BOND_RELIABILITY_ARCS,
     MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
@@ -482,6 +485,13 @@ class TestPublishedBondReliabilityEnvelope:
         carrier_properties = DirectedGraph.model_json_schema()["properties"]
         assert "maxItems" not in carrier_properties["edges"]
         assert "maximum" not in carrier_properties["vertex_count"]
+
+    def test_carrier_parse_envelope_cannot_bind_reliability_admission(self) -> None:
+        """The shared parse guard sits orders of magnitude above 12 arcs."""
+
+        assert (
+            MAX_DIRECTED_GRAPH_PARSE_EDGES > 1000 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
+        )
 
     def test_thirteenth_arc_is_rejected_by_runtime_and_absent_from_schema(self) -> None:
         schema_max_items = DirectedBondConnectionProbabilityRequest.model_json_schema()[

--- a/tests/math/probability/test_directed_bond_reliability.py
+++ b/tests/math/probability/test_directed_bond_reliability.py
@@ -13,11 +13,13 @@ from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.directed._models import DirectedGraph
 from jacobian.math.probability._models import (
     MAX_DIRECTED_BOND_RELIABILITY_ARCS,
+    MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
     MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK,
     MAX_DIRECTED_BOND_RELIABILITY_STATES,
     MAX_DIRECTED_BOND_RELIABILITY_VERTICES,
     DirectedBondConnectionProbabilityRequest,
     DirectedBondConnectionProbabilityResult,
+    DirectedBondConnectionProbabilitySource,
     DirectedBondReliabilityArcProbability,
 )
 from jacobian.math.probability._operations import _directed_bond_connection_probability
@@ -350,3 +352,78 @@ def test_zero_and_one_probabilities_keep_complete_state_convention() -> None:
     assert _probability(result) == 0
     assert result.visited_states == 4
     assert tuple(state.state_index for state in result.states) == (0, 1, 2, 3)
+
+
+def test_edgeless_source_at_the_declared_vertex_bound_stays_exact() -> None:
+    """Sparse admission materializes terminals, not every declared vertex."""
+
+    result = _directed_bond_connection_probability(
+        _request(
+            vertex_count=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES,
+            arcs=(),
+            probabilities=(),
+            source=0,
+            target=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES - 1,
+        )
+    )
+
+    assert _probability(result) == 0
+    assert result.arc_count == 0
+    assert result.visited_states == 1
+    assert tuple(state.source_reaches_target for state in result.states) == (False,)
+    replay = DirectedBondConnectionProbabilityResult.model_validate(
+        result.model_dump(mode="json")
+    )
+    assert replay == result
+
+
+def test_declared_vertex_admission_rejects_one_past_the_derived_bound() -> None:
+    with pytest.raises(ValidationError):
+        _request(
+            vertex_count=MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES + 1,
+            arcs=(),
+            probabilities=(),
+            source=0,
+            target=1,
+        )
+
+
+class TestPublishedBondReliabilityEnvelope:
+    """Published schemas advertise the bond-reliability graph envelope."""
+
+    def test_request_and_source_schemas_project_the_arc_and_vertex_bounds(
+        self,
+    ) -> None:
+        for model_type in (
+            DirectedBondConnectionProbabilityRequest,
+            DirectedBondConnectionProbabilitySource,
+        ):
+            graph_schema = model_type.model_json_schema()["properties"]["graph"]
+            assert (
+                graph_schema["properties"]["edges"]["maxItems"]
+                == MAX_DIRECTED_BOND_RELIABILITY_ARCS
+            )
+            assert (
+                graph_schema["properties"]["vertex_count"]["maximum"]
+                == MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES
+            )
+            assert "at most 12 arcs" in graph_schema["description"]
+
+    def test_shared_carrier_schema_stays_free_of_the_reliability_caps(self) -> None:
+        carrier_properties = DirectedGraph.model_json_schema()["properties"]
+        assert "maxItems" not in carrier_properties["edges"]
+        assert "maximum" not in carrier_properties["vertex_count"]
+
+    def test_thirteenth_arc_is_rejected_by_runtime_and_absent_from_schema(self) -> None:
+        schema_max_items = DirectedBondConnectionProbabilityRequest.model_json_schema()[
+            "properties"
+        ]["graph"]["properties"]["edges"]["maxItems"]
+        assert schema_max_items == MAX_DIRECTED_BOND_RELIABILITY_ARCS
+        with pytest.raises(ValidationError):
+            _request(
+                vertex_count=14,
+                arcs=tuple((index, index + 1) for index in range(13)),
+                probabilities=(Fraction(1, 2),) * 13,
+                source=0,
+                target=13,
+            )


### PR DESCRIPTION
Related to #2601.

## Problem

`DirectedGraph` encoded the 256-vertex and 512-edge envelope of direct traversal operations. A directed-bond reliability request for a 257-vertex edgeless graph was therefore rejected while parsing the shared carrier, despite fitting its own zero-arc subset envelope. On the base revision, validation raises Pydantic's `less_than_equal` error at `graph.vertex_count`.

## Solution

Keep `DirectedGraph` structural, with traversal-specific caps retained by reachability, strongly connected components, condensation, and acyclic-order requests. Directed bond reliability uses its own admitted traversal helper for enumerated states, so it no longer re-enters the unrelated reachability contract. This is one scoped instance of #2601, not its closure.

## Testing

- `make test-focused LANE=math TESTS="tests/math/graphs/test_directed_graph.py tests/math/probability/test_directed_bond_reliability.py"` — 45 passed
- `make test-catalog` — 41 passed
- `uv run --locked pytest -q tests/integration/catalog/test_directed_bond_reliability_schema.py --timeout=120` — 1 passed
- targeted advertised reliability example — 1 passed
- `git diff --check origin/main...HEAD` — passed

The graph regression constructs a 257-vertex carrier while every direct traversal request still rejects it. The reliability regression executes that edgeless request and returns exact zero.

## Public contract impact

The reusable `DirectedGraph` schema no longer advertises traversal-specific maxima. Direct traversal requests and bond-reliability result schemas retain their operation-local envelopes.

## Operation boundary ownership

- Changed stage: request bounds and kernel adapter
- Request-bounds owner and controlling quantities: direct graph operations own 256 vertices/512 edges; bond reliability owns its subset-enumeration envelope
- Backend or kernel path: direct operations retain their NetworkX paths; reliability uses a local reachability check for admitted states
- Result construction: unchanged
- Independent-result verifier: none
- Native/MCP parity: shared request models with transport-only differences
- Serialized-result and round-trip evidence: advertised reliability invocation

## Checklist

- [ ] `make check` passes (not run; focused owner, catalog, schema, and example evidence passed)