### PR TITLE
Canonicalize strict-JSON preflight containers

### DIFF
--- a/src/jacobian/_models.py
+++ b/src/jacobian/_models.py
@@ -1,6 +1,29 @@
-"""Narrow strict-model primitive shared by unrelated wire owners."""
+"""Narrow strict-model primitives shared by unrelated wire owners."""
+
+from __future__ import annotations
+
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+
+
+def canonicalize_json_containers(value: Any) -> Any:
+    """Materialize JSON arrays as immutable canonical containers.
+
+    Pydantic validates ``model_validator(mode="before")`` output with Python
+    semantics even when its caller supplied strict JSON.  Public mathematical
+    values use tuples for every sequence, so owner-local preflight validators
+    must return this projection rather than raw JSON arrays.  Mappings are
+    copied recursively: callers retain ownership of their transport payload.
+    """
+
+    if isinstance(value, list):
+        return tuple(canonicalize_json_containers(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(canonicalize_json_containers(item) for item in value)
+    if isinstance(value, dict):
+        return {key: canonicalize_json_containers(item) for key, item in value.items()}
+    return value
 
 
 class StrictModel(BaseModel):
@@ -12,4 +35,4 @@ class StrictModel(BaseModel):
     )
 
 
-__all__ = ["StrictModel"]
+__all__ = ["StrictModel", "canonicalize_json_containers"]

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -632,7 +632,9 @@ class SubsetSumProfileRequest(StrictModel):
         mode, where decoded JSON arrays no longer coerce to the declared
         tuple shapes; normalize the source value list to a tuple on a
         copied path so JSON invocation keeps working while the stored
-        sequence stays canonical.
+        sequence stays canonical. Container canonicalization preserves
+        element count and order, so the raw item-count bound is enforced
+        after it against either accepted container shape.
         """
 
         value = canonicalize_json_containers(value)
@@ -644,7 +646,7 @@ class SubsetSumProfileRequest(StrictModel):
         if isinstance(raw_source, Mapping):
             source = dict(raw_source)
             items = source.get("items")
-            if isinstance(items, list):
+            if isinstance(items, (list, tuple)):
                 source["items"] = tuple(items)
                 prepared["source"] = source
                 if len(items) > MAX_SUBSET_SUM_ITEMS:

--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -11,7 +11,7 @@ from pydantic.json_schema import WithJsonSchema
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.additive_combinatorics import _multiset_sum
 from jacobian.math.additive_combinatorics.operations import (
@@ -634,6 +634,8 @@ class SubsetSumProfileRequest(StrictModel):
         copied path so JSON invocation keeps working while the stored
         sequence stays canonical.
         """
+
+        value = canonicalize_json_containers(value)
 
         if not isinstance(value, Mapping):
             return value

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_residue.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_residue.py
@@ -9,7 +9,7 @@ from pydantic import Field, StrictBool, StringConstraints, model_validator
 from pydantic.json_schema import WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.additive_combinatorics.values import (
     IndexedIntegerSequence,
@@ -264,6 +264,8 @@ class SubsetSumResidueProfileRequest(StrictModel):
         sequence stays canonical.
         """
 
+        value = canonicalize_json_containers(value)
+
         if not isinstance(value, Mapping):
             return value
         prepared: dict[str, object] = dict(value)
@@ -360,6 +362,8 @@ class SubsetSumResidueProfileResult(StrictModel):
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
         """Reject oversized forged result containers before nested parsing."""
+
+        value = canonicalize_json_containers(value)
 
         if not isinstance(value, Mapping):
             return value

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
@@ -10,7 +10,7 @@ from pydantic.json_schema import WithJsonSchema
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.additive_combinatorics._subset_sum_target_kernel import (
     _attained_sum_interval,
@@ -227,6 +227,8 @@ class SubsetSumTargetRequest(StrictModel):
         sequence stays canonical.
         """
 
+        value = canonicalize_json_containers(value)
+
         if not isinstance(value, Mapping):
             return value
         prepared: dict[str, object] = dict(value)
@@ -296,6 +298,8 @@ class SubsetSumTargetResult(StrictModel):
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
         """Reject oversized forged result values before nested parsing."""
+
+        value = canonicalize_json_containers(value)
 
         if not isinstance(value, Mapping):
             return value

--- a/src/jacobian/math/analysis/_models.py
+++ b/src/jacobian/math/analysis/_models.py
@@ -19,7 +19,7 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
 
@@ -243,6 +243,7 @@ class IntervalExpressionEnclosureRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_tree(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if isinstance(value, Mapping):
             _bound_raw_expression(value.get("expression"))
             _bound_raw_rational(value.get("argument"), "interval-enclosure argument")
@@ -622,6 +623,7 @@ class IntervalExpressionBoxEnclosureRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_tree(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if isinstance(value, Mapping):
             _bound_raw_expression(value.get("expression"))
             _bound_raw_box(value.get("box"))
@@ -966,6 +968,7 @@ class PointEnclosureCheckRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def preflight_raw_source(cls, data: object) -> object:
+        data = canonicalize_json_containers(data)
         return _preflight_point_check_source(data)
 
     @model_validator(mode="after")
@@ -1160,6 +1163,7 @@ class PointEnclosureCheckResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def preflight_raw_source(cls, data: object) -> object:
+        data = canonicalize_json_containers(data)
         return _preflight_point_check_source(data)
 
     @model_validator(mode="after")

--- a/src/jacobian/math/coalgebras/_models.py
+++ b/src/jacobian/math/coalgebras/_models.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
 #: Decimal digit budget for an admitted field characteristic. The digit
@@ -271,6 +271,8 @@ class ComultiplicationResult(StrictModel):
         The digit budget and the equality with the already-validated
         coalgebra prime are therefore enforced on the raw nested input.
         """
+        data = canonicalize_json_containers(data)
+
         if not isinstance(data, dict):
             return data
         matrix_input = data.get("matrix")

--- a/src/jacobian/math/code_nonlinear/values.py
+++ b/src/jacobian/math/code_nonlinear/values.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Self
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 
 # A materialized code carries exactly ``length * cardinality`` binary entries.
 # Keeping that quantity below 2**19 bounds source parsing, canonical sorting,
@@ -108,16 +108,7 @@ class ExplicitBinaryCode(StrictModel):
                         f"{total_bits} bits, exceeding the "
                         f"{MAX_EXPLICIT_CODE_BITS}-bit source bound",
                     )
-        # Running a before validator moves field validation into Python
-        # mode, where decoded JSON arrays no longer coerce to the declared
-        # tuple shapes; normalize the raw containers on a copied path so
-        # JSON invocation keeps working while stored values stay canonical.
-        return {
-            **data,
-            "codewords": tuple(
-                tuple(word) if isinstance(word, list) else word for word in words
-            ),
-        }
+        return canonicalize_json_containers(data)
 
     @model_validator(mode="after")
     def require_canonical_code(self) -> Self:

--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -9,7 +9,7 @@ from pydantic import ConfigDict, Field, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import encode_strict_json, format_canonical_integer
 from jacobian.math.geometry.exact._line_arithmetic import (
     canonical_line_coefficients,
@@ -731,6 +731,8 @@ class PinnedLineDistanceResult(StrictModel):
         declared aggregate work and intermediate-memory bound through the
         typed Python boundary.
         """
+
+        data = canonicalize_json_containers(data)
 
         if not isinstance(data, dict):
             return data

--- a/src/jacobian/math/group/_models.py
+++ b/src/jacobian/math/group/_models.py
@@ -8,7 +8,7 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 
 MAX_GROUP_DEGREE = 64
 
@@ -609,6 +609,7 @@ class GroupSubgroupLatticeResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_bounded_subgroup_entries(cls, data: Any) -> Any:
+        data = canonicalize_json_containers(data)
         # Cap the entry count BEFORE nested SubgroupEntry construction: each
         # nested entry builds a backend permutation group, so a forged relayed
         # payload must not drive that work past the operation-derived bound.

--- a/src/jacobian/math/hypergraphs/_models.py
+++ b/src/jacobian/math/hypergraphs/_models.py
@@ -15,7 +15,7 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._digest import Sha256Digest
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import CanonicalLimits, encode_strict_json, sha256_digest
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -611,6 +611,8 @@ class EdgeIntersectionsResult(StrictModel):
     @classmethod
     def require_aggregate_intersection_bound(cls, data: object) -> object:
         """Reject an oversized authored ledger before nested model parsing."""
+
+        data = canonicalize_json_containers(data)
 
         if not isinstance(data, dict):
             return data

--- a/src/jacobian/math/matrices/symbolic/_models.py
+++ b/src/jacobian/math/matrices/symbolic/_models.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.polynomials.values import (
     PolynomialVariable,
     RationalFunction,
@@ -1350,6 +1350,7 @@ class SymbolicLinearSystemResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_bounded_payload_shapes(cls, data: Any) -> Any:
+        data = canonicalize_json_containers(data)
         # Cap relayed solution payloads against the retained source's column
         # count BEFORE nested RationalFunction parsing; an unbounded tuple of
         # individually valid values would otherwise be fully parsed before

--- a/src/jacobian/math/matroids/_models.py
+++ b/src/jacobian/math/matroids/_models.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 from pydantic import ConfigDict, Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
 MAX_GROUND_SIZE = 32
@@ -50,21 +50,13 @@ class LinearMatroid(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_bounded_declared_prime(cls, data: Any) -> Any:
-        # Running a before validator moves field validation into Python
-        # mode, where decoded JSON arrays no longer coerce to the declared
-        # tuple shapes; normalize entry rows to tuples on a copied path so
-        # JSON invocation keeps working while stored values stay canonical.
+        data = canonicalize_json_containers(data)
+        # Shared strict-JSON container canonicalization above keeps the
+        # nested matrix entry rows in their declared tuple shape.
         if isinstance(data, dict):
             raw = data.get("matrix")
             if isinstance(raw, dict):
                 prime = raw.get("prime")
-                entries = raw.get("entries")
-                if isinstance(entries, list):
-                    matrix = dict(raw)
-                    matrix["entries"] = tuple(
-                        tuple(row) if isinstance(row, list) else row for row in entries
-                    )
-                    data = {**data, "matrix": matrix}
             else:
                 prime = getattr(raw, "prime", None)
             if isinstance(prime, int) and not 2 <= prime <= MAX_PRIME:

--- a/src/jacobian/math/number_theory/_periodic_models.py
+++ b/src/jacobian/math/number_theory/_periodic_models.py
@@ -11,7 +11,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import (
     CanonicalLimits,
     format_canonical_integer,
@@ -267,6 +267,8 @@ class PeriodicCongruenceUnionRequest(StrictModel):
     @classmethod
     def bound_raw_source_rows(cls, data: object) -> object:
         """Reject oversized raw families before constructing every row model."""
+
+        data = canonicalize_json_containers(data)
 
         if not isinstance(data, Mapping):
             return data

--- a/src/jacobian/math/optimization/_general_models.py
+++ b/src/jacobian/math/optimization/_general_models.py
@@ -14,7 +14,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.optimization._arithmetic import rational_dot
 from jacobian.math.optimization._models import (
     MAX_LINEAR_PROGRAM_RESULT_BYTES,
@@ -236,6 +236,7 @@ class GeneralFormRationalLinearProgram(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_program(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         try:
             return _prepare_raw_general_program(value)
         except ValueError as error:
@@ -342,6 +343,7 @@ class GeneralRationalLinearProgramResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if not isinstance(value, Mapping):
             return value
         try:

--- a/src/jacobian/math/optimization/_models.py
+++ b/src/jacobian/math/optimization/_models.py
@@ -15,7 +15,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.optimization._arithmetic import rational_dot
 
 MAX_RATIONAL_DIGITS = 128
@@ -406,6 +406,7 @@ class StandardFormRationalLinearProgram(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_program(cls, value: object, info: ValidationInfo) -> object:
+        value = canonicalize_json_containers(value)
         try:
             return _prepare_raw_program(value, maximum_digits=_scalar_digit_cap(info))
         except ValueError as error:
@@ -536,6 +537,7 @@ class RationalLinearProgramResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if not isinstance(value, Mapping):
             return value
         try:

--- a/src/jacobian/math/polynomials/interpolation/_models.py
+++ b/src/jacobian/math/polynomials/interpolation/_models.py
@@ -14,7 +14,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import encode_strict_json
 from jacobian.math.polynomials.interpolation._kernel import (
     divided_difference_coefficients,
@@ -153,6 +153,7 @@ class OrdinaryDerivativeJetTable(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_raw_aggregate_bound(cls, data: object) -> object:
+        data = canonicalize_json_containers(data)
         if not isinstance(data, dict):
             return data
         jets = data.get("jets")

--- a/src/jacobian/math/polynomials/maps/_models.py
+++ b/src/jacobian/math/polynomials/maps/_models.py
@@ -10,7 +10,7 @@ from pydantic import Field, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.polynomials.maps.values import (
     MAX_MAP_INPUTS,
     MAX_MAP_OUTPUTS,
@@ -408,6 +408,8 @@ class GenericFiberCertificate(StrictModel):
     @classmethod
     def require_serialized_certificate_bounds(cls, value: Any) -> Any:
         """Reject oversized nested payloads before constructing coefficient values."""
+
+        value = canonicalize_json_containers(value)
 
         polynomials = _serialized_certificate_polynomials(value)
         if polynomials is None:

--- a/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
+++ b/src/jacobian/math/polynomials/real_algebra/_strict_sublevel_models.py
@@ -10,7 +10,7 @@ from pydantic import Field, StrictBool, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.polynomials.values import (
     RationalPolynomial,
     RationalPolynomialTerm,
@@ -214,6 +214,7 @@ class StrictSublevelMeasureRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_request(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if not isinstance(value, Mapping):
             return value
         prepared: dict[str, object] = dict(value)
@@ -429,6 +430,7 @@ class StrictSublevelMeasureResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
         if not isinstance(value, Mapping):
             return value
         prepared: dict[str, object] = dict(value)

--- a/src/jacobian/math/polytope/_models.py
+++ b/src/jacobian/math/polytope/_models.py
@@ -19,7 +19,7 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import CanonicalLimits, encode_strict_json
 from jacobian.math.polytope.values import (
     MAX_RATIONAL_POLYTOPE_DIMENSION,
@@ -269,7 +269,7 @@ def _preflight_raw_support_components(data: object) -> object:
 
     if not isinstance(data, dict):
         return data
-    canonical: Any = _tuple_canonical_containers(data)
+    canonical: Any = canonicalize_json_containers(data)
     _require_raw_support_covector_admissible(canonical)
     for vertex in _iter_raw_entries(canonical.get("polytope"), "vertices"):
         for component in _iter_raw_entries(vertex, "coordinates"):
@@ -1177,6 +1177,8 @@ class FacetIncidenceRequest(StrictModel):
         runs.
         """
 
+        data = canonicalize_json_containers(data)
+
         if not isinstance(data, dict):
             return data
         value = data.get("vertices")
@@ -1205,7 +1207,7 @@ class FacetIncidenceRequest(StrictModel):
             _require_raw_v_polytope_coordinates_within_facet_envelope(value)
             canonical = RationalVPolytope.model_validate(value)
             return {**data, "vertices": _canonical_v_polytope_vertices(canonical)}
-        return _tuple_canonical_containers(data)
+        return data
 
     @model_validator(mode="after")
     def require_admissible_full_dimensional_profile(self) -> Self:
@@ -1461,6 +1463,8 @@ class RationalExposedFace(StrictModel):
         ``require_canonical_face_vertices``.
         """
 
+        data = canonicalize_json_containers(data)
+
         estimated = _estimate_face_wire_bytes(data)
         if estimated > CanonicalLimits().max_output_bytes:
             raise _validation_error(
@@ -1584,6 +1588,8 @@ class PolytopeSupportRequest(StrictModel):
         after every declared field has been parsed.
         """
 
+        data = canonicalize_json_containers(data)
+
         canonical = _preflight_raw_support_components(data)
         _require_raw_support_request_shape(canonical)
         return canonical
@@ -1631,6 +1637,8 @@ class PolytopeSupportResult(StrictModel):
         outer shape and conclusion fields are preflighted the same way:
         an already-invalid payload must fail before any hull replay runs.
         """
+
+        data = canonicalize_json_containers(data)
 
         canonical = _preflight_raw_support_components(data)
         _require_raw_support_conclusions_admissible(canonical)
@@ -1737,24 +1745,6 @@ VertexTuple = Annotated[
 ]
 
 
-def _tuple_canonical_containers(value: Any) -> Any:
-    """Return raw JSON payloads with every sequence materialized as a tuple.
-
-    Dispatch parses each request through strict JSON validation, so a
-    preflight validator that hands back raw JSON arrays would make the
-    strict parser reject list-to-tuple coercion on canonical tuple fields.
-    Recursively converting containers keeps the preflight semantics while
-    preserving the declared canonical shapes; the payload size is already
-    bounded by the request's own container limits.
-    """
-
-    if isinstance(value, list):
-        return tuple(_tuple_canonical_containers(item) for item in value)
-    if isinstance(value, dict):
-        return {key: _tuple_canonical_containers(item) for key, item in value.items()}
-    return value
-
-
 class PolytopeVolumeRequest(StrictModel):
     """A bounded rational polytope in exactly one of the two representations.
 
@@ -1841,6 +1831,8 @@ class PolytopeVolumeRequest(StrictModel):
         already-invalid request must fail before any hull replay runs.
         """
 
+        data = canonicalize_json_containers(data)
+
         if not isinstance(data, dict):
             return data
         value = data.get("vertices")
@@ -1873,7 +1865,7 @@ class PolytopeVolumeRequest(StrictModel):
         if isinstance(value, dict) and set(value) == {"space", "vertices"}:
             canonical = RationalVPolytope.model_validate(value)
             return {**data, "vertices": _canonical_v_polytope_vertices(canonical)}
-        return _tuple_canonical_containers(data)
+        return data
 
     @model_validator(mode="after")
     def validate_representation(self) -> Self:

--- a/src/jacobian/math/prime_field_matrix/_models.py
+++ b/src/jacobian/math/prime_field_matrix/_models.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.math.prime_field_linear_algebra import PrimeFieldMatrix
 
 MAX_ROWS = 256
@@ -54,26 +54,16 @@ class PrimeFieldMatrixRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_bounded_prime(cls, data: Any) -> Any:
+        data = canonicalize_json_containers(data)
         # Bound the characteristic BEFORE the nested canonical value is
         # constructed: PrimeFieldMatrix.__post_init__ runs the (expensive)
         # primality test, so an oversized prime must be rejected first.
-        # Running a before validator moves field validation into Python
-        # mode, where decoded JSON arrays no longer coerce to the declared
-        # tuple shapes; normalize them here so JSON invocation keeps
-        # working while every stored value stays a canonical tuple.
+        # Shared strict-JSON container canonicalization above keeps the
+        # nested matrix entry rows in their declared tuple shape.
         if isinstance(data, dict):
             raw = data.get("matrix")
             if isinstance(raw, dict):
                 prime = raw.get("prime")
-                entries = raw.get("entries")
-                if isinstance(entries, list):
-                    # Copy along the rewritten path: the caller owns the
-                    # payload, so normalization must not mutate it.
-                    matrix = dict(raw)
-                    matrix["entries"] = tuple(
-                        tuple(row) if isinstance(row, list) else row for row in entries
-                    )
-                    data = {**data, "matrix": matrix}
             else:
                 prime = getattr(raw, "prime", None)
             if isinstance(prime, int) and not 2 <= prime <= MAX_PRIME:

--- a/src/jacobian/math/probability/_all_terminal_reliability.py
+++ b/src/jacobian/math/probability/_all_terminal_reliability.py
@@ -13,7 +13,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
@@ -110,6 +110,7 @@ class AllTerminalReliabilityWireResult(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def bound_raw_coefficients(cls, value: Any) -> Any:
+        value = canonicalize_json_containers(value)
         if not isinstance(value, Mapping):
             return value
         raw_counts = value.get("connected_spanning_subgraph_counts")

--- a/src/jacobian/math/probability/_local_lemma.py
+++ b/src/jacobian/math/probability/_local_lemma.py
@@ -16,7 +16,7 @@ from pydantic import (
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
 from jacobian.math.probability.local_lemma import (
@@ -191,6 +191,8 @@ class AsymmetricLocalLemmaWitnessRequest(StrictModel):
     def bound_raw_source(cls, value: Any) -> Any:
         """Reject oversized materialized input before nested rational parsing."""
 
+        value = canonicalize_json_containers(value)
+
         return _bound_raw_source(value)
 
     @model_validator(mode="after")
@@ -346,6 +348,8 @@ class AsymmetricLocalLemmaWitnessCheckResult(StrictModel):
     @classmethod
     def bound_raw_result(cls, value: Any) -> Any:
         """Bound forged result collections and rationals before replay."""
+
+        value = canonicalize_json_containers(value)
 
         return _bound_raw_result(value)
 

--- a/src/jacobian/math/probability/_mutual_information.py
+++ b/src/jacobian/math/probability/_mutual_information.py
@@ -14,7 +14,7 @@ from jacobian._exact import (
     CanonicalRational,
     require_bounded_rational,
 )
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
@@ -228,6 +228,8 @@ class FiniteJointTableMutualInformationRequest(StrictModel):
     @classmethod
     def bound_raw_probability_matrix(cls, value: Any) -> Any:
         """Reject oversized collections before parsing any rational cell model."""
+
+        value = canonicalize_json_containers(value)
         return _bound_raw_probability_matrix(value)
 
     @model_validator(mode="after")
@@ -331,6 +333,8 @@ class FiniteJointTableMutualInformationResult(StrictModel):
     @classmethod
     def bound_raw_result_collections(cls, value: Any) -> Any:
         """Reject impossible candidates before parsing their nested item models."""
+
+        value = canonicalize_json_containers(value)
 
         if not isinstance(value, Mapping):
             return value

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -21,7 +21,6 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._digest import Sha256Digest
-from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import canonicalize_json
 from jacobian.math.chain_complexes.values import ChainComplexValue

--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -21,7 +21,8 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError
 
 from jacobian._digest import Sha256Digest
-from jacobian._models import StrictModel
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.canonical import canonicalize_json
 from jacobian.math.chain_complexes.values import ChainComplexValue
 from jacobian.math.topology._barycentric import barycentric_subdivision
@@ -345,6 +346,7 @@ class SimplicialComplexRequest(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def accept_canonical_complex_value(cls, data: object) -> object:
+        data = canonicalize_json_containers(data)
         # A before-validator switches the remaining validation to python
         # semantics, where strict tuples reject JSON arrays; normalize the
         # accepted array shapes to tuples so strict JSON dispatch (the only
@@ -357,14 +359,6 @@ class SimplicialComplexRequest(StrictModel):
         if not isinstance(data, dict):
             return data
         normalized = dict(data)
-        vertices = normalized.get("vertices")
-        if isinstance(vertices, list):
-            normalized["vertices"] = tuple(vertices)
-        facets = normalized.get("facets")
-        if isinstance(facets, list):
-            normalized["facets"] = tuple(
-                tuple(facet) if isinstance(facet, list) else facet for facet in facets
-            )
         data = normalized
         if "facets" in data and "maximal_simplices" in data:
             raise _validation_error(

--- a/src/jacobian/math/words/values.py
+++ b/src/jacobian/math/words/values.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Self
 from pydantic import AfterValidator, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 
 MAX_WORD_LENGTH = 500
 MAX_ALPHABET_SIZE = 50
@@ -134,6 +134,7 @@ class ProlongableSubstitution(StrictModel):
     @model_validator(mode="before")
     @classmethod
     def require_bounded_source_before_mortality_analysis(cls, value: Any) -> Any:
+        value = canonicalize_json_containers(value)
         _require_prolongable_source_occurrence_bound(value)
         return _prepare_prolongable_substitution_input(value)
 

--- a/tests/dispatch/test_parsing.py
+++ b/tests/dispatch/test_parsing.py
@@ -5,10 +5,10 @@ from enum import StrEnum
 from typing import Annotated
 
 import pytest
-from pydantic import StrictInt, StringConstraints, ValidationError
+from pydantic import StrictInt, StringConstraints, ValidationError, model_validator
 from tests.dispatch._support import dispatch_validation_error
 
-from jacobian._models import StrictModel
+from jacobian._models import StrictModel, canonicalize_json_containers
 from jacobian.catalog.models import OperationDiscoveryRequest
 from jacobian.dispatch import parse_operation_input
 from jacobian.math.logic._cnf import SatAssignmentCheckRequest
@@ -22,6 +22,15 @@ class _Label(StrEnum):
 class _TupleRequest(StrictModel):
     labels: tuple[Annotated[str, StringConstraints(strict=True)], ...]
     limit: StrictInt
+
+
+class _PreflightTupleRequest(StrictModel):
+    entries: tuple[tuple[StrictInt, ...], ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def retain_canonical_containers(cls, value: object) -> object:
+        return canonicalize_json_containers(value)
 
 
 class _EnumRequest(StrictModel):
@@ -52,6 +61,15 @@ def test_parse_operation_input_accepts_json_arrays_for_constrained_tuples() -> N
 
     assert parsed.labels == ("left", "right")
     assert isinstance(parsed.labels, tuple)
+
+
+def test_parse_operation_input_preserves_tuples_through_before_validation() -> None:
+    parsed = parse_operation_input(
+        _PreflightTupleRequest,
+        {"entries": [[1, 2], [3, 4]]},
+    )
+
+    assert parsed.entries == ((1, 2), (3, 4))
 
 
 def test_parse_operation_input_rejects_numeric_strings_for_integers() -> None:

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -7,6 +7,7 @@ from itertools import product
 
 import pytest
 from pydantic import ValidationError
+from pydantic_core import PydanticCustomError
 
 from jacobian.canonical import (
     CanonicalLimits,
@@ -246,6 +247,45 @@ def test_wide_canonical_items_are_rejected_by_the_raw_item_count_bound() -> None
 
     with pytest.raises(ValidationError):
         SubsetSumProfileRequest.model_validate(payload)
+
+
+def test_oversized_json_list_is_rejected_before_nested_item_parsing() -> None:
+    payload = {"source": {"items": ["z", *(["1"] * MAX_SUBSET_SUM_ITEMS)]}}
+
+    with pytest.raises(ValidationError) as error:
+        SubsetSumProfileRequest.model_validate(payload)
+
+    assert (
+        f"{MAX_SUBSET_SUM_ITEMS:,}-item profile bound" in error.value.errors()[0]["msg"]
+    )
+
+
+def test_oversized_tuple_container_is_rejected_before_nested_item_parsing() -> None:
+    payload = {"source": {"items": ("z", *(["1"] * MAX_SUBSET_SUM_ITEMS))}}
+
+    with pytest.raises(ValidationError) as error:
+        SubsetSumProfileRequest.model_validate(payload)
+
+    assert (
+        f"{MAX_SUBSET_SUM_ITEMS:,}-item profile bound" in error.value.errors()[0]["msg"]
+    )
+
+
+def test_expensive_admissible_items_are_rejected_by_the_raw_preflight_bound() -> None:
+    payload = {"source": {"items": ("9" * 2_048,) * (MAX_SUBSET_SUM_ITEMS + 1)}}
+
+    with pytest.raises(PydanticCustomError) as error:
+        SubsetSumProfileRequest.bound_raw_source(payload)
+
+    assert error.value.type == "additive_combinatorics.bound_raw_source"
+
+
+def test_json_list_at_the_item_ceiling_remains_admitted_and_canonical() -> None:
+    admitted = SubsetSumProfileRequest.model_validate(
+        {"source": {"items": ["0"] * MAX_SUBSET_SUM_ITEMS}}
+    )
+
+    assert admitted.source.items == ("0",) * MAX_SUBSET_SUM_ITEMS
 
 
 @pytest.mark.parametrize(

--- a/tests/tooling/test_before_validator_containers.py
+++ b/tests/tooling/test_before_validator_containers.py
@@ -1,0 +1,53 @@
+"""Guard strict-JSON container handling in owner-local preflight validators."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _is_before_validator(decorator: ast.expr) -> bool:
+    return (
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Name)
+        and decorator.func.id == "model_validator"
+        and any(
+            keyword.arg == "mode"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value == "before"
+            for keyword in decorator.keywords
+        )
+    )
+
+
+def _uses_canonical_container_projection(function: ast.FunctionDef) -> bool:
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "canonicalize_json_containers"
+        for node in ast.walk(function)
+    )
+
+
+def test_math_before_validators_project_json_arrays_to_canonical_tuples() -> None:
+    """Preflight validators cannot hand raw JSON arrays back to Pydantic.
+
+    ``model_validator(mode="before")`` switches downstream tuple validation
+    to Python semantics.  Each owner therefore projects strict-JSON arrays
+    to its canonical tuple values before returning to Pydantic.
+    """
+
+    source_root = Path(__file__).parents[2] / "src" / "jacobian" / "math"
+    missing = [
+        f"{path.relative_to(source_root)}:{function.lineno}"
+        for path in sorted(source_root.rglob("*.py"))
+        for function in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(function, ast.FunctionDef)
+        and any(_is_before_validator(item) for item in function.decorator_list)
+        and not _uses_canonical_container_projection(function)
+    ]
+
+    assert not missing, (
+        "mode='before' validators must call canonicalize_json_containers: "
+        + ", ".join(missing)
+    )


### PR DESCRIPTION
Fixes #2608.

## Problem

`model_validator(mode="before")` makes subsequent validation run under Python strict semantics. A preflight validator that returned raw JSON arrays could therefore make valid tuple-valued requests fail strict parsing.

## Solution

Add one shared recursive canonical projection for JSON containers and apply it to every current math preflight validator. A tooling AST guard now requires all math before-validators to use it. Nested JSON arrays remain accepted, while scalar coercion stays forbidden.

## Testing

- `make test-focused LANE=dispatch TESTS=tests/dispatch/test_parsing.py` — 8 passed
- `make test-focused LANE=tooling TESTS=tests/tooling/test_before_validator_containers.py` — 1 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 41 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 611 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_strict_json_contracts.py` — 3 passed
- `make test-focused LANE=mcp TESTS=tests/mcp` — 18 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Strict JSON tuple-valued requests are accepted consistently at the dispatch boundary. Scalar coercion and operation schemas are unchanged.

## Checklist

- [ ] `make check` passes (not run; dispatch, tooling, catalog, integration, and MCP boundaries passed)