### PR TITLE
Keep npm dependency-range checks stable across routine bumps

### DIFF
--- a/npm/carrier.test.mjs
+++ b/npm/carrier.test.mjs
@@ -365,11 +365,17 @@ test("npm and Python packages publish the same release version", async () => {
 
 test("package metadata carries setup dependencies and packs the setup adapter", async () => {
   assert.equal(packageMetadata.engines.node, ">=23.5.0 || ^22.13.0 || ^20.17.0");
-  assert.deepEqual(packageMetadata.dependencies, {
-    "@iarna/toml": "^2.2.5",
-    "@inquirer/prompts": "^8.6.0",
-    "jsonc-parser": "^3.3.1",
-  });
+  assert.deepEqual(Object.keys(packageMetadata.dependencies).sort(), [
+    "@iarna/toml",
+    "@inquirer/prompts",
+    "jsonc-parser",
+  ]);
+  assert.ok(
+    Object.values(packageMetadata.dependencies).every(
+      (range) => typeof range === "string" && range.length > 0,
+    ),
+    "runtime dependency ranges must be non-empty manifest strings",
+  );
   assert.equal(packageMetadata.bundleDependencies, undefined);
   assert.deepEqual(packageMetadata.files, ["bin", "lib", "skill", "README.md"]);
   assert.deepEqual(Object.keys(packageMetadata.bin), ["jacobian"]);


### PR DESCRIPTION
Fixes #2613.

## Problem

`npm/carrier.test.mjs` compared runtime dependency ranges to literal version strings. A routine Dependabot range bump could therefore fail the npm CI lane even when the manifest and lockfile were valid.

## Solution

Keep the dependency-name set explicit, but treat each runtime range as manifest-owned metadata: the carrier test now requires every declared range to be a non-empty string rather than pinning its current spelling. This preserves detection of added or removed setup dependencies without coupling CI to routine semver range updates.

## Testing

- `make npm-test` — 16 carrier tests passed; `npm pack --dry-run ./npm` passed
- `make check-static` — Ruff, Deptry, Vulture, and mypy passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None; this changes only the npm metadata test contract.

## Checklist

- [ ] `make check` passes (not run; the CI/dependency change matrix was covered by `make check-static` and `make npm-test`)