### PR TITLE
Admit the empty ranked alphabet in tree automata

### DIFF
--- a/src/jacobian/math/tree_automata/values.py
+++ b/src/jacobian/math/tree_automata/values.py
@@ -62,7 +62,13 @@ class BottomUpTreeAutomaton(StrictModel):
     """
 
     state_count: int = Field(ge=1, le=MAX_TA_STATES)
-    arity: tuple[Arity, ...] = Field(min_length=1, max_length=MAX_TA_SYMBOLS)
+    arity: tuple[Arity, ...] = Field(
+        max_length=MAX_TA_SYMBOLS,
+        description=(
+            "arity of each ranked symbol; an empty tuple is the canonical "
+            "empty ranked alphabet, whose ground-tree language is empty"
+        ),
+    )
     transitions: tuple[TreeAutomatonTransition, ...] = Field(
         min_length=0, max_length=MAX_TA_TRANSITIONS
     )

--- a/tests/math/tree_automata/test_tree_automata.py
+++ b/tests/math/tree_automata/test_tree_automata.py
@@ -220,6 +220,37 @@ class TestRun:
 
 
 class TestAcceptedTreeCount:
+    def test_empty_ranked_alphabet_has_exact_empty_language(self):
+        """The canonical empty alphabet has no ground trees of any positive size."""
+        automaton = BottomUpTreeAutomaton(
+            state_count=2,
+            arity=(),
+            transitions=(),
+            final_states=(),
+        )
+
+        assert (
+            BottomUpTreeAutomaton.model_validate(automaton.model_dump(mode="json"))
+            == automaton
+        )
+
+        count = compute_accepted_tree_count(
+            AcceptedTreeCountRequest(automaton=automaton, tree_size=1)
+        )
+        assert count.count == "0"
+        assert count.estimated_work_bound == 0
+
+        profile = compute_tree_automaton_reachability(
+            TreeAutomatonReachabilityRequest(automaton=automaton)
+        )
+        assert profile.reachable_states == ()
+        assert profile.unreachable_states == (0, 1)
+        assert profile.witnesses == ()
+
+        arity_schema = BottomUpTreeAutomaton.model_json_schema()["properties"]["arity"]
+        assert "minItems" not in arity_schema
+        assert "empty ranked alphabet" in arity_schema["description"]
+
     def test_count_size_1(self):
         automaton = _simple_automaton()
         result = compute_accepted_tree_count(


### PR DESCRIPTION
Part of #2622.

## Problem

`BottomUpTreeAutomaton` rejected an empty ranked alphabet even though its kernels define the corresponding empty-language counts and reachability profile exactly.

## Solution

Permit `arity=()` as the canonical degenerate automaton value and add owner regressions for its exact empty-language behavior and JSON round-trip. This is one tree-automata instance of the wider #2622 container-minimum audit.

## Testing

- `make test-focused LANE=math TESTS=tests/math/tree_automata` — 48 passed
- `make test-catalog` — 41 passed
- exact added regression — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Tree automata can now express the canonical empty ranked alphabet. Existing nonempty contracts and operation IDs are unchanged.

## Checklist

- [ ] `make check` passes (not run; focused owner and catalog checks passed)