### PR TITLE
Reject nested pytest definitions in boundary-test checks

### DIFF
--- a/docs/reference/testing-strategy.md
+++ b/docs/reference/testing-strategy.md
@@ -100,6 +100,13 @@ algebraic claim. Select evidence by the claim being made:
 | Public operation | Catalog mutation conformance |
 | Process backend | Codec, version, timeout/output, and typed failure tests |
 
+When correcting an admission or boundedness rule, inspect the affected owner
+lane for assertions that pin the previous accept/reject outcome and rewrite or
+remove them in the same change. Every retained rejected boundary case must
+fail for the guard it names: keep the rest of its payload valid and assert the
+owner's structured error code. A request rejected by an earlier field bound is
+not evidence that a later cross-field admission guard ran.
+
 For example, an ideal radical needs containment and radicality evidence or an
 independent bounded oracle. A factorization needs reconstruction, retained
 unit, and positive-multiplicity properties. Known answers remain useful
@@ -131,7 +138,9 @@ error) should likewise be computed from the constant, not hardcoded:
 
 ```python
 beyond = "9" * (_MAX_MULTIVARIATE_COEFFICIENT_DIGITS + 1)
-with pytest.raises(ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"):
+with pytest.raises(
+    ValueError, match=rf"{_MAX_MULTIVARIATE_COEFFICIENT_DIGITS}-digit bound"
+):
     ...
 ```
 

--- a/tests/tooling/test_pytest_collection_ownership.py
+++ b/tests/tooling/test_pytest_collection_ownership.py
@@ -17,6 +17,43 @@ ORDINARY_OWNERS = frozenset(
 )
 
 
+def _nested_test_functions(path: Path) -> tuple[str, ...]:
+    """Return test definitions pytest cannot collect from ``path``.
+
+    Pytest discovers module-level tests and methods on test classes, but a
+    ``test_*`` definition below another function is inert.  Parsing the syntax
+    lets this ownership check catch that mistake without making collection a
+    prerequisite of each ordinary test lane.
+    """
+
+    try:
+        display_path = path.relative_to(ROOT)
+    except ValueError:
+        display_path = path.name
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    nested: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        function_depth = 0
+
+        def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+            if node.name.startswith("test_") and self.function_depth:
+                nested.append(f"{display_path}:{node.lineno}")
+            self.function_depth += 1
+            self.generic_visit(node)
+            self.function_depth -= 1
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self._visit_function(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._visit_function(node)
+
+    Visitor().visit(tree)
+    return tuple(nested)
+
+
 def _configured_testpaths() -> tuple[PurePosixPath, ...]:
     with (ROOT / "pyproject.toml").open("rb") as project_file:
         project = tomllib.load(project_file)
@@ -56,6 +93,30 @@ def test_default_testpaths_do_not_overlap_each_other() -> None:
         not _overlap(left, right)
         for left, right in combinations(_configured_testpaths(), 2)
     )
+
+
+def test_test_functions_are_not_nested_under_functions() -> None:
+    violations = tuple(
+        location
+        for path in sorted((ROOT / "tests").rglob("*.py"))
+        for location in _nested_test_functions(path)
+    )
+
+    assert violations == ()
+
+
+def test_nested_test_function_check_rejects_an_uncollected_definition(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "test_example.py"
+    path.write_text(
+        "def helper() -> None:\n"
+        "    def test_never_collected() -> None:\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+
+    assert _nested_test_functions(path) == ("test_example.py:2",)
 
 
 def test_math_tests_do_not_boot_complete_product_boundaries() -> None:


### PR DESCRIPTION
Refs #2632.

## Problem

Nested `test_*` functions are silently skipped by pytest collection, allowing apparent boundary coverage to ship without ever executing. Boundary tests also need to demonstrate the structured owner guard they claim to exercise.

## Solution

Add a tooling check that rejects nested pytest definitions and codify the guard-specific boundary-test requirement. This covers the collection defect and guidance portion of #2632; its separate load-sensitive Singular evidence remains outside this PR.

## Testing

- `uv run pytest tests/tooling/test_pytest_collection_ownership.py` — 6 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This is test-collection and evidence tooling only.

## Checklist

- [ ] `make check` passes (not complete; Ruff, format, mypy, and the focused tooling test passed)