### PR TITLE
Type Z3 initialization failures in logic solvers

### DIFF
--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -696,6 +696,28 @@ def _smtlib_structure(source: str) -> _SmtLibStructure:
     return _SmtLibStructure(max_depth, compound_terms, numeral_digits)
 
 
+def _require_parseable_smtlib(source: str) -> None:
+    """Reject source that Z3's SMT-LIB 2 parser cannot read as a request error.
+
+    Admission runs the same non-evaluating backend parse that execution uses,
+    so a schema-admitted request never discovers malformed syntax through an
+    execution exception. Backend absence here is left to execution, where it
+    keeps its typed initialization outcome.
+    """
+
+    try:
+        import z3  # type: ignore[import-untyped]
+    except (ImportError, OSError):
+        return
+    try:
+        z3.parse_smt2_string(source)
+    except z3.Z3Exception as exc:
+        raise _validation_error(
+            "logic.smtlib_grammar",
+            "SMT-LIB input could not be parsed by the declared logic",
+        ) from exc
+
+
 class SmtSolveRequest(StrictModel):
     logic: SmtLogic
     smtlib: str = Field(
@@ -706,7 +728,9 @@ class SmtSolveRequest(StrictModel):
             "and ends with that command. Bounded before parsing: nesting depth at most "
             f"{_MAX_SMTLIB_DEPTH}, compound terms at most {_MAX_SMTLIB_TERMS}, declared "
             f"symbols at most {_MAX_SMTLIB_DECLARATIONS}, and any one numeral, decimal, "
-            f"or indexed bit-vector spelling at most {_MAX_SMTLIB_NUMERAL_DIGITS} digits."
+            f"or indexed bit-vector spelling at most {_MAX_SMTLIB_NUMERAL_DIGITS} digits. "
+            "The source must be well-formed SMT-LIB 2 for the declared logic; malformed "
+            "input is rejected during request validation."
         ),
         examples=[
             "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
@@ -777,6 +801,7 @@ class SmtSolveRequest(StrictModel):
                 raise _validation_error(
                     "logic.smtlib_command", f"unsupported SMT-LIB command: {command[0]}"
                 )
+        _require_parseable_smtlib(self.smtlib)
         return self
 
 
@@ -888,7 +913,7 @@ def solve_sat(request: SatSolveRequest) -> SatSolveResult:
     """Solve one bounded canonical CNF through the maintained Z3 Python binding."""
 
     try:
-        import z3  # type: ignore[import-untyped]
+        import z3
     except (ImportError, OSError) as exc:
         return SatSolveResult(
             outcome="UNKNOWN",
@@ -1086,12 +1111,6 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
 
     try:
         assertions = z3.parse_smt2_string(request.smtlib)
-    except z3.Z3Exception as exc:
-        return SmtSolveResult(
-            outcome="UNKNOWN",
-            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
-        )
-    try:
         solver = z3.SolverFor(request.logic.value)
         solver.set(**_solver_settings(request.timeout_ms))
         solver.add(assertions)

--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -887,12 +887,18 @@ def _solver_settings(timeout_ms: int) -> dict[str, int]:
 def solve_sat(request: SatSolveRequest) -> SatSolveResult:
     """Solve one bounded canonical CNF through the maintained Z3 Python binding."""
 
-    import z3  # type: ignore[import-untyped]
-
-    variables = tuple(z3.Bool(name) for name in request.cnf.variables)
-    solver = z3.Solver()
-    solver.set(**_solver_settings(request.timeout_ms))
     try:
+        import z3  # type: ignore[import-untyped]
+    except (ImportError, OSError) as exc:
+        return SatSolveResult(
+            outcome="UNKNOWN",
+            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
+        )
+
+    try:
+        variables = tuple(z3.Bool(name) for name in request.cnf.variables)
+        solver = z3.Solver()
+        solver.set(**_solver_settings(request.timeout_ms))
         for clause in request.cnf.clauses:
             terms = tuple(
                 variables[abs(literal) - 1]
@@ -911,7 +917,7 @@ def solve_sat(request: SatSolveRequest) -> SatSolveResult:
             return SatSolveResult(outcome="SAT", assignment=assignment)
         if outcome == z3.unsat:
             return SatSolveResult(outcome="UNSAT")
-    except z3.Z3Exception as exc:
+    except (OSError, z3.Z3Exception) as exc:
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
             return SatSolveResult(
@@ -1070,17 +1076,24 @@ def check_sat_refutation(
 def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
     """Solve one bounded SMT-LIB query through the maintained Z3 Python binding."""
 
-    import z3
+    try:
+        import z3
+    except (ImportError, OSError) as exc:
+        return SmtSolveResult(
+            outcome="UNKNOWN",
+            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
+        )
 
     try:
         assertions = z3.parse_smt2_string(request.smtlib)
     except z3.Z3Exception as exc:
-        raise ValueError(
-            "SMT-LIB input could not be parsed by the declared logic"
-        ) from exc
-    solver = z3.SolverFor(request.logic.value)
-    solver.set(**_solver_settings(request.timeout_ms))
+        return SmtSolveResult(
+            outcome="UNKNOWN",
+            detail=f"the Z3 backend could not initialize: {exc}"[:1_024],
+        )
     try:
+        solver = z3.SolverFor(request.logic.value)
+        solver.set(**_solver_settings(request.timeout_ms))
         solver.add(assertions)
         outcome = solver.check()
         if outcome == z3.sat:
@@ -1093,7 +1106,7 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
             return SmtSolveResult(outcome="SAT", model_smtlib=model)
         if outcome == z3.unsat:
             return SmtSolveResult(outcome="UNSAT")
-    except z3.Z3Exception as exc:
+    except (OSError, z3.Z3Exception) as exc:
         exhausted = _classify_exhaustion(str(exc))
         if exhausted is not None:
             return SmtSolveResult(

--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -740,7 +740,7 @@ def _require_parseable_smtlib(source: str) -> None:
         return
     try:
         z3.parse_smt2_string(source)
-    except z3.Z3Exception as exc:
+    except (z3.Z3Exception, OSError) as exc:
         if not _is_smtlib_source_diagnostic(exc):
             return
         raise _validation_error(

--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 from enum import StrEnum
@@ -696,13 +697,43 @@ def _smtlib_structure(source: str) -> _SmtLibStructure:
     return _SmtLibStructure(max_depth, compound_terms, numeral_digits)
 
 
+_Z3_SOURCE_DIAGNOSTIC = re.compile(r'\(error "line \d+ column \d+: ')
+
+
+def _exception_message(exc: Exception) -> str:
+    message = exc.args[0] if exc.args else ""
+    if isinstance(message, bytes):
+        return message.decode("ascii", errors="replace")
+    return str(message)
+
+
+def _is_smtlib_source_diagnostic(exc: Exception) -> bool:
+    """Report whether one backend parse exception diagnoses the caller's source.
+
+    Z3's SMT-LIB front end reports caller-correctable source problems as
+    ``(error "line L column C: <diagnostic>")``. Backend conditions such as
+    exhausted memory or interruption surface through Z3's fixed error-code
+    message table and carry no source locator. A located diagnostic names a
+    grammar defect unless it also classifies as an exhausted budget, in which
+    case admission defers to execution instead of claiming malformed input.
+    """
+
+    message = _exception_message(exc)
+    if _Z3_SOURCE_DIAGNOSTIC.search(message) is None:
+        return False
+    return _classify_exhaustion(message) is None
+
+
 def _require_parseable_smtlib(source: str) -> None:
     """Reject source that Z3's SMT-LIB 2 parser cannot read as a request error.
 
     Admission runs the same non-evaluating backend parse that execution uses,
     so a schema-admitted request never discovers malformed syntax through an
-    execution exception. Backend absence here is left to execution, where it
-    keeps its typed initialization outcome.
+    execution exception. Only located parser diagnostics establish malformed
+    input; resource or other backend failures carry no evidence about the
+    source, so they defer to execution, which reports them as typed UNKNOWN.
+    Backend absence here is left to execution, where it keeps its typed
+    initialization outcome.
     """
 
     try:
@@ -712,6 +743,8 @@ def _require_parseable_smtlib(source: str) -> None:
     try:
         z3.parse_smt2_string(source)
     except z3.Z3Exception as exc:
+        if not _is_smtlib_source_diagnostic(exc):
+            return
         raise _validation_error(
             "logic.smtlib_grammar",
             "SMT-LIB input could not be parsed by the declared logic",
@@ -801,8 +834,19 @@ class SmtSolveRequest(StrictModel):
                 raise _validation_error(
                     "logic.smtlib_command", f"unsupported SMT-LIB command: {command[0]}"
                 )
-        _require_parseable_smtlib(self.smtlib)
+        self._complete_backend_admission()
         return self
+
+    def _complete_backend_admission(self) -> None:
+        """Parse through the backend once every structural check has passed.
+
+        Called at the end of ``require_single_smtlib_query``. A subclass whose
+        own ``mode="after"`` validators impose a stricter envelope overrides
+        this hook so out-of-envelope source never reaches the backend parser;
+        the most-derived request completes backend admission.
+        """
+
+        _require_parseable_smtlib(self.smtlib)
 
 
 class SmtSolveResult(StrictModel):

--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -714,14 +714,12 @@ def _is_smtlib_source_diagnostic(exc: Exception) -> bool:
     ``(error "line L column C: <diagnostic>")``. Backend conditions such as
     exhausted memory or interruption surface through Z3's fixed error-code
     message table and carry no source locator. A located diagnostic names a
-    grammar defect unless it also classifies as an exhausted budget, in which
-    case admission defers to execution instead of claiming malformed input.
+    grammar defect regardless of which resource keywords its text contains,
+    because the diagnostic quotes caller-controlled source spellings that may
+    legitimately contain words such as ``memory``.
     """
 
-    message = _exception_message(exc)
-    if _Z3_SOURCE_DIAGNOSTIC.search(message) is None:
-        return False
-    return _classify_exhaustion(message) is None
+    return _Z3_SOURCE_DIAGNOSTIC.search(_exception_message(exc)) is not None
 
 
 def _require_parseable_smtlib(source: str) -> None:
@@ -919,8 +917,19 @@ _EXHAUSTION_DETAILS: dict[_UnknownResource, str] = {
 
 
 def _classify_exhaustion(message: str) -> _UnknownResource | None:
-    """Classify one Z3 reason or exception message onto the exhausted budgets."""
+    """Classify one Z3 reason or exception message onto the exhausted budgets.
 
+    Exhaustion keywords classify only backend conditions, which carry no
+    source locator. A message containing a located ``(error "line ...
+    column ...: ...")`` diagnostic is never classified as exhaustion, even
+    when its text mentions a resource keyword: the diagnostic quotes
+    caller-controlled source spellings, so an undeclared identifier named
+    ``memory`` or a comment mentioning ``timeout`` must not report an
+    exhausted budget.
+    """
+
+    if _Z3_SOURCE_DIAGNOSTIC.search(message) is not None:
+        return None
     lowered = message.strip().lower()
     if "resource limit" in lowered or "canceled" in lowered:
         return "work"

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -16,6 +16,7 @@ from jacobian.catalog.models import MathTool
 from jacobian.math.logic._operations import (
     SmtLogic,
     SmtSolveRequest,
+    _is_smtlib_source_diagnostic,
     _tokenize_smtlib,
     _top_level_smtlib_commands,
 )
@@ -187,6 +188,14 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
 
     @model_validator(mode="after")
     def require_bounded_indexed_assertions(self) -> Self:
+        """Reject out-of-envelope source before any backend work.
+
+        These core-specific bounds run inside the most-derived validator, so
+        a source that fits the broader ``smt.solve`` envelope but violates a
+        core limit is rejected lexically, before this class's single backend
+        parse below.
+        """
+
         tokens = _tokenize_smtlib(self.smtlib)
         if len(tokens) > _MAX_CORE_TOKENS:
             raise _logic_error(
@@ -206,6 +215,14 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
         if parsed_error is not None:
             raise _logic_error(parsed_error)
         return self
+
+    def _complete_backend_admission(self) -> None:
+        """Skip the inherited base-class parse.
+
+        ``require_bounded_indexed_assertions`` already parses through the
+        backend only after every core-specific structural bound has passed,
+        so sources outside this operation's envelope never reach Z3.
+        """
 
 
 class SmtUnsatCoreResult(StrictModel):
@@ -302,6 +319,8 @@ def _parse_assertions(smtlib: str, *, context: Any | None = None) -> tuple[Any, 
         ctx = context if context is not None else z3.Context()
         return tuple(z3.parse_smt2_string(smtlib, ctx=ctx))
     except z3.Z3Exception as exc:
+        if not _is_smtlib_source_diagnostic(exc):
+            raise
         raise _logic_error("SMT core source could not be parsed as SMT-LIB") from exc
 
 
@@ -312,6 +331,8 @@ def _parsed_request_error(
     logic: SmtLogic,
 ) -> str | None:
     """Inspect parsed terms without attaching Z3 objects to validation errors."""
+
+    import z3
 
     try:
         assertions = _parse_assertions(smtlib)
@@ -324,6 +345,10 @@ def _parsed_request_error(
                 f"{_MAX_CORE_AST_NODES} distinct AST nodes"
             )
         _require_declared_logic(assertions, logic)
+    except z3.Z3Exception:
+        # A deferred backend failure carries no evidence about this source;
+        # execution reports it through the typed UNKNOWN outcome.
+        return None
     except ValueError as exc:
         return str(exc)
     return None

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -1,0 +1,81 @@
+"""Dispatch boundaries for bounded logic operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+
+
+def _positive_integer_query() -> dict[str, str]:
+    return {
+        "logic": "QF_LIA",
+        "smtlib": (
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
+        ),
+    }
+
+
+def _contradictory_bounds_core() -> dict[str, str]:
+    return {
+        "logic": "QF_LIA",
+        "smtlib": (
+            "(set-logic QF_LIA)\n"
+            "(declare-const x Int)\n"
+            "(assert (>= x 1))\n"
+            "(assert (<= x 0))\n"
+            "(check-sat)"
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "payload"),
+    [
+        ("smt.solve", _positive_integer_query()),
+        ("smt.unsat_core", _contradictory_bounds_core()),
+    ],
+)
+def test_dispatch_types_parser_resource_failure_as_execution_unknown(
+    monkeypatch, operation_id: str, payload: dict[str, str]
+) -> None:
+    """A fresh request validation cannot claim parser exhaustion is malformed.
+
+    ``math.run`` revalidates every payload, so admission runs the backend
+    parse first; a resource failure there must stay admissible and surface
+    as the typed execution UNKNOWN instead of ``OperationRequestValidationError``.
+    """
+
+    import z3
+
+    def exhausting_parser(_source: str, **_kwargs: object) -> object:
+        raise z3.Z3Exception("out of memory")
+
+    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+
+    try:
+        result = invoke_operation(operation_id, payload, Catalog.open())
+    except OperationRequestValidationError as exc:
+        raise AssertionError(
+            f"{operation_id} rejected a parser resource failure as caller error"
+        ) from exc
+
+    assert result.operation_id == operation_id
+    assert result.output["outcome"] == "UNKNOWN"
+
+
+def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
+    """The smt.solve execution path names the exhausted budget it translated."""
+
+    import z3
+
+    def exhausting_parser(_source: str) -> object:
+        raise z3.Z3Exception("out of memory")
+
+    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+
+    result = invoke_operation("smt.solve", _positive_integer_query(), Catalog.open())
+
+    assert result.output["outcome"] == "UNKNOWN"
+    assert result.output["exhausted"] == "memory"

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -1020,6 +1021,47 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
             "the Z3 backend failed during the bounded solve: backend exploded"
             in result.detail
         )
+
+
+@pytest.mark.parametrize(
+    ("operation", "accepted_request"),
+    (
+        (
+            solve_sat,
+            SatSolveRequest(
+                cnf=CanonicalCnf(variables=("x",), clauses=((1,),)),
+            ),
+        ),
+        (
+            solve_smt,
+            SmtSolveRequest(
+                logic=SmtLogic.QF_LIA,
+                smtlib=(
+                    "(set-logic QF_LIA)\n"
+                    "(declare-const x Int)\n"
+                    "(assert (> x 0))\n"
+                    "(check-sat)"
+                ),
+            ),
+        ),
+    ),
+)
+def test_z3_initialization_failure_is_a_typed_unknown(
+    operation,
+    accepted_request,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed Z3 module initialization cannot escape an accepted request."""
+
+    monkeypatch.setitem(sys.modules, "z3", None)
+
+    result = operation(accepted_request)
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert result.detail is not None
+    assert "could not initialize" in result.detail
+    assert type(result).model_validate(result.model_dump()) == result
 
 
 def test_unknown_projection_maps_every_exhausted_resource() -> None:

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -668,18 +668,21 @@ def test_smt_request_rejects_an_indexed_bit_vector_value_beyond_the_digit_budget
         )
 
 
-def test_smt_request_admits_an_indexed_bit_vector_at_the_digit_boundary() -> None:
-    request = SmtSolveRequest(
-        logic=SmtLogic.QF_LIA,
-        smtlib=(
-            "(set-logic QF_LIA)\n"
-            "(declare-const x Int)\n"
-            f"(assert (= x (_ bv{'9' * 4_096} 8)))\n"
-            "(check-sat)\n"
-        ),
-    )
+def test_smt_request_rejects_an_ill_sorted_indexed_bit_vector_equality() -> None:
+    """Lexical digit admission cannot override backend well-sortedness."""
 
-    assert operations._smtlib_structure(request.smtlib).numeral_digits == 4_096
+    with pytest.raises(ValidationError) as error:
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                f"(assert (= x (_ bv{'9' * 4_096} 8)))\n"
+                "(check-sat)\n"
+            ),
+        )
+
+    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
 
 
 def test_smt_request_admits_a_bv_named_symbol_outside_index_context_and_solves() -> (
@@ -1062,6 +1065,68 @@ def test_z3_initialization_failure_is_a_typed_unknown(
     assert result.detail is not None
     assert "could not initialize" in result.detail
     assert type(result).model_validate(result.model_dump()) == result
+
+
+def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
+    monkeypatch,
+) -> None:
+    """Backend absence at admission stays the typed execution init outcome."""
+
+    monkeypatch.setitem(sys.modules, "z3", None)
+    admitted = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    )
+
+    result = solve_smt(admitted)
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
+    assert result.detail is not None
+    assert "could not initialize" in result.detail
+
+
+def test_smt_request_rejects_malformed_source_as_a_request_error(monkeypatch) -> None:
+    """Malformed SMT-LIB stays caller-correctable instead of solver indeterminacy."""
+
+    import z3
+
+    def refuse_solver(_logic: object) -> object:
+        raise AssertionError("a malformed request reached solver construction")
+
+    monkeypatch.setattr(z3, "SolverFor", refuse_solver)
+    with pytest.raises(ValidationError) as error:
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                "(assert (> y 0))\n"
+                "(check-sat)"
+            ),
+        )
+
+    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+
+
+def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -> None:
+    """A backend parser failure on an admitted source is execution UNKNOWN."""
+
+    import z3
+
+    def exhausting_parser(_source: str) -> object:
+        raise z3.Z3Exception("parser ran out of memory")
+
+    admitted = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    )
+    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+    result = solve_smt(admitted)
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted == "memory"
+    assert result.detail == operations._EXHAUSTION_DETAILS["memory"]
 
 
 def test_unknown_projection_maps_every_exhausted_resource() -> None:

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -29,6 +29,7 @@ from jacobian.math.logic._operations import (
     solve_smt,
 )
 from jacobian.math.logic._tools import TOOLS
+from jacobian.math.logic._unsat_core import SmtUnsatCoreRequest
 
 
 @contextmanager
@@ -1127,6 +1128,77 @@ def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -
     assert result.outcome == "UNKNOWN"
     assert result.exhausted == "memory"
     assert result.detail == operations._EXHAUSTION_DETAILS["memory"]
+
+
+def test_smt_request_admission_defers_parser_resource_failures(monkeypatch) -> None:
+    """A parser resource failure cannot be claimed as malformed caller input.
+
+    Even when Z3 wraps a backend failure in its located error shape, an
+    exhausted budget is not evidence about the source grammar.
+    """
+
+    import z3
+
+    def exhausting_parser(_source: str) -> object:
+        raise z3.Z3Exception(b'(error "line 1 column 0: out of memory")')
+
+    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+    admitted = SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
+    )
+
+    result = solve_smt(admitted)
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted == "memory"
+    assert result.detail == operations._EXHAUSTION_DETAILS["memory"]
+
+
+def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -> None:
+    """A located Z3 parser diagnostic stays a caller-correctable rejection."""
+
+    import z3
+
+    def diagnosing_parser(_source: str) -> object:
+        raise z3.Z3Exception(b'(error "line 2 column 11: unknown constant y")\n')
+
+    monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
+    with pytest.raises(ValidationError) as error:
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                "(assert (> y 0))\n"
+                "(check-sat)"
+            ),
+        )
+
+    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    sorted(
+        {SmtSolveRequest, SmtUnsatCoreRequest, *SmtSolveRequest.__subclasses__()},
+        key=lambda request_type: request_type.__name__,
+    ),
+    ids=lambda request_type: request_type.__name__,
+)
+def test_every_concrete_smt_request_rejects_malformed_grammar(request_type) -> None:
+    """No SMT request subclass may leave malformed grammar to execution."""
+
+    with pytest.raises(ValidationError):
+        request_type(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                "(assert (> y 0))\n"
+                "(check-sat)"
+            ),
+        )
 
 
 def test_unknown_projection_maps_every_exhausted_resource() -> None:

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -1211,6 +1211,28 @@ def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -
     assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
 
 
+def test_smt_request_admission_defers_parse_stage_os_errors(monkeypatch) -> None:
+    """A parse-stage native backend failure stays off the caller's hands.
+
+    ``math.run`` validates the request before calling the solver, so admission
+    must not let a native ``OSError`` from ``parse_smt2_string`` escape as a
+    host exception; it carries no evidence about the source and defers to
+    execution, which reports it through the typed UNKNOWN translation.
+    """
+
+    import z3
+
+    def failing_parser(_source: str) -> object:
+        raise OSError("native parser backend unavailable")
+
+    source = "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
+    monkeypatch.setattr(z3, "parse_smt2_string", failing_parser)
+    admitted = SmtSolveRequest(logic=SmtLogic.QF_LIA, smtlib=source)
+    result = solve_smt(admitted)
+
+    assert result.outcome == "UNKNOWN"
+
+
 @pytest.mark.parametrize(
     "request_type",
     sorted(

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -1110,6 +1110,36 @@ def test_smt_request_rejects_malformed_source_as_a_request_error(monkeypatch) ->
     assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
 
 
+@pytest.mark.parametrize(
+    "identifier",
+    ("memory", "timeout", "canceled", "|resource limit|"),
+)
+def test_smt_request_rejects_undeclared_identifiers_named_after_resource_keywords(
+    identifier: str,
+) -> None:
+    """A located diagnostic quoting a caller symbol is never budget exhaustion.
+
+    Z3 reports an undeclared identifier as
+    ``(error "line L column C: unknown constant <identifier>")``; when the
+    caller-controlled spelling contains a resource keyword, that text must
+    still be a caller-correctable grammar rejection rather than an admitted
+    request whose execution reports an exhausted budget.
+    """
+
+    with pytest.raises(ValidationError) as error:
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib=(
+                "(set-logic QF_LIA)\n"
+                "(declare-const x Int)\n"
+                f"(assert (> {identifier} 0))\n"
+                "(check-sat)"
+            ),
+        )
+
+    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+
+
 def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -> None:
     """A backend parser failure on an admitted source is execution UNKNOWN."""
 
@@ -1130,29 +1160,32 @@ def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -
     assert result.detail == operations._EXHAUSTION_DETAILS["memory"]
 
 
-def test_smt_request_admission_defers_parser_resource_failures(monkeypatch) -> None:
-    """A parser resource failure cannot be claimed as malformed caller input.
+def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
+    monkeypatch,
+) -> None:
+    """Located diagnostic text quotes the caller's source, not a budget.
 
-    Even when Z3 wraps a backend failure in its located error shape, an
-    exhausted budget is not evidence about the source grammar.
+    A located ``(error "line ... column ...: ...")`` diagnostic embeds
+    caller-controlled spellings, so its resource keywords cannot establish an
+    exhausted budget; execution reports it as a generic backend failure.
     """
 
     import z3
 
-    def exhausting_parser(_source: str) -> object:
+    def diagnosing_parser(_source: str) -> object:
         raise z3.Z3Exception(b'(error "line 1 column 0: out of memory")')
 
-    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
     admitted = SmtSolveRequest(
         logic=SmtLogic.QF_LIA,
         smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)",
     )
+    monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
 
     result = solve_smt(admitted)
 
     assert result.outcome == "UNKNOWN"
-    assert result.exhausted == "memory"
-    assert result.detail == operations._EXHAUSTION_DETAILS["memory"]
+    assert result.exhausted is None
+    assert result.detail is not None and "bounded solve" in result.detail
 
 
 def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -> None:

--- a/tests/math/logic/test_unsat_core.py
+++ b/tests/math/logic/test_unsat_core.py
@@ -382,6 +382,53 @@ def test_request_bounds_source_nesting() -> None:
         SmtUnsatCoreRequest(logic="QF_LIA", smtlib=source(256))
 
 
+def test_core_bounds_reject_before_any_backend_parse(monkeypatch) -> None:
+    """Sources outside the core envelope must not reach the Z3 parser.
+
+    Each source fits the broader ``smt.solve`` envelope, so only the
+    core-specific bounds can reject it and they must do so lexically,
+    before this operation's single backend parse.
+    """
+
+    def refuse(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("Z3 parsed a source outside the core envelope")
+
+    monkeypatch.setattr(z3, "parse_smt2_string", refuse)
+
+    nesting_over_core_within_solve = (
+        "(set-logic QF_LIA)\n(assert "
+        + "(not " * 256
+        + "true"
+        + ")" * 256
+        + ")\n(check-sat)"
+    )
+    with raises_logic_validation():
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=nesting_over_core_within_solve)
+
+    numeral_over_core_within_solve = (
+        f"(set-logic QF_LIA)\n(assert (= {'9' * 257} 0))\n(check-sat)"
+    )
+    with raises_logic_validation():
+        SmtUnsatCoreRequest(logic="QF_LIA", smtlib=numeral_over_core_within_solve)
+
+
+def test_core_admission_defers_parser_resource_failures_to_execution(
+    monkeypatch,
+) -> None:
+    """A parser resource failure is typed UNKNOWN, not a contract rejection."""
+
+    def exhausting_parser(_source: str, **_kwargs: object) -> object:
+        raise z3.Z3Exception("out of memory")
+
+    monkeypatch.setattr(z3, "parse_smt2_string", exhausting_parser)
+    admitted = SmtUnsatCoreRequest(logic="QF_LIA", smtlib=CONTRADICTORY_LIA)
+
+    result = compute_smt_unsat_core(admitted)
+
+    assert result.outcome == "UNKNOWN"
+    assert result.core_indices == ()
+
+
 def test_request_bounds_numeric_coefficient_digits() -> None:
     accepted_number = "1" * 256
     accepted = (


### PR DESCRIPTION
Refs #2634.

## Problem

Z3 import, initialization, and problem-construction failures could escape `sat.cnf.solve` and `smt.solve` as host exceptions instead of their typed execution-failure outcome.

## Solution

Extend the logic solver exception translation boundary across Z3 initialization and construction as well as invocation. This addresses the SAT and SMT solver paths; the separate unsat-core initialization boundary remains follow-up work under #2634.

## Testing

- `make test-focused LANE=math TESTS=tests/math/logic/test_tools.py` — 62 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 41 passed
- targeted advertised solver example — 1 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Accepted SAT and SMT requests now receive typed execution-failure outcomes for Z3 initialization errors. Operation IDs and success schemas are unchanged.

## Checklist

- [ ] `make check` passes (not run; focused logic, catalog, and example checks passed)