### PR TITLE
Isolate canonical CNF contracts from logic operations

### DIFF
--- a/src/jacobian/math/logic/_cnf.py
+++ b/src/jacobian/math/logic/_cnf.py
@@ -1,0 +1,225 @@
+"""Canonical CNF values and direct bounded predicates."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import (
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import PydanticCustomError
+
+from jacobian._models import StrictModel
+
+_MAX_VARIABLES = 1_024
+_MAX_CLAUSES = 8_192
+_MAX_LITERALS = 32_768
+
+
+def _validation_error(code: str, message: str) -> PydanticCustomError:
+    return PydanticCustomError(code, message)
+
+
+class CanonicalCnf(StrictModel):
+    """A bounded canonical propositional formula value."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [{"variables": ["a", "b"], "clauses": [[-1, 2], [1]]}]
+        }
+    )
+
+    variables: tuple[str, ...] = Field(
+        max_length=_MAX_VARIABLES,
+        description="Distinct variable names in ascending lexicographic order.",
+        examples=[["a", "b"]],
+    )
+    clauses: tuple[tuple[StrictInt, ...], ...] = Field(
+        max_length=_MAX_CLAUSES,
+        description=(
+            "Unique non-tautological clauses in canonical order. Literals are signed "
+            "one-based indexes into variables and each clause is ordered by variable."
+        ),
+        examples=[[[-1, 2], [1]]],
+    )
+
+    @field_validator("variables")
+    @classmethod
+    def require_canonical_variables(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not name or len(name) > 128 for name in value):
+            raise _validation_error(
+                "logic.cnf_variable_name",
+                "CNF variables must be nonempty names of at most 128 characters",
+            )
+        if len(set(value)) != len(value) or value != tuple(sorted(value)):
+            raise _validation_error(
+                "logic.cnf_variables_not_canonical",
+                "CNF variables must be distinct and sorted",
+            )
+        return value
+
+    @model_validator(mode="after")
+    def require_canonical_clauses(self) -> Self:
+        if sum(len(clause) for clause in self.clauses) > _MAX_LITERALS:
+            raise _validation_error(
+                "logic.cnf_literal_budget",
+                f"CNF may contain at most {_MAX_LITERALS} literals",
+            )
+        try:
+            normalized = tuple(
+                _canonical_clause(clause, len(self.variables))
+                for clause in self.clauses
+            )
+        except _TautologicalClauseError as exc:
+            raise _validation_error(
+                "logic.cnf_tautological_clause", "CNF clauses must be non-tautological"
+            ) from exc
+        if self.clauses != tuple(sorted(set(normalized), key=_clause_sort_key)):
+            raise _validation_error(
+                "logic.cnf_clauses_not_canonical",
+                "CNF clauses must be unique, non-tautological, and sorted",
+            )
+        return self
+
+
+class CnfCanonicalizeRequest(StrictModel):
+    """Named clauses whose literals refer to the supplied variable order."""
+
+    variable_names: tuple[str, ...] = Field(max_length=_MAX_VARIABLES)
+    clauses: tuple[tuple[StrictInt, ...], ...] = Field(max_length=_MAX_CLAUSES)
+
+    @model_validator(mode="after")
+    def require_bounded_input(self) -> Self:
+        if any(not name or len(name) > 128 for name in self.variable_names):
+            raise _validation_error(
+                "logic.cnf_variable_name",
+                "CNF variable names must be nonempty and at most 128 characters",
+            )
+        if len(set(self.variable_names)) != len(self.variable_names):
+            raise _validation_error(
+                "logic.cnf_variable_names_not_unique",
+                "CNF variable names must be unique",
+            )
+        if sum(len(clause) for clause in self.clauses) > _MAX_LITERALS:
+            raise _validation_error(
+                "logic.cnf_literal_budget",
+                f"CNF may contain at most {_MAX_LITERALS} literals",
+            )
+        for clause in self.clauses:
+            for literal in clause:
+                if literal == 0 or abs(literal) > len(self.variable_names):
+                    raise _validation_error(
+                        "logic.cnf_literal_out_of_range",
+                        "CNF literal references an undeclared variable",
+                    )
+        return self
+
+
+class CnfCanonicalizeResult(StrictModel):
+    cnf: CanonicalCnf
+
+
+class SatAssignmentCheckRequest(StrictModel):
+    cnf: CanonicalCnf
+    assignment: tuple[StrictBool, ...] = Field(max_length=_MAX_VARIABLES)
+
+    @model_validator(mode="after")
+    def require_total_assignment(self) -> Self:
+        if len(self.assignment) != len(self.cnf.variables):
+            raise _validation_error(
+                "logic.assignment_length",
+                "assignment must contain one Boolean per CNF variable",
+            )
+        return self
+
+
+class SatAssignmentCheckResult(StrictModel):
+    satisfies: StrictBool
+    first_unsatisfied_clause: StrictInt | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def bind_failure_index(self) -> Self:
+        if self.satisfies != (self.first_unsatisfied_clause is None):
+            raise _validation_error(
+                "logic.assignment_failure_index",
+                "an assignment result must carry an index exactly when it fails",
+            )
+        return self
+
+
+def canonicalize_cnf(request: CnfCanonicalizeRequest) -> CnfCanonicalizeResult:
+    """Return the unique canonical CNF for one named clause collection."""
+
+    indexed_names = tuple(enumerate(request.variable_names, start=1))
+    sorted_names = tuple(sorted(indexed_names, key=lambda item: item[1]))
+    old_to_new = {old: new for new, (old, _name) in enumerate(sorted_names, start=1)}
+    clauses: set[tuple[int, ...]] = set()
+    for clause in request.clauses:
+        remapped = tuple(
+            old_to_new[abs(literal)] if literal > 0 else -old_to_new[abs(literal)]
+            for literal in clause
+        )
+        try:
+            clauses.add(_canonical_clause(remapped, len(sorted_names)))
+        except _TautologicalClauseError:
+            continue
+    return CnfCanonicalizeResult(
+        cnf=CanonicalCnf(
+            variables=tuple(name for _old, name in sorted_names),
+            clauses=tuple(sorted(clauses, key=_clause_sort_key)),
+        )
+    )
+
+
+def check_sat_assignment(
+    request: SatAssignmentCheckRequest,
+) -> SatAssignmentCheckResult:
+    """Evaluate a total Boolean assignment directly against one canonical CNF."""
+
+    for index, clause in enumerate(request.cnf.clauses):
+        if not any(
+            request.assignment[abs(literal) - 1]
+            if literal > 0
+            else not request.assignment[abs(literal) - 1]
+            for literal in clause
+        ):
+            return SatAssignmentCheckResult(
+                satisfies=False, first_unsatisfied_clause=index
+            )
+    return SatAssignmentCheckResult(satisfies=True)
+
+
+class _TautologicalClauseError(Exception):
+    pass
+
+
+def _canonical_clause(clause: tuple[int, ...], variable_count: int) -> tuple[int, ...]:
+    literals: set[int] = set()
+    for literal in clause:
+        if literal == 0 or abs(literal) > variable_count:
+            raise ValueError("CNF literal references an undeclared variable")
+        if -literal in literals:
+            raise _TautologicalClauseError
+        literals.add(literal)
+    return tuple(sorted(literals, key=lambda literal: (abs(literal), literal > 0)))
+
+
+def _clause_sort_key(clause: tuple[int, ...]) -> tuple[tuple[int, bool], ...]:
+    return tuple((abs(literal), literal > 0) for literal in clause)
+
+
+__all__ = [
+    "_MAX_VARIABLES",
+    "CanonicalCnf",
+    "CnfCanonicalizeRequest",
+    "CnfCanonicalizeResult",
+    "SatAssignmentCheckRequest",
+    "SatAssignmentCheckResult",
+    "canonicalize_cnf",
+    "check_sat_assignment",
+]

--- a/src/jacobian/math/logic/_operations.py
+++ b/src/jacobian/math/logic/_operations.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Annotated, Literal, NamedTuple, Self
 
 from pydantic import (
-    ConfigDict,
     Field,
     StrictBool,
     StrictInt,
@@ -22,6 +21,16 @@ from jacobian._models import StrictModel
 from jacobian.canonical import canonicalize_json
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
+from jacobian.math.logic._cnf import (
+    _MAX_VARIABLES,
+    CanonicalCnf,
+    CnfCanonicalizeRequest,
+    CnfCanonicalizeResult,
+    SatAssignmentCheckRequest,
+    SatAssignmentCheckResult,
+    canonicalize_cnf,
+    check_sat_assignment,
+)
 from jacobian.process import (
     ProcessPlatformTools,
     ProcessResourceLimits,
@@ -29,9 +38,6 @@ from jacobian.process import (
     worker_environment,
 )
 
-_MAX_VARIABLES = 1_024
-_MAX_CLAUSES = 8_192
-_MAX_LITERALS = 32_768
 _MAX_SMTLIB_BYTES = 128_000
 # Structural SMT-LIB budgets, enforced before Z3 sees the source. Depth bounds
 # the recursive-descent parser's native stack per nesting level; compound terms
@@ -79,133 +85,6 @@ _UnknownResource = Literal["time", "work", "memory"]
 
 def _validation_error(code: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(code, message)
-
-
-class CanonicalCnf(StrictModel):
-    """A bounded canonical propositional formula value."""
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "examples": [{"variables": ["a", "b"], "clauses": [[-1, 2], [1]]}]
-        }
-    )
-
-    variables: tuple[str, ...] = Field(
-        max_length=_MAX_VARIABLES,
-        description="Distinct variable names in ascending lexicographic order.",
-        examples=[["a", "b"]],
-    )
-    clauses: tuple[tuple[StrictInt, ...], ...] = Field(
-        max_length=_MAX_CLAUSES,
-        description=(
-            "Unique non-tautological clauses in canonical order. Literals are signed "
-            "one-based indexes into variables and each clause is ordered by variable."
-        ),
-        examples=[[[-1, 2], [1]]],
-    )
-
-    @field_validator("variables")
-    @classmethod
-    def require_canonical_variables(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        if any(not name or len(name) > 128 for name in value):
-            raise _validation_error(
-                "logic.cnf_variable_name",
-                "CNF variables must be nonempty names of at most 128 characters",
-            )
-        if len(set(value)) != len(value) or value != tuple(sorted(value)):
-            raise _validation_error(
-                "logic.cnf_variables_not_canonical",
-                "CNF variables must be distinct and sorted",
-            )
-        return value
-
-    @model_validator(mode="after")
-    def require_canonical_clauses(self) -> Self:
-        if sum(len(clause) for clause in self.clauses) > _MAX_LITERALS:
-            raise _validation_error(
-                "logic.cnf_literal_budget",
-                f"CNF may contain at most {_MAX_LITERALS} literals",
-            )
-        try:
-            normalized = tuple(
-                _canonical_clause(clause, len(self.variables))
-                for clause in self.clauses
-            )
-        except _TautologicalClauseError as exc:
-            raise _validation_error(
-                "logic.cnf_tautological_clause", "CNF clauses must be non-tautological"
-            ) from exc
-        if self.clauses != tuple(sorted(set(normalized), key=_clause_sort_key)):
-            raise _validation_error(
-                "logic.cnf_clauses_not_canonical",
-                "CNF clauses must be unique, non-tautological, and sorted",
-            )
-        return self
-
-
-class CnfCanonicalizeRequest(StrictModel):
-    """Named clauses whose literals refer to the supplied variable order."""
-
-    variable_names: tuple[str, ...] = Field(max_length=_MAX_VARIABLES)
-    clauses: tuple[tuple[StrictInt, ...], ...] = Field(max_length=_MAX_CLAUSES)
-
-    @model_validator(mode="after")
-    def require_bounded_input(self) -> Self:
-        if any(not name or len(name) > 128 for name in self.variable_names):
-            raise _validation_error(
-                "logic.cnf_variable_name",
-                "CNF variable names must be nonempty and at most 128 characters",
-            )
-        if len(set(self.variable_names)) != len(self.variable_names):
-            raise _validation_error(
-                "logic.cnf_variable_names_not_unique",
-                "CNF variable names must be unique",
-            )
-        if sum(len(clause) for clause in self.clauses) > _MAX_LITERALS:
-            raise _validation_error(
-                "logic.cnf_literal_budget",
-                f"CNF may contain at most {_MAX_LITERALS} literals",
-            )
-        for clause in self.clauses:
-            for literal in clause:
-                if literal == 0 or abs(literal) > len(self.variable_names):
-                    raise _validation_error(
-                        "logic.cnf_literal_out_of_range",
-                        "CNF literal references an undeclared variable",
-                    )
-        return self
-
-
-class CnfCanonicalizeResult(StrictModel):
-    cnf: CanonicalCnf
-
-
-class SatAssignmentCheckRequest(StrictModel):
-    cnf: CanonicalCnf
-    assignment: tuple[StrictBool, ...] = Field(max_length=_MAX_VARIABLES)
-
-    @model_validator(mode="after")
-    def require_total_assignment(self) -> Self:
-        if len(self.assignment) != len(self.cnf.variables):
-            raise _validation_error(
-                "logic.assignment_length",
-                "assignment must contain one Boolean per CNF variable",
-            )
-        return self
-
-
-class SatAssignmentCheckResult(StrictModel):
-    satisfies: StrictBool
-    first_unsatisfied_clause: StrictInt | None = Field(default=None, ge=0)
-
-    @model_validator(mode="after")
-    def bind_failure_index(self) -> Self:
-        if self.satisfies != (self.first_unsatisfied_clause is None):
-            raise _validation_error(
-                "logic.assignment_failure_index",
-                "an assignment result must carry an index exactly when it fails",
-            )
-        return self
 
 
 class SatSolveRequest(StrictModel):
@@ -800,48 +679,6 @@ class SmtSolveResult(StrictModel):
         return self
 
 
-def canonicalize_cnf(request: CnfCanonicalizeRequest) -> CnfCanonicalizeResult:
-    """Return the unique canonical CNF for one named clause collection."""
-
-    indexed_names = tuple(enumerate(request.variable_names, start=1))
-    sorted_names = tuple(sorted(indexed_names, key=lambda item: item[1]))
-    old_to_new = {old: new for new, (old, _name) in enumerate(sorted_names, start=1)}
-    clauses: set[tuple[int, ...]] = set()
-    for clause in request.clauses:
-        remapped = tuple(
-            old_to_new[abs(literal)] if literal > 0 else -old_to_new[abs(literal)]
-            for literal in clause
-        )
-        try:
-            clauses.add(_canonical_clause(remapped, len(sorted_names)))
-        except _TautologicalClauseError:
-            continue
-    return CnfCanonicalizeResult(
-        cnf=CanonicalCnf(
-            variables=tuple(name for _old, name in sorted_names),
-            clauses=tuple(sorted(clauses, key=_clause_sort_key)),
-        )
-    )
-
-
-def check_sat_assignment(
-    request: SatAssignmentCheckRequest,
-) -> SatAssignmentCheckResult:
-    """Evaluate a total Boolean assignment directly against one canonical CNF."""
-
-    for index, clause in enumerate(request.cnf.clauses):
-        if not any(
-            request.assignment[abs(literal) - 1]
-            if literal > 0
-            else not request.assignment[abs(literal) - 1]
-            for literal in clause
-        ):
-            return SatAssignmentCheckResult(
-                satisfies=False, first_unsatisfied_clause=index
-            )
-    return SatAssignmentCheckResult(satisfies=True)
-
-
 _EXHAUSTION_DETAILS: dict[_UnknownResource, str] = {
     "work": "the bounded solver work budget was exhausted",
     "memory": "the bounded solver memory budget was exhausted",
@@ -1107,25 +944,6 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
     return SmtSolveResult(outcome="UNKNOWN", exhausted=exhausted, detail=detail)
 
 
-class _TautologicalClauseError(Exception):
-    pass
-
-
-def _canonical_clause(clause: tuple[int, ...], variable_count: int) -> tuple[int, ...]:
-    literals: set[int] = set()
-    for literal in clause:
-        if literal == 0 or abs(literal) > variable_count:
-            raise ValueError("CNF literal references an undeclared variable")
-        if -literal in literals:
-            raise _TautologicalClauseError
-        literals.add(literal)
-    return tuple(sorted(literals, key=lambda literal: (abs(literal), literal > 0)))
-
-
-def _clause_sort_key(clause: tuple[int, ...]) -> tuple[tuple[int, bool], ...]:
-    return tuple((abs(literal), literal > 0) for literal in clause)
-
-
 LOGIC_OPERATIONS = (
     MathTool(
         operation_id="sat.cnf.canonicalize",
@@ -1235,15 +1053,10 @@ LOGIC_OPERATIONS = (
 
 __all__ = [
     "LOGIC_OPERATIONS",
-    "CanonicalCnf",
-    "CnfCanonicalizeRequest",
-    "CnfCanonicalizeResult",
     "LprAddition",
     "LprDeletion",
     "LprPropagationHint",
     "LprStep",
-    "SatAssignmentCheckRequest",
-    "SatAssignmentCheckResult",
     "SatLprRefutation",
     "SatRefutationCheckRequest",
     "SatRefutationCheckResult",
@@ -1252,8 +1065,6 @@ __all__ = [
     "SmtLogic",
     "SmtSolveRequest",
     "SmtSolveResult",
-    "canonicalize_cnf",
-    "check_sat_assignment",
     "check_sat_refutation",
     "solve_sat",
     "solve_smt",

--- a/tests/dispatch/test_parsing.py
+++ b/tests/dispatch/test_parsing.py
@@ -11,7 +11,7 @@ from tests.dispatch._support import dispatch_validation_error
 from jacobian._models import StrictModel
 from jacobian.catalog.models import OperationDiscoveryRequest
 from jacobian.dispatch import parse_operation_input
-from jacobian.math.logic._operations import SatAssignmentCheckRequest
+from jacobian.math.logic._cnf import SatAssignmentCheckRequest
 
 
 class _Label(StrEnum):

--- a/tests/integration/schema/test_guidance.py
+++ b/tests/integration/schema/test_guidance.py
@@ -6,7 +6,7 @@ import pytest
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.finite_fields import FiniteFieldPresentation
-from jacobian.math.logic._operations import CanonicalCnf
+from jacobian.math.logic._cnf import CanonicalCnf
 
 
 @pytest.mark.parametrize(

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -7,13 +7,17 @@ import pytest
 from pydantic import ValidationError
 
 from jacobian.math.logic import _operations as operations
-from jacobian.math.logic._operations import (
+from jacobian.math.logic._cnf import (
     CanonicalCnf,
     CnfCanonicalizeRequest,
+    SatAssignmentCheckRequest,
+    canonicalize_cnf,
+    check_sat_assignment,
+)
+from jacobian.math.logic._operations import (
     LprAddition,
     LprDeletion,
     LprPropagationHint,
-    SatAssignmentCheckRequest,
     SatLprRefutation,
     SatRefutationCheckRequest,
     SatSolveRequest,
@@ -21,8 +25,6 @@ from jacobian.math.logic._operations import (
     SmtLogic,
     SmtSolveRequest,
     SmtSolveResult,
-    canonicalize_cnf,
-    check_sat_assignment,
     check_sat_refutation,
     solve_sat,
     solve_smt,

--- a/tests/tooling/test_ci_test_plan.py
+++ b/tests/tooling/test_ci_test_plan.py
@@ -42,6 +42,15 @@ def test_model_change_selects_its_math_owner_and_public_contract_evidence() -> N
     assert plan.run_catalog_examples is True
 
 
+def test_canonical_cnf_contract_change_selects_public_contract_evidence() -> None:
+    plan = _plan(["src/jacobian/math/logic/_cnf.py"])
+
+    assert plan.run_math is True
+    assert plan.math_tests == ("tests/math/logic",)
+    assert plan.run_catalog is True
+    assert plan.run_catalog_examples is True
+
+
 def test_public_operation_kernel_selects_catalog_examples() -> None:
     plan = _plan(["src/jacobian/math/code_theory/_dual_operations.py"])
 

--- a/tools/ci_test_plan.py
+++ b/tools/ci_test_plan.py
@@ -36,6 +36,7 @@ _SHARED_PREFIXES = (
 _PUBLIC_MATH_FILES = frozenset(
     {
         "_admission.py",
+        "_cnf.py",
         "_models.py",
         "_operations.py",
         "_tools.py",


### PR DESCRIPTION
Refs #2519.

## Summary

Move canonical CNF values, canonicalization, and assignment checking into the CNF owner module. SAT, SMT, and LPR operation behavior remains in the current logic operations module.

No Lean code or Lean references are introduced; the prior mixed historical commit was deliberately reduced to this CNF-only extraction.

## Testing

- `uv run ruff check` on changed files — passed
- `make test-focused LANE=math TESTS=tests/math/logic/test_tools.py` — 60 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch/test_parsing.py` — 7 passed
- `make test-focused LANE=integration TESTS=tests/integration/schema/test_guidance.py` — 3 passed
- `make test-catalog` — 41 passed
- `git diff --check` — passed

## Public contract impact

None. Operation IDs, schemas, and canonical transport are unchanged; this is an owner-boundary refactor.