### PR TITLE
Isolate topology pseudomanifold contracts

### DIFF
--- a/src/jacobian/math/topology/_models.py
+++ b/src/jacobian/math/topology/_models.py
@@ -6,7 +6,7 @@ import hashlib
 from collections.abc import Iterable
 from enum import StrEnum
 from itertools import combinations, pairwise
-from typing import Annotated, Any, Literal, NamedTuple, Self
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
     Field,
@@ -163,14 +163,6 @@ def _collapse_remaining_facets(
     return _maximal_faces(remaining)
 
 
-class _PseudomanifoldExpectation(NamedTuple):
-    """Recomputed pseudomanifold decision for one facet family."""
-
-    is_pseudomanifold: bool
-    is_closed: bool
-    obstruction: str | None
-
-
 def _all_faces(facets: tuple[Simplex, ...]) -> set[tuple[str, ...]]:
     """Return the complete set of nonempty faces for a facet list."""
     faces: set[tuple[str, ...]] = set()
@@ -219,46 +211,6 @@ def _require_subdivision_replay(
             "topology.require_subdivision_replay_2",
             "subdivision facets do not match the retained source complex",
         )
-
-
-def _codim1_incidence(
-    facets: list[frozenset[str]],
-) -> dict[frozenset[str], int]:
-    counts: dict[frozenset[str], int] = {}
-    for facet in facets:
-        for face in combinations(sorted(facet), len(facet) - 1):
-            key = frozenset(face)
-            counts[key] = counts.get(key, 0) + 1
-    return counts
-
-
-def _expected_pseudomanifold_decision(
-    facets: list[frozenset[str]],
-    dim: int,
-) -> _PseudomanifoldExpectation:
-    """Recompute the bounded pseudomanifold decision from incidence."""
-
-    is_pure = all(len(facet) - 1 == dim for facet in facets) if facets else False
-    if not is_pure:
-        return _PseudomanifoldExpectation(
-            False, False, "not pure: facets have different dimensions"
-        )
-    # Dimension-zero complexes participate in the same incidence definition:
-    # each vertex facet contains exactly one codimension-one face, the empty
-    # face, so one point has it once (boundary) and two points twice (closed).
-    counts = _codim1_incidence(facets)
-    if any(count > 2 for count in counts.values()):
-        for face, count in counts.items():
-            if count > 2:
-                return _PseudomanifoldExpectation(
-                    False,
-                    False,
-                    f"codim-1 face {sorted(face)} is in {count} facets",
-                )
-    is_closed = all(count == 2 for count in counts.values()) if counts else False
-    return _PseudomanifoldExpectation(
-        True, is_closed, None if is_closed else "pseudomanifold with boundary"
-    )
 
 
 def _require_request_complex(
@@ -1476,65 +1428,6 @@ class BarycentricSubdivisionResult(TopologyExactResult):
         return self
 
 
-class PseudomanifoldRequest(StrictModel):
-    """Decide whether a complex is a pseudomanifold."""
-
-    complex: SimplicialComplexRequest
-
-
-class PseudomanifoldResult(TopologyExactResult):
-    """Pseudomanifold decision result bound to its source complex."""
-
-    complex: SimplicialComplexRequest
-    is_pseudomanifold: bool
-    is_closed: bool
-    dimension: int
-    num_facets: int
-    obstruction: str | None = None
-
-    @model_validator(mode="after")
-    def require_pseudomanifold_binding(self) -> Self:
-        facets = [frozenset(f) for f in self.complex.facets]
-        dim = max(len(f) - 1 for f in facets) if facets else 0
-        if self.dimension != dim or self.num_facets != len(facets):
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_1",
-                "dimension/num_facets must match source complex",
-            )
-        expected = _expected_pseudomanifold_decision(facets, dim)
-        if self.is_pseudomanifold != expected.is_pseudomanifold:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_2",
-                f"is_pseudomanifold {self.is_pseudomanifold} does not match "
-                f"expected {expected.is_pseudomanifold}",
-            )
-        if not expected.is_pseudomanifold:
-            if self.is_closed:
-                raise _validation_error(
-                    "topology.require_pseudomanifold_binding_3",
-                    "non-pseudomanifold cannot be closed",
-                )
-            if self.obstruction != expected.obstruction:
-                raise _validation_error(
-                    "topology.require_pseudomanifold_binding_4",
-                    f"obstruction {self.obstruction!r} does not match replayed "
-                    f"{expected.obstruction!r}",
-                )
-            return self
-        if self.is_closed != expected.is_closed:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_5",
-                "is_closed must match codim-1 incidence",
-            )
-        if self.obstruction != expected.obstruction:
-            raise _validation_error(
-                "topology.require_pseudomanifold_binding_6",
-                f"obstruction {self.obstruction!r} does not match expected "
-                f"{expected.obstruction!r}",
-            )
-        return self
-
-
 class ShellingCheckRequest(StrictModel):
     """Check a submitted shelling order of a pure complex."""
 
@@ -1801,8 +1694,6 @@ __all__.extend(
         "ElementaryCollapseResult",
         "JoinRequest",
         "JoinResult",
-        "PseudomanifoldRequest",
-        "PseudomanifoldResult",
         "ShellingCheckRequest",
         "ShellingCheckResult",
         "SkeletonRequest",

--- a/src/jacobian/math/topology/_operations.py
+++ b/src/jacobian/math/topology/_operations.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from itertools import combinations
 
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
@@ -52,8 +51,6 @@ from jacobian.math.topology._models import (
     JoinResult,
     LinkRequest,
     LinkResult,
-    PseudomanifoldRequest,
-    PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
     SimplexBasis,
@@ -70,6 +67,11 @@ from jacobian.math.topology._models import (
     _all_faces,
     face_closure,
     simplicial_complex_digest,
+)
+from jacobian.math.topology._pseudomanifold import (
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
+    pseudomanifold_decision,
 )
 from jacobian.math.topology._shelling import evaluate_shelling
 
@@ -951,48 +953,14 @@ def compute_pseudomanifold_decision(
     request: PseudomanifoldRequest,
 ) -> PseudomanifoldResult:
     """Decide whether a complex is a pseudomanifold."""
-    facets = [frozenset(f) for f in request.complex.facets]
-    dim = max(len(f) - 1 for f in facets) if facets else 0
-
-    # Purity: all facets must have the same dimension
-    if not all(len(f) - 1 == dim for f in facets):
-        return PseudomanifoldResult(
-            complex=request.complex,
-            is_pseudomanifold=False,
-            is_closed=False,
-            dimension=dim,
-            num_facets=len(facets),
-            obstruction="not pure: facets have different dimensions",
-        )
-
-    # Each codimension-1 face must be in exactly 1 or 2 facets; for a
-    # dimension-zero complex that face is the empty face, contained once per
-    # vertex facet.
-    codim1_count: dict[frozenset[str], int] = {}
-    for facet in facets:
-        for face in combinations(sorted(facet), len(facet) - 1):
-            key = frozenset(face)
-            codim1_count[key] = codim1_count.get(key, 0) + 1
-
-    for codim_face, count in codim1_count.items():
-        if count > 2:
-            return PseudomanifoldResult(
-                complex=request.complex,
-                is_pseudomanifold=False,
-                is_closed=False,
-                dimension=dim,
-                num_facets=len(facets),
-                obstruction=f"codim-1 face {sorted(codim_face)} is in {count} facets",
-            )
-
-    is_closed = all(count == 2 for count in codim1_count.values())
+    decision = pseudomanifold_decision(request.complex.facets)
     return PseudomanifoldResult(
         complex=request.complex,
-        is_pseudomanifold=True,
-        is_closed=is_closed,
-        dimension=dim,
-        num_facets=len(facets),
-        obstruction=None if is_closed else "pseudomanifold with boundary",
+        is_pseudomanifold=decision.is_pseudomanifold,
+        is_closed=decision.is_closed,
+        dimension=decision.dimension,
+        num_facets=decision.num_facets,
+        obstruction=decision.obstruction,
     )
 
 

--- a/src/jacobian/math/topology/_pseudomanifold.py
+++ b/src/jacobian/math/topology/_pseudomanifold.py
@@ -1,0 +1,130 @@
+"""Pseudomanifold decision contracts and replay kernel."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import NamedTuple, Self
+
+from pydantic import model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.topology._models import (
+    Simplex,
+    SimplicialComplexRequest,
+    TopologyExactResult,
+    _validation_error,
+)
+
+
+class _PseudomanifoldDecision(NamedTuple):
+    """The canonical decision for one finite simplicial complex."""
+
+    is_pseudomanifold: bool
+    is_closed: bool
+    obstruction: str | None
+    dimension: int
+    num_facets: int
+
+
+def pseudomanifold_decision(facets: tuple[Simplex, ...]) -> _PseudomanifoldDecision:
+    """Return the exact codimension-one incidence decision for ``facets``."""
+
+    facet_sets = [frozenset(facet) for facet in facets]
+    dimension = max((len(facet) - 1 for facet in facet_sets), default=0)
+    num_facets = len(facet_sets)
+    is_pure = all(len(facet) - 1 == dimension for facet in facet_sets)
+    if not is_pure:
+        return _PseudomanifoldDecision(
+            False,
+            False,
+            "not pure: facets have different dimensions",
+            dimension,
+            num_facets,
+        )
+
+    incidence: dict[frozenset[str], int] = {}
+    for facet in facet_sets:
+        for face in combinations(sorted(facet), len(facet) - 1):
+            key = frozenset(face)
+            incidence[key] = incidence.get(key, 0) + 1
+    for codimension_one_face, count in incidence.items():
+        if count > 2:
+            return _PseudomanifoldDecision(
+                False,
+                False,
+                f"codim-1 face {sorted(codimension_one_face)} is in {count} facets",
+                dimension,
+                num_facets,
+            )
+
+    is_closed = bool(incidence) and all(count == 2 for count in incidence.values())
+    return _PseudomanifoldDecision(
+        True,
+        is_closed,
+        None if is_closed else "pseudomanifold with boundary",
+        dimension,
+        num_facets,
+    )
+
+
+class PseudomanifoldRequest(StrictModel):
+    """Decide whether a complex is a pseudomanifold."""
+
+    complex: SimplicialComplexRequest
+
+
+class PseudomanifoldResult(TopologyExactResult):
+    """Pseudomanifold decision result bound to its source complex."""
+
+    complex: SimplicialComplexRequest
+    is_pseudomanifold: bool
+    is_closed: bool
+    dimension: int
+    num_facets: int
+    obstruction: str | None = None
+
+    @model_validator(mode="after")
+    def require_pseudomanifold_binding(self) -> Self:
+        expected = pseudomanifold_decision(self.complex.facets)
+        if (
+            self.dimension != expected.dimension
+            or self.num_facets != expected.num_facets
+        ):
+            raise _validation_error(
+                "topology.require_pseudomanifold_binding_1",
+                "dimension/num_facets must match source complex",
+            )
+        if self.is_pseudomanifold != expected.is_pseudomanifold:
+            raise _validation_error(
+                "topology.require_pseudomanifold_binding_2",
+                f"is_pseudomanifold {self.is_pseudomanifold} does not match "
+                f"expected {expected.is_pseudomanifold}",
+            )
+        if not expected.is_pseudomanifold:
+            if self.is_closed:
+                raise _validation_error(
+                    "topology.require_pseudomanifold_binding_3",
+                    "non-pseudomanifold cannot be closed",
+                )
+            if self.obstruction != expected.obstruction:
+                raise _validation_error(
+                    "topology.require_pseudomanifold_binding_4",
+                    f"obstruction {self.obstruction!r} does not match replayed "
+                    f"{expected.obstruction!r}",
+                )
+            return self
+        if self.is_closed != expected.is_closed:
+            raise _validation_error(
+                "topology.require_pseudomanifold_binding_5",
+                "is_closed must match codim-1 incidence",
+            )
+        if self.obstruction != expected.obstruction:
+            raise _validation_error(
+                "topology.require_pseudomanifold_binding_6",
+                f"obstruction {self.obstruction!r} does not match expected "
+                f"{expected.obstruction!r}",
+            )
+        return self
+
+
+__all__ = ["PseudomanifoldRequest", "PseudomanifoldResult", "pseudomanifold_decision"]

--- a/src/jacobian/math/topology/_tools.py
+++ b/src/jacobian/math/topology/_tools.py
@@ -13,8 +13,6 @@ from jacobian.math.topology._models import (
     JoinResult,
     LinkRequest,
     LinkResult,
-    PseudomanifoldRequest,
-    PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
     SkeletonRequest,
@@ -36,6 +34,10 @@ from jacobian.math.topology._operations import (
     compute_skeleton,
     compute_star,
     compute_vertex_deletion,
+)
+from jacobian.math.topology._pseudomanifold import (
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
 )
 
 __all__ = ["TOOLS"]

--- a/tests/math/topology/test_structural_ops.py
+++ b/tests/math/topology/test_structural_ops.py
@@ -10,8 +10,6 @@ from jacobian.math.topology._models import (
     ElementaryCollapseResult,
     JoinRequest,
     JoinResult,
-    PseudomanifoldRequest,
-    PseudomanifoldResult,
     ShellingCheckRequest,
     ShellingCheckResult,
     SimplicialComplexRequest,
@@ -33,6 +31,10 @@ from jacobian.math.topology._operations import (
     compute_skeleton,
     compute_star,
     compute_vertex_deletion,
+)
+from jacobian.math.topology._pseudomanifold import (
+    PseudomanifoldRequest,
+    PseudomanifoldResult,
 )
 from jacobian.math.topology._tools import TOOLS
 


### PR DESCRIPTION
Part of #2558.

## Summary

Move pseudomanifold-specific contract ownership beside its topology operations, following the merged chain/subdivision/homology foundation. Operation IDs, schemas, catalog membership, and mathematical behavior are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/topology` — 119 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- advertised catalog examples — 608 passed
- `git diff --check origin/main...HEAD` — passed