### PR TITLE
Isolate prime-affine local arithmetic contracts

### DIFF
--- a/src/jacobian/math/prime_affine_forms/__init__.py
+++ b/src/jacobian/math/prime_affine_forms/__init__.py
@@ -1,6 +1,6 @@
 """Canonical public values and native operations for prime-affine arithmetic."""
 
-from jacobian.math.prime_affine_forms._models import PrimeTupleResidueWheel
+from jacobian.math.prime_affine_forms._residue_wheel import PrimeTupleResidueWheel
 from jacobian.math.prime_affine_forms.operations import (
     enumerate_residue_wheel,
     interval_count,

--- a/src/jacobian/math/prime_affine_forms/_admissibility.py
+++ b/src/jacobian/math/prime_affine_forms/_admissibility.py
@@ -1,0 +1,143 @@
+"""Contracts and kernel for bounded prime-affine local admissibility."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+from sympy import primepi
+
+from jacobian._models import StrictModel
+from jacobian.math.prime_affine_forms._kernel import primes_through
+from jacobian.math.prime_affine_forms._local_factors import local_summary
+from jacobian.math.prime_affine_forms._models import (
+    MAX_RESULT_CHARACTER_BUDGET,
+    PrimeTupleLocalSummary,
+    _require_summary,
+    _source_character_upper_bound,
+    _summary_character_upper_bound,
+    _validation_error,
+)
+from jacobian.math.prime_affine_forms.values import MAX_AFFINE_FORMS, PrimeAffineTuple
+
+MAX_ADMISSIBILITY_CUTOFF = MAX_AFFINE_FORMS
+MAX_ADMISSIBILITY_PRIME_ROWS = 128
+MAX_ADMISSIBILITY_ROOT_CELLS = 200_000
+
+
+class PrimeTupleAdmissibilityRequest(StrictModel):
+    """Decide local admissibility by checking exactly the primes at most k."""
+
+    source: PrimeAffineTuple
+
+    @model_validator(mode="after")
+    def require_bounded_cutoff_profile(self) -> Self:
+        cutoff = self.source.form_count
+        prime_rows = int(primepi(cutoff))
+        if prime_rows > MAX_ADMISSIBILITY_PRIME_ROWS:
+            raise _validation_error(
+                f"admissibility needs {prime_rows} prime rows, exceeding "
+                f"{MAX_ADMISSIBILITY_PRIME_ROWS}"
+            )
+        root_cells = self.source.form_count * prime_rows
+        total_root_cells = 4 * root_cells
+        if total_root_cells > MAX_ADMISSIBILITY_ROOT_CELLS:
+            raise _validation_error(
+                "admissibility computation and validation may require "
+                f"{total_root_cells} root cells, "
+                f"exceeding {MAX_ADMISSIBILITY_ROOT_CELLS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in primes_through(cutoff)
+            )
+            + 16 * prime_rows
+            + 256
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "admissibility profile exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleAdmissibilityResult(StrictModel):
+    """Closed decision: every p<=k is checked and every p>k has nu_p<=k<p."""
+
+    source: PrimeAffineTuple
+    cutoff: StrictInt = Field(ge=1, le=MAX_ADMISSIBILITY_CUTOFF)
+    checked_primes: tuple[StrictInt, ...] = Field(
+        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
+    )
+    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(
+        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
+    )
+    status: Literal["LOCALLY_ADMISSIBLE", "LOCALLY_OBSTRUCTED"]
+    least_obstructing_prime: StrictInt | None = None
+    large_prime_lower_bound: StrictInt = Field(ge=2)
+    maximum_large_prime_bad_residues: StrictInt = Field(ge=1)
+
+    @model_validator(mode="after")
+    def bind_cutoff_decision(self) -> Self:
+        PrimeTupleAdmissibilityRequest(source=self.source)
+        expected_cutoff = self.source.form_count
+        expected_primes = primes_through(expected_cutoff)
+        if self.cutoff != expected_cutoff or self.checked_primes != expected_primes:
+            raise _validation_error(
+                "checked primes must be exactly every prime through the cutoff"
+            )
+        if tuple(row.prime for row in self.local_rows) != expected_primes:
+            raise _validation_error("local rows must align with every checked prime")
+        for row in self.local_rows:
+            _require_summary(self.source, row)
+        obstructing = tuple(
+            row.prime for row in self.local_rows if row.valid_count == 0
+        )
+        expected_status = "LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE"
+        if self.status != expected_status:
+            raise _validation_error(
+                "admissibility status does not match the local rows"
+            )
+        expected_first = obstructing[0] if obstructing else None
+        if self.least_obstructing_prime != expected_first:
+            raise _validation_error(
+                "least obstructing prime does not match the local rows"
+            )
+        if (
+            self.large_prime_lower_bound != expected_cutoff + 1
+            or self.maximum_large_prime_bad_residues != self.source.form_count
+        ):
+            raise _validation_error(
+                "large-prime cutoff evidence does not match the source"
+            )
+        return self
+
+
+def compute_local_admissibility(
+    request: PrimeTupleAdmissibilityRequest,
+) -> PrimeTupleAdmissibilityResult:
+    """Decide whether every prime-affine local factor has a valid residue."""
+
+    cutoff = request.source.form_count
+    checked_primes = primes_through(cutoff)
+    rows = tuple(local_summary(request.source, prime) for prime in checked_primes)
+    obstructing = tuple(row.prime for row in rows if row.valid_count == 0)
+    return PrimeTupleAdmissibilityResult(
+        source=request.source,
+        cutoff=cutoff,
+        checked_primes=checked_primes,
+        local_rows=rows,
+        status="LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE",
+        least_obstructing_prime=obstructing[0] if obstructing else None,
+        large_prime_lower_bound=cutoff + 1,
+        maximum_large_prime_bad_residues=request.source.form_count,
+    )
+
+
+__all__ = [
+    "PrimeTupleAdmissibilityRequest",
+    "PrimeTupleAdmissibilityResult",
+    "compute_local_admissibility",
+]

--- a/src/jacobian/math/prime_affine_forms/_local_factors.py
+++ b/src/jacobian/math/prime_affine_forms/_local_factors.py
@@ -1,0 +1,318 @@
+"""Contracts and kernels for bounded prime-affine local factors."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Self
+
+from pydantic import Field, StrictBool, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational
+from jacobian._models import StrictModel
+from jacobian.math.prime_affine_forms._kernel import (
+    local_bad_residues,
+    local_counts,
+    local_factor_from_bad_count,
+)
+from jacobian.math.prime_affine_forms._models import (
+    MAX_BATCH_PRIME,
+    MAX_BATCH_ROOT_WORK,
+    MAX_FACTOR_COMPONENT_DIGITS,
+    MAX_FACTOR_PRODUCT_DIGITS,
+    MAX_LOCAL_PROFILE_PRIME,
+    MAX_LOCAL_PROFILE_WORK,
+    MAX_PRIME_BATCH,
+    MAX_RESULT_CHARACTER_BUDGET,
+    CompactPrime,
+    PrimeTupleBadResidueRow,
+    PrimeTupleLocalSummary,
+    PrimeTupleResidueRow,
+    _require_prime,
+    _require_prime_set,
+    _require_summary,
+    _source_character_upper_bound,
+    _summary_character_upper_bound,
+    _validation_error,
+)
+from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
+
+
+def _digits(value: int | str) -> int:
+    return len(str(value).lstrip("-"))
+
+
+def _factor_digit_upper_bound(source: PrimeAffineTuple, prime: int) -> int:
+    bad_count, _ = local_counts(source, prime)
+    if bad_count == prime:
+        return 1
+    numerator = _digits(prime - bad_count) + (source.form_count - 1) * _digits(prime)
+    denominator = source.form_count * _digits(prime - 1)
+    return max(numerator, denominator)
+
+
+def _require_factor_output(source: PrimeAffineTuple, prime: int) -> None:
+    bound = _factor_digit_upper_bound(source, prime)
+    if bound > MAX_FACTOR_COMPONENT_DIGITS:
+        raise _validation_error(
+            "local-factor numerator or denominator may require "
+            f"{bound} digits, exceeding the bound {MAX_FACTOR_COMPONENT_DIGITS}"
+        )
+
+
+def local_summary(source: PrimeAffineTuple, prime: int) -> PrimeTupleLocalSummary:
+    """Return the canonical compact local obstruction summary."""
+
+    bad = local_bad_residues(source, prime)
+    return PrimeTupleLocalSummary(
+        prime=prime,
+        bad_residues=tuple(
+            PrimeTupleBadResidueRow(residue=residue, form_ids=form_ids)
+            for residue, form_ids in bad
+        ),
+        bad_count=len(bad),
+        valid_count=prime - len(bad),
+    )
+
+
+class PrimeTupleLocalFactorRequest(StrictModel):
+    """Compute one complete local residue profile and exact local factor."""
+
+    source: PrimeAffineTuple
+    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
+
+    @model_validator(mode="after")
+    def require_bounded_complete_profile(self) -> Self:
+        _require_prime(self.prime, maximum=MAX_LOCAL_PROFILE_PRIME)
+        _require_factor_output(self.source, self.prime)
+        work = 6 * self.source.form_count + 2 * self.prime
+        if work > MAX_LOCAL_PROFILE_WORK:
+            raise _validation_error(
+                f"local profile and validation need {work} bounded steps, "
+                f"exceeding {MAX_LOCAL_PROFILE_WORK}"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorResult(StrictModel):
+    """Source-bound complete partition modulo one prime and its local factor."""
+
+    source: PrimeAffineTuple
+    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
+    residue_rows: tuple[PrimeTupleResidueRow, ...] = Field(
+        min_length=2, max_length=MAX_LOCAL_PROFILE_PRIME
+    )
+    bad_count: StrictInt = Field(ge=0)
+    valid_count: StrictInt = Field(ge=0)
+    locally_obstructed: StrictBool
+    factor: CanonicalRational
+
+    @model_validator(mode="after")
+    def bind_complete_local_factor(self) -> Self:
+        if (
+            sum(len(row.vanishing_form_ids) for row in self.residue_rows)
+            > self.source.form_count
+        ):
+            raise _validation_error(
+                "residue incidence count exceeds the source affine-form count"
+            )
+        PrimeTupleLocalFactorRequest(source=self.source, prime=self.prime)
+        bad = dict(local_bad_residues(self.source, self.prime))
+        expected_rows = tuple(
+            (residue, bad.get(residue, ())) for residue in range(self.prime)
+        )
+        actual_rows = tuple(
+            (row.residue, row.vanishing_form_ids) for row in self.residue_rows
+        )
+        if actual_rows != expected_rows:
+            raise _validation_error(
+                "residue rows must be the complete source-bound partition"
+            )
+        expected_bad = len(bad)
+        expected_valid = self.prime - expected_bad
+        if self.bad_count != expected_bad or self.valid_count != expected_valid:
+            raise _validation_error(
+                "local counts do not match the complete residue rows"
+            )
+        if self.locally_obstructed != (expected_valid == 0):
+            raise _validation_error(
+                "local obstruction status must equal valid_count == 0"
+            )
+        if self.factor.as_fraction() != local_factor_from_bad_count(
+            self.source.form_count, self.prime, expected_bad
+        ):
+            raise _validation_error(
+                "local factor does not satisfy its defining formula"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorsRequest(StrictModel):
+    """Compute compact local factors for a canonical finite prime set."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(
+        min_length=1,
+        max_length=MAX_PRIME_BATCH,
+        description=(
+            "Distinct primes in strictly increasing order. The aggregate form/root "
+            "and exact rational-output bounds are validated before computation."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_factor_batch(self) -> Self:
+        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
+        root_cells = self.source.form_count * len(self.primes)
+        root_work = 6 * root_cells
+        if root_work > MAX_BATCH_ROOT_WORK:
+            raise _validation_error(
+                f"local-factor computation and validation need {root_work} root "
+                f"steps, exceeding {MAX_BATCH_ROOT_WORK}"
+            )
+        digit_bounds = tuple(
+            _factor_digit_upper_bound(self.source, prime) for prime in self.primes
+        )
+        if any(bound > MAX_FACTOR_COMPONENT_DIGITS for bound in digit_bounds):
+            raise _validation_error(
+                "one local factor exceeds the exact rational component-digit bound"
+            )
+        if sum(digit_bounds) > MAX_FACTOR_PRODUCT_DIGITS:
+            raise _validation_error(
+                "finite factor product exceeds the conservative exact rational "
+                f"digit bound {MAX_FACTOR_PRODUCT_DIGITS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in self.primes
+            )
+            + 128 * len(self.primes)
+            + 4 * sum(digit_bounds)
+            + 256
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "finite factor result exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleLocalFactorRow(StrictModel):
+    summary: PrimeTupleLocalSummary
+    factor: CanonicalRational
+
+
+class FinitePrimeTupleFactorProduct(StrictModel):
+    """Exact finite local-factor product, explicitly not an infinite series."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(min_length=1, max_length=MAX_PRIME_BATCH)
+    rows: tuple[PrimeTupleLocalFactorRow, ...] = Field(
+        min_length=1, max_length=MAX_PRIME_BATCH
+    )
+    product: CanonicalRational
+    first_obstructing_prime: StrictInt | None = None
+
+    @model_validator(mode="after")
+    def bind_finite_factor_product(self) -> Self:
+        PrimeTupleLocalFactorsRequest(source=self.source, primes=self.primes)
+        if tuple(row.summary.prime for row in self.rows) != self.primes:
+            raise _validation_error(
+                "local-factor rows must align with the canonical prime set"
+            )
+        expected_product = Fraction(1, 1)
+        expected_first: int | None = None
+        for row in self.rows:
+            _require_summary(self.source, row.summary)
+            expected_factor = local_factor_from_bad_count(
+                self.source.form_count,
+                row.summary.prime,
+                row.summary.bad_count,
+            )
+            if row.factor.as_fraction() != expected_factor:
+                raise _validation_error(
+                    "local factor row does not satisfy its defining formula"
+                )
+            expected_product *= expected_factor
+            if expected_first is None and row.summary.valid_count == 0:
+                expected_first = row.summary.prime
+        if self.product.as_fraction() != expected_product:
+            raise _validation_error(
+                "finite product must equal the product of every local row"
+            )
+        if self.first_obstructing_prime != expected_first:
+            raise _validation_error(
+                "first obstructing prime does not match the local rows"
+            )
+        return self
+
+
+def compute_local_factor(
+    request: PrimeTupleLocalFactorRequest,
+) -> PrimeTupleLocalFactorResult:
+    """Return one complete local residue partition and exact factor."""
+
+    bad = dict(local_bad_residues(request.source, request.prime))
+    return PrimeTupleLocalFactorResult(
+        source=request.source,
+        prime=request.prime,
+        residue_rows=tuple(
+            PrimeTupleResidueRow(
+                residue=residue,
+                vanishing_form_ids=bad.get(residue, ()),
+            )
+            for residue in range(request.prime)
+        ),
+        bad_count=len(bad),
+        valid_count=request.prime - len(bad),
+        locally_obstructed=len(bad) == request.prime,
+        factor=CanonicalRational.from_fraction(
+            local_factor_from_bad_count(
+                request.source.form_count, request.prime, len(bad)
+            )
+        ),
+    )
+
+
+def compute_local_factors(
+    request: PrimeTupleLocalFactorsRequest,
+) -> FinitePrimeTupleFactorProduct:
+    """Return compact exact local factors over one finite prime set."""
+
+    product = Fraction(1, 1)
+    rows: list[PrimeTupleLocalFactorRow] = []
+    first_obstruction: int | None = None
+    for prime in request.primes:
+        summary = local_summary(request.source, prime)
+        factor = local_factor_from_bad_count(
+            request.source.form_count, prime, summary.bad_count
+        )
+        rows.append(
+            PrimeTupleLocalFactorRow(
+                summary=summary,
+                factor=CanonicalRational.from_fraction(factor),
+            )
+        )
+        product *= factor
+        if first_obstruction is None and summary.valid_count == 0:
+            first_obstruction = prime
+    return FinitePrimeTupleFactorProduct(
+        source=request.source,
+        primes=request.primes,
+        rows=tuple(rows),
+        product=CanonicalRational.from_fraction(product),
+        first_obstructing_prime=first_obstruction,
+    )
+
+
+__all__ = [
+    "FinitePrimeTupleFactorProduct",
+    "PrimeTupleLocalFactorRequest",
+    "PrimeTupleLocalFactorResult",
+    "PrimeTupleLocalFactorRow",
+    "PrimeTupleLocalFactorsRequest",
+    "compute_local_factor",
+    "compute_local_factors",
+    "local_summary",
+]

--- a/src/jacobian/math/prime_affine_forms/_models.py
+++ b/src/jacobian/math/prime_affine_forms/_models.py
@@ -2,21 +2,17 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
-from math import prod
-from typing import Annotated, Literal, Self
+from typing import Annotated, Self
 
-from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
-from sympy import isprime, primepi
+from sympy import isprime
 
-from jacobian._exact import CanonicalInteger, CanonicalRational
+from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.affine_forms.values import (
     MAX_AFFINE_COMPONENT_DIGITS,
-    MAX_FORM_ID_LENGTH,
-    AffineComponentInteger,
     AffineFormId,
 )
 from jacobian.math.prime_affine_forms._kernel import (
@@ -24,11 +20,7 @@ from jacobian.math.prime_affine_forms._kernel import (
     interval_match_summary,
     interval_matches,
     local_bad_residues,
-    local_counts,
-    local_factor_from_bad_count,
-    primes_through,
     translated_tuple,
-    wheel_modulus,
 )
 from jacobian.math.prime_affine_forms.values import (
     MAX_AFFINE_AGGREGATE_DIGITS,
@@ -43,21 +35,10 @@ MAX_PRIME_BATCH = 64
 MAX_BATCH_ROOT_WORK = 250_000
 MAX_FACTOR_COMPONENT_DIGITS = 4_096
 MAX_FACTOR_PRODUCT_DIGITS = 8_192
-MAX_ADMISSIBILITY_CUTOFF = MAX_AFFINE_FORMS
-MAX_ADMISSIBILITY_PRIME_ROWS = 128
-MAX_ADMISSIBILITY_ROOT_CELLS = 200_000
-MAX_WHEEL_PRIMES = 64
-MAX_WHEEL_LOCAL_RESIDUES = 32_768
-MAX_WHEEL_RESIDUES = 8_192
-MAX_WHEEL_RESULT_CELLS = 65_536
-MAX_WHEEL_ENUMERATION_WORK = 300_000
-MAX_COMPACT_WHEEL_ROOT_WORK = 250_000
-MAX_COMPACT_WHEEL_SCALAR_DIGITS = 4_096
 MAX_RESULT_CHARACTER_BUDGET = 2_000_000
 MAX_INTERVAL_ENDPOINT_DIGITS = 64
 MAX_INTERVAL_REPLAY_EVALUATIONS = 200_000
 MAX_INTERVAL_ENUMERATION_CELLS = 65_536
-MAX_WHEEL_INTERVAL_LENGTH = 8_192
 
 CompactPrime = Annotated[
     StrictInt,
@@ -69,10 +50,6 @@ CompactPrime = Annotated[
             f"{MAX_BATCH_PRIME}."
         ),
     ),
-]
-CompactWheelScalar = Annotated[
-    CanonicalInteger,
-    StringConstraints(max_length=MAX_COMPACT_WHEEL_SCALAR_DIGITS, strict=True),
 ]
 IntervalEndpointInteger = Annotated[
     CanonicalInteger,
@@ -153,24 +130,6 @@ def _require_prime_set(primes: tuple[int, ...], *, maximum: int) -> None:
         raise _validation_error("primes must be distinct and strictly increasing")
     for prime in primes:
         _require_prime(prime, maximum=maximum)
-
-
-def _factor_digit_upper_bound(source: PrimeAffineTuple, prime: int) -> int:
-    bad_count, _ = local_counts(source, prime)
-    if bad_count == prime:
-        return 1
-    numerator = _digits(prime - bad_count) + (source.form_count - 1) * _digits(prime)
-    denominator = source.form_count * _digits(prime - 1)
-    return max(numerator, denominator)
-
-
-def _require_factor_output(source: PrimeAffineTuple, prime: int) -> None:
-    bound = _factor_digit_upper_bound(source, prime)
-    if bound > MAX_FACTOR_COMPONENT_DIGITS:
-        raise _validation_error(
-            "local-factor numerator or denominator may require "
-            f"{bound} digits, exceeding the bound {MAX_FACTOR_COMPONENT_DIGITS}"
-        )
 
 
 def _expected_summary(
@@ -277,529 +236,6 @@ class PrimeTupleLocalSummary(StrictModel):
         if sum(len(row.form_ids) for row in self.bad_residues) > MAX_AFFINE_FORMS:
             raise _validation_error(
                 "bad-residue incidence count exceeds the affine-form bound"
-            )
-        return self
-
-
-class PrimeTupleLocalFactorRequest(StrictModel):
-    """Compute one complete local residue profile and exact local factor."""
-
-    source: PrimeAffineTuple
-    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
-
-    @model_validator(mode="after")
-    def require_bounded_complete_profile(self) -> Self:
-        _require_prime(self.prime, maximum=MAX_LOCAL_PROFILE_PRIME)
-        _require_factor_output(self.source, self.prime)
-        work = 6 * self.source.form_count + 2 * self.prime
-        if work > MAX_LOCAL_PROFILE_WORK:
-            raise _validation_error(
-                f"local profile and validation need {work} bounded steps, "
-                f"exceeding {MAX_LOCAL_PROFILE_WORK}"
-            )
-        return self
-
-
-class PrimeTupleLocalFactorResult(StrictModel):
-    """Source-bound complete partition modulo one prime and its local factor."""
-
-    source: PrimeAffineTuple
-    prime: StrictInt = Field(ge=2, le=MAX_LOCAL_PROFILE_PRIME)
-    residue_rows: tuple[PrimeTupleResidueRow, ...] = Field(
-        min_length=2, max_length=MAX_LOCAL_PROFILE_PRIME
-    )
-    bad_count: StrictInt = Field(ge=0)
-    valid_count: StrictInt = Field(ge=0)
-    locally_obstructed: StrictBool
-    factor: CanonicalRational
-
-    @model_validator(mode="after")
-    def bind_complete_local_factor(self) -> Self:
-        if (
-            sum(len(row.vanishing_form_ids) for row in self.residue_rows)
-            > self.source.form_count
-        ):
-            raise _validation_error(
-                "residue incidence count exceeds the source affine-form count"
-            )
-        PrimeTupleLocalFactorRequest(source=self.source, prime=self.prime)
-        bad = dict(local_bad_residues(self.source, self.prime))
-        expected_rows = tuple(
-            (residue, bad.get(residue, ())) for residue in range(self.prime)
-        )
-        actual_rows = tuple(
-            (row.residue, row.vanishing_form_ids) for row in self.residue_rows
-        )
-        if actual_rows != expected_rows:
-            raise _validation_error(
-                "residue rows must be the complete source-bound partition"
-            )
-        expected_bad = len(bad)
-        expected_valid = self.prime - expected_bad
-        if self.bad_count != expected_bad or self.valid_count != expected_valid:
-            raise _validation_error(
-                "local counts do not match the complete residue rows"
-            )
-        if self.locally_obstructed != (expected_valid == 0):
-            raise _validation_error(
-                "local obstruction status must equal valid_count == 0"
-            )
-        if self.factor.as_fraction() != local_factor_from_bad_count(
-            self.source.form_count, self.prime, expected_bad
-        ):
-            raise _validation_error(
-                "local factor does not satisfy its defining formula"
-            )
-        return self
-
-
-class PrimeTupleLocalFactorsRequest(StrictModel):
-    """Compute compact local factors for a canonical finite prime set."""
-
-    source: PrimeAffineTuple
-    primes: tuple[CompactPrime, ...] = Field(
-        min_length=1,
-        max_length=MAX_PRIME_BATCH,
-        description=(
-            "Distinct primes in strictly increasing order. The aggregate form/root "
-            "and exact rational-output bounds are validated before computation."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def require_bounded_factor_batch(self) -> Self:
-        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
-        root_cells = self.source.form_count * len(self.primes)
-        root_work = 6 * root_cells
-        if root_work > MAX_BATCH_ROOT_WORK:
-            raise _validation_error(
-                f"local-factor computation and validation need {root_work} root "
-                f"steps, exceeding {MAX_BATCH_ROOT_WORK}"
-            )
-        digit_bounds = tuple(
-            _factor_digit_upper_bound(self.source, prime) for prime in self.primes
-        )
-        if any(bound > MAX_FACTOR_COMPONENT_DIGITS for bound in digit_bounds):
-            raise _validation_error(
-                "one local factor exceeds the exact rational component-digit bound"
-            )
-        if sum(digit_bounds) > MAX_FACTOR_PRODUCT_DIGITS:
-            raise _validation_error(
-                "finite factor product exceeds the conservative exact rational "
-                f"digit bound {MAX_FACTOR_PRODUCT_DIGITS}"
-            )
-        estimated_characters = (
-            _source_character_upper_bound(self.source)
-            + sum(
-                _summary_character_upper_bound(self.source, prime)
-                for prime in self.primes
-            )
-            + 128 * len(self.primes)
-            + 4 * sum(digit_bounds)
-            + 256
-        )
-        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "finite factor result exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleLocalFactorRow(StrictModel):
-    summary: PrimeTupleLocalSummary
-    factor: CanonicalRational
-
-
-class FinitePrimeTupleFactorProduct(StrictModel):
-    """Exact finite local-factor product, explicitly not an infinite series."""
-
-    source: PrimeAffineTuple
-    primes: tuple[CompactPrime, ...] = Field(min_length=1, max_length=MAX_PRIME_BATCH)
-    rows: tuple[PrimeTupleLocalFactorRow, ...] = Field(
-        min_length=1, max_length=MAX_PRIME_BATCH
-    )
-    product: CanonicalRational
-    first_obstructing_prime: StrictInt | None = None
-
-    @model_validator(mode="after")
-    def bind_finite_factor_product(self) -> Self:
-        PrimeTupleLocalFactorsRequest(source=self.source, primes=self.primes)
-        if tuple(row.summary.prime for row in self.rows) != self.primes:
-            raise _validation_error(
-                "local-factor rows must align with the canonical prime set"
-            )
-        expected_product = Fraction(1, 1)
-        expected_first: int | None = None
-        for row in self.rows:
-            _require_summary(self.source, row.summary)
-            expected_factor = local_factor_from_bad_count(
-                self.source.form_count,
-                row.summary.prime,
-                row.summary.bad_count,
-            )
-            if row.factor.as_fraction() != expected_factor:
-                raise _validation_error(
-                    "local factor row does not satisfy its defining formula"
-                )
-            expected_product *= expected_factor
-            if expected_first is None and row.summary.valid_count == 0:
-                expected_first = row.summary.prime
-        if self.product.as_fraction() != expected_product:
-            raise _validation_error(
-                "finite product must equal the product of every local row"
-            )
-        if self.first_obstructing_prime != expected_first:
-            raise _validation_error(
-                "first obstructing prime does not match the local rows"
-            )
-        return self
-
-
-class PrimeTupleAdmissibilityRequest(StrictModel):
-    """Decide local admissibility by checking exactly the primes at most k."""
-
-    source: PrimeAffineTuple
-
-    @model_validator(mode="after")
-    def require_bounded_cutoff_profile(self) -> Self:
-        cutoff = self.source.form_count
-        prime_rows = int(primepi(cutoff))
-        if prime_rows > MAX_ADMISSIBILITY_PRIME_ROWS:
-            raise _validation_error(
-                f"admissibility needs {prime_rows} prime rows, exceeding "
-                f"{MAX_ADMISSIBILITY_PRIME_ROWS}"
-            )
-        root_cells = self.source.form_count * prime_rows
-        total_root_cells = 4 * root_cells
-        if total_root_cells > MAX_ADMISSIBILITY_ROOT_CELLS:
-            raise _validation_error(
-                "admissibility computation and validation may require "
-                f"{total_root_cells} root cells, "
-                f"exceeding {MAX_ADMISSIBILITY_ROOT_CELLS}"
-            )
-        estimated_characters = (
-            _source_character_upper_bound(self.source)
-            + sum(
-                _summary_character_upper_bound(self.source, prime)
-                for prime in primes_through(cutoff)
-            )
-            + 16 * prime_rows
-            + 256
-        )
-        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "admissibility profile exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleAdmissibilityResult(StrictModel):
-    """Closed decision: every p<=k is checked and every p>k has nu_p<=k<p."""
-
-    source: PrimeAffineTuple
-    cutoff: StrictInt = Field(ge=1, le=MAX_ADMISSIBILITY_CUTOFF)
-    checked_primes: tuple[StrictInt, ...] = Field(
-        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
-    )
-    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(
-        max_length=MAX_ADMISSIBILITY_PRIME_ROWS
-    )
-    status: Literal["LOCALLY_ADMISSIBLE", "LOCALLY_OBSTRUCTED"]
-    least_obstructing_prime: StrictInt | None = None
-    large_prime_lower_bound: StrictInt = Field(ge=2)
-    maximum_large_prime_bad_residues: StrictInt = Field(ge=1)
-
-    @model_validator(mode="after")
-    def bind_cutoff_decision(self) -> Self:
-        PrimeTupleAdmissibilityRequest(source=self.source)
-        expected_cutoff = self.source.form_count
-        expected_primes = primes_through(expected_cutoff)
-        if self.cutoff != expected_cutoff or self.checked_primes != expected_primes:
-            raise _validation_error(
-                "checked primes must be exactly every prime through the cutoff"
-            )
-        if tuple(row.prime for row in self.local_rows) != expected_primes:
-            raise _validation_error("local rows must align with every checked prime")
-        for row in self.local_rows:
-            _require_summary(self.source, row)
-        obstructing = tuple(
-            row.prime for row in self.local_rows if row.valid_count == 0
-        )
-        expected_status = "LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE"
-        if self.status != expected_status:
-            raise _validation_error(
-                "admissibility status does not match the local rows"
-            )
-        expected_first = obstructing[0] if obstructing else None
-        if self.least_obstructing_prime != expected_first:
-            raise _validation_error(
-                "least obstructing prime does not match the local rows"
-            )
-        if (
-            self.large_prime_lower_bound != expected_cutoff + 1
-            or self.maximum_large_prime_bad_residues != self.source.form_count
-        ):
-            raise _validation_error(
-                "large-prime cutoff evidence does not match the source"
-            )
-        return self
-
-
-class PrimeTupleResidueWheelRequest(StrictModel):
-    """Construct a compact exact CRT wheel for a canonical finite prime set."""
-
-    source: PrimeAffineTuple
-    primes: tuple[CompactPrime, ...] = Field(
-        max_length=MAX_WHEEL_PRIMES,
-        description=(
-            "Possibly empty tuple of distinct primes in strictly increasing order; "
-            "the empty set returns the modulus-one identity wheel. This compact "
-            "operation does not enumerate all combined residues."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def require_bounded_compact_wheel(self) -> Self:
-        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
-        root_cells = self.source.form_count * len(self.primes)
-        root_work = 6 * root_cells
-        if root_work > MAX_COMPACT_WHEEL_ROOT_WORK:
-            raise _validation_error(
-                f"compact wheel computation and validation need {root_work} root "
-                f"steps, exceeding {MAX_COMPACT_WHEEL_ROOT_WORK}"
-            )
-        modulus_digits = sum(_digits(prime) for prime in self.primes) or 1
-        if modulus_digits > MAX_COMPACT_WHEEL_SCALAR_DIGITS:
-            raise _validation_error(
-                "compact wheel modulus exceeds the conservative exact scalar "
-                f"digit bound {MAX_COMPACT_WHEEL_SCALAR_DIGITS}"
-            )
-        estimated_characters = (
-            _source_character_upper_bound(self.source)
-            + sum(
-                _summary_character_upper_bound(self.source, prime)
-                for prime in self.primes
-            )
-            + 2 * modulus_digits
-            + 128
-        )
-        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "compact wheel exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleWheelResidueRow(StrictModel):
-    residue: CompactWheelScalar
-    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
-
-
-class PrimeTupleResidueWheel(StrictModel):
-    """Compact source-bound CRT wheel as a product of valid local residue sets."""
-
-    source: PrimeAffineTuple
-    primes: tuple[CompactPrime, ...] = Field(max_length=MAX_WHEEL_PRIMES)
-    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(max_length=MAX_WHEEL_PRIMES)
-    modulus: CompactWheelScalar
-    valid_count: CompactWheelScalar
-
-    @model_validator(mode="after")
-    def bind_compact_crt_wheel(self) -> Self:
-        PrimeTupleResidueWheelRequest(source=self.source, primes=self.primes)
-        if tuple(row.prime for row in self.local_rows) != self.primes:
-            raise _validation_error(
-                "wheel local rows must align with its canonical primes"
-            )
-        for row in self.local_rows:
-            _require_summary(self.source, row)
-        expected_modulus = wheel_modulus(self.primes)
-        if parse_canonical_integer(self.modulus) != expected_modulus:
-            raise _validation_error(
-                "wheel modulus must equal the product of its primes"
-            )
-        expected_count = prod((row.valid_count for row in self.local_rows), start=1)
-        if parse_canonical_integer(self.valid_count) != expected_count:
-            raise _validation_error(
-                "wheel valid_count must equal the product of local counts"
-            )
-        return self
-
-
-class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
-    """Materialize every residue of a supplied compact wheel under strict bounds."""
-
-    wheel: PrimeTupleResidueWheel
-
-    @model_validator(mode="after")
-    def require_bounded_wheel_enumeration(self) -> Self:
-        local_residue_rows = sum(self.wheel.primes)
-        if local_residue_rows > MAX_WHEEL_LOCAL_RESIDUES:
-            raise _validation_error(
-                f"wheel local residue enumeration {local_residue_rows} exceeds "
-                f"{MAX_WHEEL_LOCAL_RESIDUES}"
-            )
-        result_count = parse_canonical_integer(self.wheel.valid_count)
-        if result_count > MAX_WHEEL_RESIDUES:
-            raise _validation_error(
-                f"wheel has {result_count} valid residues, exceeding "
-                f"{MAX_WHEEL_RESIDUES}"
-            )
-        result_cells = result_count * (len(self.wheel.primes) + 1)
-        if result_cells > MAX_WHEEL_RESULT_CELLS:
-            raise _validation_error(
-                f"wheel result needs {result_cells} cells, exceeding "
-                f"{MAX_WHEEL_RESULT_CELLS}"
-            )
-        root_cells = self.wheel.source.form_count * len(self.wheel.primes)
-        replay_work = 2 * (
-            result_count * len(self.wheel.primes) + local_residue_rows + root_cells
-        )
-        if replay_work > MAX_WHEEL_ENUMERATION_WORK:
-            raise _validation_error(
-                f"wheel enumeration and validation need {replay_work} bounded "
-                f"steps, exceeding {MAX_WHEEL_ENUMERATION_WORK}"
-            )
-        modulus_digits = _digits(self.wheel.modulus)
-        component_digits = sum(_digits(prime) for prime in self.wheel.primes)
-        serialized_characters = (
-            len(self.wheel.model_dump_json())
-            + result_count
-            * (modulus_digits + component_digits + 4 * len(self.wheel.primes) + 64)
-            + 128
-        )
-        if serialized_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "wheel enumeration exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleResidueWheelEnumeration(StrictModel):
-    """Complete explicit residue realization of one compact CRT wheel."""
-
-    wheel: PrimeTupleResidueWheel
-    residues: tuple[PrimeTupleWheelResidueRow, ...] = Field(
-        max_length=MAX_WHEEL_RESIDUES
-    )
-
-    @model_validator(mode="after")
-    def bind_complete_crt_enumeration(self) -> Self:
-        result_cells = len(self.residues) + sum(
-            len(row.components) for row in self.residues
-        )
-        if result_cells > MAX_WHEEL_RESULT_CELLS:
-            raise _validation_error("wheel rows exceed the explicit result-cell bound")
-        PrimeTupleResidueWheelEnumerationRequest(wheel=self.wheel)
-        expected_count = parse_canonical_integer(self.wheel.valid_count)
-        if len(self.residues) != expected_count:
-            raise _validation_error(
-                "wheel rows do not satisfy the complete CRT reconstruction invariant"
-            )
-        residues = tuple(parse_canonical_integer(row.residue) for row in self.residues)
-        if residues != tuple(sorted(set(residues))):
-            raise _validation_error(
-                "wheel rows do not satisfy the complete CRT reconstruction invariant"
-            )
-        modulus = parse_canonical_integer(self.wheel.modulus)
-        for row, residue in zip(self.residues, residues, strict=True):
-            if not 0 <= residue < modulus or len(row.components) != len(
-                self.wheel.primes
-            ):
-                raise _validation_error(
-                    "wheel rows do not satisfy the complete CRT reconstruction invariant"
-                )
-            for prime, summary, component in zip(
-                self.wheel.primes,
-                self.wheel.local_rows,
-                row.components,
-                strict=True,
-            ):
-                bad = {item.residue for item in summary.bad_residues}
-                if (
-                    not 0 <= component < prime
-                    or residue % prime != component
-                    or component in bad
-                ):
-                    raise _validation_error(
-                        "wheel rows do not satisfy the complete CRT reconstruction "
-                        "invariant"
-                    )
-        return self
-
-
-class PrimeTupleWheelMembershipRequest(StrictModel):
-    """Check one integer against an exact residue wheel supplied unchanged."""
-
-    wheel: PrimeTupleResidueWheel
-    value: AffineComponentInteger
-
-    @model_validator(mode="after")
-    def require_bounded_value(self) -> Self:
-        if _digits(self.value) > MAX_AFFINE_COMPONENT_DIGITS:
-            raise _validation_error(
-                f"membership value must have at most {MAX_AFFINE_COMPONENT_DIGITS} digits"
-            )
-        result_characters = (
-            len(self.wheel.model_dump_json())
-            + len(self.value)
-            + _digits(self.wheel.modulus)
-            + sum(_digits(prime) for prime in self.wheel.primes)
-            + MAX_FORM_ID_LENGTH * self.wheel.source.form_count
-            + 256
-        )
-        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "wheel membership result exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleWheelMembershipResult(StrictModel):
-    wheel: PrimeTupleResidueWheel
-    value: AffineComponentInteger
-    canonical_residue: CompactWheelScalar
-    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
-    is_permitted: StrictBool
-    first_excluded_prime: StrictInt | None = None
-    vanishing_form_ids: tuple[AffineFormId, ...] = Field(max_length=MAX_AFFINE_FORMS)
-
-    @model_validator(mode="after")
-    def bind_wheel_membership(self) -> Self:
-        PrimeTupleWheelMembershipRequest(wheel=self.wheel, value=self.value)
-        value = parse_canonical_integer(self.value)
-        modulus = parse_canonical_integer(self.wheel.modulus)
-        expected_residue = value % modulus
-        expected_components = tuple(value % prime for prime in self.wheel.primes)
-        expected_prime: int | None = None
-        expected_form_ids: tuple[str, ...] = ()
-        for summary, component in zip(
-            self.wheel.local_rows, expected_components, strict=True
-        ):
-            bad = {row.residue: row.form_ids for row in summary.bad_residues}
-            if component in bad:
-                expected_prime = summary.prime
-                expected_form_ids = bad[component]
-                break
-        expected_permitted = expected_prime is None
-        if parse_canonical_integer(self.canonical_residue) != expected_residue:
-            raise _validation_error(
-                "canonical residue does not match the wheel modulus"
-            )
-        if self.components != expected_components:
-            raise _validation_error(
-                "prime components do not match the supplied integer"
-            )
-        if self.is_permitted != expected_permitted:
-            raise _validation_error(
-                "wheel membership does not match the complete residue set"
-            )
-        if (
-            self.first_excluded_prime != expected_prime
-            or self.vanishing_form_ids != expected_form_ids
-        ):
-            raise _validation_error(
-                "first local exclusion does not match the source forms"
             )
         return self
 
@@ -948,79 +384,6 @@ class PrimePatternIntervalEnumerateResult(StrictModel):
         return self
 
 
-class PrimeTupleIntervalResidueProfileRequest(StrictModel):
-    """Enumerate local-wheel survivors on one bounded closed integer interval."""
-
-    wheel: PrimeTupleResidueWheel
-    lower: IntervalEndpointInteger
-    upper: IntervalEndpointInteger
-
-    @model_validator(mode="after")
-    def require_bounded_survivor_profile(self) -> Self:
-        _, _, interval_size = _parse_interval(self.lower, self.upper)
-        if interval_size > MAX_WHEEL_INTERVAL_LENGTH:
-            raise _validation_error(
-                f"wheel interval length {interval_size} exceeds "
-                f"{MAX_WHEEL_INTERVAL_LENGTH}"
-            )
-        replay_work = 2 * interval_size * max(1, len(self.wheel.primes))
-        if replay_work > MAX_INTERVAL_REPLAY_EVALUATIONS:
-            raise _validation_error(
-                f"wheel interval profile and validation need {replay_work} "
-                f"modular checks, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
-            )
-        endpoint_digits = max(_digits(self.lower), _digits(self.upper))
-        result_characters = (
-            len(self.wheel.model_dump_json())
-            + interval_size * (endpoint_digits + 4)
-            + 192
-        )
-        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
-            raise _validation_error(
-                "wheel interval profile exceeds the conservative serialized bound"
-            )
-        return self
-
-
-class PrimeTupleIntervalResidueProfileResult(StrictModel):
-    """Exact local survivors; this value does not assert actual primality."""
-
-    wheel: PrimeTupleResidueWheel
-    lower: IntervalEndpointInteger
-    upper: IntervalEndpointInteger
-    interval_size: StrictInt = Field(ge=1, le=MAX_WHEEL_INTERVAL_LENGTH)
-    survivors: tuple[IntervalEndpointInteger, ...] = Field(
-        max_length=MAX_WHEEL_INTERVAL_LENGTH
-    )
-
-    @model_validator(mode="after")
-    def bind_complete_survivor_family(self) -> Self:
-        PrimeTupleIntervalResidueProfileRequest(
-            wheel=self.wheel, lower=self.lower, upper=self.upper
-        )
-        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
-        bad_by_prime = tuple(
-            {row.residue for row in summary.bad_residues}
-            for summary in self.wheel.local_rows
-        )
-        expected = tuple(
-            value
-            for value in range(lower, upper + 1)
-            if all(
-                value % prime not in bad
-                for prime, bad in zip(self.wheel.primes, bad_by_prime, strict=True)
-            )
-        )
-        actual = tuple(parse_canonical_integer(value) for value in self.survivors)
-        if actual != expected:
-            raise _validation_error(
-                "survivors must be the complete local wheel profile"
-            )
-        if self.interval_size != interval_size:
-            raise _validation_error("interval_size must equal upper-lower+1")
-        return self
-
-
 class PrimeAffineTranslationRequest(StrictModel):
     """Translate every source form by the variable substitution n -> n+shift."""
 
@@ -1067,16 +430,11 @@ class PrimeAffineTranslationResult(StrictModel):
 
 
 __all__ = [
-    "MAX_ADMISSIBILITY_CUTOFF",
     "MAX_BATCH_PRIME",
     "MAX_INTERVAL_ENUMERATION_CELLS",
     "MAX_INTERVAL_REPLAY_EVALUATIONS",
     "MAX_LOCAL_PROFILE_PRIME",
     "MAX_PRIME_BATCH",
-    "MAX_WHEEL_INTERVAL_LENGTH",
-    "MAX_WHEEL_PRIMES",
-    "MAX_WHEEL_RESIDUES",
-    "FinitePrimeTupleFactorProduct",
     "PrimeAffineIntervalCountRequest",
     "PrimeAffineIntervalEnumerateRequest",
     "PrimeAffineTranslationRequest",
@@ -1084,22 +442,7 @@ __all__ = [
     "PrimePatternIntervalCountResult",
     "PrimePatternIntervalEnumerateResult",
     "PrimePatternMatch",
-    "PrimeTupleAdmissibilityRequest",
-    "PrimeTupleAdmissibilityResult",
     "PrimeTupleBadResidueRow",
-    "PrimeTupleIntervalResidueProfileRequest",
-    "PrimeTupleIntervalResidueProfileResult",
-    "PrimeTupleLocalFactorRequest",
-    "PrimeTupleLocalFactorResult",
-    "PrimeTupleLocalFactorRow",
-    "PrimeTupleLocalFactorsRequest",
     "PrimeTupleLocalSummary",
     "PrimeTupleResidueRow",
-    "PrimeTupleResidueWheel",
-    "PrimeTupleResidueWheelEnumeration",
-    "PrimeTupleResidueWheelEnumerationRequest",
-    "PrimeTupleResidueWheelRequest",
-    "PrimeTupleWheelMembershipRequest",
-    "PrimeTupleWheelMembershipResult",
-    "PrimeTupleWheelResidueRow",
 ]

--- a/src/jacobian/math/prime_affine_forms/_operations.py
+++ b/src/jacobian/math/prime_affine_forms/_operations.py
@@ -2,23 +2,18 @@
 
 from __future__ import annotations
 
-from fractions import Fraction
 from math import prod
 
-from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.prime_affine_forms._kernel import (
     interval_match_summary,
     interval_matches,
-    local_bad_residues,
-    local_factor_from_bad_count,
-    primes_through,
     translated_tuple,
     wheel_modulus,
     wheel_rows,
 )
+from jacobian.math.prime_affine_forms._local_factors import local_summary
 from jacobian.math.prime_affine_forms._models import (
-    FinitePrimeTupleFactorProduct,
     PrimeAffineIntervalCountRequest,
     PrimeAffineIntervalEnumerateRequest,
     PrimeAffineTranslationRequest,
@@ -26,17 +21,10 @@ from jacobian.math.prime_affine_forms._models import (
     PrimePatternIntervalCountResult,
     PrimePatternIntervalEnumerateResult,
     PrimePatternMatch,
-    PrimeTupleAdmissibilityRequest,
-    PrimeTupleAdmissibilityResult,
-    PrimeTupleBadResidueRow,
+)
+from jacobian.math.prime_affine_forms._residue_wheel import (
     PrimeTupleIntervalResidueProfileRequest,
     PrimeTupleIntervalResidueProfileResult,
-    PrimeTupleLocalFactorRequest,
-    PrimeTupleLocalFactorResult,
-    PrimeTupleLocalFactorRow,
-    PrimeTupleLocalFactorsRequest,
-    PrimeTupleLocalSummary,
-    PrimeTupleResidueRow,
     PrimeTupleResidueWheel,
     PrimeTupleResidueWheelEnumeration,
     PrimeTupleResidueWheelEnumerationRequest,
@@ -45,99 +33,12 @@ from jacobian.math.prime_affine_forms._models import (
     PrimeTupleWheelMembershipResult,
     PrimeTupleWheelResidueRow,
 )
-from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
-
-
-def _summary(source: PrimeAffineTuple, prime: int) -> PrimeTupleLocalSummary:
-    bad = local_bad_residues(source, prime)
-    return PrimeTupleLocalSummary(
-        prime=prime,
-        bad_residues=tuple(
-            PrimeTupleBadResidueRow(residue=residue, form_ids=form_ids)
-            for residue, form_ids in bad
-        ),
-        bad_count=len(bad),
-        valid_count=prime - len(bad),
-    )
-
-
-def compute_local_factor(
-    request: PrimeTupleLocalFactorRequest,
-) -> PrimeTupleLocalFactorResult:
-    bad = dict(local_bad_residues(request.source, request.prime))
-    return PrimeTupleLocalFactorResult(
-        source=request.source,
-        prime=request.prime,
-        residue_rows=tuple(
-            PrimeTupleResidueRow(
-                residue=residue,
-                vanishing_form_ids=bad.get(residue, ()),
-            )
-            for residue in range(request.prime)
-        ),
-        bad_count=len(bad),
-        valid_count=request.prime - len(bad),
-        locally_obstructed=len(bad) == request.prime,
-        factor=CanonicalRational.from_fraction(
-            local_factor_from_bad_count(
-                request.source.form_count, request.prime, len(bad)
-            )
-        ),
-    )
-
-
-def compute_local_factors(
-    request: PrimeTupleLocalFactorsRequest,
-) -> FinitePrimeTupleFactorProduct:
-    product = Fraction(1, 1)
-    rows: list[PrimeTupleLocalFactorRow] = []
-    first_obstruction: int | None = None
-    for prime in request.primes:
-        summary = _summary(request.source, prime)
-        factor = local_factor_from_bad_count(
-            request.source.form_count, prime, summary.bad_count
-        )
-        rows.append(
-            PrimeTupleLocalFactorRow(
-                summary=summary,
-                factor=CanonicalRational.from_fraction(factor),
-            )
-        )
-        product *= factor
-        if first_obstruction is None and summary.valid_count == 0:
-            first_obstruction = prime
-    return FinitePrimeTupleFactorProduct(
-        source=request.source,
-        primes=request.primes,
-        rows=tuple(rows),
-        product=CanonicalRational.from_fraction(product),
-        first_obstructing_prime=first_obstruction,
-    )
-
-
-def compute_local_admissibility(
-    request: PrimeTupleAdmissibilityRequest,
-) -> PrimeTupleAdmissibilityResult:
-    cutoff = request.source.form_count
-    checked_primes = primes_through(cutoff)
-    rows = tuple(_summary(request.source, prime) for prime in checked_primes)
-    obstructing = tuple(row.prime for row in rows if row.valid_count == 0)
-    return PrimeTupleAdmissibilityResult(
-        source=request.source,
-        cutoff=cutoff,
-        checked_primes=checked_primes,
-        local_rows=rows,
-        status="LOCALLY_OBSTRUCTED" if obstructing else "LOCALLY_ADMISSIBLE",
-        least_obstructing_prime=obstructing[0] if obstructing else None,
-        large_prime_lower_bound=cutoff + 1,
-        maximum_large_prime_bad_residues=request.source.form_count,
-    )
 
 
 def compute_residue_wheel(
     request: PrimeTupleResidueWheelRequest,
 ) -> PrimeTupleResidueWheel:
-    local_rows = tuple(_summary(request.source, prime) for prime in request.primes)
+    local_rows = tuple(local_summary(request.source, prime) for prime in request.primes)
     return PrimeTupleResidueWheel(
         source=request.source,
         primes=request.primes,
@@ -275,9 +176,6 @@ __all__ = [
     "compute_interval_count",
     "compute_interval_enumerate",
     "compute_interval_residue_profile",
-    "compute_local_admissibility",
-    "compute_local_factor",
-    "compute_local_factors",
     "compute_residue_wheel",
     "compute_residue_wheel_enumeration",
     "compute_translation",

--- a/src/jacobian/math/prime_affine_forms/_residue_wheel.py
+++ b/src/jacobian/math/prime_affine_forms/_residue_wheel.py
@@ -1,0 +1,400 @@
+"""Typed contracts and bounded replay for prime-affine residue wheels."""
+
+from __future__ import annotations
+
+from math import prod
+from typing import Annotated, Self
+
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+
+from jacobian._exact import CanonicalInteger
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.affine_forms.values import (
+    MAX_AFFINE_COMPONENT_DIGITS,
+    MAX_FORM_ID_LENGTH,
+    AffineComponentInteger,
+    AffineFormId,
+)
+from jacobian.math.prime_affine_forms._kernel import wheel_modulus
+from jacobian.math.prime_affine_forms._models import (
+    MAX_BATCH_PRIME,
+    MAX_INTERVAL_REPLAY_EVALUATIONS,
+    MAX_RESULT_CHARACTER_BUDGET,
+    CompactPrime,
+    IntervalEndpointInteger,
+    PrimeTupleLocalSummary,
+    _digits,
+    _parse_interval,
+    _require_prime_set,
+    _require_summary,
+    _source_character_upper_bound,
+    _summary_character_upper_bound,
+    _validation_error,
+)
+from jacobian.math.prime_affine_forms.values import (
+    MAX_AFFINE_FORMS,
+    PrimeAffineTuple,
+)
+
+MAX_WHEEL_PRIMES = 64
+MAX_WHEEL_LOCAL_RESIDUES = 32_768
+MAX_WHEEL_RESIDUES = 8_192
+MAX_WHEEL_RESULT_CELLS = 65_536
+MAX_WHEEL_ENUMERATION_WORK = 300_000
+MAX_COMPACT_WHEEL_ROOT_WORK = 250_000
+MAX_COMPACT_WHEEL_SCALAR_DIGITS = 4_096
+MAX_WHEEL_INTERVAL_LENGTH = 8_192
+
+CompactWheelScalar = Annotated[
+    CanonicalInteger,
+    StringConstraints(max_length=MAX_COMPACT_WHEEL_SCALAR_DIGITS, strict=True),
+]
+
+
+class PrimeTupleResidueWheelRequest(StrictModel):
+    """Construct a compact exact CRT wheel for a canonical finite prime set."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(
+        max_length=MAX_WHEEL_PRIMES,
+        description=(
+            "Possibly empty tuple of distinct primes in strictly increasing order; "
+            "the empty set returns the modulus-one identity wheel. This compact "
+            "operation does not enumerate all combined residues."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_bounded_compact_wheel(self) -> Self:
+        _require_prime_set(self.primes, maximum=MAX_BATCH_PRIME)
+        root_cells = self.source.form_count * len(self.primes)
+        root_work = 6 * root_cells
+        if root_work > MAX_COMPACT_WHEEL_ROOT_WORK:
+            raise _validation_error(
+                f"compact wheel computation and validation need {root_work} root "
+                f"steps, exceeding {MAX_COMPACT_WHEEL_ROOT_WORK}"
+            )
+        modulus_digits = sum(_digits(prime) for prime in self.primes) or 1
+        if modulus_digits > MAX_COMPACT_WHEEL_SCALAR_DIGITS:
+            raise _validation_error(
+                "compact wheel modulus exceeds the conservative exact scalar "
+                f"digit bound {MAX_COMPACT_WHEEL_SCALAR_DIGITS}"
+            )
+        estimated_characters = (
+            _source_character_upper_bound(self.source)
+            + sum(
+                _summary_character_upper_bound(self.source, prime)
+                for prime in self.primes
+            )
+            + 2 * modulus_digits
+            + 128
+        )
+        if estimated_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "compact wheel exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleWheelResidueRow(StrictModel):
+    residue: CompactWheelScalar
+    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+
+
+class PrimeTupleResidueWheel(StrictModel):
+    """Compact source-bound CRT wheel as a product of valid local residue sets."""
+
+    source: PrimeAffineTuple
+    primes: tuple[CompactPrime, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    local_rows: tuple[PrimeTupleLocalSummary, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    modulus: CompactWheelScalar
+    valid_count: CompactWheelScalar
+
+    @model_validator(mode="after")
+    def bind_compact_crt_wheel(self) -> Self:
+        PrimeTupleResidueWheelRequest(source=self.source, primes=self.primes)
+        if tuple(row.prime for row in self.local_rows) != self.primes:
+            raise _validation_error(
+                "wheel local rows must align with its canonical primes"
+            )
+        for row in self.local_rows:
+            _require_summary(self.source, row)
+        expected_modulus = wheel_modulus(self.primes)
+        if parse_canonical_integer(self.modulus) != expected_modulus:
+            raise _validation_error(
+                "wheel modulus must equal the product of its primes"
+            )
+        expected_count = prod((row.valid_count for row in self.local_rows), start=1)
+        if parse_canonical_integer(self.valid_count) != expected_count:
+            raise _validation_error(
+                "wheel valid_count must equal the product of local counts"
+            )
+        return self
+
+
+class PrimeTupleResidueWheelEnumerationRequest(StrictModel):
+    """Materialize every residue of a supplied compact wheel under strict bounds."""
+
+    wheel: PrimeTupleResidueWheel
+
+    @model_validator(mode="after")
+    def require_bounded_wheel_enumeration(self) -> Self:
+        local_residue_rows = sum(self.wheel.primes)
+        if local_residue_rows > MAX_WHEEL_LOCAL_RESIDUES:
+            raise _validation_error(
+                f"wheel local residue enumeration {local_residue_rows} exceeds "
+                f"{MAX_WHEEL_LOCAL_RESIDUES}"
+            )
+        result_count = parse_canonical_integer(self.wheel.valid_count)
+        if result_count > MAX_WHEEL_RESIDUES:
+            raise _validation_error(
+                f"wheel has {result_count} valid residues, exceeding "
+                f"{MAX_WHEEL_RESIDUES}"
+            )
+        result_cells = result_count * (len(self.wheel.primes) + 1)
+        if result_cells > MAX_WHEEL_RESULT_CELLS:
+            raise _validation_error(
+                f"wheel result needs {result_cells} cells, exceeding "
+                f"{MAX_WHEEL_RESULT_CELLS}"
+            )
+        root_cells = self.wheel.source.form_count * len(self.wheel.primes)
+        replay_work = 2 * (
+            result_count * len(self.wheel.primes) + local_residue_rows + root_cells
+        )
+        if replay_work > MAX_WHEEL_ENUMERATION_WORK:
+            raise _validation_error(
+                f"wheel enumeration and validation need {replay_work} bounded "
+                f"steps, exceeding {MAX_WHEEL_ENUMERATION_WORK}"
+            )
+        modulus_digits = _digits(self.wheel.modulus)
+        component_digits = sum(_digits(prime) for prime in self.wheel.primes)
+        serialized_characters = (
+            len(self.wheel.model_dump_json())
+            + result_count
+            * (modulus_digits + component_digits + 4 * len(self.wheel.primes) + 64)
+            + 128
+        )
+        if serialized_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "wheel enumeration exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleResidueWheelEnumeration(StrictModel):
+    """Complete explicit residue realization of one compact CRT wheel."""
+
+    wheel: PrimeTupleResidueWheel
+    residues: tuple[PrimeTupleWheelResidueRow, ...] = Field(
+        max_length=MAX_WHEEL_RESIDUES
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_crt_enumeration(self) -> Self:
+        result_cells = len(self.residues) + sum(
+            len(row.components) for row in self.residues
+        )
+        if result_cells > MAX_WHEEL_RESULT_CELLS:
+            raise _validation_error("wheel rows exceed the explicit result-cell bound")
+        PrimeTupleResidueWheelEnumerationRequest(wheel=self.wheel)
+        expected_count = parse_canonical_integer(self.wheel.valid_count)
+        if len(self.residues) != expected_count:
+            raise _validation_error(
+                "wheel rows do not satisfy the complete CRT reconstruction invariant"
+            )
+        residues = tuple(parse_canonical_integer(row.residue) for row in self.residues)
+        if residues != tuple(sorted(set(residues))):
+            raise _validation_error(
+                "wheel rows do not satisfy the complete CRT reconstruction invariant"
+            )
+        modulus = parse_canonical_integer(self.wheel.modulus)
+        for row, residue in zip(self.residues, residues, strict=True):
+            if not 0 <= residue < modulus or len(row.components) != len(
+                self.wheel.primes
+            ):
+                raise _validation_error(
+                    "wheel rows do not satisfy the complete CRT reconstruction invariant"
+                )
+            for prime, summary, component in zip(
+                self.wheel.primes,
+                self.wheel.local_rows,
+                row.components,
+                strict=True,
+            ):
+                bad = {item.residue for item in summary.bad_residues}
+                if (
+                    not 0 <= component < prime
+                    or residue % prime != component
+                    or component in bad
+                ):
+                    raise _validation_error(
+                        "wheel rows do not satisfy the complete CRT reconstruction "
+                        "invariant"
+                    )
+        return self
+
+
+class PrimeTupleWheelMembershipRequest(StrictModel):
+    """Check one integer against an exact residue wheel supplied unchanged."""
+
+    wheel: PrimeTupleResidueWheel
+    value: AffineComponentInteger
+
+    @model_validator(mode="after")
+    def require_bounded_value(self) -> Self:
+        if _digits(self.value) > MAX_AFFINE_COMPONENT_DIGITS:
+            raise _validation_error(
+                f"membership value must have at most {MAX_AFFINE_COMPONENT_DIGITS} digits"
+            )
+        result_characters = (
+            len(self.wheel.model_dump_json())
+            + len(self.value)
+            + _digits(self.wheel.modulus)
+            + sum(_digits(prime) for prime in self.wheel.primes)
+            + MAX_FORM_ID_LENGTH * self.wheel.source.form_count
+            + 256
+        )
+        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "wheel membership result exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleWheelMembershipResult(StrictModel):
+    wheel: PrimeTupleResidueWheel
+    value: AffineComponentInteger
+    canonical_residue: CompactWheelScalar
+    components: tuple[StrictInt, ...] = Field(max_length=MAX_WHEEL_PRIMES)
+    is_permitted: StrictBool
+    first_excluded_prime: StrictInt | None = None
+    vanishing_form_ids: tuple[AffineFormId, ...] = Field(max_length=MAX_AFFINE_FORMS)
+
+    @model_validator(mode="after")
+    def bind_wheel_membership(self) -> Self:
+        PrimeTupleWheelMembershipRequest(wheel=self.wheel, value=self.value)
+        value = parse_canonical_integer(self.value)
+        modulus = parse_canonical_integer(self.wheel.modulus)
+        expected_residue = value % modulus
+        expected_components = tuple(value % prime for prime in self.wheel.primes)
+        expected_prime: int | None = None
+        expected_form_ids: tuple[str, ...] = ()
+        for summary, component in zip(
+            self.wheel.local_rows, expected_components, strict=True
+        ):
+            bad = {row.residue: row.form_ids for row in summary.bad_residues}
+            if component in bad:
+                expected_prime = summary.prime
+                expected_form_ids = bad[component]
+                break
+        expected_permitted = expected_prime is None
+        if parse_canonical_integer(self.canonical_residue) != expected_residue:
+            raise _validation_error(
+                "canonical residue does not match the wheel modulus"
+            )
+        if self.components != expected_components:
+            raise _validation_error(
+                "prime components do not match the supplied integer"
+            )
+        if self.is_permitted != expected_permitted:
+            raise _validation_error(
+                "wheel membership does not match the complete residue set"
+            )
+        if (
+            self.first_excluded_prime != expected_prime
+            or self.vanishing_form_ids != expected_form_ids
+        ):
+            raise _validation_error(
+                "first local exclusion does not match the source forms"
+            )
+        return self
+
+
+class PrimeTupleIntervalResidueProfileRequest(StrictModel):
+    """Enumerate local-wheel survivors on one bounded closed integer interval."""
+
+    wheel: PrimeTupleResidueWheel
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+
+    @model_validator(mode="after")
+    def require_bounded_survivor_profile(self) -> Self:
+        _, _, interval_size = _parse_interval(self.lower, self.upper)
+        if interval_size > MAX_WHEEL_INTERVAL_LENGTH:
+            raise _validation_error(
+                f"wheel interval length {interval_size} exceeds "
+                f"{MAX_WHEEL_INTERVAL_LENGTH}"
+            )
+        replay_work = 2 * interval_size * max(1, len(self.wheel.primes))
+        if replay_work > MAX_INTERVAL_REPLAY_EVALUATIONS:
+            raise _validation_error(
+                f"wheel interval profile and validation need {replay_work} "
+                f"modular checks, exceeding {MAX_INTERVAL_REPLAY_EVALUATIONS}"
+            )
+        endpoint_digits = max(_digits(self.lower), _digits(self.upper))
+        result_characters = (
+            len(self.wheel.model_dump_json())
+            + interval_size * (endpoint_digits + 4)
+            + 192
+        )
+        if result_characters > MAX_RESULT_CHARACTER_BUDGET:
+            raise _validation_error(
+                "wheel interval profile exceeds the conservative serialized bound"
+            )
+        return self
+
+
+class PrimeTupleIntervalResidueProfileResult(StrictModel):
+    """Exact local survivors; this value does not assert actual primality."""
+
+    wheel: PrimeTupleResidueWheel
+    lower: IntervalEndpointInteger
+    upper: IntervalEndpointInteger
+    interval_size: StrictInt = Field(ge=1, le=MAX_WHEEL_INTERVAL_LENGTH)
+    survivors: tuple[IntervalEndpointInteger, ...] = Field(
+        max_length=MAX_WHEEL_INTERVAL_LENGTH
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_survivor_family(self) -> Self:
+        PrimeTupleIntervalResidueProfileRequest(
+            wheel=self.wheel, lower=self.lower, upper=self.upper
+        )
+        lower, upper, interval_size = _parse_interval(self.lower, self.upper)
+        bad_by_prime = tuple(
+            {row.residue for row in summary.bad_residues}
+            for summary in self.wheel.local_rows
+        )
+        expected = tuple(
+            value
+            for value in range(lower, upper + 1)
+            if all(
+                value % prime not in bad
+                for prime, bad in zip(self.wheel.primes, bad_by_prime, strict=True)
+            )
+        )
+        actual = tuple(parse_canonical_integer(value) for value in self.survivors)
+        if actual != expected:
+            raise _validation_error(
+                "survivors must be the complete local wheel profile"
+            )
+        if self.interval_size != interval_size:
+            raise _validation_error("interval_size must equal upper-lower+1")
+        return self
+
+
+__all__ = [
+    "MAX_WHEEL_INTERVAL_LENGTH",
+    "MAX_WHEEL_PRIMES",
+    "MAX_WHEEL_RESIDUES",
+    "PrimeTupleIntervalResidueProfileRequest",
+    "PrimeTupleIntervalResidueProfileResult",
+    "PrimeTupleResidueWheel",
+    "PrimeTupleResidueWheelEnumeration",
+    "PrimeTupleResidueWheelEnumerationRequest",
+    "PrimeTupleResidueWheelRequest",
+    "PrimeTupleWheelMembershipRequest",
+    "PrimeTupleWheelMembershipResult",
+    "PrimeTupleWheelResidueRow",
+]

--- a/src/jacobian/math/prime_affine_forms/_tools.py
+++ b/src/jacobian/math/prime_affine_forms/_tools.py
@@ -6,39 +6,45 @@ from typing import Any
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
-from jacobian.math.prime_affine_forms._models import (
+from jacobian.math.prime_affine_forms._admissibility import (
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleAdmissibilityResult,
+    compute_local_admissibility,
+)
+from jacobian.math.prime_affine_forms._local_factors import (
     FinitePrimeTupleFactorProduct,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    compute_local_factor,
+    compute_local_factors,
+)
+from jacobian.math.prime_affine_forms._models import (
     PrimeAffineIntervalCountRequest,
     PrimeAffineIntervalEnumerateRequest,
     PrimeAffineTranslationRequest,
     PrimeAffineTranslationResult,
     PrimePatternIntervalCountResult,
     PrimePatternIntervalEnumerateResult,
-    PrimeTupleAdmissibilityRequest,
-    PrimeTupleAdmissibilityResult,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms._residue_wheel import (
     PrimeTupleIntervalResidueProfileRequest,
     PrimeTupleIntervalResidueProfileResult,
-    PrimeTupleLocalFactorRequest,
-    PrimeTupleLocalFactorResult,
-    PrimeTupleLocalFactorsRequest,
     PrimeTupleResidueWheel,
     PrimeTupleResidueWheelEnumeration,
     PrimeTupleResidueWheelEnumerationRequest,
     PrimeTupleResidueWheelRequest,
     PrimeTupleWheelMembershipRequest,
     PrimeTupleWheelMembershipResult,
-)
-from jacobian.math.prime_affine_forms._operations import (
-    compute_interval_count,
-    compute_interval_enumerate,
-    compute_interval_residue_profile,
-    compute_local_admissibility,
-    compute_local_factor,
-    compute_local_factors,
-    compute_residue_wheel,
-    compute_residue_wheel_enumeration,
-    compute_translation,
-    compute_wheel_membership,
 )
 
 

--- a/src/jacobian/math/prime_affine_forms/operations.py
+++ b/src/jacobian/math/prime_affine_forms/operations.py
@@ -3,39 +3,45 @@
 from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
-from jacobian.math.prime_affine_forms._models import (
+from jacobian.math.prime_affine_forms._admissibility import (
+    PrimeTupleAdmissibilityRequest,
+    PrimeTupleAdmissibilityResult,
+    compute_local_admissibility,
+)
+from jacobian.math.prime_affine_forms._local_factors import (
     FinitePrimeTupleFactorProduct,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    compute_local_factor,
+    compute_local_factors,
+)
+from jacobian.math.prime_affine_forms._models import (
     PrimeAffineIntervalCountRequest,
     PrimeAffineIntervalEnumerateRequest,
     PrimeAffineTranslationRequest,
     PrimeAffineTranslationResult,
     PrimePatternIntervalCountResult,
     PrimePatternIntervalEnumerateResult,
-    PrimeTupleAdmissibilityRequest,
-    PrimeTupleAdmissibilityResult,
+)
+from jacobian.math.prime_affine_forms._operations import (
+    compute_interval_count,
+    compute_interval_enumerate,
+    compute_interval_residue_profile,
+    compute_residue_wheel,
+    compute_residue_wheel_enumeration,
+    compute_translation,
+    compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms._residue_wheel import (
     PrimeTupleIntervalResidueProfileRequest,
     PrimeTupleIntervalResidueProfileResult,
-    PrimeTupleLocalFactorRequest,
-    PrimeTupleLocalFactorResult,
-    PrimeTupleLocalFactorsRequest,
     PrimeTupleResidueWheel,
     PrimeTupleResidueWheelEnumeration,
     PrimeTupleResidueWheelEnumerationRequest,
     PrimeTupleResidueWheelRequest,
     PrimeTupleWheelMembershipRequest,
     PrimeTupleWheelMembershipResult,
-)
-from jacobian.math.prime_affine_forms._operations import (
-    compute_interval_count,
-    compute_interval_enumerate,
-    compute_interval_residue_profile,
-    compute_local_admissibility,
-    compute_local_factor,
-    compute_local_factors,
-    compute_residue_wheel,
-    compute_residue_wheel_enumeration,
-    compute_translation,
-    compute_wheel_membership,
 )
 from jacobian.math.prime_affine_forms.values import PrimeAffineTuple
 

--- a/tests/math/prime_affine_forms/test_native_api.py
+++ b/tests/math/prime_affine_forms/test_native_api.py
@@ -19,29 +19,35 @@ from jacobian.math.prime_affine_forms import (
     translate_tuple,
     wheel_membership,
 )
+from jacobian.math.prime_affine_forms._admissibility import (
+    PrimeTupleAdmissibilityRequest,
+    compute_local_admissibility,
+)
+from jacobian.math.prime_affine_forms._local_factors import (
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorsRequest,
+    compute_local_factor,
+    compute_local_factors,
+)
 from jacobian.math.prime_affine_forms._models import (
     PrimeAffineIntervalCountRequest,
     PrimeAffineIntervalEnumerateRequest,
     PrimeAffineTranslationRequest,
-    PrimeTupleAdmissibilityRequest,
-    PrimeTupleIntervalResidueProfileRequest,
-    PrimeTupleLocalFactorRequest,
-    PrimeTupleLocalFactorsRequest,
-    PrimeTupleResidueWheelEnumerationRequest,
-    PrimeTupleResidueWheelRequest,
-    PrimeTupleWheelMembershipRequest,
 )
 from jacobian.math.prime_affine_forms._operations import (
     compute_interval_count,
     compute_interval_enumerate,
     compute_interval_residue_profile,
-    compute_local_admissibility,
-    compute_local_factor,
-    compute_local_factors,
     compute_residue_wheel,
     compute_residue_wheel_enumeration,
     compute_translation,
     compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms._residue_wheel import (
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
 )
 
 

--- a/tests/math/prime_affine_forms/test_prime_affine_forms.py
+++ b/tests/math/prime_affine_forms/test_prime_affine_forms.py
@@ -13,37 +13,43 @@ from jacobian.math.prime_affine_forms import (
     PrimeAffineTuple,
     PrimitiveIntegerAffineForm,
 )
-from jacobian.math.prime_affine_forms._models import (
+from jacobian.math.prime_affine_forms._admissibility import (
+    PrimeTupleAdmissibilityRequest,
+    compute_local_admissibility,
+)
+from jacobian.math.prime_affine_forms._local_factors import (
     FinitePrimeTupleFactorProduct,
+    PrimeTupleLocalFactorRequest,
+    PrimeTupleLocalFactorResult,
+    PrimeTupleLocalFactorsRequest,
+    compute_local_factor,
+    compute_local_factors,
+)
+from jacobian.math.prime_affine_forms._models import (
     PrimeAffineIntervalCountRequest,
     PrimeAffineIntervalEnumerateRequest,
     PrimeAffineTranslationRequest,
     PrimeAffineTranslationResult,
     PrimePatternIntervalCountResult,
     PrimePatternIntervalEnumerateResult,
-    PrimeTupleAdmissibilityRequest,
-    PrimeTupleIntervalResidueProfileRequest,
-    PrimeTupleLocalFactorRequest,
-    PrimeTupleLocalFactorResult,
-    PrimeTupleLocalFactorsRequest,
     PrimeTupleLocalSummary,
-    PrimeTupleResidueWheel,
-    PrimeTupleResidueWheelEnumeration,
-    PrimeTupleResidueWheelEnumerationRequest,
-    PrimeTupleResidueWheelRequest,
-    PrimeTupleWheelMembershipRequest,
 )
 from jacobian.math.prime_affine_forms._operations import (
     compute_interval_count,
     compute_interval_enumerate,
     compute_interval_residue_profile,
-    compute_local_admissibility,
-    compute_local_factor,
-    compute_local_factors,
     compute_residue_wheel,
     compute_residue_wheel_enumeration,
     compute_translation,
     compute_wheel_membership,
+)
+from jacobian.math.prime_affine_forms._residue_wheel import (
+    PrimeTupleIntervalResidueProfileRequest,
+    PrimeTupleResidueWheel,
+    PrimeTupleResidueWheelEnumeration,
+    PrimeTupleResidueWheelEnumerationRequest,
+    PrimeTupleResidueWheelRequest,
+    PrimeTupleWheelMembershipRequest,
 )
 from jacobian.math.prime_affine_forms._tools import TOOLS
 from jacobian.math.prime_affine_forms.values import MAX_AFFINE_AGGREGATE_DIGITS


### PR DESCRIPTION
Part of #2637.

## Problem

Prime-affine local factor, admissibility, and residue-wheel contracts shared one aggregate module despite being independent arithmetic families.

## Solution

Move each family to its owner-local contract and kernel module. Shared tuple, interval, and translation models remain neutral. Operation IDs, schemas, catalog membership, native interfaces, and behavior are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/prime_affine_forms` — 26 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- advertised catalog examples — 608 passed
- `uv run ruff check` and `uv run ruff format --check` — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This is an ownership refactor; the public operation surface is preserved.

## Checklist

- [ ] `make check` passes (the static phase passed; full suite completion is not claimed)