### PR TITLE
Partition core number-theory contracts by operation family

### DIFF
--- a/src/jacobian/math/number_theory/_direct_factorization_models.py
+++ b/src/jacobian/math/number_theory/_direct_factorization_models.py
@@ -1,0 +1,178 @@
+"""Typed contracts and source-bound replay for direct factorization.
+
+These models own the small, synchronous factorization envelope used by the
+divisor-enumeration and prime-factorization operations.  Certified
+factorization and primality certificates have a distinct, larger envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import Field, StringConstraints, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.number_theory._models import (
+    BoundedInteger,
+    PrimePower,
+    _validation_error,
+)
+
+# ``factorint`` is used both by the direct kernels and source-bound result
+# replay.  Twenty decimal digits keep a hard semiprime within the synchronous
+# envelope while still admitting ordinary exact divisor and factor workflows.
+MAX_DIRECT_FACTORIZATION_DIGITS = 20
+MAX_DIRECT_DIVISORS = 4_096
+MAX_DIRECT_FACTOR_ENTRIES = 256
+
+FactorizationInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^-?(?:0|[1-9][0-9]*)$",
+        max_length=MAX_DIRECT_FACTORIZATION_DIGITS,
+        strict=True,
+    ),
+]
+
+
+class FactorizationRequest(StrictModel):
+    """One bounded integer for direct exact factorization."""
+
+    value: FactorizationInteger
+
+
+class NonzeroFactorizationRequest(FactorizationRequest):
+    """One nonzero integer with a finite divisor and prime-factorization set."""
+
+    @model_validator(mode="after")
+    def require_nonzero_value(self) -> Self:
+        if int(self.value) == 0:
+            raise _validation_error(
+                "zero_has_no_finite_factorization_or_divisor_enumeration",
+                "zero has no finite factorization or divisor enumeration",
+            )
+        return self
+
+
+class DivisorListResult(StrictModel):
+    """An ordered list of positive divisors of one nonzero integer.
+
+    Retains the canonical source integer and the operation's divisor
+    convention so validation replays the exact enumeration: the list is
+    exactly all positive divisors of ``abs(value)`` (proper ones exclude
+    ``abs(value)`` itself) in ascending order.  The list may be empty:
+    ``proper_divisors(±1)`` has no positive proper divisors.  Zero remains
+    not-applicable (handled at the operation layer).  The source carries the
+    same 20-digit factorization bound as the producing requests, so replay
+    never factors outside the operation's admitted work envelope.
+    """
+
+    value: FactorizationInteger
+    divisors: tuple[BoundedInteger, ...] = Field(
+        min_length=0,
+        max_length=MAX_DIRECT_DIVISORS,
+    )
+    convention: Literal["ALL_POSITIVE_DIVISORS", "PROPER_DIVISORS"] = (
+        "ALL_POSITIVE_DIVISORS"
+    )
+
+    @model_validator(mode="after")
+    def require_source_enumeration(self) -> Self:
+        from jacobian.math.number_theory._factorization_kernels import (
+            _replayed_divisors,
+        )
+
+        values = [int(divisor) for divisor in self.divisors]
+        if any(value < 1 for value in values):
+            raise _validation_error(
+                "divisors_must_be_positive", "divisors must be positive"
+            )
+        if values != sorted(values):
+            raise _validation_error(
+                "divisors_must_be_ascending", "divisors must be ascending"
+            )
+        if len(set(values)) != len(values):
+            raise _validation_error(
+                "divisors_must_be_unique", "divisors must be unique"
+            )
+        value = int(self.value)
+        if value == 0:
+            raise _validation_error(
+                "zero_has_infinitely_many_divisors", "zero has infinitely many divisors"
+            )
+        if self.divisors != _replayed_divisors(
+            value, proper=self.convention == "PROPER_DIVISORS"
+        ):
+            raise _validation_error(
+                "divisor_list_must_enumerate_the_divisors_of_the_source",
+                "divisor list must enumerate the divisors of the source",
+            )
+        return self
+
+
+class PrimeFactorizationResult(StrictModel):
+    """The complete prime-power factorization of one nonzero integer.
+
+    Retains the canonical source integer so validation replays the defining
+    invariant: prime bases are strictly increasing proven primes with
+    positive exponents whose product reconstructs ``abs(value)`` exactly.
+    The factor list may be empty: ``±1`` has no prime factors.  Zero remains
+    not-applicable (handled at the operation layer).
+    """
+
+    value: BoundedInteger
+    factors: tuple[PrimePower, ...] = Field(
+        min_length=0,
+        max_length=MAX_DIRECT_FACTOR_ENTRIES,
+    )
+
+    @model_validator(mode="after")
+    def require_source_factorization(self) -> Self:
+        from sympy import isprime
+
+        primes = [factor.prime for factor in self.factors]
+        if len(set(primes)) != len(primes):
+            raise _validation_error(
+                "prime_factors_must_be_unique", "prime factors must be unique"
+            )
+        value = int(self.value)
+        if value == 0:
+            raise _validation_error(
+                "zero_has_no_finite_prime_factorization",
+                "zero has no finite prime factorization",
+            )
+        target = abs(value)
+        product = 1
+        previous_prime = 0
+        for factor in self.factors:
+            prime = int(factor.prime)
+            if prime <= previous_prime:
+                raise _validation_error(
+                    "prime_bases_must_be_strictly_ascending",
+                    "prime bases must be strictly ascending",
+                )
+            if prime < 2 or not isprime(prime):
+                raise _validation_error(
+                    "f_factor_prime_is_not_prime", f"{factor.prime} is not prime"
+                )
+            power_value = 1
+            for _ in range(factor.power):
+                power_value *= prime
+                if power_value > target:
+                    raise _validation_error(
+                        "prime_powers_must_multiply_to_abs_value",
+                        "prime powers must multiply to abs(value)",
+                    )
+            product *= power_value
+            if product > target:
+                raise _validation_error(
+                    "prime_powers_must_multiply_to_abs_value",
+                    "prime powers must multiply to abs(value)",
+                )
+            previous_prime = prime
+        if product != target:
+            raise _validation_error(
+                "prime_powers_must_multiply_to_abs_value",
+                "prime powers must multiply to abs(value)",
+            )
+        return self

--- a/src/jacobian/math/number_theory/_divisibility.py
+++ b/src/jacobian/math/number_theory/_divisibility.py
@@ -2,6 +2,12 @@
 
 from jacobian.catalog._examples import example
 from jacobian.math.arithmetic.values import IntegerValue
+from jacobian.math.number_theory._divisibility_models import (
+    DivisibilityRequest,
+    ExtendedGcdResult,
+    IntegerPairRequest,
+    ValuationRequest,
+)
 from jacobian.math.number_theory._divisibility_operations import (
     compute_aliquot_sum,
     compute_divisor_count,
@@ -22,12 +28,8 @@ from jacobian.math.number_theory._divisibility_operations import (
 from jacobian.math.number_theory._factorization import FACTORIZATION_OPERATIONS
 from jacobian.math.number_theory._models import (
     BooleanResult,
-    DivisibilityRequest,
-    ExtendedGcdResult,
-    IntegerPairRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
-    ValuationRequest,
 )
 from jacobian.math.number_theory._support import (
     number_theory_operation,

--- a/src/jacobian/math/number_theory/_divisibility_models.py
+++ b/src/jacobian/math/number_theory/_divisibility_models.py
@@ -1,0 +1,70 @@
+"""Typed contracts owned by integer divisibility operations."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.number_theory._models import BoundedInteger, _validation_error
+
+
+class IntegerPairRequest(StrictModel):
+    """Two canonical integers supplied to a symmetric binary operation."""
+
+    left: BoundedInteger
+    right: BoundedInteger
+
+
+class DivisibilityRequest(StrictModel):
+    """A divisor and dividend supplied to a divisibility predicate."""
+
+    divisor: BoundedInteger
+    dividend: BoundedInteger
+
+    @model_validator(mode="after")
+    def require_nonzero_divisor(self) -> Self:
+        if int(self.divisor) == 0:
+            raise _validation_error(
+                "divisor_must_be_nonzero", "divisor must be nonzero"
+            )
+        return self
+
+
+class ValuationRequest(StrictModel):
+    """One integer and a prime base supplied to a p-adic valuation."""
+
+    value: BoundedInteger
+    prime: BoundedInteger
+
+    @model_validator(mode="after")
+    def require_valid_valuation_domain(self) -> Self:
+        from sympy import isprime
+
+        if int(self.value) == 0:
+            raise _validation_error(
+                "valuation_requires_nonzero_value", "valuation requires nonzero value"
+            )
+        if int(self.prime) < 2 or not isprime(int(self.prime)):
+            raise _validation_error(
+                "valuation_requires_a_prime_absolute_base_2",
+                "valuation requires a prime absolute base >= 2",
+            )
+        return self
+
+
+class ExtendedGcdResult(StrictModel):
+    """A gcd together with exact Bezout coefficients."""
+
+    gcd: BoundedInteger
+    left_coefficient: BoundedInteger
+    right_coefficient: BoundedInteger
+
+
+__all__ = [
+    "DivisibilityRequest",
+    "ExtendedGcdResult",
+    "IntegerPairRequest",
+    "ValuationRequest",
+]

--- a/src/jacobian/math/number_theory/_divisibility_operations.py
+++ b/src/jacobian/math/number_theory/_divisibility_operations.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import math
 
 from jacobian.math.arithmetic.values import IntegerValue
-from jacobian.math.number_theory._models import (
-    BooleanResult,
+from jacobian.math.number_theory._divisibility_models import (
     DivisibilityRequest,
     ExtendedGcdResult,
     IntegerPairRequest,
+    ValuationRequest,
+)
+from jacobian.math.number_theory._models import (
+    BooleanResult,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
-    ValuationRequest,
 )
 
 

--- a/src/jacobian/math/number_theory/_factorization.py
+++ b/src/jacobian/math/number_theory/_factorization.py
@@ -8,6 +8,11 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.arithmetic.values import IntegerValue
+from jacobian.math.number_theory._direct_factorization_models import (
+    DivisorListResult,
+    NonzeroFactorizationRequest,
+    PrimeFactorizationResult,
+)
 from jacobian.math.number_theory._factorization_kernels import (
     compute_pratt_certificate,
     compute_radical,
@@ -22,11 +27,8 @@ from jacobian.math.number_theory._models import (
     BooleanResult,
     CertifiedFactorizationRequest,
     CertifiedFactorizationResult,
-    DivisorListResult,
-    NonzeroFactorizationRequest,
     PrimalityCertificateRequest,
     PrimalityCertificateResult,
-    PrimeFactorizationResult,
 )
 
 

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -6,18 +6,20 @@ import math
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.arithmetic.values import IntegerValue
+from jacobian.math.number_theory._direct_factorization_models import (
+    DivisorListResult,
+    FactorizationRequest,
+    PrimeFactorizationResult,
+)
 from jacobian.math.number_theory._models import (
     ArithmeticFunctionRequest,
     BooleanResult,
     CertifiedFactor,
     CertifiedFactorizationRequest,
     CertifiedFactorizationResult,
-    DivisorListResult,
-    FactorizationRequest,
     PrattCertificateNode,
     PrimalityCertificateRequest,
     PrimalityCertificateResult,
-    PrimeFactorizationResult,
     PrimePower,
 )
 

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -294,50 +294,6 @@ class ArithmeticFunctionRequest(StrictModel):
     n: StrictInt = Field(ge=0, le=_MAX_N_SMALL)
 
 
-class IntegerPairRequest(StrictModel):
-    """Two canonical integers supplied to a symmetric binary operation."""
-
-    left: BoundedInteger
-    right: BoundedInteger
-
-
-class DivisibilityRequest(StrictModel):
-    """A divisor and dividend supplied to a divisibility predicate."""
-
-    divisor: BoundedInteger
-    dividend: BoundedInteger
-
-    @model_validator(mode="after")
-    def require_nonzero_divisor(self) -> Self:
-        if int(self.divisor) == 0:
-            raise _validation_error(
-                "divisor_must_be_nonzero", "divisor must be nonzero"
-            )
-        return self
-
-
-class ValuationRequest(StrictModel):
-    """One integer and a prime base supplied to a p-adic valuation."""
-
-    value: BoundedInteger
-    prime: BoundedInteger
-
-    @model_validator(mode="after")
-    def require_valid_valuation_domain(self) -> Self:
-        from sympy import isprime
-
-        if int(self.value) == 0:
-            raise _validation_error(
-                "valuation_requires_nonzero_value", "valuation requires nonzero value"
-            )
-        if int(self.prime) < 2 or not isprime(int(self.prime)):
-            raise _validation_error(
-                "valuation_requires_a_prime_absolute_base_2",
-                "valuation requires a prime absolute base >= 2",
-            )
-        return self
-
-
 # ---------------------------------------------------------------------------
 # Request models — bounded non-negative / positive integers
 # ---------------------------------------------------------------------------
@@ -739,14 +695,6 @@ class PrimorialResult(StrictModel):
     """The primorial (product of the first n primes)."""
 
     value: PrimorialInteger
-
-
-class ExtendedGcdResult(StrictModel):
-    """A gcd together with exact Bezout coefficients."""
-
-    gcd: BoundedInteger
-    left_coefficient: BoundedInteger
-    right_coefficient: BoundedInteger
 
 
 class DivisorListResult(StrictModel):

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -98,10 +98,14 @@ BoundedInteger = Annotated[
         strict=True,
     ),
 ]
+
+
 class PrimalityRequest(StrictModel):
     """One bounded canonical integer for the maintained primality backend."""
 
     value: BoundedInteger
+
+
 PowerfulInteger = Annotated[
     str,
     StringConstraints(

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -12,29 +12,12 @@ integer nth root).
 from __future__ import annotations
 
 import math
-from collections import Counter
-from itertools import product
 from typing import Annotated, Literal, Self
 
-from pydantic import (
-    Field,
-    StrictBool,
-    StrictInt,
-    StringConstraints,
-    WithJsonSchema,
-    model_validator,
-)
-from pydantic.json_schema import JsonSchemaValue
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
-from jacobian.math.modular_polynomials import _INTEGER as _TERM_INTEGER
-from jacobian.math.modular_polynomials import (
-    ModularPolynomialTerm as _ModularPolynomialTerm,
-)
-from jacobian.math.modular_polynomials import (
-    NormalizedModularPolynomialTerm as _NormalizedModularPolynomialTerm,
-)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
@@ -97,12 +80,6 @@ _MAX_CRT_SIZE = 64
 _MAX_CRT_COMBINED_MODULUS = 10**_MAX_INTEGER_LENGTH
 _MAX_DIVISORS = 4_096
 _MAX_FACTOR_ENTRIES = 256
-_MAX_RESIDUE_VARIABLES = 6
-_MAX_RESIDUE_DOMAIN_SIZE = 32
-_MAX_RESIDUE_TERMS = 64
-_MAX_RESIDUE_EXPONENT = 32
-_MAX_RESIDUE_ASSIGNMENTS = 4_096
-_MAX_POLYNOMIAL_RESIDUE_MODULUS = 1_000_000
 
 # Friable counting has two exact, result-sensitive execution regimes. The
 # materialized regime uses one bytearray for primality and one for friability;
@@ -158,26 +135,6 @@ CertifiedFactorizationInteger = Annotated[
         max_length=_MAX_CERTIFIED_FACTORIZATION_LENGTH,
         strict=True,
     ),
-]
-ResidueVariableName = Annotated[
-    str,
-    StringConstraints(
-        pattern=r"^[a-z][a-z0-9_]{0,31}$",
-        max_length=32,
-        strict=True,
-    ),
-]
-ResidueDomain = Annotated[
-    tuple[StrictInt, ...],
-    Field(min_length=1, max_length=_MAX_RESIDUE_DOMAIN_SIZE),
-]
-ResidueAssignment = Annotated[
-    tuple[StrictInt, ...],
-    Field(min_length=1, max_length=_MAX_RESIDUE_VARIABLES),
-]
-CanonicalResidue = Annotated[
-    StrictInt,
-    Field(ge=0, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS),
 ]
 
 type _FriableRegime = Literal["DIRECT", "MATERIALIZED", "GENERATED"]
@@ -382,8 +339,8 @@ class FriableCountRequest(StrictModel):
 
     x: BoundedInteger = Field(
         description=(
-            f"Canonical nonnegative inclusive source bound. Easy boundary cases may "
-            f"use up to {_MAX_FRIABLE_SOURCE_DIGITS} decimal digits; other cases must fit an exact counting "
+            "Canonical nonnegative inclusive source bound. Easy boundary cases may "
+            "use up to 256 decimal digits; other cases must fit an exact counting "
             "regime selected from the source-sensitive work bounds."
         ),
         examples=["100"],
@@ -468,129 +425,6 @@ class ModulusRequest(StrictModel):
     """A single bounded modulus (2 <= modulus <= 1 000 000)."""
 
     modulus: StrictInt = Field(ge=2, le=_MAX_MODULUS)
-
-
-class ModularPolynomialVariable(StrictModel):
-    """One named variable and its canonical finite residue domain."""
-
-    name: ResidueVariableName
-    residues: ResidueDomain
-
-    @model_validator(mode="after")
-    def require_canonical_domain(self) -> Self:
-        if any(residue < 0 for residue in self.residues):
-            raise _validation_error(
-                "variable_residues_must_be_nonnegative",
-                "variable residues must be nonnegative",
-            )
-        if self.residues != tuple(sorted(set(self.residues))):
-            raise _validation_error(
-                "variable_residues_must_be_strictly_increasing",
-                "variable residues must be strictly increasing",
-            )
-        return self
-
-
-def _residue_image_term_schema() -> JsonSchemaValue:
-    """Project the shared term schema onto residue-image admission.
-
-    ``ModularPolynomialTerm`` publishes the widest consumer envelope: any
-    canonical-integer string of a sign plus 256 digits and up to 20 exponents
-    of magnitude 256. Residue-image admission rejects any coefficient string
-    longer than ``_MAX_INTEGER_LENGTH`` characters, exponent magnitudes
-    above ``_MAX_RESIDUE_EXPONENT``, and — because every exponent vector
-    must match at most ``_MAX_RESIDUE_VARIABLES`` variables — vectors longer
-    than six entries. Discovery publishes exactly that narrower envelope so
-    schema-driven callers never submit a term the request validator rejects.
-    The coefficient pattern is the shared type's own canonical-integer
-    grammar — the same compiled pattern its ``field_validator`` enforces —
-    so the published grammar cannot drift from runtime parsing. Validation
-    itself stays with the shared runtime type.
-    """
-
-    schema = _ModularPolynomialTerm.model_json_schema()
-    coefficient = schema["properties"]["coefficient"]
-    coefficient["maxLength"] = _MAX_INTEGER_LENGTH
-    coefficient["pattern"] = _TERM_INTEGER.pattern
-    exponents = schema["properties"]["exponents"]
-    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
-    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
-    return schema
-
-
-ResidueImagePolynomialTerm = Annotated[
-    _ModularPolynomialTerm,
-    WithJsonSchema(_residue_image_term_schema()),
-]
-
-
-class ModularPolynomialResidueImageRequest(StrictModel):
-    """A bounded sparse polynomial over declared finite residue domains."""
-
-    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
-    variables: tuple[ModularPolynomialVariable, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_VARIABLES,
-    )
-    terms: tuple[ResidueImagePolynomialTerm, ...] = Field(
-        min_length=0,
-        max_length=_MAX_RESIDUE_TERMS,
-    )
-
-    @model_validator(mode="after")
-    def require_canonical_bounded_polynomial(self) -> Self:
-        variable_names = [variable.name for variable in self.variables]
-        if len(variable_names) != len(set(variable_names)):
-            raise _validation_error(
-                "polynomial_variable_names_must_be_unique",
-                "polynomial variable names must be unique",
-            )
-        if any(
-            residue >= self.modulus
-            for variable in self.variables
-            for residue in variable.residues
-        ):
-            raise _validation_error(
-                "every_variable_residue_must_be_less_than_the_modulus",
-                "every variable residue must be less than the modulus",
-            )
-        assignment_count = math.prod(
-            len(variable.residues) for variable in self.variables
-        )
-        if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
-            raise _validation_error(
-                "declared_residue_domains_exceed_the_4_096_assignment_bound",
-                "declared residue domains exceed the 4,096-assignment bound",
-            )
-        if any(len(term.exponents) != len(self.variables) for term in self.terms):
-            raise _validation_error(
-                "every_term_exponent_vector_must_match_the_variable_count",
-                "every term exponent vector must match the variable count",
-            )
-        if any(
-            len(term.coefficient) > _MAX_INTEGER_LENGTH
-            or any(
-                exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
-                for exponent in term.exponents
-            )
-            for term in self.terms
-        ):
-            raise _validation_error(
-                "term_outside_residue_image_admission",
-                "term coefficient or exponents exceed the residue-image admission",
-            )
-        exponent_vectors = [term.exponents for term in self.terms]
-        if exponent_vectors != sorted(set(exponent_vectors)):
-            raise _validation_error(
-                "term_exponent_vectors_must_be_unique_and_lexicographically_increasing",
-                "term exponent vectors must be unique and lexicographically increasing",
-            )
-        if any(int(term.coefficient) % self.modulus == 0 for term in self.terms):
-            raise _validation_error(
-                "sparse_polynomial_terms_must_have_nonzero_coefficient_modulo_m",
-                "sparse polynomial terms must have nonzero coefficient modulo m",
-            )
-        return self
 
 
 class ChineseRemainderRequest(StrictModel):
@@ -915,242 +749,6 @@ class QuadraticResiduesResult(StrictModel):
     """All quadratic residues modulo one modulus."""
 
     residues: tuple[BoundedInteger, ...]
-
-
-def _residue_image_normalized_term_schema() -> JsonSchemaValue:
-    """Project the shared normalized term schema onto residue-image results.
-
-    ``NormalizedModularPolynomialTerm`` publishes the widest consumer
-    envelope: up to 20 exponent entries of arbitrary magnitude.
-    ``_validate_residue_image_shape`` rejects every normalized term whose
-    exponent vector differs from ``variable_order`` — itself capped at
-    ``_MAX_RESIDUE_VARIABLES`` entries — or carries an exponent outside
-    0..``_MAX_RESIDUE_EXPONENT``. Discovery publishes exactly that shape so
-    both residue-image operations advertise only results their declared
-    model can produce or parse. Validation itself stays with the shared
-    runtime type.
-    """
-
-    schema = _NormalizedModularPolynomialTerm.model_json_schema()
-    exponents = schema["properties"]["exponents"]
-    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
-    exponents["items"]["minimum"] = 0
-    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
-    return schema
-
-
-ResidueImageNormalizedPolynomialTerm = Annotated[
-    _NormalizedModularPolynomialTerm,
-    WithJsonSchema(_residue_image_normalized_term_schema()),
-]
-
-
-class ModularPolynomialResidueCount(StrictModel):
-    """Multiplicity of one reachable residue in the declared assignment table."""
-
-    residue: CanonicalResidue
-    count: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
-
-
-class ModularPolynomialResidueWitness(StrictModel):
-    """The first lexicographic assignment reaching one residue."""
-
-    residue: CanonicalResidue
-    assignment: ResidueAssignment
-
-
-class ModularPolynomialResidueTableRow(StrictModel):
-    """One exact assignment-to-residue evaluation."""
-
-    assignment: ResidueAssignment
-    residue: CanonicalResidue
-
-
-class ModularPolynomialResidueImageResult(StrictModel):
-    """Exact residue-image summary with an optional complete assignment table."""
-
-    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
-    variable_order: tuple[ResidueVariableName, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_VARIABLES,
-    )
-    domains: tuple[ResidueDomain, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_VARIABLES,
-    )
-    normalized_terms: tuple[ResidueImageNormalizedPolynomialTerm, ...] = Field(
-        min_length=0,
-        max_length=_MAX_RESIDUE_TERMS,
-    )
-    enumeration_scope: Literal["COMPLETE_DECLARED_CARTESIAN_PRODUCT"]
-    total_assignments: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
-    image: tuple[CanonicalResidue, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_ASSIGNMENTS,
-    )
-    residue_counts: tuple[ModularPolynomialResidueCount, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_ASSIGNMENTS,
-    )
-    witnesses: tuple[ModularPolynomialResidueWitness, ...] = Field(
-        min_length=1,
-        max_length=_MAX_RESIDUE_ASSIGNMENTS,
-    )
-    table: tuple[ModularPolynomialResidueTableRow, ...] | None = Field(
-        default=None,
-        min_length=1,
-        max_length=_MAX_RESIDUE_ASSIGNMENTS,
-    )
-
-    @model_validator(mode="after")
-    def bind_complete_residue_image(self) -> Self:
-        assignments = _validate_residue_image_shape(self)
-        residues = _validate_residue_image_table(self, assignments)
-        _validate_residue_image_summaries(self, assignments, residues)
-        return self
-
-
-def _evaluate_normalized_modular_polynomial(
-    terms: tuple[_NormalizedModularPolynomialTerm, ...],
-    assignment: tuple[int, ...],
-    modulus: int,
-) -> int:
-    value = 0
-    for term in terms:
-        monomial = term.coefficient
-        for coordinate, exponent in zip(
-            assignment,
-            term.exponents,
-            strict=True,
-        ):
-            monomial = monomial * pow(coordinate, exponent, modulus) % modulus
-        value = (value + monomial) % modulus
-    return value
-
-
-def _validate_residue_image_shape(
-    result: ModularPolynomialResidueImageResult,
-) -> tuple[tuple[int, ...], ...]:
-    if len(set(result.variable_order)) != len(result.variable_order):
-        raise _validation_error(
-            "result_variable_names_must_be_unique",
-            "result variable names must be unique",
-        )
-    if len(result.domains) != len(result.variable_order):
-        raise _validation_error(
-            "result_domains_must_match_the_variable_count",
-            "result domains must match the variable count",
-        )
-    if any(
-        domain != tuple(sorted(set(domain)))
-        or any(residue < 0 or residue >= result.modulus for residue in domain)
-        for domain in result.domains
-    ):
-        raise _validation_error(
-            "result_domains_must_contain_canonical_increasing_residues",
-            "result domains must contain canonical increasing residues",
-        )
-    if any(
-        len(term.exponents) != len(result.variable_order)
-        or term.coefficient >= result.modulus
-        or any(
-            exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
-            for exponent in term.exponents
-        )
-        for term in result.normalized_terms
-    ):
-        raise _validation_error(
-            "normalized_terms_do_not_match_the_result_scope",
-            "normalized terms do not match the result scope",
-        )
-    exponent_vectors = [term.exponents for term in result.normalized_terms]
-    if exponent_vectors != sorted(set(exponent_vectors)):
-        raise _validation_error(
-            "normalized_term_exponents_must_be_canonical",
-            "normalized term exponents must be canonical",
-        )
-    assignment_count = math.prod(len(domain) for domain in result.domains)
-    if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
-        raise _validation_error(
-            "result_domains_exceed_the_4_096_assignment_bound",
-            "result domains exceed the 4,096-assignment bound",
-        )
-    if result.total_assignments != assignment_count:
-        raise _validation_error(
-            "total_assignments_do_not_match_the_declared_domains",
-            "total assignments do not match the declared domains",
-        )
-    if result.table is not None and len(result.table) != assignment_count:
-        raise _validation_error(
-            "complete_table_length_does_not_match_the_declared_domains",
-            "complete table length does not match the declared domains",
-        )
-    assignments = tuple(product(*result.domains))
-    return assignments
-
-
-def _validate_residue_image_table(
-    result: ModularPolynomialResidueImageResult,
-    assignments: tuple[tuple[int, ...], ...],
-) -> tuple[int, ...]:
-    expected_residues = tuple(
-        _evaluate_normalized_modular_polynomial(
-            result.normalized_terms,
-            assignment,
-            result.modulus,
-        )
-        for assignment in assignments
-    )
-    if result.table is not None:
-        if tuple(row.assignment for row in result.table) != assignments:
-            raise _validation_error(
-                "complete_table_must_enumerate_the_declared_cartesian_product_in_order",
-                "complete table must enumerate the declared Cartesian product in order",
-            )
-        if tuple(row.residue for row in result.table) != expected_residues:
-            raise _validation_error(
-                "complete_table_contains_an_incorrect_polynomial_evaluation",
-                "complete table contains an incorrect polynomial evaluation",
-            )
-    return expected_residues
-
-
-def _validate_residue_image_summaries(
-    result: ModularPolynomialResidueImageResult,
-    assignments: tuple[tuple[int, ...], ...],
-    residues: tuple[int, ...],
-) -> None:
-    image = tuple(sorted(set(residues)))
-    if result.image != image:
-        raise _validation_error(
-            "residue_image_does_not_match_the_complete_table",
-            "residue image does not match the complete table",
-        )
-    counts = Counter(residues)
-    expected_counts = tuple(
-        ModularPolynomialResidueCount(residue=residue, count=counts[residue])
-        for residue in image
-    )
-    if result.residue_counts != expected_counts:
-        raise _validation_error(
-            "residue_counts_do_not_match_the_complete_table",
-            "residue counts do not match the complete table",
-        )
-    first_assignments: dict[int, tuple[int, ...]] = {}
-    for assignment, residue in zip(assignments, residues, strict=True):
-        first_assignments.setdefault(residue, assignment)
-    expected_witnesses = tuple(
-        ModularPolynomialResidueWitness(
-            residue=residue,
-            assignment=first_assignments[residue],
-        )
-        for residue in image
-    )
-    if result.witnesses != expected_witnesses:
-        raise _validation_error(
-            "residue_witnesses_must_be_the_first_table_assignments",
-            "residue witnesses must be the first table assignments",
-        )
 
 
 class ChineseRemainderResult(StrictModel):

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -31,10 +31,6 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 # ---------------------------------------------------------------------------
 
 _MAX_INTEGER_LENGTH = 256
-# FactorizationInteger covers 20-digit inputs; SymPy factorint (Pollard rho /
-# ECM) handles 20-digit semiprimes in ~0.2s, keeping the bounded
-# synchronous budget safe.
-_MAX_FACTORIZATION_LENGTH = 20
 MAX_POWERFUL_INTEGER_DIGITS = 25
 MAX_POWERFUL_CUTOFF = 100_000
 MAX_POWERFUL_FACTOR_ENTRIES = 42
@@ -78,8 +74,6 @@ _MAX_CRT_SIZE = 64
 # system must stay within the same width.  ``10 ** _MAX_INTEGER_LENGTH``
 # is the smallest excluded combined modulus (positive values only).
 _MAX_CRT_COMBINED_MODULUS = 10**_MAX_INTEGER_LENGTH
-_MAX_DIVISORS = 4_096
-_MAX_FACTOR_ENTRIES = 256
 
 # Friable counting has two exact, result-sensitive execution regimes. The
 # materialized regime uses one bytearray for primality and one for friability;
@@ -104,22 +98,10 @@ BoundedInteger = Annotated[
         strict=True,
     ),
 ]
-
-
 class PrimalityRequest(StrictModel):
     """One bounded canonical integer for the maintained primality backend."""
 
     value: BoundedInteger
-
-
-FactorizationInteger = Annotated[
-    str,
-    StringConstraints(
-        pattern=r"^-?(?:0|[1-9][0-9]*)$",
-        max_length=_MAX_FACTORIZATION_LENGTH,
-        strict=True,
-    ),
-]
 PowerfulInteger = Annotated[
     str,
     StringConstraints(
@@ -212,25 +194,6 @@ def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]
                 "generated friable counting exceeds the search-node budget",
             )
     return "GENERATED", primes
-
-
-class FactorizationRequest(StrictModel):
-    """One small integer for direct exact factorization in the server process."""
-
-    value: FactorizationInteger
-
-
-class NonzeroFactorizationRequest(FactorizationRequest):
-    """One nonzero integer with a finite divisor and prime-factorization set."""
-
-    @model_validator(mode="after")
-    def require_nonzero_value(self) -> Self:
-        if int(self.value) == 0:
-            raise _validation_error(
-                "zero_has_no_finite_factorization_or_divisor_enumeration",
-                "zero has no finite factorization or divisor enumeration",
-            )
-        return self
 
 
 class PowerfulNumberRequest(StrictModel):
@@ -531,135 +494,11 @@ class PrimorialResult(StrictModel):
     value: PrimorialInteger
 
 
-class DivisorListResult(StrictModel):
-    """An ordered list of positive divisors of one nonzero integer.
-
-    Retains the canonical source integer and the operation's divisor
-    convention so validation replays the exact enumeration: the list is
-    exactly all positive divisors of ``abs(value)`` (proper ones exclude
-    ``abs(value)`` itself) in ascending order.  The list may be empty:
-    ``proper_divisors(±1)`` has no positive proper divisors.  Zero remains
-    not-applicable (handled at the operation layer).  The source carries the
-    same 20-digit factorization bound as the producing requests, so replay
-    never factors outside the operation's admitted work envelope.
-    """
-
-    value: FactorizationInteger
-    divisors: tuple[BoundedInteger, ...] = Field(
-        min_length=0,
-        max_length=_MAX_DIVISORS,
-    )
-    convention: Literal["ALL_POSITIVE_DIVISORS", "PROPER_DIVISORS"] = (
-        "ALL_POSITIVE_DIVISORS"
-    )
-
-    @model_validator(mode="after")
-    def require_source_enumeration(self) -> Self:
-        from jacobian.math.number_theory._factorization_kernels import (
-            _replayed_divisors,
-        )
-
-        values = [int(divisor) for divisor in self.divisors]
-        if any(value < 1 for value in values):
-            raise _validation_error(
-                "divisors_must_be_positive", "divisors must be positive"
-            )
-        if values != sorted(values):
-            raise _validation_error(
-                "divisors_must_be_ascending", "divisors must be ascending"
-            )
-        if len(set(values)) != len(values):
-            raise _validation_error(
-                "divisors_must_be_unique", "divisors must be unique"
-            )
-        value = int(self.value)
-        if value == 0:
-            raise _validation_error(
-                "zero_has_infinitely_many_divisors", "zero has infinitely many divisors"
-            )
-        if self.divisors != _replayed_divisors(
-            value, proper=self.convention == "PROPER_DIVISORS"
-        ):
-            raise _validation_error(
-                "divisor_list_must_enumerate_the_divisors_of_the_source",
-                "divisor list must enumerate the divisors of the source",
-            )
-        return self
-
-
 class PrimePower(StrictModel):
     """One prime base and its exponent in a prime factorization."""
 
     prime: BoundedInteger
     power: int = Field(ge=1, le=_MAX_N_SMALL)
-
-
-class PrimeFactorizationResult(StrictModel):
-    """The complete prime-power factorization of one nonzero integer.
-
-    Retains the canonical source integer so validation replays the defining
-    invariant: prime bases are strictly increasing proven primes with
-    positive exponents whose product reconstructs ``abs(value)`` exactly.
-    The factor list may be empty: ``±1`` has no prime factors.  Zero remains
-    not-applicable (handled at the operation layer).
-    """
-
-    value: BoundedInteger
-    factors: tuple[PrimePower, ...] = Field(
-        min_length=0,
-        max_length=_MAX_FACTOR_ENTRIES,
-    )
-
-    @model_validator(mode="after")
-    def require_source_factorization(self) -> Self:
-        from sympy import isprime
-
-        primes = [factor.prime for factor in self.factors]
-        if len(set(primes)) != len(primes):
-            raise _validation_error(
-                "prime_factors_must_be_unique", "prime factors must be unique"
-            )
-        value = int(self.value)
-        if value == 0:
-            raise _validation_error(
-                "zero_has_no_finite_prime_factorization",
-                "zero has no finite prime factorization",
-            )
-        target = abs(value)
-        product = 1
-        previous_prime = 0
-        for factor in self.factors:
-            prime = int(factor.prime)
-            if prime <= previous_prime:
-                raise _validation_error(
-                    "prime_bases_must_be_strictly_ascending",
-                    "prime bases must be strictly ascending",
-                )
-            if prime < 2 or not isprime(prime):
-                raise _validation_error(
-                    "f_factor_prime_is_not_prime", f"{factor.prime} is not prime"
-                )
-            power_value = 1
-            for _ in range(factor.power):
-                power_value *= prime
-                if power_value > target:
-                    raise _validation_error(
-                        "prime_powers_must_multiply_to_abs_value",
-                        "prime powers must multiply to abs(value)",
-                    )
-            product *= power_value
-            if product > target:
-                raise _validation_error(
-                    "prime_powers_must_multiply_to_abs_value",
-                    "prime powers must multiply to abs(value)",
-                )
-            previous_prime = prime
-        if product != target:
-            raise _validation_error(
-                "prime_powers_must_multiply_to_abs_value",
-                "prime powers must multiply to abs(value)",
-            )
-        return self
 
 
 class ResidualPerfectPower(StrictModel):

--- a/src/jacobian/math/number_theory/_modular.py
+++ b/src/jacobian/math/number_theory/_modular.py
@@ -10,11 +10,13 @@ from jacobian.math.number_theory._models import (
     ChineseRemainderResult,
     JacobiSymbolRequest,
     JacobiSymbolResult,
-    ModularPolynomialResidueImageRequest,
-    ModularPolynomialResidueImageResult,
     ModularUnitRequest,
     ModulusRequest,
     QuadraticResiduesResult,
+)
+from jacobian.math.number_theory._modular_models import (
+    ModularPolynomialResidueImageRequest,
+    ModularPolynomialResidueImageResult,
 )
 from jacobian.math.number_theory._modular_operations import (
     compute_jacobi_symbol,

--- a/src/jacobian/math/number_theory/_modular_models.py
+++ b/src/jacobian/math/number_theory/_modular_models.py
@@ -1,0 +1,391 @@
+"""Typed contracts for bounded modular polynomial residue images."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from itertools import product
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    Field,
+    StrictInt,
+    StringConstraints,
+    WithJsonSchema,
+    model_validator,
+)
+from pydantic.json_schema import JsonSchemaValue
+
+from jacobian._models import StrictModel
+from jacobian.math.modular_polynomials import _INTEGER as _TERM_INTEGER
+from jacobian.math.modular_polynomials import (
+    ModularPolynomialTerm as _ModularPolynomialTerm,
+)
+from jacobian.math.modular_polynomials import (
+    NormalizedModularPolynomialTerm as _NormalizedModularPolynomialTerm,
+)
+from jacobian.math.number_theory._models import (
+    _MAX_INTEGER_LENGTH,
+    _validation_error,
+)
+
+_MAX_RESIDUE_VARIABLES = 6
+_MAX_RESIDUE_DOMAIN_SIZE = 32
+_MAX_RESIDUE_TERMS = 64
+_MAX_RESIDUE_EXPONENT = 32
+_MAX_RESIDUE_ASSIGNMENTS = 4_096
+_MAX_POLYNOMIAL_RESIDUE_MODULUS = 1_000_000
+
+ResidueVariableName = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9_]{0,31}$",
+        max_length=32,
+        strict=True,
+    ),
+]
+ResidueDomain = Annotated[
+    tuple[StrictInt, ...],
+    Field(min_length=1, max_length=_MAX_RESIDUE_DOMAIN_SIZE),
+]
+ResidueAssignment = Annotated[
+    tuple[StrictInt, ...],
+    Field(min_length=1, max_length=_MAX_RESIDUE_VARIABLES),
+]
+CanonicalResidue = Annotated[
+    StrictInt,
+    Field(ge=0, lt=_MAX_POLYNOMIAL_RESIDUE_MODULUS),
+]
+
+
+class ModularPolynomialVariable(StrictModel):
+    """One named variable and its canonical finite residue domain."""
+
+    name: ResidueVariableName
+    residues: ResidueDomain
+
+    @model_validator(mode="after")
+    def require_canonical_domain(self) -> Self:
+        if any(residue < 0 for residue in self.residues):
+            raise _validation_error(
+                "variable_residues_must_be_nonnegative",
+                "variable residues must be nonnegative",
+            )
+        if self.residues != tuple(sorted(set(self.residues))):
+            raise _validation_error(
+                "variable_residues_must_be_strictly_increasing",
+                "variable residues must be strictly increasing",
+            )
+        return self
+
+
+def _residue_image_term_schema() -> JsonSchemaValue:
+    """Project the shared term schema onto residue-image admission."""
+
+    schema = _ModularPolynomialTerm.model_json_schema()
+    coefficient = schema["properties"]["coefficient"]
+    coefficient["maxLength"] = _MAX_INTEGER_LENGTH
+    coefficient["pattern"] = _TERM_INTEGER.pattern
+    exponents = schema["properties"]["exponents"]
+    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
+    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
+    return schema
+
+
+ResidueImagePolynomialTerm = Annotated[
+    _ModularPolynomialTerm,
+    WithJsonSchema(_residue_image_term_schema()),
+]
+
+
+class ModularPolynomialResidueImageRequest(StrictModel):
+    """A bounded sparse polynomial over declared finite residue domains."""
+
+    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
+    variables: tuple[ModularPolynomialVariable, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    terms: tuple[ResidueImagePolynomialTerm, ...] = Field(
+        min_length=0,
+        max_length=_MAX_RESIDUE_TERMS,
+    )
+
+    @model_validator(mode="after")
+    def require_canonical_bounded_polynomial(self) -> Self:
+        variable_names = [variable.name for variable in self.variables]
+        if len(variable_names) != len(set(variable_names)):
+            raise _validation_error(
+                "polynomial_variable_names_must_be_unique",
+                "polynomial variable names must be unique",
+            )
+        if any(
+            residue >= self.modulus
+            for variable in self.variables
+            for residue in variable.residues
+        ):
+            raise _validation_error(
+                "every_variable_residue_must_be_less_than_the_modulus",
+                "every variable residue must be less than the modulus",
+            )
+        assignment_count = math.prod(
+            len(variable.residues) for variable in self.variables
+        )
+        if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
+            raise _validation_error(
+                "declared_residue_domains_exceed_the_4_096_assignment_bound",
+                "declared residue domains exceed the 4,096-assignment bound",
+            )
+        if any(len(term.exponents) != len(self.variables) for term in self.terms):
+            raise _validation_error(
+                "every_term_exponent_vector_must_match_the_variable_count",
+                "every term exponent vector must match the variable count",
+            )
+        if any(
+            len(term.coefficient) > _MAX_INTEGER_LENGTH
+            or any(
+                exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
+                for exponent in term.exponents
+            )
+            for term in self.terms
+        ):
+            raise _validation_error(
+                "term_outside_residue_image_admission",
+                "term coefficient or exponents exceed the residue-image admission",
+            )
+        exponent_vectors = [term.exponents for term in self.terms]
+        if exponent_vectors != sorted(set(exponent_vectors)):
+            raise _validation_error(
+                "term_exponent_vectors_must_be_unique_and_lexicographically_increasing",
+                "term exponent vectors must be unique and lexicographically increasing",
+            )
+        if any(int(term.coefficient) % self.modulus == 0 for term in self.terms):
+            raise _validation_error(
+                "sparse_polynomial_terms_must_have_nonzero_coefficient_modulo_m",
+                "sparse polynomial terms must have nonzero coefficient modulo m",
+            )
+        return self
+
+
+def _residue_image_normalized_term_schema() -> JsonSchemaValue:
+    """Project the shared normalized term schema onto residue-image results."""
+
+    schema = _NormalizedModularPolynomialTerm.model_json_schema()
+    exponents = schema["properties"]["exponents"]
+    exponents["maxItems"] = _MAX_RESIDUE_VARIABLES
+    exponents["items"]["minimum"] = 0
+    exponents["items"]["maximum"] = _MAX_RESIDUE_EXPONENT
+    return schema
+
+
+ResidueImageNormalizedPolynomialTerm = Annotated[
+    _NormalizedModularPolynomialTerm,
+    WithJsonSchema(_residue_image_normalized_term_schema()),
+]
+
+
+class ModularPolynomialResidueCount(StrictModel):
+    """Multiplicity of one reachable residue in the declared assignment table."""
+
+    residue: CanonicalResidue
+    count: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
+
+
+class ModularPolynomialResidueWitness(StrictModel):
+    """The first lexicographic assignment reaching one residue."""
+
+    residue: CanonicalResidue
+    assignment: ResidueAssignment
+
+
+class ModularPolynomialResidueTableRow(StrictModel):
+    """One exact assignment-to-residue evaluation."""
+
+    assignment: ResidueAssignment
+    residue: CanonicalResidue
+
+
+class ModularPolynomialResidueImageResult(StrictModel):
+    """Exact residue-image summary with an optional complete assignment table."""
+
+    modulus: StrictInt = Field(ge=2, le=_MAX_POLYNOMIAL_RESIDUE_MODULUS)
+    variable_order: tuple[ResidueVariableName, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    domains: tuple[ResidueDomain, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_VARIABLES,
+    )
+    normalized_terms: tuple[ResidueImageNormalizedPolynomialTerm, ...] = Field(
+        min_length=0,
+        max_length=_MAX_RESIDUE_TERMS,
+    )
+    enumeration_scope: Literal["COMPLETE_DECLARED_CARTESIAN_PRODUCT"]
+    total_assignments: StrictInt = Field(ge=1, le=_MAX_RESIDUE_ASSIGNMENTS)
+    image: tuple[CanonicalResidue, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    residue_counts: tuple[ModularPolynomialResidueCount, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    witnesses: tuple[ModularPolynomialResidueWitness, ...] = Field(
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+    table: tuple[ModularPolynomialResidueTableRow, ...] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=_MAX_RESIDUE_ASSIGNMENTS,
+    )
+
+    @model_validator(mode="after")
+    def bind_complete_residue_image(self) -> Self:
+        assignments = _validate_residue_image_shape(self)
+        residues = _validate_residue_image_table(self, assignments)
+        _validate_residue_image_summaries(self, assignments, residues)
+        return self
+
+
+def _evaluate_normalized_modular_polynomial(
+    terms: tuple[_NormalizedModularPolynomialTerm, ...],
+    assignment: tuple[int, ...],
+    modulus: int,
+) -> int:
+    value = 0
+    for term in terms:
+        monomial = term.coefficient
+        for coordinate, exponent in zip(
+            assignment,
+            term.exponents,
+            strict=True,
+        ):
+            monomial = monomial * pow(coordinate, exponent, modulus) % modulus
+        value = (value + monomial) % modulus
+    return value
+
+
+def _validate_residue_image_shape(
+    result: ModularPolynomialResidueImageResult,
+) -> tuple[tuple[int, ...], ...]:
+    if len(set(result.variable_order)) != len(result.variable_order):
+        raise _validation_error(
+            "result_variable_names_must_be_unique",
+            "result variable names must be unique",
+        )
+    if len(result.domains) != len(result.variable_order):
+        raise _validation_error(
+            "result_domains_must_match_the_variable_count",
+            "result domains must match the variable count",
+        )
+    if any(
+        domain != tuple(sorted(set(domain)))
+        or any(residue < 0 or residue >= result.modulus for residue in domain)
+        for domain in result.domains
+    ):
+        raise _validation_error(
+            "result_domains_must_contain_canonical_increasing_residues",
+            "result domains must contain canonical increasing residues",
+        )
+    if any(
+        len(term.exponents) != len(result.variable_order)
+        or term.coefficient >= result.modulus
+        or any(
+            exponent < 0 or exponent > _MAX_RESIDUE_EXPONENT
+            for exponent in term.exponents
+        )
+        for term in result.normalized_terms
+    ):
+        raise _validation_error(
+            "normalized_terms_do_not_match_the_result_scope",
+            "normalized terms do not match the result scope",
+        )
+    exponent_vectors = [term.exponents for term in result.normalized_terms]
+    if exponent_vectors != sorted(set(exponent_vectors)):
+        raise _validation_error(
+            "normalized_term_exponents_must_be_canonical",
+            "normalized term exponents must be canonical",
+        )
+    assignment_count = math.prod(len(domain) for domain in result.domains)
+    if assignment_count > _MAX_RESIDUE_ASSIGNMENTS:
+        raise _validation_error(
+            "result_domains_exceed_the_4_096_assignment_bound",
+            "result domains exceed the 4,096-assignment bound",
+        )
+    if result.total_assignments != assignment_count:
+        raise _validation_error(
+            "total_assignments_do_not_match_the_declared_domains",
+            "total assignments do not match the declared domains",
+        )
+    if result.table is not None and len(result.table) != assignment_count:
+        raise _validation_error(
+            "complete_table_length_does_not_match_the_declared_domains",
+            "complete table length does not match the declared domains",
+        )
+    return tuple(product(*result.domains))
+
+
+def _validate_residue_image_table(
+    result: ModularPolynomialResidueImageResult,
+    assignments: tuple[tuple[int, ...], ...],
+) -> tuple[int, ...]:
+    expected_residues = tuple(
+        _evaluate_normalized_modular_polynomial(
+            result.normalized_terms,
+            assignment,
+            result.modulus,
+        )
+        for assignment in assignments
+    )
+    if result.table is not None:
+        if tuple(row.assignment for row in result.table) != assignments:
+            raise _validation_error(
+                "complete_table_must_enumerate_the_declared_cartesian_product_in_order",
+                "complete table must enumerate the declared Cartesian product in order",
+            )
+        if tuple(row.residue for row in result.table) != expected_residues:
+            raise _validation_error(
+                "complete_table_contains_an_incorrect_polynomial_evaluation",
+                "complete table contains an incorrect polynomial evaluation",
+            )
+    return expected_residues
+
+
+def _validate_residue_image_summaries(
+    result: ModularPolynomialResidueImageResult,
+    assignments: tuple[tuple[int, ...], ...],
+    residues: tuple[int, ...],
+) -> None:
+    image = tuple(sorted(set(residues)))
+    if result.image != image:
+        raise _validation_error(
+            "residue_image_does_not_match_the_complete_table",
+            "residue image does not match the complete table",
+        )
+    counts = Counter(residues)
+    expected_counts = tuple(
+        ModularPolynomialResidueCount(residue=residue, count=counts[residue])
+        for residue in image
+    )
+    if result.residue_counts != expected_counts:
+        raise _validation_error(
+            "residue_counts_do_not_match_the_complete_table",
+            "residue counts do not match the complete table",
+        )
+    first_assignments: dict[int, tuple[int, ...]] = {}
+    for assignment, residue in zip(assignments, residues, strict=True):
+        first_assignments.setdefault(residue, assignment)
+    expected_witnesses = tuple(
+        ModularPolynomialResidueWitness(
+            residue=residue,
+            assignment=first_assignments[residue],
+        )
+        for residue in image
+    )
+    if result.witnesses != expected_witnesses:
+        raise _validation_error(
+            "residue_witnesses_must_be_the_first_table_assignments",
+            "residue witnesses must be the first table assignments",
+        )

--- a/src/jacobian/math/number_theory/_modular_operations.py
+++ b/src/jacobian/math/number_theory/_modular_operations.py
@@ -13,14 +13,16 @@ from jacobian.math.number_theory._models import (
     ChineseRemainderResult,
     JacobiSymbolRequest,
     JacobiSymbolResult,
+    ModularUnitRequest,
+    ModulusRequest,
+    QuadraticResiduesResult,
+)
+from jacobian.math.number_theory._modular_models import (
     ModularPolynomialResidueCount,
     ModularPolynomialResidueImageRequest,
     ModularPolynomialResidueImageResult,
     ModularPolynomialResidueTableRow,
     ModularPolynomialResidueWitness,
-    ModularUnitRequest,
-    ModulusRequest,
-    QuadraticResiduesResult,
 )
 
 

--- a/tests/math/number_theory/test_divisibility_contracts.py
+++ b/tests/math/number_theory/test_divisibility_contracts.py
@@ -6,6 +6,7 @@ import pytest
 from tests.math.number_theory._validation import expect_validation
 
 from jacobian.catalog.models import MathTool
+from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory._divisibility import DIVISIBILITY_OPERATIONS
 from jacobian.math.number_theory._divisibility_models import (
     DivisibilityRequest,
@@ -13,7 +14,6 @@ from jacobian.math.number_theory._divisibility_models import (
     IntegerPairRequest,
     ValuationRequest,
 )
-from jacobian.math.number_theory._models import IntegerValueResult
 
 
 def _operation(operation_id: str) -> MathTool[Any, Any]:
@@ -30,13 +30,13 @@ def _operation(operation_id: str) -> MathTool[Any, Any]:
         (
             "integer.compute.gcd",
             IntegerPairRequest,
-            IntegerValueResult,
+            IntegerValue,
             {"left", "right"},
         ),
         (
             "integer.compute.lcm",
             IntegerPairRequest,
-            IntegerValueResult,
+            IntegerValue,
             {"left", "right"},
         ),
         (
@@ -48,7 +48,7 @@ def _operation(operation_id: str) -> MathTool[Any, Any]:
         (
             "integer.compute.valuation",
             ValuationRequest,
-            IntegerValueResult,
+            IntegerValue,
             {"value", "prime"},
         ),
         ("integer.decide.divides", DivisibilityRequest, None, {"divisor", "dividend"}),
@@ -57,7 +57,7 @@ def _operation(operation_id: str) -> MathTool[Any, Any]:
 def test_divisibility_declarations_keep_their_owner_local_contracts(
     operation_id: str,
     request_type: type[IntegerPairRequest | DivisibilityRequest | ValuationRequest],
-    result_type: type[IntegerValueResult | ExtendedGcdResult] | None,
+    result_type: type[IntegerValue | ExtendedGcdResult] | None,
     request_fields: set[str],
 ) -> None:
     operation = _operation(operation_id)

--- a/tests/math/number_theory/test_divisibility_contracts.py
+++ b/tests/math/number_theory/test_divisibility_contracts.py
@@ -1,0 +1,77 @@
+"""Public-contract regressions for divisibility-owned models."""
+
+from typing import Any
+
+import pytest
+from tests.math.number_theory._validation import expect_validation
+
+from jacobian.catalog.models import MathTool
+from jacobian.math.number_theory._divisibility import DIVISIBILITY_OPERATIONS
+from jacobian.math.number_theory._divisibility_models import (
+    DivisibilityRequest,
+    ExtendedGcdResult,
+    IntegerPairRequest,
+    ValuationRequest,
+)
+from jacobian.math.number_theory._models import IntegerValueResult
+
+
+def _operation(operation_id: str) -> MathTool[Any, Any]:
+    return next(
+        operation
+        for operation in DIVISIBILITY_OPERATIONS
+        if operation.operation_id == operation_id
+    )
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "request_type", "result_type", "request_fields"),
+    (
+        (
+            "integer.compute.gcd",
+            IntegerPairRequest,
+            IntegerValueResult,
+            {"left", "right"},
+        ),
+        (
+            "integer.compute.lcm",
+            IntegerPairRequest,
+            IntegerValueResult,
+            {"left", "right"},
+        ),
+        (
+            "integer.compute.extended_gcd",
+            IntegerPairRequest,
+            ExtendedGcdResult,
+            {"left", "right"},
+        ),
+        (
+            "integer.compute.valuation",
+            ValuationRequest,
+            IntegerValueResult,
+            {"value", "prime"},
+        ),
+        ("integer.decide.divides", DivisibilityRequest, None, {"divisor", "dividend"}),
+    ),
+)
+def test_divisibility_declarations_keep_their_owner_local_contracts(
+    operation_id: str,
+    request_type: type[IntegerPairRequest | DivisibilityRequest | ValuationRequest],
+    result_type: type[IntegerValueResult | ExtendedGcdResult] | None,
+    request_fields: set[str],
+) -> None:
+    operation = _operation(operation_id)
+
+    assert operation.request_type is request_type
+    assert set(request_type.model_json_schema()["properties"]) == request_fields
+    if result_type is not None:
+        assert operation.result_type is result_type
+
+
+def test_divisibility_contracts_retain_their_typed_admission_errors() -> None:
+    with expect_validation("number_theory.divisor_must_be_nonzero"):
+        DivisibilityRequest(divisor="0", dividend="1")
+    with expect_validation("number_theory.valuation_requires_nonzero_value"):
+        ValuationRequest(value="0", prime="2")
+    with expect_validation("number_theory.valuation_requires_a_prime_absolute_base_2"):
+        ValuationRequest(value="1", prime="4")

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -15,6 +15,9 @@ from jacobian.math.number_theory._models import (
     PositiveIntegerRequest,
     PrimalityRequest,
 )
+from jacobian.math.number_theory._modular_models import (
+    ModularPolynomialResidueImageRequest,
+)
 
 
 @pytest.mark.parametrize("residue", [-1, 3])
@@ -103,6 +106,32 @@ def test_in_process_factorization_dependencies_have_small_input_bounds() -> None
 def test_primality_keeps_its_operation_specific_input_bound() -> None:
     with expect_validation("string_too_long"):
         PrimalityRequest(value="1" + "0" * _MAX_INTEGER_LENGTH)
+
+
+def test_modular_residue_image_contract_replays_canonical_assignments() -> None:
+    from jacobian.math.number_theory._modular_operations import (
+        compute_modular_polynomial_residue_assignments,
+    )
+
+    request = ModularPolynomialResidueImageRequest.model_validate(
+        {
+            "modulus": 5,
+            "variables": [{"name": "x", "residues": [0, 1, 2]}],
+            "terms": [{"coefficient": "2", "exponents": [2]}],
+        }
+    )
+
+    result = compute_modular_polynomial_residue_assignments(request)
+
+    assert request.__class__.model_json_schema()["title"] == (
+        "ModularPolynomialResidueImageRequest"
+    )
+    assert result.image == (0, 2, 3)
+    assert tuple(row.model_dump() for row in result.table or ()) == (
+        {"assignment": (0,), "residue": 0},
+        {"assignment": (1,), "residue": 2},
+        {"assignment": (2,), "residue": 3},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import pytest
 from tests.math.number_theory._validation import expect_validation
 
+from jacobian.math.number_theory._direct_factorization_models import (
+    MAX_DIRECT_FACTORIZATION_DIGITS,
+    DivisorListResult,
+    FactorizationRequest,
+    PrimeFactorizationResult,
+)
 from jacobian.math.number_theory._models import (
     _MAX_CRT_SIZE,
-    _MAX_FACTORIZATION_LENGTH,
     _MAX_INTEGER_LENGTH,
     ChineseRemainderRequest,
     FactorialValuationRequest,
-    FactorizationRequest,
     ModularValueRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
@@ -108,6 +112,20 @@ def test_primality_keeps_its_operation_specific_input_bound() -> None:
         PrimalityRequest(value="1" + "0" * _MAX_INTEGER_LENGTH)
 
 
+def test_direct_factorization_contract_schemas_preserve_their_envelopes() -> None:
+    """Moving direct-factorization contracts must not widen public schemas."""
+
+    request_value = FactorizationRequest.model_json_schema()["properties"]["value"]
+    divisor_source = DivisorListResult.model_json_schema()["properties"]["value"]
+    factorization_source = PrimeFactorizationResult.model_json_schema()["properties"][
+        "value"
+    ]
+
+    assert request_value["maxLength"] == MAX_DIRECT_FACTORIZATION_DIGITS
+    assert divisor_source["maxLength"] == MAX_DIRECT_FACTORIZATION_DIGITS
+    assert factorization_source["maxLength"] == _MAX_INTEGER_LENGTH
+
+
 def test_modular_residue_image_contract_replays_canonical_assignments() -> None:
     from jacobian.math.number_theory._modular_operations import (
         compute_modular_polynomial_residue_assignments,
@@ -140,8 +158,6 @@ def test_modular_residue_image_contract_replays_canonical_assignments() -> None:
 
 
 def test_divisor_list_result_replays_source_enumeration() -> None:
-    from jacobian.math.number_theory._models import DivisorListResult
-
     full = DivisorListResult(value="12", divisors=("1", "2", "3", "4", "6", "12"))
     assert full.convention == "ALL_POSITIVE_DIVISORS"
     proper = DivisorListResult(
@@ -168,10 +184,8 @@ def test_divisor_list_result_admits_twenty_digit_source_boundary() -> None:
 
     from sympy import isprime
 
-    from jacobian.math.number_theory._models import DivisorListResult
-
     prime = 99_999_999_999_999_999_989
-    assert len(str(prime)) == _MAX_FACTORIZATION_LENGTH == 20
+    assert len(str(prime)) == MAX_DIRECT_FACTORIZATION_DIGITS == 20
     assert isprime(prime)
     result = DivisorListResult(value=str(prime), divisors=("1", str(prime)))
     assert result.value == str(prime)
@@ -190,8 +204,6 @@ def test_divisor_list_result_rejects_sources_beyond_factorization_domain() -> No
     """A forged serialized output whose divisor list does not enumerate the
     source's divisors exactly is rejected by the source-bound replay."""
 
-    from jacobian.math.number_theory._models import DivisorListResult
-
     with expect_validation("number_theory."):
         DivisorListResult.model_validate(
             {
@@ -203,8 +215,6 @@ def test_divisor_list_result_rejects_sources_beyond_factorization_domain() -> No
 
 
 def test_divisor_list_result_rejects_mutations() -> None:
-    from jacobian.math.number_theory._models import DivisorListResult
-
     base = {
         "value": "12",
         "divisors": ("1", "2", "3", "4", "6", "12"),
@@ -239,7 +249,7 @@ def test_divisor_list_result_rejects_mutations() -> None:
 
 
 def test_prime_factorization_result_replays_source() -> None:
-    from jacobian.math.number_theory._models import PrimeFactorizationResult, PrimePower
+    from jacobian.math.number_theory._models import PrimePower
 
     result = PrimeFactorizationResult(
         value="72",
@@ -256,7 +266,7 @@ def test_prime_factorization_result_replays_source() -> None:
 
 
 def test_prime_factorization_result_rejects_mutations() -> None:
-    from jacobian.math.number_theory._models import PrimeFactorizationResult, PrimePower
+    from jacobian.math.number_theory._models import PrimePower
 
     with expect_validation("number_theory."):
         PrimeFactorizationResult(value="4", factors=(PrimePower(prime="4", power=1),))
@@ -282,7 +292,7 @@ def test_prime_factorization_result_rejects_mutations() -> None:
 def test_prime_factorization_result_bounds_reconstruction_work() -> None:
     """Replay rejects reconstructions larger than the source before expanding."""
 
-    from jacobian.math.number_theory._models import PrimeFactorizationResult, PrimePower
+    from jacobian.math.number_theory._models import PrimePower
 
     with expect_validation("number_theory."):
         PrimeFactorizationResult(
@@ -307,8 +317,6 @@ def test_prime_factorization_result_bounds_reconstruction_work() -> None:
 def test_prime_factorization_result_admits_full_width_source_power() -> None:
     """A source-width prime power still reconstructs exactly."""
 
-    from jacobian.math.number_theory._models import PrimeFactorizationResult
-
     width = 256
     exponent = 849
     result = PrimeFactorizationResult.model_validate(
@@ -330,11 +338,6 @@ def test_producer_results_serialize_and_reconstruct() -> None:
         enumerate_divisors,
         enumerate_proper_divisors,
         factorize_primes,
-    )
-    from jacobian.math.number_theory._models import (
-        DivisorListResult,
-        FactorizationRequest,
-        PrimeFactorizationResult,
     )
 
     request = FactorizationRequest(value="72")

--- a/tests/math/number_theory/test_modular_polynomial_values.py
+++ b/tests/math/number_theory/test_modular_polynomial_values.py
@@ -15,7 +15,7 @@ from jacobian.math.modular_polynomials import (
     NormalizedModularPolynomialTerm,
     modular_polynomial_identity,
 )
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._modular_models import (
     ModularPolynomialResidueImageRequest,
     ModularPolynomialResidueImageResult,
     ModularPolynomialVariable,


### PR DESCRIPTION
Part of #2565.

## Problem

Divisibility, modular residues, and direct factorization shared the number-theory aggregate contract module despite having independent request bounds and result ownership.

## Solution

Move those three contract families and their owner-local bounds into focused modules. Existing canonical integer and modular-polynomial values remain shared. Friable, prime, and powerful-number families are intentionally deferred. Operation IDs, schemas, catalog membership, and behavior are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/number_theory` — 234 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `uv run ruff check` and `uv run ruff format --check` — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This is an ownership refactor; the public operation surface is preserved.

## Checklist

- [ ] `make check` passes (not run)