### PR TITLE
Reuse admitted concept families in FCA operations

### DIFF
--- a/src/jacobian/math/formal_concept_analysis/_models.py
+++ b/src/jacobian/math/formal_concept_analysis/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import ConfigDict, Field, StrictInt, model_validator
+from pydantic import ConfigDict, Field, PrivateAttr, StrictInt, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -152,6 +152,13 @@ class EnumerateConceptsRequest(StrictModel):
     """Enumerate all formal concepts."""
 
     context: FormalContext
+    _admitted_concept_family: (
+        tuple[
+            FormalContext,
+            tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+        ]
+        | None
+    ) = PrivateAttr(default=None)
 
     @model_validator(mode="after")
     def require_bounded_concept_family(self) -> Self:
@@ -160,19 +167,63 @@ class EnumerateConceptsRequest(StrictModel):
         )
         if worst_case_concepts > MAX_CONCEPTS:
             from jacobian.math.formal_concept_analysis.operations import (
-                concept_family_size_capped,
+                enumerate_concepts,
             )
 
-            family_size = concept_family_size_capped(self.context, MAX_CONCEPTS)
-            if family_size > MAX_CONCEPTS:
+            try:
+                concepts = enumerate_concepts(self.context)
+            except ValueError as exc:
                 raise PydanticCustomError(
                     "formal_concept_analysis.concept_family_exceeds_bound",
                     f"the context carries more than {MAX_CONCEPTS} concepts "
                     "and concept enumeration returns at most "
                     f"{MAX_CONCEPTS}; narrow the context or split the "
                     "enumeration",
-                )
+                ) from exc
+            object.__setattr__(
+                self,
+                "_admitted_concept_family",
+                (
+                    self.context,
+                    tuple(
+                        (
+                            tuple(sorted(concept["extent"])),
+                            tuple(sorted(concept["intent"])),
+                        )
+                        for concept in concepts
+                    ),
+                ),
+            )
         return self
+
+    def _concepts_for_execution(
+        self,
+    ) -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+        """Return the exact family admitted by this request when available.
+
+        Wide contexts need a bounded exact family probe because their
+        worst-case carrier alone cannot decide admission. That probe is the
+        same deterministic NextClosure traversal the operation serves, so an
+        accepted request retains its canonical projection instead of running
+        a second exhaustive traversal. Requests constructed outside normal
+        Pydantic validation (or copied with a new context) conservatively run
+        the same bounded kernel once rather than trusting stale private data.
+        """
+        cached = self._admitted_concept_family
+        if cached is not None and cached[0] == self.context:
+            return cached[1]
+
+        from jacobian.math.formal_concept_analysis.operations import (
+            enumerate_concepts,
+        )
+
+        return tuple(
+            (
+                tuple(sorted(concept["extent"])),
+                tuple(sorted(concept["intent"])),
+            )
+            for concept in enumerate_concepts(self.context)
+        )
 
 
 class EnumerateConceptsResult(StrictModel):

--- a/src/jacobian/math/formal_concept_analysis/_operations.py
+++ b/src/jacobian/math/formal_concept_analysis/_operations.py
@@ -20,12 +20,11 @@ from jacobian.math.formal_concept_analysis.basis import (
     CanonicalImplicationBasisResult,
 )
 from jacobian.math.formal_concept_analysis.operations import (
+    _concept_lattice_from_canonical_concepts,
     attribute_derivation,
     concept_from_attributes,
     concept_from_objects,
-    concept_lattice,
     duquenne_guigues_basis,
-    enumerate_concepts,
     implication_closure,
     object_derivation,
 )
@@ -111,11 +110,9 @@ def compute_concept_from_attributes(request: AttributeSubsetRequest) -> ConceptR
 def compute_enumerate_concepts(
     request: EnumerateConceptsRequest,
 ) -> EnumerateConceptsResult:
-    concepts = enumerate_concepts(request.context)
+    concepts = request._concepts_for_execution()
     return EnumerateConceptsResult(
-        concepts=tuple(
-            (tuple(sorted(c["extent"])), tuple(sorted(c["intent"]))) for c in concepts
-        ),
+        concepts=concepts,
         count=len(concepts),
     )
 
@@ -123,7 +120,7 @@ def compute_enumerate_concepts(
 def compute_concept_lattice(
     request: EnumerateConceptsRequest,
 ) -> ConceptLatticeResult:
-    result = concept_lattice(request.context)
+    result = _concept_lattice_from_canonical_concepts(request._concepts_for_execution())
     concepts = cast(list[Any], result["concepts"])
     return ConceptLatticeResult(
         concepts=tuple(

--- a/src/jacobian/math/formal_concept_analysis/operations.py
+++ b/src/jacobian/math/formal_concept_analysis/operations.py
@@ -464,7 +464,27 @@ def concept_lattice(
 ) -> dict[str, object]:
     """Return the concept lattice: concepts, partial order by extent inclusion,
     cover relation, top and bottom concepts."""
-    concepts = enumerate_concepts(ctx)
+    return _concept_lattice_from_concepts(enumerate_concepts(ctx))
+
+
+def _concept_lattice_from_canonical_concepts(
+    concepts: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+) -> dict[str, object]:
+    """Derive one lattice from an already admitted canonical concept family."""
+
+    return _concept_lattice_from_concepts(
+        [
+            {"extent": frozenset(extent), "intent": frozenset(intent)}
+            for extent, intent in concepts
+        ]
+    )
+
+
+def _concept_lattice_from_concepts(
+    concepts: list[dict[str, frozenset[int]]],
+) -> dict[str, object]:
+    """Derive one lattice from a complete exact concept family."""
+
     n = len(concepts)
     order = _inclusion_order(concepts)
     covers = _cover_relation(order, n)

--- a/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
+++ b/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
@@ -242,6 +242,33 @@ class TestEnumeration:
                 )
             )
 
+    def test_wide_admission_reuses_its_one_exact_concept_enumeration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact wide-context admission probe is the served family."""
+        from jacobian.math.formal_concept_analysis import operations
+
+        context = FormalContext(
+            objects=tuple(f"o{index}" for index in range(14)),
+            attributes=tuple(f"a{index}" for index in range(14)),
+            incidence=(),
+        )
+        original = operations.enumerate_concepts
+        calls: list[FormalContext] = []
+
+        def counted(context: FormalContext):
+            calls.append(context)
+            return original(context)
+
+        monkeypatch.setattr(operations, "enumerate_concepts", counted)
+
+        request = EnumerateConceptsRequest(context=context)
+        assert compute_enumerate_concepts(request).count == 2
+        assert calls == [context]
+
+        assert len(compute_concept_lattice(request).concepts) == 2
+        assert calls == [context]
+
 
 # ---------------------------------------------------------------------------
 # Defining-equation replay (#2266)


### PR DESCRIPTION
## Problem

The FCA concept-enumeration and lattice-projection paths could traverse the same admitted concept family independently, despite sharing the same bounded canonical family.

## Solution

Retain the canonical family produced during admission and reuse it for both public computations. This preserves the bounded traversal and keeps the two projections aligned without changing request or result contracts.

## Testing

- `make test-focused LANE=math TESTS=tests/math/formal_concept_analysis` — 77 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- advertised catalog examples — 608 passed
- `ruff check` and `ruff format --check` — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. Public operations keep their existing schemas and mathematical results.

## Checklist

- [ ] `make check` passes (not run)