### PR TITLE
Isolate analysis enclosure contracts by family

### DIFF
--- a/src/jacobian/math/analysis/_expression_enclosure.py
+++ b/src/jacobian/math/analysis/_expression_enclosure.py
@@ -1,0 +1,96 @@
+"""Contracts for bounded pointwise interval-expression enclosures."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, Self
+
+from pydantic import Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.analysis._models import (
+    MAX_RATIONAL_DIGITS,
+    ExactDyadic,
+    IntervalExpressionNode,
+    _bound_raw_expression,
+    _bound_raw_rational,
+    _bounded_expression_nodes,
+    _validation_error,
+)
+
+
+class IntervalExpressionEnclosureRequest(StrictModel):
+    """Evaluate a bounded expression at one exact rational argument using Arb."""
+
+    expression: IntervalExpressionNode
+    argument: CanonicalRational
+    precision_bits: StrictInt = Field(default=128, ge=32, le=4096)
+
+    @model_validator(mode="before")
+    @classmethod
+    def bound_raw_tree(cls, value: object) -> object:
+        value = canonicalize_json_containers(value)
+        if isinstance(value, Mapping):
+            _bound_raw_expression(value.get("expression"))
+            _bound_raw_rational(value.get("argument"), "interval-enclosure argument")
+        return value
+
+    @model_validator(mode="after")
+    def require_bounded_tree(self) -> Self:
+        require_bounded_rational(
+            self.argument,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="interval-enclosure argument",
+        )
+        nodes = _bounded_expression_nodes(self.expression)
+        if any(node.op == "var" and node.variable is not None for node in nodes):
+            raise _validation_error(
+                "point-enclosure variable nodes must remain anonymous"
+            )
+        return self
+
+
+class IntervalExpressionEnclosureResult(StrictModel):
+    status: Literal[
+        "ENCLOSED",
+        "DOMAIN_ERROR",
+        "PRECISION_INSUFFICIENT",
+        "NONFINITE",
+        "OUTPUT_MAGNITUDE_EXCEEDED",
+    ]
+    precision_bits: StrictInt = Field(ge=32, le=4096)
+    lower: ExactDyadic | None = None
+    upper: ExactDyadic | None = None
+    relative_accuracy_bits: StrictInt | None = None
+    exact: bool = False
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_enclosure_to_status(self) -> Self:
+        enclosed = self.status == "ENCLOSED"
+        if enclosed != (self.lower is not None and self.upper is not None):
+            raise _validation_error(
+                "only an enclosed result may carry dyadic endpoints"
+            )
+        if not enclosed and (self.relative_accuracy_bits is not None or self.exact):
+            raise _validation_error(
+                "a non-enclosure cannot claim accuracy or exactness"
+            )
+        if enclosed:
+            assert self.lower is not None and self.upper is not None
+            if self.lower.compare(self.upper) > 0:
+                raise _validation_error(
+                    "enclosure lower endpoint exceeds upper endpoint"
+                )
+            if self.exact != (self.relative_accuracy_bits is None):
+                raise _validation_error(
+                    "exact enclosures omit relative accuracy; inexact ones report it"
+                )
+        return self
+
+
+__all__ = [
+    "IntervalExpressionEnclosureRequest",
+    "IntervalExpressionEnclosureResult",
+]

--- a/src/jacobian/math/analysis/_models.py
+++ b/src/jacobian/math/analysis/_models.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from enum import StrEnum
 from fractions import Fraction
 from typing import Annotated, Literal, Self
 
 from pydantic import (
-    ConfigDict,
     Field,
     StrictInt,
     StringConstraints,
@@ -34,31 +32,6 @@ MAX_EXPRESSION_DEPTH = 16
 MAX_EXPRESSION_NODES = 64
 MAX_INTEGER_EXPONENT = 64
 MAX_BOX_VARIABLES = 8
-MAX_SECOND_JET_VARIABLES = MAX_BOX_VARIABLES
-MAX_SECOND_JET_RESULT_INTERVALS = (
-    1
-    + MAX_SECOND_JET_VARIABLES
-    + MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2
-)
-
-
-def _second_jet_node_arithmetic_units(dimension: int) -> int:
-    """Bound the scalar Arb steps of one source node's dense second-order jet.
-
-    Every jet carries a value, gradient, and dense Hessian, so one node's
-    arithmetic grows quadratically in the jet dimension.  A division is the
-    most expensive node: one reciprocal power jet followed by one product jet
-    costs about ``10 * dimension**2 + 4 * dimension`` scalar steps, and the
-    padded constant covers transcendental chain-rule values.  At three
-    variables this reproduces the former flat 128-unit bound.
-    """
-    return 10 * dimension * dimension + 4 * dimension + 16
-
-
-# Twice the former 64-node x 128-unit envelope.  Every previously accepted
-# three-variable request stays admitted while the dimension-derived charge
-# admits small full-axis jets such as an eight-variable affine form.
-MAX_SECOND_JET_WORK_UNITS = 16_384
 # Cap every retained exact preflight numerator and denominator at twice the
 # maximum Arb work precision.  One Fraction binary operation or comparison can
 # transiently combine two such components, so its temporary size is separately
@@ -67,11 +40,6 @@ MAX_BOX_INTERMEDIATE_BITS = 8_192
 MAX_BOX_PREFLIGHT_TEMPORARY_BITS = 2 * MAX_BOX_INTERMEDIATE_BITS + 1
 MAX_DYADIC_EXPONENT = 2**53 - 1
 MAX_DYADIC_MANTISSA_DIGITS = 1_235
-MAX_POINT_CHECK_DYADIC_EXPONENT = 8_192
-MAX_POINT_CHECK_LOG_TERMS = 128
-MAX_POINT_CHECK_FRACTION_BITS = 131_072
-MAX_POINT_CHECK_FRACTION_UPDATES = 4 * MAX_POINT_CHECK_LOG_TERMS
-MAX_POINT_CHECK_OUTPUT_BYTES = 4_096
 
 IntervalVariable = Annotated[
     str,
@@ -94,9 +62,6 @@ type IntervalExpressionOp = Literal[
     "cos",
 ]
 type IntervalExpressionBoxEnclosureStatus = Literal[
-    "ENCLOSED", "DOMAIN_UNPROVEN", "BACKEND_ERROR"
-]
-type IntervalExpressionSecondJetEnclosureStatus = Literal[
     "ENCLOSED", "DOMAIN_UNPROVEN", "BACKEND_ERROR"
 ]
 
@@ -231,37 +196,6 @@ def _bound_raw_expression(expression: object) -> None:
         if len(children) > 2:
             raise _validation_error("expression nodes may have at most two children")
         stack.extend((child, depth + 1) for child in children)
-
-
-class IntervalExpressionEnclosureRequest(StrictModel):
-    """Evaluate a bounded expression at one exact rational argument using Arb."""
-
-    expression: IntervalExpressionNode
-    argument: CanonicalRational
-    precision_bits: StrictInt = Field(default=128, ge=32, le=4096)
-
-    @model_validator(mode="before")
-    @classmethod
-    def bound_raw_tree(cls, value: object) -> object:
-        value = canonicalize_json_containers(value)
-        if isinstance(value, Mapping):
-            _bound_raw_expression(value.get("expression"))
-            _bound_raw_rational(value.get("argument"), "interval-enclosure argument")
-        return value
-
-    @model_validator(mode="after")
-    def require_bounded_tree(self) -> Self:
-        require_bounded_rational(
-            self.argument,
-            max_digits=MAX_RATIONAL_DIGITS,
-            label="interval-enclosure argument",
-        )
-        nodes = _bounded_expression_nodes(self.expression)
-        if any(node.op == "var" and node.variable is not None for node in nodes):
-            raise _validation_error(
-                "point-enclosure variable nodes must remain anonymous"
-            )
-        return self
 
 
 class RationalIntervalBox(StrictModel):
@@ -656,134 +590,6 @@ class IntervalExpressionBoxEnclosureRequest(StrictModel):
         return self
 
 
-def _preflight_second_jet_expression(
-    node: IntervalExpressionNode,
-    variables: dict[str, _RationalBounds],
-    path: tuple[int, ...] = (),
-) -> _BoxPreflight:
-    """Prove the source tree is twice differentiable on the complete box."""
-
-    if node.op == "const":
-        assert node.value is not None
-        value = node.value.as_fraction()
-        return _bounded_rational_bounds(value, value)
-    if node.op == "var":
-        assert node.variable is not None
-        return variables[node.variable]
-
-    children: list[_BoxPreflight] = []
-    for index, child_node in enumerate(node.children):
-        child = _preflight_second_jet_expression(child_node, variables, (*path, index))
-        if isinstance(child, IntervalExpressionDomainFailure):
-            return child
-        children.append(child)
-
-    left = children[0]
-    assert isinstance(left, _RationalBounds)
-    if len(children) == 1:
-        if node.op == "sqrt" and left.lower <= 0:
-            return IntervalExpressionDomainFailure(
-                node_path=path,
-                operation="sqrt",
-                reason="SQRT_ARGUMENT_NOT_STRICTLY_POSITIVE_FOR_SECOND_JET",
-            )
-        return _preflight_box_unary(node, left, path)
-
-    right = children[1]
-    assert isinstance(right, _RationalBounds)
-    return _preflight_box_binary(node, left, right, path)
-
-
-class IntervalExpressionSecondJetEnclosureRequest(
-    IntervalExpressionBoxEnclosureRequest
-):
-    """Enclose an elementary expression and all derivatives through order two."""
-
-    @model_validator(mode="after")
-    def require_small_twice_differentiable_source(self) -> Self:
-        dimension = len(self.box.variables)
-        result_intervals = 1 + dimension + dimension * (dimension + 1) // 2
-        if result_intervals > MAX_SECOND_JET_RESULT_INTERVALS:
-            raise AssertionError(
-                "second-jet result interval accounting is inconsistent"
-            )
-        work_units = len(
-            _bounded_expression_nodes(self.expression)
-        ) * _second_jet_node_arithmetic_units(dimension)
-        if work_units > MAX_SECOND_JET_WORK_UNITS:
-            raise _validation_error(
-                f"second-jet forward arithmetic work of {work_units} scalar "
-                f"units exceeds its {MAX_SECOND_JET_WORK_UNITS}-unit bound at "
-                "this dimension"
-            )
-        _preflight_second_jet_expression(
-            self.expression, _rational_box_bounds(self.box)
-        )
-        return self
-
-
-class IntervalExpressionEnclosureResult(StrictModel):
-    status: Literal[
-        "ENCLOSED",
-        "DOMAIN_ERROR",
-        "PRECISION_INSUFFICIENT",
-        "NONFINITE",
-        "OUTPUT_MAGNITUDE_EXCEEDED",
-    ]
-    precision_bits: StrictInt = Field(ge=32, le=4096)
-    lower: ExactDyadic | None = None
-    upper: ExactDyadic | None = None
-    relative_accuracy_bits: StrictInt | None = None
-    exact: bool = False
-    detail: str = Field(min_length=1, max_length=1024)
-
-    @model_validator(mode="after")
-    def bind_enclosure_to_status(self) -> Self:
-        enclosed = self.status == "ENCLOSED"
-        if enclosed != (self.lower is not None and self.upper is not None):
-            raise _validation_error(
-                "only an enclosed result may carry dyadic endpoints"
-            )
-        if not enclosed and (self.relative_accuracy_bits is not None or self.exact):
-            raise _validation_error(
-                "a non-enclosure cannot claim accuracy or exactness"
-            )
-        if enclosed:
-            assert self.lower is not None and self.upper is not None
-            if self.lower.compare(self.upper) > 0:
-                raise _validation_error(
-                    "enclosure lower endpoint exceeds upper endpoint"
-                )
-            if self.exact != (self.relative_accuracy_bits is None):
-                raise _validation_error(
-                    "exact enclosures omit relative accuracy; inexact ones report it"
-                )
-        return self
-
-
-class RealUnaryFunction(StrEnum):
-    EXP = "EXP"
-    LOG = "LOG"
-    SQRT = "SQRT"
-    SIN = "SIN"
-    COS = "COS"
-
-
-class ArbPointEnclosureRequest(StrictModel):
-    function: RealUnaryFunction
-    argument: CanonicalRational
-    precision_bits: StrictInt = Field(default=128, ge=32, le=4096)
-
-    @model_validator(mode="after")
-    def bound_argument_size(self) -> Self:
-        require_bounded_rational(
-            self.argument,
-            max_digits=MAX_RATIONAL_DIGITS,
-            label="validated-analysis rational",
-        )
-        return self
-
-
 class ExactDyadic(StrictModel):
     """The exact value ``mantissa * 2**exponent``."""
 
@@ -834,171 +640,6 @@ class ExactDyadic(StrictModel):
         return magnitude_order if left > 0 else -magnitude_order
 
 
-type PointEnclosureCheckOutcome = Literal["ACCEPTED", "REJECTED", "NON_RESULT"]
-
-
-class ClaimedPointEnclosure(StrictModel):
-    """One claimed enclosure of a real function value by exact dyadic endpoints.
-
-    This is the domain-owned canonical value shared by the Arb producer and
-    the independent checker, so a serialized claim crosses the consumer
-    boundary unchanged. Endpoint order is deliberately not validated here: a
-    reversed claim is a checkable mathematical statement, not an invalid one.
-    """
-
-    function: RealUnaryFunction = Field(
-        description="Real function whose value the endpoints claim to enclose."
-    )
-    argument: CanonicalRational = Field(
-        description="Exact reduced rational argument with at most 128 digits per component."
-    )
-    precision_bits: StrictInt = Field(
-        ge=32,
-        le=4096,
-        description=(
-            "Precision metadata retained from the source computation; it does "
-            "not promise that an independent replay resolves the claim at "
-            "that precision."
-        ),
-    )
-    lower: ExactDyadic = Field(description="Claimed inclusive lower endpoint.")
-    upper: ExactDyadic = Field(description="Claimed inclusive upper endpoint.")
-
-    @model_validator(mode="after")
-    def bound_claim_source(self) -> Self:
-        require_bounded_rational(
-            self.argument,
-            max_digits=MAX_RATIONAL_DIGITS,
-            label="claimed point-enclosure rational",
-        )
-        return self
-
-
-def _preflight_point_check_source(data: object) -> object:
-    """Reject oversized raw source scalars before canonical integer parsing."""
-
-    if not isinstance(data, dict):
-        return data
-    enclosure = data.get("enclosure")
-    if isinstance(enclosure, ClaimedPointEnclosure):
-        raw_components: tuple[object, ...] = (
-            enclosure.argument.num,
-            enclosure.argument.den,
-        )
-    elif isinstance(enclosure, dict):
-        argument = enclosure.get("argument")
-        if isinstance(argument, CanonicalRational):
-            raw_components = (argument.num, argument.den)
-        elif isinstance(argument, dict):
-            raw_components = (argument.get("num"), argument.get("den"))
-        else:
-            raw_components = ()
-    else:
-        raw_components = ()
-    if any(
-        isinstance(component, str) and len(component.lstrip("-")) > MAX_RATIONAL_DIGITS
-        for component in raw_components
-    ):
-        raise _validation_error(
-            "point-enclosure checker raw rational component exceeds the "
-            f"{MAX_RATIONAL_DIGITS}-digit bound"
-        )
-    return data
-
-
-def _point_check_fraction_bound_bits(argument: CanonicalRational) -> int:
-    """Bound LOG/SQRT intermediates, including claim comparisons and replay."""
-
-    numerator, denominator = argument.as_integer_ratio()
-    source_bits = max(abs(numerator).bit_length(), denominator.bit_length())
-    transformed_bits = source_bits + 2
-    odd_denominator_bits = (2 * MAX_POINT_CHECK_LOG_TERMS + 1).bit_length()
-
-    # A common denominator for one upper atanh bound divides
-    # b**(2*n-1) * lcm(1, 3, ..., 2*n-1) * (2*n+1) * (b*b-a*a).
-    # Combining log(y) with k*log(2) adds the independent powers of 3 but
-    # shares the odd-denominator factors.  The coefficient k has at most
-    # source_bits.bit_length() bits after exact power-of-two range reduction.
-    combined_log_bits = (
-        (2 * MAX_POINT_CHECK_LOG_TERMS - 1) * (transformed_bits + 2)
-        + 2 * transformed_bits
-        + (MAX_POINT_CHECK_LOG_TERMS + 1) * odd_denominator_bits
-        + source_bits.bit_length()
-        + 8
-    )
-    endpoint_bits = 4 * MAX_DYADIC_MANTISSA_DIGITS + MAX_POINT_CHECK_DYADIC_EXPONENT
-    log_comparison_bits = combined_log_bits + endpoint_bits + 32
-    sqrt_comparison_bits = 2 * endpoint_bits + source_bits + 8
-    return max(log_comparison_bits, sqrt_comparison_bits)
-
-
-class PointEnclosureCheckRequest(StrictModel):
-    """Check one claimed LOG or SQRT enclosure by exact independent replay.
-
-    The claimed enclosure is one canonical ``ClaimedPointEnclosure`` accepted
-    unchanged from its source. Rational components have at most 128 decimal
-    digits. Claimed dyadic exponents must lie in -8192..8192; reversed or
-    mathematically invalid intervals remain valid claims and produce typed
-    checker outcomes. Only LOG and SQRT claims are admitted. LOG replay uses
-    at most 128 terms per series, about 400 worst-case bits after range
-    reduction, so tighter claims can produce NON_RESULT even when their
-    retained precision metadata is larger.
-    """
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "point_check_log_term_bound": MAX_POINT_CHECK_LOG_TERMS,
-            "point_check_fraction_intermediate_bit_bound": (
-                MAX_POINT_CHECK_FRACTION_BITS
-            ),
-            "point_check_producer_replay_term_update_bound": (
-                MAX_POINT_CHECK_FRACTION_UPDATES
-            ),
-            "point_check_output_byte_bound": MAX_POINT_CHECK_OUTPUT_BYTES,
-        }
-    )
-
-    enclosure: ClaimedPointEnclosure = Field(
-        description=(
-            "Canonical claimed enclosure retained verbatim from its source; "
-            "only LOG and SQRT functions are admitted."
-        )
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def preflight_raw_source(cls, data: object) -> object:
-        data = canonicalize_json_containers(data)
-        return _preflight_point_check_source(data)
-
-    @model_validator(mode="after")
-    def preflight_exact_checker(self) -> Self:
-        if self.enclosure.function not in (
-            RealUnaryFunction.LOG,
-            RealUnaryFunction.SQRT,
-        ):
-            raise _validation_error(
-                "point-enclosure checker replays only LOG and SQRT claims"
-            )
-        if any(
-            abs(endpoint.exponent) > MAX_POINT_CHECK_DYADIC_EXPONENT
-            for endpoint in (self.enclosure.lower, self.enclosure.upper)
-        ):
-            raise _validation_error(
-                "point-enclosure checker dyadic exponent exceeds the "
-                f"+/-{MAX_POINT_CHECK_DYADIC_EXPONENT} bound"
-            )
-        if (
-            _point_check_fraction_bound_bits(self.enclosure.argument)
-            > MAX_POINT_CHECK_FRACTION_BITS
-        ):
-            raise _validation_error(
-                "point-enclosure checker exact rational work exceeds the "
-                f"{MAX_POINT_CHECK_FRACTION_BITS}-bit intermediate bound"
-            )
-        return self
-
-
 class DyadicClosedInterval(StrictModel):
     """One closed interval with exact dyadic endpoints."""
 
@@ -1010,172 +651,6 @@ class DyadicClosedInterval(StrictModel):
         if self.lower.compare(self.upper) > 0:
             raise _validation_error(
                 "dyadic interval lower endpoint exceeds upper endpoint"
-            )
-        return self
-
-
-class FirstPartialEnclosure(StrictModel):
-    """One first-partial enclosure bound to the authoritative source axis."""
-
-    variable: IntervalVariable
-    enclosure: DyadicClosedInterval
-
-
-class HessianEntryEnclosure(StrictModel):
-    """One canonical upper-triangular Hessian entry over the source box."""
-
-    first_variable: IntervalVariable
-    second_variable: IntervalVariable
-    enclosure: DyadicClosedInterval
-
-
-class IntervalExpressionSecondJetEnclosureResult(
-    IntervalExpressionSecondJetEnclosureRequest
-):
-    """A source-bound rigorous value, gradient, and symmetric Hessian enclosure.
-
-    For ``ENCLOSED``, full validation recomputes the canonical jet claim from
-    its expression, axis, and source box.  ``DOMAIN_UNPROVEN`` replays its
-    deterministic first-obstruction evidence.  ``BACKEND_ERROR`` asserts no
-    enclosure conclusion at all, so it is validated structurally: rerunning
-    Arb would reject the operation's own serialized result whenever a
-    transient backend condition does not recur.
-    """
-
-    status: IntervalExpressionSecondJetEnclosureStatus
-    value: DyadicClosedInterval | None = None
-    gradient: tuple[FirstPartialEnclosure, ...] = Field(
-        default=(), max_length=MAX_SECOND_JET_VARIABLES
-    )
-    hessian: tuple[HessianEntryEnclosure, ...] = Field(
-        default=(),
-        max_length=MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2,
-    )
-    domain_failure: IntervalExpressionDomainFailure | None = None
-    method: Literal["ARB_FORWARD_SECOND_ORDER_JET"] = "ARB_FORWARD_SECOND_ORDER_JET"
-    detail: str = Field(min_length=1, max_length=1024)
-
-    @field_validator("gradient", mode="before")
-    @classmethod
-    def preserve_gradient_json_array_composition(cls, value: object) -> object:
-        if isinstance(value, (list, tuple)) and len(value) > MAX_SECOND_JET_VARIABLES:
-            raise _validation_error(
-                "second-jet result exceeds its declared interval bound"
-            )
-        if isinstance(value, list):
-            return tuple(value)
-        return value
-
-    @field_validator("hessian", mode="before")
-    @classmethod
-    def preserve_hessian_json_array_composition(cls, value: object) -> object:
-        maximum = MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2
-        if isinstance(value, (list, tuple)) and len(value) > maximum:
-            raise _validation_error(
-                "second-jet result exceeds its declared interval bound"
-            )
-        if isinstance(value, list):
-            return tuple(value)
-        return value
-
-    @model_validator(mode="after")
-    def bind_second_jet_to_source(self) -> Self:
-        enclosed = self.status == "ENCLOSED"
-        expected_pairs = tuple(
-            (first, second)
-            for first_index, first in enumerate(self.box.variables)
-            for second in self.box.variables[first_index:]
-        )
-        if enclosed != (self.value is not None):
-            raise _validation_error(
-                "only an enclosed second jet may carry a value enclosure"
-            )
-        if enclosed:
-            if tuple(entry.variable for entry in self.gradient) != self.box.variables:
-                raise _validation_error(
-                    "gradient entries must match the ordered source axis"
-                )
-            if (
-                tuple(
-                    (entry.first_variable, entry.second_variable)
-                    for entry in self.hessian
-                )
-                != expected_pairs
-            ):
-                raise _validation_error(
-                    "Hessian entries must be the canonical upper triangle of the source axis"
-                )
-            if self.domain_failure is not None:
-                raise _validation_error(
-                    "an enclosed second jet cannot carry a domain failure"
-                )
-        else:
-            if self.value is not None or self.gradient or self.hessian:
-                raise _validation_error(
-                    "a non-enclosed second jet cannot carry partial enclosures"
-                )
-            domain_unproven = self.status == "DOMAIN_UNPROVEN"
-            if domain_unproven != (self.domain_failure is not None):
-                raise _validation_error(
-                    "domain-failure evidence must agree with DOMAIN_UNPROVEN status"
-                )
-            if self.status == "BACKEND_ERROR":
-                return self
-
-        from jacobian.math.analysis._operations import _second_jet_enclosure
-
-        request = IntervalExpressionSecondJetEnclosureRequest.model_construct(
-            expression=self.expression,
-            box=self.box,
-            precision_bits=self.precision_bits,
-        )
-        if self != _second_jet_enclosure(request):
-            raise _validation_error(
-                "second-jet enclosure does not replay from its expression, axis, and source box"
-            )
-        return self
-
-
-class PointEnclosureCheckResult(StrictModel):
-    """A source-bound checker outcome replayed during result validation.
-
-    ACCEPTED means the independently proved interval is contained in the
-    claim. REJECTED covers an invalid real-domain or reversed claim, or a claim
-    proved disjoint from the true value. NON_RESULT means the independent LOG
-    enclosure still partially overlaps the claim after 128 series terms.
-    """
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "point_check_output_byte_bound": MAX_POINT_CHECK_OUTPUT_BYTES,
-        }
-    )
-
-    enclosure: ClaimedPointEnclosure
-    outcome: PointEnclosureCheckOutcome = Field(
-        description=(
-            "ACCEPTED when the independent enclosure is contained in the "
-            "claim; REJECTED for invalid or provably excluding claims; "
-            "NON_RESULT for unresolved partial overlap at the LOG term cap."
-        )
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def preflight_raw_source(cls, data: object) -> object:
-        data = canonicalize_json_containers(data)
-        return _preflight_point_check_source(data)
-
-    @model_validator(mode="after")
-    def replay_outcome(self) -> Self:
-        from jacobian.math.analysis._point_enclosure_check import (
-            point_enclosure_check_outcome,
-        )
-
-        request = PointEnclosureCheckRequest(enclosure=self.enclosure)
-        if self.outcome != point_enclosure_check_outcome(request):
-            raise _validation_error(
-                "outcome must equal the deterministic enclosure check for the retained source"
             )
         return self
 
@@ -1235,53 +710,4 @@ class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest
             raise _validation_error(
                 "box enclosure does not replay from its expression, axis, and source box"
             )
-        return self
-
-
-class ArbPointEnclosureResult(ArbPointEnclosureRequest):
-    """A source-bound Arb ball enclosure of one real function value.
-
-    Every outcome retains the request's function, argument, and precision;
-    ``enclosure`` carries the canonical ``ClaimedPointEnclosure`` only when
-    ``status`` is ``ENCLOSED``, and must restate that retained source.
-    """
-
-    status: Literal[
-        "ENCLOSED", "NONFINITE", "TIMEOUT", "BACKEND_ERROR", "OUTPUT_MAGNITUDE_EXCEEDED"
-    ]
-    enclosure: ClaimedPointEnclosure | None = None
-    relative_accuracy_bits: StrictInt | None = None
-    exact: bool = False
-    detail: str = Field(min_length=1, max_length=1024)
-
-    @model_validator(mode="after")
-    def bind_enclosure_to_status(self) -> Self:
-        enclosed = self.status == "ENCLOSED"
-        if enclosed != (self.enclosure is not None):
-            raise _validation_error(
-                "only an enclosed result may carry the point enclosure"
-            )
-        if not enclosed and (self.relative_accuracy_bits is not None or self.exact):
-            raise _validation_error(
-                "a non-enclosure cannot claim accuracy or exactness"
-            )
-        if enclosed:
-            enclosure = self.enclosure
-            assert enclosure is not None
-            if (
-                enclosure.function,
-                enclosure.argument,
-                enclosure.precision_bits,
-            ) != (self.function, self.argument, self.precision_bits):
-                raise _validation_error(
-                    "the enclosure must restate the retained request"
-                )
-            if enclosure.lower.compare(enclosure.upper) > 0:
-                raise _validation_error(
-                    "enclosure lower endpoint exceeds upper endpoint"
-                )
-            if self.exact != (self.relative_accuracy_bits is None):
-                raise _validation_error(
-                    "exact enclosures omit relative accuracy; inexact ones report it"
-                )
         return self

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -9,33 +9,40 @@ from typing import Any
 from jacobian.canonical import format_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
+from jacobian.math.analysis._expression_enclosure import (
+    IntervalExpressionEnclosureRequest,
+    IntervalExpressionEnclosureResult,
+)
 from jacobian.math.analysis._models import (
     MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
     MAX_DYADIC_EXPONENT,
-    ArbPointEnclosureRequest,
-    ArbPointEnclosureResult,
-    ClaimedPointEnclosure,
     DyadicClosedInterval,
     ExactDyadic,
-    FirstPartialEnclosure,
-    HessianEntryEnclosure,
     IntervalExpressionBoxEnclosureRequest,
     IntervalExpressionBoxEnclosureResult,
     IntervalExpressionBoxEnclosureStatus,
     IntervalExpressionDomainFailure,
-    IntervalExpressionEnclosureRequest,
-    IntervalExpressionEnclosureResult,
     IntervalExpressionNode,
-    IntervalExpressionSecondJetEnclosureRequest,
-    IntervalExpressionSecondJetEnclosureResult,
-    IntervalExpressionSecondJetEnclosureStatus,
-    PointEnclosureCheckRequest,
-    PointEnclosureCheckResult,
     _preflight_box_expression,
     _rational_box_bounds,
 )
+from jacobian.math.analysis._point_enclosure import (
+    ArbPointEnclosureRequest,
+    ArbPointEnclosureResult,
+    ClaimedPointEnclosure,
+    PointEnclosureCheckRequest,
+    PointEnclosureCheckResult,
+)
 from jacobian.math.analysis._point_enclosure_check import (
     point_enclosure_check_outcome,
+)
+from jacobian.math.analysis._second_jet import (
+    FirstPartialEnclosure,
+    HessianEntryEnclosure,
+    IntervalExpressionSecondJetEnclosureRequest,
+    IntervalExpressionSecondJetEnclosureResult,
+    IntervalExpressionSecondJetEnclosureStatus,
+    _preflight_second_jet_expression,
 )
 from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
@@ -710,8 +717,6 @@ def _constructed_second_jet_result(
 def _second_jet_enclosure(
     request: IntervalExpressionSecondJetEnclosureRequest,
 ) -> IntervalExpressionSecondJetEnclosureResult:
-    from jacobian.math.analysis._models import _preflight_second_jet_expression
-
     preflight = _preflight_second_jet_expression(
         request.expression, _rational_box_bounds(request.box)
     )

--- a/src/jacobian/math/analysis/_point_enclosure.py
+++ b/src/jacobian/math/analysis/_point_enclosure.py
@@ -1,0 +1,318 @@
+"""Contracts for bounded real-function point enclosures and their checker."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import ConfigDict, Field, StrictInt, model_validator
+
+from jacobian._exact import CanonicalRational, require_bounded_rational
+from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.analysis._models import (
+    MAX_DYADIC_MANTISSA_DIGITS,
+    MAX_RATIONAL_DIGITS,
+    ExactDyadic,
+    _validation_error,
+)
+
+MAX_POINT_CHECK_DYADIC_EXPONENT = 8_192
+MAX_POINT_CHECK_LOG_TERMS = 128
+MAX_POINT_CHECK_FRACTION_BITS = 131_072
+MAX_POINT_CHECK_FRACTION_UPDATES = 4 * MAX_POINT_CHECK_LOG_TERMS
+MAX_POINT_CHECK_OUTPUT_BYTES = 4_096
+
+
+class RealUnaryFunction(StrEnum):
+    EXP = "EXP"
+    LOG = "LOG"
+    SQRT = "SQRT"
+    SIN = "SIN"
+    COS = "COS"
+
+
+class ArbPointEnclosureRequest(StrictModel):
+    function: RealUnaryFunction
+    argument: CanonicalRational
+    precision_bits: StrictInt = Field(default=128, ge=32, le=4096)
+
+    @model_validator(mode="after")
+    def bound_argument_size(self) -> Self:
+        require_bounded_rational(
+            self.argument,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="validated-analysis rational",
+        )
+        return self
+
+
+type PointEnclosureCheckOutcome = Literal["ACCEPTED", "REJECTED", "NON_RESULT"]
+
+
+class ClaimedPointEnclosure(StrictModel):
+    """One claimed enclosure of a real function value by exact dyadic endpoints.
+
+    This is the domain-owned canonical value shared by the Arb producer and
+    the independent checker, so a serialized claim crosses the consumer
+    boundary unchanged. Endpoint order is deliberately not validated here: a
+    reversed claim is a checkable mathematical statement, not an invalid one.
+    """
+
+    function: RealUnaryFunction = Field(
+        description="Real function whose value the endpoints claim to enclose."
+    )
+    argument: CanonicalRational = Field(
+        description="Exact reduced rational argument with at most 128 digits per component."
+    )
+    precision_bits: StrictInt = Field(
+        ge=32,
+        le=4096,
+        description=(
+            "Precision metadata retained from the source computation; it does "
+            "not promise that an independent replay resolves the claim at "
+            "that precision."
+        ),
+    )
+    lower: ExactDyadic = Field(description="Claimed inclusive lower endpoint.")
+    upper: ExactDyadic = Field(description="Claimed inclusive upper endpoint.")
+
+    @model_validator(mode="after")
+    def bound_claim_source(self) -> Self:
+        require_bounded_rational(
+            self.argument,
+            max_digits=MAX_RATIONAL_DIGITS,
+            label="claimed point-enclosure rational",
+        )
+        return self
+
+
+def _preflight_point_check_source(data: object) -> object:
+    """Reject oversized raw source scalars before canonical integer parsing."""
+
+    if not isinstance(data, dict):
+        return data
+    enclosure = data.get("enclosure")
+    if isinstance(enclosure, ClaimedPointEnclosure):
+        raw_components: tuple[object, ...] = (
+            enclosure.argument.num,
+            enclosure.argument.den,
+        )
+    elif isinstance(enclosure, dict):
+        argument = enclosure.get("argument")
+        if isinstance(argument, CanonicalRational):
+            raw_components = (argument.num, argument.den)
+        elif isinstance(argument, dict):
+            raw_components = (argument.get("num"), argument.get("den"))
+        else:
+            raw_components = ()
+    else:
+        raw_components = ()
+    if any(
+        isinstance(component, str) and len(component.lstrip("-")) > MAX_RATIONAL_DIGITS
+        for component in raw_components
+    ):
+        raise _validation_error(
+            "point-enclosure checker raw rational component exceeds the "
+            f"{MAX_RATIONAL_DIGITS}-digit bound"
+        )
+    return data
+
+
+def _point_check_fraction_bound_bits(argument: CanonicalRational) -> int:
+    """Bound LOG/SQRT intermediates, including claim comparisons and replay."""
+
+    numerator, denominator = argument.as_integer_ratio()
+    source_bits = max(abs(numerator).bit_length(), denominator.bit_length())
+    transformed_bits = source_bits + 2
+    odd_denominator_bits = (2 * MAX_POINT_CHECK_LOG_TERMS + 1).bit_length()
+
+    # A common denominator for one upper atanh bound divides
+    # b**(2*n-1) * lcm(1, 3, ..., 2*n-1) * (2*n+1) * (b*b-a*a).
+    # Combining log(y) with k*log(2) adds the independent powers of 3 but
+    # shares the odd-denominator factors.  The coefficient k has at most
+    # source_bits.bit_length() bits after exact power-of-two range reduction.
+    combined_log_bits = (
+        (2 * MAX_POINT_CHECK_LOG_TERMS - 1) * (transformed_bits + 2)
+        + 2 * transformed_bits
+        + (MAX_POINT_CHECK_LOG_TERMS + 1) * odd_denominator_bits
+        + source_bits.bit_length()
+        + 8
+    )
+    endpoint_bits = 4 * MAX_DYADIC_MANTISSA_DIGITS + MAX_POINT_CHECK_DYADIC_EXPONENT
+    log_comparison_bits = combined_log_bits + endpoint_bits + 32
+    sqrt_comparison_bits = 2 * endpoint_bits + source_bits + 8
+    return max(log_comparison_bits, sqrt_comparison_bits)
+
+
+class PointEnclosureCheckRequest(StrictModel):
+    """Check one claimed LOG or SQRT enclosure by exact independent replay.
+
+    The claimed enclosure is one canonical ``ClaimedPointEnclosure`` accepted
+    unchanged from its source. Rational components have at most 128 decimal
+    digits. Claimed dyadic exponents must lie in -8192..8192; reversed or
+    mathematically invalid intervals remain valid claims and produce typed
+    checker outcomes. Only LOG and SQRT claims are admitted. LOG replay uses
+    at most 128 terms per series, about 400 worst-case bits after range
+    reduction, so tighter claims can produce NON_RESULT even when their
+    retained precision metadata is larger.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "point_check_log_term_bound": MAX_POINT_CHECK_LOG_TERMS,
+            "point_check_fraction_intermediate_bit_bound": (
+                MAX_POINT_CHECK_FRACTION_BITS
+            ),
+            "point_check_producer_replay_term_update_bound": (
+                MAX_POINT_CHECK_FRACTION_UPDATES
+            ),
+            "point_check_output_byte_bound": MAX_POINT_CHECK_OUTPUT_BYTES,
+        }
+    )
+
+    enclosure: ClaimedPointEnclosure = Field(
+        description=(
+            "Canonical claimed enclosure retained verbatim from its source; "
+            "only LOG and SQRT functions are admitted."
+        )
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def preflight_raw_source(cls, data: object) -> object:
+        return _preflight_point_check_source(canonicalize_json_containers(data))
+
+    @model_validator(mode="after")
+    def preflight_exact_checker(self) -> Self:
+        if self.enclosure.function not in (
+            RealUnaryFunction.LOG,
+            RealUnaryFunction.SQRT,
+        ):
+            raise _validation_error(
+                "point-enclosure checker replays only LOG and SQRT claims"
+            )
+        if any(
+            abs(endpoint.exponent) > MAX_POINT_CHECK_DYADIC_EXPONENT
+            for endpoint in (self.enclosure.lower, self.enclosure.upper)
+        ):
+            raise _validation_error(
+                "point-enclosure checker dyadic exponent exceeds the "
+                f"+/-{MAX_POINT_CHECK_DYADIC_EXPONENT} bound"
+            )
+        if (
+            _point_check_fraction_bound_bits(self.enclosure.argument)
+            > MAX_POINT_CHECK_FRACTION_BITS
+        ):
+            raise _validation_error(
+                "point-enclosure checker exact rational work exceeds the "
+                f"{MAX_POINT_CHECK_FRACTION_BITS}-bit intermediate bound"
+            )
+        return self
+
+
+class PointEnclosureCheckResult(StrictModel):
+    """A source-bound checker outcome replayed during result validation.
+
+    ACCEPTED means the independently proved interval is contained in the
+    claim. REJECTED covers an invalid real-domain or reversed claim, or a claim
+    proved disjoint from the true value. NON_RESULT means the independent LOG
+    enclosure still partially overlaps the claim after 128 series terms.
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "point_check_output_byte_bound": MAX_POINT_CHECK_OUTPUT_BYTES,
+        }
+    )
+
+    enclosure: ClaimedPointEnclosure
+    outcome: PointEnclosureCheckOutcome = Field(
+        description=(
+            "ACCEPTED when the independent enclosure is contained in the "
+            "claim; REJECTED for invalid or provably excluding claims; "
+            "NON_RESULT for unresolved partial overlap at the LOG term cap."
+        )
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def preflight_raw_source(cls, data: object) -> object:
+        return _preflight_point_check_source(canonicalize_json_containers(data))
+
+    @model_validator(mode="after")
+    def replay_outcome(self) -> Self:
+        from jacobian.math.analysis._point_enclosure_check import (
+            point_enclosure_check_outcome,
+        )
+
+        request = PointEnclosureCheckRequest(enclosure=self.enclosure)
+        if self.outcome != point_enclosure_check_outcome(request):
+            raise _validation_error(
+                "outcome must equal the deterministic enclosure check for the retained source"
+            )
+        return self
+
+
+class ArbPointEnclosureResult(ArbPointEnclosureRequest):
+    """A source-bound Arb ball enclosure of one real function value.
+
+    Every outcome retains the request's function, argument, and precision;
+    ``enclosure`` carries the canonical ``ClaimedPointEnclosure`` only when
+    ``status`` is ``ENCLOSED``, and must restate that retained source.
+    """
+
+    status: Literal[
+        "ENCLOSED", "NONFINITE", "TIMEOUT", "BACKEND_ERROR", "OUTPUT_MAGNITUDE_EXCEEDED"
+    ]
+    enclosure: ClaimedPointEnclosure | None = None
+    relative_accuracy_bits: StrictInt | None = None
+    exact: bool = False
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_enclosure_to_status(self) -> Self:
+        enclosed = self.status == "ENCLOSED"
+        if enclosed != (self.enclosure is not None):
+            raise _validation_error(
+                "only an enclosed result may carry the point enclosure"
+            )
+        if not enclosed and (self.relative_accuracy_bits is not None or self.exact):
+            raise _validation_error(
+                "a non-enclosure cannot claim accuracy or exactness"
+            )
+        if enclosed:
+            enclosure = self.enclosure
+            assert enclosure is not None
+            if (
+                enclosure.function,
+                enclosure.argument,
+                enclosure.precision_bits,
+            ) != (self.function, self.argument, self.precision_bits):
+                raise _validation_error(
+                    "the enclosure must restate the retained request"
+                )
+            if enclosure.lower.compare(enclosure.upper) > 0:
+                raise _validation_error(
+                    "enclosure lower endpoint exceeds upper endpoint"
+                )
+            if self.exact != (self.relative_accuracy_bits is None):
+                raise _validation_error(
+                    "exact enclosures omit relative accuracy; inexact ones report it"
+                )
+        return self
+
+
+__all__ = [
+    "MAX_POINT_CHECK_DYADIC_EXPONENT",
+    "MAX_POINT_CHECK_FRACTION_BITS",
+    "MAX_POINT_CHECK_FRACTION_UPDATES",
+    "MAX_POINT_CHECK_LOG_TERMS",
+    "MAX_POINT_CHECK_OUTPUT_BYTES",
+    "ArbPointEnclosureRequest",
+    "ArbPointEnclosureResult",
+    "ClaimedPointEnclosure",
+    "PointEnclosureCheckOutcome",
+    "PointEnclosureCheckRequest",
+    "PointEnclosureCheckResult",
+    "RealUnaryFunction",
+]

--- a/src/jacobian/math/analysis/_point_enclosure_check.py
+++ b/src/jacobian/math/analysis/_point_enclosure_check.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from fractions import Fraction
 
-from jacobian.math.analysis._models import (
+from jacobian.math.analysis._point_enclosure import (
     MAX_POINT_CHECK_LOG_TERMS,
     PointEnclosureCheckOutcome,
     PointEnclosureCheckRequest,

--- a/src/jacobian/math/analysis/_second_jet.py
+++ b/src/jacobian/math/analysis/_second_jet.py
@@ -1,0 +1,255 @@
+"""Contracts for bounded second-order interval-expression enclosures."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import Field, field_validator, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.analysis._models import (
+    MAX_BOX_VARIABLES,
+    DyadicClosedInterval,
+    IntervalExpressionBoxEnclosureRequest,
+    IntervalExpressionDomainFailure,
+    IntervalExpressionNode,
+    IntervalVariable,
+    _bounded_expression_nodes,
+    _bounded_rational_bounds,
+    _BoxPreflight,
+    _preflight_box_binary,
+    _preflight_box_unary,
+    _rational_box_bounds,
+    _RationalBounds,
+    _validation_error,
+)
+
+MAX_SECOND_JET_VARIABLES = MAX_BOX_VARIABLES
+MAX_SECOND_JET_RESULT_INTERVALS = (
+    1
+    + MAX_SECOND_JET_VARIABLES
+    + MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2
+)
+
+
+def _second_jet_node_arithmetic_units(dimension: int) -> int:
+    """Bound the scalar Arb steps of one source node's dense second-order jet.
+
+    Every jet carries a value, gradient, and dense Hessian, so one node's
+    arithmetic grows quadratically in the jet dimension. A division is the
+    most expensive node: one reciprocal power jet followed by one product jet
+    costs about ``10 * dimension**2 + 4 * dimension`` scalar steps, and the
+    padded constant covers transcendental chain-rule values. At three
+    variables this reproduces the former flat 128-unit bound.
+    """
+    return 10 * dimension * dimension + 4 * dimension + 16
+
+
+# Twice the former 64-node x 128-unit envelope. Every previously accepted
+# three-variable request stays admitted while the dimension-derived charge
+# admits small full-axis jets such as an eight-variable affine form.
+MAX_SECOND_JET_WORK_UNITS = 16_384
+
+type IntervalExpressionSecondJetEnclosureStatus = Literal[
+    "ENCLOSED", "DOMAIN_UNPROVEN", "BACKEND_ERROR"
+]
+
+
+def _preflight_second_jet_expression(
+    node: IntervalExpressionNode,
+    variables: dict[str, _RationalBounds],
+    path: tuple[int, ...] = (),
+) -> _BoxPreflight:
+    """Prove the source tree is twice differentiable on the complete box."""
+
+    if node.op == "const":
+        assert node.value is not None
+        value = node.value.as_fraction()
+        return _bounded_rational_bounds(value, value)
+    if node.op == "var":
+        assert node.variable is not None
+        return variables[node.variable]
+
+    children: list[_BoxPreflight] = []
+    for index, child_node in enumerate(node.children):
+        child = _preflight_second_jet_expression(child_node, variables, (*path, index))
+        if isinstance(child, IntervalExpressionDomainFailure):
+            return child
+        children.append(child)
+
+    left = children[0]
+    assert isinstance(left, _RationalBounds)
+    if len(children) == 1:
+        if node.op == "sqrt" and left.lower <= 0:
+            return IntervalExpressionDomainFailure(
+                node_path=path,
+                operation="sqrt",
+                reason="SQRT_ARGUMENT_NOT_STRICTLY_POSITIVE_FOR_SECOND_JET",
+            )
+        return _preflight_box_unary(node, left, path)
+
+    right = children[1]
+    assert isinstance(right, _RationalBounds)
+    return _preflight_box_binary(node, left, right, path)
+
+
+class IntervalExpressionSecondJetEnclosureRequest(
+    IntervalExpressionBoxEnclosureRequest
+):
+    """Enclose an elementary expression and all derivatives through order two."""
+
+    @model_validator(mode="after")
+    def require_small_twice_differentiable_source(self) -> Self:
+        dimension = len(self.box.variables)
+        result_intervals = 1 + dimension + dimension * (dimension + 1) // 2
+        if result_intervals > MAX_SECOND_JET_RESULT_INTERVALS:
+            raise AssertionError(
+                "second-jet result interval accounting is inconsistent"
+            )
+        work_units = len(
+            _bounded_expression_nodes(self.expression)
+        ) * _second_jet_node_arithmetic_units(dimension)
+        if work_units > MAX_SECOND_JET_WORK_UNITS:
+            raise _validation_error(
+                f"second-jet forward arithmetic work of {work_units} scalar "
+                f"units exceeds its {MAX_SECOND_JET_WORK_UNITS}-unit bound at "
+                "this dimension"
+            )
+        _preflight_second_jet_expression(
+            self.expression, _rational_box_bounds(self.box)
+        )
+        return self
+
+
+class FirstPartialEnclosure(StrictModel):
+    """One first-partial enclosure bound to the authoritative source axis."""
+
+    variable: IntervalVariable
+    enclosure: DyadicClosedInterval
+
+
+class HessianEntryEnclosure(StrictModel):
+    """One canonical upper-triangular Hessian entry over the source box."""
+
+    first_variable: IntervalVariable
+    second_variable: IntervalVariable
+    enclosure: DyadicClosedInterval
+
+
+class IntervalExpressionSecondJetEnclosureResult(
+    IntervalExpressionSecondJetEnclosureRequest
+):
+    """A source-bound rigorous value, gradient, and symmetric Hessian enclosure.
+
+    For ``ENCLOSED``, full validation recomputes the canonical jet claim from
+    its expression, axis, and source box.  ``DOMAIN_UNPROVEN`` replays its
+    deterministic first-obstruction evidence.  ``BACKEND_ERROR`` asserts no
+    enclosure conclusion at all, so it is validated structurally: rerunning
+    Arb would reject the operation's own serialized result whenever a
+    transient backend condition does not recur.
+    """
+
+    status: IntervalExpressionSecondJetEnclosureStatus
+    value: DyadicClosedInterval | None = None
+    gradient: tuple[FirstPartialEnclosure, ...] = Field(
+        default=(), max_length=MAX_SECOND_JET_VARIABLES
+    )
+    hessian: tuple[HessianEntryEnclosure, ...] = Field(
+        default=(),
+        max_length=MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2,
+    )
+    domain_failure: IntervalExpressionDomainFailure | None = None
+    method: Literal["ARB_FORWARD_SECOND_ORDER_JET"] = "ARB_FORWARD_SECOND_ORDER_JET"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @field_validator("gradient", mode="before")
+    @classmethod
+    def preserve_gradient_json_array_composition(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)) and len(value) > MAX_SECOND_JET_VARIABLES:
+            raise _validation_error(
+                "second-jet result exceeds its declared interval bound"
+            )
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("hessian", mode="before")
+    @classmethod
+    def preserve_hessian_json_array_composition(cls, value: object) -> object:
+        maximum = MAX_SECOND_JET_VARIABLES * (MAX_SECOND_JET_VARIABLES + 1) // 2
+        if isinstance(value, (list, tuple)) and len(value) > maximum:
+            raise _validation_error(
+                "second-jet result exceeds its declared interval bound"
+            )
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def bind_second_jet_to_source(self) -> Self:
+        enclosed = self.status == "ENCLOSED"
+        expected_pairs = tuple(
+            (first, second)
+            for first_index, first in enumerate(self.box.variables)
+            for second in self.box.variables[first_index:]
+        )
+        if enclosed != (self.value is not None):
+            raise _validation_error(
+                "only an enclosed second jet may carry a value enclosure"
+            )
+        if enclosed:
+            if tuple(entry.variable for entry in self.gradient) != self.box.variables:
+                raise _validation_error(
+                    "gradient entries must match the ordered source axis"
+                )
+            if (
+                tuple(
+                    (entry.first_variable, entry.second_variable)
+                    for entry in self.hessian
+                )
+                != expected_pairs
+            ):
+                raise _validation_error(
+                    "Hessian entries must be the canonical upper triangle of the source axis"
+                )
+            if self.domain_failure is not None:
+                raise _validation_error(
+                    "an enclosed second jet cannot carry a domain failure"
+                )
+        else:
+            if self.value is not None or self.gradient or self.hessian:
+                raise _validation_error(
+                    "a non-enclosed second jet cannot carry partial enclosures"
+                )
+            domain_unproven = self.status == "DOMAIN_UNPROVEN"
+            if domain_unproven != (self.domain_failure is not None):
+                raise _validation_error(
+                    "domain-failure evidence must agree with DOMAIN_UNPROVEN status"
+                )
+            if self.status == "BACKEND_ERROR":
+                return self
+
+        from jacobian.math.analysis._operations import _second_jet_enclosure
+
+        request = IntervalExpressionSecondJetEnclosureRequest.model_construct(
+            expression=self.expression,
+            box=self.box,
+            precision_bits=self.precision_bits,
+        )
+        if self != _second_jet_enclosure(request):
+            raise _validation_error(
+                "second-jet enclosure does not replay from its expression, axis, and source box"
+            )
+        return self
+
+
+__all__ = [
+    "MAX_SECOND_JET_RESULT_INTERVALS",
+    "MAX_SECOND_JET_VARIABLES",
+    "MAX_SECOND_JET_WORK_UNITS",
+    "FirstPartialEnclosure",
+    "HessianEntryEnclosure",
+    "IntervalExpressionSecondJetEnclosureRequest",
+    "IntervalExpressionSecondJetEnclosureResult",
+    "IntervalExpressionSecondJetEnclosureStatus",
+]

--- a/tests/math/test_analysis_expression_box_enclosure.py
+++ b/tests/math/test_analysis_expression_box_enclosure.py
@@ -9,10 +9,12 @@ import pytest
 from pydantic import ValidationError
 from tests.math._analysis_support import analysis_validation_error
 
+from jacobian.math.analysis._expression_enclosure import (
+    IntervalExpressionEnclosureRequest,
+)
 from jacobian.math.analysis._models import (
     IntervalExpressionBoxEnclosureRequest,
     IntervalExpressionBoxEnclosureResult,
-    IntervalExpressionEnclosureRequest,
     RationalIntervalBox,
 )
 from jacobian.math.analysis._operations import (

--- a/tests/math/test_analysis_expression_enclosure.py
+++ b/tests/math/test_analysis_expression_enclosure.py
@@ -5,12 +5,11 @@ from fractions import Fraction
 import pytest
 from tests.math._analysis_support import analysis_validation_error
 
-from jacobian.math.analysis._models import (
-    MAX_DYADIC_EXPONENT,
-    ExactDyadic,
+from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
 )
+from jacobian.math.analysis._models import MAX_DYADIC_EXPONENT, ExactDyadic
 from jacobian.math.analysis._operations import _dyadic_endpoints, _expression_enclosure
 
 

--- a/tests/math/test_analysis_expression_second_jet_enclosure.py
+++ b/tests/math/test_analysis_expression_second_jet_enclosure.py
@@ -8,12 +8,12 @@ import pytest
 from pydantic import ValidationError
 from tests.math._analysis_support import analysis_validation_error
 
-from jacobian.math.analysis._models import (
-    DyadicClosedInterval,
+from jacobian.math.analysis._models import DyadicClosedInterval
+from jacobian.math.analysis._operations import _second_jet_enclosure
+from jacobian.math.analysis._second_jet import (
     IntervalExpressionSecondJetEnclosureRequest,
     IntervalExpressionSecondJetEnclosureResult,
 )
-from jacobian.math.analysis._operations import _second_jet_enclosure
 
 
 def _q(numerator: int, denominator: int = 1) -> dict[str, str]:

--- a/tests/math/test_analysis_point_enclosure_check.py
+++ b/tests/math/test_analysis_point_enclosure_check.py
@@ -7,7 +7,9 @@ import pytest
 from pydantic import ValidationError
 from tests.math._analysis_support import analysis_validation_error
 
-from jacobian.math.analysis._models import (
+from jacobian.math.analysis._models import ExactDyadic
+from jacobian.math.analysis._operations import _check_point_enclosure
+from jacobian.math.analysis._point_enclosure import (
     MAX_POINT_CHECK_DYADIC_EXPONENT,
     MAX_POINT_CHECK_FRACTION_BITS,
     MAX_POINT_CHECK_FRACTION_UPDATES,
@@ -16,12 +18,10 @@ from jacobian.math.analysis._models import (
     ArbPointEnclosureRequest,
     ArbPointEnclosureResult,
     ClaimedPointEnclosure,
-    ExactDyadic,
     PointEnclosureCheckRequest,
     PointEnclosureCheckResult,
     _point_check_fraction_bound_bits,
 )
-from jacobian.math.analysis._operations import _check_point_enclosure
 from jacobian.math.analysis._point_enclosure_check import (
     _log_range_reduction,
     _positive_atanh_enclosures,


### PR DESCRIPTION
Fixes #2566.

## Problem

Analysis expression/box evaluation, point-enclosure checks, and second-jet evaluation shared one cross-family contract module despite having independent representations and kernel boundaries.

## Solution

Move the three enclosure families into focused owner modules. Shared expression, box, and dyadic grammar stays in `_models.py`, and Euclidean geometry remains the owner of `RationalClosedInterval`. Operation IDs, schemas, catalog membership, and behavior are unchanged.

## Testing

- `make check` — 6,368 passed
- focused analysis enclosure suite — 107 passed
- catalog request identity assertions — passed
- `ruff check` and `ruff format --check` — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This is an ownership refactor; the public operation surface is preserved.

## Checklist

- [x] `make check` passes