### PR TITLE
Reuse admitted zeta kernels in symbolic dynamics

### DIFF
--- a/src/jacobian/math/symbolic_dynamics/_models.py
+++ b/src/jacobian/math/symbolic_dynamics/_models.py
@@ -267,6 +267,49 @@ class ArtinMazurZetaResult(ArtinMazurZetaRequest):
         return self
 
 
+def _computed_artin_mazur_zeta_result(
+    request: ArtinMazurZetaRequest,
+    determinant_polynomial: RationalPolynomial,
+    zeta_function: RationalFunction,
+    coefficients: tuple[int, ...],
+) -> ArtinMazurZetaResult:
+    """Bind a fresh kernel result without a second determinant/replay pass.
+
+    ``artin_mazur_zeta`` has already established these exact values for the
+    typed request.  The public operation therefore constructs its result
+    directly; independently supplied result payloads still take the complete
+    source-binding replay in ``bind_zeta_and_periodic_replay``.
+    """
+
+    if (
+        determinant_polynomial.variables != ("t",)
+        or zeta_function.variables != ("t",)
+        or len(coefficients) != request.replay_period
+    ):
+        raise _validation_error(
+            "artin_mazur_zeta_computed_shape",
+            "computed zeta values must retain the canonical t axis and replay scope",
+        )
+    return ArtinMazurZetaResult.model_construct(
+        shift=request.shift,
+        replay_period=request.replay_period,
+        determinant_polynomial=determinant_polynomial,
+        zeta_function=zeta_function,
+        replay=tuple(
+            ArtinMazurZetaReplayRow(
+                period=period,
+                trace_fixed_points=format_canonical_integer(coefficient),
+                logarithmic_derivative_coefficient=format_canonical_integer(
+                    coefficient
+                ),
+            )
+            for period, coefficient in enumerate(coefficients, 1)
+        ),
+        convention="EDGE_SHIFT_ARTIN_MAZUR_ZETA",
+        method="SYMPY_EXACT_CHARACTERISTIC_POLYNOMIAL",
+    )
+
+
 __all__ = [
     "ArtinMazurZetaReplayRow",
     "ArtinMazurZetaRequest",

--- a/src/jacobian/math/symbolic_dynamics/_operations.py
+++ b/src/jacobian/math/symbolic_dynamics/_operations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer
 from jacobian.math.symbolic_dynamics._models import (
-    ArtinMazurZetaReplayRow,
     ArtinMazurZetaRequest,
     ArtinMazurZetaResult,
     BlockLanguageRequest,
@@ -15,6 +14,7 @@ from jacobian.math.symbolic_dynamics._models import (
     HigherBlockResult,
     PeriodicPointProfileRequest,
     PeriodicPointProfileResult,
+    _computed_artin_mazur_zeta_result,
 )
 from jacobian.math.symbolic_dynamics.operations import (
     artin_mazur_zeta,
@@ -32,20 +32,11 @@ def compute_artin_mazur_zeta(
     determinant, zeta, coefficients = artin_mazur_zeta(
         request.shift, request.replay_period
     )
-    return ArtinMazurZetaResult(
-        **request.model_dump(),
-        determinant_polynomial=determinant,
-        zeta_function=zeta,
-        replay=tuple(
-            ArtinMazurZetaReplayRow(
-                period=period,
-                trace_fixed_points=format_canonical_integer(coefficient),
-                logarithmic_derivative_coefficient=format_canonical_integer(
-                    coefficient
-                ),
-            )
-            for period, coefficient in enumerate(coefficients, 1)
-        ),
+    return _computed_artin_mazur_zeta_result(
+        request,
+        determinant,
+        zeta,
+        coefficients,
     )
 
 

--- a/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
+++ b/tests/math/symbolic_dynamics/test_symbolic_dynamics.py
@@ -76,6 +76,7 @@ def test_golden_mean_artin_mazur_zeta_is_bound_to_periodic_traces() -> None:
         "7",
         "11",
     )
+    assert ArtinMazurZetaResult.model_validate(result.model_dump(mode="json")) == result
 
     payload = result.model_dump()
     payload["replay"][2]["logarithmic_derivative_coefficient"] = "5"


### PR DESCRIPTION
Refs #1910.

## Problem

Symbolic-dynamics zeta evaluation could recompute a kernel result after the request had already admitted and constructed the same canonical bounded value.

## Solution

Reuse the admitted zeta kernel result for the operation projection. The regression exercises the public serialized result path rather than monkeypatching an internal mathematical kernel. Request and result contracts, operation IDs, and schemas are unchanged.

## Testing

- `make test-focused LANE=math TESTS=tests/math/symbolic_dynamics` — 19 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `ruff check`, `ruff format --check`, and mypy — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This retains the existing zeta invariant and transport shape.

## Checklist

- [ ] `make check` passes (running on the final branch)