### PR TITLE
Preserve checked catalog operation type bindings

### DIFF
--- a/src/jacobian/catalog/catalog.py
+++ b/src/jacobian/catalog/catalog.py
@@ -45,7 +45,7 @@ def _bind_operation[RequestT: StrictModel, ResultT: StrictModel](
                 f"{operation.operation_id} received a request outside its declared type"
             )
         result = operation.run(request)
-        if not isinstance(result, operation.result_type):
+        if type(result) is not operation.result_type:
             raise TypeError(
                 f"{operation.operation_id} returned a result outside its declared type"
             )

--- a/src/jacobian/catalog/catalog.py
+++ b/src/jacobian/catalog/catalog.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
+from jacobian._models import StrictModel
 from jacobian.catalog.builtins import BUILTIN_TOOLS
 from jacobian.catalog.models import (
     MathTool,
@@ -18,11 +20,53 @@ from jacobian.catalog.models import (
 from jacobian.catalog.search import browse_operations, discover_operations
 
 
+@dataclass(frozen=True, slots=True)
+class _BoundMathTool:
+    """One checked existential binding at the heterogeneous catalog boundary."""
+
+    request_type: type[StrictModel]
+    result_type: type[StrictModel]
+    _run: Callable[[StrictModel], StrictModel]
+
+    def run(self, request: StrictModel) -> StrictModel:
+        """Run one parsed request through its checked typed declaration."""
+
+        return self._run(request)
+
+
+def _bind_operation[RequestT: StrictModel, ResultT: StrictModel](
+    operation: MathTool[RequestT, ResultT],
+) -> _BoundMathTool:
+    """Erase one typed declaration only after retaining its runtime witnesses."""
+
+    def run(request: StrictModel) -> StrictModel:
+        if not isinstance(request, operation.request_type):
+            raise TypeError(
+                f"{operation.operation_id} received a request outside its declared type"
+            )
+        result = operation.run(request)
+        if not isinstance(result, operation.result_type):
+            raise TypeError(
+                f"{operation.operation_id} returned a result outside its declared type"
+            )
+        return result
+
+    return _BoundMathTool(
+        request_type=operation.request_type,
+        result_type=operation.result_type,
+        _run=run,
+    )
+
+
 class Catalog:
     """Direct declaration view with no overlay or state directory."""
 
     def __init__(self, operations: Iterable[MathTool[Any, Any]]) -> None:
         self._operations = _index_operations(operations)
+        self._bindings = {
+            operation_id: _bind_operation(operation)
+            for operation_id, operation in self._operations.items()
+        }
 
     @classmethod
     def open(cls) -> Catalog:
@@ -32,6 +76,11 @@ class Catalog:
         """Return the mathematical function selected by a known operation ID."""
 
         return self._operations.get(operation_id)
+
+    def _binding(self, operation_id: str) -> _BoundMathTool | None:
+        """Return the private checked binding for one selected declaration."""
+
+        return self._bindings.get(operation_id)
 
     def inspect(self, operation_id: str) -> OperationDescriptor | None:
         operation = self.operation(operation_id)

--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import time
 from collections.abc import Mapping, Sequence
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
-from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalizationError, encode_strict_json
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationId, OperationResult
@@ -58,20 +57,17 @@ def invoke_operation(
     """Select, parse, call, and project one typed mathematical operation."""
 
     started = time.monotonic()
-    operation = catalog.operation(operation_id)
-    if operation is None:
+    binding = catalog._binding(operation_id)
+    if binding is None:
         raise ValueError(f"unknown operation: {operation_id}")
     try:
-        parsed = cast(
-            StrictModel,
-            parse_operation_input(operation.request_type, payload),
-        )
+        parsed = parse_operation_input(binding.request_type, payload)
     except (CanonicalizationError, ValidationError) as exc:
         raise OperationRequestValidationError(exc) from exc
-    result = operation.run(parsed)
+    result = binding.run(parsed)
 
     return OperationResult(
-        operation_id=operation.operation_id,
+        operation_id=operation_id,
         runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
         output=result.model_dump(mode="json"),
     )

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import cast
+
 import pytest
 
+from jacobian._models import StrictModel
 from jacobian.catalog import catalog as catalog_module
 from jacobian.catalog.catalog import Catalog
-from jacobian.catalog.models import OperationDiscoveryRequest
+from jacobian.catalog.models import MathTool, OperationDiscoveryRequest
 from jacobian.catalog.search import browse_operations, discover_operations
 from jacobian.dispatch import invoke_operation
+
+
+class _BindingRequest(StrictModel):
+    value: int
+
+
+class _BindingResult(StrictModel):
+    doubled: int
+
+
+class _WrongBindingResult(StrictModel):
+    value: int
 
 
 def test_catalog_inspects_determinant_without_sqlite() -> None:
@@ -70,6 +86,23 @@ def test_invoke_operation_reports_unknown_removed_family_id(operation_id: str) -
             {"vertices": ["a"], "edges": []},
             catalog,
         )
+
+
+def test_checked_catalog_binding_rejects_an_incorrect_declared_result() -> None:
+    def wrong_result(_request: _BindingRequest) -> _WrongBindingResult:
+        return _WrongBindingResult(value=1)
+
+    operation = MathTool(
+        operation_id="test.binding.result",
+        title="Test checked result binding",
+        description="Exercise the private heterogeneous catalog boundary.",
+        request_type=_BindingRequest,
+        result_type=_BindingResult,
+        run=cast(Callable[[_BindingRequest], _BindingResult], wrong_result),
+    )
+
+    with pytest.raises(TypeError, match="returned a result outside its declared type"):
+        invoke_operation("test.binding.result", {"value": 1}, Catalog((operation,)))
 
 
 def test_explicit_binary_profile_remains_the_published_code_profile() -> None:

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -25,6 +25,10 @@ class _WrongBindingResult(StrictModel):
     value: int
 
 
+class _ExtraBindingResult(_BindingResult):
+    leaked: str
+
+
 def test_catalog_inspects_determinant_without_sqlite() -> None:
     catalog = Catalog.open()
 
@@ -103,6 +107,42 @@ def test_checked_catalog_binding_rejects_an_incorrect_declared_result() -> None:
 
     with pytest.raises(TypeError, match="returned a result outside its declared type"):
         invoke_operation("test.binding.result", {"value": 1}, Catalog((operation,)))
+
+
+def test_checked_catalog_binding_passes_exact_declared_result_unchanged() -> None:
+    def double(_request: _BindingRequest) -> _BindingResult:
+        return _BindingResult(doubled=2)
+
+    operation = MathTool(
+        operation_id="test.binding.exact",
+        title="Test exact result binding",
+        description="Exercise the private heterogeneous catalog boundary.",
+        request_type=_BindingRequest,
+        result_type=_BindingResult,
+        run=double,
+    )
+
+    result = invoke_operation("test.binding.exact", {"value": 1}, Catalog((operation,)))
+
+    assert set(result.output) == {"doubled"}
+    assert result.output["doubled"] == 2
+
+
+def test_checked_catalog_binding_rejects_result_subclass_extra_fields() -> None:
+    def leak_extra_field(_request: _BindingRequest) -> _ExtraBindingResult:
+        return _ExtraBindingResult(doubled=2, leaked="private")
+
+    operation = MathTool(
+        operation_id="test.binding.subclass",
+        title="Test subclass result binding",
+        description="Exercise the private heterogeneous catalog boundary.",
+        request_type=_BindingRequest,
+        result_type=_BindingResult,
+        run=cast(Callable[[_BindingRequest], _BindingResult], leak_extra_field),
+    )
+
+    with pytest.raises(TypeError, match="returned a result outside its declared type"):
+        invoke_operation("test.binding.subclass", {"value": 1}, Catalog((operation,)))
 
 
 def test_explicit_binary_profile_remains_the_published_code_profile() -> None:

--- a/tests/dispatch/test_dispatch.py
+++ b/tests/dispatch/test_dispatch.py
@@ -28,7 +28,7 @@ class _InvalidResultOperation:
 
 class _CatalogWithInvalidResult:
     @staticmethod
-    def operation(operation_id: str) -> _InvalidResultOperation:
+    def _binding(operation_id: str) -> _InvalidResultOperation:
         del operation_id
         return _InvalidResultOperation()
 


### PR DESCRIPTION
Fixes #2559.

## Problem

The heterogeneous catalog erased every declaration as `MathTool[Any, Any]`, and dispatch restored the request path with a broad cast before invoking the callable. A malformed declaration could therefore return the wrong result type until the later transport projection.

## Solution

Bind each declaration once through a private runtime-witnessed request/result callable at catalog construction. Dispatch invokes that checked binding without the broad cast, so an incompatible result is rejected before projection. The public catalog, operation IDs, request/result schemas, and transport behavior are unchanged.

## Testing

- `make test-focused LANE=catalog TESTS=tests/catalog` — 47 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch` — 54 passed
- `make lint typecheck` — passed
- `make architecture` — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. The change hardens an internal catalog/dispatch boundary without changing published operation contracts.

## Checklist

- [ ] `make check` passes (not run)