### PR TITLE
Publish the finite-game exact-equilibrium envelope

### DIFF
--- a/src/jacobian/math/finite_game_theory/_models.py
+++ b/src/jacobian/math/finite_game_theory/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalRational
@@ -13,6 +13,16 @@ from jacobian.math.finite_game_theory.values import DeterministicTerminalGame
 
 MAX_PLAYERS = 10
 MAX_STRATEGIES = 50
+MAX_EXACT_EQUILIBRIUM_WORK = 32_768
+
+
+def _exact_equilibrium_work(matrix: PayoffMatrix) -> int:
+    """Return the conservative exact primal/dual work measure for ``matrix``."""
+
+    denominator_digits = sum(len(value.den) for value in matrix.entries)
+    numerator_digits = max(len(value.num.lstrip("-")) for value in matrix.entries)
+    elimination_dimension = max(matrix.n_rows, matrix.n_cols) + 2
+    return elimination_dimension * (denominator_digits + numerator_digits)
 
 
 class PayoffMatrix(StrictModel):
@@ -22,9 +32,21 @@ class PayoffMatrix(StrictModel):
     (for zero-sum games, it is the negative of the row player's payoff).
     """
 
-    n_rows: int = Field(ge=1, le=MAX_STRATEGIES)
-    n_cols: int = Field(ge=1, le=MAX_STRATEGIES)
-    entries: tuple[CanonicalRational, ...]
+    n_rows: int = Field(
+        ge=1,
+        le=MAX_STRATEGIES,
+        description="Number of row-player strategies.",
+    )
+    n_cols: int = Field(
+        ge=1,
+        le=MAX_STRATEGIES,
+        description="Number of column-player strategies.",
+    )
+    entries: tuple[CanonicalRational, ...] = Field(
+        description=(
+            "Row-major payoff entries. The tuple has exactly n_rows * n_cols elements."
+        )
+    )
 
     @model_validator(mode="after")
     def require_valid_size(self) -> Self:
@@ -39,18 +61,36 @@ class PayoffMatrix(StrictModel):
 class ZeroSumGameRequest(StrictModel):
     """A 2-player zero-sum game specified by the row player's payoff matrix."""
 
-    payoff_matrix: PayoffMatrix
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "A 2-player zero-sum game specified by the row player's payoff "
+                "matrix. Exact primal and dual linear programs are admitted only "
+                "when (max(n_rows, n_cols) + 2) * (sum of payoff denominator "
+                "decimal digits + maximum payoff numerator decimal digits) is at "
+                f"most {MAX_EXACT_EQUILIBRIUM_WORK}."
+            ),
+            "x-jacobian-bounds": {
+                "max_exact_equilibrium_work": MAX_EXACT_EQUILIBRIUM_WORK,
+            },
+        }
+    )
+
+    payoff_matrix: PayoffMatrix = Field(
+        description=(
+            "Row-major zero-sum payoff matrix. Its entries must have shape "
+            "n_rows * n_cols and must fit the request's published coupled "
+            "exact-equilibrium work bound."
+        )
+    )
 
     @model_validator(mode="after")
     def require_bounded_exact_equilibrium(self) -> Self:
         matrix = self.payoff_matrix
-        denominator_digits = sum(len(value.den) for value in matrix.entries)
-        numerator_digits = max(len(value.num.lstrip("-")) for value in matrix.entries)
-        elimination_dimension = max(matrix.n_rows, matrix.n_cols) + 2
-        if elimination_dimension * (denominator_digits + numerator_digits) > 32_768:
+        if _exact_equilibrium_work(matrix) > MAX_EXACT_EQUILIBRIUM_WORK:
             raise PydanticCustomError(
                 "finite_game.exact_equilibrium_budget",
-                "payoffs exceed the exact-equilibrium result budget",
+                "payoffs exceed the published exact-equilibrium work bound",
             )
         return self
 
@@ -82,6 +122,7 @@ class DeterministicTerminalGameRequest(StrictModel):
 
 
 __all__ = [
+    "MAX_EXACT_EQUILIBRIUM_WORK",
     "BestResponseResult",
     "DeterministicTerminalGameRequest",
     "NashEquilibriumResult",

--- a/src/jacobian/math/finite_game_theory/_models.py
+++ b/src/jacobian/math/finite_game_theory/_models.py
@@ -61,6 +61,14 @@ class PayoffMatrix(StrictModel):
 class ZeroSumGameRequest(StrictModel):
     """A 2-player zero-sum game specified by the row player's payoff matrix."""
 
+    payoff_matrix: PayoffMatrix = Field(
+        description="Row-major zero-sum payoff matrix with n_rows * n_cols entries."
+    )
+
+
+class NashEquilibriumRequest(ZeroSumGameRequest):
+    """A zero-sum game admitted for exact primal/dual equilibrium solving."""
+
     model_config = ConfigDict(
         json_schema_extra={
             "description": (
@@ -74,14 +82,6 @@ class ZeroSumGameRequest(StrictModel):
                 "max_exact_equilibrium_work": MAX_EXACT_EQUILIBRIUM_WORK,
             },
         }
-    )
-
-    payoff_matrix: PayoffMatrix = Field(
-        description=(
-            "Row-major zero-sum payoff matrix. Its entries must have shape "
-            "n_rows * n_cols and must fit the request's published coupled "
-            "exact-equilibrium work bound."
-        )
     )
 
     @model_validator(mode="after")
@@ -125,6 +125,7 @@ __all__ = [
     "MAX_EXACT_EQUILIBRIUM_WORK",
     "BestResponseResult",
     "DeterministicTerminalGameRequest",
+    "NashEquilibriumRequest",
     "NashEquilibriumResult",
     "PayoffMatrix",
     "ZeroSumGameRequest",

--- a/src/jacobian/math/finite_game_theory/_operations.py
+++ b/src/jacobian/math/finite_game_theory/_operations.py
@@ -9,6 +9,7 @@ from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
     BestResponseResult,
     DeterministicTerminalGameRequest,
+    NashEquilibriumRequest,
     NashEquilibriumResult,
     ZeroSumGameRequest,
 )
@@ -42,7 +43,9 @@ def compute_best_response(request: ZeroSumGameRequest) -> BestResponseResult:
     return BestResponseResult(value=_wire_rational(best_value), best_row=best_row)
 
 
-def compute_nash_equilibrium(request: ZeroSumGameRequest) -> NashEquilibriumResult:
+def compute_nash_equilibrium(
+    request: NashEquilibriumRequest,
+) -> NashEquilibriumResult:
     """Compute one exact saddle point of a finite 2-player zero-sum game."""
 
     import sympy

--- a/src/jacobian/math/finite_game_theory/_tools.py
+++ b/src/jacobian/math/finite_game_theory/_tools.py
@@ -10,6 +10,7 @@ from jacobian.math.finite_game_theory._models import (
     MAX_EXACT_EQUILIBRIUM_WORK,
     BestResponseResult,
     DeterministicTerminalGameRequest,
+    NashEquilibriumRequest,
     NashEquilibriumResult,
     ZeroSumGameRequest,
 )
@@ -117,7 +118,7 @@ FINITE_GAME_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "row-major with n_rows * n_cols entries; exact-equilibrium admission "
         "requires its published coupled work measure to be at most "
         f"{MAX_EXACT_EQUILIBRIUM_WORK}.",
-        ZeroSumGameRequest,
+        NashEquilibriumRequest,
         NashEquilibriumResult,
         compute_nash_equilibrium,
         "game-theory",

--- a/src/jacobian/math/finite_game_theory/_tools.py
+++ b/src/jacobian/math/finite_game_theory/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.finite_game_theory._models import (
+    MAX_EXACT_EQUILIBRIUM_WORK,
     BestResponseResult,
     DeterministicTerminalGameRequest,
     NashEquilibriumResult,
@@ -112,7 +113,10 @@ FINITE_GAME_THEORY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "game_theory.nash_equilibrium.compute",
         "Compute Nash equilibrium of a zero-sum game",
         "Find the Nash equilibrium of a 2-player zero-sum game using "
-        "exact rational primal and dual linear programs.",
+        "exact rational primal and dual linear programs. Payoff entries are "
+        "row-major with n_rows * n_cols entries; exact-equilibrium admission "
+        "requires its published coupled work measure to be at most "
+        f"{MAX_EXACT_EQUILIBRIUM_WORK}.",
         ZeroSumGameRequest,
         NashEquilibriumResult,
         compute_nash_equilibrium,

--- a/tests/dispatch/test_finite_game_theory_dispatch.py
+++ b/tests/dispatch/test_finite_game_theory_dispatch.py
@@ -1,0 +1,70 @@
+"""Published-envelope checks for finite game-theory dispatch."""
+
+import pytest
+from jsonschema.validators import Draft202012Validator
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.finite_game_theory._models import MAX_EXACT_EQUILIBRIUM_WORK
+
+
+def _small_game() -> dict[str, object]:
+    return {
+        "payoff_matrix": {
+            "n_rows": 2,
+            "n_cols": 2,
+            "entries": [
+                {"num": "3", "den": "1"},
+                {"num": "0", "den": "1"},
+                {"num": "0", "den": "1"},
+                {"num": "2", "den": "1"},
+            ],
+        }
+    }
+
+
+def test_zero_sum_schema_publishes_coupled_admission_and_dispatches() -> None:
+    """The catalog schema explains the exact envelope enforced by ``math.run``."""
+
+    operation = Catalog.open().operation("game_theory.nash_equilibrium.compute")
+    assert operation is not None
+    schema = operation.request_type.model_json_schema()
+    matrix_schema = schema["$defs"]["PayoffMatrix"]
+
+    assert "n_rows * n_cols" in matrix_schema["properties"]["entries"]["description"]
+    assert (
+        "(max(n_rows, n_cols) + 2) * (sum of payoff denominator decimal digits "
+        "+ maximum payoff numerator decimal digits)"
+    ) in schema["description"]
+    assert schema["x-jacobian-bounds"]["max_exact_equilibrium_work"] == (
+        MAX_EXACT_EQUILIBRIUM_WORK
+    )
+    assert str(MAX_EXACT_EQUILIBRIUM_WORK) in operation.description
+
+    payload = _small_game()
+    assert not list(Draft202012Validator(schema).iter_errors(payload))
+    output = invoke_operation(operation.operation_id, payload, Catalog.open()).output
+    assert set(output) == {"row_strategy", "col_strategy", "value"}
+    assert len(output["row_strategy"]) == 2
+    assert len(output["col_strategy"]) == 2
+
+
+def test_zero_sum_schema_explains_structurally_valid_exact_work_rejection() -> None:
+    """A cross-field envelope remains discoverable before its typed rejection."""
+
+    operation = Catalog.open().operation("game_theory.nash_equilibrium.compute")
+    assert operation is not None
+    schema = operation.request_type.model_json_schema()
+    denominator = "1" * (MAX_EXACT_EQUILIBRIUM_WORK // 4 + 1)
+    payload = {
+        "payoff_matrix": {
+            "n_rows": 2,
+            "n_cols": 2,
+            "entries": [{"num": "1", "den": denominator}] * 4,
+        }
+    }
+
+    assert not list(Draft202012Validator(schema).iter_errors(payload))
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation(operation.operation_id, payload, Catalog.open())
+    assert exc_info.value.errors()[0]["type"] == "finite_game.exact_equilibrium_budget"

--- a/tests/dispatch/test_finite_game_theory_dispatch.py
+++ b/tests/dispatch/test_finite_game_theory_dispatch.py
@@ -6,6 +6,7 @@ from jsonschema.validators import Draft202012Validator
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
 from jacobian.math.finite_game_theory._models import MAX_EXACT_EQUILIBRIUM_WORK
+from jacobian.math.finite_game_theory._tools import FINITE_GAME_THEORY_OPERATIONS
 
 
 def _small_game() -> dict[str, object]:
@@ -68,3 +69,31 @@ def test_zero_sum_schema_explains_structurally_valid_exact_work_rejection() -> N
     with pytest.raises(OperationRequestValidationError) as exc_info:
         invoke_operation(operation.operation_id, payload, Catalog.open())
     assert exc_info.value.errors()[0]["type"] == "finite_game.exact_equilibrium_budget"
+
+
+def test_best_response_declaration_publishes_an_operation_neutral_schema() -> None:
+    """The exact-equilibrium envelope appears only on the Nash operation."""
+
+    tools = {tool.operation_id: tool for tool in FINITE_GAME_THEORY_OPERATIONS}
+    best_response_schema = tools[
+        "game_theory.best_response.compute"
+    ].request_type.model_json_schema()
+    equilibrium_schema = tools[
+        "game_theory.nash_equilibrium.compute"
+    ].request_type.model_json_schema()
+
+    assert "linear program" not in best_response_schema["description"]
+    assert "x-jacobian-bounds" not in best_response_schema
+    assert (
+        "(max(n_rows, n_cols) + 2) * (sum of payoff denominator decimal digits "
+        "+ maximum payoff numerator decimal digits)"
+    ) not in best_response_schema["description"]
+    assert str(MAX_EXACT_EQUILIBRIUM_WORK) not in str(best_response_schema)
+
+    assert "linear program" in equilibrium_schema["description"]
+    assert equilibrium_schema["x-jacobian-bounds"]["max_exact_equilibrium_work"] == (
+        MAX_EXACT_EQUILIBRIUM_WORK
+    )
+
+    payload = _small_game()
+    assert not list(Draft202012Validator(best_response_schema).iter_errors(payload))

--- a/tests/math/finite_game_theory/test_finite_game_theory.py
+++ b/tests/math/finite_game_theory/test_finite_game_theory.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.finite_game_theory._models import (
+    NashEquilibriumRequest,
     PayoffMatrix,
     ZeroSumGameRequest,
 )
@@ -37,12 +38,32 @@ class TestBestResponse:
         result = compute_best_response(req)
         assert result.best_row == 0  # Row 0 has minimum 0, Row 1 has minimum 0
 
+    def test_payoffs_beyond_the_equilibrium_bound_still_admit_best_response(
+        self,
+    ) -> None:
+        large = 10**8_200
+        req = ZeroSumGameRequest(
+            payoff_matrix=PayoffMatrix(
+                n_rows=2,
+                n_cols=2,
+                entries=(
+                    _r(Fraction(1, large - 1)),
+                    _r(Fraction(1, large - 2)),
+                    _r(Fraction(1, large - 3)),
+                    _r(Fraction(1, large - 4)),
+                ),
+            ),
+        )
+        result = compute_best_response(req)
+        assert result.best_row == 1
+        assert result.value.as_fraction() == Fraction(1, large - 3)
+
 
 class TestNashEquilibrium:
     def test_payoffs_must_bound_exact_strategy_growth(self) -> None:
         large = 10**32_767
         with pytest.raises(ValidationError) as exc_info:
-            ZeroSumGameRequest(
+            NashEquilibriumRequest(
                 payoff_matrix=PayoffMatrix(
                     n_rows=2,
                     n_cols=2,
@@ -59,7 +80,7 @@ class TestNashEquilibrium:
         )
 
     def test_pure_strategy(self) -> None:
-        req = ZeroSumGameRequest(
+        req = NashEquilibriumRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
@@ -75,7 +96,7 @@ class TestNashEquilibrium:
         assert result.value.as_fraction() == 1  # (0,0) is the pure equilibrium
 
     def test_mixed_equilibrium(self) -> None:
-        req = ZeroSumGameRequest(
+        req = NashEquilibriumRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
@@ -99,7 +120,7 @@ class TestNashEquilibrium:
         assert result.value.as_fraction() == 1
 
     def test_degenerate_game_uses_exact_linear_programming(self) -> None:
-        req = ZeroSumGameRequest(
+        req = NashEquilibriumRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=3,
                 n_cols=3,
@@ -114,7 +135,7 @@ class TestNashEquilibrium:
         assert sum(value.as_fraction() for value in result.col_strategy) == 1
 
     def test_negative_game_value_is_not_clamped_by_simplex_nonnegativity(self) -> None:
-        req = ZeroSumGameRequest(
+        req = NashEquilibriumRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,
@@ -138,7 +159,7 @@ class TestNashEquilibrium:
         self,
     ) -> None:
         values = (Fraction(1, 3), Fraction(-2, 5), Fraction(7, 4), Fraction(1, 2))
-        req = ZeroSumGameRequest(
+        req = NashEquilibriumRequest(
             payoff_matrix=PayoffMatrix(
                 n_rows=2,
                 n_cols=2,


### PR DESCRIPTION
Fixes #2586.

## Problem

The Nash-equilibrium schema represented payoff-matrix fields independently even though their entry count must equal `n_rows * n_cols`; it also omitted the coupled exact-work limit enforced by owner-local admission. Structurally valid JSON could therefore fail only after dispatch reached Pydantic validation.

## Solution

Publish the matrix-shape rule and exact-work formula with the model-owned `MAX_EXACT_EQUILIBRIUM_WORK` bound in the generated schema and catalog description. The regression proves a legal payload reaches the operation and an over-budget but structurally valid canonical payload receives the typed owner error before execution.

## Testing

- `make test-focused LANE=math TESTS=tests/math/finite_game_theory` — 25 passed
- `uv run pytest tests/dispatch/test_finite_game_theory_dispatch.py -q` — 2 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- targeted Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The generated request schema and tool guidance now expose existing coupled admission constraints. Mathematical operation semantics are unchanged.

## Checklist

- [ ] `make check` passes (not run)