### PR TITLE
Publish matroid closure subset constraints

### DIFF
--- a/src/jacobian/math/matroids/_models.py
+++ b/src/jacobian/math/matroids/_models.py
@@ -119,6 +119,7 @@ class MatroidClosureRequest(StrictModel):
             "0..matroid.matrix.columns-1; at most "
             f"{MAX_GROUND_SIZE} indices are admitted."
         ),
+        json_schema_extra={"uniqueItems": True},
     )
 
     @model_validator(mode="after")

--- a/src/jacobian/math/matroids/_models.py
+++ b/src/jacobian/math/matroids/_models.py
@@ -99,8 +99,27 @@ def validate_subset_indices(matroid: LinearMatroid, subset: Any) -> None:
 class MatroidClosureRequest(StrictModel):
     """Compute the closure of a subset in a linear matroid."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Compute the closure of a distinct subset of the ground set of "
+                "a bounded linear matroid. Ground-set elements are the columns "
+                "of `matroid.matrix`, indexed from 0 through "
+                "`matroid.matrix.columns - 1`."
+            )
+        }
+    )
+
     matroid: LinearMatroid
-    subset: tuple[StrictInt, ...] = Field(default=(), max_length=MAX_GROUND_SIZE)
+    subset: tuple[StrictInt, ...] = Field(
+        default=(),
+        max_length=MAX_GROUND_SIZE,
+        description=(
+            "Distinct ground-set indices. Every index must lie in "
+            "0..matroid.matrix.columns-1; at most "
+            f"{MAX_GROUND_SIZE} indices are admitted."
+        ),
+    )
 
     @model_validator(mode="after")
     def require_valid_subset(self) -> Self:
@@ -114,8 +133,18 @@ class MatroidClosureRequest(StrictModel):
 class MatroidClosureResult(MatroidClosureRequest):
     """The closure (flat) of a subset in a linear matroid."""
 
-    closure: tuple[StrictInt, ...] = Field(default=(), max_length=MAX_GROUND_SIZE)
-    rank: StrictInt = Field(ge=0)
+    closure: tuple[StrictInt, ...] = Field(
+        default=(),
+        max_length=MAX_GROUND_SIZE,
+        description=(
+            "The complete flat spanned by `subset`, as distinct ground-set "
+            "indices in increasing order."
+        ),
+    )
+    rank: StrictInt = Field(
+        ge=0,
+        description="The exact rank of `subset` in the declared linear matroid.",
+    )
 
     @model_validator(mode="after")
     def require_valid_closure(self) -> Self:

--- a/tests/dispatch/test_matroid_dispatch.py
+++ b/tests/dispatch/test_matroid_dispatch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from jsonschema.validators import Draft202012Validator
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.dispatch import OperationRequestValidationError, invoke_operation
@@ -17,20 +18,24 @@ def test_closure_schema_and_dispatch_share_subset_contract() -> None:
     assert descriptor is not None
     subset_schema = descriptor.input_schema["properties"]["subset"]
     assert subset_schema["maxItems"] == MAX_GROUND_SIZE
+    assert subset_schema["uniqueItems"] is True
     assert subset_schema["description"] == (
         "Distinct ground-set indices. Every index must lie in "
         "0..matroid.matrix.columns-1; at most "
         f"{MAX_GROUND_SIZE} indices are admitted."
     )
+    validator = Draft202012Validator(descriptor.input_schema)
 
     operation = catalog.operation("matroid.closure.compute")
     assert operation is not None
     advertised = operation.examples[0].input
+    assert not list(validator.iter_errors(advertised))
     result = invoke_operation("matroid.closure.compute", advertised, catalog)
     assert result.output["closure"] == [0, 1, 2]
     assert result.output["rank"] == 2
 
     duplicate_subset = {**advertised, "subset": [0, 0]}
+    assert list(validator.iter_errors(duplicate_subset))
     with pytest.raises(OperationRequestValidationError) as exc_info:
         invoke_operation("matroid.closure.compute", duplicate_subset, catalog)
     assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"

--- a/tests/dispatch/test_matroid_dispatch.py
+++ b/tests/dispatch/test_matroid_dispatch.py
@@ -1,0 +1,36 @@
+"""Dispatch-boundary tests for linear matroid operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.matroids._models import MAX_GROUND_SIZE
+
+
+def test_closure_schema_and_dispatch_share_subset_contract() -> None:
+    """The discoverable rule is the same one that ``math.run`` applies."""
+
+    catalog = Catalog.open()
+    descriptor = catalog.inspect("matroid.closure.compute")
+    assert descriptor is not None
+    subset_schema = descriptor.input_schema["properties"]["subset"]
+    assert subset_schema["maxItems"] == MAX_GROUND_SIZE
+    assert subset_schema["description"] == (
+        "Distinct ground-set indices. Every index must lie in "
+        "0..matroid.matrix.columns-1; at most "
+        f"{MAX_GROUND_SIZE} indices are admitted."
+    )
+
+    operation = catalog.operation("matroid.closure.compute")
+    assert operation is not None
+    advertised = operation.examples[0].input
+    result = invoke_operation("matroid.closure.compute", advertised, catalog)
+    assert result.output["closure"] == [0, 1, 2]
+    assert result.output["rank"] == 2
+
+    duplicate_subset = {**advertised, "subset": [0, 0]}
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation("matroid.closure.compute", duplicate_subset, catalog)
+    assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"

--- a/tests/math/matroids/test_matroids.py
+++ b/tests/math/matroids/test_matroids.py
@@ -11,7 +11,7 @@ from jacobian.math.matroids import (
     compute_matroid_closure,
     matroid_rank,
 )
-from jacobian.math.matroids._models import MatroidClosureRequest
+from jacobian.math.matroids._models import MAX_GROUND_SIZE, MatroidClosureRequest
 from jacobian.math.matroids._tools import compute_closure
 
 
@@ -104,6 +104,35 @@ class TestClosure:
         m = _matroid(5, [(1, 0), (0, 1)], 2)
         with pytest.raises(ValidationError) as exc_info:
             MatroidClosureRequest(matroid=m, subset=(2,))
+        assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"
+
+    def test_catalog_schema_publishes_and_dispatch_enforces_subset_contract(self):
+        """The discoverable rule is the same one that ``math.run`` applies."""
+        from jacobian.catalog.catalog import Catalog
+        from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+
+        catalog = Catalog.open()
+        descriptor = catalog.inspect("matroid.closure.compute")
+        assert descriptor is not None
+        schema = descriptor.input_schema
+        subset_schema = schema["properties"]["subset"]
+        assert subset_schema["maxItems"] == MAX_GROUND_SIZE
+        assert subset_schema["description"] == (
+            "Distinct ground-set indices. Every index must lie in "
+            "0..matroid.matrix.columns-1; at most "
+            f"{MAX_GROUND_SIZE} indices are admitted."
+        )
+
+        operation = catalog.operation("matroid.closure.compute")
+        assert operation is not None
+        advertised = operation.examples[0].input
+        result = invoke_operation("matroid.closure.compute", advertised, catalog)
+        assert result.output["closure"] == [0, 1, 2]
+        assert result.output["rank"] == 2
+
+        duplicate_subset = {**advertised, "subset": [0, 0]}
+        with pytest.raises(OperationRequestValidationError) as exc_info:
+            invoke_operation("matroid.closure.compute", duplicate_subset, catalog)
         assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"
 
     def test_native_closure_validates_indices(self):

--- a/tests/math/matroids/test_matroids.py
+++ b/tests/math/matroids/test_matroids.py
@@ -11,7 +11,7 @@ from jacobian.math.matroids import (
     compute_matroid_closure,
     matroid_rank,
 )
-from jacobian.math.matroids._models import MAX_GROUND_SIZE, MatroidClosureRequest
+from jacobian.math.matroids._models import MatroidClosureRequest
 from jacobian.math.matroids._tools import compute_closure
 
 
@@ -104,35 +104,6 @@ class TestClosure:
         m = _matroid(5, [(1, 0), (0, 1)], 2)
         with pytest.raises(ValidationError) as exc_info:
             MatroidClosureRequest(matroid=m, subset=(2,))
-        assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"
-
-    def test_catalog_schema_publishes_and_dispatch_enforces_subset_contract(self):
-        """The discoverable rule is the same one that ``math.run`` applies."""
-        from jacobian.catalog.catalog import Catalog
-        from jacobian.dispatch import OperationRequestValidationError, invoke_operation
-
-        catalog = Catalog.open()
-        descriptor = catalog.inspect("matroid.closure.compute")
-        assert descriptor is not None
-        schema = descriptor.input_schema
-        subset_schema = schema["properties"]["subset"]
-        assert subset_schema["maxItems"] == MAX_GROUND_SIZE
-        assert subset_schema["description"] == (
-            "Distinct ground-set indices. Every index must lie in "
-            "0..matroid.matrix.columns-1; at most "
-            f"{MAX_GROUND_SIZE} indices are admitted."
-        )
-
-        operation = catalog.operation("matroid.closure.compute")
-        assert operation is not None
-        advertised = operation.examples[0].input
-        result = invoke_operation("matroid.closure.compute", advertised, catalog)
-        assert result.output["closure"] == [0, 1, 2]
-        assert result.output["rank"] == 2
-
-        duplicate_subset = {**advertised, "subset": [0, 0]}
-        with pytest.raises(OperationRequestValidationError) as exc_info:
-            invoke_operation("matroid.closure.compute", duplicate_subset, catalog)
         assert exc_info.value.errors()[0]["type"] == "matroid.subset.invalid"
 
     def test_native_closure_validates_indices(self):


### PR DESCRIPTION
Fixes #2581.

## Problem

`matroid.closure.compute` published `subset` as only a bounded array even though owner admission also requires distinct indices within the submitted matrix column axis. A structurally valid request could therefore fail with a constraint the generated schema did not disclose.

## Solution

Publish the distinctness and matrix-column coupling in the request/result schema, deriving the maximum wording from the owner constant. The regression reads the catalog-generated schema, runs the advertised invocation through dispatch, and confirms a duplicate subset receives the typed owner error.

## Testing

- `make test-focused LANE=math TESTS=tests/math/matroids` — 11 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch` — 54 passed
- Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The generated schema now accurately documents existing request admission; mathematical behavior is unchanged.

## Checklist

- [ ] `make check` passes (Ruff and mypy passed; final broad pytest capture was unavailable)