### PR TITLE
Admit tree reroot transport projection before execution

### DIFF
--- a/src/jacobian/math/graphs/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/tree_decompositions/_models.py
@@ -22,6 +22,10 @@ def _json_array_size(item_sizes: list[int]) -> int:
     return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
 
 
+def _normalized_tree_nodes(decomposition: TreeDecomposition) -> list[str]:
+    return [unicodedata.normalize("NFC", node) for node in decomposition.tree_nodes]
+
+
 def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> int:
     """Return the exact strict-JSON size of ``reroot(decomposition, root)``.
 
@@ -55,9 +59,7 @@ def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> in
             traversal.append(neighbor)
             queue.append(neighbor)
 
-    normalized_nodes = [
-        unicodedata.normalize("NFC", node) for node in decomposition.tree_nodes
-    ]
+    normalized_nodes = _normalized_tree_nodes(decomposition)
     encoded_nodes = [len(encode_strict_json(node)) for node in normalized_nodes]
     parent_fields = []
     children: list[list[int]] = [[] for _ in decomposition.tree_nodes]
@@ -175,8 +177,16 @@ class RerootRequest(StrictModel):
         repeated node labels across its root-to-node paths.  Compute that
         deterministic projection while admitting the request, so the final
         transport wrapper never discovers an oversized result after execution.
+        Labels are compared after the transport boundary's NFC normalization,
+        so canonically equivalent spellings cannot collide as result keys.
         """
 
+        normalized_nodes = _normalized_tree_nodes(self.decomposition)
+        if len(set(normalized_nodes)) != len(normalized_nodes):
+            raise PydanticCustomError(
+                "graph.reroot_tree_node_labels_collide_after_normalization",
+                "tree node labels collide after Unicode NFC normalization",
+            )
         result_bytes = _reroot_result_wire_bytes(self.decomposition, self.root)
         output_limit = CanonicalLimits().max_output_bytes
         if result_bytes > output_limit:

--- a/src/jacobian/math/graphs/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/tree_decompositions/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unicodedata
 from collections import deque
 from typing import Self
 
@@ -27,7 +28,8 @@ def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> in
     The result's only superlinear field is the map of root-to-node paths.  Its
     exact encoded size follows from one traversal and one accumulated array
     size per node, without constructing or retaining every repeated path
-    label before admission.
+    label before admission.  Labels are measured after NFC normalization,
+    matching how the canonical transport boundary normalizes string values.
     """
 
     node_index = {node: index for index, node in enumerate(decomposition.tree_nodes)}
@@ -53,14 +55,17 @@ def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> in
             traversal.append(neighbor)
             queue.append(neighbor)
 
-    encoded_nodes = [len(encode_strict_json(node)) for node in decomposition.tree_nodes]
+    normalized_nodes = [
+        unicodedata.normalize("NFC", node) for node in decomposition.tree_nodes
+    ]
+    encoded_nodes = [len(encode_strict_json(node)) for node in normalized_nodes]
     parent_fields = []
     children: list[list[int]] = [[] for _ in decomposition.tree_nodes]
     for index in traversal:
         parent_index = parent[index]
         parent_fields.append(
             (
-                decomposition.tree_nodes[index],
+                normalized_nodes[index],
                 4 if parent_index is None else encoded_nodes[parent_index],
             )
         )
@@ -68,13 +73,13 @@ def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> in
             children[parent_index].append(index)
     children_size = strict_json_object_size(
         (
-            decomposition.tree_nodes[index],
+            normalized_nodes[index],
             _json_array_size([encoded_nodes[child] for child in children[index]]),
         )
         for index in range(len(decomposition.tree_nodes))
     )
     depth_size = strict_json_object_size(
-        (decomposition.tree_nodes[index], len(str(depth[index]))) for index in traversal
+        (normalized_nodes[index], len(str(depth[index]))) for index in traversal
     )
     path_sizes = [0] * len(decomposition.tree_nodes)
     path_sizes[root_index] = _json_array_size([encoded_nodes[root_index]])
@@ -83,7 +88,7 @@ def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> in
         assert parent_index is not None
         path_sizes[index] = path_sizes[parent_index] + 1 + encoded_nodes[index]
     paths_size = strict_json_object_size(
-        (decomposition.tree_nodes[index], path_sizes[index]) for index in traversal
+        (normalized_nodes[index], path_sizes[index]) for index in traversal
     )
     return strict_json_object_size(
         (

--- a/src/jacobian/math/graphs/tree_decompositions/_models.py
+++ b/src/jacobian/math/graphs/tree_decompositions/_models.py
@@ -2,13 +2,98 @@
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    strict_json_object_size,
+)
 from jacobian.math.graphs.tree_decompositions.values import TreeDecomposition
+
+
+def _json_array_size(item_sizes: list[int]) -> int:
+    return 2 + max(len(item_sizes) - 1, 0) + sum(item_sizes)
+
+
+def _reroot_result_wire_bytes(decomposition: TreeDecomposition, root: str) -> int:
+    """Return the exact strict-JSON size of ``reroot(decomposition, root)``.
+
+    The result's only superlinear field is the map of root-to-node paths.  Its
+    exact encoded size follows from one traversal and one accumulated array
+    size per node, without constructing or retaining every repeated path
+    label before admission.
+    """
+
+    node_index = {node: index for index, node in enumerate(decomposition.tree_nodes)}
+    root_index = node_index[root]
+    adjacency: list[list[int]] = [[] for _ in decomposition.tree_nodes]
+    for left, right in decomposition.tree_edges:
+        left_index = node_index[left]
+        right_index = node_index[right]
+        adjacency[left_index].append(right_index)
+        adjacency[right_index].append(left_index)
+
+    parent: list[int | None] = [None] * len(decomposition.tree_nodes)
+    depth = [0] * len(decomposition.tree_nodes)
+    traversal = [root_index]
+    queue = deque([root_index])
+    while queue:
+        current = queue.popleft()
+        for neighbor in adjacency[current]:
+            if neighbor == parent[current] or neighbor == root_index:
+                continue
+            parent[neighbor] = current
+            depth[neighbor] = depth[current] + 1
+            traversal.append(neighbor)
+            queue.append(neighbor)
+
+    encoded_nodes = [len(encode_strict_json(node)) for node in decomposition.tree_nodes]
+    parent_fields = []
+    children: list[list[int]] = [[] for _ in decomposition.tree_nodes]
+    for index in traversal:
+        parent_index = parent[index]
+        parent_fields.append(
+            (
+                decomposition.tree_nodes[index],
+                4 if parent_index is None else encoded_nodes[parent_index],
+            )
+        )
+        if parent_index is not None:
+            children[parent_index].append(index)
+    children_size = strict_json_object_size(
+        (
+            decomposition.tree_nodes[index],
+            _json_array_size([encoded_nodes[child] for child in children[index]]),
+        )
+        for index in range(len(decomposition.tree_nodes))
+    )
+    depth_size = strict_json_object_size(
+        (decomposition.tree_nodes[index], len(str(depth[index]))) for index in traversal
+    )
+    path_sizes = [0] * len(decomposition.tree_nodes)
+    path_sizes[root_index] = _json_array_size([encoded_nodes[root_index]])
+    for index in traversal[1:]:
+        parent_index = parent[index]
+        assert parent_index is not None
+        path_sizes[index] = path_sizes[parent_index] + 1 + encoded_nodes[index]
+    paths_size = strict_json_object_size(
+        (decomposition.tree_nodes[index], path_sizes[index]) for index in traversal
+    )
+    return strict_json_object_size(
+        (
+            ("root", encoded_nodes[root_index]),
+            ("parent", strict_json_object_size(parent_fields)),
+            ("children", children_size),
+            ("depth", depth_size),
+            ("paths", paths_size),
+        )
+    )
 
 
 class WidthRequest(StrictModel):
@@ -74,6 +159,26 @@ class RerootRequest(StrictModel):
             raise PydanticCustomError(
                 "graph.root_must_be_a_declared_tree_node",
                 "root must be a declared tree node",
+            )
+        return self
+
+    @model_validator(mode="after")
+    def require_transportable_result(self) -> Self:
+        """Preflight the owner-local root-to-node path projection.
+
+        A tree with at most 256 nodes can still produce quadratically many
+        repeated node labels across its root-to-node paths.  Compute that
+        deterministic projection while admitting the request, so the final
+        transport wrapper never discovers an oversized result after execution.
+        """
+
+        result_bytes = _reroot_result_wire_bytes(self.decomposition, self.root)
+        output_limit = CanonicalLimits().max_output_bytes
+        if result_bytes > output_limit:
+            raise PydanticCustomError(
+                "graph.reroot_result_exceeds_transport_limit",
+                "rerooted tree-decomposition paths exceed the "
+                f"{output_limit}-byte canonical output limit",
             )
         return self
 

--- a/tests/dispatch/test_tree_decomposition_dispatch.py
+++ b/tests/dispatch/test_tree_decomposition_dispatch.py
@@ -1,0 +1,73 @@
+"""Transport admission at the tree-decomposition dispatch boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationResult
+from jacobian.dispatch import (
+    OperationRequestValidationError,
+    invoke_operation,
+    parse_operation_input,
+)
+from jacobian.math.graphs.tree_decompositions._models import RerootRequest
+from jacobian.math.graphs.tree_decompositions._operations import compute_reroot
+
+
+def _path_decomposition(*, node_count: int, label_suffix: str) -> dict[str, object]:
+    nodes = [f"n{index:03d}_{label_suffix}" for index in range(node_count)]
+    return {
+        "graph": {"vertices": ["a"], "edges": []},
+        "tree_nodes": nodes,
+        "tree_edges": [
+            [nodes[index], nodes[index + 1]] for index in range(node_count - 1)
+        ],
+        "bags": [["a"] for _ in nodes],
+    }
+
+
+def test_reroot_transport_admission_round_trips_canonical_projection() -> None:
+    """A bounded source survives serialize, parse, projection, and dispatch."""
+
+    decomposition = _path_decomposition(node_count=6, label_suffix="label")
+    tree_nodes = decomposition["tree_nodes"]
+    assert isinstance(tree_nodes, list)
+    payload = {"decomposition": decomposition, "root": tree_nodes[0]}
+
+    serialized = encode_strict_json(payload)
+    request = parse_operation_input(RerootRequest, payload)
+    assert request == RerootRequest.model_validate_json(serialized)
+
+    projected = compute_reroot(request).model_dump(mode="json")
+    projected_bytes = len(encode_strict_json(projected))
+    assert projected_bytes <= CanonicalLimits().max_output_bytes
+
+    public_result = invoke_operation(
+        "graph.tree_decomposition.reroot.compute", payload, Catalog.open()
+    )
+    assert (
+        OperationResult.model_validate_json(public_result.model_dump_json())
+        == public_result
+    )
+    assert public_result.output == projected
+
+
+def test_reroot_rejects_paths_that_exceed_transport_before_execution() -> None:
+    """A small request whose repeated path labels overflow is not admitted."""
+
+    decomposition = _path_decomposition(node_count=256, label_suffix="x" * 394)
+    tree_nodes = decomposition["tree_nodes"]
+    assert isinstance(tree_nodes, list)
+    payload = {"decomposition": decomposition, "root": tree_nodes[0]}
+    assert len(encode_strict_json(payload)) <= CanonicalLimits().max_input_bytes
+
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation(
+            "graph.tree_decomposition.reroot.compute", payload, Catalog.open()
+        )
+
+    assert exc_info.value.errors()[0]["type"] == (
+        "graph.reroot_result_exceeds_transport_limit"
+    )

--- a/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
+++ b/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
@@ -200,6 +200,23 @@ class TestReroot:
             "graph.reroot_result_exceeds_transport_limit"
         )
 
+    def test_rejects_labels_colliding_after_canonicalization(self) -> None:
+        # The raw spellings are distinct, so TreeDecomposition admits them;
+        # NFC composes both to the same key and delivery would reject the
+        # result maps, so admission must reject the request instead.
+        nodes = ("e\u0301x", "\u00e9x")
+        td = TreeDecomposition(
+            graph=SimpleUndirectedGraph(vertices=("a",), edges=()),
+            tree_nodes=nodes,
+            tree_edges=((nodes[0], nodes[1]),),
+            bags=(("a",), ("a",)),
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            RerootRequest(decomposition=td, root=nodes[0])
+        assert exc_info.value.errors()[0]["type"] == (
+            "graph.reroot_tree_node_labels_collide_after_normalization"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Restrict

--- a/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
+++ b/tests/math/graphs_tree_decompositions/test_tree_decompositions.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 import pytest
 from pydantic import ValidationError
 
+from jacobian.canonical import CanonicalLimits, canonicalize_json
+from jacobian.catalog.models import OperationResult
 from jacobian.math.graphs.tree_decompositions import TreeDecomposition
 from jacobian.math.graphs.tree_decompositions._models import (
     AdhesionsRequest,
@@ -46,6 +48,20 @@ def _path_decomposition() -> TreeDecomposition:
         tree_nodes=("t0", "t1"),
         tree_edges=(("t0", "t1"),),
         bags=(("a", "b"), ("b", "c")),
+    )
+
+
+def _labeled_path_decomposition(
+    *, node_count: int, label_body: str
+) -> TreeDecomposition:
+    nodes = tuple(f"n{index:03d}_{label_body}" for index in range(node_count))
+    return TreeDecomposition(
+        graph=SimpleUndirectedGraph(vertices=("a",), edges=()),
+        tree_nodes=nodes,
+        tree_edges=tuple(
+            (nodes[index], nodes[index + 1]) for index in range(node_count - 1)
+        ),
+        bags=(("a",),) * node_count,
     )
 
 
@@ -154,6 +170,35 @@ class TestReroot:
         result = compute_reroot(RerootRequest(decomposition=td, root="t0"))
         assert result.parent["t0"] is None
         assert result.children["t0"] == ("t1",)
+
+    def test_admits_decomposed_labels_whose_canonical_projection_fits(self) -> None:
+        # Each raw label encodes to 337 bytes, so measuring the unnormalized
+        # spelling exceeds the 10 MiB transport limit; NFC composes each
+        # e + U+0301 pair into a 2-byte character and the canonical
+        # projection of the same request fits.
+        td = _labeled_path_decomposition(node_count=256, label_body="e\u0301" * 110)
+        request = RerootRequest(decomposition=td, root=td.tree_nodes[0])
+        projected = compute_reroot(request).model_dump(mode="json")
+        assert len(canonicalize_json(projected)) <= CanonicalLimits().max_output_bytes
+        public_result = OperationResult(
+            operation_id="graph.tree_decomposition.reroot.compute",
+            runtime_ms=0,
+            output=projected,
+        )
+        assert (
+            OperationResult.model_validate_json(public_result.model_dump_json())
+            == public_result
+        )
+
+    def test_rejects_projection_over_the_canonical_transport_limit(self) -> None:
+        # ASCII labels are unchanged by NFC, so the canonical projection
+        # itself exceeds the limit and admission must still reject.
+        td = _labeled_path_decomposition(node_count=256, label_body="x" * 394)
+        with pytest.raises(ValidationError) as exc_info:
+            RerootRequest(decomposition=td, root=td.tree_nodes[0])
+        assert exc_info.value.errors()[0]["type"] == (
+            "graph.reroot_result_exceeds_transport_limit"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2583.

## Problem

A valid 256-node reroot request with long labels fit the request envelope but produced a 13,843,258-byte canonical result. Dispatch ran the kernel and then raised an `OperationResult` validation error because transport fit had not been admitted.

## Solution

Calculate the exact strict-JSON reroot result size with a linear tree traversal during `RerootRequest` admission. Oversized results now fail before execution with `graph.reroot_result_exceeds_transport_limit`, without materializing repeated reroot paths.

## Regression coverage

The catalog-driven regression covers serialize → parse → canonical projection → dispatch for an admitted request, and proves the oversized request returns the typed owner error rather than executing and failing during result validation. The size calculation was cross-checked against 32 varied tree shapes.

## Testing

- graph owner suite — 549 passed
- catalog and advertised examples — 654 passed
- tree-decomposition dispatch regression — 2 passed
- `make lint` and focused mypy — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Oversized reroot results are now rejected at request admission with a typed error instead of exposing a post-execution validation failure.

## Checklist

- [ ] `make check` passes (not run)