### PR TITLE
Construct trusted coherent-configuration analysis results

### DIFF
--- a/src/jacobian/math/coherent_configurations/_operations.py
+++ b/src/jacobian/math/coherent_configurations/_operations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pydantic_core import PydanticCustomError
+
 from jacobian.math.coherent_configurations._models import (
     CoherenceObstruction,
     CoherentConfigurationAnalyzeRequest,
@@ -19,6 +21,7 @@ from jacobian.math.coherent_configurations.operations import (
     _analyze,
 )
 from jacobian.math.coherent_configurations.values import (
+    MAX_COHERENT_CONFIGURATION_RESULT_BYTES,
     CoherentConfigurationInput,
     FiniteCoherentConfiguration,
 )
@@ -70,14 +73,108 @@ def _obstruction_model(obstruction: ObstructionData) -> CoherenceObstruction:
     )
 
 
-def analysis_models_from_source(
-    source: CoherentConfigurationInput,
-) -> CoherentConfigurationAnalyzeResult:
-    """Build the unique source-bound result fields without result validation."""
+def _require_trusted_result_shape(result: CoherentConfigurationAnalyzeResult) -> None:
+    """Check every non-replay invariant of one fresh kernel result.
 
-    data: AnalysisData = _analyze(source)
+    The public result validator separately recomputes the complete coherence
+    derivation for independently supplied data.  The producing kernel already
+    performed that cubic scan, so its construction verifies only the shape and
+    transport invariants that a replay would otherwise hide.
+    """
+
+    relation_ids = set(result.configuration.relation_ids)
+    points = set(result.configuration.points)
+    relation_count = len(relation_ids)
+
+    if result.status == "NOT_COHERENT":
+        if (
+            result.coherent_configuration is not None
+            or result.fibers
+            or result.transpose_map
+            or result.intersection_numbers
+            or result.obstruction is None
+        ):
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_shape",
+                "a non-coherent result must carry exactly one obstruction",
+            )
+    else:
+        if result.coherent_configuration is None or result.obstruction is not None:
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_shape",
+                "a coherent result must carry its configuration and no obstruction",
+            )
+        if len(result.transpose_map) != relation_count:
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_transpose_map",
+                "a coherent result must give one transpose partner per relation",
+            )
+        if len(result.intersection_numbers) != relation_count**3:
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_intersection_numbers",
+                "a coherent result must give one intersection number per relation triple",
+            )
+        if len({entry.relation_id for entry in result.transpose_map}) != relation_count:
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_transpose_map",
+                "transpose-map relation identifiers must be unique",
+            )
+        if {entry.relation_id for entry in result.transpose_map} != relation_ids or any(
+            entry.transpose_relation_id not in relation_ids
+            for entry in result.transpose_map
+        ):
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_transpose_map",
+                "transpose-map relation identifiers must belong to the source",
+            )
+        intersection_keys = {
+            (
+                entry.left_relation_id,
+                entry.right_relation_id,
+                entry.target_relation_id,
+            )
+            for entry in result.intersection_numbers
+        }
+        if len(intersection_keys) != relation_count**3 or any(
+            set(key) - relation_ids for key in intersection_keys
+        ):
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_intersection_numbers",
+                "intersection-number relation triples must be the source cube",
+            )
+        if len({entry.relation_id for entry in result.fibers}) != len(result.fibers):
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_fibers",
+                "fiber relation identifiers must be unique",
+            )
+        if any(
+            entry.relation_id not in relation_ids
+            or not set(entry.points) <= points
+            or tuple(sorted(entry.points)) != entry.points
+            for entry in result.fibers
+        ):
+            raise PydanticCustomError(
+                "coherent_configuration.trusted_result_fibers",
+                "fiber data must use sorted source points and relations",
+            )
+
+    if (
+        len(result.model_dump_json().encode("utf-8"))
+        > MAX_COHERENT_CONFIGURATION_RESULT_BYTES
+    ):
+        raise PydanticCustomError(
+            "coherent_configuration.result_bytes",
+            "coherent-configuration result exceeds the byte budget",
+        )
+
+
+def _computed_analysis_result(
+    source: CoherentConfigurationInput, data: AnalysisData
+) -> CoherentConfigurationAnalyzeResult:
+    """Build a fresh result without replaying the producing cubic analysis."""
+
     if data.obstruction is not None:
-        return CoherentConfigurationAnalyzeResult.model_construct(
+        result = CoherentConfigurationAnalyzeResult.model_construct(
             configuration=source,
             status="NOT_COHERENT",
             coherent_configuration=None,
@@ -86,47 +183,57 @@ def analysis_models_from_source(
             intersection_numbers=(),
             obstruction=_obstruction_model(data.obstruction),
         )
-    configuration = FiniteCoherentConfiguration(**source.model_dump())
-    return CoherentConfigurationAnalyzeResult.model_construct(
-        configuration=source,
-        status="COHERENT_CONFIGURATION",
-        coherent_configuration=configuration,
-        fibers=tuple(
-            Fiber(relation_id=fibre.relation_id, points=fibre.points)
-            for fibre in data.fibres
-        ),
-        transpose_map=tuple(
-            TransposeRelation(
-                relation_id=entry.relation_id,
-                transpose_relation_id=entry.transpose_relation_id,
-            )
-            for entry in data.transpose_map
-        ),
-        intersection_numbers=tuple(
-            IntersectionNumber(
-                left_relation_id=entry.left_relation_id,
-                right_relation_id=entry.right_relation_id,
-                target_relation_id=entry.target_relation_id,
-                value=entry.value,
-            )
-            for entry in data.intersection_numbers
-        ),
-        obstruction=None,
-    )
+    else:
+        # ``source`` has already been parsed through CoherentConfigurationInput
+        # and ``data`` is the just-computed exact kernel output.  Avoid the
+        # FiniteCoherentConfiguration validator's duplicate complete analysis;
+        # external payloads still take that validation and the result replay.
+        configuration = FiniteCoherentConfiguration.model_construct(
+            **source.model_dump()
+        )
+        result = CoherentConfigurationAnalyzeResult.model_construct(
+            configuration=source,
+            status="COHERENT_CONFIGURATION",
+            coherent_configuration=configuration,
+            fibers=tuple(
+                Fiber(relation_id=fibre.relation_id, points=fibre.points)
+                for fibre in data.fibres
+            ),
+            transpose_map=tuple(
+                TransposeRelation(
+                    relation_id=entry.relation_id,
+                    transpose_relation_id=entry.transpose_relation_id,
+                )
+                for entry in data.transpose_map
+            ),
+            intersection_numbers=tuple(
+                IntersectionNumber(
+                    left_relation_id=entry.left_relation_id,
+                    right_relation_id=entry.right_relation_id,
+                    target_relation_id=entry.target_relation_id,
+                    value=entry.value,
+                )
+                for entry in data.intersection_numbers
+            ),
+            obstruction=None,
+        )
+    _require_trusted_result_shape(result)
+    return result
+
+
+def analysis_models_from_source(
+    source: CoherentConfigurationInput,
+) -> CoherentConfigurationAnalyzeResult:
+    """Recompute the canonical result used to validate supplied payloads."""
+
+    return _computed_analysis_result(source, _analyze(source))
 
 
 def compute_analyze(
     request: CoherentConfigurationAnalyzeRequest,
 ) -> CoherentConfigurationAnalyzeResult:
-    """Analyze one complete relation partition and replay the typed result."""
+    """Analyze one complete relation partition with one charged kernel pass."""
 
-    expected = analysis_models_from_source(request.configuration)
-    return CoherentConfigurationAnalyzeResult(
-        configuration=expected.configuration,
-        status=expected.status,
-        coherent_configuration=expected.coherent_configuration,
-        fibers=expected.fibers,
-        transpose_map=expected.transpose_map,
-        intersection_numbers=expected.intersection_numbers,
-        obstruction=expected.obstruction,
+    return _computed_analysis_result(
+        request.configuration, _analyze(request.configuration)
     )

--- a/tests/math/coherent_configurations/test_coherent_configurations.py
+++ b/tests/math/coherent_configurations/test_coherent_configurations.py
@@ -310,6 +310,26 @@ def test_maximum_point_count_translation_configuration_is_admitted() -> None:
     assert len(result.intersection_numbers) == 12**3
 
 
+def test_produced_results_round_trip_through_independent_source_replay() -> None:
+    """Both trusted outcome shapes remain valid canonical wire values."""
+
+    coherent = compute_analyze(_request(_complete_graph_k3()))
+    noncoherent = compute_analyze(_request(_path_four_relation_partition()))
+
+    assert (
+        CoherentConfigurationAnalyzeResult.model_validate(
+            coherent.model_dump(mode="json")
+        )
+        == coherent
+    )
+    assert (
+        CoherentConfigurationAnalyzeResult.model_validate(
+            noncoherent.model_dump(mode="json")
+        )
+        == noncoherent
+    )
+
+
 def test_over_relation_bound_is_rejected_before_analysis() -> None:
     payload = _thin_four_point_configuration()
     payload["relation_ids"] = [f"r{index:02d}" for index in range(17)]


### PR DESCRIPTION
Fixes #2590.

## Problem

`coherent_configuration.analyze.compute` constructed an ordinary kernel result through a model validator that reran the same cubic analysis derivation. This made trusted producer output pay independently supplied-result replay work.

## Solution

Add an owner-local trusted result factory that checks the cheap structural, source, status, and transport invariants of a fresh kernel result without rerunning the derivation. Normal serialized payload parsing keeps the complete source replay path.

## Regression coverage

Real coherent and non-coherent examples exercise producer → wire → parse equality, proving ordinary results and independently supplied values remain compatible without mocks or kernel patching.

## Testing

- coherent-configuration owner suite — 18 passed
- dispatch suite — 5 passed
- catalog suite — 46 passed
- Ruff, mypy, and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. The serialized result and mathematical analysis semantics are unchanged; ordinary producer construction no longer repeats replay work.

## Checklist

- [ ] `make check` passes (not run)