### PR TITLE
Return canonical graph values from distance geometry

### DIFF
--- a/src/jacobian/math/geometry/exact/_models.py
+++ b/src/jacobian/math/geometry/exact/_models.py
@@ -137,16 +137,8 @@ class DistanceGraphRequest(StrictModel):
         return self
 
 
-class DistanceGraphResult(StrictModel):
-    """Graph whose edges connect pairs at the target squared distance."""
-
-    vertex_count: int = Field(ge=2)
-    edges: tuple[tuple[int, int], ...]
-
-
 __all__ = [
     "DistanceGraphRequest",
-    "DistanceGraphResult",
     "DistanceMultiplicityEntry",
     "DistanceProfileRequest",
     "DistanceProfileResult",

--- a/src/jacobian/math/geometry/exact/_operations.py
+++ b/src/jacobian/math/geometry/exact/_operations.py
@@ -11,7 +11,6 @@ from jacobian.math.geometry.exact._line_arithmetic import (
 )
 from jacobian.math.geometry.exact._models import (
     DistanceGraphRequest,
-    DistanceGraphResult,
     DistanceMultiplicityEntry,
     DistanceProfileRequest,
     DistanceProfileResult,
@@ -19,6 +18,7 @@ from jacobian.math.geometry.exact._models import (
     PinnedLineDistanceRequest,
     PinnedLineDistanceResult,
 )
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 
 def _to_fraction_point(point: LabelledRationalPoint) -> tuple[Fraction, ...]:
@@ -68,7 +68,7 @@ def compute_distance_profile(
 
 def compute_distance_graph(
     request: DistanceGraphRequest,
-) -> DistanceGraphResult:
+) -> IndexedSimpleUndirectedGraph:
     """Build the graph whose edges connect pairs at the target squared distance."""
     config = request.configuration
     n = len(config.points)
@@ -81,7 +81,7 @@ def compute_distance_graph(
             if _squared_distance(points[i], points[j]) == target:
                 edges.append((i, j))
 
-    return DistanceGraphResult(
+    return IndexedSimpleUndirectedGraph(
         vertex_count=n,
         edges=tuple(edges),
     )

--- a/src/jacobian/math/geometry/exact/_tools.py
+++ b/src/jacobian/math/geometry/exact/_tools.py
@@ -8,7 +8,6 @@ from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.geometry.exact._models import (
     DistanceGraphRequest,
-    DistanceGraphResult,
     DistanceProfileRequest,
     DistanceProfileResult,
     PinnedLineDistanceRequest,
@@ -19,6 +18,7 @@ from jacobian.math.geometry.exact._operations import (
     compute_distance_profile,
     compute_pinned_line_distance_profile,
 )
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 
 def _op[
@@ -138,9 +138,10 @@ EXACT_GEOMETRY_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "geometry.points.distance_graph.compute",
         "Build distance-selected graph",
         "Given a point configuration and a target squared distance, return "
-        "the graph whose edges connect pairs at exactly that distance.",
+        "the canonical integer-indexed simple graph whose edges connect pairs "
+        "at exactly that distance.",
         DistanceGraphRequest,
-        DistanceGraphResult,
+        IndexedSimpleUndirectedGraph,
         compute_distance_graph,
         "geometry",
         "distance-graph",

--- a/tests/math/geometry/test_exact_geometry.py
+++ b/tests/math/geometry/test_exact_geometry.py
@@ -15,6 +15,8 @@ from jacobian.math.geometry.exact._operations import (
     compute_distance_graph,
     compute_distance_profile,
 )
+from jacobian.math.graphs.spectral._models import GraphSpectrumRequest
+from jacobian.math.graphs.values import IndexedSimpleUndirectedGraph
 
 
 def _make_point(label: str, coords: list[tuple[str, str]]) -> LabelledRationalPoint:
@@ -72,7 +74,31 @@ class TestDistanceGraph:
             target_squared_distance=CanonicalRational(num="1", den="1"),
         )
         result = compute_distance_graph(req)
+        assert isinstance(result, IndexedSimpleUndirectedGraph)
         assert len(result.edges) == 4
+
+    def test_serialized_result_feeds_graph_consumer_unchanged(self):
+        """A distance graph is the graphs owner's value, including no-edge cases."""
+        configuration = PointConfiguration(
+            points=(
+                _make_point("a", [("0", "1")]),
+                _make_point("b", [("1", "1")]),
+            )
+        )
+        produced = compute_distance_graph(
+            DistanceGraphRequest(
+                configuration=configuration,
+                target_squared_distance=CanonicalRational(num="2", den="1"),
+            )
+        )
+
+        assert produced == IndexedSimpleUndirectedGraph(vertex_count=2, edges=())
+        assert (
+            GraphSpectrumRequest.model_validate(
+                {"graph": produced.model_dump(mode="json")}
+            ).graph
+            == produced
+        )
 
     def test_rejects_single_point_configuration(self):
         import pytest


### PR DESCRIPTION
Fixes #2593.

## Problem

`geometry.points.distance_graph.compute` returned a local `DistanceGraphResult` with the same shape as graphs’ `IndexedSimpleUndirectedGraph`. The parallel value omitted the canonical graph owner’s edge validation and made downstream composition rely on a coincidental wire shape.

## Solution

Remove the geometry-local result model and return the canonical indexed simple graph directly. The regression proves even an edgeless produced graph serializes unchanged into the graph-spectrum request.

## Testing

- `make test-focused LANE=math TESTS=tests/math/geometry` — 39 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch` — 54 passed
- advertised catalog examples — 608 passed
- targeted Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The distance-graph result now uses the established graph value schema and its canonical invariants. Existing serialized fields remain `vertex_count` and `edges`.

## Checklist

- [ ] `make check` passes (Ruff and mypy passed; final broad pytest capture was unavailable)