### PR TITLE
Assert FCA attribute boundaries at the owning contract

### DIFF
--- a/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
+++ b/tests/math/formal_concept_analysis/test_formal_concept_analysis.py
@@ -223,7 +223,7 @@ class TestEnumeration:
         result = compute_enumerate_concepts(EnumerateConceptsRequest(context=context))
         assert result.count == 2
 
-    def test_attribute_fallback_boundary_is_admitted_and_rejected(self) -> None:
+    def test_attribute_fallback_boundary_is_admitted(self) -> None:
         wide = FormalContext(
             objects=("o0",),
             attributes=tuple(f"a{index}" for index in range(64)),
@@ -233,14 +233,22 @@ class TestEnumeration:
             compute_enumerate_concepts(EnumerateConceptsRequest(context=wide)).count
             == 2
         )
-        with pytest.raises(ValidationError):
-            EnumerateConceptsRequest(
-                context=FormalContext(
-                    objects=("o0",),
-                    attributes=tuple(f"a{index}" for index in range(65)),
-                    incidence=(),
-                )
+
+    def test_formal_context_rejects_one_attribute_above_its_contract_cap(self) -> None:
+        with pytest.raises(ValidationError) as error:
+            FormalContext(
+                objects=("o0",),
+                attributes=tuple(f"a{index}" for index in range(65)),
+                incidence=(),
             )
+        detail = error.value.errors()[0]
+        assert detail["type"] == "too_long"
+        assert detail["loc"] == ("attributes",)
+        assert detail["ctx"] == {
+            "field_type": "Tuple",
+            "max_length": 64,
+            "actual_length": 65,
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #2632.

## Problem

An FCA boundary test mixed the valid 64-attribute enumeration composition with an independent 65-attribute `FormalContext` cap and used a bare `raises` assertion. The oversized case was rejected before an enumeration request existed, so the test did not prove the intended guard.

## Solution

Split the admitted composition case from the base `FormalContext` contract boundary and assert the structured Pydantic error code, location, and length context for the latter.

## Testing

- `make test-focused LANE=math TESTS=tests/math/formal_concept_analysis` — 77 passed
- Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. This corrects regression evidence for the existing input contract.

## Checklist

- [ ] `make check` passes (not run)