### PR TITLE
Admit canonical empty words in RSK composition

### DIFF
--- a/src/jacobian/math/algebraic_combinatorics/values.py
+++ b/src/jacobian/math/algebraic_combinatorics/values.py
@@ -43,11 +43,11 @@ class RSKTableauPair(StrictModel):
     """
 
     alphabet: tuple[Symbol, ...] = Field(
-        min_length=1,
         max_length=MAX_ALPHABET_SIZE,
         description=(
             "The exact ordered source alphabet; insertion-tableau entry i "
-            "denotes alphabet[i - 1]."
+            "denotes alphabet[i - 1]. The empty alphabet is canonical exactly "
+            "when both tableaux and their common shape are empty."
         ),
         json_schema_extra={"uniqueItems": True},
     )

--- a/src/jacobian/math/words/values.py
+++ b/src/jacobian/math/words/values.py
@@ -40,7 +40,14 @@ Symbol = Annotated[
 
 
 class FiniteWord(StrictModel):
-    alphabet: tuple[Symbol, ...] = Field(min_length=1, max_length=MAX_ALPHABET_SIZE)
+    """A bounded word over an explicitly ordered finite alphabet.
+
+    The empty alphabet carries exactly the empty word.  Keeping that
+    degenerate value representable lets canonical word values compose through
+    operations such as RSK without inventing an ambient symbol.
+    """
+
+    alphabet: tuple[Symbol, ...] = Field(max_length=MAX_ALPHABET_SIZE)
     letters: tuple[str, ...] = Field(max_length=MAX_WORD_LENGTH)
 
     @model_validator(mode="after")

--- a/tests/dispatch/test_algebraic_combinatorics_dispatch.py
+++ b/tests/dispatch/test_algebraic_combinatorics_dispatch.py
@@ -1,0 +1,33 @@
+"""Dispatch composition for canonical algebraic-combinatorics values."""
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import invoke_operation
+
+
+def test_empty_word_and_empty_alphabet_compose_through_rsk_dispatch() -> None:
+    """The exact empty RSK pair reconstructs the source without an invented symbol."""
+    catalog = Catalog.open()
+    forward = invoke_operation(
+        "tableau.rsk.word.compute",
+        {
+            "word": {"alphabet": [], "letters": []},
+            "convention": "ROW_INSERTION_RSK_V1",
+        },
+        catalog,
+    )
+
+    assert forward.output["alphabet"] == []
+    assert forward.output["insertion_tableau"] == {"rows": []}
+    assert forward.output["recording_tableau"] == {"rows": []}
+    assert forward.output["shape"] == {"parts": []}
+
+    inverse = invoke_operation(
+        "tableau.rsk.inverse_word.compute",
+        {
+            "pair": forward.output,
+            "convention": "ROW_INSERTION_RSK_V1",
+        },
+        catalog,
+    )
+
+    assert inverse.output == {"alphabet": [], "letters": []}

--- a/tests/integration/catalog/test_rsk_contracts.py
+++ b/tests/integration/catalog/test_rsk_contracts.py
@@ -32,3 +32,9 @@ def test_word_rsk_descriptor_publishes_version_two() -> None:
         descriptor.input_schema["properties"]["convention"]["const"]
         == "ROW_INSERTION_RSK_V1"
     )
+    assert (
+        "minItems"
+        not in (
+            descriptor.input_schema["$defs"]["FiniteWord"]["properties"]["alphabet"]
+        )
+    )

--- a/tests/math/words/test_words.py
+++ b/tests/math/words/test_words.py
@@ -572,6 +572,17 @@ def test_value_models_reject_ambiguous_or_unbounded_inputs() -> None:
         )
 
 
+def test_empty_alphabet_carries_exactly_the_empty_word_through_json() -> None:
+    """The empty word has a canonical empty ambient alphabet."""
+    word = FiniteWord.model_validate_json(
+        '{"alphabet": [], "letters": []}', strict=True
+    )
+
+    assert word.alphabet == ()
+    assert word.letters == ()
+    assert FiniteWord.model_validate(word.model_dump(mode="json")) == word
+
+
 @pytest.mark.parametrize("symbol", ["\ud800", "\udfff", "a\ud800b"])
 def test_symbols_admit_only_unicode_scalar_strings(symbol: str) -> None:
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Part of #2622.

## Problem

`FiniteWord` and `RSKTableauPair` rejected an empty alphabet even though the empty word over that alphabet is canonical, the RSK kernels construct exact empty tableaux, and the paired inverse can consume the value. This broke valid empty/degenerate composition at the value boundary.

## Solution

Allow the empty alphabet only in these two canonical values, with their existing validators requiring no letters or tableau entries in that case. Intentionally nonempty morphism and unrelated contracts are unchanged.

## Regression coverage

The integration test runs forward RSK through `math.run`, serializes the pair, and passes it to inverse RSK through `math.run`, recovering the same empty word.

## Testing

- words and algebraic-combinatorics owner suites — 102 passed
- RSK catalog integration — 3 passed
- catalog suite — 46 passed
- algebraic-combinatorics dispatch regression — 1 passed
- Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

The canonical empty word and its empty RSK tableau pair are now admitted; nonempty contracts retain their existing constraints.

## Checklist

- [ ] `make check` passes (not run)