### PR TITLE
Share canonical rational matrices with determinant

### DIFF
--- a/src/jacobian/math/matrices/_conversions.py
+++ b/src/jacobian/math/matrices/_conversions.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
-from jacobian.math.matrices._operation_models import DeterminantRationalMatrix
 from jacobian.math.matrices.values import IntegerMatrix, RationalMatrix, SmithNormalForm
 
 __all__ = [
@@ -32,9 +31,7 @@ def rational_from_sympy(value: Any) -> CanonicalRational:
     )
 
 
-def rational_matrix_to_sympy(
-    matrix: RationalMatrix | DeterminantRationalMatrix,
-) -> Any:
+def rational_matrix_to_sympy(matrix: RationalMatrix) -> Any:
     import sympy
 
     return sympy.Matrix(

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -12,7 +12,6 @@ from jacobian._models import StrictModel
 from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
     MAX_MATRIX_SCALAR_DIGITS,
-    MAX_RATIONAL_MATRIX_ORDER,
     IntegerMatrix,
     RationalMatrix,
     require_matrix_scalar_digits,
@@ -20,6 +19,10 @@ from jacobian.math.matrices.values import (
 
 MAX_INPUT_SCALAR_DIGITS = 256
 MAX_DETERMINANT_MATRIX_DIMENSION = 64
+# The canonical dense rational matrix carries determinant inputs through
+# order 64, but Kronecker admission was established only for product axes
+# through order 50. Pin each admitted output axis to that envelope.
+MAX_KRONECKER_PRODUCT_AXIS = 50
 
 
 def _require_computation_dimensions(
@@ -569,14 +572,14 @@ class MatrixKroneckerProductRequest(StrictModel):
         _require_computation_dimensions(self.left.entries)
         _require_computation_dimensions(self.right.entries)
         if len(self.left.entries) * len(self.right.entries) > (
-            MAX_RATIONAL_MATRIX_ORDER
+            MAX_KRONECKER_PRODUCT_AXIS
         ) or len(self.left.entries[0]) * len(self.right.entries[0]) > (
-            MAX_RATIONAL_MATRIX_ORDER
+            MAX_KRONECKER_PRODUCT_AXIS
         ):
             raise _validation_error(
                 "budget_exceeded",
                 "kronecker products must fit within "
-                f"{MAX_RATIONAL_MATRIX_ORDER} rows and columns",
+                f"{MAX_KRONECKER_PRODUCT_AXIS} rows and columns",
             )
         require_matrix_scalar_digits(
             self.left.entries, maximum=MAX_INPUT_SCALAR_DIGITS, label="matrix input"

--- a/src/jacobian/math/matrices/_operation_models.py
+++ b/src/jacobian/math/matrices/_operation_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal, Self
+from typing import Literal, Self
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
@@ -20,11 +20,6 @@ from jacobian.math.matrices.values import (
 
 MAX_INPUT_SCALAR_DIGITS = 256
 MAX_DETERMINANT_MATRIX_DIMENSION = 64
-
-DeterminantRow = Annotated[
-    tuple[CanonicalRational, ...],
-    Field(min_length=1, max_length=MAX_DETERMINANT_MATRIX_DIMENSION),
-]
 
 
 def _require_computation_dimensions(
@@ -123,46 +118,27 @@ class SquareRationalMatrixRequest(StrictModel):
         return self
 
 
-class DeterminantRationalMatrix(StrictModel):
-    """One determinant-owned rational matrix bounded independently to order 64."""
-
-    domain: Literal["QQ"] = "QQ"
-    entries: tuple[DeterminantRow, ...] = Field(
-        min_length=1, max_length=MAX_DETERMINANT_MATRIX_DIMENSION
-    )
-
-    @model_validator(mode="after")
-    def require_rectangular_nonempty_rows(self) -> Self:
-        column_count = len(self.entries[0])
-        if not 1 <= column_count <= MAX_DETERMINANT_MATRIX_DIMENSION:
-            raise _validation_error(
-                "budget_exceeded",
-                "determinant matrix rows must contain between 1 and 64 entries",
-            )
-        if any(len(row) != column_count for row in self.entries):
-            raise _validation_error(
-                "budget_exceeded",
-                "determinant matrix rows must all have the same length",
-            )
-        require_matrix_scalar_digits(
-            self.entries,
-            maximum=MAX_INPUT_SCALAR_DIGITS,
-            label="determinant input",
-        )
-        return self
-
-
 class MatrixDeterminantRequest(StrictModel):
     """One square rational matrix of order at most 64."""
 
-    matrix: DeterminantRationalMatrix
+    matrix: RationalMatrix
 
     @model_validator(mode="after")
     def require_square(self) -> Self:
-        if len(self.matrix.entries) != len(self.matrix.entries[0]):
+        order = len(self.matrix.entries)
+        if order != len(self.matrix.entries[0]):
             raise _validation_error(
                 "budget_exceeded", "determinant computation requires a square matrix"
             )
+        if order > MAX_DETERMINANT_MATRIX_DIMENSION:
+            raise _validation_error(
+                "budget_exceeded", "determinant matrices are limited to order 64"
+            )
+        require_matrix_scalar_digits(
+            self.matrix.entries,
+            maximum=MAX_INPUT_SCALAR_DIGITS,
+            label="determinant input",
+        )
         return self
 
 

--- a/src/jacobian/math/matrices/analysis/_models.py
+++ b/src/jacobian/math/matrices/analysis/_models.py
@@ -20,10 +20,15 @@ from jacobian.canonical import (
     encode_strict_json,
 )
 from jacobian.math.matrices.values import (
-    MAX_RATIONAL_MATRIX_ORDER,
     RationalMatrix,
     require_matrix_scalar_digits,
 )
+
+# The canonical dense rational matrix carries determinant inputs through
+# order 64, but the symmetric definiteness request's work and result
+# budgets were established only through order 50. Pin the admitted
+# dimension to that established envelope.
+MAX_SYMMETRIC_MATRIX_DIMENSION = 50
 
 # The inertia result echoes its source matrix in the domain's dense
 # canonical form, so a request whose normalized echo is near the canonical
@@ -259,7 +264,7 @@ class MatrixEntry(StrictModel):
 class SymmetricMatrixRequest(StrictModel):
     """A symmetric rational matrix for definiteness analysis."""
 
-    dimension: int = Field(ge=1, le=MAX_RATIONAL_MATRIX_ORDER)
+    dimension: int = Field(ge=1, le=MAX_SYMMETRIC_MATRIX_DIMENSION)
     entries: tuple[MatrixEntry, ...] = Field(min_length=1)
 
     @model_validator(mode="after")

--- a/src/jacobian/math/matrices/values.py
+++ b/src/jacobian/math/matrices/values.py
@@ -22,7 +22,10 @@ MAX_MATRIX_DIMENSION = 32
 # The canonical dense rational matrix retains exact sources for analysis
 # results whose operations admit them by their own work and result budgets,
 # so its structural order is not tied to the shared computation dimension.
-MAX_RATIONAL_MATRIX_ORDER = 50
+# The determinant operation admits square matrices through order 64.  Keep
+# that complete public domain representable by the one canonical QQ matrix
+# value so a determinant consumer can accept a produced matrix unchanged.
+MAX_RATIONAL_MATRIX_ORDER = 64
 MAX_MATRIX_SCALAR_DIGITS = MAX_CANONICAL_RATIONAL_DIGITS
 
 

--- a/tests/math/matrices/test_composite_operations.py
+++ b/tests/math/matrices/test_composite_operations.py
@@ -108,10 +108,10 @@ def test_kronecker_request_rejects_products_beyond_the_canonical_matrix_order() 
 
     from jacobian.math.matrices.values import MAX_RATIONAL_MATRIX_ORDER
 
-    factor = RationalMatrix(entries=_identity_entries(8))
+    factor = RationalMatrix(entries=_identity_entries(9))
     with pytest.raises(ValidationError):
         MatrixKroneckerProductRequest(left=factor, right=factor)
-    assert MAX_RATIONAL_MATRIX_ORDER < 8 * 8
+    assert MAX_RATIONAL_MATRIX_ORDER < 9 * 9
 
 
 def test_kronecker_product_at_the_canonical_matrix_order_boundary() -> None:

--- a/tests/math/matrices/test_composite_operations.py
+++ b/tests/math/matrices/test_composite_operations.py
@@ -19,7 +19,11 @@ from jacobian.math.matrices._operations import (
     compute_partial_trace,
     compute_permanent,
 )
-from jacobian.math.matrices.values import MAX_MATRIX_DIMENSION, RationalMatrix
+from jacobian.math.matrices.values import (
+    MAX_MATRIX_DIMENSION,
+    MAX_RATIONAL_MATRIX_ORDER,
+    RationalMatrix,
+)
 
 
 def _cr(num: int, den: int = 1) -> CanonicalRational:
@@ -103,20 +107,35 @@ def test_kronecker_request_rejects_operands_above_the_computation_dimension() ->
         MatrixKroneckerProductRequest(left=unit, right=tall)
 
 
-def test_kronecker_request_rejects_products_beyond_the_canonical_matrix_order() -> None:
+def test_kronecker_request_rejects_products_beyond_the_operation_axis_budget() -> None:
     from pydantic import ValidationError
 
-    from jacobian.math.matrices.values import MAX_RATIONAL_MATRIX_ORDER
+    from jacobian.math.matrices._operation_models import (
+        MAX_KRONECKER_PRODUCT_AXIS,
+    )
 
-    factor = RationalMatrix(entries=_identity_entries(9))
-    with pytest.raises(ValidationError):
+    factor = RationalMatrix(entries=_identity_entries(8))
+    with pytest.raises(ValidationError) as excinfo:
         MatrixKroneckerProductRequest(left=factor, right=factor)
-    assert MAX_RATIONAL_MATRIX_ORDER < 9 * 9
+    assert excinfo.value.errors()[0]["type"] == "matrix.budget_exceeded"
+    assert MAX_KRONECKER_PRODUCT_AXIS < 8 * 8 <= MAX_RATIONAL_MATRIX_ORDER
 
 
-def test_kronecker_product_at_the_canonical_matrix_order_boundary() -> None:
-    from jacobian.math.matrices.values import MAX_RATIONAL_MATRIX_ORDER
+def test_kronecker_product_admits_the_operation_axis_budget_boundary() -> None:
+    from jacobian.math.matrices._operation_models import (
+        MAX_KRONECKER_PRODUCT_AXIS,
+    )
 
+    left = RationalMatrix(entries=_identity_entries(5))
+    right = RationalMatrix(entries=_identity_entries(10))
+    result = compute_kronecker_product(
+        MatrixKroneckerProductRequest(left=left, right=right)
+    )
+    assert len(result.product.entries) == MAX_KRONECKER_PRODUCT_AXIS
+    assert len(result.product.entries[0]) == MAX_KRONECKER_PRODUCT_AXIS
+
+
+def test_kronecker_product_within_the_operation_axis_budget() -> None:
     side = 7
     request = MatrixKroneckerProductRequest(
         left=RationalMatrix(entries=_identity_entries(side)),
@@ -124,7 +143,7 @@ def test_kronecker_product_at_the_canonical_matrix_order_boundary() -> None:
     )
     result = compute_kronecker_product(request)
     order = side * side
-    assert order <= MAX_RATIONAL_MATRIX_ORDER
+    assert order < MAX_RATIONAL_MATRIX_ORDER
     assert result.left_rows == result.right_rows == side
     assert len(result.product.entries) == order
     assert result.product.entries[0][0] == _cr(1)

--- a/tests/math/matrices/test_matrix_analysis.py
+++ b/tests/math/matrices/test_matrix_analysis.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.matrices.analysis._models import (
+    MAX_SYMMETRIC_MATRIX_DIMENSION,
     FarkasCertificateRequest,
     InertiaResult,
     MatrixEntry,
@@ -313,9 +314,16 @@ def test_inertia_request_admits_order_33_diagonal_source() -> None:
     assert isinstance(result.matrix, RationalMatrix)
 
 
-def test_inertia_request_rejects_dimensions_above_the_canonical_matrix_order() -> None:
-    with pytest.raises(ValidationError):
-        _inertia_request(MAX_RATIONAL_MATRIX_ORDER + 1, {(0, 0): "1"})
+@pytest.mark.parametrize(
+    "dimension",
+    range(MAX_SYMMETRIC_MATRIX_DIMENSION + 1, MAX_RATIONAL_MATRIX_ORDER + 1),
+)
+def test_inertia_request_rejects_dimensions_widened_by_the_canonical_value(
+    dimension: int,
+) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        _inertia_request(dimension, {(0, 0): "1"})
+    assert excinfo.value.errors()[0]["type"] == "less_than_equal"
 
 
 def _encoded_inertia_payload_near_limit(offset: int) -> bytes:

--- a/tests/math/matrices/test_result_source_binding.py
+++ b/tests/math/matrices/test_result_source_binding.py
@@ -10,19 +10,25 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.math.matrices._operation_models import (
+    MAX_DETERMINANT_MATRIX_DIMENSION,
+    MatrixDeterminantRequest,
     MatrixRankRequest,
     MatrixRankResult,
     NullspaceResult,
+    RationalMatrixProductRequest,
     RationalMatrixRequest,
     RrefResult,
 )
 from jacobian.math.matrices._operations import (
+    compute_determinant,
     compute_nullspace,
+    compute_product,
     compute_rank,
     compute_rref,
 )
 from jacobian.math.matrices.values import (
     MAX_MATRIX_DIMENSION,
+    MAX_RATIONAL_MATRIX_ORDER,
     RationalMatrix,
     rational_matrix_from_fractions,
 )
@@ -230,6 +236,27 @@ def test_producer_to_serialized_interoperability() -> None:
     assert list(rref.free_columns) == list(nullspace.free_columns)
 
 
+def test_product_value_feeds_determinant_without_reencoding() -> None:
+    """A matrix producer's canonical value is the determinant input value."""
+
+    left = _matrix([["1", "2"], ["3", "4"]])
+    right = _matrix([["0", "1"], ["1", "0"]])
+    product = compute_product(RationalMatrixProductRequest(left=left, right=right))
+
+    # Transport composition parses the producer's canonical payload directly,
+    # and native composition retains its exact owner type unchanged.
+    transported = MatrixDeterminantRequest.model_validate(
+        {"matrix": product.product.model_dump(mode="json")}
+    )
+    assert transported.matrix == product.product
+
+    request = MatrixDeterminantRequest(matrix=product.product)
+    assert request.matrix is product.product
+    assert compute_determinant(request).determinant == CanonicalRational(
+        num="2", den="1"
+    )
+
+
 def _identity_entries(size: int) -> tuple[tuple[CanonicalRational, ...], ...]:
     one = CanonicalRational(num="1", den="1")
     zero = CanonicalRational(num="0", den="1")
@@ -269,3 +296,9 @@ def test_request_admission_keeps_the_boundary_computation_dimension() -> None:
     assert rank.rank == MAX_MATRIX_DIMENSION
     assert len(rank.pivot_columns) == MAX_MATRIX_DIMENSION
     assert rank.matrix == boundary
+
+
+def test_determinant_accepts_the_canonical_matrix_boundary() -> None:
+    assert MAX_RATIONAL_MATRIX_ORDER == MAX_DETERMINANT_MATRIX_DIMENSION
+    matrix = RationalMatrix(entries=_identity_entries(MAX_RATIONAL_MATRIX_ORDER))
+    assert MatrixDeterminantRequest(matrix=matrix).matrix is matrix


### PR DESCRIPTION
Fixes #2626.

## Problem

Matrix determinant requests reconstructed an equivalent `DeterminantRationalMatrix` instead of accepting the canonical `RationalMatrix` produced by matrix operations. The parallel representation duplicated dense rational entries and structural validation, weakening direct composition.

## Solution

Remove the determinant-specific value model and accept `RationalMatrix` directly. The canonical structural limit now covers the admitted 64×64 determinant domain; determinant retains its own square, order, and scalar-digit admission rules.

## Regression coverage

A `MatrixProductResult.product` feeds determinant both through its serialized payload and as the direct native typed value. The 64×64 boundary remains covered.

## Testing

- focused matrices tests — 31 passed
- full matrices owner lane — passed
- catalog suite — 46 passed
- dispatch suite — passed
- Ruff and formatting checks — passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

Determinant now accepts the established canonical rational-matrix value. Its JSON shape and local execution envelope remain unchanged.

## Checklist

- [ ] `make check` passes (not run)