### PR TITLE
Guard against repository artifacts and parallel branch races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - run: make lint-full
       - run: make typecheck
       - run: make architecture
+      - run: make repository-hygiene
       - run: make todo-check
       - run: make import-contracts
       - run: make docs-linkcheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,18 @@ service behavior.
 - Preserve unrelated work in a shared checkout. Agents must not concurrently
   switch branches, stage, commit, clean, rewrite history, or edit overlapping
   paths.
+- For a parallel change wave, give each writer an isolated worktree and a
+  distinct branch. A branch has one active writer at a time; the coordinator
+  records each issue or PR claim before implementation, and a worker checks
+  for a current claim before starting the same scope.
+- Before a first public-operation push, search open pull requests for the
+  operation ID. If this change intentionally replaces an existing operation,
+  say which contract it supersedes in the PR body. After resolving a catalog
+  conflict, run catalog conformance before pushing and compare the final
+  branch diff with the intended files and public symbols.
+- Fetch the branch immediately before pushing. If its head changed, inspect
+  the landed work instead of retrying an equivalent fix. Never push to a
+  merged or closed PR head: move remaining work to a new follow-up branch.
 - Run `make check` and the named lane that owns changed behavior before
   handoff. Only the coordinating agent may run exhaustive validation in a
   shared checkout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,14 @@ while another agent is working. Integrate their edits first, then run the
 planned checks on the final tree. Use isolated worktrees only when the workflow
 explicitly assigns them.
 
+For parallel pull-request work, each writer owns one isolated worktree and
+one branch at a time. Record an issue or PR claim before implementation; check
+for a current claim and for sibling public-operation IDs before beginning the
+same scope. Fetch immediately before pushing and inspect a changed head rather
+than retrying equivalent work. Do not recreate a merged or closed pull-request
+branch: start a follow-up branch instead. The agent-facing version of this
+protocol, including conflict-resolution checks, lives in `AGENTS.md`.
+
 Before final validation, run `make check` plus the named lane that owns the
 changed behavior. If the tree changes during validation, rerun checks whose
 evidence was invalidated by that change; do not describe results from an

--- a/make/development.mk
+++ b/make/development.mk
@@ -1,4 +1,4 @@
-.PHONY: uv-version-check setup container-image eval-image eval-image-pull hooks fix lint lint-full security-audit typecheck architecture docs-command-check docs-linkcheck
+.PHONY: uv-version-check setup container-image eval-image eval-image-pull hooks fix lint lint-full security-audit typecheck architecture repository-hygiene docs-command-check docs-linkcheck
 
 uv-version-check: ## Require the repository-pinned uv release.
 	@test "$$(uv --version | awk '{print $$2}')" = "$$(tr -d '[:space:]' < .uv-version)" || { echo "install uv $$(tr -d '[:space:]' < .uv-version) before using this checkout" >&2; exit 2; }

--- a/make/development.mk
+++ b/make/development.mk
@@ -45,6 +45,9 @@ import-contracts: ## Enforce declared package dependency direction.
 architecture: ## Enforce product source boundary invariants (subprocess, shutil.which, environ, contracts, surfaces).
 	$(UV_RUN) python tools/check_architecture.py
 
+repository-hygiene: ## Reject tracked local artifacts and unresolved conflict markers.
+	$(UV_RUN) python tools/check_repository_hygiene.py
+
 docs-command-check: ## Validate Make targets and TESTS paths in command examples.
 	$(UV_RUN) python tools/check_doc_commands.py
 

--- a/tests/tooling/test_repository_hygiene.py
+++ b/tests/tooling/test_repository_hygiene.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from tools import check_repository_hygiene
 
 

--- a/tests/tooling/test_repository_hygiene.py
+++ b/tests/tooling/test_repository_hygiene.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from tools import check_repository_hygiene
+
+
+def test_rejects_artifacts_and_conflict_markers(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "pr-audit").mkdir()
+    (tmp_path / "pr-audit/report.json").write_text("{}")
+    (tmp_path / "guide.md").write_text("<<<<<<< HEAD\n")
+    monkeypatch.setattr(
+        check_repository_hygiene,
+        "tracked_paths",
+        lambda root: (Path("pr-audit/report.json"), Path("guide.md")),
+    )
+
+    assert check_repository_hygiene.check(tmp_path) == (
+        "pr-audit/report.json: forbidden local artifact",
+        "guide.md:1: unresolved conflict marker",
+    )

--- a/tests/tooling/test_repository_hygiene.py
+++ b/tests/tooling/test_repository_hygiene.py
@@ -1,19 +1,60 @@
 from pathlib import Path
 
+import pytest
+
 from tools import check_repository_hygiene
 
 
-def test_rejects_artifacts_and_conflict_markers(monkeypatch, tmp_path: Path) -> None:
+def test_rejects_artifacts_and_conflict_markers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     (tmp_path / "pr-audit").mkdir()
     (tmp_path / "pr-audit/report.json").write_text("{}")
-    (tmp_path / "guide.md").write_text("<<<<<<< HEAD\n")
+    (tmp_path / "jacobian_scale_audit_report.md").write_text("stale\n")
+    (tmp_path / ".agents-tmp-unresolved.sh").write_text("#!/bin/sh\n")
+    (tmp_path / "guide.md").write_text("<<<<<<< HEAD\n=======\n>>>>>>> main\n")
     monkeypatch.setattr(
         check_repository_hygiene,
         "tracked_paths",
-        lambda root: (Path("pr-audit/report.json"), Path("guide.md")),
+        lambda root: (
+            Path("pr-audit/report.json"),
+            Path("jacobian_scale_audit_report.md"),
+            Path(".agents-tmp-unresolved.sh"),
+            Path("guide.md"),
+        ),
     )
 
     assert check_repository_hygiene.check(tmp_path) == (
         "pr-audit/report.json: forbidden local artifact",
+        "jacobian_scale_audit_report.md: forbidden local artifact",
+        ".agents-tmp-unresolved.sh: forbidden local artifact",
         "guide.md:1: unresolved conflict marker",
+        "guide.md:2: unresolved conflict marker",
+        "guide.md:3: unresolved conflict marker",
+    )
+
+
+def test_allows_literal_markers_only_in_fixture_and_vendored_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixture = tmp_path / "tests/fixtures/merge-conflict.txt"
+    vendor = tmp_path / "vendor/merge-conflict.txt"
+    document = tmp_path / "docs/guide.md"
+    for path in (fixture, vendor, document):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("<<<<<<< HEAD\n=======\n>>>>>>> main\n", encoding="utf-8")
+    monkeypatch.setattr(
+        check_repository_hygiene,
+        "tracked_paths",
+        lambda root: (
+            Path("tests/fixtures/merge-conflict.txt"),
+            Path("vendor/merge-conflict.txt"),
+            Path("docs/guide.md"),
+        ),
+    )
+
+    assert check_repository_hygiene.check(tmp_path) == (
+        "docs/guide.md:1: unresolved conflict marker",
+        "docs/guide.md:2: unresolved conflict marker",
+        "docs/guide.md:3: unresolved conflict marker",
     )

--- a/tools/check_repository_hygiene.py
+++ b/tools/check_repository_hygiene.py
@@ -6,8 +6,11 @@ import subprocess
 from pathlib import Path, PurePosixPath
 
 ROOT = Path(__file__).resolve().parents[1]
-FORBIDDEN = (".agents-tmp-", "pr-audit/")
-MARKERS = ("<<<<<<< ", ">>>>>>> ", "======= ")
+_FIXTURE_PREFIXES = (
+    PurePosixPath("tests/fixtures"),
+    PurePosixPath("vendor"),
+    PurePosixPath("vendored"),
+)
 
 
 def tracked_paths(root: Path) -> tuple[PurePosixPath, ...]:
@@ -17,17 +20,40 @@ def tracked_paths(root: Path) -> tuple[PurePosixPath, ...]:
     return tuple(PurePosixPath(p.decode()) for p in result.stdout.split(b"\0") if p)
 
 
+def _is_local_artifact(path: PurePosixPath) -> bool:
+    """Return whether a tracked path matches a documented local-work pattern."""
+    return (
+        any(part.startswith(".agents-tmp-") for part in path.parts)
+        or "pr-audit" in path.parts
+        or (
+            path.parent == PurePosixPath(".")
+            and path.match("*audit_report*.md")
+        )
+    )
+
+
+def _allows_literal_conflict_markers(path: PurePosixPath) -> bool:
+    """Keep vendored and deliberately adversarial fixture text out of the scan."""
+    return any(path.is_relative_to(prefix) for prefix in _FIXTURE_PREFIXES)
+
+
+def _is_conflict_marker(line: str) -> bool:
+    """Recognize the three line forms emitted by Git's conflict renderer."""
+    return (
+        line.startswith("<<<<<<< ")
+        or line.startswith(">>>>>>> ")
+        or line == "======="
+    )
+
+
 def check(root: Path = ROOT) -> tuple[str, ...]:
     violations: list[str] = []
     for path in tracked_paths(root):
         name = path.as_posix()
-        forbidden_root_audit = (
-            path.parent == PurePosixPath(".")
-            and path.suffix == ".md"
-            and "audit_report" in path.stem
-        )
-        if any(pattern in name for pattern in FORBIDDEN) or forbidden_root_audit:
+        if _is_local_artifact(path):
             violations.append(f"{name}: forbidden local artifact")
+            continue
+        if _allows_literal_conflict_markers(path):
             continue
         try:
             lines = (root / path).read_text(encoding="utf-8").splitlines()
@@ -36,7 +62,7 @@ def check(root: Path = ROOT) -> tuple[str, ...]:
         violations.extend(
             f"{name}:{index}: unresolved conflict marker"
             for index, line in enumerate(lines, 1)
-            if line.startswith(MARKERS)
+            if _is_conflict_marker(line)
         )
     return tuple(violations)
 

--- a/tools/check_repository_hygiene.py
+++ b/tools/check_repository_hygiene.py
@@ -1,0 +1,47 @@
+"""Reject tracked local artifacts and unresolved conflict markers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[1]
+FORBIDDEN = (".agents-tmp-", "pr-audit/")
+MARKERS = ("<<<<<<< ", ">>>>>>> ", "======= ")
+
+
+def tracked_paths(root: Path) -> tuple[PurePosixPath, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"], check=True, capture_output=True
+    )
+    return tuple(PurePosixPath(p.decode()) for p in result.stdout.split(b"\0") if p)
+
+
+def check(root: Path = ROOT) -> tuple[str, ...]:
+    violations: list[str] = []
+    for path in tracked_paths(root):
+        name = path.as_posix()
+        forbidden_root_audit = (
+            path.parent == PurePosixPath(".")
+            and path.suffix == ".md"
+            and "audit_report" in path.stem
+        )
+        if any(pattern in name for pattern in FORBIDDEN) or forbidden_root_audit:
+            violations.append(f"{name}: forbidden local artifact")
+            continue
+        try:
+            lines = (root / path).read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        violations.extend(
+            f"{name}:{index}: unresolved conflict marker"
+            for index, line in enumerate(lines, 1)
+            if line.startswith(MARKERS)
+        )
+    return tuple(violations)
+
+
+if __name__ == "__main__":
+    failures = check()
+    print("\n".join(failures))
+    raise SystemExit(bool(failures))


### PR DESCRIPTION
## Problem

Tracked machine-local artifacts and unresolved conflict markers have reached pull-request branches, while concurrent writers can duplicate work or recreate merged PR heads.

## Solution

- add a static CI and local `make repository-hygiene` check for tracked artifact patterns and conflict markers outside deliberate fixture/vendor text;
- document claim-before-work, isolated single-writer branches, sibling operation-ID checks, fresh-head inspection, and follow-up branches for closed PRs;
- retain the existing catalog duplicate-ID checks rather than duplicate their coverage.

## Testing

- `make check` — 6,387 passed
- `make test-focused LANE=tooling TESTS=tests/tooling/test_repository_hygiene.py` — 2 passed
- `make test-focused LANE=catalog TESTS='tests/catalog/test_catalog_invariants.py tests/catalog/test_admission.py'` — 15 passed
- `make repository-hygiene`
- `make docs-linkcheck`

Fixes #2606
Fixes #2620
Refs #2589