### PR TITLE
Co-locate analysis enclosure execution families

### DIFF
--- a/src/jacobian/math/analysis/_arb.py
+++ b/src/jacobian/math/analysis/_arb.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from jacobian.canonical import format_canonical_integer
-from jacobian.math.analysis._models import MAX_DYADIC_EXPONENT, ExactDyadic
+from jacobian.math.analysis._models import (
+    MAX_DYADIC_EXPONENT,
+    ExactDyadic,
+    RationalClosedInterval,
+)
 
 
 def dyadic_endpoints(
@@ -33,4 +37,62 @@ def dyadic_endpoints(
     )
 
 
-__all__ = ["dyadic_endpoints"]
+def _normalize_dyadic_pair(mantissa: int, exponent: int) -> tuple[int, int]:
+    if mantissa == 0:
+        return 0, 0
+    while mantissa % 2 == 0:
+        mantissa //= 2
+        exponent += 1
+    return mantissa, exponent
+
+
+def _add_dyadic_pairs(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
+    common_exponent = min(left[1], right[1])
+    return _normalize_dyadic_pair(
+        (left[0] << (left[1] - common_exponent))
+        + (right[0] << (right[1] - common_exponent)),
+        common_exponent,
+    )
+
+
+def _negate_dyadic_pair(value: tuple[int, int]) -> tuple[int, int]:
+    return -value[0], value[1]
+
+
+def _halve_dyadic_pair(value: tuple[int, int]) -> tuple[int, int]:
+    return _normalize_dyadic_pair(value[0], value[1] - 1)
+
+
+def _exact_arb_dyadic_pair(value: Any) -> tuple[int, int]:
+    mantissa, exponent = value.man_exp()
+    return _normalize_dyadic_pair(int(mantissa), int(exponent))
+
+
+def arb_source_interval(interval: RationalClosedInterval) -> Any:
+    """Build one Arb ball that contains the exact rational source interval.
+
+    Arb radii have a fixed implementation precision. Anchoring a one-sided
+    interval at its endpoint nearest zero preserves a proved sign even when
+    the radius is rounded upward by python-flint's public constructor.
+    """
+
+    from flint import arb, fmpq
+
+    lower_ratio = interval.lower.as_integer_ratio()
+    upper_ratio = interval.upper.as_integer_ratio()
+    if lower_ratio == upper_ratio:
+        return arb(fmpq(*lower_ratio))
+
+    lower = _exact_arb_dyadic_pair(arb(fmpq(*lower_ratio)).lower())
+    upper = _exact_arb_dyadic_pair(arb(fmpq(*upper_ratio)).upper())
+    half_width = _halve_dyadic_pair(
+        _add_dyadic_pairs(upper, _negate_dyadic_pair(lower))
+    )
+    actual_radius = _exact_arb_dyadic_pair(arb((0, 0), half_width).upper())
+    if interval.lower.as_fraction() >= 0:
+        midpoint = _add_dyadic_pairs(lower, actual_radius)
+    elif interval.upper.as_fraction() <= 0:
+        midpoint = _add_dyadic_pairs(upper, _negate_dyadic_pair(actual_radius))
+    else:
+        midpoint = _halve_dyadic_pair(_add_dyadic_pairs(lower, upper))
+    return arb(midpoint, half_width)

--- a/src/jacobian/math/analysis/_arb.py
+++ b/src/jacobian/math/analysis/_arb.py
@@ -8,8 +8,8 @@ from jacobian.canonical import format_canonical_integer
 from jacobian.math.analysis._models import (
     MAX_DYADIC_EXPONENT,
     ExactDyadic,
-    RationalClosedInterval,
 )
+from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
 
 def dyadic_endpoints(

--- a/src/jacobian/math/analysis/_arb.py
+++ b/src/jacobian/math/analysis/_arb.py
@@ -1,0 +1,36 @@
+"""Shared Arb conversion helpers for analysis enclosure families."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.analysis._models import MAX_DYADIC_EXPONENT, ExactDyadic
+
+
+def dyadic_endpoints(
+    lower_mantissa: Any,
+    lower_exponent: Any,
+    upper_mantissa: Any,
+    upper_exponent: Any,
+) -> tuple[ExactDyadic, ExactDyadic] | None:
+    """Serialize Arb endpoints only when their exponents fit the wire contract."""
+
+    if (
+        abs(lower_exponent) > MAX_DYADIC_EXPONENT
+        or abs(upper_exponent) > MAX_DYADIC_EXPONENT
+    ):
+        return None
+    return (
+        ExactDyadic(
+            mantissa=format_canonical_integer(int(lower_mantissa)),
+            exponent=int(lower_exponent),
+        ),
+        ExactDyadic(
+            mantissa=format_canonical_integer(int(upper_mantissa)),
+            exponent=int(upper_exponent),
+        ),
+    )
+
+
+__all__ = ["dyadic_endpoints"]

--- a/src/jacobian/math/analysis/_box_enclosure.py
+++ b/src/jacobian/math/analysis/_box_enclosure.py
@@ -1,0 +1,393 @@
+"""Contracts, admission, replay, and execution for expression box enclosures."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian.catalog._examples import example
+from jacobian.catalog.models import MathTool
+from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
+from jacobian.math.analysis._models import (
+    MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
+    ExactDyadic,
+    IntervalExpressionDomainFailure,
+    IntervalExpressionNode,
+    _bounded_rational_bounds,
+    _BoxPreflight,
+    _IntervalExpressionBoxRequest,
+    _preflight_box_binary,
+    _preflight_box_unary,
+    _rational_box_bounds,
+    _RationalBounds,
+    _validation_error,
+)
+
+type IntervalExpressionBoxEnclosureStatus = Literal[
+    "ENCLOSED", "DOMAIN_UNPROVEN", "BACKEND_ERROR"
+]
+
+
+class IntervalExpressionBoxEnclosureRequest(_IntervalExpressionBoxRequest):
+    """Enclose one named-variable expression on a complete rational box."""
+
+    @model_validator(mode="after")
+    def require_bounded_box_admission(self) -> Self:
+        _preflight_box_expression(self.expression, _rational_box_bounds(self.box))
+        return self
+
+
+def _preflight_box_expression(
+    node: IntervalExpressionNode,
+    variables: dict[str, _RationalBounds],
+    path: tuple[int, ...] = (),
+) -> _BoxPreflight:
+    """Bound exact admission work and locate the first domain obstruction."""
+
+    if node.op == "const":
+        assert node.value is not None
+        value = node.value.as_fraction()
+        return _bounded_rational_bounds(value, value)
+    if node.op == "var":
+        assert node.variable is not None
+        return variables[node.variable]
+
+    children: list[_BoxPreflight] = []
+    for index, child_node in enumerate(node.children):
+        child = _preflight_box_expression(child_node, variables, (*path, index))
+        if isinstance(child, IntervalExpressionDomainFailure):
+            return child
+        children.append(child)
+
+    left = children[0]
+    assert isinstance(left, _RationalBounds)
+    if len(children) == 1:
+        return _preflight_box_unary(node, left, path)
+
+    right = children[1]
+    assert isinstance(right, _RationalBounds)
+    return _preflight_box_binary(node, left, right, path)
+
+
+class _BoxEvaluationFailure(StrEnum):
+    BACKEND_ERROR = "BACKEND_ERROR"
+
+
+def _box_domain_failure(
+    node: IntervalExpressionNode, path: tuple[int, ...]
+) -> IntervalExpressionDomainFailure:
+    if node.op == "div":
+        return IntervalExpressionDomainFailure(
+            node_path=path,
+            operation="div",
+            reason="DENOMINATOR_CONTAINS_ZERO",
+        )
+    if node.op == "pow":
+        return IntervalExpressionDomainFailure(
+            node_path=path,
+            operation="pow",
+            reason="NEGATIVE_POWER_BASE_CONTAINS_ZERO",
+        )
+    if node.op == "log":
+        return IntervalExpressionDomainFailure(
+            node_path=path,
+            operation="log",
+            reason="LOG_ARGUMENT_NOT_STRICTLY_POSITIVE",
+        )
+    if node.op == "sqrt":
+        return IntervalExpressionDomainFailure(
+            node_path=path,
+            operation="sqrt",
+            reason="SQRT_ARGUMENT_NOT_NONNEGATIVE",
+        )
+    raise AssertionError("only real-domain operations can produce a domain failure")
+
+
+def _evaluate_box_unary(
+    node: IntervalExpressionNode, value: Any, path: tuple[int, ...]
+) -> Any:
+    if node.op == "neg":
+        return -value
+    if node.op == "pow":
+        assert node.exponent is not None
+        if node.exponent < 0 and value.contains(0):
+            return _box_domain_failure(node, path)
+        return value**node.exponent
+    if node.op == "log":
+        if not value > 0:
+            return _box_domain_failure(node, path)
+        return value.log()
+    if node.op == "sqrt":
+        if not value >= 0:
+            return _box_domain_failure(node, path)
+        return value.sqrt()
+    if node.op in ("exp", "sin", "cos"):
+        return getattr(value, node.op)()
+    raise AssertionError(f"unsupported unary expression operation: {node.op}")
+
+
+def _evaluate_box_binary(
+    node: IntervalExpressionNode,
+    left: Any,
+    right: Any,
+    path: tuple[int, ...],
+) -> Any:
+    if node.op == "add":
+        return left + right
+    if node.op == "sub":
+        return left - right
+    if node.op == "mul":
+        return left * right
+    if node.op == "div":
+        if right.contains(0):
+            return _box_domain_failure(node, path)
+        return left / right
+    raise AssertionError(f"unsupported binary expression operation: {node.op}")
+
+
+def _evaluate_box_expression(
+    node: IntervalExpressionNode,
+    variables: dict[str, Any],
+    path: tuple[int, ...] = (),
+) -> Any:
+    from flint import arb, fmpq
+
+    if node.op == "const":
+        assert node.value is not None
+        return arb(fmpq(*node.value.as_integer_ratio()))
+    if node.op == "var":
+        assert node.variable is not None
+        return variables[node.variable]
+
+    values: list[Any] = []
+    for index, child in enumerate(node.children):
+        value = _evaluate_box_expression(child, variables, (*path, index))
+        if isinstance(value, (IntervalExpressionDomainFailure, _BoxEvaluationFailure)):
+            return value
+        if not value.is_finite():
+            return _BoxEvaluationFailure.BACKEND_ERROR
+        values.append(value)
+
+    left = values[0]
+    if len(values) == 1:
+        return _evaluate_box_unary(node, left, path)
+
+    right = values[1]
+    return _evaluate_box_binary(node, left, right, path)
+
+
+class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest):
+    """A replayable enclosure bound to its expression, axis, and source box.
+
+    For ``ENCLOSED``, every defined real source-box value lies between the two
+    exact dyadic endpoints. Full validation recomputes that canonical claim.
+    ``DOMAIN_UNPROVEN`` replays its deterministic first-obstruction evidence.
+    ``BACKEND_ERROR`` asserts no enclosure conclusion at all, so it is
+    validated structurally: rerunning Arb would reject the operation's own
+    serialized result whenever a transient backend condition does not recur.
+    """
+
+    status: IntervalExpressionBoxEnclosureStatus
+    lower: ExactDyadic | None = None
+    upper: ExactDyadic | None = None
+    domain_failure: IntervalExpressionDomainFailure | None = None
+    method: Literal["ARB_NATURAL_INTERVAL_EXTENSION"] = "ARB_NATURAL_INTERVAL_EXTENSION"
+    detail: str = Field(min_length=1, max_length=1024)
+
+    @model_validator(mode="after")
+    def bind_enclosure_to_source(self) -> Self:
+        enclosed = self.status == "ENCLOSED"
+        if enclosed != (self.lower is not None and self.upper is not None):
+            raise _validation_error(
+                "only an enclosed result may carry dyadic endpoints"
+            )
+        if enclosed:
+            assert self.lower is not None and self.upper is not None
+            if self.lower.compare(self.upper) > 0:
+                raise _validation_error(
+                    "enclosure lower endpoint exceeds upper endpoint"
+                )
+            if self.domain_failure is not None:
+                raise _validation_error(
+                    "an enclosed result cannot carry a domain failure"
+                )
+        else:
+            domain_unproven = self.status == "DOMAIN_UNPROVEN"
+            if domain_unproven != (self.domain_failure is not None):
+                raise _validation_error(
+                    "domain-failure evidence must agree with DOMAIN_UNPROVEN status"
+                )
+            if self.status == "BACKEND_ERROR":
+                return self
+
+        request = IntervalExpressionBoxEnclosureRequest.model_construct(
+            expression=self.expression,
+            box=self.box,
+            precision_bits=self.precision_bits,
+        )
+        if self != _box_expression_enclosure(request):
+            raise _validation_error(
+                "box enclosure does not replay from its expression, axis, and source box"
+            )
+        return self
+
+
+def _constructed_box_result(
+    request: IntervalExpressionBoxEnclosureRequest,
+    *,
+    status: IntervalExpressionBoxEnclosureStatus,
+    detail: str,
+    lower: ExactDyadic | None = None,
+    upper: ExactDyadic | None = None,
+    domain_failure: IntervalExpressionDomainFailure | None = None,
+) -> IntervalExpressionBoxEnclosureResult:
+    """Build the producer result without paying a second backend replay."""
+
+    return IntervalExpressionBoxEnclosureResult.model_construct(
+        expression=request.expression,
+        box=request.box,
+        precision_bits=request.precision_bits,
+        status=status,
+        lower=lower,
+        upper=upper,
+        domain_failure=domain_failure,
+        method="ARB_NATURAL_INTERVAL_EXTENSION",
+        detail=detail,
+    )
+
+
+def _box_expression_enclosure(
+    request: IntervalExpressionBoxEnclosureRequest,
+) -> IntervalExpressionBoxEnclosureResult:
+    preflight = _preflight_box_expression(
+        request.expression, _rational_box_bounds(request.box)
+    )
+    if isinstance(preflight, IntervalExpressionDomainFailure):
+        return _constructed_box_result(
+            request,
+            status="DOMAIN_UNPROVEN",
+            domain_failure=preflight,
+            detail=(
+                "The exact admission interval extension could not establish the "
+                "real domain at the reported source node."
+            ),
+        )
+
+    from flint import ctx
+
+    try:
+        with ctx.workprec(request.precision_bits):
+            variables = {
+                variable: arb_source_interval(interval)
+                for variable, interval in zip(
+                    request.box.variables, request.box.intervals, strict=True
+                )
+            }
+            result = _evaluate_box_expression(request.expression, variables)
+            if isinstance(result, IntervalExpressionDomainFailure):
+                return _constructed_box_result(
+                    request,
+                    status="DOMAIN_UNPROVEN",
+                    domain_failure=result,
+                    detail=(
+                        "Arb's natural interval extension could not establish the "
+                        "real domain at the reported source node."
+                    ),
+                )
+            if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
+                return _constructed_box_result(
+                    request,
+                    status="BACKEND_ERROR",
+                    detail=(
+                        "Pinned Arb returned no finite enclosure within the admitted "
+                        "fixed-precision envelope."
+                    ),
+                )
+            lower_mantissa, lower_exponent = result.lower().man_exp()
+            upper_mantissa, upper_exponent = result.upper().man_exp()
+            endpoints = dyadic_endpoints(
+                lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
+            )
+    except (OverflowError, ValueError):
+        return _constructed_box_result(
+            request,
+            status="BACKEND_ERROR",
+            detail=(
+                "Pinned Arb rejected an admitted bounded computation; no enclosure "
+                "conclusion is available."
+            ),
+        )
+
+    if endpoints is None:
+        return _constructed_box_result(
+            request,
+            status="BACKEND_ERROR",
+            detail=(
+                "Pinned Arb produced endpoints outside the admitted dyadic wire "
+                "envelope; no enclosure conclusion is available."
+            ),
+        )
+    return _constructed_box_result(
+        request,
+        status="ENCLOSED",
+        lower=endpoints[0],
+        upper=endpoints[1],
+        detail=(
+            "Pinned Arb natural interval arithmetic returned an outward-rounded "
+            "enclosure with exact dyadic endpoints."
+        ),
+    )
+
+
+BOX_EXPRESSION_ENCLOSURE_OPERATIONS = (
+    MathTool(
+        operation_id="interval.expression.box_enclosure.compute",
+        title="Enclose an elementary expression over a rational box",
+        description=(
+            "Use pinned Arb natural interval arithmetic to enclose one bounded "
+            "named-variable elementary expression over a complete ordered rational "
+            "box, or report the first source node whose real domain is unproved. "
+            "The fixed envelope admits at most 8 variables, 64 nodes, depth 16, "
+            "128-digit rationals, absolute power exponents up to 64, 4,096-bit "
+            "Arb precision, 8,192-bit retained exact admission bounds, and "
+            f"{MAX_BOX_PREFLIGHT_TEMPORARY_BITS:,}-bit Fraction temporaries."
+        ),
+        request_type=IntervalExpressionBoxEnclosureRequest,
+        result_type=IntervalExpressionBoxEnclosureResult,
+        run=_box_expression_enclosure,
+        tags=(
+            "analysis",
+            "interval",
+            "expression",
+            "box",
+            "multivariate",
+            "arb",
+            "validated",
+            "bounded",
+        ),
+        examples=(
+            example(
+                "exp_unit_interval",
+                "Enclose exp(x) over the exact rational interval 0 <= x <= 1.",
+                {
+                    "expression": {
+                        "op": "exp",
+                        "children": [{"op": "var", "variable": "x"}],
+                    },
+                    "box": {
+                        "variables": ["x"],
+                        "intervals": [
+                            {
+                                "lower": {"num": "0", "den": "1"},
+                                "upper": {"num": "1", "den": "1"},
+                            }
+                        ],
+                    },
+                    "precision_bits": 128,
+                },
+            ),
+        ),
+    ),
+)

--- a/src/jacobian/math/analysis/_models.py
+++ b/src/jacobian/math/analysis/_models.py
@@ -61,9 +61,6 @@ type IntervalExpressionOp = Literal[
     "sin",
     "cos",
 ]
-type IntervalExpressionBoxEnclosureStatus = Literal[
-    "ENCLOSED", "DOMAIN_UNPROVEN", "BACKEND_ERROR"
-]
 
 
 def _bound_raw_rational(value: object, label: str) -> None:
@@ -505,40 +502,8 @@ def _preflight_box_binary(
     return bounds
 
 
-def _preflight_box_expression(
-    node: IntervalExpressionNode,
-    variables: dict[str, _RationalBounds],
-    path: tuple[int, ...] = (),
-) -> _BoxPreflight:
-    """Bound exact admission work and locate the first domain obstruction."""
-
-    if node.op == "const":
-        assert node.value is not None
-        value = node.value.as_fraction()
-        return _bounded_rational_bounds(value, value)
-    if node.op == "var":
-        assert node.variable is not None
-        return variables[node.variable]
-
-    children: list[_BoxPreflight] = []
-    for index, child_node in enumerate(node.children):
-        child = _preflight_box_expression(child_node, variables, (*path, index))
-        if isinstance(child, IntervalExpressionDomainFailure):
-            return child
-        children.append(child)
-
-    left = children[0]
-    assert isinstance(left, _RationalBounds)
-    if len(children) == 1:
-        return _preflight_box_unary(node, left, path)
-
-    right = children[1]
-    assert isinstance(right, _RationalBounds)
-    return _preflight_box_binary(node, left, right, path)
-
-
-class IntervalExpressionBoxEnclosureRequest(StrictModel):
-    """Enclose one named-variable expression on a complete rational box."""
+class _IntervalExpressionBoxRequest(StrictModel):
+    """Shared complete-source contract for operations over rational boxes."""
 
     expression: IntervalExpressionNode = Field(
         description=(
@@ -564,7 +529,7 @@ class IntervalExpressionBoxEnclosureRequest(StrictModel):
         return value
 
     @model_validator(mode="after")
-    def require_complete_bounded_source(self) -> Self:
+    def require_complete_named_source_axis(self) -> Self:
         nodes = _bounded_expression_nodes(self.expression)
         used_variables: set[str] = set()
         for node in nodes:
@@ -586,7 +551,6 @@ class IntervalExpressionBoxEnclosureRequest(StrictModel):
                 "box variables are unused by the expression: "
                 + ", ".join(sorted(unused))
             )
-        _preflight_box_expression(self.expression, _rational_box_bounds(self.box))
         return self
 
 
@@ -651,63 +615,5 @@ class DyadicClosedInterval(StrictModel):
         if self.lower.compare(self.upper) > 0:
             raise _validation_error(
                 "dyadic interval lower endpoint exceeds upper endpoint"
-            )
-        return self
-
-
-class IntervalExpressionBoxEnclosureResult(IntervalExpressionBoxEnclosureRequest):
-    """A replayable enclosure bound to its expression, axis, and source box.
-
-    For ``ENCLOSED``, every defined real source-box value lies between the two
-    exact dyadic endpoints.  Full validation recomputes that canonical claim.
-    ``DOMAIN_UNPROVEN`` replays its deterministic first-obstruction evidence.
-    ``BACKEND_ERROR`` asserts no enclosure conclusion at all, so it is
-    validated structurally: rerunning Arb would reject the operation's own
-    serialized result whenever a transient backend condition does not recur.
-    """
-
-    status: IntervalExpressionBoxEnclosureStatus
-    lower: ExactDyadic | None = None
-    upper: ExactDyadic | None = None
-    domain_failure: IntervalExpressionDomainFailure | None = None
-    method: Literal["ARB_NATURAL_INTERVAL_EXTENSION"] = "ARB_NATURAL_INTERVAL_EXTENSION"
-    detail: str = Field(min_length=1, max_length=1024)
-
-    @model_validator(mode="after")
-    def bind_enclosure_to_source(self) -> Self:
-        enclosed = self.status == "ENCLOSED"
-        if enclosed != (self.lower is not None and self.upper is not None):
-            raise _validation_error(
-                "only an enclosed result may carry dyadic endpoints"
-            )
-        if enclosed:
-            assert self.lower is not None and self.upper is not None
-            if self.lower.compare(self.upper) > 0:
-                raise _validation_error(
-                    "enclosure lower endpoint exceeds upper endpoint"
-                )
-            if self.domain_failure is not None:
-                raise _validation_error(
-                    "an enclosed result cannot carry a domain failure"
-                )
-        else:
-            domain_unproven = self.status == "DOMAIN_UNPROVEN"
-            if domain_unproven != (self.domain_failure is not None):
-                raise _validation_error(
-                    "domain-failure evidence must agree with DOMAIN_UNPROVEN status"
-                )
-            if self.status == "BACKEND_ERROR":
-                return self
-
-        from jacobian.math.analysis._operations import _box_expression_enclosure
-
-        request = IntervalExpressionBoxEnclosureRequest.model_construct(
-            expression=self.expression,
-            box=self.box,
-            precision_bits=self.precision_bits,
-        )
-        if self != _box_expression_enclosure(request):
-            raise _validation_error(
-                "box enclosure does not replay from its expression, axis, and source box"
             )
         return self

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -8,21 +8,15 @@ from typing import Any
 
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
-from jacobian.math.analysis._arb import dyadic_endpoints
+from jacobian.math.analysis._arb import arb_source_interval, dyadic_endpoints
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
 )
 from jacobian.math.analysis._models import (
-    MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
     DyadicClosedInterval,
-    ExactDyadic,
-    IntervalExpressionBoxEnclosureRequest,
-    IntervalExpressionBoxEnclosureResult,
-    IntervalExpressionBoxEnclosureStatus,
     IntervalExpressionDomainFailure,
     IntervalExpressionNode,
-    _preflight_box_expression,
     _rational_box_bounds,
 )
 from jacobian.math.analysis._point_enclosure import (
@@ -41,7 +35,6 @@ from jacobian.math.analysis._second_jet import (
     IntervalExpressionSecondJetEnclosureStatus,
     _preflight_second_jet_expression,
 )
-from jacobian.math.geometry.boxes.values import RationalClosedInterval
 
 
 class _EvaluationFailure(StrEnum):
@@ -173,277 +166,6 @@ def _expression_enclosure(
         relative_accuracy_bits=None if exact else int(result.rel_accuracy_bits()),
         exact=exact,
         detail="Arb returned an outward-rounded enclosure with exact dyadic endpoints.",
-    )
-
-
-def _normalize_dyadic_pair(mantissa: int, exponent: int) -> tuple[int, int]:
-    if mantissa == 0:
-        return 0, 0
-    while mantissa % 2 == 0:
-        mantissa //= 2
-        exponent += 1
-    return mantissa, exponent
-
-
-def _add_dyadic_pairs(left: tuple[int, int], right: tuple[int, int]) -> tuple[int, int]:
-    common_exponent = min(left[1], right[1])
-    return _normalize_dyadic_pair(
-        (left[0] << (left[1] - common_exponent))
-        + (right[0] << (right[1] - common_exponent)),
-        common_exponent,
-    )
-
-
-def _negate_dyadic_pair(value: tuple[int, int]) -> tuple[int, int]:
-    return -value[0], value[1]
-
-
-def _halve_dyadic_pair(value: tuple[int, int]) -> tuple[int, int]:
-    return _normalize_dyadic_pair(value[0], value[1] - 1)
-
-
-def _exact_arb_dyadic_pair(value: Any) -> tuple[int, int]:
-    mantissa, exponent = value.man_exp()
-    return _normalize_dyadic_pair(int(mantissa), int(exponent))
-
-
-def _arb_source_interval(interval: RationalClosedInterval) -> Any:
-    """Build one Arb ball that contains the exact rational source interval.
-
-    Arb radii have a fixed implementation precision.  Anchoring a one-sided
-    interval at its endpoint nearest zero preserves a proved sign even when
-    the radius is rounded upward by python-flint's public constructor.
-    """
-
-    from flint import arb, fmpq
-
-    lower_ratio = interval.lower.as_integer_ratio()
-    upper_ratio = interval.upper.as_integer_ratio()
-    if lower_ratio == upper_ratio:
-        return arb(fmpq(*lower_ratio))
-
-    lower = _exact_arb_dyadic_pair(arb(fmpq(*lower_ratio)).lower())
-    upper = _exact_arb_dyadic_pair(arb(fmpq(*upper_ratio)).upper())
-    half_width = _halve_dyadic_pair(
-        _add_dyadic_pairs(upper, _negate_dyadic_pair(lower))
-    )
-    actual_radius = _exact_arb_dyadic_pair(arb((0, 0), half_width).upper())
-    if interval.lower.as_fraction() >= 0:
-        midpoint = _add_dyadic_pairs(lower, actual_radius)
-    elif interval.upper.as_fraction() <= 0:
-        midpoint = _add_dyadic_pairs(upper, _negate_dyadic_pair(actual_radius))
-    else:
-        midpoint = _halve_dyadic_pair(_add_dyadic_pairs(lower, upper))
-    return arb(midpoint, half_width)
-
-
-def _box_domain_failure(
-    node: IntervalExpressionNode, path: tuple[int, ...]
-) -> IntervalExpressionDomainFailure:
-    if node.op == "div":
-        return IntervalExpressionDomainFailure(
-            node_path=path,
-            operation="div",
-            reason="DENOMINATOR_CONTAINS_ZERO",
-        )
-    if node.op == "pow":
-        return IntervalExpressionDomainFailure(
-            node_path=path,
-            operation="pow",
-            reason="NEGATIVE_POWER_BASE_CONTAINS_ZERO",
-        )
-    if node.op == "log":
-        return IntervalExpressionDomainFailure(
-            node_path=path,
-            operation="log",
-            reason="LOG_ARGUMENT_NOT_STRICTLY_POSITIVE",
-        )
-    if node.op == "sqrt":
-        return IntervalExpressionDomainFailure(
-            node_path=path,
-            operation="sqrt",
-            reason="SQRT_ARGUMENT_NOT_NONNEGATIVE",
-        )
-    raise AssertionError("only real-domain operations can produce a domain failure")
-
-
-def _evaluate_box_unary(
-    node: IntervalExpressionNode, value: Any, path: tuple[int, ...]
-) -> Any:
-    if node.op == "neg":
-        return -value
-    if node.op == "pow":
-        assert node.exponent is not None
-        if node.exponent < 0 and value.contains(0):
-            return _box_domain_failure(node, path)
-        return value**node.exponent
-    if node.op == "log":
-        if not value > 0:
-            return _box_domain_failure(node, path)
-        return value.log()
-    if node.op == "sqrt":
-        if not value >= 0:
-            return _box_domain_failure(node, path)
-        return value.sqrt()
-    if node.op in ("exp", "sin", "cos"):
-        return getattr(value, node.op)()
-    raise AssertionError(f"unsupported unary expression operation: {node.op}")
-
-
-def _evaluate_box_binary(
-    node: IntervalExpressionNode,
-    left: Any,
-    right: Any,
-    path: tuple[int, ...],
-) -> Any:
-    if node.op == "add":
-        return left + right
-    if node.op == "sub":
-        return left - right
-    if node.op == "mul":
-        return left * right
-    if node.op == "div":
-        if right.contains(0):
-            return _box_domain_failure(node, path)
-        return left / right
-    raise AssertionError(f"unsupported binary expression operation: {node.op}")
-
-
-def _evaluate_box_expression(
-    node: IntervalExpressionNode,
-    variables: dict[str, Any],
-    path: tuple[int, ...] = (),
-) -> Any:
-    from flint import arb, fmpq
-
-    if node.op == "const":
-        assert node.value is not None
-        return arb(fmpq(*node.value.as_integer_ratio()))
-    if node.op == "var":
-        assert node.variable is not None
-        return variables[node.variable]
-
-    values: list[Any] = []
-    for index, child in enumerate(node.children):
-        value = _evaluate_box_expression(child, variables, (*path, index))
-        if isinstance(value, (IntervalExpressionDomainFailure, _BoxEvaluationFailure)):
-            return value
-        if not value.is_finite():
-            return _BoxEvaluationFailure.BACKEND_ERROR
-        values.append(value)
-
-    left = values[0]
-    if len(values) == 1:
-        return _evaluate_box_unary(node, left, path)
-
-    right = values[1]
-    return _evaluate_box_binary(node, left, right, path)
-
-
-def _constructed_box_result(
-    request: IntervalExpressionBoxEnclosureRequest,
-    *,
-    status: IntervalExpressionBoxEnclosureStatus,
-    detail: str,
-    lower: ExactDyadic | None = None,
-    upper: ExactDyadic | None = None,
-    domain_failure: IntervalExpressionDomainFailure | None = None,
-) -> IntervalExpressionBoxEnclosureResult:
-    """Build the producer result without paying a second backend replay."""
-
-    return IntervalExpressionBoxEnclosureResult.model_construct(
-        expression=request.expression,
-        box=request.box,
-        precision_bits=request.precision_bits,
-        status=status,
-        lower=lower,
-        upper=upper,
-        domain_failure=domain_failure,
-        method="ARB_NATURAL_INTERVAL_EXTENSION",
-        detail=detail,
-    )
-
-
-def _box_expression_enclosure(
-    request: IntervalExpressionBoxEnclosureRequest,
-) -> IntervalExpressionBoxEnclosureResult:
-    preflight = _preflight_box_expression(
-        request.expression, _rational_box_bounds(request.box)
-    )
-    if isinstance(preflight, IntervalExpressionDomainFailure):
-        return _constructed_box_result(
-            request,
-            status="DOMAIN_UNPROVEN",
-            domain_failure=preflight,
-            detail=(
-                "The exact admission interval extension could not establish the "
-                "real domain at the reported source node."
-            ),
-        )
-
-    from flint import ctx
-
-    try:
-        with ctx.workprec(request.precision_bits):
-            variables = {
-                variable: _arb_source_interval(interval)
-                for variable, interval in zip(
-                    request.box.variables, request.box.intervals, strict=True
-                )
-            }
-            result = _evaluate_box_expression(request.expression, variables)
-            if isinstance(result, IntervalExpressionDomainFailure):
-                return _constructed_box_result(
-                    request,
-                    status="DOMAIN_UNPROVEN",
-                    domain_failure=result,
-                    detail=(
-                        "Arb's natural interval extension could not establish the "
-                        "real domain at the reported source node."
-                    ),
-                )
-            if isinstance(result, _BoxEvaluationFailure) or not result.is_finite():
-                return _constructed_box_result(
-                    request,
-                    status="BACKEND_ERROR",
-                    detail=(
-                        "Pinned Arb returned no finite enclosure within the admitted "
-                        "fixed-precision envelope."
-                    ),
-                )
-            lower_mantissa, lower_exponent = result.lower().man_exp()
-            upper_mantissa, upper_exponent = result.upper().man_exp()
-            endpoints = dyadic_endpoints(
-                lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
-            )
-    except (OverflowError, ValueError):
-        return _constructed_box_result(
-            request,
-            status="BACKEND_ERROR",
-            detail=(
-                "Pinned Arb rejected an admitted bounded computation; no enclosure "
-                "conclusion is available."
-            ),
-        )
-
-    if endpoints is None:
-        return _constructed_box_result(
-            request,
-            status="BACKEND_ERROR",
-            detail=(
-                "Pinned Arb produced endpoints outside the admitted dyadic wire "
-                "envelope; no enclosure conclusion is available."
-            ),
-        )
-    return _constructed_box_result(
-        request,
-        status="ENCLOSED",
-        lower=endpoints[0],
-        upper=endpoints[1],
-        detail=(
-            "Pinned Arb natural interval arithmetic returned an outward-rounded "
-            "enclosure with exact dyadic endpoints."
-        ),
     )
 
 
@@ -708,7 +430,7 @@ def _second_jet_enclosure(
 
         with ctx.workprec(request.precision_bits):
             variables = {
-                variable: _arb_source_interval(interval)
+                variable: arb_source_interval(interval)
                 for variable, interval in zip(
                     request.box.variables, request.box.intervals, strict=True
                 )
@@ -901,57 +623,6 @@ EXPRESSION_ENCLOSURE_OPERATIONS = (
     ),
 )
 
-BOX_EXPRESSION_ENCLOSURE_OPERATIONS = (
-    MathTool(
-        operation_id="interval.expression.box_enclosure.compute",
-        title="Enclose an elementary expression over a rational box",
-        description=(
-            "Use pinned Arb natural interval arithmetic to enclose one bounded "
-            "named-variable elementary expression over a complete ordered rational "
-            "box, or report the first source node whose real domain is unproved. "
-            "The fixed envelope admits at most 8 variables, 64 nodes, depth 16, "
-            "128-digit rationals, absolute power exponents up to 64, 4,096-bit "
-            "Arb precision, 8,192-bit retained exact admission bounds, and "
-            f"{MAX_BOX_PREFLIGHT_TEMPORARY_BITS:,}-bit Fraction temporaries."
-        ),
-        request_type=IntervalExpressionBoxEnclosureRequest,
-        result_type=IntervalExpressionBoxEnclosureResult,
-        run=_box_expression_enclosure,
-        tags=(
-            "analysis",
-            "interval",
-            "expression",
-            "box",
-            "multivariate",
-            "arb",
-            "validated",
-            "bounded",
-        ),
-        examples=(
-            example(
-                "exp_unit_interval",
-                "Enclose exp(x) over the exact rational interval 0 <= x <= 1.",
-                {
-                    "expression": {
-                        "op": "exp",
-                        "children": [{"op": "var", "variable": "x"}],
-                    },
-                    "box": {
-                        "variables": ["x"],
-                        "intervals": [
-                            {
-                                "lower": {"num": "0", "den": "1"},
-                                "upper": {"num": "1", "den": "1"},
-                            }
-                        ],
-                    },
-                    "precision_bits": 128,
-                },
-            ),
-        ),
-    ),
-)
-
 SECOND_JET_ENCLOSURE_OPERATIONS = (
     MathTool(
         operation_id="interval.expression.second_jet_enclosure.compute",
@@ -1020,7 +691,6 @@ SECOND_JET_ENCLOSURE_OPERATIONS = (
 )
 
 __all__ = [
-    "BOX_EXPRESSION_ENCLOSURE_OPERATIONS",
     "EXPRESSION_ENCLOSURE_OPERATIONS",
     "POINT_ENCLOSURE_OPERATIONS",
     "SECOND_JET_ENCLOSURE_OPERATIONS",

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -6,16 +6,15 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-from jacobian.canonical import format_canonical_integer
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool
+from jacobian.math.analysis._arb import dyadic_endpoints
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
 )
 from jacobian.math.analysis._models import (
     MAX_BOX_PREFLIGHT_TEMPORARY_BITS,
-    MAX_DYADIC_EXPONENT,
     DyadicClosedInterval,
     ExactDyadic,
     IntervalExpressionBoxEnclosureRequest,
@@ -29,12 +28,10 @@ from jacobian.math.analysis._models import (
 from jacobian.math.analysis._point_enclosure import (
     ArbPointEnclosureRequest,
     ArbPointEnclosureResult,
-    ClaimedPointEnclosure,
     PointEnclosureCheckRequest,
     PointEnclosureCheckResult,
-)
-from jacobian.math.analysis._point_enclosure_check import (
-    point_enclosure_check_outcome,
+    _check_point_enclosure,
+    _point_enclosure,
 )
 from jacobian.math.analysis._second_jet import (
     FirstPartialEnclosure,
@@ -59,31 +56,6 @@ class _BoxEvaluationFailure(StrEnum):
 
 class _SecondJetEvaluationFailure(StrEnum):
     BACKEND_ERROR = "BACKEND_ERROR"
-
-
-def _dyadic_endpoints(
-    lower_mantissa: Any,
-    lower_exponent: Any,
-    upper_mantissa: Any,
-    upper_exponent: Any,
-) -> tuple[ExactDyadic, ExactDyadic] | None:
-    """Serialize Arb endpoints only when their exponents fit the wire contract."""
-
-    if (
-        abs(lower_exponent) > MAX_DYADIC_EXPONENT
-        or abs(upper_exponent) > MAX_DYADIC_EXPONENT
-    ):
-        return None
-    return (
-        ExactDyadic(
-            mantissa=format_canonical_integer(int(lower_mantissa)),
-            exponent=int(lower_exponent),
-        ),
-        ExactDyadic(
-            mantissa=format_canonical_integer(int(upper_mantissa)),
-            exponent=int(upper_exponent),
-        ),
-    )
 
 
 def _apply_binary(node: IntervalExpressionNode, left: Any, right: Any) -> Any:
@@ -184,7 +156,7 @@ def _expression_enclosure(
         lower_mantissa, lower_exponent = result.lower().man_exp()
         upper_mantissa, upper_exponent = result.upper().man_exp()
         exact = bool(result.is_exact())
-        endpoints = _dyadic_endpoints(
+        endpoints = dyadic_endpoints(
             lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
         )
     if endpoints is None:
@@ -441,7 +413,7 @@ def _box_expression_enclosure(
                 )
             lower_mantissa, lower_exponent = result.lower().man_exp()
             upper_mantissa, upper_exponent = result.upper().man_exp()
-            endpoints = _dyadic_endpoints(
+            endpoints = dyadic_endpoints(
                 lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
             )
     except (OverflowError, ValueError):
@@ -682,7 +654,7 @@ def _evaluate_second_jet(
 def _dyadic_closed_interval(value: Any) -> DyadicClosedInterval | None:
     lower_mantissa, lower_exponent = value.lower().man_exp()
     upper_mantissa, upper_exponent = value.upper().man_exp()
-    endpoints = _dyadic_endpoints(
+    endpoints = dyadic_endpoints(
         lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
     )
     if endpoints is None:
@@ -816,64 +788,6 @@ def _second_jet_enclosure(
             "Pinned Arb forward automatic differentiation returned outward-rounded "
             "value, gradient, and symmetric Hessian enclosures with exact dyadic endpoints."
         ),
-    )
-
-
-def _point_enclosure(
-    request: ArbPointEnclosureRequest,
-) -> ArbPointEnclosureResult:
-    from flint import arb, ctx, fmpq
-
-    numerator, denominator = request.argument.as_integer_ratio()
-    with ctx.workprec(request.precision_bits):
-        value = arb(fmpq(numerator, denominator))
-        result = getattr(value, request.function.value.lower())()
-        if not result.is_finite():
-            return ArbPointEnclosureResult(
-                function=request.function,
-                argument=request.argument,
-                precision_bits=request.precision_bits,
-                status="NONFINITE",
-                detail="Arb returned a non-finite ball; no enclosure conclusion is available.",
-            )
-        lower_mantissa, lower_exponent = result.lower().man_exp()
-        upper_mantissa, upper_exponent = result.upper().man_exp()
-        exact = bool(result.is_exact())
-        endpoints = _dyadic_endpoints(
-            lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
-        )
-    if endpoints is None:
-        return ArbPointEnclosureResult(
-            function=request.function,
-            argument=request.argument,
-            precision_bits=request.precision_bits,
-            status="OUTPUT_MAGNITUDE_EXCEEDED",
-            detail="Arb produced finite endpoints outside the interoperable dyadic exponent range.",
-        )
-    return ArbPointEnclosureResult(
-        function=request.function,
-        argument=request.argument,
-        precision_bits=request.precision_bits,
-        status="ENCLOSED",
-        enclosure=ClaimedPointEnclosure(
-            function=request.function,
-            argument=request.argument,
-            precision_bits=request.precision_bits,
-            lower=endpoints[0],
-            upper=endpoints[1],
-        ),
-        relative_accuracy_bits=None if exact else int(result.rel_accuracy_bits()),
-        exact=exact,
-        detail="Pinned Arb ball arithmetic returned an outward-rounded enclosure with exact dyadic endpoints.",
-    )
-
-
-def _check_point_enclosure(
-    request: PointEnclosureCheckRequest,
-) -> PointEnclosureCheckResult:
-    return PointEnclosureCheckResult(
-        enclosure=request.enclosure,
-        outcome=point_enclosure_check_outcome(request),
     )
 
 

--- a/src/jacobian/math/analysis/_operations.py
+++ b/src/jacobian/math/analysis/_operations.py
@@ -43,10 +43,6 @@ class _EvaluationFailure(StrEnum):
     PRECISION_INSUFFICIENT = "PRECISION_INSUFFICIENT"
 
 
-class _BoxEvaluationFailure(StrEnum):
-    BACKEND_ERROR = "BACKEND_ERROR"
-
-
 class _SecondJetEvaluationFailure(StrEnum):
     BACKEND_ERROR = "BACKEND_ERROR"
 

--- a/src/jacobian/math/analysis/_point_enclosure.py
+++ b/src/jacobian/math/analysis/_point_enclosure.py
@@ -9,6 +9,7 @@ from pydantic import ConfigDict, Field, StrictInt, model_validator
 
 from jacobian._exact import CanonicalRational, require_bounded_rational
 from jacobian._models import StrictModel, canonicalize_json_containers
+from jacobian.math.analysis._arb import dyadic_endpoints
 from jacobian.math.analysis._models import (
     MAX_DYADIC_MANTISSA_DIGITS,
     MAX_RATIONAL_DIGITS,
@@ -300,6 +301,70 @@ class ArbPointEnclosureResult(ArbPointEnclosureRequest):
                     "exact enclosures omit relative accuracy; inexact ones report it"
                 )
         return self
+
+
+def _point_enclosure(request: ArbPointEnclosureRequest) -> ArbPointEnclosureResult:
+    """Compute one bounded Arb point enclosure in its owning family."""
+
+    from flint import arb, ctx, fmpq
+
+    numerator, denominator = request.argument.as_integer_ratio()
+    with ctx.workprec(request.precision_bits):
+        value = arb(fmpq(numerator, denominator))
+        result = getattr(value, request.function.value.lower())()
+        if not result.is_finite():
+            return ArbPointEnclosureResult(
+                function=request.function,
+                argument=request.argument,
+                precision_bits=request.precision_bits,
+                status="NONFINITE",
+                detail="Arb returned a non-finite ball; no enclosure conclusion is available.",
+            )
+        lower_mantissa, lower_exponent = result.lower().man_exp()
+        upper_mantissa, upper_exponent = result.upper().man_exp()
+        exact = bool(result.is_exact())
+        endpoints = dyadic_endpoints(
+            lower_mantissa, lower_exponent, upper_mantissa, upper_exponent
+        )
+    if endpoints is None:
+        return ArbPointEnclosureResult(
+            function=request.function,
+            argument=request.argument,
+            precision_bits=request.precision_bits,
+            status="OUTPUT_MAGNITUDE_EXCEEDED",
+            detail="Arb produced finite endpoints outside the interoperable dyadic exponent range.",
+        )
+    return ArbPointEnclosureResult(
+        function=request.function,
+        argument=request.argument,
+        precision_bits=request.precision_bits,
+        status="ENCLOSED",
+        enclosure=ClaimedPointEnclosure(
+            function=request.function,
+            argument=request.argument,
+            precision_bits=request.precision_bits,
+            lower=endpoints[0],
+            upper=endpoints[1],
+        ),
+        relative_accuracy_bits=None if exact else int(result.rel_accuracy_bits()),
+        exact=exact,
+        detail="Pinned Arb ball arithmetic returned an outward-rounded enclosure with exact dyadic endpoints.",
+    )
+
+
+def _check_point_enclosure(
+    request: PointEnclosureCheckRequest,
+) -> PointEnclosureCheckResult:
+    """Replay one point-enclosure claim in its owning family."""
+
+    from jacobian.math.analysis._point_enclosure_check import (
+        point_enclosure_check_outcome,
+    )
+
+    return PointEnclosureCheckResult(
+        enclosure=request.enclosure,
+        outcome=point_enclosure_check_outcome(request),
+    )
 
 
 __all__ = [

--- a/src/jacobian/math/analysis/_second_jet.py
+++ b/src/jacobian/math/analysis/_second_jet.py
@@ -10,13 +10,13 @@ from jacobian._models import StrictModel
 from jacobian.math.analysis._models import (
     MAX_BOX_VARIABLES,
     DyadicClosedInterval,
-    IntervalExpressionBoxEnclosureRequest,
     IntervalExpressionDomainFailure,
     IntervalExpressionNode,
     IntervalVariable,
     _bounded_expression_nodes,
     _bounded_rational_bounds,
     _BoxPreflight,
+    _IntervalExpressionBoxRequest,
     _preflight_box_binary,
     _preflight_box_unary,
     _rational_box_bounds,
@@ -93,9 +93,7 @@ def _preflight_second_jet_expression(
     return _preflight_box_binary(node, left, right, path)
 
 
-class IntervalExpressionSecondJetEnclosureRequest(
-    IntervalExpressionBoxEnclosureRequest
-):
+class IntervalExpressionSecondJetEnclosureRequest(_IntervalExpressionBoxRequest):
     """Enclose an elementary expression and all derivatives through order two."""
 
     @model_validator(mode="after")

--- a/src/jacobian/math/analysis/_tools.py
+++ b/src/jacobian/math/analysis/_tools.py
@@ -1,8 +1,8 @@
 """Validated real-analysis operations."""
 
 from jacobian.catalog.models import MathTools
+from jacobian.math.analysis._box_enclosure import BOX_EXPRESSION_ENCLOSURE_OPERATIONS
 from jacobian.math.analysis._operations import (
-    BOX_EXPRESSION_ENCLOSURE_OPERATIONS,
     EXPRESSION_ENCLOSURE_OPERATIONS,
     POINT_ENCLOSURE_OPERATIONS,
     SECOND_JET_ENCLOSURE_OPERATIONS,

--- a/tests/math/test_analysis_expression_box_enclosure.py
+++ b/tests/math/test_analysis_expression_box_enclosure.py
@@ -9,16 +9,18 @@ import pytest
 from pydantic import ValidationError
 from tests.math._analysis_support import analysis_validation_error
 
+from jacobian.math.analysis._box_enclosure import (
+    IntervalExpressionBoxEnclosureRequest,
+    IntervalExpressionBoxEnclosureResult,
+    _box_expression_enclosure,
+)
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
 )
 from jacobian.math.analysis._models import (
-    IntervalExpressionBoxEnclosureRequest,
-    IntervalExpressionBoxEnclosureResult,
     RationalIntervalBox,
 )
 from jacobian.math.analysis._operations import (
-    _box_expression_enclosure,
     _expression_enclosure,
 )
 from jacobian.math.geometry.boxes import RationalAxisAlignedBox, RationalClosedInterval
@@ -395,11 +397,11 @@ def test_producer_does_not_pay_a_second_backend_replay(
 ) -> None:
     from flint import ctx
 
-    import jacobian.math.analysis._operations as operations
+    import jacobian.math.analysis._box_enclosure as box_enclosure
 
     calls = 0
     work_precisions: list[int] = []
-    original = operations._evaluate_box_expression
+    original = box_enclosure._evaluate_box_expression
 
     def counting(*args: Any, **kwargs: Any) -> Any:
         nonlocal calls
@@ -408,7 +410,7 @@ def test_producer_does_not_pay_a_second_backend_replay(
             work_precisions.append(ctx.prec)
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(operations, "_evaluate_box_expression", counting)
+    monkeypatch.setattr(box_enclosure, "_evaluate_box_expression", counting)
     _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
@@ -420,12 +422,12 @@ def test_producer_does_not_pay_a_second_backend_replay(
 def test_backend_value_error_has_a_typed_nonconclusion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import jacobian.math.analysis._operations as operations
+    import jacobian.math.analysis._box_enclosure as box_enclosure
 
     def fail(*args: Any, **kwargs: Any) -> Any:
         raise ValueError("synthetic backend rejection")
 
-    monkeypatch.setattr(operations, "_evaluate_box_expression", fail)
+    monkeypatch.setattr(box_enclosure, "_evaluate_box_expression", fail)
     result = _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
@@ -438,9 +440,9 @@ def test_backend_value_error_has_a_typed_nonconclusion(
 def test_backend_error_result_round_trips_when_the_failure_does_not_recur(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import jacobian.math.analysis._operations as operations
+    import jacobian.math.analysis._box_enclosure as box_enclosure
 
-    original = operations._evaluate_box_expression
+    original = box_enclosure._evaluate_box_expression
     calls = 0
 
     def transient_then_original(*args: Any, **kwargs: Any) -> Any:
@@ -450,7 +452,9 @@ def test_backend_error_result_round_trips_when_the_failure_does_not_recur(
             raise ValueError("transient backend rejection")
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(operations, "_evaluate_box_expression", transient_then_original)
+    monkeypatch.setattr(
+        box_enclosure, "_evaluate_box_expression", transient_then_original
+    )
     result = _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(0), Fraction(1)),),
@@ -492,12 +496,12 @@ def test_backend_error_result_round_trips_when_the_failure_does_not_recur(
 def test_backend_error_payload_cannot_smuggle_conclusion_evidence(
     field: str, payload_patch: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import jacobian.math.analysis._operations as operations
+    import jacobian.math.analysis._box_enclosure as box_enclosure
 
     def fail(*args: Any, **kwargs: Any) -> Any:
         raise ValueError("synthetic backend rejection")
 
-    monkeypatch.setattr(operations, "_evaluate_box_expression", fail)
+    monkeypatch.setattr(box_enclosure, "_evaluate_box_expression", fail)
     result = _run(
         {"op": "exp", "children": [_var("x")]},
         (("x", Fraction(1), Fraction(2)),),

--- a/tests/math/test_analysis_expression_enclosure.py
+++ b/tests/math/test_analysis_expression_enclosure.py
@@ -5,12 +5,13 @@ from fractions import Fraction
 import pytest
 from tests.math._analysis_support import analysis_validation_error
 
+from jacobian.math.analysis._arb import dyadic_endpoints
 from jacobian.math.analysis._expression_enclosure import (
     IntervalExpressionEnclosureRequest,
     IntervalExpressionEnclosureResult,
 )
 from jacobian.math.analysis._models import MAX_DYADIC_EXPONENT, ExactDyadic
-from jacobian.math.analysis._operations import _dyadic_endpoints, _expression_enclosure
+from jacobian.math.analysis._operations import _expression_enclosure
 
 
 def _run(expression: dict[str, object], argument: str = "0"):
@@ -209,4 +210,4 @@ def test_dyadic_enclosure_order_avoids_expanding_huge_binary_exponents(
 
 
 def test_non_interoperable_dyadic_exponents_have_a_typed_outcome() -> None:
-    assert _dyadic_endpoints(1, MAX_DYADIC_EXPONENT + 1, 3, 0) is None
+    assert dyadic_endpoints(1, MAX_DYADIC_EXPONENT + 1, 3, 0) is None

--- a/tests/math/test_analysis_point_enclosure_check.py
+++ b/tests/math/test_analysis_point_enclosure_check.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from tests.math._analysis_support import analysis_validation_error
 
 from jacobian.math.analysis._models import ExactDyadic
-from jacobian.math.analysis._operations import _check_point_enclosure
 from jacobian.math.analysis._point_enclosure import (
     MAX_POINT_CHECK_DYADIC_EXPONENT,
     MAX_POINT_CHECK_FRACTION_BITS,
@@ -20,7 +19,9 @@ from jacobian.math.analysis._point_enclosure import (
     ClaimedPointEnclosure,
     PointEnclosureCheckRequest,
     PointEnclosureCheckResult,
+    _check_point_enclosure,
     _point_check_fraction_bound_bits,
+    _point_enclosure,
 )
 from jacobian.math.analysis._point_enclosure_check import (
     _log_range_reduction,
@@ -133,8 +134,6 @@ def test_log_137_80_accepts_the_source_bound_arb_enclosure() -> None:
 
 
 def test_producer_enclosure_crosses_the_checker_boundary_unchanged() -> None:
-    from jacobian.math.analysis._operations import _point_enclosure
-
     producer_result = _point_enclosure(
         ArbPointEnclosureRequest.model_validate(
             {
@@ -163,8 +162,6 @@ def test_producer_enclosure_crosses_the_checker_boundary_unchanged() -> None:
 
 
 def test_nonenclosure_outcomes_retain_the_request_source() -> None:
-    from jacobian.math.analysis._operations import _point_enclosure
-
     nonfinite = _point_enclosure(
         ArbPointEnclosureRequest.model_validate(
             {
@@ -208,8 +205,6 @@ def test_nonenclosure_outcomes_retain_the_request_source() -> None:
 
 
 def test_enclosed_result_must_restate_the_retained_request_source() -> None:
-    from jacobian.math.analysis._operations import _point_enclosure
-
     producer_result = _point_enclosure(
         ArbPointEnclosureRequest.model_validate(
             {


### PR DESCRIPTION
Refs #2566.

## Problem

The merged enclosure-contract foundation left the point-enclosure compute/check kernels and the rational-box enclosure contract and kernel in the cross-family operations module. That made changes to either family continue to share an unrelated implementation surface.

## Solution

Move point execution beside the point value and checker contract, move box admission, result construction, execution, and its declaration beside the box contract, and keep the shared Arb conversions in a narrow neutral module. The catalog still publishes the same five analysis operations with unchanged IDs, schemas, examples, and mathematical behavior.

The diff deliberately does not introduce compatibility aliases or change public representations: geometry remains the owner of `RationalClosedInterval`, and the existing dyadic and expression grammar remains shared only where both families require it.

## Testing

- `make check` — 6,385 passed
- `make test-focused LANE=math TESTS='tests/math/test_analysis_expression_enclosure.py tests/math/test_analysis_expression_box_enclosure.py tests/math/test_analysis_expression_second_jet_enclosure.py tests/math/test_analysis_point_enclosure_check.py'` — 107 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 608 passed
- `git diff --check origin/main...HEAD` — passed

## Public contract impact

None. Operation IDs, request/result schemas, native interfaces, MCP projection, and mathematical semantics are unchanged.

## Operation boundary ownership

- Changed stage: owner-local request admission, kernel execution, and result construction
- Request-bounds owner and controlling quantities: box admission remains in the box family; point-check replay remains in the point family; shared expression-axis grammar remains neutral
- Backend or kernel path: the existing pinned Arb calls move unchanged to their owning families
- Result construction: existing canonical result construction and replay behavior are preserved
- Independent-result verifier: the bounded point-enclosure checker remains owner-local
- Native/MCP parity: unchanged; catalog projection remains the final transport boundary
- Serialized-result and round-trip evidence: owner regression tests and all advertised catalog examples pass

## Canonical value audit

- [x] Existing canonical values searched
- [x] Geometry retains ownership of `RationalClosedInterval`; exact dyadics and expression grammar remain shared values
- [x] Producer-to-consumer serialization is covered by the point-check and advertised-example tests

## Catalog admission

Catalog membership and existing admission decisions are unchanged; this PR only relocates the already published box declaration to its owner module.

## Closure matrix

None; #2566 was closed by the merged foundation PR.

## Checklist

- [x] `make check` passes
- [x] Catalog examples execute through the public boundary
- [x] No public operation contract changed