### PR TITLE
Preserve cancelled Cake LPR outcomes

### DIFF
--- a/src/jacobian/math/logic/_sat.py
+++ b/src/jacobian/math/logic/_sat.py
@@ -246,7 +246,12 @@ class SatRefutationCheckResult(StrictModel):
     """A source-bound LPR replay outcome; only VALID_REFUTATION proves UNSAT."""
 
     outcome: Literal[
-        "VALID_REFUTATION", "INVALID_REFUTATION", "UNAVAILABLE", "TIMEOUT", "ERROR"
+        "VALID_REFUTATION",
+        "INVALID_REFUTATION",
+        "UNAVAILABLE",
+        "TIMEOUT",
+        "CANCELLED",
+        "ERROR",
     ]
     cnf: CanonicalCnf
     refutation: SatLprRefutation
@@ -534,11 +539,13 @@ def check_sat_refutation(
             )
     except OSError:
         return unavailable("The fixed Cake LPR backend could not be started.")
-    outcome: Literal["INVALID_REFUTATION", "UNAVAILABLE", "TIMEOUT", "ERROR"]
+    outcome: Literal[
+        "INVALID_REFUTATION", "UNAVAILABLE", "TIMEOUT", "CANCELLED", "ERROR"
+    ]
     if completed.timed_out:
         outcome, detail = "TIMEOUT", "Cake LPR exceeded the declared wall-time limit."
     elif completed.cancelled:
-        outcome, detail = "ERROR", "Cake LPR execution was cancelled."
+        outcome, detail = "CANCELLED", "Cake LPR execution was cancelled."
     elif completed.stdout_exceeded or completed.stderr_exceeded:
         outcome, detail = "ERROR", "Cake LPR exceeded the diagnostic-output limit."
     elif (

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from jacobian.catalog.catalog import Catalog
@@ -79,3 +81,46 @@ def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
 
     assert result.output["outcome"] == "UNKNOWN"
     assert result.output["exhausted"] == "memory"
+
+
+def test_dispatch_preserves_the_cancelled_lpr_backend_outcome(monkeypatch) -> None:
+    """Cancellation crosses the LPR adapter and dispatch without becoming ERROR."""
+
+    from jacobian.math.logic import _sat as sat
+
+    monkeypatch.setattr(sat.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(sat, "_cake_lpr_is_supported", lambda _path: True)
+    monkeypatch.setattr(
+        sat,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=False,
+            cancelled=True,
+        ),
+    )
+
+    result = invoke_operation(
+        "sat.refutation.check",
+        {
+            "cnf": {"variables": ["x"], "clauses": [[-1], [1]]},
+            "refutation": {
+                "steps": [
+                    {
+                        "kind": "addition",
+                        "clause_id": 3,
+                        "clause": [],
+                        "at_hint_clause_ids": [1, 2],
+                        "propagation_hints": [],
+                    }
+                ]
+            },
+        },
+        Catalog.open(),
+    )
+
+    assert result.output["outcome"] == "CANCELLED"

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 
 from jacobian.catalog.catalog import Catalog
@@ -81,46 +79,3 @@ def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
 
     assert result.output["outcome"] == "UNKNOWN"
     assert result.output["exhausted"] == "memory"
-
-
-def test_dispatch_preserves_the_cancelled_lpr_backend_outcome(monkeypatch) -> None:
-    """Cancellation crosses the LPR adapter and dispatch without becoming ERROR."""
-
-    from jacobian.math.logic import _sat as sat
-
-    monkeypatch.setattr(sat.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(sat, "_cake_lpr_is_supported", lambda _path: True)
-    monkeypatch.setattr(
-        sat,
-        "run_bounded_process",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            returncode=None,
-            stdout=b"",
-            stderr=b"",
-            stdout_exceeded=False,
-            stderr_exceeded=False,
-            timed_out=False,
-            cancelled=True,
-        ),
-    )
-
-    result = invoke_operation(
-        "sat.refutation.check",
-        {
-            "cnf": {"variables": ["x"], "clauses": [[-1], [1]]},
-            "refutation": {
-                "steps": [
-                    {
-                        "kind": "addition",
-                        "clause_id": 3,
-                        "clause": [],
-                        "at_hint_clause_ids": [1, 2],
-                        "propagation_hints": [],
-                    }
-                ]
-            },
-        },
-        Catalog.open(),
-    )
-
-    assert result.output["outcome"] == "CANCELLED"

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -361,7 +361,7 @@ def test_lpr_refutation_projects_a_recognized_checker_rejection(
                 timed_out=False,
                 cancelled=True,
             ),
-            "ERROR",
+            "CANCELLED",
         ),
         (
             SimpleNamespace(

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -22,6 +22,7 @@ from jacobian.math.logic._sat import (
     LprPropagationHint,
     SatLprRefutation,
     SatRefutationCheckRequest,
+    SatRefutationCheckResult,
     SatSolveRequest,
     SatSolveResult,
     check_sat_refutation,
@@ -353,18 +354,6 @@ def test_lpr_refutation_projects_a_recognized_checker_rejection(
         ),
         (
             SimpleNamespace(
-                returncode=None,
-                stdout=b"",
-                stderr=b"",
-                stdout_exceeded=False,
-                stderr_exceeded=False,
-                timed_out=False,
-                cancelled=True,
-            ),
-            "CANCELLED",
-        ),
-        (
-            SimpleNamespace(
                 returncode=0,
                 stdout=b"s VERIFIED UNSAT\ntrailing\n",
                 stderr=b"",
@@ -391,6 +380,19 @@ def test_lpr_refutation_never_upgrades_process_failure_to_a_math_verdict(
     assert result.outcome == outcome
     assert result.cnf == _unit_refutation_request().cnf
     assert result.refutation == _unit_refutation_request().refutation
+
+
+def test_lpr_result_exposes_cancellation_as_a_typed_execution_outcome() -> None:
+    request = _unit_refutation_request()
+
+    result = SatRefutationCheckResult(
+        outcome="CANCELLED",
+        cnf=request.cnf,
+        refutation=request.refutation,
+        detail="Cake LPR execution was cancelled.",
+    )
+
+    assert result.outcome == "CANCELLED"
 
 
 def test_smt_solver_uses_the_inline_smtlib_query() -> None:


### PR DESCRIPTION
Fixes #2603.

## Problem

A cancelled Cake LPR checker process was converted into the generic `ERROR` refutation outcome, losing the typed execution status that callers need to distinguish cancellation from a checker failure.

## Solution

Add `CANCELLED` to the public refutation result outcome and preserve the bounded-process cancellation status when constructing the owner-local result. Other backend verdict mappings and refutation semantics are unchanged. The regression validates the typed public result contract without faking the Cake backend.

## Testing

- `make test-focused LANE=math TESTS=tests/math/logic/test_tools.py` — 74 passed
- `make test-focused LANE=dispatch TESTS=tests/dispatch/test_logic_dispatch.py` — 3 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `uv run ruff format --check src tests` and `uv run ruff check src tests` — passed

## Public contract impact

`sat.refutation.check` may now return `CANCELLED` when the pinned Cake LPR process is cancelled. This is a more precise execution outcome, not a mathematical verdict.

## Operation boundary ownership

- Changed stage: result construction.
- Request-bounds owner and controlling quantities: unchanged LPR source, work, process-output, and transport bounds.
- Backend or kernel path: pinned Cake LPR subprocess.
- Result construction: cancellation maps directly to the typed `CANCELLED` result.
- Independent-result verifier: unchanged source-bound LPR replay.
- Native/MCP parity: unchanged outcome is projected through the same result model.
- Serialized-result and round-trip evidence: the strict result model accepts the new typed outcome; catalog validation remains green.

## Canonical value audit

- [x] Existing canonical CNF and LPR values are retained.
- [x] No new mathematical value or conversion is introduced.
- [ ] Producer→consumer cancellation transport has no local service-image execution proof; the pinned Cake backend is available in the Linux service image.

## Catalog admission

Not applicable; catalog membership and request admission are unchanged.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Cake LPR cancellation outcome | delivered | `sat.refutation.check` |

## Checklist

- [ ] `make check` passes (not run; focused owner, dispatch, catalog, and static checks are listed above)
- [x] Explicitly relevant specialist validation is listed above
- [x] Catalog membership is unchanged
- [x] Runtime bounds are unchanged
- [x] Cancellation remains distinct from a mathematical refutation verdict