### PR TITLE
Partition number-theory contracts by operation family

### DIFF
--- a/src/jacobian/math/number_theory/__init__.py
+++ b/src/jacobian/math/number_theory/__init__.py
@@ -1,7 +1,7 @@
 """Supported exact number-theory API."""
 
+from jacobian.math.number_theory._friable_models import FriableCountResult
 from jacobian.math.number_theory._friable_operations import count_friable
-from jacobian.math.number_theory._models import FriableCountResult
 from jacobian.math.number_theory.ramanujan_sums import ramanujan_sum
 
 __all__ = ["FriableCountResult", "count_friable", "ramanujan_sum"]

--- a/src/jacobian/math/number_theory/_friable.py
+++ b/src/jacobian/math/number_theory/_friable.py
@@ -1,11 +1,11 @@
 """Public declaration for the exact bounded friable-count operation."""
 
 from jacobian.catalog._examples import example
-from jacobian.math.number_theory._friable_operations import compute_friable_count
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._friable_models import (
     FriableCountRequest,
     FriableCountResult,
 )
+from jacobian.math.number_theory._friable_operations import compute_friable_count
 from jacobian.math.number_theory._support import number_theory_operation
 
 FRIABLE_COUNT_OPERATION = number_theory_operation(

--- a/src/jacobian/math/number_theory/_friable_models.py
+++ b/src/jacobian/math/number_theory/_friable_models.py
@@ -1,0 +1,168 @@
+"""Typed contracts and bounded admission for exact friable counting."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.canonical import parse_canonical_integer
+from jacobian.math.number_theory._models import BoundedInteger, _validation_error
+
+# Friable counting has two exact, result-sensitive execution regimes. The
+# materialized regime uses one bytearray for primality and one for friability;
+# its work bound covers both the operation and result-validation replay. The
+# generated regime enumerates prime-exponent prefixes only when a conservative
+# prefix-box bound covers both passes.
+MAX_FRIABLE_MATERIALIZED_X = 1_000_000
+MAX_FRIABLE_GENERATED_CUTOFF = 10_000
+_MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS = 82_000_000
+_MAX_FRIABLE_MATERIALIZED_BYTES = 3_000_000
+_MAX_FRIABLE_GENERATED_TOTAL_NODES = 1_000_000
+# Sources are nonnegative and rejected at ``10**_MAX_FRIABLE_SOURCE_DIGITS`` or
+# above, so every admitted value carries at most this many decimal digits.
+_MAX_FRIABLE_SOURCE_DIGITS = 256
+_MAX_FRIABLE_SOURCE_ABS = 10**_MAX_FRIABLE_SOURCE_DIGITS
+
+type _FriableRegime = Literal["DIRECT", "MATERIALIZED", "GENERATED"]
+
+
+def _primes_through(limit: int) -> tuple[int, ...]:
+    """Return the primes at most a small admitted cutoff."""
+
+    if limit < 2:
+        return ()
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    for candidate in range(2, math.isqrt(limit) + 1):
+        if not sieve[candidate]:
+            continue
+        first_composite = candidate * candidate
+        composite_count = (limit - first_composite) // candidate + 1
+        sieve[first_composite : limit + 1 : candidate] = b"\x00" * composite_count
+    return tuple(index for index, is_prime in enumerate(sieve) if is_prime)
+
+
+def _maximum_exponent(x: int, prime: int) -> int:
+    """Return the largest ``exponent`` with ``prime**exponent <= x``."""
+
+    exponent = 0
+    remaining = x
+    while remaining >= prime:
+        remaining //= prime
+        exponent += 1
+    return exponent
+
+
+def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]]:
+    """Validate and select one exact friable-count execution regime."""
+
+    if x < 0 or y < 0:
+        raise _validation_error(
+            "friable_count_sources_must_be_nonnegative",
+            "friable-count sources must be nonnegative",
+        )
+    if x >= _MAX_FRIABLE_SOURCE_ABS or y >= _MAX_FRIABLE_SOURCE_ABS:
+        raise _validation_error(
+            f"friable_count_sources_must_have_at_most_{_MAX_FRIABLE_SOURCE_DIGITS}_decimal_digits",
+            f"friable-count sources must have at most {_MAX_FRIABLE_SOURCE_DIGITS} decimal digits",
+        )
+    if x == 0 or y <= 1 or y >= x:
+        return "DIRECT", ()
+
+    # Each materialized pass marks at most two harmonic series of multiples,
+    # plus one scan. Result validation replays the full exact computation.
+    per_pass_steps = x * (2 * x.bit_length() + 1)
+    materialized_bytes = 2 * (x + 1) + x // 2
+    if (
+        x <= MAX_FRIABLE_MATERIALIZED_X
+        and 2 * per_pass_steps <= _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS
+        and materialized_bytes <= _MAX_FRIABLE_MATERIALIZED_BYTES
+    ):
+        return "MATERIALIZED", ()
+
+    if y > MAX_FRIABLE_GENERATED_CUTOFF:
+        raise _validation_error(
+            "generated_friable_counting_exceeds_the_admitted_prime_cutoff",
+            "generated friable counting exceeds the admitted prime cutoff",
+        )
+
+    primes = _primes_through(y)
+    nodes_per_pass = 1
+    prefix_box = 1
+    for prime in primes:
+        prefix_box *= _maximum_exponent(x, prime) + 1
+        nodes_per_pass += prefix_box
+        if 2 * nodes_per_pass > _MAX_FRIABLE_GENERATED_TOTAL_NODES:
+            raise _validation_error(
+                "generated_friable_counting_exceeds_the_search_node_budget",
+                "generated friable counting exceeds the search-node budget",
+            )
+    return "GENERATED", primes
+
+
+class FriableCountRequest(StrictModel):
+    """One exact bounded count of positive ``y``-friable integers through ``x``."""
+
+    x: BoundedInteger = Field(
+        description=(
+            "Canonical nonnegative inclusive source bound. Easy boundary cases may "
+            f"use up to {_MAX_FRIABLE_SOURCE_DIGITS} decimal digits; other cases must fit an exact counting "
+            "regime selected from the source-sensitive work bounds."
+        ),
+        examples=["100"],
+    )
+    y: BoundedInteger = Field(
+        description=(
+            "Canonical nonnegative inclusive prime-factor cutoff. Values zero and "
+            "one use the convention that only 1 is friable when x is positive."
+        ),
+        examples=["5"],
+    )
+
+    @model_validator(mode="after")
+    def require_admitted_exact_count(self) -> Self:
+        _plan_friable_count(
+            parse_canonical_integer(self.x),
+            parse_canonical_integer(self.y),
+        )
+        return self
+
+
+class FriableCountResult(StrictModel):
+    """An exact friable count bound to its complete source pair."""
+
+    x: BoundedInteger
+    y: BoundedInteger
+    count: BoundedInteger
+
+    @model_validator(mode="after")
+    def bind_exact_count_to_sources(self) -> Self:
+        from jacobian.math.number_theory._friable_operations import count_friable
+
+        x = parse_canonical_integer(self.x)
+        y = parse_canonical_integer(self.y)
+        count = parse_canonical_integer(self.count)
+        if count < 0:
+            raise _validation_error(
+                "friable_count_must_be_nonnegative", "friable count must be nonnegative"
+            )
+        if count != count_friable(x, y):
+            raise _validation_error(
+                "friable_count_does_not_match_the_retained_sources",
+                "friable count does not match the retained sources",
+            )
+        return self
+
+
+__all__ = [
+    "MAX_FRIABLE_GENERATED_CUTOFF",
+    "MAX_FRIABLE_MATERIALIZED_X",
+    "_MAX_FRIABLE_SOURCE_ABS",
+    "_MAX_FRIABLE_SOURCE_DIGITS",
+    "FriableCountRequest",
+    "FriableCountResult",
+    "_plan_friable_count",
+]

--- a/src/jacobian/math/number_theory/_friable_operations.py
+++ b/src/jacobian/math/number_theory/_friable_operations.py
@@ -6,7 +6,7 @@ from math import isqrt
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.arithmetic.values import IntegerValue
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._friable_models import (
     FriableCountRequest,
     FriableCountResult,
     _plan_friable_count,

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -11,10 +11,9 @@ integer nth root).
 
 from __future__ import annotations
 
-import math
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+from pydantic import Field, StrictInt, StringConstraints, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
@@ -31,10 +30,6 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 # ---------------------------------------------------------------------------
 
 _MAX_INTEGER_LENGTH = 256
-MAX_POWERFUL_INTEGER_DIGITS = 25
-MAX_POWERFUL_CUTOFF = 100_000
-MAX_POWERFUL_FACTOR_ENTRIES = 42
-MAX_POWERFUL_EXPONENT = 83
 # Certified factoring uses SymPy's ``factorint`` (Pollard rho, Pollard p-1,
 # ECM) on the input and recursively on ``p - 1`` for Pratt certificates.
 # The 30-digit bound (~100 bits) is a real work bound: it keeps worst-case
@@ -76,14 +71,6 @@ BoundedInteger = Annotated[
         strict=True,
     ),
 ]
-PowerfulInteger = Annotated[
-    str,
-    StringConstraints(
-        pattern=r"^[1-9][0-9]*$",
-        max_length=MAX_POWERFUL_INTEGER_DIGITS,
-        strict=True,
-    ),
-]
 CertifiedFactorizationInteger = Annotated[
     str,
     StringConstraints(
@@ -102,18 +89,6 @@ class IntegerValueRequest(StrictModel):
     """One canonical integer supplied to a unary number-theory operation."""
 
     value: BoundedInteger
-
-
-class PowerfulNumberRequest(StrictModel):
-    """One positive canonical integer of at most 25 digits."""
-
-    value: PowerfulInteger = Field(
-        description=(
-            "Positive canonical decimal integer with at most 25 digits. The "
-            "kernel derives B=ceil(value^(1/5)), so B <= 100000."
-        ),
-        examples=["12168"],
-    )
 
 
 class ArithmeticFunctionRequest(StrictModel):
@@ -325,83 +300,6 @@ class PrimePower(StrictModel):
 
     prime: BoundedInteger
     power: int = Field(ge=1, le=_MAX_N_SMALL)
-
-
-class ResidualPerfectPower(StrictModel):
-    """An exact decomposition of the stripped residual as base**exponent."""
-
-    base: PowerfulInteger
-    exponent: StrictInt = Field(ge=2, le=MAX_POWERFUL_EXPONENT)
-
-
-class PowerfulNumberResult(StrictModel):
-    """A source-bound, replayable exact powerful-number decision."""
-
-    value: PowerfulInteger
-    conclusion: Literal[
-        "POWERFUL",
-        "EXPONENT_ONE",
-        "ROUGH_NOT_PERFECT_POWER",
-    ]
-    is_powerful: StrictBool
-    cutoff: StrictInt = Field(
-        ge=1,
-        le=MAX_POWERFUL_CUTOFF,
-        description="The canonical cutoff B=ceil(value^(1/5)); B^5 >= value.",
-    )
-    checked_through: StrictInt = Field(
-        ge=1,
-        le=MAX_POWERFUL_CUTOFF,
-        description=(
-            "All primes at most this bound were tested. It equals cutoff unless "
-            "an exponent-one prime ended the decision early."
-        ),
-    )
-    stripped_factors: tuple[PrimePower, ...] = Field(
-        min_length=0,
-        max_length=MAX_POWERFUL_FACTOR_ENTRIES,
-    )
-    residual: PowerfulInteger = Field(
-        description=(
-            "The positive cofactor after the reported prime powers are removed."
-        )
-    )
-    residual_perfect_power: ResidualPerfectPower | None = None
-
-    @model_validator(mode="after")
-    def bind_decision_to_source_by_exact_replay(self) -> Self:
-        from jacobian.canonical import parse_canonical_integer
-        from jacobian.math.number_theory._powerful_kernels import (
-            decide_powerful_data,
-        )
-
-        expected = decide_powerful_data(parse_canonical_integer(self.value))
-        factors = tuple(
-            (parse_canonical_integer(factor.prime), factor.power)
-            for factor in self.stripped_factors
-        )
-        perfect_power = (
-            None
-            if self.residual_perfect_power is None
-            else (
-                parse_canonical_integer(self.residual_perfect_power.base),
-                self.residual_perfect_power.exponent,
-            )
-        )
-        if (
-            self.conclusion != expected.conclusion
-            or self.is_powerful != (expected.conclusion == "POWERFUL")
-            or self.cutoff != expected.cutoff
-            or self.checked_through != expected.checked_through
-            or factors != expected.stripped_factors
-            or parse_canonical_integer(self.residual) != expected.residual
-            or perfect_power != expected.perfect_power
-        ):
-            raise _validation_error(
-                "powerful_number_conclusion_or_certificate_does_not_match_exact_replay",
-                "powerful-number conclusion or certificate does not match exact replay",
-            )
-        return self
 
 
 class BooleanResult(StrictModel):

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -2,7 +2,7 @@
 
 These contracts cover gcd/lcm, Bezout coefficients, divisors, prime
 factorization, p-adic valuation, multiplicative arithmetic functions,
-primality, friable counting, modular arithmetic, and integer predicates (coprimality,
+friable counting, modular arithmetic, and integer predicates (coprimality,
 divisibility, perfect/abundant/deficient, square, squarefree).  They are
 owned by the number-theory domain and intentionally exclude arithmetic-owned
 operations (absolute value, sign, decimal digit sum/count, base expansion,
@@ -49,15 +49,8 @@ _MAX_CERTIFIED_FACTORIZATION_LENGTH = 30
 # (totient, Möbius, divisor sigma, square-free predicates, and
 # multiplicative order).  The 10_000 bound keeps SymPy factoring safe for
 # in-process execution while admitting materially larger useful cases than
-# the prior 1_000 cap.  Primorial has its own request bound derived from
-# the declared result digit budget (see ``_MAX_PRIMORIAL_N``).
+# the prior 1_000 cap.
 _MAX_N_SMALL = 10_000
-# primorial(n) carries n(ln n + ln ln n)/ln 10 digits.  The declared
-# result budget is ``_MAX_PRIMORIAL_DIGITS`` (3_400), and primorial(1001)
-# already has 3397 digits while primorial(1002) has 3401, so the exact
-# admitted boundary is n <= 1001.  Defined here so ``PrimorialRequest``
-# can derive its own request-side guard from the output contract.
-_MAX_PRIMORIAL_N = 1001
 # ``_MAX_MODULUS`` is shared across modular inverse, multiplicative order,
 # quadratic residues, CRT, Jacobi symbol, and brute-force discrete log.
 # Raised to 1_000_000 for non-enumeration ops (inverse, order, CRT, Jacobi
@@ -144,25 +137,6 @@ class PositiveIntegerRequest(StrictModel):
     """One bounded positive integer (1 <= n <= 10 000)."""
 
     n: StrictInt = Field(ge=1, le=_MAX_N_SMALL)
-
-
-class PrimorialRequest(StrictModel):
-    """One bounded positive integer whose primorial fits the result contract.
-
-    ``primorial(n)`` grows like ``exp(n log n)``: the product of the first
-    ``n`` primes carries ``n(log n + log log n) / ln 10`` digits.  The
-    shared arithmetic-function bound admits values whose primorial would
-    exceed the declared ``_MAX_PRIMORIAL_DIGITS``-digit result, so this
-    request derives its own conservative ceiling from the digit bound.
-    """
-
-    n: StrictInt = Field(ge=1, le=_MAX_PRIMORIAL_N)
-
-
-class PreviousPrimeRequest(StrictModel):
-    """One bounded integer n >= 3 for previous-prime queries."""
-
-    n: StrictInt = Field(ge=3, le=_MAX_N_SMALL)
 
 
 class FloorSquareRootRequest(StrictModel):
@@ -344,23 +318,6 @@ class IntegerValueResult(StrictModel):
     """One exact integer value produced by a number-theory operation."""
 
     value: BoundedInteger
-
-
-_MAX_PRIMORIAL_DIGITS = 3_400
-PrimorialInteger = Annotated[
-    str,
-    StringConstraints(
-        pattern=r"^(?:0|[1-9][0-9]*)$",
-        max_length=_MAX_PRIMORIAL_DIGITS,
-        strict=True,
-    ),
-]
-
-
-class PrimorialResult(StrictModel):
-    """The primorial (product of the first n primes)."""
-
-    value: PrimorialInteger
 
 
 class PrimePower(StrictModel):

--- a/src/jacobian/math/number_theory/_models.py
+++ b/src/jacobian/math/number_theory/_models.py
@@ -75,21 +75,6 @@ _MAX_CRT_SIZE = 64
 # is the smallest excluded combined modulus (positive values only).
 _MAX_CRT_COMBINED_MODULUS = 10**_MAX_INTEGER_LENGTH
 
-# Friable counting has two exact, result-sensitive execution regimes. The
-# materialized regime uses one bytearray for primality and one for friability;
-# its work bound covers both the operation and result-validation replay. The
-# generated regime enumerates prime-exponent prefixes only when a conservative
-# prefix-box bound covers both passes.
-MAX_FRIABLE_MATERIALIZED_X = 1_000_000
-MAX_FRIABLE_GENERATED_CUTOFF = 10_000
-_MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS = 82_000_000
-_MAX_FRIABLE_MATERIALIZED_BYTES = 3_000_000
-_MAX_FRIABLE_GENERATED_TOTAL_NODES = 1_000_000
-# Sources are nonnegative and rejected at ``10**_MAX_FRIABLE_SOURCE_DIGITS`` or
-# above, so every admitted value carries at most this many decimal digits.
-_MAX_FRIABLE_SOURCE_DIGITS = 256
-_MAX_FRIABLE_SOURCE_ABS = 10**_MAX_FRIABLE_SOURCE_DIGITS
-
 BoundedInteger = Annotated[
     str,
     StringConstraints(
@@ -98,14 +83,6 @@ BoundedInteger = Annotated[
         strict=True,
     ),
 ]
-
-
-class PrimalityRequest(StrictModel):
-    """One bounded canonical integer for the maintained primality backend."""
-
-    value: BoundedInteger
-
-
 PowerfulInteger = Annotated[
     str,
     StringConstraints(
@@ -123,81 +100,15 @@ CertifiedFactorizationInteger = Annotated[
     ),
 ]
 
-type _FriableRegime = Literal["DIRECT", "MATERIALIZED", "GENERATED"]
+# ---------------------------------------------------------------------------
+# Request models — canonical integers (arbitrary precision, bounded string)
+# ---------------------------------------------------------------------------
 
 
-def _primes_through(limit: int) -> tuple[int, ...]:
-    """Return the primes at most a small admitted cutoff."""
+class IntegerValueRequest(StrictModel):
+    """One canonical integer supplied to a unary number-theory operation."""
 
-    if limit < 2:
-        return ()
-    sieve = bytearray(b"\x01") * (limit + 1)
-    sieve[0:2] = b"\x00\x00"
-    for candidate in range(2, math.isqrt(limit) + 1):
-        if not sieve[candidate]:
-            continue
-        first_composite = candidate * candidate
-        composite_count = (limit - first_composite) // candidate + 1
-        sieve[first_composite : limit + 1 : candidate] = b"\x00" * composite_count
-    return tuple(index for index, is_prime in enumerate(sieve) if is_prime)
-
-
-def _maximum_exponent(x: int, prime: int) -> int:
-    """Return the largest ``exponent`` with ``prime**exponent <= x``."""
-
-    exponent = 0
-    remaining = x
-    while remaining >= prime:
-        remaining //= prime
-        exponent += 1
-    return exponent
-
-
-def _plan_friable_count(x: int, y: int) -> tuple[_FriableRegime, tuple[int, ...]]:
-    """Validate and select one exact friable-count execution regime."""
-
-    if x < 0 or y < 0:
-        raise _validation_error(
-            "friable_count_sources_must_be_nonnegative",
-            "friable-count sources must be nonnegative",
-        )
-    if x >= _MAX_FRIABLE_SOURCE_ABS or y >= _MAX_FRIABLE_SOURCE_ABS:
-        raise _validation_error(
-            f"friable_count_sources_must_have_at_most_{_MAX_FRIABLE_SOURCE_DIGITS}_decimal_digits",
-            f"friable-count sources must have at most {_MAX_FRIABLE_SOURCE_DIGITS} decimal digits",
-        )
-    if x == 0 or y <= 1 or y >= x:
-        return "DIRECT", ()
-
-    # Each materialized pass marks at most two harmonic series of multiples,
-    # plus one scan. Result validation replays the full exact computation.
-    per_pass_steps = x * (2 * x.bit_length() + 1)
-    materialized_bytes = 2 * (x + 1) + x // 2
-    if (
-        x <= MAX_FRIABLE_MATERIALIZED_X
-        and 2 * per_pass_steps <= _MAX_FRIABLE_MATERIALIZED_TOTAL_STEPS
-        and materialized_bytes <= _MAX_FRIABLE_MATERIALIZED_BYTES
-    ):
-        return "MATERIALIZED", ()
-
-    if y > MAX_FRIABLE_GENERATED_CUTOFF:
-        raise _validation_error(
-            "generated_friable_counting_exceeds_the_admitted_prime_cutoff",
-            "generated friable counting exceeds the admitted prime cutoff",
-        )
-
-    primes = _primes_through(y)
-    nodes_per_pass = 1
-    prefix_box = 1
-    for prime in primes:
-        prefix_box *= _maximum_exponent(x, prime) + 1
-        nodes_per_pass += prefix_box
-        if 2 * nodes_per_pass > _MAX_FRIABLE_GENERATED_TOTAL_NODES:
-            raise _validation_error(
-                "generated_friable_counting_exceeds_the_search_node_budget",
-                "generated friable counting exceeds the search-node budget",
-            )
-    return "GENERATED", primes
+    value: BoundedInteger
 
 
 class PowerfulNumberRequest(StrictModel):
@@ -299,63 +210,6 @@ class FactorialValuationResult(StrictModel):
     n: StrictInt = Field(ge=0, le=100_000)
     base: StrictInt = Field(ge=2, le=1_000_000)
     valuation: StrictInt = Field(ge=0)
-
-
-class FriableCountRequest(StrictModel):
-    """One exact bounded count of positive ``y``-friable integers through ``x``."""
-
-    x: BoundedInteger = Field(
-        description=(
-            "Canonical nonnegative inclusive source bound. Easy boundary cases may "
-            "use up to 256 decimal digits; other cases must fit an exact counting "
-            "regime selected from the source-sensitive work bounds."
-        ),
-        examples=["100"],
-    )
-    y: BoundedInteger = Field(
-        description=(
-            "Canonical nonnegative inclusive prime-factor cutoff. Values zero and "
-            "one use the convention that only 1 is friable when x is positive."
-        ),
-        examples=["5"],
-    )
-
-    @model_validator(mode="after")
-    def require_admitted_exact_count(self) -> Self:
-        from jacobian.canonical import parse_canonical_integer
-
-        _plan_friable_count(
-            parse_canonical_integer(self.x),
-            parse_canonical_integer(self.y),
-        )
-        return self
-
-
-class FriableCountResult(StrictModel):
-    """An exact friable count bound to its complete source pair."""
-
-    x: BoundedInteger
-    y: BoundedInteger
-    count: BoundedInteger
-
-    @model_validator(mode="after")
-    def bind_exact_count_to_sources(self) -> Self:
-        from jacobian.canonical import parse_canonical_integer
-        from jacobian.math.number_theory._friable_operations import count_friable
-
-        x = parse_canonical_integer(self.x)
-        y = parse_canonical_integer(self.y)
-        count = parse_canonical_integer(self.count)
-        if count < 0:
-            raise _validation_error(
-                "friable_count_must_be_nonnegative", "friable count must be nonnegative"
-            )
-        if count != count_friable(x, y):
-            raise _validation_error(
-                "friable_count_does_not_match_the_retained_sources",
-                "friable count does not match the retained sources",
-            )
-        return self
 
 
 # ---------------------------------------------------------------------------
@@ -479,6 +333,17 @@ class DiscreteLogarithmRequest(StrictModel):
                 "base and target must be less than the modulus",
             )
         return self
+
+
+# ---------------------------------------------------------------------------
+# Result models
+# ---------------------------------------------------------------------------
+
+
+class IntegerValueResult(StrictModel):
+    """One exact integer value produced by a number-theory operation."""
+
+    value: BoundedInteger
 
 
 _MAX_PRIMORIAL_DIGITS = 3_400

--- a/src/jacobian/math/number_theory/_powerful.py
+++ b/src/jacobian/math/number_theory/_powerful.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.catalog._examples import example
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._models import PrimePower
+from jacobian.math.number_theory._powerful_kernels import decide_powerful_data
+from jacobian.math.number_theory._powerful_models import (
     PowerfulNumberRequest,
     PowerfulNumberResult,
-    PrimePower,
     ResidualPerfectPower,
 )
-from jacobian.math.number_theory._powerful_kernels import decide_powerful_data
 from jacobian.math.number_theory._support import number_theory_operation
 
 

--- a/src/jacobian/math/number_theory/_powerful_kernels.py
+++ b/src/jacobian/math/number_theory/_powerful_kernels.py
@@ -8,7 +8,7 @@ from typing import Literal
 from flint import fmpz
 from sympy.ntheory.generate import Sieve, primerange
 
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._powerful_models import (
     MAX_POWERFUL_CUTOFF,
     MAX_POWERFUL_INTEGER_DIGITS,
 )

--- a/src/jacobian/math/number_theory/_powerful_models.py
+++ b/src/jacobian/math/number_theory/_powerful_models.py
@@ -1,0 +1,128 @@
+"""Typed contracts and replay validation for powerful-number decisions."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field, StrictBool, StrictInt, StringConstraints, model_validator
+
+from jacobian._models import StrictModel
+from jacobian.math.number_theory._models import PrimePower, _validation_error
+
+# The kernel derives ``B = ceil(value**(1/5))`` and trial-divides through B.
+# These limits therefore bound both the request and the source-bound result
+# replay without requiring complete factorization.
+MAX_POWERFUL_INTEGER_DIGITS = 25
+MAX_POWERFUL_CUTOFF = 100_000
+MAX_POWERFUL_FACTOR_ENTRIES = 42
+MAX_POWERFUL_EXPONENT = 83
+
+PowerfulInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[1-9][0-9]*$",
+        max_length=MAX_POWERFUL_INTEGER_DIGITS,
+        strict=True,
+    ),
+]
+
+
+class PowerfulNumberRequest(StrictModel):
+    """One positive canonical integer of at most 25 digits."""
+
+    value: PowerfulInteger = Field(
+        description=(
+            "Positive canonical decimal integer with at most 25 digits. The "
+            "kernel derives B=ceil(value^(1/5)), so B <= 100000."
+        ),
+        examples=["12168"],
+    )
+
+
+class ResidualPerfectPower(StrictModel):
+    """An exact decomposition of the stripped residual as base**exponent."""
+
+    base: PowerfulInteger
+    exponent: StrictInt = Field(ge=2, le=MAX_POWERFUL_EXPONENT)
+
+
+class PowerfulNumberResult(StrictModel):
+    """A source-bound, replayable exact powerful-number decision."""
+
+    value: PowerfulInteger
+    conclusion: Literal[
+        "POWERFUL",
+        "EXPONENT_ONE",
+        "ROUGH_NOT_PERFECT_POWER",
+    ]
+    is_powerful: StrictBool
+    cutoff: StrictInt = Field(
+        ge=1,
+        le=MAX_POWERFUL_CUTOFF,
+        description="The canonical cutoff B=ceil(value^(1/5)); B^5 >= value.",
+    )
+    checked_through: StrictInt = Field(
+        ge=1,
+        le=MAX_POWERFUL_CUTOFF,
+        description=(
+            "All primes at most this bound were tested. It equals cutoff unless "
+            "an exponent-one prime ended the decision early."
+        ),
+    )
+    stripped_factors: tuple[PrimePower, ...] = Field(
+        min_length=0,
+        max_length=MAX_POWERFUL_FACTOR_ENTRIES,
+    )
+    residual: PowerfulInteger = Field(
+        description=(
+            "The positive cofactor after the reported prime powers are removed."
+        )
+    )
+    residual_perfect_power: ResidualPerfectPower | None = None
+
+    @model_validator(mode="after")
+    def bind_decision_to_source_by_exact_replay(self) -> PowerfulNumberResult:
+        from jacobian.canonical import parse_canonical_integer
+        from jacobian.math.number_theory._powerful_kernels import (
+            decide_powerful_data,
+        )
+
+        expected = decide_powerful_data(parse_canonical_integer(self.value))
+        factors = tuple(
+            (parse_canonical_integer(factor.prime), factor.power)
+            for factor in self.stripped_factors
+        )
+        perfect_power = (
+            None
+            if self.residual_perfect_power is None
+            else (
+                parse_canonical_integer(self.residual_perfect_power.base),
+                self.residual_perfect_power.exponent,
+            )
+        )
+        if (
+            self.conclusion != expected.conclusion
+            or self.is_powerful != (expected.conclusion == "POWERFUL")
+            or self.cutoff != expected.cutoff
+            or self.checked_through != expected.checked_through
+            or factors != expected.stripped_factors
+            or parse_canonical_integer(self.residual) != expected.residual
+            or perfect_power != expected.perfect_power
+        ):
+            raise _validation_error(
+                "powerful_number_conclusion_or_certificate_does_not_match_exact_replay",
+                "powerful-number conclusion or certificate does not match exact replay",
+            )
+        return self
+
+
+__all__ = [
+    "MAX_POWERFUL_CUTOFF",
+    "MAX_POWERFUL_EXPONENT",
+    "MAX_POWERFUL_FACTOR_ENTRIES",
+    "MAX_POWERFUL_INTEGER_DIGITS",
+    "PowerfulInteger",
+    "PowerfulNumberRequest",
+    "PowerfulNumberResult",
+    "ResidualPerfectPower",
+]

--- a/src/jacobian/math/number_theory/_prime_models.py
+++ b/src/jacobian/math/number_theory/_prime_models.py
@@ -1,0 +1,51 @@
+"""Typed contracts and bounds owned by prime operations."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field, StrictInt, StringConstraints
+
+from jacobian._models import StrictModel
+
+# ``primorial(n)`` carries n(ln n + ln ln n)/ln 10 digits.  The declared
+# result budget is ``_MAX_PRIMORIAL_DIGITS`` (3_400), and primorial(1001)
+# already has 3397 digits while primorial(1002) has 3401, so the exact
+# admitted boundary is n <= 1001.
+_MAX_PRIMORIAL_N = 1001
+_MAX_PRIMORIAL_DIGITS = 3_400
+
+
+class PrimorialRequest(StrictModel):
+    """One bounded positive integer whose primorial fits the result contract.
+
+    ``primorial(n)`` grows like ``exp(n log n)``: the product of the first
+    ``n`` primes carries ``n(log n + log log n) / ln 10`` digits.  The
+    shared arithmetic-function bound admits values whose primorial would
+    exceed the declared ``_MAX_PRIMORIAL_DIGITS``-digit result, so this
+    request derives its own conservative ceiling from the digit bound.
+    """
+
+    n: StrictInt = Field(ge=1, le=_MAX_PRIMORIAL_N)
+
+
+class PreviousPrimeRequest(StrictModel):
+    """One bounded integer n >= 3 for previous-prime queries."""
+
+    n: StrictInt = Field(ge=3, le=10_000)
+
+
+PrimorialInteger = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^(?:0|[1-9][0-9]*)$",
+        max_length=_MAX_PRIMORIAL_DIGITS,
+        strict=True,
+    ),
+]
+
+
+class PrimorialResult(StrictModel):
+    """The primorial (product of the first n primes)."""
+
+    value: PrimorialInteger

--- a/src/jacobian/math/number_theory/_prime_models.py
+++ b/src/jacobian/math/number_theory/_prime_models.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from pydantic import Field, StrictInt, StringConstraints
 
 from jacobian._models import StrictModel
+from jacobian.math.number_theory._models import BoundedInteger
 
 # ``primorial(n)`` carries n(ln n + ln ln n)/ln 10 digits.  The declared
 # result budget is ``_MAX_PRIMORIAL_DIGITS`` (3_400), and primorial(1001)
@@ -14,6 +15,12 @@ from jacobian._models import StrictModel
 # admitted boundary is n <= 1001.
 _MAX_PRIMORIAL_N = 1001
 _MAX_PRIMORIAL_DIGITS = 3_400
+
+
+class PrimalityRequest(StrictModel):
+    """One bounded canonical integer for the maintained primality backend."""
+
+    value: BoundedInteger
 
 
 class PrimorialRequest(StrictModel):

--- a/src/jacobian/math/number_theory/_prime_operations.py
+++ b/src/jacobian/math/number_theory/_prime_operations.py
@@ -7,6 +7,8 @@ from jacobian.math.number_theory._models import (
     BooleanResult,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
+)
+from jacobian.math.number_theory._prime_models import (
     PreviousPrimeRequest,
     PrimalityRequest,
     PrimorialRequest,

--- a/src/jacobian/math/number_theory/_primes.py
+++ b/src/jacobian/math/number_theory/_primes.py
@@ -6,6 +6,8 @@ from jacobian.math.number_theory._models import (
     BooleanResult,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
+)
+from jacobian.math.number_theory._prime_models import (
     PreviousPrimeRequest,
     PrimalityRequest,
     PrimorialRequest,

--- a/tests/math/number_theory/test_friable_count.py
+++ b/tests/math/number_theory/test_friable_count.py
@@ -11,14 +11,14 @@ from tests.math.number_theory._validation import expect_validation
 from jacobian.math.arithmetic import absolute_value
 from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory import FriableCountResult, count_friable
-from jacobian.math.number_theory._friable_operations import compute_friable_count
-from jacobian.math.number_theory._models import (
+from jacobian.math.number_theory._friable_models import (
     _MAX_FRIABLE_SOURCE_ABS,
     _MAX_FRIABLE_SOURCE_DIGITS,
     MAX_FRIABLE_GENERATED_CUTOFF,
     MAX_FRIABLE_MATERIALIZED_X,
     FriableCountRequest,
 )
+from jacobian.math.number_theory._friable_operations import compute_friable_count
 
 
 def _prime_factors(value: int) -> Iterator[int]:

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -17,11 +17,11 @@ from jacobian.math.number_theory._models import (
     ModularValueRequest,
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
-    PrimalityRequest,
 )
 from jacobian.math.number_theory._modular_models import (
     ModularPolynomialResidueImageRequest,
 )
+from jacobian.math.number_theory._prime_models import PrimalityRequest
 
 
 @pytest.mark.parametrize("residue", [-1, 3])

--- a/tests/math/number_theory/test_powerful.py
+++ b/tests/math/number_theory/test_powerful.py
@@ -12,14 +12,14 @@ from pydantic import ValidationError
 from sympy import factorint, isprime
 from tests.math.number_theory._validation import expect_validation
 
-from jacobian.math.number_theory._models import (
-    PowerfulNumberRequest,
-    PowerfulNumberResult,
-)
 from jacobian.math.number_theory._powerful import decide_powerful
 from jacobian.math.number_theory._powerful_kernels import (
     _perfect_power_witness,
     decide_powerful_data,
+)
+from jacobian.math.number_theory._powerful_models import (
+    PowerfulNumberRequest,
+    PowerfulNumberResult,
 )
 
 PayloadMutation = Callable[[dict[str, Any]], None]

--- a/tests/math/number_theory/test_primorial.py
+++ b/tests/math/number_theory/test_primorial.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from jacobian.math.number_theory._models import (
-    PositiveIntegerRequest,
+from jacobian.math.number_theory._models import PositiveIntegerRequest
+from jacobian.math.number_theory._prime_models import (
     PrimorialRequest,
     PrimorialResult,
 )


### PR DESCRIPTION
Part of #2565.

## Problem

Number-theory contracts for friable counts, prime and powerful-number operations, and primality certificates remained in one shared model module after their declaration families had been separated.

## Solution

Move those family-specific request/result models and bounds to their owner modules while preserving their public imports, operation IDs, serialized schemas, and existing kernels. The neutral shared model surface no longer owns those unrelated contracts.

## Testing

- `make test-focused LANE=math TESTS=tests/math/number_theory` — 234 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_builtin_examples.py` — 608 passed
- `uv run ruff format --check src tests` and `uv run ruff check src tests` — passed

## Public contract impact

None: operation IDs, request/result schemas, canonical values, and mathematical semantics are unchanged.

## Operation boundary ownership

- Changed stage: request parsing and request-bounds model ownership
- Request-bounds owner and controlling quantities: the friable, prime, powerful-number, and primality families retain their existing owner-local bounds.
- Backend or kernel path: unchanged.
- Result construction: unchanged canonical models, moved with their families.
- Independent-result verifier: unchanged where existing results accept replay.
- Native/MCP parity: unchanged.
- Serialized-result and round-trip evidence: advertised catalog examples pass.

## Canonical value audit

- [x] Existing canonical values retained; no new value introduced.
- [x] Family ownership follows the existing declaration and kernel boundaries.
- [x] Advertised serialized examples execute unchanged.

## Catalog admission

Not applicable; catalog membership and operation declarations are unchanged.

## Closure matrix

| Candidate | Outcome | Operation ID or follow-up issue |
| --- | --- | --- |
| Friable, prime, powerful, and primality contract ownership | delivered | Part of #2565 |

## Checklist

- [ ] `make check` passes (not run; focused owner, catalog, example, and static checks are listed above)
- [x] Explicitly relevant specialist validation is listed above
- [x] Catalog membership is unchanged
- [x] Runtime bounds and native/MCP semantics are unchanged
- [x] No new shared abstraction was added