### PR TITLE
Decouple moments native APIs from request models

### DIFF
--- a/src/jacobian/math/moments_orthogonal/_jacobi.py
+++ b/src/jacobian/math/moments_orthogonal/_jacobi.py
@@ -1,0 +1,131 @@
+"""Canonical-family kernel for finite Jacobi matrices."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian.math.moments_orthogonal.values import (
+    JacobiMatrix,
+    OrthogonalPolynomialFamily,
+)
+
+
+class JacobiMatrixAdmissionError(ValueError):
+    """A native Jacobi-matrix admission failure with an owner-local code."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+def _from_fraction(value: Fraction) -> CanonicalRational:
+    return CanonicalRational.from_fraction(value)
+
+
+def require_jacobi_matrix_admission(family: OrthogonalPolynomialFamily) -> None:
+    """Bound every exact entry emitted by the Jacobi-matrix kernel.
+
+    The canonical family is intentionally accepted directly: this is the
+    owner-local mathematical admission shared by the MCP request validator and
+    the native API, not a request-envelope reconstruction.
+    """
+    polys = family.polynomials
+    digit_limit = 10**MAX_CANONICAL_RATIONAL_DIGITS
+    for k in range(len(polys) - 1):
+        p_k = [coefficient.as_fraction() for coefficient in polys[k].coefficients]
+        p_next = [
+            coefficient.as_fraction() for coefficient in polys[k + 1].coefficients
+        ]
+        if k == 0:
+            alpha_k = -p_next[0]
+        else:
+            x_pk = [Fraction(0)] * (len(p_k) + 1)
+            for i, coefficient in enumerate(p_k):
+                x_pk[i + 1] = coefficient
+            residual = [
+                x_pk[i] - p_next[i] if i < len(p_next) else x_pk[i]
+                for i in range(len(x_pk))
+            ]
+            alpha_k = residual[k] if k < len(residual) else Fraction(0)
+        if abs(alpha_k.numerator) >= digit_limit or alpha_k.denominator >= digit_limit:
+            raise JacobiMatrixAdmissionError(
+                "recurrence_height",
+                f"derived recurrence entry alpha_{k} exceeds the canonical "
+                "rational digit limit; supply a family whose coefficient "
+                "differences stay representable",
+            )
+    for k in range(1, len(polys) - 1):
+        h_k = polys[k].squared_norm.as_fraction()
+        h_prev = polys[k - 1].squared_norm.as_fraction()
+        if h_prev == 0 or h_k == 0:
+            raise JacobiMatrixAdmissionError(
+                "norm_ratio",
+                f"adjacent-norm ratio beta_{k} is undefined because squared "
+                f"norm h_{k - 1 if h_prev == 0 else k} vanishes; supply a "
+                "family with nonzero norms for every emitted ratio",
+            )
+        ratio = h_k / h_prev
+        if abs(ratio.numerator) >= digit_limit or ratio.denominator >= digit_limit:
+            raise JacobiMatrixAdmissionError(
+                "norm_ratio_height",
+                f"adjacent-norm ratio beta_{k} exceeds the canonical rational "
+                "digit limit; supply a family whose squared norm ratios stay "
+                "representable",
+            )
+
+
+def jacobi_matrix_from_family(family: OrthogonalPolynomialFamily) -> JacobiMatrix:
+    """Compute the exact finite Jacobi matrix of one admitted family."""
+    polys = family.polynomials
+    n = len(polys)
+
+    if n < 2:
+        return JacobiMatrix(
+            alphas=(),
+            betas=(),
+            matrix=(),
+            variable=family.variable,
+        )
+
+    alphas: list[Fraction] = []
+    betas: list[Fraction] = []
+    for k in range(n - 1):
+        p_k = [coefficient.as_fraction() for coefficient in polys[k].coefficients]
+        p_next = [
+            coefficient.as_fraction() for coefficient in polys[k + 1].coefficients
+        ]
+        squared_norm_k = polys[k].squared_norm.as_fraction()
+
+        if k == 0:
+            alphas.append(-p_next[0])
+            betas.append(Fraction(0))
+        else:
+            squared_norm_prev = polys[k - 1].squared_norm.as_fraction()
+            x_pk = [Fraction(0)] * (len(p_k) + 1)
+            for i, coefficient in enumerate(p_k):
+                x_pk[i + 1] = coefficient
+            residual = [
+                x_pk[i] - p_next[i] if i < len(p_next) else x_pk[i]
+                for i in range(len(x_pk))
+            ]
+            alphas.append(residual[k] if k < len(residual) else Fraction(0))
+            betas.append(squared_norm_k / squared_norm_prev)
+
+    matrix_size = n - 1
+    matrix = [[Fraction(0)] * matrix_size for _ in range(matrix_size)]
+    for i in range(matrix_size):
+        matrix[i][i] = alphas[i]
+        if i < matrix_size - 1:
+            matrix[i + 1][i] = Fraction(1)
+            matrix[i][i + 1] = betas[i + 1]
+
+    return JacobiMatrix(
+        alphas=tuple(_from_fraction(alpha) for alpha in alphas),
+        betas=tuple(_from_fraction(beta) for beta in betas),
+        matrix=tuple(
+            tuple(_from_fraction(matrix[i][j]) for j in range(matrix_size))
+            for i in range(matrix_size)
+        ),
+        variable=family.variable,
+    )

--- a/src/jacobian/math/moments_orthogonal/_models.py
+++ b/src/jacobian/math/moments_orthogonal/_models.py
@@ -25,14 +25,6 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"moments_orthogonal.{reason}", message)
 
 
-class MomentsOrthogonalAdmissionError(ValueError):
-    """Native admission failure for moments-orthogonal operations."""
-
-    def __init__(self, reason: str, message: str) -> None:
-        super().__init__(message)
-        self.reason = reason
-
-
 def _require_determinant_representable(
     moments: tuple[CanonicalRational, ...], order: int
 ) -> None:
@@ -52,37 +44,6 @@ def _require_determinant_representable(
                 "determinant_height",
                 f"moment heights exceed the conservative {max(per_entry - 2, 8)}-digit "
                 f"bound for an exact order-{order} determinant",
-            )
-
-
-def _require_gram_schmidt_heights_admissible(
-    moments: tuple[CanonicalRational, ...], max_degree: int
-) -> None:
-    """Bound moment heights BEFORE any exact projection runs.
-
-    Monic Gram-Schmidt expresses every derived coefficient and squared
-    norm through degree d as a ratio of determinants of at most (d+1)
-    -square Hankel matrices over the consumed moments mu_0..mu_2d (the
-    classical Cramer-rule form of the elimination). Scaling each row by
-    its denominator product bounds an s x s rational determinant's
-    numerator and denominator by 10**(s*(s+1)*B + s) when every entry
-    carries at most B digits, so bounding each moment by the quotient
-    below guarantees every derived value stays canonical. Degree 0
-    performs no elimination - its only derived value is mu_0 itself -
-    so it needs no input gate beyond canonality.
-    """
-    if max_degree == 0:
-        return
-    side = max_degree + 1
-    per_entry = (MAX_CANONICAL_RATIONAL_DIGITS - 2 * side) // (2 * side * (side + 1))
-    bound = max(per_entry, 8)
-    for value in moments[: 2 * max_degree + 1]:
-        if RationalHeight.from_canonical(value).exceeds(bound):
-            raise MomentsOrthogonalAdmissionError(
-                "gram_schmidt_height",
-                f"moment heights exceed the conservative {bound}-digit "
-                f"bound for exact degree-{max_degree} Gram-Schmidt; supply "
-                "a smaller or better-scaled moment prefix",
             )
 
 
@@ -157,6 +118,11 @@ class OrthogonalPolynomialRequest(StrictModel):
         gate, both this admission replay and the execution that follows it
         operate on provably bounded intermediates with typed height checks.
         """
+        from jacobian.math.moments_orthogonal.operations import (
+            MomentsOrthogonalAdmissionError,
+            _require_gram_schmidt_heights_admissible,
+        )
+
         try:
             _require_gram_schmidt_heights_admissible(
                 self.prefix.moments, self.max_degree
@@ -282,87 +248,15 @@ class GaussianQuadratureRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_sufficient_moments(self) -> Self:
-        # The conservative Gram-Schmidt height gate runs BEFORE any exact
-        # projection: without it, a single schema-valid payload such as
-        # mu_0 = 10^-32767 with mu_1 = 10^32767 forces enormous exact
-        # backend work during parsing before the derived-node check fires.
-        try:
-            _require_gram_schmidt_heights_admissible(self.prefix.moments, self.order)
-        except MomentsOrthogonalAdmissionError as exc:
-            raise _validation_error(exc.reason, str(exc)) from None
-        # Building p_order projects only onto earlier polynomials, so the
-        # Gram-Schmidt kernel and the Vandermonde weight solve consume
-        # moments through mu_(2n-1) exactly; execution verifies exactness
-        # through degree 2n-1, so 2n moments are both sufficient and
-        # required.
-        needed = 2 * self.order
-        if len(self.prefix.moments) < needed:
-            raise _validation_error(
-                "insufficient_moments",
-                f"need at least {needed} moments for quadrature order {self.order}, got {len(self.prefix.moments)}",
-            )
-        return self
-
-    @model_validator(mode="after")
-    def require_rational_nodes(self) -> Self:
-        """Admit only prefixes whose degree-n orthogonal polynomial splits
-        into distinct linear factors over QQ.
-
-        The exact-node contract carries canonical rationals; algebraic
-        nodes such as +-sqrt(1/3) cannot be represented, so such prefixes
-        are rejected here instead of failing during execution. Gaussian
-        construction divides by norms only through p_{n-1}, so a vanishing
-        terminal norm (a measure supported on exactly n points) stays
-        admissible.
-        """
-        from fractions import Fraction
-
-        import sympy
-
         from jacobian.math.moments_orthogonal.operations import (
-            _build_quadrature_rule,
-            _construct_monic_orthogonal_polynomial,
-            _fraction_exceeds_canonical_limit,
+            GaussianQuadratureAdmissionError,
+            require_gaussian_quadrature_admission,
         )
 
-        moments = [Fraction(*v.as_integer_ratio()) for v in self.prefix.moments]
-        coefficients = _construct_monic_orthogonal_polynomial(moments, self.order)
-        x = sympy.Symbol(self.prefix.variable)
-        poly = sum(coefficient * x**i for i, coefficient in enumerate(coefficients))
-        _, factors = sympy.factor_list(poly)
-        if any(
-            sympy.degree(factor, x) != 1 or multiplicity != 1
-            for factor, multiplicity in factors
-        ):
-            raise _validation_error(
-                "rational_nodes",
-                f"quadrature order {self.order} requires p_{self.order} to "
-                "split into distinct linear factors over QQ so every node "
-                "is an exact rational; this moment prefix yields algebraic "
-                "or repeated nodes",
-            )
-        # Positive weights are part of the declared contract; replay the
-        # exact construction so a nonpositive weight is rejected here
-        # instead of raising during execution.
-        _nodes, weights = _build_quadrature_rule(self.prefix, self.order)
-        # Derived nodes and weights can leave the canonical range even when
-        # every input moment stays inside it; measure the exact Fractions
-        # before execution converts them.
-        if any(
-            _fraction_exceeds_canonical_limit(value) for value in (*_nodes, *weights)
-        ):
-            raise _validation_error(
-                "quadrature_height",
-                "derived quadrature nodes or weights exceed the canonical "
-                "rational digit limit; supply a moment prefix whose exact "
-                "rule stays representable",
-            )
-        if any(weight <= 0 for weight in weights):
-            raise _validation_error(
-                "positive_weights",
-                "quadrature admission requires strictly positive weights; "
-                "this moment prefix yields a nonpositive weight",
-            )
+        try:
+            require_gaussian_quadrature_admission(self.prefix, self.order)
+        except GaussianQuadratureAdmissionError as exc:
+            raise _validation_error(exc.reason, str(exc)) from None
         return self
 
 

--- a/src/jacobian/math/moments_orthogonal/_models.py
+++ b/src/jacobian/math/moments_orthogonal/_models.py
@@ -94,13 +94,15 @@ class HankelRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_sufficient_moments(self) -> Self:
-        needed = 2 * self.order + 1
-        if len(self.prefix.moments) < needed:
-            raise _validation_error(
-                "insufficient_moments",
-                f"need at least {needed} moments for order {self.order}, got {len(self.prefix.moments)}",
-            )
-        _require_determinant_representable(self.prefix.moments, self.order)
+        from jacobian.math.moments_orthogonal.operations import (
+            HankelMatrixAdmissionError,
+            require_hankel_matrix_admission,
+        )
+
+        try:
+            require_hankel_matrix_admission(self.prefix, self.order, shifted=False)
+        except HankelMatrixAdmissionError as exc:
+            raise _validation_error(exc.reason, str(exc)) from None
         return self
 
 
@@ -115,15 +117,15 @@ class ShiftedHankelRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_sufficient_moments(self) -> Self:
-        needed = 2 * self.order + 2
-        if len(self.prefix.moments) < needed:
-            raise _validation_error(
-                "insufficient_moments",
-                f"need at least {needed} moments for shifted order {self.order}, got {len(self.prefix.moments)}",
-            )
-        # The shifted determinant consumes mu_1..mu_(2r+1); bound exactly
-        # that slice so det H_r^(1) stays canonical.
-        _require_determinant_representable(self.prefix.moments[1:], self.order)
+        from jacobian.math.moments_orthogonal.operations import (
+            HankelMatrixAdmissionError,
+            require_hankel_matrix_admission,
+        )
+
+        try:
+            require_hankel_matrix_admission(self.prefix, self.order, shifted=True)
+        except HankelMatrixAdmissionError as exc:
+            raise _validation_error(exc.reason, str(exc)) from None
         return self
 
 
@@ -260,61 +262,15 @@ class JacobiMatrixRequest(StrictModel):
         height. Reject such families here so every accepted request can
         return its declared result.
         """
-        from fractions import Fraction
+        from jacobian.math.moments_orthogonal._jacobi import (
+            JacobiMatrixAdmissionError,
+            require_jacobi_matrix_admission,
+        )
 
-        polys = self.family.polynomials
-        # A canonical rational carries at most MAX_CANONICAL_RATIONAL_DIGITS
-        # digits, i.e. its absolute value stays below 10**that limit.
-        digit_limit = 10**MAX_CANONICAL_RATIONAL_DIGITS
-        # Derived alphas: alpha_0 = -p_1's constant term; for k >= 1 the
-        # residual x*p_k - p_{k+1} carries alpha_k on p_k. Each emitted
-        # entry must stay canonical before the operation converts it.
-        for k in range(len(polys) - 1):
-            p_k = [c.as_fraction() for c in polys[k].coefficients]
-            p_next = [c.as_fraction() for c in polys[k + 1].coefficients]
-            if k == 0:
-                alpha_k = -p_next[0]
-            else:
-                x_pk = [Fraction(0)] * (len(p_k) + 1)
-                for i, coefficient in enumerate(p_k):
-                    x_pk[i + 1] = coefficient
-                residual = [
-                    (x_pk[i] - p_next[i]) if i < len(p_next) else x_pk[i]
-                    for i in range(len(x_pk))
-                ]
-                alpha_k = residual[k] if k < len(residual) else Fraction(0)
-            if (
-                abs(alpha_k.numerator) >= digit_limit
-                or alpha_k.denominator >= digit_limit
-            ):
-                raise _validation_error(
-                    "recurrence_height",
-                    f"derived recurrence entry alpha_{k} exceeds the "
-                    "canonical rational digit limit; supply a family whose "
-                    "coefficient differences stay representable",
-                )
-        # The operation derives norm ratios h_k/h_{k-1} only for the
-        # interior steps that actually appear in the (n-1)-dimensional
-        # matrix; terminal ratios are never emitted and must not gate
-        # admission.
-        for k in range(1, len(polys) - 1):
-            h_k = polys[k].squared_norm.as_fraction()
-            h_prev = polys[k - 1].squared_norm.as_fraction()
-            if h_prev == 0 or h_k == 0:
-                raise _validation_error(
-                    "norm_ratio",
-                    f"adjacent-norm ratio beta_{k} is undefined because "
-                    f"squared norm h_{k - 1 if h_prev == 0 else k} vanishes; "
-                    "supply a family with nonzero norms for every emitted ratio",
-                )
-            ratio = h_k / h_prev
-            if abs(ratio.numerator) >= digit_limit or ratio.denominator >= digit_limit:
-                raise _validation_error(
-                    "norm_ratio_height",
-                    f"adjacent-norm ratio beta_{k} exceeds the canonical "
-                    "rational digit limit; supply a family whose squared "
-                    "norm ratios stay representable",
-                )
+        try:
+            require_jacobi_matrix_admission(self.family)
+        except JacobiMatrixAdmissionError as exc:
+            raise _validation_error(exc.reason, str(exc)) from None
         return self
 
 

--- a/src/jacobian/math/moments_orthogonal/_models.py
+++ b/src/jacobian/math/moments_orthogonal/_models.py
@@ -7,12 +7,7 @@ from typing import Self
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
-from jacobian._exact import (
-    MAX_CANONICAL_RATIONAL_DIGITS,
-    CanonicalRational,
-)
 from jacobian._models import StrictModel
-from jacobian.math._rational_height import RationalHeight
 from jacobian.math.moments_orthogonal.values import (
     MAX_HANKEL_ORDER,
     MAX_POLYNOMIAL_DEGREE,
@@ -23,28 +18,6 @@ from jacobian.math.moments_orthogonal.values import (
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"moments_orthogonal.{reason}", message)
-
-
-def _require_determinant_representable(
-    moments: tuple[CanonicalRational, ...], order: int
-) -> None:
-    """Bound entry heights so the exact determinant stays canonical.
-
-    The determinant of an (order+1)-square rational matrix carries at most
-    roughly (order+1)^2 * H digits for H-digit entries; capping each
-    moment's height keeps it inside MAX_CANONICAL_RATIONAL_DIGITS.
-    """
-    per_entry = MAX_CANONICAL_RATIONAL_DIGITS // ((order + 1) ** 2)
-    # A determinant reads 2r+1 consecutive moments; the shifted variant
-    # consumes mu_1..mu_(2r+1). Unconsumed moments must not prevent
-    # composition.
-    for value in moments[: 2 * order + 1]:
-        if RationalHeight.from_canonical(value).exceeds(max(per_entry - 2, 8)):
-            raise _validation_error(
-                "determinant_height",
-                f"moment heights exceed the conservative {max(per_entry - 2, 8)}-digit "
-                f"bound for an exact order-{order} determinant",
-            )
 
 
 class HankelRequest(StrictModel):

--- a/src/jacobian/math/moments_orthogonal/native.py
+++ b/src/jacobian/math/moments_orthogonal/native.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
+from jacobian.math.moments_orthogonal._jacobi import (
+    jacobi_matrix_from_family,
+    require_jacobi_matrix_admission,
+)
 from jacobian.math.moments_orthogonal._models import (
     GaussianQuadratureRequest,
-    HankelRequest,
-    JacobiMatrixRequest,
-    ShiftedHankelRequest,
 )
 from jacobian.math.moments_orthogonal.operations import (
     _require_gram_schmidt_admission,
     christoffel_darboux_kernel_from_family,
     compute_gaussian_quadrature,
-    compute_hankel_matrix,
-    compute_jacobi_matrix,
-    compute_shifted_hankel,
+    hankel_matrix_from_prefix,
     orthogonal_polynomials_from_moments,
     recurrence_coefficients_from_family,
+    require_hankel_matrix_admission,
 )
 from jacobian.math.moments_orthogonal.values import (
     ChristoffelDarbouxKernel,
@@ -41,14 +41,16 @@ __all__ = [
 
 def hankel_matrix(prefix: MomentFunctionalPrefix, order: int) -> HankelMomentMatrix:
     """Exact Hankel matrix H_order[i,j] = mu_(i+j) of one moment prefix."""
-    return compute_hankel_matrix(HankelRequest(prefix=prefix, order=order))
+    require_hankel_matrix_admission(prefix, order, shifted=False)
+    return hankel_matrix_from_prefix(prefix, order, shifted=False)
 
 
 def shifted_hankel_matrix(
     prefix: MomentFunctionalPrefix, order: int
 ) -> HankelMomentMatrix:
     """Exact shifted Hankel matrix H_order^(1)[i,j] = mu_(i+j+1)."""
-    return compute_shifted_hankel(ShiftedHankelRequest(prefix=prefix, order=order))
+    require_hankel_matrix_admission(prefix, order, shifted=True)
+    return hankel_matrix_from_prefix(prefix, order, shifted=True)
 
 
 def orthogonal_polynomials(
@@ -79,7 +81,8 @@ def christoffel_darboux_kernel(
 
 def jacobi_matrix(family: OrthogonalPolynomialFamily) -> JacobiMatrix:
     """Exact finite tridiagonal Jacobi matrix of one orthogonal family."""
-    return compute_jacobi_matrix(JacobiMatrixRequest(family=family))
+    require_jacobi_matrix_admission(family)
+    return jacobi_matrix_from_family(family)
 
 
 def gaussian_quadrature_rule(

--- a/src/jacobian/math/moments_orthogonal/native.py
+++ b/src/jacobian/math/moments_orthogonal/native.py
@@ -6,16 +6,14 @@ from jacobian.math.moments_orthogonal._jacobi import (
     jacobi_matrix_from_family,
     require_jacobi_matrix_admission,
 )
-from jacobian.math.moments_orthogonal._models import (
-    GaussianQuadratureRequest,
-)
 from jacobian.math.moments_orthogonal.operations import (
     _require_gram_schmidt_admission,
     christoffel_darboux_kernel_from_family,
-    compute_gaussian_quadrature,
+    gaussian_quadrature_rule_from_prefix,
     hankel_matrix_from_prefix,
     orthogonal_polynomials_from_moments,
     recurrence_coefficients_from_family,
+    require_gaussian_quadrature_admission,
     require_hankel_matrix_admission,
 )
 from jacobian.math.moments_orthogonal.values import (
@@ -89,6 +87,5 @@ def gaussian_quadrature_rule(
     prefix: MomentFunctionalPrefix, order: int
 ) -> GaussianQuadratureRule:
     """Exact Gaussian quadrature rule of one bounded moment prefix."""
-    return compute_gaussian_quadrature(
-        GaussianQuadratureRequest(prefix=prefix, order=order)
-    )
+    require_gaussian_quadrature_admission(prefix, order)
+    return gaussian_quadrature_rule_from_prefix(prefix, order)

--- a/src/jacobian/math/moments_orthogonal/operations.py
+++ b/src/jacobian/math/moments_orthogonal/operations.py
@@ -37,6 +37,18 @@ class HankelMatrixAdmissionError(ValueError):
         self.reason = reason
 
 
+class MomentsOrthogonalAdmissionError(ValueError):
+    """A shared value-based admission failure for moment operations."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+class GaussianQuadratureAdmissionError(MomentsOrthogonalAdmissionError):
+    """A value-based Gaussian-quadrature admission failure."""
+
+
 def _to_fraction(r: CanonicalRational) -> Fraction:
     # Canonical chunked parsing: int() on the decimal strings would trip
     # CPython's 4300-digit conversion limit inside the admitted range.
@@ -59,6 +71,25 @@ def _fraction_exceeds_canonical_limit(value: Fraction) -> bool:
         abs(value.numerator) >= _CANONICAL_DIGIT_LIMIT
         or value.denominator >= _CANONICAL_DIGIT_LIMIT
     )
+
+
+def _require_gram_schmidt_heights_admissible(
+    moments: tuple[CanonicalRational, ...], max_degree: int
+) -> None:
+    """Bound moment heights before exact Gram-Schmidt projection begins."""
+    if max_degree == 0:
+        return
+    side = max_degree + 1
+    per_entry = (MAX_CANONICAL_RATIONAL_DIGITS - 2 * side) // (2 * side * (side + 1))
+    bound = max(per_entry, 8)
+    for value in moments[: 2 * max_degree + 1]:
+        if RationalHeight.from_canonical(value).exceeds(bound):
+            raise MomentsOrthogonalAdmissionError(
+                "gram_schmidt_height",
+                f"moment heights exceed the conservative {bound}-digit "
+                f"bound for exact degree-{max_degree} Gram-Schmidt; supply "
+                "a smaller or better-scaled moment prefix",
+            )
 
 
 def _rational_det(matrix: list[list[Fraction]]) -> Fraction:
@@ -372,9 +403,6 @@ def _require_gram_schmidt_admission(
     prefix silently reads missing moments as zero) or accepting
     unsupported degrees.
     """
-    from jacobian.math.moments_orthogonal._models import (
-        _require_gram_schmidt_heights_admissible,
-    )
     from jacobian.math.moments_orthogonal.values import MAX_POLYNOMIAL_DEGREE
 
     if not 0 <= max_degree <= MAX_POLYNOMIAL_DEGREE:
@@ -604,66 +632,96 @@ def _build_quadrature_rule(
     return nodes, weights
 
 
+def require_gaussian_quadrature_admission(
+    prefix: MomentFunctionalPrefix, order: int
+) -> None:
+    """Admit a canonical prefix for one exact rational Gaussian rule."""
+    from jacobian.math.moments_orthogonal.values import MAX_QUADRATURE_ORDER
+
+    if (
+        isinstance(order, bool)
+        or not isinstance(order, int)
+        or not 1 <= order <= MAX_QUADRATURE_ORDER
+    ):
+        raise GaussianQuadratureAdmissionError(
+            "order_out_of_range",
+            f"quadrature order must be an integer between 1 and {MAX_QUADRATURE_ORDER}",
+        )
+    try:
+        _require_gram_schmidt_heights_admissible(prefix.moments, order)
+    except MomentsOrthogonalAdmissionError as exc:
+        raise GaussianQuadratureAdmissionError(exc.reason, str(exc)) from None
+    needed = 2 * order
+    if len(prefix.moments) < needed:
+        raise GaussianQuadratureAdmissionError(
+            "insufficient_moments",
+            f"need at least {needed} moments for quadrature order {order}, got "
+            f"{len(prefix.moments)}",
+        )
+
+    import sympy
+
+    moments = [_to_fraction(value) for value in prefix.moments]
+    coefficients = _construct_monic_orthogonal_polynomial(moments, order)
+    variable = sympy.Symbol(prefix.variable)
+    polynomial = sum(
+        coefficient * variable**index for index, coefficient in enumerate(coefficients)
+    )
+    _, factors = sympy.factor_list(polynomial)
+    if any(
+        sympy.degree(factor, variable) != 1 or multiplicity != 1
+        for factor, multiplicity in factors
+    ):
+        raise GaussianQuadratureAdmissionError(
+            "rational_nodes",
+            f"quadrature order {order} requires p_{order} to split into "
+            "distinct linear factors over QQ so every node is an exact rational; "
+            "this moment prefix yields algebraic or repeated nodes",
+        )
+    nodes, weights = _build_quadrature_rule(prefix, order)
+    if any(_fraction_exceeds_canonical_limit(value) for value in (*nodes, *weights)):
+        raise GaussianQuadratureAdmissionError(
+            "quadrature_height",
+            "derived quadrature nodes or weights exceed the canonical rational "
+            "digit limit; supply a moment prefix whose exact rule stays "
+            "representable",
+        )
+    if any(weight <= 0 for weight in weights):
+        raise GaussianQuadratureAdmissionError(
+            "positive_weights",
+            "quadrature admission requires strictly positive weights; this "
+            "moment prefix yields a nonpositive weight",
+        )
+
+
+def gaussian_quadrature_rule_from_prefix(
+    prefix: MomentFunctionalPrefix, order: int
+) -> GaussianQuadratureRule:
+    """Construct one admitted exact Gaussian quadrature rule."""
+    nodes_frac, weights = _build_quadrature_rule(prefix, order)
+    for k in range(2 * order):
+        approximation = sum(
+            weights[index] * nodes_frac[index] ** k for index in range(order)
+        )
+        if approximation != _to_fraction(prefix.moments[k]):
+            raise ValueError(f"quadrature is not exact at degree {k}")
+    return GaussianQuadratureRule(
+        order=order,
+        nodes=tuple(
+            QuadratureNode(node=_from_fraction(node), weight=_from_fraction(weight))
+            for node, weight in zip(nodes_frac, weights, strict=True)
+        ),
+        variable=prefix.variable,
+        exactness_degree=2 * order - 1,
+        prefix=prefix,
+    )
+
+
 def compute_gaussian_quadrature(
     request: GaussianQuadratureRequest,
 ) -> GaussianQuadratureRule:
-    """Compute an exact Gaussian quadrature rule from moments.
-
-    For small orders, we use the fact that the nodes are roots of the
-    degree-n orthogonal polynomial. We compute weights from the Vandermonde
-    moment system.
-    """
-    n = request.order
-    var = request.prefix.variable
-
-    nodes_frac, weights = _build_quadrature_rule(request.prefix, n)
-
-    # Find rational roots using the rational root theorem
-    # For a monic polynomial with rational coefficients, rational roots
-    # are of the form p/q where p | constant term, q | leading coefficient
-    # Since the polynomial is monic, q = 1, so rational roots are integers
-    # dividing the constant term
-
-    # Actually, for general rational moments, we need to clear denominators
-    # and use the rational root theorem on the resulting integer polynomial
-
-    # For now, let's use numpy or sympy for root finding
-    # But we should use exact methods. Let's try a simple approach:
-    # For small n, we can try all rational candidates
-
-    # Actually, let's use sympy for exact root finding
-    import sympy  # noqa: F401 - availability guard for the exact backend
-
-    if weights is None:
-        raise ValueError("Vandermonde system is singular")
-
-    # Check that all weights are positive
-    for w in weights:
-        if w <= 0:
-            raise ValueError(f"Non-positive weight {w} in Gaussian quadrature")
-
-    # Verify exactness through degree 2n-1 against the retained prefix.
-    prefix_moments = [_to_fraction(m) for m in request.prefix.moments]
-    for k in range(2 * n):
-        approx = sum(weights[i] * nodes_frac[i] ** k for i in range(n))
-        if k < len(prefix_moments) and approx != prefix_moments[k]:
-            raise ValueError(f"Quadrature not exact at degree {k}")
-
-    nodes = [
-        QuadratureNode(
-            node=_from_fraction(nodes_frac[i]),
-            weight=_from_fraction(weights[i]),
-        )
-        for i in range(n)
-    ]
-
-    return GaussianQuadratureRule(
-        order=n,
-        nodes=tuple(nodes),
-        variable=var,
-        exactness_degree=2 * n - 1,
-        prefix=request.prefix,
-    )
+    """MCP adapter: parse one request, call the canonical-prefix kernel."""
+    return gaussian_quadrature_rule_from_prefix(request.prefix, request.order)
 
 
 def _solve_linear_system(

--- a/src/jacobian/math/moments_orthogonal/operations.py
+++ b/src/jacobian/math/moments_orthogonal/operations.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from fractions import Fraction
 
-from jacobian._exact import CanonicalRational
+from jacobian._exact import MAX_CANONICAL_RATIONAL_DIGITS, CanonicalRational
+from jacobian.math._rational_height import RationalHeight
+from jacobian.math.moments_orthogonal._jacobi import jacobi_matrix_from_family
 from jacobian.math.moments_orthogonal._models import (
     ChristoffelDarbouxRequest,
     GaussianQuadratureRequest,
@@ -25,6 +27,14 @@ from jacobian.math.moments_orthogonal.values import (
     QuadratureNode,
     ThreeTermRecurrence,
 )
+
+
+class HankelMatrixAdmissionError(ValueError):
+    """A value-based Hankel admission failure with an owner-local code."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 def _to_fraction(r: CanonicalRational) -> Fraction:
@@ -108,44 +118,75 @@ def _eliminate_below(mat: list[list[Fraction]], rank: int, col: int) -> None:
             mat[row][j] -= factor * mat[rank][j]
 
 
-def compute_hankel_matrix(request: HankelRequest) -> HankelMomentMatrix:
-    """Compute the Hankel matrix H_r[i,j] = mu_(i+j)."""
-    moments = [_to_fraction(m) for m in request.prefix.moments]
-    order = request.order
-    matrix = [[moments[i + j] for j in range(order + 1)] for i in range(order + 1)]
-    det = _rational_det(matrix)
+def require_hankel_matrix_admission(
+    prefix: MomentFunctionalPrefix, order: int, *, shifted: bool
+) -> None:
+    """Validate one canonical prefix for a bounded Hankel construction."""
+    from jacobian.math.moments_orthogonal.values import MAX_HANKEL_ORDER
+
+    maximum = MAX_HANKEL_ORDER - int(shifted)
+    if (
+        isinstance(order, bool)
+        or not isinstance(order, int)
+        or not 0 <= order <= maximum
+    ):
+        raise HankelMatrixAdmissionError(
+            "order_out_of_range",
+            f"Hankel order must be an integer between 0 and {maximum}",
+        )
+    needed = 2 * order + 1 + int(shifted)
+    if len(prefix.moments) < needed:
+        kind = "shifted " if shifted else ""
+        raise HankelMatrixAdmissionError(
+            "insufficient_moments",
+            f"need at least {needed} moments for {kind}order {order}, got "
+            f"{len(prefix.moments)}",
+        )
+    consumed = prefix.moments[1:] if shifted else prefix.moments
+    per_entry = MAX_CANONICAL_RATIONAL_DIGITS // ((order + 1) ** 2)
+    bound = max(per_entry - 2, 8)
+    if any(
+        RationalHeight.from_canonical(value).exceeds(bound)
+        for value in consumed[: 2 * order + 1]
+    ):
+        raise HankelMatrixAdmissionError(
+            "determinant_height",
+            f"moment heights exceed the conservative {bound}-digit bound for "
+            f"an exact order-{order} determinant",
+        )
+
+
+def hankel_matrix_from_prefix(
+    prefix: MomentFunctionalPrefix, order: int, *, shifted: bool
+) -> HankelMomentMatrix:
+    """Compute one admitted ordinary or shifted exact Hankel matrix."""
+    moments = [_to_fraction(moment) for moment in prefix.moments]
+    offset = int(shifted)
+    matrix = [
+        [moments[i + j + offset] for j in range(order + 1)] for i in range(order + 1)
+    ]
+    determinant = _rational_det(matrix)
     rank = _rational_rank(matrix)
-    entries = tuple(
-        tuple(_from_fraction(matrix[i][j]) for j in range(order + 1))
-        for i in range(order + 1)
-    )
     return HankelMomentMatrix(
         order=order,
-        entries=entries,
-        determinant=_from_fraction(det),
+        entries=tuple(
+            tuple(_from_fraction(matrix[i][j]) for j in range(order + 1))
+            for i in range(order + 1)
+        ),
+        determinant=_from_fraction(determinant),
         rank=rank,
-        variable=request.prefix.variable,
+        variable=prefix.variable,
     )
+
+
+def compute_hankel_matrix(request: HankelRequest) -> HankelMomentMatrix:
+    """MCP adapter: parse one request, call the canonical-prefix kernel."""
+    return hankel_matrix_from_prefix(request.prefix, request.order, shifted=False)
 
 
 def compute_shifted_hankel(request: ShiftedHankelRequest) -> HankelMomentMatrix:
-    """Compute the shifted Hankel matrix H_r^(1)[i,j] = mu_(i+j+1)."""
-    moments = [_to_fraction(m) for m in request.prefix.moments]
-    order = request.order
-    matrix = [[moments[i + j + 1] for j in range(order + 1)] for i in range(order + 1)]
-    det = _rational_det(matrix)
-    rank = _rational_rank(matrix)
-    entries = tuple(
-        tuple(_from_fraction(matrix[i][j]) for j in range(order + 1))
-        for i in range(order + 1)
-    )
-    return HankelMomentMatrix(
-        order=order,
-        entries=entries,
-        determinant=_from_fraction(det),
-        rank=rank,
-        variable=request.prefix.variable,
-    )
+    """MCP adapter: parse one request, call the canonical-prefix kernel."""
+    return hankel_matrix_from_prefix(request.prefix, request.order, shifted=True)
 
 
 def _poly_eval(coeffs: list[Fraction], x: Fraction) -> Fraction:
@@ -514,68 +555,8 @@ def compute_christoffel_darboux(
 
 
 def compute_jacobi_matrix(request: JacobiMatrixRequest) -> JacobiMatrix:
-    """Compute the finite Jacobi matrix from the orthogonal polynomial family."""
-    family = request.family
-    polys = family.polynomials
-    n = len(polys)
-
-    if n < 2:
-        return JacobiMatrix(
-            alphas=(),
-            betas=(),
-            matrix=(),
-            variable=family.variable,
-        )
-
-    alphas: list[Fraction] = []
-    betas: list[Fraction] = []
-
-    for k in range(n - 1):
-        p_k = [_to_fraction(c) for c in polys[k].coefficients]
-        p_next = [_to_fraction(c) for c in polys[k + 1].coefficients]
-        squared_norm_k = _to_fraction(polys[k].squared_norm)
-
-        if k == 0:
-            alphas.append(-p_next[0])
-            betas.append(Fraction(0))
-        else:
-            squared_norm_prev = _to_fraction(polys[k - 1].squared_norm)
-
-            x_pk = [Fraction(0)] * (len(p_k) + 1)
-            for i in range(len(p_k)):
-                x_pk[i + 1] = p_k[i]
-
-            residual = [
-                x_pk[i] - p_next[i] if i < len(p_next) else x_pk[i]
-                for i in range(len(x_pk))
-            ]
-            alpha_k = residual[k] if k < len(residual) else Fraction(0)
-            alphas.append(alpha_k)
-
-            # Admission guarantees every norm feeding an emitted ratio is
-            # nonzero.
-            betas.append(squared_norm_k / squared_norm_prev)
-
-    matrix_size = n - 1
-    matrix = [[Fraction(0)] * matrix_size for _ in range(matrix_size)]
-    for i in range(matrix_size):
-        matrix[i][i] = alphas[i]
-        if i < matrix_size - 1:
-            # Monic-basis multiplication by x: x p_k = p_{k+1} + alpha_k p_k
-            # + beta_k p_{k-1}, so the subdiagonal carries the monic
-            # normalization 1 and the superdiagonal carries beta_{i+1}.
-            matrix[i + 1][i] = Fraction(1)
-            matrix[i][i + 1] = betas[i + 1]
-
-    return JacobiMatrix(
-        alphas=tuple(_from_fraction(a) for a in alphas),
-        betas=tuple(_from_fraction(b) for b in betas),
-        matrix=tuple(
-            tuple(_from_fraction(matrix[i][j]) for j in range(matrix_size))
-            for i in range(matrix_size)
-        ),
-        variable=family.variable,
-    )
+    """MCP adapter: parse one request, call the canonical-family kernel."""
+    return jacobi_matrix_from_family(request.family)
 
 
 def _construct_quadrature_rule(

--- a/tests/math/moments_orthogonal/test_moments.py
+++ b/tests/math/moments_orthogonal/test_moments.py
@@ -1208,6 +1208,49 @@ class TestAdmissionReplaysExecution:
 
 
 class TestNativeAdmission:
+    def test_native_hankel_surfaces_match_mcp_adapters(self) -> None:
+        """Native Hankel calls consume the canonical prefix without a request."""
+        from jacobian.math.moments_orthogonal import (
+            hankel_matrix,
+            shifted_hankel_matrix,
+        )
+        from jacobian.math.moments_orthogonal.values import MomentFunctionalPrefix
+
+        restored = MomentFunctionalPrefix.model_validate_json(
+            _prefix(_moments_uniform(6)).model_dump_json()
+        )
+        assert hankel_matrix(restored, 2) == compute_hankel_matrix(
+            HankelRequest(prefix=restored, order=2)
+        )
+        assert shifted_hankel_matrix(restored, 2) == compute_shifted_hankel(
+            ShiftedHankelRequest(prefix=restored, order=2)
+        )
+
+    def test_native_jacobi_composes_serialized_family_and_matches_mcp_adapter(
+        self,
+    ) -> None:
+        """A native family producer composes into the native Jacobi kernel.
+
+        The JSON round trip models a canonical producer payload received by a
+        second native caller. The direct and MCP paths retain one identical
+        result value while each owns its proper input boundary.
+        """
+        from jacobian.math.moments_orthogonal import (
+            jacobi_matrix,
+            orthogonal_polynomials,
+        )
+        from jacobian.math.moments_orthogonal.values import (
+            OrthogonalPolynomialFamily,
+        )
+
+        family = orthogonal_polynomials(_prefix(_moments_uniform(7)), 3)
+        restored = OrthogonalPolynomialFamily.model_validate_json(
+            family.model_dump_json()
+        )
+        expected = compute_jacobi_matrix(JacobiMatrixRequest(family=restored))
+
+        assert jacobi_matrix(restored) == expected
+
     def test_native_short_prefix_rejected_before_kernel(self) -> None:
         """The native surface applies the shared moment-count admission so
         it cannot fabricate omitted moments as zeros."""

--- a/tests/math/moments_orthogonal/test_moments.py
+++ b/tests/math/moments_orthogonal/test_moments.py
@@ -1208,6 +1208,18 @@ class TestAdmissionReplaysExecution:
 
 
 class TestNativeAdmission:
+    def test_native_quadrature_matches_mcp_adapter(self) -> None:
+        """Native quadrature consumes a canonical prefix without a request."""
+        from jacobian.math.moments_orthogonal import gaussian_quadrature_rule
+        from jacobian.math.moments_orthogonal.values import MomentFunctionalPrefix
+
+        restored = MomentFunctionalPrefix.model_validate_json(
+            _prefix(_moments_uniform(3)).model_dump_json()
+        )
+        assert gaussian_quadrature_rule(restored, 1) == compute_gaussian_quadrature(
+            GaussianQuadratureRequest(prefix=restored, order=1)
+        )
+
     def test_native_hankel_surfaces_match_mcp_adapters(self) -> None:
         """Native Hankel calls consume the canonical prefix without a request."""
         from jacobian.math.moments_orthogonal import (


### PR DESCRIPTION
Part of #2609.

Native callers for the moments/orthogonal family rebuilt wire request models and routed through MCP adapters. That made native composition depend on a transport envelope and repeated request admission.

This change gives Hankel, shifted-Hankel, Jacobi-matrix, and Gaussian-quadrature native APIs shared owner-local admission plus typed value kernels. MCP request validators and adapters retain their boundary role and delegate to those same kernels; the obsolete wire-only determinant helper is removed.

The added regressions serialize and parse canonical moment-prefix and orthogonal-family values, consume them through the public native API, and compare each result with the corresponding MCP adapter. They use no test doubles or implementation-shaped assertions.

This is intentionally one moments/orthogonal slice of #2609. It does not add the issue’s proposed repository-wide static-contract checker.

### Validation

- `make test-focused LANE=math TESTS=tests/math/moments_orthogonal` — 64 passed
- `make test-focused LANE=catalog TESTS=tests/catalog` — 46 passed
- `make check` — 6,371 passed; Ruff, formatting, and mypy passed