### PR TITLE
fix(mcp): prevent host ExceptionGroup on operation failures

### DIFF
--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -116,7 +116,7 @@ def math_run(
             message="operation payload failed validation",
             data=data.model_dump(mode="json"),
         ) from exc
-    except Exception as exc:  # noqa: BLE001 - math has no sensitive errors
+    except Exception as exc:
         raise ToolError(str(exc) or "operation failed") from exc
 
 

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -116,6 +116,8 @@ def math_run(
             message="operation payload failed validation",
             data=data.model_dump(mode="json"),
         ) from exc
+    except Exception as exc:  # noqa: BLE001 - math has no sensitive errors
+        raise ToolError(str(exc) or "operation failed") from exc
 
 
 def _request_cancellation(ctx: Context[AppState, Any]) -> _CancellationSignal:

--- a/tests/integration/catalog/test_mcp_builtin_examples.py
+++ b/tests/integration/catalog/test_mcp_builtin_examples.py
@@ -1,0 +1,110 @@
+"""MCP-level executable contracts for every advertised catalog example.
+
+Covers the transport projection (`src/jacobian/mcp/tools.py:91 math_run`)
+in addition to the dispatch path (`tests/integration/catalog/test_builtin_examples.py:27`).
+Sequential replay avoids the known concurrent-worker segfault while still
+establishing that every published example returns a mathematical value rather
+than a host-level ExceptionGroup. See https://github.com/morluto/jacobian/issues/2713.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from mcp import Client
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.mcp.server import create_server
+
+_CATALOG = Catalog.open()
+
+
+def test_mcp_advertised_examples_execute_as_typed_results() -> None:
+    async def scenario() -> None:
+        catalog = Catalog.open()
+        failures: list[str] = []
+        async with Client(create_server(), raise_exceptions=False) as client:
+            for descriptor in catalog.snapshot().operations:
+                operation = catalog.operation(descriptor.operation_id)
+                assert operation is not None
+                assert operation.examples, f"{descriptor.operation_id} must advertise an example"
+                for example in operation.examples:
+                    payload = dict(example.input)
+                    result = await client.call_tool(
+                        "math.run",
+                        {"operation_id": descriptor.operation_id, "payload": payload},
+                    )
+                    if result.is_error:
+                        text = result.content[0].text if result.content else "<no content>"
+                        failures.append(f"{descriptor.operation_id} {example.name}: is_error {text[:500]}")
+                        continue
+                    structured = result.structured_content
+                    if not isinstance(structured, dict) or "output" not in structured:
+                        failures.append(f"{descriptor.operation_id} {example.name}: missing output {structured}")
+                        continue
+                    output = structured["output"]
+                    try:
+                        validated = operation.result_type.model_validate(output)
+                    except Exception as exc:  # noqa: BLE001
+                        failures.append(f"{descriptor.operation_id} {example.name}: result validation {exc} output={json.dumps(output)[:500]}")
+                        continue
+                    if validated.model_dump(mode="json") != output:
+                        failures.append(f"{descriptor.operation_id} {example.name}: round-trip mismatch")
+                    if structured.get("operation_id") != descriptor.operation_id:
+                        failures.append(f"{descriptor.operation_id}: operation_id mismatch in MCP output")
+                    if not isinstance(structured.get("runtime_ms"), int) or structured["runtime_ms"] < 0:
+                        failures.append(f"{descriptor.operation_id}: missing/invalid runtime_ms")
+        assert not failures, "MCP example replay failures:\n" + "\n".join(failures)
+
+    asyncio.run(scenario())
+
+
+def test_mcp_host_failures_are_not_exception_groups() -> None:
+    """A broken operation must return ToolError, not a host ExceptionGroup."""
+
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+    from jacobian.catalog.models import MathTool
+    from jacobian._models import StrictModel
+    from pydantic import Field
+
+    class BoomRequest(StrictModel):
+        x: int = Field(ge=0)
+
+    class BoomResult(StrictModel):
+        y: int
+
+    def boom(_request: BoomRequest) -> BoomResult:
+        raise RuntimeError("synthetic boom")
+
+    boom_tool = MathTool(
+        operation_id="test.synthetic.boom",
+        title="Synthetic boom",
+        description="Always raises.",
+        request_type=BoomRequest,
+        result_type=BoomResult,
+        run=boom,
+    )
+
+    catalog = Catalog((*BUILTIN_TOOLS, boom_tool))
+
+    from jacobian.mcp.runtime import AppState
+    from jacobian.mcp.server import _build_server
+
+    server = _build_server(state=AppState(operation_catalog=catalog))
+
+    async def scenario() -> None:
+        async with Client(server, raise_exceptions=False) as client:
+            result = await client.call_tool(
+                "math.run",
+                {"operation_id": "test.synthetic.boom", "payload": {"x": 1}},
+            )
+            # Must be a bounded tool error, not an unhandled ExceptionGroup / crash.
+            assert result.is_error is True
+            assert result.structured_content is None
+            text = result.content[0].text if result.content else ""
+            assert "synthetic boom" in text
+            assert len(text) < 5000
+
+    asyncio.run(scenario())

--- a/tests/integration/catalog/test_mcp_builtin_examples.py
+++ b/tests/integration/catalog/test_mcp_builtin_examples.py
@@ -12,11 +12,9 @@ from __future__ import annotations
 import asyncio
 import json
 
-import pytest
-from mcp import Client
-
 from jacobian.catalog.catalog import Catalog
 from jacobian.mcp.server import create_server
+from mcp import Client
 
 _CATALOG = Catalog.open()
 
@@ -29,7 +27,9 @@ def test_mcp_advertised_examples_execute_as_typed_results() -> None:
             for descriptor in catalog.snapshot().operations:
                 operation = catalog.operation(descriptor.operation_id)
                 assert operation is not None
-                assert operation.examples, f"{descriptor.operation_id} must advertise an example"
+                assert operation.examples, (
+                    f"{descriptor.operation_id} must advertise an example"
+                )
                 for example in operation.examples:
                     payload = dict(example.input)
                     result = await client.call_tool(
@@ -37,25 +37,42 @@ def test_mcp_advertised_examples_execute_as_typed_results() -> None:
                         {"operation_id": descriptor.operation_id, "payload": payload},
                     )
                     if result.is_error:
-                        text = result.content[0].text if result.content else "<no content>"
-                        failures.append(f"{descriptor.operation_id} {example.name}: is_error {text[:500]}")
+                        text = (
+                            result.content[0].text if result.content else "<no content>"
+                        )
+                        failures.append(
+                            f"{descriptor.operation_id} {example.name}: is_error {text[:500]}"
+                        )
                         continue
                     structured = result.structured_content
                     if not isinstance(structured, dict) or "output" not in structured:
-                        failures.append(f"{descriptor.operation_id} {example.name}: missing output {structured}")
+                        failures.append(
+                            f"{descriptor.operation_id} {example.name}: missing output {structured}"
+                        )
                         continue
                     output = structured["output"]
                     try:
                         validated = operation.result_type.model_validate(output)
-                    except Exception as exc:  # noqa: BLE001
-                        failures.append(f"{descriptor.operation_id} {example.name}: result validation {exc} output={json.dumps(output)[:500]}")
+                    except Exception as exc:
+                        failures.append(
+                            f"{descriptor.operation_id} {example.name}: result validation {exc} output={json.dumps(output)[:500]}"
+                        )
                         continue
                     if validated.model_dump(mode="json") != output:
-                        failures.append(f"{descriptor.operation_id} {example.name}: round-trip mismatch")
+                        failures.append(
+                            f"{descriptor.operation_id} {example.name}: round-trip mismatch"
+                        )
                     if structured.get("operation_id") != descriptor.operation_id:
-                        failures.append(f"{descriptor.operation_id}: operation_id mismatch in MCP output")
-                    if not isinstance(structured.get("runtime_ms"), int) or structured["runtime_ms"] < 0:
-                        failures.append(f"{descriptor.operation_id}: missing/invalid runtime_ms")
+                        failures.append(
+                            f"{descriptor.operation_id}: operation_id mismatch in MCP output"
+                        )
+                    if (
+                        not isinstance(structured.get("runtime_ms"), int)
+                        or structured["runtime_ms"] < 0
+                    ):
+                        failures.append(
+                            f"{descriptor.operation_id}: missing/invalid runtime_ms"
+                        )
         assert not failures, "MCP example replay failures:\n" + "\n".join(failures)
 
     asyncio.run(scenario())
@@ -64,10 +81,11 @@ def test_mcp_advertised_examples_execute_as_typed_results() -> None:
 def test_mcp_host_failures_are_not_exception_groups() -> None:
     """A broken operation must return ToolError, not a host ExceptionGroup."""
 
+    from pydantic import Field
+
+    from jacobian._models import StrictModel
     from jacobian.catalog.builtins import BUILTIN_TOOLS
     from jacobian.catalog.models import MathTool
-    from jacobian._models import StrictModel
-    from pydantic import Field
 
     class BoomRequest(StrictModel):
         x: int = Field(ge=0)


### PR DESCRIPTION
Fixes #2713

## Root cause
`src/jacobian/mcp/tools.py:91 math_run` only mapped `OperationRequestValidationError` to `MCPError -32602`. Any other exception from `operation.run` (`src/jacobian/dispatch.py:71`) propagated through `anyio.to_thread.run_sync` and surfaced as host-level `ExceptionGroup: unhandled errors in a TaskGroup` / SIGSEGV under sustained concurrent load. The reported `abelian_group.element.order.compute` (`order_in_z6` `{"invariant_factors":[6],"coordinates":[2]}` → `order 3`) passes in isolation via both dispatch and MCP sequential, but the host boundary was not fail-closed.

Math has no sensitive errors, so generic failures can be returned as bounded `ToolError`.

## Fix
- `src/jacobian/mcp/tools.py:91` — add `except Exception` → `ToolError(str(exc))` (no sensitive data, bounded by MCP).
- Add catalog-wide MCP replay invariant `tests/integration/catalog/test_mcp_builtin_examples.py` — sequential `mcp.Client(create_server())` over all 607 ops / 641 examples, validates `result_type` round-trip and `runtime_ms`. Also asserts synthetic boom returns `ToolError` not `ExceptionGroup`.
- Covers MCP projection in addition to `tests/integration/catalog/test_builtin_examples.py:27` (dispatch). Sequential to avoid known concurrent-worker SIGSEGV after ~180 concurrent `math.run` (see #2713 investigation).

## Validation
- `dispatch` replay 641/641 pass, `mcp` sequential replay 641/641 pass, `math.find` browse 31 pages 607 IDs, invalid payload → `MCPError -32602` not `ExceptionGroup`.
- `pytest tests/integration/catalog/test_mcp_builtin_examples.py` — 2 passed (15.5s).
- `pytest tests/mcp/test_mcp_invocation_journey.py` still passes.
- Manual `abelian_group.element.order.compute` via `mcp.Client` → `{"order":3,"method":"LCM"}`.

## CI weight
MCP replay is ~15s sequential (vs dispatch ~8s). Currently gated by `tools/ci_test_plan.py:128 run_catalog_examples` (shared / math public / `src/jacobian/catalog/` / `src/jacobian/mcp/`), not every PR. If 15s is too heavy for PRs, we can restrict this test to `merge_group`/`push`/`schedule` (non-`pull_request`) or split to a separate lane — currently kept on `catalog_examples` so broken examples are caught before merge. Reviewer call: keep on PR or gate to merge only?

## Open follow-up
Concurrent `math.run` SIGSEGV after ~6×30 batches remains (direct `ThreadPoolExecutor` over dispatch is fine) — out of scope for this PR, documented in #2713. This PR makes the host fail-closed; concurrency hardening (global lock / pool cap) can follow.
