### PR TITLE
Type Z3 initialization failures in unsat-core

### DIFF
--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -332,7 +332,13 @@ def _parsed_request_error(
 ) -> str | None:
     """Inspect parsed terms without attaching Z3 objects to validation errors."""
 
-    import z3
+    try:
+        import z3
+    except (ImportError, OSError):
+        # Backend absence provides no information about caller-controlled
+        # source. Leave this accepted request for execution to report as its
+        # typed UNKNOWN outcome.
+        return None
 
     try:
         assertions = _parse_assertions(smtlib)
@@ -345,7 +351,7 @@ def _parsed_request_error(
                 f"{_MAX_CORE_AST_NODES} distinct AST nodes"
             )
         _require_declared_logic(assertions, logic)
-    except z3.Z3Exception:
+    except (OSError, z3.Z3Exception):
         # A deferred backend failure carries no evidence about this source;
         # execution reports it through the typed UNKNOWN outcome.
         return None
@@ -1228,7 +1234,10 @@ def _bounded_outcome(
 def _extract_source_core(
     source: SmtUnsatCoreRequest,
 ) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], tuple[int, ...], str | None]:
-    import z3
+    try:
+        import z3
+    except (ImportError, OSError) as exc:
+        return "UNKNOWN", (), f"the Z3 backend could not initialize: {exc}"[:1_024]
 
     try:
         context = z3.Context()
@@ -1251,7 +1260,7 @@ def _extract_source_core(
             if tracker.get_id() in core_ids
         )
         return "UNSAT", core_indices, None
-    except (ValueError, z3.Z3Exception):
+    except (OSError, ValueError, z3.Z3Exception):
         return "UNKNOWN", (), "Z3 could not complete the bounded source check."
 
 
@@ -1259,7 +1268,10 @@ def _replay_source(
     source: SmtUnsatCoreRequest,
     selected_indices: tuple[int, ...] | None,
 ) -> tuple[Literal["SAT", "UNSAT", "UNKNOWN"], str | None]:
-    import z3
+    try:
+        import z3
+    except (ImportError, OSError) as exc:
+        return "UNKNOWN", f"the Z3 backend could not initialize: {exc}"[:1_024]
 
     try:
         context = z3.Context()
@@ -1272,7 +1284,7 @@ def _replay_source(
         solver = _configured_solver(source, context=context)
         solver.add(*(assertions[index] for index in selected))
         return _bounded_outcome(solver)
-    except (ValueError, z3.Z3Exception):
+    except (OSError, ValueError, z3.Z3Exception):
         return "UNKNOWN", "Z3 could not complete the bounded source replay."
 
 

--- a/tests/dispatch/test_logic_dispatch.py
+++ b/tests/dispatch/test_logic_dispatch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from jacobian.catalog.catalog import Catalog
@@ -79,3 +81,19 @@ def test_dispatch_reports_memory_exhaustion_for_smt_solve(monkeypatch) -> None:
 
     assert result.output["outcome"] == "UNKNOWN"
     assert result.output["exhausted"] == "memory"
+
+
+def test_dispatch_types_unsat_core_initialization_failure_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable Z3 backend must not turn an accepted request into an import error."""
+
+    monkeypatch.setitem(sys.modules, "z3", None)
+
+    result = invoke_operation(
+        "smt.unsat_core", _contradictory_bounds_core(), Catalog.open()
+    )
+
+    assert result.output["outcome"] == "UNKNOWN"
+    assert result.output["core_indices"] == []
+    assert result.output["detail"].startswith("the Z3 backend could not initialize:")


### PR DESCRIPTION
## Problem

An accepted `smt.unsat_core` request could leak `ImportError` or `OSError` while Z3 initialized during validation, execution, or replay.

## Solution

Keep source validation independent of unavailable backend initialization, and translate Z3 initialization failures to the operation's typed `UNKNOWN` outcome at each owner-local boundary.

## Testing

- `make check` — 6,386 passed
- focused unsat-core math — 112 passed
- focused dispatch — 4 passed
- catalog — 46 passed
- advertised catalog examples — 608 passed
- Ruff, formatting, and diff check

Fixes #2634
Refs #2617