### PR TITLE
fix(mcp): serialize concurrent math execution

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -7,6 +7,12 @@ Jacobian exposes two MCP tools for atomic mathematics.
 - `math.run` executes one operation with a typed `payload` and returns that
   operation's typed mathematical result.
 
+A server may receive multiple `math.run` requests concurrently. Jacobian
+currently serializes mathematical kernel execution within each server instance
+because some maintained computational backends are not thread-safe. Requests
+remain independent; this affects scheduling and throughput, not the
+mathematical result contract.
+
 Built-in membership follows the
 [public mathematical operation admission contract](public-operation-admission.md),
 which keeps the public catalog distinct from the broader native Python API.

--- a/src/jacobian/mcp/runtime.py
+++ b/src/jacobian/mcp/runtime.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from _thread import LockType
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from threading import Lock
 from typing import Any
 
 from mcp.server.mcpserver import Context
@@ -15,6 +17,7 @@ from jacobian.catalog.catalog import Catalog
 class AppState:
     operation_catalog: Catalog
     authorize: Callable[[], None] | None = None
+    execution_lock: LockType = field(default_factory=Lock, repr=False, compare=False)
 
 
 class AuthenticationError(PermissionError):

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -29,6 +29,7 @@ from jacobian.mcp.runtime import (
     AppState,
     _authorize,
     _catalog,
+    _state,
 )
 from jacobian.process import bounded_process_cancellation
 
@@ -103,7 +104,12 @@ def math_run(
         # MCP runs synchronous tools in a worker thread.  Its request event
         # is polled by the shared external-process runner, which kills and
         # reaps only an operation's owned child tree.
-        with bounded_process_cancellation(_request_cancellation(ctx)):
+        # Maintained mathematical backends may retain process-global state
+        # that cannot safely execute on concurrent MCP worker threads.
+        with (
+            bounded_process_cancellation(_request_cancellation(ctx)),
+            _state(ctx).execution_lock,
+        ):
             return invoke_operation(operation_id, payload, catalog)
     except OperationRequestValidationError as exc:
         errors = _bounded_validation_issues(exc.errors())

--- a/tests/integration/catalog/test_mcp_builtin_examples.py
+++ b/tests/integration/catalog/test_mcp_builtin_examples.py
@@ -2,15 +2,18 @@
 
 Covers the transport projection (`src/jacobian/mcp/tools.py:91 math_run`)
 in addition to the dispatch path (`tests/integration/catalog/test_builtin_examples.py:27`).
-Sequential replay avoids the known concurrent-worker segfault while still
-establishing that every published example returns a mathematical value rather
-than a host-level ExceptionGroup. See https://github.com/morluto/jacobian/issues/2713.
+Sequential replay establishes that every published example returns a mathematical
+value rather than a host-level ExceptionGroup. The dedicated concurrent case below
+proves that the server serializes mathematical kernel execution. See
+https://github.com/morluto/jacobian/issues/2720.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import threading
+import time
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.mcp.server import create_server
@@ -124,5 +127,76 @@ def test_mcp_host_failures_are_not_exception_groups() -> None:
             text = result.content[0].text if result.content else ""
             assert "synthetic boom" in text
             assert len(text) < 5000
+
+    asyncio.run(scenario())
+
+
+def test_mcp_concurrent_math_runs_return_serialized_results() -> None:
+    """Concurrent clients must not enter one server's kernels simultaneously."""
+
+    from jacobian._models import StrictModel
+    from jacobian.catalog.builtins import BUILTIN_TOOLS
+    from jacobian.catalog.models import MathTool
+    from jacobian.mcp.runtime import AppState
+    from jacobian.mcp.server import _build_server
+
+    class Request(StrictModel):
+        value: int
+
+    class Result(StrictModel):
+        value: int
+        concurrent_kernel_calls: int
+
+    active_calls = 0
+    active_calls_lock = threading.Lock()
+
+    def serial_kernel(request: Request) -> Result:
+        nonlocal active_calls
+        with active_calls_lock:
+            active_calls += 1
+            concurrent_kernel_calls = active_calls
+        try:
+            # The SDK runs sync tools in worker threads. This pause turns a
+            # missing server gate into an observable, incorrect result.
+            time.sleep(0.025)
+            return Result(
+                value=request.value,
+                concurrent_kernel_calls=concurrent_kernel_calls,
+            )
+        finally:
+            with active_calls_lock:
+                active_calls -= 1
+
+    tool = MathTool(
+        operation_id="test.concurrent.serial_kernel",
+        title="Concurrent execution sentinel",
+        description="Reports concurrent mathematical-kernel calls.",
+        request_type=Request,
+        result_type=Result,
+        run=serial_kernel,
+    )
+    catalog = Catalog((*BUILTIN_TOOLS, tool))
+    server = _build_server(state=AppState(operation_catalog=catalog))
+
+    async def scenario() -> None:
+        async with Client(server, raise_exceptions=False) as client:
+            results = await asyncio.gather(
+                *(
+                    client.call_tool(
+                        "math.run",
+                        {
+                            "operation_id": "test.concurrent.serial_kernel",
+                            "payload": {"value": value},
+                        },
+                    )
+                    for value in range(12)
+                )
+            )
+
+        assert all(not result.is_error for result in results)
+        outputs = [result.structured_content["output"] for result in results]
+        assert outputs == [
+            {"value": value, "concurrent_kernel_calls": 1} for value in range(12)
+        ]
 
     asyncio.run(scenario())


### PR DESCRIPTION
Fixes #2720

## Problem

Concurrent `math.run` requests reach synchronous handlers on MCP worker threads. Several maintained mathematical backends retain state that is unsafe to use concurrently, so mixed catalog calls can corrupt backend state or terminate the host.

## Solution

Each MCP server state now owns one execution lock. `math.run` retains its synchronous worker-thread handler and acquires that lock only while invoking an operation; authorization, catalog lookup, and request validation remain outside the serialized region.

The new integration regression sends 12 `math.run` requests concurrently through one `mcp.Client`. Its sentinel operation returns the request value and the number of active kernel calls; every result must report one active call. Without the gate, overlapping worker calls produce an incorrect result.

The tool reference now documents that concurrent requests are accepted but mathematical kernel execution is currently serialized per server instance. Per-backend concurrency remains a possible later optimization.

## Testing

- `make test-focused LANE=integration TESTS=tests/integration/catalog/test_mcp_builtin_examples.py` — 3 passed.
- `make docs-linkcheck` — documentation commands and Markdown links passed.

- Specialist validation run: `make test-focused LANE=integration TESTS=tests/integration/catalog/test_mcp_builtin_examples.py`

## Public contract impact

No operation IDs, request/result schemas, native API, or mathematical semantics change. Concurrent MCP requests now have a documented scheduling guarantee.

## Operation boundary ownership

- Changed stage: transport projection / execution scheduling.
- Request-bounds owner and controlling quantities: unchanged.
- Backend or kernel path: `math.run` serializes `invoke_operation` per MCP server instance.
- Result construction: unchanged.
- Independent-result verifier: none; this path does not accept independently supplied results.
- Native/MCP parity: mathematical admission and results are unchanged; only MCP scheduling is serialized.
- Serialized-result and round-trip evidence: the concurrent MCP regression asserts each typed result payload exactly.

## Canonical value audit

Not applicable: this changes no mathematical value, request, result, producer, or consumer.

## Closure matrix

none

## Checklist

- [ ] `make check` passes
- [x] Explicitly relevant specialist validation is listed above (boundary, backend, Harbor/Oracle)
- [x] Runtime-bound changes name the request-bounds owner and execute the same semantic path for native and MCP callers (if applicable)
- [x] Result semantics distinguish exact, approximate, incomplete, unknown, and unavailable outcomes where applicable
- [x] Public operation changes include a behavioral regression copied from a motivating parent-gap request, or explain why no source request exists (if applicable)
