### PR TITLE
Publish root-system simple-reflection constraints

### DIFF
--- a/src/jacobian/math/root_systems/_models.py
+++ b/src/jacobian/math/root_systems/_models.py
@@ -25,7 +25,14 @@ def _validation_error(reason: str, message: str) -> PydanticCustomError:
 class CartanMatrixRequest(StrictModel):
     """A bounded finite-type Cartan matrix."""
 
-    matrix: tuple[tuple[int, ...], ...]
+    matrix: tuple[tuple[int, ...], ...] = Field(
+        description=(
+            "Finite-type generalized Cartan matrix of rank 1 through "
+            f"{MAX_RANK}: square, diagonal entries 2, non-positive "
+            "off-diagonal entries with paired products in {0, 1, 2, 3}, "
+            "and positive-definite symmetrization."
+        )
+    )
 
     @model_validator(mode="after")
     def require_valid_cartan(self) -> Self:
@@ -165,11 +172,31 @@ class RootSystemDataResult(StrictModel):
 
 
 class SimpleReflectionRequest(StrictModel):
-    """Request to apply a simple reflection s_i to a root lattice vector."""
+    """One bounded simple reflection on a finite-type root lattice."""
 
-    matrix: tuple[tuple[int, ...], ...]
-    vector: tuple[int, ...] = Field(min_length=1)
-    simple_index: int = Field(ge=0)
+    matrix: tuple[tuple[int, ...], ...] = Field(
+        description=(
+            "Finite-type generalized Cartan matrix of rank 1 through "
+            f"{MAX_RANK}; it must meet the same Cartan conditions as "
+            "``CartanMatrixRequest.matrix``."
+        )
+    )
+    vector: tuple[int, ...] = Field(
+        min_length=1,
+        description=(
+            "Root-lattice coordinates in the matrix's simple-root basis; "
+            "length must equal the Cartan-matrix rank, and each coordinate "
+            f"must lie in [-{MAX_REFLECTION_COORDINATE}, "
+            f"{MAX_REFLECTION_COORDINATE}]."
+        ),
+    )
+    simple_index: int = Field(
+        ge=0,
+        description=(
+            "Zero-based simple-root index; it must be smaller than the "
+            "Cartan-matrix rank."
+        ),
+    )
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:

--- a/src/jacobian/math/root_systems/_models.py
+++ b/src/jacobian/math/root_systems/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -175,13 +175,21 @@ class SimpleReflectionRequest(StrictModel):
     """One bounded simple reflection on a finite-type root lattice."""
 
     matrix: tuple[tuple[int, ...], ...] = Field(
+        min_length=1,
+        max_length=MAX_RANK,
         description=(
             "Finite-type generalized Cartan matrix of rank 1 through "
             f"{MAX_RANK}; it must meet the same Cartan conditions as "
             "``CartanMatrixRequest.matrix``."
-        )
+        ),
     )
-    vector: tuple[int, ...] = Field(
+    vector: tuple[
+        Annotated[
+            int,
+            Field(ge=-MAX_REFLECTION_COORDINATE, le=MAX_REFLECTION_COORDINATE),
+        ],
+        ...,
+    ] = Field(
         min_length=1,
         description=(
             "Root-lattice coordinates in the matrix's simple-root basis; "

--- a/src/jacobian/math/root_systems/_tools.py
+++ b/src/jacobian/math/root_systems/_tools.py
@@ -7,6 +7,7 @@ from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
 from jacobian.math.root_systems._models import (
+    MAX_RANK,
     CartanMatrixRequest,
     RootSystemDataResult,
     SimpleReflectionRequest,
@@ -75,7 +76,8 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         "Apply a simple reflection to a root lattice vector",
         "Apply the simple reflection s_i to a vector in the root lattice "
         "of a finite crystallographic root system defined by its Cartan "
-        "matrix.",
+        f"matrix of rank at most {MAX_RANK}. The vector uses that same "
+        "simple-root axis and the index is zero-based.",
         SimpleReflectionRequest,
         SimpleReflectionResult,
         compute_simple_reflection,
@@ -85,7 +87,9 @@ TOOLS: tuple[MathTool[Any, Any], ...] = (
         examples=(
             example(
                 "a2_reflection",
-                "Apply s_0 to the simple root alpha_0 in A2.",
+                "Apply s_0 to the simple root alpha_0 in A2. The matrix is "
+                "a finite-type generalized Cartan matrix, the vector has its "
+                "two simple-root coordinates, and index 0 is below its rank.",
                 {"matrix": _A2["matrix"], "vector": [1, 0], "simple_index": 0},
             ),
         ),

--- a/tests/dispatch/test_root_system_dispatch.py
+++ b/tests/dispatch/test_root_system_dispatch.py
@@ -19,6 +19,8 @@ def test_simple_reflection_catalog_contract_matches_dispatch() -> None:
     descriptor = catalog.inspect("root_system.simple_reflection.compute")
     assert descriptor is not None
     properties = descriptor.input_schema["properties"]
+    assert properties["matrix"]["minItems"] == 1
+    assert properties["matrix"]["maxItems"] == MAX_RANK
     assert f"rank 1 through {MAX_RANK}" in properties["matrix"]["description"]
     assert (
         "finite-type generalized cartan matrix"
@@ -29,6 +31,11 @@ def test_simple_reflection_catalog_contract_matches_dispatch() -> None:
         in properties["vector"]["description"]
     )
     assert str(MAX_REFLECTION_COORDINATE) in properties["vector"]["description"]
+    assert properties["vector"]["items"] == {
+        "maximum": MAX_REFLECTION_COORDINATE,
+        "minimum": -MAX_REFLECTION_COORDINATE,
+        "type": "integer",
+    }
     assert (
         "smaller than the Cartan-matrix rank"
         in properties["simple_index"]["description"]

--- a/tests/dispatch/test_root_system_dispatch.py
+++ b/tests/dispatch/test_root_system_dispatch.py
@@ -1,0 +1,48 @@
+"""Catalog and dispatch contracts for root-system operations."""
+
+from __future__ import annotations
+
+import pytest
+
+from jacobian.catalog.catalog import Catalog
+from jacobian.dispatch import OperationRequestValidationError, invoke_operation
+from jacobian.math.root_systems._models import (
+    MAX_RANK,
+    MAX_REFLECTION_COORDINATE,
+)
+
+
+def test_simple_reflection_catalog_contract_matches_dispatch() -> None:
+    """The advertised finite-type and rank rules reach the typed operation."""
+
+    catalog = Catalog.open()
+    descriptor = catalog.inspect("root_system.simple_reflection.compute")
+    assert descriptor is not None
+    properties = descriptor.input_schema["properties"]
+    assert f"rank 1 through {MAX_RANK}" in properties["matrix"]["description"]
+    assert (
+        "finite-type generalized cartan matrix"
+        in properties["matrix"]["description"].lower()
+    )
+    assert (
+        "length must equal the Cartan-matrix rank"
+        in properties["vector"]["description"]
+    )
+    assert str(MAX_REFLECTION_COORDINATE) in properties["vector"]["description"]
+    assert (
+        "smaller than the Cartan-matrix rank"
+        in properties["simple_index"]["description"]
+    )
+
+    operation = catalog.operation("root_system.simple_reflection.compute")
+    assert operation is not None
+    example = operation.examples[0]
+    assert "finite-type generalized Cartan matrix" in example.description
+    assert "two simple-root coordinates" in example.description
+    result = invoke_operation(operation.operation_id, example.input, catalog)
+    assert result.output["reflected_vector"] == [-1, 0]
+
+    malformed = {**example.input, "vector": [1]}
+    with pytest.raises(OperationRequestValidationError) as exc_info:
+        invoke_operation(operation.operation_id, malformed, catalog)
+    assert exc_info.value.errors()[0]["type"] == "root_system.vector_length_mismatch"


### PR DESCRIPTION
## Problem

The simple-reflection catalog entry accepted a finite-type Cartan matrix and coupled rank/vector/index constraints, but its schema and example did not expose those preconditions to discovery callers.

## Solution

Derive the root-system field descriptions from their owner constants, describe the finite-type shared-axis and zero-based-index constraints, and make the advertised A2 example state those preconditions.

## Testing

- `make check` — 6,409 passed before the final clean rebase
- `make test-focused LANE=math TESTS=tests/math/root_systems` — 22 passed after rebase
- `make test-focused LANE=dispatch TESTS=tests/dispatch/test_root_system_dispatch.py` — 1 passed after rebase
- `make test-focused LANE=catalog TESTS=tests/catalog` — 49 passed after rebase
- Ruff, formatting, and diff checks

Fixes #2604