### PR TITLE
fix(mcp): wire catalog MCP replay to CI and preserve generic error fix (rebase onto 2722)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           junit-artifact: junit-python-catalog-examples-3.12
           coverage-artifact: coverage-data-python-catalog-examples
           coverage-file: .coverage.python-catalog-examples
-          tests: tests/integration/catalog/test_builtin_examples.py
+          tests: tests/integration/catalog/
           collect-coverage: ${{ needs.plan.outputs.pr_lanes != 'true' }}
 
   python:

--- a/tests/tooling/test_product_ci_contract.py
+++ b/tests/tooling/test_product_ci_contract.py
@@ -96,7 +96,7 @@ def test_python_jobs_select_math_and_public_contract_evidence_from_the_plan() ->
     assert "name: python (catalog)" in workflow
     assert "name: python (catalog examples)" in workflow
     assert "tests: ${{ needs.plan.outputs.math_tests }}" in workflow
-    assert "tests: tests/integration/catalog/test_builtin_examples.py" in workflow
+    assert "tests: tests/integration/catalog/" in workflow
     for lane in ("dispatch", "cli", "tooling"):
         assert f"lane: {lane}" in workflow
     assert "lane: e2e" not in workflow


### PR DESCRIPTION
Follow-up to #2719 / #2722: rebases onto main after #2722 merged (serialize concurrent math). Keeps generic ToolError fix and CI directory wiring. Fixes #2713, addresses P2 on #2719. This PR supercedes #2719 after rebase.