### PR TITLE
Fix bounded construction regressions in probability, quivers, and additive combinatorics

### DIFF
--- a/src/jacobian/math/additive_combinatorics/_models.py
+++ b/src/jacobian/math/additive_combinatorics/_models.py
@@ -12,12 +12,17 @@ from pydantic_core import PydanticCustomError
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel, canonicalize_json_containers
-from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.canonical import (
+    CanonicalLimits,
+    format_canonical_integer,
+    parse_canonical_integer,
+    strict_json_object_size,
+)
 from jacobian.math.additive_combinatorics import _multiset_sum
-from jacobian.math.additive_combinatorics.operations import (
+from jacobian.math.additive_combinatorics._subset_sum_profile import (
     MAX_SUBSET_SUM_DP_TRANSITIONS,
     MAX_SUBSET_SUM_PROFILE_RESULT_BYTES,
-    _subset_sum_profile_envelope,
+    subset_sum_profile_envelope,
 )
 from jacobian.math.additive_combinatorics.values import (
     MAX_SUBSET_SUM_ITEMS,
@@ -41,6 +46,13 @@ _MAX_MULTISET_SUM_ENUMERATION_WORK = _multiset_sum.MAX_ENUMERATION_WORK
 _MAX_MULTISET_SUM_INTEGER_LENGTH = _multiset_sum.MAX_INTEGER_LENGTH
 _MAX_MULTISET_SUM_RESULT_DIGITS = _multiset_sum.MAX_RESULT_DIGITS
 _MAX_MULTISET_SUM_SUPPORT_SIZE = _multiset_sum.MAX_SUPPORT_SIZE
+
+# ``direct_sum_predicate`` returns a complete partition of Z_n: every residue
+# occurs exactly once in either ``representatives`` or ``missing``.  Collisions
+# are an additional, distinct-residue diagnostic.  Reserve the real canonical
+# transport budget before enumerating the missing set, rather than allowing a
+# valid computation to fail only when dispatch serializes its result.
+_MAX_DIRECT_SUM_RESULT_BYTES = CanonicalLimits().max_output_bytes
 
 # One serialized ordered-difference entry carries an eight-coordinate signed
 # difference, a multiplicity, and one index pair, which stays under 256
@@ -350,6 +362,80 @@ def _require_bounded_cartesian_product(
         )
 
 
+def _decimal_digit_sum_through(value: int) -> int:
+    """Return the total decimal digit count of the integers in ``[0, value)``."""
+
+    if value <= 0:
+        return 0
+    total = 0
+    lower = 1
+    digits = 1
+    while lower < value:
+        upper = min(value, lower * 10)
+        total += (upper - lower) * digits
+        lower = upper
+        digits += 1
+    return total + 1  # The residue 0 has one decimal digit.
+
+
+def _direct_sum_predicate_result_upper_bound(
+    modulus: int,
+    source_pair_count: int,
+) -> int:
+    """Bound the canonical JSON result for one admitted direct-sum request.
+
+    The representatives and missing lists partition the residue classes, so
+    their combined decimal text is exact. A collision needs two distinct
+    source pairs, hence at most ``source_pair_count // 2`` distinct collision
+    residues can be reported. For those optional entries, charging the widest
+    residue text is conservative.
+    """
+
+    partition_value_bytes = (
+        _decimal_digit_sum_through(modulus)
+        + 2 * modulus  # JSON string quotes
+        + modulus  # at most one comma per partition entry across two arrays
+        + 4  # the two array delimiters
+    )
+    collision_count = min(modulus, source_pair_count // 2)
+    collision_digit_bound = len(str(modulus - 1))
+    collision_value_bytes = (
+        2 if collision_count == 0 else collision_count * (collision_digit_bound + 3) + 1
+    )
+    return (
+        strict_json_object_size(
+            (
+                ("holds", len("false")),
+                ("modulus", len(str(modulus))),
+                ("representatives", 0),
+                ("collisions", collision_value_bytes),
+                ("missing", 0),
+            )
+        )
+        + partition_value_bytes
+    )
+
+
+def _require_direct_sum_result_transport_bound(
+    modulus: int,
+    left: FiniteIntegerSet,
+    right: FiniteIntegerSet,
+) -> None:
+    source_pair_count = len(left.elements) * len(right.elements)
+    predicted = _direct_sum_predicate_result_upper_bound(
+        modulus,
+        source_pair_count,
+    )
+    if predicted > _MAX_DIRECT_SUM_RESULT_BYTES:
+        raise _validation_error(
+            "direct_sum_result_transport_exceeded",
+            "direct-sum diagnostics would use up to "
+            f"{predicted:,} canonical JSON bytes, exceeding the "
+            f"{_MAX_DIRECT_SUM_RESULT_BYTES:,}-byte output limit; reduce the "
+            "modulus or partition the residue classes",
+        )
+
+
 class FiniteCyclicGroup(StrictModel):
     """The cyclic group ``Z_n`` carrying a direct-sum/tiling predicate."""
 
@@ -553,10 +639,9 @@ class MultisetSumRepresentationProfileResult(StrictModel):
     """Source-bound exact multiplicities for one complete sum scope.
 
     For each row ``s -> m``, ``m`` is the number of nondecreasing source-index
-    tuples of the declared arity summing to ``s``. The retained source, arity,
-    and optional window determine the complete candidate family and are replayed
-    during result validation. A missing row means zero only inside the declared
-    window, or globally when ``window`` is null.
+    tuples of the declared arity summing to ``s``. Deserialization validates
+    only the bounded canonical shape; the owner-local verifier checks an
+    independently supplied complete claim under the request envelope.
     """
 
     source: FiniteIntegerSet = Field(description=_MULTISET_SUM_SOURCE_DESCRIPTION)
@@ -567,30 +652,27 @@ class MultisetSumRepresentationProfileResult(StrictModel):
     )
 
     @model_validator(mode="after")
-    def replay_complete_profile(self) -> Self:
-        request = MultisetSumRepresentationProfileRequest(
-            source=self.source,
-            arity=self.arity,
-            window=self.window,
-        )
-        values = _multiset_sum_source_values(request.source)
-        bounds = (
-            request.window.as_integer_bounds() if request.window is not None else None
-        )
-        expected_counts = _multiset_sum.count_sums(values, request.arity, bounds)
-        expected_entries = tuple(
-            RepresentationProfileEntry(
-                sum=format_canonical_integer(value),
-                multiplicity=expected_counts[value],
-            )
-            for value in sorted(expected_counts)
-        )
-        if self.entries != expected_entries:
+    def require_canonical_entries(self) -> Self:
+        sums = tuple(entry.sum for entry in self.entries)
+        if sums != _sorted_canonical_integers(sums):
             raise _validation_error(
-                "replay_complete_profile",
-                "entries must equal the exact source-bound multiset-sum profile",
+                "multiset_sum_profile_entries",
+                "multiset-sum entries must be sorted and unique",
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: MultisetSumRepresentationProfileRequest,
+        entries: tuple[RepresentationProfileEntry, ...],
+    ) -> Self:
+        return cls(
+            source=request.source,
+            arity=request.arity,
+            window=request.window,
+            entries=entries,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -661,7 +743,7 @@ class SubsetSumProfileRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_admitted_profile_envelope(self) -> Self:
-        _subset_sum_profile_envelope(self.source)
+        subset_sum_profile_envelope(self.source)
         return self
 
 
@@ -711,6 +793,12 @@ class AdditiveEnergyResult(StrictModel):
             )
         return self
 
+    @classmethod
+    def _from_kernel(
+        cls, energy: int, decomposition: tuple[RepresentationProfileEntry, ...]
+    ) -> Self:
+        return cls(energy=energy, decomposition=decomposition)
+
 
 # ---------------------------------------------------------------------------
 # Sumset cardinality
@@ -751,6 +839,10 @@ class SumsetCardinalityResult(StrictModel):
             )
         return self
 
+    @classmethod
+    def _from_kernel(cls, support: tuple[CanonicalInteger, ...]) -> Self:
+        return cls(cardinality=len(support), support=support)
+
 
 # ---------------------------------------------------------------------------
 # Direct sum / tiling predicate in Z_n
@@ -770,6 +862,11 @@ class DirectSumPredicateRequest(StrictModel):
     @model_validator(mode="after")
     def require_bounded_cartesian_product(self) -> Self:
         _require_bounded_cartesian_product(self.left, self.right)
+        _require_direct_sum_result_transport_bound(
+            self.modulus,
+            self.left,
+            self.right,
+        )
         return self
 
 
@@ -792,6 +889,24 @@ class DirectSumPredicateResult(StrictModel):
                     f"direct-sum {name} values must be sorted and unique",
                 )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        holds: bool,
+        modulus: int,
+        representatives: tuple[CanonicalInteger, ...],
+        collisions: tuple[CanonicalInteger, ...],
+        missing: tuple[CanonicalInteger, ...],
+    ) -> Self:
+        return cls(
+            holds=holds,
+            modulus=modulus,
+            representatives=representatives,
+            collisions=collisions,
+            missing=missing,
+        )
 
 
 __all__ = [
@@ -886,8 +1001,7 @@ class OrderedDifferenceProfileResult(StrictModel):
     @model_validator(mode="after")
     def require_vectors(self) -> Self:
         # The canonical vector-set value enforces distinctness, uniform
-        # bounded dimension, and nonemptiness; replay binds the remaining
-        # derived fields to it.
+        # bounded dimension, and nonemptiness.
         if len(self.vectors.vectors) != self.set_size:
             raise _validation_error(
                 "require_vectors", "vectors length must equal set_size"
@@ -917,10 +1031,6 @@ class OrderedDifferenceProfileResult(StrictModel):
     def require_entries(self) -> Self:
         if self.entries:
             _check_entries_sorted(self.entries)
-            _check_entry_pairs(
-                self.entries, self.dimension, self.vectors.vectors, self.set_size
-            )
-            _check_all_pairs_exactly_once(self.entries, self.set_size)
             _check_first_collision(
                 self.entries, self.has_repeated_difference, self.first_collision
             )
@@ -929,3 +1039,28 @@ class OrderedDifferenceProfileResult(StrictModel):
                 "require_entries", "first_collision must be null when entries is empty"
             )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: OrderedDifferenceProfileRequest,
+        *,
+        dimension: int,
+        total_ordered_pairs: int,
+        support_size: int,
+        max_multiplicity: int,
+        entries: tuple[OrderedDifferenceEntry, ...],
+        has_repeated_difference: bool,
+        first_collision: OrderedDifferencePair | None,
+    ) -> Self:
+        return cls(
+            vectors=request.vectors,
+            dimension=dimension,
+            set_size=len(request.vectors.vectors),
+            total_ordered_pairs=total_ordered_pairs,
+            support_size=support_size,
+            max_multiplicity=max_multiplicity,
+            entries=entries,
+            has_repeated_difference=has_repeated_difference,
+            first_collision=first_collision,
+        )

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -28,6 +28,10 @@ from jacobian.math.additive_combinatorics._models import (
     _vector_from_ints,
 )
 from jacobian.math.additive_combinatorics._multiset_sum import count_sums
+from jacobian.math.additive_combinatorics._subset_sum_profile import (
+    subset_sum_profile_counts,
+    subset_sum_profile_envelope,
+)
 from jacobian.math.additive_combinatorics.operations import subset_sum_profile
 from jacobian.math.additive_combinatorics.values import SubsetSumProfile
 
@@ -91,12 +95,7 @@ def compute_multiset_sum_representation_profile(
         )
         for value in sorted(counts)
     )
-    return MultisetSumRepresentationProfileResult(
-        source=request.source,
-        arity=request.arity,
-        window=request.window,
-        entries=entries,
-    )
+    return MultisetSumRepresentationProfileResult._from_kernel(request, entries)
 
 
 def compute_subset_sum_profile(
@@ -127,10 +126,7 @@ def compute_additive_energy(
         for count in (counts[value],)
     )
     energy = sum(count * count for count in counts.values())
-    return AdditiveEnergyResult(
-        energy=energy,
-        decomposition=decomposition,
-    )
+    return AdditiveEnergyResult._from_kernel(energy, decomposition)
 
 
 def compute_sumset_cardinality(
@@ -141,10 +137,7 @@ def compute_sumset_cardinality(
     right = _parse_set(request.right)
     counts = _representation_function(left, right)
     support = tuple(format_canonical_integer(value) for value in _sorted_sums(counts))
-    return SumsetCardinalityResult(
-        cardinality=len(support),
-        support=support,
-    )
+    return SumsetCardinalityResult._from_kernel(support)
 
 
 def decide_direct_sum_predicate(
@@ -185,7 +178,7 @@ def decide_direct_sum_predicate(
     collisions_sorted = sorted(collisions)
     reps_sorted = sorted(representatives.keys())
 
-    return DirectSumPredicateResult(
+    return DirectSumPredicateResult._from_kernel(
         holds=not (collisions_sorted or missing),
         modulus=modulus,
         representatives=tuple(format_canonical_integer(r) for r in reps_sorted),
@@ -257,10 +250,9 @@ def compute_ordered_difference_profile(
                 first_collision = entry.pairs[0]
                 break
 
-    return OrderedDifferenceProfileResult(
-        vectors=request.vectors,
+    return OrderedDifferenceProfileResult._from_kernel(
+        request,
         dimension=dimension,
-        set_size=n,
         total_ordered_pairs=total_pairs,
         support_size=len(entries),
         max_multiplicity=max_mult,
@@ -268,3 +260,52 @@ def compute_ordered_difference_profile(
         has_repeated_difference=has_repeated,
         first_collision=first_collision,
     )
+
+
+def verify_subset_sum_profile(profile: SubsetSumProfile) -> bool:
+    """Check an independently supplied complete profile within its envelope."""
+
+    envelope = subset_sum_profile_envelope(profile.source)
+    expected = tuple(sorted(subset_sum_profile_counts(profile.source).items()))
+    actual = tuple(
+        (
+            parse_canonical_integer(entry.sum),
+            parse_canonical_integer(entry.multiplicity),
+        )
+        for entry in profile.entries
+    )
+    return (
+        len(expected) <= envelope.support_bound
+        and actual == expected
+        and parse_canonical_integer(profile.total_subsets)
+        == 1 << len(profile.source.items)
+    )
+
+
+def verify_multiset_sum_representation_profile(
+    result: MultisetSumRepresentationProfileResult,
+) -> bool:
+    """Check a supplied complete multiset-sum profile under request admission."""
+
+    request = MultisetSumRepresentationProfileRequest(
+        source=result.source, arity=result.arity, window=result.window
+    )
+    values = _multiset_sum_source_values(request.source)
+    bounds = request.window.as_integer_bounds() if request.window is not None else None
+    counts = count_sums(values, request.arity, bounds)
+    expected = tuple(
+        RepresentationProfileEntry(
+            sum=format_canonical_integer(value), multiplicity=counts[value]
+        )
+        for value in sorted(counts)
+    )
+    return result.entries == expected
+
+
+def verify_ordered_difference_profile(result: OrderedDifferenceProfileResult) -> bool:
+    """Check an independently supplied complete ordered-difference profile."""
+
+    expected = compute_ordered_difference_profile(
+        OrderedDifferenceProfileRequest(vectors=result.vectors)
+    )
+    return result == expected

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_profile.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_profile.py
@@ -1,0 +1,98 @@
+"""Bounded kernels shared by the indexed subset-sum profile boundary."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+
+from jacobian.canonical import format_canonical_integer
+from jacobian.math.additive_combinatorics.values import (
+    MAX_SUBSET_SUM_ITEMS,
+    MAX_SUBSET_SUM_PROFILE_ENTRIES,
+    IndexedIntegerSequence,
+)
+
+MAX_SUBSET_SUM_DP_TRANSITIONS = 4_000_000
+MAX_SUBSET_SUM_PROFILE_RESULT_BYTES = 4 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SubsetSumProfileEnvelope:
+    """Conservative pre-execution bounds for one complete profile."""
+
+    support_bound: int
+    transition_bound: int
+    maximum_sum_characters: int
+    maximum_multiplicity_digits: int
+    result_byte_bound: int
+
+
+def subset_sum_profile_envelope(
+    source: IndexedIntegerSequence,
+) -> SubsetSumProfileEnvelope:
+    """Derive the bounded work, intermediate, and output envelope."""
+
+    item_count = len(source.items)
+    if item_count > MAX_SUBSET_SUM_ITEMS:
+        raise ValueError(
+            "subset-sum profile source exceeds the "
+            f"{MAX_SUBSET_SUM_ITEMS:,}-item profile bound"
+        )
+    values = source.as_int_tuple()
+    total_subsets = 1 << item_count
+    negative_sum = sum(value for value in values if value < 0)
+    positive_sum = sum(value for value in values if value > 0)
+    span_bound = positive_sum - negative_sum + 1
+    grouped = Counter(value for value in values if value != 0)
+    selection_vector_bound = math.prod(
+        multiplicity + 1 for multiplicity in grouped.values()
+    )
+    support_bound = min(total_subsets, span_bound, selection_vector_bound)
+    # Construction and an explicit independently-supplied-claim verifier each
+    # make one dictionary pass with two updates per retained state.
+    transition_bound = 4 * item_count * support_bound
+    maximum_sum_characters = max(
+        len(format_canonical_integer(negative_sum)),
+        len(format_canonical_integer(positive_sum)),
+    )
+    maximum_multiplicity_digits = len(format_canonical_integer(total_subsets))
+    source_wire_bound = 64 + sum(len(item) + 3 for item in source.items)
+    entry_wire_bound = 96 + maximum_sum_characters + maximum_multiplicity_digits
+    result_byte_bound = 1024 + source_wire_bound + support_bound * entry_wire_bound
+    if support_bound > MAX_SUBSET_SUM_PROFILE_ENTRIES:
+        raise ValueError(
+            "predicted subset-sum support exceeds the "
+            f"{MAX_SUBSET_SUM_PROFILE_ENTRIES}-entry profile bound"
+        )
+    if transition_bound > MAX_SUBSET_SUM_DP_TRANSITIONS:
+        raise ValueError(
+            "predicted subset-sum DP transitions exceed the "
+            f"{MAX_SUBSET_SUM_DP_TRANSITIONS}-transition work bound"
+        )
+    if result_byte_bound > MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:
+        raise ValueError(
+            "predicted subset-sum result exceeds the "
+            f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES}-byte result bound"
+        )
+    return SubsetSumProfileEnvelope(
+        support_bound=support_bound,
+        transition_bound=transition_bound,
+        maximum_sum_characters=maximum_sum_characters,
+        maximum_multiplicity_digits=maximum_multiplicity_digits,
+        result_byte_bound=result_byte_bound,
+    )
+
+
+def subset_sum_profile_counts(source: IndexedIntegerSequence) -> dict[int, int]:
+    """Return exact counts for every indexed subset sum, including empty."""
+
+    counts: dict[int, int] = {0: 1}
+    for value in source.as_int_tuple():
+        next_counts: dict[int, int] = {}
+        for subtotal, multiplicity in counts.items():
+            next_counts[subtotal] = next_counts.get(subtotal, 0) + multiplicity
+            included = subtotal + value
+            next_counts[included] = next_counts.get(included, 0) + multiplicity
+        counts = next_counts
+    return counts

--- a/src/jacobian/math/additive_combinatorics/operations.py
+++ b/src/jacobian/math/additive_combinatorics/operations.py
@@ -2,120 +2,15 @@
 
 from __future__ import annotations
 
-import math
-from collections import Counter
-from dataclasses import dataclass
-
-from jacobian.canonical import format_canonical_integer
+from jacobian.math.additive_combinatorics import _subset_sum_profile
+from jacobian.math.additive_combinatorics._subset_sum_profile import (
+    subset_sum_profile_counts,
+    subset_sum_profile_envelope,
+)
 from jacobian.math.additive_combinatorics.values import (
-    MAX_SUBSET_SUM_ITEMS,
-    MAX_SUBSET_SUM_PROFILE_ENTRIES,
     IndexedIntegerSequence,
     SubsetSumProfile,
 )
-
-MAX_SUBSET_SUM_DP_TRANSITIONS = 4_000_000
-MAX_SUBSET_SUM_PROFILE_RESULT_BYTES = 4 * 1024 * 1024
-_SUBSET_SUM_DP_PASSES = 2
-
-
-@dataclass(frozen=True)
-class _SubsetSumProfileEnvelope:
-    """Conservative pre-execution bounds for one complete profile."""
-
-    support_bound: int
-    transition_bound: int
-    maximum_sum_characters: int
-    maximum_multiplicity_digits: int
-    result_byte_bound: int
-
-
-def _subset_sum_profile_envelope(
-    source: IndexedIntegerSequence,
-) -> _SubsetSumProfileEnvelope:
-    """Derive complete-profile work, intermediate, and output bounds.
-
-    For values grouped by equality, a subset is determined numerically by how
-    many copies of each nonzero value it selects. Thus the support is bounded
-    simultaneously by ``2^n``, the integral sum span, and the product of one
-    plus each nonzero value's multiplicity. Every intermediate DP support is a
-    subset of the final support because the exclude branch retains old sums.
-    """
-
-    item_count = len(source.items)
-    # The shared canonical sequence value carries the widest consumer
-    # envelope; the profile's own item ceiling is derived from its
-    # multiplicity representation, since total_subsets = 2**item_count is
-    # only representable within SubsetSumMultiplicity up to this count.
-    if item_count > MAX_SUBSET_SUM_ITEMS:
-        raise ValueError(
-            "subset-sum profile source exceeds the "
-            f"{MAX_SUBSET_SUM_ITEMS:,}-item profile bound"
-        )
-    values = source.as_int_tuple()
-    total_subsets = 1 << item_count
-
-    negative_sum = sum(value for value in values if value < 0)
-    positive_sum = sum(value for value in values if value > 0)
-    span_bound = positive_sum - negative_sum + 1
-
-    grouped = Counter(value for value in values if value != 0)
-    selection_vector_bound = math.prod(
-        multiplicity + 1 for multiplicity in grouped.values()
-    )
-    support_bound = min(total_subsets, span_bound, selection_vector_bound)
-    # The public result validator independently replays the DP so a forged or
-    # truncated exact profile cannot revalidate. Charge both the construction
-    # and validation passes, with two dictionary updates per retained state.
-    transition_bound = _SUBSET_SUM_DP_PASSES * 2 * item_count * support_bound
-
-    maximum_sum_characters = max(
-        len(format_canonical_integer(negative_sum)),
-        len(format_canonical_integer(positive_sum)),
-    )
-    maximum_multiplicity_digits = len(format_canonical_integer(total_subsets))
-
-    source_wire_bound = 64 + sum(len(item) + 3 for item in source.items)
-    entry_wire_bound = 96 + maximum_sum_characters + maximum_multiplicity_digits
-    result_byte_bound = 1024 + source_wire_bound + support_bound * entry_wire_bound
-
-    if support_bound > MAX_SUBSET_SUM_PROFILE_ENTRIES:
-        raise ValueError(
-            "predicted subset-sum support exceeds the "
-            f"{MAX_SUBSET_SUM_PROFILE_ENTRIES}-entry profile bound"
-        )
-    if transition_bound > MAX_SUBSET_SUM_DP_TRANSITIONS:
-        raise ValueError(
-            "predicted subset-sum DP transitions exceed the "
-            f"{MAX_SUBSET_SUM_DP_TRANSITIONS}-transition work bound"
-        )
-    if result_byte_bound > MAX_SUBSET_SUM_PROFILE_RESULT_BYTES:
-        raise ValueError(
-            "predicted subset-sum result exceeds the "
-            f"{MAX_SUBSET_SUM_PROFILE_RESULT_BYTES}-byte result bound"
-        )
-
-    return _SubsetSumProfileEnvelope(
-        support_bound=support_bound,
-        transition_bound=transition_bound,
-        maximum_sum_characters=maximum_sum_characters,
-        maximum_multiplicity_digits=maximum_multiplicity_digits,
-        result_byte_bound=result_byte_bound,
-    )
-
-
-def _subset_sum_profile_counts(source: IndexedIntegerSequence) -> dict[int, int]:
-    """Return exact counts for every indexed subset sum, including empty."""
-
-    counts: dict[int, int] = {0: 1}
-    for value in source.as_int_tuple():
-        next_counts: dict[int, int] = {}
-        for subtotal, multiplicity in counts.items():
-            next_counts[subtotal] = next_counts.get(subtotal, 0) + multiplicity
-            included = subtotal + value
-            next_counts[included] = next_counts.get(included, 0) + multiplicity
-        counts = next_counts
-    return counts
 
 
 def subset_sum_profile(source: IndexedIntegerSequence) -> SubsetSumProfile:
@@ -126,11 +21,20 @@ def subset_sum_profile(source: IndexedIntegerSequence) -> SubsetSumProfile:
     enlarge the numeric support. The empty subset is included by definition.
     """
 
-    envelope = _subset_sum_profile_envelope(source)
-    counts = _subset_sum_profile_counts(source)
+    envelope = subset_sum_profile_envelope(source)
+    counts = subset_sum_profile_counts(source)
     if len(counts) > envelope.support_bound:
         raise RuntimeError("subset-sum support exceeded its admitted bound")
-    return SubsetSumProfile.from_counts(source, counts)
+    return SubsetSumProfile._from_kernel(source, counts)
 
+
+# Compatibility aliases remain private while callers move to the owner-local
+# admission helper; they are not used by result construction.
+_subset_sum_profile_envelope = subset_sum_profile_envelope
+_subset_sum_profile_counts = subset_sum_profile_counts
+MAX_SUBSET_SUM_DP_TRANSITIONS = _subset_sum_profile.MAX_SUBSET_SUM_DP_TRANSITIONS
+MAX_SUBSET_SUM_PROFILE_RESULT_BYTES = (
+    _subset_sum_profile.MAX_SUBSET_SUM_PROFILE_RESULT_BYTES
+)
 
 __all__ = ["subset_sum_profile"]

--- a/src/jacobian/math/additive_combinatorics/values.py
+++ b/src/jacobian/math/additive_combinatorics/values.py
@@ -159,8 +159,8 @@ class SubsetSumProfileEntry(StrictModel):
 class SubsetSumProfile(StrictModel):
     """The complete exact multiplicity profile of one indexed sequence.
 
-    The empty subset is always included. Validation replays the complete
-    bounded dynamic program, binding every row and multiplicity to ``source``.
+    The empty subset is always included. Deserialization validates bounded
+    canonical shape; an owner-local verifier checks supplied exact claims.
     """
 
     source: Annotated[
@@ -175,58 +175,28 @@ class SubsetSumProfile(StrictModel):
     total_subsets: SubsetSumMultiplicity
 
     @model_validator(mode="after")
-    def bind_complete_profile(self) -> Self:
+    def require_canonical_profile_shape(self) -> Self:
         sums = tuple(parse_canonical_integer(entry.sum) for entry in self.entries)
         if sums != tuple(sorted(sums)) or len(sums) != len(set(sums)):
             raise _validation_error(
-                "bind_complete_profile",
+                "profile_entries",
                 "subset-sum profile entries must have unique sorted sums",
             )
         if self.support_size != len(self.entries):
             raise _validation_error(
-                "bind_complete_profile",
+                "profile_support_size",
                 "support_size must equal the number of profile entries",
             )
 
-        expected_total = 1 << len(self.source.items)
-        if parse_canonical_integer(self.total_subsets) != expected_total:
-            raise _validation_error(
-                "bind_complete_profile", "total_subsets must equal 2^len(source.items)"
-            )
-
-        from jacobian.math.additive_combinatorics.operations import (
-            _subset_sum_profile_counts,
-            _subset_sum_profile_envelope,
-        )
-
-        _subset_sum_profile_envelope(self.source)
-        expected = tuple(sorted(_subset_sum_profile_counts(self.source).items()))
-        actual = tuple(
-            (
-                parse_canonical_integer(entry.sum),
-                parse_canonical_integer(entry.multiplicity),
-            )
-            for entry in self.entries
-        )
-        if actual != expected:
-            raise _validation_error(
-                "bind_complete_profile",
-                "entries must be the complete exact subset-sum profile of source",
-            )
-        if sum(multiplicity for _, multiplicity in actual) != expected_total:
-            raise _validation_error(
-                "bind_complete_profile",
-                "profile multiplicities must sum to total_subsets",
-            )
         return self
 
     @classmethod
-    def from_counts(
+    def _from_kernel(
         cls,
         source: IndexedIntegerSequence,
         counts: dict[int, int],
     ) -> SubsetSumProfile:
-        """Construct the canonical source-bound profile from exact counts."""
+        """Construct a trusted canonical profile from bounded kernel output."""
 
         entries = tuple(
             SubsetSumProfileEntry(

--- a/src/jacobian/math/probability/_all_terminal_reliability.py
+++ b/src/jacobian/math/probability/_all_terminal_reliability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from math import comb
 from typing import Any, Literal, Self
 
 from pydantic import ConfigDict, Field, StrictInt, model_validator
@@ -23,9 +24,10 @@ from jacobian.math.probability.all_terminal_reliability import (
     MAX_ALL_TERMINAL_RELIABILITY_INPUT_DIGITS,
     MAX_ALL_TERMINAL_RELIABILITY_RESULT_DIGITS,
     MAX_ALL_TERMINAL_RELIABILITY_STATES,
+    AllTerminalReliabilityResult,
     _compute_all_terminal_reliability,
     _require_bounded_problem,
-    _require_source_bound_result,
+    verify_all_terminal_reliability_result,
 )
 
 
@@ -75,7 +77,12 @@ class AllTerminalReliabilityRequest(StrictModel):
 
 
 class AllTerminalReliabilityWireResult(StrictModel):
-    """Source-bound exact probability with its connected-subgraph profile."""
+    """Exact probability with its bounded connected-subgraph profile.
+
+    Deserialization checks the structural result envelope.  The kernel uses
+    ``_from_kernel`` after its one complete enumeration; an independently
+    supplied claim can be replayed with the owner-local verifier below.
+    """
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -83,8 +90,7 @@ class AllTerminalReliabilityWireResult(StrictModel):
                 "Exact all-terminal reliability bound to the retained graph and "
                 "uniform edge probability. Entry k of "
                 "`connected_spanning_subgraph_counts` is the number of connected "
-                "spanning edge subsets containing exactly k edges; result "
-                "validation replays the complete bounded enumeration."
+                "spanning edge subsets containing exactly k edges."
             )
         }
     )
@@ -130,8 +136,7 @@ class AllTerminalReliabilityWireResult(StrictModel):
         return value
 
     @model_validator(mode="after")
-    def bind_to_source_graph(self) -> Self:
-        probability = self.open_probability.as_fraction()
+    def require_bounded_shape(self) -> Self:
         require_bounded_rational(
             self.open_probability,
             max_digits=MAX_ALL_TERMINAL_RELIABILITY_INPUT_DIGITS,
@@ -142,18 +147,87 @@ class AllTerminalReliabilityWireResult(StrictModel):
             max_digits=MAX_ALL_TERMINAL_RELIABILITY_RESULT_DIGITS,
             label="all-terminal reliability result probability",
         )
+        if not 0 <= self.open_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "all-terminal reliability open probability must lie in [0, 1]"
+            )
         actual_counts = tuple(
             parse_canonical_integer(value)
             for value in self.connected_spanning_subgraph_counts
         )
-        _require_source_bound_result(
-            self.graph,
-            probability,
-            actual_counts,
-            self.reliability_probability.as_fraction(),
-            self.visited_states,
-        )
+        if len(actual_counts) != len(self.graph.edges) + 1:
+            raise _validation_error(
+                "connected-spanning-subgraph counts must cover edge counts 0..m"
+            )
+        for open_edges, count in enumerate(actual_counts):
+            if not 0 <= count <= comb(len(self.graph.edges), open_edges):
+                raise _validation_error(
+                    "connected-spanning-subgraph count lies outside its subset class"
+                )
+            if open_edges < len(self.graph.vertices) - 1 and count:
+                raise _validation_error(
+                    "a connected spanning subgraph has at least n-1 edges"
+                )
+        if self.visited_states != 1 << len(self.graph.edges):
+            raise _validation_error(
+                "visited_states does not match the complete edge powerset"
+            )
+        if not 0 <= self.reliability_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "all-terminal reliability result probability must lie in [0, 1]"
+            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: AllTerminalReliabilityRequest,
+        counts: tuple[int, ...],
+        reliability_probability: CanonicalRational,
+        visited_states: int,
+    ) -> Self:
+        """Build trusted kernel output without replaying the enumeration."""
+
+        return cls.model_construct(
+            graph=request.graph,
+            open_probability=request.open_probability,
+            connected_spanning_subgraph_counts=tuple(
+                format_canonical_integer(count) for count in counts
+            ),
+            reliability_probability=reliability_probability,
+            visited_states=visited_states,
+            event="ALL_VERTICES_CONNECTED",
+        )
+
+
+def verify_all_terminal_reliability_wire_result(
+    result: AllTerminalReliabilityWireResult,
+) -> bool:
+    """Replay one bounded independently supplied wire claim."""
+
+    try:
+        native_result = _result_to_native(result)
+    except (TypeError, ValueError):
+        return False
+    return verify_all_terminal_reliability_result(native_result)
+
+
+def _result_to_native(
+    result: AllTerminalReliabilityWireResult,
+) -> AllTerminalReliabilityResult:
+    """Convert a structurally admitted wire value for explicit verification."""
+
+    return AllTerminalReliabilityResult(
+        graph=result.graph,
+        open_probability=result.open_probability.as_fraction(),
+        connected_spanning_subgraph_counts=tuple(
+            parse_canonical_integer(value)
+            for value in result.connected_spanning_subgraph_counts
+        ),
+        reliability_probability=result.reliability_probability.as_fraction(),
+        visited_states=result.visited_states,
+        event=result.event,
+    )
 
 
 def compute_all_terminal_reliability(
@@ -163,16 +237,11 @@ def compute_all_terminal_reliability(
     counts, reliability_probability, visited_states = _compute_all_terminal_reliability(
         request.graph, probability
     )
-    return AllTerminalReliabilityWireResult(
-        graph=request.graph,
-        open_probability=request.open_probability,
-        connected_spanning_subgraph_counts=tuple(
-            format_canonical_integer(count) for count in counts
-        ),
-        reliability_probability=CanonicalRational.from_fraction(
-            reliability_probability
-        ),
-        visited_states=visited_states,
+    return AllTerminalReliabilityWireResult._from_kernel(
+        request,
+        counts,
+        CanonicalRational.from_fraction(reliability_probability),
+        visited_states,
     )
 
 

--- a/src/jacobian/math/probability/_directed_bond_reliability.py
+++ b/src/jacobian/math/probability/_directed_bond_reliability.py
@@ -34,8 +34,7 @@ MAX_DIRECTED_BOND_RELIABILITY_RATIONAL_DIGITS = (
     MAX_INPUT_RATIONAL_DIGITS * MAX_DIRECTED_BOND_RELIABILITY_ARCS
     + MAX_DIRECTED_BOND_RELIABILITY_ARCS
 )
-# The producer enumerates every arc subset and result validation replays it.
-# Per state and pass it selects open arcs, evaluates every probability,
+# The producer enumerates every arc subset once. Per state it selects open arcs, evaluates every probability,
 # collects the endpoints of open arcs into the relevant vertex set (two
 # endpoint visits per open arc), adds those arcs to the directed graph, and
 # traverses them: six arc visits. Traversal materializes only the relevant
@@ -47,8 +46,7 @@ MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES = (
     2 * MAX_DIRECTED_BOND_RELIABILITY_ARCS + 2
 )
 MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK = (
-    2
-    * MAX_DIRECTED_BOND_RELIABILITY_STATES
+    MAX_DIRECTED_BOND_RELIABILITY_STATES
     * (
         7 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
         + 4 * MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES
@@ -196,11 +194,10 @@ class DirectedBondConnectionProbabilitySource(StrictModel):
             {self.source, self.target}
             | {vertex for arc in canonical_arcs for vertex in arc}
         )
-        logical_work = 2 * state_count * (7 * arc_count + 4 * relevant_vertices + 3) + 8
+        logical_work = state_count * (7 * arc_count + 4 * relevant_vertices + 3) + 8
         if logical_work > MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK:
             raise _validation_error(
-                "directed bond reliability exceeds the complete producer and "
-                "replay work budget"
+                "directed bond reliability exceeds the complete producer work budget"
             )
         if self.graph.vertex_count > MAX_DIRECTED_BOND_RELIABILITY_DECLARED_VERTICES:
             raise _validation_error(
@@ -359,7 +356,12 @@ class DirectedBondReliabilityState(StrictModel):
 
 
 class DirectedBondConnectionProbabilityResult(StrictModel):
-    """An exact, complete, source-bound directed bond reliability result."""
+    """An exact complete directed bond reliability result.
+
+    Deserialization validates a bounded ledger shape only. The kernel builds
+    output through ``_from_kernel`` after its one complete enumeration; use
+    the explicit verifier below for independently supplied claims.
+    """
 
     source: DirectedBondConnectionProbabilitySource
     connection_probability: CanonicalRational
@@ -382,15 +384,16 @@ class DirectedBondConnectionProbabilityResult(StrictModel):
     determinism: Literal["DETERMINISTIC"] = "DETERMINISTIC"
 
     @model_validator(mode="after")
-    def bind_to_directed_bond_source(self) -> Self:
+    def require_bounded_ledger_shape(self) -> Self:
         require_bounded_rational(
             self.connection_probability,
             max_digits=MAX_DIRECTED_BOND_RELIABILITY_RATIONAL_DIGITS,
             label="directed bond connection probability",
         )
-        connection_probability, expected_states = (
-            _directed_bond_connection_probability_data(self.source)
-        )
+        if not 0 <= self.connection_probability.as_fraction() <= 1:
+            raise _validation_error(
+                "directed bond connection probability must lie in [0, 1]"
+            )
         if self.arc_count != len(self.source.graph.edges):
             raise _validation_error("arc_count must match the source graph")
         if self.visited_states != 1 << self.arc_count:
@@ -403,25 +406,33 @@ class DirectedBondConnectionProbabilityResult(StrictModel):
             raise _validation_error(
                 "state ledger indices must be complete and canonical"
             )
-        if len(expected_states) != len(self.states):
-            raise _validation_error("state ledger length does not match source replay")
-        for state, expected in zip(self.states, expected_states, strict=True):
-            open_arcs, reaches_target, state_probability = expected
-            if state.open_arcs != open_arcs:
-                raise _validation_error("state open arcs do not match source subset")
-            if state.source_reaches_target != reaches_target:
-                raise _validation_error(
-                    "state reachability does not match source subset"
-                )
-            if state.state_probability.as_fraction() != state_probability:
-                raise _validation_error(
-                    "state probability does not match source subset"
-                )
-        if self.connection_probability.as_fraction() != connection_probability:
-            raise _validation_error(
-                "connection probability does not match source replay"
-            )
         return self
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        source: DirectedBondConnectionProbabilitySource,
+        connection_probability: CanonicalRational,
+        states: tuple[DirectedBondReliabilityState, ...],
+    ) -> Self:
+        """Build trusted kernel output without replaying every arc subset."""
+
+        return cls.model_construct(
+            source=source,
+            connection_probability=connection_probability,
+            arc_count=len(source.graph.edges),
+            visited_states=len(states),
+            states=states,
+            event="DIRECTED_PATH_EXISTS",
+            arc_independence="INDEPENDENT_BERNOULLI",
+            enumeration="COMPLETE_ARC_SUBSETS",
+            completeness="COMPLETE",
+            truncated=False,
+            termination_reason="EXHAUSTED",
+            exactness="EXACT_RATIONAL",
+            determinism="DETERMINISTIC",
+        )
 
 
 def _wire(value: Any) -> CanonicalRational:
@@ -466,6 +477,30 @@ def _directed_bond_connection_probability_data(
             connection_probability += state_probability
         states.append((open_arcs, reaches_target, state_probability))
     return connection_probability, tuple(states)
+
+
+def verify_directed_bond_connection_probability_result(
+    result: DirectedBondConnectionProbabilityResult,
+) -> bool:
+    """Replay one bounded independently supplied directed bond claim."""
+
+    try:
+        connection_probability, expected_states = (
+            _directed_bond_connection_probability_data(result.source)
+        )
+    except (TypeError, ValueError):
+        return False
+    if len(expected_states) != len(result.states):
+        return False
+    for state, expected in zip(result.states, expected_states, strict=True):
+        open_arcs, reaches_target, state_probability = expected
+        if (
+            state.open_arcs != open_arcs
+            or state.source_reaches_target != reaches_target
+            or state.state_probability.as_fraction() != state_probability
+        ):
+            return False
+    return result.connection_probability.as_fraction() == connection_probability
 
 
 def _directed_path_exists(
@@ -535,11 +570,9 @@ def _directed_bond_connection_probability(
                 state_probability=_wire(state_probability),
             )
         )
-    return DirectedBondConnectionProbabilityResult(
+    return DirectedBondConnectionProbabilityResult._from_kernel(
         source=source,
         connection_probability=_wire(connection_probability),
-        arc_count=len(source.graph.edges),
-        visited_states=len(states),
         states=tuple(states),
     )
 
@@ -551,7 +584,7 @@ DIRECTED_BOND_CONNECTION_PROBABILITY_OPERATION = MathTool(
         "Compute the exact probability of a directed path from one stated "
         "source vertex to one stated target vertex in a bounded directed "
         "graph with independent rational arc-open probabilities. The complete "
-        "arc-subset ledger is source-bound and replayed."
+        "arc-subset ledger is source-bound and admits explicit bounded replay."
     ),
     request_type=DirectedBondConnectionProbabilityRequest,
     result_type=DirectedBondConnectionProbabilityResult,
@@ -608,4 +641,5 @@ __all__ = [
     "DirectedBondConnectionProbabilitySource",
     "DirectedBondReliabilityArcProbability",
     "DirectedBondReliabilityState",
+    "verify_directed_bond_connection_probability_result",
 ]

--- a/src/jacobian/math/probability/all_terminal_reliability.py
+++ b/src/jacobian/math/probability/all_terminal_reliability.py
@@ -190,6 +190,24 @@ def _require_source_bound_result(
         raise ValueError("visited_states does not match the complete edge powerset")
 
 
+def verify_all_terminal_reliability_result(
+    result: AllTerminalReliabilityResult,
+) -> bool:
+    """Replay one bounded independently supplied all-terminal claim."""
+
+    try:
+        _require_source_bound_result(
+            result.graph,
+            result.open_probability,
+            result.connected_spanning_subgraph_counts,
+            result.reliability_probability,
+            result.visited_states,
+        )
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 @dataclass(frozen=True, slots=True)
 class AllTerminalReliabilityResult:
     """A graph-bound exact reliability value and its coefficient profile."""
@@ -214,13 +232,54 @@ class AllTerminalReliabilityResult:
             raise TypeError("visited_states must be an integer")
         if self.event != "ALL_VERTICES_CONNECTED":
             raise ValueError("unsupported all-terminal reliability event")
-        _require_source_bound_result(
-            self.graph,
-            self.open_probability,
-            self.connected_spanning_subgraph_counts,
-            self.reliability_probability,
-            self.visited_states,
+        _require_bounded_problem(self.graph, self.open_probability)
+        if (
+            abs(self.reliability_probability.numerator)
+            >= _MAX_ALL_TERMINAL_RELIABILITY_RESULT_ABS
+            or self.reliability_probability.denominator
+            >= _MAX_ALL_TERMINAL_RELIABILITY_RESULT_ABS
+        ):
+            raise ValueError(
+                "all-terminal reliability result probability exceeds the "
+                f"{MAX_ALL_TERMINAL_RELIABILITY_RESULT_DIGITS}-digit bound"
+            )
+        if len(self.connected_spanning_subgraph_counts) != len(self.graph.edges) + 1:
+            raise ValueError(
+                "connected-spanning-subgraph counts must cover edge counts 0..m"
+            )
+        for open_edges, count in enumerate(self.connected_spanning_subgraph_counts):
+            if not 0 <= count <= comb(len(self.graph.edges), open_edges):
+                raise ValueError(
+                    "connected-spanning-subgraph count lies outside its subset class"
+                )
+            if open_edges < len(self.graph.vertices) - 1 and count:
+                raise ValueError("a connected spanning subgraph has at least n-1 edges")
+        if self.visited_states != 1 << len(self.graph.edges):
+            raise ValueError("visited_states does not match the complete edge powerset")
+
+    @classmethod
+    def _from_kernel(
+        cls,
+        graph: SimpleUndirectedGraph,
+        open_probability: Fraction,
+        connected_spanning_subgraph_counts: tuple[int, ...],
+        reliability_probability: Fraction,
+        visited_states: int,
+    ) -> AllTerminalReliabilityResult:
+        """Build one trusted result without re-enumerating its source graph."""
+
+        result = object.__new__(cls)
+        object.__setattr__(result, "graph", graph)
+        object.__setattr__(result, "open_probability", open_probability)
+        object.__setattr__(
+            result,
+            "connected_spanning_subgraph_counts",
+            connected_spanning_subgraph_counts,
         )
+        object.__setattr__(result, "reliability_probability", reliability_probability)
+        object.__setattr__(result, "visited_states", visited_states)
+        object.__setattr__(result, "event", "ALL_VERTICES_CONNECTED")
+        return result
 
 
 def _compute_all_terminal_reliability(
@@ -250,16 +309,17 @@ def all_terminal_reliability(
     counts, reliability_probability, visited_states = _compute_all_terminal_reliability(
         graph, open_probability
     )
-    return AllTerminalReliabilityResult(
-        graph=graph,
-        open_probability=open_probability,
-        connected_spanning_subgraph_counts=counts,
-        reliability_probability=reliability_probability,
-        visited_states=visited_states,
+    return AllTerminalReliabilityResult._from_kernel(
+        graph,
+        open_probability,
+        counts,
+        reliability_probability,
+        visited_states,
     )
 
 
 __all__ = [
     "AllTerminalReliabilityResult",
     "all_terminal_reliability",
+    "verify_all_terminal_reliability_result",
 ]

--- a/src/jacobian/math/quivers/_models.py
+++ b/src/jacobian/math/quivers/_models.py
@@ -8,6 +8,7 @@ from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
 
 from jacobian._models import StrictModel
+from jacobian.math.quivers._path_bounds import fixed_length_paths_envelope
 
 MAX_VERTICES = 128
 MAX_ARROWS = 1024
@@ -56,6 +57,16 @@ class FixedLengthPathsRequest(StrictModel):
 
     @model_validator(mode="after")
     def require_valid(self) -> Self:
+        try:
+            fixed_length_paths_envelope(
+                vertex_count=self.quiver.vertex_count,
+                arrow_count=len(self.quiver.arrows),
+                length=self.length,
+            )
+        except ValueError as exc:
+            raise _validation_error(
+                "fixed_length_paths_exceeds_envelope", str(exc)
+            ) from exc
         return self
 
 

--- a/src/jacobian/math/quivers/_path_bounds.py
+++ b/src/jacobian/math/quivers/_path_bounds.py
@@ -1,0 +1,88 @@
+"""Pre-execution envelopes for fixed-length quiver path counts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jacobian.canonical import CanonicalLimits
+
+# Strict JSON transports integer scalars only through IEEE-754's interoperable
+# integer range.  ``FixedLengthPathsResult`` deliberately exposes its counts
+# as integer scalars (rather than an operation-specific decimal wrapper), so
+# every materialized matrix entry and the aggregate count must fit this range.
+MAX_TRANSPORTABLE_PATH_COUNT = (1 << 53) - 1
+
+
+@dataclass(frozen=True)
+class FixedLengthPathsEnvelope:
+    """Conservative work, intermediate, and strict-JSON result bounds."""
+
+    path_count_bound: int
+    maximum_entry_digits: int
+    matrix_scalar_products: int
+    result_json_bytes: int
+
+
+def _matrix_json_bound(vertex_count: int, entry_digits: int) -> int:
+    """Return a byte bound for a matrix of nonnegative decimal integers."""
+
+    # ``[[e,...,e],...]``: every row has two brackets, n entries, and n - 1
+    # commas; the outer array adds two brackets and n - 1 separators.
+    return (
+        2
+        + vertex_count * (2 + vertex_count * entry_digits + vertex_count - 1)
+        + vertex_count
+        - 1
+    )
+
+
+def fixed_length_paths_envelope(
+    *, vertex_count: int, arrow_count: int, length: int
+) -> FixedLengthPathsEnvelope:
+    """Bound the complete fixed-length matrix-power computation before it runs.
+
+    There are at most ``arrow_count ** length`` composable arrow sequences.
+    Thus that same quantity bounds every matrix-power entry, their aggregate,
+    and every nonnegative intermediate in the repeated multiplication path.
+    The matrix construction performs ``length - 1`` dense products after the
+    adjacency matrix is built; their scalar-product count is retained here as
+    the operation's explicit work ledger.
+    """
+
+    path_count_bound = vertex_count if length == 0 else pow(arrow_count, length)
+    if path_count_bound > MAX_TRANSPORTABLE_PATH_COUNT:
+        raise ValueError(
+            "fixed-length path count can exceed the interoperable JSON integer "
+            f"bound of {MAX_TRANSPORTABLE_PATH_COUNT}"
+        )
+
+    entry_digits = len(str(path_count_bound))
+    matrix_bytes = _matrix_json_bound(vertex_count, entry_digits)
+    # Exact field punctuation plus the maximum decimal total and fixed method.
+    result_json_bytes = (
+        len('{"path_matrix":')
+        + matrix_bytes
+        + len(',"total_paths":')
+        + entry_digits
+        + len(',"method":"MATRIX_POWER"}')
+    )
+    output_limit = CanonicalLimits().max_output_bytes
+    if result_json_bytes > output_limit:
+        raise ValueError(
+            "fixed-length path result can exceed the "
+            f"{output_limit}-byte canonical JSON output limit"
+        )
+
+    return FixedLengthPathsEnvelope(
+        path_count_bound=path_count_bound,
+        maximum_entry_digits=entry_digits,
+        matrix_scalar_products=max(length - 1, 0) * vertex_count**3,
+        result_json_bytes=result_json_bytes,
+    )
+
+
+__all__ = [
+    "MAX_TRANSPORTABLE_PATH_COUNT",
+    "FixedLengthPathsEnvelope",
+    "fixed_length_paths_envelope",
+]

--- a/tests/math/additive_combinatorics/test_additive_combinatorics.py
+++ b/tests/math/additive_combinatorics/test_additive_combinatorics.py
@@ -1,12 +1,20 @@
 """Tests for additive combinatorics operations."""
 
-from jacobian.canonical import parse_canonical_integer
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import (
+    CanonicalLimits,
+    encode_strict_json,
+    parse_canonical_integer,
+)
 from jacobian.math.additive_combinatorics._models import (
     AdditiveEnergyRequest,
     DirectSumPredicateRequest,
     FiniteIntegerSet,
     RepresentationProfileRequest,
     SumsetCardinalityRequest,
+    _direct_sum_predicate_result_upper_bound,
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_additive_energy,
@@ -190,3 +198,37 @@ class TestDirectSumPredicate:
         result = decide_direct_sum_predicate(req)
         assert result.holds is False
         assert result.missing == tuple(str(value) for value in range(12))
+
+    def test_preflights_complete_missing_diagnostic_at_transport_boundary(self):
+        """The nearly 10 MiB empty-source result remains serializable."""
+
+        modulus = 1_048_576
+        request = DirectSumPredicateRequest(
+            modulus=modulus,
+            left=FiniteIntegerSet(elements=()),
+            right=FiniteIntegerSet(elements=()),
+        )
+
+        payload = {
+            "holds": False,
+            "modulus": modulus,
+            "representatives": [],
+            "collisions": [],
+            "missing": [str(value) for value in range(modulus)],
+        }
+        encoded = encode_strict_json(payload)
+        assert len(encoded) <= CanonicalLimits().max_output_bytes
+        assert _direct_sum_predicate_result_upper_bound(modulus, 0) >= len(encoded)
+        assert request.modulus == modulus
+
+    def test_rejects_oversized_missing_diagnostic_before_kernel_execution(self):
+        with pytest.raises(ValidationError) as exc_info:
+            DirectSumPredicateRequest(
+                modulus=1_200_000,
+                left=FiniteIntegerSet(elements=()),
+                right=FiniteIntegerSet(elements=()),
+            )
+
+        assert exc_info.value.errors()[0]["type"] == (
+            "additive_combinatorics.direct_sum_result_transport_exceeded"
+        )

--- a/tests/math/additive_combinatorics/test_multiset_sum.py
+++ b/tests/math/additive_combinatorics/test_multiset_sum.py
@@ -29,6 +29,7 @@ from jacobian.math.additive_combinatorics._multiset_sum import (
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_multiset_sum_representation_profile,
+    verify_multiset_sum_representation_profile,
 )
 
 
@@ -132,38 +133,40 @@ def test_result_retains_source_for_unchanged_recomposition() -> None:
     assert recomputed == result
 
 
-def test_result_rejects_forged_source_bound_profile() -> None:
+def test_verifier_rejects_forged_source_bound_profile() -> None:
     result = compute_multiset_sum_representation_profile(_request((0, 1, 2), 2))
     payload = result.model_dump(mode="json")
     payload["source"]["elements"] = ["0", "1", "3"]
-    with pytest.raises(ValidationError):
+    assert not verify_multiset_sum_representation_profile(
         MultisetSumRepresentationProfileResult.model_validate(payload)
+    )
 
 
-def test_result_rejects_forged_multiplicity() -> None:
+def test_verifier_rejects_forged_multiplicity() -> None:
     result = compute_multiset_sum_representation_profile(_request((0, 1, 2), 2))
     payload = result.model_dump(mode="json")
     payload["entries"][2]["multiplicity"] = 1
-    with pytest.raises(ValidationError):
+    assert not verify_multiset_sum_representation_profile(
         MultisetSumRepresentationProfileResult.model_validate(payload)
+    )
 
 
-def test_result_rejects_mutated_window() -> None:
+def test_verifier_rejects_mutated_window() -> None:
     result = compute_multiset_sum_representation_profile(_request((0, 1, 2), 2, (2, 2)))
     payload = result.model_dump(mode="json")
     payload["window"] = {"lower": "1", "upper": "2"}
-    with pytest.raises(ValidationError):
+    assert not verify_multiset_sum_representation_profile(
         MultisetSumRepresentationProfileResult.model_validate(payload)
+    )
 
 
-def test_result_round_trip_replays_the_defining_invariant() -> None:
+def test_result_round_trip_has_the_defining_invariant() -> None:
     result = compute_multiset_sum_representation_profile(
         _request((-5, 0, 9), 5, (-10, 20))
     )
-    assert (
-        MultisetSumRepresentationProfileResult.model_validate(result.model_dump())
-        == result
-    )
+    decoded = MultisetSumRepresentationProfileResult.model_validate(result.model_dump())
+    assert decoded == result
+    assert verify_multiset_sum_representation_profile(decoded)
 
 
 def test_request_requires_canonical_source_order() -> None:
@@ -292,15 +295,16 @@ def test_intersecting_window_still_pays_full_enumeration_work(
         _request((0, 1), 10**15, window)
 
 
-def test_disjoint_window_result_rejects_forged_entries() -> None:
+def test_verifier_rejects_disjoint_window_forged_entries() -> None:
     result = compute_multiset_sum_representation_profile(
         _request((0, 1), 10**15, (-10, -1))
     )
     assert result.entries == ()
     payload = result.model_dump(mode="json")
     payload["entries"] = [{"sum": "5", "multiplicity": 1}]
-    with pytest.raises(ValidationError):
+    assert not verify_multiset_sum_representation_profile(
         MultisetSumRepresentationProfileResult.model_validate(payload)
+    )
 
 
 def test_narrow_window_over_large_slot_family_matches_closed_form() -> None:

--- a/tests/math/additive_combinatorics/test_ordered_difference.py
+++ b/tests/math/additive_combinatorics/test_ordered_difference.py
@@ -13,6 +13,7 @@ from jacobian.math.additive_combinatorics._models import (
 )
 from jacobian.math.additive_combinatorics._operations import (
     compute_ordered_difference_profile,
+    verify_ordered_difference_profile,
 )
 
 
@@ -154,15 +155,16 @@ class TestOrderedDifferenceProfile:
         n = result.set_size
         assert seen == {(i, j) for i in range(n) for j in range(n) if i != j}
 
-    def test_result_rejects_forged_difference(self):
+    def test_verifier_rejects_forged_difference(self):
         req = _request((0,), (1,))
         result = compute_ordered_difference_profile(req)
         payload = result.model_dump()
         payload["entries"][-1]["difference"] = {"coordinates": ["2"]}
-        with pytest.raises(ValidationError):
+        assert not verify_ordered_difference_profile(
             OrderedDifferenceProfileResult.model_validate(payload)
+        )
 
-    def test_result_rejects_mutated_source(self):
+    def test_verifier_rejects_mutated_source(self):
         req = _request((0, 0), (1, 0), (1, 1), (0, 1))
         result = compute_ordered_difference_profile(req)
         payload = result.model_dump()
@@ -170,8 +172,9 @@ class TestOrderedDifferenceProfile:
             {"coordinates": ["9", "9"]},
             *payload["vectors"]["vectors"][1:],
         )
-        with pytest.raises(ValidationError):
+        assert not verify_ordered_difference_profile(
             OrderedDifferenceProfileResult.model_validate(payload)
+        )
 
     def test_result_rejects_later_collision_as_first_witness(self):
         """The witness must be pairs[0] of the first sorted repeated entry,

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -23,6 +23,7 @@ from jacobian.math.additive_combinatorics import (
 from jacobian.math.additive_combinatorics._models import SubsetSumProfileRequest
 from jacobian.math.additive_combinatorics._operations import (
     compute_subset_sum_profile,
+    verify_subset_sum_profile,
 )
 from jacobian.math.additive_combinatorics.operations import (
     MAX_SUBSET_SUM_DP_TRANSITIONS,
@@ -110,46 +111,44 @@ def test_conway_guy_eleven_set_has_2048_distinct_subset_sums() -> None:
     assert all(entry.multiplicity == "1" for entry in result.entries)
 
 
-def test_result_round_trip_replays_complete_profile() -> None:
+def test_result_round_trip_has_complete_profile_verifier() -> None:
     result = compute_subset_sum_profile(_request(-2, 0, 3, 3))
 
-    assert SubsetSumProfile.model_validate(result.model_dump()) == result
+    decoded = SubsetSumProfile.model_validate(result.model_dump())
+    assert decoded == result
+    assert verify_subset_sum_profile(decoded)
 
 
-def test_result_rejects_mutated_source() -> None:
+def test_verifier_rejects_mutated_source() -> None:
     result = compute_subset_sum_profile(_request(1, 1))
     payload = result.model_dump(mode="json")
     payload["source"]["items"] = ["1", "2"]
 
-    with pytest.raises(ValidationError):
-        SubsetSumProfile.model_validate(payload)
+    assert not verify_subset_sum_profile(SubsetSumProfile.model_validate(payload))
 
 
-def test_result_rejects_mutated_multiplicity() -> None:
+def test_verifier_rejects_mutated_multiplicity() -> None:
     result = compute_subset_sum_profile(_request(1, 1))
     payload = result.model_dump(mode="json")
     payload["entries"][1]["multiplicity"] = "3"
 
-    with pytest.raises(ValidationError):
-        SubsetSumProfile.model_validate(payload)
+    assert not verify_subset_sum_profile(SubsetSumProfile.model_validate(payload))
 
 
-def test_result_rejects_mutated_profile_sum() -> None:
+def test_verifier_rejects_mutated_profile_sum() -> None:
     result = compute_subset_sum_profile(_request(1, 1))
     payload = result.model_dump(mode="json")
     payload["entries"][-1]["sum"] = "3"
 
-    with pytest.raises(ValidationError):
-        SubsetSumProfile.model_validate(payload)
+    assert not verify_subset_sum_profile(SubsetSumProfile.model_validate(payload))
 
 
-def test_result_rejects_mutated_total() -> None:
+def test_verifier_rejects_mutated_total() -> None:
     result = compute_subset_sum_profile(_request(1, 1))
     payload = result.model_dump(mode="json")
     payload["total_subsets"] = "3"
 
-    with pytest.raises(ValidationError):
-        SubsetSumProfile.model_validate(payload)
+    assert not verify_subset_sum_profile(SubsetSumProfile.model_validate(payload))
 
 
 def test_result_sensitive_admission_accepts_many_repeated_zeros() -> None:

--- a/tests/math/probability/test_all_terminal_reliability.py
+++ b/tests/math/probability/test_all_terminal_reliability.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from copy import deepcopy
 from fractions import Fraction
+from importlib import import_module
 from itertools import combinations
 from typing import Any
 
@@ -17,6 +18,7 @@ from jacobian.math.probability._all_terminal_reliability import (
     AllTerminalReliabilityRequest,
     AllTerminalReliabilityWireResult,
     compute_all_terminal_reliability,
+    verify_all_terminal_reliability_wire_result,
 )
 from jacobian.math.probability._graph_connection_probability import (
     GraphConnectionProbabilityRequest,
@@ -27,6 +29,7 @@ from jacobian.math.probability.all_terminal_reliability import (
     MAX_ALL_TERMINAL_RELIABILITY_EDGES,
     AllTerminalReliabilityResult,
     all_terminal_reliability,
+    verify_all_terminal_reliability_result,
 )
 
 
@@ -144,20 +147,21 @@ def test_rosenstock_canale_nine_vertex_profile() -> None:
     assert result.reliability_probability == Fraction(66329, 131072)
 
 
-def test_native_result_replays_its_retained_graph() -> None:
+def test_native_result_requires_explicit_verification_for_replay() -> None:
     graph = _graph(
         ("a", "b", "c"),
         (("a", "b"), ("a", "c"), ("b", "c")),
     )
 
-    with pytest.raises(ValueError):
-        AllTerminalReliabilityResult(
-            graph=graph,
-            open_probability=Fraction(1, 2),
-            connected_spanning_subgraph_counts=(0, 0, 2, 1),
-            reliability_probability=Fraction(1, 2),
-            visited_states=8,
-        )
+    claim = AllTerminalReliabilityResult(
+        graph=graph,
+        open_probability=Fraction(1, 2),
+        connected_spanning_subgraph_counts=(0, 0, 2, 1),
+        reliability_probability=Fraction(1, 2),
+        visited_states=8,
+    )
+
+    assert not verify_all_terminal_reliability_result(claim)
 
 
 def test_all_terminal_event_differs_from_two_terminal_connectivity() -> None:
@@ -287,15 +291,57 @@ def test_degenerate_and_boundary_conventions(
         "source-graph",
     ),
 )
-def test_result_replay_rejects_independent_mutations(
+def test_explicit_result_verifier_rejects_independent_mutations(
     mutation: Callable[[dict[str, Any]], None],
     message: str,
 ) -> None:
     candidate = deepcopy(_triangle_result().model_dump(mode="json"))
     mutation(candidate)
 
-    with pytest.raises(ValidationError):
-        AllTerminalReliabilityWireResult.model_validate(candidate)
+    if message in {
+        "visited_states does not match",
+        "connected spanning subgraph has at least n-1 edges",
+    }:
+        with pytest.raises(ValidationError):
+            AllTerminalReliabilityWireResult.model_validate(candidate)
+    else:
+        claim = AllTerminalReliabilityWireResult.model_validate(candidate)
+        assert not verify_all_terminal_reliability_wire_result(claim)
+
+
+@pytest.mark.parametrize("wire", (False, True), ids=("native", "wire"))
+def test_successful_compute_enumerates_each_edge_subset_once(
+    monkeypatch: pytest.MonkeyPatch,
+    wire: bool,
+) -> None:
+    """Kernel output construction does not replay the complete powerset."""
+
+    native_module = import_module("jacobian.math.probability.all_terminal_reliability")
+
+    graph = _graph(
+        ("a", "b", "c", "d"),
+        (("a", "b"), ("a", "c"), ("a", "d"), ("b", "c")),
+    )
+    call_count = 0
+    original = native_module._connected_spanning_subgraph_counts
+
+    def counted(value: SimpleUndirectedGraph) -> tuple[int, ...]:
+        nonlocal call_count
+        call_count += 1
+        return original(value)
+
+    monkeypatch.setattr(native_module, "_connected_spanning_subgraph_counts", counted)
+    if wire:
+        compute_all_terminal_reliability(
+            AllTerminalReliabilityRequest(
+                graph=graph,
+                open_probability=CanonicalRational(num="1", den="2"),
+            )
+        )
+    else:
+        all_terminal_reliability(graph, Fraction(1, 2))
+
+    assert call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/math/probability/test_directed_bond_reliability.py
+++ b/tests/math/probability/test_directed_bond_reliability.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from fractions import Fraction
+from importlib import import_module
 from typing import Any
 
 import pytest
@@ -25,6 +26,7 @@ from jacobian.math.probability._directed_bond_reliability import (
     DirectedBondConnectionProbabilitySource,
     DirectedBondReliabilityArcProbability,
     _directed_bond_connection_probability,
+    verify_directed_bond_connection_probability_result,
 )
 
 
@@ -278,7 +280,7 @@ def _mutate_connection_probability(payload: dict[str, Any]) -> None:
     ),
     ids=("open-arcs", "reachability", "aggregate-probability"),
 )
-def test_result_replay_rejects_mutated_source_bound_conclusions(
+def test_explicit_result_verifier_rejects_mutated_source_bound_conclusions(
     mutation: Callable[[dict[str, Any]], None],
 ) -> None:
     result = _directed_bond_connection_probability(
@@ -293,8 +295,9 @@ def test_result_replay_rejects_mutated_source_bound_conclusions(
     payload = result.model_dump(mode="json")
     mutation(payload)
 
-    with pytest.raises(ValidationError):
-        DirectedBondConnectionProbabilityResult.model_validate(payload)
+    claim = DirectedBondConnectionProbabilityResult.model_validate(payload)
+
+    assert not verify_directed_bond_connection_probability_result(claim)
 
 
 def test_probability_bound_rejects_thirteenth_arc_before_enumeration() -> None:
@@ -309,8 +312,8 @@ def test_probability_bound_rejects_thirteenth_arc_before_enumeration() -> None:
         )
 
 
-def test_logical_work_bound_covers_two_pass_reachability_and_state_records() -> None:
-    """The 12-arc envelope charges both passes over the relevant vertices."""
+def test_logical_work_bound_covers_one_producer_pass() -> None:
+    """The 12-arc envelope charges its one subset-enumeration pass."""
     per_state_kernel_work = (
         6 * MAX_DIRECTED_BOND_RELIABILITY_ARCS
         + 4 * MAX_DIRECTED_BOND_RELIABILITY_RELEVANT_VERTICES
@@ -318,11 +321,40 @@ def test_logical_work_bound_covers_two_pass_reachability_and_state_records() -> 
     per_state_record_work = MAX_DIRECTED_BOND_RELIABILITY_ARCS + 3
 
     assert (
-        2
-        * MAX_DIRECTED_BOND_RELIABILITY_STATES
+        MAX_DIRECTED_BOND_RELIABILITY_STATES
         * (per_state_kernel_work + per_state_record_work)
         + 8
     ) == MAX_DIRECTED_BOND_RELIABILITY_LOGICAL_WORK
+
+
+def test_successful_compute_enumerates_each_arc_subset_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trusted result construction does not replay the complete state ledger."""
+
+    reliability_module = import_module(
+        "jacobian.math.probability._directed_bond_reliability"
+    )
+
+    request = _request(
+        vertex_count=4,
+        arcs=((0, 1), (0, 2), (1, 3), (2, 3)),
+        probabilities=(Fraction(1, 2),) * 4,
+        source=0,
+        target=3,
+    )
+    call_count = 0
+    original = reliability_module._directed_path_exists
+
+    def counted(**kwargs: object) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return original(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(reliability_module, "_directed_path_exists", counted)
+    _directed_bond_connection_probability(request)
+
+    assert call_count == 1 << len(request.graph.edges)
 
 
 def test_ledger_bound_rejects_large_exact_probability_products_before_enumeration() -> (

--- a/tests/math/quivers/test_quivers.py
+++ b/tests/math/quivers/test_quivers.py
@@ -1,5 +1,9 @@
 """Tests for quiver operations."""
 
+import pytest
+from pydantic import ValidationError
+
+from jacobian.canonical import encode_strict_json
 from jacobian.math.quivers._models import (
     AdjacencyMatricesRequest,
     FiniteQuiver,
@@ -56,3 +60,37 @@ def test_fixed_length_paths_zero() -> None:
     )
     result = compute_fixed_length_paths(request)
     assert result.total_paths == 2
+
+
+def test_fixed_length_paths_admits_transportable_count_boundary() -> None:
+    """Eight parallel loops have exactly 8**17 length-17 paths."""
+    request = FixedLengthPathsRequest(
+        quiver=FiniteQuiver(vertex_count=1, arrows=((0, 0),) * 8), length=17
+    )
+
+    result = compute_fixed_length_paths(request)
+
+    assert result.path_matrix == ((8**17,),)
+    assert result.total_paths == 8**17
+    # This is the actual final delivery primitive, not merely model parsing.
+    assert encode_strict_json(result.model_dump(mode="json"))
+
+
+def test_fixed_length_paths_rejects_untransportable_count_before_kernel() -> None:
+    """The next power would produce raw JSON integers above 2**53 - 1."""
+    with pytest.raises(ValidationError) as exc_info:
+        FixedLengthPathsRequest(
+            quiver=FiniteQuiver(vertex_count=1, arrows=((0, 0),) * 8), length=18
+        )
+
+    assert exc_info.value.errors()[0]["type"] == (
+        "quiver.fixed_length_paths_exceeds_envelope"
+    )
+
+
+def test_fixed_length_paths_rejects_parallel_loop_explosion_before_kernel() -> None:
+    """The reported 32-loop, length-32 request is rejected at admission."""
+    with pytest.raises(ValidationError):
+        FixedLengthPathsRequest(
+            quiver=FiniteQuiver(vertex_count=1, arrows=((0, 0),) * 32), length=32
+        )


### PR DESCRIPTION
Fixes #2746
Fixes #2747
Fixes #2748

## Problem
Successful reliability calls replayed an exponential kernel during result construction; fixed-length quiver paths could reach post-execution JSON integer failure; direct-sum diagnostics could exceed transport after the exact computation completed.

## Solution
Kernel-produced reliability outcomes now use trusted factories while explicit bounded verifiers check independently supplied claims. Quiver fixed-length admission derives count, intermediate, safe-integer, and transport bounds before execution. Direct-sum admission reserves the complete canonical diagnostic result before its kernel runs.

## Testing
- `make handoff LANE=math TESTS="tests/math/probability tests/math/quivers tests/math/additive_combinatorics"` — 282 passed

## Public contract impact
None. Operation IDs, result shapes, and admitted mathematical semantics are retained; over-envelope requests now fail at typed request admission.

## Operation boundary ownership
- Changed stage: request bounds and result construction
- Request-bounds owner and controlling quantities: owner-local powerset work, fixed-length path count/intermediate growth, and direct-sum canonical transport bytes
- Backend or kernel path: unchanged
- Result construction: trusted factories for producer results
- Independent-result verifier: owner-local bounded replayers for reliability claims
- Native/MCP parity: shared request admission and kernel path
- Serialized-result and round-trip evidence: boundary tests cover safe and rejected output envelopes