### PR TITLE
fix(mcp): add owner-scoped execution admission

### DIFF
--- a/docs/how-to/deploy-remote-mcp.md
+++ b/docs/how-to/deploy-remote-mcp.md
@@ -65,6 +65,19 @@ authenticated service. Streamable HTTP is stateless by default. Use
 `--stateful-http` only when the deployment deliberately provides stateful
 session handling.
 
+## Plan execution capacity
+
+One server process allows verified thread-safe operation paths to overlap.
+Operations whose complete maintained-backend path has not been verified share
+a conservative single-slot FIFO scope. Queueing is cancellation-aware and
+bounded; saturation returns typed `SERVER_BUSY` retry data, while successful
+responses report `queue_wait_ms` separately from kernel `runtime_ms`.
+
+Because the service and catalog are stateless, deploy multiple supervised
+process replicas when one unsafe-backend slot does not provide enough
+throughput. Route each MCP request to one replica; do not rely on stateful HTTP
+sessions unless `--stateful-http` was explicitly selected.
+
 ## Install the example service files
 
 [`deploy/systemd/jacobian-mcp.service`](../../deploy/systemd/jacobian-mcp.service)

--- a/docs/how-to/invoke-domain-operations.md
+++ b/docs/how-to/invoke-domain-operations.md
@@ -27,4 +27,5 @@ jacobian run integer.compute.extended_gcd --json '{"left":"84","right":"30"}'
 ```
 
 The CLI prints a JSON envelope containing the operation ID, its typed `output`,
-and `runtime_ms`. It does not retain results or create workflow state.
+`runtime_ms`, and `queue_wait_ms` (zero for direct CLI execution). It does not
+retain results or create workflow state.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -53,3 +53,21 @@ caller-supplied pagination cursor. The built-in MCP resource
 `operation://catalog` provides an exact bulk export; ordinary discovery should
 prefer `math.find`. The server registers typed Pydantic tools directly with the
 MCP Python SDK.
+
+## Execution capacity and cancellation
+
+Each operation owner declares the concurrency safety of its complete kernel
+path. Operations backed only by verified thread-safe code may overlap in one
+server process. All other operations share a conservative FIFO serialization
+scope unless an owner declares a narrower verified backend scope; omission is
+therefore fail-closed rather than concurrent by default.
+
+Waiting for a serialized backend is bounded and cancellation-aware. If the
+queue limit expires, `math.run` returns a typed `SERVER_BUSY` transport error
+with the operation ID, observed queue wait, configured wait limit, and retry
+guidance. Successful calls report `queue_wait_ms` separately from kernel
+`runtime_ms`. A cancelled queued request never enters the kernel. Cancellation
+of an admitted in-process kernel remains cooperative and best-effort because a
+Python worker thread cannot be terminated safely; request-owned subprocesses
+receive the cancellation signal through the bounded process runner, which
+terminates and reaps their owned process tree.

--- a/src/jacobian/catalog/catalog.py
+++ b/src/jacobian/catalog/catalog.py
@@ -16,6 +16,7 @@ from jacobian.catalog.models import (
     OperationDiscoveryRequest,
     OperationDiscoveryResult,
     OperationExample,
+    OperationExecutionAdmission,
 )
 from jacobian.catalog.search import browse_operations, discover_operations
 
@@ -26,6 +27,7 @@ class _BoundMathTool:
 
     request_type: type[StrictModel]
     result_type: type[StrictModel]
+    execution_admission: OperationExecutionAdmission
     _run: Callable[[StrictModel], StrictModel]
 
     def run(self, request: StrictModel) -> StrictModel:
@@ -54,6 +56,7 @@ def _bind_operation[RequestT: StrictModel, ResultT: StrictModel](
     return _BoundMathTool(
         request_type=operation.request_type,
         result_type=operation.result_type,
+        execution_admission=operation.execution_admission,
         _run=run,
     )
 

--- a/src/jacobian/catalog/models.py
+++ b/src/jacobian/catalog/models.py
@@ -220,6 +220,7 @@ class OperationResult(StrictModel):
 
     operation_id: OperationId
     runtime_ms: int = Field(ge=0, strict=True)
+    queue_wait_ms: int = Field(default=0, ge=0, strict=True)
     output: dict[str, Any]
 
     @model_validator(mode="after")
@@ -242,6 +243,35 @@ class OperationCatalogSnapshot(StrictModel):
 
 
 @dataclass(frozen=True, slots=True)
+class OperationExecutionAdmission:
+    """One owner's immutable assertion about concurrent kernel execution.
+
+    A serialization key names the process-local safety boundary shared by
+    operations whose maintained backends have not been verified for concurrent
+    worker-thread entry. ``None`` is reserved for an owner that has verified
+    its complete request path for concurrent execution.
+    """
+
+    serialization_key: str | None
+
+    def __post_init__(self) -> None:
+        if self.serialization_key is not None and not self.serialization_key.strip():
+            raise ValueError("execution serialization keys must not be empty")
+
+    @property
+    def permits_concurrency(self) -> bool:
+        """Whether the owner verified concurrent entry into this kernel."""
+
+        return self.serialization_key is None
+
+
+DEFAULT_EXECUTION_ADMISSION = OperationExecutionAdmission(
+    serialization_key="unverified-maintained-backend"
+)
+VERIFIED_CONCURRENT_EXECUTION = OperationExecutionAdmission(serialization_key=None)
+
+
+@dataclass(frozen=True, slots=True)
 class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
     """One discoverable mathematical function and its public typed contract."""
 
@@ -253,6 +283,7 @@ class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
     run: Callable[[RequestT], ResultT]
     tags: tuple[str, ...] = ()
     examples: tuple[OperationExample, ...] = ()
+    execution_admission: OperationExecutionAdmission = DEFAULT_EXECUTION_ADMISSION
 
     def __post_init__(self) -> None:
         if not self.operation_id.strip():
@@ -270,6 +301,8 @@ class MathTool[RequestT: StrictModel, ResultT: StrictModel]:
 type MathTools = tuple[MathTool[Any, Any], ...]
 
 __all__ = [
+    "DEFAULT_EXECUTION_ADMISSION",
+    "VERIFIED_CONCURRENT_EXECUTION",
     "MathTool",
     "MathTools",
     "OperationBrowseCard",
@@ -281,6 +314,7 @@ __all__ = [
     "OperationDiscoveryResult",
     "OperationDomainValidationError",
     "OperationExample",
+    "OperationExecutionAdmission",
     "OperationId",
     "OperationResult",
 ]

--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -13,7 +13,9 @@ from jacobian._models import StrictModel
 from jacobian.canonical import CanonicalizationError, encode_strict_json
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import (
+    DEFAULT_EXECUTION_ADMISSION,
     OperationDomainValidationError,
+    OperationExecutionAdmission,
     OperationId,
     OperationResult,
 )
@@ -51,6 +53,7 @@ class _PreparedOperation:
     """One request parsed against its selected immutable operation binding."""
 
     operation_id: OperationId
+    execution_admission: OperationExecutionAdmission
     run: Callable[[StrictModel], StrictModel]
     request: StrictModel
 
@@ -94,6 +97,11 @@ def _prepare_operation(
         raise OperationRequestValidationError(exc) from exc
     return _PreparedOperation(
         operation_id=operation_id,
+        execution_admission=getattr(
+            binding,
+            "execution_admission",
+            DEFAULT_EXECUTION_ADMISSION,
+        ),
         run=binding.run,
         request=parsed,
     )
@@ -103,6 +111,7 @@ def _invoke_prepared_operation(
     prepared: _PreparedOperation,
     *,
     started: float | None = None,
+    queue_wait_ms: int = 0,
 ) -> OperationResult:
     """Run one already-admitted request and project its typed result."""
 
@@ -113,6 +122,7 @@ def _invoke_prepared_operation(
     return OperationResult(
         operation_id=prepared.operation_id,
         runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
+        queue_wait_ms=queue_wait_ms,
         output=result.model_dump(mode="json"),
     )
 

--- a/src/jacobian/math/logic/_tools.py
+++ b/src/jacobian/math/logic/_tools.py
@@ -1,7 +1,11 @@
 """Catalog declarations for bounded logic operations."""
 
 from jacobian.catalog._examples import example
-from jacobian.catalog.models import MathTool, MathTools
+from jacobian.catalog.models import (
+    VERIFIED_CONCURRENT_EXECUTION,
+    MathTool,
+    MathTools,
+)
 from jacobian.math.logic._cnf import (
     CnfCanonicalizeRequest,
     CnfCanonicalizeResult,
@@ -31,6 +35,7 @@ TOOLS: MathTools = (
         request_type=CnfCanonicalizeRequest,
         result_type=CnfCanonicalizeResult,
         run=canonicalize_cnf,
+        execution_admission=VERIFIED_CONCURRENT_EXECUTION,
         tags=("sat", "cnf", "canonical"),
         examples=(
             example(
@@ -47,6 +52,7 @@ TOOLS: MathTools = (
         request_type=SatAssignmentCheckRequest,
         result_type=SatAssignmentCheckResult,
         run=check_sat_assignment,
+        execution_admission=VERIFIED_CONCURRENT_EXECUTION,
         tags=("sat", "cnf", "assignment", "predicate"),
         examples=(
             example(

--- a/src/jacobian/mcp/models.py
+++ b/src/jacobian/mcp/models.py
@@ -75,6 +75,10 @@ class OperationSearchResult(StrictModel):
     truncated: bool
     next_cursor: str | None = None
     catalog_resource: Literal["operation://catalog"] = "operation://catalog"
+    response_byte_limit: StrictInt
+    truncation_reason: Literal["BYTE_LIMIT"] | None = None
+    query_metadata_truncated: bool = False
+    match_metadata_truncated: bool = False
 
 
 class OperationBrowseResult(StrictModel):
@@ -85,6 +89,9 @@ class OperationBrowseResult(StrictModel):
     truncated: bool
     next_cursor: str | None = None
     catalog_resource: Literal["operation://catalog"] = "operation://catalog"
+    response_byte_limit: StrictInt
+    truncation_reason: Literal["BYTE_LIMIT"] | None = None
+    operation_metadata_truncated: bool = False
 
 
 class OperationInspectionResult(StrictModel):
@@ -118,6 +125,21 @@ class OperationInvalidRequestData(StrictModel):
     )
 
 
+class OperationBusyData(StrictModel):
+    """Structured retry guidance for bounded execution-capacity contention."""
+
+    code: Literal["SERVER_BUSY"] = "SERVER_BUSY"
+    stage: Literal["execution_admission"] = "execution_admission"
+    operation_id: OperationId
+    queue_wait_ms: StrictInt = Field(ge=0)
+    queue_wait_limit_ms: StrictInt = Field(gt=0)
+    retryable: Literal[True] = True
+    hint: str = (
+        "Retry after the current serialized operation completes, or use an "
+        "independent Jacobian server process for separate execution capacity."
+    )
+
+
 class OperationDiscoveryError(StrictModel):
     kind: Literal["error"]
     error: OperationDiscoveryErrorDetail
@@ -142,6 +164,7 @@ class OperationFindResponse(
 __all__ = [
     "OperationBrowseRequest",
     "OperationBrowseResult",
+    "OperationBusyData",
     "OperationDiscoveryError",
     "OperationDiscoveryErrorDetail",
     "OperationFindRequest",

--- a/src/jacobian/mcp/projections.py
+++ b/src/jacobian/mcp/projections.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import Any, cast
 
 from jacobian.catalog.catalog import Catalog
 from jacobian.catalog.models import OperationDiscoveryRequest
 from jacobian.catalog.search import OperationDiscoveryCursorError
+
+_DISCOVERY_RESPONSE_BYTE_LIMIT = 16_384
+
+
+def _mcp_text_json_bytes(value: object) -> bytes:
+    """Measure JSON as the MCP SDK renders structured tool results."""
+
+    return json.dumps(value, ensure_ascii=False, indent=2).encode("utf-8")
 
 
 def _operation_discovery_response(
@@ -39,11 +48,19 @@ def _operation_discovery_response(
                 ),
             },
         }
-    return {
-        "kind": "discovery",
-        **discovered.model_dump(mode="json"),
-        "catalog_resource": "operation://catalog",
-    }
+    return _compact_operation_cards_response(
+        {
+            "kind": "discovery",
+            **discovered.model_dump(mode="json"),
+            "catalog_resource": "operation://catalog",
+            "response_byte_limit": _DISCOVERY_RESPONSE_BYTE_LIMIT,
+            "truncation_reason": None,
+            "query_metadata_truncated": False,
+            "match_metadata_truncated": False,
+        },
+        cards_key="matches",
+        metadata_truncated_key="match_metadata_truncated",
+    )
 
 
 def _operation_browse_response(
@@ -72,8 +89,97 @@ def _operation_browse_response(
                 ),
             },
         }
-    return {
-        "kind": "browse",
-        **browsed.model_dump(mode="json"),
-        "catalog_resource": "operation://catalog",
-    }
+    return _compact_operation_cards_response(
+        {
+            "kind": "browse",
+            **browsed.model_dump(mode="json"),
+            "catalog_resource": "operation://catalog",
+            "response_byte_limit": _DISCOVERY_RESPONSE_BYTE_LIMIT,
+            "truncation_reason": None,
+            "operation_metadata_truncated": False,
+        },
+        cards_key="operations",
+        metadata_truncated_key="operation_metadata_truncated",
+    )
+
+
+def _compact_operation_cards_response(
+    response: dict[str, Any],
+    *,
+    cards_key: str,
+    metadata_truncated_key: str,
+) -> dict[str, Any]:
+    """Bound one compact response while preserving deterministic pagination."""
+
+    cards = cast(list[dict[str, Any]], response[cards_key])
+    while (
+        len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT
+        and len(cards) > 1
+    ):
+        cards.pop()
+        response["truncated"] = True
+        response["next_cursor"] = cards[-1]["operation_id"]
+        response["truncation_reason"] = "BYTE_LIMIT"
+
+    if len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT:
+        for card in cards:
+            if card.get("tags"):
+                card["tags"] = []
+                response[metadata_truncated_key] = True
+                response["truncation_reason"] = "BYTE_LIMIT"
+
+    if len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT:
+        for card in cards:
+            description = card.get("description")
+            if not isinstance(description, str):
+                continue
+            response[metadata_truncated_key] = True
+            response["truncation_reason"] = "BYTE_LIMIT"
+            _truncate_text_field_to_budget(
+                response,
+                card,
+                field="description",
+                value=description,
+            )
+
+    if len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT:
+        query = response.get("query")
+        if isinstance(query, str):
+            response["query_metadata_truncated"] = True
+            response["truncation_reason"] = "BYTE_LIMIT"
+            _truncate_text_field_to_budget(
+                response,
+                response,
+                field="query",
+                value=query,
+            )
+
+    if len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT:
+        raise RuntimeError("compact operation response exceeds its hard byte limit")
+    return response
+
+
+def _truncate_text_field_to_budget(
+    response: dict[str, Any],
+    projection: dict[str, Any],
+    *,
+    field: str,
+    value: str,
+) -> None:
+    """Retain the longest UTF-8 text prefix that fits the response."""
+
+    projection[field] = "."
+    if len(_mcp_text_json_bytes(response)) > _DISCOVERY_RESPONSE_BYTE_LIMIT:
+        return
+    lower = 0
+    upper = len(value)
+    while lower < upper:
+        midpoint = (lower + upper + 1) // 2
+        suffix = "..." if midpoint < len(value) else ""
+        projection[field] = f"{value[:midpoint]}{suffix}"
+        if len(_mcp_text_json_bytes(response)) <= _DISCOVERY_RESPONSE_BYTE_LIMIT:
+            lower = midpoint
+        else:
+            upper = midpoint - 1
+    suffix = "..." if lower < len(value) else ""
+    projection[field] = f"{value[:lower]}{suffix}" or "."

--- a/src/jacobian/mcp/runtime.py
+++ b/src/jacobian/mcp/runtime.py
@@ -2,19 +2,162 @@
 
 from __future__ import annotations
 
+import math
+import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
+from threading import Condition, Lock
 from typing import Any
 
 from mcp.server.mcpserver import Context
 
 from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import OperationExecutionAdmission
+
+_EXECUTION_QUEUE_POLL_SECONDS = 0.05
+_DEFAULT_EXECUTION_QUEUE_WAIT_SECONDS = 30.0
+
+
+class ExecutionAdmissionStatus(Enum):
+    """One terminal outcome from bounded execution-capacity admission."""
+
+    ADMITTED = "admitted"
+    CANCELLED = "cancelled"
+    BUSY = "busy"
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionPermit:
+    """One acquired owner-local execution slot, or a terminal rejection."""
+
+    status: ExecutionAdmissionStatus
+    serialization_key: str | None
+    waited_ms: int
+
+
+class _ExecutionGate:
+    """One FIFO, single-worker gate for a shared backend safety boundary."""
+
+    def __init__(self) -> None:
+        self._condition = Condition()
+        self._queue: list[object] = []
+        self._running = False
+
+    def acquire(
+        self,
+        cancellation: Any,
+        *,
+        timeout_seconds: float,
+        serialization_key: str,
+    ) -> ExecutionPermit:
+        started = time.monotonic()
+        deadline = started + timeout_seconds
+        token = object()
+        with self._condition:
+            self._queue.append(token)
+            while True:
+                if cancellation.is_set():
+                    self._queue.remove(token)
+                    self._condition.notify_all()
+                    return ExecutionPermit(
+                        status=ExecutionAdmissionStatus.CANCELLED,
+                        serialization_key=None,
+                        waited_ms=_elapsed_ms(started),
+                    )
+                if not self._running and self._queue[0] is token:
+                    self._queue.pop(0)
+                    self._running = True
+                    return ExecutionPermit(
+                        status=ExecutionAdmissionStatus.ADMITTED,
+                        serialization_key=serialization_key,
+                        waited_ms=_elapsed_ms(started),
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._queue.remove(token)
+                    self._condition.notify_all()
+                    return ExecutionPermit(
+                        status=ExecutionAdmissionStatus.BUSY,
+                        serialization_key=None,
+                        waited_ms=_elapsed_ms(started),
+                    )
+                self._condition.wait(min(_EXECUTION_QUEUE_POLL_SECONDS, remaining))
+
+    def release(self) -> None:
+        with self._condition:
+            if not self._running:
+                raise RuntimeError("execution gate released without an admitted kernel")
+            self._running = False
+            self._condition.notify_all()
+
+
+class ExecutionAdmissionController:
+    """Admit requests according to immutable owner-declared safety scopes."""
+
+    def __init__(self) -> None:
+        self._gates_lock = Lock()
+        self._gates: dict[str, _ExecutionGate] = {}
+
+    def acquire(
+        self,
+        admission: OperationExecutionAdmission,
+        cancellation: Any,
+        *,
+        timeout_seconds: float,
+    ) -> ExecutionPermit:
+        serialization_key = admission.serialization_key
+        if serialization_key is None:
+            status = (
+                ExecutionAdmissionStatus.CANCELLED
+                if cancellation.is_set()
+                else ExecutionAdmissionStatus.ADMITTED
+            )
+            return ExecutionPermit(
+                status=status,
+                serialization_key=None,
+                waited_ms=0,
+            )
+        with self._gates_lock:
+            gate = self._gates.setdefault(serialization_key, _ExecutionGate())
+        return gate.acquire(
+            cancellation,
+            timeout_seconds=timeout_seconds,
+            serialization_key=serialization_key,
+        )
+
+    def release(self, permit: ExecutionPermit) -> None:
+        serialization_key = permit.serialization_key
+        if serialization_key is None:
+            return
+        with self._gates_lock:
+            gate = self._gates.get(serialization_key)
+        if gate is None:
+            raise RuntimeError("execution permit refers to an unknown safety boundary")
+        gate.release()
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(0, round((time.monotonic() - started) * 1_000))
 
 
 @dataclass(frozen=True, slots=True)
 class AppState:
     operation_catalog: Catalog
     authorize: Callable[[], None] | None = None
+    execution_admission: ExecutionAdmissionController = field(
+        default_factory=ExecutionAdmissionController,
+        repr=False,
+        compare=False,
+    )
+    execution_queue_wait_seconds: float = _DEFAULT_EXECUTION_QUEUE_WAIT_SECONDS
+
+    def __post_init__(self) -> None:
+        if (
+            not math.isfinite(self.execution_queue_wait_seconds)
+            or self.execution_queue_wait_seconds <= 0
+        ):
+            raise ValueError("execution queue wait must be finite and positive")
 
 
 class AuthenticationError(PermissionError):

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -20,6 +20,7 @@ from jacobian.dispatch import (
 )
 from jacobian.mcp.models import (
     OperationBrowseRequest,
+    OperationBusyData,
     OperationFindRequest,
     OperationFindResponse,
     OperationInspectionResult,
@@ -33,14 +34,18 @@ from jacobian.mcp.projections import (
 )
 from jacobian.mcp.runtime import (
     AppState,
+    ExecutionAdmissionStatus,
     _authorize,
     _catalog,
+    _state,
 )
 from jacobian.process import bounded_process_cancellation
 
 _MAX_VALIDATION_ERRORS = 64
 _MAX_VALIDATION_LOCATION_COMPONENTS = 32
 _MAX_VALIDATION_LOCATION_LENGTH = 128
+_MAX_VALIDATION_ISSUES_BYTES = 48 * 1_024
+_SERVER_BUSY = -32_001
 
 
 class _CancellationSignal(Protocol):
@@ -133,29 +138,63 @@ def _run_prepared_operation(
     prepared: _PreparedOperation,
     ctx: Context[AppState, Any],
 ) -> OperationResult:
-    """Run one prepared operation without serializing independent requests."""
+    """Admit one prepared operation through its owner-declared safety scope."""
 
     cancellation = _request_cancellation(ctx)
     if cancellation.is_set():
         raise ToolError("operation cancelled before execution")
-    with bounded_process_cancellation(cancellation):
-        return _invoke_prepared_operation(prepared)
+    state = _state(ctx)
+    permit = state.execution_admission.acquire(
+        prepared.execution_admission,
+        cancellation,
+        timeout_seconds=state.execution_queue_wait_seconds,
+    )
+    if permit.status is ExecutionAdmissionStatus.CANCELLED:
+        raise ToolError("operation cancelled before execution")
+    if permit.status is ExecutionAdmissionStatus.BUSY:
+        wait_limit_ms = max(1, round(state.execution_queue_wait_seconds * 1_000))
+        data = OperationBusyData(
+            operation_id=prepared.operation_id,
+            queue_wait_ms=permit.waited_ms,
+            queue_wait_limit_ms=wait_limit_ms,
+        )
+        raise MCPError(
+            code=_SERVER_BUSY,
+            message="mathematical execution capacity is busy",
+            data=data.model_dump(mode="json"),
+        )
+    try:
+        if cancellation.is_set():
+            raise ToolError("operation cancelled before execution")
+        with bounded_process_cancellation(cancellation):
+            return _invoke_prepared_operation(
+                prepared,
+                queue_wait_ms=permit.waited_ms,
+            )
+    finally:
+        state.execution_admission.release(permit)
 
 
 def _bounded_validation_issues(
     errors: Sequence[Mapping[str, Any]],
 ) -> tuple[OperationValidationIssue, ...]:
-    """Build bounded field diagnostics without reflecting raw caller input."""
+    """Build aggregate-bounded diagnostics without reflecting raw caller input."""
+
+    from jacobian.canonical import encode_strict_json
 
     issues: list[OperationValidationIssue] = []
     for error in errors[:_MAX_VALIDATION_ERRORS]:
-        issues.append(
-            OperationValidationIssue(
-                location=_bounded_validation_location(error["loc"]),
-                code=str(error["type"]),
-                message=_bounded_validation_message(error["msg"]),
-            )
+        issue = OperationValidationIssue(
+            location=_bounded_validation_location(error["loc"]),
+            code=_bounded_text(str(error["type"]), 128),
+            message=_bounded_validation_message(error["msg"]),
         )
+        encoded_candidate = encode_strict_json(
+            [existing.model_dump(mode="json") for existing in (*issues, issue)]
+        )
+        if len(encoded_candidate) > _MAX_VALIDATION_ISSUES_BYTES:
+            break
+        issues.append(issue)
     return tuple(issues)
 
 

--- a/tests/mcp/test_math_run_execution_gate.py
+++ b/tests/mcp/test_math_run_execution_gate.py
@@ -1,0 +1,306 @@
+"""Owner-declared MCP execution admission, cancellation, and capacity contracts."""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.shared.exceptions import MCPError
+
+from jacobian._models import StrictModel
+from jacobian.catalog.catalog import Catalog
+from jacobian.catalog.models import MathTool, OperationResult
+from jacobian.mcp.runtime import AppState
+from jacobian.mcp.tools import math_run
+
+
+class _Request(StrictModel):
+    value: int
+
+
+class _Result(StrictModel):
+    value: int
+
+
+def _context(state: AppState, cancellation: threading.Event) -> Any:
+    return cast(
+        Any,
+        SimpleNamespace(
+            request_context=SimpleNamespace(
+                lifespan_context=state,
+                session=SimpleNamespace(
+                    _request_outbound=SimpleNamespace(cancel_requested=cancellation)
+                ),
+            )
+        ),
+    )
+
+
+def _call(
+    state: AppState,
+    operation_id: str,
+    value: int,
+    cancellation: threading.Event,
+    outcomes: dict[int, OperationResult | Exception],
+) -> None:
+    try:
+        outcomes[value] = math_run(
+            operation_id,
+            {"value": value},
+            ctx=_context(state, cancellation),
+        )
+    except Exception as exc:
+        outcomes[value] = exc
+
+
+def test_builtin_concurrency_is_an_explicit_owner_declaration() -> None:
+    catalog = Catalog.open()
+
+    for operation_id in ("sat.cnf.canonicalize", "sat.assignment.check"):
+        operation = catalog.operation(operation_id)
+        assert operation is not None
+        assert operation.execution_admission.permits_concurrency
+
+    unverified = catalog.operation("integer.compute.extended_gcd")
+    assert unverified is not None
+    assert not unverified.execution_admission.permits_concurrency
+
+
+def test_unverified_owner_path_is_serialized_under_contention() -> None:
+    active_calls = 0
+    maximum_active_calls = 0
+    active_lock = threading.Lock()
+
+    def kernel(request: _Request) -> _Result:
+        nonlocal active_calls, maximum_active_calls
+        with active_lock:
+            active_calls += 1
+            maximum_active_calls = max(maximum_active_calls, active_calls)
+        try:
+            time.sleep(0.005)
+            return _Result(value=request.value)
+        finally:
+            with active_lock:
+                active_calls -= 1
+
+    tool = MathTool(
+        operation_id="test.execution_admission.serialized",
+        title="Serialized owner path",
+        description="Detects overlapping entry into an unverified kernel.",
+        request_type=_Request,
+        result_type=_Result,
+        run=kernel,
+    )
+    state = AppState(operation_catalog=Catalog((tool,)))
+    worker_count = 24
+    start = threading.Barrier(worker_count + 1)
+    outcomes: dict[int, OperationResult | Exception] = {}
+
+    def worker(value: int) -> None:
+        start.wait(timeout=2)
+        _call(state, tool.operation_id, value, threading.Event(), outcomes)
+
+    workers = [threading.Thread(target=worker, args=(value,)) for value in range(24)]
+    for worker_thread in workers:
+        worker_thread.start()
+    start.wait(timeout=2)
+    for worker_thread in workers:
+        worker_thread.join(timeout=5)
+        assert not worker_thread.is_alive()
+
+    assert maximum_active_calls == 1
+    assert len(outcomes) == worker_count
+    assert all(isinstance(outcome, OperationResult) for outcome in outcomes.values())
+
+
+def test_math_run_rejects_cancelled_request_while_waiting_for_owner_gate() -> None:
+    invocations: list[int] = []
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def kernel(request: _Request) -> _Result:
+        invocations.append(request.value)
+        if request.value == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+        return _Result(value=request.value)
+
+    tool = MathTool(
+        operation_id="test.execution_admission.cancelled",
+        title="Cancelled owner gate",
+        description="Records whether a cancelled waiter enters the kernel.",
+        request_type=_Request,
+        result_type=_Result,
+        run=kernel,
+    )
+    state = AppState(operation_catalog=Catalog((tool,)))
+    outcomes: dict[int, OperationResult | Exception] = {}
+    first = threading.Thread(
+        target=_call,
+        args=(state, tool.operation_id, 1, threading.Event(), outcomes),
+    )
+    cancellation = threading.Event()
+    second = threading.Thread(
+        target=_call,
+        args=(state, tool.operation_id, 2, cancellation, outcomes),
+    )
+
+    first.start()
+    assert first_started.wait(timeout=1)
+    second.start()
+    time.sleep(0.1)
+    cancellation.set()
+    second.join(timeout=1)
+    assert not second.is_alive()
+    release_first.set()
+    first.join(timeout=1)
+    assert not first.is_alive()
+
+    assert isinstance(outcomes[2], ToolError)
+    assert "cancelled before execution" in str(outcomes[2])
+    assert invocations == [1]
+
+
+def test_math_run_validates_before_owner_capacity_admission() -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def kernel(request: _Request) -> _Result:
+        first_started.set()
+        assert release_first.wait(timeout=2)
+        return _Result(value=request.value)
+
+    tool = MathTool(
+        operation_id="test.execution_admission.validation",
+        title="Owner admission validation",
+        description="Validates before waiting for execution capacity.",
+        request_type=_Request,
+        result_type=_Result,
+        run=kernel,
+    )
+    state = AppState(
+        operation_catalog=Catalog((tool,)),
+        execution_queue_wait_seconds=0.05,
+    )
+    outcomes: dict[int, OperationResult | Exception] = {}
+    holder = threading.Thread(
+        target=_call,
+        args=(state, tool.operation_id, 1, threading.Event(), outcomes),
+    )
+    holder.start()
+    assert first_started.wait(timeout=1)
+    try:
+        with pytest.raises(MCPError) as invalid_error:
+            math_run(
+                tool.operation_id,
+                {"value": "invalid"},
+                ctx=_context(state, threading.Event()),
+            )
+        assert invalid_error.value.code == -32602
+        assert invalid_error.value.data["code"] == "INVALID_REQUEST"
+    finally:
+        release_first.set()
+        holder.join(timeout=1)
+    assert not holder.is_alive()
+
+
+def test_math_run_reports_typed_server_busy_after_bounded_wait() -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def kernel(request: _Request) -> _Result:
+        first_started.set()
+        assert release_first.wait(timeout=2)
+        return _Result(value=request.value)
+
+    tool = MathTool(
+        operation_id="test.execution_admission.busy",
+        title="Busy owner gate",
+        description="Exercises bounded MCP capacity admission.",
+        request_type=_Request,
+        result_type=_Result,
+        run=kernel,
+    )
+    state = AppState(
+        operation_catalog=Catalog((tool,)),
+        execution_queue_wait_seconds=0.05,
+    )
+    outcomes: dict[int, OperationResult | Exception] = {}
+    holder = threading.Thread(
+        target=_call,
+        args=(state, tool.operation_id, 1, threading.Event(), outcomes),
+    )
+    holder.start()
+    assert first_started.wait(timeout=1)
+    try:
+        with pytest.raises(MCPError) as busy_error:
+            math_run(
+                tool.operation_id,
+                {"value": 2},
+                ctx=_context(state, threading.Event()),
+            )
+        assert busy_error.value.code == -32_001
+        assert busy_error.value.message == "mathematical execution capacity is busy"
+        busy_data = busy_error.value.data
+        assert busy_data["code"] == "SERVER_BUSY"
+        assert busy_data["stage"] == "execution_admission"
+        assert busy_data["operation_id"] == tool.operation_id
+        assert busy_data["queue_wait_ms"] >= 50
+        assert busy_data["queue_wait_limit_ms"] == 50
+        assert busy_data["retryable"] is True
+        assert "Retry" in busy_data["hint"]
+    finally:
+        release_first.set()
+        holder.join(timeout=1)
+    assert not holder.is_alive()
+
+
+def test_owner_gate_admits_waiters_in_arrival_order() -> None:
+    entered: list[int] = []
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def kernel(request: _Request) -> _Result:
+        entered.append(request.value)
+        if request.value == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+        return _Result(value=request.value)
+
+    tool = MathTool(
+        operation_id="test.execution_admission.fifo",
+        title="FIFO owner gate",
+        description="Exercises FIFO execution-capacity admission.",
+        request_type=_Request,
+        result_type=_Result,
+        run=kernel,
+    )
+    state = AppState(operation_catalog=Catalog((tool,)))
+    outcomes: dict[int, OperationResult | Exception] = {}
+    workers = [
+        threading.Thread(
+            target=_call,
+            args=(state, tool.operation_id, value, threading.Event(), outcomes),
+        )
+        for value in (1, 2, 3)
+    ]
+    workers[0].start()
+    assert first_started.wait(timeout=1)
+    workers[1].start()
+    time.sleep(0.05)
+    workers[2].start()
+    time.sleep(0.05)
+    release_first.set()
+    for worker_thread in workers:
+        worker_thread.join(timeout=1)
+        assert not worker_thread.is_alive()
+
+    assert entered == [1, 2, 3]
+    assert all(isinstance(outcome, OperationResult) for outcome in outcomes.values())
+    second = outcomes[2]
+    assert isinstance(second, OperationResult)
+    assert second.queue_wait_ms >= 50

--- a/tests/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/mcp/test_mcp_catalog_and_policy.py
@@ -5,7 +5,26 @@ from __future__ import annotations
 import asyncio
 import json
 
+from mcp.types import (
+    CallToolResult,
+    ReadResourceResult,
+    TextContent,
+    TextResourceContents,
+)
+
 from jacobian.mcp.server import create_server
+
+
+def _tool_text(result: CallToolResult) -> str:
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    return content.text
+
+
+def _resource_text(result: ReadResourceResult) -> str:
+    content = result.contents[0]
+    assert isinstance(content, TextResourceContents)
+    return content.text
 
 
 def test_mcp_catalog_is_the_complete_static_operation_library() -> None:
@@ -17,7 +36,7 @@ def test_mcp_catalog_is_the_complete_static_operation_library() -> None:
             raise_exceptions=True,
         ) as client:
             resource = await client.read_resource("operation://catalog")
-            catalog = json.loads(resource.contents[0].text)
+            catalog = json.loads(_resource_text(resource))
             assert catalog["operations"]
             assert "policy_profile" not in catalog
             assert "policy_digest" not in catalog
@@ -39,7 +58,7 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
             raise_exceptions=True,
         ) as client:
             resource_result = await client.read_resource("operation://catalog")
-            full_catalog = json.loads(resource_result.contents[0].text)
+            full_catalog = json.loads(_resource_text(resource_result))
             discoverable_ids = {
                 descriptor["operation_id"] for descriptor in full_catalog["operations"]
             }
@@ -50,8 +69,9 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
             )
             assert isinstance(listed.structured_content, dict)
             index = listed.structured_content
-            assert len(listed.content[0].text.encode("utf-8")) <= 16 * 1024
-            assert json.loads(listed.content[0].text) == index
+            listed_text = _tool_text(listed)
+            assert len(listed_text.encode("utf-8")) <= 16 * 1024
+            assert json.loads(listed_text) == index
             assert index["response_byte_limit"] == 16 * 1024
             assert "discovery_version" not in index
             assert len(index["matches"]) <= 20
@@ -76,7 +96,7 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
                 )
                 assert isinstance(next_page.structured_content, dict)
                 page = next_page.structured_content
-                assert len(next_page.content[0].text.encode("utf-8")) <= 16 * 1024
+                assert len(_tool_text(next_page).encode("utf-8")) <= 16 * 1024
                 indexed_ids.update(
                     descriptor["operation_id"] for descriptor in page["matches"]
                 )
@@ -120,7 +140,7 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
                     }
                 },
             )
-            invalid = json.loads(invalid_cursor.content[0].text)
+            invalid = json.loads(_tool_text(invalid_cursor))
             assert invalid["error"]["code"] == "INVALID_CURSOR"
 
     asyncio.run(scenario())
@@ -135,7 +155,7 @@ def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
             raise_exceptions=True,
         ) as client:
             resource_result = await client.read_resource("operation://catalog")
-            full_catalog = json.loads(resource_result.contents[0].text)
+            full_catalog = json.loads(_resource_text(resource_result))
             catalog_ids = [
                 descriptor["operation_id"] for descriptor in full_catalog["operations"]
             ]
@@ -147,8 +167,9 @@ def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
                 assert isinstance(page_result.structured_content, dict)
                 page = page_result.structured_content
                 assert page["kind"] == "browse"
-                assert len(page_result.content[0].text.encode("utf-8")) <= 16 * 1024
-                assert json.loads(page_result.content[0].text) == page
+                page_text = _tool_text(page_result)
+                assert len(page_text.encode("utf-8")) <= 16 * 1024
+                assert json.loads(page_text) == page
                 assert page["response_byte_limit"] == 16 * 1024
                 assert "discovery_version" not in page
                 assert len(page["operations"]) <= 20
@@ -180,7 +201,7 @@ def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
                     }
                 },
             )
-            invalid = json.loads(invalid_cursor.content[0].text)
+            invalid = json.loads(_tool_text(invalid_cursor))
             assert invalid["error"]["code"] == "INVALID_CURSOR"
 
     asyncio.run(scenario())
@@ -223,7 +244,7 @@ def test_mcp_search_and_browse_bound_unrestricted_card_metadata() -> None:
             )
             assert isinstance(searched.structured_content, dict)
             search_page = searched.structured_content
-            assert len(searched.content[0].text.encode("utf-8")) <= 16 * 1024
+            assert len(_tool_text(searched).encode("utf-8")) <= 16 * 1024
             assert search_page["response_byte_limit"] == 16 * 1024
             assert search_page["truncation_reason"] == "BYTE_LIMIT"
             assert search_page["match_metadata_truncated"] is True
@@ -234,7 +255,7 @@ def test_mcp_search_and_browse_bound_unrestricted_card_metadata() -> None:
             )
             assert isinstance(long_query.structured_content, dict)
             long_query_page = long_query.structured_content
-            assert len(long_query.content[0].text.encode("utf-8")) <= 16 * 1024
+            assert len(_tool_text(long_query).encode("utf-8")) <= 16 * 1024
             assert long_query_page["query_metadata_truncated"] is True
             assert long_query_page["truncation_reason"] == "BYTE_LIMIT"
 
@@ -244,7 +265,7 @@ def test_mcp_search_and_browse_bound_unrestricted_card_metadata() -> None:
                 browsed = await client.call_tool("math.find", {"request": request})
                 assert isinstance(browsed.structured_content, dict)
                 browse_page = browsed.structured_content
-                assert len(browsed.content[0].text.encode("utf-8")) <= 16 * 1024
+                assert len(_tool_text(browsed).encode("utf-8")) <= 16 * 1024
                 assert browse_page["response_byte_limit"] == 16 * 1024
                 assert browse_page["truncation_reason"] == "BYTE_LIMIT"
                 assert browse_page["operation_metadata_truncated"] is True

--- a/tests/mcp/test_mcp_catalog_and_policy.py
+++ b/tests/mcp/test_mcp_catalog_and_policy.py
@@ -52,6 +52,7 @@ def test_mcp_compact_operation_index_is_searchable_and_paginated() -> None:
             index = listed.structured_content
             assert len(listed.content[0].text.encode("utf-8")) <= 16 * 1024
             assert json.loads(listed.content[0].text) == index
+            assert index["response_byte_limit"] == 16 * 1024
             assert "discovery_version" not in index
             assert len(index["matches"]) <= 20
             indexed_ids = {
@@ -148,6 +149,7 @@ def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
                 assert page["kind"] == "browse"
                 assert len(page_result.content[0].text.encode("utf-8")) <= 16 * 1024
                 assert json.loads(page_result.content[0].text) == page
+                assert page["response_byte_limit"] == 16 * 1024
                 assert "discovery_version" not in page
                 assert len(page["operations"]) <= 20
                 assert all(
@@ -180,5 +182,80 @@ def test_mcp_operation_browse_pages_the_complete_immutable_library() -> None:
             )
             invalid = json.loads(invalid_cursor.content[0].text)
             assert invalid["error"]["code"] == "INVALID_CURSOR"
+
+    asyncio.run(scenario())
+
+
+def test_mcp_search_and_browse_bound_unrestricted_card_metadata() -> None:
+    from jacobian._models import StrictModel
+    from jacobian.catalog.catalog import Catalog
+    from jacobian.catalog.models import MathTool
+    from jacobian.mcp.runtime import AppState
+    from jacobian.mcp.server import _build_server
+
+    class Request(StrictModel):
+        value: int
+
+    class Result(StrictModel):
+        value: int
+
+    tools = tuple(
+        MathTool(
+            operation_id=f"test.large_metadata.card{index}",
+            title=f"Large metadata card {index}",
+            description="exact " + ("数学" * 12_000),
+            request_type=Request,
+            result_type=Result,
+            run=lambda request: Result(value=request.value),
+            tags=("标签" * 12_000,),
+        )
+        for index in range(4)
+    )
+    server = _build_server(state=AppState(operation_catalog=Catalog(tools)))
+
+    async def scenario() -> None:
+        from mcp import Client
+
+        async with Client(server, raise_exceptions=True) as client:
+            searched = await client.call_tool(
+                "math.find",
+                {"request": {"op": "search", "query": "exact", "limit": 4}},
+            )
+            assert isinstance(searched.structured_content, dict)
+            search_page = searched.structured_content
+            assert len(searched.content[0].text.encode("utf-8")) <= 16 * 1024
+            assert search_page["response_byte_limit"] == 16 * 1024
+            assert search_page["truncation_reason"] == "BYTE_LIMIT"
+            assert search_page["match_metadata_truncated"] is True
+
+            long_query = await client.call_tool(
+                "math.find",
+                {"request": {"op": "search", "query": "q" * 20_000}},
+            )
+            assert isinstance(long_query.structured_content, dict)
+            long_query_page = long_query.structured_content
+            assert len(long_query.content[0].text.encode("utf-8")) <= 16 * 1024
+            assert long_query_page["query_metadata_truncated"] is True
+            assert long_query_page["truncation_reason"] == "BYTE_LIMIT"
+
+            request: dict[str, object] = {"op": "browse", "limit": 4}
+            browsed_ids: list[str] = []
+            while True:
+                browsed = await client.call_tool("math.find", {"request": request})
+                assert isinstance(browsed.structured_content, dict)
+                browse_page = browsed.structured_content
+                assert len(browsed.content[0].text.encode("utf-8")) <= 16 * 1024
+                assert browse_page["response_byte_limit"] == 16 * 1024
+                assert browse_page["truncation_reason"] == "BYTE_LIMIT"
+                assert browse_page["operation_metadata_truncated"] is True
+                browsed_ids.extend(
+                    operation["operation_id"] for operation in browse_page["operations"]
+                )
+                cursor = browse_page["next_cursor"]
+                if cursor is None:
+                    break
+                request["cursor"] = cursor
+
+        assert browsed_ids == sorted(tool.operation_id for tool in tools)
 
     asyncio.run(scenario())

--- a/tests/mcp/test_mcp_invocation_journey.py
+++ b/tests/mcp/test_mcp_invocation_journey.py
@@ -20,13 +20,33 @@ MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
 
 
+def test_validation_issue_projection_enforces_aggregate_byte_budget() -> None:
+    from jacobian.canonical import encode_strict_json
+    from jacobian.mcp.tools import _bounded_validation_issues
+
+    errors = [
+        {
+            "loc": tuple(f"{'location' * 32}{component}" for component in range(32)),
+            "type": "validation_code" * 32,
+            "msg": "validation message " * 128,
+        }
+        for _ in range(64)
+    ]
+
+    issues = _bounded_validation_issues(errors)
+    encoded = encode_strict_json([issue.model_dump(mode="json") for issue in issues])
+
+    assert 0 < len(issues) < 64
+    assert len(encoded) <= 48 * 1_024
+
+
 def test_mcp_runs_independent_sync_operations_concurrently() -> None:
     """One slow kernel cannot block an independent MCP request."""
 
     from jacobian._models import StrictModel
     from jacobian.catalog.builtins import BUILTIN_TOOLS
     from jacobian.catalog.catalog import Catalog
-    from jacobian.catalog.models import MathTool
+    from jacobian.catalog.models import VERIFIED_CONCURRENT_EXECUTION, MathTool
     from jacobian.mcp.runtime import AppState
     from jacobian.mcp.server import _build_server
 
@@ -62,6 +82,7 @@ def test_mcp_runs_independent_sync_operations_concurrently() -> None:
         request_type=Request,
         result_type=Result,
         run=concurrent_kernel,
+        execution_admission=VERIFIED_CONCURRENT_EXECUTION,
     )
     server = _build_server(
         state=AppState(operation_catalog=Catalog((*BUILTIN_TOOLS, tool)))
@@ -253,6 +274,7 @@ def test_mcp_describes_and_invokes_operations(tmp_path: Path) -> None:
                 for component in issue["location"]
                 if isinstance(component, str)
             )
+            assert len(json.dumps(bounded_data).encode("utf-8")) <= 64 * 1_024
 
             with pytest.raises(MCPError) as multiple_errors:
                 await client.call_tool(

--- a/tests/mcp/test_mcp_invocation_journey.py
+++ b/tests/mcp/test_mcp_invocation_journey.py
@@ -13,11 +13,18 @@ from pathlib import Path
 
 import pytest
 from mcp.shared.exceptions import MCPError
+from mcp.types import CallToolResult, TextContent
 
 from jacobian.mcp.server import create_server
 
 MATH_TOOL_NAMES = {"math.find", "math.run"}
 MCP_TOOL_NAMES = MATH_TOOL_NAMES
+
+
+def _tool_text(result: CallToolResult) -> str:
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    return content.text
 
 
 def test_validation_issue_projection_enforces_aggregate_byte_budget() -> None:
@@ -141,7 +148,7 @@ def test_mcp_describes_and_invokes_operations(tmp_path: Path) -> None:
                 },
             )
             assert isinstance(result.structured_content, dict)
-            response = json.loads(result.content[0].text)
+            response = json.loads(_tool_text(result))
             assert response["runtime_ms"] >= 0
             assert isinstance(result.structured_content, dict)
             assert "mcp_projection" not in result.structured_content
@@ -312,8 +319,9 @@ def test_mcp_describes_and_invokes_operations(tmp_path: Path) -> None:
                 },
             )
             assert unknown.is_error is True
-            assert "unknown operation" in unknown.content[0].text
-            assert len(unknown.content[0].text.encode("utf-8")) < 2_048
+            unknown_text = _tool_text(unknown)
+            assert "unknown operation" in unknown_text
+            assert len(unknown_text.encode("utf-8")) < 2_048
             assert unknown.structured_content is None
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Problem

This is the remaining execution-admission repair discovered after [#2751](https://github.com/morluto/jacobian/pull/2751) merged. It addresses the unresolved production behavior from [#2749](https://github.com/morluto/jacobian/issues/2749) without modifying the merged PR.

The landed adapter allowed synchronous `math.run` calls to overlap without an operation-owner assertion that the complete maintained-backend path was thread-safe. The pre-edit live MCP reproduction reported `unsafe_overlap: true` for two default/unclassified calls. Review also identified that the refactor had removed the MCP discovery and validation response-byte budgets and the obsolete process-global gate tests had not been migrated to the replacement design.

## Solution

- Add immutable, owner-declared `OperationExecutionAdmission` metadata to each `MathTool` and carry it through catalog binding and prepared dispatch.
- Fail closed: unverified maintained-backend paths share a conservative process-local FIFO serialization key. Only the two pure SAT normalization/checking paths are explicitly declared verified for concurrent entry.
- Validate before capacity admission. Make queue waiting cancellation-aware and bounded, remove cancelled waiters before kernel entry, and return typed `SERVER_BUSY` data after the queue deadline.
- Report successful `queue_wait_ms` independently from kernel `runtime_ms`; direct CLI execution remains queue-free and reports zero.
- Preserve the existing request-owned subprocess cancellation context around admitted execution, including graceful/forced process-tree termination and reaping.
- Restore a 16 KiB rendered MCP budget for discovery/browse pages and a 48 KiB aggregate budget for validation issues, without reflecting raw caller input.
- Replace the deleted global-gate tests with deterministic owner-admission, FIFO, cancellation, backpressure, verified-overlap, response-cap, and stress coverage. Update deployment and tool documentation.

## Testing

Every reproduction and validation command ran in a named tmux session with a saved `.command`, complete `.log`, `.status`, `EXIT_STATUS`, and `FINISHED_UTC` record.

Pre-edit reproduction:

```sh
uv run python tmp/pr2751-tmux/reproduce_unclassified_overlap.py
```

Result: live MCP reported `unsafe_overlap: true`, reproducing concurrent entry into an unverified kernel.

Fresh follow-up acceptance:

```sh
make affected AFFECTED_BASE=origin/main
```

Result: scoped Ruff and mypy passed; the exact macOS run stopped at the same 17 multivariate factor-worker `RLIMIT_AS` failures reproduced on the untouched baseline (`6061 passed, 60 skipped`). No changed MCP path failed.

```sh
make affected AFFECTED_BASE=origin/main PYTEST_ARGS="--ignore=tests/math/polynomials/multivariate/test_factor.py --ignore=tests/process/polynomial_maps/test_generic_degree_singular_process.py"
```

Result: every locally available selected lane passed: 6,032 math tests, 49 catalog tests, 638 catalog/example integration tests, 4 CLI tests, 66 dispatch tests, 753 integration tests, 247 tooling tests, 27 MCP tests, and 157 process tests (6 skipped). The planner then reached `make test-singular` and stopped because Singular 4.4 is not installed on this macOS host. Installed-wheel and pinned Singular evidence remain selected for hosted CI.

```sh
make handoff LANE=mcp TESTS="tests/mcp/test_math_run_execution_gate.py tests/mcp/test_mcp_invocation_journey.py tests/mcp/test_mcp_catalog_and_policy.py"
```

Result: repository-wide Ruff and formatting passed (2,803 files), mypy passed (1,106 files), and 14 focused MCP tests passed.

```sh
make test-mcp
```

Result: 27 passed, including stdio cancellation, graceful/forced process-tree cleanup, owner serialization, queue cancellation/backpressure, and response-byte caps.

```sh
uv run --locked pytest -n 0 --timeout=120 tests/mcp/test_math_run_execution_gate.py tests/mcp/test_mcp_invocation_journey.py::test_mcp_runs_independent_sync_operations_concurrently --count=10 --durations=10
```

Result: 70 passed. Verified-safe operations overlapped while the unverified owner path remained serialized under repeated contention.

```sh
make docs-linkcheck
```

Result: documentation command validation and Markdown link checking passed.

The frozen-tree broad ordinary gate also passed on the supported macOS surface:

```sh
make check PYTEST_ARGS=--ignore=tests/math/polynomials/multivariate/test_factor.py
```

Result: 6,398 passed, 60 skipped.

## Public contract impact

MCP transport contract only. Successful `math.run` results add `queue_wait_ms`; saturated serialized paths return typed `SERVER_BUSY` transport data; discovery/browse responses expose deterministic byte-limit truncation metadata. Mathematical request domains, operation IDs, kernels, and mathematical result semantics are unchanged.

## Operation boundary ownership

- Changed stage: catalog declaration, request-scoped execution admission, and MCP transport projection.
- Request-bounds owner and controlling quantities: operation-owned request models remain unchanged; `AppState.execution_queue_wait_seconds` bounds the process-local admission wait.
- Backend or kernel path: each immutable `MathTool` declares its complete-path concurrency status; unverified paths fail closed, and request-owned subprocesses continue through the bounded process runner.
- Result construction: mathematical result construction is unchanged; MCP adds admission telemetry after typed execution.
- Independent-result verifier: none; this change does not accept independently supplied mathematical results.
- Native/MCP parity: both paths execute the same typed operation. Native dispatch has no MCP queue and reports zero queue wait; MCP applies transport-only capacity admission and cancellation.
- Serialized-result and round-trip evidence: catalog binding, dispatch, MCP structured-content, validation-cap, and producer/consumer integration tests pass.

## Canonical value audit

- [x] Existing canonical values searched; no new mathematical value was introduced.
- [x] Ownership distinction documented; admission and queue telemetry are transport/execution data, not mathematical values.
- [x] Producer→consumer mathematical serialization remains unchanged and is covered by integration tests.

## Catalog admission

Not applicable. Catalog membership and public mathematical semantics are unchanged; this adds immutable execution-admission metadata to existing operations.

## Closure matrix

None. This is the focused remaining repair for #2749 after #2751 merged.

## Checklist

- [x] `make handoff LANE=mcp TESTS=...` passes.
- [x] `make test-mcp` and repeated concurrency/admission stress are listed above.
- [x] Harbor task or verifier changes are not applicable.
- [x] Catalog membership is unchanged; owner-local execution declarations are explicit and fail closed.
- [x] Runtime-bound changes name the owner and preserve the same semantic operation path for native and MCP callers.
- [x] Mathematical result semantics are unchanged.
- [x] The motivating live MCP overlap regression is reproduced and covered by replacement tests.
- [x] Queue boundary, cancellation, timeout/backpressure, FIFO, and repeated-contention evidence is included.
- [x] No new mathematical shared abstraction or kernel duplication is introduced.
