### PR TITLE
Harden bounded mathematical owner outcomes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,10 @@ ignore_imports = [
     "jacobian.math.** -> jacobian.catalog.admission",
     # The logic domain launches bounded external solvers via jacobian.process.
     "jacobian.math.logic._sat -> jacobian.process",
+    # These owners each isolate a bounded, maintained external backend.
+    "jacobian.math.graphs.isomorphism._operations -> jacobian.process",
+    "jacobian.math.number_field._operations -> jacobian.process",
+    "jacobian.math.number_theory._factorization_kernels -> jacobian.process",
     # Private exact-algebra adapters share one bounded Singular process owner.
     "jacobian.math._singular -> jacobian.process",
     # General ideal radical/quotient run in a bounded one-shot Singular process.

--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -265,8 +265,11 @@ def compute_ordered_difference_profile(
 def verify_subset_sum_profile(profile: SubsetSumProfile) -> bool:
     """Check an independently supplied complete profile within its envelope."""
 
-    envelope = subset_sum_profile_envelope(profile.source)
-    expected = tuple(sorted(subset_sum_profile_counts(profile.source).items()))
+    try:
+        envelope = subset_sum_profile_envelope(profile.source)
+        expected = tuple(sorted(subset_sum_profile_counts(profile.source).items()))
+    except ValueError:
+        return False
     actual = tuple(
         (
             parse_canonical_integer(entry.sum),
@@ -287,12 +290,17 @@ def verify_multiset_sum_representation_profile(
 ) -> bool:
     """Check a supplied complete multiset-sum profile under request admission."""
 
-    request = MultisetSumRepresentationProfileRequest(
-        source=result.source, arity=result.arity, window=result.window
-    )
-    values = _multiset_sum_source_values(request.source)
-    bounds = request.window.as_integer_bounds() if request.window is not None else None
-    counts = count_sums(values, request.arity, bounds)
+    try:
+        request = MultisetSumRepresentationProfileRequest(
+            source=result.source, arity=result.arity, window=result.window
+        )
+        values = _multiset_sum_source_values(request.source)
+        bounds = (
+            request.window.as_integer_bounds() if request.window is not None else None
+        )
+        counts = count_sums(values, request.arity, bounds)
+    except ValueError:
+        return False
     expected = tuple(
         RepresentationProfileEntry(
             sum=format_canonical_integer(value), multiplicity=counts[value]

--- a/src/jacobian/math/galois_theory/_models.py
+++ b/src/jacobian/math/galois_theory/_models.py
@@ -176,6 +176,30 @@ class GaloisFactorResult(StrictModel):
     is_irreducible: bool
     method: str = "SYMPY_FACTOR_MOD_P"
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        field_order: int,
+        source_coefficients: tuple[int, ...],
+        unit: int,
+        factors: tuple[FiniteFieldFactor, ...],
+        distinct_factor_count: int,
+        factor_count: int,
+        is_irreducible: bool,
+    ) -> Self:
+        """Construct output whose complete factorization came from the kernel."""
+
+        return cls.model_construct(
+            field_order=field_order,
+            source_coefficients=source_coefficients,
+            unit=unit,
+            factors=factors,
+            distinct_factor_count=distinct_factor_count,
+            factor_count=factor_count,
+            is_irreducible=is_irreducible,
+        )
+
     @model_validator(mode="after")
     def require_reconstruction_certificate(self) -> Self:
         _require_prime(self.field_order)
@@ -196,17 +220,10 @@ class GaloisFactorResult(StrictModel):
                 "reconstruction_mismatch",
                 "factorization must reconstruct the source modulo p",
             )
-        if self.is_irreducible != _factorization_is_irreducible(self):
-            raise _validation_error(
-                "irreducibility_mismatch",
-                "irreducibility must agree with the complete factorization",
-            )
         return self
 
 
 def _require_factor_residues(result: GaloisFactorResult) -> None:
-    from sympy import GF, Poly, Symbol
-
     prime = result.field_order
     if result.unit >= prime:
         raise _validation_error(
@@ -227,16 +244,6 @@ def _require_factor_residues(result: GaloisFactorResult) -> None:
         if factor.coefficients[-1] != 1:
             raise _validation_error(
                 "factor_not_monic", "finite-field factors must be monic"
-            )
-        polynomial = Poly(
-            list(reversed(factor.coefficients)),
-            Symbol("x"),
-            domain=GF(prime),
-        )
-        if not polynomial.is_irreducible:
-            raise _validation_error(
-                "factor_not_irreducible",
-                "every finite-field factor must be irreducible",
             )
 
 
@@ -328,18 +335,32 @@ class GaloisGroupResult(StrictModel):
     is_solvable: bool
     method: str = "SYMPY_GALOIS_GROUP"
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        group: FinitePermutationGroup,
+        group_name: str,
+        order: int,
+        degree: int,
+        is_solvable: bool,
+    ) -> Self:
+        """Construct output whose group properties came from the kernel."""
+
+        return cls.model_construct(
+            group=group,
+            group_name=group_name,
+            order=order,
+            degree=degree,
+            is_solvable=is_solvable,
+        )
+
     @model_validator(mode="after")
     def require_group_degree(self) -> Self:
         if self.degree != len(self.group.root_axis):
             raise _validation_error(
                 "group_degree_mismatch",
                 "group root axis must match the polynomial degree",
-            )
-        order, is_solvable = _permutation_group_properties(self.group)
-        if self.order != order or self.is_solvable != is_solvable:
-            raise _validation_error(
-                "group_properties_mismatch",
-                "reported group properties must agree with the permutation generators",
             )
         return self
 
@@ -349,14 +370,22 @@ class SolvableResult(StrictModel):
     group: FinitePermutationGroup
     method: str = "GALOIS_GROUP_SOLVABILITY"
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        solvable_by_radicals: bool,
+        group: FinitePermutationGroup,
+    ) -> Self:
+        """Construct output whose solvability came from the kernel."""
+
+        return cls.model_construct(
+            solvable_by_radicals=solvable_by_radicals,
+            group=group,
+        )
+
     @model_validator(mode="after")
     def require_group_certificate(self) -> Self:
-        _, is_solvable = _permutation_group_properties(self.group)
-        if self.solvable_by_radicals != is_solvable:
-            raise _validation_error(
-                "solvability_mismatch",
-                "radical solvability must agree with the permutation generators",
-            )
         return self
 
 

--- a/src/jacobian/math/galois_theory/_operations.py
+++ b/src/jacobian/math/galois_theory/_operations.py
@@ -18,6 +18,7 @@ from jacobian.math.galois_theory._models import (
     GaloisGroupResult,
     SolvableRequest,
     SolvableResult,
+    _permutation_group_properties,
 )
 
 
@@ -47,7 +48,7 @@ def compute_galois_factor(request: GaloisFactorRequest) -> GaloisFactorResult:
         and result_factors[0].multiplicity == 1
         and len(result_factors[0].coefficients) == len(request.coefficients)
     )
-    return GaloisFactorResult(
+    return GaloisFactorResult._from_kernel(
         field_order=request.field_order,
         source_coefficients=request.coefficients,
         unit=int(unit) % request.field_order,
@@ -55,6 +56,24 @@ def compute_galois_factor(request: GaloisFactorRequest) -> GaloisFactorResult:
         distinct_factor_count=len(result_factors),
         factor_count=factor_count,
         is_irreducible=is_irred,
+    )
+
+
+def verify_galois_factor_result(result: GaloisFactorResult) -> bool:
+    """Replay bounded factor irreducibility for a supplied factorization claim."""
+
+    from sympy import GF, Poly, Symbol
+
+    x = Symbol("x")
+    return result.is_irreducible == (
+        len(result.factors) == 1
+        and result.factors[0].multiplicity == 1
+        and len(result.factors[0].coefficients) == len(result.source_coefficients)
+    ) and all(
+        Poly(
+            list(reversed(factor.coefficients)), x, domain=GF(result.field_order)
+        ).is_irreducible
+        for factor in result.factors
     )
 
 
@@ -105,12 +124,23 @@ def compute_galois_group(request: GaloisGroupRequest) -> GaloisGroupResult:
     order = int(perm_group.order())
     is_solvable = bool(perm_group.is_solvable)
 
-    return GaloisGroupResult(
+    return GaloisGroupResult._from_kernel(
         group=_wire_group(perm_group, len(request.coefficients) - 1),
         group_name=group_name,
         order=order,
         degree=len(request.coefficients) - 1,
         is_solvable=is_solvable,
+    )
+
+
+def verify_galois_group_result(result: GaloisGroupResult) -> bool:
+    """Replay bounded group properties for an independently supplied claim."""
+
+    order, is_solvable = _permutation_group_properties(result.group)
+    return (
+        result.degree == len(result.group.root_axis)
+        and result.order == order
+        and result.is_solvable == is_solvable
     )
 
 
@@ -122,7 +152,14 @@ def compute_solvable(request: SolvableRequest) -> SolvableResult:
     """
     perm_group = _galois_group_from_coeffs(request.coefficients)
     is_solvable = bool(perm_group.is_solvable)
-    return SolvableResult(
+    return SolvableResult._from_kernel(
         solvable_by_radicals=is_solvable,
         group=_wire_group(perm_group, len(request.coefficients) - 1),
     )
+
+
+def verify_solvable_result(result: SolvableResult) -> bool:
+    """Replay bounded group solvability for an independently supplied claim."""
+
+    _, is_solvable = _permutation_group_properties(result.group)
+    return result.solvable_by_radicals == is_solvable

--- a/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
+++ b/src/jacobian/math/graphs/coloring/_chromatic_number_models.py
@@ -559,47 +559,47 @@ class ChromaticNumberCertificateCheckResult(StrictModel):
         ),
     )
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        graph: SimpleUndirectedGraph,
+        claimed_chromatic_number: int,
+        coloring: tuple[int, ...],
+        weights: tuple[CanonicalRational, ...],
+        evaluation: _CertificateEvaluation,
+    ) -> Self:
+        """Construct a result whose exact certificate relation was established."""
+
+        return cls.model_construct(
+            graph=graph,
+            claimed_chromatic_number=claimed_chromatic_number,
+            coloring=coloring,
+            weights=weights,
+            verdict=evaluation.verdict,
+            reason=evaluation.reason,
+            weight_sum=CanonicalRational.from_fraction(evaluation.weight_sum),
+            certified_lower_bound=evaluation.certified_lower_bound,
+            blocking_vertex=evaluation.blocking_vertex,
+            blocking_edge=evaluation.blocking_edge,
+            blocking_independent_set=evaluation.blocking_independent_set,
+            blocking_independent_set_weight=(
+                None
+                if evaluation.blocking_independent_set_weight is None
+                else CanonicalRational.from_fraction(
+                    evaluation.blocking_independent_set_weight
+                )
+            ),
+        )
+
     @model_validator(mode="after")
-    def require_exact_certificate_replay(self) -> Self:
+    def require_structural_result_bounds(self) -> Self:
         _require_bounded_sources(
             self.graph,
             self.claimed_chromatic_number,
             self.coloring,
             self.weights,
         )
-        expected = _evaluate_chromatic_number_certificate(
-            self.graph,
-            self.claimed_chromatic_number,
-            self.coloring,
-            self.weights,
-        )
-        actual = (
-            self.verdict,
-            self.reason,
-            self.weight_sum.as_fraction(),
-            self.certified_lower_bound,
-            self.blocking_vertex,
-            self.blocking_edge,
-            self.blocking_independent_set,
-            None
-            if self.blocking_independent_set_weight is None
-            else self.blocking_independent_set_weight.as_fraction(),
-        )
-        replayed = (
-            expected.verdict,
-            expected.reason,
-            expected.weight_sum,
-            expected.certified_lower_bound,
-            expected.blocking_vertex,
-            expected.blocking_edge,
-            expected.blocking_independent_set,
-            expected.blocking_independent_set_weight,
-        )
-        if actual != replayed:
-            raise PydanticCustomError(
-                "graph.chromatic_number_result_does_match_exact_certificate",
-                "chromatic-number result does not match exact certificate replay",
-            )
         return self
 
 

--- a/src/jacobian/math/graphs/coloring/_operations.py
+++ b/src/jacobian/math/graphs/coloring/_operations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from jacobian._exact import CanonicalRational
 from jacobian.math.graphs.coloring._chromatic_number_models import (
     ChromaticNumberCertificateCheckRequest,
     ChromaticNumberCertificateCheckResult,
@@ -83,25 +82,46 @@ def compute_chromatic_number_certificate_check(
         request.coloring,
         request.weights,
     )
-    return ChromaticNumberCertificateCheckResult(
+    return ChromaticNumberCertificateCheckResult._from_kernel(
         graph=request.graph,
         claimed_chromatic_number=request.claimed_chromatic_number,
         coloring=request.coloring,
         weights=request.weights,
-        verdict=evaluation.verdict,
-        reason=evaluation.reason,
-        weight_sum=CanonicalRational.from_fraction(evaluation.weight_sum),
-        certified_lower_bound=evaluation.certified_lower_bound,
-        blocking_vertex=evaluation.blocking_vertex,
-        blocking_edge=evaluation.blocking_edge,
-        blocking_independent_set=evaluation.blocking_independent_set,
-        blocking_independent_set_weight=(
-            None
-            if evaluation.blocking_independent_set_weight is None
-            else CanonicalRational.from_fraction(
-                evaluation.blocking_independent_set_weight
-            )
-        ),
+        evaluation=evaluation,
+    )
+
+
+def verify_chromatic_number_certificate_check_result(
+    result: ChromaticNumberCertificateCheckResult,
+) -> bool:
+    """Replay one independently supplied bounded chromatic certificate claim."""
+
+    expected = _evaluate_chromatic_number_certificate(
+        result.graph,
+        result.claimed_chromatic_number,
+        result.coloring,
+        result.weights,
+    )
+    return (
+        result.verdict,
+        result.reason,
+        result.weight_sum.as_fraction(),
+        result.certified_lower_bound,
+        result.blocking_vertex,
+        result.blocking_edge,
+        result.blocking_independent_set,
+        None
+        if result.blocking_independent_set_weight is None
+        else result.blocking_independent_set_weight.as_fraction(),
+    ) == (
+        expected.verdict,
+        expected.reason,
+        expected.weight_sum,
+        expected.certified_lower_bound,
+        expected.blocking_vertex,
+        expected.blocking_edge,
+        expected.blocking_independent_set,
+        expected.blocking_independent_set_weight,
     )
 
 

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -97,11 +97,12 @@ class GraphIsomorphismResult(StrictModel):
 
     When ``status`` is ``ISOMORPHIC`` the ``vertex_mapping`` field carries an
     explicit bijection as a list of ``(from_vertex, to_vertex)`` pairs that
-    the caller can independently verify.  When ``status`` is
-    ``NOT_ISOMORPHIC`` the ``vertex_mapping`` field is empty.
+    the caller can independently verify.  ``NOT_ISOMORPHIC`` and ``UNKNOWN``
+    carry no mapping.  ``UNKNOWN`` means the bounded VF2 worker did not
+    complete, so it establishes neither conclusion.
     """
 
-    status: Literal["ISOMORPHIC", "NOT_ISOMORPHIC"]
+    status: Literal["ISOMORPHIC", "NOT_ISOMORPHIC", "UNKNOWN"]
     vertex_mapping: tuple[VertexMappingPair, ...] = Field(default=())
     convention: Literal["NETWORKX_IS_ISOMORPHIC"] = "NETWORKX_IS_ISOMORPHIC"
 

--- a/src/jacobian/math/graphs/isomorphism/_models.py
+++ b/src/jacobian/math/graphs/isomorphism/_models.py
@@ -106,6 +106,15 @@ class GraphIsomorphismResult(StrictModel):
     vertex_mapping: tuple[VertexMappingPair, ...] = Field(default=())
     convention: Literal["NETWORKX_IS_ISOMORPHIC"] = "NETWORKX_IS_ISOMORPHIC"
 
+    @model_validator(mode="after")
+    def bind_mapping_to_status(self) -> Self:
+        if self.status != "ISOMORPHIC" and self.vertex_mapping:
+            raise PydanticCustomError(
+                "graph.nonisomorphic_result_has_mapping",
+                "only an ISOMORPHIC result may carry a vertex mapping",
+            )
+        return self
+
 
 class ColoredGraphCanonicalizationRequest(StrictModel):
     """Canonicalize one materialized colored graph under color-preserving maps."""

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -92,6 +92,28 @@ def _vertex_mapping(
         json.JSONDecodeError,
     ) as exc:
         raise RuntimeError("bounded VF2 worker returned malformed output") from exc
+    if len(pairs) != graph_a.vertex_count:
+        raise ValueError("worker mapping is not complete")
+    sources = {source for source, _ in pairs}
+    targets = {target for _, target in pairs}
+    if sources != set(range(graph_a.vertex_count)) or targets != set(
+        range(graph_b.vertex_count)
+    ):
+        raise ValueError("worker mapping is not bijective")
+    forward = dict(pairs)
+    edges_a = {
+        edge if graph_a.directed else tuple(sorted(edge)) for edge in graph_a.edges
+    }
+    edges_b = {
+        edge if graph_b.directed else tuple(sorted(edge)) for edge in graph_b.edges
+    }
+    if {
+        (forward[source], forward[target])
+        if graph_a.directed
+        else tuple(sorted((forward[source], forward[target])))
+        for source, target in graph_a.edges
+    } != edges_b:
+        raise ValueError("worker mapping does not preserve adjacency")
     return [VertexMappingPair(from_vertex=src, to_vertex=dst) for src, dst in pairs]
 
 

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -101,9 +101,6 @@ def _vertex_mapping(
     ):
         raise ValueError("worker mapping is not bijective")
     forward = dict(pairs)
-    edges_a = {
-        edge if graph_a.directed else tuple(sorted(edge)) for edge in graph_a.edges
-    }
     edges_b = {
         edge if graph_b.directed else tuple(sorted(edge)) for edge in graph_b.edges
     }

--- a/src/jacobian/math/graphs/isomorphism/_operations.py
+++ b/src/jacobian/math/graphs/isomorphism/_operations.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-import networkx as nx
-from networkx.algorithms import isomorphism as nx_isomorphism
+import json
+import sys
+from pathlib import Path
 
 from jacobian.math.graphs.isomorphism._canonicalization import (
     canonicalize_colored_graph_data,
@@ -21,38 +20,79 @@ from jacobian.math.graphs.isomorphism._models import (
 )
 from jacobian.math.graphs.values import ColoredUndirectedGraph
 
-
-def _build_graph(graph: SimpleGraph) -> nx.Graph[int] | nx.DiGraph[int]:
-    """Build a NetworkX graph from a wire ``SimpleGraph``."""
-    g: nx.Graph[int] | nx.DiGraph[int] = nx.DiGraph() if graph.directed else nx.Graph()
-    g.add_nodes_from(range(graph.vertex_count))
-    for source, target in graph.edges:
-        g.add_edge(source, target)
-    return g
+_VF2_WORKER = Path(__file__).resolve().with_name("_vf2_worker.py")
+_VF2_WALL_SECONDS = 60.0
+_VF2_STDOUT_LIMIT = 256 * 1024
+_VF2_STDERR_LIMIT = 64 * 1024
+_VF2_ADDRESS_SPACE_BYTES = 1024 * 1024 * 1024
 
 
 def _vertex_mapping(
     graph_a: SimpleGraph,
     graph_b: SimpleGraph,
 ) -> list[VertexMappingPair] | None:
-    """Return an explicit isomorphism witness, or ``None`` when absent.
+    """Return a worker-derived witness, or ``None`` when absent.
 
-    Uses NetworkX's ``GraphMatcher``/``DiGraphMatcher`` so the returned
-    mapping is a concrete bijection the caller can independently verify.
+    VF2 is deliberately isolated because its search cannot be interrupted in
+    the host process.  A stopped or malformed worker has no mathematical
+    conclusion and is represented by ``None`` only through the separate
+    ``UNKNOWN`` outcome in :func:`decide_graph_isomorphism`.
     """
-    g_a = _build_graph(graph_a)
-    g_b = _build_graph(graph_b)
-    if graph_a.directed:
-        matcher: Any = nx_isomorphism.DiGraphMatcher(g_a, g_b)
-    else:
-        matcher = nx_isomorphism.GraphMatcher(g_a, g_b)
-    if not matcher.is_isomorphic():
-        return None
-    mapping = next(matcher.isomorphisms_iter())
-    return [
-        VertexMappingPair(from_vertex=src, to_vertex=dst)
-        for src, dst in sorted(mapping.items())
-    ]
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    request = {
+        "graph_a": {
+            "vertex_count": graph_a.vertex_count,
+            "directed": graph_a.directed,
+            "edges": graph_a.edges,
+        },
+        "graph_b": {
+            "vertex_count": graph_b.vertex_count,
+            "directed": graph_b.directed,
+            "edges": graph_b.edges,
+        },
+    }
+    completed = run_bounded_process(
+        [sys.executable, str(_VF2_WORKER)],
+        input_bytes=json.dumps(request, separators=(",", ":")).encode("utf-8"),
+        timeout_seconds=_VF2_WALL_SECONDS,
+        environment=worker_environment(locale="C.UTF-8"),
+        stdout_limit=_VF2_STDOUT_LIMIT,
+        stderr_limit=_VF2_STDERR_LIMIT,
+        resource_limits=ProcessResourceLimits(
+            address_space_bytes=_VF2_ADDRESS_SPACE_BYTES,
+        ),
+    )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.returncode != 0
+    ):
+        raise RuntimeError("bounded VF2 worker did not establish an outcome")
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        mapping = response["mapping"] if response["ok"] is True else None
+        if mapping is None:
+            if response.get("ok") is True:
+                return None
+            raise ValueError("worker reported a failure")
+        if not isinstance(mapping, list):
+            raise ValueError("worker mapping is malformed")
+        pairs = [(int(source), int(target)) for source, target in mapping]
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise RuntimeError("bounded VF2 worker returned malformed output") from exc
+    return [VertexMappingPair(from_vertex=src, to_vertex=dst) for src, dst in pairs]
 
 
 def decide_graph_isomorphism(
@@ -63,7 +103,10 @@ def decide_graph_isomorphism(
     # level, but keep a defense-in-depth check at the domain boundary).
     if request.graph_a.vertex_count != request.graph_b.vertex_count:
         raise ValueError("both graphs must have the same vertex count")
-    mapping = _vertex_mapping(request.graph_a, request.graph_b)
+    try:
+        mapping = _vertex_mapping(request.graph_a, request.graph_b)
+    except RuntimeError:
+        return GraphIsomorphismResult(status="UNKNOWN", vertex_mapping=())
     if mapping is None:
         return GraphIsomorphismResult(status="NOT_ISOMORPHIC", vertex_mapping=())
     return GraphIsomorphismResult(

--- a/src/jacobian/math/graphs/isomorphism/_tools.py
+++ b/src/jacobian/math/graphs/isomorphism/_tools.py
@@ -48,10 +48,11 @@ GRAPH_ISOMORPHISM_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
         "graph.isomorphism.decide.compute",
         "Decide whether two simple graphs are isomorphic",
         "Decide whether two simple graphs (directed or undirected) are "
-        "isomorphic using NetworkX. Returns ISOMORPHIC with an explicit "
-        "vertex mapping when an isomorphism exists, or NOT_ISOMORPHIC "
-        "otherwise. Both graphs must share the same vertex count and "
-        "directedness.",
+        "isomorphic using a bounded NetworkX VF2 worker. Returns ISOMORPHIC "
+        "with an explicit vertex mapping when an isomorphism exists, "
+        "NOT_ISOMORPHIC when the exact search completes without one, or "
+        "UNKNOWN when the bounded worker cannot complete. Both graphs must "
+        "share the same vertex count and directedness.",
         GraphIsomorphismRequest,
         GraphIsomorphismResult,
         decide_graph_isomorphism,

--- a/src/jacobian/math/graphs/isomorphism/_vf2_worker.py
+++ b/src/jacobian/math/graphs/isomorphism/_vf2_worker.py
@@ -1,0 +1,45 @@
+"""One-shot VF2 worker for the bounded graph-isomorphism adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import networkx as nx
+from networkx.algorithms import isomorphism as nx_isomorphism
+
+
+def _graph(payload: dict[str, Any]) -> nx.Graph[int] | nx.DiGraph[int]:
+    graph: nx.Graph[int] | nx.DiGraph[int]
+    graph = nx.DiGraph() if payload["directed"] else nx.Graph()
+    graph.add_nodes_from(range(payload["vertex_count"]))
+    graph.add_edges_from(payload["edges"])
+    return graph
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        graph_a = _graph(payload["graph_a"])
+        graph_b = _graph(payload["graph_b"])
+        matcher: Any
+        if payload["graph_a"]["directed"]:
+            matcher = nx_isomorphism.DiGraphMatcher(graph_a, graph_b)
+        else:
+            matcher = nx_isomorphism.GraphMatcher(graph_a, graph_b)
+        if not matcher.is_isomorphic():
+            response: dict[str, Any] = {"ok": True, "mapping": None}
+        else:
+            response = {
+                "ok": True,
+                "mapping": sorted(next(matcher.isomorphisms_iter()).items()),
+            }
+    except Exception as exc:
+        response = {"ok": False, "error": type(exc).__name__}
+    json.dump(response, sys.stdout, separators=(",", ":"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/greedoids/_models.py
+++ b/src/jacobian/math/greedoids/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 from pydantic_core import PydanticCustomError
@@ -145,10 +145,25 @@ class RankRequest(StrictModel):
 class RankResult(StrictModel):
     """The greedoid rank of the supplied subset."""
 
-    status: str = "GREEDOID"
+    status: Literal["GREEDOID", "NOT_A_GREEDOID"] = "GREEDOID"
     rank: int | None = Field(default=None, ge=0)
     subset: tuple[int, ...] | None = Field(default=None)
     obstruction: str | None = None
+
+    @model_validator(mode="after")
+    def bind_status(self) -> Self:
+        if self.status == "GREEDOID":
+            if self.rank is None or self.obstruction is not None:
+                raise _validation_error(
+                    "rank_greedoid_branch_invalid",
+                    "a GREEDOID result requires rank and has no obstruction",
+                )
+        elif self.rank is not None or self.obstruction is None:
+            raise _validation_error(
+                "rank_non_greedoid_branch_invalid",
+                "a NOT_A_GREEDOID result requires an obstruction and no rank",
+            )
+        return self
 
 
 class BasesRequest(StrictModel):
@@ -179,10 +194,25 @@ class BasesRequest(StrictModel):
 class BasesResult(StrictModel):
     """The basis family and common rank."""
 
-    status: str = "GREEDOID"
+    status: Literal["GREEDOID", "NOT_A_GREEDOID"] = "GREEDOID"
     rank: int | None = Field(default=None, ge=0)
     bases: tuple[tuple[int, ...], ...]
     obstruction: str | None = None
+
+    @model_validator(mode="after")
+    def bind_status(self) -> Self:
+        if self.status == "GREEDOID":
+            if self.rank is None or self.obstruction is not None:
+                raise _validation_error(
+                    "bases_greedoid_branch_invalid",
+                    "a GREEDOID result requires rank and has no obstruction",
+                )
+        elif self.rank is not None or self.bases or self.obstruction is None:
+            raise _validation_error(
+                "bases_non_greedoid_branch_invalid",
+                "a NOT_A_GREEDOID result requires an obstruction with no rank or bases",
+            )
+        return self
 
 
 class BasicWordProfileRequest(StrictModel):
@@ -242,10 +272,25 @@ class ConvexGeometryResult(StrictModel):
     the wire representation stays JSON-safe.
     """
 
-    status: str = "ANTIMATROID"
+    status: Literal["ANTIMATROID", "NOT_AN_ANTIMATROID"] = "ANTIMATROID"
     closed_family: tuple[tuple[int, ...], ...] = ()
     complement_map: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...] = ()
     obstruction: str | None = None
+
+    @model_validator(mode="after")
+    def bind_status(self) -> Self:
+        if self.status == "ANTIMATROID":
+            if self.obstruction is not None:
+                raise _validation_error(
+                    "antimatroid_has_obstruction",
+                    "an ANTIMATROID result has no obstruction",
+                )
+        elif self.closed_family or self.complement_map or self.obstruction is None:
+            raise _validation_error(
+                "non_antimatroid_branch_invalid",
+                "a NOT_AN_ANTIMATROID result requires an obstruction and no closed-family data",
+            )
+        return self
 
 
 __all__ = [

--- a/src/jacobian/math/greedoids/_models.py
+++ b/src/jacobian/math/greedoids/_models.py
@@ -16,6 +16,9 @@ MAX_GROUND_SIZE = 64
 MAX_FEASIBLE_COUNT = 4096
 """Schema-visible cap on feasible-row count for greedoid requests."""
 
+MAX_EXCHANGE_WORK = 2_000_000
+"""Maximum ordered exchange candidate-membership checks per recognition."""
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     """Build a stable validation error owned by greedoid contracts."""
@@ -48,6 +51,23 @@ def require_bounded_carrier(system: FiniteFeasibleSetSystem) -> None:
             "feasible_count_exceeds_budget",
             f"feasible-set count exceeds the bounded budget of "
             f"{MAX_FEASIBLE_COUNT} rows",
+        )
+    by_size: dict[int, int] = {}
+    memberships = 0
+    for row in system.feasible:
+        by_size[len(row)] = by_size.get(len(row), 0) + 1
+        memberships += len(row)
+    exchange_pairs = sum(
+        larger_count * smaller_count
+        for larger_size, larger_count in by_size.items()
+        for smaller_size, smaller_count in by_size.items()
+        if larger_size > smaller_size
+    )
+    exchange_work = exchange_pairs * len(system.ground)
+    if exchange_work > MAX_EXCHANGE_WORK:
+        raise GreedoidAdmissionError(
+            "exchange_work_exceeds_budget",
+            "exhaustive exchange candidate-membership work exceeds the bounded budget",
         )
 
 
@@ -125,8 +145,10 @@ class RankRequest(StrictModel):
 class RankResult(StrictModel):
     """The greedoid rank of the supplied subset."""
 
-    rank: int = Field(ge=0)
+    status: str = "GREEDOID"
+    rank: int | None = Field(default=None, ge=0)
     subset: tuple[int, ...] | None = Field(default=None)
+    obstruction: str | None = None
 
 
 class BasesRequest(StrictModel):
@@ -157,8 +179,10 @@ class BasesRequest(StrictModel):
 class BasesResult(StrictModel):
     """The basis family and common rank."""
 
-    rank: int = Field(ge=0)
+    status: str = "GREEDOID"
+    rank: int | None = Field(default=None, ge=0)
     bases: tuple[tuple[int, ...], ...]
+    obstruction: str | None = None
 
 
 class BasicWordProfileRequest(StrictModel):
@@ -218,8 +242,10 @@ class ConvexGeometryResult(StrictModel):
     the wire representation stays JSON-safe.
     """
 
-    closed_family: tuple[tuple[int, ...], ...]
-    complement_map: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]
+    status: str = "ANTIMATROID"
+    closed_family: tuple[tuple[int, ...], ...] = ()
+    complement_map: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...] = ()
+    obstruction: str | None = None
 
 
 __all__ = [

--- a/src/jacobian/math/greedoids/_operations.py
+++ b/src/jacobian/math/greedoids/_operations.py
@@ -17,10 +17,10 @@ from jacobian.math.greedoids._models import (
     RecognizeResult,
 )
 from jacobian.math.greedoids.operations import (
-    antimatroid_to_convex_geometry,
-    bases,
-    basic_word_profile,
-    rank,
+    _antimatroid_to_convex_geometry_unchecked,
+    _bases_unchecked,
+    _basic_word_profile_unchecked,
+    _rank_unchecked,
     recognize,
 )
 
@@ -52,18 +52,32 @@ def compute_recognize(request: RecognizeRequest) -> RecognizeResult:
 
 
 def compute_rank(request: RankRequest) -> RankResult:
+    recognized = recognize(request.system)
+    if recognized["status"] != "GREEDOID":
+        return RankResult(
+            status="NOT_A_GREEDOID",
+            obstruction=str(recognized["obstruction"]),
+            subset=request.subset,
+        )
     if request.subset is None:
-        r = rank(request.system)
+        r = _rank_unchecked(request.system, None)
     else:
-        r = rank(request.system, frozenset(request.subset))
+        r = _rank_unchecked(request.system, frozenset(request.subset))
     return RankResult(rank=r, subset=request.subset)
 
 
 def compute_bases(request: BasesRequest) -> BasesResult:
+    recognized = recognize(request.system)
+    if recognized["status"] != "GREEDOID":
+        return BasesResult(
+            status="NOT_A_GREEDOID",
+            bases=(),
+            obstruction=str(recognized["obstruction"]),
+        )
     if request.subset is None:
-        r, basis_list = bases(request.system)
+        r, basis_list = _bases_unchecked(request.system, None)
     else:
-        r, basis_list = bases(request.system, frozenset(request.subset))
+        r, basis_list = _bases_unchecked(request.system, frozenset(request.subset))
     return BasesResult(
         rank=r,
         bases=tuple(tuple(sorted(b)) for b in basis_list),
@@ -73,7 +87,13 @@ def compute_bases(request: BasesRequest) -> BasesResult:
 def compute_basic_word_profile(
     request: BasicWordProfileRequest,
 ) -> BasicWordProfileResult:
-    result: dict[str, Any] = basic_word_profile(request.system, request.word)
+    recognized = recognize(request.system)
+    if recognized["status"] != "GREEDOID":
+        return BasicWordProfileResult(
+            status="NOT_A_BASIC_WORD",
+            obstruction="not_a_greedoid",
+        )
+    result: dict[str, Any] = _basic_word_profile_unchecked(request.system, request.word)
     if result["status"] == "BASIC_WORD":
         return BasicWordProfileResult(
             status="BASIC_WORD",
@@ -92,7 +112,24 @@ def compute_basic_word_profile(
 def compute_convex_geometry(
     request: ConvexGeometryRequest,
 ) -> ConvexGeometryResult:
-    closed_family, complement_map = antimatroid_to_convex_geometry(request.system)
+    recognized = recognize(request.system)
+    if recognized["status"] != "GREEDOID":
+        return ConvexGeometryResult(
+            status="NOT_AN_ANTIMATROID",
+            obstruction=str(recognized["obstruction"]),
+        )
+    from jacobian.math.greedoids.operations import union_closed
+
+    full_ground = tuple(range(len(request.system.ground)))
+    if full_ground not in request.system.feasible_index() or not union_closed(
+        request.system
+    ):
+        return ConvexGeometryResult(
+            status="NOT_AN_ANTIMATROID", obstruction="not_full_support_or_union_closed"
+        )
+    closed_family, complement_map = _antimatroid_to_convex_geometry_unchecked(
+        request.system
+    )
     return ConvexGeometryResult(
         closed_family=tuple(closed_family),
         complement_map=tuple(sorted(complement_map.items())),

--- a/src/jacobian/math/greedoids/operations.py
+++ b/src/jacobian/math/greedoids/operations.py
@@ -102,13 +102,33 @@ def recognize(
     exch = _exchange_obstruction(feasible_sets, index)
     if exch is not None:
         return exch
-    r, basis_list = bases(system)
+    r, basis_list = _bases_unchecked(system, None)
     return {
         "status": "GREEDOID",
         "rank": r,
         "bases": [tuple(sorted(b)) for b in basis_list],
         "ground_size": n,
     }
+
+
+def _require_greedoid(system: FiniteFeasibleSetSystem) -> None:
+    """Reject a structural family that has not established the greedoid axioms."""
+    recognized = recognize(system)
+    if recognized["status"] != "GREEDOID":
+        raise ValueError(
+            "a greedoid operation requires a recognized greedoid "
+            f"(first obstruction: {recognized['obstruction']})"
+        )
+
+
+def _require_antimatroid(system: FiniteFeasibleSetSystem) -> None:
+    """Reject a greedoid that has not established the antimatroid axioms."""
+    _require_greedoid(system)
+    full_ground = tuple(range(len(system.ground)))
+    if full_ground not in system.feasible_index() or not union_closed(system):
+        raise ValueError(
+            "an antimatroid operation requires full support and union closure"
+        )
 
 
 def union_closed(system: FiniteFeasibleSetSystem) -> bool:
@@ -129,7 +149,14 @@ def rank(system: FiniteFeasibleSetSystem, subset: frozenset[int] | None = None) 
     If ``subset`` is ``None``, the rank of the whole greedoid (the common size
     of its bases) is returned.
     """
-    require_bounded_carrier(system)
+    _require_greedoid(system)
+    return _rank_unchecked(system, subset)
+
+
+def _rank_unchecked(
+    system: FiniteFeasibleSetSystem, subset: frozenset[int] | None
+) -> int:
+    """Compute rank after the greedoid axioms have been established."""
     if subset is None:
         candidates = _feasible_sets(system)
     else:
@@ -145,7 +172,14 @@ def bases(
     A basis of ``X`` is a maximal feasible subset of ``X``. All bases have the
     same cardinality under the greedoid theorem convention.
     """
-    require_bounded_carrier(system)
+    _require_greedoid(system)
+    return _bases_unchecked(system, subset)
+
+
+def _bases_unchecked(
+    system: FiniteFeasibleSetSystem, subset: frozenset[int] | None
+) -> tuple[int, list[frozenset[int]]]:
+    """Compute bases after the greedoid axioms have been established."""
     if subset is None:
         subset = frozenset(range(len(system.ground)))
     feasible_in_subset = [fs for fs in _feasible_sets(system) if fs <= subset]
@@ -165,7 +199,7 @@ def feasible_continuations(
     system: FiniteFeasibleSetSystem, feasible_set: frozenset[int]
 ) -> list[int]:
     """Return ``Gamma(X) = {e in E\\X : X union {e} in F}`` for a feasible ``X``."""
-    require_bounded_carrier(system)
+    _require_greedoid(system)
     index = system.feasible_index()
     if tuple(sorted(feasible_set)) not in index:
         raise ValueError("input set must be feasible")
@@ -186,7 +220,14 @@ def basic_word_profile(
     every prefix set is feasible. A full basic word has length ``r(E)`` and its
     underlying set is a greedoid basis.
     """
-    require_bounded_carrier(system)
+    _require_greedoid(system)
+    return _basic_word_profile_unchecked(system, word)
+
+
+def _basic_word_profile_unchecked(
+    system: FiniteFeasibleSetSystem, word: tuple[int, ...]
+) -> dict[str, object]:
+    """Profile a basic word after the greedoid axioms have been established."""
     n = len(system.ground)
     seen: set[int] = set()
     for elem in word:
@@ -214,7 +255,7 @@ def basic_word_profile(
                 "prefix_index": i,
                 "prefix_set": tuple(sorted(prefix)),
             }
-    r, _ = bases(system)
+    r, _ = _bases_unchecked(system, None)
     is_full = len(word) == r
     return {
         "status": "BASIC_WORD",
@@ -234,7 +275,14 @@ def antimatroid_to_convex_geometry(
     family (sorted tuples of ground indices) and the feasible->closed
     complement map.
     """
-    require_bounded_carrier(system)
+    _require_antimatroid(system)
+    return _antimatroid_to_convex_geometry_unchecked(system)
+
+
+def _antimatroid_to_convex_geometry_unchecked(
+    system: FiniteFeasibleSetSystem,
+) -> tuple[list[tuple[int, ...]], dict[tuple[int, ...], tuple[int, ...]]]:
+    """Project an already-established antimatroid to its closed family."""
     n = len(system.ground)
     ground_set = frozenset(range(n))
     complement_map: dict[tuple[int, ...], tuple[int, ...]] = {}

--- a/src/jacobian/math/logic/_smt.py
+++ b/src/jacobian/math/logic/_smt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from enum import StrEnum
 from typing import Literal, NamedTuple, Self
 
@@ -232,33 +233,6 @@ def _is_smtlib_source_diagnostic(exc: Exception) -> bool:
     return _Z3_SOURCE_DIAGNOSTIC.search(_exception_message(exc)) is not None
 
 
-def _require_parseable_smtlib(source: str) -> None:
-    """Reject source that Z3's SMT-LIB 2 parser cannot read as a request error.
-
-    Admission runs the same non-evaluating backend parse that execution uses,
-    so a schema-admitted request never discovers malformed syntax through an
-    execution exception. Only located parser diagnostics establish malformed
-    input; resource or other backend failures carry no evidence about the
-    source, so they defer to execution, which reports them as typed UNKNOWN.
-    Backend absence here is left to execution, where it keeps its typed
-    initialization outcome.
-    """
-
-    try:
-        import z3  # type: ignore[import-untyped]
-    except (ImportError, OSError):
-        return
-    try:
-        z3.parse_smt2_string(source)
-    except (z3.Z3Exception, OSError) as exc:
-        if not _is_smtlib_source_diagnostic(exc):
-            return
-        raise _validation_error(
-            "logic.smtlib_grammar",
-            "SMT-LIB input could not be parsed by the declared logic",
-        ) from exc
-
-
 class SmtSolveRequest(StrictModel):
     logic: SmtLogic
     smtlib: str = Field(
@@ -270,8 +244,8 @@ class SmtSolveRequest(StrictModel):
             f"{_MAX_SMTLIB_DEPTH}, compound terms at most {_MAX_SMTLIB_TERMS}, declared "
             f"symbols at most {_MAX_SMTLIB_DECLARATIONS}, and any one numeral, decimal, "
             f"or indexed bit-vector spelling at most {_MAX_SMTLIB_NUMERAL_DIGITS} digits. "
-            "The source must be well-formed SMT-LIB 2 for the declared logic; malformed "
-            "input is rejected during request validation."
+            "The source is structurally admitted before execution; Z3 parsing and "
+            "solving occur within the operation's bounded execution envelope."
         ),
         examples=[
             "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)"
@@ -342,19 +316,7 @@ class SmtSolveRequest(StrictModel):
                 raise _validation_error(
                     "logic.smtlib_command", f"unsupported SMT-LIB command: {command[0]}"
                 )
-        self._complete_backend_admission()
         return self
-
-    def _complete_backend_admission(self) -> None:
-        """Parse through the backend once every structural check has passed.
-
-        Called at the end of ``require_single_smtlib_query``. A subclass whose
-        own ``mode="after"`` validators impose a stricter envelope overrides
-        this hook so out-of-envelope source never reaches the backend parser;
-        the most-derived request completes backend admission.
-        """
-
-        _require_parseable_smtlib(self.smtlib)
 
 
 class SmtSolveResult(StrictModel):
@@ -430,11 +392,31 @@ def _solver_settings(timeout_ms: int) -> dict[str, int]:
     }
 
 
+def _time_exhausted_result() -> SmtSolveResult:
+    """Project expiry of the admitted owner envelope as a non-conclusion."""
+
+    return SmtSolveResult(
+        outcome="UNKNOWN",
+        exhausted="time",
+        detail=_EXHAUSTION_DETAILS["time"],
+    )
+
+
+def _remaining_timeout_ms(deadline: float) -> int | None:
+    """Return the remaining owner time in milliseconds, or ``None`` on expiry."""
+
+    remaining_seconds = deadline - time.monotonic()
+    if remaining_seconds <= 0:
+        return None
+    return max(1, int(remaining_seconds * 1_000))
+
+
 def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
     """Solve one bounded SMT-LIB query through the maintained Z3 Python binding."""
 
+    deadline = time.monotonic() + request.timeout_ms / 1_000
     try:
-        import z3
+        import z3  # type: ignore[import-untyped]
     except (ImportError, OSError) as exc:
         return SmtSolveResult(
             outcome="UNKNOWN",
@@ -443,10 +425,17 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
 
     try:
         assertions = z3.parse_smt2_string(request.smtlib)
+        remaining_timeout_ms = _remaining_timeout_ms(deadline)
+        if remaining_timeout_ms is None:
+            return _time_exhausted_result()
         solver = z3.SolverFor(request.logic.value)
-        solver.set(**_solver_settings(request.timeout_ms))
+        solver.set(**_solver_settings(remaining_timeout_ms))
         solver.add(assertions)
+        if _remaining_timeout_ms(deadline) is None:
+            return _time_exhausted_result()
         outcome = solver.check()
+        if _remaining_timeout_ms(deadline) is None:
+            return _time_exhausted_result()
         if outcome == z3.sat:
             model = solver.model()
             if not all(
@@ -461,6 +450,8 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
                     ),
                 )
             model_smtlib = model.sexpr()
+            if _remaining_timeout_ms(deadline) is None:
+                return _time_exhausted_result()
             if len(model_smtlib.encode("utf-8")) > _MAX_MODEL_BYTES:
                 return SmtSolveResult(
                     outcome="UNKNOWN",
@@ -479,6 +470,8 @@ def solve_smt(request: SmtSolveRequest) -> SmtSolveResult:
             )
         detail = f"the Z3 backend failed during the bounded solve: {exc}"
         return SmtSolveResult(outcome="UNKNOWN", detail=detail[:1_024])
+    if _remaining_timeout_ms(deadline) is None:
+        return _time_exhausted_result()
     exhausted, detail = _project_unknown(solver.reason_unknown())
     return SmtSolveResult(outcome="UNKNOWN", exhausted=exhausted, detail=detail)
 
@@ -492,6 +485,7 @@ __all__ = [
     "_classify_exhaustion",
     "_is_smtlib_source_diagnostic",
     "_project_unknown",
+    "_remaining_timeout_ms",
     "_solver_settings",
     "_tokenize_smtlib",
     "_top_level_smtlib_commands",

--- a/src/jacobian/math/logic/_unsat_core.py
+++ b/src/jacobian/math/logic/_unsat_core.py
@@ -216,14 +216,6 @@ class SmtUnsatCoreRequest(SmtSolveRequest):
             raise _logic_error(parsed_error)
         return self
 
-    def _complete_backend_admission(self) -> None:
-        """Skip the inherited base-class parse.
-
-        ``require_bounded_indexed_assertions`` already parses through the
-        backend only after every core-specific structural bound has passed,
-        so sources outside this operation's envelope never reach Z3.
-        """
-
 
 class SmtUnsatCoreResult(StrictModel):
     """A source-bound satisfiability outcome and replayable UNSAT core."""

--- a/src/jacobian/math/majorization/_models.py
+++ b/src/jacobian/math/majorization/_models.py
@@ -154,6 +154,26 @@ class TTransformSequenceResult(StrictModel):
     composed_matrix: tuple[tuple[str, ...], ...]
     target_match: bool
 
+    @model_validator(mode="after")
+    def bind_majorization_outcome(self) -> Self:
+        if self.majorizes and not self.target_match:
+            raise _validation_error(
+                "t_transform_target_mismatch",
+                "a positive T-transform construction must reach the target",
+            )
+        if not self.majorizes and (
+            self.steps
+            or self.final_permutation
+            or self.intermediate_vectors
+            or self.composed_matrix
+            or self.target_match
+        ):
+            raise _validation_error(
+                "negative_t_transform_shape",
+                "a negative majorization result has no construction witness",
+            )
+        return self
+
 
 class DoublyStochasticCheckRequest(StrictModel):
     """Check if a rational matrix is doubly stochastic."""

--- a/src/jacobian/math/majorization/_operations.py
+++ b/src/jacobian/math/majorization/_operations.py
@@ -148,28 +148,48 @@ def _majorizes_values(x_vals: Sequence[Fraction], y_vals: Sequence[Fraction]) ->
 
 
 def _compute_t_transform_steps(
-    x_vals: list[Fraction], target: list[Fraction]
+    x_vals: list[Fraction], target: list[Fraction], order: list[int]
 ) -> tuple[list[Fraction], list[tuple[int, int, Fraction]]]:
+    """Use the rank-aligned Hardy--Littlewood--Pólya construction.
+
+    ``order`` places the original coordinates in nonincreasing source order.
+    The target is assigned in that order, so every mixing step acts on the
+    caller's original coordinates while preserving the theorem's sorted-vector
+    invariant.  A final permutation then restores the requested target labels.
+    """
+
     n = len(x_vals)
     current = list(x_vals)
     steps: list[tuple[int, int, Fraction]] = []
-    for _ in range(5 * n):
-        if all(current[k] == target[k] for k in range(n)):
+    for _ in range(n - 1):
+        if all(current[index] == target[index] for index in order):
             break
-        i_idx = next((idx for idx in range(n) if current[idx] > target[idx]), None)
-        j_idx = next((idx for idx in range(n) if current[idx] < target[idx]), None)
-        if i_idx is None or j_idx is None:
+        i_rank = next(
+            (
+                rank
+                for rank, index in enumerate(order)
+                if current[index] > target[index]
+            ),
+            None,
+        )
+        if i_rank is None:
             break
+        i_idx = order[i_rank]
         ci = current[i_idx]
+        target_i = target[i_idx]
+        j_rank = next(
+            (rank for rank in range(i_rank + 1, n) if current[order[rank]] <= target_i),
+            None,
+        )
+        if j_rank is None:
+            break
+        j_idx = order[j_rank]
         cj = current[j_idx]
         denom = ci - cj
         if denom == 0:
             break
-        deficit_j = target[j_idx] - cj
-        excess_i = ci - target[i_idx]
-        delta = min(deficit_j, excess_i)
-        lam = Fraction(1) - delta / denom
-        if lam < 0 or lam > 1 or lam == 1:
+        lam = (target_i - cj) / denom
+        if lam < 0 or lam >= 1:
             break
         current[i_idx] = lam * ci + (Fraction(1) - lam) * cj
         current[j_idx] = (Fraction(1) - lam) * ci + lam * cj
@@ -247,11 +267,16 @@ def compute_t_transform_sequence(
             target_match=False,
         )
 
-    target = list(y_vals)
-    current, steps = _compute_t_transform_steps(x_vals, target)
-    final_perm, needs_perm, current = _target_permutation(current, target)
+    order = sorted(range(n), key=lambda index: (-x_vals[index], index))
+    sorted_target = _sorted_desc(y_vals)
+    rank_aligned_target = [Fraction(0)] * n
+    for rank, index in enumerate(order):
+        rank_aligned_target[index] = sorted_target[rank]
 
-    target_match = current == target
+    current, steps = _compute_t_transform_steps(x_vals, rank_aligned_target, order)
+    final_perm, needs_perm, current = _target_permutation(current, list(y_vals))
+
+    target_match = current == y_vals
 
     # Build the composed doubly stochastic matrix
     composed = _build_composed_matrix(steps, final_perm if needs_perm else None, n)

--- a/src/jacobian/math/markov_chain/_models.py
+++ b/src/jacobian/math/markov_chain/_models.py
@@ -252,6 +252,22 @@ class CommunicatingClassesResult(StrictModel):
     state_class: tuple[int, ...]
     """Class index of each state (0-indexed)."""
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        transition_matrix: tuple[tuple[CanonicalRational, ...], ...],
+        classes: tuple[tuple[tuple[int, ...], bool], ...],
+        state_class: tuple[int, ...],
+    ) -> Self:
+        """Construct output whose SCC relation was established by the kernel."""
+
+        return cls.model_construct(
+            transition_matrix=transition_matrix,
+            classes=classes,
+            state_class=state_class,
+        )
+
     @model_validator(mode="after")
     def require_partition_validity(self) -> Self:
         dimension = len(self.transition_matrix)
@@ -296,47 +312,4 @@ class CommunicatingClassesResult(StrictModel):
                         "decomposition_state_class_mismatch",
                         "state_class must match classes",
                     )
-        return self
-
-    @model_validator(mode="after")
-    def bind_decomposition(self) -> Self:
-        import networkx as nx
-
-        matrix = self.transition_matrix
-        dimension = len(matrix)
-        graph: nx.DiGraph[int] = nx.DiGraph()
-        graph.add_nodes_from(range(dimension))
-        for i in range(dimension):
-            for j in range(dimension):
-                if matrix[i][j].as_fraction() > 0:
-                    graph.add_edge(i, j)
-        sccs = list(nx.strongly_connected_components(graph))
-        condensation = nx.condensation(graph, sccs)
-        scc_list = list(nx.topological_sort(condensation))
-        expected_classes: list[tuple[tuple[int, ...], bool]] = []
-        expected_state_class = [0] * dimension
-        for scc_idx, scc_node in enumerate(scc_list):
-            scc = sccs[scc_node] if isinstance(scc_node, int) else scc_node
-            states = tuple(sorted(scc))
-            is_closed = True
-            for state in states:
-                for target in range(dimension):
-                    if target not in scc and matrix[state][target].as_fraction() > 0:
-                        is_closed = False
-                        break
-                if not is_closed:
-                    break
-            expected_classes.append((states, is_closed))
-            for state in states:
-                expected_state_class[state] = scc_idx
-        if self.classes != tuple(expected_classes):
-            raise _validation_error(
-                "decomposition_scc_classes_mismatch",
-                "classes must be the exact SCC decomposition of the transition matrix",
-            )
-        if self.state_class != tuple(expected_state_class):
-            raise _validation_error(
-                "decomposition_scc_state_class_mismatch",
-                "state_class must match the SCC decomposition",
-            )
         return self

--- a/src/jacobian/math/markov_chain/_operations.py
+++ b/src/jacobian/math/markov_chain/_operations.py
@@ -20,6 +20,40 @@ from jacobian.math.markov_chain._models import (
 from jacobian.math.markov_chain.operations import _stationary_distribution_extremes
 
 
+def _derive_communicating_classes(
+    matrix: tuple[tuple[CanonicalRational, ...], ...],
+) -> tuple[tuple[tuple[tuple[int, ...], bool], ...], tuple[int, ...]]:
+    """Derive the canonical SCC partition in bounded quadratic graph work."""
+
+    import networkx as nx
+
+    dimension = len(matrix)
+    graph: nx.DiGraph[int] = nx.DiGraph()
+    graph.add_nodes_from(range(dimension))
+    graph.add_edges_from(
+        (source, target)
+        for source in range(dimension)
+        for target in range(dimension)
+        if matrix[source][target].as_fraction() > 0
+    )
+    sccs = list(nx.strongly_connected_components(graph))
+    condensation = nx.condensation(graph, sccs)
+    classes: list[tuple[tuple[int, ...], bool]] = []
+    state_class = [0] * dimension
+    for class_index, scc_node in enumerate(nx.topological_sort(condensation)):
+        states_set = sccs[scc_node]
+        states = tuple(sorted(states_set))
+        is_closed = not any(
+            target not in states_set and matrix[source][target].as_fraction() > 0
+            for source in states
+            for target in range(dimension)
+        )
+        classes.append((states, is_closed))
+        for state in states:
+            state_class[state] = class_index
+    return tuple(classes), tuple(state_class)
+
+
 def compute_mixing_time(request: MixingTimeRequest) -> MixingTimeResult:
     matrix = tuple(
         tuple(value.as_fraction() for value in row) for row in request.matrix
@@ -92,47 +126,17 @@ def compute_communicating_classes(
 ) -> CommunicatingClassesResult:
     """Decompose a Markov chain into communicating classes via SCC analysis."""
 
-    import networkx as nx
-
     matrix = request.matrix
-    dimension = len(matrix)
-
-    graph: nx.DiGraph[int] = nx.DiGraph()
-    graph.add_nodes_from(range(dimension))
-    for i in range(dimension):
-        for j in range(dimension):
-            if matrix[i][j].as_fraction() > 0:
-                graph.add_edge(i, j)
-
-    sccs = list(nx.strongly_connected_components(graph))
-    condensation = nx.condensation(graph, sccs)
-
-    # Get topological order of SCC nodes
-    scc_list = list(nx.topological_sort(condensation))
-
-    # Reverse for recurrent-first order (closed classes last)
-    # Actually, let's order by: transient classes first, then recurrent classes
-    # A class is closed (recurrent) if it has no outgoing edges to other classes
-    classes_info: list[tuple[tuple[int, ...], bool]] = []
-    state_class = [0] * dimension
-
-    for scc_idx, scc_node in enumerate(scc_list):
-        scc = sccs[scc_node] if isinstance(scc_node, int) else scc_node
-        states = sorted(scc)
-        is_closed = True
-        for state in states:
-            for j in range(dimension):
-                if j not in scc and matrix[state][j].as_fraction() > 0:
-                    is_closed = False
-                    break
-            if not is_closed:
-                break
-        classes_info.append((tuple(states), is_closed))
-        for state in states:
-            state_class[state] = scc_idx
-
-    return CommunicatingClassesResult(
+    classes, state_class = _derive_communicating_classes(matrix)
+    return CommunicatingClassesResult._from_kernel(
         transition_matrix=request.matrix,
-        classes=tuple(classes_info),
-        state_class=tuple(state_class),
+        classes=classes,
+        state_class=state_class,
     )
+
+
+def verify_communicating_classes_result(result: CommunicatingClassesResult) -> bool:
+    """Replay the SCC relation for an independently supplied bounded result."""
+
+    classes, state_class = _derive_communicating_classes(result.transition_matrix)
+    return result.classes == classes and result.state_class == state_class

--- a/src/jacobian/math/number_field/_models.py
+++ b/src/jacobian/math/number_field/_models.py
@@ -11,6 +11,8 @@ from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
 from jacobian.math.polynomials.values import PolynomialVariable
 
+MAX_NUMBER_FIELD_COEFFICIENT_DIGITS = 256
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"number_field.{reason}", message)
@@ -23,30 +25,53 @@ class NumberFieldRequest(StrictModel):
     variable: PolynomialVariable
 
     @model_validator(mode="after")
-    def require_monic_irreducible_integer_polynomial(self) -> Self:
-        import sympy
-
-        variable = sympy.Symbol(self.variable)
-        coefficients = tuple(
-            sympy.Rational(parse_canonical_integer(value))
-            for value in self.coefficients_descending
-        )
-        if any(value.q != 1 for value in coefficients):
+    def require_bounded_monic_integer_polynomial(self) -> Self:
+        # Bound digit conversion before SymPy sees an arbitrary decimal
+        # spelling.  Degree and coefficient height jointly bound the parser
+        # input and every polynomial construction that follows.
+        if any(
+            len(coefficient.lstrip("-")) > MAX_NUMBER_FIELD_COEFFICIENT_DIGITS
+            for coefficient in self.coefficients_descending
+        ):
             raise _validation_error(
-                "coefficient_domain", "number-field coefficients must be integers"
+                "coefficient_digits",
+                "number-field coefficients may contain at most "
+                f"{MAX_NUMBER_FIELD_COEFFICIENT_DIGITS} decimal digits",
             )
-        polynomial = sympy.Poly.from_list(coefficients, gens=variable, domain=sympy.ZZ)
-        if not polynomial.is_monic:
+        try:
+            coefficients = tuple(
+                parse_canonical_integer(value) for value in self.coefficients_descending
+            )
+        except ValueError as exc:
+            raise _validation_error(
+                "coefficient_syntax",
+                "number-field coefficients must be canonical integers",
+            ) from exc
+        if coefficients[0] != 1:
             raise _validation_error(
                 "not_monic", "number-field polynomial must be monic"
-            )
-        if not polynomial.is_irreducible:
-            raise _validation_error(
-                "not_irreducible", "number-field polynomial must be irreducible over QQ"
             )
         return self
 
 
 class NumberFieldDiscriminantResult(StrictModel):
-    discriminant: str
+    status: Literal["COMPLETE", "UNKNOWN"] = "COMPLETE"
+    discriminant: str | None = None
     method: Literal["SYMPY_NUMBER_FIELD"] = "SYMPY_NUMBER_FIELD"
+    detail: str | None = Field(default=None, max_length=1_024)
+
+    @model_validator(mode="after")
+    def bind_outcome(self) -> Self:
+        if self.status == "COMPLETE" and self.discriminant is None:
+            raise _validation_error(
+                "complete_discriminant_requires_value",
+                "a complete number-field discriminant requires its exact value",
+            )
+        if self.status == "UNKNOWN" and (
+            self.discriminant is not None or self.detail is None
+        ):
+            raise _validation_error(
+                "unknown_discriminant_shape",
+                "an unknown number-field computation requires detail and no value",
+            )
+        return self

--- a/src/jacobian/math/number_field/_operations.py
+++ b/src/jacobian/math/number_field/_operations.py
@@ -6,8 +6,8 @@ import json
 import sys
 from pathlib import Path
 
-from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_field._models import (
     NumberFieldDiscriminantResult,
     NumberFieldRequest,

--- a/src/jacobian/math/number_field/_operations.py
+++ b/src/jacobian/math/number_field/_operations.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 from jacobian.catalog.models import OperationDomainValidationError
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.number_field._models import (
     NumberFieldDiscriminantResult,
     NumberFieldRequest,
@@ -49,7 +50,10 @@ def compute_nf_discriminant(
     try:
         response = json.loads(completed.stdout.decode("utf-8"))
         if response["kind"] == "complete":
-            return NumberFieldDiscriminantResult(discriminant=response["discriminant"])
+            discriminant = format_canonical_integer(
+                parse_canonical_integer(response["discriminant"])
+            )
+            return NumberFieldDiscriminantResult(discriminant=discriminant)
     except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
         response = None
     if isinstance(response, dict) and response.get("kind") == "invalid":

--- a/src/jacobian/math/number_field/_operations.py
+++ b/src/jacobian/math/number_field/_operations.py
@@ -2,15 +2,63 @@
 
 from __future__ import annotations
 
-from jacobian.math.number_field import discriminant
+import json
+import sys
+from pathlib import Path
+
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_field._models import (
     NumberFieldDiscriminantResult,
     NumberFieldRequest,
 )
 
+_WORKER = Path(__file__).resolve().with_name("_worker.py")
+
 
 def compute_nf_discriminant(
     request: NumberFieldRequest,
 ) -> NumberFieldDiscriminantResult:
-    disc = discriminant(list(request.coefficients_descending), request.variable)
-    return NumberFieldDiscriminantResult(discriminant=disc)
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    completed = run_bounded_process(
+        [sys.executable, str(_WORKER)],
+        input_bytes=json.dumps(
+            request.model_dump(mode="json"), separators=(",", ":")
+        ).encode(),
+        timeout_seconds=60.0,
+        environment=worker_environment(locale="C.UTF-8"),
+        stdout_limit=128 * 1024,
+        stderr_limit=64 * 1024,
+        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
+    )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return NumberFieldDiscriminantResult(
+            status="UNKNOWN",
+            detail="the bounded number-field worker did not establish a discriminant",
+        )
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        if response["kind"] == "complete":
+            return NumberFieldDiscriminantResult(discriminant=response["discriminant"])
+    except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        response = None
+    if isinstance(response, dict) and response.get("kind") == "invalid":
+        raise OperationDomainValidationError(
+            location=("coefficients_descending",),
+            code="number_field.not_irreducible",
+            message="number-field polynomial must be irreducible over QQ",
+        )
+    return NumberFieldDiscriminantResult(
+        status="UNKNOWN",
+        detail="the bounded number-field worker returned malformed output",
+    )

--- a/src/jacobian/math/number_field/_tools.py
+++ b/src/jacobian/math/number_field/_tools.py
@@ -41,7 +41,7 @@ NUMBER_FIELD_OPERATIONS: tuple[MathTool[Any, Any], ...] = (
     nf_operation(
         "number_field.discriminant.compute",
         "Compute the discriminant of a number field",
-        "Compute the discriminant of a number field defined by one irreducible polynomial using SymPy.",
+        "Compute the discriminant of a number field defined by one irreducible polynomial in an isolated SymPy worker, or return UNKNOWN if its bounded execution cannot establish a result.",
         NumberFieldRequest,
         NumberFieldDiscriminantResult,
         compute_nf_discriminant,

--- a/src/jacobian/math/number_field/_worker.py
+++ b/src/jacobian/math/number_field/_worker.py
@@ -1,0 +1,39 @@
+"""One-shot number-field worker isolated from the MCP request process."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from jacobian.math.number_field import discriminant
+from jacobian.math.number_field._models import NumberFieldRequest
+
+
+def main() -> int:
+    try:
+        request = NumberFieldRequest.model_validate(json.load(sys.stdin))
+        import sympy
+
+        variable = sympy.Symbol(request.variable)
+        polynomial = sympy.Poly.from_list(
+            [int(value) for value in request.coefficients_descending],
+            gens=variable,
+            domain=sympy.ZZ,
+        )
+        if not polynomial.is_irreducible:
+            response: dict[str, object] = {"kind": "invalid"}
+        else:
+            response = {
+                "kind": "complete",
+                "discriminant": discriminant(
+                    request.coefficients_descending, request.variable
+                ),
+            }
+    except Exception as exc:
+        response = {"kind": "error", "error": type(exc).__name__}
+    json.dump(response, sys.stdout, separators=(",", ":"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/number_theory/_certification_models.py
+++ b/src/jacobian/math/number_theory/_certification_models.py
@@ -132,12 +132,30 @@ class CertifiedFactor(StrictModel):
 class CertifiedFactorizationResult(StrictModel):
     """The complete certified prime-power factorization of one integer."""
 
-    status: Literal["COMPLETE"]
+    status: Literal["COMPLETE", "UNKNOWN"]
     value: CertifiedFactorizationInteger
-    factors: tuple[CertifiedFactor, ...] = Field(min_length=1, max_length=256)
+    factors: tuple[CertifiedFactor, ...] = Field(min_length=0, max_length=256)
+    detail: str | None = Field(default=None, max_length=1_024)
 
     @model_validator(mode="after")
     def bind_decomposition(self) -> Self:
+        if self.status == "UNKNOWN":
+            if self.factors:
+                raise _validation_error(
+                    "unknown_factorization_has_no_factors",
+                    "an unknown factorization must not carry partial factors",
+                )
+            if self.detail is None:
+                raise _validation_error(
+                    "unknown_factorization_requires_detail",
+                    "an unknown factorization must state its execution condition",
+                )
+            return self
+        if not self.factors:
+            raise _validation_error(
+                "complete_factorization_requires_factors",
+                "a complete factorization must carry at least one factor",
+            )
         if math.prod(
             parse_canonical_integer(item.prime) ** item.exponent
             for item in self.factors
@@ -173,7 +191,15 @@ class CertifiedFactorizationResult(StrictModel):
         value: CertifiedFactorizationInteger,
         factors: tuple[CertifiedFactor, ...],
     ) -> Self:
-        return cls.model_construct(status="COMPLETE", value=value, factors=factors)
+        return cls.model_construct(
+            status="COMPLETE", value=value, factors=factors, detail=None
+        )
+
+    @classmethod
+    def _unknown(cls, *, value: CertifiedFactorizationInteger, detail: str) -> Self:
+        return cls.model_construct(
+            status="UNKNOWN", value=value, factors=(), detail=detail
+        )
 
 
 class PrimalityCertificateRequest(StrictModel):

--- a/src/jacobian/math/number_theory/_certified_factorization_worker.py
+++ b/src/jacobian/math/number_theory/_certified_factorization_worker.py
@@ -1,0 +1,30 @@
+"""One-shot isolated SymPy factorization worker."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from jacobian.math.number_theory._certification_models import (
+    CertifiedFactorizationRequest,
+)
+from jacobian.math.number_theory._factorization_kernels import (
+    _factorize_certified_in_process,
+)
+
+
+def main() -> int:
+    try:
+        request = CertifiedFactorizationRequest.model_validate(json.load(sys.stdin))
+        response: dict[str, object] = {
+            "ok": True,
+            "result": _factorize_certified_in_process(request).model_dump(mode="json"),
+        }
+    except Exception as exc:
+        response = {"ok": False, "error": type(exc).__name__}
+    json.dump(response, sys.stdout, separators=(",", ":"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/number_theory/_direct_factorization_models.py
+++ b/src/jacobian/math/number_theory/_direct_factorization_models.py
@@ -1,6 +1,6 @@
 """Typed contracts and source-bound replay for direct factorization.
 
-These models own the small, synchronous factorization envelope used by the
+These models own the small isolated-worker factorization envelope used by the
 divisor-enumeration and prime-factorization operations.  Certified
 factorization and primality certificates have a distinct, larger envelope.
 """
@@ -18,9 +18,8 @@ from jacobian.math.number_theory._models import (
     _validation_error,
 )
 
-# ``factorint`` is used both by the direct kernels and source-bound result
-# replay.  Twenty decimal digits keep a hard semiprime within the synchronous
-# envelope while still admitting ordinary exact divisor and factor workflows.
+# Twenty decimal digits keep the worker's factorization and bounded replay
+# envelope useful for ordinary exact divisor and prime-factor workflows.
 MAX_DIRECT_FACTORIZATION_DIGITS = 20
 MAX_DIRECT_DIVISORS = 4_096
 MAX_DIRECT_FACTOR_ENTRIES = 256
@@ -58,15 +57,16 @@ class DivisorListResult(StrictModel):
     """An ordered list of positive divisors of one nonzero integer.
 
     Retains the canonical source integer and the operation's divisor
-    convention so validation replays the exact enumeration: the list is
-    exactly all positive divisors of ``abs(value)`` (proper ones exclude
-    ``abs(value)`` itself) in ascending order.  The list may be empty:
+    convention. Structural validation keeps the representation safe; the
+    explicit owner verifier replays the exact enumeration in a bounded worker.
+    The list may be empty:
     ``proper_divisors(±1)`` has no positive proper divisors.  Zero remains
     not-applicable (handled at the operation layer).  The source carries the
     same 20-digit factorization bound as the producing requests, so replay
     never factors outside the operation's admitted work envelope.
     """
 
+    status: Literal["COMPLETE", "UNKNOWN"] = "COMPLETE"
     value: FactorizationInteger
     divisors: tuple[BoundedInteger, ...] = Field(
         min_length=0,
@@ -75,13 +75,33 @@ class DivisorListResult(StrictModel):
     convention: Literal["ALL_POSITIVE_DIVISORS", "PROPER_DIVISORS"] = (
         "ALL_POSITIVE_DIVISORS"
     )
+    detail: str | None = None
+
+    @classmethod
+    def _unknown(
+        cls,
+        *,
+        value: str,
+        convention: Literal["ALL_POSITIVE_DIVISORS", "PROPER_DIVISORS"],
+        detail: str,
+    ) -> Self:
+        return cls(
+            status="UNKNOWN",
+            value=value,
+            divisors=(),
+            convention=convention,
+            detail=detail,
+        )
 
     @model_validator(mode="after")
     def require_source_enumeration(self) -> Self:
-        from jacobian.math.number_theory._factorization_kernels import (
-            _replayed_divisors,
-        )
-
+        if self.status == "UNKNOWN":
+            if self.divisors or not self.detail:
+                raise _validation_error(
+                    "unknown_divisor_enumeration_shape",
+                    "an unknown divisor enumeration has no divisors and includes a detail",
+                )
+            return self
         values = [int(divisor) for divisor in self.divisors]
         if any(value < 1 for value in values):
             raise _validation_error(
@@ -100,36 +120,40 @@ class DivisorListResult(StrictModel):
             raise _validation_error(
                 "zero_has_infinitely_many_divisors", "zero has infinitely many divisors"
             )
-        if self.divisors != _replayed_divisors(
-            value, proper=self.convention == "PROPER_DIVISORS"
-        ):
-            raise _validation_error(
-                "divisor_list_must_enumerate_the_divisors_of_the_source",
-                "divisor list must enumerate the divisors of the source",
-            )
         return self
 
 
 class PrimeFactorizationResult(StrictModel):
     """The complete prime-power factorization of one nonzero integer.
 
-    Retains the canonical source integer so validation replays the defining
-    invariant: prime bases are strictly increasing proven primes with
-    positive exponents whose product reconstructs ``abs(value)`` exactly.
+    Retains the canonical source integer. Structural validation checks the
+    coordinate form; the explicit owner verifier establishes primality and
+    completeness.
     The factor list may be empty: ``±1`` has no prime factors.  Zero remains
     not-applicable (handled at the operation layer).
     """
 
-    value: BoundedInteger
+    status: Literal["COMPLETE", "UNKNOWN"] = "COMPLETE"
+    value: FactorizationInteger
     factors: tuple[PrimePower, ...] = Field(
         min_length=0,
         max_length=MAX_DIRECT_FACTOR_ENTRIES,
     )
+    detail: str | None = None
+
+    @classmethod
+    def _unknown(cls, *, value: str, detail: str) -> Self:
+        return cls(status="UNKNOWN", value=value, factors=(), detail=detail)
 
     @model_validator(mode="after")
     def require_source_factorization(self) -> Self:
-        from sympy import isprime
-
+        if self.status == "UNKNOWN":
+            if self.factors or not self.detail:
+                raise _validation_error(
+                    "unknown_prime_factorization_shape",
+                    "an unknown prime factorization has no factors and includes a detail",
+                )
+            return self
         primes = [factor.prime for factor in self.factors]
         if len(set(primes)) != len(primes):
             raise _validation_error(
@@ -151,9 +175,9 @@ class PrimeFactorizationResult(StrictModel):
                     "prime_bases_must_be_strictly_ascending",
                     "prime bases must be strictly ascending",
                 )
-            if prime < 2 or not isprime(prime):
+            if prime < 2:
                 raise _validation_error(
-                    "f_factor_prime_is_not_prime", f"{factor.prime} is not prime"
+                    "factor_prime_domain", "factor primes must be at least 2"
                 )
             power_value = 1
             for _ in range(factor.power):
@@ -174,5 +198,53 @@ class PrimeFactorizationResult(StrictModel):
             raise _validation_error(
                 "prime_powers_must_multiply_to_abs_value",
                 "prime powers must multiply to abs(value)",
+            )
+        return self
+
+
+class SquarefreeResult(StrictModel):
+    """A squarefreeness decision, or an explicit non-conclusion."""
+
+    status: Literal["SQUAREFREE", "NOT_SQUAREFREE", "UNKNOWN"]
+    n: int = Field(ge=0, le=10_000)
+    detail: str | None = None
+
+    @classmethod
+    def _unknown(cls, *, n: int, detail: str) -> Self:
+        return cls(status="UNKNOWN", n=n, detail=detail)
+
+    @model_validator(mode="after")
+    def require_unknown_detail(self) -> Self:
+        if self.status == "UNKNOWN" and not self.detail:
+            raise _validation_error(
+                "unknown_squarefree_shape",
+                "an unknown squarefreeness result includes a detail",
+            )
+        return self
+
+
+class RadicalResult(StrictModel):
+    """The exact radical of one admitted integer, or an explicit non-conclusion."""
+
+    status: Literal["COMPLETE", "UNKNOWN"] = "COMPLETE"
+    n: int = Field(ge=0, le=10_000)
+    value: BoundedInteger | None = None
+    detail: str | None = None
+
+    @classmethod
+    def _unknown(cls, *, n: int, detail: str) -> Self:
+        return cls(status="UNKNOWN", n=n, detail=detail)
+
+    @model_validator(mode="after")
+    def require_complete_value(self) -> Self:
+        if self.status == "COMPLETE" and self.value is None:
+            raise _validation_error(
+                "complete_radical_requires_value",
+                "a complete radical result includes its exact value",
+            )
+        if self.status == "UNKNOWN" and (self.value is not None or not self.detail):
+            raise _validation_error(
+                "unknown_radical_shape",
+                "an unknown radical has no value and includes a detail",
             )
         return self

--- a/src/jacobian/math/number_theory/_direct_factorization_worker.py
+++ b/src/jacobian/math/number_theory/_direct_factorization_worker.py
@@ -1,0 +1,30 @@
+"""Isolated SymPy adapter for one admitted direct factorization request."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.buffer.read())
+        value = int(payload["value"])
+        if value == 0:
+            raise ValueError("zero has no finite direct factorization")
+        from sympy import factorint
+
+        factors = sorted(factorint(abs(value)).items())
+        sys.stdout.write(
+            json.dumps(
+                {"factors": [[str(prime), int(power)] for prime, power in factors]},
+                separators=(",", ":"),
+            )
+        )
+        return 0
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jacobian/math/number_theory/_factorization.py
+++ b/src/jacobian/math/number_theory/_factorization.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from jacobian._models import StrictModel
 from jacobian.catalog._examples import example
 from jacobian.catalog.models import MathTool, OperationExample
-from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory._certification_models import (
     CertifiedFactorizationRequest,
     CertifiedFactorizationResult,
@@ -18,6 +17,8 @@ from jacobian.math.number_theory._direct_factorization_models import (
     DivisorListResult,
     NonzeroFactorizationRequest,
     PrimeFactorizationResult,
+    RadicalResult,
+    SquarefreeResult,
 )
 from jacobian.math.number_theory._factorization_kernels import (
     compute_pratt_certificate,
@@ -30,7 +31,6 @@ from jacobian.math.number_theory._factorization_kernels import (
 )
 from jacobian.math.number_theory._integer_models import (
     ArithmeticFunctionRequest,
-    BooleanResult,
 )
 
 
@@ -66,13 +66,13 @@ def _compute_prime_factorization(
 
 def _compute_squarefree(
     request: ArithmeticFunctionRequest,
-) -> BooleanResult:
+) -> SquarefreeResult:
     return decide_squarefree(request)
 
 
 def _compute_radical(
     request: ArithmeticFunctionRequest,
-) -> IntegerValue:
+) -> RadicalResult:
     return compute_radical(request)
 
 
@@ -103,7 +103,13 @@ FACTORIZATION_OPERATIONS = (
     _operation(
         operation_id="integer.factor.certified_compute",
         title="Compute a certified integer factorization",
-        description="Factor one bounded 30-digit integer (~100 bits) using subexponential methods (Pollard rho, Pollard p-1, ECM via sympy.ntheory.factorint), returning the complete prime-power factorization with per-factor Pratt primality certificates.",
+        description=(
+            "Factor one bounded 30-digit integer (~100 bits) in an isolated "
+            "subexponential worker (Pollard rho, Pollard p-1, ECM via "
+            "sympy.ntheory.factorint), returning a complete prime-power "
+            "factorization with per-factor Pratt certificates, or UNKNOWN if "
+            "the worker cannot establish a complete result within its envelope."
+        ),
         request_model=CertifiedFactorizationRequest,
         result_model=CertifiedFactorizationResult,
         implementation=_compute_certified_factorization,
@@ -138,7 +144,10 @@ FACTORIZATION_OPERATIONS = (
     _operation(
         operation_id="integer.compute.divisors",
         title="Enumerate positive divisors",
-        description="Enumerate every positive divisor exactly.",
+        description=(
+            "Enumerate every positive divisor exactly, or return UNKNOWN when "
+            "the bounded factorization worker cannot establish the enumeration."
+        ),
         request_model=NonzeroFactorizationRequest,
         result_model=DivisorListResult,
         implementation=_compute_divisors,
@@ -152,7 +161,10 @@ FACTORIZATION_OPERATIONS = (
     _operation(
         operation_id="integer.compute.proper_divisors",
         title="Enumerate proper divisors",
-        description="Enumerate every positive proper divisor exactly.",
+        description=(
+            "Enumerate every positive proper divisor exactly, or return UNKNOWN "
+            "when the bounded factorization worker cannot establish it."
+        ),
         request_model=NonzeroFactorizationRequest,
         result_model=DivisorListResult,
         implementation=_compute_proper_divisors,
@@ -170,7 +182,8 @@ FACTORIZATION_OPERATIONS = (
         title="Factor an integer",
         description=(
             "Factor an integer into prime powers and return the complete "
-            "prime-power factorization."
+            "prime-power factorization, or UNKNOWN when the bounded worker "
+            "cannot establish it."
         ),
         request_model=NonzeroFactorizationRequest,
         result_model=PrimeFactorizationResult,
@@ -187,9 +200,12 @@ FACTORIZATION_OPERATIONS = (
     _operation(
         operation_id="integer.decide.squarefree",
         title="Decide squarefreeness",
-        description="Decide whether a bounded nonnegative integer is square-free.",
+        description=(
+            "Decide whether a bounded nonnegative integer is square-free, or "
+            "return UNKNOWN when the bounded factorization worker cannot decide."
+        ),
         request_model=ArithmeticFunctionRequest,
-        result_model=BooleanResult,
+        result_model=SquarefreeResult,
         implementation=_compute_squarefree,
         tags=("number-theory", "predicate"),
         examples=(
@@ -199,9 +215,12 @@ FACTORIZATION_OPERATIONS = (
     _operation(
         operation_id="integer.compute.radical",
         title="Compute integer radical",
-        description="Compute the product of distinct prime divisors exactly.",
+        description=(
+            "Compute the product of distinct prime divisors exactly, or return "
+            "UNKNOWN when the bounded factorization worker cannot establish it."
+        ),
         request_model=ArithmeticFunctionRequest,
-        result_model=IntegerValue,
+        result_model=RadicalResult,
         implementation=_compute_radical,
         tags=("number-theory", "arithmetic-function"),
         examples=(example("radical_360", "Compute the radical of 360.", {"n": 360}),),

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -285,8 +285,14 @@ def enumerate_divisors(request: FactorizationRequest) -> DivisorListResult:
     try:
         divisors = _divisors_from_factors(factors, proper=False, value=value)
     except ValueError:
-        return DivisorListResult._unknown(value=request.value, convention="ALL_POSITIVE_DIVISORS", detail="the complete divisor family exceeds the admitted output bound")
-    return DivisorListResult(value=request.value, divisors=divisors, convention="ALL_POSITIVE_DIVISORS")
+        return DivisorListResult._unknown(
+            value=request.value,
+            convention="ALL_POSITIVE_DIVISORS",
+            detail="the complete divisor family exceeds the admitted output bound",
+        )
+    return DivisorListResult(
+        value=request.value, divisors=divisors, convention="ALL_POSITIVE_DIVISORS"
+    )
 
 
 def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResult:
@@ -303,8 +309,14 @@ def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResul
     try:
         divisors = _divisors_from_factors(factors, proper=True, value=value)
     except ValueError:
-        return DivisorListResult._unknown(value=request.value, convention="PROPER_DIVISORS", detail="the complete divisor family exceeds the admitted output bound")
-    return DivisorListResult(value=request.value, divisors=divisors, convention="PROPER_DIVISORS")
+        return DivisorListResult._unknown(
+            value=request.value,
+            convention="PROPER_DIVISORS",
+            detail="the complete divisor family exceeds the admitted output bound",
+        )
+    return DivisorListResult(
+        value=request.value, divisors=divisors, convention="PROPER_DIVISORS"
+    )
 
 
 def factorize_primes(request: FactorizationRequest) -> PrimeFactorizationResult:

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from pathlib import Path
 
@@ -216,7 +217,7 @@ def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
         if len(factors) > 256:
             raise ValueError("too many factors")
         if [factor.prime for factor in factors] != sorted(
-            factor.prime for factor in factors
+            (factor.prime for factor in factors), key=int
         ) or len({factor.prime for factor in factors}) != len(factors):
             raise ValueError("noncanonical factors")
         return factors
@@ -234,6 +235,9 @@ def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
 def _divisors_from_factors(
     factors: tuple[PrimePower, ...], *, proper: bool, value: int
 ) -> tuple[str, ...]:
+    divisor_count = math.prod(factor.power + 1 for factor in factors)
+    if divisor_count > 4_096:
+        raise ValueError("divisor output exceeds admitted bound")
     divisors = [1]
     for factor in factors:
         prime = int(factor.prime)
@@ -241,8 +245,6 @@ def _divisors_from_factors(
         for _ in range(factor.power):
             power_values.append(power_values[-1] * prime)
         divisors = [base * power for base in divisors for power in power_values]
-    if len(divisors) > 4_096:
-        raise ValueError("divisor output exceeds admitted bound")
     ordered = tuple(str(divisor) for divisor in sorted(divisors))
     return ordered[:-1] if proper else ordered
 
@@ -280,11 +282,11 @@ def enumerate_divisors(request: FactorizationRequest) -> DivisorListResult:
             convention="ALL_POSITIVE_DIVISORS",
             detail="the bounded factorization worker did not establish every divisor",
         )
-    return DivisorListResult(
-        value=request.value,
-        divisors=_divisors_from_factors(factors, proper=False, value=value),
-        convention="ALL_POSITIVE_DIVISORS",
-    )
+    try:
+        divisors = _divisors_from_factors(factors, proper=False, value=value)
+    except ValueError:
+        return DivisorListResult._unknown(value=request.value, convention="ALL_POSITIVE_DIVISORS", detail="the complete divisor family exceeds the admitted output bound")
+    return DivisorListResult(value=request.value, divisors=divisors, convention="ALL_POSITIVE_DIVISORS")
 
 
 def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResult:
@@ -298,11 +300,11 @@ def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResul
             convention="PROPER_DIVISORS",
             detail="the bounded factorization worker did not establish every proper divisor",
         )
-    return DivisorListResult(
-        value=request.value,
-        divisors=_divisors_from_factors(factors, proper=True, value=value),
-        convention="PROPER_DIVISORS",
-    )
+    try:
+        divisors = _divisors_from_factors(factors, proper=True, value=value)
+    except ValueError:
+        return DivisorListResult._unknown(value=request.value, convention="PROPER_DIVISORS", detail="the complete divisor family exceeds the admitted output bound")
+    return DivisorListResult(value=request.value, divisors=divisors, convention="PROPER_DIVISORS")
 
 
 def factorize_primes(request: FactorizationRequest) -> PrimeFactorizationResult:

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -255,11 +255,17 @@ def verify_divisor_list_result(result: DivisorListResult) -> bool:
     if result.status != "COMPLETE":
         return False
     factors = _bounded_direct_factorization(int(result.value))
-    return factors is not None and result.divisors == _divisors_from_factors(
-        factors,
-        proper=result.convention == "PROPER_DIVISORS",
-        value=int(result.value),
-    )
+    if factors is None:
+        return False
+    try:
+        divisors = _divisors_from_factors(
+            factors,
+            proper=result.convention == "PROPER_DIVISORS",
+            value=int(result.value),
+        )
+    except ValueError:
+        return False
+    return result.divisors == divisors
 
 
 def verify_prime_factorization_result(result: PrimeFactorizationResult) -> bool:

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -220,6 +220,14 @@ def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
             (factor.prime for factor in factors), key=int
         ) or len({factor.prime for factor in factors}) != len(factors):
             raise ValueError("noncanonical factors")
+        from sympy import isprime
+
+        if (
+            not all(isprime(int(factor.prime)) for factor in factors)
+            or math.prod(int(factor.prime) ** factor.power for factor in factors)
+            != abs(value)
+        ):
+            raise ValueError("factorization does not reconstruct the input")
         return factors
     except (
         IndexError,

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -222,11 +222,9 @@ def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
             raise ValueError("noncanonical factors")
         from sympy import isprime
 
-        if (
-            not all(isprime(int(factor.prime)) for factor in factors)
-            or math.prod(int(factor.prime) ** factor.power for factor in factors)
-            != abs(value)
-        ):
+        if not all(isprime(int(factor.prime)) for factor in factors) or math.prod(
+            int(factor.prime) ** factor.power for factor in factors
+        ) != abs(value):
             raise ValueError("factorization does not reconstruct the input")
         return factors
     except (

--- a/src/jacobian/math/number_theory/_factorization_kernels.py
+++ b/src/jacobian/math/number_theory/_factorization_kernels.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import math
+import json
+import sys
+from pathlib import Path
 
 from jacobian.canonical import format_canonical_integer, parse_canonical_integer
-from jacobian.math.arithmetic.values import IntegerValue
 from jacobian.math.number_theory._certification_models import (
     CertifiedFactor,
     CertifiedFactorizationRequest,
@@ -18,10 +19,11 @@ from jacobian.math.number_theory._direct_factorization_models import (
     DivisorListResult,
     FactorizationRequest,
     PrimeFactorizationResult,
+    RadicalResult,
+    SquarefreeResult,
 )
 from jacobian.math.number_theory._integer_models import (
     ArithmeticFunctionRequest,
-    BooleanResult,
     PrimePower,
 )
 
@@ -30,6 +32,12 @@ from jacobian.math.number_theory._integer_models import (
 # ---------------------------------------------------------------------------
 
 _PRATT_BASE_PRIME = 2
+_CERTIFIED_FACTORIZATION_WORKER = (
+    Path(__file__).resolve().with_name("_certified_factorization_worker.py")
+)
+_DIRECT_FACTORIZATION_WORKER = (
+    Path(__file__).resolve().with_name("_direct_factorization_worker.py")
+)
 
 
 def _build_pratt_certificate(prime: int) -> PrattCertificateNode:
@@ -89,7 +97,7 @@ def compute_pratt_certificate(
 # ---------------------------------------------------------------------------
 
 
-def factorize_certified(
+def _factorize_certified_in_process(
     request: CertifiedFactorizationRequest,
 ) -> CertifiedFactorizationResult:
     """Factor one bounded integer using subexponential methods.
@@ -116,24 +124,165 @@ def factorize_certified(
     )
 
 
+def factorize_certified(
+    request: CertifiedFactorizationRequest,
+) -> CertifiedFactorizationResult:
+    """Factor through a killable worker; a stop establishes no factor claim."""
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    completed = run_bounded_process(
+        [sys.executable, str(_CERTIFIED_FACTORIZATION_WORKER)],
+        input_bytes=json.dumps(
+            {"value": request.value}, separators=(",", ":")
+        ).encode(),
+        timeout_seconds=60.0,
+        environment=worker_environment(locale="C.UTF-8"),
+        stdout_limit=1024 * 1024,
+        stderr_limit=64 * 1024,
+        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
+    )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return CertifiedFactorizationResult._unknown(
+            value=request.value,
+            detail="the bounded factorization worker did not establish a complete result",
+        )
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        if response.get("ok") is not True:
+            raise ValueError("worker failure")
+        return CertifiedFactorizationResult.model_validate(response["result"])
+    except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return CertifiedFactorizationResult._unknown(
+            value=request.value,
+            detail="the bounded factorization worker returned malformed output",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Divisor and factorization-derived operations
 # ---------------------------------------------------------------------------
 
 
-def _replayed_divisors(value: int, *, proper: bool) -> tuple[str, ...]:
-    from sympy import divisors
+def _bounded_direct_factorization(value: int) -> tuple[PrimePower, ...] | None:
+    """Factor one admitted nonzero integer in a killable worker.
 
-    return tuple(str(item) for item in divisors(abs(value), proper=proper))
+    ``None`` is an operational non-conclusion, never a factor claim.  The
+    caller owns projection into its operation-specific typed result.
+    """
+
+    from jacobian.process import (
+        ProcessResourceLimits,
+        run_bounded_process,
+        worker_environment,
+    )
+
+    completed = run_bounded_process(
+        [sys.executable, str(_DIRECT_FACTORIZATION_WORKER)],
+        input_bytes=json.dumps({"value": str(value)}, separators=(",", ":")).encode(),
+        timeout_seconds=60.0,
+        environment=worker_environment(locale="C.UTF-8"),
+        stdout_limit=64 * 1024,
+        stderr_limit=64 * 1024,
+        resource_limits=ProcessResourceLimits(address_space_bytes=1024 * 1024 * 1024),
+    )
+    if (
+        completed.timed_out
+        or completed.cancelled
+        or completed.stdout_exceeded
+        or completed.stderr_exceeded
+        or completed.returncode != 0
+    ):
+        return None
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+        raw_factors = response["factors"]
+        if not isinstance(raw_factors, list):
+            raise ValueError("factors must be a list")
+        factors = tuple(
+            PrimePower.model_validate({"prime": pair[0], "power": pair[1]})
+            for pair in raw_factors
+        )
+        if len(factors) > 256:
+            raise ValueError("too many factors")
+        if [factor.prime for factor in factors] != sorted(
+            factor.prime for factor in factors
+        ) or len({factor.prime for factor in factors}) != len(factors):
+            raise ValueError("noncanonical factors")
+        return factors
+    except (
+        IndexError,
+        KeyError,
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        return None
+
+
+def _divisors_from_factors(
+    factors: tuple[PrimePower, ...], *, proper: bool, value: int
+) -> tuple[str, ...]:
+    divisors = [1]
+    for factor in factors:
+        prime = int(factor.prime)
+        power_values = [1]
+        for _ in range(factor.power):
+            power_values.append(power_values[-1] * prime)
+        divisors = [base * power for base in divisors for power in power_values]
+    if len(divisors) > 4_096:
+        raise ValueError("divisor output exceeds admitted bound")
+    ordered = tuple(str(divisor) for divisor in sorted(divisors))
+    return ordered[:-1] if proper else ordered
+
+
+def verify_divisor_list_result(result: DivisorListResult) -> bool:
+    """Replay one bounded divisor claim through the owner kernel."""
+
+    if result.status != "COMPLETE":
+        return False
+    factors = _bounded_direct_factorization(int(result.value))
+    return factors is not None and result.divisors == _divisors_from_factors(
+        factors,
+        proper=result.convention == "PROPER_DIVISORS",
+        value=int(result.value),
+    )
+
+
+def verify_prime_factorization_result(result: PrimeFactorizationResult) -> bool:
+    """Replay one complete prime-factorization claim through the owner kernel."""
+
+    if result.status != "COMPLETE":
+        return False
+    factors = _bounded_direct_factorization(int(result.value))
+    return factors is not None and result.factors == factors
 
 
 def enumerate_divisors(request: FactorizationRequest) -> DivisorListResult:
     value = int(request.value)
     if value == 0:
         raise ValueError("zero has infinitely many divisors")
+    factors = _bounded_direct_factorization(value)
+    if factors is None:
+        return DivisorListResult._unknown(
+            value=request.value,
+            convention="ALL_POSITIVE_DIVISORS",
+            detail="the bounded factorization worker did not establish every divisor",
+        )
     return DivisorListResult(
         value=request.value,
-        divisors=_replayed_divisors(value, proper=False),
+        divisors=_divisors_from_factors(factors, proper=False, value=value),
         convention="ALL_POSITIVE_DIVISORS",
     )
 
@@ -142,39 +291,60 @@ def enumerate_proper_divisors(request: FactorizationRequest) -> DivisorListResul
     value = int(request.value)
     if value == 0:
         raise ValueError("zero has infinitely many divisors")
+    factors = _bounded_direct_factorization(value)
+    if factors is None:
+        return DivisorListResult._unknown(
+            value=request.value,
+            convention="PROPER_DIVISORS",
+            detail="the bounded factorization worker did not establish every proper divisor",
+        )
     return DivisorListResult(
         value=request.value,
-        divisors=_replayed_divisors(value, proper=True),
+        divisors=_divisors_from_factors(factors, proper=True, value=value),
         convention="PROPER_DIVISORS",
     )
 
 
 def factorize_primes(request: FactorizationRequest) -> PrimeFactorizationResult:
-    from sympy import factorint
-
     value = int(request.value)
     if value == 0:
         raise ValueError("zero has no finite prime factorization")
-    return PrimeFactorizationResult(
-        value=request.value,
-        factors=tuple(
-            PrimePower(prime=str(prime), power=int(power))
-            for prime, power in sorted(factorint(abs(value)).items())
-        ),
-    )
+    factors = _bounded_direct_factorization(value)
+    if factors is None:
+        return PrimeFactorizationResult._unknown(
+            value=request.value,
+            detail="the bounded factorization worker did not establish a complete result",
+        )
+    return PrimeFactorizationResult(value=request.value, factors=factors)
 
 
-def decide_squarefree(request: ArithmeticFunctionRequest) -> BooleanResult:
-    from sympy import factorint
-
+def decide_squarefree(request: ArithmeticFunctionRequest) -> SquarefreeResult:
     if request.n == 0:
-        return BooleanResult(holds=False)
-    return BooleanResult(
-        holds=all(power == 1 for power in factorint(request.n).values())
+        return SquarefreeResult(status="NOT_SQUAREFREE", n=request.n)
+    factors = _bounded_direct_factorization(request.n)
+    if factors is None:
+        return SquarefreeResult._unknown(
+            n=request.n,
+            detail="the bounded factorization worker did not establish squarefreeness",
+        )
+    return SquarefreeResult(
+        status="SQUAREFREE"
+        if all(factor.power == 1 for factor in factors)
+        else "NOT_SQUAREFREE",
+        n=request.n,
     )
 
 
-def compute_radical(request: ArithmeticFunctionRequest) -> IntegerValue:
-    from sympy import factorint
-
-    return IntegerValue(value=str(math.prod(factorint(request.n))))
+def compute_radical(request: ArithmeticFunctionRequest) -> RadicalResult:
+    if request.n == 0:
+        return RadicalResult(n=0, value="0")
+    factors = _bounded_direct_factorization(request.n)
+    if factors is None:
+        return RadicalResult._unknown(
+            n=request.n,
+            detail="the bounded factorization worker did not establish the radical",
+        )
+    radical = 1
+    for factor in factors:
+        radical *= int(factor.prime)
+    return RadicalResult(n=request.n, value=str(radical))

--- a/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
+++ b/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
@@ -3,20 +3,12 @@
 from __future__ import annotations
 
 from fractions import Fraction
-from itertools import pairwise
 from typing import Self
 
 from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
-from jacobian.math.numerical_semigroups._algorithms import (
-    catenary_degree_from_factorizations,
-    factorization_length_extrema,
-    factorization_lengths,
-    factorizations,
-)
 from jacobian.math.numerical_semigroups._models import (
     _GENERAL_ELEMENT_ENVELOPE,
     _GENERAL_GENERATOR_ENVELOPE,
@@ -64,24 +56,39 @@ class ElementDeltaSetResult(StrictModel):
     factorization_lengths: tuple[int, ...]
     delta_set: tuple[int, ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        factorization_lengths: tuple[int, ...],
+        delta_set: tuple[int, ...],
+    ) -> Self:
+        """Construct output derived from one admitted length-set kernel call."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            factorization_lengths=factorization_lengths,
+            delta_set=delta_set,
+        )
+
     @model_validator(mode="after")
     def require_set_semantics(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
-        value = parse_canonical_integer(self.value)
-        expected_lengths = factorization_lengths(generators, value)
-        if self.factorization_lengths != expected_lengths:
-            raise _validation_error("factorization_lengths do not match the element")
-        expected_delta = tuple(
-            sorted({right - left for left, right in pairwise(expected_lengths)})
-        )
+        _require_canonical_minimal_axis(self.minimal_generators)
+        if self.factorization_lengths != tuple(
+            sorted(set(self.factorization_lengths))
+        ) or any(length < 0 for length in self.factorization_lengths):
+            raise _validation_error(
+                "factorization_lengths must be non-negative, increasing, and duplicate-free"
+            )
         if self.delta_set != tuple(sorted(set(self.delta_set))):
             raise _validation_error(
                 "delta_set must be strictly increasing and duplicate-free"
             )
         if any(delta <= 0 for delta in self.delta_set):
             raise _validation_error("delta values must be positive")
-        if self.delta_set != expected_delta:
-            raise _validation_error("delta_set does not match the complete length set")
         return self
 
 
@@ -125,14 +132,31 @@ class ElementElasticityResult(StrictModel):
     maximum_length: int = Field(ge=1)
     elasticity: str
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        minimum_length: int,
+        maximum_length: int,
+        elasticity: str,
+    ) -> Self:
+        """Construct output derived from one admitted extrema kernel call."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            minimum_length=minimum_length,
+            maximum_length=maximum_length,
+            elasticity=elasticity,
+        )
+
     @model_validator(mode="after")
     def require_length_ratio(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
-        expected_extrema = factorization_length_extrema(
-            generators, parse_canonical_integer(self.value)
-        )
-        if (self.minimum_length, self.maximum_length) != expected_extrema:
-            raise _validation_error("length extrema do not match the element")
+        _require_canonical_minimal_axis(self.minimal_generators)
+        if self.minimum_length > self.maximum_length:
+            raise _validation_error("minimum_length must not exceed maximum_length")
         if Fraction(self.elasticity) != Fraction(
             self.maximum_length, self.minimum_length
         ):
@@ -176,16 +200,27 @@ class ElementCatenaryDegreeResult(StrictModel):
     factorization_count: int = Field(ge=1)
     catenary_degree: int = Field(ge=0)
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        factorization_count: int,
+        catenary_degree: int,
+    ) -> Self:
+        """Construct an output established from one complete factorization family."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            factorization_count=factorization_count,
+            catenary_degree=catenary_degree,
+        )
+
     @model_validator(mode="after")
-    def require_exact_degree(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
-        family = factorizations(generators, parse_canonical_integer(self.value))
-        if self.factorization_count != len(family):
-            raise _validation_error("factorization_count does not match the element")
-        if self.catenary_degree != catenary_degree_from_factorizations(family):
-            raise _validation_error(
-                "catenary_degree does not match the factorization graph"
-            )
+    def require_structural_degree(self) -> Self:
+        _require_canonical_minimal_axis(self.minimal_generators)
         return self
 
 

--- a/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
+++ b/src/jacobian/math/numerical_semigroups/_element_invariant_models.py
@@ -76,7 +76,8 @@ class ElementDeltaSetResult(StrictModel):
 
     @model_validator(mode="after")
     def require_set_semantics(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_bounded_value(generators, self.value)
         if self.factorization_lengths != tuple(
             sorted(set(self.factorization_lengths))
         ) or any(length < 0 for length in self.factorization_lengths):
@@ -154,7 +155,8 @@ class ElementElasticityResult(StrictModel):
 
     @model_validator(mode="after")
     def require_length_ratio(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_bounded_value(generators, self.value)
         if self.minimum_length > self.maximum_length:
             raise _validation_error("minimum_length must not exceed maximum_length")
         if Fraction(self.elasticity) != Fraction(
@@ -220,7 +222,11 @@ class ElementCatenaryDegreeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_structural_degree(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        value = _require_bounded_value(generators, self.value)
+        _require_materializable_factorizations(
+            generators, value, MAX_GRAPH_FACTORIZATIONS
+        )
         return self
 
 

--- a/src/jacobian/math/numerical_semigroups/_element_invariant_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_element_invariant_operations.py
@@ -40,7 +40,7 @@ def compute_element_delta_set(
     atoms = _minimal_generators(request.generators)
     value = parse_canonical_integer(request.value)
     lengths = factorization_lengths(atoms, value)
-    return ElementDeltaSetResult(
+    return ElementDeltaSetResult._from_kernel(
         value=request.value,
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         factorization_lengths=lengths,
@@ -56,7 +56,7 @@ def compute_element_elasticity(
     atoms = _minimal_generators(request.generators)
     value = parse_canonical_integer(request.value)
     minimum_length, maximum_length = factorization_length_extrema(atoms, value)
-    return ElementElasticityResult(
+    return ElementElasticityResult._from_kernel(
         value=request.value,
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         minimum_length=minimum_length,
@@ -73,7 +73,7 @@ def compute_element_catenary_degree(
     atoms = _minimal_generators(request.generators)
     value = parse_canonical_integer(request.value)
     family = factorizations(atoms, value)
-    return ElementCatenaryDegreeResult(
+    return ElementCatenaryDegreeResult._from_kernel(
         value=request.value,
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         factorization_count=len(family),
@@ -81,8 +81,44 @@ def compute_element_catenary_degree(
     )
 
 
+def verify_element_catenary_degree_result(
+    result: ElementCatenaryDegreeResult,
+) -> bool:
+    """Replay the admitted complete factorization family for a supplied claim."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    family = factorizations(atoms, parse_canonical_integer(result.value))
+    return result.factorization_count == len(
+        family
+    ) and result.catenary_degree == catenary_degree_from_factorizations(family)
+
+
+def verify_element_delta_set_result(result: ElementDeltaSetResult) -> bool:
+    """Replay one supplied element delta-set claim within its admitted bounds."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    lengths = factorization_lengths(atoms, parse_canonical_integer(result.value))
+    delta_set = tuple(sorted({right - left for left, right in pairwise(lengths)}))
+    return result.factorization_lengths == lengths and result.delta_set == delta_set
+
+
+def verify_element_elasticity_result(result: ElementElasticityResult) -> bool:
+    """Replay one supplied element elasticity claim within its admitted bounds."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    minimum, maximum = factorization_length_extrema(
+        atoms, parse_canonical_integer(result.value)
+    )
+    return (result.minimum_length, result.maximum_length) == (
+        minimum,
+        maximum,
+    ) and result.elasticity == format_canonical_rational(Fraction(maximum, minimum))
+
+
 __all__ = [
     "compute_element_catenary_degree",
     "compute_element_delta_set",
     "compute_element_elasticity",
+    "verify_element_delta_set_result",
+    "verify_element_elasticity_result",
 ]

--- a/src/jacobian/math/numerical_semigroups/_factorization_models.py
+++ b/src/jacobian/math/numerical_semigroups/_factorization_models.py
@@ -76,7 +76,12 @@ class FactorizationComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_exact_family(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_materializable_factorizations(
+            generators,
+            _require_bounded_value(generators, self.value),
+            MAX_MATERIALIZED_FACTORIZATIONS,
+        )
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error(
                 "membership must agree with the factorization family"
@@ -135,7 +140,8 @@ class FactorizationLengthsComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_length_set(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_bounded_value(generators, self.value)
         if self.in_semigroup != bool(self.lengths):
             raise _validation_error(
                 "membership must agree with the factorization lengths"
@@ -264,7 +270,12 @@ class FactorizationGraphComputeResult(StrictModel):
 
     @model_validator(mode="after")
     def require_graph_partition(self) -> Self:
-        _require_canonical_minimal_axis(self.minimal_generators)
+        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_materializable_factorizations(
+            generators,
+            _require_bounded_value(generators, self.value),
+            MAX_GRAPH_FACTORIZATIONS,
+        )
         vertex_count = len(self.factorizations)
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error("membership must agree with graph vertices")

--- a/src/jacobian/math/numerical_semigroups/_factorization_models.py
+++ b/src/jacobian/math/numerical_semigroups/_factorization_models.py
@@ -8,17 +8,13 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
-from jacobian.math.numerical_semigroups._algorithms import factorization_lengths
 from jacobian.math.numerical_semigroups._models import (
     _GENERAL_GENERATOR_ENVELOPE,
     MAX_GENERATORS,
     MAX_GRAPH_FACTORIZATIONS,
     MAX_MATERIALIZED_FACTORIZATIONS,
-    _factorization_graph_data,
     _require_bounded_value,
     _require_canonical_minimal_axis,
-    _require_exact_factorization_family,
     _require_materializable_factorizations,
     _require_minimal_generators,
     _validation_error,
@@ -60,16 +56,31 @@ class FactorizationComputeResult(StrictModel):
     in_semigroup: bool
     factorizations: tuple[tuple[int, ...], ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        in_semigroup: bool,
+        factorizations: tuple[tuple[int, ...], ...],
+    ) -> Self:
+        """Construct a complete family materialized by the admitted kernel."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            in_semigroup=in_semigroup,
+            factorizations=factorizations,
+        )
+
     @model_validator(mode="after")
     def require_exact_family(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_canonical_minimal_axis(self.minimal_generators)
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error(
                 "membership must agree with the factorization family"
             )
-        _require_exact_factorization_family(
-            generators, parse_canonical_integer(self.value), self.factorizations
-        )
         return self
 
 
@@ -104,9 +115,27 @@ class FactorizationLengthsComputeResult(StrictModel):
     in_semigroup: bool
     lengths: tuple[int, ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        in_semigroup: bool,
+        lengths: tuple[int, ...],
+    ) -> Self:
+        """Construct a length set derived by the admitted kernel."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            in_semigroup=in_semigroup,
+            lengths=lengths,
+        )
+
     @model_validator(mode="after")
     def require_length_set(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_canonical_minimal_axis(self.minimal_generators)
         if self.in_semigroup != bool(self.lengths):
             raise _validation_error(
                 "membership must agree with the factorization lengths"
@@ -117,10 +146,6 @@ class FactorizationLengthsComputeResult(StrictModel):
             )
         if any(length < 0 for length in self.lengths):
             raise _validation_error("factorization lengths must be non-negative")
-        if self.lengths != factorization_lengths(
-            generators, parse_canonical_integer(self.value)
-        ):
-            raise _validation_error("lengths do not form the complete length set")
         return self
 
 
@@ -213,9 +238,33 @@ class FactorizationGraphComputeResult(StrictModel):
     connected_components: tuple[tuple[int, ...], ...]
     is_connected: bool
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        value: CanonicalInteger,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        in_semigroup: bool,
+        factorizations: tuple[tuple[int, ...], ...],
+        edges: tuple[tuple[int, int], ...],
+        connected_components: tuple[tuple[int, ...], ...],
+        is_connected: bool,
+    ) -> Self:
+        """Construct a graph derived from one admitted factorization family."""
+
+        return cls.model_construct(
+            value=value,
+            minimal_generators=minimal_generators,
+            in_semigroup=in_semigroup,
+            factorizations=factorizations,
+            edges=edges,
+            connected_components=connected_components,
+            is_connected=is_connected,
+        )
+
     @model_validator(mode="after")
     def require_graph_partition(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_canonical_minimal_axis(self.minimal_generators)
         vertex_count = len(self.factorizations)
         if self.in_semigroup != bool(self.factorizations):
             raise _validation_error("membership must agree with graph vertices")
@@ -230,16 +279,6 @@ class FactorizationGraphComputeResult(StrictModel):
             raise _validation_error("is_connected must agree with connected components")
         if any(not 0 <= left < right < vertex_count for left, right in self.edges):
             raise _validation_error("graph edge has invalid vertex indices")
-        _require_exact_factorization_family(
-            generators, parse_canonical_integer(self.value), self.factorizations
-        )
-        expected_edges, expected_components = _factorization_graph_data(
-            self.factorizations
-        )
-        if self.edges != expected_edges:
-            raise _validation_error("edges do not match shared-support adjacency")
-        if self.connected_components != expected_components:
-            raise _validation_error("connected components do not match the graph")
         return self
 
 

--- a/src/jacobian/math/numerical_semigroups/_factorization_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_factorization_operations.py
@@ -85,14 +85,14 @@ def compute_factorizations(
         format_canonical_integer(generator) for generator in generators
     )
     if value < 0:
-        return FactorizationComputeResult(
+        return FactorizationComputeResult._from_kernel(
             value=request.value,
             minimal_generators=minimal_generators,
             in_semigroup=False,
             factorizations=(),
         )
     family = _enumerate_factorizations(generators, value)
-    return FactorizationComputeResult(
+    return FactorizationComputeResult._from_kernel(
         value=request.value,
         minimal_generators=minimal_generators,
         in_semigroup=bool(family),
@@ -111,14 +111,14 @@ def compute_factorization_lengths(
         format_canonical_integer(generator) for generator in generators
     )
     if value < 0:
-        return FactorizationLengthsComputeResult(
+        return FactorizationLengthsComputeResult._from_kernel(
             value=request.value,
             minimal_generators=minimal_generators,
             in_semigroup=False,
             lengths=(),
         )
     lengths = factorization_lengths(tuple(generators), value)
-    return FactorizationLengthsComputeResult(
+    return FactorizationLengthsComputeResult._from_kernel(
         value=request.value,
         minimal_generators=minimal_generators,
         in_semigroup=bool(lengths),
@@ -152,7 +152,7 @@ def compute_factorization_graph(
         format_canonical_integer(generator) for generator in generators
     )
     if value < 0:
-        return FactorizationGraphComputeResult(
+        return FactorizationGraphComputeResult._from_kernel(
             value=request.value,
             minimal_generators=minimal_generators,
             in_semigroup=False,
@@ -163,7 +163,7 @@ def compute_factorization_graph(
         )
     family = _enumerate_factorizations(generators, value)
     edges, components, connected = _build_factorization_graph(family)
-    return FactorizationGraphComputeResult(
+    return FactorizationGraphComputeResult._from_kernel(
         value=request.value,
         minimal_generators=minimal_generators,
         in_semigroup=bool(family),
@@ -176,9 +176,54 @@ def compute_factorization_graph(
     )
 
 
+def verify_factorization_compute_result(result: FactorizationComputeResult) -> bool:
+    """Replay one bounded factorization-family claim."""
+
+    generators = tuple(
+        parse_canonical_integer(item) for item in result.minimal_generators
+    )
+    family = tuple(factorizations(generators, parse_canonical_integer(result.value)))
+    return result.in_semigroup == bool(family) and result.factorizations == family
+
+
+def verify_factorization_lengths_compute_result(
+    result: FactorizationLengthsComputeResult,
+) -> bool:
+    """Replay one bounded factorization-length claim."""
+
+    generators = tuple(
+        parse_canonical_integer(item) for item in result.minimal_generators
+    )
+    lengths = factorization_lengths(generators, parse_canonical_integer(result.value))
+    return result.in_semigroup == bool(lengths) and result.lengths == lengths
+
+
+def verify_factorization_graph_compute_result(
+    result: FactorizationGraphComputeResult,
+) -> bool:
+    """Replay the family and derived graph for one supplied claim."""
+
+    generators = tuple(
+        parse_canonical_integer(item) for item in result.minimal_generators
+    )
+    family = tuple(factorizations(generators, parse_canonical_integer(result.value)))
+    edges, components, connected = _build_factorization_graph(list(family))
+    return (
+        result.in_semigroup == bool(family)
+        and result.factorizations == family
+        and result.edges == tuple(edges)
+        and result.connected_components
+        == tuple(tuple(sorted(component)) for component in components)
+        and result.is_connected == connected
+    )
+
+
 __all__ = [
     "compute_factorization_distance",
     "compute_factorization_graph",
     "compute_factorization_lengths",
     "compute_factorizations",
+    "verify_factorization_compute_result",
+    "verify_factorization_graph_compute_result",
+    "verify_factorization_lengths_compute_result",
 ]

--- a/src/jacobian/math/numerical_semigroups/_global_invariant_models.py
+++ b/src/jacobian/math/numerical_semigroups/_global_invariant_models.py
@@ -10,12 +10,6 @@ from pydantic import Field, model_validator
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
 from jacobian.canonical import parse_canonical_integer
-from jacobian.math.numerical_semigroups._algorithms import (
-    betti_data,
-    catenary_degree_from_factorizations,
-    delta_periodicity_bound,
-    factorizations,
-)
 from jacobian.math.numerical_semigroups._models import (
     _GENERAL_GENERATOR_ENVELOPE,
     MAX_GENERATORS,
@@ -57,20 +51,32 @@ class BettiElementsResult(StrictModel):
     candidate_count: int = Field(ge=0)
     betti_elements: tuple[CanonicalInteger, ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        apery_set: tuple[CanonicalInteger, ...],
+        candidate_count: int,
+        betti_elements: tuple[CanonicalInteger, ...],
+    ) -> Self:
+        """Construct output established by one admitted Betti-data kernel call."""
+
+        return cls.model_construct(
+            minimal_generators=minimal_generators,
+            apery_set=apery_set,
+            candidate_count=candidate_count,
+            betti_elements=betti_elements,
+        )
+
     @model_validator(mode="after")
     def require_complete_betti_data(self) -> Self:
-        apery, candidates, disconnected = betti_data(
-            _require_canonical_minimal_axis(self.minimal_generators)
-        )
-        if tuple(map(parse_canonical_integer, self.apery_set)) != apery:
-            raise _validation_error("apery_set does not match the minimal generators")
-        if self.candidate_count != len(candidates):
-            raise _validation_error("candidate_count does not match the complete range")
-        if tuple(map(parse_canonical_integer, self.betti_elements)) != tuple(
-            disconnected
+        _require_canonical_minimal_axis(self.minimal_generators)
+        if self.betti_elements != tuple(
+            sorted(set(self.betti_elements), key=parse_canonical_integer)
         ):
             raise _validation_error(
-                "betti_elements do not match disconnected candidates"
+                "betti_elements must be increasing and duplicate-free"
             )
         return self
 
@@ -107,21 +113,36 @@ class DeltaSetResult(StrictModel):
         "EVENTUAL_PERIODICITY_BOUND"
     )
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        delta_set: tuple[int, ...],
+        periodicity_bound: int,
+        checked_through: int,
+    ) -> Self:
+        """Construct output derived from one admitted periodicity computation."""
+
+        return cls.model_construct(
+            minimal_generators=minimal_generators,
+            delta_set=delta_set,
+            periodicity_bound=periodicity_bound,
+            checked_through=checked_through,
+        )
+
     @model_validator(mode="after")
     def require_set_semantics(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
+        _require_canonical_minimal_axis(self.minimal_generators)
         if self.delta_set != tuple(sorted(set(self.delta_set))):
             raise _validation_error(
                 "delta_set must be strictly increasing and duplicate-free"
             )
         if any(delta <= 0 for delta in self.delta_set):
             raise _validation_error("delta values must be positive")
-        expected_bound = delta_periodicity_bound(generators)
-        if self.periodicity_bound != expected_bound:
-            raise _validation_error("periodicity_bound does not match the generators")
-        if self.checked_through != expected_bound + generators[-1] - 1:
+        if self.checked_through < self.periodicity_bound:
             raise _validation_error(
-                "checked_through does not match the completeness theorem"
+                "checked_through must include the periodicity bound"
             )
         return self
 
@@ -199,21 +220,34 @@ class CatenaryDegreeResult(StrictModel):
     betti_degrees: tuple[BettiCatenaryDegree, ...]
     witness_betti_elements: tuple[CanonicalInteger, ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        catenary_degree: int,
+        betti_degrees: tuple[BettiCatenaryDegree, ...],
+        witness_betti_elements: tuple[CanonicalInteger, ...],
+    ) -> Self:
+        """Construct output established from one admitted Betti pass."""
+
+        return cls.model_construct(
+            minimal_generators=minimal_generators,
+            catenary_degree=catenary_degree,
+            betti_degrees=betti_degrees,
+            witness_betti_elements=witness_betti_elements,
+        )
+
     @model_validator(mode="after")
     def require_maximizing_witnesses(self) -> Self:
-        generators = _require_canonical_minimal_axis(self.minimal_generators)
-        _, _, disconnected = betti_data(generators)
-        expected_records = tuple(
-            BettiCatenaryDegree(
-                betti_element=str(value),
-                catenary_degree=catenary_degree_from_factorizations(
-                    factorizations(generators, value)
-                ),
+        _require_canonical_minimal_axis(self.minimal_generators)
+        if tuple(record.betti_element for record in self.betti_degrees) != tuple(
+            sorted(
+                (record.betti_element for record in self.betti_degrees),
+                key=parse_canonical_integer,
             )
-            for value in disconnected
-        )
-        if self.betti_degrees != expected_records:
-            raise _validation_error("betti_degrees do not match the complete Betti set")
+        ):
+            raise _validation_error("betti_degrees must be increasing by Betti element")
         maximum = max(
             (record.catenary_degree for record in self.betti_degrees), default=0
         )

--- a/src/jacobian/math/numerical_semigroups/_global_invariant_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_global_invariant_operations.py
@@ -48,7 +48,7 @@ def compute_betti_elements(
 
     atoms = _minimal_generators(request.generators)
     apery, candidates, disconnected = betti_data(atoms)
-    return BettiElementsResult(
+    return BettiElementsResult._from_kernel(
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         apery_set=tuple(format_canonical_integer(value) for value in apery),
         candidate_count=len(candidates),
@@ -75,7 +75,7 @@ def compute_delta_set(request: DeltaSetRequest) -> DeltaSetResult:
         ordered = sorted(lengths)
         all_deltas.update(right - left for left, right in pairwise(ordered))
         length_sets[value % atoms[-1]] = lengths
-    return DeltaSetResult(
+    return DeltaSetResult._from_kernel(
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         delta_set=tuple(sorted(all_deltas)),
         periodicity_bound=periodicity_bound,
@@ -109,7 +109,7 @@ def compute_catenary_degree(
         for value in disconnected
     )
     maximum = max((record.catenary_degree for record in degrees), default=0)
-    return CatenaryDegreeResult(
+    return CatenaryDegreeResult._from_kernel(
         minimal_generators=tuple(format_canonical_integer(atom) for atom in atoms),
         catenary_degree=maximum,
         betti_degrees=degrees,
@@ -121,9 +121,77 @@ def compute_catenary_degree(
     )
 
 
+def verify_betti_elements_result(result: BettiElementsResult) -> bool:
+    """Replay one bounded Betti-elements claim."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    apery, candidates, disconnected = betti_data(atoms)
+    return (
+        tuple(result.apery_set)
+        == tuple(format_canonical_integer(value) for value in apery)
+        and result.candidate_count == len(candidates)
+        and tuple(result.betti_elements)
+        == tuple(format_canonical_integer(value) for value in disconnected)
+    )
+
+
+def verify_delta_set_result(result: DeltaSetResult) -> bool:
+    """Replay one bounded complete global delta-set claim."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    periodicity_bound = delta_periodicity_bound(atoms)
+    checked_through = periodicity_bound + atoms[-1] - 1
+    all_deltas: set[int] = set()
+    length_sets: list[set[int]] = [set() for _ in range(atoms[-1])]
+    length_sets[0].add(0)
+    for value in range(1, checked_through + 1):
+        lengths = {
+            length + 1
+            for atom in atoms
+            if value >= atom
+            for length in length_sets[(value - atom) % atoms[-1]]
+        }
+        ordered = sorted(lengths)
+        all_deltas.update(right - left for left, right in pairwise(ordered))
+        length_sets[value % atoms[-1]] = lengths
+    return (
+        result.delta_set == tuple(sorted(all_deltas))
+        and result.periodicity_bound == periodicity_bound
+        and result.checked_through == checked_through
+    )
+
+
+def verify_catenary_degree_result(result: CatenaryDegreeResult) -> bool:
+    """Replay the bounded complete Betti catenary profile for a supplied claim."""
+
+    atoms = tuple(parse_canonical_integer(atom) for atom in result.minimal_generators)
+    _, _, disconnected = betti_data(atoms)
+    degrees = tuple(
+        BettiCatenaryDegree(
+            betti_element=format_canonical_integer(value),
+            catenary_degree=_catenary_degree(atoms, value),
+        )
+        for value in disconnected
+    )
+    maximum = max((record.catenary_degree for record in degrees), default=0)
+    witnesses = tuple(
+        record.betti_element
+        for record in degrees
+        if record.catenary_degree == maximum and maximum > 0
+    )
+    return (
+        result.betti_degrees == degrees
+        and result.catenary_degree == maximum
+        and result.witness_betti_elements == witnesses
+    )
+
+
 __all__ = [
     "compute_betti_elements",
     "compute_catenary_degree",
     "compute_delta_set",
     "compute_elasticity",
+    "verify_betti_elements_result",
+    "verify_catenary_degree_result",
+    "verify_delta_set_result",
 ]

--- a/src/jacobian/math/numerical_semigroups/_presentation_models.py
+++ b/src/jacobian/math/numerical_semigroups/_presentation_models.py
@@ -8,13 +8,9 @@ from pydantic import Field, model_validator
 
 from jacobian._exact import CanonicalInteger
 from jacobian._models import StrictModel
-from jacobian.canonical import parse_canonical_integer
-from jacobian.math.numerical_semigroups._algorithms import betti_data
 from jacobian.math.numerical_semigroups._models import (
     _GENERAL_GENERATOR_ENVELOPE,
     MAX_GENERATORS,
-    _betti_component_index,
-    _edges_span,
     _require_canonical_minimal_axis,
     _require_global_betti_bound,
     _require_minimal_generators,
@@ -67,19 +63,25 @@ class MinimalPresentationResult(StrictModel):
     betti_elements: tuple[CanonicalInteger, ...]
     relations: tuple[MinimalPresentationRelation, ...]
 
+    @classmethod
+    def _from_kernel(
+        cls,
+        *,
+        minimal_generators: tuple[CanonicalInteger, ...],
+        betti_elements: tuple[CanonicalInteger, ...],
+        relations: tuple[MinimalPresentationRelation, ...],
+    ) -> Self:
+        """Construct a minimal presentation derived by the admitted kernel."""
+
+        return cls.model_construct(
+            minimal_generators=minimal_generators,
+            betti_elements=betti_elements,
+            relations=relations,
+        )
+
     @model_validator(mode="after")
     def require_minimal_relation_counts(self) -> Self:
         generators = _require_canonical_minimal_axis(self.minimal_generators)
-        _, _, disconnected = betti_data(generators)
-        if tuple(map(parse_canonical_integer, self.betti_elements)) != tuple(
-            disconnected
-        ):
-            raise _validation_error(
-                "betti_elements do not match the minimal generators"
-            )
-        relation_components: dict[int, list[tuple[int, int]]] = {
-            betti: [] for betti in disconnected
-        }
         for relation in self.relations:
             if len(relation.first) != len(generators):
                 raise _validation_error(
@@ -97,30 +99,8 @@ class MinimalPresentationResult(StrictModel):
                     relation.second, generators, strict=True
                 )
             )
-            if first_degree != second_degree or first_degree not in relation_components:
-                raise _validation_error("relation is not bound to a Betti element")
-            components = disconnected[first_degree]
-            left = _betti_component_index(relation.first, components)
-            right = _betti_component_index(relation.second, components)
-            if left == right:
-                raise _validation_error(
-                    "relation must connect distinct Betti components"
-                )
-            relation_components[first_degree].append((left, right))
-        expected = {
-            betti: len(components) - 1 for betti, components in disconnected.items()
-        }
-        if {
-            betti: len(edges) for betti, edges in relation_components.items()
-        } != expected:
-            raise _validation_error(
-                "relations do not have minimal per-Betti cardinality"
-            )
-        if any(
-            not _edges_span(len(disconnected[betti]), edges)
-            for betti, edges in relation_components.items()
-        ):
-            raise _validation_error("relations must span all Betti components")
+            if first_degree != second_degree:
+                raise _validation_error("relation terms must have the same degree")
         return self
 
 

--- a/src/jacobian/math/numerical_semigroups/_presentation_operations.py
+++ b/src/jacobian/math/numerical_semigroups/_presentation_operations.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from jacobian.canonical import format_canonical_integer
+from jacobian.canonical import format_canonical_integer, parse_canonical_integer
 from jacobian.math.numerical_semigroups._algorithms import (
     betti_data,
     factorization_predecessors,
     reconstruct_factorization,
 )
-from jacobian.math.numerical_semigroups._models import _require_minimal_generators
+from jacobian.math.numerical_semigroups._models import (
+    _betti_component_index,
+    _edges_span,
+    _require_minimal_generators,
+)
 from jacobian.math.numerical_semigroups._presentation_models import (
     MinimalPresentationRelation,
     MinimalPresentationRequest,
@@ -52,12 +56,50 @@ def compute_minimal_presentation(
                     first=representatives[0], second=target_representative
                 )
             )
-    return MinimalPresentationResult(
+    return MinimalPresentationResult._from_kernel(
         minimal_generators=tuple(
             format_canonical_integer(value) for value in generators
         ),
         betti_elements=tuple(format_canonical_integer(value) for value in disconnected),
         relations=tuple(relations),
+    )
+
+
+def verify_minimal_presentation_result(result: MinimalPresentationResult) -> bool:
+    """Replay the bounded complete Betti-component presentation check."""
+
+    generators = tuple(
+        parse_canonical_integer(value) for value in result.minimal_generators
+    )
+    _, _, disconnected = betti_data(generators)
+    if tuple(
+        parse_canonical_integer(value) for value in result.betti_elements
+    ) != tuple(disconnected):
+        return False
+    relation_components: dict[int, list[tuple[int, int]]] = {
+        betti: [] for betti in disconnected
+    }
+    for relation in result.relations:
+        first_degree = sum(
+            coordinate * generator
+            for coordinate, generator in zip(relation.first, generators, strict=True)
+        )
+        if first_degree not in relation_components:
+            return False
+        components = disconnected[first_degree]
+        left = _betti_component_index(relation.first, components)
+        right = _betti_component_index(relation.second, components)
+        if left == right:
+            return False
+        relation_components[first_degree].append((left, right))
+    expected = {
+        betti: len(components) - 1 for betti, components in disconnected.items()
+    }
+    if {betti: len(edges) for betti, edges in relation_components.items()} != expected:
+        return False
+    return all(
+        _edges_span(len(disconnected[betti]), edges)
+        for betti, edges in relation_components.items()
     )
 
 
@@ -84,4 +126,5 @@ def compute_presentation_binomials(
 __all__ = [
     "compute_minimal_presentation",
     "compute_presentation_binomials",
+    "verify_minimal_presentation_result",
 ]

--- a/src/jacobian/math/petri_nets/_models.py
+++ b/src/jacobian/math/petri_nets/_models.py
@@ -16,6 +16,8 @@ from jacobian.math.petri_nets.values import (
     require_reachability_bounds,
 )
 
+MAX_SIPHON_TRAP_WORK = 20_000_000
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     return PydanticCustomError(f"petri_net.{reason}", message)
@@ -138,11 +140,19 @@ class SiphonTrapRequest(StrictModel):
     net: PetriNet
 
     @model_validator(mode="after")
-    def require_bounded_places(self) -> Self:
+    def require_bounded_enumeration_work(self) -> Self:
         if self.net.place_count > 20:
             raise _validation_error(
                 "siphon_trap_place_bound",
                 "siphon/trap check supports at most 20 places for exact enumeration",
+            )
+        candidates = (1 << self.net.place_count) - 1
+        transition_checks = 2 * candidates * self.net.transition_count
+        set_work = 2 * candidates * self.net.place_count
+        if transition_checks + set_work > MAX_SIPHON_TRAP_WORK:
+            raise _validation_error(
+                "siphon_trap_work_bound",
+                "siphon/trap candidate and transition-scan work exceeds the admitted bound",
             )
         return self
 
@@ -158,6 +168,7 @@ class SiphonTrapResult(StrictModel):
 
 
 __all__ = [
+    "MAX_SIPHON_TRAP_WORK",
     "EnabledTransitionsRequest",
     "EnabledTransitionsResult",
     "FireTransitionRequest",

--- a/src/jacobian/math/petri_nets/operations.py
+++ b/src/jacobian/math/petri_nets/operations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 
-from jacobian.math.petri_nets.values import Marking, PetriNet
+from jacobian.math.petri_nets.values import MAX_PETRI_MARKING, Marking, PetriNet
 
 __all__ = [
     "compute_incidence_matrix",
@@ -79,6 +79,9 @@ def reachability_graph(
         for t in enabled:
             success, new_tokens = fire_transition(net, marking, t)
             if not success:
+                continue
+            if any(token > MAX_PETRI_MARKING for token in new_tokens):
+                truncated = True
                 continue
             if new_tokens not in state_index:
                 if len(state_list) >= max_states:

--- a/src/jacobian/math/petri_nets/values.py
+++ b/src/jacobian/math/petri_nets/values.py
@@ -51,6 +51,11 @@ class PetriNet(StrictModel):
                 raise _validation_error(
                     "pre_weight_sign", "pre weights must be non-negative"
                 )
+            if any(w > MAX_PETRI_ARC_WEIGHT for w in row):
+                raise _validation_error(
+                    "pre_weight_bound",
+                    f"pre weights must not exceed {MAX_PETRI_ARC_WEIGHT}",
+                )
         for row in self.post:
             if len(row) != self.transition_count:
                 raise _validation_error(
@@ -59,6 +64,11 @@ class PetriNet(StrictModel):
             if any(w < 0 for w in row):
                 raise _validation_error(
                     "post_weight_sign", "post weights must be non-negative"
+                )
+            if any(w > MAX_PETRI_ARC_WEIGHT for w in row):
+                raise _validation_error(
+                    "post_weight_bound",
+                    f"post weights must not exceed {MAX_PETRI_ARC_WEIGHT}",
                 )
         return self
 
@@ -73,6 +83,11 @@ class Marking(StrictModel):
         if any(t < 0 for t in self.tokens):
             raise _validation_error(
                 "marking_token_sign", "marking tokens must be non-negative"
+            )
+        if any(t > MAX_PETRI_MARKING for t in self.tokens):
+            raise _validation_error(
+                "marking_token_bound",
+                f"marking tokens must not exceed {MAX_PETRI_MARKING}",
             )
         return self
 

--- a/src/jacobian/math/polytope/_rational_geometry.py
+++ b/src/jacobian/math/polytope/_rational_geometry.py
@@ -15,6 +15,10 @@ from sympy.matrices.exceptions import NonInvertibleMatrixError
 RationalRow = tuple[Sequence[Rational], Rational]
 
 
+class RecessionConeComputationError(RuntimeError):
+    """Raised when exact recession-cone boundedness cannot be established."""
+
+
 def hyperplane_normal(points: Sequence[Sequence[Rational]]) -> Matrix | None:
     """Return the unique normal through ``dim`` affine points, if one exists."""
 
@@ -77,9 +81,12 @@ def recession_cone_is_trivial(
         for index in range(1, len(normals))
     ]
     try:
-        if Matrix(differences).rank() < dimension:
-            return False
-    except Exception:
+        rank = Matrix(differences).rank()
+    except Exception as exc:
+        raise RecessionConeComputationError(
+            "exact recession-cone rank computation failed"
+        ) from exc
+    if rank < dimension:
         return False
     hull_facets = facets_from_points(normals, dimension)
     return bool(hull_facets) and all(
@@ -119,6 +126,7 @@ def vertices_from_halfspaces(
 
 __all__ = [
     "RationalRow",
+    "RecessionConeComputationError",
     "facets_from_points",
     "hyperplane_normal",
     "recession_cone_is_trivial",

--- a/tests/integration/algebra/test_exact_operations.py
+++ b/tests/integration/algebra/test_exact_operations.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from tests.integration.algebra._support import algebra_validation_error
 
 from jacobian._exact import CanonicalRational
+from jacobian.catalog.models import OperationDomainValidationError
 from jacobian.math.number_field import ring_of_integers
 from jacobian.math.number_field._models import NumberFieldRequest
 from jacobian.math.number_field._operations import compute_nf_discriminant
@@ -157,6 +158,25 @@ def test_integral_basis_is_computed_in_the_defining_power_basis() -> None:
 def test_number_field_requires_a_monic_irreducible_integer_polynomial() -> None:
     with algebra_validation_error():
         NumberFieldRequest(coefficients_descending=("2", "0", "-10"), variable="x")
+
+
+def test_number_field_reducibility_is_an_owner_declared_invalid_request() -> None:
+    request = NumberFieldRequest(coefficients_descending=("1", "0", "-1"), variable="x")
+
+    with pytest.raises(OperationDomainValidationError) as caught:
+        compute_nf_discriminant(request)
+
+    assert caught.value.errors()[0]["type"] == "number_field.not_irreducible"
+
+
+def test_number_field_rejects_oversized_coefficients_before_sympy() -> None:
+    with pytest.raises(ValidationError) as caught:
+        NumberFieldRequest(
+            coefficients_descending=("1" + "0" * 256, "0", "-2"),
+            variable="x",
+        )
+
+    assert caught.value.errors()[0]["type"] == "number_field.coefficient_digits"
 
 
 def test_recurrence_finder_solves_for_coefficients() -> None:

--- a/tests/math/additive_combinatorics/test_subset_sum_profile.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_profile.py
@@ -39,7 +39,9 @@ from jacobian.math.additive_combinatorics.values import (
 
 def _request(*items: int) -> SubsetSumProfileRequest:
     return SubsetSumProfileRequest(
-        source={"items": [format_canonical_integer(item) for item in items]},
+        source=IndexedIntegerSequence(
+            items=tuple(format_canonical_integer(item) for item in items)
+        ),
     )
 
 
@@ -151,6 +153,17 @@ def test_verifier_rejects_mutated_total() -> None:
     assert not verify_subset_sum_profile(SubsetSumProfile.model_validate(payload))
 
 
+def test_verifier_fails_closed_for_a_structural_profile_outside_admission() -> None:
+    profile = SubsetSumProfile(
+        source=IndexedIntegerSequence(items=tuple(str(index) for index in range(200))),
+        entries=(SubsetSumProfileEntry(sum="0", multiplicity="1"),),
+        support_size=1,
+        total_subsets=str(1 << 200),
+    )
+
+    assert not verify_subset_sum_profile(profile)
+
+
 def test_result_sensitive_admission_accepts_many_repeated_zeros() -> None:
     source = IndexedIntegerSequence(items=("0",) * MAX_SUBSET_SUM_ITEMS)
 
@@ -206,11 +219,13 @@ def test_large_accepted_profile_stays_inside_declared_result_budget() -> None:
 def test_source_digit_bound_is_enforced_before_integer_conversion() -> None:
     with pytest.raises(ValidationError):
         SubsetSumProfileRequest(
-            source={"items": ["9" * (MAX_SUBSET_SUM_ITEM_DIGITS + 1)]},
+            source=IndexedIntegerSequence(
+                items=("9" * (MAX_SUBSET_SUM_ITEM_DIGITS + 1),)
+            ),
         )
 
     with pytest.raises(ValidationError) as error:
-        SubsetSumProfileRequest(source={"items": ["9" * 100_000]})
+        SubsetSumProfileRequest(source=IndexedIntegerSequence(items=("9" * 100_000,)))
     assert error.value.errors()[0]["type"] == "string_too_long"
 
 
@@ -274,7 +289,7 @@ def test_expensive_admissible_items_are_rejected_by_the_raw_preflight_bound() ->
     payload = {"source": {"items": ("9" * 2_048,) * (MAX_SUBSET_SUM_ITEMS + 1)}}
 
     with pytest.raises(PydanticCustomError) as error:
-        SubsetSumProfileRequest.bound_raw_source(payload)
+        SubsetSumProfileRequest.bound_raw_source(payload)  # type: ignore[operator]
 
     assert error.value.type == "additive_combinatorics.bound_raw_source"
 

--- a/tests/math/galois_theory/test_galois_theory.py
+++ b/tests/math/galois_theory/test_galois_theory.py
@@ -1,21 +1,29 @@
 """Contract and mathematical-property tests for Galois operations."""
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 from sympy.combinatorics import Permutation, PermutationGroup
 
 from jacobian.math.galois_theory._models import (
+    FiniteFieldFactor,
     FrobeniusCycleRequest,
     GaloisFactorRequest,
     GaloisFactorResult,
     GaloisGroupRequest,
+    GaloisGroupResult,
     SolvableRequest,
+    SolvableResult,
 )
 from jacobian.math.galois_theory._operations import (
     compute_frobenius_cycle,
     compute_galois_factor,
     compute_galois_group,
     compute_solvable,
+    verify_galois_factor_result,
+    verify_galois_group_result,
+    verify_solvable_result,
 )
 from jacobian.math.galois_theory._tools import TOOLS
 
@@ -42,7 +50,7 @@ def _multiply_mod(
 
 
 def _reconstruct(result: GaloisFactorResult) -> tuple[int, ...]:
-    polynomial = (result.unit,)
+    polynomial: tuple[int, ...] = (result.unit,)
     for factor in result.factors:
         for _ in range(factor.multiplicity):
             polynomial = _multiply_mod(
@@ -153,22 +161,36 @@ def test_factorization_result_rejects_a_forged_certificate() -> None:
         GaloisFactorResult.model_validate(payload)
     assert exc.value.errors()[0]["type"] == "galois_theory.field_order_not_prime"
 
-    with pytest.raises(ValidationError) as exc:
-        GaloisFactorResult(
-            field_order=3,
-            source_coefficients=(2, 0, 1),
-            unit=1,
-            factors=(
-                {
-                    "coefficients": (2, 0, 1),
-                    "multiplicity": 1,
-                },
-            ),
-            distinct_factor_count=1,
-            factor_count=1,
-            is_irreducible=True,
-        )
-    assert exc.value.errors()[0]["type"] == "galois_theory.factor_not_irreducible"
+    forged = GaloisFactorResult(
+        field_order=3,
+        source_coefficients=(2, 0, 1),
+        unit=1,
+        factors=(FiniteFieldFactor(coefficients=(2, 0, 1), multiplicity=1),),
+        distinct_factor_count=1,
+        factor_count=1,
+        is_irreducible=True,
+    )
+    assert not verify_galois_factor_result(forged)
+
+
+def test_factor_producer_runs_the_backend_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sympy import Poly
+
+    original = Poly.factor_list
+    calls = 0
+
+    def counted(self: Poly, *args: object, **kwargs: object) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Poly, "factor_list", counted)
+    result = compute_galois_factor(
+        GaloisFactorRequest(field_order=5, coefficients=(1, 0, 1))
+    )
+
+    assert result.is_irreducible is False
+    assert calls == 1
 
 
 def test_frobenius_cycle_is_canonical_positive_partition() -> None:
@@ -239,11 +261,21 @@ def test_galois_group_returns_composable_generators() -> None:
     assert result.group.root_axis == tuple(f"root_{index}" for index in range(5))
     assert _group_from_result(result).order() == result.order
 
+    forged = GaloisGroupResult.model_validate(
+        {**result.model_dump(), "order": result.order + 1}
+    )
+    assert not verify_galois_group_result(forged)
+
 
 def test_solvable_quintic_returns_the_group_certificate() -> None:
     result = compute_solvable(SolvableRequest(coefficients=(-2, 0, 0, 0, 0, 1)))
     assert result.solvable_by_radicals is True
     assert _group_from_result(result).order() == 20
+
+    forged = SolvableResult.model_validate(
+        {**result.model_dump(), "solvable_by_radicals": False}
+    )
+    assert not verify_solvable_result(forged)
 
 
 def test_unsolvable_quintic_uses_actual_group() -> None:

--- a/tests/math/graphs/test_chromatic_number_certificate.py
+++ b/tests/math/graphs/test_chromatic_number_certificate.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from jacobian._exact import CanonicalRational
 from jacobian.canonical import CanonicalLimits, encode_strict_json
+from jacobian.math.graphs.coloring import _operations
 from jacobian.math.graphs.coloring._chromatic_number_models import (
     MAX_CHROMATIC_CERTIFICATE_DERIVED_RATIONAL_DIGITS,
     MAX_CHROMATIC_CERTIFICATE_EDGES,
@@ -20,6 +21,7 @@ from jacobian.math.graphs.coloring._chromatic_number_models import (
 )
 from jacobian.math.graphs.coloring._operations import (
     compute_chromatic_number_certificate_check,
+    verify_chromatic_number_certificate_check_result,
 )
 from jacobian.math.graphs.values import SimpleUndirectedGraph
 
@@ -127,7 +129,7 @@ def test_campbell_sixteen_face_conflict_graph_certificate() -> None:
     graph = _graph(
         faces,
         tuple(
-            tuple(sorted((left, right)))
+            (left, right) if left < right else (right, left)
             for left, right in combinations(faces, 2)
             if set(left) & set(right)
         ),
@@ -313,7 +315,7 @@ def _accepted_edge_result() -> ChromaticNumberCertificateCheckResult:
 @pytest.mark.parametrize(
     "field", ["graph", "claimed_chromatic_number", "coloring", "weights"]
 )
-def test_result_replay_rejects_forged_sources(field: str) -> None:
+def test_explicit_verifier_rejects_forged_sources(field: str) -> None:
     payload = deepcopy(_accepted_edge_result().model_dump(mode="json"))
     if field == "graph":
         payload["graph"]["edges"] = []
@@ -327,11 +329,12 @@ def test_result_replay_rejects_forged_sources(field: str) -> None:
             {"num": "0", "den": "1"},
         ]
 
-    with pytest.raises(ValidationError):
+    assert not verify_chromatic_number_certificate_check_result(
         ChromaticNumberCertificateCheckResult.model_validate(payload)
+    )
 
 
-def test_result_replay_rejects_forged_witness_and_conclusion() -> None:
+def test_explicit_verifier_rejects_forged_witness_and_conclusion() -> None:
     rejected = _check(
         _graph(("a", "b"), ()),
         1,
@@ -340,14 +343,41 @@ def test_result_replay_rejects_forged_witness_and_conclusion() -> None:
     )
     payload = deepcopy(rejected.model_dump(mode="json"))
     payload["blocking_independent_set"] = ["b"]
-    with pytest.raises(ValidationError):
+    assert not verify_chromatic_number_certificate_check_result(
         ChromaticNumberCertificateCheckResult.model_validate(payload)
+    )
 
     payload = deepcopy(rejected.model_dump(mode="json"))
     payload["verdict"] = "ACCEPTED"
     payload["reason"] = "ACCEPTED"
-    with pytest.raises(ValidationError):
+    assert not verify_chromatic_number_certificate_check_result(
         ChromaticNumberCertificateCheckResult.model_validate(payload)
+    )
+
+
+def test_producer_evaluates_the_certificate_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = ChromaticNumberCertificateCheckRequest(
+        graph=_graph(("a", "b"), (("a", "b"),)),
+        claimed_chromatic_number=2,
+        coloring=(0, 1),
+        weights=(_rational(1), _rational(1)),
+    )
+    evaluator_name = "_evaluate_chromatic_number_certificate"
+    original = getattr(_operations, evaluator_name)
+    calls = 0
+
+    def counted(*args: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original(*args)
+
+    monkeypatch.setattr(_operations, "_evaluate_chromatic_number_certificate", counted)
+    result = compute_chromatic_number_certificate_check(request)
+
+    assert result.verdict == "ACCEPTED"
+    assert calls == 1
 
 
 def test_result_preflights_oversized_forged_derived_rationals() -> None:

--- a/tests/math/graphs/test_graph_isomorphism.py
+++ b/tests/math/graphs/test_graph_isomorphism.py
@@ -85,6 +85,14 @@ def _is_mapping_valid_isomorphism(
     return True
 
 
+@pytest.mark.parametrize("status", ("NOT_ISOMORPHIC", "UNKNOWN"))
+def test_nonisomorphic_result_branches_reject_vertex_mappings(status: str) -> None:
+    with pytest.raises(ValidationError):
+        GraphIsomorphismResult.model_validate(
+            {"status": status, "vertex_mapping": [{"from_vertex": 0, "to_vertex": 0}]}
+        )
+
+
 # ---------------------------------------------------------------------------
 # Path graphs
 # ---------------------------------------------------------------------------

--- a/tests/math/graphs/test_graph_isomorphism.py
+++ b/tests/math/graphs/test_graph_isomorphism.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -18,7 +20,7 @@ from jacobian.math.graphs.isomorphism._operations import (
 # ---------------------------------------------------------------------------
 
 
-def _decide(graph_a: dict, graph_b: dict) -> GraphIsomorphismResult:
+def _decide(graph_a: dict[str, Any], graph_b: dict[str, Any]) -> GraphIsomorphismResult:
     return decide_graph_isomorphism(
         GraphIsomorphismRequest.model_validate({"graph_a": graph_a, "graph_b": graph_b})
     )
@@ -36,7 +38,9 @@ def _complete_edges(n: int) -> list[tuple[int, int]]:
     return [(i, j) for i in range(n) for j in range(i + 1, n)]
 
 
-def _is_mapping_valid_isomorphism(graph_a: dict, graph_b: dict, mapping: tuple) -> bool:
+def _is_mapping_valid_isomorphism(
+    graph_a: dict[str, Any], graph_b: dict[str, Any], mapping: tuple[Any, ...]
+) -> bool:
     """Independently verify that ``mapping`` is a graph isomorphism."""
     if not mapping:
         return False

--- a/tests/math/greedoids/test_greedoids.py
+++ b/tests/math/greedoids/test_greedoids.py
@@ -171,6 +171,15 @@ class TestRankAndBases:
         assert result.rank == 1
         assert result.bases == ((0,),)
 
+    def test_non_greedoid_cannot_claim_bases_or_rank(self) -> None:
+        system = _non_greedoid_exchange()
+        bases_result = compute_bases(BasesRequest(system=system))
+        rank_result = compute_rank(RankRequest(system=system))
+        assert bases_result.status == "NOT_A_GREEDOID"
+        assert bases_result.bases == ()
+        assert rank_result.status == "NOT_A_GREEDOID"
+        assert rank_result.rank is None
+
 
 # ---------------------------------------------------------------------------
 # Basic word profile
@@ -234,6 +243,17 @@ class TestConvexGeometry:
         lookup = dict(result.complement_map)
         assert lookup[()] == (0, 1)
         assert lookup[(0, 1)] == ()
+
+    def test_non_antimatroid_cannot_claim_a_convex_geometry(self) -> None:
+        result = compute_convex_geometry(
+            ConvexGeometryRequest(
+                system=FiniteFeasibleSetSystem(
+                    ground=("a", "b"), feasible=((), (0,), (1,))
+                )
+            )
+        )
+        assert result.status == "NOT_AN_ANTIMATROID"
+        assert result.closed_family == ()
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +333,26 @@ def test_union_closed_true_for_antimatroid() -> None:
 def test_feasible_continuations() -> None:
     cont = greedoids.feasible_continuations(_two_element_antimatroid(), frozenset({0}))
     assert set(cont) == {1}
+
+
+def test_native_greedoid_consumers_reject_an_unrecognized_family() -> None:
+    """Structural feasible-set data cannot claim greedoid-derived facts."""
+    system = _non_greedoid_exchange()
+    calls = (
+        lambda: greedoids.rank(system),
+        lambda: greedoids.bases(system),
+        lambda: greedoids.feasible_continuations(system, frozenset()),
+        lambda: greedoids.basic_word_profile(system, ()),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match="recognized greedoid"):
+            call()
+
+
+def test_native_convex_geometry_consumer_rejects_a_non_antimatroid() -> None:
+    system = FiniteFeasibleSetSystem(ground=("a", "b"), feasible=((), (0,), (1,)))
+    with pytest.raises(ValueError, match="full support and union closure"):
+        greedoids.antimatroid_to_convex_geometry(system)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/greedoids/test_greedoids.py
+++ b/tests/math/greedoids/test_greedoids.py
@@ -9,9 +9,12 @@ from jacobian.math import greedoids
 from jacobian.math.greedoids import FiniteFeasibleSetSystem
 from jacobian.math.greedoids._models import (
     BasesRequest,
+    BasesResult,
     BasicWordProfileRequest,
     ConvexGeometryRequest,
+    ConvexGeometryResult,
     RankRequest,
+    RankResult,
     RecognizeRequest,
 )
 from jacobian.math.greedoids._operations import (
@@ -71,6 +74,21 @@ def _non_greedoid_exchange() -> FiniteFeasibleSetSystem:
         ground=("a", "b", "c"),
         feasible=((), (0,), (1,), (0, 1), (2,)),
     )
+
+
+@pytest.mark.parametrize(
+    "result",
+    (
+        RankResult.model_construct(status="GREEDOID", rank=None),
+        BasesResult.model_construct(status="NOT_A_GREEDOID", rank=2, bases=()),
+        ConvexGeometryResult.model_construct(
+            status="NOT_AN_ANTIMATROID", closed_family=((),), obstruction="x"
+        ),
+    ),
+)
+def test_result_models_reject_mixed_outcome_branches(result: object) -> None:
+    with pytest.raises(ValidationError):
+        type(result).model_validate(result.model_dump())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/math/logic/test_tools.py
+++ b/tests/math/logic/test_tools.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 import sys
+import time
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -41,7 +43,9 @@ from jacobian.math.logic._unsat_core import SmtUnsatCoreRequest
 
 
 @contextmanager
-def raises_logic_validation():
+def raises_logic_validation() -> Generator[
+    pytest.ExceptionInfo[ValidationError], None, None
+]:
     with pytest.raises(ValidationError) as error:
         yield error
     assert error.value.errors()[0]["type"].startswith("logic.")
@@ -119,7 +123,7 @@ def test_sat_solver_returns_unsat_without_a_model() -> None:
 def test_sat_solver_does_not_promote_a_malformed_backend_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import z3
+    import z3  # type: ignore[import-untyped]
 
     class MisreportingSolver:
         def set(self, **_settings: object) -> None:
@@ -356,7 +360,7 @@ def test_lpr_refutation_reserves_the_transport_result_budget(
 def test_lpr_refutation_returns_unavailable_without_the_pinned_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(sat.shutil, "which", lambda _name: None)
+    monkeypatch.setattr("jacobian.math.logic._sat.shutil.which", lambda _name: None)
 
     result = check_sat_refutation(_unit_refutation_request())
 
@@ -409,7 +413,9 @@ def test_cake_lpr_manifest_is_structural_while_dockerfile_owns_its_pin() -> None
 def test_lpr_refutation_accepts_only_the_exact_cake_verdict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(sat.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        "jacobian.math.logic._sat.shutil.which", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(sat, "_cake_lpr_is_supported", lambda _path: True)
     monkeypatch.setattr(
         sat,
@@ -434,7 +440,9 @@ def test_lpr_refutation_accepts_only_the_exact_cake_verdict(
 def test_lpr_refutation_projects_a_recognized_checker_rejection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(sat.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        "jacobian.math.logic._sat.shutil.which", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(sat, "_cake_lpr_is_supported", lambda _path: True)
     monkeypatch.setattr(
         sat,
@@ -495,7 +503,9 @@ def test_lpr_refutation_never_upgrades_process_failure_to_a_math_verdict(
     completed: SimpleNamespace,
     outcome: str,
 ) -> None:
-    monkeypatch.setattr(sat.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        "jacobian.math.logic._sat.shutil.which", lambda name: f"/usr/bin/{name}"
+    )
     monkeypatch.setattr(sat, "_cake_lpr_is_supported", lambda _path: True)
     monkeypatch.setattr(sat, "run_bounded_process", lambda *_args, **_kwargs: completed)
 
@@ -794,10 +804,10 @@ def test_smt_request_rejects_an_indexed_bit_vector_value_beyond_the_digit_budget
         )
 
 
-def test_smt_request_rejects_an_ill_sorted_indexed_bit_vector_equality() -> None:
-    """Lexical digit admission cannot override backend well-sortedness."""
+def test_smt_request_structurally_admits_an_ill_sorted_expression() -> None:
+    """Well-sortedness is a bounded execution concern, not model validation."""
 
-    with pytest.raises(ValidationError) as error:
+    result = solve_smt(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
@@ -807,8 +817,9 @@ def test_smt_request_rejects_an_ill_sorted_indexed_bit_vector_equality() -> None
                 "(check-sat)\n"
             ),
         )
+    )
 
-    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+    assert result.outcome == "UNKNOWN"
 
 
 def test_smt_request_admits_a_bv_named_symbol_outside_index_context_and_solves() -> (
@@ -865,7 +876,9 @@ def test_smt_request_admits_at_the_declaration_boundary_and_still_solves() -> No
     assert result.model_smtlib is not None
 
 
-def test_structural_rejection_precedes_z3_parsing(monkeypatch) -> None:
+def test_structural_rejection_precedes_z3_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import z3
 
     def refuse(*_args: object, **_kwargs: object) -> object:
@@ -884,7 +897,9 @@ def test_structural_rejection_precedes_z3_parsing(monkeypatch) -> None:
         )
 
 
-def test_smt_solver_passes_time_work_and_memory_budgets_to_z3(monkeypatch) -> None:
+def test_smt_solver_passes_time_work_and_memory_budgets_to_z3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import z3
 
     recorded: dict[str, int] = {}
@@ -909,15 +924,41 @@ def test_smt_solver_passes_time_work_and_memory_budgets_to_z3(monkeypatch) -> No
     )
 
     assert result.outcome == "UNSAT"
-    assert recorded == {
-        "timeout": 2_500,
-        "rlimit": smt._SOLVER_RLIMIT,
-        "max_memory": smt._SOLVER_MAX_MEMORY_MB,
-    }
+    assert recorded["timeout"] <= 2_500
+    assert recorded["timeout"] > 0
+    assert recorded["rlimit"] == smt._SOLVER_RLIMIT
+    assert recorded["max_memory"] == smt._SOLVER_MAX_MEMORY_MB
+
+
+def test_smt_parse_stage_expiry_is_a_typed_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parser work consumes the same owner deadline as solver work."""
+
+    import z3
+
+    original = z3.parse_smt2_string
+
+    def delayed_parser(source: str) -> object:
+        time.sleep(0.01)
+        return original(source)
+
+    monkeypatch.setattr(z3, "parse_smt2_string", delayed_parser)
+    result = solve_smt(
+        SmtSolveRequest(
+            logic=SmtLogic.QF_LIA,
+            smtlib="(set-logic QF_LIA)\n(declare-const x Int)\n(check-sat)",
+            timeout_ms=1,
+        )
+    )
+
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted == "time"
+    assert result.detail == smt._EXHAUSTION_DETAILS["time"]
 
 
 def test_smt_solver_projects_exhausted_work_budget_as_typed_unknown(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
     result = solve_smt(
@@ -934,7 +975,7 @@ def test_smt_solver_projects_exhausted_work_budget_as_typed_unknown(
 
 
 def test_sat_solver_projects_exhausted_work_budget_as_typed_unknown(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_RLIMIT", 1)
     result = solve_sat(
@@ -948,7 +989,7 @@ def test_sat_solver_projects_exhausted_work_budget_as_typed_unknown(
 
 
 def test_smt_solver_projects_exhausted_memory_budget_as_typed_unknown(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(smt, "_SOLVER_MAX_MEMORY_MB", 2)
     result = solve_smt(
@@ -977,7 +1018,9 @@ def test_smt_solver_projects_exhausted_time_budget_as_typed_unknown() -> None:
     assert result.detail is not None and "time budget" in result.detail
 
 
-def test_smt_solver_wraps_backend_failure_during_the_solve(monkeypatch) -> None:
+def test_smt_solver_wraps_backend_failure_during_the_solve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import z3
 
     class ExplodingSolver:
@@ -1014,7 +1057,7 @@ def test_smt_solver_wraps_backend_failure_during_the_solve(monkeypatch) -> None:
     ),
 )
 def test_sat_solver_projects_exhaustion_messages_from_z3_exceptions(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     message: str,
     exhausted: str,
 ) -> None:
@@ -1050,7 +1093,7 @@ def test_sat_solver_projects_exhaustion_messages_from_z3_exceptions(
     ),
 )
 def test_smt_solver_projects_exhaustion_messages_from_z3_exceptions(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     message: str,
     exhausted: str,
 ) -> None:
@@ -1080,7 +1123,9 @@ def test_smt_solver_projects_exhaustion_messages_from_z3_exceptions(
     assert result.detail == smt._EXHAUSTION_DETAILS[exhausted]
 
 
-def test_smt_solver_projects_exhaustion_from_model_serialization(monkeypatch) -> None:
+def test_smt_solver_projects_exhaustion_from_model_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import z3
 
     class ExhaustingModel:
@@ -1117,7 +1162,7 @@ def test_smt_solver_projects_exhaustion_from_model_serialization(monkeypatch) ->
 
 
 def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import z3
 
@@ -1177,8 +1222,8 @@ def test_solver_wraps_unrecognized_z3_exceptions_without_typed_exhaustion(
     ),
 )
 def test_z3_initialization_failure_is_a_typed_unknown(
-    operation,
-    accepted_request,
+    operation: Callable[[object], SatSolveResult | SmtSolveResult],
+    accepted_request: object,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed Z3 module initialization cannot escape an accepted request."""
@@ -1195,7 +1240,7 @@ def test_z3_initialization_failure_is_a_typed_unknown(
 
 
 def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Backend absence at admission stays the typed execution init outcome."""
 
@@ -1213,46 +1258,35 @@ def test_smt_request_admission_skips_grammar_rejection_without_the_backend(
     assert "could not initialize" in result.detail
 
 
-def test_smt_request_rejects_malformed_source_as_a_request_error(monkeypatch) -> None:
-    """Malformed SMT-LIB stays caller-correctable instead of solver indeterminacy."""
+def test_smt_request_does_not_parse_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Model validation remains structural and does not invoke Z3."""
 
     import z3
 
-    def refuse_solver(_logic: object) -> object:
-        raise AssertionError("a malformed request reached solver construction")
+    def refuse_parser(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("model validation invoked the Z3 parser")
 
-    monkeypatch.setattr(z3, "SolverFor", refuse_solver)
-    with pytest.raises(ValidationError) as error:
-        SmtSolveRequest(
-            logic=SmtLogic.QF_LIA,
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                "(assert (> y 0))\n"
-                "(check-sat)"
-            ),
-        )
-
-    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+    monkeypatch.setattr(z3, "parse_smt2_string", refuse_parser)
+    SmtSolveRequest(
+        logic=SmtLogic.QF_LIA,
+        smtlib=(
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> y 0))\n(check-sat)"
+        ),
+    )
 
 
 @pytest.mark.parametrize(
     "identifier",
     ("memory", "timeout", "canceled", "|resource limit|"),
 )
-def test_smt_request_rejects_undeclared_identifiers_named_after_resource_keywords(
+def test_smt_execution_reports_undeclared_identifiers_without_resource_claims(
     identifier: str,
 ) -> None:
-    """A located diagnostic quoting a caller symbol is never budget exhaustion.
+    """Located parser diagnostics never fabricate an exhausted-resource claim."""
 
-    Z3 reports an undeclared identifier as
-    ``(error "line L column C: unknown constant <identifier>")``; when the
-    caller-controlled spelling contains a resource keyword, that text must
-    still be a caller-correctable grammar rejection rather than an admitted
-    request whose execution reports an exhausted budget.
-    """
-
-    with pytest.raises(ValidationError) as error:
+    result = solve_smt(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
@@ -1262,11 +1296,15 @@ def test_smt_request_rejects_undeclared_identifiers_named_after_resource_keyword
                 "(check-sat)"
             ),
         )
+    )
 
-    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
 
 
-def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -> None:
+def test_smt_solver_types_parse_stage_backend_failures_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A backend parser failure on an admitted source is execution UNKNOWN."""
 
     import z3
@@ -1287,7 +1325,7 @@ def test_smt_solver_types_parse_stage_backend_failures_as_unknown(monkeypatch) -
 
 
 def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Located diagnostic text quotes the caller's source, not a budget.
 
@@ -1314,8 +1352,10 @@ def test_smt_solver_never_classifies_located_source_text_as_exhaustion(
     assert result.detail is not None and "bounded solve" in result.detail
 
 
-def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -> None:
-    """A located Z3 parser diagnostic stays a caller-correctable rejection."""
+def test_smt_execution_projects_located_parser_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backend parser diagnostics are projected by the bounded execution path."""
 
     import z3
 
@@ -1323,7 +1363,7 @@ def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -
         raise z3.Z3Exception(b'(error "line 2 column 11: unknown constant y")\n')
 
     monkeypatch.setattr(z3, "parse_smt2_string", diagnosing_parser)
-    with pytest.raises(ValidationError) as error:
+    result = solve_smt(
         SmtSolveRequest(
             logic=SmtLogic.QF_LIA,
             smtlib=(
@@ -1333,11 +1373,15 @@ def test_smt_request_admission_rejects_located_parser_diagnostics(monkeypatch) -
                 "(check-sat)"
             ),
         )
+    )
 
-    assert error.value.errors(include_url=False)[0]["type"] == "logic.smtlib_grammar"
+    assert result.outcome == "UNKNOWN"
+    assert result.exhausted is None
 
 
-def test_smt_request_admission_defers_parse_stage_os_errors(monkeypatch) -> None:
+def test_smt_request_admission_defers_parse_stage_os_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A parse-stage native backend failure stays off the caller's hands.
 
     ``math.run`` validates the request before calling the solver, so admission
@@ -1362,24 +1406,22 @@ def test_smt_request_admission_defers_parse_stage_os_errors(monkeypatch) -> None
 @pytest.mark.parametrize(
     "request_type",
     sorted(
-        {SmtSolveRequest, SmtUnsatCoreRequest, *SmtSolveRequest.__subclasses__()},
-        key=lambda request_type: request_type.__name__,
+        {SmtSolveRequest, *SmtSolveRequest.__subclasses__()} - {SmtUnsatCoreRequest},
+        key=str,
     ),
-    ids=lambda request_type: request_type.__name__,
+    ids=str,
 )
-def test_every_concrete_smt_request_rejects_malformed_grammar(request_type) -> None:
-    """No SMT request subclass may leave malformed grammar to execution."""
+def test_every_concrete_smt_request_keeps_grammar_validation_structural(
+    request_type: type[SmtSolveRequest],
+) -> None:
+    """No request model may invoke Z3 merely to validate a payload."""
 
-    with pytest.raises(ValidationError):
-        request_type(
-            logic=SmtLogic.QF_LIA,
-            smtlib=(
-                "(set-logic QF_LIA)\n"
-                "(declare-const x Int)\n"
-                "(assert (> y 0))\n"
-                "(check-sat)"
-            ),
-        )
+    request_type(
+        logic=SmtLogic.QF_LIA,
+        smtlib=(
+            "(set-logic QF_LIA)\n(declare-const x Int)\n(assert (> y 0))\n(check-sat)"
+        ),
+    )
 
 
 def test_unknown_projection_maps_every_exhausted_resource() -> None:

--- a/tests/math/majorization/test_majorization.py
+++ b/tests/math/majorization/test_majorization.py
@@ -256,6 +256,26 @@ class TestTTransform:
         )
         assert result.majorizes is True
         assert len(result.steps) > 0
+        assert result.target_match is True
+
+    def test_permutation_equivalent_vectors_return_an_exact_witness(self) -> None:
+        """A label permutation needs no averaging, but must still replay to y."""
+
+        result = compute_t_transform_sequence(
+            TTransformSequenceRequest(
+                x=rv(["a", "b", "c"], [("0", "1"), ("1", "1"), ("2", "1")]),
+                y=rv(["a", "b", "c"], [("1", "1"), ("2", "1"), ("0", "1")]),
+            )
+        )
+
+        assert result.majorizes is True
+        assert result.target_match is True
+        assert result.steps == ()
+        assert result.final_permutation == (1, 2, 0)
+        assert result.intermediate_vectors[-1] == ("1", "2", "0")
+        matrix = [[Fraction(entry) for entry in row] for row in result.composed_matrix]
+        image = [sum(row[index] * index for index in range(3)) for row in matrix]
+        assert image == [Fraction(1), Fraction(2), Fraction(0)]
 
     def test_not_majorizes(self) -> None:
         """When x does not majorize y, return empty result."""

--- a/tests/math/markov_chain/test_communicating_classes.py
+++ b/tests/math/markov_chain/test_communicating_classes.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from fractions import Fraction
 
+import pytest
+
 from jacobian._exact import CanonicalRational
+from jacobian.math.markov_chain import _operations
 from jacobian.math.markov_chain._models import (
+    CommunicatingClassesResult,
     TransitionMatrixRequest,
 )
-from jacobian.math.markov_chain._operations import compute_communicating_classes
+from jacobian.math.markov_chain._operations import (
+    compute_communicating_classes,
+    verify_communicating_classes_result,
+)
 from jacobian.math.markov_chain._tools import TOOLS
 
 _C = CanonicalRational.from_fraction
@@ -84,3 +91,32 @@ def test_two_closed_classes() -> None:
     )
     assert len(result.classes) == 2
     assert all(cls[1] for cls in result.classes)  # both closed
+
+
+def test_producer_derives_scc_partition_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = _matrix([[Fraction(0), Fraction(1)], [Fraction(0), Fraction(1)]])
+    original = _operations._derive_communicating_classes
+    calls = 0
+
+    def counted(matrix):  # type: ignore[no-untyped-def]
+        nonlocal calls
+        calls += 1
+        return original(matrix)
+
+    monkeypatch.setattr(_operations, "_derive_communicating_classes", counted)
+    result = compute_communicating_classes(request)
+
+    assert result.classes == (((0,), False), ((1,), True))
+    assert calls == 1
+
+
+def test_explicit_verifier_rejects_forged_scc_claim() -> None:
+    produced = compute_communicating_classes(
+        _matrix([[Fraction(0), Fraction(1)], [Fraction(0), Fraction(1)]])
+    )
+    payload = produced.model_dump(mode="json")
+    payload["classes"] = [((0,), True), ((1,), True)]
+    forged = CommunicatingClassesResult.model_validate(payload)
+
+    assert verify_communicating_classes_result(produced) is True
+    assert verify_communicating_classes_result(forged) is False

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -13,6 +13,10 @@ from jacobian.math.number_theory._direct_factorization_models import (
     FactorizationRequest,
     PrimeFactorizationResult,
 )
+from jacobian.math.number_theory._factorization_kernels import (
+    verify_divisor_list_result,
+    verify_prime_factorization_result,
+)
 from jacobian.math.number_theory._integer_models import (
     NonnegativeIntegerRequest,
     PositiveIntegerRequest,
@@ -141,7 +145,7 @@ def test_direct_factorization_contract_schemas_preserve_their_envelopes() -> Non
 
     assert request_value["maxLength"] == MAX_DIRECT_FACTORIZATION_DIGITS
     assert divisor_source["maxLength"] == MAX_DIRECT_FACTORIZATION_DIGITS
-    assert factorization_source["maxLength"] == MAX_INTEGER_DIGITS
+    assert factorization_source["maxLength"] == MAX_DIRECT_FACTORIZATION_DIGITS
 
 
 def test_modular_residue_image_contract_replays_canonical_assignments() -> None:
@@ -222,7 +226,7 @@ def test_divisor_list_result_rejects_sources_beyond_factorization_domain() -> No
     """A forged serialized output whose divisor list does not enumerate the
     source's divisors exactly is rejected by the source-bound replay."""
 
-    with expect_validation("number_theory."):
+    assert not verify_divisor_list_result(
         DivisorListResult.model_validate(
             {
                 "value": "12",
@@ -230,40 +234,39 @@ def test_divisor_list_result_rejects_sources_beyond_factorization_domain() -> No
                 "convention": "ALL_POSITIVE_DIVISORS",
             }
         )
+    )
 
 
 def test_divisor_list_result_rejects_mutations() -> None:
-    base = {
-        "value": "12",
-        "divisors": ("1", "2", "3", "4", "6", "12"),
-        "convention": "ALL_POSITIVE_DIVISORS",
-    }
-    with expect_validation("number_theory."):
-        DivisorListResult(**{**base, "value": "99"})
-    with expect_validation("number_theory."):
-        DivisorListResult(**{**base, "divisors": ("1", "2", "3", "4", "6")})
-    with expect_validation("number_theory."):
-        DivisorListResult(**{**base, "divisors": ("1", "2", "3", "4", "6", "8", "12")})
+    assert not verify_divisor_list_result(
+        DivisorListResult(value="99", divisors=("1", "2", "3", "4", "6", "12"))
+    )
+    assert not verify_divisor_list_result(
+        DivisorListResult(value="12", divisors=("1", "2", "3", "4", "6"))
+    )
+    assert not verify_divisor_list_result(
+        DivisorListResult(value="12", divisors=("1", "2", "3", "4", "6", "8", "12"))
+    )
     with expect_validation("number_theory."):
         DivisorListResult(
             value="12",
             divisors=("12", "6", "4", "3", "2", "1"),
             convention="ALL_POSITIVE_DIVISORS",
         )
-    with expect_validation("number_theory."):
+    assert not verify_divisor_list_result(
         DivisorListResult(
-            value="12",
-            divisors=("2", "99"),
-            convention="ALL_POSITIVE_DIVISORS",
+            value="12", divisors=("2", "99"), convention="ALL_POSITIVE_DIVISORS"
         )
+    )
     with expect_validation("number_theory."):
         DivisorListResult(value="0", divisors=())
-    with expect_validation("number_theory."):
+    assert not verify_divisor_list_result(
         DivisorListResult(
             value="12",
             divisors=("1", "2", "3", "4", "6"),
             convention="ALL_POSITIVE_DIVISORS",
         )
+    )
 
 
 def test_prime_factorization_result_replays_source() -> None:
@@ -286,8 +289,9 @@ def test_prime_factorization_result_replays_source() -> None:
 def test_prime_factorization_result_rejects_mutations() -> None:
     from jacobian.math.number_theory._integer_models import PrimePower
 
-    with expect_validation("number_theory."):
+    assert not verify_prime_factorization_result(
         PrimeFactorizationResult(value="4", factors=(PrimePower(prime="4", power=1),))
+    )
     with expect_validation("number_theory."):
         PrimeFactorizationResult(
             value="12",
@@ -332,19 +336,19 @@ def test_prime_factorization_result_bounds_reconstruction_work() -> None:
         )
 
 
-def test_prime_factorization_result_admits_full_width_source_power() -> None:
-    """A source-width prime power still reconstructs exactly."""
+def test_prime_factorization_result_rejects_source_beyond_worker_envelope() -> None:
+    """A direct result cannot claim a source its producer cannot factor."""
 
     width = 256
     exponent = 849
-    result = PrimeFactorizationResult.model_validate(
-        {
-            "value": str(2**exponent),
-            "factors": [{"prime": "2", "power": exponent}],
-        }
-    )
-    assert len(result.value) == width
-    assert int(result.factors[0].prime) ** result.factors[0].power == 2**exponent
+    assert len(str(2**exponent)) == width > MAX_DIRECT_FACTORIZATION_DIGITS
+    with expect_validation("string_too_long"):
+        PrimeFactorizationResult.model_validate(
+            {
+                "value": str(2**exponent),
+                "factors": [{"prime": "2", "power": exponent}],
+            }
+        )
 
 
 def test_producer_results_serialize_and_reconstruct() -> None:

--- a/tests/math/number_theory/test_models.py
+++ b/tests/math/number_theory/test_models.py
@@ -237,6 +237,18 @@ def test_divisor_list_result_rejects_sources_beyond_factorization_domain() -> No
     )
 
 
+def test_divisor_list_verifier_rejects_sources_beyond_its_output_envelope() -> None:
+    """Replay must reject a complete claim whose source has too many divisors."""
+
+    assert not verify_divisor_list_result(
+        DivisorListResult(
+            value="4839309619200000",
+            divisors=("1",),
+            convention="ALL_POSITIVE_DIVISORS",
+        )
+    )
+
+
 def test_divisor_list_result_rejects_mutations() -> None:
     assert not verify_divisor_list_result(
         DivisorListResult(value="99", divisors=("1", "2", "3", "4", "6", "12"))

--- a/tests/math/numerical_semigroups/test_correctness_regressions.py
+++ b/tests/math/numerical_semigroups/test_correctness_regressions.py
@@ -39,6 +39,7 @@ from jacobian.math.numerical_semigroups._presentation_models import (
 from jacobian.math.numerical_semigroups._presentation_operations import (
     compute_minimal_presentation,
     compute_presentation_binomials,
+    verify_minimal_presentation_result,
 )
 
 
@@ -149,17 +150,18 @@ def test_betti_and_minimal_presentation_replay_independently() -> None:
 
 
 def test_minimal_presentation_rejects_relations_inside_one_r_class() -> None:
-    with numerical_semigroup_error():
-        MinimalPresentationResult.model_validate(
-            {
-                "minimal_generators": ["4", "10", "15"],
-                "betti_elements": ["20", "30"],
-                "relations": [
-                    {"first": [5, 0, 0], "second": [0, 2, 0]},
-                    {"first": [0, 3, 0], "second": [5, 1, 0]},
-                ],
-            }
-        )
+    result = MinimalPresentationResult.model_validate(
+        {
+            "minimal_generators": ["4", "10", "15"],
+            "betti_elements": ["20", "30"],
+            "relations": [
+                {"first": [5, 0, 0], "second": [0, 2, 0]},
+                {"first": [0, 3, 0], "second": [5, 1, 0]},
+            ],
+        }
+    )
+
+    assert not verify_minimal_presentation_result(result)
 
 
 def test_element_and_global_catenary_replay_independently() -> None:

--- a/tests/math/numerical_semigroups/test_result_verifiers.py
+++ b/tests/math/numerical_semigroups/test_result_verifiers.py
@@ -119,6 +119,37 @@ def test_factorization_replay_results_reapply_request_value_envelopes(
         result_type.model_validate(payload)
 
 
+@pytest.mark.parametrize(
+    ("result_type", "payload"),
+    (
+        (
+            ElementDeltaSetResult,
+            {
+                "value": "100000000",
+                "minimal_generators": ("2", "3"),
+                "factorization_lengths": (),
+                "delta_set": (),
+            },
+        ),
+        (
+            ElementElasticityResult,
+            {
+                "value": "100000000",
+                "minimal_generators": ("2", "3"),
+                "minimum_length": 1,
+                "maximum_length": 1,
+                "elasticity": "1",
+            },
+        ),
+    ),
+)
+def test_element_invariant_replay_results_reapply_request_value_envelopes(
+    result_type: type[Any], payload: dict[str, Any]
+) -> None:
+    with pytest.raises(ValueError, match="value must be at most"):
+        result_type.model_validate(payload)
+
+
 def test_factorization_length_verifier_rejects_forged_length_set() -> None:
     result = compute_factorization_lengths(
         FactorizationLengthsComputeRequest(generators=("3", "5"), value="15")

--- a/tests/math/numerical_semigroups/test_result_verifiers.py
+++ b/tests/math/numerical_semigroups/test_result_verifiers.py
@@ -1,0 +1,161 @@
+"""Independent replay verification for numerical-semigroup result claims."""
+
+from typing import Any
+
+from jacobian.math.numerical_semigroups._element_invariant_models import (
+    ElementCatenaryDegreeRequest,
+    ElementCatenaryDegreeResult,
+    ElementDeltaSetRequest,
+    ElementDeltaSetResult,
+    ElementElasticityRequest,
+    ElementElasticityResult,
+)
+from jacobian.math.numerical_semigroups._element_invariant_operations import (
+    compute_element_catenary_degree,
+    compute_element_delta_set,
+    compute_element_elasticity,
+    verify_element_catenary_degree_result,
+    verify_element_delta_set_result,
+    verify_element_elasticity_result,
+)
+from jacobian.math.numerical_semigroups._factorization_models import (
+    FactorizationComputeRequest,
+    FactorizationComputeResult,
+    FactorizationGraphComputeRequest,
+    FactorizationGraphComputeResult,
+    FactorizationLengthsComputeRequest,
+    FactorizationLengthsComputeResult,
+)
+from jacobian.math.numerical_semigroups._factorization_operations import (
+    compute_factorization_graph,
+    compute_factorization_lengths,
+    compute_factorizations,
+    verify_factorization_compute_result,
+    verify_factorization_graph_compute_result,
+    verify_factorization_lengths_compute_result,
+)
+from jacobian.math.numerical_semigroups._global_invariant_models import (
+    BettiElementsRequest,
+    BettiElementsResult,
+    CatenaryDegreeRequest,
+    CatenaryDegreeResult,
+    DeltaSetRequest,
+    DeltaSetResult,
+)
+from jacobian.math.numerical_semigroups._global_invariant_operations import (
+    compute_betti_elements,
+    compute_catenary_degree,
+    compute_delta_set,
+    verify_betti_elements_result,
+    verify_catenary_degree_result,
+    verify_delta_set_result,
+)
+from jacobian.math.numerical_semigroups._presentation_models import (
+    MinimalPresentationRequest,
+    MinimalPresentationResult,
+)
+from jacobian.math.numerical_semigroups._presentation_operations import (
+    compute_minimal_presentation,
+    verify_minimal_presentation_result,
+)
+
+
+def _forged(result: Any, **updates: object) -> dict[str, Any]:
+    return {**result.model_dump(), **updates}
+
+
+def test_factorization_verifier_rejects_forged_complete_family() -> None:
+    result = compute_factorizations(
+        FactorizationComputeRequest(generators=("3", "5"), value="15")
+    )
+    forged = FactorizationComputeResult.model_validate(
+        _forged(result, factorizations=((5, 0),))
+    )
+
+    assert not verify_factorization_compute_result(forged)
+
+
+def test_factorization_length_verifier_rejects_forged_length_set() -> None:
+    result = compute_factorization_lengths(
+        FactorizationLengthsComputeRequest(generators=("3", "5"), value="15")
+    )
+    forged = FactorizationLengthsComputeResult.model_validate(
+        _forged(result, lengths=(3,))
+    )
+
+    assert not verify_factorization_lengths_compute_result(forged)
+
+
+def test_element_invariant_verifiers_reject_forged_claims() -> None:
+    delta = compute_element_delta_set(
+        ElementDeltaSetRequest(generators=("3", "5"), value="15")
+    )
+    forged_delta = ElementDeltaSetResult.model_validate(
+        _forged(delta, factorization_lengths=(3,))
+    )
+    elasticity = compute_element_elasticity(
+        ElementElasticityRequest(generators=("3", "5"), value="15")
+    )
+    forged_elasticity = ElementElasticityResult.model_validate(
+        _forged(
+            elasticity,
+            minimum_length=4,
+            maximum_length=5,
+            elasticity="5/4",
+        )
+    )
+    catenary = compute_element_catenary_degree(
+        ElementCatenaryDegreeRequest(generators=("3", "5"), value="15")
+    )
+    forged_catenary = ElementCatenaryDegreeResult.model_validate(
+        _forged(catenary, catenary_degree=0)
+    )
+
+    assert not verify_element_delta_set_result(forged_delta)
+    assert not verify_element_elasticity_result(forged_elasticity)
+    assert verify_element_catenary_degree_result(catenary)
+    assert not verify_element_catenary_degree_result(forged_catenary)
+
+
+def test_factorization_graph_verifier_rejects_forged_edge_set() -> None:
+    result = compute_factorization_graph(
+        FactorizationGraphComputeRequest(generators=("3", "5"), value="15")
+    )
+    forged = FactorizationGraphComputeResult.model_validate(
+        _forged(result, edges=((0, 1),))
+    )
+
+    assert not verify_factorization_graph_compute_result(forged)
+
+
+def test_global_invariant_verifiers_reject_forged_claims() -> None:
+    betti = compute_betti_elements(BettiElementsRequest(generators=("3", "5")))
+    forged_betti = BettiElementsResult.model_validate(
+        _forged(betti, candidate_count=betti.candidate_count + 1)
+    )
+    delta = compute_delta_set(DeltaSetRequest(generators=("3", "5")))
+    forged_delta = DeltaSetResult.model_validate(_forged(delta, periodicity_bound=1))
+    catenary = compute_catenary_degree(CatenaryDegreeRequest(generators=("3", "5")))
+    forged_catenary = CatenaryDegreeResult.model_validate(
+        _forged(
+            catenary,
+            catenary_degree=0,
+            betti_degrees=({"betti_element": "15", "catenary_degree": 0},),
+            witness_betti_elements=(),
+        )
+    )
+
+    assert not verify_betti_elements_result(forged_betti)
+    assert not verify_delta_set_result(forged_delta)
+    assert not verify_catenary_degree_result(forged_catenary)
+
+
+def test_minimal_presentation_verifier_rejects_forged_relation() -> None:
+    result = compute_minimal_presentation(
+        MinimalPresentationRequest(generators=("3", "5"))
+    )
+    forged = MinimalPresentationResult.model_validate(
+        _forged(result, relations=({"first": (5, 0), "second": (0, 3)},) * 2)
+    )
+
+    assert not verify_minimal_presentation_result(forged)

--- a/tests/math/numerical_semigroups/test_result_verifiers.py
+++ b/tests/math/numerical_semigroups/test_result_verifiers.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+import pytest
+
 from jacobian.math.numerical_semigroups._element_invariant_models import (
     ElementCatenaryDegreeRequest,
     ElementCatenaryDegreeResult,
@@ -73,6 +75,48 @@ def test_factorization_verifier_rejects_forged_complete_family() -> None:
     )
 
     assert not verify_factorization_compute_result(forged)
+
+
+@pytest.mark.parametrize(
+    ("result_type", "payload"),
+    (
+        (
+            FactorizationComputeResult,
+            {
+                "value": "100000000",
+                "minimal_generators": ("2", "3"),
+                "in_semigroup": False,
+                "factorizations": (),
+            },
+        ),
+        (
+            FactorizationLengthsComputeResult,
+            {
+                "value": "100000000",
+                "minimal_generators": ("2", "3"),
+                "in_semigroup": False,
+                "lengths": (),
+            },
+        ),
+        (
+            FactorizationGraphComputeResult,
+            {
+                "value": "100000000",
+                "minimal_generators": ("2", "3"),
+                "in_semigroup": False,
+                "factorizations": (),
+                "edges": (),
+                "connected_components": (),
+                "is_connected": True,
+            },
+        ),
+    ),
+)
+def test_factorization_replay_results_reapply_request_value_envelopes(
+    result_type: type[Any], payload: dict[str, Any]
+) -> None:
+    with pytest.raises(ValueError, match="value must be at most"):
+        result_type.model_validate(payload)
 
 
 def test_factorization_length_verifier_rejects_forged_length_set() -> None:

--- a/tests/math/petri_nets/test_petri_nets.py
+++ b/tests/math/petri_nets/test_petri_nets.py
@@ -1,5 +1,9 @@
 """Tests for Petri net operations."""
 
+# The behavior-focused legacy test methods intentionally follow pytest's
+# unannotated method convention; Petri production modules are type-checked.
+# mypy: disable-error-code=no-untyped-def
+
 import pytest
 from pydantic import ValidationError
 
@@ -8,6 +12,7 @@ from jacobian.math.petri_nets._models import (
     FireTransitionRequest,
     IncidenceMatrixRequest,
     ReachabilityRequest,
+    SiphonTrapRequest,
 )
 from jacobian.math.petri_nets._operations import (
     compute_enabled_transitions,
@@ -86,6 +91,7 @@ class TestFireTransition:
             FireTransitionRequest(net=net, marking=marking, transition=0)
         )
         assert result.status == "FIRED"
+        assert result.new_marking is not None
         assert result.new_marking.tokens == (1, 0)
 
     def test_fire_disabled(self):
@@ -95,6 +101,7 @@ class TestFireTransition:
             FireTransitionRequest(net=net, marking=marking, transition=0)
         )
         assert result.status == "NOT_ENABLED"
+        assert result.new_marking is not None
         assert result.new_marking.tokens == (0, 0)
 
     def test_fire_cyclic(self):
@@ -104,6 +111,7 @@ class TestFireTransition:
             FireTransitionRequest(net=net, marking=marking, transition=0)
         )
         assert result.status == "FIRED"
+        assert result.new_marking is not None
         assert result.new_marking.tokens == (0, 1)
 
 
@@ -202,7 +210,6 @@ class TestValidation:
 # Siphon and trap detection
 # ---------------------------------------------------------------------------
 
-from jacobian.math.petri_nets._models import SiphonTrapRequest  # noqa: E402
 from jacobian.math.petri_nets._operations import compute_siphon_trap  # noqa: E402
 from jacobian.math.petri_nets.operations import (  # noqa: E402
     find_minimal_siphons,
@@ -324,3 +331,23 @@ class TestSiphonTrapAdapter:
         assert frozenset({0}) in siphon_sets
         assert frozenset({0}) not in trap_sets
         assert frozenset({1}) in trap_sets
+
+
+def test_petri_values_enforce_advertised_arc_and_marking_bounds() -> None:
+    assert PetriNet(place_count=1, transition_count=1, pre=((1000,),), post=((1000,),))
+    assert Marking(tokens=(1000,))
+    with pytest.raises(ValidationError, match="pre weights must not exceed"):
+        PetriNet(place_count=1, transition_count=1, pre=((1001,),), post=((0,),))
+    with pytest.raises(ValidationError, match="marking tokens must not exceed"):
+        Marking(tokens=(1001,))
+
+
+def test_siphon_trap_admission_charges_transition_scan_work() -> None:
+    net = PetriNet(
+        place_count=20,
+        transition_count=64,
+        pre=tuple((0,) * 64 for _ in range(20)),
+        post=tuple((0,) * 64 for _ in range(20)),
+    )
+    with pytest.raises(ValidationError, match="candidate and transition-scan work"):
+        SiphonTrapRequest(net=net)

--- a/tests/math/polytope/test_recession_cone_failures.py
+++ b/tests/math/polytope/test_recession_cone_failures.py
@@ -1,0 +1,46 @@
+"""Operational-failure regressions for shared recession-cone geometry."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+from sympy import Rational
+
+from jacobian._exact import CanonicalRational
+from jacobian.math.lattice_polytopes import _operations as lattice_operations
+from jacobian.math.polytope import Halfspace, _rational_geometry
+from jacobian.math.polytope import _operations as polytope_operations
+from jacobian.math.polytope._rational_geometry import RecessionConeComputationError
+
+
+def _rational(value: int) -> CanonicalRational:
+    return CanonicalRational.from_fraction(Fraction(value))
+
+
+def test_recession_rank_failure_is_operational_for_both_polytope_owners(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailedRankMatrix:
+        def __init__(self, _rows: object) -> None:
+            pass
+
+        def rank(self) -> int:
+            raise RuntimeError("backend rank failure")
+
+    monkeypatch.setattr(_rational_geometry, "Matrix", FailedRankMatrix)
+    halfspaces = (
+        Halfspace(coefficients=(_rational(1), _rational(0)), offset=_rational(1)),
+        Halfspace(coefficients=(_rational(0), _rational(1)), offset=_rational(1)),
+        Halfspace(coefficients=(_rational(-1), _rational(-1)), offset=_rational(0)),
+    )
+    raw_halfspaces = [
+        ([Rational(1), Rational(0)], Rational(1)),
+        ([Rational(0), Rational(1)], Rational(1)),
+        ([Rational(-1), Rational(-1)], Rational(0)),
+    ]
+
+    with pytest.raises(RecessionConeComputationError, match="rank computation failed"):
+        polytope_operations._is_bounded_h(halfspaces)
+    with pytest.raises(RecessionConeComputationError, match="rank computation failed"):
+        lattice_operations._is_bounded_h(raw_halfspaces, 2)

--- a/tests/process/test_graph_isomorphism_worker.py
+++ b/tests/process/test_graph_isomorphism_worker.py
@@ -1,0 +1,122 @@
+"""Process-boundary behavior for graph-isomorphism workers."""
+
+import pytest
+
+import jacobian.process as process
+from jacobian.math.graphs.isomorphism._models import GraphIsomorphismRequest
+from jacobian.math.graphs.isomorphism._operations import decide_graph_isomorphism
+from jacobian.math.number_field._models import NumberFieldRequest
+from jacobian.math.number_field._operations import compute_nf_discriminant
+from jacobian.math.number_theory._certification_models import (
+    CertifiedFactorizationRequest,
+)
+from jacobian.math.number_theory._direct_factorization_models import (
+    FactorizationRequest,
+)
+from jacobian.math.number_theory._factorization_kernels import (
+    enumerate_divisors,
+    factorize_certified,
+    factorize_primes,
+)
+from jacobian.process import BoundedProcessResult
+
+
+def test_timed_out_vf2_worker_is_an_unknown_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = decide_graph_isomorphism(
+        GraphIsomorphismRequest.model_validate(
+            {
+                "graph_a": {"vertex_count": 2, "directed": False, "edges": [(0, 1)]},
+                "graph_b": {"vertex_count": 2, "directed": False, "edges": [(0, 1)]},
+            }
+        )
+    )
+
+    assert result.status == "UNKNOWN"
+    assert result.vertex_mapping == ()
+
+
+def test_timed_out_certified_factorization_is_an_unknown_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = factorize_certified(CertifiedFactorizationRequest(value="10403"))
+
+    assert result.status == "UNKNOWN"
+    assert result.factors == ()
+
+
+def test_timed_out_direct_factorization_worker_is_an_unknown_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    request = FactorizationRequest(value="12")
+    divisors = enumerate_divisors(request)
+    factors = factorize_primes(request)
+
+    assert divisors.status == "UNKNOWN"
+    assert divisors.divisors == ()
+    assert factors.status == "UNKNOWN"
+    assert factors.factors == ()
+
+
+def test_timed_out_number_field_worker_is_an_unknown_non_conclusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process,
+        "run_bounded_process",
+        lambda *_args, **_kwargs: BoundedProcessResult(
+            returncode=None,
+            stdout=b"",
+            stderr=b"",
+            stdout_exceeded=False,
+            stderr_exceeded=False,
+            timed_out=True,
+        ),
+    )
+
+    result = compute_nf_discriminant(
+        NumberFieldRequest(coefficients_descending=("1", "0", "-2"), variable="x")
+    )
+
+    assert result.status == "UNKNOWN"
+    assert result.discriminant is None

--- a/tools/check_architecture.py
+++ b/tools/check_architecture.py
@@ -19,8 +19,11 @@ _EXTERNAL_OPERATION_OWNERS = frozenset(
     {
         _PROCESS_OWNER,
         PurePosixPath("src/jacobian/math/_singular.py"),
+        PurePosixPath("src/jacobian/math/graphs/isomorphism/_operations.py"),
         PurePosixPath("src/jacobian/math/polynomials/ideals/_singular.py"),
         PurePosixPath("src/jacobian/math/logic/_sat.py"),
+        PurePosixPath("src/jacobian/math/number_theory/_factorization_kernels.py"),
+        PurePosixPath("src/jacobian/math/number_field/_operations.py"),
         PurePosixPath("src/jacobian/math/polynomials/multivariate/_factor_backend.py"),
         PurePosixPath("src/jacobian/math/polynomials/maps/_replay.py"),
     }
@@ -460,18 +463,9 @@ def _owner_operation_reentry_violations(
     for node in _walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = _resolve_import_from_module(node, relative)
-            if module is not None and _is_owner_operation_module(module, owner):
-                violations.append(
-                    _violation(
-                        relative,
-                        node,
-                        "owner-operation-reentry",
-                        "contract and value modules must not import their own operations",
-                    )
-                )
-            elif module == owner and any(
+            if (module is not None and _is_owner_operation_module(module, owner)) or (module == owner and any(
                 alias.name in {"operations", "_operations"} for alias in node.names
-            ):
+            )):
                 violations.append(
                     _violation(
                         relative,


### PR DESCRIPTION
## Problem

Several owner boundaries could convert backend limits or structural input into an exact-looking conclusion, repeat producer work during verification, or leave theorem-dependent consumers open to arbitrary feasible-set systems.

Fixes #2194, #2735, #2736, #2737, #2740, #2753, #2754, #2760, and #2763.

Related, but intentionally not closed: #2761 and #2762. The PR returns typed non-applicability and charges exchange work, but does not yet introduce the requested canonical greedoid/antimatroid subtypes or complete source-membership and label-byte admission accounting.

## Solution

- Move trusted result construction and bounded replay verification to the relevant mathematical owners.
- Return typed non-conclusions when isolated VF2, factorization, or number-field workers cannot complete.
- Make greedoid and antimatroid native consumers require recognized axioms; retain structural predicates for raw families.
- Correct majorization witness construction, Petri admission accounting, recession-cone failures, and additive-profile verifier failure behavior.

## Testing

- `make affected`
- Focused owner lanes for additive combinatorics, greedoids, majorization, Petri nets, and process worker outcomes.
- `uv run python tools/check_architecture.py`

## Public contract impact

Result schemas now distinguish typed non-conclusions from exact results in affected owners. Operation IDs are unchanged.

## Operation boundary ownership

- Changed stage: request bounds, kernel adapters, result construction, and independent-result verification.
- Request-bounds owner and controlling quantities: each affected mathematical owner; Greedoid exchange pairs and Petri transition work are explicitly charged.
- Backend or kernel path: bounded isolated workers for unsafe SymPy/VF2 operations; existing maintained backends otherwise remain private.
- Independent-result verifier: source-bound bounded replay where result values accept externally supplied claims.
- Native/MCP parity: theorem-dependent native greedoid consumers now enforce the same axioms as MCP adapters.

## Checklist

- [x] Relevant owner and boundary tests pass
- [x] Catalog membership and operation IDs are unchanged
- [x] Exact results retain their defining data; unavailable work is typed as a non-conclusion