### PR TITLE
Carry one request deadline through dispatch

### DIFF
--- a/src/jacobian/dispatch.py
+++ b/src/jacobian/dispatch.py
@@ -109,11 +109,12 @@ def _invoke_prepared_operation(
     if started is None:
         started = time.monotonic()
     result = prepared.run(prepared.request)
+    output = result.model_dump(mode="json")
 
     return OperationResult(
         operation_id=prepared.operation_id,
         runtime_ms=max(0, round((time.monotonic() - started) * 1000)),
-        output=result.model_dump(mode="json"),
+        output=output,
     )
 
 

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -115,6 +115,8 @@ def math_run(
         # preparation because owner admission may itself use a child worker.
         with bounded_process_cancellation(cancellation):
             prepared = _prepare_operation(operation_id, payload, catalog)
+            if cancellation.is_set():
+                raise ToolError("operation cancelled before execution")
             return _invoke_prepared_operation(prepared, started=started)
     except (OperationRequestValidationError, OperationDomainValidationError) as exc:
         errors = _bounded_validation_issues(exc.errors())

--- a/src/jacobian/mcp/tools.py
+++ b/src/jacobian/mcp/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping, Sequence
 from typing import Any, Protocol
 
@@ -16,7 +17,6 @@ from jacobian.dispatch import (
     OperationRequestValidationError,
     _invoke_prepared_operation,
     _prepare_operation,
-    _PreparedOperation,
 )
 from jacobian.mcp.models import (
     OperationBrowseRequest,
@@ -104,12 +104,18 @@ def math_run(
     catalog = _catalog(ctx)
     if catalog.operation(operation_id) is None:
         raise ToolError(f"unknown operation: {operation_id}")
+    cancellation = _request_cancellation(ctx)
+    if cancellation.is_set():
+        raise ToolError("operation cancelled before execution")
     try:
-        prepared = _prepare_operation(operation_id, payload, catalog)
+        started = time.monotonic()
         # MCP runs synchronous tools in a worker thread.  Its request event
         # is polled by the shared external-process runner, which kills and
-        # reaps only an operation's owned child tree.
-        return _run_prepared_operation(prepared, ctx)
+        # reaps only an operation's owned child tree.  Bind it before
+        # preparation because owner admission may itself use a child worker.
+        with bounded_process_cancellation(cancellation):
+            prepared = _prepare_operation(operation_id, payload, catalog)
+            return _invoke_prepared_operation(prepared, started=started)
     except (OperationRequestValidationError, OperationDomainValidationError) as exc:
         errors = _bounded_validation_issues(exc.errors())
         data = OperationInvalidRequestData(
@@ -127,19 +133,6 @@ def _request_cancellation(ctx: Context[AppState, Any]) -> _CancellationSignal:
     """Return MCP 2.1's request signal through its only available SDK seam."""
 
     return ctx.request_context.session._request_outbound.cancel_requested
-
-
-def _run_prepared_operation(
-    prepared: _PreparedOperation,
-    ctx: Context[AppState, Any],
-) -> OperationResult:
-    """Run one prepared operation without serializing independent requests."""
-
-    cancellation = _request_cancellation(ctx)
-    if cancellation.is_set():
-        raise ToolError("operation cancelled before execution")
-    with bounded_process_cancellation(cancellation):
-        return _invoke_prepared_operation(prepared)
 
 
 def _bounded_validation_issues(

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -354,8 +354,6 @@ def run_bounded_process(
     # cannot acquire a second, fresh cleanup clock after the admitted lifetime.
     started = time.monotonic()
     absolute_deadline = started + timeout_seconds
-    cleanup_allowance = min(_PIPE_DRAIN_GRACE_SECONDS, timeout_seconds / 4)
-    execution_deadline = absolute_deadline - cleanup_allowance
 
     start_new_session = os.name == "posix"
     creationflags = (
@@ -379,8 +377,7 @@ def run_bounded_process(
         stdin_file.write(input_bytes)
         stdin_file.seek(0)
         # Spooling is part of the admitted execution envelope.  Do not launch
-        # a worker once it has already consumed the execution portion that was
-        # reserved before teardown.
+        # a worker after it has consumed the request's complete deadline.
         if cancellation_event is not None and cancellation_event.is_set():
             return BoundedProcessResult(
                 returncode=None,
@@ -391,7 +388,7 @@ def run_bounded_process(
                 timed_out=False,
                 cancelled=True,
             )
-        if time.monotonic() >= execution_deadline:
+        if time.monotonic() >= absolute_deadline:
             return BoundedProcessResult(
                 returncode=None,
                 stdout=b"",
@@ -465,7 +462,7 @@ def run_bounded_process(
         try:
             timed_out, cancelled = _monitor_bounded_process(
                 process,
-                deadline=execution_deadline,
+                deadline=absolute_deadline,
                 cancellation_event=cancellation_event,
                 platform_tools=platform_tools,
             )

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -354,6 +354,8 @@ def run_bounded_process(
     # cannot acquire a second, fresh cleanup clock after the admitted lifetime.
     started = time.monotonic()
     absolute_deadline = started + timeout_seconds
+    cleanup_allowance = min(_PIPE_DRAIN_GRACE_SECONDS, timeout_seconds / 100)
+    execution_deadline = absolute_deadline - cleanup_allowance
 
     start_new_session = os.name == "posix"
     creationflags = (
@@ -388,7 +390,7 @@ def run_bounded_process(
                 timed_out=False,
                 cancelled=True,
             )
-        if time.monotonic() >= absolute_deadline:
+        if time.monotonic() >= execution_deadline:
             return BoundedProcessResult(
                 returncode=None,
                 stdout=b"",
@@ -462,7 +464,7 @@ def run_bounded_process(
         try:
             timed_out, cancelled = _monitor_bounded_process(
                 process,
-                deadline=absolute_deadline,
+                deadline=execution_deadline,
                 cancellation_event=cancellation_event,
                 platform_tools=platform_tools,
             )

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -278,8 +278,15 @@ def _monitor_bounded_process(
     Returns ``(timed_out, cancelled)``.
     """
 
-    timed_out = False
+    # Setup may consume the execution allowance before monitoring starts.  Do
+    # not accept an already-exited child as timely merely because ``poll``
+    # would skip the loop below.
+    timed_out = time.monotonic() >= deadline
     cancelled = False
+    if timed_out:
+        _kill_process_tree(process, platform_tools)
+        process.wait()
+        return timed_out, cancelled
     while process.poll() is None:
         if cancellation_event is not None and cancellation_event.is_set():
             cancelled = True

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -303,13 +303,14 @@ def _drain_reader_threads(
     process: subprocess.Popen[bytes],
     readers: tuple[threading.Thread, ...],
     platform_tools: ProcessPlatformTools | None,
+    *,
+    cleanup_deadline: float,
 ) -> bool:
     """Kill the tree, drain readers, and return ``True`` if any survived."""
 
     _kill_process_tree(process, platform_tools)
-    drain_deadline = time.monotonic() + _PIPE_DRAIN_GRACE_SECONDS
     for reader in readers:
-        reader.join(timeout=max(0.0, drain_deadline - time.monotonic()))
+        reader.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
     return any(reader.is_alive() for reader in readers)
 
 
@@ -341,6 +342,14 @@ def run_bounded_process(
     if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
         raise ValueError("subprocess timeout must be positive")
 
+    # This envelope includes input spooling, process setup, execution, result
+    # capture, and reaping.  Keep a finite portion for teardown so a timeout
+    # cannot acquire a second, fresh cleanup clock after the admitted lifetime.
+    started = time.monotonic()
+    absolute_deadline = started + timeout_seconds
+    cleanup_allowance = min(_PIPE_DRAIN_GRACE_SECONDS, timeout_seconds / 4)
+    execution_deadline = absolute_deadline - cleanup_allowance
+
     start_new_session = os.name == "posix"
     creationflags = (
         int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
@@ -362,6 +371,28 @@ def run_bounded_process(
     with tempfile.TemporaryFile() as stdin_file:
         stdin_file.write(input_bytes)
         stdin_file.seek(0)
+        # Spooling is part of the admitted execution envelope.  Do not launch
+        # a worker once it has already consumed the execution portion that was
+        # reserved before teardown.
+        if cancellation_event is not None and cancellation_event.is_set():
+            return BoundedProcessResult(
+                returncode=None,
+                stdout=b"",
+                stderr=b"",
+                stdout_exceeded=False,
+                stderr_exceeded=False,
+                timed_out=False,
+                cancelled=True,
+            )
+        if time.monotonic() >= execution_deadline:
+            return BoundedProcessResult(
+                returncode=None,
+                stdout=b"",
+                stderr=b"",
+                stdout_exceeded=False,
+                stderr_exceeded=False,
+                timed_out=True,
+            )
         bounded_command, limits_applied_before_exec = (
             _resource_limited_command(command, resource_limits, prlimit_executable)
             if resource_limits is not None
@@ -422,11 +453,12 @@ def run_bounded_process(
         for reader in readers:
             reader.start()
 
-        deadline = time.monotonic() + timeout_seconds
+        timed_out = False
+        cancelled = False
         try:
             timed_out, cancelled = _monitor_bounded_process(
                 process,
-                deadline=deadline,
+                deadline=execution_deadline,
                 cancellation_event=cancellation_event,
                 platform_tools=platform_tools,
             )
@@ -434,9 +466,12 @@ def run_bounded_process(
             # A clean worker may leave descendants holding inherited pipe
             # handles. Terminate the process group before draining so those
             # handles cannot turn successful completion into a false timeout.
-            if _drain_reader_threads(process, readers, platform_tools) and not (
-                stdout_exceeded.is_set() or stderr_exceeded.is_set()
-            ):
+            if _drain_reader_threads(
+                process,
+                readers,
+                platform_tools,
+                cleanup_deadline=absolute_deadline,
+            ) and not (stdout_exceeded.is_set() or stderr_exceeded.is_set()):
                 # A descendant may have escaped the worker process group while
                 # retaining a pipe. Fail closed instead of returning partial
                 # output as a successful worker completion.  Do not override

--- a/tests/dispatch/test_dispatch.py
+++ b/tests/dispatch/test_dispatch.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import time
+from typing import cast
+
 import pytest
-from pydantic import ValidationError
+from pydantic import ValidationError, field_serializer
 
 from jacobian._models import StrictModel
 from jacobian.catalog.catalog import Catalog
@@ -14,6 +17,13 @@ class _Request(StrictModel):
 
 class _Result(StrictModel):
     value: int
+
+
+class _TimedResult(_Result):
+    @field_serializer("value")
+    def serialize_value(self, value: int) -> int:
+        time.monotonic()
+        return value
 
 
 class _InvalidResultOperation:
@@ -31,6 +41,23 @@ class _CatalogWithInvalidResult:
     def _binding(operation_id: str) -> _InvalidResultOperation:
         del operation_id
         return _InvalidResultOperation()
+
+
+class _TimedResultOperation:
+    operation_id = "test.timed-result"
+    request_type = _Request
+
+    @staticmethod
+    def run(request: StrictModel) -> StrictModel:
+        assert isinstance(request, _Request)
+        return _TimedResult(value=request.value)
+
+
+class _CatalogWithTimedResult:
+    @staticmethod
+    def _binding(operation_id: str) -> _TimedResultOperation:
+        del operation_id
+        return _TimedResultOperation()
 
 
 def test_invoke_operation_runs_determinant_directly() -> None:
@@ -103,3 +130,17 @@ def test_dispatch_classifies_noncanonical_json_as_request_validation() -> None:
         invoke_operation("test.invalid-result", {"value": 1.5}, catalog)  # type: ignore[arg-type]
 
     assert error.value.errors()[0]["type"] == "canonicalization_error"
+
+
+def test_runtime_includes_canonical_result_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = iter((1.0, 1.1, 1.2))
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+
+    result = invoke_operation(
+        "test.timed-result", {"value": 7}, cast(Catalog, _CatalogWithTimedResult())
+    )
+
+    assert result.output == {"value": 7}
+    assert result.runtime_ms == 200

--- a/tests/process/test_bounded_process.py
+++ b/tests/process/test_bounded_process.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import Never
 
 import pytest
 
@@ -18,6 +19,31 @@ from jacobian.process import (
     bounded_process_cancellation,
     run_bounded_process,
 )
+
+
+def test_expired_input_spooling_does_not_launch_a_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monotonic = iter((0.0, 2.0))
+    monkeypatch.setattr("jacobian.process.time.monotonic", lambda: next(monotonic))
+
+    def fail_to_launch(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError("expired request must not launch a worker")
+
+    monkeypatch.setattr("jacobian.process.subprocess.Popen", fail_to_launch)
+
+    completed = run_bounded_process(
+        [sys.executable, "-c", "raise SystemExit(0)"],
+        input_bytes=b"input",
+        timeout_seconds=1,
+        environment=dict(os.environ),
+        stdout_limit=4096,
+        stderr_limit=4096,
+    )
+
+    assert completed.timed_out
+    assert not completed.cancelled
+    assert completed.returncode is None
 
 
 @pytest.mark.parametrize("timeout_seconds", [math.inf, math.nan])


### PR DESCRIPTION
## Problem

Runtime measurement and bounded subprocess cleanup previously used separate timing windows, while MCP cancellation was bound after request preparation. That left owner execution envelopes incomplete.

Fixes #2728 and #2729.

## Solution

- Start the request lifetime before preparation and bind MCP cancellation at the entry boundary.
- Measure `runtime_ms` through canonical result projection.
- Consume one absolute deadline through bounded-process launch, streaming, conversion, termination, and reaping, with cleanup reserved from the admitted envelope.

## Testing

- `make affected`
- `uv run pytest tests/dispatch/test_dispatch.py tests/process/test_bounded_process.py -q`

## Public contract impact

No operation IDs or result schemas change. `runtime_ms` now has the documented dispatch-to-canonical-projection meaning.

## Operation boundary ownership

- Changed stage: dispatch and transport projection.
- Request-bounds owner and controlling quantities: the request-scoped deadline established before preparation.
- Wall deadline: a single absolute deadline, including named cleanup allowance.
- Native/MCP parity: both paths share owner execution timing; MCP additionally receives the SDK cancellation signal.

## Checklist

- [x] Relevant runtime and process tests pass
- [x] No global execution lock or durable task state added