### PR TITLE
Bound repository command execution

### DIFF
--- a/benchmarks/validation/test_tooling_command_runner.py
+++ b/benchmarks/validation/test_tooling_command_runner.py
@@ -173,7 +173,9 @@ def test_tool_command_timeout_is_preserved_with_streaming(tmp_path: Path) -> Non
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group fixture")
-def test_reader_timeout_kills_descendants_that_hold_output_pipes(tmp_path: Path) -> None:
+def test_reader_timeout_kills_descendants_that_hold_output_pipes(
+    tmp_path: Path,
+) -> None:
     pid_file = tmp_path / "descendant.pid"
     descendant = "import time; time.sleep(30)"
     root = (

--- a/benchmarks/validation/test_tooling_command_runner.py
+++ b/benchmarks/validation/test_tooling_command_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -169,6 +170,40 @@ def test_tool_command_timeout_is_preserved_with_streaming(tmp_path: Path) -> Non
 
     assert result.status is ToolCommandStatus.TIMED_OUT
     assert streamed == b"ready\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group fixture")
+def test_reader_timeout_kills_descendants_that_hold_output_pipes(tmp_path: Path) -> None:
+    pid_file = tmp_path / "descendant.pid"
+    descendant = "import time; time.sleep(30)"
+    root = (
+        "import pathlib, subprocess, sys; "
+        f"child = subprocess.Popen([sys.executable, '-c', {descendant!r}]); "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid))"
+    )
+
+    result = run_tool_command(
+        ToolCommandRequest(
+            executable=sys.executable,
+            arguments=("-c", root),
+            cwd=str(tmp_path),
+            timeout_seconds=0.4,
+            stdout_limit_bytes=128,
+            stderr_limit_bytes=128,
+        )
+    )
+
+    assert result.status is ToolCommandStatus.TIMED_OUT
+    child_pid = int(pid_file.read_text())
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError(f"descendant (pid={child_pid}) survived reader timeout")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX executable path fixture")

--- a/benchmarks/validation/test_tooling_interactive_command.py
+++ b/benchmarks/validation/test_tooling_interactive_command.py
@@ -214,9 +214,8 @@ def test_interactive_stderr_is_bounded(tmp_path: Path) -> None:
         while not command.stderr_exceeded and time.monotonic() < deadline:
             time.sleep(0.01)
         assert command.stderr_exceeded is True
-        command.send("ping")
         with pytest.raises(RuntimeError, match="stderr bounds"):
-            command.read_response()
+            command.send("ping")
     finally:
         command.close()
     assert len(command.stderr) <= 64

--- a/tests/process/tooling/test_command_runner.py
+++ b/tests/process/tooling/test_command_runner.py
@@ -1,0 +1,65 @@
+"""Lifecycle evidence for the repository command runner."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from tools.command_runner import (
+    ToolCommandRequest,
+    ToolCommandStatus,
+    ToolInteractiveCommand,
+    ToolInteractiveRequest,
+    ToolInteractiveStatus,
+    run_tool_command,
+)
+
+
+def test_command_timeout_includes_launch_execution_and_reaping(tmp_path: Path) -> None:
+    request = ToolCommandRequest(
+        executable=str(Path(sys.executable).resolve()),
+        arguments=("-c", "import time; time.sleep(30)"),
+        environment=dict(os.environ),
+        cwd=str(tmp_path),
+        timeout_seconds=0.4,
+        stdout_limit_bytes=4096,
+        stderr_limit_bytes=4096,
+    )
+
+    started = time.monotonic()
+    result = run_tool_command(request)
+
+    assert result.status is ToolCommandStatus.TIMED_OUT
+    assert time.monotonic() - started < 0.8
+
+
+def test_interactive_send_is_bounded_when_child_does_not_read(tmp_path: Path) -> None:
+    command = ToolInteractiveCommand(
+        ToolInteractiveRequest(
+            executable=str(Path(sys.executable).resolve()),
+            arguments=("-c", "import time; time.sleep(30)"),
+            environment=dict(os.environ),
+            cwd=str(tmp_path),
+            startup_timeout_seconds=0.2,
+            read_timeout_seconds=0.2,
+            shutdown_timeout_seconds=0.2,
+            stdout_limit_bytes=4096,
+            stderr_limit_bytes=4096,
+        )
+    )
+    command.start()
+
+    started = time.monotonic()
+    try:
+        command.send("x" * (2 * 1024 * 1024))
+    except TimeoutError:
+        pass
+    else:  # pragma: no cover - a pipe unexpectedly accepting all input is unsafe
+        raise AssertionError(
+            "interactive write should time out when the child does not read"
+        )
+
+    assert command.status is ToolInteractiveStatus.TIMED_OUT
+    assert time.monotonic() - started < 0.6

--- a/tests/process/tooling/test_process_supervisor.py
+++ b/tests/process/tooling/test_process_supervisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import time
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -94,3 +95,17 @@ def test_omitted_environment_preserves_the_parent_environment(
 
     assert result.exit_code == 0
     assert not result.timed_out
+
+
+def test_text_only_output_stream_receives_decoded_child_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = StringIO()
+    monkeypatch.setattr("tools.process_supervisor.sys.stdout", output)
+
+    result = run_process_tree(
+        (sys.executable, "-c", "print('hello')"), timeout=5.0, cwd=tmp_path
+    )
+
+    assert result.exit_code == 0
+    assert output.getvalue() == "hello\n"

--- a/tests/process/tooling/test_process_supervisor.py
+++ b/tests/process/tooling/test_process_supervisor.py
@@ -5,6 +5,7 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
 from tools.process_supervisor import run_process_tree
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -74,3 +75,22 @@ def test_timeout_kills_a_descendant_that_ignores_sigterm(tmp_path: Path) -> None
     assert still_alive is False, (
         f"descendant (pid={child_pid}) survived timeout — SIGKILL not sent?"
     )
+
+
+def test_omitted_environment_preserves_the_parent_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JACOBIAN_SUPERVISOR_ENV_PROBE", "available")
+
+    result = run_process_tree(
+        (
+            sys.executable,
+            "-c",
+            "import os; raise SystemExit(os.environ['JACOBIAN_SUPERVISOR_ENV_PROBE'] != 'available')",
+        ),
+        timeout=5.0,
+        cwd=tmp_path,
+    )
+
+    assert result.exit_code == 0
+    assert not result.timed_out

--- a/tests/tooling/test_affected_validation.py
+++ b/tests/tooling/test_affected_validation.py
@@ -180,9 +180,12 @@ def test_selected_commands_use_the_bounded_operator_runner(
         *,
         cwd: Path,
         timeout_seconds: float,
+        stdout_limit_bytes: int,
+        stderr_limit_bytes: int,
         environment: dict[str, str],
     ) -> ToolCommandResult:
         assert environment["PATH"]
+        assert stdout_limit_bytes == stderr_limit_bytes == 64 * 1024 * 1024
         observed.append((command, arguments, cwd, timeout_seconds))
         return ToolCommandResult(
             status=ToolCommandStatus.EXITED,

--- a/tests/tooling/test_affected_validation.py
+++ b/tests/tooling/test_affected_validation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from tools.command_runner import ToolCommandResult, ToolCommandStatus
 
 ROOT = Path(__file__).parents[2]
 
@@ -131,3 +132,70 @@ def test_changed_paths_include_worktree_and_untracked_files(
         "src/jacobian/math/graphs/values.py",
         "tests/math/graphs/test_graph_coloring.py",
     )
+
+
+def test_git_metadata_queries_use_the_bounded_operator_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load()
+    observed: list[tuple[str, tuple[str, ...], Path, float]] = []
+
+    def run_operator(
+        command: str,
+        arguments: tuple[str, ...],
+        *,
+        cwd: Path,
+        timeout_seconds: float,
+        stdout_limit_bytes: int,
+        stderr_limit_bytes: int,
+        environment: dict[str, str],
+    ) -> ToolCommandResult:
+        assert environment["PATH"]
+        assert stdout_limit_bytes == 4 * 1024 * 1024
+        assert stderr_limit_bytes == 1024 * 1024
+        observed.append((command, arguments, cwd, timeout_seconds))
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"deadbeef\n",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(runner, "run_operator_command", run_operator)
+
+    assert runner._git("rev-parse", "HEAD", repository=ROOT) == "deadbeef"
+    assert observed == [("git", ("rev-parse", "HEAD"), ROOT, 30.0)]
+
+
+def test_selected_commands_use_the_bounded_operator_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load()
+    observed: list[tuple[str, tuple[str, ...], Path, float]] = []
+
+    def run_operator(
+        command: str,
+        arguments: tuple[str, ...],
+        *,
+        cwd: Path,
+        timeout_seconds: float,
+        environment: dict[str, str],
+    ) -> ToolCommandResult:
+        assert environment["PATH"]
+        observed.append((command, arguments, cwd, timeout_seconds))
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"selected output\n",
+            stderr=b"selected diagnostics\n",
+        )
+
+    monkeypatch.setattr(runner, "run_operator_command", run_operator)
+
+    runner._run((("make", "test-math"),), repository=ROOT)
+
+    assert observed == [("make", ("test-math",), ROOT, 30 * 60)]
+    captured = capsys.readouterr()
+    assert "selected output" in captured.out
+    assert "selected diagnostics" in captured.err

--- a/tests/tooling/test_github_workflow_inventory.py
+++ b/tests/tooling/test_github_workflow_inventory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -87,3 +88,30 @@ def test_registered_workflows_use_the_bounded_operator_runner(
     assert _registered_from_gh() == {"ci"}
     assert observed["command"] == "gh"
     assert observed["timeout_seconds"] == 30.0
+
+
+def test_registered_workflows_preserve_gh_authentication_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tools.inventory_github_workflows as inventory
+
+    monkeypatch.setenv("GH_TOKEN", "token")
+    monkeypatch.setenv("UNRELATED_SECRET", "not-forwarded")
+    observed: dict[str, object] = {}
+
+    def run_operator(*_args: object, **kwargs: object) -> ToolCommandResult:
+        observed.update(kwargs)
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"[]",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(inventory, "run_operator_command", run_operator)
+
+    assert _registered_from_gh() == set()
+    environment = observed["environment"]
+    assert isinstance(environment, Mapping)
+    assert environment["GH_TOKEN"] == "token"
+    assert "UNRELATED_SECRET" not in environment

--- a/tests/tooling/test_github_workflow_inventory.py
+++ b/tests/tooling/test_github_workflow_inventory.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from tools.command_runner import ToolCommandResult, ToolCommandStatus
 from tools.inventory_github_workflows import (
     WORKFLOW_LIST_LIMIT,
+    _registered_from_gh,
     _stems_from_workflow_rows,
     _workflow_list_command,
     classify,
@@ -58,3 +60,30 @@ def test_workflow_list_fails_closed_when_gh_hits_the_limit() -> None:
                 for index in range(WORKFLOW_LIST_LIMIT)
             ]
         )
+
+
+def test_registered_workflows_use_the_bounded_operator_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tools.inventory_github_workflows as inventory
+
+    observed: dict[str, object] = {}
+
+    def run_operator(
+        command: str,
+        arguments: list[str],
+        **kwargs: object,
+    ) -> ToolCommandResult:
+        observed.update(command=command, arguments=arguments, **kwargs)
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b'[{"path": ".github/workflows/ci.yml"}]',
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(inventory, "run_operator_command", run_operator)
+
+    assert _registered_from_gh() == {"ci"}
+    assert observed["command"] == "gh"
+    assert observed["timeout_seconds"] == 30.0

--- a/tests/tooling/test_repository_hygiene.py
+++ b/tests/tooling/test_repository_hygiene.py
@@ -1,7 +1,58 @@
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 from tools import check_repository_hygiene
+from tools.command_runner import ToolCommandResult, ToolCommandStatus
+
+
+def test_tracked_paths_uses_the_bounded_git_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    seen: dict[str, object] = {}
+
+    def run(
+        command: str, arguments: tuple[str, ...], **kwargs: object
+    ) -> ToolCommandResult:
+        seen.update(command=command, arguments=arguments, **kwargs)
+        return ToolCommandResult(
+            status=ToolCommandStatus.EXITED,
+            exit_code=0,
+            stdout=b"src/jacobian/__init__.py\0",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(check_repository_hygiene, "run_operator_command", run)
+
+    assert check_repository_hygiene.tracked_paths(tmp_path) == (
+        PurePosixPath("src/jacobian/__init__.py"),
+    )
+    assert seen == {
+        "command": "git",
+        "arguments": ("ls-files", "-z"),
+        "cwd": tmp_path,
+        "timeout_seconds": 30.0,
+        "stdout_limit_bytes": 16 * 1024 * 1024,
+        "stderr_limit_bytes": 64 * 1024,
+    }
+
+
+def test_tracked_paths_rejects_a_failed_bounded_git_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        check_repository_hygiene,
+        "run_operator_command",
+        lambda *_args, **_kwargs: ToolCommandResult(
+            status=ToolCommandStatus.TIMED_OUT,
+            exit_code=None,
+            stdout=b"",
+            stderr=b"",
+            diagnostic="timed out",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        check_repository_hygiene.tracked_paths(tmp_path)
 
 
 def test_rejects_artifacts_and_conflict_markers(

--- a/tools/affected_validation.py
+++ b/tools/affected_validation.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -14,9 +13,29 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from tools.ci_test_plan import TestPlan, build_plan  # noqa: E402
-from tools.command_runner import ToolCommandStatus, run_operator_command  # noqa: E402
+from tools.command_runner import (  # noqa: E402
+    ToolCommandStatus,
+    operator_environment,
+    run_operator_command,
+)
 
 _STATIC_PREFIXES = ("src/", "tests/", "benchmarks/")
+_VALIDATION_ENVIRONMENT = (
+    "PATH",
+    "AFFECTED_BASE",
+    "PYTEST_ARGS",
+    "PYTEST_DIAGNOSTIC_ARGS",
+    "ALLOW_PARALLEL_VALIDATION",
+    "UV_CACHE_DIR",
+    "UV_PYTHON_INSTALL_DIR",
+    "VIRTUAL_ENV",
+)
+
+
+def _validation_environment() -> dict[str, str]:
+    """Forward documented validation controls without ambient environment leakage."""
+
+    return dict(operator_environment(include=_VALIDATION_ENVIRONMENT))
 
 
 def _git(*arguments: str, repository: Path) -> str:
@@ -29,7 +48,7 @@ def _git(*arguments: str, repository: Path) -> str:
         timeout_seconds=30.0,
         stdout_limit_bytes=4 * 1024 * 1024,
         stderr_limit_bytes=1024 * 1024,
-        environment={"PATH": os.environ.get("PATH", "")},
+        environment=_validation_environment(),
     )
     if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
         diagnostic = result.diagnostic or result.stderr.decode("utf-8", "replace")
@@ -137,7 +156,7 @@ def _run(commands: Sequence[Sequence[str]], *, repository: Path) -> None:
             command[1:],
             cwd=repository,
             timeout_seconds=30 * 60,
-            environment={"PATH": os.environ.get("PATH", "")},
+            environment=_validation_environment(),
         )
         if result.stdout:
             sys.stdout.write(result.stdout.decode("utf-8", "replace"))

--- a/tools/affected_validation.py
+++ b/tools/affected_validation.py
@@ -31,6 +31,7 @@ _VALIDATION_ENVIRONMENT = (
     "VIRTUAL_ENV",
 )
 _BOUNDARY_LANE_TIMEOUT_SECONDS = 4_800
+_VALIDATION_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024
 
 
 def _validation_environment() -> dict[str, str]:
@@ -161,6 +162,8 @@ def _run(commands: Sequence[Sequence[str]], *, repository: Path) -> None:
                 if len(command) > 1 and command[1] in {"test-process", "test-mcp"}
                 else 30 * 60
             ),
+            stdout_limit_bytes=_VALIDATION_OUTPUT_LIMIT_BYTES,
+            stderr_limit_bytes=_VALIDATION_OUTPUT_LIMIT_BYTES,
             environment=_validation_environment(),
         )
         if result.stdout:

--- a/tools/affected_validation.py
+++ b/tools/affected_validation.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
+import os
 import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -14,16 +14,27 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from tools.ci_test_plan import TestPlan, build_plan  # noqa: E402
+from tools.command_runner import ToolCommandStatus, run_operator_command  # noqa: E402
 
 _STATIC_PREFIXES = ("src/", "tests/", "benchmarks/")
 
 
 def _git(*arguments: str, repository: Path) -> str:
-    """Return one Git query's decoded standard output."""
+    """Return one bounded Git metadata query's decoded standard output."""
 
-    return subprocess.check_output(
-        ("git", *arguments), cwd=repository, text=True
-    ).strip()
+    result = run_operator_command(
+        "git",
+        arguments,
+        cwd=repository,
+        timeout_seconds=30.0,
+        stdout_limit_bytes=4 * 1024 * 1024,
+        stderr_limit_bytes=1024 * 1024,
+        environment={"PATH": os.environ.get("PATH", "")},
+    )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        diagnostic = result.diagnostic or result.stderr.decode("utf-8", "replace")
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {diagnostic.strip()}")
+    return result.stdout.decode("utf-8", "strict").strip()
 
 
 def changed_paths(*, base: str, repository: Path) -> tuple[str, str, tuple[str, ...]]:
@@ -121,7 +132,21 @@ def commands_for_plan(
 def _run(commands: Sequence[Sequence[str]], *, repository: Path) -> None:
     for command in commands:
         print("+", " ".join(command), flush=True)
-        subprocess.run(command, cwd=repository, check=True)
+        result = run_operator_command(
+            command[0],
+            command[1:],
+            cwd=repository,
+            timeout_seconds=30 * 60,
+            environment={"PATH": os.environ.get("PATH", "")},
+        )
+        if result.stdout:
+            sys.stdout.write(result.stdout.decode("utf-8", "replace"))
+        if result.stderr:
+            sys.stderr.write(result.stderr.decode("utf-8", "replace"))
+        if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+            raise SystemExit(
+                result.diagnostic or f"{' '.join(command)} failed with {result.status}"
+            )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tools/affected_validation.py
+++ b/tools/affected_validation.py
@@ -30,6 +30,7 @@ _VALIDATION_ENVIRONMENT = (
     "UV_PYTHON_INSTALL_DIR",
     "VIRTUAL_ENV",
 )
+_BOUNDARY_LANE_TIMEOUT_SECONDS = 4_800
 
 
 def _validation_environment() -> dict[str, str]:
@@ -155,7 +156,11 @@ def _run(commands: Sequence[Sequence[str]], *, repository: Path) -> None:
             command[0],
             command[1:],
             cwd=repository,
-            timeout_seconds=30 * 60,
+            timeout_seconds=(
+                _BOUNDARY_LANE_TIMEOUT_SECONDS
+                if len(command) > 1 and command[1] in {"test-process", "test-mcp"}
+                else 30 * 60
+            ),
             environment=_validation_environment(),
         )
         if result.stdout:

--- a/tools/check_repository_hygiene.py
+++ b/tools/check_repository_hygiene.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from tools.command_runner import ToolCommandStatus, run_operator_command
 
-ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE_PREFIXES = (
     PurePosixPath("tests/fixtures"),
     PurePosixPath("vendor"),

--- a/tools/check_repository_hygiene.py
+++ b/tools/check_repository_hygiene.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path, PurePosixPath
+
+from tools.command_runner import ToolCommandStatus, run_operator_command
 
 ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE_PREFIXES = (
@@ -14,9 +15,20 @@ _FIXTURE_PREFIXES = (
 
 
 def tracked_paths(root: Path) -> tuple[PurePosixPath, ...]:
-    result = subprocess.run(
-        ["git", "-C", str(root), "ls-files", "-z"], check=True, capture_output=True
+    """Return tracked paths through the bounded repository-command policy."""
+
+    result = run_operator_command(
+        "git",
+        ("ls-files", "-z"),
+        cwd=root,
+        timeout_seconds=30.0,
+        stdout_limit_bytes=16 * 1024 * 1024,
+        stderr_limit_bytes=64 * 1024,
     )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        raise RuntimeError(
+            result.diagnostic or "git ls-files failed during repository hygiene check"
+        )
     return tuple(PurePosixPath(p.decode()) for p in result.stdout.split(b"\0") if p)
 
 
@@ -25,10 +37,7 @@ def _is_local_artifact(path: PurePosixPath) -> bool:
     return (
         any(part.startswith(".agents-tmp-") for part in path.parts)
         or "pr-audit" in path.parts
-        or (
-            path.parent == PurePosixPath(".")
-            and path.match("*audit_report*.md")
-        )
+        or (path.parent == PurePosixPath(".") and path.match("*audit_report*.md"))
     )
 
 
@@ -39,11 +48,7 @@ def _allows_literal_conflict_markers(path: PurePosixPath) -> bool:
 
 def _is_conflict_marker(line: str) -> bool:
     """Recognize the three line forms emitted by Git's conflict renderer."""
-    return (
-        line.startswith("<<<<<<< ")
-        or line.startswith(">>>>>>> ")
-        or line == "======="
-    )
+    return line.startswith(("<<<<<<< ", ">>>>>>> ")) or line == "======="
 
 
 def check(root: Path = ROOT) -> tuple[str, ...]:

--- a/tools/command_runner.py
+++ b/tools/command_runner.py
@@ -585,6 +585,7 @@ class ToolInteractiveCommand:
         self._stdout_closed = threading.Event()
         self._stdout_exceeded = threading.Event()
         self._responses_read = 0
+        self._exchange_deadline: float | None = None
         self._status = ToolInteractiveStatus.START_FAILED
 
     @property
@@ -679,6 +680,7 @@ class ToolInteractiveCommand:
             else self._request.read_timeout_seconds
         )
         deadline = time.monotonic() + timeout
+        self._exchange_deadline = deadline
         while not write_complete.wait(timeout=0.05):
             abort = self._check_read_abort(deadline)
             if abort is not None:
@@ -726,7 +728,7 @@ class ToolInteractiveCommand:
             if self._responses_read == 0
             else self._request.read_timeout_seconds
         )
-        deadline = time.monotonic() + timeout
+        deadline = self._exchange_deadline or (time.monotonic() + timeout)
         response_bytes = 0
         while True:
             abort = self._check_read_abort(deadline)
@@ -745,6 +747,7 @@ class ToolInteractiveCommand:
                     if abort is not None:
                         raise abort
                     self._responses_read += 1
+                    self._exchange_deadline = None
                     return "\n".join(lines)
                 continue
             response_bytes += len(item.encode("utf-8", "replace"))

--- a/tools/command_runner.py
+++ b/tools/command_runner.py
@@ -463,6 +463,8 @@ def _finish_tool_process(
             )
     for reader in readers:
         reader.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+    if any(reader.is_alive() for reader in readers):
+        status = ToolCommandStatus.TIMED_OUT
     if status is ToolCommandStatus.EXITED:
         if stdout_overflow.is_set() or stderr_overflow.is_set():
             status = ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED

--- a/tools/command_runner.py
+++ b/tools/command_runner.py
@@ -369,6 +369,7 @@ def run_tool_command(
         stdout_overflow=stdout_overflow,
         stderr_overflow=stderr_overflow,
         sink_failure=sink_failure,
+        reader_deadline=execution_deadline,
         cleanup_deadline=absolute_deadline,
     )
 
@@ -441,6 +442,7 @@ def _finish_tool_process(
     stdout_overflow: threading.Event,
     stderr_overflow: threading.Event,
     sink_failure: queue.Queue[tuple[str, str]],
+    reader_deadline: float,
     cleanup_deadline: float,
 ) -> ToolCommandResult:
     if status is not ToolCommandStatus.EXITED:
@@ -462,9 +464,12 @@ def _finish_tool_process(
                 diagnostic="tool process did not stop within the shutdown deadline",
             )
     for reader in readers:
-        reader.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+        reader.join(timeout=max(0.0, reader_deadline - time.monotonic()))
     if any(reader.is_alive() for reader in readers):
         status = ToolCommandStatus.TIMED_OUT
+        _kill_tool_process_tree(process)
+        for reader in readers:
+            reader.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
     if status is ToolCommandStatus.EXITED:
         if stdout_overflow.is_set() or stderr_overflow.is_set():
             status = ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED

--- a/tools/command_runner.py
+++ b/tools/command_runner.py
@@ -37,6 +37,7 @@ _OPERATOR_ENVIRONMENT_ALLOWLIST = frozenset(
     }
 )
 _GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_TOOL_CLEANUP_ALLOWANCE_SECONDS = 0.5
 
 
 class ToolCommandStatus(StrEnum):
@@ -328,6 +329,12 @@ def run_tool_command(
 ) -> ToolCommandResult:
     """Execute a tooling request without shell parsing or ambient discovery."""
 
+    started = time.monotonic()
+    absolute_deadline = started + request.timeout_seconds
+    cleanup_allowance = min(
+        _TOOL_CLEANUP_ALLOWANCE_SECONDS, request.timeout_seconds / 4
+    )
+    execution_deadline = absolute_deadline - cleanup_allowance
     process = _launch_tool_process(request)
     if isinstance(process, tuple):
         return ToolCommandResult(
@@ -341,14 +348,17 @@ def run_tool_command(
         _start_stream_readers(process, request)
     )
     _start_input_writer(process, request.stdin_bytes)
-    deadline = time.monotonic() + request.timeout_seconds
-    status = _poll_tool_status(
-        process,
-        request,
-        stdout_overflow,
-        stderr_overflow,
-        sink_failure,
-        deadline,
+    status = (
+        ToolCommandStatus.TIMED_OUT
+        if time.monotonic() >= execution_deadline
+        else _poll_tool_status(
+            process,
+            request,
+            stdout_overflow,
+            stderr_overflow,
+            sink_failure,
+            execution_deadline,
+        )
     )
     return _finish_tool_process(
         process,
@@ -359,6 +369,7 @@ def run_tool_command(
         stdout_overflow=stdout_overflow,
         stderr_overflow=stderr_overflow,
         sink_failure=sink_failure,
+        cleanup_deadline=absolute_deadline,
     )
 
 
@@ -430,15 +441,16 @@ def _finish_tool_process(
     stdout_overflow: threading.Event,
     stderr_overflow: threading.Event,
     sink_failure: queue.Queue[tuple[str, str]],
+    cleanup_deadline: float,
 ) -> ToolCommandResult:
     if status is not ToolCommandStatus.EXITED:
         _kill_tool_process_tree(process)
     try:
-        process.wait(timeout=5.0)
+        process.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
     except subprocess.TimeoutExpired:
         process.kill()
         try:
-            process.wait(timeout=5.0)
+            process.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
         except subprocess.TimeoutExpired:
             return ToolCommandResult(
                 status=status,
@@ -450,7 +462,7 @@ def _finish_tool_process(
                 diagnostic="tool process did not stop within the shutdown deadline",
             )
     for reader in readers:
-        reader.join(timeout=1.0)
+        reader.join(timeout=max(0.0, cleanup_deadline - time.monotonic()))
     if status is ToolCommandStatus.EXITED:
         if stdout_overflow.is_set() or stderr_overflow.is_set():
             status = ToolCommandStatus.OUTPUT_LIMIT_EXCEEDED
@@ -486,7 +498,7 @@ class ToolInteractiveRequest:
     """Immutable request for one long-lived interactive tooling process.
 
     The process owns its own process group, bounded stderr capture, startup
-    deadline, per-read deadline, and shutdown deadline.  Callers exchange
+    deadline, per-exchange deadline, and shutdown deadline.  Callers exchange
     line-delimited request/response frames through the typed
     :class:`ToolInteractiveCommand` methods and never touch ``subprocess``
     directly.
@@ -639,17 +651,48 @@ class ToolInteractiveCommand:
             self._stdout_queue.put(line)
 
     def send(self, frame: str) -> None:
-        """Write one request frame (without trailing newline) to the child stdin."""
+        """Write one request frame (without trailing newline) within its deadline."""
         if self._process is None or self._process.stdin is None:
             raise RuntimeError("interactive process is not started")
-        try:
-            self._process.stdin.write(frame + "\n\n")
-            self._process.stdin.flush()
-        except (BrokenPipeError, OSError) as exc:
+        if not isinstance(frame, str):
+            raise TypeError("interactive frame must be a string")
+
+        write_failure: queue.Queue[BaseException] = queue.Queue(maxsize=1)
+        write_complete = threading.Event()
+        stdin = self._process.stdin
+
+        def write_frame() -> None:
+            try:
+                stdin.write(frame + "\n\n")
+                stdin.flush()
+            except Exception as exc:  # surfaced on the caller thread below
+                write_failure.put(exc)
+            finally:
+                write_complete.set()
+
+        threading.Thread(target=write_frame, daemon=True).start()
+        timeout = (
+            self._request.startup_timeout_seconds
+            if self._responses_read == 0
+            else self._request.read_timeout_seconds
+        )
+        deadline = time.monotonic() + timeout
+        while not write_complete.wait(timeout=0.05):
+            abort = self._check_read_abort(deadline)
+            if abort is not None:
+                raise abort
+        abort = self._check_read_abort(deadline)
+        if abort is not None:
+            raise abort
+        if write_failure.empty():
+            return
+        exc = write_failure.get_nowait()
+        if isinstance(exc, (BrokenPipeError, OSError)):
             self._abort(ToolInteractiveStatus.CLOSED)
             raise RuntimeError(
                 "interactive process closed before receiving input"
             ) from exc
+        raise RuntimeError("interactive process failed while receiving input") from exc
 
     def _check_read_abort(self, deadline: float) -> Exception | None:
         """Return an abort exception if a read must stop, else ``None``."""

--- a/tools/inventory_github_workflows.py
+++ b/tools/inventory_github_workflows.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 
-from tools.command_runner import ToolCommandStatus, run_operator_command
+from tools.command_runner import (
+    ToolCommandStatus,
+    operator_environment,
+    run_operator_command,
+)
 
 HISTORICAL_PREFIXES = ("agent-port-", "agent-rebase-")
 WORKFLOW_LIST_LIMIT = 1000
@@ -90,7 +93,16 @@ def _registered_from_gh() -> set[str]:
         timeout_seconds=30.0,
         stdout_limit_bytes=4 * 1024 * 1024,
         stderr_limit_bytes=1024 * 1024,
-        environment={"PATH": os.environ.get("PATH", "")},
+        environment=operator_environment(
+            include=(
+                "PATH",
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "GH_CONFIG_DIR",
+                "XDG_CONFIG_HOME",
+                "HOME",
+            )
+        ),
     )
     if completed.status is not ToolCommandStatus.EXITED or completed.exit_code != 0:
         diagnostic = completed.stderr.decode("utf-8", "replace").strip()

--- a/tools/inventory_github_workflows.py
+++ b/tools/inventory_github_workflows.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
+import os
 from pathlib import Path
+
+from tools.command_runner import ToolCommandStatus, run_operator_command
 
 HISTORICAL_PREFIXES = ("agent-port-", "agent-rebase-")
 WORKFLOW_LIST_LIMIT = 1000
@@ -80,15 +82,24 @@ def _stems_from_workflow_rows(rows: object) -> set[str]:
 
 
 def _registered_from_gh() -> set[str]:
-    completed = subprocess.run(
-        _workflow_list_command(),
-        check=False,
-        capture_output=True,
-        text=True,
+    command = _workflow_list_command()
+    completed = run_operator_command(
+        command[0],
+        command[1:],
+        cwd=Path.cwd().resolve(),
+        timeout_seconds=30.0,
+        stdout_limit_bytes=4 * 1024 * 1024,
+        stderr_limit_bytes=1024 * 1024,
+        environment={"PATH": os.environ.get("PATH", "")},
     )
-    if completed.returncode != 0:
-        raise SystemExit(completed.stderr.strip() or "gh workflow list failed")
-    return _stems_from_workflow_rows(json.loads(completed.stdout))
+    if completed.status is not ToolCommandStatus.EXITED or completed.exit_code != 0:
+        diagnostic = completed.stderr.decode("utf-8", "replace").strip()
+        raise SystemExit(
+            diagnostic or completed.diagnostic or "gh workflow list failed"
+        )
+    return _stems_from_workflow_rows(
+        json.loads(completed.stdout.decode("utf-8", "strict"))
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/process_supervisor.py
+++ b/tools/process_supervisor.py
@@ -28,14 +28,15 @@ class ProcessTreeResult:
 def _stream(stream: object) -> Callable[[bytes], None] | None:
     """Return a byte sink for an inherited text or binary stream."""
 
-    binary = getattr(stream, "buffer", stream)
-    write = getattr(binary, "write", None)
-    flush = getattr(binary, "flush", None)
+    binary = getattr(stream, "buffer", None)
+    target = binary if binary is not None else stream
+    write = getattr(target, "write", None)
+    flush = getattr(target, "flush", None)
     if not callable(write):
         return None
 
     def sink(block: bytes) -> None:
-        write(block)
+        write(block if binary is not None else block.decode("utf-8", "replace"))
         if callable(flush):
             flush()
 

--- a/tools/process_supervisor.py
+++ b/tools/process_supervisor.py
@@ -1,48 +1,45 @@
-"""Supervise one child process tree and kill every descendant on timeout."""
+"""Compatibility projection for bounded repository command execution."""
 
 from __future__ import annotations
 
 import os
-import signal
-import subprocess
-from collections.abc import Mapping, Sequence
-from contextlib import suppress
+import sys
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-_GRACEFUL_SHUTDOWN_SECONDS = 5.0
+from tools.command_runner import (
+    ToolCommandRequest,
+    ToolCommandStatus,
+    run_tool_command,
+)
+
+_PROCESS_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
 class ProcessTreeResult:
-    """Exit status of one supervised process tree."""
+    """Exit status of one repository command tree."""
 
     exit_code: int
     timed_out: bool
 
 
-def kill_process_tree(process: subprocess.Popen[bytes]) -> None:
-    """Terminate a child and every descendant in its process group or job."""
+def _stream(stream: object) -> Callable[[bytes], None] | None:
+    """Return a byte sink for an inherited text or binary stream."""
 
-    if os.name == "posix":
-        with suppress(ProcessLookupError, PermissionError):
-            os.killpg(process.pid, signal.SIGTERM)
-        with suppress(subprocess.TimeoutExpired):
-            process.wait(timeout=_GRACEFUL_SHUTDOWN_SECONDS)
-        # The root process can exit after SIGTERM while a descendant that
-        # ignored the signal remains. Always SIGKILL the group.
-        with suppress(ProcessLookupError, PermissionError):
-            os.killpg(process.pid, signal.SIGKILL)
-        with suppress(subprocess.TimeoutExpired, ProcessLookupError):
-            process.wait(timeout=_GRACEFUL_SHUTDOWN_SECONDS)
-        return
-    process.terminate()
-    try:
-        process.wait(timeout=_GRACEFUL_SHUTDOWN_SECONDS)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        with suppress(subprocess.TimeoutExpired):
-            process.wait(timeout=_GRACEFUL_SHUTDOWN_SECONDS)
+    binary = getattr(stream, "buffer", stream)
+    write = getattr(binary, "write", None)
+    flush = getattr(binary, "flush", None)
+    if not callable(write):
+        return None
+
+    def sink(block: bytes) -> None:
+        write(block)
+        if callable(flush):
+            flush()
+
+    return sink
 
 
 def run_process_tree(
@@ -52,24 +49,30 @@ def run_process_tree(
     cwd: Path,
     env: Mapping[str, str] | None = None,
 ) -> ProcessTreeResult:
-    """Run ``command`` in a new process group and kill the tree on timeout.
+    """Run one absolute repository command under the shared bounded runner."""
 
-    Standard streams are inherited. The returned exit code is the child's
-    actual status, or ``1`` when the outer deadline fires.
-    """
-
+    if not command:
+        raise ValueError("command must not be empty")
     if timeout <= 0:
         raise ValueError("timeout must be positive")
-    process = subprocess.Popen(
-        list(command),
-        cwd=cwd,
-        env=None if env is None else dict(env),
-        start_new_session=os.name == "posix",
-        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+    request = ToolCommandRequest(
+        executable=command[0],
+        arguments=tuple(command[1:]),
+        environment=dict(os.environ) if env is None else env,
+        cwd=str(cwd.resolve()),
+        timeout_seconds=timeout,
+        stdout_limit_bytes=_PROCESS_OUTPUT_LIMIT_BYTES,
+        stderr_limit_bytes=_PROCESS_OUTPUT_LIMIT_BYTES,
+        stdout_sink=_stream(sys.stdout),
+        stderr_sink=_stream(sys.stderr),
     )
-    try:
-        returncode = process.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        kill_process_tree(process)
-        return ProcessTreeResult(exit_code=1, timed_out=True)
-    return ProcessTreeResult(exit_code=int(returncode), timed_out=False)
+    completed = run_tool_command(request)
+    return ProcessTreeResult(
+        exit_code=(
+            completed.exit_code
+            if completed.status is ToolCommandStatus.EXITED
+            and completed.exit_code is not None
+            else 1
+        ),
+        timed_out=completed.status is ToolCommandStatus.TIMED_OUT,
+    )


### PR DESCRIPTION
## Problem

Repository helpers still had direct command paths with independent cleanup clocks and blocking interactive writes. This made local validation and inventory work harder to cancel or bound consistently.

Fixes #2731 and #2732.

Related, but intentionally not closed: #2733. This PR makes writes deadline-aware, but the remaining issue requires a distinct bounded frame/queue policy and blocked-writer lifecycle proof.

## Solution

- Give the repository command runner one absolute execution-and-cleanup envelope.
- Make interactive writes cancellable and deadline-aware.
- Migrate affected validation, repository hygiene, workflow inventory, and process supervision to the bounded runner, including Git metadata queries.

## Testing

- `make affected`
- `uv run pytest tests/tooling/test_affected_validation.py tests/process/tooling/test_command_runner.py -q`
- `uv run python tools/check_architecture.py`

## Public contract impact

None. This changes repository-maintenance execution only.

## Operation boundary ownership

Not applicable; this is repository tooling rather than a mathematical operation boundary.

## Checklist

- [x] Tooling command lifecycle is bounded through launch, I/O, termination, and reaping
- [x] Direct arbitrary-command callers use the shared runner
- [x] Focused tooling and process tests pass