### PR TITLE
Remove owner replay and bound validation execution

### DIFF
--- a/src/jacobian/math/additive_combinatorics/_operations.py
+++ b/src/jacobian/math/additive_combinatorics/_operations.py
@@ -32,8 +32,15 @@ from jacobian.math.additive_combinatorics._subset_sum_profile import (
     subset_sum_profile_counts,
     subset_sum_profile_envelope,
 )
+from jacobian.math.additive_combinatorics._subset_sum_target import (
+    SubsetSumTargetRequest,
+    SubsetSumTargetResult,
+)
+from jacobian.math.additive_combinatorics._subset_sum_target_kernel import (
+    _solve_subset_sum_target,
+)
 from jacobian.math.additive_combinatorics.operations import subset_sum_profile
-from jacobian.math.additive_combinatorics.values import SubsetSumProfile
+from jacobian.math.additive_combinatorics.values import IndexSubset, SubsetSumProfile
 
 
 def _parse_set(spec: FiniteIntegerSet) -> frozenset[int]:
@@ -104,6 +111,37 @@ def compute_subset_sum_profile(
     """Compute the complete exact indexed-subset sum profile."""
 
     return subset_sum_profile(request.source)
+
+
+def verify_subset_sum_target_result(result: SubsetSumTargetResult) -> bool:
+    """Verify an independently supplied target decision within its envelope."""
+
+    try:
+        request = SubsetSumTargetRequest(
+            source=result.source,
+            target=result.target,
+            allow_empty_subset=result.allow_empty_subset,
+        )
+        values = tuple(parse_canonical_integer(value) for value in request.source.items)
+        target = parse_canonical_integer(request.target)
+        indices = _solve_subset_sum_target(
+            values, target, allow_empty_subset=request.allow_empty_subset
+        )
+    except ValueError:
+        return False
+    if indices is None:
+        return (
+            result.status == "NOT_ATTAINED"
+            and result.witness is None
+            and result.reconstructed_sum is None
+        )
+    return (
+        result.status == "ATTAINED"
+        and result.witness == IndexSubset(indices=indices)
+        and result.reconstructed_sum
+        == format_canonical_integer(sum(values[index] for index in indices))
+        and sum(values[index] for index in indices) == target
+    )
 
 
 def compute_additive_energy(

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
@@ -25,12 +25,10 @@ from jacobian.math.additive_combinatorics.values import (
 MAX_SUBSET_SUM_INTEGER_DIGITS = 256
 MAX_SUBSET_SUM_REACHABLE_STATES = 65_536
 MAX_SUBSET_SUM_TRANSITIONS_PER_PASS = 500_000
-# One complete public call performs four charged DP-equivalent passes: the
-# request admission scan, the solver kernel, and their source-binding replays
-# inside result validation. Each pass inspects the same reachable states
-# through the same resolving prefix, so charging four identical per-pass
-# ceilings bounds every accepted complete call.
-MAX_SUBSET_SUM_COMPLETE_CALL_PASSES = 4
+# One complete public call performs two charged DP-equivalent passes: request
+# admission and the solver kernel. Independent claims are checked explicitly
+# by the owner verifier, rather than as a result-model side effect.
+MAX_SUBSET_SUM_COMPLETE_CALL_PASSES = 2
 MAX_SUBSET_SUM_TOTAL_TRANSITIONS = (
     MAX_SUBSET_SUM_COMPLETE_CALL_PASSES * MAX_SUBSET_SUM_TRANSITIONS_PER_PASS
 )
@@ -143,11 +141,10 @@ def _require_admitted_work(
     prefix replay never resolves must fit the exhaustive reachable-state and
     transition bounds across the whole source before execution.
 
-    The public path performs this scan twice (request admission and its
-    source-binding replay inside result validation) and runs the kernel
-    equally often (computation and validation replay). Each pass inspects the
-    same reachable states through the same prefix, so charging four identical
-    per-pass ceilings bounds every accepted complete call by
+    The public path performs this scan once for request admission and runs the
+    kernel once for computation. Each pass inspects the same reachable states
+    through the same prefix, so charging two identical per-pass ceilings bounds
+    every accepted complete call by
     ``MAX_SUBSET_SUM_TOTAL_TRANSITIONS``.
     """
 
@@ -361,57 +358,34 @@ class SubsetSumTargetResult(StrictModel):
                 )
         return prepared
 
-    @model_validator(mode="after")
-    def bind_decision_to_source(self) -> Self:
-        request = SubsetSumTargetRequest(
-            source=self.source,
-            target=self.target,
-            allow_empty_subset=self.allow_empty_subset,
-        )
+    @classmethod
+    def _from_kernel(
+        cls,
+        request: SubsetSumTargetRequest,
+        indices: tuple[int, ...] | None,
+    ) -> Self:
+        """Construct trusted output without replaying the target search."""
+
+        if indices is None:
+            return cls.model_construct(
+                source=request.source,
+                target=request.target,
+                allow_empty_subset=request.allow_empty_subset,
+                status="NOT_ATTAINED",
+                witness=None,
+                reconstructed_sum=None,
+            )
         values = tuple(parse_canonical_integer(value) for value in request.source.items)
-        target = parse_canonical_integer(request.target)
-        expected_indices = _solve_subset_sum_target(
-            values,
-            target,
+        return cls.model_construct(
+            source=request.source,
+            target=request.target,
             allow_empty_subset=request.allow_empty_subset,
+            status="ATTAINED",
+            witness=IndexSubset(indices=indices),
+            reconstructed_sum=format_canonical_integer(
+                sum(values[index] for index in indices)
+            ),
         )
-
-        if expected_indices is None:
-            if self.status != "NOT_ATTAINED":
-                raise _validation_error(
-                    "bind_decision_to_source",
-                    "status must report the exhaustive target decision",
-                )
-            if self.witness is not None or self.reconstructed_sum is not None:
-                raise _validation_error(
-                    "bind_decision_to_source",
-                    "an unattained target cannot carry a witness or sum",
-                )
-            return self
-
-        if self.status != "ATTAINED":
-            raise _validation_error(
-                "bind_decision_to_source",
-                "status must report the exhaustive target decision",
-            )
-        expected_witness = IndexSubset(indices=expected_indices)
-        if self.witness != expected_witness:
-            raise _validation_error(
-                "bind_decision_to_source",
-                "witness must be the canonical attaining index subset",
-            )
-        expected_sum = sum(values[index] for index in expected_indices)
-        expected_sum_wire = format_canonical_integer(expected_sum)
-        if self.reconstructed_sum != expected_sum_wire:
-            raise _validation_error(
-                "bind_decision_to_source",
-                "reconstructed_sum must equal the witness sum",
-            )
-        if expected_sum != target:
-            raise _validation_error(
-                "bind_decision_to_source", "witness sum must equal the requested target"
-            )
-        return self
 
 
 def solve_subset_sum_target_request(
@@ -427,22 +401,9 @@ def solve_subset_sum_target_request(
         allow_empty_subset=request.allow_empty_subset,
     )
     if indices is None:
-        return SubsetSumTargetResult(
-            source=request.source,
-            target=request.target,
-            allow_empty_subset=request.allow_empty_subset,
-            status="NOT_ATTAINED",
-        )
+        return SubsetSumTargetResult._from_kernel(request, None)
 
-    reconstructed_sum = sum(values[index] for index in indices)
-    return SubsetSumTargetResult(
-        source=request.source,
-        target=request.target,
-        allow_empty_subset=request.allow_empty_subset,
-        status="ATTAINED",
-        witness=IndexSubset(indices=indices),
-        reconstructed_sum=format_canonical_integer(reconstructed_sum),
-    )
+    return SubsetSumTargetResult._from_kernel(request, indices)
 
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:

--- a/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
+++ b/src/jacobian/math/additive_combinatorics/_subset_sum_target.py
@@ -291,6 +291,21 @@ class SubsetSumTargetResult(StrictModel):
         description="The exact sum reconstructed from an attaining witness.",
     )
 
+    @model_validator(mode="after")
+    def require_result_branch_shape(self) -> Self:
+        if self.status == "ATTAINED":
+            if self.witness is None or self.reconstructed_sum is None:
+                raise _validation_error(
+                    "result_branch_shape",
+                    "an ATTAINED result requires a witness and reconstructed sum",
+                )
+        elif self.witness is not None or self.reconstructed_sum is not None:
+            raise _validation_error(
+                "result_branch_shape",
+                "a NOT_ATTAINED result cannot carry a witness or reconstructed sum",
+            )
+        return self
+
     @model_validator(mode="before")
     @classmethod
     def bound_raw_result(cls, value: object) -> object:

--- a/src/jacobian/math/greedoids/_models.py
+++ b/src/jacobian/math/greedoids/_models.py
@@ -19,6 +19,18 @@ MAX_FEASIBLE_COUNT = 4096
 MAX_EXCHANGE_WORK = 2_000_000
 """Maximum ordered exchange candidate-membership checks per recognition."""
 
+MAX_GROUND_LABEL_UTF8_BYTES = 1_024
+"""Maximum UTF-8 size of one retained ground label."""
+
+MAX_GROUND_LABEL_TOTAL_UTF8_BYTES = 65_536
+"""Maximum UTF-8 storage for all retained ground labels."""
+
+MAX_INTERMEDIATE_MEMBERSHIPS = 262_144
+"""Maximum feasible-row membership storage inspected by a kernel."""
+
+MAX_RESULT_BYTES = 2_000_000
+"""Conservative bound for complete index-family results."""
+
 
 def _validation_error(reason: str, message: str) -> PydanticCustomError:
     """Build a stable validation error owned by greedoid contracts."""
@@ -52,22 +64,58 @@ def require_bounded_carrier(system: FiniteFeasibleSetSystem) -> None:
             f"feasible-set count exceeds the bounded budget of "
             f"{MAX_FEASIBLE_COUNT} rows",
         )
+    label_bytes = 0
+    for label in system.ground:
+        try:
+            encoded_length = len(label.encode("utf-8"))
+        except UnicodeError as exc:
+            raise GreedoidAdmissionError(
+                "ground_label_invalid_utf8",
+                "ground labels must be UTF-8 encodable",
+            ) from exc
+        if encoded_length > MAX_GROUND_LABEL_UTF8_BYTES:
+            raise GreedoidAdmissionError(
+                "ground_label_exceeds_budget",
+                "a ground label exceeds the bounded UTF-8 size budget",
+            )
+        label_bytes += encoded_length
+    if label_bytes > MAX_GROUND_LABEL_TOTAL_UTF8_BYTES:
+        raise GreedoidAdmissionError(
+            "ground_labels_exceed_budget",
+            "ground labels exceed the bounded UTF-8 storage budget",
+        )
     by_size: dict[int, int] = {}
     memberships = 0
     for row in system.feasible:
         by_size[len(row)] = by_size.get(len(row), 0) + 1
         memberships += len(row)
+    if memberships > MAX_INTERMEDIATE_MEMBERSHIPS:
+        raise GreedoidAdmissionError(
+            "intermediate_memberships_exceed_budget",
+            "feasible-set memberships exceed the bounded intermediate-storage budget",
+        )
     exchange_pairs = sum(
         larger_count * smaller_count
         for larger_size, larger_count in by_size.items()
         for smaller_size, smaller_count in by_size.items()
         if larger_size > smaller_size
     )
-    exchange_work = exchange_pairs * len(system.ground)
-    if exchange_work > MAX_EXCHANGE_WORK:
+    candidate_membership_probes = exchange_pairs * len(system.ground)
+    accessibility_probes = memberships
+    total_probes = candidate_membership_probes + accessibility_probes
+    if total_probes > MAX_EXCHANGE_WORK:
         raise GreedoidAdmissionError(
             "exchange_work_exceeds_budget",
-            "exhaustive exchange candidate-membership work exceeds the bounded budget",
+            "exhaustive exchange and accessibility membership work exceeds the bounded budget",
+        )
+    # Recognition and bases can retain every feasible row. Charge the exact
+    # index-family shape, including tuple delimiters and the source labels,
+    # before any kernel allocates its working index.
+    result_bytes = label_bytes + memberships * 3 + len(system.feasible) * 16
+    if result_bytes > MAX_RESULT_BYTES:
+        raise GreedoidAdmissionError(
+            "result_exceeds_budget",
+            "the complete greedoid result exceeds the bounded result budget",
         )
 
 
@@ -121,7 +169,7 @@ class RankRequest(StrictModel):
     """Compute greedoid rank for an optional ground subset."""
 
     system: FiniteFeasibleSetSystem
-    subset: tuple[int, ...] | None = Field(default=None)
+    subset: tuple[int, ...] | None = Field(default=None, max_length=MAX_GROUND_SIZE)
 
     @model_validator(mode="after")
     def require_valid_subset(self) -> Self:
@@ -170,7 +218,7 @@ class BasesRequest(StrictModel):
     """Compute the maximal feasible subsets (bases)."""
 
     system: FiniteFeasibleSetSystem
-    subset: tuple[int, ...] | None = Field(default=None)
+    subset: tuple[int, ...] | None = Field(default=None, max_length=MAX_GROUND_SIZE)
 
     @model_validator(mode="after")
     def require_valid_subset(self) -> Self:
@@ -219,7 +267,7 @@ class BasicWordProfileRequest(StrictModel):
     """Profile a candidate basic word."""
 
     system: FiniteFeasibleSetSystem
-    word: tuple[int, ...] = Field(default=())
+    word: tuple[int, ...] = Field(default=(), max_length=MAX_GROUND_SIZE)
 
     @model_validator(mode="after")
     def require_bounded_system(self) -> Self:

--- a/src/jacobian/process.py
+++ b/src/jacobian/process.py
@@ -486,7 +486,11 @@ def run_bounded_process(
             process.stdout.close()
             process.stderr.close()
             for reader in readers:
-                reader.join(timeout=0.1)
+                # Closing the pipes can unblock a reader that was still
+                # draining when the shared cleanup deadline expired.  Give
+                # it only the time remaining in that same envelope; never
+                # append a fresh grace period after the request has ended.
+                reader.join(timeout=max(0.0, absolute_deadline - time.monotonic()))
 
     return BoundedProcessResult(
         returncode=process.returncode,

--- a/tests/math/additive_combinatorics/test_subset_sum_target.py
+++ b/tests/math/additive_combinatorics/test_subset_sum_target.py
@@ -13,6 +13,9 @@ from jacobian.math.additive_combinatorics import (
     IndexSubset,
     subset_sum_profile,
 )
+from jacobian.math.additive_combinatorics._operations import (
+    verify_subset_sum_target_result,
+)
 from jacobian.math.additive_combinatorics._subset_sum_residue import (
     SubsetSumResidueProfileRequest,
     compute_subset_sum_residue_profile,
@@ -179,7 +182,7 @@ def test_input_permutations_preserve_status_and_transport_a_witness() -> None:
         assert sum(values[index] for index in result.witness.indices) == 3
 
 
-def test_result_rejects_source_decision_and_witness_mutations() -> None:
+def test_verifier_rejects_source_decision_and_witness_mutations() -> None:
     valid = _operation().run(_request((3, 2, 5), 5, allow_empty_subset=False))
     payload = valid.model_dump(mode="json")
     mutations = (
@@ -195,14 +198,14 @@ def test_result_rejects_source_decision_and_witness_mutations() -> None:
         {**payload, "reconstructed_sum": "6"},
     )
     for mutation in mutations:
-        with pytest.raises(ValidationError):
-            SubsetSumTargetResult.model_validate(mutation)
+        candidate = SubsetSumTargetResult.model_validate(mutation)
+        assert not verify_subset_sum_target_result(candidate)
 
     empty = _operation().run(_request((), 0, allow_empty_subset=True))
-    with pytest.raises(ValidationError):
-        SubsetSumTargetResult.model_validate(
-            {**empty.model_dump(mode="json"), "allow_empty_subset": False}
-        )
+    candidate = SubsetSumTargetResult.model_validate(
+        {**empty.model_dump(mode="json"), "allow_empty_subset": False}
+    )
+    assert not verify_subset_sum_target_result(candidate)
 
 
 def test_result_bounds_raw_witness_and_sum_before_replay() -> None:
@@ -244,19 +247,19 @@ def test_request_admits_large_low_state_and_exact_digit_and_state_boundaries() -
 def test_request_rejects_immediately_above_each_search_bound() -> None:
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={"items": ["1" + "0" * 256]},
+            source={"items": ["1" + "0" * 256]},  # type: ignore[arg-type]
             target="0",
             allow_empty_subset=False,
         )
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={"items": ["-" + "9" * 256]},
+            source={"items": ["-" + "9" * 256]},  # type: ignore[arg-type]
             target="-" + "9" * 263,
             allow_empty_subset=True,
         )
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={"items": ["-" + "9" * 256]},
+            source={"items": ["-" + "9" * 256]},  # type: ignore[arg-type]
             target="9" * 263,
             allow_empty_subset=True,
         )
@@ -265,7 +268,7 @@ def test_request_rejects_immediately_above_each_search_bound() -> None:
     above_wire_count = (4 * 1024 * 1024 - 64) // (len(widest) + 4) + 1
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={"items": [widest] * above_wire_count},
+            source={"items": [widest] * above_wire_count},  # type: ignore[arg-type]
             target="0",
             allow_empty_subset=True,
         )
@@ -284,7 +287,7 @@ def test_request_rejects_immediately_above_each_search_bound() -> None:
     # pushes 2**17 reachable states past the 65,536-state bound.
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={
+            source={  # type: ignore[arg-type]
                 "items": [str(1 << exponent) for exponent in range(16)] + ["131072"]
             },
             target="100000",
@@ -459,7 +462,7 @@ def test_request_resolves_targets_beyond_the_derived_subset_sum_width() -> None:
 
     wide = _operation().run(
         SubsetSumTargetRequest(
-            source={"items": []},
+            source={"items": []},  # type: ignore[arg-type]
             target="1" + "0" * 256,
             allow_empty_subset=False,
         )
@@ -564,7 +567,9 @@ def test_resolving_scan_is_charged_against_the_transition_bound() -> None:
 
     with pytest.raises(ValidationError):
         SubsetSumTargetRequest(
-            source={"items": [str(value) for value in powers + (0,) * 6 + (1,)]},
+            source={  # type: ignore[arg-type]
+                "items": [str(value) for value in powers + (0,) * 6 + (1,)]
+            },
             target=target,
             allow_empty_subset=True,
         )

--- a/tests/math/greedoids/test_greedoids.py
+++ b/tests/math/greedoids/test_greedoids.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from jacobian.math import greedoids
 from jacobian.math.greedoids import FiniteFeasibleSetSystem
 from jacobian.math.greedoids._models import (
+    MAX_GROUND_LABEL_UTF8_BYTES,
     BasesRequest,
     BasesResult,
     BasicWordProfileRequest,
@@ -104,6 +105,18 @@ def test_catalog_contains_only_audited_agent_outcomes() -> None:
         "greedoid.basic_word.profile.compute",
         "greedoid.convex_geometry.compute",
     }
+
+
+def test_recognition_rejects_a_ground_label_outside_utf8_budget() -> None:
+    with pytest.raises(ValidationError, match="ground_label_exceeds_budget"):
+        compute_recognize(
+            RecognizeRequest(
+                system=FiniteFeasibleSetSystem(
+                    ground=("x" * (MAX_GROUND_LABEL_UTF8_BYTES + 1),),
+                    feasible=((),),
+                )
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tooling/test_validation_lock.py
+++ b/tests/tooling/test_validation_lock.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 import pytest
+import tools.with_validation_lock as validation_lock
 from tools.with_validation_lock import main
 
 ROOT = Path(__file__).parents[2]
@@ -57,3 +58,25 @@ def test_second_broad_run_is_rejected_while_lock_is_held(
     finally:
         holder.wait(timeout=15)
     assert holder.returncode == 0
+
+
+def test_timed_out_command_releases_the_validation_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_worktree(tmp_path))
+    monkeypatch.setattr(validation_lock, "_VALIDATION_TIMEOUT_SECONDS", 0.2)
+
+    result = main(
+        [
+            "run",
+            "--target",
+            "test-timeout",
+            "--",
+            sys.executable,
+            "-c",
+            "import time; time.sleep(30)",
+        ]
+    )
+
+    assert result != 0
+    assert main(["status"]) == 0

--- a/tools/with_validation_lock.py
+++ b/tools/with_validation_lock.py
@@ -26,7 +26,13 @@ from tools.command_runner import (  # noqa: E402
 LOCK_NAME = ".jacobian-validation.lock"
 _VALIDATION_TIMEOUT_SECONDS = 4_800.0
 _VALIDATION_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024
-_VALIDATION_ENVIRONMENT = ("PATH", "VIRTUAL_ENV", "UV_CACHE_DIR", "UV_PYTHON_INSTALL_DIR")
+_VALIDATION_ENVIRONMENT = (
+    "PATH",
+    "VIRTUAL_ENV",
+    "UV_CACHE_DIR",
+    "UV_PYTHON_INSTALL_DIR",
+    "MAKEFLAGS",
+)
 
 
 def _repo_root() -> Path:

--- a/tools/with_validation_lock.py
+++ b/tools/with_validation_lock.py
@@ -6,12 +6,27 @@ import argparse
 import fcntl
 import json
 import os
-import subprocess
+import shutil
+import sys
 import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.command_runner import (  # noqa: E402
+    ToolCommandRequest,
+    ToolCommandStatus,
+    operator_environment,
+    run_tool_command,
+)
+
 LOCK_NAME = ".jacobian-validation.lock"
+_VALIDATION_TIMEOUT_SECONDS = 4_800.0
+_VALIDATION_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024
+_VALIDATION_ENVIRONMENT = ("PATH", "VIRTUAL_ENV", "UV_CACHE_DIR", "UV_PYTHON_INSTALL_DIR")
 
 
 def _repo_root() -> Path:
@@ -35,6 +50,21 @@ def _read_payload(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise SystemExit("validation lock payload must be an object")
     return payload
+
+
+def _stream_to(stream: Any) -> Any:
+    """Return a byte sink that preserves the wrapped command's output."""
+
+    binary = getattr(stream, "buffer", None)
+    target = binary if binary is not None else stream
+
+    def sink(block: bytes) -> None:
+        target.write(block if binary is not None else block.decode("utf-8", "replace"))
+        flush = getattr(target, "flush", None)
+        if callable(flush):
+            flush()
+
+    return sink
 
 
 def _run(target: str, command: list[str]) -> int:
@@ -61,7 +91,33 @@ def _run(target: str, command: list[str]) -> int:
         os.lseek(fd, 0, os.SEEK_SET)
         os.write(fd, encoded)
         os.fsync(fd)
-        return subprocess.call(command)
+        executable = command[0]
+        if Path(executable).is_absolute():
+            resolved = str(Path(executable).resolve(strict=True))
+        else:
+            candidate = shutil.which(executable)
+            if candidate is None:
+                print(f"validation command is unavailable: {executable}", file=sys.stderr)
+                return 127
+            resolved = candidate
+        result = run_tool_command(
+            ToolCommandRequest(
+                executable=resolved,
+                arguments=tuple(command[1:]),
+                environment=operator_environment(include=_VALIDATION_ENVIRONMENT),
+                cwd=str(root.resolve(strict=True)),
+                timeout_seconds=_VALIDATION_TIMEOUT_SECONDS,
+                stdout_limit_bytes=_VALIDATION_OUTPUT_LIMIT_BYTES,
+                stderr_limit_bytes=_VALIDATION_OUTPUT_LIMIT_BYTES,
+                stdout_sink=_stream_to(sys.stdout),
+                stderr_sink=_stream_to(sys.stderr),
+            )
+        )
+        if result.status is ToolCommandStatus.EXITED and result.exit_code is not None:
+            return result.exit_code
+        if result.diagnostic:
+            print(result.diagnostic, file=sys.stderr)
+        return 124 if result.status is ToolCommandStatus.TIMED_OUT else 125
     finally:
         os.close(fd)
 


### PR DESCRIPTION
## Problem
Several bounded owner paths still replayed mathematical work during trusted result construction, while Greedoid admission omitted important intermediate and exact-result costs. Repository validation commands also bypassed the bounded command runner.

## Solution
- Use trusted subset-sum result construction and an explicit bounded verifier for independent claims.
- Account for Greedoid label bytes, feasible memberships, exchange/accessibility probes, and complete result size.
- Keep process cleanup within the absolute deadline and route the validation lock through the bounded command runner.

## Testing
- Focused additive-combinatorics, Greedoid, process, and tooling tests
- `make affected AFFECTED_BASE=origin/main` lint/format stages
- Architecture scan and full Harbor validation
- Remote CI: math, MCP/process boundaries, tooling, catalog, wheels, and required gate passed

## Public contract impact
No operation IDs or transport schemas change. Trusted construction removes producer-side replay; independent result data remains explicitly verifiable.

## Related issues
Fixes #2742
Fixes #2762
Fixes #2732

## Intentionally unchanged
No process-wide execution lock, synthetic response cap, workflow executor, durable state, or global execution serialization is introduced.
