### PR TITLE
Bound Harbor validation producer execution

### DIFF
--- a/benchmarks/tooling/harbor_suite.py
+++ b/benchmarks/tooling/harbor_suite.py
@@ -19,7 +19,11 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-from tools.command_runner import ToolCommandStatus, run_operator_command
+from tools.command_runner import (
+    ToolCommandStatus,
+    operator_environment,
+    run_operator_command,
+)
 
 from benchmarks.tooling.errors import HarborSuiteError
 from benchmarks.tooling.harbor_digest import (
@@ -856,6 +860,12 @@ def _is_ignored_python_cache(path: Path) -> bool:
         timeout_seconds=10.0,
         stdout_limit_bytes=4096,
         stderr_limit_bytes=4096,
+        environment={
+            **operator_environment(),
+            # Do not accidentally consult a parent repository when a caller
+            # supplies an isolated synthetic Harbor root.
+            "GIT_CEILING_DIRECTORIES": str(ROOT.parent),
+        },
     )
     return result.status is ToolCommandStatus.EXITED and result.exit_code == 0
 

--- a/benchmarks/validation/_solution.py
+++ b/benchmarks/validation/_solution.py
@@ -1,0 +1,51 @@
+"""Bounded execution helpers for task solution and oracle programs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from tools.command_runner import (
+    ToolCommandRequest,
+    ToolCommandStatus,
+    operator_environment,
+    run_tool_command,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+_OUTPUT_LIMIT_BYTES = 64 * 1024 * 1024
+_ENVIRONMENT = ("PATH", "PYTHONPATH", "VIRTUAL_ENV")
+
+
+def run_solution(
+    task: Path,
+    app: Path,
+    *,
+    script: str = "solve.py",
+    arguments: tuple[str, ...] = ("--root",),
+    timeout_seconds: float = 300.0,
+) -> None:
+    """Run one task-owned producer under the bounded tooling boundary."""
+
+    task_root = task.resolve(strict=True)
+    app_root = app.resolve(strict=True)
+    command_arguments = (str(task_root / "solution" / script), *arguments)
+    if arguments == ("--root",):
+        command_arguments = (*command_arguments, str(app_root))
+    result = run_tool_command(
+        ToolCommandRequest(
+            executable=sys.executable,
+            arguments=command_arguments,
+            environment=operator_environment(include=_ENVIRONMENT),
+            cwd=str(ROOT),
+            timeout_seconds=timeout_seconds,
+            stdout_limit_bytes=_OUTPUT_LIMIT_BYTES,
+            stderr_limit_bytes=_OUTPUT_LIMIT_BYTES,
+        )
+    )
+    if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
+        detail = result.diagnostic or result.stderr.decode("utf-8", "replace")
+        raise RuntimeError(f"task producer failed: {detail.strip()}")
+
+
+__all__ = ["run_solution"]

--- a/benchmarks/validation/conjecture_probes_v1/test_bsd_infinite_order_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_bsd_infinite_order_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -17,10 +16,7 @@ def case(tmp_path: Path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_constant_weight_code_a23_6_10_2992.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_constant_weight_code_a23_6_10_2992.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -19,10 +18,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_hadamard_order12_construction.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hadamard_order12_construction.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -18,10 +17,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_hadamard_order664_construction.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hadamard_order664_construction.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -17,10 +16,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hadwiger_triangle_free_minor_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -20,10 +19,7 @@ def case(tmp_path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_happy_ending_convex_position.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_happy_ending_convex_position.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -18,10 +17,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_hodge_blowup_divisor_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_hodge_blowup_divisor_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -19,10 +18,7 @@ def case(tmp_path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return (app, logs, json.loads((app / "submission.json").read_text()))
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_littlewood_certified_finite_search.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_littlewood_certified_finite_search.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -19,10 +18,7 @@ def case(tmp_path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return (app, logs, json.loads((app / "submission.json").read_text()))
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_moser_radical_branch_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_moser_radical_branch_audit.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -17,10 +16,7 @@ def case(tmp_path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_navier_stokes_polynomial_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_navier_stokes_polynomial_certificate.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from fractions import Fraction
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -30,10 +29,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return (app, logs, json.loads((app / "submission.json").read_text()))
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_perfect_cuboid_scope_audit.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_perfect_cuboid_scope_audit.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -18,10 +17,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_projective_plane_order11_construction.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_projective_plane_order11_construction.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -20,10 +19,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_ramsey_r3_13_lower_bound_61.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_ramsey_r3_13_lower_bound_61.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -17,10 +16,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_reconstruction_deck_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -17,10 +16,7 @@ def case(tmp_path: Path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_totient_preimage_completeness_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_totient_preimage_completeness_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -20,10 +19,7 @@ def case(tmp_path: Path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_yang_mills_gauge_invariance_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_yang_mills_gauge_invariance_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -20,10 +19,7 @@ def case(tmp_path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/conjecture_probes_v1/test_zarankiewicz_projective_plane_certificate.py
+++ b/benchmarks/validation/conjecture_probes_v1/test_zarankiewicz_projective_plane_certificate.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import run_verifier_in_child
 
 ROOT = Path(__file__).parents[3]
@@ -20,10 +19,7 @@ def case(tmp_path: Path):
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment/input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution/solve.py"), "--root", str(app)],
-        check=True,
-    )
+    run_solution(TASK, app)
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/benchmarks/validation/mathematical_benchmarks_v1/test_multiplicative_grid_extremum.py
+++ b/benchmarks/validation/mathematical_benchmarks_v1/test_multiplicative_grid_extremum.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
+from benchmarks.validation._solution import run_solution
 from benchmarks.validation._verifier_child import VerifierOutput
 from benchmarks.validation.mathematical_benchmarks_v1 import _verifier
 
@@ -26,10 +25,7 @@ def _case(tmp_path: Path) -> tuple[Path, Path, dict]:
     app.mkdir(parents=True)
     logs.mkdir(parents=True)
     shutil.copy2(TASK / "environment" / "input.json", app / "input.json")
-    subprocess.run(
-        [sys.executable, str(TASK / "solution" / "oracle.py"), str(app)],
-        check=True,
-    )
+    run_solution(TASK, app, script="oracle.py", arguments=(str(app),))
     return app, logs, json.loads((app / "submission.json").read_text())
 
 

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -131,7 +131,10 @@ def _run_checked(
     if output:
         print(output)
     if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
-        detail = result.diagnostic or f"status={result.status}, exit={result.exit_code}"
+        detail = result.diagnostic or (
+            f"status={result.status}, exit={result.exit_code}, "
+            f"stdout_limit={OUTPUT_LIMIT}, stderr_limit={OUTPUT_LIMIT}"
+        )
         raise TaskWorkflowError(f"{label} failed after {elapsed:.2f}s ({detail})")
     timings.append(StageTiming(label=label, seconds=elapsed))
 

--- a/tools/harbor_task_workflow.py
+++ b/tools/harbor_task_workflow.py
@@ -131,10 +131,13 @@ def _run_checked(
     if output:
         print(output)
     if result.status is not ToolCommandStatus.EXITED or result.exit_code != 0:
-        detail = result.diagnostic or (
+        detail = (
             f"status={result.status}, exit={result.exit_code}, "
-            f"stdout_limit={OUTPUT_LIMIT}, stderr_limit={OUTPUT_LIMIT}"
+            f"timeout={timeout_seconds}, stdout_limit={OUTPUT_LIMIT}, "
+            f"stderr_limit={OUTPUT_LIMIT}"
         )
+        if result.diagnostic:
+            detail += f", diagnostic={result.diagnostic}"
         raise TaskWorkflowError(f"{label} failed after {elapsed:.2f}s ({detail})")
     timings.append(StageTiming(label=label, seconds=elapsed))
 


### PR DESCRIPTION
## Problem
Harbor validation producers and oracles used direct subprocess calls, so task execution did not consistently inherit the repository’s bounded timeout, output, process-tree, and cleanup contract. Harbor topology tests also treated caches under synthetic roots as Git-ignored when a parent repository happened to provide the ignore rule.

## Solution
- Add a shared bounded `run_solution` helper for task solution/oracle programs.
- Migrate all direct benchmark validation producer calls to that helper.
- Make Harbor cache checks stop Git discovery above the supplied validation root.

## Testing
- `make harbor-check`
- `make harbor-validation-tests` — 1,633 passed, 1 skipped
- Remote Harbor validation and benchmark contract checks passed
- Ruff, focused mypy, architecture, and formatting checks passed

## Public contract impact
None. This changes only validation infrastructure and preserves exact task outputs.

## Related issues
Related to #1540
Related to #631
Related to #2732

## Intentionally unchanged
No task contract, verifier semantics, network policy, or mathematical result is changed. The preserved untracked Erdos vocabulary audit is intentionally outside this PR.
